### PR TITLE
Fixes #1097: update syntax highlighting to the current 0.2 grammar

### DIFF
--- a/src/vscode-gsharp/src/test/grammar.test.ts
+++ b/src/vscode-gsharp/src/test/grammar.test.ts
@@ -1,0 +1,187 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+// Implementation-grounded conformance tests for the G# TextMate grammar.
+//
+// The reserved keyword set is parsed directly out of the compiler's
+// SyntaxFacts.GetKeywordKind so that this test fails if the language adds or
+// removes a reserved keyword without the grammar being updated to match.
+
+const repoRoot = path.resolve(__dirname, '../../../..');
+const grammarPath = path.resolve(
+  __dirname,
+  '../../syntaxes/gsharp.tmLanguage.json',
+);
+const injectionPath = path.resolve(
+  __dirname,
+  '../../syntaxes/gsharp-markdown-injection.json',
+);
+const syntaxFactsPath = path.resolve(
+  repoRoot,
+  'src/Core/CodeAnalysis/Syntax/SyntaxFacts.cs',
+);
+
+const grammar = JSON.parse(fs.readFileSync(grammarPath, 'utf8'));
+
+function reservedKeywordsFromCompiler(): string[] {
+  const source = fs.readFileSync(syntaxFactsPath, 'utf8');
+  // Inside SyntaxFacts.GetKeywordKind every reserved keyword appears as a
+  // `case "word":` label; it is the only switch in the file keyed by string.
+  const matches = source.matchAll(/case\s+"([a-zA-Z]+)":/g);
+  return Array.from(matches, (m) => m[1]).sort();
+}
+
+function repositoryMatchStrings(section: string): string[] {
+  const patterns = grammar.repository[section]?.patterns ?? [];
+  return patterns
+    .map((p: {match?: string}) => p.match)
+    .filter((m: string | undefined): m is string => typeof m === 'string');
+}
+
+describe('gsharp.tmLanguage.json', () => {
+  it('is well-formed JSON with the expected scope name', () => {
+    expect(grammar.scopeName).toBe('source.gsharp');
+    const injection = JSON.parse(fs.readFileSync(injectionPath, 'utf8'));
+    expect(injection.scopeName).toBe('markdown.gsharp.codeblock');
+  });
+
+  it('highlights every reserved keyword the compiler recognises', () => {
+    const reserved = reservedKeywordsFromCompiler();
+    // Sanity: the parse found a plausible keyword set.
+    expect(reserved).toContain('protected');
+    expect(reserved).toContain('func');
+    expect(reserved.length).toBeGreaterThan(40);
+
+    const matchers = [
+      ...repositoryMatchStrings('keywords'),
+      ...repositoryMatchStrings('constants'),
+    ].map((m) => new RegExp(m));
+
+    const uncovered = reserved.filter(
+      (kw) => !matchers.some((r) => r.test(kw)),
+    );
+    expect(uncovered).toEqual([]);
+  });
+
+  it('covers the new 0.2 contextual keywords', () => {
+    const contextual = repositoryMatchStrings('keywords').map(
+      (m) => new RegExp(m),
+    );
+    const required = [
+      'unsafe',
+      'fixed',
+      'stackalloc',
+      'unmanaged',
+      'init',
+      'params',
+      'explicit',
+      'implicit',
+      'and',
+      'or',
+      'not',
+      'scoped',
+      'ref',
+    ];
+    const missing = required.filter(
+      (kw) => !contextual.some((r) => r.test(kw)),
+    );
+    expect(missing).toEqual([]);
+  });
+
+  it('does not treat `where` as a keyword (G# uses bracketed constraints)', () => {
+    const matchers = [
+      ...repositoryMatchStrings('keywords'),
+      ...repositoryMatchStrings('declarations'),
+    ].map((m) => new RegExp(m));
+    expect(matchers.some((r) => r.test('where'))).toBe(false);
+  });
+
+  it('highlights all built-in primitive type names', () => {
+    const typeMatchers = repositoryMatchStrings('types').map(
+      (m) => new RegExp(m),
+    );
+    const primitives = [
+      'bool',
+      'uint8',
+      'int8',
+      'int16',
+      'uint16',
+      'int32',
+      'uint32',
+      'int64',
+      'uint64',
+      'nint',
+      'nuint',
+      'float32',
+      'float64',
+      'decimal',
+      'char',
+      'string',
+      'object',
+      'void',
+      // friendly aliases accepted by the binder
+      'byte',
+      'sbyte',
+      'short',
+      'ushort',
+      'int',
+      'uint',
+      'long',
+      'ulong',
+      'float',
+      'double',
+    ];
+    const missing = primitives.filter(
+      (t) => !typeMatchers.some((r) => r.test(t)),
+    );
+    expect(missing).toEqual([]);
+  });
+
+  describe('operator tokenization', () => {
+    const operatorPatterns: {name: string; match: string}[] =
+      grammar.repository.operators.patterns;
+
+    // Emulates the TextMate engine for a single, isolated operator token:
+    // the first pattern (in array order) that matches at index 0 wins. The
+    // matched text must consume the whole operator — this guards the
+    // longest-match-first ordering so e.g. `->` is not split into `-` + `>`.
+    function tokenize(op: string): {name: string; text: string} | null {
+      for (const p of operatorPatterns) {
+        const m = new RegExp(p.match).exec(op);
+        if (m && m.index === 0) {
+          return {name: p.name, text: m[0]};
+        }
+      }
+      return null;
+    }
+
+    const cases: [string, string][] = [
+      ['..', 'keyword.operator.range.gsharp'],
+      ['...', 'keyword.operator.range.gsharp'],
+      ['->', 'keyword.operator.arrow.gsharp'],
+      ['=>', 'keyword.operator.arrow.gsharp'],
+      ['<-', 'keyword.operator.channel.gsharp'],
+      ['++', 'keyword.operator.increment.gsharp'],
+      ['--', 'keyword.operator.increment.gsharp'],
+      ['&^', 'keyword.operator.bitwise.gsharp'],
+      ['&^=', 'keyword.operator.bitwise.gsharp'],
+      ['!!', 'keyword.operator.null-forgiving.gsharp'],
+      ['??', 'keyword.operator.null-coalescing.gsharp'],
+      ['??=', 'keyword.operator.null-coalescing.gsharp'],
+      ['?.', 'keyword.operator.null-conditional.gsharp'],
+      ['?[', 'keyword.operator.null-conditional.gsharp'],
+      [':=', 'keyword.operator.assignment.gsharp'],
+      ['<<=', 'keyword.operator.assignment.gsharp'],
+      ['>>=', 'keyword.operator.assignment.gsharp'],
+      ['<<', 'keyword.operator.bitwise.gsharp'],
+      ['>>', 'keyword.operator.bitwise.gsharp'],
+    ];
+
+    it.each(cases)('tokenizes %s as a single operator', (op, scope) => {
+      const result = tokenize(op);
+      expect(result).not.toBeNull();
+      expect(result!.text).toBe(op);
+      expect(result!.name).toBe(scope);
+    });
+  });
+});

--- a/src/vscode-gsharp/syntaxes/gsharp.tmLanguage.json
+++ b/src/vscode-gsharp/syntaxes/gsharp.tmLanguage.json
@@ -219,7 +219,7 @@
         },
         {
           "name": "keyword.modifier.contextual.gsharp",
-          "match": "\\b(data|delegate|event|in|init|inline|make|nameof|out|prop|raise|record|ref|remove|scoped|shared|typeof|when|where|with|yield)\\b"
+          "match": "\\b(and|convenience|data|deinit|delegate|event|explicit|fixed|implicit|in|init|inline|make|nameof|not|or|out|params|prop|raise|record|ref|remove|scoped|shared|stackalloc|typeof|unmanaged|unsafe|when|with|yield)\\b"
         },
         {
           "name": "keyword.other.accessor.gsharp",
@@ -260,14 +260,47 @@
       ]
     },
     "operators": {
+      "comment": "Patterns are ordered longest-match-first so multi-character operators win over their single-character prefixes.",
       "patterns": [
         {
           "name": "keyword.operator.range.gsharp",
-          "match": "\\.\\.\\."
+          "match": "\\.\\.\\.|\\.\\."
+        },
+        {
+          "name": "keyword.operator.assignment.gsharp",
+          "match": "<<=|>>="
         },
         {
           "name": "keyword.operator.null-coalescing.gsharp",
-          "match": "\\?\\?=|\\?\\?"
+          "match": "\\?\\?="
+        },
+        {
+          "name": "keyword.operator.bitwise.gsharp",
+          "match": "&\\^="
+        },
+        {
+          "name": "keyword.operator.arrow.gsharp",
+          "match": "->|=>"
+        },
+        {
+          "name": "keyword.operator.channel.gsharp",
+          "match": "<-"
+        },
+        {
+          "name": "keyword.operator.increment.gsharp",
+          "match": "\\+\\+|--"
+        },
+        {
+          "name": "keyword.operator.bitwise.gsharp",
+          "match": "&\\^"
+        },
+        {
+          "name": "keyword.operator.assignment.gsharp",
+          "match": ":="
+        },
+        {
+          "name": "keyword.operator.null-coalescing.gsharp",
+          "match": "\\?\\?"
         },
         {
           "name": "keyword.operator.null-conditional.gsharp",
@@ -278,32 +311,44 @@
           "match": "!!"
         },
         {
+          "name": "keyword.operator.bitwise.gsharp",
+          "match": "<<|>>"
+        },
+        {
+          "name": "keyword.operator.logical.gsharp",
+          "match": "&&|\\|\\|"
+        },
+        {
+          "name": "keyword.operator.comparison.gsharp",
+          "match": "==|!=|<=|>="
+        },
+        {
+          "name": "keyword.operator.assignment.gsharp",
+          "match": "\\+=|-=|\\*=|/=|%=|&=|\\|=|\\^="
+        },
+        {
           "name": "keyword.operator.ternary.gsharp",
           "match": "\\?|:"
         },
         {
           "name": "keyword.operator.comparison.gsharp",
-          "match": "(==|!=|<=|>=|<|>)"
+          "match": "<|>"
         },
         {
           "name": "keyword.operator.logical.gsharp",
-          "match": "(&&|\\|\\||!)"
-        },
-        {
-          "name": "keyword.operator.assignment.gsharp",
-          "match": "(\\+=|-=|\\*=|/=|%=|&=|\\|=|\\^=|<<=|>>=|=)"
+          "match": "!"
         },
         {
           "name": "keyword.operator.bitwise.gsharp",
-          "match": "(&|\\||\\^|~|<<|>>)"
+          "match": "&|\\||\\^|~"
         },
         {
           "name": "keyword.operator.arithmetic.gsharp",
-          "match": "(\\+|-|\\*|/|%)"
+          "match": "\\+|-|\\*|/|%"
         },
         {
-          "name": "keyword.operator.arrow.gsharp",
-          "match": "(->|=>)"
+          "name": "keyword.operator.assignment.gsharp",
+          "match": "="
         }
       ]
     },

--- a/website/docs/ref/spec.md
+++ b/website/docs/ref/spec.md
@@ -55,7 +55,13 @@ The reserved keywords are:
 as async await break case catch chan class const continue default defer do else enum false fallthrough finally for func go goto guard if import interface internal is let map nil open operator override package private protected public range return scope sealed select sequence struct switch throw true try type using var while
 ```
 
-Several words are contextual rather than reserved. `data`, `inline`, `prop`, `event`, `shared`, `init`, `get`, `set`, `add`, `remove`, `raise`, `in`, `out`, `yield`, `with`, `typeof`, `nameof`, and `make` retain identifier status except in the grammar contexts described below. The legacy `record` contextual keyword was removed by ADR-0078; the lexer still recognises it so the parser can emit the GS0307 migration diagnostic (`use data struct` / `data class`).
+Several words are contextual rather than reserved: they retain identifier status except in the specific grammar contexts described below. The full set the parser recognises contextually is:
+
+```text
+add and base convenience data deinit delegate event explicit fixed get implicit in init inline make nameof not or out params prop raise ref remove scoped set shared stackalloc this typeof unmanaged unsafe when with yield
+```
+
+Notable contextual roles: `prop`, `event`, `delegate`, `data`, `inline`, `shared`, `convenience`, and `deinit` introduce or modify members; `get`, `set`, `add`, `remove`, and `raise` name accessors; `in`, `out`, `ref`, `scoped`, and `params` modify parameters; `explicit` and `implicit` mark conversion operators; `and`, `or`, and `not` combine patterns; `this` and `base` reference the receiver; `when` guards a `catch`/`case`; and `make`, `with`, `yield`, `typeof`, and `nameof` are expression forms. The `init` parameterless-constructor constraint (`[T init()]`) was renamed from the former `new()` spelling by ADR-0097 (issue #997); `new` is therefore no longer a constraint keyword. The unsafe/low-level words `unsafe`, `fixed`, `stackalloc`, and `unmanaged` are contextual (for example `stackalloc` is recognised only in the `stackalloc [` shape) and otherwise remain ordinary identifiers. The legacy `record` contextual keyword was removed by ADR-0078; the lexer still recognises it so the parser can emit the GS0307 migration diagnostic (`use data struct` / `data class`).
 
 ### Operators and punctuation
 

--- a/website/src/theme/prism-include-languages.ts
+++ b/website/src/theme/prism-include-languages.ts
@@ -15,13 +15,21 @@ import type {Optional} from 'utility-types';
 function registerGSharp(Prism: typeof PrismNamespace): void {
   // Reserved keywords recognized by the lexer (SyntaxFacts.GetKeywordKind).
   const keywords =
-    /\b(?:as|async|await|break|case|catch|chan|class|const|continue|default|defer|do|else|enum|fallthrough|finally|for|func|go|goto|guard|if|import|interface|internal|is|let|map|open|operator|override|package|private|public|range|return|scope|sealed|select|sequence|struct|switch|throw|try|type|using|var|while)\b/;
+    /\b(?:as|async|await|break|case|catch|chan|class|const|continue|default|defer|do|else|enum|fallthrough|finally|for|func|go|goto|guard|if|import|interface|internal|is|let|map|open|operator|override|package|private|protected|public|range|return|scope|sealed|select|sequence|struct|switch|throw|try|type|using|var|while)\b/;
 
   // Contextual keywords: ordinary identifiers that act as keywords in context.
+  // Grounded in the parser's contextual recognitions (Text == "…" checks),
+  // covering member/declaration words (`prop`, `event`, `delegate`, `data`,
+  // `inline`, `shared`, `convenience`, `deinit`), accessors (`get`/`set`/`add`/
+  // `remove`/`raise`), parameter modifiers (`in`/`out`/`ref`/`scoped`/`params`),
+  // conversion operators (`explicit`/`implicit`), pattern combinators
+  // (`and`/`or`/`not`), the `init()` constructor constraint (renamed from
+  // `new()` by ADR-0097 / issue #997), and the unsafe/low-level words
+  // (`unsafe`/`fixed`/`stackalloc`/`unmanaged`).
   // `record` was removed in v0.2; the lexer still recognises it so the parser
   // can emit the GS0307 migration diagnostic, so we keep it here for fidelity.
   const contextualKeywords =
-    /\b(?:add|data|delegate|event|get|in|init|inline|make|nameof|out|prop|raise|record|ref|remove|scoped|set|shared|typeof|when|where|with|yield)\b/;
+    /\b(?:add|and|base|convenience|data|deinit|delegate|event|explicit|fixed|get|implicit|in|init|inline|make|nameof|not|or|out|params|prop|raise|record|ref|remove|scoped|set|shared|stackalloc|this|typeof|unmanaged|unsafe|when|with|yield)\b/;
 
   // Built-in primitive type names (TypeSymbol). Width-bearing names are
   // canonical; friendly aliases (`int`, `long`, etc.) are accepted by the
@@ -104,7 +112,7 @@ function registerGSharp(Prism: typeof PrismNamespace): void {
     operator:
       // Order matters in Prism alternations — list multi-character operators
       // first so they win over their single-character prefixes.
-      /\?\?=|\?\?|\?\.|\?\[|!!|\+\+|--|<-|->|=>|:=|&&|\|\||==|!=|<=|>=|<<=|>>=|<<|>>|\.\.\.|&\^|[+\-*/%&|^!<>=]=?|[~?:.]/,
+      /\?\?=|\?\?|\?\.|\?\[|!!|\+\+|--|<-|->|=>|:=|&&|\|\||==|!=|<=|>=|<<=|>>=|<<|>>|\.\.\.|\.\.|&\^=|&\^|[+\-*/%&|^!<>=]=?|@|[~?:.]/,
     punctuation: /[{}[\];(),]/,
   };
 


### PR DESCRIPTION
Fixes #1097

Brings all three syntax-highlighting artifacts into conformance with the implemented G# 0.2 grammar. Everything is grounded in the compiler source (`SyntaxFacts.GetKeywordKind`, the parser's contextual `Text == "…"` checks, and `TypeSymbol`/`Binder` primitive names).

## 1. Grammar reference — `website/docs/ref/spec.md`
- Replaced the partial *contextual keywords* enumeration with the full set the parser recognises, grouped by role (member/declaration words, accessors, parameter modifiers, conversion operators, pattern combinators `and`/`or`/`not`, expression forms, and the unsafe/low-level words).
- Documented that the `init()` parameterless-constructor constraint replaced the former `new()` spelling (ADR-0097 / #997), so `new` is no longer a constraint keyword.
- Called out that `unsafe`, `fixed`, `stackalloc`, and `unmanaged` are **contextual** (e.g. `stackalloc` only in the `stackalloc [` shape).
- (`website/versioned_docs/version-0.2/ref/spec.md` is a frozen snapshot and was intentionally left untouched.)

## 2. Prism grammar — `website/src/theme/prism-include-languages.ts`
- Added the missing reserved keyword **`protected`**.
- Rebuilt the contextual-keyword regex from the implementation (now includes `and`, `or`, `not`, `convenience`, `deinit`, `explicit`, `implicit`, `fixed`, `params`, `stackalloc`, `this`, `base`, `unmanaged`, `unsafe`, …) and **dropped `where`** (G# uses bracketed `[T init()]` constraints, not a `where` clause).
- Operators: added range **`..`**, bit-clear-assign **`&^=`**, and the **`@`** annotation marker (the existing `!!`, `??`, `?.`, `->`, `<-`, `:=`, `++`/`--` were already covered).

## 3. TextMate grammar — `src/vscode-gsharp/syntaxes/gsharp.tmLanguage.json`
- Contextual keywords: added `unsafe`, `fixed`, `stackalloc`, `unmanaged`, `params`, `explicit`, `implicit`, `and`, `or`, `not`; dropped `where`.
- Reordered the operator patterns **longest-match-first** and added `..` (range), `<-` (channel), `++`/`--` (incr/decr), `&^`/`&^=` (bit-clear), and `:=` (short decl). This reordering also fixes pre-existing mis-tokenization where `->`, `=>`, `<<=`, and `>>=` were split into single-character pieces.
- JSON remains well-formed (the extension loads it).

## New constructs now highlighted
`unsafe` context, unmanaged pointers / address-of `&` / deref `*`, `stackalloc [n]T{…}`, `fixed` statement + fixed-size buffers, ranges `lo..hi` / from-end `^n`, the `init()` generic constraint, `unmanaged` constraint, pattern combinators `and`/`or`/`not`, non-null `!!`, null-coalescing `??`/`?.`/`??=`, struct-pointer member access `->`, channel `<-`.

## Verification
- **Docs build:** `npm ci && npm run build` in `website/` → `[SUCCESS] Generated static files`. (One pre-existing broken-anchor warning in `guide/types-and-values`, unrelated to this change.)
- **VSCode extension:** in `src/vscode-gsharp/` → `npm run compile` ✅, `npm run lint` ✅ (clean), `npm run test:unit` ✅ **37 tests pass**.
- Added implementation-grounded grammar conformance tests (`src/vscode-gsharp/src/test/grammar.test.ts`) that parse the reserved keyword set out of `SyntaxFacts.cs` and assert the TextMate grammar covers every reserved keyword, the new 0.2 contextual keywords, all primitive types, and tokenizes the new/multi-character operators (`..`, `->`, `<-`, `++`, `&^`, `<<=`, …) as single tokens.

## Deferred work
None.
