### PR TITLE
Fix #1046: support jagged/nested array element types (`[][]T`, `[]*T`, `[]map[K]V`)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -1992,6 +1992,22 @@ public sealed class Binder
             return ChannelTypeSymbol.Get(elementType);
         }
 
+        // Issue #1046: an array/slice whose element is itself a (non-identifier)
+        // nested type clause — jagged arrays `[][]T`, arrays of pointers `[]*T`,
+        // arrays of maps `[]map[K,V]`, etc. The element is bound recursively and
+        // wrapped in the appropriate slice/array symbol, mirroring the flat
+        // identifier-element path below.
+        if (syntax.IsArray && syntax.HasNestedArrayElement)
+        {
+            var nestedElement = BindTypeClause(syntax.ArrayElementType);
+            if (nestedElement == null)
+            {
+                return null;
+            }
+
+            return ApplyArraySuffix(syntax, nestedElement);
+        }
+
         // ADR-0040: sequence type clause `sequence[T]`.
         // ADR-0042: `async sequence[T]` resolves to IAsyncEnumerable[T] in any
         // type-clause position; the unmodified `sequence[T]` stays IEnumerable[T]
@@ -2126,10 +2142,10 @@ public sealed class Binder
                     // the type-erased closed CLR shape so call-site inference,
                     // return-type substitution, and user-type emit can recover
                     // the real type argument.
-                    return ImportedTypeSymbol.GetConstructed(closed, clrOpenType, symbolicArgs.MoveToImmutable());
+                    return ApplyArraySuffix(syntax, ImportedTypeSymbol.GetConstructed(closed, clrOpenType, symbolicArgs.MoveToImmutable()));
                 }
 
-                return TypeSymbol.FromClrType(closed);
+                return ApplyArraySuffix(syntax, TypeSymbol.FromClrType(closed));
             }
             catch (System.ArgumentException)
             {
@@ -2242,7 +2258,22 @@ public sealed class Binder
             }
         }
 
-        if (!syntax.IsArray)
+        return ApplyArraySuffix(syntax, element);
+    }
+
+    /// <summary>
+    /// Wraps a resolved element type in the slice/array symbol implied by the
+    /// array prefix of <paramref name="syntax"/> (<c>[]T</c> → slice, <c>[N]T</c>
+    /// → fixed-length array), or returns the element unchanged when the clause
+    /// has no array prefix. Reports an invalid-array-length diagnostic and
+    /// returns <c>null</c> when a fixed-length prefix carries a malformed length.
+    /// </summary>
+    /// <param name="syntax">The (possibly array-prefixed) type clause.</param>
+    /// <param name="element">The already-resolved element type.</param>
+    /// <returns>The slice/array symbol, the element itself, or <c>null</c> on error.</returns>
+    private TypeSymbol ApplyArraySuffix(TypeClauseSyntax syntax, TypeSymbol element)
+    {
+        if (element == null || !syntax.IsArray)
         {
             return element;
         }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
@@ -844,11 +844,25 @@ internal sealed partial class ExpressionBinder
 
     internal BoundExpression BindArrayCreationExpression(ArrayCreationExpressionSyntax syntax)
     {
-        var elementType = lookupType(syntax.ElementTypeIdentifier.Text);
-        if (elementType == null)
+        TypeSymbol elementType;
+        if (syntax.HasNestedElementTypeClause)
         {
-            Diagnostics.ReportUndefinedType(syntax.ElementTypeIdentifier.Location, syntax.ElementTypeIdentifier.Text);
-            return new BoundErrorExpression(null);
+            // Issue #1046: jagged-array literal — the element is a nested type
+            // clause (`[][]int32{ … }`), resolved recursively.
+            elementType = bindTypeClause(syntax.ElementTypeClause);
+            if (elementType == null)
+            {
+                return new BoundErrorExpression(null);
+            }
+        }
+        else
+        {
+            elementType = lookupType(syntax.ElementTypeIdentifier.Text);
+            if (elementType == null)
+            {
+                Diagnostics.ReportUndefinedType(syntax.ElementTypeIdentifier.Location, syntax.ElementTypeIdentifier.Text);
+                return new BoundErrorExpression(null);
+            }
         }
 
         var elements = ImmutableArray.CreateBuilder<BoundExpression>(syntax.Elements.Count);

--- a/src/Core/CodeAnalysis/Syntax/ArrayCreationExpressionSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/ArrayCreationExpressionSyntax.cs
@@ -40,6 +40,39 @@ public sealed class ArrayCreationExpressionSyntax : ExpressionSyntax
         CloseBraceToken = closeBraceToken;
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ArrayCreationExpressionSyntax"/> class
+    /// whose element type is itself a (non-identifier) nested type clause — enabling
+    /// jagged-array literals such as <c>[][]int32{ []int32{1}, []int32{2, 3} }</c> (issue #1046).
+    /// </summary>
+    /// <param name="syntaxTree">The parent syntax tree.</param>
+    /// <param name="openBracketToken">The opening bracket token.</param>
+    /// <param name="lengthToken">The literal length token.</param>
+    /// <param name="closeBracketToken">The closing bracket token.</param>
+    /// <param name="elementTypeClause">The nested element type clause.</param>
+    /// <param name="openBraceToken">The opening brace token.</param>
+    /// <param name="elements">The element initialisers.</param>
+    /// <param name="closeBraceToken">The closing brace token.</param>
+    public ArrayCreationExpressionSyntax(
+        SyntaxTree syntaxTree,
+        SyntaxToken openBracketToken,
+        SyntaxToken lengthToken,
+        SyntaxToken closeBracketToken,
+        TypeClauseSyntax elementTypeClause,
+        SyntaxToken openBraceToken,
+        SeparatedSyntaxList<ExpressionSyntax> elements,
+        SyntaxToken closeBraceToken)
+        : base(syntaxTree)
+    {
+        OpenBracketToken = openBracketToken;
+        LengthToken = lengthToken;
+        CloseBracketToken = closeBracketToken;
+        ElementTypeClause = elementTypeClause;
+        OpenBraceToken = openBraceToken;
+        Elements = elements;
+        CloseBraceToken = closeBraceToken;
+    }
+
     /// <inheritdoc/>
     public override SyntaxKind Kind => SyntaxKind.ArrayCreationExpression;
 
@@ -52,8 +85,14 @@ public sealed class ArrayCreationExpressionSyntax : ExpressionSyntax
     /// <summary>Gets the closing bracket token.</summary>
     public SyntaxToken CloseBracketToken { get; }
 
-    /// <summary>Gets the element type identifier.</summary>
+    /// <summary>Gets the element type identifier, or <c>null</c> when the element is a nested type clause (see <see cref="ElementTypeClause"/>).</summary>
     public SyntaxToken ElementTypeIdentifier { get; }
+
+    /// <summary>Gets the nested element type clause for a jagged-array literal (issue #1046), or <c>null</c> when the element is a plain identifier carried via <see cref="ElementTypeIdentifier"/>.</summary>
+    public TypeClauseSyntax ElementTypeClause { get; }
+
+    /// <summary>Gets a value indicating whether this literal's element type is a nested type clause rather than a plain identifier (issue #1046).</summary>
+    public bool HasNestedElementTypeClause => ElementTypeClause != null;
 
     /// <summary>Gets the opening brace token.</summary>
     public SyntaxToken OpenBraceToken { get; }

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -3448,10 +3448,61 @@ public class Parser
             }
 
             var closeBracket = MatchToken(SyntaxKind.CloseSquareBracketToken);
+
+            // Issue #1046: a jagged/nested array element — the element type is
+            // itself a non-identifier type clause (`[][]T`, `[]*T`, `[]map[K,V]`,
+            // `[]chan T`, `[]func(...) R`, `[](T1, T2)`, …). When the token after
+            // `]` does not begin a plain (possibly dotted/generic) identifier
+            // element, parse the element recursively and store it as a nested
+            // type clause via `TypeClauseSyntax.CreateArray`. The common
+            // `[]Identifier`/`[]Foo.Bar`/`[]List[int32]` forms keep the existing
+            // flat representation so nothing regresses.
+            if (Current.Kind != SyntaxKind.IdentifierToken)
+            {
+                var nestedElement = ParseTypeClause();
+                var nestedQuestion = Current.Kind == SyntaxKind.QuestionToken ? MatchToken(SyntaxKind.QuestionToken) : null;
+                return TypeClauseSyntax.CreateArray(
+                    syntaxTree,
+                    openBracket,
+                    length,
+                    closeBracket,
+                    nestedElement,
+                    nestedQuestion);
+            }
+
             var elementIdentifier = MatchToken(SyntaxKind.IdentifierToken);
 
             // Issue #526: an array/slice of a nested CLR type — `[]Outer.Inner`.
             var (arrayDots, arrayQualifiers) = ParseQualifierSegments();
+
+            // Phase 4.3c: an array/slice of a constructed generic type —
+            // `[]List[int32]`. The optional type-argument list attaches to the
+            // (last) element identifier, mirroring the non-array path below.
+            SyntaxToken arrayTypeArgOpen = null;
+            SeparatedSyntaxList<TypeClauseSyntax> arrayTypeArgs = default;
+            SyntaxToken arrayTypeArgClose = null;
+            if (Current.Kind == SyntaxKind.OpenSquareBracketToken)
+            {
+                arrayTypeArgOpen = MatchToken(SyntaxKind.OpenSquareBracketToken);
+                var nodesAndSeparators = ImmutableArray.CreateBuilder<SyntaxNode>();
+                while (Current.Kind != SyntaxKind.CloseSquareBracketToken &&
+                       Current.Kind != SyntaxKind.EndOfFileToken)
+                {
+                    nodesAndSeparators.Add(ParseTypeClause());
+                    if (Current.Kind == SyntaxKind.CommaToken)
+                    {
+                        nodesAndSeparators.Add(MatchToken(SyntaxKind.CommaToken));
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+
+                arrayTypeArgs = new SeparatedSyntaxList<TypeClauseSyntax>(nodesAndSeparators.ToImmutable());
+                arrayTypeArgClose = MatchToken(SyntaxKind.CloseSquareBracketToken);
+            }
+
             var arrayQuestion = Current.Kind == SyntaxKind.QuestionToken ? MatchToken(SyntaxKind.QuestionToken) : null;
             return new TypeClauseSyntax(
                 syntaxTree,
@@ -3461,9 +3512,9 @@ public class Parser
                 elementIdentifier,
                 arrayDots,
                 arrayQualifiers,
-                typeArgumentOpenBracketToken: null,
-                typeArguments: default,
-                typeArgumentCloseBracketToken: null,
+                arrayTypeArgOpen,
+                arrayTypeArgs,
+                arrayTypeArgClose,
                 arrayQuestion);
         }
 
@@ -6889,6 +6940,28 @@ public class Parser
         }
 
         var closeBracket = MatchToken(SyntaxKind.CloseSquareBracketToken);
+
+        // Issue #1046: a jagged-array literal whose element is itself a
+        // non-identifier type clause (`[][]int32{ … }`, `[]*int32{ … }`, …).
+        // Parse the element recursively when the token after `]` does not begin
+        // a plain identifier element; otherwise keep the flat identifier form.
+        if (Current.Kind != SyntaxKind.IdentifierToken)
+        {
+            var nestedElementType = ParseTypeClause();
+            var nestedOpenBrace = MatchToken(SyntaxKind.OpenBraceToken);
+            var nestedElements = ParseArrayInitializerElements();
+            var nestedCloseBrace = MatchToken(SyntaxKind.CloseBraceToken);
+            return new ArrayCreationExpressionSyntax(
+                syntaxTree,
+                openBracket,
+                length,
+                closeBracket,
+                nestedElementType,
+                nestedOpenBrace,
+                nestedElements,
+                nestedCloseBrace);
+        }
+
         var elementType = MatchToken(SyntaxKind.IdentifierToken);
         var openBrace = MatchToken(SyntaxKind.OpenBraceToken);
         var elements = ParseArrayInitializerElements();

--- a/src/Core/CodeAnalysis/Syntax/TypeClauseSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/TypeClauseSyntax.cs
@@ -232,6 +232,28 @@ public sealed class TypeClauseSyntax : SyntaxNode
     }
 #pragma warning restore SA1642
 
+    /// <summary>Initializes a new instance of the <see cref="TypeClauseSyntax"/> class for an array/slice whose element is itself a (non-identifier) nested type clause — e.g. a jagged array <c>[][]T</c>, an array of pointers <c>[]*T</c>, or an array of maps <c>[]map[K,V]</c> (issue #1046).</summary>
+#pragma warning disable SA1642
+    private TypeClauseSyntax(
+        SyntaxTree syntaxTree,
+        SyntaxToken openBracketToken,
+        SyntaxToken lengthToken,
+        SyntaxToken closeBracketToken,
+        TypeClauseSyntax arrayElementType,
+        SyntaxToken questionToken,
+        bool isNestedArray)
+        : base(syntaxTree)
+    {
+        OpenBracketToken = openBracketToken;
+        LengthToken = lengthToken;
+        CloseBracketToken = closeBracketToken;
+        ArrayElementType = arrayElementType;
+        QuestionToken = questionToken;
+        QualifierDotTokens = ImmutableArray<SyntaxToken>.Empty;
+        QualifierIdentifierTokens = ImmutableArray<SyntaxToken>.Empty;
+    }
+#pragma warning restore SA1642
+
     /// <summary>Initializes a new instance of the <see cref="TypeClauseSyntax"/> class for a sequence type (ADR-0040) — optionally prefixed by the <c>async</c> modifier per ADR-0042.</summary>
 #pragma warning disable SA1642
     private TypeClauseSyntax(
@@ -425,6 +447,12 @@ public sealed class TypeClauseSyntax : SyntaxNode
     /// <summary>Gets a value indicating whether this clause denotes an array-shaped type (fixed-length array or slice).</summary>
     public bool IsArray => OpenBracketToken != null;
 
+    /// <summary>Gets the nested element type clause for a jagged/nested array (issue #1046), or <c>null</c> when the array element is a plain identifier element carried via <see cref="Identifier"/>/<see cref="QualifierIdentifierTokens"/>/<see cref="TypeArguments"/>.</summary>
+    public TypeClauseSyntax ArrayElementType { get; }
+
+    /// <summary>Gets a value indicating whether this array/slice clause stores its element as a nested type clause (jagged array, array of pointers, array of maps, …) rather than a flat identifier element (issue #1046).</summary>
+    public bool HasNestedArrayElement => ArrayElementType != null;
+
     /// <summary>Gets a value indicating whether this clause denotes a variable-length slice type <c>[]T</c>.</summary>
     public bool IsSlice => OpenBracketToken != null && LengthToken == null;
 
@@ -592,6 +620,25 @@ public sealed class TypeClauseSyntax : SyntaxNode
         SyntaxToken questionToken)
     {
         return new TypeClauseSyntax(syntaxTree, starToken, pointeeType, questionToken, isPointer: true);
+    }
+
+    /// <summary>Creates an array/slice type clause <c>[N]T</c>/<c>[]T</c> whose element <paramref name="elementType"/> is itself a nested type clause — enabling jagged arrays <c>[][]T</c>, arrays of pointers <c>[]*T</c>, arrays of maps <c>[]map[K,V]</c>, etc. (issue #1046).</summary>
+    /// <param name="syntaxTree">The parent syntax tree.</param>
+    /// <param name="openBracketToken">The opening <c>[</c> token of the array/slice prefix.</param>
+    /// <param name="lengthToken">The numeric length token for a fixed-length array, or <c>null</c> for a slice.</param>
+    /// <param name="closeBracketToken">The closing <c>]</c> token of the array/slice prefix.</param>
+    /// <param name="elementType">The nested element type clause.</param>
+    /// <param name="questionToken">The optional trailing <c>?</c> nullability marker.</param>
+    /// <returns>An array/slice type clause carrying a nested element type clause.</returns>
+    public static TypeClauseSyntax CreateArray(
+        SyntaxTree syntaxTree,
+        SyntaxToken openBracketToken,
+        SyntaxToken lengthToken,
+        SyntaxToken closeBracketToken,
+        TypeClauseSyntax elementType,
+        SyntaxToken questionToken)
+    {
+        return new TypeClauseSyntax(syntaxTree, openBracketToken, lengthToken, closeBracketToken, elementType, questionToken, isNestedArray: true);
     }
 
     /// <summary>Creates a sequence type clause <c>sequence[T]</c> (ADR-0040).</summary>

--- a/test/Compiler.Tests/Emit/Issue1046JaggedArrayEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1046JaggedArrayEmitTests.cs
@@ -1,0 +1,180 @@
+// <copyright file="Issue1046JaggedArrayEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// End-to-end emit tests for issue #1046 — jagged/nested array types. The
+/// array/slice element is now a full nested type clause, so <c>[][]T</c>
+/// (jagged), <c>[]*T</c> and <c>[]map[K]V</c> parse, bind and emit. These tests
+/// build a runnable program, ilverify it, execute it and assert the runtime
+/// output. The motivating case is C# <c>byte[][]</c> → G# <c>[][]uint8</c>.
+/// <para>
+/// Note: depth is exercised here with double-nested array literals. Triple+
+/// nested array <em>literals</em> can exceed the historical fixed method
+/// <c>maxstack</c> of 8 — a pre-existing engine limitation that affects any
+/// deeply nested expression (e.g. <c>add(1, add(2, add(3, …)))</c>), not just
+/// arrays — so it is intentionally out of scope here. Triple-nested array
+/// <em>type clauses</em> (e.g. <c>[][][]int32</c> declarations) work fine.
+/// </para>
+/// </summary>
+public class Issue1046JaggedArrayEmitTests
+{
+    [Fact]
+    public void JaggedSliceLiteral_AllocatesReadsElements_PrintsValues()
+    {
+        // The core issue scenario: declare a jagged slice, build it from inner
+        // slice literals, read its length and individual elements.
+        var source = """
+            package Test
+            import System
+            var jagged [][]int32 = [][]int32{ []int32{1, 2}, []int32{3, 4, 5} }
+            Console.WriteLine(jagged.Length)
+            Console.WriteLine(jagged[0][1])
+            Console.WriteLine(jagged[1][2])
+            """;
+
+        Assert.Equal("2\n2\n5\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void JaggedByteArray_TheMotivatingCsharpCase_RoundTrips()
+    {
+        // C# `byte[][]` maps to G# `[][]uint8` (DashChunkReader.cs migration).
+        var source = """
+            package Test
+            import System
+            var rows [][]uint8 = [][]uint8{ []uint8{uint8(10), uint8(20)}, []uint8{uint8(30)} }
+            Console.WriteLine(rows.Length)
+            Console.WriteLine(rows[0][1])
+            Console.WriteLine(rows[1][0])
+            """;
+
+        Assert.Equal("2\n20\n30\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void JaggedSlice_AssignedThroughParameterAndReturn_RoundTrips()
+    {
+        // Jagged types flow through parameter and return positions.
+        var source = """
+            package Test
+            import System
+            func first(grid [][]int32) []int32 { return grid[0] }
+            var grid [][]int32 = [][]int32{ []int32{7, 8}, []int32{9} }
+            var row []int32 = first(grid)
+            Console.WriteLine(row[1])
+            """;
+
+        Assert.Equal("8\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void JaggedSlice_IsPattern_SmartCast_Runs()
+    {
+        // `o is [][]uint8` smart-cast parses, binds and evaluates at runtime.
+        var source = """
+            package Test
+            import System
+            func check(o object) bool {
+                return o is [][]uint8
+            }
+            var rows [][]uint8 = [][]uint8{ []uint8{uint8(1)}, []uint8{uint8(2)} }
+            Console.WriteLine(check(rows))
+            """;
+
+        Assert.Equal("True\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1046_run_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var (compileExit, compileText) = RunCompiler(new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            });
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileText}");
+            IlVerifier.Verify(outPath);
+
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            TryDeleteDirectory(tempDir);
+        }
+    }
+
+    private static (int Exit, string Output) RunCompiler(string[] args)
+    {
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        return (compileExit, compileOut.ToString() + compileErr.ToString());
+    }
+
+    private static void TryDeleteDirectory(string dir)
+    {
+        try
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+        catch
+        {
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue1046JaggedArrayParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue1046JaggedArrayParserTests.cs
@@ -1,0 +1,225 @@
+// <copyright file="Issue1046JaggedArrayParserTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Issue #1046: the array/slice type clause <c>[]T</c> previously required the
+/// element <c>T</c> to be a bare (qualified, possibly generic) identifier, so
+/// jagged arrays <c>[][]T</c>, arrays of pointers <c>[]*T</c> and arrays of
+/// maps <c>[]map[K]V</c> failed to parse with GS0005. The element is now a full
+/// nested <see cref="TypeClauseSyntax"/> (mirroring the pointer/chan/map element
+/// recursion). These tests cover the parser layer; binding/runtime behaviour is
+/// covered by emit tests in test/Compiler.Tests/Emit/.
+/// </summary>
+public class Issue1046JaggedArrayParserTests
+{
+    private static TypeClauseSyntax LocalVarType(string typeText)
+    {
+        var source = $@"
+package P
+func Use() {{
+    var x {typeText} = default({typeText})
+}}
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+        var fn = tree.Root.Members.OfType<FunctionDeclarationSyntax>().Single();
+        var varDecl = fn.Body.Statements.OfType<VariableDeclarationSyntax>().Single();
+        Assert.NotNull(varDecl.TypeClause);
+        return varDecl.TypeClause;
+    }
+
+    [Fact]
+    public void JaggedSlice_InVarDeclaration_Parses_AsNestedSliceElement()
+    {
+        // The exact repro from the issue body: `var x [][]uint8 = default(...)`.
+        var type = LocalVarType("[][]uint8");
+
+        Assert.True(type.IsArray);
+        Assert.True(type.IsSlice);
+        Assert.True(type.HasNestedArrayElement);
+
+        var inner = type.ArrayElementType;
+        Assert.NotNull(inner);
+        Assert.True(inner.IsSlice);
+        Assert.False(inner.HasNestedArrayElement);
+        Assert.Equal("uint8", inner.Identifier.Text);
+    }
+
+    [Fact]
+    public void TripleNestedSlice_Parses_TwoLevelsDeep()
+    {
+        var type = LocalVarType("[][][]int32");
+
+        Assert.True(type.IsSlice);
+        Assert.True(type.HasNestedArrayElement);
+        var lvl2 = type.ArrayElementType;
+        Assert.True(lvl2.IsSlice);
+        Assert.True(lvl2.HasNestedArrayElement);
+        var lvl3 = lvl2.ArrayElementType;
+        Assert.True(lvl3.IsSlice);
+        Assert.False(lvl3.HasNestedArrayElement);
+        Assert.Equal("int32", lvl3.Identifier.Text);
+    }
+
+    [Fact]
+    public void SizedJaggedArray_Parses_WithLengthAndNestedSliceElement()
+    {
+        var type = LocalVarType("[3][]uint8");
+
+        Assert.True(type.IsArray);
+        Assert.False(type.IsSlice);
+        Assert.NotNull(type.LengthToken);
+        Assert.True(type.HasNestedArrayElement);
+        Assert.True(type.ArrayElementType.IsSlice);
+    }
+
+    [Fact]
+    public void ArrayOfMap_Parses_WithNestedMapElement()
+    {
+        var type = LocalVarType("[]map[string,int32]");
+
+        Assert.True(type.IsSlice);
+        Assert.True(type.HasNestedArrayElement);
+        Assert.True(type.ArrayElementType.IsMap);
+    }
+
+    [Fact]
+    public void ArrayOfChannel_Parses_WithNestedChannelElement()
+    {
+        var type = LocalVarType("[]chan int32");
+
+        Assert.True(type.IsSlice);
+        Assert.True(type.HasNestedArrayElement);
+        Assert.True(type.ArrayElementType.IsChannel);
+    }
+
+    [Fact]
+    public void ArrayOfPointer_Parses_WithNestedPointerElement()
+    {
+        var type = LocalVarType("[]*int32");
+
+        Assert.True(type.IsSlice);
+        Assert.True(type.HasNestedArrayElement);
+        Assert.True(type.ArrayElementType.IsPointer);
+    }
+
+    [Fact]
+    public void JaggedSlice_InParameterPosition_Parses()
+    {
+        const string source = @"
+package P
+func Use(grid [][]uint8) {
+}
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+        var fn = tree.Root.Members.OfType<FunctionDeclarationSyntax>().Single();
+        var param = fn.Parameters.Single();
+        Assert.True(param.Type.IsSlice);
+        Assert.True(param.Type.HasNestedArrayElement);
+        Assert.True(param.Type.ArrayElementType.IsSlice);
+    }
+
+    [Fact]
+    public void JaggedSlice_InReturnPosition_Parses()
+    {
+        const string source = @"
+package P
+func Make() [][]uint8 {
+    return default([][]uint8)
+}
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+        var fn = tree.Root.Members.OfType<FunctionDeclarationSyntax>().Single();
+        Assert.True(fn.Type.IsSlice);
+        Assert.True(fn.Type.HasNestedArrayElement);
+        Assert.True(fn.Type.ArrayElementType.IsSlice);
+    }
+
+    [Fact]
+    public void JaggedSlice_InFieldPosition_Parses()
+    {
+        const string source = @"
+package P
+class Grid {
+    var Cells [][]uint8
+}
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+    }
+
+    [Fact]
+    public void JaggedSlice_InIsPattern_Parses()
+    {
+        const string source = @"
+package P
+func Use(o object) bool {
+    return o is [][]uint8
+}
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+    }
+
+    // ---- Regression: existing element forms must still parse the flat path. ----
+
+    [Fact]
+    public void SingleSlice_OfIdentifier_StillParses_Flat()
+    {
+        var type = LocalVarType("[]uint8");
+
+        Assert.True(type.IsSlice);
+        Assert.False(type.HasNestedArrayElement);
+        Assert.Equal("uint8", type.Identifier.Text);
+    }
+
+    [Fact]
+    public void Slice_OfQualifiedName_StillParses_Flat()
+    {
+        var type = LocalVarType("[]Outer.Inner");
+
+        Assert.True(type.IsSlice);
+        Assert.False(type.HasNestedArrayElement);
+        Assert.Equal("Outer", type.Identifier.Text);
+        Assert.Equal("Outer.Inner", type.DottedName);
+    }
+
+    [Fact]
+    public void Slice_OfGenericName_StillParses_Flat()
+    {
+        var type = LocalVarType("[]List[int32]");
+
+        Assert.True(type.IsSlice);
+        Assert.False(type.HasNestedArrayElement);
+        Assert.Equal("List", type.Identifier.Text);
+        Assert.True(type.HasTypeArguments);
+    }
+
+    [Fact]
+    public void Pointer_OfIdentifier_StillParses()
+    {
+        var type = LocalVarType("*int32");
+
+        Assert.True(type.IsPointer);
+        Assert.False(type.IsArray);
+        Assert.NotNull(type.PointerPointeeType);
+    }
+
+    [Fact]
+    public void Map_StillParses()
+    {
+        var type = LocalVarType("map[string,int32]");
+
+        Assert.True(type.IsMap);
+        Assert.False(type.IsArray);
+    }
+}

--- a/website/docs/ref/spec.md
+++ b/website/docs/ref/spec.md
@@ -161,11 +161,12 @@ Integral types are `int8`, `uint8`, `int16`, `uint16`, `int32`, `uint32`, `int64
 
 ### Arrays and slices
 
-Fixed arrays are written `[N]T`, and slices are written `[]T`. Array and slice composite literals use the same bracketed prefix with an element type identifier:
+Fixed arrays are written `[N]T`, and slices are written `[]T`. The element type `T` is an arbitrary type clause, not just an identifier (issue #1046): it may itself be an array/slice, so jagged arrays such as `[][]uint8` (the G# spelling of C# `byte[][]`) and deeper nestings (`[][][]int32`) are allowed, as are arrays of pointers (`[]*int32`), maps (`[]map[K]V`), channels (`[]chan T`), and generic or qualified names (`[]List[int32]`, `[]Outer.Inner`). Array and slice composite literals use the same bracketed prefix with the element type, which likewise may be nested (`[][]int32{ []int32{1, 2}, []int32{3} }`):
 
 ```gsharp
 let xs = []int32{1, 2, 3}
 let ys = [3]int32{1, 2, 3}
+let grid = [][]int32{ []int32{1, 2}, []int32{3, 4, 5} }
 ```
 
 Slices are backed by CLR arrays. `len` and `cap` observe array length, and `append` allocates and copies into a new array in the current implementation. The `len`, `cap`, `append`, `delete`, and `make` built-ins are Go-style and require `import Gsharp.Extensions.Go` (ADR-0083); see [Go-style built-ins (`import Gsharp.Extensions.Go`)](#go-style-built-ins-import-gsharpextensionsgo) for the gate and the .NET-idiomatic alternatives (`.Length`, `.Count`, `.Remove(k)`, `List[T].Add`).
@@ -331,7 +332,8 @@ The implementation emits **reified CLR generic metadata** for user-declared and 
 
 ```ebnf
 TypeClause = identifier TypeArgList? "?"?
-           | "[" number? "]" identifier "?"?
+           | "[" number? "]" identifier TypeArgList? "?"?
+           | "[" number? "]" TypeClause "?"?
            | "(" TypeClause { "," TypeClause } ")" "?"?
            | "(" TypeClauseList? ")" "->" TypeClause "?"?
            | "async" "(" TypeClauseList? ")" "->" TypeClause "?"?


### PR DESCRIPTION
## Summary
The array/slice type clause `[]T` required the element `T` to be a bare (qualified, possibly generic) **identifier**, so jagged arrays `[][]T`, arrays of pointers `[]*T`, and arrays of maps `[]map[K]V` failed to parse with `GS0005`. C# `byte[][]` (G# `[][]uint8`) — discovered migrating `Oahu.Decrypt`'s `DashChunkReader.cs` — could not be expressed.

## Root cause
`Parser.ParseTypeClause()`'s array arm consumed `[` `]` then did `MatchToken(IdentifierToken)` for the element, storing a **flat** representation (identifier + qualifier dots + type-args) on `TypeClauseSyntax`. A `[`/`*`/`map`-introduced element could neither be represented nor parsed.

## Fix
Make the array **element** an arbitrary nested `TypeClauseSyntax`, mirroring the existing pointer/chan/map element recursion:

- **`Parser.ParseTypeClause`** — when the token after `]` does not begin a plain identifier element, recurse into `ParseTypeClause()` and store the element via the new `TypeClauseSyntax.CreateArray(...)` factory. The flat identifier path is kept for `[]Identifier`/`[]Foo.Bar` (no regression) and now also consumes a trailing generic type-argument list (`[]List[int32]`).
- **`TypeClauseSyntax`** — nested-array constructor + `ArrayElementType`/`HasNestedArrayElement` + `CreateArray` factory.
- **`Binder.BindNonNullableTypeClause`** — bind a nested array element recursively; factor slice/array wrapping into `ApplyArraySuffix`, routing the generic-import and method-end paths through it (fixes `[]List[int32]` resolving to a slice).
- **`ArrayCreationExpressionSyntax` / `ExpressionBinder.BindArrayCreationExpression` / `Parser.ParseArrayCreationExpression`** — extend jagged-array **literals** (`[][]int32{ ... }`) the same way, so jagged arrays can actually be allocated.

Representation chosen: a nested `TypeClauseSyntax ArrayElementType` (mirrors `PointerPointeeType`/`ChanElementType`/`MapValueType`). **No new `SyntaxKind`/`BoundNodeKind`** and **no new sample** — only existing nodes extended (tripwires satisfied; no coverage-matrix/baseline regen needed).

`[]*T` (array of pointers, in an `unsafe` context) **is included**.

## Tests
- `test/Core.Tests/CodeAnalysis/Syntax/Issue1046JaggedArrayParserTests.cs` (15 tests): `[][]uint8` repro; depth 2 & 3; sized `[3][]uint8`; `[]map`, `[]chan`, `[]*int32`; decl/param/return/field/`is` positions; regression for `[]uint8`, `[]Outer.Inner`, `[]List[int32]`, `*T`, `map`.
- `test/Compiler.Tests/Emit/Issue1046JaggedArrayEmitTests.cs` (4 tests): end-to-end allocate/read jagged `[][]int32` & `[][]uint8` (the `byte[][]` case), param/return round-trip, `is [][]uint8` — each ilverified + executed with asserted stdout.

Results:
- `dotnet build GSharp.sln -c Release -graph` → **0 Error(s)**
- Core.Tests full: **3656 passed**, 1 skipped (incl. `RefactoringBaseline` 131 passed — byte-identical IL gate intact)
- `--filter FullyQualifiedName~Issue1046` (Core): **15 passed**
- `--filter FullyQualifiedName~Issue1046` (Compiler): **4 passed**
- `--filter Array|Slice|TypeClause` (Compiler): **135 passed**

## Docs
`website/docs/ref/spec.md` array-type section + EBNF updated to state the element is a full type clause (jagged arrays allowed).

## Known limitation (pre-existing, out of scope)
Triple+ nested array **literals** can exceed the historical fixed method `maxstack` of 8 → `InvalidProgramException`. This is a **pre-existing** engine limitation affecting any deeply nested expression (e.g. `add(1, add(2, add(3, ...)))` crashes identically), not specific to arrays. Triple+ nested array **type clauses** (`[][][]int32` declarations/`default`) work. A global `maxstack` fix was deliberately reverted because it would rewrite every method header and break the byte-identical `RefactoringBaseline` gate; it warrants its own PR.

Fixes #1046