### PR TITLE
Fixes #1087: resolve explicit base ctor on a generic base class

### DIFF
--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -6410,7 +6410,10 @@ internal sealed class DeclarationBinder
         // overload by argument types, mirroring C# where a derived constructor
         // may chain to any accessible base constructor. The primary-only fast
         // path below covers classes that declare no explicit init bodies.
-        if (!baseClassSymbol.ExplicitConstructors.IsDefaultOrEmpty)
+        // Issue #1087: a constructed generic base (e.g. `Base[int32]`) does not
+        // carry its own explicit-constructor table — consult the open
+        // definition's via EffectiveExplicitConstructors.
+        if (!baseClassSymbol.EffectiveExplicitConstructors.IsDefaultOrEmpty)
         {
             return ResolveGSharpExplicitBaseConstructor(argLocation, baseClassSymbol, boundArguments, location);
         }
@@ -6458,6 +6461,7 @@ internal sealed class DeclarationBinder
         TextLocation location)
     {
         ConstructorSymbol best = null;
+        ImmutableArray<TypeSymbol> bestParamTypes = default;
         var bestExactMatches = -1;
         var ambiguous = false;
         var anyArgIsError = false;
@@ -6470,20 +6474,25 @@ internal sealed class DeclarationBinder
             }
         }
 
-        foreach (var candidate in baseClassSymbol.ExplicitConstructors)
+        // Issue #1087: iterate the effective explicit-constructor set (the open
+        // definition's, for a constructed generic base) and compare against each
+        // candidate's type-argument-substituted parameter signature so that a
+        // generic base ctor such as `init(a T)` matches `: base(value)` on a
+        // constructed `Base[int32]`.
+        foreach (var candidate in baseClassSymbol.EffectiveExplicitConstructors)
         {
-            var parameters = candidate.Parameters;
-            if (parameters.Length != boundArguments.Count)
+            var paramTypes = baseClassSymbol.GetConstructorParameterTypesForConstruction(candidate);
+            if (paramTypes.Length != boundArguments.Count)
             {
                 continue;
             }
 
             var applicable = true;
             var exactMatches = 0;
-            for (var i = 0; i < parameters.Length; i++)
+            for (var i = 0; i < paramTypes.Length; i++)
             {
                 var argType = boundArguments[i].Type;
-                var paramType = parameters[i].Type;
+                var paramType = paramTypes[i];
                 if (argType == paramType)
                 {
                     exactMatches++;
@@ -6512,6 +6521,7 @@ internal sealed class DeclarationBinder
             if (exactMatches > bestExactMatches)
             {
                 best = candidate;
+                bestParamTypes = paramTypes;
                 bestExactMatches = exactMatches;
                 ambiguous = false;
             }
@@ -6533,11 +6543,10 @@ internal sealed class DeclarationBinder
             return null;
         }
 
-        var bestParams = best.Parameters;
         var convertedArgs = ImmutableArray.CreateBuilder<BoundExpression>(boundArguments.Count);
         for (var i = 0; i < boundArguments.Count; i++)
         {
-            convertedArgs.Add(conversions.BindConversion(argLocation(i), boundArguments[i], bestParams[i].Type));
+            convertedArgs.Add(conversions.BindConversion(argLocation(i), boundArguments[i], bestParamTypes[i]));
         }
 
         return new BaseConstructorInitializer(convertedArgs.ToImmutable(), baseClassSymbol, best);

--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -359,6 +359,24 @@ public sealed class StructSymbol : TypeSymbol
     public ImmutableArray<ConstructorSymbol> ExplicitConstructors { get; private set; } = ImmutableArray<ConstructorSymbol>.Empty;
 
     /// <summary>
+    /// Gets the explicit <c>init(...)</c> constructors visible on
+    /// this symbol, looking through to the generic definition for a constructed
+    /// (closed) generic type (issue #1087). A constructed <see cref="StructSymbol"/> produced
+    /// by <see cref="CreateConstructed"/> does not carry its own explicit
+    /// constructor table (those are populated on the open definition after the
+    /// constructed shell already exists), so base-constructor resolution against
+    /// a constructed generic base must consult the definition's table. The
+    /// returned <see cref="ConstructorSymbol"/> instances are the definition's,
+    /// which is exactly what the emitter keys its constructor handles by; use
+    /// <see cref="GetConstructorParameterTypesForConstruction"/> to obtain the
+    /// type-argument-substituted parameter signatures for overload matching.
+    /// </summary>
+    public ImmutableArray<ConstructorSymbol> EffectiveExplicitConstructors =>
+        !ExplicitConstructors.IsDefaultOrEmpty || Definition == null
+            ? ExplicitConstructors
+            : Definition.ExplicitConstructors;
+
+    /// <summary>
     /// Gets the user-declared <c>deinit { … }</c> destructor on this class
     /// (ADR-0068 / issue #698), or <c>null</c> when the class has none.
     /// Populated by the binder; consumed by the emitter to materialise the
@@ -996,6 +1014,52 @@ public sealed class StructSymbol : TypeSymbol
 
         var key = BuildArgsKey(typeArguments);
         return ConstructedCache.GetOrAdd((definition, key), _ => CreateConstructed(definition, typeArguments));
+    }
+
+    /// <summary>
+    /// Issue #1087: gets the parameter types of <paramref name="constructor"/>
+    /// as observed on this (possibly constructed) symbol. For a constructed
+    /// closed generic type, the open-definition constructor's parameter types
+    /// have this symbol's type arguments substituted for the definition's type
+    /// parameters (e.g. <c>init(a T)</c> on <c>Base[T]</c> surfaces as
+    /// <c>init(a int32)</c> on <c>Base[int32]</c>); for a non-generic or open
+    /// symbol the declared parameter types are returned unchanged.
+    /// </summary>
+    /// <param name="constructor">A constructor drawn from <see cref="EffectiveExplicitConstructors"/>.</param>
+    /// <returns>The (substituted, when constructed) parameter types in declaration order.</returns>
+    public ImmutableArray<TypeSymbol> GetConstructorParameterTypesForConstruction(ConstructorSymbol constructor)
+    {
+        var parameters = constructor.Parameters;
+        if (Definition == null
+            || TypeArguments.IsDefaultOrEmpty
+            || Definition.TypeParameters.IsDefaultOrEmpty
+            || parameters.IsDefaultOrEmpty)
+        {
+            var asTypes = ImmutableArray.CreateBuilder<TypeSymbol>(parameters.IsDefaultOrEmpty ? 0 : parameters.Length);
+            if (!parameters.IsDefaultOrEmpty)
+            {
+                foreach (var p in parameters)
+                {
+                    asTypes.Add(p.Type);
+                }
+            }
+
+            return asTypes.ToImmutable();
+        }
+
+        var subst = new Dictionary<TypeParameterSymbol, TypeSymbol>(Definition.TypeParameters.Length);
+        for (var i = 0; i < Definition.TypeParameters.Length && i < TypeArguments.Length; i++)
+        {
+            subst[Definition.TypeParameters[i]] = TypeArguments[i];
+        }
+
+        var builder = ImmutableArray.CreateBuilder<TypeSymbol>(parameters.Length);
+        foreach (var p in parameters)
+        {
+            builder.Add(SubstituteTypeForConstruction(p.Type, subst));
+        }
+
+        return builder.MoveToImmutable();
     }
 
     /// <summary>

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1087GenericBaseCtorTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1087GenericBaseCtorTests.cs
@@ -1,0 +1,155 @@
+// <copyright file="Issue1087GenericBaseCtorTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1087: a derived class's base-initializer (<c>: base(...)</c>) must be
+/// able to resolve an explicit <c>init(...)</c> constructor declared on a
+/// GENERIC base class. A constructed (closed) generic base symbol does not carry
+/// its own explicit-constructor table — those live on the open definition — so
+/// resolution must look through to the definition and substitute the type
+/// arguments into each candidate constructor's parameter signature. Before the
+/// fix the constructed base fell back to its (empty) primary-constructor set and
+/// reported a spurious GS0214.
+/// </summary>
+public class Issue1087GenericBaseCtorTests
+{
+    [Fact]
+    public void BaseInitializer_GenericBaseExplicitCtor_CompilesCleanly()
+    {
+        // The minimal #1087 repro: explicit init on a generic base, resolved
+        // through a closed `Base[int32]`.
+        var source = """
+            package p
+            open class Base[T] {
+                init(a int32) { }
+            }
+            class Deriv : Base[int32] {
+                init() : base(1) { }
+            }
+            """;
+
+        var scope = BindSources(source);
+
+        Assert.Empty(scope.Diagnostics);
+    }
+
+    [Fact]
+    public void BaseInitializer_NonGenericBaseExplicitCtor_StillCompilesCleanly()
+    {
+        // Control: the identical shape with a NON-generic base must keep working.
+        var source = """
+            package p
+            open class Base {
+                init(a int32) { }
+            }
+            class Deriv : Base {
+                init() : base(1) { }
+            }
+            """;
+
+        var scope = BindSources(source);
+
+        Assert.Empty(scope.Diagnostics);
+    }
+
+    [Fact]
+    public void BaseInitializer_GenericDerivedForwardsTypeArgument_CompilesCleanly()
+    {
+        // The derived type is itself generic and forwards its type argument to
+        // the generic base (`Deriv[U] : Base[U]`).
+        var source = """
+            package p
+            open class Base[T] {
+                init(a int32) { }
+            }
+            class Deriv[U] : Base[U] {
+                init() : base(1) { }
+            }
+            """;
+
+        var scope = BindSources(source);
+
+        Assert.Empty(scope.Diagnostics);
+    }
+
+    [Fact]
+    public void BaseInitializer_GenericBaseCtorUsesTypeParameter_SubstitutesAndCompiles()
+    {
+        // The base ctor parameter is the type parameter itself: `init(a T)` on
+        // `Base[T]` must surface as `init(a int32)` on `Base[int32]`, so the
+        // int32 argument matches after substitution.
+        var source = """
+            package p
+            open class Base[T] {
+                init(a T) { }
+            }
+            class Deriv : Base[int32] {
+                init() : base(7) { }
+            }
+            """;
+
+        var scope = BindSources(source);
+
+        Assert.Empty(scope.Diagnostics);
+    }
+
+    [Fact]
+    public void BaseInitializer_IntermediateGenericBaseInChain_CompilesCleanly()
+    {
+        // An intermediate generic base class in the inheritance chain, plus a
+        // base ctor whose parameter is the type parameter.
+        var source = """
+            package p
+            open class A[T] {
+                init(a T) { }
+            }
+            open class B[T] : A[T] {
+                init(b T) : base(b) { }
+            }
+            class C : B[int32] {
+                init() : base(3) { }
+            }
+            """;
+
+        var scope = BindSources(source);
+
+        Assert.Empty(scope.Diagnostics);
+    }
+
+    [Fact]
+    public void BaseInitializer_GenericBaseWrongArgumentCount_ReportsGs0214()
+    {
+        // Negative case: a wrong argument count against a generic base must
+        // still report GS0214 (no accessible base constructor).
+        var source = """
+            package p
+            open class Base[T] {
+                init(a int32) { }
+            }
+            class Deriv : Base[int32] {
+                init() : base(1, 2) { }
+            }
+            """;
+
+        var scope = BindSources(source);
+
+        Assert.Contains(scope.Diagnostics, d => d.Id == "GS0214");
+    }
+
+    private static BoundGlobalScope BindSources(params string[] sources)
+    {
+        var trees = ImmutableArray.CreateRange(
+            sources.Select(s => SyntaxTree.Parse(SourceText.From(s))));
+        return Binder.BindGlobalScope(previous: null, trees);
+    }
+}


### PR DESCRIPTION
Fixes #1087

## Root cause
A derived class's `: base(...)` initializer could not resolve an explicit `init(...)` constructor declared on a **generic** base class, reporting a spurious `GS0214` ("Class 'Base' has no accessible constructor that takes N argument(s)"). The same shape with a non-generic base compiled fine.

Base-constructor resolution consulted `StructSymbol.ExplicitConstructors` on the **constructed** (closed) generic base symbol (e.g. `Base[int32]`). `StructSymbol.CreateConstructed` does not carry the explicit-constructor table onto the constructed shell — those constructors are populated on the open definition only *after* the constructed symbol already exists — so the table was empty. Resolution then fell back to the primary/empty constructor set and reported `GS0214`.

## Fix (pure binding/symbol logic)
- `StructSymbol.EffectiveExplicitConstructors` — looks through a constructed symbol to its definition's explicit-constructor table.
- `StructSymbol.GetConstructorParameterTypesForConstruction` — returns a candidate ctor's parameter types with the constructed type's type arguments substituted for the definition's type parameters (so `init(a T)` on `Base[T]` matches as `init(a int32)` on `Base[int32]`).
- `DeclarationBinder.ResolveGSharpBaseConstructor` / `ResolveGSharpExplicitBaseConstructor` now use the effective constructor set and substituted parameter signatures for overload matching and argument conversion. The resolved `ConstructorSymbol` remains the **definition's**, which is what the emitter keys its constructor handles by (type-erased generics already alias the constructed type to the definition's rows, so emit needs no change — verified below).

No new `SyntaxKind`/`BoundNodeKind` introduced.

## Regression coverage
`test/Core.Tests/CodeAnalysis/Binding/Issue1087GenericBaseCtorTests.cs`:
- generic-base repro compiles
- non-generic control still compiles
- generic-derived forwarding type arg (`Deriv[U] : Base[U]`)
- base ctor parameter is the type parameter (`init(a T)`) — substitution
- intermediate generic base in the chain
- negative wrong-arg-count still reports `GS0214`

## Verification
- Minimal repro now compiles via `gsc` (no `GS0214`); non-generic control still compiles; generic-derived, type-parameter-ctor, and intermediate-generic-base variants all emit a `.dll`. Wrong-arg-count case still reports `GS0214`.
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release`: **3806 passed, 1 skipped, 0 failed**.
- New `Issue1087` tests: 6 passed.

Nothing deferred.
