### PR TITLE
Fixes #1049: map void/nullable-void function return to Action (no Func<...,Void> ICE)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -998,7 +998,7 @@ internal sealed partial class ExpressionBinder
         }
 
         TypeSymbol erasedReturn;
-        if (functionType.ReturnType == null || functionType.ReturnType == TypeSymbol.Void)
+        if (FunctionTypeSymbol.IsVoidReturn(functionType.ReturnType))
         {
             erasedReturn = TypeSymbol.Void;
         }

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -2215,7 +2215,7 @@ internal sealed class MemberLookup
             }
         }
 
-        var isVoid = functionType.ReturnType == null || functionType.ReturnType == TypeSymbol.Void;
+        var isVoid = FunctionTypeSymbol.IsVoidReturn(functionType.ReturnType);
         Type returnClr = null;
         if (!isVoid && !TryEraseDelegateComponentClrType(functionType.ReturnType, out returnClr))
         {

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -8956,7 +8956,7 @@ internal sealed class ReflectionMetadataEmitter
     // signature encoding stays consistent end-to-end.
     internal Type ResolveDelegateClrType(FunctionTypeSymbol fnType)
     {
-        bool isVoid = fnType.ReturnType == null || fnType.ReturnType == TypeSymbol.Void;
+        bool isVoid = FunctionTypeSymbol.IsVoidReturn(fnType.ReturnType);
         int arity = fnType.ParameterTypes.Length;
 
         if (isVoid && arity == 0)
@@ -9019,7 +9019,7 @@ internal sealed class ReflectionMetadataEmitter
     /// </summary>
     internal void EncodeFunctionTypeSymbol(SignatureTypeEncoder encoder, FunctionTypeSymbol fnType)
     {
-        bool isVoid = fnType.ReturnType == null || fnType.ReturnType == TypeSymbol.Void;
+        bool isVoid = FunctionTypeSymbol.IsVoidReturn(fnType.ReturnType);
         int arity = fnType.ParameterTypes.Length;
 
         if (isVoid && arity == 0)
@@ -9127,7 +9127,7 @@ internal sealed class ReflectionMetadataEmitter
 
         var parent = this.GetFunctionDelegateTypeSpec(fnType);
 
-        bool isVoid = fnType.ReturnType == null || fnType.ReturnType == TypeSymbol.Void;
+        bool isVoid = FunctionTypeSymbol.IsVoidReturn(fnType.ReturnType);
         int arity = fnType.ParameterTypes.Length;
 
         // The MemberRef signature for a method on a generic TypeSpec

--- a/src/Core/CodeAnalysis/Symbols/FunctionTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/FunctionTypeSymbol.cs
@@ -171,6 +171,30 @@ public sealed class FunctionTypeSymbol : TypeSymbol
     /// </summary>
     internal static void ClearCache() => Cache.Clear();
 
+    /// <summary>
+    /// Issue #1049: returns whether a function-type return slot denotes "no
+    /// value" for the purpose of selecting <c>System.Action&lt;...&gt;</c> over
+    /// <c>System.Func&lt;..., R&gt;</c>. A slot is void when it is
+    /// <see langword="null"/>, <see cref="TypeSymbol.Void"/>, or a
+    /// <see cref="NullableTypeSymbol"/> wrapping <see cref="TypeSymbol.Void"/>.
+    /// </summary>
+    /// <remarks>
+    /// A function type cannot be parenthesised in G# (<c>(() -> void)?</c> is a
+    /// parse error), so <c>(Args) -> void?</c> is the only spelling of a
+    /// nullable delegate and binds with a nullable-<c>void</c> return. Its
+    /// underlying return is still <c>void</c>, so it must map to
+    /// <c>System.Action&lt;...&gt;</c>; treating it as a non-void return built
+    /// the illegal <c>System.Func&lt;..., System.Void&gt;</c> instantiation and
+    /// crashed with GS9998.
+    /// </remarks>
+    /// <param name="returnType">The function-type return slot.</param>
+    /// <returns><see langword="true"/> when the (unwrapped) return type is void.</returns>
+    internal static bool IsVoidReturn(TypeSymbol returnType)
+    {
+        var underlying = returnType is NullableTypeSymbol nullable ? nullable.UnderlyingType : returnType;
+        return underlying == null || underlying == TypeSymbol.Void;
+    }
+
     private static void AppendIdentityKey(System.Text.StringBuilder builder, TypeSymbol type)
     {
         switch (type)
@@ -225,7 +249,7 @@ public sealed class FunctionTypeSymbol : TypeSymbol
             paramClr[i] = pt;
         }
 
-        bool isVoid = returnType == null || returnType == TypeSymbol.Void;
+        bool isVoid = IsVoidReturn(returnType);
         if (isVoid)
         {
             switch (paramClr.Length)

--- a/test/Compiler.Tests/Emit/Issue1049NullableVoidDelegateEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1049NullableVoidDelegateEmitTests.cs
@@ -1,0 +1,146 @@
+// <copyright file="Issue1049NullableVoidDelegateEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1049: emitting a nullable function (delegate) type whose return type
+/// is <c>void</c> — e.g. <c>(Args) -> void?</c> — crashed the compiler with
+/// <c>GS9998: ArgumentException: The type 'System.Void' may not be used as a
+/// type argument</c>. A function type cannot be parenthesised in G#
+/// (<c>(() -> void)?</c> is a parse error), so <c>(Args) -> void?</c> is the
+/// only way to spell a nullable delegate; its underlying return is still
+/// <c>void</c>, so it must map to <c>System.Action&lt;...&gt;</c> rather than
+/// the illegal <c>System.Func&lt;..., System.Void&gt;</c>.
+/// </summary>
+public class Issue1049NullableVoidDelegateEmitTests
+{
+    [Fact]
+    public void NullableVoidDelegateField_NoArgs_EmitsAsAction()
+    {
+        var asm = LoadCompiled("""
+            package p
+            class C {
+                var f () -> void?
+            }
+            """);
+
+        var field = FindField(asm, "p", "C", "f");
+        Assert.Equal("System.Action", field.FieldType.FullName);
+    }
+
+    [Fact]
+    public void NullableVoidDelegateField_OneArg_EmitsAsActionOfArg()
+    {
+        var asm = LoadCompiled("""
+            package p
+            class C {
+                var g (int32) -> void?
+            }
+            """);
+
+        var field = FindField(asm, "p", "C", "g");
+        Assert.True(
+            field.FieldType.IsGenericType
+            && field.FieldType.GetGenericTypeDefinition().FullName == "System.Action`1",
+            $"expected System.Action`1 but was '{field.FieldType.FullName}'");
+        Assert.Equal(typeof(int).FullName, field.FieldType.GetGenericArguments()[0].FullName);
+    }
+
+    [Fact]
+    public void PlainVoidDelegateField_StillEmitsAsAction_RegressionGuard()
+    {
+        // Control: the non-nullable `() -> void` shape already mapped to
+        // System.Action and must keep doing so after the fix.
+        var asm = LoadCompiled("""
+            package p
+            class C {
+                var f () -> void
+            }
+            """);
+
+        var field = FindField(asm, "p", "C", "f");
+        Assert.Equal("System.Action", field.FieldType.FullName);
+    }
+
+    [Fact]
+    public void NullableNonVoidReturnDelegateField_StillEmitsAsFunc_RegressionGuard()
+    {
+        // Control: a nullable *non-void* return is unaffected — it stays a
+        // System.Func<int32, int32> (the `?` annotation on a value-type
+        // return shares the underlying CLR representation).
+        var asm = LoadCompiled("""
+            package p
+            class C {
+                var h (int32) -> int32?
+            }
+            """);
+
+        var field = FindField(asm, "p", "C", "h");
+        Assert.True(
+            field.FieldType.IsGenericType
+            && field.FieldType.GetGenericTypeDefinition().FullName == "System.Func`2",
+            $"expected System.Func`2 but was '{field.FieldType.FullName}'");
+    }
+
+    private static FieldInfo FindField(Assembly asm, string ns, string typeName, string fieldName)
+    {
+        var full = ns + "." + typeName;
+        var type = asm.GetType(full, throwOnError: false)
+            ?? asm.GetTypes().FirstOrDefault(t =>
+                string.Equals(t.Namespace, ns, StringComparison.Ordinal)
+                && string.Equals(t.Name, typeName, StringComparison.Ordinal));
+        Assert.NotNull(type);
+
+        var field = type.GetField(
+            fieldName,
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static);
+        Assert.NotNull(field);
+        return field;
+    }
+
+    private static Assembly LoadCompiled(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1049_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:library",
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+        IlVerifier.Verify(outPath);
+
+        var ctx = new AssemblyLoadContext(name: "gs_issue1049_" + Guid.NewGuid(), isCollectible: true);
+        return ctx.LoadFromAssemblyPath(outPath);
+    }
+}


### PR DESCRIPTION
Fixes #1049

## Root cause
A nullable function (delegate) type whose return type is `void` — e.g. `(Args) -> void?` — crashed `gsc` with:

```
error GS9998: ArgumentException: The type 'System.Void' may not be used as a type argument.
```

Every site that selects `System.Action<...>` vs `System.Func<..., R>` computed the void test as `returnType == TypeSymbol.Void`. For `(Args) -> void?` the return type binds to a `NullableTypeSymbol` wrapping `void`, so the check was `false` and the code built `System.Func<..., System.Void>` — an illegal generic instantiation that throws in `MakeGenericType` / metadata signature encoding.

A function type cannot be parenthesised in G# (`(() -> void)?` is a parse error, GS0005), so `(Args) -> void?` is the *only* way to spell a nullable delegate. Its underlying return is still `void`, so it must map to `System.Action<...>`, never to `Func<..., Void>`.

## Fix
- Add `FunctionTypeSymbol.IsVoidReturn(TypeSymbol)`, which unwraps a `NullableTypeSymbol` before checking for `void`.
- Route every Action-vs-Func decision through it:
  - `FunctionTypeSymbol.BuildClrType` (the symbol-level `ClrType`, where the crash originated)
  - `ReflectionMetadataEmitter.ResolveDelegateClrType`, `EncodeFunctionTypeSymbol`, `GetFunctionDelegateInvokeRef` (metadata signature / delegate-spec / Invoke encoders)
  - `ExpressionBinder` and `MemberLookup` delegate-erasure paths used by overload resolution (would otherwise build `Func<..., Void>` / `Nullable<void>`)

No new `SyntaxKind` / `BoundNodeKind` were added — this is a pure semantic/emit fix. No `x == typeof(T)` comparisons introduced (issue #835 tripwire).

## Minimal repro
```
package p
class C {
    var f () -> void?
}
```
```
dotnet gsc.dll /target:library /out:m1.dll /targetframework:net10.0 m1.gs
```
Before: `error GS9998: ArgumentException: The type 'System.Void' may not be used as a type argument.`
After: `Wrote m1.dll`

## Verification
- Repro now compiles; variants `(int32) -> void?` and `(Task) -> void?` compile too.
- Reflection over the emitted assembly confirms `() -> void?` → `System.Action`, `(int32) -> void?` → `System.Action`1[System.Int32]`.
- Controls still pass: `() -> void` → `System.Action`, `(int32) -> int32?` → `System.Func`2`.
- New `Issue1049NullableVoidDelegateEmitTests` (4 tests) — all pass.
- `dotnet test Core.Tests --filter FunctionType|Delegate|Nullable` — 252 passed.
- `dotnet test Compiler.Tests --filter Issue527|ReifiedGenerics` — 33 passed.
- Full `GSharp.sln` build: `0 Error(s)`.
