### PR TITLE
cs2gs: complete Oahu.Foundation translate stage (interface inheritance, generic interface methods, unsafe pointers) (#914)

### DIFF
--- a/docs/adr/0115-csharp-to-gsharp-migration-tool.md
+++ b/docs/adr/0115-csharp-to-gsharp-migration-tool.md
@@ -636,6 +636,8 @@ re-greening earlier stages and surfacing the next layer of gaps:
 | #993 | an `is`/`case` type pattern **with** a binder (`x is T t`) leaves the binder unbound | GS0125 | open (L5 uses the no-binder form `x is T`) |
 | #994 | `yield break` has no canonical G# form | GS0005 | open (translation-unsupported) |
 | #1002 | a user reference-type async iterator (`IAsyncEnumerable[UserClass]`) → IL erases to `IAsyncEnumerable<object>` | ilverify `StackUnexpected` | **resolved** (user reference- and value-type element async iterators emit, ilverify, and run; `await for s in seq` recovers the user element type) |
+| #1006 | interface inheritance `interface B : A { … }` won't parse | GS0005 | **resolved** (parser/binder accept an interface base-interface clause; cs2gs now emits `interface B : A, C { … }` — Oahu.Foundation `Types/Interfaces.cs`) |
+| #1007 | a generic interface method signature `func F[T](…) R;` won't parse | GS0005 | **resolved** (parser/binder accept generic methods in interfaces; cs2gs now emits the `[T]` clause on interface methods — Oahu.Foundation `Diagnostics/Interfaces.cs`) |
 
 Earlier L3 not going fully green was the **intended** objective-2 outcome: the
 residual failure was a real compiler gap (#985), captured and filed rather than
@@ -991,62 +993,64 @@ constant keeps its explicit `init()` body, because G# has a field member initial
 
 Translating the external **`Oahu.Foundation`** project drove its
 `translation-unsupported` count from **105** (25 construct kinds) to **9
-diagnostics across 3 files**, all of which are **genuine G# compiler/language
-gaps** (not translator defects) — every other Foundation file translates **and**
-round-trips. The translator emits the canonical mappings of §B.35 for all other
-constructs. The three residual gaps were each reproduced directly with `gsc`
-(version **0.2.132+417bdb25ec**) and contrasted with a passing control; per
-ADR-0115 they are documented here for the orchestrator to file as `bug,Oats`
-issues and are out of scope for the translator-only PR.
+diagnostics across 3 files**, and a **follow-up round (this PR, leveraging the
+now-merged compiler fixes #1006 and #1007) drove that to 0** — `Oahu.Foundation`
+now reaches **translate = passed** (every file round-trips, 0 unsupported). The
+three residual gaps were each reproduced directly with `gsc`
+(version **0.2.132+417bdb25ec**) and contrasted with a passing control; the
+first two were genuine G# compiler/language gaps that the compiler team has since
+fixed (#1006 interface inheritance, #1007 generic interface methods), and the
+translator now emits the canonical G# form for all three (the pointer surface is
+the excepted unsafe-interop surface — see OF-3).
 
-**OF-1 — interface inheritance `interface B : A { … }` won't parse (`GS0005`).**
-A C# interface that extends another interface has no canonical G# spelling: the
-parser's `ParseInterfaceDeclarationNew` has no base-clause handling and goes
-straight to `MatchToken(OpenBraceToken)`. A **class** base clause
-(`class C : A, B {}`) parses, so this is interface-specific. The translator
-reports the base interface as unsupported and drops it (leaving non-gating
-semantic diagnostics). Source: `Types/Interfaces.cs`.
-
-```gs
-// repro — GS0005: Unexpected token <ColonToken>, expected <OpenBraceToken>:
-package T
-interface A { func F(); }
-interface B : A { func G(); }
-```
-```gs
-// control — a class base clause parses:
-package T
-interface A { func F(); }
-class C : A { func F() { } }
-```
-
-**OF-2 — a generic interface method signature `func IsPrim[T]() bool;` won't parse (`GS0005`).**
-A type-parameterized method **signature** inside an interface has no G# spelling:
-the parser rejects the `[T]` type-parameter list on an interface method. Generic
-methods work on **classes** and **free functions** — only the interface signature
-form fails. The translator reports it unsupported and drops the type parameters.
-Source: `Diagnostics/Interfaces.cs`.
+**OF-1 — interface inheritance `interface B : A { … }` (RESOLVED, #1006).**
+A C# interface that extends another interface originally had no canonical G#
+spelling: the parser's `ParseInterfaceDeclarationNew` had no base-clause handling
+and went straight to `MatchToken(OpenBraceToken)`. **Issue #1006 added an
+interface base-interface clause to the parser/binder**, so `interface B : A, C { … }`
+is now legal G#. The translator now emits the base list through the same
+base-clause path as a class (no Unsupported diagnostic). Source:
+`Types/Interfaces.cs` → emits `interface IBookMeta : IAudioQuality { … }`.
 
 ```gs
-// repro — GS0005: Unexpected token <OpenSquareBracketToken>, expected <OpenParenthesisToken>:
+// now compiles (#1006 merged):
 package T
-interface IP { func IsPrim[T]() bool; }
-```
-```gs
-// control — a generic method on a class parses:
-package T
-class C { func IsPrim[T]() bool { return true } }
+interface A { func F() int32; }
+interface B : A { func G() int32; }
 ```
 
-**OF-3 — unsafe pointer types (`void*` / `byte*` / `int*`) have no G# form.**
+**OF-2 — a generic interface method signature `func IsPrim[T]() bool;` (RESOLVED, #1007).**
+A type-parameterized method **signature** inside an interface originally had no G#
+spelling: the parser rejected the `[T]` type-parameter list on an interface
+method. **Issue #1007 added generic methods in interfaces**, so the bodyless form
+`func F[T](…) R;` is now legal G#. The translator now retains the type-parameter
+list on interface methods (no Unsupported diagnostic). Source:
+`Diagnostics/Interfaces.cs` → emits `func IsPrimitiveType[T]() bool;`.
+
+```gs
+// now compiles (#1007 merged):
+package T
+interface A { func Echo[T](x T) T; }
+```
+
+**OF-3 — unsafe pointer types (`void*` / `byte*` / `int*`) → canonical prefix `*T` (excepted unsafe-interop surface).**
 `Win32/Win32FileIO.cs` is an `unsafe class` using raw pointer types throughout.
-G# has **no pointer-type token** at all, so there is no canonical mapping. The
-type mapper records a structured `PointerType` Unsupported diagnostic and emits
-an `object` placeholder for the field/parameter type. Source: `Win32/Win32FileIO.cs`.
+G# has a **byref/pointer prefix form `*T`** (spec §"Byref/pointer syntax exists
+as `*T`"; grammar `'*' TypeClause '?'?`), so a C# **postfix** `T*` translates to
+the canonical G# **prefix** `*T` — `byte*` → `*uint8`, `int*` → `*int32`, and
+`void*` (no managed pointee) → `*uint8` (a raw byte pointer). The emitted form
+**round-trips through the parser**, so the translate stage passes with no
+Unsupported diagnostic. This is the **excepted unsafe-interop surface**: the G#
+binder (not the parser) steers callers to `ref`/`out`/`in` (`GS0243`) and rejects
+pointer **fields** (`GS9006`), so the **compile** stage still fails on
+`Win32FileIO.gs` — this is expected and accepted (managed G# has no unsafe
+pointer-deref/field semantics). A C# **function pointer** still has no canonical
+managed form and remains a `PointerType` Unsupported diagnostic. Source:
+`Win32/Win32FileIO.cs`.
 
 ```cs
-// repro (C#) — no G# equivalent exists for a pointer type:
-public unsafe void Read(byte* buffer, int length) { }
+// repro (C#) — postfix T* maps to prefix *T (parses; binder flags GS0243):
+public unsafe bool ReadFile(byte* buffer, int* bytesRead, void* pBuf);
 ```
 
 Two **translator faithfulness additions** the Oahu.Foundation round surfaced (no

--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/GTypeReference.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/GTypeReference.cs
@@ -87,6 +87,32 @@ public sealed class TupleTypeReference : GTypeReference
 }
 
 /// <summary>
+/// A managed-pointer / byref type rendered in the canonical G# <b>prefix</b>
+/// form <c>*Element</c> (spec §"Byref/pointer syntax exists as <c>*T</c>",
+/// grammar <c>'*' TypeClause '?'?</c>). A C# postfix <c>T*</c> (e.g.
+/// <c>byte*</c>, <c>int*</c>, <c>void*</c>) maps to this node; <c>void*</c>
+/// has no managed pointee so it maps to <c>*uint8</c> (a raw byte pointer).
+/// These appear only on the unsafe Win32 P/Invoke interop surface: the form
+/// round-trips through the parser, though the binder later steers callers to
+/// <c>ref</c>/<c>out</c>/<c>in</c> (GS0243/GS9006) — the excepted unsafe-interop
+/// surface (ADR-0115 §G).
+/// </summary>
+public sealed class PointerTypeReference : GTypeReference
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PointerTypeReference"/> class.
+    /// </summary>
+    /// <param name="elementType">The pointee (element) type.</param>
+    public PointerTypeReference(GTypeReference elementType)
+    {
+        ElementType = elementType;
+    }
+
+    /// <summary>Gets the pointee (element) type.</summary>
+    public GTypeReference ElementType { get; }
+}
+
+/// <summary>
 /// A delegate type in the canonical arrow form <c>(A, B) -&gt; R</c>
 /// (ADR-0075, ADR-0115 §B.8). A multi-value return spells <c>-&gt; (T1, T2)</c>;
 /// a void return spells <c>-&gt; void</c>; an async delegate spells

--- a/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
@@ -124,6 +124,9 @@ public static class GSharpPrinter
             case ArrayTypeReference array:
                 return $"[]{RenderType(array.ElementType)}";
 
+            case PointerTypeReference pointer:
+                return $"*{RenderType(pointer.ElementType)}";
+
             case TupleTypeReference tuple:
                 return $"({string.Join(", ", tuple.ElementTypes.Select(RenderType))})";
 

--- a/tools/cs2gs/Cs2Gs.Tests/OahuFoundationTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuFoundationTranslationTests.cs
@@ -22,10 +22,11 @@ namespace Cs2Gs.Tests;
 /// and verbatim-identifier sanitization, width-bearing integer literals, the
 /// catch-all <c>catch</c>, and unbound-generic <c>typeof</c>. Each snippet uses a
 /// uniquely named user type and asserts a clean round-trip with the real G#
-/// parser. The remaining Oahu.Foundation gaps (interface inheritance, generic
-/// interface methods, unsafe pointers) are genuine G# language gaps and are
-/// asserted to emit a structured <see cref="TranslationSeverity.Unsupported"/>
-/// diagnostic rather than malformed G#.
+/// parser. The Oahu.Foundation interface-inheritance, generic-interface-method,
+/// and unsafe-pointer constructs now translate to canonical G# (interface
+/// inheritance and generic interface methods became legal G# via issues #1006
+/// and #1007; unsafe pointers map to the prefix <c>*T</c> form, the excepted
+/// unsafe Win32-interop surface).
 /// </summary>
 public class OahuFoundationTranslationTests
 {
@@ -326,15 +327,15 @@ namespace Demo
 
     /// <summary>
     /// ADR-0115 §G: an interface that extends another interface
-    /// (`interface IChild : IParent`) has no canonical G# form (the parser's
-    /// interface production accepts no base clause). The translator records a
-    /// structured Unsupported diagnostic and drops the base so the rest of the
-    /// file still round-trips.
+    /// (`interface IChild : IParent`) now translates to the canonical G# base
+    /// clause `interface IChildX : IParentX { ... }` (G# parser supports
+    /// interface inheritance since issue #1006). No Unsupported diagnostic is
+    /// raised and the emitted G# round-trips through the real parser.
     /// </summary>
     [Fact]
-    public void InterfaceInheritance_ReportsCompilerGap()
+    public void InterfaceInheritance_EmitsBaseClause()
     {
-        TranslationContext context = TranslateUnitWithContext(@"
+        (string printed, TranslationContext context) = TranslateUnitWithPrinted(@"
 namespace Demo
 {
     public interface IParentX
@@ -348,42 +349,69 @@ namespace Demo
     }
 }");
 
-        Assert.Contains(
+        Assert.Contains("interface IChildX : IParentX", printed);
+        Assert.DoesNotContain(
             context.Diagnostics,
-            d => d.Severity == TranslationSeverity.Unsupported &&
-                 d.Message.Contains("cannot declare base interfaces"));
+            d => d.Severity == TranslationSeverity.Unsupported);
     }
 
     /// <summary>
-    /// ADR-0115 §G: a generic interface method (`bool IsPrimitive&lt;T&gt;()`) has no
-    /// canonical G# form (the interface-method production accepts no `[T]`
-    /// clause). The translator records a structured Unsupported diagnostic and
-    /// drops the type-parameter list so the rest of the file still round-trips.
+    /// ADR-0115 §G: a generic interface method (`bool IsPrimitive&lt;T&gt;()`) now
+    /// translates to the canonical bodyless G# form `func IsPrimitive[T]() bool;`
+    /// (G# parser supports generic methods in interfaces since issue #1007). No
+    /// Unsupported diagnostic is raised and the emitted G# round-trips.
     /// </summary>
     [Fact]
-    public void GenericInterfaceMethod_ReportsCompilerGap()
+    public void GenericInterfaceMethod_EmitsTypeParameterList()
     {
-        TranslationContext context = TranslateUnitWithContext(@"
+        (string printed, TranslationContext context) = TranslateUnitWithPrinted(@"
 namespace Demo
 {
     public interface IGenX
     {
         bool IsPrimitive<T>();
+
+        string Format<T>(T value);
     }
 }");
 
-        Assert.Contains(
+        Assert.Contains("func IsPrimitive[T]() bool;", printed);
+        Assert.Contains("func Format[T](value T) string;", printed);
+        Assert.DoesNotContain(
             context.Diagnostics,
-            d => d.Severity == TranslationSeverity.Unsupported &&
-                 d.Message.Contains("cannot declare generic type parameters"));
+            d => d.Severity == TranslationSeverity.Unsupported);
     }
 
     /// <summary>
-    /// ADR-0115 §G: an unsafe pointer type (`void*`/`byte*`) has no canonical G#
-    /// form. The type mapper records a structured Unsupported diagnostic (kind
-    /// <c>PointerType</c>) rather than emitting a type-less field; this gap is
-    /// exercised end-to-end on the real <c>Win32FileIO.cs</c> in the corpus run.
+    /// ADR-0115 §G: an unsafe pointer type (C# postfix `T*`) now translates to
+    /// the canonical G# PREFIX managed-pointer form `*T`; a `void*` (no managed
+    /// pointee) maps to `*uint8`. The emitted G# round-trips through the parser.
+    /// No Unsupported diagnostic is raised — the binder later steers callers to
+    /// `ref`/`out`/`in` (GS0243) on the excepted unsafe Win32-interop surface,
+    /// which the corpus compile stage exercises on the real Win32FileIO.cs.
     /// </summary>
+    [Fact]
+    public void PointerType_EmitsCanonicalPrefixForm()
+    {
+        (string printed, TranslationContext context) = TranslateUnitWithPrinted(@"
+namespace Demo
+{
+    public static unsafe class PtrX
+    {
+        [System.Runtime.InteropServices.DllImport(""kernel32.dll"")]
+        public static extern bool ReadFile(void* pBuffer, int* pBytesRead, byte* pBuf);
+    }
+}");
+
+        Assert.Contains("pBuffer *uint8", printed);
+        Assert.Contains("pBytesRead *int32", printed);
+        Assert.Contains("pBuf *uint8", printed);
+        Assert.DoesNotContain(
+            context.Diagnostics,
+            d => d.Severity == TranslationSeverity.Unsupported);
+    }
+
+
     private static string TranslateUnit(string source)
     {
         (string printed, RoundTripResult result) = TranslateAndValidate(source);
@@ -394,22 +422,22 @@ namespace Demo
         return printed;
     }
 
-    private static TranslationContext TranslateUnitWithContext(string source)
+    private static (string Printed, TranslationContext Context) TranslateUnitWithPrinted(string source)
     {
         LoadedCSharpProject project = LoadProject(source);
         LoadedDocument document = Assert.Single(project.Documents);
         var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
         CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
 
-        // The printed output must still round-trip: a genuine compiler gap is
-        // reported as a diagnostic but never left as malformed, unparseable G#.
+        // The emitted G# must round-trip through the real parser even on the
+        // unsafe-interop surface (the binder, not the parser, flags GS0243).
         string printed = GSharpPrinter.Print(unit);
         RoundTripResult result = GSharpRoundTrip.Validate(printed);
         Assert.True(
             result.Success,
-            "Even with a reported gap the emitted G# must round-trip. Errors:\n" +
+            "Emitted G# must round-trip. Errors:\n" +
                 string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
-        return context;
+        return (printed, context);
     }
 
     private static (string Printed, RoundTripResult Result) TranslateAndValidate(string source)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -1135,20 +1135,10 @@ public sealed class CSharpToGSharpTranslator
                 isOverride = false;
             }
 
-            // G# interface method signatures cannot declare generic type
-            // parameters: the parser's interface-method production accepts no
-            // `[T]` clause (a generic method is legal on a class or as a free
-            // func, but not in an interface). This is a genuine G# language gap;
-            // record it and drop the type-parameter list so the rest of the file
-            // still round-trips (the construct is already gated by the report).
-            if (inInterface && typeParameters.Count > 0)
-            {
-                this.context.ReportUnsupported(
-                    node,
-                    $"interface method '{node.Identifier.Text}' is generic ([{string.Join(", ", typeParameters.Select(t => t.Name))}]); G# interface method signatures cannot declare generic type parameters. G# language gap.");
-                typeParameters = new List<TypeParameter>();
-            }
-
+            // Generic interface methods are supported by the G# parser since
+            // issue #1007 (`func F[T](...) R;`); the printer emits the
+            // type-parameter list via the same path as a class method or free
+            // func, so the `[T]` clause is retained on interface methods.
             var method = new MethodDeclaration(
                 SanitizeIdentifier(node.Identifier.Text),
                 parameters: parameters,
@@ -1522,19 +1512,10 @@ public sealed class CSharpToGSharpTranslator
                     continue;
                 }
 
-                // G# interfaces cannot extend other interfaces: the parser's
-                // interface production (`ParseInterfaceDeclarationNew`) accepts no
-                // base-type clause, so `interface IChild : IParent` has no canonical
-                // G# form. This is a genuine G# language gap (not a translator gap);
-                // record it and drop the base so the rest of the file still emits.
-                if (kind == TypeDeclarationKind.Interface)
-                {
-                    this.context.ReportUnsupported(
-                        node,
-                        $"interface '{symbol.Name}' extends interface '{iface.Name}'; G# interfaces cannot declare base interfaces (no parser support for an interface base clause). G# language gap.");
-                    continue;
-                }
-
+                // Interface inheritance is supported by the G# parser since
+                // issue #1006 (`interface B : A, C { ... }`); the printer emits
+                // base interfaces via the same base-clause path as a class, so
+                // a base interface is added to the interface's base list.
                 interfaces.Add(this.typeMapper.Map(iface, this.context, location));
             }
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
@@ -55,15 +55,35 @@ public sealed class CSharpTypeMapper
             return new NamedTypeReference(UnsupportedPlaceholderType);
         }
 
-        // G# has no unsafe pointer types: a C# `T*`, `void*`, or function pointer
-        // has no canonical managed G# form (ADR-0115 §B / G# language gap). Record
-        // a structured Unsupported diagnostic rather than emit a malformed
-        // type-less field/parameter.
-        if (type is IPointerTypeSymbol or IFunctionPointerTypeSymbol)
+        // A C# unsafe pointer type (`T*`, `void*`) maps to the canonical G#
+        // PREFIX managed-pointer form `*T` (spec §"Byref/pointer syntax exists
+        // as `*T`"; grammar `'*' TypeClause '?'?`). `void*` has no managed
+        // pointee, so it maps to `*uint8` (a raw byte pointer). The emitted
+        // form round-trips through the parser; the binder later steers callers
+        // to ref/out/in (GS0243) and rejects pointer fields (GS9006) — the
+        // excepted unsafe Win32-interop surface (ADR-0115 §G). A FUNCTION
+        // pointer has no canonical managed G# form and stays Unsupported.
+        if (type is IPointerTypeSymbol pointer)
+        {
+            ITypeSymbol pointee = pointer.PointedAtType;
+            GTypeReference element = pointee == null || pointee.SpecialType == SpecialType.System_Void
+                ? new NamedTypeReference("uint8")
+                : this.Map(pointee, context, location);
+            context.Report(new TranslationDiagnostic(
+                "PointerType",
+                $"unsafe pointer type '{type.ToDisplayString()}' maps to the canonical G# prefix-pointer form; the binder steers callers to ref/out/in (GS0243) on the excepted unsafe Win32-interop surface (ADR-0115 §G).",
+                location,
+                TranslationSeverity.Info));
+            return new PointerTypeReference(element);
+        }
+
+        // G# has no managed form for a C# function pointer; record a structured
+        // Unsupported diagnostic rather than emit a malformed type.
+        if (type is IFunctionPointerTypeSymbol)
         {
             context.Report(new TranslationDiagnostic(
                 "PointerType",
-                $"unsafe pointer type '{type.ToDisplayString()}' has no canonical G# form; G# does not support pointer/unsafe types.",
+                $"unsafe function-pointer type '{type.ToDisplayString()}' has no canonical G# form; G# does not support function-pointer types.",
                 location,
                 TranslationSeverity.Unsupported));
             return new NamedTypeReference(UnsupportedPlaceholderType);
@@ -91,6 +111,8 @@ public sealed class CSharpTypeMapper
                 return new NamedTypeReference(named.Name, named.TypeArguments) { IsNullable = isNullable };
             case ArrayTypeReference array:
                 return new ArrayTypeReference(array.ElementType) { IsNullable = isNullable };
+            case PointerTypeReference pointer:
+                return new PointerTypeReference(pointer.ElementType) { IsNullable = isNullable };
             case TupleTypeReference tuple:
                 return new TupleTypeReference(tuple.ElementTypes) { IsNullable = isNullable };
             case ArrowTypeReference arrow:

--- a/tools/cs2gs/Cs2Gs.Translator/Loading/CSharpProjectLoader.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/Loading/CSharpProjectLoader.cs
@@ -120,7 +120,7 @@ public static class CSharpProjectLoader
             assemblyName,
             trees,
             resolvedReferences,
-            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary).WithAllowUnsafe(true));
 
         IReadOnlyList<LoadedDocument> documents = BuildDocuments(compilation);
         IReadOnlyList<Diagnostic> loadDiagnostics = SignificantDiagnostics(compilation);


### PR DESCRIPTION
## Summary

Completes the **translate stage** for `Oahu.Foundation` in the cs2gs C#→G# translator (#914), leveraging the now-merged G# compiler fixes **#1006** (interface inheritance) and **#1007** (generic methods in interfaces). After rebuilding on current `main`, Foundation had **9** translation-unsupported diagnostics across 3 files; this PR drives that to **0** and Foundation now reaches **translate = passed** (every file round-trips).

## What now translates

| Construct | File(s) | Before | After |
| --- | --- | --- | --- |
| Interface inheritance | `Types/Interfaces.cs` | `InterfaceDeclaration` ×1 Unsupported | `interface IBookMeta : IAudioQuality { … }` |
| Generic interface methods | `Diagnostics/Interfaces.cs` | `MethodDeclaration` ×2 Unsupported | `func IsPrimitiveType[T]() bool;` (bodyless) |
| Unsafe pointer types | `Win32/Win32FileIO.cs` | `PointerType` ×6 Unsupported | C# postfix `T*` → G# prefix `*T` |

**Foundation translation-unsupported count: 9 → 0.**

### Details
- **Interface inheritance** — an `InterfaceDeclarationSyntax` base list now emits via the same base-clause path as a class (was `ReportUnsupported`). Verified `interface B : A { … }` compiles with `gsc`.
- **Generic interface methods** — an interface method's `[T]` type-parameter list is retained, emitting the canonical bodyless `func F[T](…) R;`. Verified with `gsc`.
- **Pointer types** — a C# **postfix** `T*` maps to the canonical G# **prefix** `*T` (spec §"Byref/pointer syntax exists as `*T`"): `byte*`/`void*` → `*uint8`, `int*` → `*int32`. Adds a `PointerTypeReference` AST node + printer case. Function pointers remain Unsupported (no managed form).

## Unsafe-interop caveat (expected / excepted)
The emitted prefix-pointer text **round-trips through the parser**, so translate passes. These unsafe Win32 P/Invoke pointers do **not** fully compile under G#'s managed-pointer rules: the **binder** (not the parser) steers callers to `ref`/`out`/`in` (`GS0243`) and rejects pointer **fields** (`GS9006`). The **compile** stage therefore still fails on `Win32FileIO.gs` — this is the **expected, excepted** unsafe-interop surface and is not a translator defect. The compile stage compiles each `.gs` standalone, so it additionally surfaces pre-existing cross-file reference errors unrelated to this change.

## Tests
Extended `tools/cs2gs/Cs2Gs.Tests/OahuFoundationTranslationTests.cs`:
- `InterfaceInheritance_EmitsBaseClause` — asserts `interface IChildX : IParentX`, no Unsupported diagnostic.
- `GenericInterfaceMethod_EmitsTypeParameterList` — asserts `func IsPrimitive[T]() bool;` / `func Format[T](value T) string;`, no Unsupported diagnostic.
- `PointerType_EmitsCanonicalPrefixForm` — asserts `*uint8`/`*int32` prefix mapping, round-trips, no Unsupported diagnostic.

Enabled `AllowUnsafe` in the in-memory C# test loader so pointer snippets bind (matching the real corpus build). The two former "ReportsCompilerGap" tests were rewritten to assert the new emit behavior.

`dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release` → **155 passed, 0 failed**.

## Build / validation
- `dotnet build GSharp.sln -c Release -graph` → **0 warnings / 0 errors**.
- `cs2gs migrate … --app corpus/Oahu.Foundation` → `summary.json` shows `stages[translate].status == "passed"`, `artifactCount == 0`.
- ADR-0115 §G updated: OF-1/OF-2 resolved (#1006/#1007), OF-3 now maps to prefix `*T` with the unsafe-interop compile caveat; status table adds #1006/#1007; Foundation reaches translate=passed.

Translator-only scope; no gsc compiler (`src/Core/…`) changes.

Refs #914, #1006, #1007.
