### PR TITLE
Skip libc-dependent PInvoke conformance samples on Windows

### DIFF
--- a/test/Compiler.Tests/LanguageConformance/SampleConformanceTests.cs
+++ b/test/Compiler.Tests/LanguageConformance/SampleConformanceTests.cs
@@ -25,6 +25,16 @@ namespace GSharp.Compiler.Tests.LanguageConformance;
 /// </remarks>
 public class SampleConformanceTests
 {
+    // Samples that DllImport Unix-style `libc` and therefore cannot run on
+    // Windows (issue #1010). They remain covered on Linux/macOS.
+    private static readonly HashSet<string> WindowsSkippedSamples = new(StringComparer.Ordinal)
+    {
+        "PInvoke.gs",
+        "PInvokeLibraryImport.gs",
+        "PInvokeRefOutIn.gs",
+        "PInvokeMarshalAs.gs",
+    };
+
     public static IEnumerable<object[]> Samples()
     {
         var samplesDir = LocateSamplesDirectory();
@@ -33,13 +43,22 @@ public class SampleConformanceTests
             yield break;
         }
 
+        var isWindows = OperatingSystem.IsWindows();
+
         // Single-file samples: <name>.gs paired with <name>.golden in samples/.
         foreach (var gs in Directory.EnumerateFiles(samplesDir, "*.gs", SearchOption.TopDirectoryOnly).OrderBy(p => p))
         {
             var golden = Path.ChangeExtension(gs, ".golden");
             if (File.Exists(golden))
             {
-                yield return new object[] { Path.GetFileName(gs) };
+                var fileName = Path.GetFileName(gs);
+                if (isWindows && WindowsSkippedSamples.Contains(fileName))
+                {
+                    // Skipped on Windows: see issue #1010.
+                    continue;
+                }
+
+                yield return new object[] { fileName };
             }
         }
 


### PR DESCRIPTION
The four PInvoke samples `PInvoke.gs`, `PInvokeLibraryImport.gs`, `PInvokeRefOutIn.gs`, and `PInvokeMarshalAs.gs` `DllImport` Unix-style `libc`, which isn't available on Windows and throws `DllNotFoundException` at run time.

Filter them out of `SampleConformanceTests.Samples()` discovery when `OperatingSystem.IsWindows()`; they remain fully covered on Linux/macOS. The controls (`PInvokeFunctionPointer.gs`, `PInvokeStructMarshalling.gs`) continue to run on Windows.

Verified locally on Windows: the 2 control PInvoke tests pass and the 4 libc samples are no longer collected.

Fixes #1010