### PR TITLE
Fixes #1070: make static const / shared fields visible in field initializers

### DIFF
--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -799,6 +799,16 @@ internal sealed class DeclarationBinder
         var constFieldsBuilder = ImmutableArray.CreateBuilder<FieldSymbol>();
         var pendingConstInitializers = new List<(FieldSymbol Field, FieldDeclarationSyntax Syntax, TypeSymbol FieldType)>();
 
+        // Issue #1070: `shared`-block static field initializers and `shared`/const
+        // initializers are also deferred so that ALL of them are bound in a single
+        // pass once every static member symbol (static field, const, static
+        // property) of the enclosing type exists. Binding them in a scope that
+        // exposes those static members makes a field initializer able to reference
+        // a sibling `const` or `shared` field regardless of declaration order,
+        // matching the static-member visibility a method/constructor body already has.
+        var pendingStaticFieldInitializers = new List<(FieldSymbol Field, ExpressionSyntax InitSyntax, TypeSymbol FieldType)>();
+        var pendingSharedConstInitializers = new List<(FieldSymbol Field, FieldDeclarationSyntax Syntax, TypeSymbol FieldType)>();
+
         foreach (var fieldSyntax in syntax.Fields)
         {
             var fieldName = fieldSyntax.Identifier.Text;
@@ -1154,60 +1164,16 @@ internal sealed class DeclarationBinder
         // primary-constructor parameters so they can be forwarded to the base.
         BindBaseConstructorInitializer(syntax, structSymbol, baseClassSymbol, importedBaseType, primaryCtorParameters);
 
-        // Issue #640: now that the struct symbol exists, bind the deferred
-        // instance-field initializer expressions and install them on the symbol.
-        if (pendingInstanceInitializers.Count > 0)
-        {
-            // Issue #948: an instance field initializer runs before the
-            // constructor body, so it cannot reference `this`, other instance
-            // members, or constructor parameters (matching C#). Collect the
-            // forbidden names so we can report a precise diagnostic.
-            var instanceMemberNames = new HashSet<string>(System.StringComparer.Ordinal) { "this" };
-            foreach (var f in fields)
-            {
-                instanceMemberNames.Add(f.Name);
-            }
-
-            foreach (var p in primaryCtorParameters)
-            {
-                instanceMemberNames.Add(p.Name);
-            }
-
-            var instanceInitBuilder = ImmutableDictionary.CreateBuilder<FieldSymbol, BoundExpression>();
-            foreach (var (fieldSym, initSyntax, fieldType) in pendingInstanceInitializers)
-            {
-                if (TryFindInstanceMemberReference(initSyntax, instanceMemberNames, out var offendingName, out var offendingLocation))
-                {
-                    Diagnostics.ReportFieldInitializerCannotReferenceInstanceMember(offendingLocation, offendingName);
-                    continue;
-                }
-
-                var boundInit = bindExpression(initSyntax);
-                var convertedInit = conversions.BindConversion(initSyntax.Location, boundInit, fieldType);
-                instanceInitBuilder[fieldSym] = convertedInit;
-            }
-
-            structSymbol.SetInstanceFieldInitializers(instanceInitBuilder.ToImmutable());
-        }
-
-        // Issue #948: bind and fold the deferred const-field initializers to a
-        // compile-time constant, then install the const fields on the symbol.
+        // Issue #640 / issue #1070: the deferred instance-field initializer
+        // expressions, const-field foldings, and `shared`-block initializers are
+        // all bound later in a single consolidated pass (see "Issue #1070:
+        // consolidated field-initializer binding" below), once every static
+        // member symbol of the enclosing type has been created. That ordering is
+        // what lets an initializer reference a sibling `const`/`shared` field
+        // regardless of declaration order. Here we only install the const-field
+        // SYMBOLS so downstream member signatures can reference them by name.
         if (constFieldsBuilder.Count > 0)
         {
-            foreach (var (constField, fieldSyntaxNode, fieldType) in pendingConstInitializers)
-            {
-                var boundInit = bindExpression(fieldSyntaxNode.Initializer);
-                var convertedInit = conversions.BindConversion(fieldSyntaxNode.Initializer.Location, boundInit, fieldType);
-                if (TryFoldConstantFieldValue(convertedInit, fieldType, out var constantValue))
-                {
-                    constField.SetConstantValue(constantValue);
-                }
-                else if (boundInit is not BoundErrorExpression && convertedInit is not BoundErrorExpression)
-                {
-                    Diagnostics.ReportConstFieldInitializerNotConstant(fieldSyntaxNode.Initializer.Location, constField.Name);
-                }
-            }
-
             structSymbol.SetConstFields(constFieldsBuilder.ToImmutable());
         }
 
@@ -1910,7 +1876,6 @@ internal sealed class DeclarationBinder
             // Static fields
             var staticFieldsBuilder = ImmutableArray.CreateBuilder<FieldSymbol>();
             var sharedConstFieldsBuilder = ImmutableArray.CreateBuilder<FieldSymbol>();
-            var initializersBuilder = ImmutableDictionary.CreateBuilder<FieldSymbol, BoundExpression>();
             foreach (var fieldSyntax in syntax.SharedBlock.Fields)
             {
                 var fieldName = fieldSyntax.Identifier.Text;
@@ -1967,16 +1932,10 @@ internal sealed class DeclarationBinder
                     }
                     else
                     {
-                        var boundConst = bindExpression(fieldSyntax.Initializer);
-                        var convertedConst = conversions.BindConversion(fieldSyntax.Initializer.Location, boundConst, fieldType);
-                        if (TryFoldConstantFieldValue(convertedConst, fieldType, out var sharedConstValue))
-                        {
-                            sharedConstField.SetConstantValue(sharedConstValue);
-                        }
-                        else if (boundConst is not BoundErrorExpression && convertedConst is not BoundErrorExpression)
-                        {
-                            Diagnostics.ReportConstFieldInitializerNotConstant(fieldSyntax.Initializer.Location, fieldName);
-                        }
+                        // Issue #1070: defer folding to the consolidated pass so a
+                        // shared const can reference a sibling static/const member
+                        // regardless of declaration order.
+                        pendingSharedConstInitializers.Add((sharedConstField, fieldSyntax, fieldType));
                     }
 
                     sharedConstFieldsBuilder.Add(sharedConstField);
@@ -1997,22 +1956,17 @@ internal sealed class DeclarationBinder
 
                 Binder.AttachDocumentation(fieldSymbol, fieldSyntax);
 
-                // Issue #262: bind the initializer expression if present.
+                // Issue #262 / issue #1070: defer initializer binding to the
+                // consolidated pass so it can see all sibling static/const members.
                 if (fieldSyntax.Initializer != null)
                 {
-                    var boundInit = bindExpression(fieldSyntax.Initializer);
-                    var convertedInit = conversions.BindConversion(fieldSyntax.Initializer.Location, boundInit, fieldType);
-                    initializersBuilder[fieldSymbol] = convertedInit;
+                    pendingStaticFieldInitializers.Add((fieldSymbol, fieldSyntax.Initializer, fieldType));
                 }
 
                 staticFieldsBuilder.Add(fieldSymbol);
             }
 
             structSymbol.SetStaticFields(staticFieldsBuilder.ToImmutable());
-            if (initializersBuilder.Count > 0)
-            {
-                structSymbol.SetStaticFieldInitializers(initializersBuilder.ToImmutable());
-            }
 
             // Issue #948: merge any const fields declared inside the shared block
             // with the body-level const fields already installed on the symbol.
@@ -2435,6 +2389,80 @@ internal sealed class DeclarationBinder
             structSymbol.SetStaticEvents(staticEventsBuilder.ToImmutable());
         }
 
+        // Issue #1070: consolidated field-initializer binding. Every static member
+        // symbol of the enclosing type (class const fields, `shared` static fields,
+        // `shared` const fields, and static properties) now exists on the struct
+        // symbol, so bind ALL deferred initializers in a single scope that exposes
+        // those static members by bare name — exactly the visibility a
+        // method/constructor body already enjoys (see Binder.BindProgram). This
+        // makes a `const`/`shared` field referenced from a field initializer resolve
+        // regardless of declaration order, and clears the GS0125 / cascading GS0159
+        // diagnostics that previously fired because the static member was not in
+        // scope. Instance members remain out of scope (a field initializer has no
+        // `this`), so genuine instance-member references are still rejected below.
+        using (PushStaticMemberScope(structSymbol))
+        {
+            // Fold class const initializers first so a `shared` const that
+            // references a class const can read its already-folded value.
+            foreach (var (constField, fieldSyntaxNode, fieldType) in pendingConstInitializers)
+            {
+                BindAndFoldConstFieldInitializer(constField, fieldSyntaxNode, fieldType);
+            }
+
+            foreach (var (constField, fieldSyntaxNode, fieldType) in pendingSharedConstInitializers)
+            {
+                BindAndFoldConstFieldInitializer(constField, fieldSyntaxNode, fieldType);
+            }
+
+            // Bind `shared` static field initializers.
+            if (pendingStaticFieldInitializers.Count > 0)
+            {
+                var staticInitBuilder = ImmutableDictionary.CreateBuilder<FieldSymbol, BoundExpression>();
+                foreach (var (fieldSym, initSyntax, fieldType) in pendingStaticFieldInitializers)
+                {
+                    var boundInit = bindExpression(initSyntax);
+                    var convertedInit = conversions.BindConversion(initSyntax.Location, boundInit, fieldType);
+                    staticInitBuilder[fieldSym] = convertedInit;
+                }
+
+                structSymbol.SetStaticFieldInitializers(staticInitBuilder.ToImmutable());
+            }
+
+            // Bind instance field initializers. These run before the constructor
+            // body, so they cannot reference `this`, other instance members, or
+            // constructor parameters (matching C#); a genuine instance-member
+            // reference is reported precisely rather than as a bare GS0125.
+            if (pendingInstanceInitializers.Count > 0)
+            {
+                var instanceMemberNames = new HashSet<string>(System.StringComparer.Ordinal) { "this" };
+                foreach (var f in fields)
+                {
+                    instanceMemberNames.Add(f.Name);
+                }
+
+                foreach (var p in primaryCtorParameters)
+                {
+                    instanceMemberNames.Add(p.Name);
+                }
+
+                var instanceInitBuilder = ImmutableDictionary.CreateBuilder<FieldSymbol, BoundExpression>();
+                foreach (var (fieldSym, initSyntax, fieldType) in pendingInstanceInitializers)
+                {
+                    if (TryFindInstanceMemberReference(initSyntax, instanceMemberNames, out var offendingName, out var offendingLocation))
+                    {
+                        Diagnostics.ReportFieldInitializerCannotReferenceInstanceMember(offendingLocation, offendingName);
+                        continue;
+                    }
+
+                    var boundInit = bindExpression(initSyntax);
+                    var convertedInit = conversions.BindConversion(initSyntax.Location, boundInit, fieldType);
+                    instanceInitBuilder[fieldSym] = convertedInit;
+                }
+
+                structSymbol.SetInstanceFieldInitializers(instanceInitBuilder.ToImmutable());
+            }
+        }
+
         // Phase 3.B.4: validate interface implementation. Walks each
         // implemented interface and confirms the class (including inherited
         // methods) provides a same-name, same-signature method. The check
@@ -2494,6 +2522,86 @@ internal sealed class DeclarationBinder
         {
             pendingAbstractImplementationChecks.Add((syntax, structSymbol));
         }
+    }
+
+    /// <summary>
+    /// Issue #1070: binds and folds a deferred <c>const</c>-field initializer to a
+    /// compile-time constant, reporting GS-not-constant if the expression is not a
+    /// constant. Shared by the class-body and <c>shared</c>-block const paths.
+    /// </summary>
+    private void BindAndFoldConstFieldInitializer(FieldSymbol constField, FieldDeclarationSyntax fieldSyntaxNode, TypeSymbol fieldType)
+    {
+        var boundInit = bindExpression(fieldSyntaxNode.Initializer);
+        var convertedInit = conversions.BindConversion(fieldSyntaxNode.Initializer.Location, boundInit, fieldType);
+        if (TryFoldConstantFieldValue(convertedInit, fieldType, out var constantValue))
+        {
+            constField.SetConstantValue(constantValue);
+        }
+        else if (boundInit is not BoundErrorExpression && convertedInit is not BoundErrorExpression)
+        {
+            Diagnostics.ReportConstFieldInitializerNotConstant(fieldSyntaxNode.Initializer.Location, constField.Name);
+        }
+    }
+
+    /// <summary>
+    /// Issue #1070: pushes a child scope that exposes the enclosing type's static
+    /// members — static fields, const fields, and static properties — as bare
+    /// names, then makes it the active binding scope. This mirrors the
+    /// static-member visibility that method/constructor bodies already have (see
+    /// <c>Binder.BindProgram</c>), so a field initializer (instance
+    /// <c>let</c>/<c>var</c>, <c>shared</c> field, or <c>const</c>) can reference a
+    /// sibling <c>const</c> or <c>shared</c> field regardless of declaration order.
+    /// The returned token restores the previous scope when disposed.
+    /// </summary>
+    private StaticMemberScope PushStaticMemberScope(StructSymbol structSymbol)
+    {
+        var previous = binderCtx.RootScope;
+        var staticScope = new BoundScope(previous);
+
+        if (!structSymbol.StaticFields.IsDefaultOrEmpty)
+        {
+            foreach (var fld in structSymbol.StaticFields)
+            {
+                staticScope.TryDeclareVariable(new ImplicitStaticFieldVariableSymbol(structSymbol, fld));
+            }
+        }
+
+        if (!structSymbol.ConstFields.IsDefaultOrEmpty)
+        {
+            foreach (var fld in structSymbol.ConstFields)
+            {
+                staticScope.TryDeclareVariable(new ImplicitStaticFieldVariableSymbol(structSymbol, fld));
+            }
+        }
+
+        if (!structSymbol.StaticProperties.IsDefaultOrEmpty)
+        {
+            foreach (var prop in structSymbol.StaticProperties)
+            {
+                staticScope.TryDeclareVariable(new ImplicitStaticPropertyVariableSymbol(structSymbol, prop));
+            }
+        }
+
+        binderCtx.RootScope = staticScope;
+        return new StaticMemberScope(binderCtx, previous);
+    }
+
+    /// <summary>
+    /// Issue #1070: restores the binder's root scope to the value captured before
+    /// <see cref="PushStaticMemberScope"/> installed the static-member scope.
+    /// </summary>
+    private readonly struct StaticMemberScope : System.IDisposable
+    {
+        private readonly BinderContext binderCtx;
+        private readonly BoundScope previous;
+
+        public StaticMemberScope(BinderContext binderCtx, BoundScope previous)
+        {
+            this.binderCtx = binderCtx;
+            this.previous = previous;
+        }
+
+        public void Dispose() => binderCtx.RootScope = previous;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -960,6 +960,18 @@ internal sealed class ReflectionMetadataEmitter
                 nextFieldRow += s.StaticFields.Length;
             }
 
+            // Issue #948 / issue #1070: const fields are emitted as CLR literal
+            // field rows (see TypeDefEmitter.EmitStructTypeDef), so they must be
+            // counted here too. Omitting them under-reserved the FieldDef range
+            // and shifted every following type's fieldList pointer by the const
+            // count, leaking the last field of a const-bearing type onto the next
+            // TypeDef (producing invalid IL such as `stsfld` of another type's
+            // initonly field in a `.cctor`).
+            if (!s.ConstFields.IsDefaultOrEmpty)
+            {
+                nextFieldRow += s.ConstFields.Length;
+            }
+
             // Issue #263: backing fields for static auto-properties.
             foreach (var p in s.StaticProperties)
             {

--- a/test/Compiler.Tests/Emit/Issue1070FieldInitializerStaticEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1070FieldInitializerStaticEmitTests.cs
@@ -1,0 +1,187 @@
+// <copyright file="Issue1070FieldInitializerStaticEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1070 end-to-end coverage. A static member of a type (a <c>const</c>,
+/// or a <c>shared</c> field) must be visible from a field-initializer expression
+/// in the same type. These tests round-trip the scenario through compile →
+/// IL-verify → run so we confirm both that binding succeeds (no GS0125 / GS0159)
+/// and that the emitted code loads the static member correctly at runtime:
+/// <list type="bullet">
+/// <item>an instance field initializer that sizes an array from a class
+/// <c>const</c> (the const is inlined as the array length);</item>
+/// <item>a <c>shared</c> field initializer that references an earlier
+/// <c>shared</c> field (a <c>ldsfld</c> of the sibling static field).</item>
+/// </list>
+/// </summary>
+public class Issue1070FieldInitializerStaticEmitTests
+{
+    [Fact]
+    public void InstanceFieldInit_FromConst_And_SharedFieldInit_FromSharedField_Roundtrips()
+    {
+        var source = """
+            package P
+            import System
+
+            class Buffer {
+                const BlockSize int32 = 16
+                public let data []uint8 = System.GC.AllocateArray[uint8](BlockSize)
+            }
+
+            class Stats {
+                shared {
+                    let Rates []int32 = []int32{10, 20, 30}
+                    let First int32 = Rates[0]
+                    let Total int32 = Rates[0] + Rates[1] + Rates[2]
+
+                    public func Combined() int32 {
+                        return First + Total
+                    }
+                }
+            }
+
+            let b = Buffer()
+            Console.WriteLine(b.data.Length)
+            Console.WriteLine(Stats.Combined())
+            """;
+
+        var output = CompileAndRun(source);
+
+        // 16 = const BlockSize used as the instance array length.
+        // 70 = First(10) + Total(10+20+30=60); First and Total are shared
+        // field initializers that read the sibling shared `Rates` field.
+        Assert.Equal("16\n70\n", output);
+    }
+
+    [Fact]
+    public void InstanceFieldInit_FromConst_OrderIndependent_Roundtrips()
+    {
+        // The const is declared AFTER the field initializer that uses it.
+        var source = """
+            package P
+            import System
+
+            class Buffer {
+                public let data []uint8 = System.GC.AllocateArray[uint8](BlockSize)
+                const BlockSize int32 = 24
+            }
+
+            let b = Buffer()
+            Console.WriteLine(b.data.Length)
+            """;
+
+        var output = CompileAndRun(source);
+
+        Assert.Equal("24\n", output);
+    }
+
+    [Fact]
+    public void ConstBearingType_FollowedBySharedFields_HasCorrectFieldRows()
+    {
+        // Regression for the FieldDef-row planner: a `const` field is emitted as a
+        // CLR literal field row, so it must be counted when reserving FieldDef
+        // rows. Previously the planner omitted const fields, which shifted every
+        // following type's fieldList pointer and leaked the last `shared` field of
+        // the following type onto the synthesized <Program> type — producing
+        // invalid IL (a `.cctor` storing another type's initonly field). IL-verify
+        // would catch the regression; the runtime values confirm correct binding.
+        var source = """
+            package P
+            import System
+
+            class Limits {
+                const Cap int32 = 8
+            }
+
+            class Stats {
+                shared {
+                    let A int32 = 1
+                    let B int32 = 2
+                    let C int32 = 3
+                }
+            }
+
+            Console.WriteLine(Stats.A + Stats.B + Stats.C)
+            """;
+
+        var output = CompileAndRun(source);
+
+        Assert.Equal("6\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1070_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1070FieldInitializerStaticTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1070FieldInitializerStaticTests.cs
@@ -1,0 +1,141 @@
+// <copyright file="Issue1070FieldInitializerStaticTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1070: a static member of a type (a <c>const</c>, or a <c>shared</c>
+/// field) must be visible from a field-initializer expression in the same type,
+/// just like it already is from a method/constructor body. These binder tests
+/// assert that such references no longer produce GS0125 ("Variable doesn't
+/// exist") nor the cascading GS0159, that the resolution is order-independent,
+/// and that genuine instance-member references are still rejected (GS0377).
+/// </summary>
+public class Issue1070FieldInitializerStaticTests
+{
+    [Fact]
+    public void InstanceInitializer_ReferencingClassConst_NoGS0125OrGS0159()
+    {
+        const string source =
+            "package p\n" +
+            "class C {\n" +
+            "    private let buf []uint8 = System.GC.AllocateArray[uint8](BlockSize)\n" +
+            "    const BlockSize int32 = 16\n" +
+            "}\n";
+
+        var diagnostics = GetDiagnostics(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0125");
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0159");
+    }
+
+    [Fact]
+    public void InstanceInitializer_ReferencingClassConst_OrderIndependent()
+    {
+        // The const is declared BEFORE the field initializer here; still resolves.
+        const string source =
+            "package p\n" +
+            "class C {\n" +
+            "    const BlockSize int32 = 16\n" +
+            "    private let buf []uint8 = System.GC.AllocateArray[uint8](BlockSize)\n" +
+            "}\n";
+
+        var diagnostics = GetDiagnostics(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0125");
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0159");
+    }
+
+    [Fact]
+    public void SharedFieldInitializer_ReferencingSiblingSharedField_NoGS0125()
+    {
+        const string source =
+            "package p\n" +
+            "class C {\n" +
+            "    shared {\n" +
+            "        let Rates []int32 = []int32{1, 2, 3}\n" +
+            "        let First int32 = Rates[0]\n" +
+            "    }\n" +
+            "}\n";
+
+        var diagnostics = GetDiagnostics(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0125");
+    }
+
+    [Fact]
+    public void InstanceInitializer_ReferencingSharedField_NoGS0125()
+    {
+        const string source =
+            "package p\n" +
+            "class C {\n" +
+            "    shared { let S int32 = 7 }\n" +
+            "    let x int32 = S\n" +
+            "}\n";
+
+        var diagnostics = GetDiagnostics(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0125");
+    }
+
+    [Fact]
+    public void SharedFieldInitializer_ReferencingClassConst_NoGS0125()
+    {
+        const string source =
+            "package p\n" +
+            "class C {\n" +
+            "    const Factor int32 = 10\n" +
+            "    shared { let Scaled int32 = Factor * 2 }\n" +
+            "}\n";
+
+        var diagnostics = GetDiagnostics(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0125");
+    }
+
+    [Fact]
+    public void InstanceInitializer_ReferencingInstanceMember_StillReportsGS0377()
+    {
+        const string source =
+            "package p\n" +
+            "class C {\n" +
+            "    let a int32 = 5\n" +
+            "    let b int32 = a\n" +
+            "}\n";
+
+        var diagnostics = GetDiagnostics(source);
+
+        Assert.Contains(diagnostics, d => d.Id == "GS0377");
+    }
+
+    [Fact]
+    public void FieldInitializer_ReferencingUndefinedName_StillReportsGS0125()
+    {
+        const string source =
+            "package p\n" +
+            "class C {\n" +
+            "    let b int32 = doesNotExist\n" +
+            "}\n";
+
+        var diagnostics = GetDiagnostics(source);
+
+        Assert.Contains(diagnostics, d => d.Id == "GS0125");
+    }
+
+    private static IEnumerable<Diagnostic> GetDiagnostics(string source)
+    {
+        var tree = SyntaxTree.Parse(source);
+        var compilation = new Compilation(tree);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return result.Diagnostics.ToList();
+    }
+}


### PR DESCRIPTION
## Summary
Fixes #1070. A static member of a type (a `const`, or a `shared` field) was not visible from a **field-initializer** expression in the same type, producing **GS0125 "Variable doesn't exist"** plus a cascading **GS0159**. The same member resolved fine from method/constructor bodies. The problem was order-independent.

## Root cause
Field initializers (instance `let`/`var`, `shared` fields, and `const` foldings) were bound in `DeclarationBinder` using the binder's plain root scope, which does **not** contain the enclosing type's static members. Method/constructor bodies instead inject the type's static fields, const fields, and static properties as implicit bare-name variables before binding (`Binder.BindProgram`), which is why they could see static members regardless of declaration order.

## Fix
- **`DeclarationBinder`**: defer all field-initializer binding to a single consolidated pass that runs once every static member symbol of the type exists, and bind them inside a child scope that exposes those static members (`PushStaticMemberScope`). This mirrors method-body visibility and is order-independent. Instance members remain out of scope, so genuine instance-member references are still rejected (GS0377) and truly-undefined names still report GS0125.
- **`ReflectionMetadataEmitter`** (tightly-coupled pre-existing bug surfaced by this change): the FieldDef-row planner `PlanAggregateFields` did **not** count `const` fields, although `TypeDefEmitter` emits them as CLR literal field rows. With a const-bearing type present, every following type's `fieldList` pointer was shifted, leaking the last `shared` field of the next type onto the synthesized `<Program>` type and producing **invalid IL** (a `.cctor` storing another type's `initonly` field). Counting const fields in the planner restores contiguous, correct FieldDef ranges. (This reproduces on `main` for any const-bearing class followed by another field-owning type + top-level statements; #1070's fix made it far more reachable.)

After the fix both the GS0125 and the cascading GS0159 disappear; `System.GC.AllocateArray[T](n)` resolves once its argument resolves.

## Tests
**`test/Core.Tests/.../Issue1070FieldInitializerStaticTests.cs`** (binding):
- const visible in instance field init (no GS0125/GS0159)
- order-independent (const declared before/after the initializer)
- shared field init referencing a sibling shared field
- instance field init referencing a shared field
- shared field init referencing a class const
- (negative) instance-member reference still GS0377
- (negative) truly-undefined name still GS0125

**`test/Compiler.Tests/Emit/Issue1070FieldInitializerStaticEmitTests.cs`** (compile + IL-verify + run):
- instance field initializer sizes an array from a class `const` (asserts array length 16/24) and shared field initializers reference an earlier shared field (asserts computed value 70)
- order-independent variant
- regression for the const FieldDef-row planning (const-bearing class followed by a shared-field class)

## Validation
- All three issue repros compile clean with the freshly built `gsc`.
- Full `Core.Tests`: 3734 passed.
- `Compiler.Tests` filtered slices (Shared/Const/Field/Enum/Nested/Layout/Static/Metadata + Issue1070): all passed; emit programs IL-verify and run with correct values.
