### PR TITLE
Fixes #1038: standalone System.Range value (let r = 1..3)

### DIFF
--- a/docs/adr/0127-standalone-range-value.md
+++ b/docs/adr/0127-standalone-range-value.md
@@ -1,0 +1,90 @@
+# ADR-0127: Standalone `System.Range` value (`let r = 1..3`)
+
+- **Status**: Accepted
+- **Date**: 2026-06-24
+- **Phase**: Phase 9 — language depth / collection ergonomics
+- **Related**: issue #1016 (the `..` range/slice operator), issue #1022 (the from-end `^n` marker, [ADR-0123](0123-from-end-index-operator.md)), issue [#1038](https://github.com/DavidObando/gsharp/issues/1038)
+
+## Context
+
+Issue #1016 added the C#-style `..` range/slice operator **inside an indexer**
+(`a[lo..hi]`, with the open forms `a[..hi]`, `a[lo..]`, `a[..]`) and issue #1022
+([ADR-0123](0123-from-end-index-operator.md)) added the from-end `^n` marker in
+the leading position of an index/range bound. Both intentionally **deferred** a
+standalone `System.Range`-producing expression:
+
+```gsharp
+let r = 1..3        // r : System.Range
+let s = a[r]        // index by a Range value
+```
+
+Lifting `..` into the general expression grammar requires choosing a precedence,
+binding the four open forms to a constructed `System.Range`, deciding how the
+from-end `^` marker behaves where a leading `^` is ambiguous with one's-complement,
+and allowing a `System.Range`-typed value to be used as an index argument.
+
+## Decision
+
+1. **Grammar / precedence.** A standalone range is a new expression layer
+   (`ParseRangeExpression`) sitting directly under the assignment/ternary tail
+   and above null-coalescing. Each bound is a full null-coalescing expression, so
+   **`..` binds looser than every binary operator**: `1+2..3+4` parses as
+   `(1+2)..(3+4)`, matching the issue's stated requirement. All four open forms
+   (`lo..hi`, `lo..`, `..hi`, `..`) are supported. An open upper bound (`lo..`)
+   terminates at a closing delimiter, a separator, or a **line break**, so
+   `let r = 1..` on its own line is the open range `1..end` rather than a
+   continuation onto the next statement.
+
+2. **No interference with the index grammar.** Inside an index bracket the `..`
+   token is owned by the index-argument parser (`ParseIndexArgument` /
+   `ParseIndexBound`), exactly as in #1016/#1022. The standalone range layer is
+   suppressed while parsing an index bound (a `suppressRangeOperator` depth
+   counter), so `a[lo..hi]`, `a[^2..]`, and `a[a..^b]` parse byte-for-byte as
+   before. The counter is re-cleared inside parentheses and argument lists, so a
+   parenthesised or argument-position range nested in an index bound
+   (`a[(1..3)]`, `a[f(1..3)]`) is still recognised as a standalone value.
+
+3. **From-end `^` restriction.** A from-end `^n` marker is supported in the
+   **upper** bound of a standalone range (`lo..^hi`, `..^hi`), where it is
+   unambiguous because it immediately follows `..`. A **leading** `^` at the very
+   start of a standalone range (`^a..b`) is **not** supported: the parser reads
+   `^a` as the one's-complement unary operator, and the binder reports the new
+   **GS0410** diagnostic so the from-end intent is not silently misread. To slice
+   from the end, index the value directly (`arr[^a..]`, the #1022 path); to use a
+   one's-complement value as a from-start lower bound, parenthesise it
+   (`(^a)..b`).
+
+4. **Binding / lowering.** A standalone range binds to `new System.Range(start,
+   end)`, where each bound is a `System.Index`: a plain value `v` → `Index(v)`
+   (from-start), a `^n` marker → `Index(n, fromEnd: true)`, an open lower → the
+   start, an open upper → the end. This mirrors how C# lowers a range expression
+   and reuses the same `BuildSystemRangeValue` helper as the #1016
+   `this[System.Range]` indexer path. The value is typed `System.Range`. No new
+   `BoundNodeKind` is introduced.
+
+5. **Indexing by a range value (`a[r]`).** A `System.Range`-typed value used as
+   an index argument slices the receiver with the *same* shapes as the syntactic
+   `a[1..3]` form — arrays/slices copy via `Array.Copy`, `string` uses
+   `Substring`, span-like values use `Slice`, and a `this[System.Range]` indexer
+   is called with the value directly. The concrete `start`/`length` are resolved
+   from the range value at runtime via `System.Index.GetOffset(length)`. The
+   index expression is bound once and reused across the ordinary index paths to
+   avoid re-binding; `default`/interpolated index syntaxes (which can never be a
+   range value) keep their dedicated conversion handling.
+
+## Consequences
+
+- `let r = 1..3` gives `r : System.Range`; all four open forms bind, emit, and
+  evaluate; `a[r]` slices arrays, `[]T` slices, strings, and span-like values
+  (and any `this[System.Range]` type), matching C# semantics.
+- The #1016/#1022 index-bracket forms are unaffected (regression tests assert
+  `a[1..^1]`, `a[..^3]`, `a[^2..]` are unchanged), and the existing
+  one's-complement/XOR uses of `^` keep their meaning.
+- The one genuinely ambiguous position — a leading `^` in a standalone range —
+  is rejected with a clear, actionable diagnostic (GS0410) rather than silently
+  misinterpreted.
+
+## Deferred
+
+None. The standalone range is implemented end-to-end (parse, bind, emit,
+interpret, and `a[r]` indexing across all supported receiver shapes).

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -779,6 +779,22 @@ parameter; `GS0394` requires that at least one of the source or target type is a
 owned struct and that the two types differ; `GS0395` rejects a second conversion
 (implicit or explicit) with the same source/target pair.
 
+## Standalone range from-end marker diagnostic (GS0410)
+
+| ID | Severity | Description |
+|----|----------|-------------|
+| GS0410 | Error | A from-end index marker `^` is only valid inside index brackets (e.g. `arr[^1]` or `arr[a..^b]`) or after `..` in a standalone range upper bound (`a..^b`); a standalone range cannot start with `^`. Use an indexer, or parenthesise a one's-complement bound (`(^a)..b`). |
+
+GS0410 fires for the standalone range/slice value added in issue #1038
+(`let r = 1..3`). The lower bound of a standalone range may not begin with `^`,
+because a leading `^` is genuinely ambiguous with the one's-complement unary
+operator (`^a` parses as `~a`). The from-end marker is therefore restricted to
+the unambiguous positions: inside index brackets (the #1022 path —
+`arr[^1]`, `arr[^2..]`, `arr[a..^b]`) and the upper bound of a standalone range
+(`..^b`, `a..^b`). To slice from the end of a value, index it directly
+(`arr[^a..]`); to use a one's-complement value as a from-start lower bound,
+parenthesise it (`(^a)..b`).
+
 ## Internal compiler error diagnostics (GS9998–GS9999)
 
 | ID | Severity | Description |

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -2387,20 +2387,49 @@ internal sealed partial class ExpressionBinder
             return BindFromEndIndex(target, fromEndSyntax, targetLocation);
         }
 
+        // Issue #1038: an index whose value is a `System.Range` slices the
+        // target (`let r = 1..3; a[r]`, or the inline `a[(1..3)]`), dispatching
+        // to the same array/string/span/`this[System.Range]` shapes used by the
+        // syntactic `a[1..3]` form. Bind the index once here and reuse the bound
+        // expression in the ordinary index paths below to avoid re-binding.
+        // `default`/interpolated index syntaxes can never be a range value and
+        // keep their dedicated conversion handling, so they are not pre-bound.
+        BoundExpression boundIndex = null;
+        if (indexSyntax is not DefaultExpressionSyntax && indexSyntax is not InterpolatedStringExpressionSyntax)
+        {
+            boundIndex = BindExpression(indexSyntax);
+            if (boundIndex is BoundErrorExpression)
+            {
+                return boundIndex;
+            }
+
+            if (IsSystemRangeType(boundIndex.Type))
+            {
+                return BindRangeValueSlice(target, boundIndex, targetLocation);
+            }
+        }
+
+        BoundExpression ConvertIndex(TypeSymbol conversionTargetType) =>
+            boundIndex != null
+                ? conversions.BindConversion(indexSyntax.Location, boundIndex, conversionTargetType)
+                : conversions.BindConversion(indexSyntax, conversionTargetType);
+
+        BoundExpression BoundIndexArg() => boundIndex ?? BindExpression(indexSyntax);
+
         // Phase 3.A.4: map indexing `m[k]` — key bound to K, result type V.
         // The Go convention "zero value if missing" applies at evaluation;
         // the bound representation reuses BoundIndexExpression with the
         // element type set to V.
         if (target.Type is MapTypeSymbol mapType)
         {
-            var key = conversions.BindConversion(indexSyntax, mapType.KeyType);
+            var key = ConvertIndex(mapType.KeyType);
             return new BoundIndexExpression(null, target, key, mapType.ValueType);
         }
 
         var element = GetIndexElementType(target.Type);
         if (element != null)
         {
-            var index = conversions.BindConversion(indexSyntax, TypeSymbol.Int32);
+            var index = ConvertIndex(TypeSymbol.Int32);
             return new BoundIndexExpression(null, target, index, element);
         }
 
@@ -2412,7 +2441,7 @@ internal sealed partial class ExpressionBinder
         // use them to type the element correctly (e.g., `list[0]` on `List<string?>` → `string?`).
         if (target.Type is NullabilityAnnotatedTypeSymbol annotIdx && annotIdx.ClrType is System.Type clrAnnotIdx)
         {
-            var idxArgsAnnot = ImmutableArray.Create(BindExpression(indexSyntax));
+            var idxArgsAnnot = ImmutableArray.Create(BoundIndexArg());
             if (this.memberLookup.TryResolveClrIndexer(clrAnnotIdx, idxArgsAnnot, out var idxPropAnnot))
             {
                 var elemTypeAnnot = annotIdx.GetTypeArgumentSymbolForClrType(idxPropAnnot.PropertyType);
@@ -2421,7 +2450,7 @@ internal sealed partial class ExpressionBinder
         }
         else if (target.Type is ImportedTypeSymbol && target.Type.ClrType is System.Type clrTarget)
         {
-            var idxArgs = ImmutableArray.Create(BindExpression(indexSyntax));
+            var idxArgs = ImmutableArray.Create(BoundIndexArg());
             if (this.memberLookup.TryResolveClrIndexer(clrTarget, idxArgs, out var idxProp))
             {
                 var elementType = MapErasedIndexerElementType((ImportedTypeSymbol)target.Type, idxProp);
@@ -2445,7 +2474,7 @@ internal sealed partial class ExpressionBinder
             var paramType = readSubstitution != null
                 ? Binder.SubstituteType(readIndexer.Parameters[0].Type, readSubstitution)
                 : readIndexer.Parameters[0].Type;
-            var indexArg = conversions.BindConversion(indexSyntax, paramType);
+            var indexArg = ConvertIndex(paramType);
             var elementType = readSubstitution != null
                 ? Binder.SubstituteType(readIndexer.Type, readSubstitution)
                 : readIndexer.Type;
@@ -3334,6 +3363,20 @@ internal sealed partial class ExpressionBinder
 
     private BoundExpression BindRangeIndexerSlice(BoundExpression target, RangeExpressionSyntax range, PropertyInfo indexer)
     {
+        var rangeValue = BuildSystemRangeValue(range);
+        var resultType = TypeSymbol.FromClrType(indexer.PropertyType);
+        return new BoundClrIndexExpression(range, target, indexer, ImmutableArray.Create(rangeValue), resultType);
+    }
+
+    // Issue #1016/#1022/#1038: construct a `System.Range` value from a range
+    // expression's bounds. Each bound becomes a `System.Index`: an open lower
+    // defaults to the start (`Index(0, fromEnd: false)`), an open upper to the
+    // end (`Index(0, fromEnd: true)`), a `^n` marker to `Index(n, fromEnd:
+    // true)`, and a plain value `v` to `Index(v, fromEnd: false)`. Shared by the
+    // `this[System.Range]` indexer-slice path (#1016) and the standalone range
+    // value `let r = 1..3` (#1038).
+    private BoundExpression BuildSystemRangeValue(RangeExpressionSyntax range)
+    {
         var indexCtor = typeof(System.Index).GetConstructor(new[] { typeof(int), typeof(bool) });
         var rangeCtor = typeof(System.Range).GetConstructor(new[] { typeof(System.Index), typeof(System.Index) });
         var indexSym = TypeSymbol.FromClrType(typeof(System.Index));
@@ -3342,7 +3385,7 @@ internal sealed partial class ExpressionBinder
         BoundExpression MakeIndex(ExpressionSyntax boundSyntax, bool defaultFromEnd)
         {
             // Issue #1022: a `^n` bound becomes System.Index(n, fromEnd: true);
-            // the System.Range indexer computes the concrete offset at runtime.
+            // the System.Range value resolves the concrete offset at runtime.
             if (boundSyntax is FromEndIndexExpressionSyntax fromEnd)
             {
                 var endValue = conversions.BindConversion(fromEnd.Operand, TypeSymbol.Int32);
@@ -3372,15 +3415,203 @@ internal sealed partial class ExpressionBinder
             ? MakeIndex(range.UpperBound, defaultFromEnd: false)
             : MakeIndex(null, defaultFromEnd: true);
 
-        var rangeValue = new BoundClrConstructorCallExpression(
+        return new BoundClrConstructorCallExpression(
             null,
             typeof(System.Range),
             rangeCtor,
             ImmutableArray.Create<BoundExpression>(startIndex, endIndex),
             rangeSym);
+    }
 
-        var resultType = TypeSymbol.FromClrType(indexer.PropertyType);
-        return new BoundClrIndexExpression(range, target, indexer, ImmutableArray.Create<BoundExpression>(rangeValue), resultType);
+    // Issue #1038: bind a standalone range expression (`let r = 1..3`) to a
+    // constructed `System.Range` value. A leading `^` at the very start is
+    // genuinely ambiguous with the one's-complement unary operator, so the
+    // parser reads `^a..` as `(~a)..`; reject that here (GS0410) so the from-end
+    // intent isn't silently misread — use an indexer (`arr[^a..]`) or
+    // parenthesise the complement (`(^a)..`).
+    private BoundExpression BindStandaloneRange(RangeExpressionSyntax range)
+    {
+        if (range.LowerBound is UnaryExpressionSyntax leadingUnary
+            && leadingUnary.OperatorToken.Kind == SyntaxKind.HatToken)
+        {
+            Diagnostics.ReportFromEndMarkerNotAllowedInStandaloneRange(leadingUnary.OperatorToken.Location);
+            _ = BindExpression(leadingUnary.Operand);
+            if (range.UpperBound != null)
+            {
+                _ = BindExpression(range.UpperBound is FromEndIndexExpressionSyntax fe ? fe.Operand : range.UpperBound);
+            }
+
+            return new BoundErrorExpression(range);
+        }
+
+        return BuildSystemRangeValue(range);
+    }
+
+    // Issue #1038: slice a target by a runtime `System.Range` value (`a[r]`,
+    // where `r : System.Range`). Mirrors the syntactic `a[1..3]` shapes from
+    // #1016 but reads the concrete `start`/`length` from the range value via
+    // `System.Index.GetOffset(length)` rather than from syntactic bounds:
+    //   - arrays / slices (`[N]T`, `[]T`, CLR `T[]`) -> new T[len] + Array.Copy.
+    //   - `string` -> Substring(start, len).
+    //   - span-like types (`int Length`/`Count` + `Slice(int, int)`).
+    //   - a type exposing `this[System.Range]` -> call it with the value directly.
+    private BoundExpression BindRangeValueSlice(BoundExpression target, BoundExpression rangeValue, TextLocation targetLocation)
+    {
+        var arrayElement = GetArraySliceElementType(target.Type);
+        if (arrayElement != null)
+        {
+            var statements = ImmutableArray.CreateBuilder<BoundStatement>();
+            var (srcRef, startRef, lenRef) = BuildRangeValueBounds(
+                target,
+                rangeValue,
+                src => new BoundLenExpression(null, src),
+                statements);
+
+            var resultType = SliceTypeSymbol.Get(arrayElement);
+            var dstLocal = DeclareRangeTemp("dst", resultType, new BoundArrayCreationExpression(null, resultType, lenRef), statements);
+            var dstRef = new BoundVariableExpression(null, dstLocal);
+
+            var copyMethod = typeof(System.Array).GetMethod(
+                "Copy",
+                new[] { typeof(System.Array), typeof(int), typeof(System.Array), typeof(int), typeof(int) });
+            var copyCall = new BoundClrStaticCallExpression(
+                null,
+                copyMethod,
+                TypeSymbol.Void,
+                ImmutableArray.Create<BoundExpression>(srcRef, startRef, dstRef, new BoundLiteralExpression(null, 0), lenRef));
+            statements.Add(new BoundExpressionStatement(null, copyCall));
+
+            return new BoundBlockExpression(null, statements.ToImmutable(), new BoundVariableExpression(null, dstLocal));
+        }
+
+        if (target.Type == TypeSymbol.String)
+        {
+            var statements = ImmutableArray.CreateBuilder<BoundStatement>();
+            var (srcRef, startRef, lenRef) = BuildRangeValueBounds(
+                target,
+                rangeValue,
+                src => new BoundLenExpression(null, src),
+                statements);
+
+            var substring = typeof(string).GetMethod("Substring", new[] { typeof(int), typeof(int) });
+            var call = new BoundImportedInstanceCallExpression(
+                null,
+                srcRef,
+                substring,
+                TypeSymbol.String,
+                ImmutableArray.Create<BoundExpression>(startRef, lenRef));
+            return new BoundBlockExpression(null, statements.ToImmutable(), call);
+        }
+
+        var clrType = target.Type.ClrType;
+        if (clrType != null)
+        {
+            if (TryFindRangeIndexer(clrType, out var rangeIndexer))
+            {
+                var resultType = TypeSymbol.FromClrType(rangeIndexer.PropertyType);
+                return new BoundClrIndexExpression(null, target, rangeIndexer, ImmutableArray.Create(rangeValue), resultType);
+            }
+
+            if (TryFindSliceShape(clrType, out var lengthMember, out var sliceMethod))
+            {
+                var statements = ImmutableArray.CreateBuilder<BoundStatement>();
+                var (srcRef, startRef, lenRef) = BuildRangeValueBounds(
+                    target,
+                    rangeValue,
+                    src => new BoundClrPropertyAccessExpression(null, src, lengthMember, TypeSymbol.Int32),
+                    statements);
+
+                var returnType = TypeSymbol.FromClrType(sliceMethod.ReturnType);
+                var call = new BoundImportedInstanceCallExpression(
+                    null,
+                    srcRef,
+                    sliceMethod,
+                    returnType,
+                    ImmutableArray.Create<BoundExpression>(startRef, lenRef));
+                return new BoundBlockExpression(null, statements.ToImmutable(), call);
+            }
+        }
+
+        Diagnostics.ReportTypeNotSliceable(targetLocation, target.Type);
+        return new BoundErrorExpression(null);
+    }
+
+    // Issue #1038: emit the `src`/`start`/`len` temporaries for slicing by a
+    // runtime `System.Range` value. The source length is computed once; the
+    // range's `Start`/`End` indices are resolved to concrete offsets via
+    // `System.Index.GetOffset(length)`, and `len = end - start`.
+    private (BoundExpression Src, BoundExpression Start, BoundExpression Len) BuildRangeValueBounds(
+        BoundExpression target,
+        BoundExpression rangeValue,
+        Func<BoundExpression, BoundExpression> lengthOf,
+        ImmutableArray<BoundStatement>.Builder statements)
+    {
+        var indexSym = TypeSymbol.FromClrType(typeof(System.Index));
+        var startProp = typeof(System.Range).GetProperty("Start");
+        var endProp = typeof(System.Range).GetProperty("End");
+        var getOffset = typeof(System.Index).GetMethod("GetOffset", new[] { typeof(int) });
+
+        var srcLocal = DeclareRangeTemp("src", target.Type, target, statements);
+
+        BoundExpression SrcRef() => new BoundVariableExpression(null, srcLocal);
+
+        var srcLenLocal = DeclareRangeTemp("srclen", TypeSymbol.Int32, lengthOf(SrcRef()), statements);
+
+        BoundExpression SrcLenRef() => new BoundVariableExpression(null, srcLenLocal);
+
+        var rngLocal = DeclareRangeTemp("rng", rangeValue.Type, rangeValue, statements);
+
+        BoundExpression RngRef() => new BoundVariableExpression(null, rngLocal);
+
+        // Resolve Start/End (System.Index) into addressable locals so the
+        // struct-receiver GetOffset call has an address to load.
+        var startIdxLocal = DeclareRangeTemp(
+            "startidx",
+            indexSym,
+            new BoundClrPropertyAccessExpression(null, RngRef(), startProp, indexSym),
+            statements);
+        var endIdxLocal = DeclareRangeTemp(
+            "endidx",
+            indexSym,
+            new BoundClrPropertyAccessExpression(null, RngRef(), endProp, indexSym),
+            statements);
+
+        var startExpr = new BoundImportedInstanceCallExpression(
+            null,
+            new BoundVariableExpression(null, startIdxLocal),
+            getOffset,
+            TypeSymbol.Int32,
+            ImmutableArray.Create<BoundExpression>(SrcLenRef()));
+        var startLocal = DeclareRangeTemp("start", TypeSymbol.Int32, startExpr, statements);
+
+        var endExpr = new BoundImportedInstanceCallExpression(
+            null,
+            new BoundVariableExpression(null, endIdxLocal),
+            getOffset,
+            TypeSymbol.Int32,
+            ImmutableArray.Create<BoundExpression>(SrcLenRef()));
+        var endLocal = DeclareRangeTemp("end", TypeSymbol.Int32, endExpr, statements);
+
+        var subtractOp = BoundBinaryOperator.Bind(SyntaxKind.MinusToken, TypeSymbol.Int32, TypeSymbol.Int32);
+        var lengthExpr = new BoundBinaryExpression(
+            null,
+            new BoundVariableExpression(null, endLocal),
+            subtractOp,
+            new BoundVariableExpression(null, startLocal));
+        var lenLocal = DeclareRangeTemp("len", TypeSymbol.Int32, lengthExpr, statements);
+
+        return (
+            new BoundVariableExpression(null, srcLocal),
+            new BoundVariableExpression(null, startLocal),
+            new BoundVariableExpression(null, lenLocal));
+    }
+
+    // Issue #1038: a `System.Range`-typed value used as an index argument
+    // (`a[r]`) slices the target. Uses ClrTypeUtilities.IsSameAs per the issue
+    // #835 guard against reference-identity typeof comparisons.
+    private static bool IsSystemRangeType(TypeSymbol type)
+    {
+        return type?.ClrType != null && type.ClrType.IsSameAs(typeof(System.Range));
     }
 
     private static bool TryFindRangeIndexer(Type clrType, out PropertyInfo indexer)

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -296,6 +296,18 @@ internal sealed partial class ExpressionBinder
                 // BoundBaseInterfaceCallExpression emits a non-virtual call
                 // into the interface's default body.
                 return BindBaseInterfaceCallExpression((BaseInterfaceCallExpressionSyntax)syntax);
+            case SyntaxKind.RangeExpression:
+                // Issue #1038: a standalone range `lo..hi` (and the open forms)
+                // binds to a constructed `System.Range` value.
+                return BindStandaloneRange((RangeExpressionSyntax)syntax);
+            case SyntaxKind.FromEndIndexExpression:
+                // Issue #1038: a bare `^n` from-end marker is only meaningful as
+                // an index/range bound (handled inside the index-argument and
+                // range binders); surfacing it standalone is rejected (GS0410).
+                var bareFromEnd = (FromEndIndexExpressionSyntax)syntax;
+                Diagnostics.ReportFromEndMarkerNotAllowedInStandaloneRange(bareFromEnd.HatToken.Location);
+                _ = BindExpression(bareFromEnd.Operand);
+                return new BoundErrorExpression(null);
             default:
                 throw new Exception($"Unexpected syntax {syntax.Kind}");
         }

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -1673,6 +1673,21 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
     }
 
     /// <summary>
+    /// GS0410: a from-end index marker <c>^</c> appeared where it is not
+    /// allowed — at the very start of a standalone range expression
+    /// (<c>^a..b</c>) or as a bare expression. The leading <c>^</c> is
+    /// ambiguous with the one's-complement unary operator, so it is only
+    /// recognised as a from-end marker inside index brackets
+    /// (<c>arr[^1]</c>, <c>arr[a..^b]</c>) or after <c>..</c> in a standalone
+    /// range upper bound (<c>a..^b</c>) (issue #1038).
+    /// </summary>
+    /// <param name="location">The text location of the <c>^</c> marker.</param>
+    public void ReportFromEndMarkerNotAllowedInStandaloneRange(TextLocation location)
+    {
+        Report(location, "GS0410", "A from-end index marker '^' is only valid inside index brackets (e.g. 'arr[^1]' or 'arr[a..^b]') or after '..' in a standalone range upper bound ('a..^b'); a standalone range cannot start with '^'. Use an indexer, or parenthesise a one's-complement bound ('(^a)..b') (issue #1038).");
+    }
+
+    /// <summary>
     /// Reports that an <c>async func(...)</c> type clause has an explicit
     /// <c>Task[…]</c> (or other Task-shaped) return type. The <c>async</c>
     /// modifier already implies a Task wrap, so the explicit wrap is

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -55,6 +55,17 @@ public class Parser
     // parenthesised lambda `(x) -> body` remains available in unsafe contexts.
     private int unsafeDepth;
 
+    // Issue #1038: depth counter that suppresses the standalone range operator
+    // (`lo..hi`) while parsing the bound of an index expression. Inside `[...]`
+    // the `..` token is owned by the index-argument parser
+    // (<see cref="ParseIndexArgument"/>), so the general-expression range layer
+    // (<see cref="ParseRangeExpression"/>) must stand down there to keep the
+    // #1016/#1022 index-range/from-end behaviour byte-for-byte unchanged.
+    // Nested grouping contexts (parentheses, argument lists) save+clear the
+    // counter so a parenthesised or argument-position range (`a[(1..3)]`,
+    // `a[f(1..3)]`) is still recognised as a standalone `System.Range` value.
+    private int suppressRangeOperator;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="Parser"/> class.
     /// </summary>
@@ -6151,7 +6162,7 @@ public class Parser
             return new AssignmentExpressionSyntax(syntaxTree, identifierToken2, equalsToken, binary);
         }
 
-        var expression = ParseNullCoalescingExpression();
+        var expression = ParseRangeExpression();
 
         // Issue #507: indexer assignment whose target is an arbitrary expression
         // (e.g. `obj.Member[k] = v`, `a.b.c[k] = v`, `(GetThing())[i] = v`). The
@@ -6238,6 +6249,94 @@ public class Parser
         }
 
         return expression;
+    }
+
+    // Issue #1038: parse a standalone range expression `lo..hi` (and the open
+    // forms `..hi`, `lo..`, `..`) producing a `System.Range` value. The `..`
+    // operator binds looser than every binary operator, so `1+2..3+4` parses as
+    // `(1+2)..(3+4)`: each bound is a full null-coalescing expression. A from-end
+    // `^n` marker is recognised only in the *upper* bound (immediately after
+    // `..`), where it is unambiguous with one's-complement; a leading `^` at the
+    // very start keeps its one's-complement meaning and the binder rejects such a
+    // standalone lower bound with GS0410 (use `arr[^a..]` or parenthesise).
+    //
+    // While parsing an index bound the range layer is suppressed (see
+    // <see cref="suppressRangeOperator"/>) so `a[lo..hi]` / `a[^2..]` stay owned
+    // by <see cref="ParseIndexArgument"/>.
+    private ExpressionSyntax ParseRangeExpression()
+    {
+        if (suppressRangeOperator > 0)
+        {
+            return ParseNullCoalescingExpression();
+        }
+
+        ExpressionSyntax lower = null;
+        if (Current.Kind != SyntaxKind.DotDotToken)
+        {
+            lower = ParseNullCoalescingExpression();
+        }
+
+        if (Current.Kind != SyntaxKind.DotDotToken)
+        {
+            // No `..` follows — an ordinary expression (`lower` is non-null here
+            // because the open-lower `..` form is handled by the branch above).
+            return lower;
+        }
+
+        var dotDotToken = NextToken();
+
+        ExpressionSyntax upper = null;
+        if (RangeUpperBoundFollows(dotDotToken))
+        {
+            upper = ParseRangeUpperBound();
+        }
+
+        return new RangeExpressionSyntax(syntaxTree, lower, dotDotToken, upper);
+    }
+
+    // Issue #1038: decide whether an upper bound follows a standalone `lo..`. The
+    // open-ended form `lo..` ends at a closing delimiter, a separator, or a
+    // newline (G# treats a line break after `..` as terminating the open range,
+    // so `let r = 1..\nfoo()` is `1..` followed by a fresh statement rather than
+    // `1..foo()`).
+    private bool RangeUpperBoundFollows(SyntaxToken dotDotToken)
+    {
+        if (IsCurrentOnNewLineAfter(dotDotToken))
+        {
+            return false;
+        }
+
+        switch (Current.Kind)
+        {
+            case SyntaxKind.CloseParenthesisToken:
+            case SyntaxKind.CloseBraceToken:
+            case SyntaxKind.CloseSquareBracketToken:
+            case SyntaxKind.CommaToken:
+            case SyntaxKind.SemicolonToken:
+            case SyntaxKind.ColonToken:
+            case SyntaxKind.EqualsToken:
+            case SyntaxKind.EndOfFileToken:
+            case SyntaxKind.DotDotToken:
+                return false;
+            default:
+                return true;
+        }
+    }
+
+    // Issue #1038: parse the upper bound of a standalone range. A leading `^`
+    // here (immediately after `..`) is the from-end marker (`lo..^hi`, `..^3`),
+    // reusing the #1022 `FromEndIndexExpressionSyntax`; otherwise the bound is an
+    // ordinary null-coalescing expression.
+    private ExpressionSyntax ParseRangeUpperBound()
+    {
+        if (Current.Kind == SyntaxKind.HatToken)
+        {
+            var hatToken = NextToken();
+            var operand = ParseNullCoalescingExpression();
+            return new FromEndIndexExpressionSyntax(syntaxTree, hatToken, operand);
+        }
+
+        return ParseNullCoalescingExpression();
     }
 
     // Issue #941: `a ?? b` binary null-coalescing operator. Parsed as its own
@@ -6637,16 +6736,31 @@ public class Parser
     // scoped to this leading position: a `^` anywhere else (including inside the
     // offset expression itself, e.g. `a[^(x ^ y)]`) keeps its ordinary
     // one's-complement / bitwise-XOR meaning.
+    //
+    // Issue #1038: the bound is parsed with the standalone range layer
+    // suppressed, so the `..` between bounds (and the trailing `..` of `a[^2..]`)
+    // is owned by <see cref="ParseIndexArgument"/> rather than being absorbed
+    // into the bound's own expression. A parenthesised or argument-position
+    // range nested inside the bound re-enables the layer at its grouping
+    // boundary (`a[(1..3)]`).
     private ExpressionSyntax ParseIndexBound()
     {
-        if (Current.Kind == SyntaxKind.HatToken)
+        suppressRangeOperator++;
+        try
         {
-            var hatToken = NextToken();
-            var operand = ParseExpression();
-            return new FromEndIndexExpressionSyntax(syntaxTree, hatToken, operand);
-        }
+            if (Current.Kind == SyntaxKind.HatToken)
+            {
+                var hatToken = NextToken();
+                var operand = ParseExpression();
+                return new FromEndIndexExpressionSyntax(syntaxTree, hatToken, operand);
+            }
 
-        return ParseExpression();
+            return ParseExpression();
+        }
+        finally
+        {
+            suppressRangeOperator--;
+        }
     }
 
     // be reused as the LHS of an indexer assignment. Returns true and yields a
@@ -8177,6 +8291,11 @@ public class Parser
         // trailing object initializer.
         var savedSuppress = suppressTrailingObjectInitializer;
         suppressTrailingObjectInitializer = 0;
+
+        // Issue #1038: an argument list is a fresh context, so a standalone
+        // range argument (`f(1..3)`) is recognised even inside an index bound.
+        var savedRange = suppressRangeOperator;
+        suppressRangeOperator = 0;
         try
         {
             return ParseArgumentsCore();
@@ -8184,6 +8303,7 @@ public class Parser
         finally
         {
             suppressTrailingObjectInitializer = savedSuppress;
+            suppressRangeOperator = savedRange;
         }
     }
 
@@ -8690,6 +8810,12 @@ public class Parser
         ExpressionSyntax expression;
         var savedSuppress = suppressTrailingObjectInitializer;
         suppressTrailingObjectInitializer = 0;
+
+        // Issue #1038: a parenthesised expression is a fresh context, so a
+        // parenthesised range (`a[(1..3)]`) is recognised as a standalone
+        // `System.Range` value even inside an index bound.
+        var savedRange = suppressRangeOperator;
+        suppressRangeOperator = 0;
         try
         {
             expression = ParseExpression();
@@ -8697,6 +8823,7 @@ public class Parser
         finally
         {
             suppressTrailingObjectInitializer = savedSuppress;
+            suppressRangeOperator = savedRange;
         }
 
         // ADR-0061: `(cond ? lvalue : lvalue)` parses as a conditional ref-arg

--- a/test/Compiler.Tests/Emit/Issue1038StandaloneRangeEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1038StandaloneRangeEmitTests.cs
@@ -1,0 +1,330 @@
+// <copyright file="Issue1038StandaloneRangeEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1038: emit/execution coverage for the standalone range value
+/// (<c>let r = 1..3</c>) and its use as an index argument (<c>a[r]</c>). These
+/// tests compile and run emitted programs (with ilverify) and assert the printed
+/// results across arrays, <c>[]T</c> slices, strings, and span-like values, plus
+/// the from-end upper bound and the four open forms.
+/// </summary>
+public class Issue1038StandaloneRangeEmitTests
+{
+    [Fact]
+    public void RangeValue_SlicesArray_ClosedRange()
+    {
+        var source = """
+            package P
+            import System
+
+            let a = []int32{10, 20, 30, 40, 50}
+            let r = 1..3
+            let b = a[r]
+            Console.WriteLine(b.Length)
+            Console.WriteLine(b[0])
+            Console.WriteLine(b[1])
+            """;
+
+        Assert.Equal("2\n20\n30\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void RangeValue_SlicesArray_OpenLowerBound()
+    {
+        var source = """
+            package P
+            import System
+
+            let a = []int32{10, 20, 30, 40, 50}
+            let r = ..2
+            let b = a[r]
+            Console.WriteLine(b.Length)
+            Console.WriteLine(b[0])
+            Console.WriteLine(b[1])
+            """;
+
+        Assert.Equal("2\n10\n20\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void RangeValue_SlicesArray_OpenUpperBound()
+    {
+        var source = """
+            package P
+            import System
+
+            let a = []int32{10, 20, 30, 40, 50}
+            let r = 3..
+            let b = a[r]
+            Console.WriteLine(b.Length)
+            Console.WriteLine(b[0])
+            Console.WriteLine(b[1])
+            """;
+
+        Assert.Equal("2\n40\n50\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void RangeValue_SlicesArray_FullRange()
+    {
+        var source = """
+            package P
+            import System
+
+            let a = []int32{1, 2, 3, 4}
+            let r = ..
+            let b = a[r]
+            Console.WriteLine(b.Length)
+            Console.WriteLine(b[0])
+            Console.WriteLine(b[3])
+            """;
+
+        Assert.Equal("4\n1\n4\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void RangeValue_FromEndUpperBound_SlicesArray()
+    {
+        var source = """
+            package P
+            import System
+
+            let a = []int32{10, 20, 30, 40, 50}
+            let r = 1..^1
+            let b = a[r]
+            Console.WriteLine(b.Length)
+            Console.WriteLine(b[0])
+            Console.WriteLine(b[2])
+            """;
+
+        Assert.Equal("3\n20\n40\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void RangeValue_OpenLowerWithFromEndUpper_SlicesArray()
+    {
+        var source = """
+            package P
+            import System
+
+            let a = []int32{10, 20, 30, 40, 50}
+            let r = ..^2
+            let b = a[r]
+            Console.WriteLine(b.Length)
+            Console.WriteLine(b[0])
+            Console.WriteLine(b[2])
+            """;
+
+        Assert.Equal("3\n10\n30\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void RangeValue_SlicesString()
+    {
+        var source = """
+            package P
+            import System
+
+            let s = "hello world"
+            let r = 6..
+            Console.WriteLine(s[r])
+            """;
+
+        Assert.Equal("world\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void RangeValue_AdditivePrecedence()
+    {
+        // 1+1..2+2 == 2..4 -> {30, 40}.
+        var source = """
+            package P
+            import System
+
+            let a = []int32{10, 20, 30, 40, 50}
+            let r = 1+1..2+2
+            let b = a[r]
+            Console.WriteLine(b.Length)
+            Console.WriteLine(b[0])
+            Console.WriteLine(b[1])
+            """;
+
+        Assert.Equal("2\n30\n40\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void RangeValue_InlineParenthesized()
+    {
+        var source = """
+            package P
+            import System
+
+            let a = []int32{10, 20, 30, 40, 50}
+            let b = a[(1..3)]
+            Console.WriteLine(b.Length)
+            Console.WriteLine(b[0])
+            """;
+
+        Assert.Equal("2\n20\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void RangeValue_SlicesSpanLike_ArraySegment()
+    {
+        // ArraySegment<int> exposes Count + Slice(int, int): the span-like path.
+        var source = """
+            package P
+            import System
+
+            let a = []int32{10, 20, 30, 40, 50}
+            let seg = ArraySegment[int32](a)
+            let r = 1..4
+            let s = seg[r]
+            Console.WriteLine(s.Count)
+            Console.WriteLine(s[0])
+            Console.WriteLine(s[2])
+            """;
+
+        Assert.Equal("3\n20\n40\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void LeadingFromEndMarker_ReportsGs0410()
+    {
+        var source = """
+            package P
+            import System
+
+            let r = ^1..3
+            Console.WriteLine(0)
+            """;
+
+        var diagnostics = CompileExpectingFailure(source);
+        Assert.Contains("GS0410", diagnostics);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1038_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi);
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    private static string CompileExpectingFailure(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1038_neg_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            try
+            {
+                var compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+                Assert.NotEqual(0, compileExit);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            return compileOut.ToString() + compileErr.ToString();
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1038StandaloneRangeBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1038StandaloneRangeBindingTests.cs
@@ -1,0 +1,114 @@
+// <copyright file="Issue1038StandaloneRangeBindingTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1038: binder/interpreter coverage for the standalone range value
+/// (<c>let r = 1..3</c>) and its use as an index argument (<c>a[r]</c>). The
+/// four open forms bind to a constructed <c>System.Range</c>; indexing an array
+/// or string by a range value slices it. A leading <c>^</c> at the start of a
+/// standalone range reports GS0410.
+/// </summary>
+public class Issue1038StandaloneRangeBindingTests
+{
+    [Fact]
+    public void StandaloneRange_IsSystemRangeTyped()
+    {
+        var result = Evaluate("let r = 1..3\nr.GetType().FullName");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("System.Range", result.Value);
+    }
+
+    [Fact]
+    public void RangeValue_IndexesArray_ClosedRange()
+    {
+        var result = Evaluate("var xs = [5]int32{10, 20, 30, 40, 50}\nlet r = 1..3\nlet ys = xs[r]\nys[0] + ys[1]");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(50, result.Value);
+    }
+
+    [Fact]
+    public void RangeValue_IndexesArray_OpenLowerBound()
+    {
+        var result = Evaluate("var xs = [5]int32{10, 20, 30, 40, 50}\nlet r = ..2\nlet ys = xs[r]\nys[0] + ys[1]");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(30, result.Value);
+    }
+
+    [Fact]
+    public void RangeValue_IndexesArray_OpenUpperBound()
+    {
+        var result = Evaluate("var xs = [5]int32{10, 20, 30, 40, 50}\nlet r = 3..\nlet ys = xs[r]\nys[0] + ys[1]");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(90, result.Value);
+    }
+
+    [Fact]
+    public void RangeValue_IndexesArray_FullRange()
+    {
+        var result = Evaluate("var xs = [3]int32{7, 8, 9}\nlet r = ..\nlet ys = xs[r]\nys[0] + ys[1] + ys[2]");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(24, result.Value);
+    }
+
+    [Fact]
+    public void RangeValue_FromEndUpperBound_IndexesArray()
+    {
+        // xs[1..^1] keeps indices 1, 2, 3 (drops the last).
+        var result = Evaluate("var xs = [5]int32{10, 20, 30, 40, 50}\nlet r = 1..^1\nlet ys = xs[r]\nys.Length * 1000 + ys[0] + ys[2]");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal((3 * 1000) + 20 + 40, result.Value);
+    }
+
+    [Fact]
+    public void RangeValue_IndexesString()
+    {
+        var result = Evaluate("let s = \"hello world\"\nlet r = 0..5\ns[r]");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("hello", result.Value);
+    }
+
+    [Fact]
+    public void InlineParenthesizedRange_IndexesArray()
+    {
+        var result = Evaluate("var xs = [5]int32{10, 20, 30, 40, 50}\nlet ys = xs[(1..3)]\nys[0] + ys[1]");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(50, result.Value);
+    }
+
+    [Fact]
+    public void RangeBindsLooserThanAdditive()
+    {
+        // 1+1..2+2 == 2..4 -> xs[2..4] == {30, 40}.
+        var result = Evaluate("var xs = [5]int32{10, 20, 30, 40, 50}\nlet r = 1+1..2+2\nlet ys = xs[r]\nys.Length * 1000 + ys[0] + ys[1]");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal((2 * 1000) + 30 + 40, result.Value);
+    }
+
+    [Fact]
+    public void LeadingFromEndMarker_ReportsGs0410()
+    {
+        var diagnostics = GetDiagnostics("let r = ^1..3\nr");
+        Assert.Contains(diagnostics, d => d.Id == "GS0410");
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+
+    private static IEnumerable<Diagnostic> GetDiagnostics(string source)
+        => Evaluate(source).Diagnostics;
+}

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue1038StandaloneRangeParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue1038StandaloneRangeParserTests.cs
@@ -1,0 +1,175 @@
+// <copyright file="Issue1038StandaloneRangeParserTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Issue #1038: parser-level coverage for the standalone range expression
+/// <c>lo..hi</c> (and the open forms <c>..hi</c>, <c>lo..</c>, <c>..</c>) that
+/// produces a <c>System.Range</c> value outside of an index bracket. The <c>..</c>
+/// operator binds looser than every binary operator, so <c>1+2..3+4</c> parses as
+/// <c>(1+2)..(3+4)</c>; a from-end <c>^n</c> marker is recognised in the upper
+/// bound (<c>lo..^hi</c>).
+/// </summary>
+public class Issue1038StandaloneRangeParserTests
+{
+    private static RangeExpressionSyntax GetInitializerRange(string source)
+    {
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+        var stmt = tree.Root.Members
+            .OfType<GlobalStatementSyntax>()
+            .Select(g => g.Statement)
+            .OfType<VariableDeclarationSyntax>()
+            .Single();
+        return Assert.IsType<RangeExpressionSyntax>(stmt.Initializer);
+    }
+
+    [Fact]
+    public void Parses_StandaloneClosedRange()
+    {
+        var range = GetInitializerRange("""
+            package P
+            let r = 1..3
+            """);
+        Assert.NotNull(range.LowerBound);
+        Assert.NotNull(range.UpperBound);
+        Assert.Equal(SyntaxKind.DotDotToken, range.DotDotToken.Kind);
+    }
+
+    [Fact]
+    public void Parses_StandaloneOpenLowerBound()
+    {
+        var range = GetInitializerRange("""
+            package P
+            let r = ..3
+            """);
+        Assert.Null(range.LowerBound);
+        Assert.NotNull(range.UpperBound);
+    }
+
+    [Fact]
+    public void Parses_StandaloneOpenUpperBound()
+    {
+        var range = GetInitializerRange("""
+            package P
+            let r = 1..
+            """);
+        Assert.NotNull(range.LowerBound);
+        Assert.Null(range.UpperBound);
+    }
+
+    [Fact]
+    public void Parses_StandaloneFullyOpenRange()
+    {
+        var range = GetInitializerRange("""
+            package P
+            let r = ..
+            """);
+        Assert.Null(range.LowerBound);
+        Assert.Null(range.UpperBound);
+    }
+
+    [Fact]
+    public void RangeBindsLooserThanAdditive()
+    {
+        // `1+2..3+4` must parse as `(1+2)..(3+4)`: each bound is the whole
+        // additive expression, not just the adjacent operand.
+        var range = GetInitializerRange("""
+            package P
+            let r = 1+2..3+4
+            """);
+        Assert.IsType<BinaryExpressionSyntax>(range.LowerBound);
+        Assert.IsType<BinaryExpressionSyntax>(range.UpperBound);
+    }
+
+    [Fact]
+    public void Parses_FromEndUpperBound()
+    {
+        var range = GetInitializerRange("""
+            package P
+            let r = 1..^1
+            """);
+        Assert.NotNull(range.LowerBound);
+        Assert.IsType<FromEndIndexExpressionSyntax>(range.UpperBound);
+    }
+
+    [Fact]
+    public void Parses_FromEndUpperBound_OpenLower()
+    {
+        var range = GetInitializerRange("""
+            package P
+            let r = ..^2
+            """);
+        Assert.Null(range.LowerBound);
+        Assert.IsType<FromEndIndexExpressionSyntax>(range.UpperBound);
+    }
+
+    [Fact]
+    public void OpenUpperBound_StopsAtNewline()
+    {
+        // A line break after `..` terminates the open range rather than
+        // absorbing the next statement as the upper bound.
+        var tree = SyntaxTree.Parse("""
+            package P
+            let r = 1..
+            let s = 5
+            """);
+        Assert.Empty(tree.Diagnostics);
+        var decls = tree.Root.Members
+            .OfType<GlobalStatementSyntax>()
+            .Select(g => g.Statement)
+            .OfType<VariableDeclarationSyntax>()
+            .ToList();
+        Assert.Equal(2, decls.Count);
+        var range = Assert.IsType<RangeExpressionSyntax>(decls[0].Initializer);
+        Assert.NotNull(range.LowerBound);
+        Assert.Null(range.UpperBound);
+    }
+
+    [Fact]
+    public void IndexRange_StillParsesInsideBrackets()
+    {
+        // The index-bracket range path (#1016/#1022) is unchanged: `a[^2..]`
+        // is a RangeExpression whose lower bound is a from-end marker.
+        var tree = SyntaxTree.Parse("""
+            package P
+            let x = a[^2..]
+            """);
+        Assert.Empty(tree.Diagnostics);
+        var stmt = tree.Root.Members
+            .OfType<GlobalStatementSyntax>()
+            .Select(g => g.Statement)
+            .OfType<VariableDeclarationSyntax>()
+            .Single();
+        var index = Assert.IsType<IndexExpressionSyntax>(stmt.Initializer);
+        var range = Assert.IsType<RangeExpressionSyntax>(index.Index);
+        Assert.IsType<FromEndIndexExpressionSyntax>(range.LowerBound);
+        Assert.Null(range.UpperBound);
+    }
+
+    [Fact]
+    public void ParenthesizedRange_InsideIndexBracket()
+    {
+        // `a[(1..3)]` is an ordinary index whose argument is a parenthesised
+        // standalone range value (NOT a syntactic index-range).
+        var tree = SyntaxTree.Parse("""
+            package P
+            let x = a[(1..3)]
+            """);
+        Assert.Empty(tree.Diagnostics);
+        var stmt = tree.Root.Members
+            .OfType<GlobalStatementSyntax>()
+            .Select(g => g.Statement)
+            .OfType<VariableDeclarationSyntax>()
+            .Single();
+        var index = Assert.IsType<IndexExpressionSyntax>(stmt.Initializer);
+        var paren = Assert.IsType<ParenthesizedExpressionSyntax>(index.Index);
+        Assert.IsType<RangeExpressionSyntax>(paren.Expression);
+    }
+}

--- a/website/docs/ref/spec.md
+++ b/website/docs/ref/spec.md
@@ -59,7 +59,7 @@ Several words are contextual rather than reserved. `data`, `inline`, `prop`, `ev
 
 ### Operators and punctuation
 
-Compound assignment recognizes `+=`, `-=`, `*=`, `/=`, `%=`, `^=`, `&=`, `|=`, `&^=`, `<<=`, and `>>=`. The parser rewrites these as assignment with the corresponding binary operator. `++` and `--` are statement forms on identifiers. The null-coalescing compound assignment `??=` (ADR-0072) writes the right-hand side into the left only when the lvalue currently reads as nil; see [Null-coalescing compound assignment](#null-coalescing-compound-assignment--adr-0072) under *Statements*. The `..` range operator slices a sliceable value inside an indexer (`a[lo..hi]`), and a leading `^n` marks a from-end index (`a[^1]`, `a[1..^1]`); see [Range and slice expressions](#range-and-slice-expressions-issue-1016). `@` begins annotations on declarations.
+Compound assignment recognizes `+=`, `-=`, `*=`, `/=`, `%=`, `^=`, `&=`, `|=`, `&^=`, `<<=`, and `>>=`. The parser rewrites these as assignment with the corresponding binary operator. `++` and `--` are statement forms on identifiers. The null-coalescing compound assignment `??=` (ADR-0072) writes the right-hand side into the left only when the lvalue currently reads as nil; see [Null-coalescing compound assignment](#null-coalescing-compound-assignment--adr-0072) under *Statements*. The `..` range operator slices a sliceable value inside an indexer (`a[lo..hi]`) and also forms a standalone `System.Range` value (`let r = 1..3`; issue #1038), and a leading `^n` marks a from-end index (`a[^1]`, `a[1..^1]`); see [Range and slice expressions](#range-and-slice-expressions-issue-1016). `@` begins annotations on declarations.
 
 ### Integer literals
 
@@ -682,7 +682,7 @@ let c = xs[2..]    // open upper bound -> {30, 40, 50}
 let d = xs[..]     // full copy -> {10, 20, 30, 40, 50}
 ```
 
-The lower bound defaults to `0` and the upper bound defaults to the length of the target. Both bounds are `int32` offsets from the start; the result spans `[lower, upper)` (upper-exclusive), exactly like C#. The `..` operator is only recognized inside an index `[...]`; there is no standalone `System.Range`-producing expression yet.
+The lower bound defaults to `0` and the upper bound defaults to the length of the target. Both bounds are `int32` offsets from the start; the result spans `[lower, upper)` (upper-exclusive), exactly like C#. The same `..` operator also forms a **standalone `System.Range` value** outside an index (issue #1038, below).
 
 The binder resolves the target type to one of the following sliceable shapes and lowers the range to the corresponding BCL surface:
 
@@ -714,7 +714,25 @@ A bare `a[^n]` reads the single element `length - n` from an array/slice, a `str
 
 The `^n` marker is only recognized at the *start* of an index/range bound. Elsewhere — including inside the offset expression itself (e.g. `a[^(x ^ y)]`) — `^` keeps its ordinary prefix one's-complement and infix bitwise-XOR meanings unchanged. For example, `a[i ^ j]` is an XOR-computed single index, and `^5` outside brackets is one's-complement.
 
-Standalone `System.Range` values (`let r = 1..3`) are not yet supported and are tracked separately.
+#### Standalone range values (issue #1038)
+
+The `..` operator also forms a **standalone `System.Range` value** outside an index, in the general expression grammar:
+
+```gsharp
+let r = 1..3       // r : System.Range
+let s = a[r]       // index an array/slice/string/span by a Range value
+let full = ..      // Range.All
+let tail = 2..     // 2..end
+let head = ..^1    // start..^1 (drop the last)
+```
+
+All four open forms (`lo..hi`, `lo..`, `..hi`, `..`) are supported. A bound becomes a `System.Index`: a plain value `v` is `Index(v)` (from-start), a `^n` marker is `Index(n, fromEnd: true)`, an open lower defaults to the start, and an open upper defaults to the end. The value is constructed as `new System.Range(start, end)`, matching how C# lowers a range expression, and is typed `System.Range`.
+
+**Precedence.** The `..` operator binds *looser than every binary operator*, so each bound is a full expression: `1+2..3+4` parses as `(1+2)..(3+4)`. An open upper bound (`lo..`) ends at a closing delimiter, a separator, or a line break — so `let r = 1..` on its own line is the open range `1..end`, not a continuation onto the next statement.
+
+**Indexing by a range value.** A `System.Range`-typed value used as an index argument (`a[r]`, or the inline `a[(1..3)]`) slices the receiver using the *same* shapes as the syntactic `a[1..3]` form: arrays/slices copy via `Array.Copy`, `string` uses `Substring`, span-like values use `Slice`, and a `this[System.Range]` indexer is called with the value directly. The concrete `start`/`length` are resolved from the range value at runtime via `System.Index.GetOffset(length)`.
+
+**From-end restriction.** A from-end `^n` marker is allowed in the *upper* bound of a standalone range (`lo..^hi`, `..^hi`), where it is unambiguous because it follows `..`. A *leading* `^` at the very start of a standalone range is **not** allowed (`^a..b`), because it is genuinely ambiguous with the one's-complement unary operator (`^a` parses as `~a`); such a form reports `GS0410`. To slice from the end, index the value directly (`arr[^a..]`); to use a one's-complement value as a from-start lower bound, parenthesise it (`(^a)..b`).
 
 ### Composite literals
 
@@ -824,7 +842,8 @@ Assignment        = identifier "=" Assignment
                   | identifier "[" Expression "]" "=" Assignment
                   | identifier "." identifier "=" Assignment
                   | AccessorExpression ( "+=" | "-=" ) Assignment
-                  | BinaryExpression .
+                  | RangeExpression .
+RangeExpression   = BinaryExpression? ".." ( "^"? BinaryExpression )? | BinaryExpression .  (* standalone System.Range value, issue #1038; `..` binds looser than every binary operator, so `1+2..3+4` is `(1+2)..(3+4)`. A leading `^` is rejected (GS0410); a `^` upper bound is a from-end marker. Suppressed inside an index bound, where IndexArgument owns `..`. *)
 BinaryExpression  = PrefixExpression { BinaryOperator PrefixExpression } .
 PrefixExpression  = ( "+" | "-" | "!" | "^" | "*" | "&" | "<-" | "await" | "++" | "--" ) PrefixExpression | PostfixExpression .
 PostfixExpression = PrimaryExpression { "!!" } { ( "." | "?." ) NameOrCall | ( "[" | "?[" ) IndexArgument "]" } ( "++" | "--" )? ( "with" "{" FieldEqualsList? "}" )? .
@@ -1441,7 +1460,8 @@ Assignment        ::= identifier '=' Assignment
                     | '*' PrefixExpression '=' Assignment                (* indirect (pointer) assignment, ADR-0060 *)
                     | (identifier | PostfixExpression) ('+=' | '-=') Assignment   (* event subscribe / unsubscribe *)
                     | ConditionalExpression
-ConditionalExpression ::= NullCoalescingExpression ('?' Assignment ':' Assignment)?   (* ternary, ADR-0062 *)
+ConditionalExpression ::= RangeExpression ('?' Assignment ':' Assignment)?   (* ternary, ADR-0062 *)
+RangeExpression   ::= NullCoalescingExpression? '..' ('^'? NullCoalescingExpression)? | NullCoalescingExpression   (* standalone System.Range value, issue #1038; `..` binds looser than all binary operators. A leading '^' is rejected (GS0410); a '^' upper bound is a from-end marker. Suppressed inside an index bound (IndexArgument owns '..'); re-enabled inside parens/argument lists. *)
 NullCoalescingExpression ::= WithExpression ('??' NullCoalescingExpression)?  (* right-assoc null-coalescing, Issue #941 *)
 WithExpression    ::= BinaryExpression ('with' '{' FieldEqualsList? '}')*    (* non-destructive record update *)
 CompoundAssign    ::= '+=' | '-=' | '*=' | '/=' | '%=' | '^=' | '&=' | '|=' | '&^=' | '<<=' | '>>=' | '??='


### PR DESCRIPTION
Fixes #1038

Implements the standalone `System.Range`-producing expression end-to-end (parse, bind, emit, interpret) and allows a `System.Range`-typed value to be used as an index argument (`a[r]`), extending the index-bracket `..` range/slice operator from #1016/#1022.

## Chosen `..` precedence
`..` binds **looser than every binary operator**, so `1+2..3+4` parses as `(1+2)..(3+4)` (each bound is a full null-coalescing expression), matching the issue's stated requirement. A new `ParseRangeExpression` layer sits between the assignment/ternary tail and null-coalescing. An open upper bound (`lo..`) terminates at a closing delimiter, a separator, or a **line break**, so `let r = 1..` on its own line is the open range `1..end`, not a continuation onto the next statement.

## Standalone-`^` decision
A from-end `^n` marker is supported in the **upper** bound of a standalone range (`lo..^hi`, `..^hi`), where it is unambiguous because it follows `..`. A **leading** `^` at the very start of a standalone range (`^a..b`) is **rejected** with the new **GS0410** diagnostic, because it is genuinely ambiguous with the one's-complement unary operator (`^a` parses as `~a`). To slice from the end, index the value directly (`arr[^a..]`, the #1022 path); to use a one's-complement value as a from-start lower bound, parenthesise it (`(^a)..b`).

## What I implemented
- **Parse**: `ParseRangeExpression` for the four open forms (`lo..hi`, `lo..`, `..hi`, `..`). The standalone layer is suppressed (a `suppressRangeOperator` counter) while parsing an index bound so `a[lo..hi]` / `a[^2..]` stay owned by `ParseIndexArgument` — the #1016/#1022 index grammar is byte-for-byte unchanged. The counter is re-cleared inside parentheses and argument lists, so `a[(1..3)]` and `a[f(1..3)]` are recognised as range values.
- **Bind**: a standalone range binds to `new System.Range(start, end)` with each bound a `System.Index` (shared `BuildSystemRangeValue` helper, reused by the existing `this[System.Range]` indexer path). `let r = 1..3` gives `r : System.Range`.
- **`a[r]` indexing** over: arrays/slices (`[]T`, `[N]T`, CLR `T[]`) via `Array.Copy`, `string` via `Substring`, span-like values (`Length`/`Count` + `Slice`) e.g. `ArraySegment`, and any `this[System.Range]` type. `start`/`length` are resolved from the runtime range value via `System.Index.GetOffset(length)`.
- No new `SyntaxKind` or `BoundNodeKind` (reuses `RangeExpression` / `FromEndIndexExpression` and existing bound nodes).
- **Docs**: ADR-0127, `website/docs/ref/spec.md` (range section + both grammar appendices), `docs/diagnostics.md` (GS0410).

## How tested
- `dotnet build GSharp.sln -c Release`: succeeded.
- New tests (all pass): parser (`Issue1038StandaloneRangeParserTests`, 12), binder/interpreter (`Issue1038StandaloneRangeBindingTests`, 10), emit/execution (`Issue1038StandaloneRangeEmitTests`, 11) — covering the four forms, `lo..^hi`, additive precedence, inline `a[(1..3)]`, span-like `ArraySegment`, string slicing, and the GS0410 negative.
- Regression: full `Core.Tests` (3796 passed, 1 skipped) including the full Syntax suite and coverage-matrix golden; `Issue1016`/`Issue1022` Core (30) and emit (18); indexer/map/pointer/slice/array emit batches (70 + 39 + 43); `LanguageConformance` + `Acceptance` (122). No regressions.

## Deferred work
None.
