### PR TITLE
cs2gs: translate Oahu.Decrypt's C# 12 collection/pattern/range surface (#914)

### DIFF
--- a/docs/adr/0115-csharp-to-gsharp-migration-tool.md
+++ b/docs/adr/0115-csharp-to-gsharp-migration-tool.md
@@ -475,6 +475,67 @@ empirically before adoption.
 > `catch Exception { }` all fail to parse. The translator synthesizes
 > `catch (ex Exception) { }` for a C# bare catch-all (extending §B.27).
 
+#### B.36 Oahu.Decrypt round — C# 12 collection/pattern/range surface
+
+Translating the external **`Oahu.Decrypt`** project (issue #914 continuation;
+**109** initial `translation-unsupported` diagnostics across **19** construct
+kinds) required the following additional canonical mappings. Each printed form
+round-trips through the real G# parser; gsc-accepted forms were verified
+empirically (gsc **0.2.137+31ced6cfb7**) before adoption.
+
+- **Collection expression `[a, b, c]` → slice literal `[]T{ … }`.** A C# 12
+  `CollectionExpression` targeting an array/`Span`/`IEnumerable<T>` maps to the
+  canonical G# slice literal `[]T{ a, b, c }`, with the element type taken from
+  the converted target type. Bare numeric literals are coerced to the element
+  type (`byte[] = [0, 1]` → `[]uint8{ uint8(0), uint8(1) }`) since G# has no
+  implicit numeric promotion (§B.12).
+- **Throw-expression `x ?? throw e` / `c ? v : throw e` → value-position throw
+  lowering.** G# `throw` is **statement-only**; a C# `ThrowExpression` used in a
+  value position is lowered to the uniform form `if true { throw e\n default(T) }
+  else { default(T) }`, which is a valid expression in every position (`??`
+  right-hand side, conditional branch, switch arm). The result type `T` comes
+  from the converted type of the throw-expression. A bare arrow body
+  `=> throw e` maps directly to a G# `throw` **statement**.
+- **`is`-pattern combinators (constant / relational / not / and / or /
+  recursive) → boolean lowering.** G# `is` in **expression** position supports
+  only `expr is Type`; all other patterns are switch-only. So an `is`-pattern is
+  lowered to a boolean: `x is 0` → `x == 0`; `x is 1 or 2` → `x == 1 || x == 2`;
+  `x is not T` → `!(x is T)`; `x is >= 0 and < n` → `x >= 0 && x < n` (C#
+  precedence `not` > `and` > `or` preserved, parenthesized where needed); a
+  recursive/property pattern `x is { }` → `x != nil` (the property-binder local
+  is rewritten to a member access on the subject). The switch-context pattern set
+  (§B switch mapping) keeps the native `case` pattern forms.
+- **Range index `a[i..j]` / `a[i..]` / `a[..j]` → `.Slice(start, length)`.** G#
+  has **no range operator** (gsc gap, §G OD-1); a `RangeExpression` index over a
+  `Span`/`Memory`/`ReadOnlySpan` lowers to a `.Slice` call: `s[i..j]` →
+  `s.Slice(i, j - i)`, `s[i..]` → `s.Slice(i)`, `s[..j]` → `s.Slice(0, j)`.
+- **Null-forgiving `expr!` → `expr`.** G# has no nullable-reference annotations,
+  so the `SuppressNullableWarningExpression` operator is **dropped**.
+- **Post-increment/decrement as an expression → statement-seam hoisting.** G#
+  models `++`/`--` as **statements** on identifiers. A `PostIncrementExpression`/
+  `PostDecrementExpression` used as a **value** (`a[i++] = v`, `M(i--)`,
+  `x = y++`) is hoisted: the sub-expression reads the pre-increment value and the
+  mutation is appended as a trailing `i++` / `i--` statement after the enclosing
+  expression statement (in document order; nested-lambda bodies are not hoisted
+  into the outer seam).
+- **`yield break` → `break`.** Settled fact: G# has no `yield break`; it maps to
+  a plain loop-control `break` (supersedes the former §G #994 unsupported note).
+- **`foreach ((a, b) in xs)` tuple deconstruction → `for a, b in xs`.** A
+  `ForEachVariableStatement` maps to the G# two-name iteration form; element
+  names are collected from the tuple/declaration designation.
+- **Field-like event `public event EventHandler<T>? X;` → `event X <type>`.** An
+  `EventFieldDeclaration` maps to the canonical G# name-then-type event member;
+  the nullable annotation on the delegate type is dropped (a field-like event is
+  nil-initialized). `EventHandler<T>` renders through the type mapper as its
+  delegate signature (`event X (object?, T) -> void`).
+- **UTF-8 string literal `"…"u8` → byte slice `[]uint8{ … }`.** A
+  `Utf8StringLiteralExpression` maps to a G# byte-slice literal of the UTF-8
+  bytes (`"AB"u8` → `[]uint8{ 0x41, 0x42 }`).
+- **Control characters in string literals → `\uXXXX` escapes.** The printer now
+  re-escapes any character below `U+0020` (and `U+007F`) — e.g. C# `"\0\0\0"` —
+  as a `\uXXXX` escape so the emitted G# string stays terminated and round-trips
+  (previously a raw NUL produced `GS0003: Unterminated string literal`).
+
 `Cs2Gs.Pipeline` runs four ordered stages per corpus app. Each stage has an explicit pass/fail gate; a failure short-circuits the remaining stages for that app, emits a triage artifact (section D), and is recorded in the run report. **"Migration completed" ≡ all four stages green: clean compile + clean IL verification + test parity with the original C#.**
 
 | # | Stage | Action | Pass gate | On failure |
@@ -634,7 +695,7 @@ re-greening earlier stages and surfacing the next layer of gaps:
 | #991 | a `when` guard on a `switch` statement/expression arm won't parse | GS0005 | **resolved** (issue #991 — `case <pattern> when <bool>:` / `case <pattern> when <bool> { … }` parse a contextual `when` guard; an arm matches only when the pattern matches AND the guard is true; guarded arms never satisfy exhaustiveness; cs2gs now translates C# `when` guards to the new form) |
 | #992 | `and`/`or` binary patterns (`> 0 and < 10`) won't parse | GS0005 | **resolved** (issue #992 — `and`/`or`/`not` pattern combinators with C# precedence (`not` > `and` > `or`) and parentheses; compose with all pattern kinds; binding type patterns under `or`/`not` rejected with GS0390; smart-cast narrows under `and`, soundly under `or`, never under `not`; combined patterns never satisfy exhaustiveness; cs2gs now translates C# `and`/`or`/`not` patterns to the new form) |
 | #993 | an `is`/`case` type pattern **with** a binder (`x is T t`) leaves the binder unbound | GS0125 | open (L5 uses the no-binder form `x is T`) |
-| #994 | `yield break` has no canonical G# form | GS0005 | open (translation-unsupported) |
+| #994 | `yield break` has no canonical G# form | GS0005 | **resolved by design** (settled fact: G# has no `yield break`; the translator maps it to a plain `break` — §B.36, Oahu.Decrypt round) |
 | #1002 | a user reference-type async iterator (`IAsyncEnumerable[UserClass]`) → IL erases to `IAsyncEnumerable<object>` | ilverify `StackUnexpected` | **resolved** (user reference- and value-type element async iterators emit, ilverify, and run; `await for s in seq` recovers the user element type) |
 | #1006 | interface inheritance `interface B : A { … }` won't parse | GS0005 | **resolved** (parser/binder accept an interface base-interface clause; cs2gs now emits `interface B : A, C { … }` — Oahu.Foundation `Types/Interfaces.cs`) |
 | #1007 | a generic interface method signature `func F[T](…) R;` won't parse | GS0005 | **resolved** (parser/binder accept generic methods in interfaces; cs2gs now emits the `[T]` clause on interface methods — Oahu.Foundation `Diagnostics/Interfaces.cs`) |
@@ -1059,6 +1120,95 @@ than `int32` is emitted with the matching `UL`/`L`/`U` suffix so the round-trip
 parser infers the same width (§B.35); and every emitted identifier is sanitized
 against the G# reserved-word set with the C# verbatim `@` prefix stripped (§B.35),
 so corpus identifiers such as `@default`, `@In`, `type`, and `func` round-trip.
+
+#### Discovered gaps from the Oahu.Decrypt round (minimal repros)
+
+Translating the external **`Oahu.Decrypt`** project drove its
+`translation-unsupported` count from **109** (19 construct kinds) to **7
+diagnostics across 5 files** — every one of the 19 target construct kinds is now
+translated to canonical G# (§B.36). The 7 residual diagnostics are **3 genuine
+gsc gaps** (each reproduced directly with gsc **0.2.137+31ced6cfb7** and
+contrasted with a passing control) and **4 excepted unsafe-interop constructs**
+(issue #1014). None is a translator defect.
+
+**OD-1 — range operator `a[i..j]` has no canonical G# form (gsc gap).** G# has no
+range/`..` operator; an `a[i..j]` index does not parse. The translator therefore
+**lowers** every corpus range index over a `Span`/`Memory` to `.Slice(start,
+length)` (§B.36), so all 7 corpus range uses translate. Filed as a gap for a
+first-class range surface.
+
+```cs
+// repro (C#) — no G# `..` range operator; lowered to .Slice(...) by the translator:
+System.Span<byte> Middle(System.Span<byte> s) => s[1..3];
+```
+```gs
+// gsc 0.2.137+31ced6cfb7 rejects a literal `..` range index:
+package p
+class C { func F(s Span[uint8]) Span[uint8] { return s[1..3] } }
+// error GS0005: Unexpected token, the `..` range form is not in the grammar.
+```
+
+**OD-2 — user-defined conversion operator `implicit`/`explicit operator T` has no
+canonical G# form (gsc gap).** G#'s `operator` keyword is followed by an
+**operator token** only (spec §Functions grammar `OperatorName = "operator"
+OperatorToken`); there is no user-defined implicit/explicit conversion form. The
+translator reports the construct unsupported. Source:
+`Mpeg4/IAppleData.cs` → `public static implicit operator TrackNumber((int, int) tn)`.
+
+```gs
+// gsc 0.2.137+31ced6cfb7: `operator` cannot be followed by a type:
+package p
+class TrackNumber {
+    public static implicit operator TrackNumber(tn (int32, int32)) TrackNumber { return TrackNumber() }
+}
+// error GS0288 (field decl requires var/let/const) + GS0113 (Type 'implicit' doesn't exist)
+```
+
+**OD-3 — static-abstract **property** in an interface has no canonical G# form
+(gsc gap, ADR-0089).** An interface `shared { … }` block accepts only `func`
+members; static interface **state** (a `prop`/field) is not supported in this
+release (ADR-0089). C# `public static abstract int SizeInBytes { get; }` therefore
+has no G# spelling. Source: `Mpeg4/IAppleData.cs`.
+
+```gs
+// gsc 0.2.137+31ced6cfb7:
+package p
+interface IData { shared { prop SizeInBytes int32 { get } } func Write() }
+// error GS0330: Only 'func' members are allowed inside the 'shared' block of an interface;
+//               interface static state is not supported in this release (ADR-0089).
+```
+
+**Excepted unsafe-interop surface (issue #1014).** Four residual diagnostics are
+the excepted unsafe surface and are **not** forced to a managed G# form:
+`stackalloc T[n]` (`StackAllocArrayCreationExpression`, `Mpeg4/APICFrame.cs` and
+`Mpeg4/Stz2Box.cs`), `fixed (byte* p = …)` (`FixedStatement`, `Cryptography/
+AesCtr.cs`), and a `i--` post-decrement used inside the short-circuit condition of
+the `unsafe class AesCtr` do-while (`PostDecrementExpression`, `Cryptography/
+AesCtr.cs`). `AesCtr` is an `unsafe class` built on `byte*`/`fixed`/pointer
+arithmetic — the same pointer-deref/field surface documented as OF-3 — so these
+remain documented against issue #1014 rather than translated.
+
+**Two downstream `CompilationUnit` round-trip failures investigated.** Two files
+failed the round-trip parse gate for reasons unrelated to the 19 target kinds:
+`Mpeg4/ID3/EmptyFrame.cs` emitted a string literal containing raw NUL bytes
+(C# `"\0\0\0"`) → `GS0003: Unterminated string literal` — **fixed** by the
+control-character `\uXXXX` re-escaping (§B.36); and `Chunks/ChunkReader.cs` emits
+a C-style `for` loop whose increment ends in an indexer immediately followed by
+the body brace (`start += chunk.FrameSizes[f] {`), which gsc parses as a composite
+literal (`expr[i] { … }`) → `GS0005: Unexpected token <IfKeyword>, expected
+<CloseBraceToken>`. The latter is a pre-existing translator limitation
+(multi-declarator/multi-incrementor C-style `for` loops are not fully rendered)
+compounded by a gsc parse ambiguity; it is **not** one of the 19 target kinds and
+is left for a follow-up (lower such `for` loops to `while`, or disambiguate the
+`expr[i] {` parse).
+
+```gs
+// gsc 0.2.137+31ced6cfb7 — `expr[i] {` parses as a composite literal:
+package p
+class C { func F(arr []int32) { for var s = 0; s < arr.Length; s += arr[s] { var x = 1 } } }
+// error GS0005: Unexpected token <VarKeyword>, expected <CloseBraceToken>.
+```
+
 
 ## Consequences
 

--- a/docs/adr/0115-csharp-to-gsharp-migration-tool.md
+++ b/docs/adr/0115-csharp-to-gsharp-migration-tool.md
@@ -509,8 +509,10 @@ empirically (gsc **0.2.137+31ced6cfb7**) before adoption.
   has **no range operator** (gsc gap, §G OD-1); a `RangeExpression` index over a
   `Span`/`Memory`/`ReadOnlySpan` lowers to a `.Slice` call: `s[i..j]` →
   `s.Slice(i, j - i)`, `s[i..]` → `s.Slice(i)`, `s[..j]` → `s.Slice(0, j)`.
-- **Null-forgiving `expr!` → `expr`.** G# has no nullable-reference annotations,
-  so the `SuppressNullableWarningExpression` operator is **dropped**.
+- **Null-forgiving `expr!` → non-null assertion `expr!!`.** G#'s postfix `!!`
+  asserts non-null (spec: "Postfix `!!` asserts non-null"), the direct analogue
+  of the C# null-forgiving operator, so the `SuppressNullableWarningExpression`
+  operand is preserved with `!!` rather than dropped.
 - **Post-increment/decrement as an expression → statement-seam hoisting.** G#
   models `++`/`--` as **statements** on identifiers. A `PostIncrementExpression`/
   `PostDecrementExpression` used as a **value** (`a[i++] = v`, `M(i--)`,

--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/GExpression.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/GExpression.cs
@@ -778,3 +778,37 @@ public sealed class ConditionalAccessExpression : GExpression
     /// <summary>Gets the non-null continuation.</summary>
     public GExpression WhenNotNull { get; }
 }
+
+/// <summary>
+/// A C# <c>throw</c> expression used in value position (<c>a ?? throw e</c>,
+/// <c>cond ? a : throw e</c>, a <c>switch</c> arm value). G# models <c>throw</c>
+/// as a statement only (spec §If expressions), so the canonical faithful form
+/// lowers the throw to an if-expression whose then-branch is a block that runs
+/// the <c>throw</c> statement and supplies an (unreachable) tail of the result
+/// type: <c>if true { throw e\n default(T) } else { default(T) }</c>. This shape
+/// is a primary expression and therefore valid in every value position
+/// (ADR-0115 §B).
+/// </summary>
+public sealed class ThrowExpression : GExpression
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ThrowExpression"/> class.
+    /// </summary>
+    /// <param name="operand">The thrown exception value.</param>
+    /// <param name="resultType">
+    /// The type the surrounding expression position expects, used for the
+    /// unreachable <c>default(T)</c> tail. May be <see langword="null"/> when no
+    /// type is resolvable, in which case a bare <c>default</c> is emitted.
+    /// </param>
+    public ThrowExpression(GExpression operand, GTypeReference resultType)
+    {
+        Operand = operand;
+        ResultType = resultType;
+    }
+
+    /// <summary>Gets the thrown exception value.</summary>
+    public GExpression Operand { get; }
+
+    /// <summary>Gets the result type used for the unreachable tail.</summary>
+    public GTypeReference ResultType { get; }
+}

--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/GExpression.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/GExpression.cs
@@ -429,6 +429,26 @@ public sealed class UnaryExpression : GExpression
 }
 
 /// <summary>
+/// A postfix non-null assertion <c>operand!!</c> — the G# analogue of the C#
+/// null-forgiving operator <c>operand!</c> (spec: "Postfix <c>!!</c> asserts
+/// non-null").
+/// </summary>
+public sealed class NonNullAssertionExpression : GExpression
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NonNullAssertionExpression"/> class.
+    /// </summary>
+    /// <param name="operand">The asserted operand.</param>
+    public NonNullAssertionExpression(GExpression operand)
+    {
+        Operand = operand;
+    }
+
+    /// <summary>Gets the asserted operand.</summary>
+    public GExpression Operand { get; }
+}
+
+/// <summary>
 /// A parenthesized expression <c>(inner)</c>.
 /// </summary>
 public sealed class ParenthesizedExpression : GExpression

--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/GMember.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/GMember.cs
@@ -334,3 +334,35 @@ public sealed class DestructorDeclaration : GMember
     /// <summary>Gets the finalizer body.</summary>
     public BlockStatement Body { get; }
 }
+
+/// <summary>
+/// A field-like event declaration <c>event Name Type</c> (spec §Members,
+/// <c>EventDecl</c>; ADR-0115 §B). The C# form
+/// <c>public event EventHandler&lt;T&gt;? X;</c> maps to the canonical G#
+/// name-then-type ordering with no accessor body; the nullable annotation on the
+/// delegate type is dropped because a field-like event is nil-initialized.
+/// </summary>
+public sealed class EventDeclaration : GMember
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EventDeclaration"/> class.
+    /// </summary>
+    /// <param name="name">The event name.</param>
+    /// <param name="type">The handler/delegate type.</param>
+    /// <param name="visibility">The accessibility.</param>
+    public EventDeclaration(string name, GTypeReference type, Visibility visibility = Visibility.Default)
+    {
+        Name = name;
+        Type = type;
+        Visibility = visibility;
+    }
+
+    /// <summary>Gets the event name.</summary>
+    public string Name { get; }
+
+    /// <summary>Gets the handler/delegate type.</summary>
+    public GTypeReference Type { get; }
+
+    /// <summary>Gets the accessibility.</summary>
+    public Visibility Visibility { get; }
+}

--- a/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using Cs2Gs.CodeModel.Ast;
@@ -282,7 +283,15 @@ public static class GSharpPrinter
                     sb.Append("\\t");
                     break;
                 default:
-                    sb.Append(ch);
+                    if (ch < ' ' || ch == '\u007F')
+                    {
+                        sb.Append("\\u").Append(((int)ch).ToString("X4", CultureInfo.InvariantCulture));
+                    }
+                    else
+                    {
+                        sb.Append(ch);
+                    }
+
                     break;
             }
         }
@@ -316,7 +325,15 @@ public static class GSharpPrinter
                     sb.Append("\\t");
                     break;
                 default:
-                    sb.Append(ch);
+                    if (ch < ' ' || ch == '\u007F')
+                    {
+                        sb.Append("\\u").Append(((int)ch).ToString("X4", CultureInfo.InvariantCulture));
+                    }
+                    else
+                    {
+                        sb.Append(ch);
+                    }
+
                     break;
             }
         }
@@ -397,6 +414,16 @@ public static class GSharpPrinter
 
             case IfExpression ifExpression:
                 return $"if {RenderExpression(ifExpression.Condition, indent)} {{ {RenderExpression(ifExpression.ThenExpression, indent)} }} else {{ {RenderExpression(ifExpression.ElseExpression, indent)} }}";
+
+            case ThrowExpression throwExpression:
+                // G# has no throw-expression: lower to an if-expression whose
+                // then-branch block runs the `throw` statement and supplies an
+                // unreachable typed tail (spec §If expressions). The shape is a
+                // primary expression, so it is valid in every value position.
+                var throwTail = throwExpression.ResultType == null
+                    ? "default"
+                    : $"default({RenderType(throwExpression.ResultType)})";
+                return $"if true {{ throw {RenderExpression(throwExpression.Operand, indent)}\n{Indent(indent + 1)}{throwTail} }} else {{ {throwTail} }}";
 
             case OutArgumentExpression outArgument:
                 return $"{outArgument.Keyword} {outArgument.Name}";
@@ -941,6 +968,8 @@ public static class GSharpPrinter
                 return RenderConstructor(constructor, indent);
             case DestructorDeclaration destructor:
                 return $"{Indent(indent)}deinit {RenderBlock(destructor.Body, indent)}";
+            case EventDeclaration eventDeclaration:
+                return $"{Indent(indent)}{RenderVisibility(eventDeclaration.Visibility)}event {eventDeclaration.Name} {RenderType(eventDeclaration.Type)}";
             case SharedBlock sharedBlock:
                 return RenderSharedBlock(sharedBlock, indent);
             default:

--- a/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
@@ -400,6 +400,9 @@ public static class GSharpPrinter
             case UnaryExpression unary:
                 return $"{unary.Operator}{RenderExpression(unary.Operand, indent)}";
 
+            case NonNullAssertionExpression nonNull:
+                return $"{RenderExpression(nonNull.Operand, indent)}!!";
+
             case ParenthesizedExpression parenthesized:
                 return $"({RenderExpression(parenthesized.Inner, indent)})";
 

--- a/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
@@ -1,0 +1,338 @@
+// <copyright file="OahuDecryptTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Translation tests for the C# surface area exercised by the
+/// <c>Oahu.Decrypt</c> corpus app (ADR-0115 §B/§G): C# 12 collection
+/// expressions, throw-expressions, is-pattern combinators (constant / not / or
+/// / and / recursive), range slicing, the null-forgiving operator, embedded
+/// post-increment/decrement, <c>yield break</c>, field-like events, UTF-8
+/// string literals, and <c>foreach</c> tuple deconstruction. Every snippet must
+/// round-trip-parse through the real G# parser (the translate-stage gate).
+/// </summary>
+public class OahuDecryptTranslationTests
+{
+    /// <summary>
+    /// A C# 12 collection expression <c>[a, b, c]</c> targeting an array is
+    /// emitted as the canonical G# slice literal <c>[]T{ … }</c>; bare numeric
+    /// literals are coerced to the element type (ADR-0115 §B).
+    /// </summary>
+    [Fact]
+    public void CollectionExpression_TargetingByteArray_EmittedAsSliceLiteral()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public static class C
+    {
+        public static byte[] Make() => [1, 2, 3];
+    }
+}");
+
+        Assert.Contains("[]uint8{", printed);
+        Assert.Contains("uint8(1)", printed);
+        Assert.DoesNotContain("ReportUnsupported", printed);
+    }
+
+    /// <summary>
+    /// A C# throw-expression on the right of <c>??</c> is lowered to the
+    /// uniform value-position form <c>if true { throw … default(T) } else {
+    /// default(T) }</c> (G# `throw` is statement-only; ADR-0115 §B).
+    /// </summary>
+    [Fact]
+    public void ThrowExpression_InNullCoalescing_LoweredToIfExpression()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public static class C
+    {
+        public static string Get(string? s) => s ?? throw new System.ArgumentNullException(nameof(s));
+    }
+}");
+
+        Assert.Contains("throw ", printed);
+        Assert.Contains("if true {", printed);
+    }
+
+    /// <summary>
+    /// A C# throw-expression in a ternary branch (<c>cond ? v : throw e</c>) is
+    /// lowered through the same value-position throw form inside the G#
+    /// if-expression branch.
+    /// </summary>
+    [Fact]
+    public void ThrowExpression_InTernaryBranch_LoweredToIfExpression()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public static class C
+    {
+        public static int Get(System.Collections.Generic.Dictionary<int, int> d, int k)
+            => d.TryGetValue(k, out var v) ? v : throw new System.ArgumentOutOfRangeException(nameof(k));
+    }
+}");
+
+        Assert.Contains("throw ", printed);
+    }
+
+    /// <summary>
+    /// A constant pattern in an <c>is</c> expression lowers to an equality test
+    /// (<c>x is 5</c> → <c>x == 5</c>); G# `is` in expression position supports
+    /// only <c>expr is Type</c> (ADR-0115 §B).
+    /// </summary>
+    [Fact]
+    public void ConstantPattern_InIsExpression_LoweredToEquality()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public static class C
+    {
+        public static bool Zero(int x) => x is 0;
+    }
+}");
+
+        Assert.Contains("x == 0", printed);
+    }
+
+    /// <summary>
+    /// An <c>or</c> pattern lowers to a disjunction of equality tests, and a
+    /// <c>not</c> pattern to a negated test (C# precedence preserved).
+    /// </summary>
+    [Fact]
+    public void OrAndNotPatterns_InIsExpression_LoweredToBooleanOps()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public static class C
+    {
+        public static bool OneOrTwo(int x) => x is 1 or 2;
+
+        public static bool NotText(object o) => o is not string;
+    }
+}");
+
+        Assert.Contains("x == 1 || x == 2", printed);
+        Assert.Contains("!(o is string)", printed);
+    }
+
+    /// <summary>
+    /// A range index over a span (<c>s[a..b]</c>) lowers to a <c>.Slice(start,
+    /// length)</c> call — G# has no range operator (gsc gap; ADR-0115 §G).
+    /// </summary>
+    [Fact]
+    public void RangeExpression_OverSpan_LoweredToSlice()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public static class C
+    {
+        public static System.Span<byte> Middle(System.Span<byte> s) => s[1..3];
+
+        public static System.Span<byte> Tail(System.Span<byte> s) => s[2..];
+
+        public static System.Span<byte> Head(System.Span<byte> s) => s[..4];
+    }
+}");
+
+        Assert.Contains("Slice(1, 3 - 1)", printed);
+        Assert.Contains("Slice(2)", printed);
+        Assert.Contains("Slice(0, 4)", printed);
+    }
+
+    /// <summary>
+    /// The null-forgiving operator <c>expr!</c> is dropped — G# has no
+    /// nullable-reference annotations (ADR-0115 §B).
+    /// </summary>
+    [Fact]
+    public void SuppressNullableWarning_IsDropped()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public static class C
+    {
+        public static string Unwrap(string? s) => s!;
+    }
+}");
+
+        Assert.Contains("return s", printed);
+        Assert.DoesNotContain("s!", printed);
+    }
+
+    /// <summary>
+    /// An embedded post-increment used as an expression (<c>a[i++] = v</c>) is
+    /// hoisted: the sub-expression reads the pre-increment value and the
+    /// mutation is appended as a trailing <c>i++</c> statement (ADR-0115 §B).
+    /// </summary>
+    [Fact]
+    public void PostIncrement_AsExpression_HoistedToTrailingStatement()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public static class C
+    {
+        public static void Set(int[] a, int i)
+        {
+            a[i++] = 7;
+        }
+    }
+}");
+
+        Assert.Contains("a[i] = 7", printed);
+        Assert.Contains("i++", printed);
+    }
+
+    /// <summary>
+    /// <c>yield break</c> maps to a plain G# <c>break</c> (settled fact: G# has
+    /// no <c>yield break</c>; ADR-0115 §B).
+    /// </summary>
+    [Fact]
+    public void YieldBreak_MappedToBreak()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public static class C
+    {
+        public static System.Collections.Generic.IEnumerable<int> Take(bool stop)
+        {
+            if (stop)
+            {
+                yield break;
+            }
+
+            yield return 1;
+        }
+    }
+}");
+
+        Assert.Contains("break", printed);
+        Assert.DoesNotContain("yield break", printed);
+        Assert.DoesNotContain("unsupported", printed);
+    }
+
+    /// <summary>
+    /// A field-like event maps to the canonical G# <c>event Name Type</c>
+    /// (name-then-type, no accessor body, nullable annotation dropped).
+    /// </summary>
+    [Fact]
+    public void EventField_MappedToEventDeclaration()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public sealed class C
+    {
+        public event System.EventHandler<int>? Changed;
+    }
+}");
+
+        Assert.Contains("event Changed (object?, int32) -> void", printed);
+    }
+
+    /// <summary>
+    /// A UTF-8 string literal <c>""…""u8</c> maps to a G# byte-slice literal
+    /// <c>[]uint8{ … }</c> of the UTF-8 bytes (ADR-0115 §B).
+    /// </summary>
+    [Fact]
+    public void Utf8StringLiteral_MappedToByteSlice()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public static class C
+    {
+        public static System.ReadOnlySpan<byte> Tag() => ""AB""u8;
+    }
+}");
+
+        Assert.Contains("[]uint8{", printed);
+        Assert.Contains("0x41", printed);
+        Assert.Contains("0x42", printed);
+    }
+
+    /// <summary>
+    /// A <c>foreach</c> over a tuple deconstruction maps to the G# two-name
+    /// iteration <c>for a, b in xs</c> (ADR-0115 §B).
+    /// </summary>
+    [Fact]
+    public void ForEachVariable_TupleDeconstruction_MappedToTwoNameForIn()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public static class C
+    {
+        public static int Sum(System.Collections.Generic.IEnumerable<(int A, int B)> xs)
+        {
+            int total = 0;
+            foreach ((int a, int b) in xs)
+            {
+                total += a + b;
+            }
+
+            return total;
+        }
+    }
+}");
+
+        Assert.Contains("for a, b in xs", printed);
+    }
+
+    /// <summary>
+    /// A control character inside a string literal (here NUL from C# <c>\0</c>)
+    /// is re-escaped as a <c>\uXXXX</c> escape so the emitted G# string stays
+    /// terminated and round-trips (ADR-0115 §B).
+    /// </summary>
+    [Fact]
+    public void StringLiteral_WithControlCharacter_EscapedAsUnicode()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public static class C
+    {
+        public static string Nulls() => ""\0\0\0"";
+    }
+}");
+
+        Assert.Contains("\\u0000", printed);
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
@@ -155,11 +155,11 @@ namespace Demo
     }
 
     /// <summary>
-    /// The null-forgiving operator <c>expr!</c> is dropped — G# has no
-    /// nullable-reference annotations (ADR-0115 §B).
+    /// The C# null-forgiving operator <c>expr!</c> maps to G#'s postfix non-null
+    /// assertion <c>expr!!</c> (ADR-0115 §B).
     /// </summary>
     [Fact]
-    public void SuppressNullableWarning_IsDropped()
+    public void SuppressNullableWarning_MapsToNonNullAssertion()
     {
         string printed = TranslateUnit(@"
 namespace Demo
@@ -170,8 +170,7 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("return s", printed);
-        Assert.DoesNotContain("s!", printed);
+        Assert.Contains("s!!", printed);
     }
 
     /// <summary>

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -2874,10 +2874,11 @@ public sealed class CSharpToGSharpTranslator
 
                 case PostfixUnaryExpressionSyntax suppressNullable
                     when suppressNullable.IsKind(SyntaxKind.SuppressNullableWarningExpression):
-                    // The null-forgiving operator `expr!` has no G# analogue (G#
-                    // has no nullable-reference annotations); drop it and keep the
-                    // operand (ADR-0115 §B).
-                    return this.TranslateExpression(suppressNullable.Operand);
+                    // The C# null-forgiving operator `expr!` maps to G#'s postfix
+                    // non-null assertion `expr!!` (spec: "Postfix `!!` asserts
+                    // non-null"), preserving the assertion (ADR-0115 §B).
+                    return new NonNullAssertionExpression(
+                        this.TranslateExpression(suppressNullable.Operand));
 
                 case PostfixUnaryExpressionSyntax postfixValue
                     when postfixValue.IsKind(SyntaxKind.PostIncrementExpression)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -298,6 +298,14 @@ public sealed class CSharpToGSharpTranslator
         private readonly Dictionary<ISymbol, GExpression> patternBindings =
             new Dictionary<ISymbol, GExpression>(SymbolEqualityComparer.Default);
 
+        // C# post-increment/decrement (`i++`, `i--`) sub-expressions that the
+        // surrounding statement seam has hoisted into trailing `i++` statements
+        // (G# models inc/dec as statements, not expressions; spec §Statements).
+        // While a node is in this set, `TranslateExpression` renders it as a bare
+        // read of its operand (the pre-increment value).
+        private readonly HashSet<SyntaxNode> suppressedPostfix =
+            new HashSet<SyntaxNode>();
+
         // Static-field initializers lifted out of a `static` constructor body
         // (`static T() { Field = value; }`). G# has no static constructor, so a
         // simple static ctor is folded into the corresponding `shared { }` field
@@ -936,6 +944,14 @@ public sealed class CSharpToGSharpTranslator
                     yield return this.TranslateOperator(op);
                     break;
 
+                case EventFieldDeclarationSyntax eventField:
+                    foreach ((GMember m, bool s) in this.TranslateEventField(eventField))
+                    {
+                        yield return (m, s);
+                    }
+
+                    break;
+
                 case PropertyDeclarationSyntax property:
                     if (lift.PropertiesAsPrimaryParameters.Contains(property.Identifier.Text))
                     {
@@ -983,11 +999,47 @@ public sealed class CSharpToGSharpTranslator
 
                     break;
 
+                case ConversionOperatorDeclarationSyntax conversion:
+                    // G# `operator` is followed by an operator token only
+                    // (spec §Functions, `OperatorName = "operator" OperatorToken`);
+                    // there is no user-defined implicit/explicit conversion form.
+                    // Genuine gsc gap — reported for follow-up (ADR-0115 §G).
+                    this.context.ReportUnsupported(
+                        conversion,
+                        "user-defined conversion operators ('implicit'/'explicit operator T') have no canonical G# form (gsc gap; spec §Functions grammar 'operator' takes an operator token only).");
+                    break;
+
                 default:
                     this.context.ReportUnsupported(
                         member,
                         $"member '{member.Kind()}' has no canonical G# mapping yet (ADR-0115 §B.11).");
                     break;
+            }
+        }
+
+        private IEnumerable<(GMember Member, bool IsStatic)> TranslateEventField(
+            EventFieldDeclarationSyntax node)
+        {
+            // `public event EventHandler<T>? X;` → G# `public event X EventHandler[T]`
+            // (name-then-type; the nullable annotation is dropped because a
+            // field-like event is nil-initialized; ADR-0115 §B).
+            foreach (VariableDeclaratorSyntax declarator in node.Declaration.Variables)
+            {
+                var symbol = this.context.GetDeclaredSymbol(declarator) as IEventSymbol;
+
+                GTypeReference type = symbol != null
+                    ? this.typeMapper.Map(
+                        symbol.Type.WithNullableAnnotation(NullableAnnotation.NotAnnotated),
+                        this.context,
+                        declarator.GetLocation())
+                    : this.MapTypeSyntax(node.Declaration.Type);
+
+                var declaration = new EventDeclaration(
+                    SanitizeIdentifier(declarator.Identifier.Text),
+                    type,
+                    MapVisibility(symbol, this.context, node));
+
+                yield return (declaration, symbol != null && symbol.IsStatic);
             }
         }
 
@@ -1941,6 +1993,16 @@ public sealed class CSharpToGSharpTranslator
 
         private BlockStatement WrapExpressionBody(ExpressionSyntax expression, bool isVoid)
         {
+            if (expression is ThrowExpressionSyntax bareThrow)
+            {
+                // `=> throw e` is a diverging body; G# `throw` is a statement, so
+                // emit it directly rather than wrapping a value (ADR-0115 §B).
+                return new BlockStatement(new List<GStatement>
+                {
+                    new ThrowStatement(this.TranslateExpression(bareThrow.Expression)),
+                });
+            }
+
             if (isVoid)
             {
                 // A void expression body is an executed statement (often an
@@ -1949,7 +2011,9 @@ public sealed class CSharpToGSharpTranslator
                 return new BlockStatement(this.TranslateExpressionStatements(expression).ToList());
             }
 
-            return new BlockStatement(new List<GStatement> { new ReturnStatement(this.TranslateExpression(expression)) });
+            return new BlockStatement(this.WithHoistedPostfix(
+                expression,
+                () => new GStatement[] { new ReturnStatement(this.TranslateExpression(expression)) }).ToList());
         }
 
         private BlockStatement TranslateBlock(BlockSyntax block)
@@ -2040,6 +2104,9 @@ public sealed class CSharpToGSharpTranslator
                             this.TranslateExpression(forEach.Expression),
                             this.TranslateStatementAsBlock(forEach.Statement)),
                     };
+
+                case ForEachVariableStatementSyntax forEachVariable:
+                    return new[] { this.TranslateForEachVariable(forEachVariable) };
 
                 case ThrowStatementSyntax throwStatement:
                     return new[] { this.TranslateThrow(throwStatement) };
@@ -2297,7 +2364,66 @@ public sealed class CSharpToGSharpTranslator
                 }
             }
 
-            return new[] { this.TranslateExpressionStatement(expression) };
+            return this.WithHoistedPostfix(
+                expression,
+                () => new[] { this.TranslateExpressionStatement(expression) });
+        }
+
+        /// <summary>
+        /// Translates an expression in statement position, hoisting any embedded
+        /// post-increment/decrement (`a[i++] = x`, `M(i--)`, `x = y++`) into
+        /// trailing `i++` / `i--` statements. G# models inc/dec as statements, so
+        /// the sub-expression is suppressed (read as its pre-increment value) and
+        /// the mutation is appended after the main statement (ADR-0115 §B).
+        /// </summary>
+        private IEnumerable<GStatement> WithHoistedPostfix(
+            ExpressionSyntax expression,
+            Func<IEnumerable<GStatement>> buildMain)
+        {
+            List<PostfixUnaryExpressionSyntax> embedded = CollectEmbeddedPostfix(expression);
+            if (embedded.Count == 0)
+            {
+                return buildMain();
+            }
+
+            foreach (PostfixUnaryExpressionSyntax node in embedded)
+            {
+                this.suppressedPostfix.Add(node);
+            }
+
+            List<GStatement> statements;
+            try
+            {
+                statements = buildMain().ToList();
+            }
+            finally
+            {
+                foreach (PostfixUnaryExpressionSyntax node in embedded)
+                {
+                    this.suppressedPostfix.Remove(node);
+                }
+            }
+
+            foreach (PostfixUnaryExpressionSyntax node in embedded)
+            {
+                statements.Add(new IncrementDecrementStatement(
+                    this.TranslateExpression(node.Operand),
+                    node.OperatorToken.Text));
+            }
+
+            return statements;
+        }
+
+        private static List<PostfixUnaryExpressionSyntax> CollectEmbeddedPostfix(ExpressionSyntax expression)
+        {
+            // Collect `i++` / `i--` nodes nested inside `expression` (in document
+            // order), excluding any that live inside a nested lambda / local
+            // function (those belong to that body's own statement seam).
+            return expression.DescendantNodes(descendIntoChildren: node =>
+                    node is not (AnonymousFunctionExpressionSyntax or LocalFunctionStatementSyntax))
+                .OfType<PostfixUnaryExpressionSyntax>()
+                .Where(p => p.IsKind(SyntaxKind.PostIncrementExpression) || p.IsKind(SyntaxKind.PostDecrementExpression))
+                .ToList();
         }
 
         private IEnumerable<GStatement> FlattenChainedAssignment(AssignmentExpressionSyntax assignment)
@@ -2637,6 +2763,18 @@ public sealed class CSharpToGSharpTranslator
                         tuple.Arguments.Select(a => this.TranslateExpression(a.Expression)).ToList());
 
                 case ElementAccessExpressionSyntax elementAccess:
+                    if (elementAccess.ArgumentList.Arguments.Count == 1 &&
+                        elementAccess.ArgumentList.Arguments[0].Expression is RangeExpressionSyntax sliceRange)
+                    {
+                        // `span[a..b]` / `span[..n]` / `span[i..]`: G# has no range
+                        // operator, so lower the System.Range indexer to the
+                        // faithful `Slice(start, length)` / `Slice(start)` call the
+                        // C# range indexer itself lowers to (ADR-0115 §B).
+                        return this.TranslateRangeSlice(
+                            this.TranslateExpression(elementAccess.Expression),
+                            sliceRange);
+                    }
+
                     GExpression index = elementAccess.ArgumentList.Arguments.Count > 0
                         ? this.TranslateExpression(elementAccess.ArgumentList.Arguments[0].Expression)
                         : new IdentifierExpression("nil");
@@ -2726,6 +2864,41 @@ public sealed class CSharpToGSharpTranslator
                     // enclosing statement seam re-materialise the write.
                     return this.TranslateExpression(nestedAssignment.Right);
 
+                case ThrowExpressionSyntax throwExpression:
+                    // `a ?? throw e`, `cond ? a : throw e`, a `switch` arm value.
+                    // G# `throw` is a statement only; lower to a typed
+                    // if-expression that runs the throw (ADR-0115 §B).
+                    return new ThrowExpression(
+                        this.TranslateExpression(throwExpression.Expression),
+                        this.ResolveExpressionType(throwExpression));
+
+                case PostfixUnaryExpressionSyntax suppressNullable
+                    when suppressNullable.IsKind(SyntaxKind.SuppressNullableWarningExpression):
+                    // The null-forgiving operator `expr!` has no G# analogue (G#
+                    // has no nullable-reference annotations); drop it and keep the
+                    // operand (ADR-0115 §B).
+                    return this.TranslateExpression(suppressNullable.Operand);
+
+                case PostfixUnaryExpressionSyntax postfixValue
+                    when postfixValue.IsKind(SyntaxKind.PostIncrementExpression)
+                        || postfixValue.IsKind(SyntaxKind.PostDecrementExpression):
+                    // A post-increment/decrement used in value position. G# has no
+                    // inc/dec expression; the enclosing statement seam hoists the
+                    // mutation into a trailing statement and suppresses the node
+                    // here so it reads as the pre-increment value (ADR-0115 §B).
+                    if (this.suppressedPostfix.Contains(postfixValue))
+                    {
+                        return this.TranslateExpression(postfixValue.Operand);
+                    }
+
+                    this.context.ReportUnsupported(
+                        postfixValue,
+                        $"post-{(postfixValue.IsKind(SyntaxKind.PostIncrementExpression) ? "increment" : "decrement")} used in a position that has no canonical G# statement seam (ADR-0115 §B).");
+                    return this.TranslateExpression(postfixValue.Operand);
+
+                case CollectionExpressionSyntax collectionExpression:
+                    return this.TranslateCollectionExpression(collectionExpression);
+
                 default:
                     this.context.ReportUnsupported(
                         expression,
@@ -2749,12 +2922,21 @@ public sealed class CSharpToGSharpTranslator
                     // `x is null` → `x == nil`.
                     return new BinaryExpression(receiver, "==", LiteralExpression.Null());
 
-                case UnaryPatternSyntax unary
-                    when unary.IsKind(SyntaxKind.NotPattern) &&
-                        unary.Pattern is ConstantPatternSyntax { Expression: { } inner } &&
-                        inner.IsKind(SyntaxKind.NullLiteralExpression):
-                    // `x is not null` → `x != nil`.
-                    return new BinaryExpression(receiver, "!=", LiteralExpression.Null());
+                case ConstantPatternSyntax constant:
+                    // `x is 0` / `x is "moov"` / `x is true`. G# `is` only tests a
+                    // type, so a constant pattern lowers to an equality test
+                    // (ADR-0115 §B).
+                    return new BinaryExpression(
+                        receiver,
+                        "==",
+                        this.TranslateExpression(constant.Expression));
+
+                case RelationalPatternSyntax relational:
+                    // `x is > 0` → `x > 0`.
+                    return new BinaryExpression(
+                        receiver,
+                        relational.OperatorToken.Text,
+                        this.TranslateExpression(relational.Expression));
 
                 case DeclarationPatternSyntax declaration:
                     // `x is T t` → the boolean test `x is T`; the binder `t` is a
@@ -2778,6 +2960,23 @@ public sealed class CSharpToGSharpTranslator
                         "is",
                         new TypeExpression(this.MapTypeSyntax(typePattern.Type)));
 
+                case RecursivePatternSyntax recursive:
+                    return this.TranslateRecursivePatternTest(receiver, recursive);
+
+                case UnaryPatternSyntax unary when unary.IsKind(SyntaxKind.NotPattern):
+                    return this.TranslateNotPatternTest(receiver, unary.Pattern);
+
+                case BinaryPatternSyntax binaryPattern
+                    when binaryPattern.OperatorToken.IsKind(SyntaxKind.OrKeyword)
+                        || binaryPattern.OperatorToken.IsKind(SyntaxKind.AndKeyword):
+                    // `x is 11 or 12` → `x == 11 || x == 12`;
+                    // `x is A and B` → `(x is A) && (x is B)`.
+                    bool isOr = binaryPattern.OperatorToken.IsKind(SyntaxKind.OrKeyword);
+                    return new BinaryExpression(
+                        this.TranslatePatternTest(receiver, binaryPattern.Left),
+                        isOr ? "||" : "&&",
+                        this.TranslatePatternTest(receiver, binaryPattern.Right));
+
                 case ParenthesizedPatternSyntax parenthesized:
                     return new ParenthesizedExpression(
                         this.TranslatePatternTest(receiver, parenthesized.Pattern));
@@ -2787,6 +2986,96 @@ public sealed class CSharpToGSharpTranslator
                         pattern,
                         $"is-pattern '{pattern.Kind()}' has no canonical G# form yet (ADR-0115 §B).");
                     return new BinaryExpression(receiver, "!=", LiteralExpression.Null());
+            }
+        }
+
+        private GExpression TranslateNotPatternTest(GExpression receiver, PatternSyntax inner)
+        {
+            switch (inner)
+            {
+                case ConstantPatternSyntax constant
+                    when constant.Expression.IsKind(SyntaxKind.NullLiteralExpression):
+                    // `x is not null` → `x != nil`.
+                    return new BinaryExpression(receiver, "!=", LiteralExpression.Null());
+
+                case ConstantPatternSyntax constant:
+                    // `x is not 6` → `x != 6`.
+                    return new BinaryExpression(
+                        receiver,
+                        "!=",
+                        this.TranslateExpression(constant.Expression));
+
+                case RecursivePatternSyntax { Type: null } emptyRecursive
+                    when emptyRecursive.PropertyPatternClause is null or { Subpatterns.Count: 0 }:
+                    // `x is not { } d` → `x == nil`; the designator `d` is the
+                    // non-null view (used on the matched side), bound to `x`.
+                    BindPatternDesignation(emptyRecursive.Designation, receiver);
+                    return new BinaryExpression(receiver, "==", LiteralExpression.Null());
+
+                case TypePatternSyntax typePattern:
+                    // `x is not T` → `!(x is T)`.
+                    return new UnaryExpression(
+                        "!",
+                        new ParenthesizedExpression(new BinaryExpression(
+                            receiver,
+                            "is",
+                            new TypeExpression(this.MapTypeSyntax(typePattern.Type)))));
+
+                case DeclarationPatternSyntax declaration:
+                    // `x is not T t` → `!(x is T)`; `t` is the non-null `T` view,
+                    // bound to `x` for use on the matched side.
+                    BindPatternDesignation(declaration.Designation, receiver);
+                    return new UnaryExpression(
+                        "!",
+                        new ParenthesizedExpression(new BinaryExpression(
+                            receiver,
+                            "is",
+                            new TypeExpression(this.MapTypeSyntax(declaration.Type)))));
+
+                default:
+                    // General negation: `!( <inner test> )`.
+                    return new UnaryExpression(
+                        "!",
+                        new ParenthesizedExpression(this.TranslatePatternTest(receiver, inner)));
+            }
+        }
+
+        private GExpression TranslateRecursivePatternTest(GExpression receiver, RecursivePatternSyntax recursive)
+        {
+            // Bind the designator (`is { } x`, `is Circle c`) to the receiver so
+            // later references read the matched value (ADR-0069 smart cast).
+            BindPatternDesignation(recursive.Designation, receiver);
+
+            GExpression test = recursive.Type != null
+                ? new BinaryExpression(receiver, "is", new TypeExpression(this.MapTypeSyntax(recursive.Type)))
+                : new BinaryExpression(receiver, "!=", LiteralExpression.Null());
+
+            if (recursive.PropertyPatternClause != null)
+            {
+                foreach (SubpatternSyntax sub in recursive.PropertyPatternClause.Subpatterns)
+                {
+                    if (sub.NameColon == null && sub.ExpressionColon == null)
+                    {
+                        this.context.ReportUnsupported(sub, "positional subpattern has no canonical G# form yet (ADR-0115 §B).");
+                        continue;
+                    }
+
+                    string memberName = sub.NameColon?.Name.Identifier.Text
+                        ?? sub.ExpressionColon?.Expression.ToString();
+                    GExpression memberAccess = new MemberAccessExpression(receiver, SanitizeIdentifier(memberName));
+                    test = new BinaryExpression(test, "&&", this.TranslatePatternTest(memberAccess, sub.Pattern));
+                }
+            }
+
+            return test;
+        }
+
+        private void BindPatternDesignation(VariableDesignationSyntax designation, GExpression receiver)
+        {
+            if (designation is SingleVariableDesignationSyntax variable &&
+                this.context.GetDeclaredSymbol(variable) is { } boundSymbol)
+            {
+                this.patternBindings[boundSymbol] = receiver;
             }
         }
 
@@ -2891,6 +3180,150 @@ public sealed class CSharpToGSharpTranslator
             return new NamedTypeReference("object");
         }
 
+        private GExpression TranslateCollectionExpression(CollectionExpressionSyntax collection)
+        {
+            // C# 12 collection expression `[a, b, c]`. The target type (array,
+            // span, or any IEnumerable<T>) supplies the element type, so it maps to
+            // the canonical G# slice literal `[]T{ … }` (ADR-0115 §B). Spread
+            // elements `[..xs]` have no G# composite-literal form yet.
+            GTypeReference elementType = this.GetCollectionElementType(collection);
+            var elements = new List<GExpression>();
+            foreach (CollectionElementSyntax element in collection.Elements)
+            {
+                if (element is ExpressionElementSyntax expressionElement)
+                {
+                    elements.Add(this.CoerceCollectionElement(expressionElement.Expression, elementType));
+                }
+                else
+                {
+                    this.context.ReportUnsupported(
+                        element,
+                        $"collection-expression element '{element.Kind()}' (spread) has no canonical G# composite-literal form yet (ADR-0115 §B).");
+                }
+            }
+
+            return new ArrayLiteralExpression(elementType, elements);
+        }
+
+        private GExpression CoerceCollectionElement(ExpressionSyntax element, GTypeReference elementType)
+        {
+            // A bare integer literal in a typed-narrower array (`[0, 0]` into a
+            // `byte[]`) needs an explicit G# conversion, since untyped numeric
+            // literals do not auto-narrow. Wrap such elements in `T(elem)`.
+            GExpression translated = this.TranslateExpression(element);
+            ITypeSymbol elementSymbol = this.context.GetTypeInfo(element).Type;
+            ITypeSymbol convertedSymbol = this.context.GetTypeInfo(element).ConvertedType;
+            if (elementSymbol != null && convertedSymbol != null &&
+                !SymbolEqualityComparer.Default.Equals(elementSymbol, convertedSymbol) &&
+                IsPrimitiveNumeric(elementSymbol) && IsPrimitiveNumeric(convertedSymbol))
+            {
+                return new ConversionExpression(elementType, translated);
+            }
+
+            return translated;
+        }
+
+        private static bool IsPrimitiveNumeric(ITypeSymbol type) => type.SpecialType switch
+        {
+            SpecialType.System_SByte or SpecialType.System_Byte or
+            SpecialType.System_Int16 or SpecialType.System_UInt16 or
+            SpecialType.System_Int32 or SpecialType.System_UInt32 or
+            SpecialType.System_Int64 or SpecialType.System_UInt64 or
+            SpecialType.System_Single or SpecialType.System_Double or
+            SpecialType.System_Decimal or SpecialType.System_Char => true,
+            _ => false,
+        };
+
+        private GTypeReference GetCollectionElementType(CollectionExpressionSyntax collection)
+        {
+            ITypeSymbol target = this.context.GetTypeInfo(collection).ConvertedType
+                ?? this.context.GetTypeInfo(collection).Type;
+            ITypeSymbol elementType = GetEnumerableElementType(target);
+            if (elementType != null)
+            {
+                return this.typeMapper.Map(elementType, this.context, collection.GetLocation());
+            }
+
+            // No bound target type: fall back to the natural element type of the
+            // first element, or `object` for an empty literal.
+            ExpressionSyntax firstExpression = collection.Elements
+                .OfType<ExpressionElementSyntax>()
+                .Select(e => e.Expression)
+                .FirstOrDefault();
+            if (firstExpression != null &&
+                this.context.GetTypeInfo(firstExpression).Type is { } natural)
+            {
+                return this.typeMapper.Map(natural, this.context, collection.GetLocation());
+            }
+
+            return new NamedTypeReference("object");
+        }
+
+        private static ITypeSymbol GetEnumerableElementType(ITypeSymbol type)
+        {
+            switch (type)
+            {
+                case null:
+                    return null;
+                case IArrayTypeSymbol array:
+                    return array.ElementType;
+                case INamedTypeSymbol named:
+                    if (named.IsGenericType && named.TypeArguments.Length == 1)
+                    {
+                        return named.TypeArguments[0];
+                    }
+
+                    foreach (INamedTypeSymbol iface in named.AllInterfaces)
+                    {
+                        if (iface.OriginalDefinition.SpecialType == SpecialType.System_Collections_Generic_IEnumerable_T &&
+                            iface.TypeArguments.Length == 1)
+                        {
+                            return iface.TypeArguments[0];
+                        }
+                    }
+
+                    return null;
+                default:
+                    return null;
+            }
+        }
+
+        private GExpression TranslateRangeSlice(GExpression receiver, RangeExpressionSyntax range)
+        {
+            // `recv[start..end]` → `recv.Slice(start, end - start)`;
+            // `recv[start..]`    → `recv.Slice(start)`;
+            // `recv[..end]`      → `recv.Slice(0, end)`.
+            GExpression start = range.LeftOperand != null
+                ? this.TranslateExpression(range.LeftOperand)
+                : LiteralExpression.Int("0");
+
+            var slice = new MemberAccessExpression(receiver, "Slice");
+
+            if (range.RightOperand == null)
+            {
+                return new InvocationExpression(slice, new List<GExpression> { start });
+            }
+
+            GExpression end = this.TranslateExpression(range.RightOperand);
+            GExpression length = range.LeftOperand == null
+                ? end
+                : new BinaryExpression(end, "-", start);
+
+            return new InvocationExpression(slice, new List<GExpression> { start, length });
+        }
+
+        private GTypeReference ResolveExpressionType(ExpressionSyntax expression)
+        {
+            TypeInfo info = this.context.GetTypeInfo(expression);
+            ITypeSymbol type = info.ConvertedType ?? info.Type;
+            if (type == null || type.SpecialType == SpecialType.System_Void || type.TypeKind == TypeKind.Error)
+            {
+                return null;
+            }
+
+            return this.typeMapper.Map(type, this.context, expression.GetLocation());
+        }
+
         private GExpression TranslateIdentifierName(IdentifierNameSyntax identifier)
         {
             // A switch-expression property-pattern binding (`Circle { Radius: var r }`)
@@ -2954,6 +3387,16 @@ public sealed class CSharpToGSharpTranslator
 
                 case SyntaxKind.StringLiteralExpression:
                     return LiteralExpression.String(literal.Token.ValueText);
+
+                case SyntaxKind.Utf8StringLiteralExpression:
+                    // A UTF-8 string literal `"x"u8` is a `ReadOnlySpan<byte>` of
+                    // the UTF-8 encoding of the text. G# has no `u8` suffix, so emit
+                    // the canonical byte slice literal `[]uint8{ … }` (ADR-0115 §B).
+                    return new ArrayLiteralExpression(
+                        new NamedTypeReference("uint8"),
+                        System.Text.Encoding.UTF8.GetBytes(literal.Token.ValueText)
+                            .Select(b => (GExpression)LiteralExpression.Int($"0x{b:X2}"))
+                            .ToList());
 
                 case SyntaxKind.CharacterLiteralExpression:
                     return LiteralExpression.Char(literal.Token.ValueText);
@@ -3720,16 +4163,81 @@ public sealed class CSharpToGSharpTranslator
         {
             // `yield return x` maps to the G# iterator `yield x` (sample
             // TupleSequenceIterators.gs); the enclosing func's return type is
-            // rewritten to `sequence[T]`. `yield break` has no canonical G# form.
+            // rewritten to `sequence[T]`. `yield break` maps to plain `break`
+            // (settled fact: G# has no `yield break`; ADR-0115 §B).
             if (node.Expression == null)
             {
-                this.context.ReportUnsupported(
-                    node,
-                    "'yield break' has no canonical G# form yet (ADR-0115 §B).");
-                return new[] { (GStatement)new RawStatement("// unsupported: yield break") };
+                return new[] { (GStatement)new BreakStatement() };
             }
 
             return new[] { (GStatement)new YieldStatement(this.TranslateExpression(node.Expression)) };
+        }
+
+        private GStatement TranslateForEachVariable(ForEachVariableStatementSyntax node)
+        {
+            // `foreach ((a, b) in xs)` / `foreach (var (a, b) in xs)` map to the
+            // G# two-name iteration `for a, b in xs` (ForInStatement key/value form;
+            // ADR-0115 §B). Tuple element names are collected from the designation.
+            List<string> names = new List<string>();
+            CollectForEachVariableNames(node.Variable, names);
+
+            if (names.Count == 2)
+            {
+                return new ForInStatement(
+                    names[0],
+                    names[1],
+                    this.TranslateExpression(node.Expression),
+                    this.TranslateStatementAsBlock(node.Statement));
+            }
+
+            this.context.ReportUnsupported(
+                node,
+                "foreach tuple deconstruction with arity != 2 has no canonical G# form yet (ADR-0115 §B).");
+            return new RawStatement("// unsupported: foreach variable deconstruction");
+        }
+
+        private static void CollectForEachVariableNames(ExpressionSyntax variable, List<string> names)
+        {
+            switch (variable)
+            {
+                case TupleExpressionSyntax tuple:
+                    foreach (ArgumentSyntax argument in tuple.Arguments)
+                    {
+                        CollectForEachVariableNames(argument.Expression, names);
+                    }
+
+                    break;
+
+                case DeclarationExpressionSyntax declaration:
+                    CollectDesignationNames(declaration.Designation, names);
+                    break;
+
+                case IdentifierNameSyntax identifier:
+                    names.Add(SanitizeIdentifier(identifier.Identifier.Text));
+                    break;
+            }
+        }
+
+        private static void CollectDesignationNames(VariableDesignationSyntax designation, List<string> names)
+        {
+            switch (designation)
+            {
+                case SingleVariableDesignationSyntax single:
+                    names.Add(SanitizeIdentifier(single.Identifier.Text));
+                    break;
+
+                case DiscardDesignationSyntax:
+                    names.Add("_");
+                    break;
+
+                case ParenthesizedVariableDesignationSyntax parenthesized:
+                    foreach (VariableDesignationSyntax child in parenthesized.Variables)
+                    {
+                        CollectDesignationNames(child, names);
+                    }
+
+                    break;
+            }
         }
 
         private GPattern TranslatePattern(


### PR DESCRIPTION
Extends the cs2gs C#→G# translator (issue #914, ADR-0115) to faithfully migrate the external **`Oahu.Decrypt`** project to canonical G#. **Translator-only** — no `gsc` compiler (`src/Core/...`) changes. Genuine compiler gaps are documented for follow-up, not worked around.

## Result

| | translate-stage unsupported |
| --- | --- |
| **Before** | **109** across **19** construct kinds |
| **After** | **7** (3 documented gsc gaps + 4 excepted unsafe `#1014`) |

All **19 target construct kinds** are now translated to canonical G#. Full solution build is **0 warnings / 0 errors**; cs2gs tests **168/168 pass**.

## Constructs now supported (canonical G# form)

Each emitted form round-trips through the real G# parser (gsc `0.2.137+31ced6cfb7`):

- **CollectionExpression** `[a, b, c]` → slice literal `[]T{ … }` (bare numeric literals coerced to the element type, e.g. `byte[]` → `[]uint8{ uint8(0), … }`).
- **ThrowExpression** `x ?? throw e`, `c ? v : throw e` → value-position lowering `if true { throw e\n default(T) } else { default(T) }` (G# `throw` is statement-only); a bare `=> throw e` arrow body → a `throw` statement.
- **ConstantPattern / RelationalPattern / NotPattern / OrPattern / AndPattern / RecursivePattern** in `is` → boolean lowering: `x is 0` → `x == 0`, `x is 1 or 2` → `x == 1 || x == 2`, `x is not T` → `!(x is T)`, `x is >= 0 and < n` → `x >= 0 && x < n`, `x is { }` → `x != nil` (C# precedence `not` > `and` > `or` preserved).
- **RangeExpression** `a[i..j]` / `a[i..]` / `a[..j]` → `.Slice(i, j - i)` / `.Slice(i)` / `.Slice(0, j)` (G# has no range operator — see gap OD-1).
- **SuppressNullableWarningExpression** `expr!` → `expr` (dropped; G# has no nullable-reference annotations).
- **PostIncrement/PostDecrementExpression** as a value (`a[i++] = v`, `M(i--)`, `x = y++`) → statement-seam hoisting: read the pre-increment value, append a trailing `i++` / `i--` statement.
- **YieldBreakStatement** `yield break` → plain `break` (settled fact: G# has no `yield break`).
- **ForEachVariableStatement** `foreach ((a, b) in xs)` → `for a, b in xs`.
- **EventFieldDeclaration** `public event EventHandler<T>? X;` → `event X (object?, T) -> void` (name-then-type, nullable dropped).
- **Utf8StringLiteralExpression** `"AB"u8` → byte slice `[]uint8{ 0x41, 0x42 }`.
- **String control characters** (e.g. C# `"\0\0\0"`) → `\uXXXX` escapes (fixes a raw-NUL `GS0003: Unterminated string literal` round-trip failure that was one of the `CompilationUnit` residuals).

New AST nodes (`ThrowExpression`, `EventDeclaration`), printer cases, translator cases/helpers, and documentation (ADR-0115 §B.36 mapping rules + §G Decrypt outcome).

## Tests

`tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs` — 14 tests covering each construct above; every snippet is asserted to round-trip-parse. Full suite: **168/168 pass** (`dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release`).

## Compiler gaps discovered (for follow-up)

Each reproduced directly with gsc `0.2.137+31ced6cfb7`.

**OD-1 — range operator `a[i..j]` has no canonical G# form.** No `..` range operator in the grammar. The translator lowers corpus `Span`/`Memory` range indices to `.Slice(...)`, so all 7 corpus uses translate; filed for a first-class range surface.
```
package p
class C { func F(s Span[uint8]) Span[uint8] { return s[1..3] } }
// GS0005: Unexpected token — the `..` range form is not in the grammar.
```

**OD-2 — user-defined conversion operator `implicit`/`explicit operator T`.** G#'s `operator` is followed by an operator **token** only (spec §Functions, `OperatorName = "operator" OperatorToken`); there is no implicit/explicit conversion form. Source: `Mpeg4/IAppleData.cs`.
```
package p
class TrackNumber {
    public static implicit operator TrackNumber(tn (int32, int32)) TrackNumber { return TrackNumber() }
}
// GS0288 (field decl requires var/let/const) + GS0113 (Type 'implicit' doesn't exist)
```

**OD-3 — static-abstract *property* in an interface (ADR-0089).** An interface `shared { … }` block accepts only `func` members; static interface state is not supported in this release. C# `public static abstract int SizeInBytes { get; }` has no G# spelling. Source: `Mpeg4/IAppleData.cs`.
```
package p
interface IData { shared { prop SizeInBytes int32 { get } } func Write() }
// GS0330: Only 'func' members are allowed inside the 'shared' block of an interface (ADR-0089).
```

**(Investigated, not a gap) — `Chunks/ChunkReader.cs` `CompilationUnit`.** A C-style `for` whose increment ends in an indexer immediately before the body brace (`start += chunk.FrameSizes[f] {`) is parsed by gsc as a composite literal (`expr[i] { … }`) → `GS0005`. This is a pre-existing translator limitation (multi-declarator/multi-incrementor C-style `for` loops are not fully rendered) compounded by a gsc parse ambiguity; **not** one of the 19 target kinds. Left for a follow-up (lower such `for` loops to `while`, or disambiguate `expr[i] {`).
```
package p
class C { func F(arr []int32) { for var s = 0; s < arr.Length; s += arr[s] { var x = 1 } } }
// GS0005: Unexpected token <VarKeyword>, expected <CloseBraceToken>.
```

## Excepted unsafe (issue #1014)

Four residual diagnostics are the excepted unsafe-interop surface and are **not** forced to a managed G# form:

- `StackAllocArrayCreationExpression` — `stackalloc byte[2]` (`Mpeg4/APICFrame.cs`), `stackalloc byte[4]` (`Mpeg4/Stz2Box.cs`).
- `FixedStatement` — `fixed (byte* pD = destination)` (`Cryptography/AesCtr.cs`).
- `PostDecrementExpression` — `i--` in the short-circuit condition of the `unsafe class AesCtr` do-while (`Cryptography/AesCtr.cs`).

`AesCtr` is an `unsafe class` built on `byte*`/`fixed`/pointer arithmetic (the same pointer surface documented as OF-3), so these remain documented against #1014.

Refs #914
