### PR TITLE
Fixes #1061: bind self-referential constraints on interface declarations

### DIFF
--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -3735,13 +3735,50 @@ internal sealed class DeclarationBinder
 
         // Phase 4.3c / ADR-0020: bind type parameters at declaration time so
         // method-signature binding (which happens later) can resolve them.
-        var typeParameters = BindTypeParameterList(syntax.TypeParameterList);
+        //
+        // Issue #1061: register the interface's name shell BETWEEN creating the
+        // bare type parameters and resolving their constraints (mirroring the
+        // class/struct path from #1056). This puts the declaring interface's own
+        // name and arity in scope while its type-parameter constraints are bound,
+        // so a self-referential / CRTP constraint such as
+        // `interface IData[T IData]` or `interface IData[TData IAppleData[TData]]`
+        // resolves the interface being declared instead of failing with GS0113.
+        var registered = false;
+        var registrationFailed = false;
+        var typeParameters = BindTypeParameterList(
+            syntax.TypeParameterList,
+            bareSymbols =>
+            {
+                if (!bareSymbols.IsDefaultOrEmpty)
+                {
+                    interfaceSymbol.SetTypeParameters(bareSymbols);
+                }
+
+                if (!scope.TryDeclareTypeAlias(name, interfaceSymbol))
+                {
+                    Diagnostics.ReportSymbolAlreadyDeclared(syntax.Identifier.Location, name);
+                    registrationFailed = true;
+                    return;
+                }
+
+                registered = true;
+            });
+
+        if (registrationFailed)
+        {
+            return null;
+        }
+
+        // Bind the fully-resolved type parameters (with constraints) onto the
+        // interface symbol; the callback only attached the bare symbols.
         if (!typeParameters.IsDefaultOrEmpty)
         {
             interfaceSymbol.SetTypeParameters(typeParameters);
         }
 
-        if (!scope.TryDeclareTypeAlias(name, interfaceSymbol))
+        // Non-generic interfaces (or the defensive fallback when the callback did
+        // not run) register the name shell here.
+        if (!registered && !scope.TryDeclareTypeAlias(name, interfaceSymbol))
         {
             Diagnostics.ReportSymbolAlreadyDeclared(syntax.Identifier.Location, name);
             return null;

--- a/test/Compiler.Tests/Emit/Issue1061InterfaceCrtpConstraintEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1061InterfaceCrtpConstraintEmitTests.cs
@@ -1,0 +1,129 @@
+// <copyright file="Issue1061InterfaceCrtpConstraintEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1061: end-to-end CLR emit + ilverify coverage for a self-referential /
+/// CRTP constraint on an INTERFACE declaration (the interface's own type
+/// parameter constrained by the interface being declared). A missing or garbled
+/// GenericParamConstraint metadata row pointing at the interface would fail
+/// ilverify, so a clean verification confirms the constraint binds and emits
+/// correctly — the same way the class CRTP shape does (issue #1056).
+/// </summary>
+public class Issue1061InterfaceCrtpConstraintEmitTests
+{
+    [Fact]
+    public void Library_SelfReferentialInterfaceConstraint_BareName_PassesIlVerify()
+    {
+        var source = """
+            package p
+            interface IData[T IData] {
+                func Write(d int32);
+            }
+            """;
+
+        var dllPath = CompileLibrary(source);
+        TryCleanup(dllPath);
+    }
+
+    [Fact]
+    public void Library_SelfReferentialInterfaceConstraint_Crtp_PassesIlVerify()
+    {
+        var source = """
+            package p
+            interface IData[TData IData[TData]] {
+                func Write(d int32);
+            }
+            """;
+
+        var dllPath = CompileLibrary(source);
+        TryCleanup(dllPath);
+    }
+
+    [Fact]
+    public void Library_CrtpInterfaceWithConcreteImplementer_PassesIlVerify()
+    {
+        // The CRTP interface together with a concrete implementer that supplies
+        // itself as the type argument (`class C : IData[C]`). The implementer
+        // must satisfy the self-referential constraint, and the produced
+        // assembly (interface TypeDef + GenericParamConstraint + implementing
+        // class) must verify.
+        var source = """
+            package p
+            interface IData[T IData[T]] {
+                func Write(d int32);
+            }
+            class C : IData[C] {
+                func Write(d int32) { }
+            }
+            """;
+
+        var dllPath = CompileLibrary(source);
+        TryCleanup(dllPath);
+    }
+
+    private static string CompileLibrary(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1061_lib_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        var args = new[]
+        {
+            "/out:" + outPath,
+            "/target:library",
+            "/targetframework:net10.0",
+            srcPath,
+        };
+
+        RunCompiler(args);
+        IlVerifier.Verify(outPath);
+        return outPath;
+    }
+
+    private static void RunCompiler(string[] args)
+    {
+        using var stdoutWriter = new StringWriter();
+        using var stderrWriter = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(stdoutWriter);
+        Console.SetError(stderrWriter);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+    }
+
+    private static void TryCleanup(string dllPath)
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(dllPath);
+            if (dir != null && Directory.Exists(dir))
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+        catch
+        {
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1061InterfaceCrtpConstraintTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1061InterfaceCrtpConstraintTests.cs
@@ -1,0 +1,92 @@
+// <copyright file="Issue1061InterfaceCrtpConstraintTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1061: a self-referential / CRTP constraint on an INTERFACE
+/// declaration — where the interface's own type parameter is constrained by the
+/// interface being declared — must bind the same way it does on a class or
+/// struct (issue #1056). The declaring interface's name and arity are now in
+/// scope while its type-parameter constraints are bound, so
+/// <c>interface IData[T IData]</c> and <c>interface IData[TData IData[TData]]</c>
+/// resolve the interface instead of failing with GS0113. A value type used as a
+/// constraint is still GS0153 and a genuinely-unknown constraint name is still
+/// GS0113 (the blanket GS0113 suppression is NOT introduced).
+/// </summary>
+public class Issue1061InterfaceCrtpConstraintTests
+{
+    [Fact]
+    public void SelfReferentialInterfaceConstraint_BareName_BindsWithoutDiagnostics()
+    {
+        const string source = """
+            package p
+            interface IData[T IData] {
+                func Write(d int32);
+            }
+            """;
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(source)));
+        Assert.Empty(compilation.GlobalScope.Diagnostics);
+
+        var iface = compilation.GlobalScope.Interfaces.Single(i => i.Name == "IData");
+        var tp = Assert.Single(iface.TypeParameters);
+        Assert.NotNull(tp.InterfaceConstraint);
+        Assert.Same(iface, tp.InterfaceConstraint);
+    }
+
+    [Fact]
+    public void SelfReferentialInterfaceConstraint_Crtp_BindsWithoutDiagnostics()
+    {
+        const string source = """
+            package p
+            interface IData[TData IData[TData]] {
+                func Write(d int32);
+            }
+            """;
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(source)));
+        Assert.Empty(compilation.GlobalScope.Diagnostics);
+
+        var iface = compilation.GlobalScope.Interfaces.Single(i => i.Name == "IData");
+        var tp = Assert.Single(iface.TypeParameters);
+        Assert.NotNull(tp.InterfaceConstraint);
+        Assert.Same(iface, tp.InterfaceConstraint.Definition ?? tp.InterfaceConstraint);
+    }
+
+    [Fact]
+    public void ValueTypeConstraintOnInterface_StillReportsGS0153()
+    {
+        // A value type is not a legal constraint even after #1061; the GS0113
+        // suppression is specific to the declaring interface's own name.
+        const string source = """
+            package p
+            interface IBad[T int32] {
+                func Write(d int32);
+            }
+            """;
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(source)));
+        Assert.Contains(compilation.GlobalScope.Diagnostics, d => d.Id == "GS0153");
+    }
+
+    [Fact]
+    public void UnknownConstraintTypeNameOnInterface_StillReportsGS0113()
+    {
+        // A genuinely-unknown constraint type name still fails with GS0113; the
+        // fix did not blanket-suppress the "type doesn't exist" diagnostic.
+        const string source = """
+            package p
+            interface IBad[T DoesNotExist] {
+                func Write(d int32);
+            }
+            """;
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(source)));
+        Assert.Contains(compilation.GlobalScope.Diagnostics, d => d.Id == "GS0113");
+    }
+}


### PR DESCRIPTION
Fixes #1061

## Root cause
A self-referential / CRTP generic constraint on an **interface** declaration — where the interface's own type parameter is constrained by the interface being declared (`interface IData[T IData]` / `interface IData[TData IData[TData]]`) — failed with `GS0113: Type 'IData' doesn't exist.`

`DeclareInterfaceSymbol` bound the type-parameter list (which resolves constraints) **before** registering the interface name in scope via `TryDeclareTypeAlias`, so the declaring interface's own name was not visible while binding its own constraints. The analogous class/struct shape was already fixed by #1056.

## Fix
`DeclareInterfaceSymbol` now registers the interface's name shell **between** creating the bare type parameters and resolving their constraints, reusing the between-passes callback that `BindTypeParameterList` exposes (added by #1056). The bare type parameters are attached to the interface symbol and the name + arity is published into scope before constraint clauses bind, so the self-referential constraint resolves the in-flight interface. `ResolveInterfaceConstraint` (#1052) already accepts a user interface as a constraint, so no resolution change was needed. Duplicate-name detection and the non-generic path are preserved.

## Verification
- `dotnet build GSharp.sln -c Release -graph` → 0 errors.
- Both failing repros compile clean; the class-CRTP control (`open class Box[T Box[T]]`) still compiles; a builtin value-type constraint (`interface IBad[T int32]`) still reports **GS0153**; an unknown-name constraint (`interface IBad[T DoesNotExist]`) still reports **GS0113** (no blanket suppression).
- New `Issue1061` binder tests (4) and emit tests (3, incl. a concrete `class C : IData[C]` implementer) pass; **ilverify** accepts the emitted assemblies (GenericParamConstraint row intact).
- Regression slices green: Compiler.Tests `Issue1056`/`Issue1052`/`Constraint` (26), full `Core.Tests` (3690 passed, 1 skipped).

## Tests added
- `test/Core.Tests/CodeAnalysis/Binding/Issue1061InterfaceCrtpConstraintTests.cs`
- `test/Compiler.Tests/Emit/Issue1061InterfaceCrtpConstraintEmitTests.cs`
