### PR TITLE
cs2gs: translate C# null! null-literal to default(T) not nil!! (Refs #914, #1072)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
@@ -174,6 +174,35 @@ namespace Demo
     }
 
     /// <summary>
+    /// The C# null-forgiving <em>null literal</em> <c>null!</c> (passing null where
+    /// a non-nullable reference is expected) maps to <c>default(T)</c> for the
+    /// expected type — not <c>nil!!</c>, which G#'s Kotlin-style nullability
+    /// rejects (the assertion keeps the operand type <c>nil</c>, issue #1072).
+    /// <c>default(T)</c> is null at runtime — faithful to <c>null!</c> — and is a
+    /// native non-nullable G# value (#914).
+    /// </summary>
+    [Fact]
+    public void SuppressNullableWarning_OnNullLiteralArgument_MapsToDefaultOfExpectedType()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class Node
+    {
+        public Node(Node parent) { }
+    }
+
+    public class Root : Node
+    {
+        public Root() : base(null!) { }
+    }
+}");
+
+        Assert.Contains("base(default(Node))", printed);
+        Assert.DoesNotContain("nil!!", printed);
+    }
+
+    /// <summary>
     /// An embedded post-increment used as an expression (<c>a[i++] = v</c>) is
     /// hoisted: the sub-expression reads the pre-increment value and the
     /// mutation is appended as a trailing <c>i++</c> statement (ADR-0115 §B).

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -3637,6 +3637,22 @@ public sealed class CSharpToGSharpTranslator
                     // The C# null-forgiving operator `expr!` maps to G#'s postfix
                     // non-null assertion `expr!!` (spec: "Postfix `!!` asserts
                     // non-null"), preserving the assertion (ADR-0115 §B).
+                    //
+                    // Exception: the C# null-forgiving null literal `null!` (used to
+                    // pass null where a non-nullable reference is expected, e.g.
+                    // `: base(header, null!)`). G# follows Kotlin-style nullability
+                    // and rejects `nil!!` — the assertion keeps the operand's type
+                    // `nil`, so it cannot satisfy a non-nullable target (GS0154 /
+                    // GS0155 / a misleading GS0214 in base-initializer position,
+                    // issue #1072). Emit `default(T)` for the expected (converted)
+                    // type instead: this is null at runtime — behaviourally
+                    // identical to C#'s `null!` — and is a native, non-nullable G#
+                    // value (#914, #1072).
+                    if (suppressNullable.Operand.IsKind(SyntaxKind.NullLiteralExpression))
+                    {
+                        return new DefaultValueExpression(this.ResolveExpressionType(suppressNullable));
+                    }
+
                     return new NonNullAssertionExpression(
                         this.TranslateExpression(suppressNullable.Operand));
 


### PR DESCRIPTION
## Summary

The C# null-forgiving **null literal** `null!` — used to pass null where a non-nullable reference is expected, e.g. `: base(header, null!)` — was translated to `nil!!`. G# follows Kotlin-style nullability and **rejects `nil!!`**: the `!!` non-null assertion keeps the operand's type `nil`, so it cannot satisfy a non-nullable target, producing `GS0154` / `GS0155` (or a misleading `GS0214` "no constructor takes N arguments" in base-initializer position — issue #1072).

Per maintainer guidance, cs2gs now maps a null-forgiving **null literal** to **`default(T)`** for the expected (converted) type, instead of `nil!!`. `default(T)` is null at runtime — behaviourally identical to C#'s `null!` — and is a native, non-nullable G# value. The null-forgiving operator on any other operand (e.g. a nullable variable `x!`) continues to map to `x!!`.

## Example

```csharp
public class Id3Tag : Frame
{
    private Id3Tag(Stream file, Id3Header header) : base(header, null!) { ... }
}
```
Before: `private init(file Stream, header Id3Header) : base(header, nil!!) { ... }` → `GS0214`.
After:  `private init(file Stream, header Id3Header) : base(header, default(Frame)) { ... }` → compiles.

## Effect on Oahu.Decrypt migration

Clears the last binding/translation error on `Oahu.Decrypt`'s `Id3Tag` (`: base(header, null!)`). (A separate, newly-exposed compiler emit-stage gap is tracked separately.)

## Tests

- New translator unit test `SuppressNullableWarning_OnNullLiteralArgument_MapsToDefaultOfExpectedType`.
- cs2gs suite: **185 passed, 0 failed**.

Refs #914, #1072. No Co-authored-by.
