### PR TITLE
Fixes #1080: scope nested-type name uniqueness to enclosing type

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundScope.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundScope.cs
@@ -526,13 +526,60 @@ public sealed class BoundScope
         // Issue #1051: key by (simple name, generic arity) so that a type and a
         // same-named generic of different arity coexist. A genuine duplicate —
         // same name AND same arity — still collides and reports GS0102.
-        var key = MangleArity(name, GetTypeAliasArity(target));
-        if (typeAliases.ContainsKey(key))
+        var arity = GetTypeAliasArity(target);
+        var key = MangleArity(name, arity);
+        if (!typeAliases.ContainsKey(key))
+        {
+            typeAliases.Add(key, target);
+            return true;
+        }
+
+        // Issue #1080: a name clash on the simple (arity-bearing) key is only a
+        // genuine duplicate — GS0102 — when both types live in the SAME
+        // declaration scope (both top-level, or both nested in the SAME
+        // enclosing type). A nested type must NOT collide with a package-level
+        // type of the same simple name, nor with a nested type of a DIFFERENT
+        // enclosing type. Such non-conflicting types coexist: the package-level
+        // (top-level) type keeps the simple key so it stays resolvable by simple
+        // name, while the nested "loser" is retained under its containing-type-
+        // qualified key (so emit — which enumerates the stored values — still
+        // produces its TypeDef).
+        var existing = typeAliases[key];
+        var targetEnclosing = TypeContainingType(target);
+        var existingEnclosing = TypeContainingType(existing);
+        if (IsSameDeclarationScope(existingEnclosing, targetEnclosing))
         {
             return false;
         }
 
-        typeAliases.Add(key, target);
+        // Prefer the top-level type as the owner of the simple key. If a nested
+        // type currently occupies the simple key but the incoming type is
+        // top-level, evict the nested type to its qualified key and install the
+        // top-level type under the simple key.
+        if (targetEnclosing == null && existingEnclosing != null)
+        {
+            var existingQualifiedKey = MangleArity(QualifiedTypeName(existing), arity);
+            if (typeAliases.TryGetValue(existingQualifiedKey, out var occupant) && !ReferenceEquals(occupant, existing))
+            {
+                return false;
+            }
+
+            typeAliases[existingQualifiedKey] = existing;
+            typeAliases[key] = target;
+            return true;
+        }
+
+        // The incoming type is nested and clashes with a differently-scoped type
+        // already holding the simple key. Retain it under its qualified key. A
+        // clash on the qualified key means a genuine duplicate within the SAME
+        // enclosing type — report GS0102.
+        var qualifiedKey = MangleArity(QualifiedTypeName(target), arity);
+        if (typeAliases.ContainsKey(qualifiedKey))
+        {
+            return false;
+        }
+
+        typeAliases.Add(qualifiedKey, target);
         return true;
     }
 
@@ -708,6 +755,47 @@ public sealed class BoundScope
     /// <returns>The composite storage key.</returns>
     private static string MangleArity(string name, int arity)
         => arity <= 0 ? name : name + "`" + arity.ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+    /// <summary>
+    /// Issue #1080: returns the enclosing type of a (possibly nested) user type
+    /// symbol — the value set via <c>SetContainingType</c> during declaration
+    /// binding — or <c>null</c> for a top-level type or a non-aggregate symbol.
+    /// </summary>
+    private static TypeSymbol TypeContainingType(TypeSymbol type) => type switch
+    {
+        StructSymbol s => s.ContainingType,
+        EnumSymbol e => e.ContainingType,
+        InterfaceSymbol i => i.ContainingType,
+        _ => null,
+    };
+
+    /// <summary>
+    /// Issue #1080: two type declarations share a declaration scope when both
+    /// are top-level (no enclosing type) or both are nested directly in the
+    /// SAME enclosing type. Only same-scope same-name types are duplicates.
+    /// </summary>
+    private static bool IsSameDeclarationScope(TypeSymbol a, TypeSymbol b)
+        => a == null ? b == null : ReferenceEquals(a, b);
+
+    /// <summary>
+    /// Issue #1080: builds the containing-type-qualified dotted name of a type
+    /// (e.g. <c>Outer.Middle.Inner</c> for a doubly-nested type, or the plain
+    /// simple name for a top-level type) by walking the enclosing-type chain.
+    /// Used as the fallback storage key for a nested type whose simple name is
+    /// already taken by a differently-scoped type, so it remains a distinct
+    /// stored value without colliding.
+    /// </summary>
+    private static string QualifiedTypeName(TypeSymbol type)
+    {
+        var parts = new List<string>();
+        for (var current = type; current != null; current = TypeContainingType(current))
+        {
+            parts.Add(current.Name);
+        }
+
+        parts.Reverse();
+        return string.Join(".", parts);
+    }
 
     /// <summary>
     /// Issue #1051: parses a composite storage key, reporting whether it names

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -281,7 +281,7 @@ internal sealed class DeclarationBinder
         }
     }
 
-    internal EnumSymbol BindEnumDeclaration(EnumDeclarationSyntax syntax, PackageSymbol package)
+    internal EnumSymbol BindEnumDeclaration(EnumDeclarationSyntax syntax, PackageSymbol package, TypeSymbol containingType = null)
     {
         var name = syntax.Identifier.Text;
 
@@ -293,6 +293,16 @@ internal sealed class DeclarationBinder
 
         var accessibility = resolveAccessibility(syntax.AccessibilityModifier);
         var enumSymbol = new EnumSymbol(name, accessibility, package.Name, syntax);
+
+        // Issue #1080: set the enclosing type BEFORE registering the name so the
+        // scope can scope name-uniqueness to the enclosing type (a nested type
+        // must not collide with a same-named package-level or differently-nested
+        // type).
+        if (containingType != null)
+        {
+            enumSymbol.SetContainingType(containingType);
+        }
+
         Binder.AttachDocumentation(enumSymbol, syntax);
         enumSymbol.SetAttributes(BindAttributes(
             syntax.Annotations,
@@ -471,7 +481,7 @@ internal sealed class DeclarationBinder
     /// with the base clause and all members — are bound and installed later by
     /// <see cref="BindStructDeclarationBody"/>.
     /// </summary>
-    internal StructSymbol DeclareStructShell(StructDeclarationSyntax syntax, PackageSymbol package)
+    internal StructSymbol DeclareStructShell(StructDeclarationSyntax syntax, PackageSymbol package, TypeSymbol containingType = null)
     {
         var name = syntax.Identifier.Text;
 
@@ -501,7 +511,7 @@ internal sealed class DeclarationBinder
                     syntax.TypeParameterList,
                     bareSymbols =>
                     {
-                        structSymbol = CreateAndRegisterStructShell(syntax, package, accessibility, name, bareSymbols);
+                        structSymbol = CreateAndRegisterStructShell(syntax, package, accessibility, name, bareSymbols, containingType);
                     });
             }
         }
@@ -512,7 +522,7 @@ internal sealed class DeclarationBinder
 
         // Non-generic types (or the defensive fallback when the callback did not
         // run) construct and register the shell here.
-        structSymbol ??= CreateAndRegisterStructShell(syntax, package, accessibility, name, typeParameters);
+        structSymbol ??= CreateAndRegisterStructShell(syntax, package, accessibility, name, typeParameters, containingType);
 
         return structSymbol;
     }
@@ -529,7 +539,8 @@ internal sealed class DeclarationBinder
         PackageSymbol package,
         Accessibility accessibility,
         string name,
-        ImmutableArray<TypeParameterSymbol> typeParameters)
+        ImmutableArray<TypeParameterSymbol> typeParameters,
+        TypeSymbol containingType = null)
     {
         // Issue #949 / #973: construct the struct symbol shell now and register
         // it in scope so that (a) the type may reference itself as a generic
@@ -554,6 +565,13 @@ internal sealed class DeclarationBinder
         if (!typeParameters.IsDefaultOrEmpty)
         {
             structSymbol.SetTypeParameters(typeParameters);
+        }
+
+        // Issue #1080: set the enclosing type BEFORE registering the name so the
+        // scope can scope name-uniqueness to the enclosing type.
+        if (containingType != null)
+        {
+            structSymbol.SetContainingType(containingType);
         }
 
         if (!scope.TryDeclareTypeAlias(name, structSymbol))
@@ -2704,10 +2722,9 @@ internal sealed class DeclarationBinder
             switch (nested)
             {
                 case StructDeclarationSyntax nestedStruct:
-                    var nestedStructSymbol = DeclareStructShell(nestedStruct, package);
+                    var nestedStructSymbol = DeclareStructShell(nestedStruct, package, containerSymbol);
                     if (nestedStructSymbol != null)
                     {
-                        nestedStructSymbol.SetContainingType(containerSymbol);
                         nestedStructShells[nestedStruct] = nestedStructSymbol;
                         DeclareNestedTypeShells(nestedStruct, nestedStructSymbol, package);
                     }
@@ -2715,15 +2732,13 @@ internal sealed class DeclarationBinder
                     break;
 
                 case EnumDeclarationSyntax nestedEnum:
-                    var nestedEnumSymbol = BindEnumDeclaration(nestedEnum, package);
-                    nestedEnumSymbol?.SetContainingType(containerSymbol);
+                    BindEnumDeclaration(nestedEnum, package, containerSymbol);
                     break;
 
                 case InterfaceDeclarationSyntax nestedInterface:
-                    var nestedInterfaceSymbol = DeclareInterfaceSymbol(nestedInterface, package);
+                    var nestedInterfaceSymbol = DeclareInterfaceSymbol(nestedInterface, package, containerSymbol);
                     if (nestedInterfaceSymbol != null)
                     {
-                        nestedInterfaceSymbol.SetContainingType(containerSymbol);
                         nestedInterfaceShells[nestedInterface] = nestedInterfaceSymbol;
                     }
 
@@ -3928,12 +3943,20 @@ internal sealed class DeclarationBinder
         return $"{dotted}[{string.Join(", ", args)}]";
     }
 
-    internal InterfaceSymbol DeclareInterfaceSymbol(InterfaceDeclarationSyntax syntax, PackageSymbol package)
+    internal InterfaceSymbol DeclareInterfaceSymbol(InterfaceDeclarationSyntax syntax, PackageSymbol package, TypeSymbol containingType = null)
     {
         var name = syntax.Identifier.Text;
         var accessibility = resolveAccessibility(syntax.AccessibilityModifier);
         var interfaceSymbol = new InterfaceSymbol(name, accessibility, syntax, package.Name);
         Binder.AttachDocumentation(interfaceSymbol, syntax);
+
+        // Issue #1080: set the enclosing type BEFORE registering the name so the
+        // scope can scope name-uniqueness to the enclosing type.
+        if (containingType != null)
+        {
+            interfaceSymbol.SetContainingType(containingType);
+        }
+
         interfaceSymbol.SetAttributes(BindAttributes(
             syntax.Annotations,
             AttributeTargetKind.Type,

--- a/test/Compiler.Tests/Emit/Issue1080NestedTypeNameCollisionEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1080NestedTypeNameCollisionEmitTests.cs
@@ -1,0 +1,111 @@
+// <copyright file="Issue1080NestedTypeNameCollisionEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1080: two nested types that share a simple name across DIFFERENT
+/// enclosing types — and a nested type whose simple name matches a package-level
+/// type — must no longer collide with <c>GS0102</c>. Each retained type must
+/// emit as its own CLR (nested) TypeDef, pass ilverify, and run. Follow-up to
+/// #1069.
+/// </summary>
+public class Issue1080NestedTypeNameCollisionEmitTests
+{
+    [Fact]
+    public void SameNestedSimpleName_DifferentOuters_BothEmitAsDistinctNestedTypes()
+    {
+        var asm = CompileToLibrary("""
+            package P
+
+            open class A {
+                func Make() int32 {
+                    let i = Inner{X: 1}
+                    return i.X
+                }
+
+                struct Inner { var X int32 }
+            }
+
+            open class B {
+                func Other() int32 {
+                    let j = Probe{Y: 2}
+                    return j.Y
+                }
+
+                struct Inner { var Z int32 }
+
+                struct Probe { var Y int32 }
+            }
+            """);
+
+        // Both `Inner` nested structs emit as distinct CLR nested types, each
+        // declared in its own enclosing type — they no longer collide (#1080).
+        var inners = asm.GetTypes().Where(t => t.Name == "Inner" && t.IsNested).ToList();
+        Assert.Equal(2, inners.Count);
+        Assert.Contains(inners, t => t.DeclaringType!.Name == "A");
+        Assert.Contains(inners, t => t.DeclaringType!.Name == "B");
+    }
+
+    [Fact]
+    public void PackageLevelType_VersusNestedDataStruct_SameName_BothEmit()
+    {
+        var asm = CompileToLibrary("""
+            package P
+
+            class SampleEntry { var A int32 }
+
+            class SttsBox {
+                data struct SampleEntry(FrameCount uint32, FrameDelta uint32) { }
+            }
+            """);
+
+        var topLevel = asm.GetTypes().Single(t => t.Name == "SampleEntry" && !t.IsNested);
+        Assert.Null(topLevel.DeclaringType);
+
+        var nested = asm.GetTypes().Single(t => t.Name == "SampleEntry" && t.IsNested);
+        Assert.Equal("SttsBox", nested.DeclaringType!.Name);
+    }
+
+    private static Assembly CompileToLibrary(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1080_lib_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:library",
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(compileExit == 0, $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+        IlVerifier.Verify(outPath);
+        return Assembly.Load(File.ReadAllBytes(outPath));
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1080NestedTypeNameCollisionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1080NestedTypeNameCollisionTests.cs
@@ -1,0 +1,122 @@
+// <copyright file="Issue1080NestedTypeNameCollisionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1080: nested-type name uniqueness must be scoped to the ENCLOSING
+/// type. Two nested types with the same simple name in DIFFERENT enclosing
+/// types — or a nested type whose simple name matches a package-level type —
+/// must NOT collide with <c>GS0102</c>. A genuine duplicate (same simple name in
+/// the SAME enclosing type, or two package-level types of the same name) must
+/// still report <c>GS0102</c>. Follow-up to #1069.
+/// </summary>
+public class Issue1080NestedTypeNameCollisionTests
+{
+    [Fact]
+    public void SameNestedSimpleName_DifferentOuters_DoesNotCollide()
+    {
+        var scope = BindSource("""
+            package p
+            class A { class Inner { var X int32 } }
+            class B { class Inner { var Y int32 } }
+            """);
+
+        Assert.DoesNotContain(GetBinderDiagnostics(scope), d => d.Id == "GS0102");
+        Assert.Empty(GetBinderDiagnostics(scope));
+
+        // Both nested types are retained as distinct declared structs, each with
+        // the correct enclosing type.
+        var inners = scope.Structs.Where(s => s.Name == "Inner").ToList();
+        Assert.Equal(2, inners.Count);
+        Assert.Contains(inners, i => i.ContainingType?.Name == "A");
+        Assert.Contains(inners, i => i.ContainingType?.Name == "B");
+    }
+
+    [Fact]
+    public void PackageLevelType_VersusNestedDataStruct_SameName_DoesNotCollide()
+    {
+        var scope = BindSource("""
+            package p
+            class SampleEntry { var A int32 }
+            class SttsBox {
+                data struct SampleEntry(FrameCount uint32, FrameDelta uint32) { }
+            }
+            """);
+
+        Assert.DoesNotContain(GetBinderDiagnostics(scope), d => d.Id == "GS0102");
+        Assert.Empty(GetBinderDiagnostics(scope));
+
+        var entries = scope.Structs.Where(s => s.Name == "SampleEntry").ToList();
+        Assert.Equal(2, entries.Count);
+
+        // The package-level type stays resolvable by its simple name.
+        var packageLevel = (StructSymbol)scope.TypeAliases["SampleEntry"];
+        Assert.Null(packageLevel.ContainingType);
+
+        // The nested type is retained under its qualified key and carries the
+        // enclosing type.
+        var nested = entries.Single(e => e.ContainingType != null);
+        Assert.Equal("SttsBox", nested.ContainingType.Name);
+    }
+
+    [Theory]
+    [InlineData("class Inner { var X int32 }")]
+    [InlineData("struct Inner { var X int32 }")]
+    [InlineData("data struct Inner(X uint32) { }")]
+    [InlineData("enum Inner { Red, Green }")]
+    public void SameNestedKind_DifferentOuters_DoesNotCollide(string nestedDecl)
+    {
+        var scope = BindSource($$"""
+            package p
+            class A { {{nestedDecl}} }
+            class B { {{nestedDecl}} }
+            """);
+
+        Assert.DoesNotContain(GetBinderDiagnostics(scope), d => d.Id == "GS0102");
+        Assert.Empty(GetBinderDiagnostics(scope));
+    }
+
+    [Fact]
+    public void DuplicateNestedSimpleName_SameOuter_StillReportsGS0102()
+    {
+        var scope = BindSource("""
+            package p
+            class A { class Inner { var X int32 } class Inner { var Y int32 } }
+            """);
+
+        Assert.Contains(GetBinderDiagnostics(scope), d => d.Id == "GS0102");
+    }
+
+    [Fact]
+    public void DuplicatePackageLevelType_StillReportsGS0102()
+    {
+        var scope = BindSource("""
+            package p
+            class Dup { var X int32 }
+            class Dup { var Y int32 }
+            """);
+
+        Assert.Contains(GetBinderDiagnostics(scope), d => d.Id == "GS0102");
+    }
+
+    private static BoundGlobalScope BindSource(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        return Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+    }
+
+    private static System.Collections.Generic.IEnumerable<GSharp.Core.CodeAnalysis.Diagnostic> GetBinderDiagnostics(BoundGlobalScope scope)
+    {
+        return scope.Diagnostics;
+    }
+}


### PR DESCRIPTION
Fixes #1080

## Problem
Nested type declarations were registered in the package-level type table keyed only by their **simple name**. Two nested types sharing a simple name in *different* enclosing types — or a nested type whose simple name matched a package-level type — incorrectly collided with `GS0102: '<Name>' is already declared.` (follow-up to #1069).

```gsharp
package p
class A { class Inner { var X int32 } }
class B { class Inner { var Y int32 } }   // was: GS0102 'Inner' already declared
```
```gsharp
package p
class SampleEntry { var A int32 }
class SttsBox { data struct SampleEntry(FrameCount uint32, FrameDelta uint32) { } }   // was: GS0102 'SampleEntry'
```

## Root cause
All user types (top-level and nested) were stored in `BoundScope.typeAliases`, keyed by `(simpleName, arity)`. The duplicate check (`GS0102`) treated `A.Inner` / `B.Inner` (and package `SampleEntry` vs `SttsBox.SampleEntry`) as duplicates because they shared a key. `ContainingType` was also set *after* registration, so the scope couldn't see the enclosing type when deciding uniqueness.

## Fix
- `BoundScope.TryDeclareTypeAlias` now scopes name uniqueness to the **enclosing type**: a simple-name clash is a genuine duplicate (GS0102) only when both types share the same declaration scope (both top-level, or both nested directly in the same enclosing type). Otherwise the types coexist — the top-level type keeps the simple key (still resolvable by simple name) and the differently-scoped nested type is retained under its containing-type-qualified key, so emit (which enumerates stored *values* and groups by `ContainingType`) still produces its nested `TypeDef`.
- `SetContainingType` is now called **before** the nested struct/class/data-struct/enum/interface name is registered, so the scope can observe the enclosing type at decision time.

This is pure symbol/declaration-binding logic — no new `SyntaxKind`/`BoundNodeKind`.

## Preserved behavior (regression guards)
- Two nested types with the same name in the **same** enclosing type still report `GS0102`.
- Two package-level types with the same name still report `GS0102`.

## Verification
Repros now compile (`Wrote r.dll`), all four nested kinds (class/struct/data struct/enum) compile, both negative guards still fail with `GS0102`, and both emitted assemblies contain the two distinct (nested) `TypeDef`s.

- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release` -> **3758 passed, 1 skipped, 0 failed**
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Release --filter "FullyQualifiedName~Issue1080"` -> **2 passed**

## Tests added
- `test/Core.Tests/CodeAnalysis/Binding/Issue1080NestedTypeNameCollisionTests.cs`
- `test/Compiler.Tests/Emit/Issue1080NestedTypeNameCollisionEmitTests.cs`

## Note
Cross-type *unqualified* resolution of two same-named nested types from inside the "wrong" enclosing type (e.g. referencing `Inner` from inside `B` when `A.Inner` holds the simple key) still resolves to the simple-key holder. This is a pre-existing limitation of #1069's flat-scope simple-name visibility (such code could not compile at all before this fix) and is out of scope for the collision issue; qualified references and per-type emission are correct.
