### PR TITLE
Fix Issue661 nullable enum tests on Windows (CRLF normalization)

### DIFF
--- a/test/Compiler.Tests/Emit/Issue661NullableEnumAssertEqualEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue661NullableEnumAssertEqualEmitTests.cs
@@ -34,7 +34,7 @@ public class Issue661NullableEnumAssertEqualEmitTests
             }
             """;
 
-        Assert.Equal("PASS\n", CompileAndRun(source));
+        Assert.Equal("PASS\n", CompileAndRun(source).Replace("\r\n", "\n"));
     }
 
     [Fact]
@@ -53,7 +53,7 @@ public class Issue661NullableEnumAssertEqualEmitTests
             }
             """;
 
-        Assert.Equal("PASS\n", CompileAndRun(source));
+        Assert.Equal("PASS\n", CompileAndRun(source).Replace("\r\n", "\n"));
     }
 
     [Fact]
@@ -72,7 +72,7 @@ public class Issue661NullableEnumAssertEqualEmitTests
             }
             """;
 
-        Assert.Equal("PASS\n", CompileAndRun(source));
+        Assert.Equal("PASS\n", CompileAndRun(source).Replace("\r\n", "\n"));
     }
 
     [Fact]
@@ -93,7 +93,7 @@ public class Issue661NullableEnumAssertEqualEmitTests
             }
             """;
 
-        Assert.Equal("EQUAL\n", CompileAndRun(source));
+        Assert.Equal("EQUAL\n", CompileAndRun(source).Replace("\r\n", "\n"));
     }
 
     private static string CompileAndRun(string source)


### PR DESCRIPTION
Normalize captured stdout line endings before asserting in `Issue661NullableEnumAssertEqualEmitTests`, matching the pattern already used in newer Issue9xx/10xx Emit tests (e.g. `Issue990UserClassIteratorEmitTests`).

On Windows `Console.WriteLine` emits `\r\n`, so the existing `Assert.Equal("PASS\n", ...)` failed for 4 tests. Linux/macOS were unaffected.

Verified locally: 4/4 pass.

Fixes #1011