### PR TITLE
cs2gs: emit faithful G# for conversion operators, stackalloc, fixed, and inc/dec-as-expression

### DIFF
--- a/docs/adr/0115-csharp-to-gsharp-migration-tool.md
+++ b/docs/adr/0115-csharp-to-gsharp-migration-tool.md
@@ -513,13 +513,44 @@ empirically (gsc **0.2.137+31ced6cfb7**) before adoption.
   asserts non-null (spec: "Postfix `!!` asserts non-null"), the direct analogue
   of the C# null-forgiving operator, so the `SuppressNullableWarningExpression`
   operand is preserved with `!!` rather than dropped.
-- **Post-increment/decrement as an expression → statement-seam hoisting.** G#
-  models `++`/`--` as **statements** on identifiers. A `PostIncrementExpression`/
-  `PostDecrementExpression` used as a **value** (`a[i++] = v`, `M(i--)`,
-  `x = y++`) is hoisted: the sub-expression reads the pre-increment value and the
-  mutation is appended as a trailing `i++` / `i--` statement after the enclosing
-  expression statement (in document order; nested-lambda bodies are not hoisted
-  into the outer seam).
+- **Post/pre-increment/decrement as an expression.** G# now models `++`/`--`
+  both as statements *and* as value-producing expressions (issue #1027). A
+  `PostIncrementExpression`/`PostDecrementExpression` used as a **value** in a
+  position that has a canonical statement seam (`a[i++] = v`, `M(i--)`,
+  `x = y++`) is still hoisted: the sub-expression reads the pre-increment value
+  and the mutation is appended as a trailing `i++` / `i--` statement after the
+  enclosing expression statement (in document order; nested-lambda bodies are
+  not hoisted into the outer seam). In a position with **no** statement seam —
+  e.g. inside the short-circuit `&&` condition of an `unsafe` do-while
+  (`while data[i] == 0 && i-- > 0`) — the faithful inline `i--` / `i++` / `--i`
+  / `++i` expression is emitted directly (formerly reported unsupported).
+- **User-defined conversion operator → `func operator implicit/explicit`** (issue
+  #1017). A C# `public static implicit operator T(U x)` maps to the in-body
+  member `func operator implicit(x U) T` (and `explicit` → `func operator
+  explicit(x U) T`); the single source parameter is preserved and the operator
+  target becomes the return type. `public static` is dropped. (Formerly reported
+  unsupported with a now-obsolete "gsc gap" note.)
+- **`stackalloc T[n]` → `stackalloc gT[n]`** (issue #1024). The element type is
+  mapped through the C#→G# type mapper (`byte` → `uint8`), so `stackalloc byte[2]`
+  → `stackalloc uint8[2]`. In a safe context this yields `Span<T>`; as an unsafe
+  pointer target it yields `T*`.
+- **`fixed (T* p = src) { … }` → `fixed p *gT = src { … }`** (issue #1026). The
+  paren-less G# `fixed` pins a managed array/string and is only legal inside an
+  `unsafe` context; multiple declarators emit nested `fixed` blocks. The required
+  `unsafe` context is supplied by the `unsafe`-modifier mapping below.
+- **`unsafe` modifier mapping** (issue #1026 / ADR-0122). A C# `unsafe class C`
+  → G# `unsafe class C` (the `unsafe` modifier precedes the visibility on a type
+  declaration). A C# `unsafe` *method* maps by wrapping its body in an
+  `unsafe { }` block (the parser does not combine a visibility modifier with
+  `unsafe func`). A C# `unsafe { }` block maps to a G# `unsafe { }` block. This
+  mapping is required for `fixed`, pointer-target `stackalloc`, and pointer code
+  to be legal.
+- **Tuple-deconstruction assignment `(a, b) = (x, y)` → element-wise
+  assignment.** G# has no tuple-assignment form, so an assignment whose left side
+  is a tuple of existing variables is lowered to element-wise assignments through
+  fresh temporaries (`var __decon0 = x; var __decon1 = y; a = __decon0; b =
+  __decon1`), preserving C#'s evaluate-all-then-assign order (and aliasing such as
+  `(a, b) = (b, a)`).
 - **`yield break` → `break`.** Settled fact: G# has no `yield break`; it maps to
   a plain loop-control `break` (supersedes the former §G #994 unsupported note).
 - **`foreach ((a, b) in xs)` tuple deconstruction → `for a, b in xs`.** A
@@ -1126,12 +1157,17 @@ so corpus identifiers such as `@default`, `@In`, `type`, and `func` round-trip.
 #### Discovered gaps from the Oahu.Decrypt round (minimal repros)
 
 Translating the external **`Oahu.Decrypt`** project drove its
-`translation-unsupported` count from **109** (19 construct kinds) to **7
-diagnostics across 5 files** — every one of the 19 target construct kinds is now
-translated to canonical G# (§B.36). The 7 residual diagnostics are **3 genuine
-gsc gaps** (each reproduced directly with gsc **0.2.137+31ced6cfb7** and
-contrasted with a passing control) and **4 excepted unsafe-interop constructs**
-(issue #1014). None is a translator defect.
+`translation-unsupported` count from **109** (19 construct kinds) to **0**: the
+app now reaches **translate = PASS** (every emitted `.gs` round-trips; zero
+Unsupported diagnostics). The conversion-operator (#1017), `stackalloc` (#1024),
+`fixed` (#1026), and inc/dec-as-expression (#1027) features are now translated to
+faithful canonical G# (§B), and the C# `unsafe` modifiers they require are mapped
+to G#. Two further pre-existing translator round-trip residuals surfaced once the
+former unsafe-interop diagnostics stopped masking them (a `data struct` with an
+explicit constructor needing a primary-constructor lift, and a tuple-deconstruction
+assignment `(a, b) = (x, y)`) and were also fixed (§B). The remaining `OD-1`/`OD-3`
+notes below record genuine gsc gaps the translator works around; the **compile**
+stage may still fail on the OF-3 managed pointer surface, which is expected.
 
 **OD-1 — range operator `a[i..j]` has no canonical G# form (gsc gap).** G# has no
 range/`..` operator; an `a[i..j]` index does not parse. The translator therefore
@@ -1150,20 +1186,18 @@ class C { func F(s Span[uint8]) Span[uint8] { return s[1..3] } }
 // error GS0005: Unexpected token, the `..` range form is not in the grammar.
 ```
 
-**OD-2 — user-defined conversion operator `implicit`/`explicit operator T` has no
-canonical G# form (gsc gap).** G#'s `operator` keyword is followed by an
-**operator token** only (spec §Functions grammar `OperatorName = "operator"
-OperatorToken`); there is no user-defined implicit/explicit conversion form. The
-translator reports the construct unsupported. Source:
-`Mpeg4/IAppleData.cs` → `public static implicit operator TrackNumber((int, int) tn)`.
+**OD-2 — user-defined conversion operator `implicit`/`explicit operator T`
+(RESOLVED, #1017).** G# now accepts a user-defined conversion member
+`func operator implicit(x U) T` / `func operator explicit(x U) T`. The translator
+emits the canonical in-body form (§B): `public static implicit operator
+TrackNumber((int, int) tn)` → `func operator implicit(tn (int32, int32))
+TrackNumber`. Source: `Mpeg4/IAppleData.cs`.
 
 ```gs
-// gsc 0.2.137+31ced6cfb7: `operator` cannot be followed by a type:
-package p
+// gsc accepts the in-body conversion member:
 class TrackNumber {
-    public static implicit operator TrackNumber(tn (int32, int32)) TrackNumber { return TrackNumber() }
+    func operator implicit(tn (int32, int32)) TrackNumber { return TrackNumber() }
 }
-// error GS0288 (field decl requires var/let/const) + GS0113 (Type 'implicit' doesn't exist)
 ```
 
 **OD-3 — static-abstract **property** in an interface has no canonical G# form
@@ -1180,15 +1214,19 @@ interface IData { shared { prop SizeInBytes int32 { get } } func Write() }
 //               interface static state is not supported in this release (ADR-0089).
 ```
 
-**Excepted unsafe-interop surface (issue #1014).** Four residual diagnostics are
-the excepted unsafe surface and are **not** forced to a managed G# form:
-`stackalloc T[n]` (`StackAllocArrayCreationExpression`, `Mpeg4/APICFrame.cs` and
-`Mpeg4/Stz2Box.cs`), `fixed (byte* p = …)` (`FixedStatement`, `Cryptography/
-AesCtr.cs`), and a `i--` post-decrement used inside the short-circuit condition of
-the `unsafe class AesCtr` do-while (`PostDecrementExpression`, `Cryptography/
-AesCtr.cs`). `AesCtr` is an `unsafe class` built on `byte*`/`fixed`/pointer
-arithmetic — the same pointer-deref/field surface documented as OF-3 — so these
-remain documented against issue #1014 rather than translated.
+**Unsafe-interop surface now translated to faithful forms (issues #1024/#1026/
+#1027).** What were formerly four excepted residual diagnostics now emit faithful
+canonical G# and pass the translate gate: `stackalloc T[n]`
+(`StackAllocArrayCreationExpression`, `Mpeg4/APICFrame.cs` and `Mpeg4/Stz2Box.cs`)
+→ `stackalloc gT[n]` (#1024); `fixed (byte* p = …) { … }` (`FixedStatement`,
+`Cryptography/AesCtr.cs`) → the paren-less `fixed p *uint8 = … { … }` inside an
+`unsafe { }` body (#1026); and the `i--` post-decrement used inside the
+short-circuit condition of the `unsafe class AesCtr` do-while
+(`PostDecrementExpression`, `Cryptography/AesCtr.cs`) → the inline value-producing
+`i--` expression (#1027). The C# `unsafe` modifiers required for these forms are
+mapped to G# (`unsafe class`, `unsafe { }` method body). These now round-trip;
+`AesCtr.gs` may still fail the **compile** stage on the same managed
+pointer-deref/field surface documented as OF-3, which is expected and accepted.
 
 **Two downstream `CompilationUnit` round-trip failures investigated.** Two files
 failed the round-trip parse gate for reasons unrelated to the 19 target kinds:

--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/GExpression.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/GExpression.cs
@@ -449,6 +449,62 @@ public sealed class NonNullAssertionExpression : GExpression
 }
 
 /// <summary>
+/// A value-producing increment/decrement expression — postfix <c>x++</c> /
+/// <c>x--</c> or prefix <c>++x</c> / <c>--x</c> (gsc issue #1027). G# now models
+/// inc/dec as expressions, so they may appear in value positions (e.g. inside a
+/// short-circuit condition) where no statement seam can hoist them.
+/// </summary>
+public sealed class IncrementDecrementExpression : GExpression
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IncrementDecrementExpression"/> class.
+    /// </summary>
+    /// <param name="operand">The operand being mutated.</param>
+    /// <param name="op">The operator token (<c>++</c> or <c>--</c>).</param>
+    /// <param name="isPrefix">Whether the operator precedes the operand.</param>
+    public IncrementDecrementExpression(GExpression operand, string op, bool isPrefix)
+    {
+        Operand = operand;
+        Operator = op;
+        IsPrefix = isPrefix;
+    }
+
+    /// <summary>Gets the operand being mutated.</summary>
+    public GExpression Operand { get; }
+
+    /// <summary>Gets the operator token.</summary>
+    public string Operator { get; }
+
+    /// <summary>Gets a value indicating whether the operator precedes the operand.</summary>
+    public bool IsPrefix { get; }
+}
+
+/// <summary>
+/// A <c>stackalloc ElemType[count]</c> expression (gsc issue #1024). In a safe
+/// context this yields a <c>Span&lt;T&gt;</c>; targeting a raw pointer inside an
+/// <c>unsafe</c> context yields <c>T*</c>.
+/// </summary>
+public sealed class StackAllocExpression : GExpression
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StackAllocExpression"/> class.
+    /// </summary>
+    /// <param name="elementType">The element type.</param>
+    /// <param name="count">The element-count expression.</param>
+    public StackAllocExpression(GTypeReference elementType, GExpression count)
+    {
+        ElementType = elementType;
+        Count = count;
+    }
+
+    /// <summary>Gets the element type.</summary>
+    public GTypeReference ElementType { get; }
+
+    /// <summary>Gets the element-count expression.</summary>
+    public GExpression Count { get; }
+}
+
+/// <summary>
 /// A parenthesized expression <c>(inner)</c>.
 /// </summary>
 public sealed class ParenthesizedExpression : GExpression

--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/GStatement.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/GStatement.cs
@@ -22,13 +22,21 @@ public sealed class BlockStatement : GStatement
     /// Initializes a new instance of the <see cref="BlockStatement"/> class.
     /// </summary>
     /// <param name="statements">The contained statements.</param>
-    public BlockStatement(IReadOnlyList<GStatement> statements = null)
+    /// <param name="isUnsafe">Whether this block is an <c>unsafe { … }</c> block (ADR-0122 / issue #1014).</param>
+    public BlockStatement(IReadOnlyList<GStatement> statements = null, bool isUnsafe = false)
     {
         Statements = statements ?? new List<GStatement>();
+        IsUnsafe = isUnsafe;
     }
 
     /// <summary>Gets the contained statements.</summary>
     public IReadOnlyList<GStatement> Statements { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether this block is an <c>unsafe { … }</c> block
+    /// introducing an unsafe context (ADR-0122 / issue #1014).
+    /// </summary>
+    public bool IsUnsafe { get; }
 }
 
 /// <summary>
@@ -600,4 +608,39 @@ public sealed class LocalFunctionStatement : GStatement
 
     /// <summary>Gets the function literal.</summary>
     public LambdaExpression Lambda { get; }
+}
+
+/// <summary>
+/// A G# <c>fixed name *ElemType = source { body }</c> statement (ADR-0122 /
+/// issue #1026). Pins a managed array/string and exposes a raw pointer for the
+/// duration of <see cref="Body"/>. Only legal inside an <c>unsafe</c> context.
+/// </summary>
+public sealed class FixedStatement : GStatement
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FixedStatement"/> class.
+    /// </summary>
+    /// <param name="name">The pinned pointer variable name.</param>
+    /// <param name="pointerType">The pointer type clause (<c>*ElemType</c>).</param>
+    /// <param name="source">The managed source expression being pinned.</param>
+    /// <param name="body">The fixed-region body.</param>
+    public FixedStatement(string name, GTypeReference pointerType, GExpression source, BlockStatement body)
+    {
+        Name = name;
+        PointerType = pointerType;
+        Source = source;
+        Body = body;
+    }
+
+    /// <summary>Gets the pinned pointer variable name.</summary>
+    public string Name { get; }
+
+    /// <summary>Gets the pointer type clause.</summary>
+    public GTypeReference PointerType { get; }
+
+    /// <summary>Gets the managed source expression being pinned.</summary>
+    public GExpression Source { get; }
+
+    /// <summary>Gets the fixed-region body.</summary>
+    public BlockStatement Body { get; }
 }

--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/TypeDeclaration.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/TypeDeclaration.cs
@@ -29,6 +29,7 @@ public sealed class TypeDeclaration : GMember
     /// <param name="isAbstract">Whether the type is <c>abstract</c>.</param>
     /// <param name="hasBody">Whether to render a body block (false emits the bodyless primary-ctor form).</param>
     /// <param name="attributes">The type attributes.</param>
+    /// <param name="isUnsafe">Whether the type is <c>unsafe</c> (its body is an unsafe context).</param>
     public TypeDeclaration(
         TypeDeclarationKind kind,
         string name,
@@ -42,7 +43,8 @@ public sealed class TypeDeclaration : GMember
         bool isSealed = false,
         bool isAbstract = false,
         bool hasBody = true,
-        IReadOnlyList<AttributeUse> attributes = null)
+        IReadOnlyList<AttributeUse> attributes = null,
+        bool isUnsafe = false)
     {
         Kind = kind;
         Name = name;
@@ -57,6 +59,7 @@ public sealed class TypeDeclaration : GMember
         IsAbstract = isAbstract;
         HasBody = hasBody;
         Attributes = attributes ?? new List<AttributeUse>();
+        IsUnsafe = isUnsafe;
     }
 
     /// <summary>Gets the aggregate kind.</summary>
@@ -97,6 +100,12 @@ public sealed class TypeDeclaration : GMember
 
     /// <summary>Gets the type attributes.</summary>
     public IReadOnlyList<AttributeUse> Attributes { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the type is <c>unsafe</c> (ADR-0122 /
+    /// issue #1014); its whole body is an unsafe context.
+    /// </summary>
+    public bool IsUnsafe { get; }
 }
 
 /// <summary>

--- a/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
@@ -403,6 +403,14 @@ public static class GSharpPrinter
             case NonNullAssertionExpression nonNull:
                 return $"{RenderExpression(nonNull.Operand, indent)}!!";
 
+            case IncrementDecrementExpression incDec:
+                return incDec.IsPrefix
+                    ? $"{incDec.Operator}{RenderExpression(incDec.Operand, indent)}"
+                    : $"{RenderExpression(incDec.Operand, indent)}{incDec.Operator}";
+
+            case StackAllocExpression stackAlloc:
+                return $"stackalloc {RenderType(stackAlloc.ElementType)}[{RenderExpression(stackAlloc.Count, indent)}]";
+
             case ParenthesizedExpression parenthesized:
                 return $"({RenderExpression(parenthesized.Inner, indent)})";
 
@@ -416,7 +424,7 @@ public static class GSharpPrinter
                 return RenderSwitchExpression(switchExpression, indent);
 
             case IfExpression ifExpression:
-                return $"if {RenderExpression(ifExpression.Condition, indent)} {{ {RenderExpression(ifExpression.ThenExpression, indent)} }} else {{ {RenderExpression(ifExpression.ElseExpression, indent)} }}";
+                return $"if {RenderExpression(ifExpression.Condition, indent)} {{ {RenderBranchValue(ifExpression.ThenExpression, indent)} }} else {{ {RenderBranchValue(ifExpression.ElseExpression, indent)} }}";
 
             case ThrowExpression throwExpression:
                 // G# has no throw-expression: lower to an if-expression whose
@@ -454,6 +462,20 @@ public static class GSharpPrinter
             default:
                 throw new ArgumentException($"Unsupported expression: {expression?.GetType().Name}");
         }
+    }
+
+    private static string RenderBranchValue(GExpression expression, int indent)
+    {
+        // A switch expression rendered bare as the tail of an `if`-expression
+        // branch block (`else { switch … }`) is re-parsed as a switch STATEMENT
+        // (whose arms use `{ … }` bodies, not `case …:`), so it is parenthesized
+        // to keep it in expression position. Other expressions are unaffected.
+        if (expression is SwitchExpression)
+        {
+            return $"({RenderExpression(expression, indent)})";
+        }
+
+        return RenderExpression(expression, indent);
     }
 
     private static string RenderCollectionInitializer(CollectionInitializerExpression collection, int indent)
@@ -674,6 +696,9 @@ public static class GSharpPrinter
             case IncrementDecrementStatement incDec:
                 return $"{pad}{RenderExpression(incDec.Target, indent)}{incDec.Operator}";
 
+            case FixedStatement fixedStatement:
+                return $"{pad}fixed {fixedStatement.Name} {RenderType(fixedStatement.PointerType)} = {RenderExpression(fixedStatement.Source, indent)} {RenderBlock(fixedStatement.Body, indent)}";
+
             case ForInStatement forIn:
                 var loopVars = string.IsNullOrEmpty(forIn.ValueName)
                     ? forIn.VariableName
@@ -823,12 +848,14 @@ public static class GSharpPrinter
 
     private static string RenderBlock(BlockStatement block, int indent)
     {
+        var prefix = block.IsUnsafe ? "unsafe " : string.Empty;
         if (block.Statements.Count == 0)
         {
-            return "{\n" + Indent(indent) + "}";
+            return prefix + "{\n" + Indent(indent) + "}";
         }
 
         var sb = new StringBuilder();
+        sb.Append(prefix);
         sb.Append('{');
         foreach (var statement in block.Statements)
         {
@@ -1005,6 +1032,13 @@ public static class GSharpPrinter
         var sb = new StringBuilder();
         sb.Append(RenderAttributeBlock(declaration.Attributes, indent));
         sb.Append(pad);
+        if (declaration.IsUnsafe)
+        {
+            // ADR-0122 / issue #1014: the `unsafe` contextual modifier precedes
+            // the accessibility keyword (`unsafe public class …`).
+            sb.Append("unsafe ");
+        }
+
         sb.Append(RenderVisibility(declaration.Visibility));
         if (declaration.IsOpen)
         {

--- a/tools/cs2gs/Cs2Gs.Tests/FaithfulUnsafeFormTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/FaithfulUnsafeFormTranslationTests.cs
@@ -1,0 +1,257 @@
+// <copyright file="FaithfulUnsafeFormTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Targeted translation tests for the faithful G# forms that the translator now
+/// emits for previously-unsupported C# constructs (ADR-0115 §B; translator
+/// follow-up to issues #1017, #1024, #1026, #1027): user-defined conversion
+/// operators, <c>stackalloc</c>, the <c>fixed</c> statement (with its required
+/// <c>unsafe</c>-context modifier mapping), and post/pre increment/decrement
+/// used as a value-producing expression. Each test asserts the faithful G# form
+/// is present and that the emitted G# round-trip-parses through the real gsc
+/// front-end (the round-trip assertion lives in <see cref="Translate"/>).
+/// </summary>
+public class FaithfulUnsafeFormTranslationTests
+{
+    /// <summary>
+    /// Issue #1017: a C# <c>public static implicit operator T(U x)</c> maps to an
+    /// in-body <c>func operator implicit (x U) T</c> member; the source parameter
+    /// becomes the single parameter and the C# operator target becomes the return
+    /// type.
+    /// </summary>
+    [Fact]
+    public void ImplicitConversionOperator_TranslatesToFuncOperatorImplicit()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public readonly struct Celsius
+    {
+        public Celsius(float value) { Value = value; }
+        public float Value { get; }
+        public static implicit operator float(Celsius c) => c.Value;
+    }
+}");
+
+        Assert.Contains("func operator implicit(c Celsius) float32", printed);
+    }
+
+    /// <summary>
+    /// Issue #1017: a C# <c>public static explicit operator T(U x)</c> maps to an
+    /// in-body <c>func operator explicit (x U) T</c> member.
+    /// </summary>
+    [Fact]
+    public void ExplicitConversionOperator_TranslatesToFuncOperatorExplicit()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public readonly struct Celsius
+    {
+        public Celsius(float value) { Value = value; }
+        public float Value { get; }
+        public static explicit operator Celsius(float f) => new Celsius(f);
+    }
+}");
+
+        Assert.Contains("func operator explicit(f float32) Celsius", printed);
+    }
+
+    /// <summary>
+    /// Issue #1024: a C# <c>stackalloc byte[2]</c> maps to the faithful G#
+    /// <c>stackalloc uint8[2]</c> expression with the element type mapped through
+    /// the C#-to-G# type mapper.
+    /// </summary>
+    [Fact]
+    public void StackAlloc_TranslatesToFaithfulStackAllocExpression()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    using System;
+    public static class Buffers
+    {
+        public static int First()
+        {
+            Span<byte> word = stackalloc byte[2];
+            return word.Length;
+        }
+    }
+}");
+
+        Assert.Contains("stackalloc uint8[2]", printed);
+    }
+
+    /// <summary>
+    /// Issue #1026: a C# <c>fixed (byte* p = src) { ... }</c> inside an
+    /// <c>unsafe</c> method maps to the paren-less G# <c>fixed p *uint8 = src { ...
+    /// }</c>. The method's <c>unsafe</c> modifier is mapped by wrapping the body in
+    /// an <c>unsafe { }</c> block (required for the <c>fixed</c> form to be legal).
+    /// </summary>
+    [Fact]
+    public void FixedStatement_TranslatesToFaithfulFixedInsideUnsafe()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public static class Pinner
+    {
+        public static unsafe void Zero(byte[] destination)
+        {
+            fixed (byte* pD = destination)
+            {
+                pD[0] = 0;
+            }
+        }
+    }
+}");
+
+        Assert.Contains("unsafe {", printed);
+        Assert.Contains("fixed pD *uint8 = destination {", printed);
+    }
+
+    /// <summary>
+    /// Issue #1026: a C# <c>unsafe class</c> maps to a G# <c>unsafe class</c> (the
+    /// <c>unsafe</c> modifier precedes the visibility on the type declaration).
+    /// </summary>
+    [Fact]
+    public void UnsafeClass_TranslatesToUnsafeClassModifier()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public unsafe class Native
+    {
+        public int Value;
+    }
+}");
+
+        Assert.Contains("unsafe class Native", printed);
+    }
+
+    /// <summary>
+    /// Issue #1027: a C# post-decrement used as a value inside a short-circuit
+    /// <c>&amp;&amp;</c> condition (no canonical statement seam) is emitted inline
+    /// as the faithful value-producing G# <c>i--</c> expression.
+    /// </summary>
+    [Fact]
+    public void PostDecrementInShortCircuitCondition_EmitsInlineDecrement()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public static class Scanner
+    {
+        public static int LastNonZero(byte[] data)
+        {
+            int i = data.Length;
+            do
+            {
+                i = i;
+            }
+            while (i > 0 && data[i - 1] == 0 && i-- > 0);
+            return i;
+        }
+    }
+}");
+
+        Assert.Contains("i--", printed);
+    }
+
+    /// <summary>
+    /// ADR-0115 §B: a C# tuple-deconstruction *assignment* to existing variables
+    /// (<c>(a, b) = (x, y)</c>) has no G# tuple-assignment form, so it is lowered
+    /// to element-wise assignments through temporaries (preserving C#'s
+    /// evaluate-all-then-assign order). The emitted G# must round-trip-parse.
+    /// </summary>
+    [Fact]
+    public void TupleDeconstructionAssignment_LowersToElementWiseAssignments()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public static class Swapper
+    {
+        public static int Combine(int x, int y)
+        {
+            int a = 0;
+            int b = 0;
+            (a, b) = (x, y);
+            return a - b;
+        }
+    }
+}");
+
+        Assert.Contains("a = __decon", printed);
+        Assert.Contains("b = __decon", printed);
+        Assert.DoesNotContain("(a, b) =", printed);
+    }
+
+    /// <summary>
+    /// ADR-0115 §B.3: a C# <c>record struct</c> with an explicit
+    /// parameter-to-member constructor cannot keep an in-body <c>init</c> (the G#
+    /// parser only accepts a primary constructor on a <c>data struct</c>), so the
+    /// constructor is lifted to the primary constructor.
+    /// </summary>
+    [Fact]
+    public void RecordStructWithExplicitConstructor_LiftsToPrimaryConstructor()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public readonly record struct Entry
+    {
+        public Entry(uint first, uint second)
+        {
+            First = first;
+            Second = second;
+        }
+
+        public uint First { get; }
+
+        public uint Second { get; }
+    }
+}");
+
+        Assert.Contains("data struct Entry(", printed);
+        Assert.DoesNotContain("init(", printed);
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        (string printed, _) = Translate(source);
+        return printed;
+    }
+
+    private static (string Printed, TranslationContext Context) Translate(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return (printed, context);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -318,6 +318,10 @@ public sealed class CSharpToGSharpTranslator
         // immutable (let) per ADR-0115 §B.3.
         private SyntaxNode currentBodyScope;
 
+        // Monotonic counter for synthesizing unique temporaries when lowering
+        // tuple-deconstruction assignments (`(a, b) = (x, y)`); ADR-0115 §B.
+        private int deconCounter;
+
         // When translating the body of a lifted owned-value-aggregate receiver
         // method (issue #938), the implicit `this.` of a bare instance-member
         // reference must be made explicit through the receiver name (`self.`),
@@ -731,7 +735,8 @@ public sealed class CSharpToGSharpTranslator
                 visibility: MapVisibility(symbol, this.context, node),
                 isOpen: isOpen || wasAbstract,
                 isAbstract: false,
-                attributes: this.MapAttributes(node.AttributeLists));
+                attributes: this.MapAttributes(node.AttributeLists),
+                isUnsafe: node.Modifiers.Any(SyntaxKind.UnsafeKeyword));
         }
 
         /// <summary>
@@ -749,7 +754,18 @@ public sealed class CSharpToGSharpTranslator
             INamedTypeSymbol symbol,
             TypeDeclarationKind kind)
         {
-            if (symbol == null || (kind != TypeDeclarationKind.Class && kind != TypeDeclarationKind.Struct))
+            // A C# `record struct` with an explicit (non-positional) constructor
+            // cannot keep an in-body `init` member: the G# parser only accepts a
+            // primary constructor on a `data struct`. Such a record-struct
+            // constructor is therefore lifted to the primary constructor just like
+            // a plain struct/class (ADR-0115 §B.3 / issue #1024 follow-up).
+            bool isRecordStructLift = kind == TypeDeclarationKind.DataStruct
+                && node is RecordDeclarationSyntax { ParameterList: null };
+
+            if (symbol == null ||
+                (kind != TypeDeclarationKind.Class
+                    && kind != TypeDeclarationKind.Struct
+                    && !isRecordStructLift))
             {
                 return ConstructorLift.None;
             }
@@ -761,7 +777,9 @@ public sealed class CSharpToGSharpTranslator
 
             // A record already owns a primary constructor, and zero or many
             // instance constructors are out of scope for the L1 canonicalization.
-            if (instanceCtors.Count != 1 || node is RecordDeclarationSyntax)
+            // The record-struct lift above is the sole exception: it has no
+            // positional primary constructor and exactly one explicit one.
+            if (instanceCtors.Count != 1 || (node is RecordDeclarationSyntax && !isRecordStructLift))
             {
                 return ConstructorLift.None;
             }
@@ -1000,13 +1018,14 @@ public sealed class CSharpToGSharpTranslator
                     break;
 
                 case ConversionOperatorDeclarationSyntax conversion:
-                    // G# `operator` is followed by an operator token only
-                    // (spec §Functions, `OperatorName = "operator" OperatorToken`);
-                    // there is no user-defined implicit/explicit conversion form.
-                    // Genuine gsc gap — reported for follow-up (ADR-0115 §G).
-                    this.context.ReportUnsupported(
-                        conversion,
-                        "user-defined conversion operators ('implicit'/'explicit operator T') have no canonical G# form (gsc gap; spec §Functions grammar 'operator' takes an operator token only).");
+                    // gsc issue #1017: a C# user-defined conversion operator
+                    // (`public static implicit/explicit operator T(U x)`) maps to
+                    // the canonical G# `func operator implicit/explicit (x U) T`
+                    // in-body member. `implicit`/`explicit` are contextual keywords
+                    // right after `operator`; the single C# parameter is the
+                    // conversion source and the C# target type becomes the return
+                    // type (ADR-0115 §B).
+                    yield return this.TranslateConversionOperator(conversion);
                     break;
 
                 default:
@@ -1167,6 +1186,22 @@ public sealed class CSharpToGSharpTranslator
                 this.currentReceiverName = previousReceiver;
             }
 
+            // ADR-0122 / issue #1014: a C# `unsafe` method body is an unsafe
+            // context. The G# member-level `unsafe func` modifier does not combine
+            // with an accessibility keyword in the grammar, so — unless the whole
+            // owning type is already `unsafe` — the body is wrapped in an
+            // `unsafe { … }` block, which round-trips with any visibility and gives
+            // the same unsafe context.
+            if (body != null &&
+                node.Modifiers.Any(SyntaxKind.UnsafeKeyword) &&
+                !node.Ancestors().OfType<TypeDeclarationSyntax>().Any(t => t.Modifiers.Any(SyntaxKind.UnsafeKeyword)))
+            {
+                body = new BlockStatement(new GStatement[]
+                {
+                    new BlockStatement(body.Statements, isUnsafe: true),
+                });
+            }
+
             bool isOverride = symbol != null && symbol.IsOverride;
 
             // Interface members are implicitly abstract in C#; in canonical G# the
@@ -1262,6 +1297,42 @@ public sealed class CSharpToGSharpTranslator
             // Operators carry the receiver-clause form and are lifted to a top-level
             // sibling; returning IsStatic=false routes them through the existing
             // receiver-clause lift in VisitAggregate.
+            return (method, false);
+        }
+
+        private (GMember Member, bool IsStatic) TranslateConversionOperator(ConversionOperatorDeclarationSyntax node)
+        {
+            // gsc issue #1017: `public static implicit operator T(U x)` →
+            // `func operator implicit (x U) T { ... }` (and `explicit` likewise).
+            // The single C# parameter is the conversion source; the C# target type
+            // (`node.Type`) becomes the G# return type. `implicit`/`explicit` is a
+            // contextual keyword that forms the operator name.
+            string kindKeyword = node.ImplicitOrExplicitKeyword.IsKind(SyntaxKind.ImplicitKeyword)
+                ? "implicit"
+                : "explicit";
+
+            var symbol = this.context.GetDeclaredSymbol(node) as IMethodSymbol;
+            List<Parameter> parameters = this.MapParameters(symbol, node.ParameterList, skipFirst: false);
+
+            GTypeReference returnType = symbol != null
+                ? this.typeMapper.Map(symbol.ReturnType, this.context, node.Type.GetLocation())
+                : this.MapTypeSyntax(node.Type);
+
+            BlockStatement body = (node.Body != null || node.ExpressionBody != null)
+                ? this.TranslateBody(node, $"conversion operator '{kindKeyword}'")
+                : null;
+
+            var method = new MethodDeclaration(
+                $"operator {kindKeyword}",
+                parameters: parameters,
+                returnType: returnType,
+                body: body,
+                attributes: this.MapAttributes(node.AttributeLists));
+
+            // The conversion operator has no receiver clause, so it stays an
+            // in-body member of the owning type (returning IsStatic=false routes it
+            // to the instance-member list in VisitAggregate, which the parser
+            // accepts directly in the type body).
             return (method, false);
         }
 
@@ -2027,6 +2098,36 @@ public sealed class CSharpToGSharpTranslator
             return new BlockStatement(statements);
         }
 
+        private IEnumerable<GStatement> TranslateFixedStatement(FixedStatementSyntax node)
+        {
+            // Translate the innermost body once; multiple declarators nest as
+            // successive `fixed` blocks (`fixed a … { fixed b … { body } }`).
+            BlockStatement body = this.TranslateStatementAsBlock(node.Statement);
+
+            VariableDeclarationSyntax declaration = node.Declaration;
+            GTypeReference pointerType = this.MapTypeSyntax(declaration.Type);
+
+            for (int i = declaration.Variables.Count - 1; i >= 0; i--)
+            {
+                VariableDeclaratorSyntax declarator = declaration.Variables[i];
+                GExpression source = declarator.Initializer != null
+                    ? this.TranslateExpression(declarator.Initializer.Value)
+                    : new IdentifierExpression("nil");
+                body = new BlockStatement(new GStatement[]
+                {
+                    new FixedStatement(
+                        SanitizeIdentifier(declarator.Identifier.Text),
+                        pointerType,
+                        source,
+                        body),
+                });
+            }
+
+            // Unwrap the single outer wrapper block so the caller receives the
+            // `fixed` statement(s) directly.
+            return body.Statements;
+        }
+
         private BlockStatement TranslateStatementAsBlock(StatementSyntax statement)
         {
             if (statement is BlockSyntax block)
@@ -2074,6 +2175,22 @@ public sealed class CSharpToGSharpTranslator
                     // G# arithmetic is unchecked by default and has no
                     // `checked`/`unchecked` block keyword; emit the inner block.
                     return new[] { (GStatement)this.TranslateBlock(checkedStatement.Block) };
+
+                case UnsafeStatementSyntax unsafeStatement:
+                    // ADR-0122 / issue #1014: a C# `unsafe { … }` block maps to the
+                    // G# `unsafe { … }` block, introducing an unsafe context.
+                    return new[]
+                    {
+                        (GStatement)new BlockStatement(
+                            this.TranslateBlock(unsafeStatement.Block).Statements,
+                            isUnsafe: true),
+                    };
+
+                case FixedStatementSyntax fixedStatement:
+                    // gsc issue #1026: a C# `fixed (T* p = src) { … }` pins a managed
+                    // array/string and exposes a raw pointer, mapping to the G#
+                    // `fixed p *T = src { … }` form (only legal inside `unsafe`).
+                    return this.TranslateFixedStatement(fixedStatement);
 
                 case ReturnStatementSyntax ret:
                     return new[]
@@ -2356,6 +2473,19 @@ public sealed class CSharpToGSharpTranslator
                     };
                 }
 
+                // `(a, b) = (x, y)` deconstruction *assignment* to existing
+                // variables. G# has no tuple-assignment form, so lower to
+                // element-wise assignments. RHS elements are captured into temps
+                // first to preserve C#'s evaluate-all-then-assign semantics
+                // (handles aliasing such as `(a, b) = (b, a)`); ADR-0115 §B.
+                if (assignment.Left is TupleExpressionSyntax leftTuple &&
+                    assignment.Right is TupleExpressionSyntax rightTuple &&
+                    leftTuple.Arguments.Count == rightTuple.Arguments.Count &&
+                    leftTuple.Arguments.All(a => a.Expression is not DeclarationExpressionSyntax))
+                {
+                    return this.LowerTupleAssignment(leftTuple, rightTuple);
+                }
+
                 if (assignment.Right is AssignmentExpressionSyntax)
                 {
                     // `a = b = c` → `b = c` then `a = b`. G# assignment is a
@@ -2443,6 +2573,35 @@ public sealed class CSharpToGSharpTranslator
             {
                 statements.Add(new AssignmentStatement(lefts[i].Target, rhs, lefts[i].Op));
                 rhs = lefts[i].Target;
+            }
+
+            return statements;
+        }
+
+        private IEnumerable<GStatement> LowerTupleAssignment(
+            TupleExpressionSyntax leftTuple,
+            TupleExpressionSyntax rightTuple)
+        {
+            int count = leftTuple.Arguments.Count;
+            var temps = new List<string>(count);
+            var statements = new List<GStatement>();
+
+            for (int i = 0; i < count; i++)
+            {
+                string temp = $"__decon{this.deconCounter++}";
+                temps.Add(temp);
+                statements.Add(new LocalDeclarationStatement(
+                    BindingKind.Var,
+                    temp,
+                    type: null,
+                    initializer: this.TranslateExpression(rightTuple.Arguments[i].Expression)));
+            }
+
+            for (int i = 0; i < count; i++)
+            {
+                statements.Add(new AssignmentStatement(
+                    this.TranslateExpression(leftTuple.Arguments[i].Expression),
+                    new IdentifierExpression(temps[i])));
             }
 
             return statements;
@@ -2883,19 +3042,26 @@ public sealed class CSharpToGSharpTranslator
                 case PostfixUnaryExpressionSyntax postfixValue
                     when postfixValue.IsKind(SyntaxKind.PostIncrementExpression)
                         || postfixValue.IsKind(SyntaxKind.PostDecrementExpression):
-                    // A post-increment/decrement used in value position. G# has no
-                    // inc/dec expression; the enclosing statement seam hoists the
-                    // mutation into a trailing statement and suppresses the node
-                    // here so it reads as the pre-increment value (ADR-0115 §B).
+                    // A post-increment/decrement used in value position. When the
+                    // enclosing statement seam already hoisted the mutation into a
+                    // trailing statement, the node is suppressed here and reads as
+                    // its pre-increment value (ADR-0115 §B).
                     if (this.suppressedPostfix.Contains(postfixValue))
                     {
                         return this.TranslateExpression(postfixValue.Operand);
                     }
 
-                    this.context.ReportUnsupported(
-                        postfixValue,
-                        $"post-{(postfixValue.IsKind(SyntaxKind.PostIncrementExpression) ? "increment" : "decrement")} used in a position that has no canonical G# statement seam (ADR-0115 §B).");
-                    return this.TranslateExpression(postfixValue.Operand);
+                    // gsc issue #1027: G# now models inc/dec as value-producing
+                    // expressions, so a postfix in a position with no statement seam
+                    // (e.g. inside a short-circuit `&&` condition) emits the faithful
+                    // inline `x++` / `x--` form.
+                    return new IncrementDecrementExpression(
+                        this.TranslateExpression(postfixValue.Operand),
+                        postfixValue.OperatorToken.Text,
+                        isPrefix: false);
+
+                case StackAllocArrayCreationExpressionSyntax stackAlloc:
+                    return this.TranslateStackAlloc(stackAlloc);
 
                 case CollectionExpressionSyntax collectionExpression:
                     return this.TranslateCollectionExpression(collectionExpression);
@@ -3112,6 +3278,41 @@ public sealed class CSharpToGSharpTranslator
                 new List<GTypeReference> { elementType });
         }
 
+        private GExpression TranslateStackAlloc(StackAllocArrayCreationExpressionSyntax node)
+        {
+            // gsc issue #1024: C# `stackalloc T[n]` → G# `stackalloc gT[n]`. In a
+            // safe context this yields `Span[T]`; targeting a raw pointer inside an
+            // `unsafe` context yields `*T`. The element type is mapped through the
+            // standard C#→G# type mapper (`byte`→`uint8`).
+            GTypeReference elementType;
+            GExpression count;
+            if (node.Type is ArrayTypeSyntax arrayType)
+            {
+                elementType = this.MapTypeSyntax(arrayType.ElementType);
+                count = arrayType.RankSpecifiers.Count > 0 &&
+                    arrayType.RankSpecifiers[0].Sizes.Count > 0 &&
+                    arrayType.RankSpecifiers[0].Sizes[0] is { } sizeExpr &&
+                    !sizeExpr.IsKind(SyntaxKind.OmittedArraySizeExpression)
+                    ? this.TranslateExpression(sizeExpr)
+                    : null;
+            }
+            else
+            {
+                elementType = new NamedTypeReference("uint8");
+                count = null;
+            }
+
+            // An explicit initializer (`stackalloc byte[] { 1, 2 }`) supplies the
+            // length; fall back to the element count when no size is spelled.
+            if (count == null && node.Initializer != null)
+            {
+                count = LiteralExpression.Int(
+                    node.Initializer.Expressions.Count.ToString(CultureInfo.InvariantCulture));
+            }
+
+            return new StackAllocExpression(elementType, count ?? LiteralExpression.Int("0"));
+        }
+
         private GExpression TranslateImplicitArrayCreation(ImplicitArrayCreationExpressionSyntax creation)
         {
             GTypeReference elementType = this.GetArrayElementType(creation, null);
@@ -3183,6 +3384,24 @@ public sealed class CSharpToGSharpTranslator
 
         private GExpression TranslateCollectionExpression(CollectionExpressionSyntax collection)
         {
+            // An empty collection expression (`[]`) targeting a concrete
+            // constructible collection class (e.g. `Dictionary<,> d = []`,
+            // `List<T> l = []`) maps to a constructor call of that type. The slice
+            // literal `[]T{ … }` only models arrays/spans; a `Dictionary`'s element
+            // type is `KeyValuePair<,>`, whose generic `[...]` would otherwise be
+            // emitted into a malformed `[]KeyValuePair[…]{}` literal (ADR-0115 §B).
+            ITypeSymbol target = this.context.GetTypeInfo(collection).ConvertedType
+                ?? this.context.GetTypeInfo(collection).Type;
+            if (collection.Elements.Count == 0 &&
+                target is INamedTypeSymbol { TypeKind: TypeKind.Class } namedTarget &&
+                this.typeMapper.Map(namedTarget, this.context, collection.GetLocation()) is NamedTypeReference targetRef)
+            {
+                return new InvocationExpression(
+                    new IdentifierExpression(targetRef.Name),
+                    new List<GExpression>(),
+                    targetRef.TypeArguments.Count > 0 ? targetRef.TypeArguments : null);
+            }
+
             // C# 12 collection expression `[a, b, c]`. The target type (array,
             // span, or any IEnumerable<T>) supplies the element type, so it maps to
             // the canonical G# slice literal `[]T{ … }` (ADR-0115 §B). Spread


### PR DESCRIPTION
## Summary

Translator-only change (ADR-0115 / cs2gs). Makes the C#→canonical-G# migration tool **emit** the now-supported faithful G# forms for four constructs instead of reporting them `Unsupported`. This drives the driving corpus app **Oahu.Decrypt** from `translate = FAIL` to **`translate = PASS`**.

**No gsc/compiler changes** — nothing under `src/` or `src/Core/` is touched. All four G# language features were already implemented and merged in gsc on this branch's base; this PR only updates the translator emission, plus cs2gs tests and ADR-0115.

Translator follow-up to #914 and feature issues #1017 / #1024 / #1026 / #1027. (No `Fixes #` — there is no single tracking issue.)

## The four faithful-form mappings

1. **User-defined conversion operators (#1017).** C# `public static implicit operator T(U x)` → in-body member `func operator implicit(x U) T` (and `explicit` → `func operator explicit(x U) T`). The single source parameter is preserved; the operator target becomes the return type; `public static` is dropped.
   *Implemented in* `CSharpToGSharpTranslator.cs` — replaced the `ConversionOperatorDeclarationSyntax` `ReportUnsupported` arm with `TranslateConversionOperator`.

2. **stackalloc (#1024).** C# `stackalloc byte[2]` → `stackalloc uint8[2]` (element type mapped through the existing C#→G# type mapper).
   *Implemented in* `CSharpToGSharpTranslator.cs` — new `StackAllocArrayCreationExpressionSyntax` case → `TranslateStackAlloc`; new `StackAllocExpression` AST node + printer case.

3. **fixed statement (#1026).** C# `fixed (byte* p = src) { … }` → paren-less `fixed p *uint8 = src { … }` (multiple declarators nest). Requires an `unsafe` context.
   *Implemented in* `CSharpToGSharpTranslator.cs` — new `FixedStatementSyntax` case → `TranslateFixedStatement`; new `FixedStatement` AST node + printer case.

4. **Increment/decrement as an expression (#1027).** C# `i--` / `i++` / `--i` / `++i` used as a **value** in a position with no canonical statement seam (e.g. the short-circuit `&&` condition of an `unsafe` do-while) is now emitted inline as the faithful value-producing G# expression. The existing statement-seam **hoisting** behaviour for the simple cases is retained, so no passing app regresses.
   *Implemented in* `CSharpToGSharpTranslator.cs` (expression-switch postfix handler) + new `IncrementDecrementExpression` AST node + printer case.

### Unsafe-modifier mapping (required, #1026)
The `fixed`/pointer forms are only legal inside `unsafe`, so C# `unsafe` modifiers are now mapped to G#:
- `unsafe class C` → `unsafe class C` (modifier precedes visibility on a type);
- `unsafe` method → body wrapped in `unsafe { }` (the parser does not combine a visibility modifier with `unsafe func`);
- `unsafe { }` block → `unsafe { }`.

### Two pre-existing residuals also fixed (tools/cs2gs only)
cs2gs records all `CompilationUnit` round-trip failures under one shared fingerprint, so only one artifact is written per run — this **masked** several independent files. Once the four unsafe diagnostics above stopped failing, two unrelated pre-existing translator round-trip bugs surfaced and were fixed:
- **record struct with an explicit ctor** now lifts to a primary constructor (`data struct Name(params)`) — a `data struct` cannot hold an in-body `init`;
- **tuple-deconstruction assignment** `(a, b) = (x, y)` now lowers to element-wise assignments through temporaries (G# has no tuple-assignment form).

## Oahu.Decrypt `translate` result

| | BEFORE | AFTER |
|---|---|---|
| **translate** | **FAIL** | **PASS** |

Residual-kind histogram (BEFORE), via the `translate-*.json` artifacts:
- `ConversionOperatorDeclaration` (IAppleData.cs)
- `StackAllocArrayCreationExpression` ×2 (APICFrame.cs, Stz2Box.cs)
- `FixedStatement` (AesCtr.cs)
- `PostDecrementExpression` (AesCtr.cs)
- `CompilationUnit` round-trip failure (one written artifact masking several files: Mp4aWriter empty-collection-expr, Mp4File switch-expression-in-branch, StscBox/SttsBox data-struct-init, DashChunkEntryies/InterleavedIterator tuple-assign)

**AFTER: 0 residual translate diagnostics — `translate = PASS`.** The `compile` stage still fails on `AesCtr.gs`'s managed pointer-deref/field surface (documented OF-3) and is **accepted** for this PR per scope (`compile`/`ilverify`/`test-parity` may skip/fail on unrelated cross-file/external-dependency reasons).

## Validation

- **Build:** `dotnet build GSharp.sln -c Release -graph` → **0 Error(s)**.
- **cs2gs unit tests:** `dotnet test tools/cs2gs/Cs2Gs.Tests` → **176 passed, 0 failed** (168 prior + 8 new focused tests covering conversion operator implicit+explicit, stackalloc, fixed inside unsafe, the unsafe-class modifier, inc/dec in a short-circuit condition, tuple-assignment lowering, and the record-struct primary-ctor lift; each asserts the faithful form **and** round-trips through gsc).
- **Committed corpus** (`migrate` over L1–L5): L1/L2/L4/L5 fully green; L3 `translate = PASS`, `compile = FAIL` — this is the **expected** state asserted by `MigrationPipelineTests.L3_CompileStageFailure_WritesTriageArtifact` (the L3 indexer empty-getter is pre-existing and not in this diff). No regressions.

## Docs
ADR-0115 updated: §B mapping rules gain bullets for the four faithful forms + the `unsafe`-modifier mapping + tuple-assignment lowering; the §G Oahu.Decrypt notes (`OD-2`, the "excepted unsafe-interop surface" paragraph, and the round summary) are updated to record resolution instead of the stale "gsc gap / excepted" notes.