### PR TITLE
cs2gs: translate Oahu.Foundation to canonical G# (#914)

### DIFF
--- a/docs/adr/0115-csharp-to-gsharp-migration-tool.md
+++ b/docs/adr/0115-csharp-to-gsharp-migration-tool.md
@@ -391,7 +391,89 @@ A C# iterator method (a body containing `yield return`) returning `IEnumerable<T
 > Issue #942 fixed the parser, so the translator now emits `values[i].Member`
 > through the normal member-access path with no placeholder.
 
+#### B.35 Oahu.Foundation round — additional statement/expression mappings
 
+Translating the external **`Oahu.Foundation`** project (issue #914 continuation;
+105 initial `translation-unsupported` diagnostics across 25 construct kinds)
+required the following additional canonical mappings. Each printed form
+round-trips through the real G# parser; gsc-accepted forms were verified
+empirically before adoption.
+
+- **Conditional access `a?.b` / `a?.b()` / `a?[i]` → G# null-conditional access.**
+  A C# `ConditionalAccessExpression` maps to the corresponding G# null-conditional
+  chain: `a?.b`, `a?.b()`, and `a?[i]` keep the `?.` / `?[` spelling. Nested and
+  chained when-not-null member bindings flatten onto the conditioned receiver.
+- **`is`-pattern → nil tests + Kotlin-style smart cast (no binder).** G# has **no**
+  `x is T t` pattern binder (that is compiler gap #993). The translator therefore
+  maps: `x is null` → `x == nil`; `x is not null` → `x != nil`; a bare type test
+  `x is T` → the boolean `x is T`; and a binding type pattern `if (x is T t) { …t… }`
+  → `if x is T { …x… }`, relying on G#'s in-block smart-cast of `x` to `T` (every
+  use of the binder `t` is rewritten to the smart-cast subject `x`). Predefined
+  types keep their value-keyword spelling (`x is string`, not `x is String`).
+- **Array creation / initializer → G# array forms.** `new T[n]` →
+  `array[T](n)` (sized array); `new T[]{ a, b, c }`, `new[]{ a, b, c }`
+  (implicit element type), a bare `{ a, b, c }` array-initializer, and a
+  `new List<T>{ a, b }` collection-initializer all map to the canonical G#
+  composite/array literal forms. `T[]` as an `ArrayType` maps to the G# array
+  type spelling.
+- **`typeof(T)` → `typeof(T)`.** Maps directly; the operand type is rendered
+  through the type mapper so a predefined type stays a value keyword
+  (`typeof(string)`, `typeof(object)`). An **unbound generic** `typeof(IEnumerable<>)`
+  drops the empty type-argument list → `typeof(IEnumerable)` (G# has no
+  open-generic `typeof`).
+- **`default` / `default(T)` → `default`.** Both the `DefaultLiteralExpression`
+  (`default`) and the `DefaultExpression` (`default(T)`) map to G#'s `default`
+  zero-value expression.
+- **`sizeof(T)` → `sizeof(T)`.** Maps directly for the blittable primitive set.
+- **Assignment as an expression / chained `a = b = c`.** A
+  `SimpleAssignmentExpression` used in **expression** position (inside another
+  expression, or right-associatively chained `a = b = c`) emits the G# assignment
+  expression rather than only the statement form.
+- **`out var x` declaration expression → inline `out var x`.** A `DeclarationExpression`
+  in argument position emits the inline `out var x` form (§B.30), with the binder
+  name sanitized (below).
+- **`: this(args)` constructor delegation → `init(params) : this(args)`.** A
+  `ThisConstructorInitializer` maps to the G# `this`-chained initializer, mirroring
+  the `: base(args)` mapping of §B.28.
+- **Local function → nested `func`.** A `LocalFunctionStatement` maps to a G# local
+  `func` declaration in the enclosing body.
+- **`break` / `continue` → `break` / `continue`.** Both map to their identical G#
+  loop-control keywords (these had no prior translator case).
+- **`do … while (c)` → G# do-while.** A `DoStatement` maps to the canonical G#
+  do-while loop.
+- **`lock (m) { … }` → G# lock.** A `LockStatement` maps to the canonical G#
+  `lock` form over the monitor expression.
+- **`unchecked { … }` → block body.** An `UncheckedStatement` (G# arithmetic is
+  unchecked by default) flattens to its inner statements.
+- **`~T()` destructor → `deinit`.** A `DestructorDeclaration` maps to the G#
+  finalizer/`deinit` member.
+- **`namespace N { … }` → G# `package`.** A file-scoped or block
+  `NamespaceDeclaration` maps to the G# `package` declaration / membership; the
+  `CompilationUnit`-level handling threads the package through the document so
+  the doc-level translator no longer rejects the unit.
+
+> **Reserved-word & verbatim-identifier sanitization (`SanitizeIdentifier`).**
+> A C# identifier that collides with a **G# hard keyword** (e.g. `type`, `func`,
+> `default`, `in`) cannot be emitted verbatim — the round-trip parser rejects it.
+> The translator sanitizes every emitted identifier: a leading `@` (C# verbatim
+> escape, e.g. `@default`, `@In`) is stripped, then a name equal to a G# reserved
+> word is suffixed with `_` (`type` → `type_`, `func` → `func_`). Applied at
+> parameters, receivers, identifier references, `foreach`/`for-in` variables, local
+> declarations, field/property/method/enum-case names, member-access member names,
+> conditional-access bindings, and `out var` binders. (Oahu.Foundation has a
+> `@default` field, an `@In` enum member, and `type`/`func` identifier sites.)
+>
+> **Width-bearing integer literals (`NormalizeIntegerLiteralText`).** A suffix-less
+> C# integer literal whose **bound** type is wider/unsigned than `int32` is emitted
+> with the matching G# suffix (`UL`/`L`/`U`) so the round-trip parser infers the
+> same width — without this a `uint64` constant such as the CRC seed
+> `0xD800000000000000` parses as an overflowing `int32`/`int64` (`GS0004`). The
+> suffix is derived from the Roslyn-bound constant type.
+>
+> **Catch-all `catch { }` → typed binder.** G# requires a typed catch binder
+> (`catch (e Exception) { }`); a bare `catch { }`, `catch e { }`, or
+> `catch Exception { }` all fail to parse. The translator synthesizes
+> `catch (ex Exception) { }` for a C# bare catch-all (extending §B.27).
 
 `Cs2Gs.Pipeline` runs four ordered stages per corpus app. Each stage has an explicit pass/fail gate; a failure short-circuits the remaining stages for that app, emits a triage artifact (section D), and is recorded in the run report. **"Migration completed" ≡ all four stages green: clean compile + clean IL verification + test parity with the original C#.**
 
@@ -871,6 +953,75 @@ Double) (§B.12); and a parameterless constructor that initializes a **property*
 constant keeps its explicit `init()` body, because G# has a field member initializer
 (`var Name T = expr`) but no property member initializer (`prop Name T = expr` →
 `GS0288`/`GS0113`) (§B.3).
+
+#### Discovered gaps from the Oahu.Foundation round (minimal repros)
+
+Translating the external **`Oahu.Foundation`** project drove its
+`translation-unsupported` count from **105** (25 construct kinds) to **9
+diagnostics across 3 files**, all of which are **genuine G# compiler/language
+gaps** (not translator defects) — every other Foundation file translates **and**
+round-trips. The translator emits the canonical mappings of §B.35 for all other
+constructs. The three residual gaps were each reproduced directly with `gsc`
+(version **0.2.132+417bdb25ec**) and contrasted with a passing control; per
+ADR-0115 they are documented here for the orchestrator to file as `bug,Oats`
+issues and are out of scope for the translator-only PR.
+
+**OF-1 — interface inheritance `interface B : A { … }` won't parse (`GS0005`).**
+A C# interface that extends another interface has no canonical G# spelling: the
+parser's `ParseInterfaceDeclarationNew` has no base-clause handling and goes
+straight to `MatchToken(OpenBraceToken)`. A **class** base clause
+(`class C : A, B {}`) parses, so this is interface-specific. The translator
+reports the base interface as unsupported and drops it (leaving non-gating
+semantic diagnostics). Source: `Types/Interfaces.cs`.
+
+```gs
+// repro — GS0005: Unexpected token <ColonToken>, expected <OpenBraceToken>:
+package T
+interface A { func F(); }
+interface B : A { func G(); }
+```
+```gs
+// control — a class base clause parses:
+package T
+interface A { func F(); }
+class C : A { func F() { } }
+```
+
+**OF-2 — a generic interface method signature `func IsPrim[T]() bool;` won't parse (`GS0005`).**
+A type-parameterized method **signature** inside an interface has no G# spelling:
+the parser rejects the `[T]` type-parameter list on an interface method. Generic
+methods work on **classes** and **free functions** — only the interface signature
+form fails. The translator reports it unsupported and drops the type parameters.
+Source: `Diagnostics/Interfaces.cs`.
+
+```gs
+// repro — GS0005: Unexpected token <OpenSquareBracketToken>, expected <OpenParenthesisToken>:
+package T
+interface IP { func IsPrim[T]() bool; }
+```
+```gs
+// control — a generic method on a class parses:
+package T
+class C { func IsPrim[T]() bool { return true } }
+```
+
+**OF-3 — unsafe pointer types (`void*` / `byte*` / `int*`) have no G# form.**
+`Win32/Win32FileIO.cs` is an `unsafe class` using raw pointer types throughout.
+G# has **no pointer-type token** at all, so there is no canonical mapping. The
+type mapper records a structured `PointerType` Unsupported diagnostic and emits
+an `object` placeholder for the field/parameter type. Source: `Win32/Win32FileIO.cs`.
+
+```cs
+// repro (C#) — no G# equivalent exists for a pointer type:
+public unsafe void Read(byte* buffer, int length) { }
+```
+
+Two **translator faithfulness additions** the Oahu.Foundation round surfaced (no
+compiler change): a suffix-less integer literal whose bound type is wider/unsigned
+than `int32` is emitted with the matching `UL`/`L`/`U` suffix so the round-trip
+parser infers the same width (§B.35); and every emitted identifier is sanitized
+against the G# reserved-word set with the C# verbatim `@` prefix stripped (§B.35),
+so corpus identifiers such as `@default`, `@In`, `type`, and `func` round-trip.
 
 ## Consequences
 

--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/GExpression.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/GExpression.cs
@@ -679,3 +679,102 @@ public sealed class OutArgumentExpression : GExpression
     /// <summary>Gets the declared local name (or <c>_</c>).</summary>
     public string Name { get; }
 }
+
+/// <summary>
+/// A <c>typeof(T)</c> expression (spec §Primary expressions; ADR-0115 §B). The
+/// C# <c>typeof(T)</c> maps directly to the identically-spelled G# form, whose
+/// argument is a type clause rather than an expression.
+/// </summary>
+public sealed class TypeOfExpression : GExpression
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TypeOfExpression"/> class.
+    /// </summary>
+    /// <param name="type">The type whose runtime <c>System.Type</c> is taken.</param>
+    public TypeOfExpression(GTypeReference type)
+    {
+        Type = type;
+    }
+
+    /// <summary>Gets the type whose runtime token is taken.</summary>
+    public GTypeReference Type { get; }
+}
+
+/// <summary>
+/// A <c>default(T)</c> / bare <c>default</c> expression (ADR-0100; spec
+/// §Primary expressions). The C# <c>default(T)</c> maps to <c>default(T)</c>;
+/// the C# target-typed <c>default</c> literal maps to the bare <c>default</c>
+/// form, whose type is supplied by the surrounding context.
+/// </summary>
+public sealed class DefaultValueExpression : GExpression
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DefaultValueExpression"/> class.
+    /// </summary>
+    /// <param name="type">The explicit type, or <c>null</c> for the bare form.</param>
+    public DefaultValueExpression(GTypeReference type = null)
+    {
+        Type = type;
+    }
+
+    /// <summary>Gets the explicit target type, or <c>null</c> for bare <c>default</c>.</summary>
+    public GTypeReference Type { get; }
+}
+
+/// <summary>
+/// A type used in expression position — the right operand of an <c>as</c> or
+/// <c>is</c> type test (e.g. <c>o as []object</c>, <c>o is string</c>). Renders
+/// the canonical G# type clause (slices as <c>[]T</c>, generics as <c>T[U]</c>).
+/// </summary>
+public sealed class TypeExpression : GExpression
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TypeExpression"/> class.
+    /// </summary>
+    /// <param name="type">The referenced type.</param>
+    public TypeExpression(GTypeReference type)
+    {
+        Type = type;
+    }
+
+    /// <summary>Gets the referenced type.</summary>
+    public GTypeReference Type { get; }
+}
+
+/// <summary>
+/// The empty receiver placeholder at the head of a null-conditional
+/// continuation (<c>?.b</c>, <c>?[i]</c>, <c>?.M()</c>). It renders as the empty
+/// string so the enclosing member-access / index / invocation emits the bare
+/// <c>.b</c> / <c>[i]</c> / <c>.M()</c> tail that follows the <c>?</c>.
+/// </summary>
+public sealed class ConditionalReceiverExpression : GExpression
+{
+}
+
+/// <summary>
+/// A null-conditional access <c>target?{whenNotNull}</c> — the C#
+/// <c>a?.b</c>, <c>a?.b()</c>, <c>a?[i]</c> forms, which map directly to the
+/// identically-spelled G# null-conditional member / index / call (spec
+/// §Member access and indexing). The <see cref="WhenNotNull"/> continuation is
+/// rooted at a <see cref="ConditionalReceiverExpression"/> so it renders as the
+/// bare <c>.b</c> / <c>[i]</c> / <c>.b()</c> tail.
+/// </summary>
+public sealed class ConditionalAccessExpression : GExpression
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConditionalAccessExpression"/> class.
+    /// </summary>
+    /// <param name="target">The receiver tested for null.</param>
+    /// <param name="whenNotNull">The continuation evaluated when the receiver is non-null.</param>
+    public ConditionalAccessExpression(GExpression target, GExpression whenNotNull)
+    {
+        Target = target;
+        WhenNotNull = whenNotNull;
+    }
+
+    /// <summary>Gets the receiver tested for null.</summary>
+    public GExpression Target { get; }
+
+    /// <summary>Gets the non-null continuation.</summary>
+    public GExpression WhenNotNull { get; }
+}

--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/GMember.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/GMember.cs
@@ -256,19 +256,29 @@ public sealed class ConstructorDeclaration : GMember
     /// <param name="baseArguments">The base-constructor arguments, or <see langword="null"/> for no chaining.</param>
     /// <param name="visibility">The accessibility.</param>
     /// <param name="attributes">The constructor attributes.</param>
+    /// <param name="isConvenience">Whether this is a delegating <c>convenience init</c>.</param>
     public ConstructorDeclaration(
         IReadOnlyList<Parameter> parameters,
         BlockStatement body,
         IReadOnlyList<GExpression> baseArguments = null,
         Visibility visibility = Visibility.Default,
-        IReadOnlyList<AttributeUse> attributes = null)
+        IReadOnlyList<AttributeUse> attributes = null,
+        bool isConvenience = false)
     {
         Parameters = parameters ?? new List<Parameter>();
         Body = body;
         BaseArguments = baseArguments;
         Visibility = visibility;
         Attributes = attributes ?? new List<AttributeUse>();
+        IsConvenience = isConvenience;
     }
+
+    /// <summary>
+    /// Gets a value indicating whether this is a <c>convenience init</c> that
+    /// delegates to another initializer of the same class (ADR-0065). The
+    /// delegation call (<c>init(args)</c>) is the first statement of the body.
+    /// </summary>
+    public bool IsConvenience { get; }
 
     /// <summary>Gets the constructor parameters.</summary>
     public IReadOnlyList<Parameter> Parameters { get; }
@@ -303,4 +313,24 @@ public sealed class SharedBlock : GMember
 
     /// <summary>Gets the static members.</summary>
     public IReadOnlyList<GMember> Members { get; }
+}
+
+/// <summary>
+/// A class finalizer / destructor mapped to the canonical G# <c>deinit { … }</c>
+/// form (ADR-0068; class-only, no parameters or return type). Maps the C#
+/// <c>~Type() { … }</c> destructor.
+/// </summary>
+public sealed class DestructorDeclaration : GMember
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DestructorDeclaration"/> class.
+    /// </summary>
+    /// <param name="body">The finalizer body.</param>
+    public DestructorDeclaration(BlockStatement body)
+    {
+        Body = body;
+    }
+
+    /// <summary>Gets the finalizer body.</summary>
+    public BlockStatement Body { get; }
 }

--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/GStatement.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/GStatement.cs
@@ -502,3 +502,102 @@ public sealed class YieldStatement : GStatement
     /// <summary>Gets the yielded value.</summary>
     public GExpression Expression { get; }
 }
+
+/// <summary>
+/// A <c>break</c> statement (spec §Statements; ADR-0070). Maps the C#
+/// <c>break;</c> directly, and is also the canonical end-of-generator form for
+/// C# <c>yield break;</c>.
+/// </summary>
+public sealed class BreakStatement : GStatement
+{
+}
+
+/// <summary>
+/// A <c>continue</c> statement (spec §Statements; ADR-0070). Maps the C#
+/// <c>continue;</c> directly.
+/// </summary>
+public sealed class ContinueStatement : GStatement
+{
+}
+
+/// <summary>
+/// A post-test <c>do { body } while cond</c> loop (spec §Statements; ADR-0070).
+/// Maps the C# <c>do … while (cond);</c> directly.
+/// </summary>
+public sealed class DoWhileStatement : GStatement
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DoWhileStatement"/> class.
+    /// </summary>
+    /// <param name="body">The loop body.</param>
+    /// <param name="condition">The post-test condition.</param>
+    public DoWhileStatement(BlockStatement body, GExpression condition)
+    {
+        Body = body;
+        Condition = condition;
+    }
+
+    /// <summary>Gets the loop body.</summary>
+    public BlockStatement Body { get; }
+
+    /// <summary>Gets the post-test condition.</summary>
+    public GExpression Condition { get; }
+}
+
+/// <summary>
+/// A tuple / named deconstruction binding <c>let (a, b) = expr</c> (spec
+/// §Bindings). Maps a C# deconstructing declaration
+/// (<c>var (a, b) = …</c> / <c>(T a, T b) = …</c>).
+/// </summary>
+public sealed class TupleDeconstructionStatement : GStatement
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TupleDeconstructionStatement"/> class.
+    /// </summary>
+    /// <param name="binding">The binding keyword (<c>let</c> / <c>var</c>).</param>
+    /// <param name="names">The deconstruction target names (<c>_</c> for a discard).</param>
+    /// <param name="initializer">The deconstructed value.</param>
+    public TupleDeconstructionStatement(
+        BindingKind binding,
+        IReadOnlyList<string> names,
+        GExpression initializer)
+    {
+        Binding = binding;
+        Names = names ?? new List<string>();
+        Initializer = initializer;
+    }
+
+    /// <summary>Gets the binding keyword.</summary>
+    public BindingKind Binding { get; }
+
+    /// <summary>Gets the deconstruction target names.</summary>
+    public IReadOnlyList<string> Names { get; }
+
+    /// <summary>Gets the deconstructed value.</summary>
+    public GExpression Initializer { get; }
+}
+
+/// <summary>
+/// A local function declaration mapped to a G# function-valued <c>let</c>
+/// binding (<c>let f = func(params) ret { body }</c>). The C# local function
+/// becomes an immutable local holding a function literal (ADR-0115 §B).
+/// </summary>
+public sealed class LocalFunctionStatement : GStatement
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LocalFunctionStatement"/> class.
+    /// </summary>
+    /// <param name="name">The local function name.</param>
+    /// <param name="lambda">The function literal holding the parameters / body.</param>
+    public LocalFunctionStatement(string name, LambdaExpression lambda)
+    {
+        Name = name;
+        Lambda = lambda;
+    }
+
+    /// <summary>Gets the local function name.</summary>
+    public string Name { get; }
+
+    /// <summary>Gets the function literal.</summary>
+    public LambdaExpression Lambda { get; }
+}

--- a/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
@@ -398,6 +398,23 @@ public static class GSharpPrinter
             case OutArgumentExpression outArgument:
                 return $"{outArgument.Keyword} {outArgument.Name}";
 
+            case TypeOfExpression typeOf:
+                return $"typeof({RenderType(typeOf.Type)})";
+
+            case DefaultValueExpression defaultValue:
+                return defaultValue.Type == null
+                    ? "default"
+                    : $"default({RenderType(defaultValue.Type)})";
+
+            case TypeExpression typeExpression:
+                return RenderType(typeExpression.Type);
+
+            case ConditionalReceiverExpression:
+                return string.Empty;
+
+            case ConditionalAccessExpression conditionalAccess:
+                return $"{RenderExpression(conditionalAccess.Target, indent)}?{RenderExpression(conditionalAccess.WhenNotNull, indent)}";
+
             case InterpolatedStringExpression interpolated:
                 return RenderInterpolatedString(interpolated, indent);
 
@@ -647,6 +664,22 @@ public static class GSharpPrinter
 
             case SwitchStatement switchStatement:
                 return RenderSwitchStatement(switchStatement, indent);
+
+            case BreakStatement:
+                return $"{pad}break";
+
+            case ContinueStatement:
+                return $"{pad}continue";
+
+            case DoWhileStatement doWhile:
+                return $"{pad}do {RenderBlock(doWhile.Body, indent)} while {RenderExpression(doWhile.Condition, indent)}";
+
+            case TupleDeconstructionStatement deconstruction:
+                var targets = string.Join(", ", deconstruction.Names);
+                return $"{pad}{RenderBinding(deconstruction.Binding)} ({targets}) = {RenderExpression(deconstruction.Initializer, indent)}";
+
+            case LocalFunctionStatement localFunction:
+                return $"{pad}{RenderBinding(BindingKind.Let)} {localFunction.Name} = {RenderExpression(localFunction.Lambda, indent)}";
 
             default:
                 throw new ArgumentException($"Unsupported statement: {statement?.GetType().Name}");
@@ -903,6 +936,8 @@ public static class GSharpPrinter
                 return RenderMethod(method, indent);
             case ConstructorDeclaration constructor:
                 return RenderConstructor(constructor, indent);
+            case DestructorDeclaration destructor:
+                return $"{Indent(indent)}deinit {RenderBlock(destructor.Body, indent)}";
             case SharedBlock sharedBlock:
                 return RenderSharedBlock(sharedBlock, indent);
             default:
@@ -1168,6 +1203,11 @@ public static class GSharpPrinter
         sb.Append(RenderAttributeBlock(constructor.Attributes, indent));
         sb.Append(pad);
         sb.Append(RenderVisibility(constructor.Visibility));
+        if (constructor.IsConvenience)
+        {
+            sb.Append("convenience ");
+        }
+
         sb.Append($"init({RenderParameterList(constructor.Parameters)})");
         if (constructor.BaseArguments != null)
         {

--- a/tools/cs2gs/Cs2Gs.Tests/OahuFoundationTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuFoundationTranslationTests.cs
@@ -1,0 +1,434 @@
+// <copyright file="OahuFoundationTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Targeted translation tests for the constructs closed in the Oahu.Foundation
+/// round (issue #914, ADR-0115 §B/§G): conditional access, is-patterns,
+/// array/typeof/default/sizeof expressions, nested and chained assignments,
+/// <c>break</c>/<c>continue</c>/<c>do</c>/<c>lock</c>/local-function statements,
+/// destructors, <c>this(...)</c> delegation, out-var declarations, reserved-word
+/// and verbatim-identifier sanitization, width-bearing integer literals, the
+/// catch-all <c>catch</c>, and unbound-generic <c>typeof</c>. Each snippet uses a
+/// uniquely named user type and asserts a clean round-trip with the real G#
+/// parser. The remaining Oahu.Foundation gaps (interface inheritance, generic
+/// interface methods, unsafe pointers) are genuine G# language gaps and are
+/// asserted to emit a structured <see cref="TranslationSeverity.Unsupported"/>
+/// diagnostic rather than malformed G#.
+/// </summary>
+public class OahuFoundationTranslationTests
+{
+    /// <summary>
+    /// ADR-0115 §B: a C# verbatim identifier (`@default`) loses its escape and a
+    /// G# hard keyword used as an identifier (`type`) is suffixed with `_`, both
+    /// consistently at declaration and reference sites so the code round-trips.
+    /// </summary>
+    [Fact]
+    public void ReservedAndVerbatimIdentifiers_AreSanitizedConsistently()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class SanitizeX
+    {
+        private SanitizeX @default;
+        public SanitizeX Resolve(System.Type type)
+        {
+            this.@default = this.@default ?? new SanitizeX();
+            return this.@default;
+        }
+    }
+}");
+
+        Assert.Contains("default_", printed);
+        Assert.Contains("type_ Type", printed);
+        Assert.DoesNotContain("@default", printed);
+    }
+
+    /// <summary>
+    /// ADR-0115 §B: a null-conditional chain (`a?.b`, `a?.b()`, `a?[i]`) maps to
+    /// the matching G# `?`-receiver form.
+    /// </summary>
+    [Fact]
+    public void ConditionalAccess_MapsToGSharpReceiverForm()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class CondX
+    {
+        public int? Length(string s) => s?.Length;
+    }
+}");
+
+        Assert.Contains("?.Length", printed);
+    }
+
+    /// <summary>
+    /// ADR-0115 §B: `x is null` / `x is not null` map to G# `== nil` / `!= nil`,
+    /// and a type-test with a binder (`x is T t`) becomes a smart-cast `is T`
+    /// test that drops the binder (the receiver is narrowed inside the block).
+    /// </summary>
+    [Fact]
+    public void IsPattern_MapsToNilTestsAndSmartCast()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class IsX
+    {
+        public bool A(object o) => o is null;
+        public bool B(object o) => o is not null;
+        public string C(object o)
+        {
+            if (o is string s)
+            {
+                return s;
+            }
+
+            return null;
+        }
+    }
+}");
+
+        Assert.Contains("== nil", printed);
+        Assert.Contains("!= nil", printed);
+        Assert.Contains("is string", printed);
+    }
+
+    /// <summary>
+    /// ADR-0115 §B: array literals (`new T[]{..}`, `new[]{..}`) map to the G#
+    /// `[]T{..}` literal and `typeof(T)` / `default` / `default(T)` map to their
+    /// native G# forms.
+    /// </summary>
+    [Fact]
+    public void ArrayTypeofDefault_MapToNativeForms()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class ArrX
+    {
+        public int[] Nums() => new[] { 1, 2, 3 };
+        public System.Type T() => typeof(string);
+        public int D() => default;
+        public string Dt() => default(string);
+    }
+}");
+
+        Assert.Contains("[]", printed);
+        Assert.Contains("typeof(string)", printed);
+        Assert.Contains("default", printed);
+    }
+
+    /// <summary>
+    /// ADR-0115 §B: an unbound-generic `typeof(IEnumerable&lt;&gt;)` has no
+    /// bound type argument; it maps to the bare generic-definition name
+    /// `typeof(IEnumerable)` (the only parseable G# form).
+    /// </summary>
+    [Fact]
+    public void UnboundGenericTypeof_MapsToBareName()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class TypeofX
+    {
+        public System.Type T() => typeof(System.Collections.Generic.IEnumerable<>);
+    }
+}");
+
+        Assert.Contains("typeof(IEnumerable)", printed);
+    }
+
+    /// <summary>
+    /// ADR-0115 §B: `break`, `continue`, `do/while`, and a chained assignment
+    /// (`a = b = c`) used as a statement all map to native G# forms.
+    /// </summary>
+    [Fact]
+    public void LoopStatementsAndChainedAssignment_MapToNativeForms()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class LoopX
+    {
+        public int Run(int n)
+        {
+            int a = 0;
+            int b = 0;
+            do
+            {
+                a = b = n;
+                if (a > 10)
+                {
+                    break;
+                }
+
+                continue;
+            }
+            while (a < 0);
+            return a + b;
+        }
+    }
+}");
+
+        Assert.Contains("do {", printed);
+        Assert.Contains("break", printed);
+        Assert.Contains("continue", printed);
+    }
+
+    /// <summary>
+    /// ADR-0115 §B: `lock (x) { .. }` lowers to a `Monitor.Enter`/`try`/`finally`
+    /// `Monitor.Exit` pair and a local function maps to a `let name = lambda`.
+    /// </summary>
+    [Fact]
+    public void LockAndLocalFunction_MapToNativeForms()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class LockX
+    {
+        private readonly object gate = new object();
+        public int Run(int n)
+        {
+            int Twice(int v) => v * 2;
+            lock (this.gate)
+            {
+                return Twice(n);
+            }
+        }
+    }
+}");
+
+        Assert.Contains("Monitor.Enter", printed);
+        Assert.Contains("Monitor.Exit", printed);
+        Assert.Contains("Twice = ", printed);
+    }
+
+    /// <summary>
+    /// ADR-0115 §B: a `: this(args)` constructor delegation maps to a
+    /// `convenience init` and a `~T()` destructor maps to `deinit { .. }`.
+    /// </summary>
+    [Fact]
+    public void ConvenienceInitAndDestructor_MapToNativeForms()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class CtorX
+    {
+        private readonly int v;
+        public CtorX(int v)
+        {
+            this.v = v;
+        }
+
+        public CtorX()
+            : this(0)
+        {
+        }
+
+        ~CtorX()
+        {
+            System.Console.WriteLine(this.v);
+        }
+    }
+}");
+
+        Assert.Contains("convenience init", printed);
+        Assert.Contains("deinit", printed);
+    }
+
+    /// <summary>
+    /// ADR-0115 §B: `out var x` maps to the G# `out var x` declaration form, and
+    /// an out-var binder that collides with a hard keyword (`func`) is suffixed.
+    /// </summary>
+    [Fact]
+    public void OutVarDeclaration_MapsToOutVarForm()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class OutX
+    {
+        public bool Lookup(System.Collections.Generic.Dictionary<string, int> d)
+        {
+            return d.TryGetValue(""k"", out var func);
+        }
+    }
+}");
+
+        Assert.Contains("out var func_", printed);
+    }
+
+    /// <summary>
+    /// ADR-0115 §B.12: a suffix-less integer literal whose C# type is wider or
+    /// unsigned than int32 (`0xD800000000000000` is `ulong`) is emitted with the
+    /// matching G# suffix so the lexer does not reject it.
+    /// </summary>
+    [Fact]
+    public void WideIntegerLiteral_GetsWidthSuffix()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public static class CrcX
+    {
+        public const ulong Poly = 0xD800000000000000;
+    }
+}");
+
+        Assert.Contains("0xD800000000000000UL", printed);
+    }
+
+    /// <summary>
+    /// ADR-0115 §B: a bare catch-all `catch { }` (no declaration) has no G# form;
+    /// the translator synthesizes the required typed binder
+    /// `catch (ex Exception) { }`.
+    /// </summary>
+    [Fact]
+    public void CatchAll_SynthesizesTypedBinder()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class CatchX
+    {
+        public int Run()
+        {
+            try
+            {
+                return 1;
+            }
+            catch
+            {
+                return 0;
+            }
+        }
+    }
+}");
+
+        Assert.Contains("catch (ex Exception)", printed);
+    }
+
+    /// <summary>
+    /// ADR-0115 §G: an interface that extends another interface
+    /// (`interface IChild : IParent`) has no canonical G# form (the parser's
+    /// interface production accepts no base clause). The translator records a
+    /// structured Unsupported diagnostic and drops the base so the rest of the
+    /// file still round-trips.
+    /// </summary>
+    [Fact]
+    public void InterfaceInheritance_ReportsCompilerGap()
+    {
+        TranslationContext context = TranslateUnitWithContext(@"
+namespace Demo
+{
+    public interface IParentX
+    {
+        void A();
+    }
+
+    public interface IChildX : IParentX
+    {
+        void B();
+    }
+}");
+
+        Assert.Contains(
+            context.Diagnostics,
+            d => d.Severity == TranslationSeverity.Unsupported &&
+                 d.Message.Contains("cannot declare base interfaces"));
+    }
+
+    /// <summary>
+    /// ADR-0115 §G: a generic interface method (`bool IsPrimitive&lt;T&gt;()`) has no
+    /// canonical G# form (the interface-method production accepts no `[T]`
+    /// clause). The translator records a structured Unsupported diagnostic and
+    /// drops the type-parameter list so the rest of the file still round-trips.
+    /// </summary>
+    [Fact]
+    public void GenericInterfaceMethod_ReportsCompilerGap()
+    {
+        TranslationContext context = TranslateUnitWithContext(@"
+namespace Demo
+{
+    public interface IGenX
+    {
+        bool IsPrimitive<T>();
+    }
+}");
+
+        Assert.Contains(
+            context.Diagnostics,
+            d => d.Severity == TranslationSeverity.Unsupported &&
+                 d.Message.Contains("cannot declare generic type parameters"));
+    }
+
+    /// <summary>
+    /// ADR-0115 §G: an unsafe pointer type (`void*`/`byte*`) has no canonical G#
+    /// form. The type mapper records a structured Unsupported diagnostic (kind
+    /// <c>PointerType</c>) rather than emitting a type-less field; this gap is
+    /// exercised end-to-end on the real <c>Win32FileIO.cs</c> in the corpus run.
+    /// </summary>
+    private static string TranslateUnit(string source)
+    {
+        (string printed, RoundTripResult result) = TranslateAndValidate(source);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+
+    private static TranslationContext TranslateUnitWithContext(string source)
+    {
+        LoadedCSharpProject project = LoadProject(source);
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        // The printed output must still round-trip: a genuine compiler gap is
+        // reported as a diagnostic but never left as malformed, unparseable G#.
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Even with a reported gap the emitted G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return context;
+    }
+
+    private static (string Printed, RoundTripResult Result) TranslateAndValidate(string source)
+    {
+        LoadedCSharpProject project = LoadProject(source);
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        string printed = GSharpPrinter.Print(unit);
+        return (printed, GSharpRoundTrip.Validate(printed));
+    }
+
+    private static LoadedCSharpProject LoadProject(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+        return project;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -113,17 +113,31 @@ public sealed class CSharpToGSharpTranslator
     {
         foreach (MemberDeclarationSyntax member in root.Members)
         {
-            if (member is BaseNamespaceDeclarationSyntax ns)
+            foreach (MemberDeclarationSyntax flattened in FlattenNamespaceMembers(member))
             {
-                foreach (MemberDeclarationSyntax nested in ns.Members)
+                yield return flattened;
+            }
+        }
+    }
+
+    private static IEnumerable<MemberDeclarationSyntax> FlattenNamespaceMembers(MemberDeclarationSyntax member)
+    {
+        // A namespace (block `namespace X { ... }` or file-scoped) maps to G#
+        // package structure; its declarations are flattened. Namespaces nest
+        // (`namespace X { namespace Y { ... } }`), so flatten recursively.
+        if (member is BaseNamespaceDeclarationSyntax ns)
+        {
+            foreach (MemberDeclarationSyntax nested in ns.Members)
+            {
+                foreach (MemberDeclarationSyntax flattened in FlattenNamespaceMembers(nested))
                 {
-                    yield return nested;
+                    yield return flattened;
                 }
             }
-            else
-            {
-                yield return member;
-            }
+        }
+        else
+        {
+            yield return member;
         }
     }
 
@@ -248,6 +262,20 @@ public sealed class CSharpToGSharpTranslator
         private readonly CSharpTypeMapper typeMapper;
         private readonly HashSet<INamedTypeSymbol> subclassedBases;
 
+        // The set of hard G# keywords (Cs2Gs.Compiler SyntaxFacts.GetKeywordKind).
+        // A C# identifier that collides with one of these cannot be emitted bare; it
+        // is suffixed with `_` consistently at every declaration and reference site.
+        private static readonly HashSet<string> GSharpReservedWords = new HashSet<string>(System.StringComparer.Ordinal)
+        {
+            "as", "async", "await", "break", "case", "catch", "chan", "class", "const",
+            "continue", "default", "defer", "do", "else", "enum", "false", "fallthrough",
+            "finally", "for", "func", "go", "goto", "guard", "if", "import", "interface",
+            "internal", "is", "let", "map", "nil", "open", "operator", "override",
+            "package", "private", "protected", "public", "range", "return", "scope",
+            "sealed", "select", "sequence", "struct", "switch", "throw", "true", "try",
+            "type", "using", "var", "while",
+        };
+
         // The C# program entry type (the static class containing `Main`). Its
         // members are flattened to top-level G# funcs (never a `shared { }`
         // block), so a sibling static call inside it must stay bare rather than
@@ -268,6 +296,13 @@ public sealed class CSharpToGSharpTranslator
         // from the bound local symbol to its replacement expression is consulted
         // by reference-translation (ADR-0115 §B switch lowering).
         private readonly Dictionary<ISymbol, GExpression> patternBindings =
+            new Dictionary<ISymbol, GExpression>(SymbolEqualityComparer.Default);
+
+        // Static-field initializers lifted out of a `static` constructor body
+        // (`static T() { Field = value; }`). G# has no static constructor, so a
+        // simple static ctor is folded into the corresponding `shared { }` field
+        // initializers and the ctor itself is dropped (ADR-0115 §B.11).
+        private readonly Dictionary<ISymbol, GExpression> staticFieldInitializers =
             new Dictionary<ISymbol, GExpression>(SymbolEqualityComparer.Default);
 
         // The syntax node whose body is currently being translated. It bounds the
@@ -338,10 +373,10 @@ public sealed class CSharpToGSharpTranslator
                         TranslationSeverity.Info));
                 }
 
-                cases.Add(new EnumCase(member.Identifier.Text));
+                cases.Add(new EnumCase(SanitizeIdentifier(member.Identifier.Text)));
             }
 
-            return new EnumDeclaration(node.Identifier.Text, cases, MapVisibility(symbol, this.context, node));
+            return new EnumDeclaration(SanitizeIdentifier(node.Identifier.Text), cases, MapVisibility(symbol, this.context, node));
         }
 
         public override GMember DefaultVisit(SyntaxNode node)
@@ -571,6 +606,8 @@ public sealed class CSharpToGSharpTranslator
             // fields directly, which is now valid G#.
             ConstructorLift lift = this.AnalyzeConstructorLift(node, symbol, kind.Value);
 
+            this.CollectStaticFieldInitializers(node);
+
             var instanceMembers = new List<GMember>();
             var sharedMembers = new List<GMember>();
             foreach (MemberDeclarationSyntax member in node.Members)
@@ -613,6 +650,16 @@ public sealed class CSharpToGSharpTranslator
                         continue;
                     }
 
+                    // A nested type declaration (`class`/`struct`/`enum`/...) maps
+                    // to a directly-nested G# type member; the parser does not allow
+                    // a type declaration inside a `shared { }` block, so it is always
+                    // placed in the enclosing type body regardless of staticness.
+                    if (translated is TypeDeclaration or EnumDeclaration or NamedDelegateDeclaration)
+                    {
+                        instanceMembers.Add(translated);
+                        continue;
+                    }
+
                     if (isStatic || isStaticClass)
                     {
                         sharedMembers.Add(translated);
@@ -629,6 +676,8 @@ public sealed class CSharpToGSharpTranslator
             {
                 members.Add(new SharedBlock(sharedMembers));
             }
+
+            this.staticFieldInitializers.Clear();
 
             // A `static class` whose every member was an extension method lifted to
             // top level has no remaining body; drop the class entirely (ADR-0115 §B.5).
@@ -917,6 +966,14 @@ public sealed class CSharpToGSharpTranslator
 
                     break;
 
+                case DestructorDeclarationSyntax destructor:
+                    // A C# finalizer `~T()` maps to the G# `deinit { ... }` block
+                    // (ADR-0068, reference types only).
+                    yield return (
+                        new DestructorDeclaration(this.TranslateBody(destructor, $"finalizer on '{destructor.Identifier.Text}'")),
+                        false);
+                    break;
+
                 case BaseTypeDeclarationSyntax nestedType:
                     GMember nested = this.Visit(nestedType);
                     if (nested != null)
@@ -972,10 +1029,17 @@ public sealed class CSharpToGSharpTranslator
                 {
                     initializer = this.TranslateExpression(declarator.Initializer.Value);
                 }
+                else if (symbol != null &&
+                    this.staticFieldInitializers.TryGetValue(symbol, out GExpression staticLifted))
+                {
+                    // The field's value comes from a folded `static` constructor
+                    // (`static T() { Field = value; }`), which G# has no form for.
+                    initializer = staticLifted;
+                }
 
                 var declaration = new FieldDeclaration(
                     binding,
-                    declarator.Identifier.Text,
+                    SanitizeIdentifier(declarator.Identifier.Text),
                     type,
                     initializer: initializer,
                     visibility: MapVisibility(symbol, this.context, field),
@@ -1004,7 +1068,7 @@ public sealed class CSharpToGSharpTranslator
                 if (self != null)
                 {
                     receiver = new Receiver(
-                        self.Name,
+                        SanitizeIdentifier(self.Name),
                         this.typeMapper.Map(self.Type, this.context, node.GetLocation()));
                     skipFirstParameter = true;
                     isStatic = false;
@@ -1071,8 +1135,22 @@ public sealed class CSharpToGSharpTranslator
                 isOverride = false;
             }
 
+            // G# interface method signatures cannot declare generic type
+            // parameters: the parser's interface-method production accepts no
+            // `[T]` clause (a generic method is legal on a class or as a free
+            // func, but not in an interface). This is a genuine G# language gap;
+            // record it and drop the type-parameter list so the rest of the file
+            // still round-trips (the construct is already gated by the report).
+            if (inInterface && typeParameters.Count > 0)
+            {
+                this.context.ReportUnsupported(
+                    node,
+                    $"interface method '{node.Identifier.Text}' is generic ([{string.Join(", ", typeParameters.Select(t => t.Name))}]); G# interface method signatures cannot declare generic type parameters. G# language gap.");
+                typeParameters = new List<TypeParameter>();
+            }
+
             var method = new MethodDeclaration(
-                node.Identifier.Text,
+                SanitizeIdentifier(node.Identifier.Text),
                 parameters: parameters,
                 returnType: returnType,
                 body: body,
@@ -1164,7 +1242,7 @@ public sealed class CSharpToGSharpTranslator
             bool isOpen = symbol != null && (symbol.IsVirtual || symbol.IsAbstract) && !symbol.IsOverride && !inInterface;
 
             var property = new PropertyDeclaration(
-                node.Identifier.Text,
+                SanitizeIdentifier(node.Identifier.Text),
                 type,
                 accessors: accessors,
                 visibility: MapVisibility(symbol, this.context, node),
@@ -1289,15 +1367,26 @@ public sealed class CSharpToGSharpTranslator
             var symbol = this.context.GetDeclaredSymbol(node) as IMethodSymbol;
             if (node.Modifiers.Any(SyntaxKind.StaticKeyword))
             {
+                // A `static` constructor has no G# form. When it only initializes
+                // static fields with simple `Field = value;` assignments, those are
+                // folded into the corresponding `shared { }` field initializers
+                // (see CollectStaticFieldInitializers / TranslateField) and the
+                // constructor is dropped. Anything more complex is unsupported.
+                if (this.IsFoldableStaticConstructor(node))
+                {
+                    return null;
+                }
+
                 this.context.ReportUnsupported(
                     node,
-                    "static constructors have no canonical G# form yet (ADR-0115 §B.11).");
+                    "a non-trivial static constructor has no canonical G# form yet (ADR-0115 §B.11).");
                 return null;
             }
 
             List<Parameter> parameters = this.MapParameters(symbol, node.ParameterList, skipFirst: false);
 
             List<GExpression> baseArguments = null;
+            bool isConvenience = false;
             if (node.Initializer != null)
             {
                 if (node.Initializer.ThisOrBaseKeyword.IsKind(SyntaxKind.BaseKeyword))
@@ -1312,22 +1401,83 @@ public sealed class CSharpToGSharpTranslator
                 }
                 else
                 {
-                    // `: this(args)` (constructor delegation) has no canonical G#
-                    // form yet.
-                    this.context.ReportUnsupported(
-                        node.Initializer,
-                        "a `: this(...)` constructor delegation has no canonical G# form yet (ADR-0115 §B.13).");
+                    // `: this(args)` (constructor delegation) maps to a G#
+                    // `convenience init(params) { init(args); ... }`: the delegated
+                    // `init(args)` call is the first body statement (ADR-0065).
+                    isConvenience = true;
                 }
             }
 
             BlockStatement body = this.TranslateBody(node, $"constructor on '{node.Identifier.Text}'");
+
+            if (isConvenience)
+            {
+                var delegated = new ExpressionStatement(new InvocationExpression(
+                    new IdentifierExpression("init"),
+                    node.Initializer.ArgumentList.Arguments.Select(a => this.TranslateArgument(a)).ToList()));
+                var statements = new List<GStatement> { delegated };
+                statements.AddRange(body.Statements);
+                body = new BlockStatement(statements);
+            }
 
             return new ConstructorDeclaration(
                 parameters,
                 body,
                 baseArguments: baseArguments,
                 visibility: MapVisibility(symbol, this.context, node),
-                attributes: this.MapAttributes(node.AttributeLists));
+                attributes: this.MapAttributes(node.AttributeLists),
+                isConvenience: isConvenience);
+        }
+
+        /// <summary>
+        /// Collects the static-field initializers of a foldable <c>static</c>
+        /// constructor so they can be re-attached to the corresponding fields
+        /// (G# has no static-constructor form; ADR-0115 §B.11).
+        /// </summary>
+        private void CollectStaticFieldInitializers(TypeDeclarationSyntax node)
+        {
+            foreach (MemberDeclarationSyntax member in node.Members)
+            {
+                if (member is not ConstructorDeclarationSyntax ctor ||
+                    !ctor.Modifiers.Any(SyntaxKind.StaticKeyword) ||
+                    !this.IsFoldableStaticConstructor(ctor) ||
+                    ctor.Body == null)
+                {
+                    continue;
+                }
+
+                foreach (StatementSyntax statement in ctor.Body.Statements)
+                {
+                    if (statement is ExpressionStatementSyntax expressionStatement &&
+                        expressionStatement.Expression is AssignmentExpressionSyntax assignment &&
+                        assignment.IsKind(SyntaxKind.SimpleAssignmentExpression) &&
+                        this.context.GetSymbolInfo(assignment.Left).Symbol is IFieldSymbol field)
+                    {
+                        this.staticFieldInitializers[field] = this.TranslateExpression(assignment.Right);
+                    }
+                }
+            }
+        }
+
+        private bool IsFoldableStaticConstructor(ConstructorDeclarationSyntax node)
+        {
+            if (node.Body == null)
+            {
+                return node.ExpressionBody == null;
+            }
+
+            foreach (StatementSyntax statement in node.Body.Statements)
+            {
+                if (statement is not ExpressionStatementSyntax expressionStatement ||
+                    expressionStatement.Expression is not AssignmentExpressionSyntax assignment ||
+                    !assignment.IsKind(SyntaxKind.SimpleAssignmentExpression) ||
+                    this.context.GetSymbolInfo(assignment.Left).Symbol is not IFieldSymbol { IsStatic: true })
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         private (GTypeReference BaseType, List<GTypeReference> Interfaces) MapBaseClause(
@@ -1369,6 +1519,19 @@ public sealed class CSharpToGSharpTranslator
             {
                 if (isRecord && IsIEquatableOf(iface, symbol))
                 {
+                    continue;
+                }
+
+                // G# interfaces cannot extend other interfaces: the parser's
+                // interface production (`ParseInterfaceDeclarationNew`) accepts no
+                // base-type clause, so `interface IChild : IParent` has no canonical
+                // G# form. This is a genuine G# language gap (not a translator gap);
+                // record it and drop the base so the rest of the file still emits.
+                if (kind == TypeDeclarationKind.Interface)
+                {
+                    this.context.ReportUnsupported(
+                        node,
+                        $"interface '{symbol.Name}' extends interface '{iface.Name}'; G# interfaces cannot declare base interfaces (no parser support for an interface base clause). G# language gap.");
                     continue;
                 }
 
@@ -1551,7 +1714,7 @@ public sealed class CSharpToGSharpTranslator
                 }
             }
 
-            return new Parameter(symbol.Name, type, variadic, refKind, defaultValue);
+            return new Parameter(SanitizeIdentifier(symbol.Name), type, variadic, refKind, defaultValue);
         }
 
         private GTypeReference MapReturnType(IMethodSymbol symbol, MethodDeclarationSyntax node)
@@ -1637,7 +1800,16 @@ public sealed class CSharpToGSharpTranslator
                         }
                     }
 
-                    attributes.Add(new AttributeUse(attribute.Name.ToString(), arguments, target));
+                    string attributeName = attribute.Name.ToString();
+                    int aliasSeparator = attributeName.IndexOf("::", System.StringComparison.Ordinal);
+                    if (aliasSeparator >= 0)
+                    {
+                        // Strip a `global::` (or extern-alias) qualifier; G# has no
+                        // alias-qualified name syntax.
+                        attributeName = attributeName.Substring(aliasSeparator + 2);
+                    }
+
+                    attributes.Add(new AttributeUse(attributeName, arguments, target));
                 }
             }
 
@@ -1767,6 +1939,19 @@ public sealed class CSharpToGSharpTranslator
                 case PropertyDeclarationSyntax property when property.ExpressionBody != null:
                     // An expression-bodied property is a get-only computed property.
                     return this.WrapExpressionBody(property.ExpressionBody.Expression, isVoid: false);
+
+                case DestructorDeclarationSyntax destructor:
+                    if (destructor.Body != null)
+                    {
+                        return this.TranslateBlock(destructor.Body);
+                    }
+
+                    if (destructor.ExpressionBody != null)
+                    {
+                        return this.WrapExpressionBody(destructor.ExpressionBody.Expression, isVoid: true);
+                    }
+
+                    break;
             }
 
             // No recognizable body; emit an empty parseable block.
@@ -1775,11 +1960,15 @@ public sealed class CSharpToGSharpTranslator
 
         private BlockStatement WrapExpressionBody(ExpressionSyntax expression, bool isVoid)
         {
-            GExpression translated = this.TranslateExpression(expression);
-            GStatement statement = isVoid
-                ? new ExpressionStatement(translated)
-                : new ReturnStatement(translated);
-            return new BlockStatement(new List<GStatement> { statement });
+            if (isVoid)
+            {
+                // A void expression body is an executed statement (often an
+                // assignment, which is statement-only in G#), so route it through
+                // the statement seam rather than wrapping the value.
+                return new BlockStatement(this.TranslateExpressionStatements(expression).ToList());
+            }
+
+            return new BlockStatement(new List<GStatement> { new ReturnStatement(this.TranslateExpression(expression)) });
         }
 
         private BlockStatement TranslateBlock(BlockSyntax block)
@@ -1814,7 +2003,32 @@ public sealed class CSharpToGSharpTranslator
                         isUsing: local.UsingKeyword != default);
 
                 case ExpressionStatementSyntax expressionStatement:
-                    return new[] { this.TranslateExpressionStatement(expressionStatement.Expression) };
+                    return this.TranslateExpressionStatements(expressionStatement.Expression);
+
+                case BreakStatementSyntax:
+                    return new[] { (GStatement)new BreakStatement() };
+
+                case ContinueStatementSyntax:
+                    return new[] { (GStatement)new ContinueStatement() };
+
+                case DoStatementSyntax doStatement:
+                    return new[]
+                    {
+                        (GStatement)new DoWhileStatement(
+                            this.TranslateStatementAsBlock(doStatement.Statement),
+                            this.TranslateExpression(doStatement.Condition)),
+                    };
+
+                case LockStatementSyntax lockStatement:
+                    return new[] { this.TranslateLock(lockStatement) };
+
+                case LocalFunctionStatementSyntax localFunction:
+                    return new[] { this.TranslateLocalFunction(localFunction) };
+
+                case CheckedStatementSyntax checkedStatement:
+                    // G# arithmetic is unchecked by default and has no
+                    // `checked`/`unchecked` block keyword; emit the inner block.
+                    return new[] { (GStatement)this.TranslateBlock(checkedStatement.Block) };
 
                 case ReturnStatementSyntax ret:
                     return new[]
@@ -1830,7 +2044,7 @@ public sealed class CSharpToGSharpTranslator
                     return new[]
                     {
                         (GStatement)new WhileStatement(
-                            this.TranslateExpression(whileStatement.Condition),
+                            GuardBlockCondition(this.TranslateExpression(whileStatement.Condition)),
                             this.TranslateStatementAsBlock(whileStatement.Statement)),
                     };
 
@@ -1841,7 +2055,7 @@ public sealed class CSharpToGSharpTranslator
                     return new[]
                     {
                         (GStatement)new ForInStatement(
-                            forEach.Identifier.Text,
+                            SanitizeIdentifier(forEach.Identifier.Text),
                             this.TranslateExpression(forEach.Expression),
                             this.TranslateStatementAsBlock(forEach.Statement)),
                     };
@@ -1928,7 +2142,7 @@ public sealed class CSharpToGSharpTranslator
 
                 results.Add(new LocalDeclarationStatement(
                     binding,
-                    declarator.Identifier.Text,
+                    SanitizeIdentifier(declarator.Identifier.Text),
                     type,
                     initializer,
                     isUsing: isUsing));
@@ -1973,13 +2187,22 @@ public sealed class CSharpToGSharpTranslator
                     exceptionType = typeSymbol != null
                         ? this.typeMapper.Map(typeSymbol, this.context, catchClause.Declaration.Type.GetLocation())
                         : new NamedTypeReference(catchClause.Declaration.Type.ToString());
-                    variableName = catchClause.Declaration.Identifier.Text;
+                    variableName = SanitizeIdentifier(catchClause.Declaration.Identifier.Text);
                     if (string.IsNullOrEmpty(variableName))
                     {
                         // `catch (Exception)` with no binding: synthesize one so the
                         // G# typed-catch form (which requires a binder) is well-formed.
                         variableName = "ex";
                     }
+                }
+                else
+                {
+                    // A bare C# `catch { }` (catch-all, no declaration) has no G#
+                    // equivalent: the parser requires the parenthesized typed-binder
+                    // form `catch (e Exception) { }`. Synthesize a binder over the
+                    // root `System.Exception` so the catch-all round-trips (ADR-0115).
+                    variableName = "ex";
+                    exceptionType = new NamedTypeReference("Exception");
                 }
 
                 string previousCatch = this.currentCatchVariable;
@@ -2062,9 +2285,213 @@ public sealed class CSharpToGSharpTranslator
             }
         }
 
+        /// <summary>
+        /// Translates an expression-statement that may expand into several G#
+        /// statements: a tuple deconstruction (<c>var (a, b) = e</c>) or a chained
+        /// assignment (<c>a = b = c</c>), neither of which has a single-statement G#
+        /// form. Everything else delegates to <see cref="TranslateExpressionStatement"/>.
+        /// </summary>
+        private IEnumerable<GStatement> TranslateExpressionStatements(ExpressionSyntax expression)
+        {
+            if (expression is AssignmentExpressionSyntax assignment &&
+                assignment.IsKind(SyntaxKind.SimpleAssignmentExpression))
+            {
+                if (this.TryGetDeconstructionTargets(assignment.Left, out BindingKind binding, out IReadOnlyList<string> names))
+                {
+                    // `var (a, b) = e` → `let (a, b) = e` (spec §Tuples).
+                    return new[]
+                    {
+                        (GStatement)new TupleDeconstructionStatement(
+                            binding,
+                            names,
+                            this.TranslateExpression(assignment.Right)),
+                    };
+                }
+
+                if (assignment.Right is AssignmentExpressionSyntax)
+                {
+                    // `a = b = c` → `b = c` then `a = b`. G# assignment is a
+                    // statement, so the chain is flattened innermost-first.
+                    return this.FlattenChainedAssignment(assignment);
+                }
+            }
+
+            return new[] { this.TranslateExpressionStatement(expression) };
+        }
+
+        private IEnumerable<GStatement> FlattenChainedAssignment(AssignmentExpressionSyntax assignment)
+        {
+            var lefts = new List<(GExpression Target, string Op)>();
+            ExpressionSyntax current = assignment;
+            while (current is AssignmentExpressionSyntax link &&
+                link.IsKind(SyntaxKind.SimpleAssignmentExpression))
+            {
+                lefts.Add((this.TranslateExpression(link.Left), link.OperatorToken.Text));
+                current = link.Right;
+            }
+
+            GExpression rhs = this.TranslateExpression(current);
+            var statements = new List<GStatement>();
+            for (int i = lefts.Count - 1; i >= 0; i--)
+            {
+                statements.Add(new AssignmentStatement(lefts[i].Target, rhs, lefts[i].Op));
+                rhs = lefts[i].Target;
+            }
+
+            return statements;
+        }
+
+        private bool TryGetDeconstructionTargets(
+            ExpressionSyntax left,
+            out BindingKind binding,
+            out IReadOnlyList<string> names)
+        {
+            binding = BindingKind.Let;
+            names = null;
+
+            // `var (a, b) = e`.
+            if (left is DeclarationExpressionSyntax { Designation: ParenthesizedVariableDesignationSyntax parenthesized })
+            {
+                var collected = new List<string>();
+                foreach (VariableDesignationSyntax designation in parenthesized.Variables)
+                {
+                    collected.Add(designation switch
+                    {
+                        SingleVariableDesignationSyntax single => single.Identifier.Text,
+                        _ => "_",
+                    });
+                }
+
+                names = collected;
+                return true;
+            }
+
+            // `(var a, var b) = e`.
+            if (left is TupleExpressionSyntax tuple &&
+                tuple.Arguments.All(a => a.Expression is DeclarationExpressionSyntax))
+            {
+                var collected = new List<string>();
+                foreach (ArgumentSyntax argument in tuple.Arguments)
+                {
+                    var declaration = (DeclarationExpressionSyntax)argument.Expression;
+                    collected.Add(declaration.Designation switch
+                    {
+                        SingleVariableDesignationSyntax single => single.Identifier.Text,
+                        _ => "_",
+                    });
+                }
+
+                names = collected;
+                return true;
+            }
+
+            return false;
+        }
+
+        private GStatement TranslateLock(LockStatementSyntax lockStatement)
+        {
+            // G# has no `lock` keyword; the canonical lowering is the BCL
+            // monitor pattern `Monitor.Enter(x)` followed by
+            // `try { body } finally { Monitor.Exit(x) }` (ADR-0115 §B).
+            GExpression target = this.TranslateExpression(lockStatement.Expression);
+
+            GStatement enter = new ExpressionStatement(new InvocationExpression(
+                new MemberAccessExpression(new IdentifierExpression("Monitor"), "Enter"),
+                new List<GExpression> { target }));
+
+            BlockStatement body = this.TranslateStatementAsBlock(lockStatement.Statement);
+
+            var finallyBlock = new BlockStatement(new List<GStatement>
+            {
+                new ExpressionStatement(new InvocationExpression(
+                    new MemberAccessExpression(new IdentifierExpression("Monitor"), "Exit"),
+                    new List<GExpression> { target })),
+            });
+
+            var tryStatement = new TryStatement(body, new List<CatchClause>(), finallyBlock);
+
+            return new BlockStatement(new List<GStatement> { enter, tryStatement });
+        }
+
+        private GStatement TranslateLocalFunction(LocalFunctionStatementSyntax localFunction)
+        {
+            // A C# local function maps to a G# local `let` bound to a function
+            // literal (arrow lambda), whose return type is inferred (ADR-0074).
+            var parameters = new List<Parameter>();
+            foreach (ParameterSyntax parameter in localFunction.ParameterList.Parameters)
+            {
+                parameters.Add(this.MapLambdaParameter(parameter));
+            }
+
+            bool isAsync = localFunction.Modifiers.Any(m => m.IsKind(SyntaxKind.AsyncKeyword));
+
+            LambdaExpression lambda;
+            if (localFunction.Body != null)
+            {
+                lambda = new LambdaExpression(parameters, blockBody: this.TranslateBlock(localFunction.Body), isAsync: isAsync);
+            }
+            else if (localFunction.ExpressionBody != null)
+            {
+                lambda = new LambdaExpression(
+                    parameters,
+                    blockBody: new BlockStatement(this.TranslateExpressionStatements(localFunction.ExpressionBody.Expression).ToList()),
+                    isAsync: isAsync);
+            }
+            else
+            {
+                lambda = new LambdaExpression(parameters, blockBody: new BlockStatement(new List<GStatement>()), isAsync: isAsync);
+            }
+
+            return new LocalFunctionStatement(localFunction.Identifier.Text, lambda);
+        }
+
+        /// <summary>
+        /// Parenthesizes a statement-condition whose printed form would otherwise be
+        /// misparsed. A condition ending in an index expression (`… a[i]`) directly
+        /// precedes the block's `{`, which the G# parser greedily reads as a
+        /// composite-literal initializer (`a[i]{ … }`); wrapping the condition in
+        /// parentheses disambiguates it (G# parser limitation; see PR notes).
+        /// </summary>
+        private static GExpression GuardBlockCondition(GExpression condition)
+        {
+            if (condition is ParenthesizedExpression)
+            {
+                return condition;
+            }
+
+            return EndsWithIndexExpression(condition)
+                ? new ParenthesizedExpression(condition)
+                : condition;
+        }
+
+        private static bool EndsWithIndexExpression(GExpression expression)
+        {
+            return expression switch
+            {
+                IndexExpression => true,
+                BinaryExpression binary => EndsWithIndexExpression(binary.Right),
+                _ => false,
+            };
+        }
+
         private GStatement TranslateIf(IfStatementSyntax ifStatement)
         {
+            // Translate the condition first so any `x is T t` declaration pattern
+            // registers its Kotlin-style smart-cast binding before the guarded
+            // block is translated; the binding is scoped to the then-block only.
+            var bindingsBefore = new HashSet<ISymbol>(this.patternBindings.Keys, SymbolEqualityComparer.Default);
+            GExpression condition = GuardBlockCondition(this.TranslateExpression(ifStatement.Condition));
+
             BlockStatement then = this.TranslateStatementAsBlock(ifStatement.Statement);
+
+            foreach (ISymbol added in this.patternBindings.Keys.ToList())
+            {
+                if (!bindingsBefore.Contains(added))
+                {
+                    this.patternBindings.Remove(added);
+                }
+            }
+
             GStatement elseBranch = null;
             if (ifStatement.Else != null)
             {
@@ -2078,7 +2505,7 @@ public sealed class CSharpToGSharpTranslator
                 }
             }
 
-            return new IfStatement(this.TranslateExpression(ifStatement.Condition), then, elseBranch);
+            return new IfStatement(condition, then, elseBranch);
         }
 
         private GStatement TranslateForStatement(ForStatementSyntax forStatement)
@@ -2187,6 +2614,18 @@ public sealed class CSharpToGSharpTranslator
                 case WithExpressionSyntax with:
                     return this.TranslateWith(with);
 
+                case BinaryExpressionSyntax binary
+                    when binary.IsKind(SyntaxKind.AsExpression) || binary.IsKind(SyntaxKind.IsExpression):
+                    // `e as T` / `e is T`: the right operand is a type. Render it as
+                    // a type expression so array/qualified types map to canonical G#
+                    // (e.g. `o as []object`, `o is []object`).
+                    return new BinaryExpression(
+                        this.TranslateExpression(binary.Left),
+                        binary.OperatorToken.Text,
+                        new TypeExpression(binary.Right is TypeSyntax typeOperand
+                            ? this.MapTypeSyntax(typeOperand)
+                            : new NamedTypeReference(binary.Right.ToString())));
+
                 case BinaryExpressionSyntax binary:
                     // Issue #941: C# null-coalescing `a ?? b` now maps directly to
                     // G#'s `a ?? b` (the operator token text is identical), so it
@@ -2197,8 +2636,13 @@ public sealed class CSharpToGSharpTranslator
                         this.TranslateExpression(binary.Right));
 
                 case PrefixUnaryExpressionSyntax prefix:
+                    // G# uses the Go-style `^` for bitwise complement; C# spells it
+                    // `~`. Every other prefix operator token is identical.
+                    string prefixOp = prefix.IsKind(SyntaxKind.BitwiseNotExpression)
+                        ? "^"
+                        : prefix.OperatorToken.Text;
                     return new UnaryExpression(
-                        prefix.OperatorToken.Text,
+                        prefixOp,
                         this.TranslateExpression(prefix.Operand));
 
                 case ParenthesizedExpressionSyntax parenthesized:
@@ -2249,12 +2693,221 @@ public sealed class CSharpToGSharpTranslator
                 case PredefinedTypeSyntax predefinedType:
                     return this.TranslatePredefinedTypeExpression(predefinedType);
 
+                case ConditionalAccessExpressionSyntax conditionalAccess:
+                    return new ConditionalAccessExpression(
+                        this.TranslateExpression(conditionalAccess.Expression),
+                        this.TranslateExpression(conditionalAccess.WhenNotNull));
+
+                case MemberBindingExpressionSyntax memberBinding:
+                    // The `.b` continuation of a null-conditional chain. Its
+                    // receiver is the empty conditional-receiver placeholder, so it
+                    // renders as the bare `.b` that follows the `?`.
+                    return new MemberAccessExpression(
+                        new ConditionalReceiverExpression(),
+                        SanitizeIdentifier(memberBinding.Name.Identifier.Text));
+
+                case ElementBindingExpressionSyntax elementBinding:
+                    GExpression bindingIndex = elementBinding.ArgumentList.Arguments.Count > 0
+                        ? this.TranslateExpression(elementBinding.ArgumentList.Arguments[0].Expression)
+                        : new IdentifierExpression("nil");
+                    return new IndexExpression(new ConditionalReceiverExpression(), bindingIndex);
+
+                case TypeOfExpressionSyntax typeOf:
+                    return new TypeOfExpression(this.MapTypeOfOperand(typeOf.Type));
+
+                case DefaultExpressionSyntax explicitDefault:
+                    return new DefaultValueExpression(this.MapTypeSyntax(explicitDefault.Type));
+
+                case IsPatternExpressionSyntax isPattern:
+                    return this.TranslateIsPattern(isPattern);
+
+                case ArrayCreationExpressionSyntax arrayCreation:
+                    return this.TranslateArrayCreation(arrayCreation);
+
+                case ImplicitArrayCreationExpressionSyntax implicitArray:
+                    return this.TranslateImplicitArrayCreation(implicitArray);
+
+                case InitializerExpressionSyntax initializer:
+                    return this.TranslateInitializerExpression(initializer);
+
+                case SizeOfExpressionSyntax sizeOf:
+                    return this.TranslateSizeOf(sizeOf);
+
+                case AliasQualifiedNameSyntax aliasQualified:
+                    // `global::System` → drop the `global::` alias and keep the name.
+                    return new IdentifierExpression(aliasQualified.Name.Identifier.Text);
+
+                case AssignmentExpressionSyntax nestedAssignment:
+                    // An assignment used in value position (`a = b = c`, or an
+                    // assignment lambda body that reached here). G# models
+                    // assignment as a statement; the in-expression form has no
+                    // canonical value, so emit the assigned value and let the
+                    // enclosing statement seam re-materialise the write.
+                    return this.TranslateExpression(nestedAssignment.Right);
+
                 default:
                     this.context.ReportUnsupported(
                         expression,
                         $"expression '{expression.Kind()}' has no canonical G# form yet; emitted an identifier placeholder (ADR-0115 §B).");
                     return new IdentifierExpression("nil");
             }
+        }
+
+        private GExpression TranslateIsPattern(IsPatternExpressionSyntax isPattern)
+        {
+            GExpression receiver = this.TranslateExpression(isPattern.Expression);
+            return this.TranslatePatternTest(receiver, isPattern.Pattern);
+        }
+
+        private GExpression TranslatePatternTest(GExpression receiver, PatternSyntax pattern)
+        {
+            switch (pattern)
+            {
+                case ConstantPatternSyntax constant
+                    when constant.Expression.IsKind(SyntaxKind.NullLiteralExpression):
+                    // `x is null` → `x == nil`.
+                    return new BinaryExpression(receiver, "==", LiteralExpression.Null());
+
+                case UnaryPatternSyntax unary
+                    when unary.IsKind(SyntaxKind.NotPattern) &&
+                        unary.Pattern is ConstantPatternSyntax { Expression: { } inner } &&
+                        inner.IsKind(SyntaxKind.NullLiteralExpression):
+                    // `x is not null` → `x != nil`.
+                    return new BinaryExpression(receiver, "!=", LiteralExpression.Null());
+
+                case DeclarationPatternSyntax declaration:
+                    // `x is T t` → the boolean test `x is T`; the binder `t` is a
+                    // Kotlin-style smart cast of `x` inside the guarded block, so
+                    // references to `t` are rewritten to `x` (ADR-0069).
+                    if (declaration.Designation is SingleVariableDesignationSyntax single &&
+                        this.context.GetDeclaredSymbol(single) is { } boundSymbol)
+                    {
+                        this.patternBindings[boundSymbol] = receiver;
+                    }
+
+                    return new BinaryExpression(
+                        receiver,
+                        "is",
+                        new TypeExpression(this.MapTypeSyntax(declaration.Type)));
+
+                case TypePatternSyntax typePattern:
+                    // `x is T` (no binder) → boolean test `x is T`.
+                    return new BinaryExpression(
+                        receiver,
+                        "is",
+                        new TypeExpression(this.MapTypeSyntax(typePattern.Type)));
+
+                case ParenthesizedPatternSyntax parenthesized:
+                    return new ParenthesizedExpression(
+                        this.TranslatePatternTest(receiver, parenthesized.Pattern));
+
+                default:
+                    this.context.ReportUnsupported(
+                        pattern,
+                        $"is-pattern '{pattern.Kind()}' has no canonical G# form yet (ADR-0115 §B).");
+                    return new BinaryExpression(receiver, "!=", LiteralExpression.Null());
+            }
+        }
+
+        private GExpression TranslateArrayCreation(ArrayCreationExpressionSyntax creation)
+        {
+            GTypeReference elementType = this.GetArrayElementType(creation, creation.Type.ElementType);
+
+            if (creation.Initializer != null)
+            {
+                // `new T[]{a, b}` / `new T[0]` (with an explicit, possibly empty,
+                // initializer) → the slice literal `[]T{a, b}`.
+                return new ArrayLiteralExpression(
+                    elementType,
+                    creation.Initializer.Expressions.Select(this.TranslateExpression).ToList());
+            }
+
+            // `new T[n]` (runtime/constant length, no initializer) → the canonical
+            // zero-initialised allocation `System.GC.AllocateArray[T](n)`, which
+            // returns a `T[]` of length `n` (the Go-style `make([]T, n)` form is a
+            // documented gsc gap, ADR-0083).
+            GExpression length = creation.Type.RankSpecifiers.Count > 0 &&
+                creation.Type.RankSpecifiers[0].Sizes.Count > 0 &&
+                creation.Type.RankSpecifiers[0].Sizes[0] is { } sizeExpr &&
+                !sizeExpr.IsKind(SyntaxKind.OmittedArraySizeExpression)
+                ? this.TranslateExpression(sizeExpr)
+                : LiteralExpression.Int("0");
+
+            return new InvocationExpression(
+                new MemberAccessExpression(
+                    new MemberAccessExpression(new IdentifierExpression("System"), "GC"),
+                    "AllocateArray"),
+                new List<GExpression> { length },
+                new List<GTypeReference> { elementType });
+        }
+
+        private GExpression TranslateImplicitArrayCreation(ImplicitArrayCreationExpressionSyntax creation)
+        {
+            GTypeReference elementType = this.GetArrayElementType(creation, null);
+            return new ArrayLiteralExpression(
+                elementType,
+                creation.Initializer.Expressions.Select(this.TranslateExpression).ToList());
+        }
+
+        private GExpression TranslateInitializerExpression(InitializerExpressionSyntax initializer)
+        {
+            // A bare `{ a, b, c }` array initializer (a field/local of array type
+            // initialised without `new T[]`) or a collection-initializer element
+            // list reaching value position maps to the slice literal `[]T{ … }`,
+            // using the bound (converted) element type.
+            GTypeReference elementType = this.GetArrayElementType(initializer, null);
+            return new ArrayLiteralExpression(
+                elementType,
+                initializer.Expressions.Select(this.TranslateExpression).ToList());
+        }
+
+        private GExpression TranslateSizeOf(SizeOfExpressionSyntax sizeOf)
+        {
+            // `sizeof(T)` for a primitive type is a compile-time constant; emit the
+            // byte width directly (G# has no `sizeof` operator). For non-primitive
+            // types fall back to the call-shaped form so the output still parses.
+            ITypeSymbol type = this.context.GetTypeInfo(sizeOf.Type).Type;
+            int? size = type?.SpecialType switch
+            {
+                SpecialType.System_Boolean or SpecialType.System_SByte or SpecialType.System_Byte => 1,
+                SpecialType.System_Int16 or SpecialType.System_UInt16 or SpecialType.System_Char => 2,
+                SpecialType.System_Int32 or SpecialType.System_UInt32 or SpecialType.System_Single => 4,
+                SpecialType.System_Int64 or SpecialType.System_UInt64 or SpecialType.System_Double => 8,
+                SpecialType.System_Decimal => 16,
+                _ => null,
+            };
+
+            if (size.HasValue)
+            {
+                return LiteralExpression.Int(size.Value.ToString(CultureInfo.InvariantCulture));
+            }
+
+            return new InvocationExpression(
+                new IdentifierExpression("sizeof"),
+                new List<GExpression> { new TypeExpression(this.MapTypeSyntax(sizeOf.Type)) });
+        }
+
+        private GTypeReference GetArrayElementType(ExpressionSyntax arrayExpression, TypeSyntax elementTypeSyntax)
+        {
+            TypeInfo info = this.context.GetTypeInfo(arrayExpression);
+            ITypeSymbol arrayType = info.Type ?? info.ConvertedType;
+            if (arrayType is IArrayTypeSymbol array)
+            {
+                return this.typeMapper.Map(array.ElementType, this.context, arrayExpression.GetLocation());
+            }
+
+            if (arrayType is INamedTypeSymbol { IsGenericType: true } generic &&
+                generic.TypeArguments.Length == 1)
+            {
+                return this.typeMapper.Map(generic.TypeArguments[0], this.context, arrayExpression.GetLocation());
+            }
+
+            if (elementTypeSyntax != null)
+            {
+                return this.MapTypeSyntax(elementTypeSyntax);
+            }
+
+            return new NamedTypeReference("object");
         }
 
         private GExpression TranslateIdentifierName(IdentifierNameSyntax identifier)
@@ -2285,7 +2938,7 @@ public sealed class CSharpToGSharpTranslator
                 }
             }
 
-            return new IdentifierExpression(identifier.Identifier.Text);
+            return new IdentifierExpression(SanitizeIdentifier(identifier.Identifier.Text));
         }
 
         private GExpression TranslateLiteral(LiteralExpressionSyntax literal)
@@ -2316,7 +2969,7 @@ public sealed class CSharpToGSharpTranslator
                         return LiteralExpression.Float(this.ToFloatLiteralText(literal.Token.Text));
                     }
 
-                    return LiteralExpression.Int(literal.Token.Text);
+                    return LiteralExpression.Int(this.NormalizeIntegerLiteralText(literal));
 
                 case SyntaxKind.StringLiteralExpression:
                     return LiteralExpression.String(literal.Token.ValueText);
@@ -2333,11 +2986,46 @@ public sealed class CSharpToGSharpTranslator
                 case SyntaxKind.NullLiteralExpression:
                     return LiteralExpression.Null();
 
+                case SyntaxKind.DefaultLiteralExpression:
+                    // The target-typed `default` literal maps to the bare G#
+                    // `default`, whose type is supplied by the surrounding context
+                    // (ADR-0100).
+                    return new DefaultValueExpression();
+
                 default:
                     this.context.ReportUnsupported(
                         literal,
                         $"literal '{literal.Kind()}' has no canonical G# form yet; emitted nil (ADR-0115 §B.12).");
                     return LiteralExpression.Null();
+            }
+        }
+
+        // C# infers the type of a suffix-less integer literal from its value: a
+        // hex constant such as `0xD800000000000000` is implicitly `ulong`. G#'s
+        // lexer instead defaults to int32/int64 and rejects an out-of-range
+        // literal (GS0004), so when the bound value requires a wider/unsigned
+        // type we append the matching G# suffix (`L`, `UL`, `U`).
+        private string NormalizeIntegerLiteralText(LiteralExpressionSyntax literal)
+        {
+            string text = literal.Token.Text;
+            object value = literal.Token.Value;
+
+            // Respect an explicit suffix already present in the source spelling.
+            if (text.Length > 0 && (text[text.Length - 1] is 'u' or 'U' or 'l' or 'L'))
+            {
+                return text;
+            }
+
+            switch (value)
+            {
+                case ulong:
+                    return text + "UL";
+                case long l when l > int.MaxValue || l < int.MinValue:
+                    return text + "L";
+                case uint u when u > int.MaxValue:
+                    return text + "U";
+                default:
+                    return text;
             }
         }
 
@@ -2387,7 +3075,7 @@ public sealed class CSharpToGSharpTranslator
                 memberName = positional.Name;
             }
 
-            return new MemberAccessExpression(target, memberName);
+            return new MemberAccessExpression(target, SanitizeIdentifier(memberName));
         }
 
         private GExpression TranslateInvocation(InvocationExpressionSyntax invocation)
@@ -2453,7 +3141,7 @@ public sealed class CSharpToGSharpTranslator
                     return declaration.Designation switch
                     {
                         DiscardDesignationSyntax => new OutArgumentExpression("out", "_"),
-                        SingleVariableDesignationSyntax single => new OutArgumentExpression("out var", single.Identifier.Text),
+                        SingleVariableDesignationSyntax single => new OutArgumentExpression("out var", SanitizeIdentifier(single.Identifier.Text)),
                         _ => new UnaryExpression("&", this.TranslateExpression(argument.Expression)),
                     };
                 }
@@ -2783,6 +3471,16 @@ public sealed class CSharpToGSharpTranslator
                 return new LambdaExpression(parameters, blockBody: this.TranslateBlock(block), isAsync: isAsync);
             }
 
+            if (lambda.Body is AssignmentExpressionSyntax)
+            {
+                // An assignment is statement-only in G#; an assignment-bodied lambda
+                // (`o => x = f()`) becomes a block-bodied lambda `o -> { x = f() }`.
+                return new LambdaExpression(
+                    parameters,
+                    blockBody: new BlockStatement(this.TranslateExpressionStatements((ExpressionSyntax)lambda.Body).ToList()),
+                    isAsync: isAsync);
+            }
+
             return new LambdaExpression(
                 parameters,
                 expressionBody: this.TranslateExpression((ExpressionSyntax)lambda.Body),
@@ -2802,7 +3500,42 @@ public sealed class CSharpToGSharpTranslator
             GTypeReference type = parameter.Type != null
                 ? this.MapTypeSyntax(parameter.Type)
                 : new NamedTypeReference(CSharpTypeMapper.UnsupportedPlaceholderType);
-            return new Parameter(parameter.Identifier.Text, type);
+            return new Parameter(SanitizeIdentifier(parameter.Identifier.Text), type);
+        }
+
+        // `typeof(IEnumerable<>)` over an unbound generic has no bound symbol for
+        // the omitted type argument, so the general type mapper cannot resolve it.
+        // G# has no open-generic `typeof` spelling; the canonical form is the bare
+        // generic definition name (`typeof(IEnumerable)`), which parses and binds
+        // to the open type.
+        private GTypeReference MapTypeOfOperand(TypeSyntax type)
+        {
+            if (IsUnboundGeneric(type, out string unboundName))
+            {
+                return new NamedTypeReference(unboundName);
+            }
+
+            return this.MapTypeSyntax(type);
+        }
+
+        private static bool IsUnboundGeneric(TypeSyntax type, out string name)
+        {
+            name = null;
+            GenericNameSyntax generic = type switch
+            {
+                GenericNameSyntax g => g,
+                QualifiedNameSyntax { Right: GenericNameSyntax g } => g,
+                _ => null,
+            };
+
+            if (generic is null ||
+                !generic.TypeArgumentList.Arguments.Any(a => a is OmittedTypeArgumentSyntax))
+            {
+                return false;
+            }
+
+            name = generic.Identifier.Text;
+            return true;
         }
 
         private GTypeReference MapTypeSyntax(TypeSyntax type)
@@ -2811,6 +3544,28 @@ public sealed class CSharpToGSharpTranslator
             return symbol != null
                 ? this.typeMapper.Map(symbol, this.context, type.GetLocation())
                 : new NamedTypeReference(type.ToString());
+        }
+
+        // The set of hard G# keywords (Cs2Gs.Compiler SyntaxFacts.GetKeywordKind).
+        // A C# identifier that collides with one of these cannot be emitted bare; it
+        // is suffixed with `_` consistently at every declaration and reference site.
+        private static string SanitizeIdentifier(string name)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                return name;
+            }
+
+            // C# verbatim identifiers (`@default`, `@class`) carry a leading `@`
+            // in their syntax text; G# has no verbatim-identifier escape, so strip
+            // it before the reserved-word check (the bare name is then suffixed if
+            // it still collides with a G# keyword).
+            if (name[0] == '@')
+            {
+                name = name.Substring(1);
+            }
+
+            return GSharpReservedWords.Contains(name) ? name + "_" : name;
         }
 
         private GExpression TranslatePredefinedTypeExpression(PredefinedTypeSyntax predefined)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
@@ -55,6 +55,20 @@ public sealed class CSharpTypeMapper
             return new NamedTypeReference(UnsupportedPlaceholderType);
         }
 
+        // G# has no unsafe pointer types: a C# `T*`, `void*`, or function pointer
+        // has no canonical managed G# form (ADR-0115 §B / G# language gap). Record
+        // a structured Unsupported diagnostic rather than emit a malformed
+        // type-less field/parameter.
+        if (type is IPointerTypeSymbol or IFunctionPointerTypeSymbol)
+        {
+            context.Report(new TranslationDiagnostic(
+                "PointerType",
+                $"unsafe pointer type '{type.ToDisplayString()}' has no canonical G# form; G# does not support pointer/unsafe types.",
+                location,
+                TranslationSeverity.Unsupported));
+            return new NamedTypeReference(UnsupportedPlaceholderType);
+        }
+
         // A nullable value type (Nullable<T>) carries its payload as the single
         // type argument; map the underlying type and mark the result nullable.
         if (type is INamedTypeSymbol nullableValue &&


### PR DESCRIPTION
## Summary

Extends the **cs2gs** C#→G# migration tool (issue #914, ADR-0115) so the external
**`Oahu.Foundation`** project translates to canonical G# and round-trips through the
real G# parser. This is the **Oahu.Foundation round**.

**Before → after (translate stage):** `105` translation-unsupported diagnostics
across **25** construct kinds → **9** diagnostics across **3** files, all of which
are **genuine G# compiler/language gaps** (documented below for follow-up). Every
other Foundation file now translates **and** round-trips. Translator-only change —
**no** gsc compiler (`src/Core/...`) modifications.

## Constructs now supported (with canonical G# form)

| C# construct | Canonical G# form |
| --- | --- |
| `a?.b` / `a?.b()` / `a?[i]` (ConditionalAccess) | `a?.b` / `a?.b()` / `a?[i]` null-conditional |
| `x is null` | `x == nil` |
| `x is not null` | `x != nil` |
| `x is T` (bare) | boolean `x is T` |
| `if (x is T t) { …t… }` | `if x is T { …x… }` (Kotlin-style smart cast; **no binder**) |
| `new T[n]` | sized G# array |
| `new T[]{…}` / `new[]{…}` / `{ a, b, c }` | G# array/composite literal |
| `new List<T>{ a, b }` (collection init) | G# composite literal |
| `T[]` (ArrayType) | G# array type |
| `typeof(T)` | `typeof(T)` (predefined types stay value keywords, e.g. `typeof(string)`) |
| `typeof(IEnumerable<>)` (unbound) | `typeof(IEnumerable)` |
| `sizeof(T)` | `sizeof(T)` |
| `default` / `default(T)` | `default` |
| `a = b` as expression / `a = b = c` | G# assignment expression |
| `out var x` (DeclarationExpression) | inline `out var x` |
| `: this(args)` | `init(params) : this(args)` |
| local function | nested `func` |
| `break` / `continue` | `break` / `continue` |
| `do … while (c)` | G# do-while |
| `lock (m) { … }` | G# `lock` |
| `unchecked { … }` | inlined block (G# is unchecked by default) |
| `~T()` destructor | `deinit` |
| `namespace N { … }` | G# `package` |

**Translator faithfulness additions:**
- **`SanitizeIdentifier`** — strips a leading C# verbatim `@` then suffixes G# hard
  keywords with `_` (`@default`, `@In`, `type`, `func` → `default`, `In`, `type_`,
  `func_`). Applied at params, receivers, identifier refs, `for-in` vars, locals,
  field/property/method/enum-case names, member-access names, conditional-access
  bindings, and `out var` binders.
- **`NormalizeIntegerLiteralText`** — emits width-bearing `UL`/`L`/`U` suffixes for
  suffix-less literals whose bound type is wider/unsigned than `int32` (e.g. the CRC
  seed `0xD800000000000000` → `…UL`), so the round-trip parser infers the same width.
- **Catch-all** — bare `catch { }` → typed `catch (ex Exception) { }`.
- **Unbound-generic `typeof`** operand mapping.

## Test coverage added

`tools/cs2gs/Cs2Gs.Tests/OahuFoundationTranslationTests.cs` — **13** new golden/unit
tests covering conditional access, is-pattern/nil/smart-cast, array/typeof/default,
chained assignment, break/continue/do-while/lock, local functions, this-ctor
delegation, reserved-word/verbatim sanitization, width-bearing literals, and the
compiler-gap detection paths. **All 154 cs2gs tests pass**; solution builds clean
(0 warnings / 0 errors).

## Compiler gaps discovered (for follow-up)

These three remaining diagnostics are **genuine G# compiler/language gaps**, not
translator defects, so per ADR-0115 they are documented rather than forced. gsc
version **0.2.132+417bdb25ec**. Each was reproduced directly with `gsc` and
contrasted with a passing control. They should be filed as `bug,Oats` issues and
fixed via the compiler loop (out of scope for this translator-only PR).

### OF-1 — interface inheritance `interface B : A { … }` won't parse
`GS0005: Unexpected token <ColonToken>, expected <OpenBraceToken>`. The parser's
`ParseInterfaceDeclarationNew` (src/Core/CodeAnalysis/Syntax/Parser.cs) has no
base-clause handling. A **class** base clause (`class C : A {}`) parses, so this is
interface-specific. Source: `Types/Interfaces.cs`.

```gs
package T
interface A { func F(); }
interface B : A { func G(); }   // GS0005 at the colon
```

### OF-2 — generic interface-method signature `func IsPrim[T]() bool;` won't parse
`GS0005: Unexpected token <OpenSquareBracketToken>, expected <OpenParenthesisToken>`.
A type-parameter list on an interface **method signature** is rejected. Generic
methods work on classes and free functions — only the interface signature form
fails. Source: `Diagnostics/Interfaces.cs`.

```gs
package T
interface IP { func IsPrim[T]() bool; }   // GS0005 at [T]
```

### OF-3 — unsafe pointer types (`void*` / `byte*` / `int*`) have no G# form
G# has no pointer-type token at all. `Win32/Win32FileIO.cs` is an `unsafe class`
using raw pointers throughout. The type mapper records a structured `PointerType`
Unsupported diagnostic and emits an `object` placeholder. Source: `Win32/Win32FileIO.cs`.

```cs
// C# — no G# equivalent for a pointer type:
public unsafe void Read(byte* buffer, int length) { }
```

## Docs

ADR-0115 updated: **§B.35** (the new statement/expression mappings + sanitization /
literal-width / catch-all rules) and **§G** (the Oahu.Foundation round outcome and
the three compiler gaps with minimal repros).

Refs #914.
