### PR TITLE
Fix #1023: C-style for with indexer-tailed header mis-parsed as composite literal

### DIFF
--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -4910,7 +4910,19 @@ public class Parser
         StatementSyntax post = null;
         if (Current.Kind != SyntaxKind.OpenBraceToken)
         {
-            post = ParseSimpleStatement();
+            // Issue #1023: the post statement sits immediately before the body
+            // `{`. Suppress trailing object-initializer wrapping so an indexer-
+            // or call-tailed post (`s += arr[s] { … }`) does not consume the
+            // loop body's opening brace as a composite literal.
+            suppressTrailingObjectInitializer++;
+            try
+            {
+                post = ParseSimpleStatement();
+            }
+            finally
+            {
+                suppressTrailingObjectInitializer--;
+            }
         }
 
         var body = ParseStatement();
@@ -6946,9 +6958,28 @@ public class Parser
 
         // Follow-set per ADR-0020: '(' (call), '{' (composite literal), '.' (member access).
         var nextKind = Peek(pos).Kind;
-        if (nextKind == SyntaxKind.OpenParenthesisToken
-            || nextKind == SyntaxKind.OpenBraceToken)
+        if (nextKind == SyntaxKind.OpenParenthesisToken)
         {
+            return true;
+        }
+
+        if (nextKind == SyntaxKind.OpenBraceToken)
+        {
+            // Issue #1023: in a statement-header controlling expression
+            // (`if`/`while`/`for` clauses, `switch`/`match` subject, …) the
+            // trailing `{` opens the statement body, not a composite literal.
+            // The same Go-style suppression that blocks `Type { … }` /
+            // `Call() { … }` here must also block the generic-composite
+            // `name[args] { … }` shape, so an indexer-tailed header such as
+            // `for …; s += arr[s] { … }` binds `[s]` as an indexer and lets
+            // `{` open the loop body. Nested contexts (parens, brackets,
+            // argument lists) clear the counter, so `List[int]{…}` still
+            // parses inside those.
+            if (suppressTrailingObjectInitializer > 0)
+            {
+                return false;
+            }
+
             return true;
         }
 

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue1023ForIndexerHeaderParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue1023ForIndexerHeaderParserTests.cs
@@ -1,0 +1,153 @@
+// <copyright file="Issue1023ForIndexerHeaderParserTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Issue #1023: a C-style <c>for</c> whose increment (or condition) ends in an
+/// indexer (<c>expr[i]</c>) immediately before the body <c>{</c> must bind the
+/// <c>[i]</c> as an indexer and let <c>{</c> open the loop body — it must NOT
+/// be mis-parsed as the generic-composite literal shape <c>name[args] { … }</c>.
+/// <para>
+/// The shared Go-style suppression that already blocks <c>Type { … }</c> and
+/// <c>Call() { … }</c> in statement-header controlling expressions
+/// (<c>if</c>/<c>while</c>/<c>for</c> clauses, <c>switch</c>/<c>match</c>
+/// subject) is now also honoured by <c>LooksLikeGenericCallSite</c> for the
+/// trailing <c>{</c> follow-set marker. These tests lock that contract in at
+/// the parser layer and guard against regressing legitimate composite-literal
+/// parsing in expression position.
+/// </para>
+/// </summary>
+public class Issue1023ForIndexerHeaderParserTests
+{
+    private static IEnumerable<SyntaxNode> Descendants(SyntaxNode node)
+    {
+        foreach (var child in node.GetChildren())
+        {
+            yield return child;
+            foreach (var d in Descendants(child))
+            {
+                yield return d;
+            }
+        }
+    }
+
+    [Fact]
+    public void ForClause_Post_Ending_In_Indexer_Parses_Without_Diagnostics()
+    {
+        // The canonical repro from the issue.
+        const string source = @"
+package p
+class C { func F(arr []int32) { for var s = 0; s < arr.Length; s += arr[s] { var x = 1 } } }
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var forClause = Descendants(tree.Root).OfType<ForClauseStatementSyntax>().Single();
+
+        // The post must be `s += arr[s]` (an indexer-tailed assignment), and the
+        // body must be a real block — not swallowed by a composite literal.
+        Assert.NotNull(forClause.Post);
+        Assert.IsType<BlockStatementSyntax>(forClause.Body);
+
+        // No part of the header may have been reinterpreted as a struct literal.
+        Assert.Empty(Descendants(forClause.Post).OfType<StructLiteralExpressionSyntax>());
+        Assert.Contains(Descendants(forClause.Post), n => n is IndexExpressionSyntax);
+    }
+
+    [Fact]
+    public void ForClause_Condition_Ending_In_Indexer_Parses_Without_Diagnostics()
+    {
+        const string source = @"
+package p
+class C { func F(arr []int32) { for var i = 0; arr[i] > 0; i = i + 1 { break } } }
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var forClause = Descendants(tree.Root).OfType<ForClauseStatementSyntax>().Single();
+        Assert.IsType<BlockStatementSyntax>(forClause.Body);
+        Assert.Contains(Descendants(forClause.Condition), n => n is IndexExpressionSyntax);
+    }
+
+    [Fact]
+    public void ForCondition_Form_Ending_In_Indexer_Parses_Without_Diagnostics()
+    {
+        // The condition-only `for cond { … }` form whose condition ends in an
+        // indexer must also let `{` open the body.
+        const string source = @"
+package p
+class C { func F(arr []bool) { for arr[0] { break } } }
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var forCond = Descendants(tree.Root).OfType<ForConditionStatementSyntax>().Single();
+        Assert.IsType<BlockStatementSyntax>(forCond.Body);
+    }
+
+    [Fact]
+    public void If_With_Indexer_Tailed_Condition_Parses_Without_Diagnostics()
+    {
+        const string source = @"
+package p
+class C { func F(arr []int32) { if arr[0] > 0 { var x = 1 } } }
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+    }
+
+    [Fact]
+    public void While_With_Indexer_Tailed_Condition_Parses_Without_Diagnostics()
+    {
+        const string source = @"
+package p
+class C { func F(arr []int32) { while arr[0] > 0 { break } } }
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+    }
+
+    [Fact]
+    public void GenericCompositeLiteral_In_Expression_Position_Still_Parses_As_StructLiteral()
+    {
+        // Regression guard: the suppression must apply ONLY in statement-header
+        // controlling-expression contexts. In ordinary expression position a
+        // `name[args] { … }` shape is still a generic composite literal.
+        const string source = @"
+package p
+class Box[T] { var Value T }
+class C { func F() { var b = Box[int32]{Value: 42} } }
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var structLiteral = Descendants(tree.Root).OfType<StructLiteralExpressionSyntax>().Single();
+        Assert.Equal("Box", structLiteral.TypeIdentifier.Text);
+        Assert.NotNull(structLiteral.TypeArgumentList);
+        Assert.Single(structLiteral.Initializers);
+    }
+
+    [Fact]
+    public void BareStructLiteral_In_Expression_Position_Still_Parses()
+    {
+        const string source = @"
+package p
+class Point { var X int32
+ var Y int32 }
+class C { func F() { var p = Point{X: 1, Y: 2} } }
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var structLiteral = Descendants(tree.Root).OfType<StructLiteralExpressionSyntax>().Single();
+        Assert.Equal("Point", structLiteral.TypeIdentifier.Text);
+        Assert.Equal(2, structLiteral.Initializers.Count);
+    }
+}

--- a/website/docs/ref/spec.md
+++ b/website/docs/ref/spec.md
@@ -990,6 +990,18 @@ The optional `SimpleStmt` of the C-style three-part `for` accepts a `var`
 or `let` declaration (e.g. `for var i = 0; i < n; i++`), an assignment, an
 increment / decrement, or an expression statement.
 
+A controlling expression in a statement header — the `for` condition or
+post-statement, the condition-only `for`/`while` condition, the `if`
+condition, and the `switch`/`match` subject — never treats a trailing `{` as
+a composite-literal brace. As in Go, the `{` opens the statement body. This
+applies even when the controlling expression ends in an indexer
+(`for var s = 0; s < n; s += arr[s] { … }`) or a generic-composite shape
+(`name[args] { … }`): the brackets bind as an indexer / type-argument list and
+the following `{` opens the body. Composite literals are still parsed normally
+in ordinary expression position (`var b = Box[int32]{Value: 42}`,
+`Point{X: 1, Y: 2}`) and inside a nested parenthesized/bracketed/argument
+context within a header (issue #1023).
+
 `while` evaluates its condition first and runs the body while the condition is
 true. `do`-`while` always runs the body once before evaluating the condition;
 the body must be a block.


### PR DESCRIPTION
## Summary
Fixes #1023.

A C-style `for` whose increment (or condition) ends in an indexer `expr[i]`
immediately before the body `{` was mis-parsed as a generic-composite
literal `name[args] { ... }`, failing with `GS0005`.

### Repro (now compiles)
```gsharp
package p
class C { func F(arr []int32) { for var s = 0; s < arr.Length; s += arr[s] { var x = 1 } } }
```

## Root cause
In a statement-header controlling expression, `if`/`while` already suppress
trailing composite/object-initializer wrapping via the
`suppressTrailingObjectInitializer` counter (`ParseExpressionInBodyHeader`).
Two gaps let the `for` post slip through:

1. `ParseForClauseStatement` parsed the `post` simple statement without
   raising the suppression counter, even though `post` sits immediately
   before the body `{`.
2. `LooksLikeGenericCallSite` committed `name[args] {` to a generic composite
   literal site for the `{` follow-set marker regardless of the suppression
   flag.

## Fix (`src/Core/CodeAnalysis/Syntax/Parser.cs`)
- `ParseForClauseStatement`: parse `post` with `suppressTrailingObjectInitializer`
  raised, mirroring the condition.
- `LooksLikeGenericCallSite`: when the follow-set marker is `{` and suppression
  is active, return `false` — the brackets bind as an indexer and `{` opens the
  body, matching Go composite-literal-in-statement-header rules.

`if`/`while` already suppressed this (via `ParseExpressionInBodyHeader`); only
the `for` path needed the propagation, plus the shared `LooksLikeGenericCallSite`
guard.

## Compatibility
Composite literals in ordinary expression position still parse and bind:
`var b = Box[int32]{Value: 42}`, `var p = Point{X: 1, Y: 2}`. Nested
paren/bracket/argument contexts within a header clear the counter, so
`List[int]{...}` still works there.

## Tests
- New `test/Core.Tests/CodeAnalysis/Syntax/Issue1023ForIndexerHeaderParserTests.cs`
  (7 tests): repro parses; indexer-tailed `if`/`while`/`for` headers all parse;
  for-condition ending in an indexer parses; generic + bare composite literals in
  expression position still parse as `StructLiteralExpressionSyntax`.
- `--filter "FullyQualifiedName~Issue1023"` -> 7 passed.
- Existing for-loop / composite / generic / struct-literal parser tests -> 480 passed.
- Full `CodeAnalysis.Syntax` namespace -> 652 passed.

No new `SyntaxKind`/`BoundNodeKind` and no new top-level sample. Spec updated
(`website/docs/ref/spec.md`, For loops section).
