### PR TITLE
Fixes #1060: resolve ': base(args)' against explicit base init constructors

### DIFF
--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -5779,7 +5779,7 @@ internal sealed class DeclarationBinder
         return new BaseConstructorInitializer(convertedArgs.ToImmutable(), bestCtor, refKindsBuilder.ToImmutable());
     }
 
-    /// <summary>Resolves a base-constructor initializer against a GSharp base class's primary constructor (issue #306). Returns <c>null</c> (after reporting a diagnostic) when no match.</summary>
+    /// <summary>Resolves a base-constructor initializer against a GSharp base class's constructors (issue #306). Returns <c>null</c> (after reporting a diagnostic) when no match.</summary>
     private BaseConstructorInitializer ResolveGSharpBaseConstructor(
         System.Func<int, TextLocation> argLocation,
         string derivedNameForDiag,
@@ -5791,6 +5791,18 @@ internal sealed class DeclarationBinder
         {
             Diagnostics.ReportNoMatchingBaseConstructor(location, derivedNameForDiag, boundArguments.Count);
             return null;
+        }
+
+        // Issue #1060: when the base class declares explicit `init(...)`
+        // constructors, the `: base(args)` initializer must resolve against the
+        // full overload set — every explicit init plus (when present) the
+        // synthesized primary-constructor designated init — selecting the best
+        // overload by argument types, mirroring C# where a derived constructor
+        // may chain to any accessible base constructor. The primary-only fast
+        // path below covers classes that declare no explicit init bodies.
+        if (!baseClassSymbol.ExplicitConstructors.IsDefaultOrEmpty)
+        {
+            return ResolveGSharpExplicitBaseConstructor(argLocation, baseClassSymbol, boundArguments, location);
         }
 
         var baseParams = baseClassSymbol.PrimaryConstructorParameters;
@@ -5820,6 +5832,105 @@ internal sealed class DeclarationBinder
         }
 
         return new BaseConstructorInitializer(convertedArgs.ToImmutable(), baseClassSymbol);
+    }
+
+    /// <summary>
+    /// Issue #1060: resolves a <c>: base(args)</c> initializer against the explicit
+    /// <c>init(...)</c> constructors declared on a GSharp base class (which already
+    /// includes the synthesized primary-constructor designated init when present),
+    /// selecting the best overload by argument types. Returns <c>null</c> (after
+    /// reporting a diagnostic) when no accessible base constructor matches.
+    /// </summary>
+    private BaseConstructorInitializer ResolveGSharpExplicitBaseConstructor(
+        System.Func<int, TextLocation> argLocation,
+        StructSymbol baseClassSymbol,
+        ImmutableArray<BoundExpression>.Builder boundArguments,
+        TextLocation location)
+    {
+        ConstructorSymbol best = null;
+        var bestExactMatches = -1;
+        var ambiguous = false;
+        var anyArgIsError = false;
+
+        foreach (var arg in boundArguments)
+        {
+            if (arg.Type == TypeSymbol.Error)
+            {
+                anyArgIsError = true;
+            }
+        }
+
+        foreach (var candidate in baseClassSymbol.ExplicitConstructors)
+        {
+            var parameters = candidate.Parameters;
+            if (parameters.Length != boundArguments.Count)
+            {
+                continue;
+            }
+
+            var applicable = true;
+            var exactMatches = 0;
+            for (var i = 0; i < parameters.Length; i++)
+            {
+                var argType = boundArguments[i].Type;
+                var paramType = parameters[i].Type;
+                if (argType == paramType)
+                {
+                    exactMatches++;
+                    continue;
+                }
+
+                // Error-typed arguments don't disqualify a candidate: a prior
+                // diagnostic already explains the bad argument.
+                if (argType == TypeSymbol.Error)
+                {
+                    continue;
+                }
+
+                if (!Conversion.Classify(argType, paramType).IsImplicit)
+                {
+                    applicable = false;
+                    break;
+                }
+            }
+
+            if (!applicable)
+            {
+                continue;
+            }
+
+            if (exactMatches > bestExactMatches)
+            {
+                best = candidate;
+                bestExactMatches = exactMatches;
+                ambiguous = false;
+            }
+            else if (exactMatches == bestExactMatches)
+            {
+                ambiguous = true;
+            }
+        }
+
+        if (best == null || ambiguous)
+        {
+            // Suppress the GS0214 cascade when an argument already failed to
+            // bind (an error type was produced upstream).
+            if (!anyArgIsError)
+            {
+                Diagnostics.ReportNoMatchingBaseConstructor(location, baseClassSymbol.Name, boundArguments.Count);
+            }
+
+            return null;
+        }
+
+        var bestParams = best.Parameters;
+        var convertedArgs = ImmutableArray.CreateBuilder<BoundExpression>(boundArguments.Count);
+        for (var i = 0; i < boundArguments.Count; i++)
+        {
+            convertedArgs.Add(conversions.BindConversion(argLocation(i), boundArguments[i], bestParams[i].Type));
+        }
+
+        return new BaseConstructorInitializer(convertedArgs.ToImmutable(), baseClassSymbol, best);
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs
@@ -1510,6 +1510,17 @@ internal sealed class TypeDefEmitter
         }
 
         var gsharpBase = init.GSharpBaseType;
+
+        // Issue #1060: when the base initializer resolved to a specific explicit
+        // `init(...)` constructor on the GSharp base class, target that exact
+        // constructor's metadata handle (pre-registered for every non-SM class
+        // before any body is emitted), not just the base's primary/first ctor.
+        if (init.GSharpConstructor != null
+            && this.cache.ExplicitCtorHandles.TryGetValue(init.GSharpConstructor, out var explicitHandle))
+        {
+            return explicitHandle;
+        }
+
         if (init.Arguments.Length > 0
             && gsharpBase.HasPrimaryConstructor
             && this.cache.ClassPrimaryCtorHandles.TryGetValue(gsharpBase, out var primaryHandle))

--- a/src/Core/CodeAnalysis/Symbols/BaseConstructorInitializer.cs
+++ b/src/Core/CodeAnalysis/Symbols/BaseConstructorInitializer.cs
@@ -41,10 +41,23 @@ public sealed class BaseConstructorInitializer
     /// <param name="arguments">The bound, conversion-applied argument expressions.</param>
     /// <param name="gsharpBaseType">The GSharp base class whose primary constructor is targeted.</param>
     public BaseConstructorInitializer(ImmutableArray<BoundExpression> arguments, StructSymbol gsharpBaseType)
+        : this(arguments, gsharpBaseType, gsharpConstructor: null)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BaseConstructorInitializer"/>
+    /// class targeting a specific explicit <c>init(...)</c> constructor declared on a GSharp base class (issue #1060).
+    /// </summary>
+    /// <param name="arguments">The bound, conversion-applied argument expressions.</param>
+    /// <param name="gsharpBaseType">The GSharp base class whose constructor is targeted.</param>
+    /// <param name="gsharpConstructor">The resolved explicit base-class constructor, or <see langword="null"/> to target the primary constructor.</param>
+    public BaseConstructorInitializer(ImmutableArray<BoundExpression> arguments, StructSymbol gsharpBaseType, ConstructorSymbol gsharpConstructor)
     {
         Arguments = arguments;
         ClrConstructor = null;
         GSharpBaseType = gsharpBaseType;
+        GSharpConstructor = gsharpConstructor;
         ArgumentRefKinds = ImmutableArray<RefKind>.Empty;
     }
 
@@ -59,6 +72,13 @@ public sealed class BaseConstructorInitializer
 
     /// <summary>Gets the GSharp base class whose constructor is targeted, or <c>null</c> when the base class is an imported CLR type.</summary>
     public StructSymbol GSharpBaseType { get; }
+
+    /// <summary>
+    /// Gets the resolved explicit <c>init(...)</c> constructor on the GSharp base class
+    /// that this initializer targets, or <see langword="null"/> when the target is the base class's
+    /// primary constructor (or the base is an imported CLR type) (issue #1060).
+    /// </summary>
+    public ConstructorSymbol GSharpConstructor { get; }
 
     /// <summary>Gets a value indicating whether the targeted base constructor lives on an imported CLR type.</summary>
     public bool IsClrBase => ClrConstructor != null;
@@ -75,6 +95,6 @@ public sealed class BaseConstructorInitializer
     {
         return IsClrBase
             ? new BaseConstructorInitializer(arguments, ClrConstructor, ArgumentRefKinds)
-            : new BaseConstructorInitializer(arguments, GSharpBaseType);
+            : new BaseConstructorInitializer(arguments, GSharpBaseType, GSharpConstructor);
     }
 }

--- a/test/Compiler.Tests/Emit/Issue1060BaseInitChainingEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1060BaseInitChainingEmitTests.cs
@@ -1,0 +1,270 @@
+// <copyright file="Issue1060BaseInitChainingEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1060: end-to-end CLR emit + ilverify coverage for a derived class
+/// constructor initializer (<c>init(...) : base(args)</c>) chaining to a base
+/// class's explicit <c>init(...)</c> member constructors (rather than only a
+/// primary constructor). Validates that the resolved base constructor is the
+/// one actually invoked in emitted CIL (the <c>call instance void
+/// Base::.ctor(...)</c> targets the selected overload), that overload selection
+/// among multiple explicit base inits is by argument types, and that the
+/// pre-existing primary-ctor and CLR-base chaining paths are not regressed.
+/// </summary>
+public class Issue1060BaseInitChainingEmitTests
+{
+    [Fact]
+    public void EndToEnd_ChainToSingleExplicitBaseInit_RunsBaseCtorAndSetsField()
+    {
+        var source = """
+            package p
+            open class A {
+                var X int32
+                init(x int32) { X = x }
+            }
+            class B : A {
+                init(x int32) : base(x) { }
+            }
+            func Main() {
+                var b = B(7)
+                System.Console.WriteLine(b.X)
+            }
+            """;
+        var output = CompileAndRun(source);
+        Assert.Equal("7\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_SelectsAmongMultipleExplicitBaseInitsByArgCount()
+    {
+        var source = """
+            package p
+            open class A {
+                var Tag string
+                init(x int32) { Tag = "one" }
+                init(x int32, y int32) { Tag = "two" }
+            }
+            class B : A {
+                init() : base(1, 2) { }
+            }
+            func Main() {
+                var b = B()
+                System.Console.WriteLine(b.Tag)
+            }
+            """;
+        var output = CompileAndRun(source);
+        Assert.Equal("two\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_SelectsAmongMultipleExplicitBaseInitsByArgType()
+    {
+        var source = """
+            package p
+            open class A {
+                var Tag string
+                init(x int32) { Tag = "int" }
+                init(s string) { Tag = "string" }
+            }
+            class B : A {
+                init() : base("hi") { }
+            }
+            func Main() {
+                var b = B()
+                System.Console.WriteLine(b.Tag)
+            }
+            """;
+        var output = CompileAndRun(source);
+        Assert.Equal("string\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_ChainToBasePrimaryConstructor_StillWorks()
+    {
+        var source = """
+            package p
+            open class A(X int32) {}
+            class B : A {
+                init(x int32) : base(x) {}
+                func Read() int32 { return X }
+            }
+            func Main() {
+                var b = B(42)
+                System.Console.WriteLine(b.Read())
+            }
+            """;
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_ChainToClrBaseConstructor_StillWorks()
+    {
+        var source = """
+            package p
+            class MyError : System.Exception {
+                var Code int32
+                init(m string, c int32) : base(m) { Code = c }
+            }
+            func Main() {
+                var e = MyError("boom", 13)
+                System.Console.WriteLine(e.Message)
+                System.Console.WriteLine(e.Code)
+            }
+            """;
+        var output = CompileAndRun(source);
+        Assert.Equal("boom\n13\n", output);
+    }
+
+    [Fact]
+    public void Library_ChainToExplicitBaseInit_PassesIlVerify()
+    {
+        // ilverify is invoked unconditionally by CompileLibrary; emitting a call
+        // to the wrong base .ctor token (e.g. a non-existent parameterless ctor)
+        // would fail verification here.
+        var source = """
+            package p
+            open class A {
+                var X int32
+                init(x int32) { X = x }
+                init(x int32, y int32) { X = x + y }
+            }
+            class B : A {
+                init(x int32) : base(x) { }
+                init() : base(1, 2) { }
+            }
+            """;
+
+        var dllPath = CompileLibrary(source);
+        TryCleanup(dllPath);
+    }
+
+    private static string CompileLibrary(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1060_lib_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        var args = new[]
+        {
+            "/out:" + outPath,
+            "/target:library",
+            "/targetframework:net10.0",
+            srcPath,
+        };
+
+        RunCompiler(args);
+        IlVerifier.Verify(outPath);
+        return outPath;
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1060_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            RunCompiler(args);
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static void RunCompiler(string[] args)
+    {
+        using var stdoutWriter = new StringWriter();
+        using var stderrWriter = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(stdoutWriter);
+        Console.SetError(stderrWriter);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+    }
+
+    private static void TryCleanup(string dllPath)
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(dllPath);
+            if (dir != null && Directory.Exists(dir))
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+        catch
+        {
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1060BaseInitChainingBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1060BaseInitChainingBinderTests.cs
@@ -1,0 +1,112 @@
+// <copyright file="Issue1060BaseInitChainingBinderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1060 — binder-level tests confirming that a derived class's
+/// constructor initializer (<c>init(...) : base(args)</c>) resolves against the
+/// base class's explicit <c>init(...)</c> member constructors (and a primary
+/// constructor when present), not only the primary constructor. The previously
+/// failing repros must now bind with zero diagnostics; a genuinely-missing base
+/// constructor must still report GS0214.
+/// </summary>
+public class Issue1060BaseInitChainingBinderTests
+{
+    [Fact]
+    public void ChainToSingleExplicitBaseInit_BindsWithoutDiagnostics()
+    {
+        var source = @"
+package p
+open class A {
+    var X int32
+    init(x int32) { X = x }
+}
+class B : A {
+    init(x int32) : base(x) { }
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void SelectsAmongMultipleExplicitBaseInits_BindsWithoutDiagnostics()
+    {
+        var source = @"
+package p
+open class A {
+    init(x int32) {}
+    init(x int32, y int32) {}
+}
+class B : A {
+    init() : base(1, 2) { }
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void ChainToBasePrimaryConstructor_StillBindsWithoutDiagnostics()
+    {
+        var source = @"
+package p
+open class A(X int32) {}
+class B : A {
+    init(x int32) : base(x) {}
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void NoMatchingBaseConstructor_ReportsGs0214()
+    {
+        var source = @"
+package p
+open class A {
+    init(x int32) {}
+}
+class B : A {
+    init() : base(""nope"") {}
+}
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0214");
+    }
+
+    [Fact]
+    public void WrongArgumentCountForExplicitBaseInit_ReportsGs0214()
+    {
+        var source = @"
+package p
+open class A {
+    init(x int32) {}
+}
+class B : A {
+    init() : base(1, 2) {}
+}
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0214");
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
Fixes #1060

## Root cause
A derived class's constructor initializer `init(...) : base(args)` only resolved against the base class's **primary** constructor. When the base class declared its constructors as explicit `init(...)` members (no primary constructor), the base-initializer call failed with `GS0214` even though a matching explicit `init` exists and is directly callable.

Direct construction (`A(5)`) and chaining to a base *primary* constructor already worked — the gap was isolated to the `: base(args)` overload-resolution path: `ResolveGSharpBaseConstructor` only matched the base's `PrimaryConstructorParameters`, and the emitter's `GetBaseInitializerCtorToken` only targeted the base's primary/first ctor handle.

## Fix
- **Binding/overload resolution** (`DeclarationBinder.ResolveGSharpBaseConstructor`): when the base class declares explicit `init(...)` constructors, resolve the initializer against the full overload set (every explicit init plus the synthesized primary-ctor designated init when present), selecting the best overload by argument types — mirroring C#, where a derived ctor may chain to any accessible base ctor. The primary-ctor-only fast path is retained for classes with no explicit init bodies.
- **Symbol** (`BaseConstructorInitializer`): carries the resolved `GSharpConstructor` so the emitter knows the exact base `.ctor`.
- **Emit** (`TypeDefEmitter.GetBaseInitializerCtorToken`): targets the resolved explicit ctor's pre-registered metadata handle, so the emitted `call instance void Base::.ctor(...)` invokes the selected overload and the assembly passes ilverify.

The imported-CLR-base path (e.g. `MyError : Exception`) is unchanged and not regressed.

## Verification
- `dotnet build GSharp.sln -c Release -graph` → 0 errors.
- Failing repro now compiles with zero diagnostics; multi-init selection (`init() : base(1, 2)` picks the 2-arg init) compiles; a genuinely-absent base ctor (`: base("nope")`) still reports `GS0214`.
- New `test/Compiler.Tests/Emit/Issue1060BaseInitChainingEmitTests.cs` (6 tests, CompileAndRun + ilverify): single explicit base init, selection by arg count and by arg type, primary-ctor regression, CLR-base regression, ilverify library guard — all pass.
- New `test/Core.Tests/CodeAnalysis/Binding/Issue1060BaseInitChainingBinderTests.cs` (5 tests) — all pass.
- Constructor-related Compiler.Tests slice (42 tests) passes; full `test/Core.Tests` (3686 tests) passes.
- `samples/ExplicitConstructor.gs` and `samples/Deinit.gs` compile cleanly and run with correct output (including the CLR-base `MyError : Exception` case).

No new SyntaxKind/BoundNodeKind introduced.