### PR TITLE
Fixes #1088: compare symbolic type args for constructed-generic identity

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -203,25 +203,20 @@ public sealed class Conversion
         // parameter type and the `List[T]` declared return type) are distinct
         // symbol instances but denote the same type. Treat them as identity so
         // `return items` inside a generic function binds.
-        if (from is ImportedTypeSymbol fromGeneric && fromGeneric.HasTypeParameterArgument
-            && to is ImportedTypeSymbol toGeneric && toGeneric.HasTypeParameterArgument
-            && ReferenceEquals(fromGeneric.OpenDefinition, toGeneric.OpenDefinition)
-            && fromGeneric.TypeArguments.Length == toGeneric.TypeArguments.Length)
+        // Issue #1088 extends this to the same-compilation user-type-argument
+        // case (e.g. `Channel[BufferEntry]`), where one side's `ClrType` erases
+        // to `Channel`1[object]` (or is null entirely) while both carry the
+        // same symbolic argument. Comparing the SYMBOLIC type arguments — rather
+        // than the erased `ClrType` — lets `let ch Channel[BufferEntry] = ...`
+        // bind even though `BufferEntry` has a null `ClrType` during binding.
+        if (from is ImportedTypeSymbol fromGeneric
+            && to is ImportedTypeSymbol toGeneric
+            && fromGeneric.OpenDefinition != null
+            && toGeneric.OpenDefinition != null
+            && (fromGeneric.HasSubstitutableTypeArgument || toGeneric.HasSubstitutableTypeArgument)
+            && AreConstructedGenericsIdentical(fromGeneric, toGeneric))
         {
-            var equivalent = true;
-            for (var i = 0; i < fromGeneric.TypeArguments.Length; i++)
-            {
-                if (!ReferenceEquals(fromGeneric.TypeArguments[i], toGeneric.TypeArguments[i]))
-                {
-                    equivalent = false;
-                    break;
-                }
-            }
-
-            if (equivalent)
-            {
-                return Conversion.Identity;
-            }
+            return Conversion.Identity;
         }
 
         // Phase 3.C.1 / ADR-0001: T → T? is an implicit widening; T? → T?
@@ -554,6 +549,85 @@ public sealed class Conversion
         }
 
         return Conversion.None;
+    }
+
+    /// <summary>
+    /// Issue #1088: determines whether two constructed generic
+    /// <see cref="ImportedTypeSymbol"/> instances denote the same closed type
+    /// by comparing their open definitions and SYMBOLIC type arguments, rather
+    /// than their (possibly erased) <see cref="TypeSymbol.ClrType"/>. A
+    /// same-compilation user type used as a CLR generic argument has a
+    /// <see langword="null"/> <c>ClrType</c> and erases to <c>object</c> on the
+    /// closed shape, so a purely CLR-based comparison spuriously fails for
+    /// otherwise identical instantiations (e.g. the declared variable type
+    /// <c>Channel[BufferEntry]</c> vs. a factory method's return type).
+    /// </summary>
+    private static bool AreConstructedGenericsIdentical(ImportedTypeSymbol from, ImportedTypeSymbol to)
+    {
+        if (!ClrTypeUtilities.IsSameAs(from.OpenDefinition, to.OpenDefinition))
+        {
+            return false;
+        }
+
+        if (from.TypeArguments.IsDefaultOrEmpty || to.TypeArguments.IsDefaultOrEmpty
+            || from.TypeArguments.Length != to.TypeArguments.Length)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < from.TypeArguments.Length; i++)
+        {
+            if (!AreTypeArgumentsEquivalent(from.TypeArguments[i], to.TypeArguments[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Issue #1088: compares two symbolic generic type arguments for identity,
+    /// recovering same-compilation user types whose <see cref="TypeSymbol.ClrType"/>
+    /// has erased to <c>object</c> (or is <see langword="null"/>). Same-compilation
+    /// symbols are reference-equal; distinct user types differ by reference / name
+    /// so genuine negative conversions (e.g. <c>Channel[A]</c> → <c>Channel[B]</c>)
+    /// still report GS0155.
+    /// </summary>
+    private static bool AreTypeArgumentsEquivalent(TypeSymbol a, TypeSymbol b)
+    {
+        if (ReferenceEquals(a, b))
+        {
+            return true;
+        }
+
+        if (a is null || b is null)
+        {
+            return false;
+        }
+
+        // Nested constructed generics (e.g. List[List[MyGs]]) compare structurally.
+        if (a is ImportedTypeSymbol nestedA && b is ImportedTypeSymbol nestedB
+            && nestedA.OpenDefinition != null && nestedB.OpenDefinition != null)
+        {
+            return AreConstructedGenericsIdentical(nestedA, nestedB);
+        }
+
+        // Both arguments resolve to a real CLR type: compare those by name.
+        if (a.ClrType != null && b.ClrType != null)
+        {
+            return ClrTypeUtilities.AreSame(a.ClrType, b.ClrType);
+        }
+
+        // Both arguments are same-compilation user types with a null ClrType:
+        // compare by symbol kind and name so distinct user types stay distinct.
+        if (a.ClrType == null && b.ClrType == null)
+        {
+            return a.GetType() == b.GetType()
+                && string.Equals(a.Name, b.Name, StringComparison.Ordinal);
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1088GenericIdentityTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1088GenericIdentityTests.cs
@@ -1,0 +1,216 @@
+// <copyright file="Issue1088GenericIdentityTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Regression tests for issue #1088: assigning the result of a
+/// constructed-generic factory/method call to a variable or field of the SAME
+/// constructed-generic type must bind when the type argument is a
+/// <em>same-compilation</em> user type.
+/// <para>
+/// A same-compilation user type used as a CLR generic argument has a
+/// <c>null</c> <c>ClrType</c> during binding and erases to <c>object</c> on the
+/// closed <see cref="GSharp.Core.CodeAnalysis.Symbols.ImportedTypeSymbol"/>.
+/// Comparing the erased <c>ClrType</c>s of the declared type
+/// (<c>Channel[BufferEntry]</c>) against the method return type spuriously
+/// reported <c>GS0155</c> with two IDENTICAL display names. The conversion
+/// classifier now compares the SYMBOLIC type arguments structurally, so genuine
+/// identity binds while distinct user-type arguments still fail.
+/// </para>
+/// </summary>
+public class Issue1088GenericIdentityTests
+{
+    private static ReferenceResolver MetadataLoadContextResolver()
+    {
+        var paths = new[]
+        {
+            typeof(object).Assembly.Location,
+            typeof(System.Console).Assembly.Location,
+            typeof(System.Threading.Channels.Channel).Assembly.Location,
+            typeof(System.Threading.Channels.BoundedChannelOptions).Assembly.Location,
+            typeof(System.Collections.Generic.List<>).Assembly.Location,
+        }
+        .Where(p => !string.IsNullOrEmpty(p))
+        .Distinct(StringComparer.OrdinalIgnoreCase)
+        .ToArray();
+
+        return ReferenceResolver.WithReferences(paths);
+    }
+
+    private static ImmutableArray<Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var globalScope = Binder.BindGlobalScope(
+            previous: null,
+            ImmutableArray.Create(tree),
+            MetadataLoadContextResolver());
+        var program = Binder.BindProgram(globalScope, MetadataLoadContextResolver());
+        return globalScope.Diagnostics.AddRange(program.Diagnostics);
+    }
+
+    [Fact]
+    public void Constructed_Generic_With_UserType_Arg_Binds_In_Method_Body()
+    {
+        // The exact repro from issue #1088.
+        var source = """
+            package p
+            import System.Threading.Channels
+
+            class BufferEntry {
+            }
+
+            class C {
+                func M() {
+                    let ch Channel[BufferEntry] = Channel.CreateBounded[BufferEntry](BoundedChannelOptions(2))
+                }
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void Constructed_Generic_With_UserType_Arg_Binds_In_Field_Initializer()
+    {
+        var source = """
+            package p
+            import System.Threading.Channels
+
+            class BufferEntry {
+            }
+
+            class C {
+                private let ch Channel[BufferEntry] = Channel.CreateBounded[BufferEntry](BoundedChannelOptions(2))
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void Constructed_Generic_With_BclType_Arg_Still_Binds_In_Field_Initializer()
+    {
+        // Control: the all-BCL type argument case worked before the fix and
+        // must keep working.
+        var source = """
+            package p
+            import System.Threading.Channels
+
+            class C {
+                private let ch Channel[int32] = Channel.CreateBounded[int32](BoundedChannelOptions(2))
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void Constructed_Generic_With_BclType_Arg_Still_Binds_In_Method_Body()
+    {
+        var source = """
+            package p
+            import System.Threading.Channels
+
+            class C {
+                func M() {
+                    let ch Channel[int32] = Channel.CreateBounded[int32](BoundedChannelOptions(2))
+                }
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void Same_Compilation_User_Generic_Identity_Binds()
+    {
+        // The fallback repro: a same-compilation user generic with a
+        // same-compilation user-type argument round-trips through a factory.
+        var source = """
+            package p
+
+            class Box[T] {
+            }
+
+            class BufferEntry {
+            }
+
+            class C {
+                func mk() Box[BufferEntry] {
+                    return Box[BufferEntry]()
+                }
+
+                func use() {
+                    let b Box[BufferEntry] = mk()
+                }
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void Distinct_User_Type_Arguments_Still_Report_GS0155()
+    {
+        // Negative: distinct user-type arguments must NOT be treated as
+        // identical, so the spurious-conversion guard does not over-match.
+        var source = """
+            package p
+
+            class Box[T] {
+            }
+
+            class A {
+            }
+
+            class B {
+            }
+
+            class C {
+                func mk() Box[A] {
+                    return Box[A]()
+                }
+
+                func use() {
+                    let b Box[B] = mk()
+                }
+            }
+            """;
+
+        Assert.Contains(Bind(source), d => d.Id == "GS0155");
+    }
+
+    [Fact]
+    public void Mismatched_Bcl_And_User_Type_Arguments_Still_Report_GS0155()
+    {
+        // Negative: a BCL-arg construction is not assignable to a user-type-arg
+        // declaration of the same open generic.
+        var source = """
+            package p
+            import System.Threading.Channels
+
+            class BufferEntry {
+            }
+
+            class C {
+                func M() {
+                    let ch Channel[BufferEntry] = Channel.CreateBounded[int32](BoundedChannelOptions(2))
+                }
+            }
+            """;
+
+        Assert.Contains(Bind(source), d => d.Id == "GS0155");
+    }
+}


### PR DESCRIPTION
Fixes #1088

## Root cause
Assigning the result of a constructed-generic factory/method call to a variable or field of the SAME constructed-generic type reported a false `GS0155: Cannot convert type ... to ...` (with two IDENTICAL display names) when the type argument was a **same-compilation user type** (e.g. `Channel[BufferEntry]`). With a BCL type argument (e.g. `Channel[int32]`) the identical code compiled.

A same-compilation user type used as a CLR generic argument has a null `TypeSymbol.ClrType` during binding and erases to `<object>` on the closed `ImportedTypeSymbol.ClrType`. The conversion classifier in `Conversion.Classify` had an identity fast-path for constructed generics, but it only fired when both sides had a type-*parameter* argument (`HasTypeParameterArgument`). For same-compilation user-type arguments it fell through to a CLR-based comparison that saw `Channel`1[object]` (or `null`) on one side and `Channel`1[object]` on the other and failed.

## Fix
The identity check for two constructed `ImportedTypeSymbol`s now compares their open definitions and **symbolic** type arguments structurally — independent of CLR erasure — gated on `HasSubstitutableTypeArgument` (which recovers same-compilation args whose `ClrType` is null). Helpers `AreConstructedGenericsIdentical` / `AreTypeArgumentsEquivalent` recurse into nested generics, compare real CLR args by name, and compare same-compilation user args by symbol kind + name so distinct user types stay distinct.

Negative conversions are preserved: distinct user-type args (`Box[A]` -> `Box[B]`) and BCL/user mismatches (`Channel[int32]` -> `Channel[BufferEntry]`) still report GS0155.

## Files changed
- `src/Core/CodeAnalysis/Binding/Conversion.cs`
- `test/Core.Tests/CodeAnalysis/Binding/Issue1088GenericIdentityTests.cs` (new)

## Verification
- Exact issue repro (`Channel.CreateBounded[BufferEntry]` into `let ch Channel[BufferEntry]`) now compiles (gsc: `Wrote x.dll`, previously GS0155).
- Field-initializer and method-body positives compile; BCL controls compile.
- Negatives still emit GS0155 (distinct user types; BCL/user mismatch).
- New `Issue1088GenericIdentityTests`: 7/7 passing.
- Full `Core.Tests`: **3819 passed, 1 skipped, 0 failed**.