### PR TITLE
Fixes #1069: support nested struct / data struct / enum declarations

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -704,6 +704,12 @@ public sealed class Binder
             if (structSymbol != null)
             {
                 declaredStructs.Add((structSyntax, structSymbol));
+
+                // Issue #1069: declare the type-name shells of any nested types
+                // (recursively) right after the enclosing shell, so a sibling
+                // member signature can forward-reference a nested type by name.
+                // The bodies are bound later in phase 2 (BindNestedTypeBodies).
+                binder.declarations.DeclareNestedTypeShells(structSyntax, structSymbol, owningPackage);
             }
         }
 
@@ -2449,6 +2455,91 @@ public sealed class Binder
     /// working end-to-end.
     /// </para>
     /// </summary>
+    /// <summary>
+    /// Issue #1069: returns the enclosing type of a (possibly nested) user type
+    /// symbol — the value set via <c>SetContainingType</c> during declaration
+    /// binding — or <c>null</c> for a top-level type or a non-aggregate symbol.
+    /// </summary>
+    private static TypeSymbol SymbolContainingType(TypeSymbol type) => type switch
+    {
+        StructSymbol s => s.ContainingType,
+        EnumSymbol e => e.ContainingType,
+        InterfaceSymbol i => i.ContainingType,
+        _ => null,
+    };
+
+    /// <summary>
+    /// Issue #1069: resolves a dotted type clause (<c>Outer.Entry</c>,
+    /// <c>Outer.Middle.Inner</c>) to a user-defined nested type declared in the
+    /// current compilation, by walking the enclosing-type chain. Each segment
+    /// after the first must name a type whose enclosing type is the symbol
+    /// resolved for the preceding segment. Returns <c>null</c> when the chain
+    /// does not resolve to such a user nested type, letting the caller fall back
+    /// to the reflection-based CLR nested-type walk. Type arguments on the
+    /// deepest segment construct the closed generic type; array suffixes are
+    /// applied by the caller.
+    /// </summary>
+    private TypeSymbol TryResolveUserNestedTypeChain(TypeClauseSyntax syntax, string[] segmentTexts)
+    {
+        if (segmentTexts.Length < 2)
+        {
+            return null;
+        }
+
+        var current = LookupType(segmentTexts[0]);
+        if (current == null)
+        {
+            return null;
+        }
+
+        for (var i = 1; i < segmentTexts.Length; i++)
+        {
+            var nested = LookupType(segmentTexts[i]);
+            if (nested == null || !ReferenceEquals(SymbolContainingType(nested), current))
+            {
+                return null;
+            }
+
+            current = nested;
+        }
+
+        if (!syntax.HasTypeArguments)
+        {
+            return current;
+        }
+
+        // Construct the closed generic for the deepest (named) segment.
+        var typeArgsBuilder = ImmutableArray.CreateBuilder<TypeSymbol>(syntax.TypeArguments.Count);
+        foreach (var taSyntax in syntax.TypeArguments)
+        {
+            var ta = BindTypeClause(taSyntax);
+            if (ta == null)
+            {
+                return null;
+            }
+
+            if (TypeSymbol.IsByRefLike(ta))
+            {
+                Diagnostics.ReportByRefLikeEscape(taSyntax.Identifier?.Location ?? syntax.Identifier.Location, ta, "be used as a generic type argument");
+                return null;
+            }
+
+            typeArgsBuilder.Add(ta);
+        }
+
+        var typeArgs = typeArgsBuilder.MoveToImmutable();
+        switch (current)
+        {
+            case StructSymbol genericStruct when genericStruct.IsGenericDefinition && genericStruct.TypeParameters.Length == typeArgs.Length:
+                return StructSymbol.Construct(genericStruct, typeArgs);
+            case InterfaceSymbol genericIface when genericIface.IsGenericDefinition && genericIface.TypeParameters.Length == typeArgs.Length:
+                return InterfaceSymbol.Construct(genericIface, typeArgs);
+            default:
+                Diagnostics.ReportTypeNotGeneric(syntax.Identifier.Location, syntax.DottedName);
+                return null;
+        }
+    }
+
     private TypeSymbol BindQualifiedTypeName(TypeClauseSyntax syntax)
     {
         var totalSegments = 1 + syntax.QualifierIdentifierTokens.Length;
@@ -2460,6 +2551,17 @@ public sealed class Binder
         }
 
         var targetArity = syntax.HasTypeArguments ? syntax.TypeArguments.Count : 0;
+
+        // Issue #1069: a dotted name may reference a *user-defined* nested type
+        // declared in the current compilation (e.g. `Outer.Entry`,
+        // `Outer.Color`). Such types have no reflectable CLR `Type` while we are
+        // still binding, so the reflection-based prefix walk below cannot see
+        // them. Resolve them symbolically through the enclosing-type chain first.
+        var userNested = TryResolveUserNestedTypeChain(syntax, segmentTexts);
+        if (userNested != null)
+        {
+            return userNested;
+        }
 
         // Greedy: prefer the longest outer prefix that resolves to a real type,
         // then walk the remaining segments as nested types. Going longest-first

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -83,6 +83,17 @@ internal sealed class DeclarationBinder
     private readonly List<(StructDeclarationSyntax Syntax, StructSymbol Symbol)> pendingAbstractImplementationChecks
         = new List<(StructDeclarationSyntax, StructSymbol)>();
 
+    // Issue #1069: nested struct/class and interface type-name shells declared in
+    // phase 1 (DeclareNestedTypeShells) so a sibling member signature can
+    // forward-reference a nested type by name. The recorded shells are reused in
+    // phase 2 (BindNestedTypeBodies) to bind the bodies without re-declaring the
+    // type alias. Nested enums are fully bound during the shell phase (their
+    // members reference no user types) and so are not tracked here.
+    private readonly Dictionary<StructDeclarationSyntax, StructSymbol> nestedStructShells
+        = new Dictionary<StructDeclarationSyntax, StructSymbol>();
+    private readonly Dictionary<InterfaceDeclarationSyntax, InterfaceSymbol> nestedInterfaceShells
+        = new Dictionary<InterfaceDeclarationSyntax, InterfaceSymbol>();
+
     public DeclarationBinder(
         BinderContext binderCtx,
         ConversionClassifier conversions,
@@ -2469,10 +2480,12 @@ internal sealed class DeclarationBinder
         // ADR-0068 / issue #698: bind the optional class destructor (`deinit { … }`).
         BindDeinitDeclaration(syntax, structSymbol, package);
 
-        // Issue #910 / ADR-0110: bind nested type declarations (class / struct /
-        // interface / enum) declared inside this aggregate's body, recording the
-        // enclosing type so the emitter materialises real CLR nested types.
-        BindNestedTypeDeclarations(syntax, structSymbol, package);
+        // Issue #910 / ADR-0110 / issue #1069: bind the BODIES of the nested type
+        // declarations declared inside this aggregate's body. Their type-name
+        // shells were declared earlier (DeclareNestedTypeShells) so sibling
+        // member signatures could forward-reference them; here we fill in their
+        // members. The emitter materialises real CLR nested types.
+        BindNestedTypeBodies(syntax, package);
 
         // Issue #987: queue the abstract-member contract check for classes. A
         // concrete (non-`open`) class with a base must override every inherited
@@ -2484,21 +2497,26 @@ internal sealed class DeclarationBinder
     }
 
     /// <summary>
-    /// Issue #910 / ADR-0110: binds the nested type declarations declared in a
-    /// class or struct body. Each nested declaration is bound through the same
-    /// driver used for top-level types and tagged with its enclosing type via
-    /// <c>SetContainingType</c>. Nested-in-nested declarations are handled
-    /// recursively because the per-kind binders bind their own nested types.
+    /// Issue #910 / ADR-0110 / issue #1069: binds the BODIES of the nested type
+    /// declarations declared in a class or struct body, reusing the type-name
+    /// shells declared earlier by <see cref="DeclareNestedTypeShells"/> (phase 1).
+    /// Splitting shell declaration from body binding lets a sibling member
+    /// signature (a field/property/parameter/return type, a generic argument, an
+    /// array element type, …) forward-reference any nested type by simple name,
+    /// for every nested kind (<c>class</c>/<c>struct</c>/<c>data struct</c>/
+    /// <c>interface</c>/<c>enum</c>). Nested enums are fully bound in the shell
+    /// phase (their members reference no user types) and need no body pass here.
+    /// Nested-in-nested declarations are handled recursively because the
+    /// per-kind body binders bind their own nested types.
     /// <para>
-    /// All four nested kinds (<c>class</c>/<c>struct</c>/<c>interface</c>/
-    /// <c>enum</c>) inside either encloser (<c>class</c> or <c>struct</c>) are
-    /// emitted as real CLR nested types. The emitter materialises every
+    /// All nested kinds inside either encloser (<c>class</c> or <c>struct</c>)
+    /// are emitted as real CLR nested types. The emitter materialises every
     /// enclosing TypeDef row before its nested rows (ECMA-335 §II.22.32) via a
     /// unified pre-order emission pass (ADR-0110), so no kind/encloser
     /// combination needs to be deferred.
     /// </para>
     /// </summary>
-    private void BindNestedTypeDeclarations(StructDeclarationSyntax containerSyntax, TypeSymbol containerSymbol, PackageSymbol package)
+    private void BindNestedTypeBodies(StructDeclarationSyntax containerSyntax, PackageSymbol package)
     {
         if (containerSyntax.NestedTypes.IsDefaultOrEmpty)
         {
@@ -2518,8 +2536,69 @@ internal sealed class DeclarationBinder
             switch (nested)
             {
                 case StructDeclarationSyntax nestedStruct:
-                    var nestedStructSymbol = BindStructDeclaration(nestedStruct, package);
-                    nestedStructSymbol?.SetContainingType(containerSymbol);
+                    // The shell (and its own nested shells, recursively) was
+                    // declared in phase 1; bind its body now. Binding the body
+                    // recurses into BindNestedTypeBodies for nested-in-nested.
+                    if (nestedStructShells.TryGetValue(nestedStruct, out var nestedStructSymbol))
+                    {
+                        BindStructDeclarationBody(nestedStruct, package, nestedStructSymbol);
+                    }
+
+                    break;
+
+                case EnumDeclarationSyntax:
+                    // Nested enums are fully bound in the shell phase.
+                    break;
+
+                case InterfaceDeclarationSyntax nestedInterface:
+                    if (nestedInterfaceShells.TryGetValue(nestedInterface, out var nestedInterfaceSymbol))
+                    {
+                        BindInterfaceMembers(nestedInterface, nestedInterfaceSymbol, package);
+                    }
+
+                    break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Issue #1069 (phase 1): declares the type-name shells of the nested types
+    /// declared in <paramref name="containerSyntax"/> and records the enclosing
+    /// type on each via <c>SetContainingType</c>, BEFORE any member body of the
+    /// enclosing type is bound. This makes every nested type resolvable by simple
+    /// name from within the enclosing type (and as a CLR nested type by qualified
+    /// name from outside) regardless of declaration order, mirroring the
+    /// two-phase scheme used for top-level types (#973).
+    /// <list type="bullet">
+    /// <item><c>struct</c>/<c>class</c>/<c>data struct</c>: a shell is declared
+    /// (fields/base bound later) and its own nested shells are declared
+    /// recursively.</item>
+    /// <item><c>enum</c>: fully bound now — enum members reference no user types,
+    /// so there is nothing to defer.</item>
+    /// <item><c>interface</c>: a shell is declared; its method signatures are
+    /// bound later by <see cref="BindNestedTypeBodies"/>.</item>
+    /// </list>
+    /// </summary>
+    internal void DeclareNestedTypeShells(StructDeclarationSyntax containerSyntax, TypeSymbol containerSymbol, PackageSymbol package)
+    {
+        if (containerSyntax.NestedTypes.IsDefaultOrEmpty)
+        {
+            return;
+        }
+
+        foreach (var nested in containerSyntax.NestedTypes)
+        {
+            switch (nested)
+            {
+                case StructDeclarationSyntax nestedStruct:
+                    var nestedStructSymbol = DeclareStructShell(nestedStruct, package);
+                    if (nestedStructSymbol != null)
+                    {
+                        nestedStructSymbol.SetContainingType(containerSymbol);
+                        nestedStructShells[nestedStruct] = nestedStructSymbol;
+                        DeclareNestedTypeShells(nestedStruct, nestedStructSymbol, package);
+                    }
+
                     break;
 
                 case EnumDeclarationSyntax nestedEnum:
@@ -2531,8 +2610,8 @@ internal sealed class DeclarationBinder
                     var nestedInterfaceSymbol = DeclareInterfaceSymbol(nestedInterface, package);
                     if (nestedInterfaceSymbol != null)
                     {
-                        BindInterfaceMembers(nestedInterface, nestedInterfaceSymbol, package);
                         nestedInterfaceSymbol.SetContainingType(containerSymbol);
+                        nestedInterfaceShells[nestedInterface] = nestedInterfaceSymbol;
                     }
 
                     break;

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -507,6 +507,27 @@ internal sealed partial class ExpressionBinder
             return qualifiedCtorCall;
         }
 
+        // Issue #1069: a nested user type referenced by a qualified name from
+        // outside its enclosing type (`Outer.Entry(...)`, `Outer.Inner().M()`).
+        // Nested types are also visible by their simple name in the flat package
+        // scope, so an enclosing-type qualifier in front of a nested-type
+        // construction/member-access is redundant: peel it off and bind the
+        // remainder by simple name. This mirrors how the enclosing type's own
+        // members reference a sibling nested type. It only fires when the left
+        // segment is a user aggregate type and the next segment names one of its
+        // nested types, and never for a bare-name terminal segment (handled as a
+        // type receiver below), so it cannot shadow ordinary static-member access.
+        if (syntax.LeftPart is NameExpressionSyntax enclosingNameSyntax
+            && syntax.RightPart is not NameExpressionSyntax
+            && scope.TryLookupSymbol(enclosingNameSyntax.IdentifierToken.Text) is not VariableSymbol
+            && scope.TryLookupTypeAlias(enclosingNameSyntax.IdentifierToken.Text, out var enclosingAliasType)
+            && IsUserAggregateType(enclosingAliasType)
+            && TryGetHeadIdentifier(syntax.RightPart, out var headIdentifier)
+            && IsNestedTypeOf(headIdentifier, enclosingAliasType))
+        {
+            return BindExpression(syntax.RightPart);
+        }
+
         // Determine what the left side of the accessor is: either an imported
         // class (for static member access) or a value-producing expression (for
         // instance member access). Then apply the right side, which may itself
@@ -697,6 +718,29 @@ internal sealed partial class ExpressionBinder
             // construction's TypeSpec and the interpreter keys per construction.
             userInterfaceSymbol = constructedInterface;
         }
+        else if (leftPart is AccessorExpressionSyntax qualifiedNestedType
+            && !qualifiedNestedType.IsNullConditional
+            && TryResolveQualifiedUserNestedType(qualifiedNestedType, out var qualifiedNestedSymbol))
+        {
+            // Issue #1069: a qualified nested *type* used as the receiver of a
+            // further member access, e.g. `Outer.Color.Red` (the `Outer.Color`
+            // sub-chain names the nested enum) or `Outer.Inner.StaticMember`.
+            switch (qualifiedNestedSymbol)
+            {
+                case EnumSymbol qualifiedEnum:
+                    enumSymbol = qualifiedEnum;
+                    break;
+                case StructSymbol qualifiedStruct:
+                    userStructSymbol = qualifiedStruct;
+                    break;
+                case InterfaceSymbol qualifiedInterface:
+                    userInterfaceSymbol = qualifiedInterface;
+                    break;
+                default:
+                    receiver = BindExpression(leftPart);
+                    break;
+            }
+        }
         else
         {
             receiver = BindExpression(leftPart);
@@ -718,6 +762,110 @@ internal sealed partial class ExpressionBinder
         }
 
         return BindAccessorStep(receiver, classSymbol, rightPart);
+    }
+
+    /// <summary>
+    /// Issue #1069: returns the enclosing (containing) type of a user-defined
+    /// nested type symbol, or <see langword="null"/> for a top-level type or a
+    /// kind that cannot be nested.
+    /// </summary>
+    private static TypeSymbol GetSymbolContainingType(TypeSymbol type) => type switch
+    {
+        StructSymbol s => s.ContainingType,
+        EnumSymbol e => e.ContainingType,
+        InterfaceSymbol i => i.ContainingType,
+        _ => null,
+    };
+
+    /// <summary>
+    /// Issue #1069: a user-defined aggregate type (class/struct, enum, or
+    /// interface) declared in the current compilation, as opposed to an imported
+    /// CLR type or a predefined primitive alias.
+    /// </summary>
+    private static bool IsUserAggregateType(TypeSymbol type) =>
+        type is StructSymbol or EnumSymbol or InterfaceSymbol;
+
+    /// <summary>
+    /// Issue #1069: whether <paramref name="name"/> resolves to a user-defined
+    /// type whose enclosing type is <paramref name="container"/>.
+    /// </summary>
+    private bool IsNestedTypeOf(string name, TypeSymbol container) =>
+        scope.TryLookupTypeAlias(name, out var candidate)
+        && IsUserAggregateType(candidate)
+        && ReferenceEquals(GetSymbolContainingType(candidate), container);
+
+    /// <summary>
+    /// Issue #1069: returns the leftmost identifier of an accessor-chain segment
+    /// (the head of a call, index, accessor, or bare name), used to detect when a
+    /// qualified reference targets a nested type by its simple name.
+    /// </summary>
+    private static bool TryGetHeadIdentifier(ExpressionSyntax expression, out string identifier)
+    {
+        switch (expression)
+        {
+            case NameExpressionSyntax name:
+                identifier = name.IdentifierToken.Text;
+                return true;
+            case CallExpressionSyntax call:
+                identifier = call.Identifier.Text;
+                return true;
+            case AccessorExpressionSyntax accessor:
+                return TryGetHeadIdentifier(accessor.LeftPart, out identifier);
+            case IndexExpressionSyntax index:
+                return TryGetHeadIdentifier(index.Target, out identifier);
+            case StructLiteralExpressionSyntax structLiteral:
+                identifier = structLiteral.TypeIdentifier.Text;
+                return true;
+            case ObjectCreationExpressionSyntax objectCreation:
+                return TryGetHeadIdentifier(objectCreation.Target, out identifier);
+            default:
+                identifier = null;
+                return false;
+        }
+    }
+
+    /// <summary>
+    /// Issue #1069: resolves a dotted accessor of the form
+    /// <c>Outer.Nested</c> (optionally deeper, <c>A.B.C</c>) to the user-defined
+    /// nested type it names, by walking the enclosing-type chain. Each segment
+    /// after the first must name a user type whose enclosing type is the symbol
+    /// resolved for the preceding segment. Returns <see langword="false"/> when
+    /// the chain is not a pure user nested-type reference.
+    /// </summary>
+    private bool TryResolveQualifiedUserNestedType(AccessorExpressionSyntax accessor, out TypeSymbol nestedType)
+    {
+        nestedType = null;
+
+        if (accessor.RightPart is not NameExpressionSyntax rightName)
+        {
+            return false;
+        }
+
+        TypeSymbol container;
+        switch (accessor.LeftPart)
+        {
+            case NameExpressionSyntax leftName
+                when scope.TryLookupTypeAlias(leftName.IdentifierToken.Text, out var leftType)
+                    && IsUserAggregateType(leftType):
+                container = leftType;
+                break;
+            case AccessorExpressionSyntax leftAccessor
+                when TryResolveQualifiedUserNestedType(leftAccessor, out var leftNested):
+                container = leftNested;
+                break;
+            default:
+                return false;
+        }
+
+        if (!scope.TryLookupTypeAlias(rightName.IdentifierToken.Text, out var candidate)
+            || !IsUserAggregateType(candidate)
+            || !ReferenceEquals(GetSymbolContainingType(candidate), container))
+        {
+            return false;
+        }
+
+        nestedType = candidate;
+        return true;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -2405,8 +2405,12 @@ internal sealed class OverloadResolver
             // or inline-struct type, treat it as a ctor call instead — even
             // when no explicit/primary constructor is declared, so the user
             // sees an actionable "wrong argument count" diagnostic rather
-            // than a misleading conversion error (issue #524).
-            if (!(type is StructSymbol singleArgStruct && (singleArgStruct.IsClass || singleArgStruct.IsInline)))
+            // than a misleading conversion error (issue #524). Issue #1069: a
+            // value struct (e.g. a `data struct`) declaring a primary
+            // constructor is likewise positionally constructible — `Entry(1)`
+            // builds the struct, not a conversion to it.
+            if (!(type is StructSymbol singleArgStruct
+                  && (singleArgStruct.IsClass || singleArgStruct.IsInline || singleArgStruct.HasPrimaryConstructor)))
             {
                 // ADR-0047 §6 / #175: `Type(x)` as an explicit conversion
                 // is still a use of the named type.
@@ -2423,7 +2427,11 @@ internal sealed class OverloadResolver
         // parameterless default constructor — the emitter already produces
         // a `.ctor()` for such classes (see EmitClassDefaultConstructor),
         // so we just need the binder to route `ClassName()` through here.
-        if (lookupType(syntax.Identifier.Text) is StructSymbol classType && (classType.IsClass || classType.IsInline))
+        // Issue #1069: a value struct (e.g. a `data struct`) declaring a
+        // primary constructor is also positionally constructible —
+        // `Entry(1, 2)` lowers to a struct literal initializing its fields.
+        if (lookupType(syntax.Identifier.Text) is StructSymbol classType
+            && (classType.IsClass || classType.IsInline || classType.HasPrimaryConstructor))
         {
             return BindConstructorCallExpression(syntax, classType);
         }

--- a/test/Compiler.Tests/Emit/Issue1069NestedTypesEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1069NestedTypesEmitTests.cs
@@ -1,0 +1,282 @@
+// <copyright file="Issue1069NestedTypesEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1069: nested <c>struct</c>, <c>data struct</c>, and <c>enum</c>
+/// declarations inside a class must emit as real CLR nested types, be
+/// constructible and usable from the enclosing type's members and from outside
+/// by qualified name, pass ilverify, and execute with the expected runtime
+/// values. Nested <c>class</c> already worked and is covered for regression.
+/// </summary>
+public class Issue1069NestedTypesEmitTests
+{
+    [Fact]
+    public void NestedDataStruct_ConstructedAndUsed_Runs()
+    {
+        var output = CompileAndRun("""
+            package P
+
+            import System
+
+            open class Outer {
+                func Make() uint32 {
+                    let e = Entry(7u)
+                    return e.X
+                }
+
+                data struct Entry(X uint32) { }
+            }
+
+            let o = Outer()
+            Console.WriteLine(int32(o.Make()))
+            """);
+
+        Assert.Equal("7\n", output);
+    }
+
+    [Fact]
+    public void NestedEnum_AccessedAndUsed_Runs()
+    {
+        var output = CompileAndRun("""
+            package P
+
+            import System
+
+            open class Outer {
+                func Make() Color {
+                    return Color.Green
+                }
+
+                enum Color { Red, Green }
+            }
+
+            let o = Outer()
+            Console.WriteLine(int32(o.Make()))
+            """);
+
+        Assert.Equal("1\n", output);
+    }
+
+    [Fact]
+    public void NestedPlainStruct_MembersAccessed_Runs()
+    {
+        var output = CompileAndRun("""
+            package P
+
+            import System
+
+            open class Outer {
+                func Make() int32 {
+                    let e = Entry{X: 9}
+                    return e.X
+                }
+
+                struct Entry { var X int32 }
+            }
+
+            let o = Outer()
+            Console.WriteLine(o.Make())
+            """);
+
+        Assert.Equal("9\n", output);
+    }
+
+    [Fact]
+    public void NestedClass_ConstructedFromEnclosingMethod_Runs_Regression()
+    {
+        var output = CompileAndRun("""
+            package P
+
+            import System
+
+            open class Outer {
+                func Make() int32 {
+                    let i = Inner() { X = 5 }
+                    return i.X
+                }
+
+                class Inner { prop X int32 { get; init; } }
+            }
+
+            let o = Outer()
+            Console.WriteLine(o.Make())
+            """);
+
+        Assert.Equal("5\n", output);
+    }
+
+    [Fact]
+    public void NestedTypes_AccessedByQualifiedNameFromOutside_Runs()
+    {
+        var output = CompileAndRun("""
+            package P
+
+            import System
+
+            open class Outer {
+                data struct Entry(X uint32) { }
+                enum Color { Red, Green }
+                struct Point { var X int32 }
+            }
+
+            let e = Outer.Entry(4u)
+            Console.WriteLine(int32(e.X))
+            let c = Outer.Color.Green
+            Console.WriteLine(int32(c))
+            let p = Outer.Point{X: 11}
+            Console.WriteLine(p.X)
+            """);
+
+        Assert.Equal("4\n1\n11\n", output);
+    }
+
+    [Fact]
+    public void NestedDataStructAndEnum_EmitAsClrNestedTypes()
+    {
+        var assembly = CompileToLibrary("""
+            package P
+
+            open class Outer {
+                data struct Entry(X uint32) { }
+                enum Color { Red, Green }
+                struct Point { var X int32 }
+            }
+            """);
+
+        var outer = Enumerable.Single(assembly.GetTypes(), t => t.Name == "Outer");
+
+        foreach (var nestedName in new[] { "Entry", "Color", "Point" })
+        {
+            var nested = outer.GetNestedType(nestedName, BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(nested);
+            Assert.True(nested!.IsNested, $"{nestedName} should be a CLR nested type");
+            Assert.Equal(outer, nested.DeclaringType);
+        }
+
+        var color = outer.GetNestedType("Color", BindingFlags.Public | BindingFlags.NonPublic);
+        Assert.True(color!.IsEnum);
+
+        var entry = outer.GetNestedType("Entry", BindingFlags.Public | BindingFlags.NonPublic);
+        Assert.True(entry!.IsValueType);
+
+        var point = outer.GetNestedType("Point", BindingFlags.Public | BindingFlags.NonPublic);
+        Assert.True(point!.IsValueType);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1069_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}):\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static Assembly CompileToLibrary(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1069_lib_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:library",
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(compileExit == 0, $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+        IlVerifier.Verify(outPath);
+        return Assembly.Load(File.ReadAllBytes(outPath));
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1069NestedTypesTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1069NestedTypesTests.cs
@@ -1,0 +1,185 @@
+// <copyright file="Issue1069NestedTypesTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1069: nested <c>struct</c>, <c>data struct</c>, and <c>enum</c>
+/// declarations inside a class/struct must be registered into the enclosing
+/// type's scope so they resolve by simple name (from the enclosing type and the
+/// rest of the compilation) and by qualified name (<c>Outer.Entry</c>), are
+/// constructible, and expose their members. Nested <c>class</c> already worked
+/// and is covered here for regression.
+/// </summary>
+public class Issue1069NestedTypesTests
+{
+    [Fact]
+    public void NestedDataStruct_ResolvesBySimpleName_AsReturnTypeAndConstructed()
+    {
+        var scope = BindSource("""
+            package p
+            open class Outer {
+                func Make() Entry { return Entry(1u) }
+                data struct Entry(X uint32) { }
+            }
+            """);
+
+        Assert.Empty(GetBinderDiagnostics(scope));
+
+        var entry = (StructSymbol)scope.TypeAliases["Entry"];
+        var outer = (StructSymbol)scope.TypeAliases["Outer"];
+        Assert.Same(outer, entry.ContainingType);
+        Assert.True(entry.HasPrimaryConstructor);
+    }
+
+    [Fact]
+    public void NestedDataStruct_ResolvesByQualifiedName()
+    {
+        var scope = BindSource("""
+            package p
+            open class Outer {
+                func Make() Outer.Entry { return Outer.Entry(2u) }
+                data struct Entry(X uint32) { }
+            }
+            """);
+
+        Assert.Empty(GetBinderDiagnostics(scope));
+
+        var entry = (StructSymbol)scope.TypeAliases["Entry"];
+        var outer = (StructSymbol)scope.TypeAliases["Outer"];
+        Assert.Same(outer, entry.ContainingType);
+    }
+
+    [Fact]
+    public void NestedEnum_ResolvesBySimpleName()
+    {
+        var scope = BindSource("""
+            package p
+            open class Outer {
+                func Make() Color { return Color.Red }
+                enum Color { Red, Green }
+            }
+            """);
+
+        Assert.Empty(GetBinderDiagnostics(scope));
+
+        var color = (EnumSymbol)scope.TypeAliases["Color"];
+        var outer = (StructSymbol)scope.TypeAliases["Outer"];
+        Assert.Same(outer, color.ContainingType);
+    }
+
+    [Fact]
+    public void NestedEnum_ResolvesByQualifiedName()
+    {
+        var scope = BindSource("""
+            package p
+            open class Outer {
+                func Make() Outer.Color { return Outer.Color.Green }
+                enum Color { Red, Green }
+            }
+            """);
+
+        Assert.Empty(GetBinderDiagnostics(scope));
+
+        var color = (EnumSymbol)scope.TypeAliases["Color"];
+        var outer = (StructSymbol)scope.TypeAliases["Outer"];
+        Assert.Same(outer, color.ContainingType);
+    }
+
+    [Fact]
+    public void NestedPlainStruct_MembersResolve()
+    {
+        var scope = BindSource("""
+            package p
+            open class Outer {
+                func Make() int32 {
+                    let e = Entry{X: 1}
+                    return e.X
+                }
+                struct Entry { var X int32 }
+            }
+            """);
+
+        Assert.Empty(GetBinderDiagnostics(scope));
+
+        var entry = (StructSymbol)scope.TypeAliases["Entry"];
+        var outer = (StructSymbol)scope.TypeAliases["Outer"];
+        Assert.Same(outer, entry.ContainingType);
+        Assert.False(entry.IsClass);
+    }
+
+    [Fact]
+    public void NestedClass_StillResolves_Regression()
+    {
+        var scope = BindSource("""
+            package p
+            open class Outer {
+                func Make() int32 {
+                    let e = Inner()
+                    return e.X
+                }
+                class Inner { prop X int32 { get; init; } }
+            }
+            """);
+
+        Assert.Empty(GetBinderDiagnostics(scope));
+
+        var inner = (StructSymbol)scope.TypeAliases["Inner"];
+        var outer = (StructSymbol)scope.TypeAliases["Outer"];
+        Assert.Same(outer, inner.ContainingType);
+        Assert.True(inner.IsClass);
+    }
+
+    [Fact]
+    public void NestedTypes_UsableAsFieldAndArrayElement()
+    {
+        var scope = BindSource("""
+            package p
+            open class Outer {
+                var First Entry
+                func Many() []Entry { return [Entry(1u)] }
+                data struct Entry(X uint32) { }
+            }
+            """);
+
+        Assert.Empty(GetBinderDiagnostics(scope));
+
+        var entry = (StructSymbol)scope.TypeAliases["Entry"];
+        var outer = (StructSymbol)scope.TypeAliases["Outer"];
+        Assert.Same(outer, entry.ContainingType);
+    }
+
+    [Fact]
+    public void AbsentNestedType_ReportsTypeDoesNotExist()
+    {
+        var scope = BindSource("""
+            package p
+            open class Outer {
+                func Make() Missing { return Missing(1u) }
+                data struct Entry(X uint32) { }
+            }
+            """);
+
+        Assert.Contains(GetBinderDiagnostics(scope), d => d.Id == "GS0113");
+    }
+
+    private static BoundGlobalScope BindSource(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        return Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+    }
+
+    private static System.Collections.Generic.IEnumerable<GSharp.Core.CodeAnalysis.Diagnostic> GetBinderDiagnostics(BoundGlobalScope scope)
+    {
+        return scope.Diagnostics;
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1069. Nested type declarations inside a class/struct only worked for nested **classes**. Nested **struct**, **data struct**, and **enum** declarations were not registered into the enclosing type's scope, so they could not be resolved (GS0113) or have their members accessed (GS0158).

| Nested kind | Before | After |
|---|---|---|
| `class` | works | works (regression-covered) |
| `struct` | GS0158 (members invisible) | full member access |
| `data struct` | GS0113 (type not found) | resolvable + constructible |
| `enum` | GS0113 (type not found) | resolvable |

## Root cause

Nested type-name *shells* were declared at the **end** of the enclosing type's body binding, **after** sibling member signatures (field/property/parameter/return/generic-arg/array-element types) were already bound. Method bodies bind later (deferred), which is why a nested type was visible from inside a method body but not from a type annotation, and why only the partially-deferred class path appeared to work.

## Fix

Split nested-type binding into two phases, mirroring the top-level two-phase scheme (#973):

- **`DeclareNestedTypeShells`** (phase 1) declares nested type-name shells (recursively, including nested-in-nested) and sets `ContainingType` **before** any enclosing member signature is bound, so every nested kind resolves by simple name regardless of declaration order. Nested enums are fully bound here.
- **`BindNestedTypeBodies`** (phase 2) binds the recorded shells' bodies.

Additional, smaller fixes required for full coverage:

- **`OverloadResolver`**: routes positional data-struct construction (`Entry(1u)`) through the constructor-call path via `HasPrimaryConstructor`.
- **`Binder`**: resolves qualified nested type *annotations* (`Outer.Entry`, `Outer.Color`) against user nested-type symbols by walking the `ContainingType` chain.
- **`ExpressionBinder`**: peels a redundant enclosing-type qualifier in front of a nested-type reference in *expressions* (`Outer.Entry(5u)`, `Outer.Color.Red`, `Outer.Point{X: 1}`, `Outer.Inner()`), since nested types are also visible by simple name in the flat package scope.

All four nested kinds now emit as **real CLR nested TypeDefs**, IL-verify, and run.

## Coverage

Nested types work as field/property/parameter/return types, array element types (`[]Entry`), generic arguments (`List[Entry]`), in object-initializer / data-struct construction, referencing the enclosing type and sibling nested types, by **simple** and **qualified** name (annotation and expression), from inside and outside the enclosing type. Verified via reflection that emitted types are CLR nested value types / nested enums.

## Tests

- `test/Core.Tests/CodeAnalysis/Binding/Issue1069NestedTypesTests.cs` (8 tests): nested data struct resolves by simple + qualified name; nested enum resolves by simple + qualified name; nested plain-struct members resolve; nested type as field/array element; regression nested class; negative — absent nested type still reports GS0113.
- `test/Compiler.Tests/Emit/Issue1069NestedTypesEmitTests.cs` (6 tests): compile + IL-verify + **run** programs constructing/using a nested data struct, nested enum, nested plain struct, qualified external access, and reflection assertions that the emitted types are CLR nested types.

All new tests pass. Full Core.Tests (3714) green; targeted Compiler.Tests emit slices (nested / struct / enum / data struct) green. No new SyntaxKind/BoundNodeKind, no new top-level samples.

## Notes (not regressions, pre-existing general behaviors)

- `data struct Entry(X uint32)` requires `Entry(1u)` — G# has no implicit int→uint literal coercion (also fails at top level). 
- Plain `struct` with `prop X { get; init; }` is initialized via `Entry() { X = v }` object-initializer; struct-literal `{X: v}` targets fields. Both behaviors reproduce at top level and are out of scope for this nesting fix.
