### PR TITLE
Fixes #1066: satisfy interface members inherited from a base class

### DIFF
--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -2804,31 +2804,32 @@ internal sealed class DeclarationBinder
                         continue;
                     }
 
-                    var found = false;
-                    foreach (var implProp in structSymbol.Properties)
+                    // Issue #1066: an interface property may be satisfied by a
+                    // property implemented (or inherited) ANYWHERE in the base
+                    // chain, not only one declared directly on this class.
+                    // TypeMemberModel.TryGetProperty walks BaseClass this-first,
+                    // mirroring C# semantics where a base class's accessible
+                    // instance member satisfies an interface listed on a
+                    // derived class.
+                    var found = TypeMemberModel.TryGetProperty(structSymbol, iprop.Name, out var implProp);
+                    if (found)
                     {
-                        if (implProp.Name == iprop.Name)
+                        if (iprop.HasGetter && !implProp.HasGetter)
                         {
-                            if (iprop.HasGetter && !implProp.HasGetter)
-                            {
-                                Diagnostics.ReportInterfaceMethodNotImplemented(
-                                    syntax.Identifier.Location,
-                                    structSymbol.Name,
-                                    iface.Name,
-                                    iprop.Name + " (getter)");
-                            }
+                            Diagnostics.ReportInterfaceMethodNotImplemented(
+                                syntax.Identifier.Location,
+                                structSymbol.Name,
+                                iface.Name,
+                                iprop.Name + " (getter)");
+                        }
 
-                            if (iprop.HasSetter && !implProp.HasSetter)
-                            {
-                                Diagnostics.ReportInterfaceMethodNotImplemented(
-                                    syntax.Identifier.Location,
-                                    structSymbol.Name,
-                                    iface.Name,
-                                    iprop.Name + " (setter)");
-                            }
-
-                            found = true;
-                            break;
+                        if (iprop.HasSetter && !implProp.HasSetter)
+                        {
+                            Diagnostics.ReportInterfaceMethodNotImplemented(
+                                syntax.Identifier.Location,
+                                structSymbol.Name,
+                                iface.Name,
+                                iprop.Name + " (setter)");
                         }
                     }
 

--- a/test/Compiler.Tests/Emit/Issue1066InheritedInterfaceEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1066InheritedInterfaceEmitTests.cs
@@ -1,0 +1,204 @@
+// <copyright file="Issue1066InheritedInterfaceEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1066: a leaf class satisfies an interface member when the member is
+/// implemented (or inherited) anywhere in its base-class chain, even when the
+/// interface is reached through interface inheritance (<c>IDerived : IBase</c>)
+/// or re-stated on a derived class. These tests give end-to-end CLR emit +
+/// ilverify coverage and confirm the inherited implementation dispatches
+/// correctly at runtime when invoked through an interface-typed reference.
+/// </summary>
+public class Issue1066InheritedInterfaceEmitTests
+{
+    [Fact]
+    public void EndToEnd_InterfaceMethodInheritedFromBase_DispatchesThroughInterfaceReference()
+    {
+        // Leaf (→ Mid → Base) satisfies IBase.M via Base's implementation and is
+        // attached to IBase through IDerived : IBase. Calling M() through an
+        // IBase-typed parameter must resolve the inherited implementation.
+        var source = """
+            package p
+            interface IBase { func M() int32; }
+            interface IDerived : IBase { }
+            open class Base : IBase {
+                func M() int32 { return 7 }
+            }
+            open class Mid : Base { init() { } }
+            class Leaf : Mid, IDerived { init() { } }
+            func Get(x IBase) int32 { return x.M() }
+            func Main() { System.Console.WriteLine(Get(Leaf())) }
+            """;
+        var output = CompileAndRun(source);
+        Assert.Equal("7\n", output);
+    }
+
+    [Fact]
+    public void Library_InterfacePropertyInheritedFromBase_PassesIlVerify()
+    {
+        // The canonical issue repro: IBase requires `prop H`, Base implements it,
+        // and Leaf reaches IBase through IDerived. ilverify (invoked by
+        // CompileLibrary) confirms the emitted assembly is verifiable.
+        var source = """
+            package p
+            interface IBase { prop H int32 { get; } }
+            interface IDerived : IBase { }
+            open class Base : IBase {
+                prop H int32 { get; init; }
+                init(h int32) { H = h }
+            }
+            open class Mid : Base { init(h int32) : base(h) { } }
+            class Leaf : Mid, IDerived { init(h int32) : base(h) { } }
+            """;
+
+        var dllPath = CompileLibrary(source);
+        TryCleanup(dllPath);
+    }
+
+    [Fact]
+    public void Library_InterfaceOnDerivedSatisfiedByImmediateBase_PassesIlVerify()
+    {
+        // Requirement coming from a directly-listed interface implemented by a
+        // base class.
+        var source = """
+            package p
+            interface IBase { func M() int32; }
+            open class Base {
+                func M() int32 { return 3 }
+            }
+            class Leaf : Base, IBase { init() { } }
+            """;
+
+        var dllPath = CompileLibrary(source);
+        TryCleanup(dllPath);
+    }
+
+    private static string CompileLibrary(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1066_lib_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        var args = new[]
+        {
+            "/out:" + outPath,
+            "/target:library",
+            "/targetframework:net10.0",
+            srcPath,
+        };
+
+        RunCompiler(args);
+        IlVerifier.Verify(outPath);
+        return outPath;
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1066_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            RunCompiler(args);
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static void RunCompiler(string[] args)
+    {
+        using var stdoutWriter = new StringWriter();
+        using var stderrWriter = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(stdoutWriter);
+        Console.SetError(stderrWriter);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+    }
+
+    private static void TryCleanup(string dllPath)
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(dllPath);
+            if (dir != null && Directory.Exists(dir))
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+        catch
+        {
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1066InheritedInterfaceTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1066InheritedInterfaceTests.cs
@@ -1,0 +1,97 @@
+// <copyright file="Issue1066InheritedInterfaceTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1066: a class satisfies an interface member when the member is
+/// implemented (or inherited) ANYWHERE in its base-class chain — not only when
+/// declared directly on the class. Mirrors C# semantics where a base class's
+/// accessible instance member satisfies an interface listed on a derived class.
+/// The interface-satisfaction check must walk <c>BaseClass</c> for both methods
+/// and properties (including the property's accessors).
+/// </summary>
+public class Issue1066InheritedInterfaceTests
+{
+    [Fact]
+    public void LeafInheritsProperty_ViaTransitiveInterface_BindsWithNoDiagnostics()
+    {
+        // The canonical repro from the issue: IBase requires `prop H`, Base
+        // implements it, and Leaf (→ Mid → Base) lists IDerived : IBase.
+        const string source = """
+            package p
+            interface IBase { prop H int32 { get; } }
+            interface IDerived : IBase { }
+            open class Base : IBase {
+                prop H int32 { get; init; }
+                init(h int32) { H = h }
+            }
+            open class Mid : Base { init(h int32) : base(h) { } }
+            class Leaf : Mid, IDerived { init(h int32) : base(h) { } }
+            """;
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void DerivedClassListsInterface_PropertyImplementedOnImmediateBase_BindsClean()
+    {
+        // Requirement comes from a directly-listed interface implemented by a
+        // base class.
+        const string source = """
+            package p
+            interface IBase { prop H int32 { get; } }
+            open class Base {
+                prop H int32 { get; init; }
+                init(h int32) { H = h }
+            }
+            class Leaf : Base, IBase { init(h int32) : base(h) { } }
+            """;
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void LeafInheritsMethod_ViaTransitiveInterface_BindsWithNoDiagnostics()
+    {
+        // Interface METHOD (not just a property) inherited from a base class.
+        const string source = """
+            package p
+            interface IBase { func M() int32; }
+            interface IDerived : IBase { }
+            open class Base : IBase {
+                func M() int32 { return 7 }
+            }
+            open class Mid : Base { }
+            class Leaf : Mid, IDerived { }
+            """;
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void GenuinelyUnimplementedInterfaceMember_StillReportsGS0187()
+    {
+        // Negative guard: neither the class nor any base implements `prop H`.
+        const string source = """
+            package p
+            interface IBase { prop H int32 { get; } }
+            open class Base { }
+            class Leaf : Base, IBase { }
+            """;
+        Assert.Contains(Bind(source), d => d.Id == "GS0187");
+    }
+
+    private static IReadOnlyList<Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.GlobalScope.Diagnostics.ToList();
+    }
+}


### PR DESCRIPTION
Fixes #1066.

## Root cause
`DeclarationBinder.VerifyInterfaceImplementations` verified interface **property** requirements by scanning only the class's OWN declared properties (`structSymbol.Properties`). When a class inherited the property implementation from a base class — and the interface requirement was reached via interface inheritance (`IDerived : IBase`) or re-stated on a derived class — the check failed to find the member and wrongly emitted `GS0187: does not implement interface method`.

Repro that previously failed:
```gsharp
package p
interface IBase { prop H int32 { get; } }
interface IDerived : IBase { }
open class Base : IBase {
    prop H int32 { get; init; }
    init(h int32) { H = h }
}
open class Mid : Base { init(h int32) : base(h) { } }
class Leaf : Mid, IDerived { init(h int32) : base(h) { } }
```

## Fix
Route the property lookup through `TypeMemberModel.TryGetProperty` (ADR-0112), which walks the `BaseClass` chain this-first. This mirrors C# semantics: a base class's accessible instance member satisfies an interface listed on a derived class. The accessor (getter/setter) checks now run against the resolved (possibly inherited) property. The interface **method** path already used `GetMethodsIncludingInherited`, so it was unaffected and continues to work.

## Verification
- `dotnet build GSharp.sln -c Release -graph` → 0 errors, 0 warnings.
- Failing repro now compiles clean; the negative guard (interface member implemented nowhere in the chain) still reports `GS0187`.
- New `test/Core.Tests/CodeAnalysis/Binding/Issue1066InheritedInterfaceTests.cs` — property/method/transitive-interface satisfaction + negative `GS0187` guard.
- New `test/Compiler.Tests/Emit/Issue1066InheritedInterfaceEmitTests.cs` — ilverify-clean library emit and `CompileAndRun` confirming an inherited implementation dispatches correctly through an interface-typed reference (returns `7`).
- Full `test/Core.Tests` → 3694 passed. Compiler slices `~Issue1066`, `~Interface`, `~Implement`, `~Issue1052`, `~Issue1056`, `~Issue1061` → all green (168 + 3 passed).

## Deferred / out of scope
Accessing an interface **property** member *through an interface-typed reference* (e.g. `func Get(x IBase) int32 { return x.H }`) still fails with `GS0158: Cannot find member H` — but this is a pre-existing member-lookup limitation independent of #1066 (it reproduces with a single non-inheriting class implementing the interface directly). The emit test therefore exercises interface-typed dispatch via a method and uses ilverify for the inherited-property library case.