### PR TITLE
Fixes #1055: substitute constructed-base type args in override matching

### DIFF
--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -1302,12 +1302,13 @@ internal sealed class DeclarationBinder
                         // an unrelated same-name overload no longer steals the slot.
                         var baseOverloads = structSymbol.BaseClass?.GetMethodsIncludingInherited(methodName)
                             ?? System.Collections.Immutable.ImmutableArray<FunctionSymbol>.Empty;
+                        var baseTypeArgSubst = BuildBaseTypeArgumentSubstitution(structSymbol);
                         FunctionSymbol baseMethod = null;
                         FunctionSymbol baseSignatureMatch = null;
                         foreach (var candidate in baseOverloads)
                         {
                             baseMethod ??= candidate;
-                            if (SignaturesMatch(candidate, methodParameters, returnType, methodReturnRefKind))
+                            if (SignaturesMatch(candidate, methodParameters, returnType, methodReturnRefKind, baseTypeArgSubst))
                             {
                                 baseSignatureMatch = candidate;
                                 break;
@@ -1373,6 +1374,7 @@ internal sealed class DeclarationBinder
                         // A new same-name overload that does not match any base entry
                         // is a brand-new overload, not an accidental shadow.
                         var baseOverloads = structSymbol.BaseClass.GetMethodsIncludingInherited(methodName);
+                        var baseTypeArgSubst = BuildBaseTypeArgumentSubstitution(structSymbol);
                         foreach (var shadowed in baseOverloads)
                         {
                             if (!shadowed.IsOpen)
@@ -1380,7 +1382,7 @@ internal sealed class DeclarationBinder
                                 continue;
                             }
 
-                            if (SignaturesMatch(shadowed, methodParameters, returnType, methodReturnRefKind))
+                            if (SignaturesMatch(shadowed, methodParameters, returnType, methodReturnRefKind, baseTypeArgSubst))
                             {
                                 Diagnostics.ReportMissingOverride(methodSyntax.Identifier.Location, shadowed.ReceiverType.Name, methodName);
                                 break;
@@ -5052,6 +5054,56 @@ internal sealed class DeclarationBinder
         Diagnostics.ReportConstraintNotInterface(p.Constraint.Location, resolved.Name);
     }
 
+    /// <summary>
+    /// Issue #1055: builds the substitution mapping each base class's generic
+    /// type parameters onto the concrete type arguments supplied where that base
+    /// is inherited as a constructed generic. Walking the <see cref="StructSymbol.BaseClass"/>
+    /// chain closest-first lets a deeper base's type arguments (which are expressed
+    /// in terms of a shallower base's type parameters) resolve transitively, so a
+    /// multi-level chain such as <c>Leaf : Mid[int32] : Base[T]</c> maps
+    /// <c>Base.T -&gt; int32</c>. The resulting map is consumed by
+    /// <see cref="SignaturesMatch(FunctionSymbol, ImmutableArray{ParameterSymbol}, TypeSymbol, RefKind, IReadOnlyDictionary{TypeParameterSymbol, TypeSymbol})"/>
+    /// so an override whose concrete signature mentions the substituted types is
+    /// matched against the base member's un-substituted (open) signature. Returns
+    /// <c>null</c> when no constructed base contributes a substitution.
+    /// </summary>
+    private static IReadOnlyDictionary<TypeParameterSymbol, TypeSymbol> BuildBaseTypeArgumentSubstitution(StructSymbol derived)
+    {
+        Dictionary<TypeParameterSymbol, TypeSymbol> subst = null;
+        for (var b = derived?.BaseClass; b != null; b = b.BaseClass)
+        {
+            if (b.Definition == null || b.TypeArguments.IsDefaultOrEmpty)
+            {
+                continue;
+            }
+
+            var defParams = b.Definition.TypeParameters;
+            if (defParams.IsDefaultOrEmpty)
+            {
+                continue;
+            }
+
+            var count = System.Math.Min(defParams.Length, b.TypeArguments.Length);
+            for (var i = 0; i < count; i++)
+            {
+                var arg = b.TypeArguments[i];
+
+                // A deeper base's type argument may itself be a type parameter of
+                // a shallower (already-processed) base; resolve it transitively so
+                // the map always lands on the concrete type in the derived context.
+                if (arg is TypeParameterSymbol tpArg && subst != null && subst.TryGetValue(tpArg, out var resolved))
+                {
+                    arg = resolved;
+                }
+
+                subst ??= new Dictionary<TypeParameterSymbol, TypeSymbol>();
+                subst[defParams[i]] = arg;
+            }
+        }
+
+        return subst;
+    }
+
     private static bool SignaturesMatch(FunctionSymbol baseMethod, ImmutableArray<ParameterSymbol> derivedParams, TypeSymbol derivedReturnType)
         => SignaturesMatch(baseMethod, derivedParams, derivedReturnType, RefKind.None);
 
@@ -5205,7 +5257,7 @@ internal sealed class DeclarationBinder
     /// <c>IEnumerator[T]</c>) are not equated — so genuinely mismatched
     /// signatures are still rejected with GS0187.
     /// </summary>
-    private static bool TypeSignaturesEquivalent(TypeSymbol a, TypeSymbol b)
+    internal static bool TypeSignaturesEquivalent(TypeSymbol a, TypeSymbol b)
         => TypeSignaturesEquivalent(a, b, typeParamMap: null);
 
     private static bool TypeSignaturesEquivalent(

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -595,6 +595,8 @@ internal sealed class ReflectionMetadataEmitter
             this.EncodeTypeSymbol,
             this.EncodeReturnSymbol,
             this.GetTypeReference,
+            this.GetUserStructTypeSpec,
+            this.ResolveConstructedBaseParameterlessCtorToken,
             this.customAttrEncoder.NextParameterHandle,
             this.customAttrEncoder.EmitUserAttributes,
             this.customAttrEncoder.EmitIsReadOnlyAttributeOnParameter,
@@ -6874,6 +6876,55 @@ internal sealed class ReflectionMetadataEmitter
                     }
                 });
         return this.GetUserStructMethodRef(structType, primaryDef, ".ctor", sigBlob);
+    }
+
+    /// <summary>
+    /// Issue #1055: resolves the parameter-less base constructor token for a
+    /// class whose base is a CONSTRUCTED generic user class (e.g.
+    /// <c>Derived : Base[int32]</c>). The base ctor's MethodDef is keyed by the
+    /// open definition, so the token is emitted as a MemberRef parented at the
+    /// constructed base's TypeSpec via <see cref="GetUserStructMethodRef"/> so
+    /// the chained <c>call</c> targets the correct instantiated base subobject
+    /// and the assembly verifies.
+    /// </summary>
+    internal EntityHandle ResolveConstructedBaseParameterlessCtorToken(StructSymbol constructedBase)
+    {
+        var def = constructedBase.Definition ?? constructedBase;
+
+        if (this.cache.ClassPrimaryCtorHandles.TryGetValue(def, out var primaryDef))
+        {
+            var defParams = def.PrimaryConstructorParameters;
+            var primarySig = new BlobBuilder();
+            new BlobEncoder(primarySig)
+                .MethodSignature(isInstanceMethod: true)
+                .Parameters(
+                    defParams.IsDefaultOrEmpty ? 0 : defParams.Length,
+                    r => r.Void(),
+                    ps =>
+                    {
+                        if (defParams.IsDefaultOrEmpty)
+                        {
+                            return;
+                        }
+
+                        foreach (var p in defParams)
+                        {
+                            EncodeTypeSymbol(ps.AddParameter().Type(isByRef: p.RefKind != RefKind.None), p.Type);
+                        }
+                    });
+            return this.GetUserStructMethodRef(constructedBase, primaryDef, ".ctor", primarySig);
+        }
+
+        if (this.cache.ClassCtorHandles.TryGetValue(def, out var defaultDef))
+        {
+            var defaultSig = new BlobBuilder();
+            new BlobEncoder(defaultSig)
+                .MethodSignature(isInstanceMethod: true)
+                .Parameters(0, r => r.Void(), _ => { });
+            return this.GetUserStructMethodRef(constructedBase, defaultDef, ".ctor", defaultSig);
+        }
+
+        return this.wellKnown.ObjectCtorRef;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs
@@ -91,6 +91,8 @@ internal sealed class TypeDefEmitter
     private readonly Action<SignatureTypeEncoder, TypeSymbol> encodeTypeSymbol;
     private readonly Action<ReturnTypeEncoder, TypeSymbol, RefKind> encodeReturnSymbol;
     private readonly Func<Type, TypeReferenceHandle> getTypeReference;
+    private readonly Func<StructSymbol, EntityHandle> getUserStructTypeSpec;
+    private readonly Func<StructSymbol, EntityHandle> resolveConstructedBaseCtorToken;
     private readonly Func<ParameterHandle> nextParameterHandle;
     private readonly Action<EntityHandle, Symbol, AttributeTargetKind> emitUserAttributes;
     private readonly Action<ParameterHandle> emitIsReadOnlyAttributeOnParameter;
@@ -110,6 +112,8 @@ internal sealed class TypeDefEmitter
         Action<SignatureTypeEncoder, TypeSymbol> encodeTypeSymbol,
         Action<ReturnTypeEncoder, TypeSymbol, RefKind> encodeReturnSymbol,
         Func<Type, TypeReferenceHandle> getTypeReference,
+        Func<StructSymbol, EntityHandle> getUserStructTypeSpec,
+        Func<StructSymbol, EntityHandle> resolveConstructedBaseCtorToken,
         Func<ParameterHandle> nextParameterHandle,
         Action<EntityHandle, Symbol, AttributeTargetKind> emitUserAttributes,
         Action<ParameterHandle> emitIsReadOnlyAttributeOnParameter,
@@ -128,6 +132,8 @@ internal sealed class TypeDefEmitter
         this.encodeTypeSymbol = encodeTypeSymbol ?? throw new ArgumentNullException(nameof(encodeTypeSymbol));
         this.encodeReturnSymbol = encodeReturnSymbol ?? throw new ArgumentNullException(nameof(encodeReturnSymbol));
         this.getTypeReference = getTypeReference ?? throw new ArgumentNullException(nameof(getTypeReference));
+        this.getUserStructTypeSpec = getUserStructTypeSpec ?? throw new ArgumentNullException(nameof(getUserStructTypeSpec));
+        this.resolveConstructedBaseCtorToken = resolveConstructedBaseCtorToken ?? throw new ArgumentNullException(nameof(resolveConstructedBaseCtorToken));
         this.nextParameterHandle = nextParameterHandle ?? throw new ArgumentNullException(nameof(nextParameterHandle));
         this.emitUserAttributes = emitUserAttributes ?? throw new ArgumentNullException(nameof(emitUserAttributes));
         this.emitIsReadOnlyAttributeOnParameter = emitIsReadOnlyAttributeOnParameter ?? throw new ArgumentNullException(nameof(emitIsReadOnlyAttributeOnParameter));
@@ -418,6 +424,14 @@ internal sealed class TypeDefEmitter
                 // System.Attribute, regardless of any other resolution.
                 baseType = this.wellKnown.GetSystemAttributeTypeRef();
             }
+            else if (structSym.BaseClass != null && !structSym.BaseClass.TypeArguments.IsDefaultOrEmpty)
+            {
+                // Issue #1055: the base is a CONSTRUCTED generic user class
+                // (e.g. `Derived : Base[int32]`). Reference it via a TypeSpec
+                // naming the generic instantiation so the runtime sees the
+                // correct base subobject layout, vtable slots and type identity.
+                baseType = this.getUserStructTypeSpec(structSym.BaseClass);
+            }
             else if (structSym.BaseClass != null && this.cache.StructTypeDefs.TryGetValue(structSym.BaseClass, out var baseHandle))
             {
                 baseType = baseHandle;
@@ -546,7 +560,12 @@ internal sealed class TypeDefEmitter
             }
 
             typeAttrs = classAttrs;
-            if (structSym.BaseClass != null && this.cache.StructTypeDefs.TryGetValue(structSym.BaseClass, out var baseHandle))
+            if (structSym.BaseClass != null && !structSym.BaseClass.TypeArguments.IsDefaultOrEmpty)
+            {
+                // Issue #1055: nested class extending a constructed generic base.
+                baseType = this.getUserStructTypeSpec(structSym.BaseClass);
+            }
+            else if (structSym.BaseClass != null && this.cache.StructTypeDefs.TryGetValue(structSym.BaseClass, out var baseHandle))
             {
                 baseType = baseHandle;
             }
@@ -1409,6 +1428,15 @@ internal sealed class TypeDefEmitter
     /// <summary>Resolves the <c>.ctor()</c> token a derived class's ctor should chain to: either the base class's default ctor (already emitted) or <see cref="WellKnownReferences.ObjectCtorRef"/>.</summary>
     private EntityHandle GetBaseCtorToken(StructSymbol classSym)
     {
+        // Issue #1055: the base is a CONSTRUCTED generic user class. Its ctor
+        // MethodDef is keyed by the open definition, so resolve a MemberRef
+        // parented at the constructed base's TypeSpec instead of falling back to
+        // System.Object (which would chain past the real base subobject).
+        if (classSym.BaseClass != null && !classSym.BaseClass.TypeArguments.IsDefaultOrEmpty)
+        {
+            return this.resolveConstructedBaseCtorToken(classSym.BaseClass);
+        }
+
         if (classSym.BaseClass != null && this.cache.ClassCtorHandles.TryGetValue(classSym.BaseClass, out var baseCtor))
         {
             return baseCtor;

--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -209,32 +209,13 @@ public sealed class StructSymbol : TypeSymbol
                 return false;
             }
 
-            var names = new System.Collections.Generic.HashSet<string>(System.StringComparer.Ordinal);
-            for (var c = this; c != null; c = c.BaseClass)
-            {
-                if (c.Methods.IsDefaultOrEmpty)
-                {
-                    continue;
-                }
-
-                foreach (var m in c.Methods)
-                {
-                    names.Add(m.Name);
-                }
-            }
-
-            foreach (var name in names)
-            {
-                foreach (var effective in GetMethodsIncludingInherited(name))
-                {
-                    if (effective.IsAbstract)
-                    {
-                        return true;
-                    }
-                }
-            }
-
-            return false;
+            // Issue #1055: an abstract base method whose signature uses the base's
+            // generic type parameters is implemented by an override whose concrete
+            // signature matches the substituted base signature. Route through the
+            // substitution-aware unimplemented-method computation so a class that
+            // inherits a constructed generic base (e.g. `Derived : Base[int32]`)
+            // and overrides every abstract member is correctly treated as concrete.
+            return !GetUnimplementedAbstractMethods().IsDefaultOrEmpty;
         }
     }
 
@@ -812,6 +793,14 @@ public sealed class StructSymbol : TypeSymbol
     /// after override resolution) that is still <see cref="FunctionSymbol.IsAbstract"/>.
     /// A concrete (non-<c>open</c>) class with a non-empty result fails to satisfy
     /// its abstract base contract.
+    /// <para>
+    /// Issue #1055: when a base is inherited as a CONSTRUCTED generic (e.g.
+    /// <c>Derived : Base[int32]</c>), an abstract base method whose signature uses
+    /// the base's type parameters is satisfied by an override whose CONCRETE
+    /// signature matches the substituted base signature. The substitution is
+    /// composed across every hop of the inheritance chain so multi-level
+    /// constructions (<c>Leaf : Mid[int32] : Base[T]</c>) resolve correctly.
+    /// </para>
     /// </summary>
     /// <returns>The set of still-abstract effective methods; empty when none.</returns>
     public ImmutableArray<FunctionSymbol> GetUnimplementedAbstractMethods()
@@ -821,29 +810,84 @@ public sealed class StructSymbol : TypeSymbol
             return ImmutableArray<FunctionSymbol>.Empty;
         }
 
-        var names = new System.Collections.Generic.HashSet<string>(System.StringComparer.Ordinal);
+        // Capture each class along the chain (most-derived first) together with the
+        // substitution that maps its declaration's type parameters onto the concrete
+        // type arguments seen in THIS class's context. A deeper base's type arguments
+        // are expressed in terms of a shallower base's type parameters, so resolving
+        // each argument through the running map composes the substitution across hops.
+        var levels = new List<(StructSymbol Cls, Dictionary<TypeParameterSymbol, TypeSymbol> Subst)>();
+        Dictionary<TypeParameterSymbol, TypeSymbol> running = null;
         for (var c = this; c != null; c = c.BaseClass)
         {
-            if (c.Methods.IsDefaultOrEmpty)
+            if (c.Definition != null
+                && !c.TypeArguments.IsDefaultOrEmpty
+                && !c.Definition.TypeParameters.IsDefaultOrEmpty)
+            {
+                var defParams = c.Definition.TypeParameters;
+                var count = System.Math.Min(defParams.Length, c.TypeArguments.Length);
+                for (var i = 0; i < count; i++)
+                {
+                    var arg = c.TypeArguments[i];
+                    if (arg is TypeParameterSymbol tpArg && running != null && running.TryGetValue(tpArg, out var resolved))
+                    {
+                        arg = resolved;
+                    }
+
+                    running ??= new Dictionary<TypeParameterSymbol, TypeSymbol>();
+                    running[defParams[i]] = arg;
+                }
+            }
+
+            levels.Add((c, running == null ? null : new Dictionary<TypeParameterSymbol, TypeSymbol>(running)));
+        }
+
+        ImmutableArray<FunctionSymbol>.Builder builder = null;
+        for (var k = 0; k < levels.Count; k++)
+        {
+            var (cls, subst) = levels[k];
+            if (cls.Methods.IsDefaultOrEmpty)
             {
                 continue;
             }
 
-            foreach (var m in c.Methods)
+            foreach (var abstractMethod in cls.Methods)
             {
-                names.Add(m.Name);
-            }
-        }
+                if (!abstractMethod.IsAbstract)
+                {
+                    continue;
+                }
 
-        ImmutableArray<FunctionSymbol>.Builder builder = null;
-        foreach (var name in names)
-        {
-            foreach (var effective in GetMethodsIncludingInherited(name))
-            {
-                if (effective.IsAbstract)
+                // Implemented when a strictly more-derived class declares a
+                // non-abstract method whose concrete signature matches the
+                // abstract base method's signature after substitution.
+                var implemented = false;
+                for (var kk = 0; kk < k && !implemented; kk++)
+                {
+                    var derivedCls = levels[kk].Cls;
+                    if (derivedCls.Methods.IsDefaultOrEmpty)
+                    {
+                        continue;
+                    }
+
+                    foreach (var candidate in derivedCls.Methods)
+                    {
+                        if (candidate.IsAbstract)
+                        {
+                            continue;
+                        }
+
+                        if (AbstractMethodSatisfiedBy(abstractMethod, subst, candidate))
+                        {
+                            implemented = true;
+                            break;
+                        }
+                    }
+                }
+
+                if (!implemented)
                 {
                     builder ??= ImmutableArray.CreateBuilder<FunctionSymbol>();
-                    builder.Add(effective);
+                    builder.Add(abstractMethod);
                 }
             }
         }
@@ -1114,6 +1158,59 @@ public sealed class StructSymbol : TypeSymbol
 
         return builder.MoveToImmutable();
     }
+
+    /// <summary>
+    /// Issue #1055: decides whether <paramref name="candidate"/> (a more-derived,
+    /// non-abstract method) implements <paramref name="abstractMethod"/> once the
+    /// abstract method's signature is substituted with <paramref name="subst"/>
+    /// (the constructed-base type arguments). Compares name, arity, parameter
+    /// count, ref-kinds and parameter types — mirroring CLR override matching.
+    /// </summary>
+    private static bool AbstractMethodSatisfiedBy(
+        FunctionSymbol abstractMethod,
+        Dictionary<TypeParameterSymbol, TypeSymbol> subst,
+        FunctionSymbol candidate)
+    {
+        if (!string.Equals(abstractMethod.Name, candidate.Name, System.StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var baseParams = CallableParametersOf(abstractMethod);
+        var derivedParams = CallableParametersOf(candidate);
+        if (baseParams.Length != derivedParams.Length)
+        {
+            return false;
+        }
+
+        var baseArity = abstractMethod.TypeParameters.IsDefaultOrEmpty ? 0 : abstractMethod.TypeParameters.Length;
+        var derivedArity = candidate.TypeParameters.IsDefaultOrEmpty ? 0 : candidate.TypeParameters.Length;
+        if (baseArity != derivedArity)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < baseParams.Length; i++)
+        {
+            if (baseParams[i].RefKind != derivedParams[i].RefKind)
+            {
+                return false;
+            }
+
+            var baseType = subst != null
+                ? SubstituteTypeForConstruction(baseParams[i].Type, subst)
+                : baseParams[i].Type;
+            if (!DeclarationBinder.TypeSignaturesEquivalent(baseType, derivedParams[i].Type))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static ImmutableArray<ParameterSymbol> CallableParametersOf(FunctionSymbol method)
+        => method.ExplicitReceiverParameter == null ? method.Parameters : method.Parameters.RemoveAt(0);
 
     private static TypeSymbol SubstituteTypeForConstruction(TypeSymbol type, Dictionary<TypeParameterSymbol, TypeSymbol> subst)
     {

--- a/test/Compiler.Tests/Emit/Issue1055OverrideGenericBaseEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1055OverrideGenericBaseEmitTests.cs
@@ -1,0 +1,165 @@
+// <copyright file="Issue1055OverrideGenericBaseEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1055: when a class overrides an <c>open</c> base member whose
+/// signature USES the base class's generic type parameters, and the base is
+/// inherited as a CONSTRUCTED generic (e.g. <c>Derived : Base[int32, int32]</c>),
+/// the override-matcher must first substitute the constructed base's type
+/// arguments into the candidate base member's signature before comparing.
+/// These tests compile and run an end-to-end program that dispatches through a
+/// base-typed reference to confirm the override is correctly bound, emitted
+/// (with the right base <c>extends</c> TypeSpec and base-ctor chaining), and
+/// dispatched at runtime; the emitted IL is also checked with <c>ilverify</c>.
+/// </summary>
+public class Issue1055OverrideGenericBaseEmitTests
+{
+    [Fact]
+    public void OverrideMethodUsingTypeParams_ConstructedBase_DispatchesThroughBaseRef_Runs()
+    {
+        var source = """
+            package p
+            open class Base[TIn, TOut] {
+                open func Transform(x TIn) TOut;
+            }
+            class Derived : Base[int32, int32] {
+                override func Transform(x int32) int32 { return x + 1 }
+            }
+            func Main() {
+                let b Base[int32, int32] = Derived()
+                System.Console.WriteLine(b.Transform(41))
+            }
+            """;
+
+        Assert.Equal("42\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void OverridePropertyUsingTypeParam_ConstructedBase_DispatchesThroughBaseRef_Runs()
+    {
+        var source = """
+            package p
+            open class Holder[T] {
+                open prop Value T { get; }
+            }
+            class IntHolder : Holder[int32] {
+                override prop Value int32 { get { return 7 } }
+            }
+            func Main() {
+                let h Holder[int32] = IntHolder()
+                System.Console.WriteLine(h.Value)
+            }
+            """;
+
+        Assert.Equal("7\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void OverrideMethodAcrossTwoConstructedLevels_DispatchesThroughMidRef_Runs()
+    {
+        // Leaf : Mid[int32] : Base[T] — the substitution composes across each
+        // hop so the abstract `Do(x T) T` declared on Mid[T] is matched by the
+        // concrete `Do(x int32) int32` override on Leaf.
+        var source = """
+            package p
+            open class Base[T] {
+                open prop Size int32 { get; }
+            }
+            open class Mid[T] : Base[T] {
+                open func Do(x T) T;
+            }
+            open class Leaf : Mid[int32] {
+                override prop Size int32 { get { return 1 } }
+                override func Do(x int32) int32 { return x + 100 }
+            }
+            func Main() {
+                let m Mid[int32] = Leaf()
+                System.Console.WriteLine(m.Do(5))
+            }
+            """;
+
+        Assert.Equal("105\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1055_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/ClassTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ClassTests.cs
@@ -439,6 +439,82 @@ class B : A {
     }
 
     [Fact]
+    public void Override_ConstructedGenericBase_UsingTypeParams_Binds()
+    {
+        // Issue #1055: the base member signature USES the base's type
+        // parameters and the base is inherited as a constructed generic, so the
+        // matcher must substitute TIn->int32, TOut->int32 before comparing.
+        var source = @"
+open class Base[TIn, TOut] {
+    open func Transform(x TIn) TOut;
+}
+class Derived : Base[int32, int32] {
+    override func Transform(x int32) int32 { return x + 1 }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void Override_ConstructedGenericBase_Property_UsingTypeParam_Binds()
+    {
+        // Issue #1055: property whose type is the base's type parameter.
+        var source = @"
+open class Holder[T] {
+    open prop Value T { get; }
+}
+class IntHolder : Holder[int32] {
+    override prop Value int32 { get { return 7 } }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void Override_ConstructedGenericBase_TwoLevels_Binds()
+    {
+        // Issue #1055: substitution must compose across each inheritance hop
+        // (Leaf : Mid[int32] : Base[T]).
+        var source = @"
+open class Base[T] {
+    open prop Size int32 { get; }
+}
+open class Mid[T] : Base[T] {
+    open func Do(x T) T;
+}
+open class Leaf : Mid[int32] {
+    override prop Size int32 { get { return 1 } }
+    override func Do(x int32) int32 { return x + 100 }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void Override_ConstructedGenericBase_RealMismatch_Diagnoses()
+    {
+        // Issue #1055: after substituting TIn->int32, TOut->int32 the override's
+        // parameter type (string) genuinely mismatches and must still report.
+        var source = @"
+open class Base[TIn, TOut] {
+    open func Transform(x TIn) TOut;
+}
+class Derived : Base[int32, int32] {
+    override func Transform(x string) int32 { return 1 }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Message.Contains("match the base method"));
+    }
+
+    [Fact]
     public void Inheritance_InheritedFieldAccessibleByBareName()
     {
         var source = @"


### PR DESCRIPTION
## Fixes #1055

### Problem
When a class overrides an `open` base member whose signature **uses the base class's generic type parameters**, and the base is inherited as a **constructed** generic, gsc failed override matching. The matcher compared the override's concrete signature against the base member's **un-substituted** signature (`(TIn) TOut`) instead of first substituting the constructed base's type arguments (`TIn -> int32, TOut -> int32`).

#### Repros that FAILED before this PR
```
package p
open class Base[TIn, TOut] { open func Transform(x TIn) TOut; }
open class Derived : Base[int32, int32] {
    override func Transform(x int32) int32 { return x + 1 }   // was GS0185
}
```
Two-level chain (grandparent + parent type params):
```
package p
open class Base[T] { protected open prop Size int32 { get; } }
open class Mid[T] : Base[T] { open func Do(x T) T; }
open class Leaf : Mid[int32] {
    protected override prop Size int32 { get { return 1 } }
    override func Do(x int32) int32 { return x }              // was GS0185
}
```

### Fix
- **`DeclarationBinder`** — new `BuildBaseTypeArgumentSubstitution` walks the `BaseClass` chain closest-first and **composes** a type-param→concrete map across every hop (resolving a deeper base's type argument that is itself a shallower base's type parameter, so multi-level chains like `Leaf : Mid[int32] : Base[T]` work). The map flows into the existing `SignaturesMatch(..., typeParamMap)` / `TypeSignaturesEquivalent` path at both the override-match and missing-override sites. Covers return type, parameter types, and (for properties) the property type. Genuine post-substitution mismatches still report **GS0185/GS0183**; a non-open base member still reports **GS0184**.
- **`StructSymbol`** — `GetUnimplementedAbstractMethods()` / `IsAbstract` made substitution-aware so a concrete override of an abstract generic-base member is recognized as satisfying it (was GS0386/GS0387 at instantiation).
- **`TypeDefEmitter` + `ReflectionMetadataEmitter`** — emit the correct base `extends` TypeSpec and base parameterless-ctor `MemberRef` for constructed generic bases (previously keyed by definition only, producing `extends System.Object` and an `Object::.ctor` chain — the assembly segfaulted / failed ILVerify).

### Verification
- Both failing repros now compile (`Wrote ...`).
- The "base member does not use the type parameter" control still compiles.
- A real post-substitution mismatch (`override func Transform(x string) int32`) still reports **GS0185**; a non-open base still reports **GS0184**.
- Dynamic dispatch through a base reference prints **42** (single level) and **105** (two constructed levels); emitted IL is **ilverify-clean**.
- `dotnet build GSharp.sln -c Release -graph` → **0 Error(s), 0 Warning(s)**.
- New tests: `Issue1055OverrideGenericBaseEmitTests` (3 emit/run, incl. property + two-level) and 4 binding tests in `ClassTests`. Core.Tests override/inherit/virtual (81) and abstract/generic/constructed (296) slices green.

### Deferred
Nothing in scope was deferred. Noted separately: a **pre-existing, #1055-independent** bug exists where a `protected` property override in a multi-level chain emits an accessor with reduced CLR access (`TypeLoadException: ... cannot reduce access`). It reproduces with **non-generic** classes too, so it is out of scope here; the two-level regression test uses a public property to exercise the generic-substitution path under test.
