### PR TITLE
Fixes #1051: key types by name+arity so Foo and Foo[T] coexist

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -1676,7 +1676,7 @@ public sealed class Binder
 
             foreach (var alias in previous.TypeAliases)
             {
-                scope.TryDeclareTypeAlias(alias.Key, alias.Value);
+                scope.TryRedeclareTypeAlias(alias.Key, alias.Value);
             }
 
             foreach (var f in previous.Functions)
@@ -2179,7 +2179,12 @@ public sealed class Binder
         }
         else
         {
-            element = LookupType(syntax.Identifier.Text);
+            // Issue #1051: resolve by (name, arity) so that a same-named type
+            // and a generic of different arity coexist. With a type-argument
+            // list, prefer the matching generic definition; without one, prefer
+            // the arity-0 type.
+            var requestedArity = syntax.HasTypeArguments ? syntax.TypeArguments.Count : 0;
+            element = LookupType(syntax.Identifier.Text, requestedArity);
             if (element == null)
             {
                 Diagnostics.ReportUndefinedType(syntax.Identifier.Location, syntax.Identifier.Text);
@@ -3796,6 +3801,9 @@ public sealed class Binder
     }
 
     private TypeSymbol LookupType(string name)
+        => LookupType(name, preferredArity: -1);
+
+    private TypeSymbol LookupType(string name, int preferredArity)
     {
         // Issue #944: a parse-recovery artifact (e.g. a malformed type clause
         // with no identifier) can reach here with a null/empty name. Treat it
@@ -3873,7 +3881,7 @@ public sealed class Binder
                 return TypeSymbol.Void;
         }
 
-        if (scope.TryLookupTypeAlias(name, out var aliased))
+        if (scope.TryLookupTypeAlias(name, preferredArity, out var aliased))
         {
             return aliased;
         }
@@ -3889,7 +3897,7 @@ public sealed class Binder
     /// <summary>
     /// Issue #525: resolves a class declaration's base-type identifier to an
     /// imported CLR interface. Honors imports and aliases (via
-    /// <see cref="LookupType"/>) for simple names and falls back to direct
+    /// <see cref="LookupType(string)"/>) for simple names and falls back to direct
     /// fully-qualified resolution against the reference set. Only public
     /// CLR interface types are accepted; classes, value types, and other
     /// references are rejected so the regular "cannot find type" diagnostic
@@ -3938,7 +3946,7 @@ public sealed class Binder
 
     /// <summary>
     /// Issue #296: resolves a class declaration's base-type name to an imported
-    /// CLR base class. Honors imports and aliases (via <see cref="LookupType"/>)
+    /// CLR base class. Honors imports and aliases (via <see cref="LookupType(string)"/>)
     /// for simple names and falls back to direct fully-qualified resolution.
     /// Only non-sealed reference (class) types are accepted as a base; CLR
     /// interfaces, value types, and sealed classes are rejected so the regular

--- a/src/Core/CodeAnalysis/Binding/BoundScope.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundScope.cs
@@ -523,29 +523,113 @@ public sealed class BoundScope
             typeAliases = new Dictionary<string, TypeSymbol>();
         }
 
-        if (typeAliases.ContainsKey(name))
+        // Issue #1051: key by (simple name, generic arity) so that a type and a
+        // same-named generic of different arity coexist. A genuine duplicate —
+        // same name AND same arity — still collides and reports GS0102.
+        var key = MangleArity(name, GetTypeAliasArity(target));
+        if (typeAliases.ContainsKey(key))
         {
             return false;
         }
 
-        typeAliases.Add(name, target);
+        typeAliases.Add(key, target);
         return true;
     }
 
     /// <summary>
-    /// Tries to look up a type alias by name.
+    /// Issue #1051: re-declares a type alias under its already-computed storage
+    /// key (as returned by <see cref="GetDeclaredTypeAliases"/>) without
+    /// re-deriving the arity suffix. Used when threading aliases from a previous
+    /// submission's global scope into a fresh scope so generic keys are not
+    /// double-mangled.
+    /// </summary>
+    /// <param name="key">The composite storage key.</param>
+    /// <param name="target">The underlying type.</param>
+    /// <returns>Whether the alias was declared (false if the key was already taken).</returns>
+    public bool TryRedeclareTypeAlias(string key, TypeSymbol target)
+    {
+        if (key == null)
+        {
+            return false;
+        }
+
+        if (typeAliases == null)
+        {
+            typeAliases = new Dictionary<string, TypeSymbol>();
+        }
+
+        if (typeAliases.ContainsKey(key))
+        {
+            return false;
+        }
+
+        typeAliases.Add(key, target);
+        return true;
+    }
+
+    /// <summary>
+    /// Tries to look up a type alias by name, preferring the arity-0 type.
     /// </summary>
     /// <param name="name">The alias name.</param>
     /// <param name="type">The aliased type, when found.</param>
     /// <returns>Whether an alias exists.</returns>
     public bool TryLookupTypeAlias(string name, out TypeSymbol type)
+        => TryLookupTypeAlias(name, preferredArity: -1, out type);
+
+    /// <summary>
+    /// Issue #1051: tries to look up a type alias by (name, arity). When
+    /// <paramref name="preferredArity"/> is non-negative, the type with exactly
+    /// that generic arity is returned if present; otherwise the lookup falls
+    /// back to the arity-0 type (plain name) and then to the lowest-arity
+    /// same-name variant. A negative <paramref name="preferredArity"/> means
+    /// "no arity preference" and resolves the arity-0 type first.
+    /// </summary>
+    /// <param name="name">The alias name.</param>
+    /// <param name="preferredArity">The preferred generic arity, or -1 for none.</param>
+    /// <param name="type">The aliased type, when found.</param>
+    /// <returns>Whether an alias exists.</returns>
+    public bool TryLookupTypeAlias(string name, int preferredArity, out TypeSymbol type)
     {
-        if (name != null && typeAliases != null && typeAliases.TryGetValue(name, out type))
+        type = null;
+        if (name == null || typeAliases == null)
+        {
+            return false;
+        }
+
+        if (preferredArity > 0)
+        {
+            var key = MangleArity(name, preferredArity);
+            if (typeAliases.TryGetValue(key, out type))
+            {
+                return true;
+            }
+        }
+
+        // Fall back to the arity-0 type (whose key is the plain simple name).
+        if (typeAliases.TryGetValue(name, out type))
         {
             return true;
         }
 
-        type = null;
+        // No arity-0 type: resolve the lowest-arity same-name generic variant
+        // so a lone generic definition keeps resolving by simple name.
+        TypeSymbol best = null;
+        var bestArity = int.MaxValue;
+        foreach (var pair in typeAliases)
+        {
+            if (TryParseAritySuffix(pair.Key, name, out var arity) && arity < bestArity)
+            {
+                best = pair.Value;
+                bestArity = arity;
+            }
+        }
+
+        if (best != null)
+        {
+            type = best;
+            return true;
+        }
+
         return false;
     }
 
@@ -591,6 +675,68 @@ public sealed class BoundScope
         => typeAliases == null
             ? ImmutableArray<DelegateTypeSymbol>.Empty
             : typeAliases.Values.OfType<DelegateTypeSymbol>().ToImmutableArray();
+
+    /// <summary>
+    /// Issue #1051: computes the generic arity (number of type parameters) of a
+    /// type used as the storage-key discriminator. C#/CLR allow two types that
+    /// share a simple name but differ by generic arity (e.g. <c>Foo</c> and
+    /// <c>Foo[T]</c>, mirroring <c>Task</c>/<c>Task&lt;T&gt;</c>) to coexist as
+    /// distinct types keyed by (name, arity). Only open generic DEFINITIONS
+    /// carry an arity; constructed instances and plain aliases are arity 0.
+    /// </summary>
+    /// <param name="target">The type whose arity is requested.</param>
+    /// <returns>The generic arity, or 0 for non-generic / constructed types.</returns>
+    private static int GetTypeAliasArity(TypeSymbol target)
+    {
+        return target switch
+        {
+            StructSymbol s when s.IsGenericDefinition => s.TypeParameters.Length,
+            InterfaceSymbol i when i.IsGenericDefinition => i.TypeParameters.Length,
+            _ => 0,
+        };
+    }
+
+    /// <summary>
+    /// Issue #1051: builds the storage key for a type alias keyed by
+    /// (simple name, generic arity). Arity-0 types keep their plain simple name
+    /// as the key (so existing simple-name lookups keep working), while generic
+    /// definitions are suffixed with the CLR backtick-arity convention
+    /// (e.g. <c>Foo`1</c>), letting <c>Foo</c> and <c>Foo[T]</c> coexist.
+    /// </summary>
+    /// <param name="name">The simple type name.</param>
+    /// <param name="arity">The generic arity.</param>
+    /// <returns>The composite storage key.</returns>
+    private static string MangleArity(string name, int arity)
+        => arity <= 0 ? name : name + "`" + arity.ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+    /// <summary>
+    /// Issue #1051: parses a composite storage key, reporting whether it names
+    /// the requested simple name as a generic-arity variant and, if so, the
+    /// arity it encodes.
+    /// </summary>
+    /// <param name="key">The composite storage key.</param>
+    /// <param name="name">The simple type name to match.</param>
+    /// <param name="arity">The parsed arity, when matched.</param>
+    /// <returns>Whether the key encodes a generic variant of <paramref name="name"/>.</returns>
+    private static bool TryParseAritySuffix(string key, string name, out int arity)
+    {
+        arity = 0;
+        if (key == null || name == null || key.Length <= name.Length + 1)
+        {
+            return false;
+        }
+
+        if (!key.StartsWith(name, StringComparison.Ordinal) || key[name.Length] != '`')
+        {
+            return false;
+        }
+
+        return int.TryParse(
+            key.Substring(name.Length + 1),
+            System.Globalization.NumberStyles.None,
+            System.Globalization.CultureInfo.InvariantCulture,
+            out arity);
+    }
 
     private static ImmutableArray<ParameterSymbol> SigCallableParameters(FunctionSymbol f)
         => f.ExplicitReceiverParameter == null ? f.Parameters : f.Parameters.RemoveAt(0);

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
@@ -440,7 +440,13 @@ internal sealed partial class ExpressionBinder
     private BoundExpression BindStructLiteralExpression(StructLiteralExpressionSyntax syntax)
     {
         var typeName = syntax.TypeIdentifier.Text;
-        if (!scope.TryLookupTypeAlias(typeName, out var resolvedType) || !(resolvedType is StructSymbol structSymbol))
+
+        // Issue #1051: when the literal carries an explicit type-argument list,
+        // resolve the same-named generic definition of the matching arity so a
+        // non-generic `Foo` and a generic `Foo[T]` can coexist. Without one,
+        // prefer the arity-0 type (falling back to a lone generic for inference).
+        var preferredArity = syntax.TypeArgumentList != null ? syntax.TypeArgumentList.Arguments.Count : -1;
+        if (!scope.TryLookupTypeAlias(typeName, preferredArity, out var resolvedType) || !(resolvedType is StructSymbol structSymbol))
         {
             Diagnostics.ReportUnableToFindType(syntax.TypeIdentifier.Location, typeName);
             return new BoundErrorExpression(null);

--- a/test/Compiler.Tests/Emit/Issue1051GenericArityTypesEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1051GenericArityTypesEmitTests.cs
@@ -1,0 +1,135 @@
+// <copyright file="Issue1051GenericArityTypesEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1051: a type and a same-named generic of a different arity
+/// (<c>Foo</c> and <c>Foo[T]</c>, mirroring <c>Task</c>/<c>Task&lt;T&gt;</c>)
+/// coexist as distinct types keyed by (name, arity). The CLR mangles a generic
+/// type's metadata name with the backtick-arity suffix (<c>Foo`1</c>) while the
+/// arity-0 type keeps the bare name, so both emit to distinct TypeDefs and the
+/// produced assembly is valid and runs.
+/// </summary>
+public class Issue1051GenericArityTypesEmitTests
+{
+    [Fact]
+    public void Arity0AndArityNSameName_EmitsAndRuns()
+    {
+        var source = """
+            package p
+            open class Box { func A() int32 { return 1 } }
+            open class Box[T] : Box { var V T }
+            func Main() {
+                let a = Box()
+                let b = Box[int32]{V: 5}
+                System.Console.WriteLine(a.A() + b.V)
+            }
+            """;
+
+        Assert.Equal("6\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void SameNamedInterfaceAndGenericInterface_EmitsAndRuns()
+    {
+        var source = """
+            package p
+            import System
+
+            interface I { func Tag() int32; }
+            interface I[T] { func Wrap(v T) T; }
+
+            class C : I { func Tag() int32 { return 7 } }
+            class D[T] : I[T] { func Wrap(v T) T { return v } }
+
+            func Main() {
+                let c = C{}
+                let d = D[int32]{}
+                Console.WriteLine(c.Tag() + d.Wrap(3))
+            }
+            """;
+
+        Assert.Equal("10\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1051_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new System.Collections.Generic.List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+
+            // (a) Static verification: the emitted IL must be valid.
+            IlVerifier.Verify(outPath);
+
+            // (b) Dynamic verification: the emitted code must execute.
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1051GenericArityTypesTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1051GenericArityTypesTests.cs
@@ -1,0 +1,134 @@
+// <copyright file="Issue1051GenericArityTypesTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1051: C#/CLR key types by (simple name, generic arity), so a type and
+/// a same-named generic of a different arity — <c>Foo</c> and <c>Foo[T]</c>,
+/// mirroring <c>Task</c>/<c>Task&lt;T&gt;</c> — coexist as distinct types. The
+/// binder must not report GS0102 ("already declared") for that pair, must resolve
+/// a reference to the type matching the supplied number of type arguments, and
+/// must still report GS0102 for a genuine duplicate (same name AND same arity).
+/// </summary>
+public class Issue1051GenericArityTypesTests
+{
+    [Fact]
+    public void ClassAndSameNamedGeneric_DifferentArity_BindsWithNoDiagnostics()
+    {
+        const string source = """
+            package p
+            open class Mp4Operation { }
+            open class Mp4Operation[TOutput] : Mp4Operation { }
+            """;
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void ClassAndSameNamedGeneric_BothSymbolsAreDeclared()
+    {
+        const string source = """
+            package p
+            open class Mp4Operation { }
+            open class Mp4Operation[TOutput] : Mp4Operation { }
+            """;
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(source)));
+        Assert.Empty(compilation.GlobalScope.Diagnostics);
+
+        var byName = compilation.GlobalScope.Structs
+            .Where(s => s.Name == "Mp4Operation")
+            .ToList();
+        Assert.Equal(2, byName.Count);
+        Assert.Contains(byName, s => s.TypeParameters.Length == 0);
+        Assert.Contains(byName, s => s.TypeParameters.Length == 1);
+
+        // The generic's base type resolves to the arity-0 type.
+        var generic = byName.Single(s => s.TypeParameters.Length == 1);
+        var baseClass = generic.BaseClass;
+        Assert.NotNull(baseClass);
+        Assert.Equal("Mp4Operation", baseClass.Name);
+        Assert.Empty(baseClass.TypeParameters);
+    }
+
+    [Fact]
+    public void InterfaceAndSameNamedGeneric_DifferentArity_BindsWithNoDiagnostics()
+    {
+        const string source = """
+            package p
+            interface I { }
+            interface I[T] { }
+            class C : I { }
+            class D[T] : I[T] { }
+            """;
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void GenuineDuplicateClass_SameArity0_ReportsGS0102()
+    {
+        const string source = """
+            package p
+            open class X { }
+            open class X { }
+            """;
+        var diagnostics = Bind(source);
+        Assert.Contains(diagnostics, d => d.Id == "GS0102");
+    }
+
+    [Fact]
+    public void GenuineDuplicateGeneric_SameArity1_ReportsGS0102()
+    {
+        const string source = """
+            package p
+            class X[T] { }
+            class X[T] { }
+            """;
+        var diagnostics = Bind(source);
+        Assert.Contains(diagnostics, d => d.Id == "GS0102");
+    }
+
+    [Fact]
+    public void ReferenceWithoutTypeArgs_ResolvesArity0_NoSpuriousNotGeneric()
+    {
+        const string source = """
+            package p
+            open class Box { }
+            open class Box[T] : Box { }
+            func F(b Box) { }
+            """;
+        var diagnostics = Bind(source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0149");
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void ReferenceWithTypeArgs_ResolvesGenericArity_NoSpuriousNotGeneric()
+    {
+        const string source = """
+            package p
+            open class Box { }
+            open class Box[T] : Box { var V T }
+            func F(b Box[int32]) { }
+            """;
+        var diagnostics = Bind(source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0149");
+        Assert.Empty(diagnostics);
+    }
+
+    private static IReadOnlyList<Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.GlobalScope.Diagnostics.ToList();
+    }
+}


### PR DESCRIPTION
Fixes #1051

## Problem
G# rejected two types that share a simple name but differ by **generic arity**, reporting `GS0102: '<name>' is already declared`. C#/CLR allow this: `Foo` and `Foo<T>` are distinct types keyed by (name, arity) — extremely common (`Task`/`Task<T>`). Dependents then cascaded into `GS0149 'X' is not generic`.

Minimal repro (previously FAILED, now compiles):
```
package p
open class Mp4Operation { }
open class Mp4Operation[TOutput] : Mp4Operation { }
```

## Root cause
`BoundScope.typeAliases` (the user type/symbol table) was keyed by simple name alone, so a type and a same-named generic of a different arity collided.

## What changed
- **`BoundScope`**: type aliases are now keyed by **(simple name, generic arity)**. Arity-0 types keep their plain simple name as the key; generic definitions get the CLR backtick-arity suffix (`Foo` -> `Foo` + backtick + arity). A genuine duplicate (same name AND same arity) still collides and reports `GS0102`. Lookup is arity-aware (`TryLookupTypeAlias(name, preferredArity, ...)`): the type whose arity matches the supplied number of type arguments wins, falling back to the arity-0 type when none are supplied.
- **`Binder.LookupType(name, preferredArity)`**: the type-clause resolver passes the type-argument count, so `Mp4Operation[TOutput] : Mp4Operation` binds the base to the arity-0 type while constructed-generic references resolve to the arity-N type. This removes the spurious `GS0149`.
- **`ExpressionBinder.Literals`**: struct/class literals (`Box[int32]{...}`) resolve the matching generic arity.
- **Emit**: no change needed — the emitter already mangles generic TypeDef names (`MangleGenericName`) and keys its handle maps by symbol reference, so both types emit to distinct TypeDefs (`Mp4Operation` and `Mp4Operation` + backtick + `1`).

## Tests added
- `test/Core.Tests/.../Issue1051GenericArityTypesTests.cs` — binding: coexistence, both symbols declared, base resolves to arity-0, interfaces, no spurious GS0149, and genuine-duplicate (arity 0 and arity 1) still report `GS0102`.
- `test/Compiler.Tests/Emit/Issue1051GenericArityTypesEmitTests.cs` — compile+run exercising arity-0 and arity-N same-name classes (prints `6`) and interfaces (prints `10`), with IL verification.

## Verification
- Minimal repro: `Wrote /tmp/a.dll`; metadata contains both `Mp4Operation` and `Mp4Operation`+backtick+`1`.
- Genuine duplicate (arity 0 and arity 1) still errors `GS0102`.
- Constructed use runs and prints `6`:
```
open class Box { func A() int32 { return 1 } }
open class Box[T] : Box { var V T }
func Main() { let a = Box(); let b = Box[int32]{V: 5}; System.Console.WriteLine(a.A() + b.V) }
```
- Interfaces (`interface I { } interface I[T] { } class C : I { } class D[T] : I[T] { }`) compile.
- New tests green; binding regression slice (Declaration/Generic/Duplicate/Alias/Struct/Interface/Scope) green; full `dotnet build GSharp.sln -c Release -graph` -> 0 Errors.

Nothing deferred.
