### PR TITLE
Fixes #1068: resolve interface property access on interface-typed references

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -1675,6 +1675,30 @@ internal sealed partial class ExpressionBinder
 
                     Diagnostics.ReportUnableToFindMember(ne.Location, ne.IdentifierToken.Text);
                 }
+                else if (receiver != null && receiver.Type is InterfaceSymbol ifaceSym)
+                {
+                    // Issue #1068: read a property declared on the static
+                    // interface type (or any base interface) through an
+                    // interface-typed receiver. Interface methods already
+                    // dispatch via the InterfaceSymbol path in
+                    // ExpressionBinder.Calls.cs; this mirrors that for
+                    // properties so `b.H` (b : IBase) resolves the abstract
+                    // accessor and emits a verifiable `callvirt get_H`.
+                    // Inherited base-interface members are surfaced because
+                    // TypeMemberModel.TryGetProperty walks SelfAndAllBaseInterfaces.
+                    if (TypeMemberModel.TryGetProperty(ifaceSym, ne.IdentifierToken.Text, out var ifaceProp, out _))
+                    {
+                        if (!ifaceProp.HasGetter)
+                        {
+                            Diagnostics.ReportCannotAssign(ne.Location, ne.IdentifierToken.Text);
+                            return new BoundErrorExpression(null);
+                        }
+
+                        return new BoundPropertyAccessExpression(null, receiver, null, ifaceProp);
+                    }
+
+                    Diagnostics.ReportUnableToFindMember(ne.Location, ne.IdentifierToken.Text);
+                }
                 else if (receiver != null && receiver.Type is TupleTypeSymbol tupleSym)
                 {
                     // Phase 4.5: tuple element access via Item1..ItemN.

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -486,6 +486,30 @@ internal sealed partial class ExpressionBinder
             return new BoundClrPropertyAssignmentExpression(null, instReceiver, instanceMember, instConverted, instTargetSymbol);
         }
 
+        // Issue #1068: an interface-typed variable receiver (`d.W = v` where
+        // d : IDerived) writes the interface property setter (walking base
+        // interfaces). Mirrors the read path and the expression-receiver write
+        // path; the emitter dispatches via `callvirt set_W`.
+        if (variable.Type is InterfaceSymbol ifaceVarType)
+        {
+            if (TypeMemberModel.TryGetProperty(ifaceVarType, syntax.FieldIdentifier.Text, out var ifaceProp, out _))
+            {
+                if (!ifaceProp.HasSetter)
+                {
+                    Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, syntax.FieldIdentifier.Text);
+                    return new BoundErrorExpression(null);
+                }
+
+                var ifaceConverted = conversions.BindConversion(syntax.Value.Location, value, ifaceProp.Type);
+                var ifaceReceiver = implicitFieldReceiverExpr ?? new BoundVariableExpression(null, variable);
+                EnforceInitOnlyAssignment(ifaceProp, ifaceReceiver, syntax.EqualsToken.Location);
+                return new BoundPropertyAssignmentExpression(null, ifaceReceiver, null, ifaceProp, ifaceConverted);
+            }
+
+            Diagnostics.ReportUnableToFindMember(syntax.FieldIdentifier.Location, syntax.FieldIdentifier.Text);
+            return new BoundErrorExpression(null);
+        }
+
         if (!(variable.Type is StructSymbol structSymbol))
         {
             Diagnostics.ReportUnableToFindMember(syntax.FieldIdentifier.Location, syntax.FieldIdentifier.Text);
@@ -1215,6 +1239,29 @@ internal sealed partial class ExpressionBinder
                     var inhConverted = conversions.BindConversion(syntax.Value.Location, value, inhTargetSymbol);
                     return new BoundClrPropertyAssignmentExpression(null, receiver, clrMember, inhConverted, inhTargetSymbol);
                 }
+            }
+
+            Diagnostics.ReportUnableToFindMember(syntax.FieldIdentifier.Location, fieldName);
+            return new BoundErrorExpression(null);
+        }
+
+        // Issue #1068: write a property declared on the static interface type
+        // (or any base interface) through an interface-typed receiver. Mirrors
+        // the property read path in ExpressionBinder.Access.cs so `b.H = v`
+        // (b : IBase) dispatches via a verifiable `callvirt set_H`.
+        if (receiverType is InterfaceSymbol ifaceSym)
+        {
+            if (TypeMemberModel.TryGetProperty(ifaceSym, fieldName, out var ifaceProp, out _))
+            {
+                if (!ifaceProp.HasSetter)
+                {
+                    Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, fieldName);
+                    return new BoundErrorExpression(null);
+                }
+
+                var ifaceConverted = conversions.BindConversion(syntax.Value.Location, value, ifaceProp.Type);
+                EnforceInitOnlyAssignment(ifaceProp, receiver, syntax.EqualsToken.Location);
+                return new BoundPropertyAssignmentExpression(null, receiver, null, ifaceProp, ifaceConverted);
             }
 
             Diagnostics.ReportUnableToFindMember(syntax.FieldIdentifier.Location, fieldName);

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
@@ -638,9 +638,14 @@ internal sealed partial class MethodBodyEmitter
         // spilled to a temp and addressed via `ldloca` rather than left as
         // a value on the stack (unverifiable / SIGSEGV).
         var receiverIsClass = access.Receiver.Type is StructSymbol rs && rs.IsClass;
+
+        // Issue #1068: an interface-typed receiver dispatches the property
+        // accessor virtually (`callvirt get_X`) against the abstract interface
+        // accessor MethodDef.
+        var receiverIsInterface = access.Receiver.Type is InterfaceSymbol;
         this.EmitInstanceReceiver(access.Receiver);
 
-        this.il.OpCode(receiverIsClass ? ILOpCode.Callvirt : ILOpCode.Call);
+        this.il.OpCode(receiverIsClass || receiverIsInterface ? ILOpCode.Callvirt : ILOpCode.Call);
         this.il.Token(getterHandle);
     }
 
@@ -694,12 +699,17 @@ internal sealed partial class MethodBodyEmitter
         // receivers spill to a temp and pass `ldloca` as `this` instead
         // of leaving a value on the stack.
         var receiverIsClass = assn.Receiver.Type is StructSymbol rs && rs.IsClass;
+
+        // Issue #1068: an interface-typed receiver dispatches the property
+        // setter virtually (`callvirt set_X`) against the abstract interface
+        // accessor MethodDef.
+        var receiverIsInterface = assn.Receiver.Type is InterfaceSymbol;
         this.EmitInstanceReceiver(assn.Receiver);
 
         this.EmitExpression(assn.Value);
         this.il.OpCode(ILOpCode.Dup);
         this.il.StoreLocal(valueSlot);
-        this.il.OpCode(receiverIsClass ? ILOpCode.Callvirt : ILOpCode.Call);
+        this.il.OpCode(receiverIsClass || receiverIsInterface ? ILOpCode.Callvirt : ILOpCode.Call);
         this.il.Token(setterHandle);
 
         // Expression result: the value we just stored — no second receiver

--- a/test/Compiler.Tests/Emit/Issue1068InterfacePropertyAccessEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1068InterfacePropertyAccessEmitTests.cs
@@ -1,0 +1,153 @@
+// <copyright file="Issue1068InterfacePropertyAccessEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1068: end-to-end emit + execute coverage for reading and writing a
+/// property through an interface-typed reference. Interface methods already
+/// dispatched correctly; property access on an interface receiver previously
+/// failed to bind (GS0158). The fix routes interface property reads/writes
+/// through the canonical member-resolution layer and emits a verifiable
+/// <c>callvirt get_X</c> / <c>callvirt set_X</c> against the abstract interface
+/// accessor.
+///
+/// Each test compiles via <c>gsc</c>, ilverifies the produced PE, then runs the
+/// assembly under <c>dotnet exec</c> and asserts on captured stdout.
+/// </summary>
+public class Issue1068InterfacePropertyAccessEmitTests
+{
+    [Fact]
+    public void GetOnlyProperty_ReadThroughInterfaceReference_DispatchesToImplementer()
+    {
+        var source = """
+            package t
+            import System
+
+            interface IBase { prop H int32 { get; } }
+
+            class C : IBase {
+                prop H int32 { get; init; }
+                init(h int32) { H = h }
+            }
+
+            func read(b IBase) int32 { return b.H }
+
+            var c = C(42)
+            Console.WriteLine(read(c))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void InheritedAndDeclaredProperties_ReadAndWriteThroughInterfaceReference()
+    {
+        // H is inherited from IBase; W is declared on IDerived with a setter.
+        // All access goes through interface-typed references.
+        var source = """
+            package t
+            import System
+
+            interface IBase { prop H int32 { get; } }
+            interface IDerived : IBase { prop W int32 { get; set; } }
+
+            class C : IDerived {
+                prop H int32 { get; init; }
+                prop W int32 { get; set; }
+                init(h int32) { H = h }
+            }
+
+            func readH(b IBase) int32 { return b.H }
+            func writeW(d IDerived, v int32) { d.W = v }
+
+            var c = C(40)
+            writeW(c, 2)
+            var d IDerived = c
+            Console.WriteLine(readH(c))
+            Console.WriteLine(d.W)
+            Console.WriteLine(d.H)
+            Console.WriteLine(readH(c) + d.W + d.H)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("40\n2\n40\n82\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1068_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1068InterfacePropertyAccessTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1068InterfacePropertyAccessTests.cs
@@ -1,0 +1,125 @@
+// <copyright file="Issue1068InterfacePropertyAccessTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1068: reading (and writing) a property through an interface-typed
+/// reference must bind, mirroring the already-working interface method path.
+/// Property member access on an interface receiver previously fell through to
+/// GS0158 because the member-access binder only modelled interface methods,
+/// not interface properties. The binder now routes interface property lookups
+/// through <c>TypeMemberModel.TryGetProperty</c>, which also walks base
+/// interfaces.
+/// </summary>
+public class Issue1068InterfacePropertyAccessTests
+{
+    [Fact]
+    public void GetOnlyProperty_ReadThroughInterfaceReference_Binds()
+    {
+        const string source = """
+            package p
+            interface IBase { prop H int32 { get; } }
+            class C : IBase {
+                prop H int32 { get; init; }
+                init(h int32) { H = h }
+            }
+            func read(b IBase) int32 { return b.H }
+            """;
+        var diagnostics = Bind(source);
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void InheritedProperty_ReadThroughDerivedInterfaceReference_Binds()
+    {
+        // H is declared on IBase and reached through an IDerived-typed
+        // reference — the lookup must walk the base interface chain.
+        const string source = """
+            package p
+            interface IBase { prop H int32 { get; } }
+            interface IDerived : IBase { prop W int32 { get; set; } }
+            class C : IDerived {
+                prop H int32 { get; init; }
+                prop W int32 { get; set; }
+                init(h int32) { H = h }
+            }
+            func read(d IDerived) int32 { return d.H }
+            """;
+        var diagnostics = Bind(source);
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void GetSetProperty_WriteThroughInterfaceReference_Binds()
+    {
+        const string source = """
+            package p
+            interface IBag { prop W int32 { get; set; } }
+            class C : IBag {
+                prop W int32 { get; set; }
+            }
+            func write(b IBag, v int32) { b.W = v }
+            func read(b IBag) int32 { return b.W }
+            """;
+        var diagnostics = Bind(source);
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void AbsentMember_ThroughInterfaceReference_ReportsGS0158()
+    {
+        // A truly-absent member must still surface "Cannot find member".
+        const string source = """
+            package p
+            interface IBase { prop H int32 { get; } }
+            class C : IBase {
+                prop H int32 { get; init; }
+                init(h int32) { H = h }
+            }
+            func read(b IBase) int32 { return b.Missing }
+            """;
+        var diagnostics = Bind(source);
+        Assert.Contains(diagnostics, d => d.Id == "GS0158");
+    }
+
+    [Fact]
+    public void GetOnlyProperty_WriteThroughInterfaceReference_ReportsCannotAssign()
+    {
+        // IBase.H has no setter, so writing it through the interface reference
+        // must be rejected rather than silently succeeding.
+        const string source = """
+            package p
+            interface IBase { prop H int32 { get; } }
+            class C : IBase {
+                prop H int32 { get; init; }
+                init(h int32) { H = h }
+            }
+            func write(b IBase, v int32) { b.H = v }
+            """;
+        var diagnostics = Bind(source);
+        Assert.Contains(diagnostics, d => d.Id == "GS0127");
+    }
+
+    private static IReadOnlyList<Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+
+        // BoundProgram fully binds function bodies (where member access is
+        // resolved), surfacing body-level diagnostics such as GS0158/GS0127 —
+        // GlobalScope.Diagnostics only covers declaration-level binding.
+        return compilation.GlobalScope.Diagnostics
+            .Concat(compilation.BoundProgram.Diagnostics)
+            .ToList();
+    }
+}


### PR DESCRIPTION
Fixes #1068

## Root cause
Accessing an interface **property** through an interface-typed reference reported `GS0158: Cannot find member`, while interface **methods** through the same kind of reference dispatched correctly. The member-access binder modelled only interface methods on an interface-typed receiver: the property read path in `ExpressionBinder.Access.cs` and the two property write paths in `ExpressionBinder.Assignments.cs` had no `InterfaceSymbol` branch, so an interface-typed receiver never consulted the canonical inherited-aware member-resolution layer (`TypeMemberModel.TryGetProperty`, ADR-0112) — which already models interface properties, including those inherited from a base interface.

## Fix
- **Read** (`ExpressionBinder.Access.cs`): interface-typed receiver property reads now route through `TypeMemberModel.TryGetProperty` and bind a `BoundPropertyAccessExpression` (get-only reads supported; missing getter reports cannot-assign).
- **Write** (`ExpressionBinder.Assignments.cs`): added an `InterfaceSymbol` branch to both the variable-target and expression-receiver property assignment paths (`get; set;` and `get; init;`, including base-interface members); get-only writes report `GS0127`; truly-absent members still report `GS0158`.
- **Emit** (`MethodBodyEmitter.MemberAccess.cs`): interface property accessors are dispatched with `callvirt get_X` / `callvirt set_X` against the abstract interface accessor MethodDef.

Base-interface inheritance works for free because `TypeMemberModel.TryGetProperty` walks `SelfAndAllBaseInterfaces()`.

## Tests
- `test/Core.Tests/.../Issue1068InterfacePropertyAccessTests.cs`: get-only read binds; inherited base-interface read binds; `get; set;` write binds; absent member still reports `GS0158`; get-only write reports `GS0127`.
- `test/Compiler.Tests/Emit/Issue1068InterfacePropertyAccessEmitTests.cs`: compile + IL-verify + run programs reading/writing interface properties (declared and inherited from a base interface) through interface-typed references, asserting runtime values.

All new tests pass. Full `Core.Tests` (3699 passing) and 240 interface/property emit tests pass with no regressions.

Nothing deferred: get-only, get/set, get/init, base-interface inheritance, and read + write through interface-typed references are all covered.
