### PR TITLE
Fixes #1085: bind base-initializer arguments after explicit constructors are populated

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -719,6 +719,14 @@ public sealed class Binder
             binder.declarations.BindStructDeclarationBody(structSyntax, owningPackage, structSymbol);
         }
 
+        // Issue #1085: now that every type body is bound and every type's explicit
+        // constructors are populated, bind the deferred base-constructor-initializer
+        // (`: base(...)`) argument lists. Argument expressions may construct other
+        // user types whose constructors only exist after their (possibly later)
+        // source file was bound; deferring this resolution makes base-initializer
+        // argument binding independent of source-file order.
+        binder.declarations.BindPendingBaseInitializers();
+
         // Issue #973: now that every class shell has had its base clause bound
         // and its base class installed, screen the resolved base relation for
         // transitive inheritance cycles (e.g. `class B : C` / `class C : B`).

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -83,6 +83,19 @@ internal sealed class DeclarationBinder
     private readonly List<(StructDeclarationSyntax Syntax, StructSymbol Symbol)> pendingAbstractImplementationChecks
         = new List<(StructDeclarationSyntax, StructSymbol)>();
 
+    // Issue #1085: base-constructor-initializer (`: base(...)`) argument binding
+    // is deferred until every declared type's explicit constructors have been
+    // populated. The argument expressions may construct OTHER user types (e.g.
+    // `: base(H(1))`), and resolving such a constructor call requires the
+    // referenced type's ExplicitConstructor(s) to already exist. Because type
+    // bodies are bound one file at a time, a base-initializer in a file processed
+    // before the constructed type's file would otherwise resolve against an
+    // empty (not-yet-populated) constructor shell and wrongly report GS0144.
+    // Method bodies already see fully-populated constructors because they are
+    // bound in a later phase; deferring base-initializer argument binding to a
+    // post-pass gives it the same guarantee, regardless of source-file order.
+    private readonly List<Action> pendingBaseInitializerBindings = new List<Action>();
+
     // Issue #1069: nested struct/class and interface type-name shells declared in
     // phase 1 (DeclareNestedTypeShells) so a sibling member signature can
     // forward-reference a nested type by name. The recorded shells are reused in
@@ -2888,6 +2901,20 @@ internal sealed class DeclarationBinder
     /// bound so the base-class method sets are complete. An <c>open</c> class may
     /// leave inherited abstract members unimplemented (it stays abstract itself).
     /// </summary>
+    // Issue #1085: run all deferred base-constructor-initializer bindings. Must
+    // be called after every declared type body has been bound (so all explicit
+    // constructors exist) and before lowering/emit consume the resolved
+    // initializers.
+    internal void BindPendingBaseInitializers()
+    {
+        foreach (var bind in pendingBaseInitializerBindings)
+        {
+            bind();
+        }
+
+        pendingBaseInitializerBindings.Clear();
+    }
+
     internal void VerifyAbstractMethodImplementations()
     {
         foreach (var (syntax, structSymbol) in pendingAbstractImplementationChecks)
@@ -6138,6 +6165,31 @@ internal sealed class DeclarationBinder
             return;
         }
 
+        // Issue #1085: defer the actual argument binding and base-constructor
+        // resolution until all declared types' explicit constructors exist.
+        var capturedScope = scope;
+        pendingBaseInitializerBindings.Add(() =>
+        {
+            var outerScope = scope;
+            scope = capturedScope;
+            try
+            {
+                BindBaseConstructorInitializerCore(syntax, structSymbol, baseClassSymbol, importedBaseType, primaryCtorParameters);
+            }
+            finally
+            {
+                scope = outerScope;
+            }
+        });
+    }
+
+    private void BindBaseConstructorInitializerCore(
+        StructDeclarationSyntax syntax,
+        StructSymbol structSymbol,
+        StructSymbol baseClassSymbol,
+        TypeSymbol importedBaseType,
+        ImmutableArray<ParameterSymbol> primaryCtorParameters)
+    {
         var location = syntax.BaseConstructorOpenParenthesisToken.Location;
 
         if (baseClassSymbol == null && importedBaseType == null)
@@ -6555,7 +6607,10 @@ internal sealed class DeclarationBinder
             }
 
             // ADR-0065 §2: enforce constraints on convenience initializers.
-            if (ctor.IsConvenience && ctor.BaseInitializer != null)
+            // Issue #1085: base-initializer resolution is deferred, so detect the
+            // `: base(...)` presence from syntax rather than the (not-yet-set)
+            // resolved BaseInitializer symbol.
+            if (ctor.IsConvenience && ctorSyntax.HasBaseInitializer)
             {
                 Diagnostics.ReportConvenienceInitMayNotCallBase(ctorSyntax.BaseKeyword.Location, structSymbol.Name);
             }
@@ -6749,48 +6804,78 @@ internal sealed class DeclarationBinder
 
         // Resolve the optional `: base(args)` initializer, with the constructor
         // parameters in scope so they can be forwarded to the base.
+        //
+        // Issue #1085: the argument expressions may construct other user types
+        // whose explicit constructors are not yet populated when this type body
+        // is bound (the constructed type may live in a source file processed
+        // later). Defer the argument binding and base-constructor resolution to
+        // a post-pass that runs after every declared type's constructors exist.
         if (ctorSyntax.HasBaseInitializer)
         {
-            var location = ctorSyntax.BaseKeyword.Location;
-
-            var savedScope = scope;
-            scope = new BoundScope(savedScope);
-            foreach (var p in ctorFunction.Parameters)
+            var capturedScope = scope;
+            pendingBaseInitializerBindings.Add(() =>
             {
-                scope.TryDeclareVariable(p);
-            }
-
-            var boundArguments = ImmutableArray.CreateBuilder<BoundExpression>(ctorSyntax.BaseArguments.Count);
-            for (var i = 0; i < ctorSyntax.BaseArguments.Count; i++)
-            {
-                boundArguments.Add(bindExpression(ctorSyntax.BaseArguments[i]));
-            }
-
-            scope = savedScope;
-
-            if (baseClassSymbol == null && importedBaseType == null)
-            {
-                Diagnostics.ReportBaseConstructorArgumentsWithoutBase(location);
-            }
-            else if (importedBaseType?.ClrType is System.Type clrBase)
-            {
-                var init = ResolveClrBaseConstructor(i => ctorSyntax.BaseArguments[i].Location, clrBase, boundArguments, location);
-                if (init != null)
+                var outerScope = scope;
+                scope = capturedScope;
+                try
                 {
-                    constructorSymbol.SetBaseInitializer(init);
+                    BindConstructorBaseInitializerCore(ctorSyntax, constructorSymbol, ctorFunction, structSymbol, baseClassSymbol, importedBaseType);
                 }
-            }
-            else
-            {
-                var init = ResolveGSharpBaseConstructor(i => ctorSyntax.BaseArguments[i].Location, structSymbol.Name, baseClassSymbol, boundArguments, location);
-                if (init != null)
+                finally
                 {
-                    constructorSymbol.SetBaseInitializer(init);
+                    scope = outerScope;
                 }
-            }
+            });
         }
 
         return constructorSymbol;
+    }
+
+    private void BindConstructorBaseInitializerCore(
+        ConstructorDeclarationSyntax ctorSyntax,
+        ConstructorSymbol constructorSymbol,
+        FunctionSymbol ctorFunction,
+        StructSymbol structSymbol,
+        StructSymbol baseClassSymbol,
+        TypeSymbol importedBaseType)
+    {
+        var location = ctorSyntax.BaseKeyword.Location;
+
+        var savedScope = scope;
+        scope = new BoundScope(savedScope);
+        foreach (var p in ctorFunction.Parameters)
+        {
+            scope.TryDeclareVariable(p);
+        }
+
+        var boundArguments = ImmutableArray.CreateBuilder<BoundExpression>(ctorSyntax.BaseArguments.Count);
+        for (var i = 0; i < ctorSyntax.BaseArguments.Count; i++)
+        {
+            boundArguments.Add(bindExpression(ctorSyntax.BaseArguments[i]));
+        }
+
+        scope = savedScope;
+
+        if (baseClassSymbol == null && importedBaseType == null)
+        {
+            Diagnostics.ReportBaseConstructorArgumentsWithoutBase(location);
+        }
+        else if (importedBaseType?.ClrType is System.Type clrBase)
+        {
+            var init = ResolveClrBaseConstructor(i => ctorSyntax.BaseArguments[i].Location, clrBase, boundArguments, location);
+            if (init != null)
+            {
+                constructorSymbol.SetBaseInitializer(init);
+            }
+        }
+        else
+        {
+            var init = ResolveGSharpBaseConstructor(i => ctorSyntax.BaseArguments[i].Location, structSymbol.Name, baseClassSymbol, boundArguments, location);
+            if (init != null)
+            {
+                constructorSymbol.SetBaseInitializer(init);
+            }
+        }
     }
 
     /// <summary>

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1085BaseInitializerOrderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1085BaseInitializerOrderTests.cs
@@ -1,0 +1,104 @@
+// <copyright file="Issue1085BaseInitializerOrderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1085: constructing a class that declares an explicit <c>init(...)</c>
+/// inside a base-initializer (<c>: base(...)</c>) must bind correctly regardless
+/// of the order in which the source files are processed. The base-initializer
+/// argument expressions are bound in a deferred pass that runs after every
+/// declared type's explicit constructors are populated, so a constructed type
+/// declared in a file processed AFTER the caller no longer resolves against an
+/// empty constructor shell (which previously produced a spurious GS0144).
+/// </summary>
+public class Issue1085BaseInitializerOrderTests
+{
+    private const string CallerFile = """
+        package p
+        open class Base(h H, x int32) { }
+        class Derived : Base {
+            init() : base(H(1), 0) { }
+        }
+        """;
+
+    private const string DefinitionFile = """
+        package p
+        class H {
+            init(v int32) { }
+        }
+        """;
+
+    [Fact]
+    public void BaseInitializerArgument_ConstructsTypeFromLaterFile_CompilesCleanly()
+    {
+        // Caller file FIRST — the constructed type `H` is declared in a file
+        // processed afterwards. This is the failing order from #1085.
+        var scope = BindSources(CallerFile, DefinitionFile);
+
+        Assert.Empty(scope.Diagnostics);
+    }
+
+    [Fact]
+    public void BaseInitializerArgument_DefinitionFileFirst_StillCompilesCleanly()
+    {
+        // The already-working order must keep working.
+        var scope = BindSources(DefinitionFile, CallerFile);
+
+        Assert.Empty(scope.Diagnostics);
+    }
+
+    [Fact]
+    public void BaseInitializerArgument_ConstructedTypeHasMultipleOverloads_CompilesCleanly()
+    {
+        var definitionWithOverloads = """
+            package p
+            class H {
+                init(v int32) { }
+                init(v int32, w int32) { }
+            }
+            """;
+
+        var scope = BindSources(CallerFile, definitionWithOverloads);
+
+        Assert.Empty(scope.Diagnostics);
+    }
+
+    [Fact]
+    public void BaseInitializerArgument_AcrossPackages_CallerFirst_CompilesCleanly()
+    {
+        var caller = """
+            package p
+            import q
+            open class Base(h H, x int32) { }
+            class Derived : Base {
+                init() : base(H(1), 0) { }
+            }
+            """;
+
+        var definition = """
+            package q
+            class H {
+                init(v int32) { }
+            }
+            """;
+
+        var scope = BindSources(caller, definition);
+
+        Assert.Empty(scope.Diagnostics);
+    }
+
+    private static BoundGlobalScope BindSources(params string[] sources)
+    {
+        var trees = ImmutableArray.CreateRange(
+            System.Linq.Enumerable.Select(sources, s => SyntaxTree.Parse(SourceText.From(s))));
+        return Binder.BindGlobalScope(previous: null, trees);
+    }
+}


### PR DESCRIPTION
Fixes #1085

## Problem
Constructing a class that declares an explicit `init(...)` inside a base-initializer (`: base(...)`) failed with a spurious `GS0144` when the constructed type was defined in a source file processed **after** the caller's file. The same construction in a method body always bound correctly — only base-initializer argument binding was order-sensitive.

## Root cause
Base-constructor-initializer argument expressions (both the class-level primary `: Base(...)` in `BindBaseConstructorInitializer` and the per-constructor `init() : base(...)` in `BindSingleConstructorDeclaration`) were bound during the per-type body pass, which processes one source file at a time. When an argument constructs another user type (e.g. `H(1)`), `OverloadResolver.BindConstructorCallExpression` dispatches to the explicit-constructor path only when `classType.ExplicitConstructor != null`. For a type declared in a later file, `ExplicitConstructor` was still null, so resolution fell back to the empty primary-constructor shell (0 params) and reported `GS0144`.

## Fix
Defer base-initializer argument binding (and the base-constructor resolution it triggers) to a post-pass (`BindPendingBaseInitializers`) that runs after every declared type's explicit constructors are populated — i.e. the same guarantee method bodies already have. Base-subobject constructor resolution is unchanged; only the timing of argument binding moves. The convenience-init `: base(...)` constraint now reads `ctorSyntax.HasBaseInitializer` from syntax (the resolved symbol is no longer set at that point).

## Verification
- Minimal repro compiles in **both** file orders (caller-first and definition-first).
- Cross-package variant (caller `import`s the definition's package) compiles caller-first.
- Constructed type with multiple `init` overloads compiles caller-first.
- Method-body control (`return H(1)`) still compiles caller-first.
- New `Issue1085BaseInitializerOrderTests` (4 facts) pass.
- Full `Core.Tests` suite green: 3780 passed, 1 skipped.

Pure binding/phase-ordering change — no new SyntaxKind/BoundNodeKind.