### PR TITLE
cs2gs: fix null-conditional generic args, nested BCL type qualification, Channels reference, enum extension methods

### DIFF
--- a/tools/cs2gs/Cs2Gs.Pipeline/CompileStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/CompileStage.cs
@@ -47,7 +47,7 @@ public sealed class CompileStage : IMigrationStage
             gsFiles,
             outputPath,
             context.App.TargetKind,
-            context.App.ReferencedAssemblies);
+            BuildReferenceSet(context.App.ReferencedAssemblies));
 
         File.WriteAllText(
             Path.Combine(context.AppRunDir, "gsc.compile.log"),
@@ -84,6 +84,66 @@ public sealed class CompileStage : IMigrationStage
         }
 
         return Task.FromResult(StageOutcome.Failed(artifacts));
+    }
+
+    /// <summary>
+    /// Builds the full <c>/reference:</c> set passed to <c>gsc</c>. gsc's
+    /// <c>WithReferences</c> resolver projects every referenced CLR type through
+    /// an isolated <c>MetadataLoadContext</c> seeded from the supplied paths, so
+    /// a partial BCL set leaves core types (even <c>System.Int32</c>)
+    /// unresolvable. The emitted G# also imports namespaces such as
+    /// <c>System.Threading.Channels</c> and <c>System.Memory</c> that the gsc
+    /// host does not load by default. Passing the complete shared-framework
+    /// assembly set makes every framework type (including <c>Channel</c> /
+    /// <c>Span</c>) resolvable while keeping the app's own sibling references.
+    /// </summary>
+    /// <param name="appReferences">The app's sibling assembly references.</param>
+    /// <returns>The deduplicated reference path set.</returns>
+    private static IReadOnlyList<string> BuildReferenceSet(IReadOnlyList<string> appReferences)
+    {
+        var references = new List<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        if (appReferences is not null)
+        {
+            foreach (string reference in appReferences)
+            {
+                if (!string.IsNullOrWhiteSpace(reference) && seen.Add(reference))
+                {
+                    references.Add(reference);
+                }
+            }
+        }
+
+        foreach (string frameworkReference in FrameworkReferencePaths())
+        {
+            if (seen.Add(frameworkReference))
+            {
+                references.Add(frameworkReference);
+            }
+        }
+
+        return references;
+    }
+
+    /// <summary>
+    /// Enumerates the shared-framework assemblies for the running runtime (the
+    /// <c>Microsoft.NETCore.App</c> directory). This is the same shared framework
+    /// the out-of-process <c>gsc</c> resolves against, so the paths are valid for
+    /// the compiler subprocess.
+    /// </summary>
+    /// <returns>The absolute paths of the shared-framework assemblies.</returns>
+    private static IReadOnlyList<string> FrameworkReferencePaths()
+    {
+        string runtimeDir = System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory();
+        if (string.IsNullOrEmpty(runtimeDir) || !Directory.Exists(runtimeDir))
+        {
+            return Array.Empty<string>();
+        }
+
+        return Directory.EnumerateFiles(runtimeDir, "*.dll", SearchOption.TopDirectoryOnly)
+            .OrderBy(p => p, StringComparer.Ordinal)
+            .ToList();
     }
 
     /// <summary>

--- a/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
@@ -314,6 +314,89 @@ namespace Demo
         Assert.Contains("\\u0000", printed);
     }
 
+    /// <summary>
+    /// A generic call chained after a null-conditional <c>?.</c>
+    /// (<c>t.GetChild&lt;MdiaBox&gt;()?.GetChild&lt;HdlrBox&gt;()</c>) must keep
+    /// its type arguments on every link of the chain, not just the first
+    /// (ADR-0115 §B). The member-binding after <c>?.</c> carries a
+    /// <c>GenericNameSyntax</c> whose type-argument list must be lifted onto the
+    /// G# bracket form, otherwise the chained call loses <c>[T…]</c> and binds to
+    /// the wrong (or no) overload.
+    /// </summary>
+    [Fact]
+    public void NullConditionalChainedGenericCall_PreservesTypeArguments()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class HdlrBox { public string HandlerType => ""soun""; }
+    public class MdiaBox { public T GetChild<T>() => default; }
+    public class TrakBox { public T GetChild<T>() => default; }
+    public static class C
+    {
+        public static string Handler(TrakBox t) =>
+            t.GetChild<MdiaBox>()?.GetChild<HdlrBox>()?.HandlerType;
+    }
+}");
+
+        Assert.Contains("t.GetChild[MdiaBox]()?.GetChild[HdlrBox]()?.HandlerType", printed);
+        Assert.DoesNotContain("?.GetChild()", printed);
+    }
+
+    /// <summary>
+    /// A reference to a nested BCL type
+    /// (<c>ConfiguredTaskAwaitable.ConfiguredTaskAwaiter</c>) must be qualified
+    /// with its containing type (ADR-0115 §B.12). Emitting the innermost name
+    /// alone produces an unresolvable <c>ConfiguredTaskAwaiter</c> (GS0113).
+    /// </summary>
+    [Fact]
+    public void NestedBclType_QualifiedWithContainingType()
+    {
+        string printed = TranslateUnit(@"
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+namespace Demo
+{
+    public class C
+    {
+        public ConfiguredTaskAwaitable.ConfiguredTaskAwaiter Awaiter(Task t) =>
+            t.ConfigureAwait(false).GetAwaiter();
+    }
+}");
+
+        Assert.Contains("ConfiguredTaskAwaitable.ConfiguredTaskAwaiter", printed);
+    }
+
+    /// <summary>
+    /// A C# extension method whose <c>this</c> receiver is an enum cannot use the
+    /// G# receiver-clause form (ADR-0079; gsc rejects it with GS0103 "receiver
+    /// type must be a struct or class declared in the same package"). It must be
+    /// emitted as a plain static helper and its call sites rewritten to the
+    /// positional form <c>Owner.Method(receiver, …)</c>.
+    /// </summary>
+    [Fact]
+    public void EnumExtensionMethod_EmittedAsPlainFunc_AndCallSiteRewritten()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public enum ChannelGroups { Mono, Stereo }
+    public static class Ac4Extensions
+    {
+        public static int ChannelCount(this ChannelGroups channels) =>
+            channels == ChannelGroups.Stereo ? 2 : 1;
+    }
+    public class User
+    {
+        public int Use(ChannelGroups g) => g.ChannelCount();
+    }
+}");
+
+        Assert.Contains("func ChannelCount(channels ChannelGroups) int32", printed);
+        Assert.DoesNotContain("func (channels ChannelGroups) ChannelCount", printed);
+        Assert.Contains("Ac4Extensions.ChannelCount(g)", printed);
+    }
+
     private static string TranslateUnit(string source)
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -1434,9 +1434,13 @@ public sealed class CSharpToGSharpTranslator
             if (symbol != null && symbol.IsExtensionMethod)
             {
                 // C# extension methods translate to the receiver-clause form on a
-                // non-owned type (ADR-0115 §B.5).
+                // non-owned type (ADR-0115 §B.5). A receiver clause is only valid
+                // on a struct/class (ADR-0079); an extension on an enum receiver
+                // is rejected by gsc (GS0103 "must be a struct or class"), so it
+                // stays a plain static helper and its call sites are rewritten to
+                // the positional form `Owner.Method(receiver, …)`.
                 IParameterSymbol self = symbol.Parameters.FirstOrDefault();
-                if (self != null)
+                if (self != null && self.Type.TypeKind != TypeKind.Enum)
                 {
                     receiver = new Receiver(
                         SanitizeIdentifier(self.Name),
@@ -4075,6 +4079,28 @@ public sealed class CSharpToGSharpTranslator
             GExpression target;
             IReadOnlyList<GTypeReference> typeArguments = null;
 
+            // A C# extension method whose receiver is an enum is emitted as a
+            // plain static helper (a receiver clause is rejected on enums,
+            // GS0103). Rewrite the call `x.M(args)` to the positional form
+            // `Owner.M(x, args)` so it binds to that helper.
+            if (invocation.Expression is MemberAccessExpressionSyntax extMember
+                && this.context.GetSymbolInfo(invocation).Symbol is IMethodSymbol extMethod
+                && TryGetEnumExtension(extMethod, out string extOwner, out string extName))
+            {
+                var extArgs = new List<GExpression>
+                {
+                    this.TranslateExpression(extMember.Expression),
+                };
+                extArgs.AddRange(invocation.ArgumentList.Arguments.Select(a => this.TranslateArgument(a)));
+                IReadOnlyList<GTypeReference> extTypeArgs = extMember.Name is GenericNameSyntax extGeneric
+                    ? this.MapTypeArguments(extGeneric)
+                    : null;
+                return new InvocationExpression(
+                    new MemberAccessExpression(new IdentifierExpression(extOwner), extName),
+                    extArgs,
+                    extTypeArgs);
+            }
+
             // A generic call `Foo<T>(...)` carries its type arguments on the name;
             // lift them onto the G# bracket-type-argument form `Foo[T](...)`.
             if (invocation.Expression is GenericNameSyntax generic)
@@ -4089,6 +4115,18 @@ public sealed class CSharpToGSharpTranslator
                     this.TranslateExpression(member.Expression),
                     memberGeneric.Identifier.Text);
                 typeArguments = this.MapTypeArguments(memberGeneric);
+            }
+            else if (invocation.Expression is MemberBindingExpressionSyntax memberBinding
+                && memberBinding.Name is GenericNameSyntax memberBindingGeneric)
+            {
+                // A generic call chained after a null-conditional `?.`
+                // (`x?.GetChild<HdlrBox>()`) reaches here as a member-binding
+                // whose name carries the type arguments. Preserve them on the
+                // bracket-type-argument form so the chained call keeps `[T...]`.
+                target = new MemberAccessExpression(
+                    new ConditionalReceiverExpression(),
+                    memberBindingGeneric.Identifier.Text);
+                typeArguments = this.MapTypeArguments(memberBindingGeneric);
             }
             else if (invocation.Expression is IdentifierNameSyntax bareName &&
                 this.context.GetSymbolInfo(bareName).Symbol is IMethodSymbol { IsStatic: true } staticMethod &&
@@ -4114,6 +4152,39 @@ public sealed class CSharpToGSharpTranslator
                 .ToList();
 
             return new InvocationExpression(target, arguments, typeArguments);
+        }
+
+        /// <summary>
+        /// Determines whether <paramref name="method"/> is a C# extension method
+        /// whose receiver (<c>this</c>) parameter is an enum. Such an extension
+        /// cannot carry a G# receiver clause (ADR-0079; gsc reports GS0103), so it
+        /// is emitted as a plain static helper and its call sites are rewritten to
+        /// the positional form <c>Owner.Method(receiver, …)</c>.
+        /// </summary>
+        /// <param name="method">The bound (possibly reduced) call symbol.</param>
+        /// <param name="ownerName">The declaring static class name when matched.</param>
+        /// <param name="methodName">The helper method name when matched.</param>
+        /// <returns><see langword="true"/> when the call targets an enum extension.</returns>
+        private static bool TryGetEnumExtension(IMethodSymbol method, out string ownerName, out string methodName)
+        {
+            ownerName = null;
+            methodName = null;
+            if (method == null || !method.IsExtensionMethod)
+            {
+                return false;
+            }
+
+            ITypeSymbol receiverType = method.ReceiverType
+                ?? method.Parameters.FirstOrDefault()?.Type;
+            if (receiverType?.TypeKind != TypeKind.Enum)
+            {
+                return false;
+            }
+
+            IMethodSymbol original = method.ReducedFrom ?? method;
+            ownerName = original.ContainingType?.Name;
+            methodName = original.Name;
+            return ownerName != null;
         }
 
         /// <summary>

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
@@ -217,13 +217,37 @@ public sealed class CSharpTypeMapper
                 List<GTypeReference> args = named.TypeArguments
                     .Select(a => this.Map(a, context, location))
                     .ToList();
-                return new NamedTypeReference(named.Name, args);
+                return new NamedTypeReference(QualifiedTypeName(named), args);
             }
 
-            return new NamedTypeReference(named.Name);
+            return new NamedTypeReference(QualifiedTypeName(named));
         }
 
         return new NamedTypeReference(type.Name);
+    }
+
+    // A nested type is referenced through its containing type(s)
+    // (`ConfiguredTaskAwaitable.ConfiguredTaskAwaiter`); emitting the innermost
+    // name alone makes the reference unresolvable. Walk the containing-type chain
+    // and join with '.' so nested types stay qualified (ADR-0115 §B.12). Only
+    // metadata (BCL/external) nested types are qualified: a source-declared
+    // nested type is emitted by the translator as a directly-nested G# member and
+    // is referenced by its simple name within the package, so qualifying it would
+    // break round-trip parsing of generic-argument positions.
+    private static string QualifiedTypeName(INamedTypeSymbol named)
+    {
+        if (named.ContainingType == null || named.Locations.Any(l => l.IsInSource))
+        {
+            return named.Name;
+        }
+
+        var parts = new List<string>();
+        for (INamedTypeSymbol current = named; current != null; current = current.ContainingType)
+        {
+            parts.Insert(0, current.Name);
+        }
+
+        return string.Join(".", parts);
     }
 
     private ArrowTypeReference MapDelegate(IMethodSymbol invoke, TranslationContext context, Location location)


### PR DESCRIPTION
Four translator/pipeline fixes that improve **Oahu.Decrypt** translation fidelity. Part of the cs2gs umbrella (#914).

## Defect 1 — Generic type argument dropped on a call chained after `?.`
**Before:** `t.GetChild<MdiaBox>()?.GetChild<HdlrBox>()?.HandlerType` → `t.GetChild[MdiaBox]()?.GetChild()?.HandlerType` (the chained call lost `[HdlrBox]`).
**After:** `t.GetChild[MdiaBox]()?.GetChild[HdlrBox]()?.HandlerType`.
**Root cause:** a generic call chained after a null-conditional `?.` reaches `TranslateInvocation` as a `MemberBindingExpressionSyntax` whose `Name` is a `GenericNameSyntax`; the type-argument list was not carried through. Added a branch that lifts those type arguments onto the G# bracket form.
**File:** `Cs2Gs.Translator/CSharpToGSharpTranslator.cs`.

## Defect 2 — Nested BCL type emitted unqualified
**Before:** `ConfiguredTaskAwaitable.ConfiguredTaskAwaiter` (the `GetAwaiter()` return type) → bare `ConfiguredTaskAwaiter` → `GS0113`.
**After:** `ConfiguredTaskAwaitable.ConfiguredTaskAwaiter`.
**Root cause:** the type mapper emitted only the innermost name. It now walks the containing-type chain for **metadata (non-source)** nested types and joins with `.`. Source-declared nested types keep their simple name (they are emitted as directly-nested G# members) so generic-argument-position round-trip parsing is preserved.
**File:** `Cs2Gs.Translator/CSharpTypeMapper.cs`.

## Defect 3 — `System.Threading.Channels` not referenced by the compile stage
**Before:** `Channel` / `Channel.CreateBounded` → `GS0113 Type 'Channel' doesn't exist`.
**After:** `Channel` resolves. The `import System.Threading.Channels` was already emitted; the missing piece was the gsc reference set. `CompileStage` now passes the full shared-framework reference set to gsc — gsc's `WithReferences` resolver runs in an isolated `MetadataLoadContext` where a *partial* BCL set leaves even `System.Int32` unresolvable, so the complete shared-framework assembly set is passed (covers `Channel`, `Span`, etc.).
**File:** `Cs2Gs.Pipeline/CompileStage.cs`.

## Defect 4 — Extension method on an enum
**Before:** `public static int ChannelCount(this ChannelGroups channels)` → `func (channels ChannelGroups) ChannelCount() int32` → `GS0103` (receiver clauses are reserved for owned structs/classes, ADR-0079).
**After:** plain static helper `func ChannelCount(channels ChannelGroups) int32` and call sites rewritten to the positional form `Ac4Extensions.ChannelCount(x)`.
**Root cause:** the extension-method path unconditionally produced a receiver clause. It now skips the receiver clause when the `this` parameter is an enum and rewrites direct call sites.
**File:** `Cs2Gs.Translator/CSharpToGSharpTranslator.cs`.

## Verification
Re-running the Oahu.Decrypt migration, these targeted errors are **gone**:
- `GS0113` ConfiguredTaskAwaiter (Mp4Operation)
- `GS0113` Channel (FrameFilterBase)
- `GS0103` ChannelGroups (Ac4Extensions)

The translate stage stays **PASS**. Full cs2gs test suite is green (**179 tests**), including 3 new focused tests in `OahuDecryptTranslationTests.cs` (defects 1, 2, 4).

### Not addressed (out of translator scope)
The `GS0214 MultipartFilterBase` + `GS0158 AudioTrack` errors remain. Investigation shows these are **not** caused by the translator: they stem from a gsc limitation resolving a base constructor against a **constructed generic base type** (`LosslessMultipartFilter : MultipartFilterBase<FrameEntry, NewSplitCallback>` calling `: base(...)`). Reproduced minimally — `class Deriv : Base[int32]` calling `: base(...)` reports GS0214 regardless of argument count, while a non-generic base binds fine. The `GS0158 AudioTrack` errors are a cascade of that failed base-call binding. Fixing this requires a change in the gsc compiler (`src/`), which is out of scope for this translator batch. The remaining `GS0125`/`GS0159`/`GS0155` FrameFilterBase field-init errors are likewise out of scope (handled separately).
