### PR TITLE
Add from-end index operator `^n` for index/range bounds (#1022)

### DIFF
--- a/docs/adr/0123-from-end-index-operator.md
+++ b/docs/adr/0123-from-end-index-operator.md
@@ -1,0 +1,64 @@
+# ADR-0123: From-end index operator (`^n`) for index and range bounds
+
+- **Status**: Accepted
+- **Date**: 2026-06-23
+- **Phase**: Phase 9 — language depth / collection ergonomics
+- **Related**: issue #1016 (the `..` range/slice operator), issue [#1022](https://github.com/DavidObando/gsharp/issues/1022)
+
+## Context
+
+Issue #1016 added the C#-style `..` range/slice operator inside an indexer
+(`a[lo..hi]`, `a[..hi]`, `a[lo..]`, `a[..]`) for arrays/slices, strings,
+span-like values, and `System.Range` indexers. It intentionally **deferred** the
+C# "from-end" index operator `^n` (`a[^1]`, `a[..^1]`, `a[1..^1]`), which maps to
+`System.Index` with `fromEnd: true`.
+
+The deferral existed because `^` already has two meanings in G#:
+
+- prefix **one's-complement** (`^x`), and
+- infix **bitwise-XOR** (`a ^ b`).
+
+Reusing `^` as a leading from-end marker inside `[...]` is genuinely ambiguous
+with those meanings and needs a deliberate disambiguation rule.
+
+## Decision
+
+1. **Disambiguation by position.** A `^` is treated as a from-end index marker
+   **only in the leading position of an index or range bound** — that is, the
+   first token of the single index in `a[^n]`, or the first token of either side
+   of a range in `a[^lo..^hi]`. The index-argument parser (`ParseIndexArgument`
+   → `ParseIndexBound`) is the only place that recognizes it. Everywhere else —
+   including inside the offset expression itself (`a[^(x ^ y)]`), a non-leading
+   `^` inside the bracket (`a[i ^ j]`), and any `^` outside `[...]` (`^5`,
+   `a ^ b`) — `^` keeps its existing one's-complement / XOR meaning unchanged.
+
+2. **Syntax.** A new `FromEndIndexExpressionSyntax`
+   (`SyntaxKind.FromEndIndexExpression`) wraps the `^` token and its offset
+   operand. It is produced uniformly for both the bare single-index case
+   (`a[^n]`, where it is the index of an `IndexExpressionSyntax`) and as the
+   lower/upper bound of a `RangeExpressionSyntax` (`a[1..^1]`, `a[^2..]`). This
+   keeps the two surfaces consistent and confines the new grammar to the
+   index-argument parser. No new `BoundNodeKind` is introduced.
+
+3. **Binding / lowering.** From-end indices lower to existing bound nodes at bind
+   time (mirroring how #1016 lowered ranges), so emit and the interpreter share
+   one path:
+   - **Single index `a[^n]`** reads `length - n`:
+     - arrays/slices (`[N]T`, `[]T`, CLR `T[]`) → `src[len(src) - n]`;
+     - a type with a `this[System.Index]` indexer → the indexer is called with
+       `System.Index(n, fromEnd: true)` (the runtime resolves the offset);
+     - a type with an `int Length`/`int Count` property plus a `this[int]`
+       indexer (`string`, `List[T]`, span-like) → `src[Length - n]`.
+   - **From-end bound in a range** computes `length - n` at lowering time for the
+     array/string/span-like paths; for a `this[System.Range]` indexer it is
+     passed through as `System.Index(n, fromEnd: true)` so the BCL indexer
+     computes the offset.
+
+## Consequences
+
+- `a[^1]` is the last element, `a[^n]` is `length - n`, and from-end bounds work
+  in every range form, matching C# semantics.
+- The existing one's-complement and XOR uses of `^` are provably unaffected
+  (regression tests assert `^5`, `6 ^ 3`, and `a[i ^ j]` keep their meanings).
+- Standalone `System.Range`-producing expressions (`let r = 1..3`) remain
+  unsupported and are tracked separately as a follow-up.

--- a/docs/coverage-matrix.md
+++ b/docs/coverage-matrix.md
@@ -98,6 +98,7 @@ ForEllipsisStatement
 ForInfiniteStatement
 ForKeyword
 ForRangeStatement
+FromEndIndexExpression
 FuncKeyword
 FunctionDeclaration
 FunctionLiteralExpression

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -2007,6 +2007,13 @@ internal sealed partial class ExpressionBinder
             return BindRangeSlice(target, rangeSyntax, targetLocation);
         }
 
+        // Issue #1022: a from-end index (`a[^n]`) reads the single element
+        // `length - n`.
+        if (indexSyntax is FromEndIndexExpressionSyntax fromEndSyntax)
+        {
+            return BindFromEndIndex(target, fromEndSyntax, targetLocation);
+        }
+
         // Phase 3.A.4: map indexing `m[k]` — key bound to K, result type V.
         // The Go convention "zero value if missing" applies at evaluation;
         // the bound representation reuses BoundIndexExpression with the
@@ -2668,6 +2675,78 @@ internal sealed partial class ExpressionBinder
     //   - `string` -> Substring(start, len).
     //   - span-like types with `int Length`/`int Count` + `Slice(int, int)`.
     //   - types with a `this[System.Range]` indexer -> call it directly.
+    // Issue #1022: bind a single from-end index `target[^n]` to the element at
+    // `length - n`. The bound representation reuses existing nodes wrapped in a
+    // BoundBlockExpression (no new bound-node kind). Indexable shapes mirror C#:
+    //   - arrays / slices (`[N]T`, `[]T`, CLR `T[]`) -> `src[len(src) - n]`.
+    //   - types with a `this[System.Index]` indexer -> call it with `^n`.
+    //   - types with `int Length`/`int Count` + a `this[int]` indexer (string,
+    //     List<T>, span-like) -> `src[Length - n]`.
+    private BoundExpression BindFromEndIndex(BoundExpression target, FromEndIndexExpressionSyntax fromEnd, TextLocation targetLocation)
+    {
+        if (target is BoundErrorExpression || target.Type == TypeSymbol.Error || target.Type == null)
+        {
+            _ = BindExpression(fromEnd.Operand);
+            return new BoundErrorExpression(null);
+        }
+
+        var element = GetIndexElementType(target.Type);
+        if (element != null)
+        {
+            var statements = ImmutableArray.CreateBuilder<BoundStatement>();
+            var srcLocal = DeclareRangeTemp("src", target.Type, target, statements);
+            var idx = MakeFromEndOffset(fromEnd, new BoundLenExpression(null, new BoundVariableExpression(null, srcLocal)));
+            var read = new BoundIndexExpression(null, new BoundVariableExpression(null, srcLocal), idx, element);
+            return new BoundBlockExpression(fromEnd, statements.ToImmutable(), read);
+        }
+
+        var clrType = target.Type.ClrType;
+        if (clrType != null)
+        {
+            if (TryFindIndexIndexer(clrType, out var indexIndexer))
+            {
+                var indexCtor = typeof(System.Index).GetConstructor(new[] { typeof(int), typeof(bool) });
+                var indexSym = TypeSymbol.FromClrType(typeof(System.Index));
+                var offset = conversions.BindConversion(fromEnd.Operand, TypeSymbol.Int32);
+                var indexValue = new BoundClrConstructorCallExpression(
+                    null,
+                    typeof(System.Index),
+                    indexCtor,
+                    ImmutableArray.Create<BoundExpression>(offset, new BoundLiteralExpression(null, true)),
+                    indexSym);
+                var resultType = TypeSymbol.FromClrType(indexIndexer.PropertyType);
+                return new BoundClrIndexExpression(fromEnd, target, indexIndexer, ImmutableArray.Create<BoundExpression>(indexValue), resultType);
+            }
+
+            if (TryFindCountedIntIndexer(clrType, out var lengthMember, out var intIndexer))
+            {
+                var statements = ImmutableArray.CreateBuilder<BoundStatement>();
+                var srcLocal = DeclareRangeTemp("src", target.Type, target, statements);
+                var lengthExpr = new BoundClrPropertyAccessExpression(null, new BoundVariableExpression(null, srcLocal), lengthMember, TypeSymbol.Int32);
+                var idx = MakeFromEndOffset(fromEnd, lengthExpr);
+                var resultType = TypeSymbol.FromClrType(intIndexer.PropertyType);
+                var read = new BoundClrIndexExpression(
+                    null,
+                    new BoundVariableExpression(null, srcLocal),
+                    intIndexer,
+                    ImmutableArray.Create<BoundExpression>(idx),
+                    resultType);
+                return new BoundBlockExpression(fromEnd, statements.ToImmutable(), read);
+            }
+        }
+
+        Diagnostics.ReportTypeNotIndexable(targetLocation, target.Type);
+        return new BoundErrorExpression(null);
+    }
+
+    // `length - n` for a from-end index `^n`.
+    private BoundExpression MakeFromEndOffset(FromEndIndexExpressionSyntax fromEnd, BoundExpression lengthExpr)
+    {
+        var offset = conversions.BindConversion(fromEnd.Operand, TypeSymbol.Int32);
+        var subtractOp = BoundBinaryOperator.Bind(SyntaxKind.MinusToken, TypeSymbol.Int32, TypeSymbol.Int32);
+        return new BoundBinaryExpression(null, lengthExpr, subtractOp, offset);
+    }
+
     private BoundExpression BindRangeSlice(BoundExpression target, RangeExpressionSyntax range, TextLocation targetLocation)
     {
         if (target is BoundErrorExpression || target.Type == TypeSymbol.Error || target.Type == null)
@@ -2739,9 +2818,12 @@ internal sealed partial class ExpressionBinder
         return local;
     }
 
-    // Binds the lower/upper bounds (each optional) as int32 expressions and
-    // emits the `src`, `start`, and `len` temporaries shared by the array,
-    // string, and span-like slicing paths. `len = (upper ?? lengthOf(src)) - start`.
+    // Binds the lower/upper bounds (each optional, each possibly a from-end
+    // `^n` marker — issue #1022) as int32 expressions and emits the `src`,
+    // source-length, `start`, and `len` temporaries shared by the array,
+    // string, and span-like slicing paths. A from-end bound `^n` lowers to
+    // `srcLen - n`; an open lower bound is `0` and an open upper bound is
+    // `srcLen`. `len = upper - start`.
     private (BoundExpression Src, BoundExpression Start, BoundExpression Len) BuildSliceBounds(
         BoundExpression target,
         RangeExpressionSyntax range,
@@ -2749,17 +2831,20 @@ internal sealed partial class ExpressionBinder
         ImmutableArray<BoundStatement>.Builder statements)
     {
         var srcLocal = DeclareRangeTemp("src", target.Type, target, statements);
-        var srcRef = new BoundVariableExpression(null, srcLocal);
 
-        var lowerBound = range.LowerBound != null
-            ? conversions.BindConversion(range.LowerBound, TypeSymbol.Int32)
-            : new BoundLiteralExpression(null, 0);
+        BoundExpression SrcRef() => new BoundVariableExpression(null, srcLocal);
+
+        // Compute the source length once; required for open upper bounds and for
+        // any from-end (`^n`) bound, and harmless otherwise.
+        var srcLenLocal = DeclareRangeTemp("srclen", TypeSymbol.Int32, lengthOf(SrcRef()), statements);
+
+        BoundExpression SrcLenRef() => new BoundVariableExpression(null, srcLenLocal);
+
+        var lowerBound = BindRangeBoundValue(range.LowerBound, SrcLenRef, new BoundLiteralExpression(null, 0));
         var startLocal = DeclareRangeTemp("start", TypeSymbol.Int32, lowerBound, statements);
         var startRef = new BoundVariableExpression(null, startLocal);
 
-        var upperBound = range.UpperBound != null
-            ? conversions.BindConversion(range.UpperBound, TypeSymbol.Int32)
-            : lengthOf(new BoundVariableExpression(null, srcLocal));
+        var upperBound = BindRangeBoundValue(range.UpperBound, SrcLenRef, SrcLenRef());
 
         var subtractOp = BoundBinaryOperator.Bind(SyntaxKind.MinusToken, TypeSymbol.Int32, TypeSymbol.Int32);
         var lengthExpr = new BoundBinaryExpression(null, upperBound, subtractOp, startRef);
@@ -2769,6 +2854,26 @@ internal sealed partial class ExpressionBinder
             new BoundVariableExpression(null, srcLocal),
             new BoundVariableExpression(null, startLocal),
             new BoundVariableExpression(null, lenLocal));
+    }
+
+    // Issue #1022: bind a single range bound to an int32 offset. A from-end
+    // marker `^n` lowers to `srcLen - n`; a missing bound uses
+    // <paramref name="defaultValue"/>; otherwise the bound is the plain value.
+    private BoundExpression BindRangeBoundValue(ExpressionSyntax boundSyntax, Func<BoundExpression> srcLenRef, BoundExpression defaultValue)
+    {
+        if (boundSyntax == null)
+        {
+            return defaultValue;
+        }
+
+        if (boundSyntax is FromEndIndexExpressionSyntax fromEnd)
+        {
+            var offset = conversions.BindConversion(fromEnd.Operand, TypeSymbol.Int32);
+            var subtractOp = BoundBinaryOperator.Bind(SyntaxKind.MinusToken, TypeSymbol.Int32, TypeSymbol.Int32);
+            return new BoundBinaryExpression(null, srcLenRef(), subtractOp, offset);
+        }
+
+        return conversions.BindConversion(boundSyntax, TypeSymbol.Int32);
     }
 
     private BoundExpression BindArraySlice(BoundExpression target, RangeExpressionSyntax range, TypeSymbol elementType)
@@ -2852,8 +2957,21 @@ internal sealed partial class ExpressionBinder
         var indexSym = TypeSymbol.FromClrType(typeof(System.Index));
         var rangeSym = TypeSymbol.FromClrType(typeof(System.Range));
 
-        BoundExpression MakeIndex(ExpressionSyntax boundSyntax, bool fromEnd)
+        BoundExpression MakeIndex(ExpressionSyntax boundSyntax, bool defaultFromEnd)
         {
+            // Issue #1022: a `^n` bound becomes System.Index(n, fromEnd: true);
+            // the System.Range indexer computes the concrete offset at runtime.
+            if (boundSyntax is FromEndIndexExpressionSyntax fromEnd)
+            {
+                var endValue = conversions.BindConversion(fromEnd.Operand, TypeSymbol.Int32);
+                return new BoundClrConstructorCallExpression(
+                    null,
+                    typeof(System.Index),
+                    indexCtor,
+                    ImmutableArray.Create<BoundExpression>(endValue, new BoundLiteralExpression(null, true)),
+                    indexSym);
+            }
+
             var value = boundSyntax != null
                 ? conversions.BindConversion(boundSyntax, TypeSymbol.Int32)
                 : new BoundLiteralExpression(null, 0);
@@ -2861,16 +2979,16 @@ internal sealed partial class ExpressionBinder
                 null,
                 typeof(System.Index),
                 indexCtor,
-                ImmutableArray.Create<BoundExpression>(value, new BoundLiteralExpression(null, fromEnd)),
+                ImmutableArray.Create<BoundExpression>(value, new BoundLiteralExpression(null, defaultFromEnd)),
                 indexSym);
         }
 
         // Open lower defaults to the start (0, from-start); open upper defaults
         // to the end (^0, i.e. value 0 from-end).
-        var startIndex = MakeIndex(range.LowerBound, fromEnd: false);
+        var startIndex = MakeIndex(range.LowerBound, defaultFromEnd: false);
         var endIndex = range.UpperBound != null
-            ? MakeIndex(range.UpperBound, fromEnd: false)
-            : MakeIndex(null, fromEnd: true);
+            ? MakeIndex(range.UpperBound, defaultFromEnd: false)
+            : MakeIndex(null, defaultFromEnd: true);
 
         var rangeValue = new BoundClrConstructorCallExpression(
             null,
@@ -2896,6 +3014,57 @@ internal sealed partial class ExpressionBinder
         }
 
         indexer = null;
+        return false;
+    }
+
+    // Issue #1022: a type that exposes a `this[System.Index]` indexer can serve
+    // a from-end index directly (the indexer resolves `^n` at runtime).
+    private static bool TryFindIndexIndexer(Type clrType, out PropertyInfo indexer)
+    {
+        foreach (var property in clrType.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            var indexParams = property.GetIndexParameters();
+            if (indexParams.Length == 1 && indexParams[0].ParameterType.IsSameAs(typeof(System.Index)))
+            {
+                indexer = property;
+                return true;
+            }
+        }
+
+        indexer = null;
+        return false;
+    }
+
+    // Issue #1022: a type with an `int Length`/`int Count` property and a
+    // `this[int]` indexer (string, List<T>, span-like) can serve a from-end
+    // index as `this[Length - n]`.
+    private static bool TryFindCountedIntIndexer(Type clrType, out MemberInfo lengthMember, out PropertyInfo intIndexer)
+    {
+        lengthMember = null;
+        intIndexer = null;
+
+        var lengthProp = clrType.GetProperty("Length", BindingFlags.Public | BindingFlags.Instance);
+        if (lengthProp == null || !lengthProp.PropertyType.IsSameAs(typeof(int)))
+        {
+            lengthProp = clrType.GetProperty("Count", BindingFlags.Public | BindingFlags.Instance);
+        }
+
+        if (lengthProp == null || !lengthProp.PropertyType.IsSameAs(typeof(int)))
+        {
+            return false;
+        }
+
+        foreach (var property in clrType.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            var indexParams = property.GetIndexParameters();
+            if (indexParams.Length == 1 && indexParams[0].ParameterType.IsSameAs(typeof(int)))
+            {
+                lengthMember = lengthProp;
+                intIndexer = property;
+                return true;
+            }
+        }
+
         return false;
     }
 

--- a/src/Core/CodeAnalysis/Syntax/FromEndIndexExpressionSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/FromEndIndexExpressionSyntax.cs
@@ -1,0 +1,45 @@
+// <copyright file="FromEndIndexExpressionSyntax.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Core.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Issue #1022: represents a C#-style "from-end" index marker <c>^n</c> used in
+/// the leading position of an index or range bound (<c>a[^1]</c>,
+/// <c>a[1..^1]</c>, <c>a[^2..]</c>). The offset is measured from the end of the
+/// indexed value, mapping to <c>System.Index(n, fromEnd: true)</c> semantics:
+/// the concrete offset is <c>length - n</c>.
+/// </summary>
+/// <remarks>
+/// This node is produced only by the index-argument parser, so the prefix
+/// <c>^</c> one's-complement and infix <c>^</c> bitwise-XOR meanings of the hat
+/// token are unchanged everywhere else in the grammar.
+/// </remarks>
+public sealed class FromEndIndexExpressionSyntax : ExpressionSyntax
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FromEndIndexExpressionSyntax"/> class.
+    /// </summary>
+    /// <param name="syntaxTree">The parent syntax tree.</param>
+    /// <param name="hatToken">The leading <c>^</c> marker token.</param>
+    /// <param name="operand">The from-end offset expression (<c>n</c> in <c>^n</c>).</param>
+    public FromEndIndexExpressionSyntax(
+        SyntaxTree syntaxTree,
+        SyntaxToken hatToken,
+        ExpressionSyntax operand)
+        : base(syntaxTree)
+    {
+        HatToken = hatToken;
+        Operand = operand;
+    }
+
+    /// <inheritdoc/>
+    public override SyntaxKind Kind => SyntaxKind.FromEndIndexExpression;
+
+    /// <summary>Gets the leading <c>^</c> marker token.</summary>
+    public SyntaxToken HatToken { get; }
+
+    /// <summary>Gets the from-end offset expression.</summary>
+    public ExpressionSyntax Operand { get; }
+}

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -6200,7 +6200,7 @@ public class Parser
         if (Current.Kind != SyntaxKind.DotDotToken
             && Current.Kind != SyntaxKind.CloseSquareBracketToken)
         {
-            lower = ParseExpression();
+            lower = ParseIndexBound();
         }
 
         if (Current.Kind != SyntaxKind.DotDotToken)
@@ -6216,10 +6216,28 @@ public class Parser
         if (Current.Kind != SyntaxKind.CloseSquareBracketToken
             && Current.Kind != SyntaxKind.DotDotToken)
         {
-            upper = ParseExpression();
+            upper = ParseIndexBound();
         }
 
         return new RangeExpressionSyntax(syntaxTree, lower, dotDotToken, upper);
+    }
+
+    // Issue #1022: parse a single index/range bound, recognising a leading `^`
+    // as the C# "from-end" index marker (`a[^1]`, `a[1..^1]`) rather than the
+    // one's-complement unary operator. The disambiguation is intentionally
+    // scoped to this leading position: a `^` anywhere else (including inside the
+    // offset expression itself, e.g. `a[^(x ^ y)]`) keeps its ordinary
+    // one's-complement / bitwise-XOR meaning.
+    private ExpressionSyntax ParseIndexBound()
+    {
+        if (Current.Kind == SyntaxKind.HatToken)
+        {
+            var hatToken = NextToken();
+            var operand = ParseExpression();
+            return new FromEndIndexExpressionSyntax(syntaxTree, hatToken, operand);
+        }
+
+        return ParseExpression();
     }
 
     // be reused as the LHS of an indexer assignment. Returns true and yields a

--- a/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
@@ -164,6 +164,7 @@ public enum SyntaxKind
     MapEntry,
     IndexExpression,
     RangeExpression,
+    FromEndIndexExpression,
     IndexAssignmentExpression,
     MemberIndexAssignmentExpression,
     CompoundIndexAssignmentExpression,

--- a/test/Compiler.Tests/Emit/Issue1022FromEndIndexEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1022FromEndIndexEmitTests.cs
@@ -1,0 +1,232 @@
+// <copyright file="Issue1022FromEndIndexEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1022: the from-end index marker <c>^n</c> indexes/slices from the end
+/// of an array, slice, string, or span-like value. These tests compile and run
+/// emitted programs and assert the printed results, covering:
+/// <list type="bullet">
+/// <item><description>a bare <c>a[^n]</c> single-element read (<c>length - n</c>).</description></item>
+/// <item><description>from-end bounds in ranges (<c>a[1..^1]</c>, <c>a[..^3]</c>, <c>a[^2..]</c>).</description></item>
+/// <item><description>arrays/slices, strings, and span-like (<c>ArraySegment</c>) targets.</description></item>
+/// <item><description>regression: one's-complement and XOR <c>^</c> are unchanged.</description></item>
+/// </list>
+/// </summary>
+public class Issue1022FromEndIndexEmitTests
+{
+    [Fact]
+    public void IntArray_SingleFromEndIndex()
+    {
+        var source = """
+            package P
+            import System
+
+            let a = []int32{10, 20, 30, 40, 50}
+            Console.WriteLine(a[^1])
+            Console.WriteLine(a[^2])
+            Console.WriteLine(a[^5])
+            """;
+
+        Assert.Equal("50\n40\n10\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void IntArray_FromEndUpperBound_DropsLast()
+    {
+        var source = """
+            package P
+            import System
+
+            let a = []int32{10, 20, 30, 40, 50}
+            let b = a[1..^1]
+            Console.WriteLine(b.Length)
+            Console.WriteLine(b[0])
+            Console.WriteLine(b[2])
+            """;
+
+        Assert.Equal("3\n20\n40\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void IntArray_FromEndUpperBound_OpenLower()
+    {
+        var source = """
+            package P
+            import System
+
+            let a = []int32{10, 20, 30, 40, 50}
+            let b = a[..^3]
+            Console.WriteLine(b.Length)
+            Console.WriteLine(b[0])
+            Console.WriteLine(b[1])
+            """;
+
+        Assert.Equal("2\n10\n20\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void IntArray_FromEndLowerBound_OpenUpper()
+    {
+        var source = """
+            package P
+            import System
+
+            let a = []int32{10, 20, 30, 40, 50}
+            let b = a[^2..]
+            Console.WriteLine(b.Length)
+            Console.WriteLine(b[0])
+            Console.WriteLine(b[1])
+            """;
+
+        Assert.Equal("2\n40\n50\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void IntArray_FromEndBothBounds()
+    {
+        var source = """
+            package P
+            import System
+
+            let a = []int32{10, 20, 30, 40, 50}
+            let b = a[^4..^1]
+            Console.WriteLine(b.Length)
+            Console.WriteLine(b[0])
+            Console.WriteLine(b[2])
+            """;
+
+        Assert.Equal("3\n20\n40\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void String_FromEndForms()
+    {
+        var source = """
+            package P
+            import System
+
+            let s = "abcdef"
+            Console.WriteLine(s[..^3])
+            Console.WriteLine(s[1..^1])
+            Console.WriteLine(s[^2..])
+            """;
+
+        Assert.Equal("abc\nbcde\nef\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void ArraySegment_SpanLikeFromEndSlice()
+    {
+        // ArraySegment[T] has `int Count`; from-end bounds compute against it.
+        var source = """
+            package P
+            import System
+
+            let arr = []int32{10, 20, 30, 40, 50}
+            let seg = ArraySegment[int32](arr)
+            let sub = seg[1..^1]
+            Console.WriteLine(sub.Count)
+            Console.WriteLine(sub[0])
+            Console.WriteLine(sub[2])
+            """;
+
+        Assert.Equal("3\n20\n40\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void OnesComplementAndXor_Unchanged()
+    {
+        // Regression: prefix `^` (one's-complement) and infix `^` (XOR) keep
+        // their existing meanings outside the leading index-bound position.
+        var source = """
+            package P
+            import System
+
+            let a = []int32{10, 20, 30, 40, 50}
+            Console.WriteLine(^0)
+            Console.WriteLine(6 ^ 3)
+            Console.WriteLine(a[1 ^ 2])
+            """;
+
+        Assert.Equal("-1\n5\n40\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1022_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi);
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1022FromEndIndexBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1022FromEndIndexBindingTests.cs
@@ -1,0 +1,108 @@
+// <copyright file="Issue1022FromEndIndexBindingTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1022: binder/interpreter coverage for the from-end index marker
+/// <c>^n</c>. A bare <c>a[^n]</c> reads <c>length - n</c>; from-end bounds in a
+/// range compute the concrete offset at lowering time. Regression checks keep
+/// the one's-complement / XOR meanings of <c>^</c> intact.
+/// </summary>
+public class Issue1022FromEndIndexBindingTests
+{
+    [Fact]
+    public void SingleFromEndIndex_LastElement()
+    {
+        var result = Evaluate("var xs = [5]int32{10, 20, 30, 40, 50}\nxs[^1]");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(50, result.Value);
+    }
+
+    [Fact]
+    public void SingleFromEndIndex_NthFromEnd()
+    {
+        var result = Evaluate("var xs = [5]int32{10, 20, 30, 40, 50}\nxs[^2]");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(40, result.Value);
+    }
+
+    [Fact]
+    public void FromEndUpperBound_DropsLast()
+    {
+        var result = Evaluate("var xs = [5]int32{10, 20, 30, 40, 50}\nlet ys = xs[1..^1]\nys[0] + ys[ys.Length - 1]");
+        Assert.Empty(result.Diagnostics);
+
+        // ys = {20, 30, 40}; first + last = 60.
+        Assert.Equal(60, result.Value);
+    }
+
+    [Fact]
+    public void FromEndUpperBound_OpenLower_DropsLastThree()
+    {
+        var result = Evaluate("var xs = [5]int32{10, 20, 30, 40, 50}\nlet ys = xs[..^3]\nys.Length * 1000 + ys[0] + ys[1]");
+        Assert.Empty(result.Diagnostics);
+
+        // ys = {10, 20}; len 2 -> 2030.
+        Assert.Equal(2030, result.Value);
+    }
+
+    [Fact]
+    public void FromEndLowerBound_OpenUpper_LastTwo()
+    {
+        var result = Evaluate("var xs = [5]int32{10, 20, 30, 40, 50}\nlet ys = xs[^2..]\nys.Length * 1000 + ys[0] + ys[1]");
+        Assert.Empty(result.Diagnostics);
+
+        // ys = {40, 50}; len 2 -> 2090.
+        Assert.Equal(2090, result.Value);
+    }
+
+    [Fact]
+    public void StringSlice_FromEndUpperBound()
+    {
+        var result = Evaluate("let s = \"abcdef\"\ns[..^3]");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("abc", result.Value);
+    }
+
+    [Fact]
+    public void StringSlice_FromEndBothEnds()
+    {
+        var result = Evaluate("let s = \"abcdef\"\ns[1..^1]");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("bcde", result.Value);
+    }
+
+    [Fact]
+    public void OnesComplement_StillEvaluates()
+    {
+        var result = Evaluate("^0");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(-1, result.Value);
+    }
+
+    [Fact]
+    public void Xor_StillEvaluates()
+    {
+        var result = Evaluate("6 ^ 3");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(5, result.Value);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue1022FromEndIndexParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue1022FromEndIndexParserTests.cs
@@ -1,0 +1,114 @@
+// <copyright file="Issue1022FromEndIndexParserTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Issue #1022: parser-level coverage for the from-end index marker <c>^n</c>.
+/// In the leading position of an index/range bound the hat token introduces a
+/// <see cref="FromEndIndexExpressionSyntax"/> (<c>a[^1]</c>, <c>a[1..^1]</c>,
+/// <c>a[^2..]</c>); everywhere else <c>^</c> keeps its one's-complement /
+/// bitwise-XOR meaning.
+/// </summary>
+public class Issue1022FromEndIndexParserTests
+{
+    private static ExpressionSyntax GetInitializer(string source)
+    {
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+        var stmt = tree.Root.Members
+            .OfType<GlobalStatementSyntax>()
+            .Select(g => g.Statement)
+            .OfType<VariableDeclarationSyntax>()
+            .Single();
+        return stmt.Initializer;
+    }
+
+    [Fact]
+    public void SingleFromEndIndex_ParsesAsFromEndMarker()
+    {
+        var index = Assert.IsType<IndexExpressionSyntax>(GetInitializer("""
+            package P
+            let x = a[^1]
+            """));
+        var fromEnd = Assert.IsType<FromEndIndexExpressionSyntax>(index.Index);
+        Assert.Equal(SyntaxKind.HatToken, fromEnd.HatToken.Kind);
+        Assert.IsType<LiteralExpressionSyntax>(fromEnd.Operand);
+    }
+
+    [Fact]
+    public void FromEndUpperBound_InClosedRange()
+    {
+        var index = Assert.IsType<IndexExpressionSyntax>(GetInitializer("""
+            package P
+            let x = a[1..^1]
+            """));
+        var range = Assert.IsType<RangeExpressionSyntax>(index.Index);
+        Assert.IsType<LiteralExpressionSyntax>(range.LowerBound);
+        Assert.IsType<FromEndIndexExpressionSyntax>(range.UpperBound);
+    }
+
+    [Fact]
+    public void FromEndUpperBound_InOpenLowerRange()
+    {
+        var index = Assert.IsType<IndexExpressionSyntax>(GetInitializer("""
+            package P
+            let x = a[..^3]
+            """));
+        var range = Assert.IsType<RangeExpressionSyntax>(index.Index);
+        Assert.Null(range.LowerBound);
+        Assert.IsType<FromEndIndexExpressionSyntax>(range.UpperBound);
+    }
+
+    [Fact]
+    public void FromEndLowerBound_InOpenUpperRange()
+    {
+        var index = Assert.IsType<IndexExpressionSyntax>(GetInitializer("""
+            package P
+            let x = a[^2..]
+            """));
+        var range = Assert.IsType<RangeExpressionSyntax>(index.Index);
+        Assert.IsType<FromEndIndexExpressionSyntax>(range.LowerBound);
+        Assert.Null(range.UpperBound);
+    }
+
+    [Fact]
+    public void FromEnd_BothBounds()
+    {
+        var index = Assert.IsType<IndexExpressionSyntax>(GetInitializer("""
+            package P
+            let x = a[^3..^1]
+            """));
+        var range = Assert.IsType<RangeExpressionSyntax>(index.Index);
+        Assert.IsType<FromEndIndexExpressionSyntax>(range.LowerBound);
+        Assert.IsType<FromEndIndexExpressionSyntax>(range.UpperBound);
+    }
+
+    [Fact]
+    public void OnesComplement_OutsideBrackets_StillUnary()
+    {
+        // Prefix `^` outside an index bound remains one's-complement.
+        var unary = Assert.IsType<UnaryExpressionSyntax>(GetInitializer("""
+            package P
+            let x = ^5
+            """));
+        Assert.Equal(SyntaxKind.HatToken, unary.OperatorToken.Kind);
+    }
+
+    [Fact]
+    public void Xor_Binary_StillParsesInsideBrackets()
+    {
+        // A non-leading `^` inside the bracket is the binary XOR operator, not a
+        // from-end marker.
+        var index = Assert.IsType<IndexExpressionSyntax>(GetInitializer("""
+            package P
+            let x = a[i ^ j]
+            """));
+        Assert.IsType<BinaryExpressionSyntax>(index.Index);
+    }
+}

--- a/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
+++ b/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
@@ -98,6 +98,7 @@ ForEllipsisStatement
 ForInfiniteStatement
 ForKeyword
 ForRangeStatement
+FromEndIndexExpression
 FuncKeyword
 FunctionDeclaration
 FunctionLiteralExpression

--- a/website/docs/ref/spec.md
+++ b/website/docs/ref/spec.md
@@ -59,7 +59,7 @@ Several words are contextual rather than reserved. `data`, `inline`, `prop`, `ev
 
 ### Operators and punctuation
 
-Compound assignment recognizes `+=`, `-=`, `*=`, `/=`, `%=`, `^=`, `&=`, `|=`, `&^=`, `<<=`, and `>>=`. The parser rewrites these as assignment with the corresponding binary operator. `++` and `--` are statement forms on identifiers. The null-coalescing compound assignment `??=` (ADR-0072) writes the right-hand side into the left only when the lvalue currently reads as nil; see [Null-coalescing compound assignment](#null-coalescing-compound-assignment--adr-0072) under *Statements*. The `..` range operator slices a sliceable value inside an indexer (`a[lo..hi]`); see [Range and slice expressions](#range-and-slice-expressions-issue-1016). `@` begins annotations on declarations.
+Compound assignment recognizes `+=`, `-=`, `*=`, `/=`, `%=`, `^=`, `&=`, `|=`, `&^=`, `<<=`, and `>>=`. The parser rewrites these as assignment with the corresponding binary operator. `++` and `--` are statement forms on identifiers. The null-coalescing compound assignment `??=` (ADR-0072) writes the right-hand side into the left only when the lvalue currently reads as nil; see [Null-coalescing compound assignment](#null-coalescing-compound-assignment--adr-0072) under *Statements*. The `..` range operator slices a sliceable value inside an indexer (`a[lo..hi]`), and a leading `^n` marks a from-end index (`a[^1]`, `a[1..^1]`); see [Range and slice expressions](#range-and-slice-expressions-issue-1016). `@` begins annotations on declarations.
 
 ### Integer literals
 
@@ -687,7 +687,28 @@ The binder resolves the target type to one of the following sliceable shapes and
 | Span-like value (`int Length`/`int Count` + `Slice(int, int)`, e.g. `Span[T]`, `ReadOnlySpan[T]`, `Memory[T]`, `ArraySegment[T]`) | `value.Slice(start, length)` |
 | A type exposing an indexer accepting `System.Range` | the `this[System.Range]` indexer is called directly with a constructed `System.Range` |
 
-Slicing a target that matches none of these shapes reports `GS0392`. The from-end index operator (`^n`, as in `a[..^1]`) is **not** supported because `^` is already the one's-complement / bitwise-XOR operator in G#; from-end indices are tracked as a follow-up. Standalone `System.Range` values (`let r = 1..3`) are likewise not yet supported.
+Slicing a target that matches none of these shapes reports `GS0392`.
+
+#### From-end indices (`^n`, issue #1022)
+
+A **from-end index** marker `^n` (mirroring C# `System.Index` with `fromEnd: true`) is recognized in the *leading position* of an index or range bound. It measures the offset `n` from the end of the target, i.e. the concrete offset is `length - n`:
+
+```gsharp
+let xs = []int32{10, 20, 30, 40, 50}
+let last = xs[^1]    // last element -> 50
+let nth  = xs[^2]    // second from end -> 40
+let a = xs[1..^1]    // drop first and last -> {20, 30, 40}
+let b = xs[..^3]     // all but last 3 -> {10, 20}
+let c = xs[^2..]     // last 2 -> {40, 50}
+let s = "abcdef"
+let head = s[..^3]   // "abc"
+```
+
+A bare `a[^n]` reads the single element `length - n` from an array/slice, a `string`, or any value with an `int Length`/`int Count` property plus a `this[int]` or `this[System.Index]` indexer. Inside a range, a from-end bound computes `length - n` at lowering time for the array/string/span-like paths, and is passed through as `System.Index(n, fromEnd: true)` when the target exposes a `this[System.Range]` indexer.
+
+The `^n` marker is only recognized at the *start* of an index/range bound. Elsewhere — including inside the offset expression itself (e.g. `a[^(x ^ y)]`) — `^` keeps its ordinary prefix one's-complement and infix bitwise-XOR meanings unchanged. For example, `a[i ^ j]` is an XOR-computed single index, and `^5` outside brackets is one's-complement.
+
+Standalone `System.Range` values (`let r = 1..3`) are not yet supported and are tracked separately.
 
 ### Composite literals
 
@@ -1416,7 +1437,8 @@ BinaryOperator    ::= '*' | '/' | '%' | '<<' | '>>' | '&' | '&^'
 PrefixExpression  ::= ('+' | '-' | '!' | '^' | '*' | '&' | '<-' | 'await') PrefixExpression | PostfixExpression
 PostfixExpression ::= PrimaryExpression PostfixOp*
 PostfixOp         ::= '!!' | ('.' | '?.') NameOrCall | ('[' | '?[') IndexArgument ']'
-IndexArgument     ::= Expression | Expression? '..' Expression?   (* range/slice form, issue #1016 *)
+IndexArgument     ::= IndexBound | IndexBound? '..' IndexBound?   (* range/slice form, issue #1016; from-end via issue #1022 *)
+IndexBound        ::= '^'? Expression                            (* leading '^' marks a from-end index, issue #1022 *)
 NameOrCall        ::= identifier | Call | GenericCall
 PrimaryExpression ::= Literal | identifier
                     | Call | GenericCall | NullableTypeCall | ObjectCreation


### PR DESCRIPTION
## Summary

Implements the C# **from-end index operator `^n`** (issue #1022), extending the
`..` range/slice operator from #1016. `^n` maps to `System.Index` from-end
semantics — the concrete offset is `length - n`.

- `a[^1]` → last element; `a[^n]` → `length - n`.
- From-end bounds in every range form: `a[1..^1]` (drop first+last), `a[..^3]`
  (all but last 3), `a[^2..]` (last 2), `a[^4..^1]` (both ends from end).
- Targets: arrays/slices, `string`, span-like (`Length`/`Count` + `Slice` /
  `this[int]`), and `this[System.Range]` / `this[System.Index]` indexers.
  Array/string/span paths compute `length - n` at lowering time; `System.Range`
  indexer targets pass `System.Index(n, fromEnd: true)` through to the BCL.

## Disambiguation

`^` is recognized as a from-end marker **only in the leading position of an
index/range bound** (scoped to the index-argument parser). Everywhere else —
prefix one's-complement (`^5`), infix XOR (`a ^ b`, `a[i ^ j]`), and `^` inside
the offset expression — keeps its existing meaning, proven by regression tests.

## Implementation notes

- New `FromEndIndexExpressionSyntax` / `SyntaxKind.FromEndIndexExpression`,
  produced uniformly for the bare single-index case and as range bounds.
  Coverage-matrix golden + `docs/coverage-matrix.md` updated accordingly.
- **No new `BoundNodeKind`** — from-end lowers to existing bound nodes
  (`BoundBlockExpression` + temps), mirroring #1016. No exhaustiveness-allowlist
  or refactoring-baseline changes were needed (no new sample added).
- Docs: `website/docs/ref/spec.md` (range/slice section + grammar) and new
  **ADR-0123** recording the `^` disambiguation rule and lowering.

## Tests

- Parser: `Issue1022FromEndIndexParserTests` (single + range bounds, XOR /
  one's-complement still parse correctly).
- Binder/interpreter: `Issue1022FromEndIndexBindingTests`.
- Emit (CompileAndRun + ilverify): `Issue1022FromEndIndexEmitTests` covering
  arrays, strings, `ArraySegment`, and the one's-complement/XOR regression.

Verified locally: `dotnet build GSharp.sln -c Release -graph` → 0 errors; full
`Core.Tests` 3611 passed / 1 skipped; `Compiler.Tests` filtered to
`Issue1022|Issue1016` → 18 passed.

## Deferred

Standalone `System.Range` values (`let r = 1..3`) — explicitly a related,
separable item in #1022 — are tracked separately in #1038 (general-expression
precedence for `..`, `^n` ambiguity at expression start, and indexing by a
`Range` variable are independent design decisions).

Fixes #1022
