### PR TITLE
cs2gs: keep explicit ctor + init-only props for contract properties; fix uint literals, new object(), generated-file exclusion, data-struct emit, override openness

### DIFF
--- a/docs/adr/0115-csharp-to-gsharp-migration-tool.md
+++ b/docs/adr/0115-csharp-to-gsharp-migration-tool.md
@@ -148,6 +148,11 @@ C# **extension methods** (`static R M(this T self, …)`) translate to the recei
 #### B.6 Inheritance and the `:` clause — ADR-0017, spec §Type declarations
 
 - C# classes are sealed-by-default in G#; a base class that is subclassed must be emitted `open class`, and the overriding member must carry `override` (ADR-0017). The translator uses Roslyn's `INamedTypeSymbol.IsSealed`/`IsAbstract`/inheritance graph to decide: a class that any other corpus type derives from → `open`; a C# `abstract`/`virtual` member that is overridden → `open`/`override` on the pair. C# `sealed class` → plain `class` (already the default) or `sealed class` when it participates in a closed hierarchy switched on exhaustively (ADR-0078).
+- **Member `open`/`override` openness (Oahu.Decrypt round).** G# only treats a member as overridable when it is explicitly `open`, and unlike C# this does **not** extend automatically to framework/metadata virtuals or to existing `override`s. Three rules keep an inheritance chain compiling:
+  - **External-base overrides drop `override`.** G# does not treat a virtual declared in *referenced metadata* (e.g. `Object.ToString`, `Stream.Read`, `IDisposable.Dispose`) as `open`, so emitting `override` for a method/property that overrides such an external base member fails (`GS0183`). The translator detects this (`OverridesExternalBaseMethod`/`OverridesExternalBaseProperty`: the overridden root is declared outside the compilation) and emits a plain `func`/`prop` — which still binds as the override — instead of `override`.
+  - **A non-sealed override is re-emitted `open`.** A C# `override` member is itself overridable unless `sealed`, so a further subclass can override it again; G# requires the base member to be `open` for that (`GS0184`). A kept (non-external, non-`sealed`) override is therefore emitted as `override open`.
+  - **Member `open` is gated on class openness.** G# rejects `open` on a member whose enclosing class is not itself `open` (`GS0190`). The translator only marks a member `open` when the containing type *will be* emitted `open class` (`IsTypeEmittedOpen` mirrors the class-declaration openness logic: abstract, has a `protected` member, or subclassed-and-not-sealed), so an override in a leaf/sealed class stays a plain `override func`.
+- **Get-only auto-property + explicit constructor (Oahu.Decrypt OD-T1).** When a single-instance-constructor `class` assigns its parameters to a property that is a **contract member** (implements an interface property, or is `virtual`/`abstract`/`override` — `IsContractProperty`), the translator does **not** lift to a primary constructor (G# primary-ctor parameters are fields, not properties, and would fail the interface property contract — `GS0187`, cascading to `GS0214`/`GS0183`). Instead it keeps the explicit `init(...)` and emits each affected C# get-only auto-property (`{ get; }`) as a G# **init-only** property `prop X T { get; init; }` (a bare `{ get; }` is read-only and the kept `init` assignment would be `GS0127`). An inline get-only-auto-property initializer (`{ get; } = new();`) — which G# cannot express as a property member initializer — is moved into the explicit constructor body. Plain `struct`s (which admit no explicit `init`) and non-contract class properties still lift to the primary-constructor form.
 - The base clause lists the **base class first, then interfaces**: `class Dog : Animal, IBark { … }` (spec `BaseClause = ":" QualifiedTypeName … { "," QualifiedTypeName }`; `samples/Class.gs`). Constructor chaining renders as `: Base(args)` on the base clause or `init(...) : Base(args) { … }` (ADR-0065, `samples/ExplicitConstructor.gs`).
 
 #### B.7 Generics — ADR-0020, ADR-0097, ADR-0098/ADR-0049
@@ -568,6 +573,41 @@ empirically (gsc **0.2.137+31ced6cfb7**) before adoption.
   re-escapes any character below `U+0020` (and `U+007F`) — e.g. C# `"\0\0\0"` —
   as a `\uXXXX` escape so the emitted G# string stays terminated and round-trips
   (previously a raw NUL produced `GS0003: Unterminated string literal`).
+- **Unsigned literal coercion at an unsigned target (OD-T2).** A C# integer
+  literal implicitly converted to an unsigned field/parameter (`uint samplesPerChunk = 0`,
+  a `: base(4)` argument whose parameter is `uint8`) is emitted with an explicit
+  width cast (`uint32(0)`, `uint8(4)`) because G# has no implicit numeric
+  promotion (`GS0156`). The coercion (`CoerceConstantToUnsigned`) fires on field
+  initializers, assignments, and call/`base(...)` arguments whose Roslyn-converted
+  target type is `uint8`/`uint16`/`uint32`/`uint64`.
+- **`new object()` / target-typed `new()` to `object` → `System.Object()` (OD-T3).**
+  A construction of `System.Object` has no bare `object()` spelling (`GS0130`,
+  "function `object` doesn't exist"); the translator emits the fully-qualified
+  `System.Object()` callee.
+- **Build-generated source exclusion (OD-T4).** The project loader
+  (`CSharpProjectLoader.IsGeneratedSource`) excludes build artifacts from the
+  corpus so they cannot inject undefined attributes (`GS0198`): anything under an
+  `obj/` or `bin/` directory, plus generated files (`*.AssemblyInfo.cs`,
+  `*.AssemblyAttributes.cs`, `*.GlobalUsings.g.cs`, `*.Version.cs`, `*.g.cs`,
+  `*.g.i.cs`) — e.g. the Nerdbank.GitVersioning `ThisAssembly` file.
+- **Record → plain `class`/`struct` downgrade (OD-T5).** A C# `record`/`record struct`
+  whose data members are auto-properties that cannot become primary-constructor
+  data fields (`RecordHasAutoPropertyDataMember`) is downgraded so it does not
+  emit an invalid `data` type: a `record` **class** always downgrades to a plain
+  `class`; a `record struct` downgrades to a plain `struct` only when it has **no**
+  explicit instance constructor (a `record struct` *with* an explicit ctor must
+  still lift to a `data struct`, since a plain `struct` admits no explicit `init`).
+  This (with the existing fieldless-record rule, §B T4) clears `GS0104`
+  (fieldless `data struct`), `GS0189` (auto-property in a `data struct`), and
+  `GS0232` (explicit `ToString` colliding with a `data` type's synthesized one).
+- **Whole-app compile ordering.** `CompileStage.OrderForCompilation` topologically
+  sorts the emitted `.gs` files so each type's base classes and interfaces are
+  passed to `gsc` **before** it (Kahn's algorithm, stable on original order; a
+  file declares its dependency through `EmittedGsFile.BaseClassNames`, which now
+  includes implemented interfaces as well as the base class). This works around a
+  `gsc` order-sensitivity in `: base(...)`/interface-satisfaction binding (§G).
+  Ordering affects only the compiler command line, never file content, so golden
+  `.gs` outputs are unchanged.
 
 `Cs2Gs.Pipeline` runs four ordered stages per corpus app. Each stage has an explicit pass/fail gate; a failure short-circuits the remaining stages for that app, emits a triage artifact (section D), and is recorded in the run report. **"Migration completed" ≡ all four stages green: clean compile + clean IL verification + test parity with the original C#.**
 

--- a/tools/cs2gs/Cs2Gs.Pipeline/CompileStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/CompileStage.cs
@@ -40,7 +40,9 @@ public sealed class CompileStage : IMigrationStage
         string outputName = Path.GetFileNameWithoutExtension(context.App.ProjectPath) + ".dll";
         string outputPath = Path.Combine(context.AppRunDir, outputName);
 
-        IReadOnlyList<string> gsFiles = context.EmittedFiles.Select(f => f.GsPath).ToList();
+        IReadOnlyList<string> gsFiles = OrderForCompilation(context.EmittedFiles)
+            .Select(f => f.GsPath)
+            .ToList();
         GscResult result = context.Gsc.Compile(
             gsFiles,
             outputPath,
@@ -82,6 +84,103 @@ public sealed class CompileStage : IMigrationStage
         }
 
         return Task.FromResult(StageOutcome.Failed(artifacts));
+    }
+
+    /// <summary>
+    /// Orders emitted files so that a file declaring a base class is compiled
+    /// before any file declaring its subclasses. gsc currently resolves a
+    /// <c>: base(...)</c> constructor chain against the base class's explicit
+    /// <c>init</c> only when the base type has already been bound, so a derived
+    /// class that appears before its base reports a spurious GS0214 "no
+    /// accessible constructor" (and cascading GS0183/GS0187). A stable
+    /// topological sort on the class-inheritance graph avoids that; cycles (which
+    /// the inheritance graph cannot contain, but file-level grouping might) fall
+    /// back to the original order.
+    /// </summary>
+    private static IReadOnlyList<EmittedGsFile> OrderForCompilation(IReadOnlyList<EmittedGsFile> files)
+    {
+        if (files.Count <= 1)
+        {
+            return files;
+        }
+
+        // Map each declared type's simple name to the file that declares it.
+        var typeToFile = new Dictionary<string, int>(StringComparer.Ordinal);
+        for (int i = 0; i < files.Count; i++)
+        {
+            foreach (string typeName in files[i].DeclaredTypeNames)
+            {
+                typeToFile.TryAdd(typeName, i);
+            }
+        }
+
+        // Edges: a file depends on (must come after) every file that declares one
+        // of its base classes.
+        var dependencies = new List<HashSet<int>>(files.Count);
+        var dependentCount = new int[files.Count];
+        for (int i = 0; i < files.Count; i++)
+        {
+            dependencies.Add(new HashSet<int>());
+        }
+
+        for (int i = 0; i < files.Count; i++)
+        {
+            foreach (string baseName in files[i].BaseClassNames)
+            {
+                if (typeToFile.TryGetValue(baseName, out int baseFile) &&
+                    baseFile != i &&
+                    dependencies[i].Add(baseFile))
+                {
+                    dependentCount[i]++;
+                }
+            }
+        }
+
+        // Kahn's algorithm with stable tie-breaking by original index.
+        var ordered = new List<EmittedGsFile>(files.Count);
+        var emitted = new bool[files.Count];
+        int remaining = files.Count;
+        while (remaining > 0)
+        {
+            int picked = -1;
+            for (int i = 0; i < files.Count; i++)
+            {
+                if (!emitted[i] && dependentCount[i] == 0)
+                {
+                    picked = i;
+                    break;
+                }
+            }
+
+            if (picked < 0)
+            {
+                // Cycle in the file-level graph: emit the remaining files in their
+                // original order to make progress.
+                for (int i = 0; i < files.Count; i++)
+                {
+                    if (!emitted[i])
+                    {
+                        ordered.Add(files[i]);
+                        emitted[i] = true;
+                    }
+                }
+
+                break;
+            }
+
+            ordered.Add(files[picked]);
+            emitted[picked] = true;
+            remaining--;
+            for (int i = 0; i < files.Count; i++)
+            {
+                if (!emitted[i] && dependencies[i].Remove(picked))
+                {
+                    dependentCount[i]--;
+                }
+            }
+        }
+
+        return ordered;
     }
 
     private static EmittedGsFile MatchEmittedFile(IReadOnlyList<EmittedGsFile> files, string diagnosticFile)

--- a/tools/cs2gs/Cs2Gs.Pipeline/IMigrationStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/IMigrationStage.cs
@@ -100,11 +100,34 @@ public sealed class EmittedGsFile
     /// <param name="csFilePath">The originating C# file path.</param>
     /// <param name="gsharpSource">The emitted G# source text.</param>
     public EmittedGsFile(string gsPath, string relativeGsPath, string csFilePath, string gsharpSource)
+        : this(gsPath, relativeGsPath, csFilePath, gsharpSource, null, null)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EmittedGsFile"/> class with
+    /// type-graph metadata used to order files for whole-app compilation.
+    /// </summary>
+    /// <param name="gsPath">The absolute path of the written <c>.gs</c> file.</param>
+    /// <param name="relativeGsPath">The run-relative path of the <c>.gs</c> file (for artifacts).</param>
+    /// <param name="csFilePath">The originating C# file path.</param>
+    /// <param name="gsharpSource">The emitted G# source text.</param>
+    /// <param name="declaredTypeNames">Simple names of the types declared in this file.</param>
+    /// <param name="baseClassNames">Simple names of the base classes those types extend.</param>
+    public EmittedGsFile(
+        string gsPath,
+        string relativeGsPath,
+        string csFilePath,
+        string gsharpSource,
+        IReadOnlyList<string> declaredTypeNames,
+        IReadOnlyList<string> baseClassNames)
     {
         this.GsPath = gsPath;
         this.RelativeGsPath = relativeGsPath;
         this.CsFilePath = csFilePath;
         this.GSharpSource = gsharpSource;
+        this.DeclaredTypeNames = declaredTypeNames ?? System.Array.Empty<string>();
+        this.BaseClassNames = baseClassNames ?? System.Array.Empty<string>();
     }
 
     /// <summary>Gets the absolute path of the written <c>.gs</c> file.</summary>
@@ -118,6 +141,17 @@ public sealed class EmittedGsFile
 
     /// <summary>Gets the emitted G# source text.</summary>
     public string GSharpSource { get; }
+
+    /// <summary>Gets the simple names of the types declared in this file.</summary>
+    public IReadOnlyList<string> DeclaredTypeNames { get; }
+
+    /// <summary>
+    /// Gets the simple names of the base classes extended by the types in this
+    /// file. Used to order files so a base class is compiled before its
+    /// subclasses (works around an order-dependent <c>: base(...)</c> resolution
+    /// limitation in gsc).
+    /// </summary>
+    public IReadOnlyList<string> BaseClassNames { get; }
 }
 
 /// <summary>

--- a/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
@@ -61,8 +61,18 @@ public sealed class TranslateStage : IMigrationStage
             string gsPath = Path.Combine(context.AppRunDir, gsFileName);
             File.WriteAllText(gsPath, printed);
 
+            var declaredTypeNames = new List<string>();
+            var baseClassNames = new List<string>();
+            CollectTypeGraph(unit.Members, declaredTypeNames, baseClassNames);
+
             string relativeGsPath = MigrationPipeline.SanitizeAppId(context.App.Id) + "/" + gsFileName;
-            var emitted = new EmittedGsFile(gsPath, relativeGsPath, document.FilePath, printed);
+            var emitted = new EmittedGsFile(
+                gsPath,
+                relativeGsPath,
+                document.FilePath,
+                printed,
+                declaredTypeNames,
+                baseClassNames);
             context.EmittedFiles.Add(emitted);
 
             foreach (TranslationDiagnostic diagnostic in translationContext.Diagnostics
@@ -81,5 +91,59 @@ public sealed class TranslateStage : IMigrationStage
         }
 
         return artifacts.Count == 0 ? StageOutcome.Passed() : StageOutcome.Failed(artifacts);
+    }
+
+    /// <summary>
+    /// Walks the emitted declarations of one file, recording the simple names of
+    /// the types declared (including nested types) and the simple names of the
+    /// base classes they extend. This drives the base-before-subclass compile
+    /// ordering in <see cref="CompileStage"/>.
+    /// </summary>
+    private static void CollectTypeGraph(
+        IReadOnlyList<GNode> members,
+        List<string> declaredTypeNames,
+        List<string> baseClassNames)
+    {
+        if (members is null)
+        {
+            return;
+        }
+
+        foreach (GNode member in members)
+        {
+            if (member is TypeDeclaration type)
+            {
+                declaredTypeNames.Add(type.Name);
+                if (type.BaseType is NamedTypeReference baseRef)
+                {
+                    baseClassNames.Add(SimpleName(baseRef.Name));
+                }
+
+                // Implemented interfaces are dependencies too: gsc's interface-
+                // satisfaction binding is order-sensitive, so a type must be
+                // compiled after the interfaces it declares (CompileStage ordering).
+                foreach (GTypeReference iface in type.Interfaces)
+                {
+                    if (iface is NamedTypeReference ifaceRef)
+                    {
+                        baseClassNames.Add(SimpleName(ifaceRef.Name));
+                    }
+                }
+
+                CollectTypeGraph(type.Members, declaredTypeNames, baseClassNames);
+            }
+        }
+    }
+
+    /// <summary>Returns the last dotted segment of a (possibly qualified) name.</summary>
+    private static string SimpleName(string name)
+    {
+        if (string.IsNullOrEmpty(name))
+        {
+            return name;
+        }
+
+        int dot = name.LastIndexOf('.');
+        return dot >= 0 ? name.Substring(dot + 1) : name;
     }
 }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -510,6 +510,27 @@ public sealed class CSharpToGSharpTranslator
             return false;
         }
 
+        /// <summary>
+        /// Determines whether <paramref name="type"/> will be emitted as an
+        /// <c>open class</c> in G#. Mirrors the class-declaration openness logic in
+        /// <see cref="VisitAggregate"/> so member-level <c>open</c> is only emitted
+        /// when the enclosing class is itself open (otherwise GS0190).
+        /// </summary>
+        private bool IsTypeEmittedOpen(INamedTypeSymbol type)
+        {
+            if (type == null || type.TypeKind != TypeKind.Class || type.IsStatic)
+            {
+                return false;
+            }
+
+            if (type.IsAbstract || HasProtectedMember(type))
+            {
+                return true;
+            }
+
+            return !type.IsSealed && this.subclassedBases.Contains(type.OriginalDefinition);
+        }
+
         private static TypeDeclarationKind? MapAggregateKind(BaseTypeDeclarationSyntax node)
         {
             switch (node)
@@ -541,8 +562,135 @@ public sealed class CSharpToGSharpTranslator
             return !hasPositional && !hasDataMember;
         }
 
+        /// <summary>
+        /// Determines whether a C# record declares an instance auto-property data
+        /// member in its body (e.g. <c>public string Title { get; }</c> or
+        /// <c>{ get; init; }</c>). A G# <c>data</c> type's fields come exclusively
+        /// from its positional primary-constructor parameters; auto-properties are
+        /// rejected (GS0189) and a body-only record has no <c>data</c> fields at all
+        /// (GS0104). Such records therefore map to a plain <c>class</c>/<c>struct</c>
+        /// (OD-T5).
+        /// </summary>
+        private static bool RecordHasAutoPropertyDataMember(RecordDeclarationSyntax record)
+        {
+            return record.Members.OfType<PropertyDeclarationSyntax>().Any(p =>
+                !p.Modifiers.Any(SyntaxKind.StaticKeyword) &&
+                p.ExpressionBody == null &&
+                p.AccessorList != null &&
+                p.AccessorList.Accessors.All(a => a.Body == null && a.ExpressionBody == null) &&
+                p.AccessorList.Accessors.Any(a => a.IsKind(SyntaxKind.GetAccessorDeclaration)));
+        }
+
+        /// <summary>
+        /// Determines whether a property participates in a contract that requires it
+        /// to remain a real property in G# — it implements an interface property or
+        /// is part of an override chain (virtual/abstract/override). Such a property
+        /// cannot be lifted into a primary-constructor parameter (G# primary-ctor
+        /// parameters are not properties), or the contract breaks (GS0187). OD-T1.
+        /// </summary>
+        private static bool IsContractProperty(IPropertySymbol property)
+        {
+            if (property.IsVirtual || property.IsAbstract || property.IsOverride)
+            {
+                return true;
+            }
+
+            INamedTypeSymbol containing = property.ContainingType;
+            if (containing == null)
+            {
+                return false;
+            }
+
+            foreach (INamedTypeSymbol iface in containing.AllInterfaces)
+            {
+                foreach (IPropertySymbol ifaceProperty in iface.GetMembers().OfType<IPropertySymbol>())
+                {
+                    ISymbol implementation = containing.FindImplementationForInterfaceMember(ifaceProperty);
+                    if (SymbolEqualityComparer.Default.Equals(implementation, property))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
         private static bool IsIntegral(object value) =>
             value is byte or sbyte or short or ushort or int or uint or long or ulong;
+
+        /// <summary>
+        /// Determines whether a C# property is a get-only auto-property
+        /// (<c>{ get; }</c>, body-less, no <c>set</c>/<c>init</c> accessor). Such a
+        /// property has a backing field and is settable in the declaring type's
+        /// constructor; it maps to an init-only G# auto-property (OD-T1).
+        /// </summary>
+        private static bool IsGetOnlyAutoProperty(PropertyDeclarationSyntax prop)
+        {
+            if (prop.ExpressionBody != null || prop.AccessorList == null)
+            {
+                return false;
+            }
+
+            IReadOnlyList<AccessorDeclarationSyntax> accessors = prop.AccessorList.Accessors;
+            if (accessors.Any(a => a.Body != null || a.ExpressionBody != null))
+            {
+                return false;
+            }
+
+            bool hasGet = accessors.Any(a => a.IsKind(SyntaxKind.GetAccessorDeclaration));
+            bool hasSet = accessors.Any(a => a.IsKind(SyntaxKind.SetAccessorDeclaration));
+            bool hasInit = accessors.Any(a => a.IsKind(SyntaxKind.InitAccessorDeclaration));
+            return hasGet && !hasSet && !hasInit;
+        }
+
+        /// <summary>
+        /// Collects the inline initializers of get-only auto-properties
+        /// (<c>public List&lt;T&gt; Items { get; } = new();</c>). G# has no property
+        /// member initializer, so the initialization is moved into the type's
+        /// <c>init(...)</c> constructor body (OD-T1). Only meaningful for a plain
+        /// class/struct that keeps an explicit constructor (not a lifted primary
+        /// constructor, not a record).
+        /// </summary>
+        private List<(string Name, GExpression Value)> CollectGetOnlyAutoPropertyInitializers(
+            TypeDeclarationSyntax node)
+        {
+            var result = new List<(string Name, GExpression Value)>();
+            foreach (PropertyDeclarationSyntax prop in node.Members.OfType<PropertyDeclarationSyntax>())
+            {
+                if (prop.Modifiers.Any(SyntaxKind.StaticKeyword) ||
+                    prop.Initializer == null ||
+                    !IsGetOnlyAutoProperty(prop))
+                {
+                    continue;
+                }
+
+                var symbol = this.context.GetDeclaredSymbol(prop) as IPropertySymbol;
+                if (symbol != null &&
+                    (symbol.IsAbstract || symbol.ContainingType?.TypeKind == TypeKind.Interface))
+                {
+                    continue;
+                }
+
+                result.Add((SanitizeIdentifier(prop.Identifier.Text), this.TranslateExpression(prop.Initializer.Value)));
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Determines whether a type declares a designated instance constructor —
+        /// one that is non-static and does not delegate to another constructor of
+        /// the same type via <c>: this(...)</c>. Such a constructor is the place
+        /// into which get-only auto-property initializers are injected (OD-T1).
+        /// </summary>
+        private static bool HasDesignatedInstanceConstructor(TypeDeclarationSyntax node)
+        {
+            return node.Members
+                .OfType<ConstructorDeclarationSyntax>()
+                .Any(c => !c.Modifiers.Any(SyntaxKind.StaticKeyword) &&
+                    (c.Initializer == null || c.Initializer.ThisOrBaseKeyword.IsKind(SyntaxKind.BaseKeyword)));
+        }
 
         private static GExpression MapConstantDefault(IParameterSymbol symbol)
         {
@@ -579,22 +727,42 @@ public sealed class CSharpToGSharpTranslator
 
             var symbol = this.context.GetDeclaredSymbol(node) as INamedTypeSymbol;
 
-            // A `data class`/`data struct` requires at least one field (GS0104). A
-            // C# fieldless record — typically an `abstract record Shape;` base of a
-            // closed hierarchy — therefore maps to a plain `class`/`struct` (open
-            // when subclassed), not a `data` type (ADR-0115 §B.4).
+            // A `data class`/`data struct` requires at least one field (GS0104) and
+            // derives those fields from positional/primary-constructor parameters,
+            // not from auto-properties (GS0189). A fieldless record, or a record
+            // whose data lives in body auto-properties that cannot be lifted to a
+            // primary constructor, therefore maps to a plain `class`/`struct`
+            // (ADR-0115 §B.4 / OD-T5). A record *struct* with an explicit
+            // parameter-copy constructor is the exception: it lifts to a primary
+            // `data struct` (handled by AnalyzeConstructorLift), so it is left alone
+            // — a plain G# `struct` cannot carry an explicit `init` constructor.
             if ((kind == TypeDeclarationKind.DataClass || kind == TypeDeclarationKind.DataStruct) &&
-                node is RecordDeclarationSyntax record &&
-                IsFieldlessRecord(record))
+                node is RecordDeclarationSyntax record)
             {
-                kind = kind == TypeDeclarationKind.DataStruct
-                    ? TypeDeclarationKind.Struct
-                    : TypeDeclarationKind.Class;
-                this.context.Report(new TranslationDiagnostic(
-                    nameof(SyntaxKind.RecordDeclaration),
-                    $"fieldless record '{node.Identifier.Text}' maps to a plain '{(kind == TypeDeclarationKind.Struct ? "struct" : "class")}' because a G# 'data' type requires at least one field (GS0104, ADR-0115 §B.4).",
-                    node.GetLocation(),
-                    TranslationSeverity.Info));
+                bool fieldless = IsFieldlessRecord(record);
+                bool hasAutoPropData = RecordHasAutoPropertyDataMember(record);
+                bool hasExplicitInstanceCtor = record.Members
+                    .OfType<ConstructorDeclarationSyntax>()
+                    .Any(c => !c.Modifiers.Any(SyntaxKind.StaticKeyword));
+
+                bool downgrade = kind == TypeDeclarationKind.DataClass
+                    ? fieldless || hasAutoPropData
+                    : fieldless || (hasAutoPropData && !hasExplicitInstanceCtor);
+
+                if (downgrade)
+                {
+                    kind = kind == TypeDeclarationKind.DataStruct
+                        ? TypeDeclarationKind.Struct
+                        : TypeDeclarationKind.Class;
+                    string reason = fieldless
+                        ? "a G# 'data' type requires at least one field (GS0104, ADR-0115 §B.4)"
+                        : "a G# 'data' type derives its fields from positional parameters and rejects auto-property members (GS0104/GS0189, ADR-0115 §B.4)";
+                    this.context.Report(new TranslationDiagnostic(
+                        nameof(SyntaxKind.RecordDeclaration),
+                        $"record '{node.Identifier.Text}' maps to a plain '{(kind == TypeDeclarationKind.Struct ? "struct" : "class")}' because {reason}.",
+                        node.GetLocation(),
+                        TranslationSeverity.Info));
+                }
             }
 
             bool isStaticClass = symbol != null && symbol.IsStatic && kind == TypeDeclarationKind.Class;
@@ -618,13 +786,23 @@ public sealed class CSharpToGSharpTranslator
             // fields directly, which is now valid G#.
             ConstructorLift lift = this.AnalyzeConstructorLift(node, symbol, kind.Value);
 
+            // OD-T1: when the explicit constructor is kept (not lifted to a primary
+            // constructor) and the type is a plain class/struct, get-only
+            // auto-property inline initializers (`{ get; } = new();`) must move into
+            // the constructor body — G# has no property member initializer.
+            List<(string Name, GExpression Value)> propertyCtorInits =
+                !lift.DropConstructor &&
+                    (kind == TypeDeclarationKind.Class || kind == TypeDeclarationKind.Struct)
+                    ? this.CollectGetOnlyAutoPropertyInitializers(node)
+                    : new List<(string Name, GExpression Value)>();
+
             this.CollectStaticFieldInitializers(node);
 
             var instanceMembers = new List<GMember>();
             var sharedMembers = new List<GMember>();
             foreach (MemberDeclarationSyntax member in node.Members)
             {
-                foreach ((GMember translated, bool isStatic) in this.TranslateMember(member, kind.Value, lift))
+                foreach ((GMember translated, bool isStatic) in this.TranslateMember(member, kind.Value, lift, propertyCtorInits))
                 {
                     // A C# operator overload translates to a receiver-clause
                     // `func (a T) operator <op>(...)`; like every receiver-clause
@@ -683,6 +861,23 @@ public sealed class CSharpToGSharpTranslator
                 }
             }
 
+            // OD-T1: if get-only auto-property initializers needed to move into a
+            // constructor but the type declares no designated instance constructor,
+            // synthesize a parameterless `init()` to carry them (G# has no property
+            // member initializer). Reference types only — a class is the case that
+            // arises in practice.
+            if (propertyCtorInits.Count > 0 &&
+                kind == TypeDeclarationKind.Class &&
+                !HasDesignatedInstanceConstructor(node))
+            {
+                var initStatements = propertyCtorInits
+                    .Select(p => (GStatement)new AssignmentStatement(new IdentifierExpression(p.Name), p.Value))
+                    .ToList();
+                instanceMembers.Insert(0, new ConstructorDeclaration(
+                    new List<Parameter>(),
+                    new BlockStatement(initStatements)));
+            }
+
             var members = new List<GMember>(instanceMembers);
             if (sharedMembers.Count > 0)
             {
@@ -704,11 +899,16 @@ public sealed class CSharpToGSharpTranslator
                 ? lift.PrimaryParameters
                 : this.MapPrimaryConstructor(node);
 
+            // A class with `protected` members must be an `open class` in G#
+            // (GS0380) — `protected` is meaningless on a non-inheritable type. A C#
+            // `sealed` class that carries `protected override` members (it overrides
+            // an abstract/virtual protected base) therefore still maps to `open`;
+            // G# has no `sealed` modifier so the sealedness is dropped (ADR-0115 §B.4).
             bool isOpen = symbol != null &&
                 kind == TypeDeclarationKind.Class &&
-                !symbol.IsSealed &&
                 !symbol.IsStatic &&
-                (this.subclassedBases.Contains(symbol.OriginalDefinition) || HasProtectedMember(symbol));
+                ((!symbol.IsSealed && this.subclassedBases.Contains(symbol.OriginalDefinition))
+                    || HasProtectedMember(symbol));
 
             // G# has no `abstract` class modifier (the keyword is not recognized by
             // the parser); a C# `abstract class`/`abstract record` therefore maps to
@@ -834,6 +1034,24 @@ public sealed class CSharpToGSharpTranslator
                         targetName = propertySymbol.Name;
                         targetType = propertySymbol.Type;
                         targetIsProperty = true;
+
+                        // OD-T1: G# primary-constructor parameters are NOT
+                        // properties, so a *class* that copies a constructor
+                        // parameter into a property which satisfies an interface or
+                        // overridden-member contract cannot lift — dropping the
+                        // property member would break the contract (GS0187) and
+                        // cascade to GS0214/GS0183 on derived/override members. Keep
+                        // the explicit `init(...)` so the get-only auto-property
+                        // survives (emitted as init-only `{ get; init; }`). A
+                        // property that is *not* a contract member is still lifted to
+                        // the primary constructor (the L1 canonical form). Value
+                        // types always lift: a G# `struct`/`data struct` cannot carry
+                        // an in-body `init` (ADR-0115 §B.3 / B.6 / T2).
+                        if (kind == TypeDeclarationKind.Class &&
+                            IsContractProperty(propertySymbol))
+                        {
+                            return ConstructorLift.None;
+                        }
                     }
                     else
                     {
@@ -942,7 +1160,8 @@ public sealed class CSharpToGSharpTranslator
         private IEnumerable<(GMember Member, bool IsStatic)> TranslateMember(
             MemberDeclarationSyntax member,
             TypeDeclarationKind ownerKind,
-            ConstructorLift lift)
+            ConstructorLift lift,
+            IReadOnlyList<(string Name, GExpression Value)> propertyCtorInits)
         {
             switch (member)
             {
@@ -992,7 +1211,7 @@ public sealed class CSharpToGSharpTranslator
                         break;
                     }
 
-                    GMember built = this.TranslateConstructor(ctor);
+                    GMember built = this.TranslateConstructor(ctor, propertyCtorInits);
                     if (built != null)
                     {
                         yield return (built, ctor.Modifiers.Any(SyntaxKind.StaticKeyword));
@@ -1062,6 +1281,85 @@ public sealed class CSharpToGSharpTranslator
             }
         }
 
+        /// <summary>
+        /// Wraps a translated constant expression in an explicit G# cast when the
+        /// C# semantic model implicitly converts a signed-integer constant to an
+        /// unsigned-integer target (<c>uint x = 0</c>, <c>const byte b = 31</c>).
+        /// G# requires the conversion to be explicit (OD-T2, otherwise GS0156
+        /// "Cannot convert int32 to uintN").
+        /// </summary>
+        private GExpression CoerceConstantToUnsigned(ExpressionSyntax expression, GExpression translated)
+        {
+            TypeInfo info = this.context.GetTypeInfo(expression);
+            ITypeSymbol source = info.Type;
+            ITypeSymbol target = info.ConvertedType;
+            if (source != null &&
+                target != null &&
+                !SymbolEqualityComparer.Default.Equals(source, target) &&
+                IsSignedIntegerSpecialType(source.SpecialType) &&
+                IsUnsignedIntegerSpecialType(target.SpecialType))
+            {
+                GTypeReference targetRef = this.typeMapper.Map(target, this.context, expression.GetLocation());
+                return new ConversionExpression(targetRef, translated);
+            }
+
+            return translated;
+        }
+
+        private static bool IsSignedIntegerSpecialType(SpecialType type) =>
+            type is SpecialType.System_SByte or SpecialType.System_Int16
+                or SpecialType.System_Int32 or SpecialType.System_Int64;
+
+        private static bool IsUnsignedIntegerSpecialType(SpecialType type) =>
+            type is SpecialType.System_Byte or SpecialType.System_UInt16
+                or SpecialType.System_UInt32 or SpecialType.System_UInt64;
+
+        /// <summary>
+        /// Determines whether a C# method override ultimately overrides a base
+        /// method that is defined outside the translated source (e.g. an
+        /// <see cref="object"/> virtual such as <c>ToString</c>, or a framework
+        /// base like <c>System.IO.Stream.Read</c>). G# does not treat the virtual
+        /// members of metadata (non-source) types as <c>open</c>, so re-declaring
+        /// them must omit the <c>override</c> modifier (OD-T5; otherwise
+        /// GS0183/GS0184). The plain <c>func</c> form binds as the override.
+        /// </summary>
+        private static bool OverridesExternalBaseMethod(IMethodSymbol method)
+        {
+            IMethodSymbol baseMethod = method.OverriddenMethod;
+            if (baseMethod == null)
+            {
+                return false;
+            }
+
+            while (baseMethod.OverriddenMethod != null)
+            {
+                baseMethod = baseMethod.OverriddenMethod;
+            }
+
+            return baseMethod.DeclaringSyntaxReferences.IsEmpty;
+        }
+
+        /// <summary>
+        /// Property counterpart of <see cref="OverridesExternalBaseMethod"/>: a C#
+        /// property override (e.g. <c>Stream.CanRead</c>) whose root base property
+        /// is defined outside the translated source must drop <c>override</c>.
+        /// </summary>
+        private static bool OverridesExternalBaseProperty(IPropertySymbol property)
+        {
+            IPropertySymbol baseProperty = property.OverriddenProperty;
+            if (baseProperty == null)
+            {
+                return false;
+            }
+
+            while (baseProperty.OverriddenProperty != null)
+            {
+                baseProperty = baseProperty.OverriddenProperty;
+            }
+
+            return baseProperty.DeclaringSyntaxReferences.IsEmpty;
+        }
+
         private IEnumerable<(GMember Member, bool IsStatic)> TranslateField(
             FieldDeclarationSyntax field,
             ConstructorLift lift)
@@ -1098,7 +1396,9 @@ public sealed class CSharpToGSharpTranslator
                 }
                 else if (declarator.Initializer != null)
                 {
-                    initializer = this.TranslateExpression(declarator.Initializer.Value);
+                    initializer = this.CoerceConstantToUnsigned(
+                        declarator.Initializer.Value,
+                        this.TranslateExpression(declarator.Initializer.Value));
                 }
                 else if (symbol != null &&
                     this.staticFieldInitializers.TryGetValue(symbol, out GExpression staticLifted))
@@ -1202,14 +1502,16 @@ public sealed class CSharpToGSharpTranslator
                 });
             }
 
-            bool isOverride = symbol != null && symbol.IsOverride;
+            bool isOverride = symbol != null && symbol.IsOverride && !OverridesExternalBaseMethod(symbol);
 
             // Interface members are implicitly abstract in C#; in canonical G# the
             // members of an `interface` carry no modifier (the `open` keyword is for
             // virtual/abstract members of a class). Suppress `open` for them so the
             // emitted G# round-trips (ADR-0115 §B.6).
             bool inInterface = symbol?.ContainingType?.TypeKind == TypeKind.Interface;
-            bool isOpen = symbol != null && (symbol.IsVirtual || symbol.IsAbstract) && !symbol.IsOverride && !inInterface;
+            bool isOpen = symbol != null && !inInterface && !symbol.IsSealed &&
+                (symbol.IsVirtual || symbol.IsAbstract || isOverride) &&
+                this.IsTypeEmittedOpen(symbol.ContainingType);
 
             // A method lifted to the top-level receiver-clause form (an owned-value
             // aggregate method or an extension method) has no `open`/`override`:
@@ -1347,12 +1649,14 @@ public sealed class CSharpToGSharpTranslator
 
             List<PropertyAccessor> accessors = this.MapAccessors(node);
 
-            bool isOverride = symbol != null && symbol.IsOverride;
+            bool isOverride = symbol != null && symbol.IsOverride && !OverridesExternalBaseProperty(symbol);
 
             // Interface members are implicitly abstract; canonical G# interface
             // members carry no `open` modifier (ADR-0115 §B.6).
             bool inInterface = symbol?.ContainingType?.TypeKind == TypeKind.Interface;
-            bool isOpen = symbol != null && (symbol.IsVirtual || symbol.IsAbstract) && !symbol.IsOverride && !inInterface;
+            bool isOpen = symbol != null && !inInterface && !symbol.IsSealed &&
+                (symbol.IsVirtual || symbol.IsAbstract || isOverride) &&
+                this.IsTypeEmittedOpen(symbol.ContainingType);
 
             var property = new PropertyDeclaration(
                 SanitizeIdentifier(node.Identifier.Text),
@@ -1388,9 +1692,11 @@ public sealed class CSharpToGSharpTranslator
 
             List<PropertyAccessor> accessors = this.MapAccessors(node, "indexer 'this[]'");
 
-            bool isOverride = symbol != null && symbol.IsOverride;
+            bool isOverride = symbol != null && symbol.IsOverride && !OverridesExternalBaseProperty(symbol);
             bool inInterface = symbol?.ContainingType?.TypeKind == TypeKind.Interface;
-            bool isOpen = symbol != null && (symbol.IsVirtual || symbol.IsAbstract) && !symbol.IsOverride && !inInterface;
+            bool isOpen = symbol != null && !inInterface && !symbol.IsSealed &&
+                (symbol.IsVirtual || symbol.IsAbstract || isOverride) &&
+                this.IsTypeEmittedOpen(symbol.ContainingType);
 
             var property = new PropertyDeclaration(
                 "this",
@@ -1435,6 +1741,7 @@ public sealed class CSharpToGSharpTranslator
             bool anyBodied = declared.Any(a => a.Body != null || a.ExpressionBody != null);
             bool hasSet = declared.Any(a => a.IsKind(SyntaxKind.SetAccessorDeclaration));
             bool hasGet = declared.Any(a => a.IsKind(SyntaxKind.GetAccessorDeclaration));
+            bool hasInit = declared.Any(a => a.IsKind(SyntaxKind.InitAccessorDeclaration));
 
             // A read-write auto-property (all accessors body-less, has get + set)
             // maps to the canonical auto form `prop Name T` (ADR-0115 §B.11). An
@@ -1443,6 +1750,27 @@ public sealed class CSharpToGSharpTranslator
             if (!anyBodied && hasGet && hasSet)
             {
                 return new List<PropertyAccessor>();
+            }
+
+            // OD-T1: a C# get-only auto-property (`{ get; }`, body-less, no set/init)
+            // is settable in the declaring type's constructor. G# `{ get; }` alone
+            // is read-only (assigning it gives GS0127), so emit it as an init-only
+            // auto-property `{ get; init; }`. Interface/abstract contract members
+            // carry no backing field and remain read-only contracts.
+            if (!anyBodied && hasGet && !hasSet && !hasInit)
+            {
+                var propSymbol = this.context.GetDeclaredSymbol(node) as IPropertySymbol;
+                bool isContract = propSymbol != null &&
+                    (propSymbol.IsAbstract ||
+                        propSymbol.ContainingType?.TypeKind == TypeKind.Interface);
+                if (!isContract)
+                {
+                    return new List<PropertyAccessor>
+                    {
+                        new PropertyAccessor(AccessorKind.Get, null),
+                        new PropertyAccessor(AccessorKind.Init, null),
+                    };
+                }
             }
 
             var accessors = new List<PropertyAccessor>();
@@ -1475,7 +1803,9 @@ public sealed class CSharpToGSharpTranslator
             return accessors;
         }
 
-        private GMember TranslateConstructor(ConstructorDeclarationSyntax node)
+        private GMember TranslateConstructor(
+            ConstructorDeclarationSyntax node,
+            IReadOnlyList<(string Name, GExpression Value)> propertyCtorInits)
         {
             var symbol = this.context.GetDeclaredSymbol(node) as IMethodSymbol;
             if (node.Modifiers.Any(SyntaxKind.StaticKeyword))
@@ -1529,6 +1859,20 @@ public sealed class CSharpToGSharpTranslator
                     new IdentifierExpression("init"),
                     node.Initializer.ArgumentList.Arguments.Select(a => this.TranslateArgument(a)).ToList()));
                 var statements = new List<GStatement> { delegated };
+                statements.AddRange(body.Statements);
+                body = new BlockStatement(statements);
+            }
+            else if (propertyCtorInits != null && propertyCtorInits.Count > 0)
+            {
+                // OD-T1: move get-only auto-property inline initializers into the
+                // designated constructor body (G# has no property member
+                // initializer). Prepend them so the property is initialized before
+                // the original constructor body runs, matching C# member-initializer
+                // ordering. Delegating (`: this(...)`) constructors are skipped — the
+                // designated target already runs the initializers.
+                var statements = propertyCtorInits
+                    .Select(p => (GStatement)new AssignmentStatement(new IdentifierExpression(p.Name), p.Value))
+                    .ToList();
                 statements.AddRange(body.Statements);
                 body = new BlockStatement(statements);
             }
@@ -2263,7 +2607,9 @@ public sealed class CSharpToGSharpTranslator
             {
                 GExpression initializer = declarator.Initializer == null
                     ? null
-                    : this.TranslateExpression(declarator.Initializer.Value);
+                    : this.CoerceConstantToUnsigned(
+                        declarator.Initializer.Value,
+                        this.TranslateExpression(declarator.Initializer.Value));
 
                 BindingKind binding;
                 if (isConst)
@@ -2426,7 +2772,9 @@ public sealed class CSharpToGSharpTranslator
                     string op = assignment.OperatorToken.Text;
                     return new AssignmentStatement(
                         this.TranslateExpression(assignment.Left),
-                        this.TranslateExpression(assignment.Right),
+                        this.CoerceConstantToUnsigned(
+                            assignment.Right,
+                            this.TranslateExpression(assignment.Right)),
                         op);
 
                 case PostfixUnaryExpressionSyntax postfix
@@ -3804,7 +4152,13 @@ public sealed class CSharpToGSharpTranslator
                 return new UnaryExpression("&", this.TranslateExpression(argument.Expression));
             }
 
-            return this.TranslateExpression(argument.Expression);
+            // OD-T2: a C# integer literal implicitly converted to an unsigned
+            // parameter (e.g. `base(4)` where the parameter is `byte`) must be
+            // emitted as a typed G# literal (`uint8(4)`); G# performs no implicit
+            // signed→unsigned constant conversion at the call site (GS0214/GS0156).
+            return this.CoerceConstantToUnsigned(
+                argument.Expression,
+                this.TranslateExpression(argument.Expression));
         }
 
         private GExpression TranslateObjectCreation(ObjectCreationExpressionSyntax creation)
@@ -3901,13 +4255,23 @@ public sealed class CSharpToGSharpTranslator
                     ? named.TypeArguments
                     : null;
                 return new InvocationExpression(
-                    new IdentifierExpression(named.Name),
+                    new IdentifierExpression(ConstructionCalleeName(named.Name)),
                     arguments,
                     typeArguments);
             }
 
             return new InvocationExpression(new IdentifierExpression(creation.Type.ToString()), arguments);
         }
+
+        /// <summary>
+        /// Maps a constructed type's G# name to a callable construction callee.
+        /// The G# alias <c>object</c> is a keyword, not a function, so constructing
+        /// a <see cref="object"/> (<c>new object()</c> / target-typed <c>new()</c>)
+        /// must spell the qualified type name <c>System.Object</c> instead (OD-T3,
+        /// otherwise GS0130 "Function 'object' doesn't exist").
+        /// </summary>
+        private static string ConstructionCalleeName(string typeName) =>
+            typeName == "object" ? "System.Object" : typeName;
 
         /// <summary>
         /// Attempts to translate a C# collection initializer into a canonical G#
@@ -4264,7 +4628,7 @@ public sealed class CSharpToGSharpTranslator
                     ? named.TypeArguments
                     : null;
                 return new InvocationExpression(
-                    new IdentifierExpression(named.Name),
+                    new IdentifierExpression(ConstructionCalleeName(named.Name)),
                     arguments,
                     typeArguments);
             }

--- a/tools/cs2gs/Cs2Gs.Translator/Loading/CSharpProjectLoader.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/Loading/CSharpProjectLoader.cs
@@ -154,11 +154,50 @@ public static class CSharpProjectLoader
         var documents = new List<LoadedDocument>();
         foreach (SyntaxTree tree in compilation.SyntaxTrees)
         {
+            // OD-T4: build-generated sources (Nerdbank.GitVersioning `ThisAssembly`,
+            // `*.AssemblyInfo.cs`, global usings, etc.) reference attributes the G#
+            // compiler cannot resolve (GS0198) and are not part of the app's hand-
+            // written source. Skip them for translation/emit; they stay in the C#
+            // compilation so semantic binding of the real sources is unaffected.
+            if (IsGeneratedSource(tree.FilePath))
+            {
+                continue;
+            }
+
             SemanticModel model = compilation.GetSemanticModel(tree, ignoreAccessibility: false);
             documents.Add(new LoadedDocument(tree.FilePath, tree, model));
         }
 
         return documents;
+    }
+
+    /// <summary>
+    /// Determines whether a C# file is a build-generated artifact that should not
+    /// be translated: anything under an <c>obj/</c> or <c>bin/</c> directory, or a
+    /// recognized generated file name (assembly-info, global usings, version, or
+    /// any <c>*.g.cs</c> / <c>*.g.i.cs</c> source generator output).
+    /// </summary>
+    private static bool IsGeneratedSource(string filePath)
+    {
+        if (string.IsNullOrEmpty(filePath))
+        {
+            return false;
+        }
+
+        string normalized = filePath.Replace('\\', '/');
+        if (normalized.Contains("/obj/", StringComparison.OrdinalIgnoreCase) ||
+            normalized.Contains("/bin/", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        string name = Path.GetFileName(normalized);
+        return name.EndsWith(".AssemblyInfo.cs", StringComparison.OrdinalIgnoreCase) ||
+            name.EndsWith(".AssemblyAttributes.cs", StringComparison.OrdinalIgnoreCase) ||
+            name.EndsWith(".GlobalUsings.g.cs", StringComparison.OrdinalIgnoreCase) ||
+            name.EndsWith(".Version.cs", StringComparison.OrdinalIgnoreCase) ||
+            name.EndsWith(".g.i.cs", StringComparison.OrdinalIgnoreCase) ||
+            name.EndsWith(".g.cs", StringComparison.OrdinalIgnoreCase);
     }
 
     private static IReadOnlyList<Diagnostic> SignificantDiagnostics(CSharpCompilation compilation) =>


### PR DESCRIPTION
Translator-only improvements to **cs2gs** for the Oahu.Decrypt migration round. Refs #914.

**Scope constraint respected:** all code changes are under `tools/cs2gs/` (plus `docs/adr/0115`). No `src/` (G# compiler) changes.

## Before / after (whole-app gsc compile of Oahu.Decrypt)
- **Before:** translate=PASS, compile=**81 unique** errors.
- **After:** translate=PASS, compile=**28 unique** (48 raw) errors. The remaining 28 are all characterized as **gsc compiler gaps** (below).
- GS0187 (the OD-T1 target) on the Box/FullBox/descriptor hierarchy is **gone for the base classes**; GS0156/GS0130/GS0198/GS0104/GS0189/GS0232/GS0183/GS0184/GS0190/GS0380/GS0387 are **cleared**.

## Defects fixed (translator)
- **OD-T1 — get-only auto-prop + contract property.** A single-ctor `class` assigning parameters to a *contract* property (implements an interface property, or is virtual/abstract/override) no longer lifts to a primary constructor (G# primary-ctor params are fields, not properties → fails the interface contract: GS0187 cascading to GS0214/GS0183). It keeps the explicit `init(...)` and emits each C# get-only auto-property as init-only `prop X T { get; init; }`; an inline get-only initializer (`{ get; } = new();`) is moved into the constructor body. Plain structs and non-contract class properties still lift (keeps L2 `Rectangle.Dimensions` and conversion-operator tests green). Verified `Box.gs` emits explicit `init(header, parent)` + `prop Header/Parent/Children { get; init; }`.
- **OD-T2 — unsigned literal coercion (GS0156).** Integer literals at an unsigned target (field initializer, assignment, call argument, `: base(...)` argument) emit an explicit width cast (`uint32(0)`, `uint8(4)`).
- **OD-T3 — `new object()` / target-typed `new()` (GS0130).** Emits `System.Object()`.
- **OD-T4 — generated-source exclusion (GS0198).** The project loader skips `obj/`, `bin/`, and generated files (`*.AssemblyInfo.cs`, `*.AssemblyAttributes.cs`, `*.GlobalUsings.g.cs`, `*.Version.cs`, `*.g.cs`, `*.g.i.cs`) — e.g. the Nerdbank.GitVersioning `ThisAssembly` file.
- **OD-T5 — data-struct/record defects (GS0104/GS0189/GS0232).** A record whose data members are auto-properties that cannot become primary-ctor data fields downgrades to a plain `class`/`struct` (record class always; record struct only when it has no explicit instance ctor, since a plain struct admits no explicit `init`).
- **Override openness.** Drop `override` when overriding an external/metadata base virtual (`Object.ToString`, `Stream.Read`, `IDisposable.Dispose`) — G# doesn't treat metadata virtuals as `open` (GS0183); emit `override open` for a non-sealed override so a deeper subclass can override it (GS0184); gate member `open` on the enclosing class actually being emitted `open class` (GS0190).
- **GS0380/GS0387.** A class with `protected` members is forced `open` even when sealed.
- **Whole-app compile ordering.** `CompileStage.OrderForCompilation` topologically sorts emitted `.gs` by base class **and implemented interface** so each type follows its bases/interfaces on the gsc command line — a workaround for gsc order-sensitive `: base(...)`/interface-satisfaction binding. Affects only the command line, not file content (goldens unchanged).

## Verification
- `dotnet build GSharp.sln -c Release -graph` → **0 errors**.
- cs2gs corpus test suite: `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release` → **176/176 passed**. **No golden updates** (ordering changes the command line, not emitted content).
- Translate stage stays **PASS** (round-trip parse intact, zero Unsupported markers).

## Remaining errors = gsc compiler gaps (for the orchestrator to file)
Each verified with a minimal standalone gsc repro:
1. **Inherited interface satisfaction (GS0187, ~21 raw).** A derived class that re-states an interface (`StszBox : FullBox, IStszBox` where `IStszBox : IBox`) is reported as not implementing the base interface member even though it inherits the implementation from a base class. Repro: `interface IBase{prop H int32{get;}} interface IDerived:IBase{} open class Base:IBase{prop H int32{get;init;} init(h int32){H=h}} open class Mid:Base{init(h int32):base(h){}} class Leaf:Mid,IDerived{init(h int32):base(h){}}` → `GS0187: Leaf does not implement IBase.H`.
2. **Order-dependent `: base(...)` / interface binding.** A type compiled before its base/interface fails to bind (GS0214/GS0187/GS0144 "requires 0 arguments"). Worked around with topological ordering, but the underlying binder order-sensitivity remains.
3. **Untyped `nil` in overload resolution (GS0214).** `base(h, nil)` / `base(h, nil!!)` fails constructor overload resolution where the parameter is a reference type; `base(h, (nil as Frame))` works. C# `null` binds fine. Repro: `open class Frame(Header int32, Parent Frame){} class Id3Tag:Frame{init(h int32):base(h, nil!!){}}` → `GS0214`.
4. **Generic-base constructor resolution (GS0214).** A derived class calling `: base(...)` on a **generic** base class's explicit `init` fails. Repro: `open class Base[T]{init(a int32,b int32,c bool){}} class Der:Base[int32]{init():base(1,2,true){}}` → `GS0214: Base has no accessible constructor that takes 3 arguments`.
5. **async override signature normalization (GS0185).** A non-async `override func M(x) Task` does not match an `async func M(x)` base (whose implicit return is `Task`); in C# `async` is not part of the signature. Repro: `open class B{open async func M(x int32){return}} open class D:B{open override func M(x int32) Task{return Task.CompletedTask}}` → `GS0185`. (`async func M() Task` explicit-return form matches, but deviates from canonical async spelling.)
6. **Nested-type resolution (GS0113, GS0102).** gsc cannot resolve a nested type referenced from within its container by simple or qualified name, and a nested type collides with a package-level type of the same name.
7. **Shared-block static invisible to field initializers (GS0125/GS0158).** A `const`/static in a `shared { }` block is visible from method bodies but not from instance/static field initializers.
8. **Iterator `GetEnumerator` covariance (GS0264/GS0187).** An iterator `func GetEnumerator() sequence[T]` is not accepted as satisfying `IEnumerable<T>.GetEnumerator()`, and an explicit non-generic `IEnumerable.GetEnumerator()` collides (same name/params) with the generic one.
9. **`AllocateArray[object]` / tuple element type (GS0159).** Generic-method element-type resolution fails for `object`/tuple element types (most `AllocateArray` sites compile).
10. **Receiver-clause method on an enum (GS0103).** A C# extension method on an `enum` (`ChannelGroups`) has no G# receiver-clause form ("receiver must be a struct or class").