### PR TITLE
Fixes #1071: normalize async effective return type in override and interface matching

### DIFF
--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -1296,6 +1296,11 @@ internal sealed class DeclarationBinder
                     var methodParameters = parameters.ToImmutable();
                     var methodReturnRefKind = ValidateReturnRefKind(methodSyntax, returnType);
 
+                    // Issue #1071: the effective async flag (mirrors
+                    // FunctionSymbol.IsAsync below) so override / shadow matching
+                    // compares the async-normalized effective return type.
+                    var methodIsAsync = methodSyntax.IsAsync || isAsyncIteratorReturnType(returnType);
+
                     // Phase 3.B.3 sub-step 3: open/override validation against
                     // base class chain per ADR-0017.
                     FunctionSymbol overriddenMethod = null;
@@ -1312,7 +1317,7 @@ internal sealed class DeclarationBinder
                         foreach (var candidate in baseOverloads)
                         {
                             baseMethod ??= candidate;
-                            if (SignaturesMatch(candidate, methodParameters, returnType, methodReturnRefKind, baseTypeArgSubst))
+                            if (SignaturesMatch(candidate, methodParameters, returnType, methodReturnRefKind, baseTypeArgSubst, methodIsAsync))
                             {
                                 baseSignatureMatch = candidate;
                                 break;
@@ -1386,7 +1391,7 @@ internal sealed class DeclarationBinder
                                 continue;
                             }
 
-                            if (SignaturesMatch(shadowed, methodParameters, returnType, methodReturnRefKind, baseTypeArgSubst))
+                            if (SignaturesMatch(shadowed, methodParameters, returnType, methodReturnRefKind, baseTypeArgSubst, methodIsAsync))
                             {
                                 Diagnostics.ReportMissingOverride(methodSyntax.Identifier.Location, shadowed.ReceiverType.Name, methodName);
                                 break;
@@ -2872,7 +2877,7 @@ internal sealed class DeclarationBinder
                             continue;
                         }
 
-                        if (SignaturesMatch(imethod, GetCallableParameters(candidate), candidate.Type, candidate.ReturnRefKind, methodTypeParamMap))
+                        if (SignaturesMatch(imethod, GetCallableParameters(candidate), candidate.Type, candidate.ReturnRefKind, methodTypeParamMap, candidate.IsAsync))
                         {
                             signatureMatch = candidate;
                             break;
@@ -3093,7 +3098,7 @@ internal sealed class DeclarationBinder
                 {
                     foreach (var candidate in structSymbol.GetMethodsIncludingInherited(imethod.Name))
                     {
-                        if (SignaturesMatch(imethod, GetCallableParameters(candidate), candidate.Type, candidate.ReturnRefKind))
+                        if (SignaturesMatch(imethod, GetCallableParameters(candidate), candidate.Type, candidate.ReturnRefKind, typeParamMap: null, candidate.IsAsync))
                         {
                             Diagnostics.ReportImplementerOverridesPrivateInterfaceMember(
                                 syntax.Identifier.Location,
@@ -5524,7 +5529,15 @@ internal sealed class DeclarationBinder
         => SignaturesMatch(baseMethod, derivedParams, derivedReturnType, RefKind.None);
 
     private static bool SignaturesMatch(FunctionSymbol baseMethod, ImmutableArray<ParameterSymbol> derivedParams, TypeSymbol derivedReturnType, RefKind derivedReturnRefKind)
-        => SignaturesMatch(baseMethod, derivedParams, derivedReturnType, derivedReturnRefKind, typeParamMap: null);
+        => SignaturesMatch(baseMethod, derivedParams, derivedReturnType, derivedReturnRefKind, typeParamMap: null, derivedIsAsync: false);
+
+    private static bool SignaturesMatch(
+        FunctionSymbol baseMethod,
+        ImmutableArray<ParameterSymbol> derivedParams,
+        TypeSymbol derivedReturnType,
+        RefKind derivedReturnRefKind,
+        IReadOnlyDictionary<TypeParameterSymbol, TypeSymbol> typeParamMap)
+        => SignaturesMatch(baseMethod, derivedParams, derivedReturnType, derivedReturnRefKind, typeParamMap, derivedIsAsync: false);
 
     /// <summary>
     /// Issue #1007: signature matching for interface satisfaction / override
@@ -5541,9 +5554,10 @@ internal sealed class DeclarationBinder
         ImmutableArray<ParameterSymbol> derivedParams,
         TypeSymbol derivedReturnType,
         RefKind derivedReturnRefKind,
-        IReadOnlyDictionary<TypeParameterSymbol, TypeSymbol> typeParamMap)
+        IReadOnlyDictionary<TypeParameterSymbol, TypeSymbol> typeParamMap,
+        bool derivedIsAsync)
     {
-        if (!TypeSignaturesEquivalent(baseMethod.Type, derivedReturnType, typeParamMap))
+        if (!ReturnTypesMatch(baseMethod, derivedReturnType, derivedIsAsync, typeParamMap))
         {
             return false;
         }
@@ -5578,6 +5592,44 @@ internal sealed class DeclarationBinder
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// Issue #1071: compares the base / interface method's declared return type
+    /// against the derived (overriding / implementing) method's <em>effective</em>
+    /// return type, normalizing for <c>async</c>. An <c>async func</c> with no
+    /// annotation has effective return type <c>Task</c>; <c>async func ... T</c>
+    /// has effective return type <c>Task[T]</c>. When exactly one of the two
+    /// methods is async, the non-async side's declared <c>Task</c> / <c>Task[T]</c>
+    /// is unwrapped to its awaited result and compared against the async side's
+    /// declared (awaited) return type; otherwise the declared types are compared
+    /// directly. Genuine return-type mismatches (e.g. an async <c>Task</c> method
+    /// against a base declaring <c>Task[int32]</c>) are still rejected.
+    /// </summary>
+    private static bool ReturnTypesMatch(
+        FunctionSymbol baseMethod,
+        TypeSymbol derivedReturnType,
+        bool derivedIsAsync,
+        IReadOnlyDictionary<TypeParameterSymbol, TypeSymbol> typeParamMap)
+    {
+        var baseIsAsync = baseMethod.IsAsync;
+        if (baseIsAsync == derivedIsAsync)
+        {
+            return TypeSignaturesEquivalent(baseMethod.Type, derivedReturnType, typeParamMap);
+        }
+
+        if (derivedIsAsync)
+        {
+            // Derived is async (declared = awaited result); the base must declare
+            // the matching Task / Task[T] wrapper.
+            return AsyncReturnTypeNormalizer.TryUnwrapTaskReturnType(baseMethod.Type, out var baseAwaited)
+                && TypeSignaturesEquivalent(baseAwaited, derivedReturnType, typeParamMap);
+        }
+
+        // Base is async (declared = awaited result); the derived (non-async)
+        // method must declare the matching Task / Task[T] wrapper.
+        return AsyncReturnTypeNormalizer.TryUnwrapTaskReturnType(derivedReturnType, out var derivedAwaited)
+            && TypeSignaturesEquivalent(baseMethod.Type, derivedAwaited, typeParamMap);
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -1131,7 +1131,20 @@ internal sealed class MemberLookup
                 continue;
             }
 
-            if (!ClrTypeUtilities.AreSame(NullableLifting.GetEffectiveClrType(candidate.Type), clrMethod.ReturnType))
+            // Issue #1071: an `async func` implementing a CLR interface method
+            // declared with an explicit `Task` / `Task[T]` return type has a
+            // declared (awaited) return of void / T. Compare the contract's
+            // unwrapped awaited result against the candidate's declared type.
+            var candidateReturnClr = NullableLifting.GetEffectiveClrType(candidate.Type);
+            if (candidate.IsAsync
+                && AsyncReturnTypeNormalizer.TryUnwrapTaskClrType(clrMethod.ReturnType, out var awaitedReturnClr))
+            {
+                if (!ClrTypeUtilities.AreSame(candidateReturnClr, awaitedReturnClr))
+                {
+                    continue;
+                }
+            }
+            else if (!ClrTypeUtilities.AreSame(candidateReturnClr, clrMethod.ReturnType))
             {
                 continue;
             }

--- a/src/Core/CodeAnalysis/Emit/MethodInfoHelpers.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodInfoHelpers.cs
@@ -126,7 +126,19 @@ internal static class MethodInfoHelpers
                         continue;
                     }
 
-                    if (returnClr != null && !ClrTypeUtilities.AreSame(returnClr, clrMethod.ReturnType))
+                    // Issue #1071: an `async func` implementing a CLR interface
+                    // method declared with an explicit `Task` / `Task[T]` return
+                    // type has a declared (awaited) CLR return of void / T.
+                    // Compare the contract's unwrapped awaited result.
+                    if (method.IsAsync
+                        && AsyncReturnTypeNormalizer.TryUnwrapTaskClrType(clrMethod.ReturnType, out var awaitedClr))
+                    {
+                        if (returnClr != null && !ClrTypeUtilities.AreSame(returnClr, awaitedClr))
+                        {
+                            continue;
+                        }
+                    }
+                    else if (returnClr != null && !ClrTypeUtilities.AreSame(returnClr, clrMethod.ReturnType))
                     {
                         continue;
                     }
@@ -162,7 +174,7 @@ internal static class MethodInfoHelpers
     /// <returns>True if the signatures are equivalent.</returns>
     public static bool MethodSignaturesMatch(FunctionSymbol interfaceMethod, FunctionSymbol implementationMethod)
     {
-        if (interfaceMethod.Name != implementationMethod.Name || interfaceMethod.Type != implementationMethod.Type)
+        if (interfaceMethod.Name != implementationMethod.Name || !ReturnTypesMatch(interfaceMethod, implementationMethod))
         {
             return false;
         }
@@ -194,4 +206,47 @@ internal static class MethodInfoHelpers
     /// <returns>The "as-called" parameter list.</returns>
     public static ImmutableArray<ParameterSymbol> CallableParameters(FunctionSymbol method)
         => method.ExplicitReceiverParameter == null ? method.Parameters : method.Parameters.RemoveAt(0);
+
+    /// <summary>
+    /// Issue #1071: compares an interface method's declared return type against
+    /// the implementing method's <em>effective</em> return type, normalizing for
+    /// <c>async</c> so an <c>async func</c> (effective return <c>Task</c> /
+    /// <c>Task[T]</c>) is recognised as implementing an interface method declared
+    /// with the explicit <c>Task</c> / <c>Task[T]</c> return type. Required so
+    /// the implementing async method is promoted to a virtual interface slot at
+    /// emit time.
+    /// </summary>
+    private static bool ReturnTypesMatch(FunctionSymbol interfaceMethod, FunctionSymbol implementationMethod)
+    {
+        if (interfaceMethod.IsAsync == implementationMethod.IsAsync)
+        {
+            return ReferenceEquals(interfaceMethod.Type, implementationMethod.Type);
+        }
+
+        if (implementationMethod.IsAsync)
+        {
+            return AsyncReturnTypeNormalizer.TryUnwrapTaskReturnType(interfaceMethod.Type, out var awaited)
+                && AwaitedTypesMatch(awaited, implementationMethod.Type);
+        }
+
+        return AsyncReturnTypeNormalizer.TryUnwrapTaskReturnType(implementationMethod.Type, out var awaited2)
+            && AwaitedTypesMatch(interfaceMethod.Type, awaited2);
+    }
+
+    private static bool AwaitedTypesMatch(TypeSymbol a, TypeSymbol b)
+    {
+        if (ReferenceEquals(a, b))
+        {
+            return true;
+        }
+
+        if (a == null || b == null)
+        {
+            return false;
+        }
+
+        var ca = a.ClrType;
+        var cb = b.ClrType;
+        return ca != null && cb != null && ClrTypeUtilities.AreSame(ca, cb);
+    }
 }

--- a/src/Core/CodeAnalysis/Symbols/AsyncReturnTypeNormalizer.cs
+++ b/src/Core/CodeAnalysis/Symbols/AsyncReturnTypeNormalizer.cs
@@ -1,0 +1,121 @@
+// <copyright file="AsyncReturnTypeNormalizer.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Threading.Tasks;
+
+namespace GSharp.Core.CodeAnalysis.Symbols;
+
+/// <summary>
+/// Issue #1071: helpers for comparing the <em>effective</em> (post-async-
+/// normalization) return type of a method against a base / interface method.
+/// An <c>async func M()</c> with no return annotation has declared return type
+/// <c>void</c> but an effective return type of <c>Task</c>; an
+/// <c>async func M() T</c> has declared return type <c>T</c> but an effective
+/// return type of <c>Task[T]</c>. The override-matching and interface-
+/// satisfaction comparisons must use the effective return type so an async
+/// method validly overrides / implements a base declared with the explicit
+/// <c>Task</c> / <c>Task[T]</c> return type.
+/// </summary>
+internal static class AsyncReturnTypeNormalizer
+{
+    /// <summary>
+    /// Unwraps the awaited result of a <c>Task</c> / <c>Task[T]</c> /
+    /// <c>ValueTask</c> / <c>ValueTask[T]</c> return type symbol: the
+    /// non-generic forms resolve to <see cref="TypeSymbol.Void"/>, the generic
+    /// forms to their result-type argument. Returns <c>false</c> for any other
+    /// shape (so a genuine non-Task return type is never spuriously matched
+    /// against an async method).
+    /// </summary>
+    /// <param name="type">The (declared) return type symbol to unwrap.</param>
+    /// <param name="awaited">The unwrapped awaited result type, when this returns <c>true</c>.</param>
+    /// <returns><c>true</c> when <paramref name="type"/> is a Task / ValueTask shape.</returns>
+    public static bool TryUnwrapTaskReturnType(TypeSymbol type, out TypeSymbol awaited)
+    {
+        awaited = null;
+        if (type == null)
+        {
+            return false;
+        }
+
+        // #313 symbolic construction: a Task[T] / ValueTask[T] over an in-scope
+        // generic type parameter is type-erased in its ClrType, so recover the
+        // symbolic result argument from the open definition + type arguments.
+        if (type is ImportedTypeSymbol imported
+            && imported.OpenDefinition != null
+            && !imported.TypeArguments.IsDefaultOrEmpty
+            && imported.TypeArguments.Length == 1)
+        {
+            var openName = imported.OpenDefinition.FullName;
+            if (openName == "System.Threading.Tasks.Task`1"
+                || openName == "System.Threading.Tasks.ValueTask`1")
+            {
+                awaited = imported.TypeArguments[0];
+                return true;
+            }
+        }
+
+        var clr = type.ClrType;
+        if (clr == null)
+        {
+            return false;
+        }
+
+        if (clr.IsSameAs(typeof(Task)) || clr.IsSameAs(typeof(ValueTask)))
+        {
+            awaited = TypeSymbol.Void;
+            return true;
+        }
+
+        if (clr.IsGenericType && !clr.IsGenericTypeDefinition)
+        {
+            var definition = clr.GetGenericTypeDefinition();
+            if (definition.IsSameAs(typeof(Task<>)) || definition.IsSameAs(typeof(ValueTask<>)))
+            {
+                awaited = TypeSymbol.FromClrType(clr.GetGenericArguments()[0]);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// CLR-type companion to <see cref="TryUnwrapTaskReturnType"/>: unwraps the
+    /// awaited result of a <c>Task</c> / <c>Task&lt;T&gt;</c> / <c>ValueTask</c>
+    /// / <c>ValueTask&lt;T&gt;</c> CLR return type (the non-generic forms resolve
+    /// to <c>typeof(void)</c>). Used for matching an async method against an
+    /// imported CLR interface method whose contract carries the explicit
+    /// <c>Task</c> return type. Returns <c>false</c> for any other shape.
+    /// </summary>
+    /// <param name="type">The CLR return type to unwrap.</param>
+    /// <param name="awaited">The unwrapped awaited CLR result type, when this returns <c>true</c>.</param>
+    /// <returns><c>true</c> when <paramref name="type"/> is a Task / ValueTask shape.</returns>
+    public static bool TryUnwrapTaskClrType(Type type, out Type awaited)
+    {
+        awaited = null;
+        if (type == null)
+        {
+            return false;
+        }
+
+        if (type.IsSameAs(typeof(Task)) || type.IsSameAs(typeof(ValueTask)))
+        {
+            awaited = typeof(void);
+            return true;
+        }
+
+        if (type.IsGenericType && !type.IsGenericTypeDefinition)
+        {
+            var definition = type.GetGenericTypeDefinition();
+            if (definition.IsSameAs(typeof(Task<>)) || definition.IsSameAs(typeof(ValueTask<>)))
+            {
+                awaited = type.GetGenericArguments()[0];
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue1071AsyncOverrideEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1071AsyncOverrideEmitTests.cs
@@ -1,0 +1,146 @@
+// <copyright file="Issue1071AsyncOverrideEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1071: an <c>async func</c> validly overrides a base method declared
+/// <c>func M() Task</c> / <c>func M() Task[T]</c>, and validly implements an
+/// interface method declared the same way. This emit test compiles and runs a
+/// program that dispatches through a <em>base reference</em> to an async
+/// override and through an <em>interface reference</em> to an async
+/// implementation, awaiting both and asserting the observable effects/values —
+/// confirming the overriding/implementing async methods occupy proper
+/// override / interface-impl slots and the produced assembly IL-verifies and
+/// runs.
+/// </summary>
+public class Issue1071AsyncOverrideEmitTests
+{
+    [Fact]
+    public void AsyncOverrideAndInterfaceImpl_DispatchThroughBaseAndInterface_RunsCorrectly()
+    {
+        var source = """
+            package p
+
+            import System
+            import System.Threading.Tasks
+
+            open class Base {
+                public open func DoAsync() Task;
+            }
+
+            open class Derived : Base {
+                public override async func DoAsync() {
+                    await Task.CompletedTask
+                    Console.WriteLine("override-ran")
+                }
+            }
+
+            interface I { func GetAsync() Task[int32]; }
+
+            class C : I {
+                public async func GetAsync() int32 {
+                    await Task.CompletedTask
+                    return 42
+                }
+            }
+
+            let b Base = Derived()
+            b.DoAsync().GetAwaiter().GetResult()
+            let i I = C()
+            let v = i.GetAsync().GetAwaiter().GetResult()
+            Console.WriteLine(v)
+            """;
+
+        var output = CompileAndRunThroughMetadataLoadContext(source);
+
+        Assert.Equal("override-ran\n42\n", output);
+    }
+
+    private static string CompileAndRunThroughMetadataLoadContext(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1071_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location);
+            var references = Directory
+                .EnumerateFiles(runtimeDir, "*.dll", SearchOption.TopDirectoryOnly)
+                .Where(p => Path.GetFileName(p).StartsWith("System.", StringComparison.OrdinalIgnoreCase)
+                            || string.Equals(Path.GetFileName(p), "mscorlib.dll", StringComparison.OrdinalIgnoreCase)
+                            || string.Equals(Path.GetFileName(p), "netstandard.dll", StringComparison.OrdinalIgnoreCase))
+                .ToArray();
+
+            Assert.NotEmpty(references);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                var args = new List<string>
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                };
+                args.AddRange(references.Select(r => "/reference:" + r));
+                args.Add(srcPath);
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+            IlVerifier.Verify(outPath);
+            Assert.True(File.Exists(outPath), $"expected emitted assembly at {outPath}");
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi);
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1071AsyncOverrideTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1071AsyncOverrideTests.cs
@@ -1,0 +1,156 @@
+// <copyright file="Issue1071AsyncOverrideTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1071: the override-matching and interface-satisfaction comparisons
+/// must use a method's <em>effective</em> (post-async-normalization) return
+/// type. An <c>async func M()</c> with no annotation has effective return type
+/// <c>Task</c>; <c>async func M() T</c> has effective return type <c>Task[T]</c>.
+/// Previously the comparison used the declared return type, so an async
+/// override of <c>func M() Task</c> tripped GS0185 and an async implementation
+/// of an interface <c>func M() Task;</c> tripped GS0187. Genuine return-type
+/// mismatches must still be rejected.
+/// </summary>
+public class Issue1071AsyncOverrideTests
+{
+    [Fact]
+    public void AsyncOverride_OfTaskReturningBaseMethod_BindsWithoutDiagnostics()
+    {
+        const string source = """
+            package p
+            import System.Threading.Tasks
+            open class Base {
+                protected open func DoAsync() Task;
+            }
+            open class Derived : Base {
+                protected override async func DoAsync() {
+                    await Task.CompletedTask
+                }
+            }
+            """;
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void NonAsyncControl_TaskReturningOverride_BindsWithoutDiagnostics()
+    {
+        // The semantically identical non-async override (already accepted) — the
+        // only difference from the async case is async-return normalization.
+        const string source = """
+            package p
+            import System.Threading.Tasks
+            open class Base {
+                protected open func DoAsync() Task;
+            }
+            open class Derived : Base {
+                protected override func DoAsync() Task {
+                    return Task.CompletedTask
+                }
+            }
+            """;
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void AsyncImplementation_OfTaskReturningInterfaceMethod_BindsWithoutDiagnostics()
+    {
+        const string source = """
+            package p
+            import System.Threading
+            import System.Threading.Tasks
+            interface I { func RunAsync(c CancellationTokenSource) Task; }
+            class C : I {
+                async func RunAsync(c CancellationTokenSource) { await Task.CompletedTask }
+            }
+            """;
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void AsyncValueOverride_OfGenericTaskReturningBaseMethod_BindsWithoutDiagnostics()
+    {
+        const string source = """
+            package p
+            import System.Threading.Tasks
+            open class Base {
+                protected open func GetAsync() Task[int32];
+            }
+            open class Derived : Base {
+                protected override async func GetAsync() int32 {
+                    await Task.CompletedTask
+                    return 5
+                }
+            }
+            """;
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void AsyncValueImplementation_OfGenericTaskReturningInterfaceMethod_BindsWithoutDiagnostics()
+    {
+        const string source = """
+            package p
+            import System.Threading.Tasks
+            interface I { func GetAsync() Task[int32]; }
+            class C : I {
+                async func GetAsync() int32 {
+                    await Task.CompletedTask
+                    return 7
+                }
+            }
+            """;
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void AsyncTaskOverride_OfGenericTaskBaseMethod_StillReportsGS0185()
+    {
+        // Genuine return-type mismatch: effective Task vs base Task[int32].
+        const string source = """
+            package p
+            import System.Threading.Tasks
+            open class Base {
+                protected open func DoAsync() Task[int32];
+            }
+            open class Derived : Base {
+                protected override async func DoAsync() {
+                    await Task.CompletedTask
+                }
+            }
+            """;
+        Assert.Contains(Bind(source), d => d.Id == "GS0185");
+    }
+
+    [Fact]
+    public void AsyncTaskImplementation_OfGenericTaskInterfaceMethod_StillReportsGS0187()
+    {
+        // Genuine return-type mismatch: effective Task vs interface Task[int32].
+        const string source = """
+            package p
+            import System.Threading.Tasks
+            interface I { func RunAsync() Task[int32]; }
+            class C : I {
+                async func RunAsync() { await Task.CompletedTask }
+            }
+            """;
+        Assert.Contains(Bind(source), d => d.Id == "GS0187");
+    }
+
+    private static IReadOnlyList<Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.GlobalScope.Diagnostics.ToList();
+    }
+}


### PR DESCRIPTION
Fixes #1071

## Root cause

A G# `async func` declares its **awaited result** type — `async func M()` has
declared return type `void`, `async func M() T` has declared return type `T` —
but its **effective** return type is `Task` / `Task[T]`. The override-matching
and interface-satisfaction comparisons compared the *declared* return type
against the base / interface method's declared `Task` / `Task[T]`, so:

1. **Override**: `async func DoAsync()` overriding base `func DoAsync() Task`
   reported **GS0185** (override must match the base return type).
2. **Interface impl**: `async func RunAsync(...)` implementing interface
   `func RunAsync(...) Task;` reported **GS0187** (does not implement interface
   method).

Both are the same gap: the async effective return type was not used in member
matching.

## Fix

New `AsyncReturnTypeNormalizer` helper unwraps the awaited result of a
`Task`/`Task[T]`/`ValueTask`/`ValueTask[T]` return on both the `TypeSymbol` and
the CLR-`Type` level. Member-matching now compares the **async-normalized
effective return type** at every site:

- `DeclarationBinder` override-matching, shadow detection, and interface
  satisfaction (GS0185 / GS0187) via a new `ReturnTypesMatch` helper threaded
  through `SignaturesMatch` (new `derivedIsAsync` argument).
- `MemberLookup.HasMatchingMethodForClrSignature` — async implementation of an
  imported **CLR** interface method.
- Emit `MethodInfoHelpers` (`MethodSignaturesMatch` + the CLR-interface branch)
  so the implementing async method is promoted to a proper interface-impl /
  virtual slot and the produced assembly IL-verifies and dispatches correctly.

When exactly one of the two methods is async, the non-async side's declared
`Task` / `Task[T]` is unwrapped and compared against the async side's declared
(awaited) return type. **Genuine mismatches are still rejected** — e.g. an async
`Task` method against a base/interface declaring `Task[int32]` still reports
GS0185 / GS0187.

Covers both the void-like (`Task`) and value (`Task[T]`) forms, and both the
override and interface-implementation paths.

## Tests

- `test/Core.Tests/CodeAnalysis/Binding/Issue1071AsyncOverrideTests.cs` (7 tests):
  async override of `func M() Task` binds; non-async control binds; async impl of
  interface `func M() Task;` binds; async value override / impl of `Task[int32]`
  binds; negative async `Task` override of base `Task[int32]` still GS0185;
  negative async `Task` interface-impl of `Task[int32]` still GS0187.
- `test/Compiler.Tests/Emit/Issue1071AsyncOverrideEmitTests.cs`: compile +
  IL-verify + **run** a program that awaits an async override through a base
  reference and an async interface-impl through an interface reference, asserting
  observable output (`override-ran` and `42`).

## Validation

- Both issue repros (override + interface) now compile clean with the freshly
  built `gsc`; both negative cases still error.
- Full `Core.Tests`: 3741 passed, 0 failed.
- `Compiler.Tests` Async/Override/Interface slice: 252 passed, 0 failed.
- New `Issue1071` binding (7) + emit (1) tests pass.
