### PR TITLE
Fix IAsyncEnumerable[UserType] erasing to IAsyncEnumerable<object> (#1002)

### DIFF
--- a/docs/adr/0115-csharp-to-gsharp-migration-tool.md
+++ b/docs/adr/0115-csharp-to-gsharp-migration-tool.md
@@ -553,6 +553,7 @@ re-greening earlier stages and surfacing the next layer of gaps:
 | #992 | `and`/`or` binary patterns (`> 0 and < 10`) won't parse | GS0005 | **resolved** (issue #992 — `and`/`or`/`not` pattern combinators with C# precedence (`not` > `and` > `or`) and parentheses; compose with all pattern kinds; binding type patterns under `or`/`not` rejected with GS0390; smart-cast narrows under `and`, soundly under `or`, never under `not`; combined patterns never satisfy exhaustiveness; cs2gs now translates C# `and`/`or`/`not` patterns to the new form) |
 | #993 | an `is`/`case` type pattern **with** a binder (`x is T t`) leaves the binder unbound | GS0125 | open (L5 uses the no-binder form `x is T`) |
 | #994 | `yield break` has no canonical G# form | GS0005 | open (translation-unsupported) |
+| #1002 | a user reference-type async iterator (`IAsyncEnumerable[UserClass]`) → IL erases to `IAsyncEnumerable<object>` | ilverify `StackUnexpected` | **resolved** (user reference- and value-type element async iterators emit, ilverify, and run; `await for s in seq` recovers the user element type) |
 
 Earlier L3 not going fully green was the **intended** objective-2 outcome: the
 residual failure was a real compiler gap (#985), captured and filed rather than
@@ -795,6 +796,38 @@ func shapes() sequence[Shape] { yield Shape() }
 ```gs
 // control — a BCL element type compiles:
 func names() sequence[string] { yield "a" }
+```
+
+**#1002 — a user reference-type async iterator (`IAsyncEnumerable[UserClass]`) → IL erases to `IAsyncEnumerable<object>`. RESOLVED.**
+Parallel to #990 but for the async-iterator path. The synthesized state machine's
+`IAsyncEnumerable<T>` / `IAsyncEnumerator<T>` interface rows and the
+`GetAsyncEnumerator` return signature erased the user element type to `object`
+(`elementType.ClrType ?? typeof(object)`), making the kickoff's `IAsyncEnumerable<Shape>`
+return type generic-invariance-invalid (ilverify `StackUnexpected`). The consumer
+side (`await for s in seq`) suffered a parallel erasure: the lowering read `Current`
+off the closed `IAsyncEnumerator<object>` shape, yielding an `object` assigned into
+a strongly-typed `Shape` loop slot. Both are now fixed by routing user element
+types through the symbolic TypeSpec encoder (interface rows + `GetAsyncEnumerator`
+signature) and through a symbolic `IAsyncEnumerator[ElementSym]` enumerator type
+in the `await for` lowering, mirroring the synchronous symbolic-open path. User
+reference- and value-type element async iterators now compile, ilverify, and run.
+
+```gs
+// now compiles, ilverifies, and runs:
+open class Shape { func Tag() string { return "shape" } }
+async func shapes() IAsyncEnumerable[Shape] {
+    yield Shape()
+    await Task.Delay(1)
+    yield Shape()
+}
+async func Run() {
+    await for s in shapes() { Console.WriteLine(s.Tag()) }
+}
+Run().Wait()
+```
+```gs
+// control — a BCL element type compiles:
+async func nums() IAsyncEnumerable[int32] { yield 1 }
 ```
 
 **#991 — a `when` guard (resolved).**

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -246,6 +246,44 @@ internal sealed class MemberLookup
     public static bool TryGetAsyncEnumerableElementType(TypeSymbol type, out TypeSymbol elementType)
     {
         elementType = null;
+
+        // Issue #1002 (parallel to #939 / #990 for sync `for-in`): an
+        // `IAsyncEnumerable[Shape]` whose `Shape` is a same-compilation
+        // user `class` / `data struct` is modelled as an
+        // `ImportedTypeSymbol` carrying `Shape` symbolically in
+        // `TypeArguments` while its `ClrType` is the erased
+        // `IAsyncEnumerable<object>` (user types have no ClrType yet, so
+        // `MakeGenericType` falls back to `object`). Walking only the CLR
+        // type below would type the `await for s in seq` loop variable as
+        // `object` and member access (`s.Tag()`) would fail to bind.
+        // Honour the symbolic argument first so the loop variable
+        // recovers the member-bearing user `Shape` symbol.
+        if (type is ImportedTypeSymbol importedSym
+            && importedSym.OpenDefinition != null
+            && importedSym.HasSubstitutableTypeArgument)
+        {
+            if (importedSym.OpenDefinition.FullName == "System.Collections.Generic.IAsyncEnumerable`1"
+                && importedSym.TypeArguments.Length == 1)
+            {
+                elementType = importedSym.TypeArguments[0];
+                return true;
+            }
+
+            // The receiver may be a user/BCL type that implements
+            // `IAsyncEnumerable[Shape]`; probe the OpenDefinition for the
+            // interface and substitute the symbolic argument back.
+            foreach (var iface in EnumerateSelfAndInterfaces(importedSym.OpenDefinition))
+            {
+                if (iface.IsGenericType
+                    && !iface.IsGenericTypeDefinition
+                    && iface.GetGenericTypeDefinition().FullName == "System.Collections.Generic.IAsyncEnumerable`1")
+                {
+                    elementType = MapOpenClrTypeToSymbolic(iface.GetGenericArguments()[0], importedSym);
+                    return true;
+                }
+            }
+        }
+
         var clr = type?.ClrType;
         if (clr == null)
         {

--- a/src/Core/CodeAnalysis/Emit/MethodBodyPlanner.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyPlanner.cs
@@ -915,12 +915,38 @@ internal sealed class MethodBodyPlanner
 
     public void AddAsyncIteratorInterfaceImplementations(StructSymbol smClass, AsyncIteratorPlan plan)
     {
-        var elementClr = plan.ElementType.ClrType ?? typeof(object);
+        var elementType = plan.ElementType;
         var typeDef = this.cache.StructTypeDefs[smClass];
 
+        // Issue #1002 (parallel to #990): a user-declared element type
+        // (`class` / `data struct` emitted in this same assembly) has no
+        // ClrType, so the CLR-erased
+        // `MakeGenericType(elementType.ClrType ?? object)` path below would
+        // record `IAsyncEnumerable<object>` / `IAsyncEnumerator<object>` on
+        // the SM class. That makes `shapes()` (signature
+        // `IAsyncEnumerable<Shape>`) return a value whose runtime type only
+        // implements `IAsyncEnumerable<object>` — invalid under generic
+        // invariance (ilverify StackUnexpected). Route such element types
+        // through the symbolic TypeSpec encoder so the interface rows
+        // carry the strongly-typed `IAsyncEnumerable<Shape>` /
+        // `IAsyncEnumerator<Shape>`.
+        var elementNeedsSymbolic = elementType?.ClrType == null;
+        EntityHandle asyncEnumeratorHandle;
+        EntityHandle asyncEnumerableHandle;
+        if (elementNeedsSymbolic)
+        {
+            asyncEnumeratorHandle = this.BuildGenericInterfaceTypeSpec(typeof(System.Collections.Generic.IAsyncEnumerator<>), elementType);
+            asyncEnumerableHandle = this.BuildGenericInterfaceTypeSpec(typeof(System.Collections.Generic.IAsyncEnumerable<>), elementType);
+        }
+        else
+        {
+            var elementClr = elementType.ClrType;
+            asyncEnumeratorHandle = this.getTypeHandleForMember(typeof(System.Collections.Generic.IAsyncEnumerator<>).MakeGenericType(elementClr));
+            asyncEnumerableHandle = this.getTypeHandleForMember(typeof(System.Collections.Generic.IAsyncEnumerable<>).MakeGenericType(elementClr));
+        }
+
         // IAsyncEnumerator<T>
-        this.emitCtx.Metadata.AddInterfaceImplementation(typeDef,
-            this.getTypeHandleForMember(typeof(System.Collections.Generic.IAsyncEnumerator<>).MakeGenericType(elementClr)));
+        this.emitCtx.Metadata.AddInterfaceImplementation(typeDef, asyncEnumeratorHandle);
 
         // IAsyncDisposable
         this.emitCtx.Metadata.AddInterfaceImplementation(typeDef,
@@ -929,8 +955,7 @@ internal sealed class MethodBodyPlanner
         if (plan.IsEnumerable)
         {
             // IAsyncEnumerable<T>
-            this.emitCtx.Metadata.AddInterfaceImplementation(typeDef,
-                this.getTypeHandleForMember(typeof(System.Collections.Generic.IAsyncEnumerable<>).MakeGenericType(elementClr)));
+            this.emitCtx.Metadata.AddInterfaceImplementation(typeDef, asyncEnumerableHandle);
         }
 
         // IValueTaskSource<bool>

--- a/src/Core/CodeAnalysis/Emit/StateMachineEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/StateMachineEmitter.cs
@@ -768,7 +768,23 @@ internal sealed class StateMachineEmitter
             FunctionSymbol getAsyncEnumerator = null;
             if (plan.IsEnumerable)
             {
-                var enumeratorType = TypeSymbol.FromClrType(typeof(System.Collections.Generic.IAsyncEnumerator<>).MakeGenericType(elementType.ClrType ?? typeof(object)));
+                // Issue #1002 (parallel to #990 sync iterators): a user-declared
+                // element type (`class` / `data struct`) has no ClrType, so the
+                // `MakeGenericType(elementType.ClrType ?? object)` path below
+                // would erase to `IAsyncEnumerator<object>`. That makes
+                // `shapes()` (signature `IAsyncEnumerable<Shape>`) return an SM
+                // whose `GetAsyncEnumerator` advertises `IAsyncEnumerator<object>`
+                // — invalid under generic invariance (ilverify StackUnexpected).
+                // Route such element types through the symbolic
+                // `ImportedTypeSymbol.GetConstructed` so the encoder emits a
+                // strongly-typed `IAsyncEnumerator<Shape>` GENERICINST blob
+                // referencing the user TypeDef.
+                TypeSymbol enumeratorType = elementType?.ClrType == null
+                    ? (TypeSymbol)ImportedTypeSymbol.GetConstructed(
+                        typeof(System.Collections.Generic.IAsyncEnumerator<>).MakeGenericType(typeof(object)),
+                        typeof(System.Collections.Generic.IAsyncEnumerator<>),
+                        ImmutableArray.Create<TypeSymbol>(elementType))
+                    : TypeSymbol.FromClrType(typeof(System.Collections.Generic.IAsyncEnumerator<>).MakeGenericType(elementType.ClrType));
                 var ctParam = new ParameterSymbol("cancellationToken", TypeSymbol.FromClrType(typeof(System.Threading.CancellationToken)));
                 getAsyncEnumerator = new FunctionSymbol("GetAsyncEnumerator", ImmutableArray.Create(ctParam), enumeratorType, null, hostPackage, Accessibility.Public, (TypeSymbol)smClass);
                 methods.Add(getAsyncEnumerator);

--- a/src/Core/CodeAnalysis/Lowering/Iterators/AsyncIteratorRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/Iterators/AsyncIteratorRewriter.cs
@@ -133,6 +133,28 @@ public static class AsyncIteratorRewriter
             return aseq.ElementType;
         }
 
+        // Issue #1002 (parallel to #990): `IAsyncEnumerable[Shape]` where
+        // `Shape` is a same-compilation user class is modelled as an
+        // ImportedTypeSymbol carrying `Shape` symbolically in
+        // `TypeArguments`. Its `ClrType` is the erased
+        // `IAsyncEnumerable<object>` (user types have no ClrType yet, so
+        // `MakeGenericType` falls back to `object`). If we go through the
+        // ClrType branch below we'd extract `typeof(object)` as the
+        // element type and the synthesized state machine would advertise
+        // `IAsyncEnumerable<object>` — invalid under generic invariance
+        // (ilverify StackUnexpected). Honour the symbolic argument so the
+        // SM emits the strongly-typed `IAsyncEnumerable<Shape>` /
+        // `IAsyncEnumerator<Shape>`.
+        if (type is ImportedTypeSymbol imported
+            && imported.OpenDefinition != null
+            && !imported.TypeArguments.IsDefaultOrEmpty
+            && imported.TypeArguments.Length == 1
+            && (imported.OpenDefinition.FullName == "System.Collections.Generic.IAsyncEnumerable`1"
+                || imported.OpenDefinition.FullName == "System.Collections.Generic.IAsyncEnumerator`1"))
+        {
+            return imported.TypeArguments[0];
+        }
+
         var clr = type?.ClrType;
         if (clr == null || !clr.IsGenericType || clr.IsGenericTypeDefinition)
         {

--- a/src/Core/CodeAnalysis/Lowering/Lowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/Lowerer.cs
@@ -576,10 +576,40 @@ public sealed class Lowerer : BoundTreeRewriter
         var valueTaskClr = disposeAsync.ReturnType;
 
         var cancellationTokenType = TypeSymbol.FromClrType(cancellationTokenClr);
-        var enumeratorType = TypeSymbol.FromClrType(enumeratorClr);
         var valueTaskBoolType = TypeSymbol.FromClrType(valueTaskBoolClr);
         var valueTaskType = TypeSymbol.FromClrType(valueTaskClr);
-        var currentType = TypeSymbol.FromClrType(currentProperty.PropertyType);
+
+        // Issue #1002 (parallel to #774 for sync `for-in`): when the stream
+        // is a symbolic `ImportedTypeSymbol IAsyncEnumerable[Shape]` whose
+        // `Shape` is a same-compilation user type, the closed CLR shape is
+        // erased to `IAsyncEnumerable<object>` and the discovered
+        // `enumeratorClr` becomes `IAsyncEnumerator<object>`. Reading
+        // `Current` from that closed property yields `object`, which the
+        // verifier rejects when stored into the strongly-typed
+        // `valueVariable` (Shape) — even though the runtime tolerates the
+        // reference. Synthesize a symbolic `IAsyncEnumerator[Shape]` so
+        // the BoundClrPropertyAccessExpression carries the user's `Shape`,
+        // mirroring the synchronous symbolic-open path.
+        TypeSymbol enumeratorType;
+        TypeSymbol currentType;
+        if (stream.Type is ImportedTypeSymbol streamImp
+            && streamImp.HasSubstitutableTypeArgument
+            && streamImp.OpenDefinition != null
+            && streamImp.OpenDefinition.FullName == "System.Collections.Generic.IAsyncEnumerable`1"
+            && streamImp.TypeArguments.Length == 1)
+        {
+            var elementSym = streamImp.TypeArguments[0];
+            enumeratorType = ImportedTypeSymbol.GetConstructed(
+                enumeratorClr,
+                typeof(System.Collections.Generic.IAsyncEnumerator<>),
+                ImmutableArray.Create<TypeSymbol>(elementSym));
+            currentType = elementSym;
+        }
+        else
+        {
+            enumeratorType = TypeSymbol.FromClrType(enumeratorClr);
+            currentType = TypeSymbol.FromClrType(currentProperty.PropertyType);
+        }
 
         var enumeratorSymbol = new LocalVariableSymbol("$awaitEnum", isReadOnly: true, type: enumeratorType);
         var enumeratorExpr = new BoundVariableExpression(null, enumeratorSymbol);

--- a/test/Compiler.Tests/Emit/Issue1002UserClassAsyncIteratorEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1002UserClassAsyncIteratorEmitTests.cs
@@ -1,0 +1,252 @@
+// <copyright file="Issue1002UserClassAsyncIteratorEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1002 (parallel to #990) — emit + IL-verify + run coverage for
+/// <em>async</em> iterators whose element type is a user-declared
+/// reference type (e.g. <c>IAsyncEnumerable[Shape]</c> where
+/// <c>Shape</c> is a user class).
+/// <para>Before the fix the state machine's
+/// <c>IAsyncEnumerable&lt;T&gt;</c> / <c>IAsyncEnumerator&lt;T&gt;</c>
+/// interface rows and the <c>GetAsyncEnumerator</c> return signature
+/// erased the user element type to <c>object</c> via
+/// <c>elementType.ClrType ?? typeof(object)</c>, producing
+/// generic-invariance-invalid IL: an <c>async func shapes() IAsyncEnumerable[Shape]</c>
+/// kickoff returned a value whose runtime type only implemented
+/// <c>IAsyncEnumerable&lt;object&gt;</c> (ilverify
+/// <c>StackUnexpected: found ref '...d__1' expected ref 'IAsyncEnumerable`1&lt;T.Shape&gt;'</c>).</para>
+/// <para>The consumer side (<c>await for s in shapes()</c>) suffered a
+/// parallel erasure: the await-for lowering read <c>Current</c> off the
+/// closed <c>IAsyncEnumerator&lt;object&gt;</c> shape, which yielded an
+/// <c>object</c> assigned into the strongly-typed <c>Shape</c> loop slot
+/// — also rejected by ilverify even though the reference was correct at
+/// runtime.</para>
+/// </summary>
+public class Issue1002UserClassAsyncIteratorEmitTests
+{
+    [Fact]
+    public void UserReferenceTypeAsyncIterator_Compiles_And_IlVerifies()
+    {
+        var source = """
+            package T
+            import System.Collections.Generic
+            import System.Threading.Tasks
+            open class Shape { }
+            async func shapes() IAsyncEnumerable[Shape] {
+                yield Shape()
+                await Task.Delay(1)
+                yield Shape()
+            }
+            """;
+
+        // CompileToFile asserts gsc exit 0 and runs ilverify.
+        CompileToFile(source, target: "library");
+    }
+
+    [Fact]
+    public void UserReferenceTypeAsyncIterator_EndToEnd_PrintsShapeTwice()
+    {
+        var source = """
+            package T
+            import System
+            import System.Collections.Generic
+            import System.Threading.Tasks
+            open class Shape { func Tag() string { return "shape" } }
+            async func shapes() IAsyncEnumerable[Shape] {
+                yield Shape()
+                await Task.Delay(1)
+                yield Shape()
+            }
+            async func Run() {
+                let seq = shapes()
+                await for s in seq {
+                    Console.WriteLine(s.Tag())
+                }
+            }
+            Run().Wait()
+            """;
+
+        var output = CompileRunAndCaptureOutput(source);
+
+        var lines = output.Replace("\r\n", "\n").TrimEnd('\n').Split('\n');
+        Assert.Equal(new[] { "shape", "shape" }, lines);
+    }
+
+    [Fact]
+    public void UserReferenceTypeAsyncIterator_AccumulatesValues()
+    {
+        var source = """
+            package T
+            import System.Collections.Generic
+            import System.Threading.Tasks
+            open class Box { var value int32 = 0 }
+            async func boxes() IAsyncEnumerable[Box] {
+                var a = Box()
+                a.value = 10
+                yield a
+                await Task.Delay(1)
+                var b = Box()
+                b.value = 20
+                yield b
+                await Task.Delay(1)
+                var c = Box()
+                c.value = 30
+                yield c
+            }
+            public var total = 0
+            async func Run() {
+                await for b in boxes() {
+                    total = total + b.value
+                }
+            }
+            Run().Wait()
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal(60, GetIntField(assembly, "total"));
+    }
+
+    [Fact]
+    public void UserValueStructAsyncIterator_AccumulatesCorrectly()
+    {
+        var source = """
+            package T
+            import System.Collections.Generic
+            import System.Threading.Tasks
+            data struct Point { var x int32 }
+            async func points() IAsyncEnumerable[Point] {
+                yield Point{x: 1}
+                await Task.Delay(1)
+                yield Point{x: 2}
+                await Task.Delay(1)
+                yield Point{x: 3}
+            }
+            public var total = 0
+            async func Run() {
+                await for p in points() {
+                    total = total + p.x
+                }
+            }
+            Run().Wait()
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal(6, GetIntField(assembly, "total"));
+    }
+
+    [Fact]
+    public void BclInt32AsyncElementControl_StillCompilesAndRuns()
+    {
+        var source = """
+            package T
+            import System.Collections.Generic
+            import System.Threading.Tasks
+            async func nums() IAsyncEnumerable[int32] {
+                yield 1
+                await Task.Delay(1)
+                yield 2
+            }
+            public var sum = 0
+            async func Run() {
+                await for n in nums() {
+                    sum = sum + n
+                }
+            }
+            Run().Wait()
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal(3, GetIntField(assembly, "sum"));
+    }
+
+    private static Assembly CompileAndRun(string source)
+    {
+        var outPath = CompileToFile(source, target: "exe");
+        var bytes = File.ReadAllBytes(outPath);
+        var assembly = Assembly.Load(bytes);
+
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+        entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+
+        return assembly;
+    }
+
+    private static string CompileRunAndCaptureOutput(string source)
+    {
+        var outPath = CompileToFile(source, target: "exe");
+        var bytes = File.ReadAllBytes(outPath);
+        var assembly = Assembly.Load(bytes);
+
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+
+        using var captured = new StringWriter();
+        var prevOut = Console.Out;
+        Console.SetOut(captured);
+        try
+        {
+            entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+        }
+
+        return captured.ToString();
+    }
+
+    private static string CompileToFile(string source, string target)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1002_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:" + target,
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+        IlVerifier.Verify(outPath);
+        return outPath;
+    }
+
+    private static int GetIntField(Assembly assembly, string name)
+    {
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var field = program.GetField(name, BindingFlags.Public | BindingFlags.Static);
+        return (int)field!.GetValue(null)!;
+    }
+}


### PR DESCRIPTION
Closes #1002.

Parallel to #990 (sync iterators) but for the **async**-iterator path.

### Root causes

1. **Iterator-side erasure.** AsyncIteratorRewriter.GetAsyncIteratorElementType walked stream.Type.ClrType; for a same-compilation user element type (e.g. `IAsyncEnumerable[Shape]` where `Shape` is a user class) the `ClrType` is the erased `IAsyncEnumerable<object>`. The plan therefore carried `object` as the element type, and the SM's `IAsyncEnumerable<T>` / `IAsyncEnumerator<T>` interface rows + the `GetAsyncEnumerator` return signature erased to `<object>` (`elementType.ClrType ?? typeof(object)`). The kickoff's `IAsyncEnumerable<Shape>` return type was thus generic-invariance-invalid — ilverify reported `StackUnexpected: found ref '...d__1' expected ref 'IAsyncEnumerable`1<T.Shape>'`.

2. **Consumer-side erasure.** `await for s in seq` over that same symbolic `IAsyncEnumerable` was lowered by reading `Current` off the closed `IAsyncEnumerator<object>` reflection shape, yielding an `object` assigned into the strongly-typed `Shape` loop slot. The runtime tolerated it (the reference is correct) but ilverify rejected the mismatch.

### Fix

* `AsyncIteratorRewriter.GetAsyncIteratorElementType` honours `ImportedTypeSymbol.TypeArguments[0]` when the open def is `IAsyncEnumerable`1` / `IAsyncEnumerator`1`.
* `MethodBodyPlanner.AddAsyncIteratorInterfaceImplementations` + `StateMachineEmitter.cs` route user element types (null `ClrType`) through the symbolic TypeSpec / `ImportedTypeSymbol.GetConstructed` encoder so the SM's interface rows and `GetAsyncEnumerator` signature carry the strongly-typed `IAsyncEnumerable<Shape>` / `IAsyncEnumerator<Shape>`.
* `MemberLookup.TryGetAsyncEnumerableElementType` honours `ImportedTypeSymbol.HasSubstitutableTypeArgument` (parallel to the #774 / #939 sync `for-in` path).
* `Lowerer.LowerAwaitForRange` synthesises a symbolic `IAsyncEnumerator[ElementSym]` via `ImportedTypeSymbol.GetConstructed` so the `Current` access in the rewritten loop body carries the user's element type instead of `object`.

### Tests

Adds `Issue1002UserClassAsyncIteratorEmitTests` covering: a user reference element (Shape), a user value-struct element (data struct Point), end-to-end `await for` runs, and a BCL int32 control. All 5 new tests pass; the existing 85 iterator / async-iterator tests (#641, #647, #652, #655, #689, #774, #798, #810, #937, #939, #990, …) and 412 non-Issue Emit tests + 308 Emit Issue 8xx-10xx tests all still pass; Core.Tests green (3518/3518). Pre-existing PInvoke and NullableEnum baseline failures verified on `main` and unrelated.

Updates ADR-0115 §G #1002 to resolved.