### PR TITLE
Fixes #1100: encode generic member access over same-compilation user type args without throwing

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ControlFlowGraph.cs
+++ b/src/Core/CodeAnalysis/Binding/ControlFlowGraph.cs
@@ -289,13 +289,15 @@ public sealed class ControlFlowGraph
                     case BoundNodeKind.ChannelSendStatement:
                     case BoundNodeKind.SelectStatement:
                     case BoundNodeKind.ScopeStatement:
+                    case BoundNodeKind.FixedStatement:
                     case BoundNodeKind.AwaitForRangeStatement:
                     case BoundNodeKind.PatternSwitchStatement:
                     case BoundNodeKind.YieldStatement:
                         // Treat exception-flow constructs as opaque statements; precise
                         // CFG modeling of catch/finally edges is deferred to a later phase.
                         // GoStatement and ChannelSendStatement fall through to the next
-                        // statement at the CFG level.
+                        // statement at the CFG level. A FixedStatement carries a pinned
+                        // body that likewise falls through to the following statement.
                         statements.Add(statement);
                         break;
                     default:
@@ -400,6 +402,7 @@ public sealed class ControlFlowGraph
                         case BoundNodeKind.ChannelSendStatement:
                         case BoundNodeKind.SelectStatement:
                         case BoundNodeKind.ScopeStatement:
+                        case BoundNodeKind.FixedStatement:
                         case BoundNodeKind.AwaitForRangeStatement:
                         case BoundNodeKind.PatternSwitchStatement:
                         case BoundNodeKind.YieldStatement:

--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -643,29 +643,35 @@ public sealed class Conversion
             return false;
         }
 
-        var invoke = delegateType.GetMethod("Invoke");
-        if (invoke == null)
+        // Issue #1100: a constructed generic delegate closed over a
+        // same-compilation user type (e.g. `Action[Entry]`) surfaces as a
+        // `System.Reflection.Emit.TypeBuilderInstantiation` whose
+        // `GetMethod("Invoke")` throws `NotSupportedException` ("TypeBuilder
+        // generic instantiation does not support resolving members"). Recover
+        // the `Invoke` signature from the open generic definition and
+        // substitute the type arguments by position so convertibility is
+        // decided without resolving a member directly off the instantiation.
+        if (!TryGetDelegateInvokeSignature(delegateType, out var invokeParamTypes, out var invokeReturnType))
         {
             return false;
         }
 
-        var parms = invoke.GetParameters();
-        if (parms.Length != fn.ParameterTypes.Length)
+        if (invokeParamTypes.Length != fn.ParameterTypes.Length)
         {
             return false;
         }
 
-        for (var i = 0; i < parms.Length; i++)
+        for (var i = 0; i < invokeParamTypes.Length; i++)
         {
             var fnParamClr = fn.ParameterTypes[i]?.ClrType;
-            if (fnParamClr == null || !ClrTypeUtilities.IsAssignableByName(parms[i].ParameterType, fnParamClr))
+            if (fnParamClr == null || !ClrTypeUtilities.IsAssignableByName(invokeParamTypes[i], fnParamClr))
             {
                 return false;
             }
         }
 
-        var invokeReturnIsVoid = invoke.ReturnType == null
-            || string.Equals(invoke.ReturnType.FullName, "System.Void", StringComparison.Ordinal);
+        var invokeReturnIsVoid = invokeReturnType == null
+            || string.Equals(invokeReturnType.FullName, "System.Void", StringComparison.Ordinal);
         if (fn.ReturnType == TypeSymbol.Void || fn.ReturnType == null)
         {
             return invokeReturnIsVoid;
@@ -677,7 +683,97 @@ public sealed class Conversion
         }
 
         var fnReturnClr = fn.ReturnType.ClrType;
-        return fnReturnClr != null && ClrTypeUtilities.IsAssignableByName(invoke.ReturnType, fnReturnClr);
+        return fnReturnClr != null && ClrTypeUtilities.IsAssignableByName(invokeReturnType, fnReturnClr);
+    }
+
+    /// <summary>
+    /// Issue #1100: resolves a delegate type's <c>Invoke</c> parameter and
+    /// return types without resolving a member directly off a
+    /// <c>System.Reflection.Emit.TypeBuilderInstantiation</c>. A
+    /// constructed generic delegate closed over a same-compilation user type
+    /// (whose CLR backing is an in-flight emit <c>TypeBuilder</c>) cannot serve
+    /// <see cref="Type.GetMethod(string)"/> — it throws
+    /// <see cref="NotSupportedException"/>. In that case the <c>Invoke</c>
+    /// signature is recovered from the open generic definition and each
+    /// generic parameter is substituted by position with the constructed type's
+    /// actual type argument. Returns <see langword="false"/> when no usable
+    /// <c>Invoke</c> can be resolved.
+    /// </summary>
+    private static bool TryGetDelegateInvokeSignature(Type delegateType, out Type[] parameterTypes, out Type returnType)
+    {
+        parameterTypes = Array.Empty<Type>();
+        returnType = null;
+
+        try
+        {
+            var invoke = delegateType.GetMethod("Invoke");
+            if (invoke == null)
+            {
+                return false;
+            }
+
+            var parms = invoke.GetParameters();
+            parameterTypes = new Type[parms.Length];
+            for (var i = 0; i < parms.Length; i++)
+            {
+                parameterTypes[i] = parms[i].ParameterType;
+            }
+
+            returnType = invoke.ReturnType;
+            return true;
+        }
+        catch (NotSupportedException)
+        {
+            // delegateType is a TypeBuilderInstantiation; fall through to the
+            // open-definition resolution below.
+        }
+
+        if (!delegateType.IsGenericType || delegateType.IsGenericTypeDefinition)
+        {
+            return false;
+        }
+
+        Type definition;
+        Type[] typeArguments;
+        try
+        {
+            definition = delegateType.GetGenericTypeDefinition();
+            typeArguments = delegateType.GetGenericArguments();
+        }
+        catch (NotSupportedException)
+        {
+            return false;
+        }
+
+        var openInvoke = definition.GetMethod("Invoke");
+        if (openInvoke == null)
+        {
+            return false;
+        }
+
+        Type Substitute(Type t)
+        {
+            if (t != null && t.IsGenericParameter)
+            {
+                var pos = t.GenericParameterPosition;
+                if ((uint)pos < (uint)typeArguments.Length)
+                {
+                    return typeArguments[pos];
+                }
+            }
+
+            return t;
+        }
+
+        var openParms = openInvoke.GetParameters();
+        parameterTypes = new Type[openParms.Length];
+        for (var i = 0; i < openParms.Length; i++)
+        {
+            parameterTypes[i] = Substitute(openParms[i].ParameterType);
+        }
+
+        returnType = Substitute(openInvoke.ReturnType);
+        return true;
     }
 
     /// <summary>
@@ -790,7 +886,29 @@ public sealed class Conversion
             return true;
         }
 
-        return type?.ClrType?.IsEnum == true;
+        var clr = type?.ClrType;
+        if (clr == null)
+        {
+            return false;
+        }
+
+        // Issue #1100: a constructed generic delegate closed over a
+        // same-compilation user type (whose CLR backing is an in-flight emit
+        // TypeBuilder) surfaces as a
+        // System.Reflection.Emit.TypeBuilderInstantiation. Its reflection
+        // predicates throw NotSupportedException ("TypeBuilder generic
+        // instantiation does not support resolving members") — IsEnum probes the
+        // base-type chain via IsSubclassOf, which is one of the unsupported
+        // operations. Such a delegate type is never an enum, so treat a throw as
+        // a definite "not enum-like".
+        try
+        {
+            return clr.IsEnum;
+        }
+        catch (NotSupportedException)
+        {
+            return false;
+        }
     }
 
     private static bool IsInterfaceLikeType(TypeSymbol type)
@@ -800,7 +918,23 @@ public sealed class Conversion
             return true;
         }
 
-        return type?.ClrType?.IsInterface == true;
+        var clr = type?.ClrType;
+        if (clr == null)
+        {
+            return false;
+        }
+
+        // Issue #1100: as with IsEnumLikeType, querying IsInterface on a
+        // TypeBuilderInstantiation throws NotSupportedException. A constructed
+        // generic delegate is never an interface.
+        try
+        {
+            return clr.IsInterface;
+        }
+        catch (NotSupportedException)
+        {
+            return false;
+        }
     }
 
     private static bool IsValueTypeLikeFrom(TypeSymbol type)

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -1176,7 +1176,17 @@ internal sealed partial class ExpressionBinder
         }
 
         var mapped = MemberLookup.MapOpenClrTypeToSymbolic(openReturn, imp.OpenDefinition, imp.TypeArguments);
-        return TypeSymbol.ContainsTypeParameter(mapped) ? mapped : null;
+
+        // Issue #1100: keep the symbolic projection when the recovered return
+        // type references a same-compilation user type as well (not only an
+        // in-scope type parameter). A constructed BCL generic over a
+        // same-compilation class — e.g. `Queue[Entry].Dequeue()` — projects the
+        // open `T` return to the user `Entry` symbol (whose `ClrType` is null
+        // while being emitted). Without this the result type-erases to `object`
+        // and an `Entry`-typed target fails to bind (GS0155).
+        return TypeSymbol.ContainsTypeParameter(mapped) || TypeSymbol.ContainsSameCompilationUserType(mapped)
+            ? mapped
+            : null;
     }
 
     /// <summary>

--- a/test/Compiler.Tests/Emit/Issue1100GenericMemberOnUserTypeArgEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1100GenericMemberOnUserTypeArgEmitTests.cs
@@ -1,0 +1,201 @@
+// <copyright file="Issue1100GenericMemberOnUserTypeArgEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1100: emitting a member access (method call / field access /
+/// constructor) on a constructed BCL generic type whose type argument is a
+/// same-compilation user type — e.g. <c>Queue[Entry]</c> with <c>Entry</c>
+/// declared in the same assembly — aborted compilation with
+/// <c>GS9998: NotSupportedException: TypeBuilder generic instantiation does not
+/// support resolving members</c>.
+/// <para>
+/// Root cause: <see cref="GSharp.Core.CodeAnalysis.Symbols.FunctionTypeSymbol"/>
+/// closed the host-runtime open delegate definition over type arguments loaded
+/// by the reference resolver's <c>MetadataLoadContext</c>; mixing reflection
+/// contexts made <c>Type.MakeGenericType</c> return a
+/// <c>System.Reflection.Emit.TypeBuilderInstantiation</c>, and every subsequent
+/// reflection probe (binding-time convertibility checks, emit member
+/// resolution) threw <see cref="NotSupportedException"/>. The fix surfaces a
+/// null (symbolic) CLR type for such unusable instantiations, and the binder
+/// recovers the symbolic generic-method return type so <c>Queue[Entry].Dequeue()</c>
+/// binds to <c>Entry</c> rather than erasing to <c>object</c>.
+/// </para>
+/// These tests compile, IL-verify, and run the minimal repro end to end,
+/// proving emit no longer throws.
+/// </summary>
+public class Issue1100GenericMemberOnUserTypeArgEmitTests
+{
+    [Fact]
+    public void QueueOfUserType_EnqueueDequeueCount_EmitsAndRuns()
+    {
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            class Entry {
+                var Value int32
+                init(value int32) {
+                    Value = value
+                }
+            }
+
+            class C {
+                let q Queue[Entry] = Queue[Entry]()
+
+                func add(e Entry) {
+                    q.Enqueue(e)
+                }
+
+                func count() int32 {
+                    return q.Count
+                }
+
+                func drainSum() int32 {
+                    var total = 0
+                    while q.Count > 0 {
+                        let x = q.Dequeue()
+                        total = total + x.Value
+                    }
+                    return total
+                }
+            }
+
+            var c = C()
+            c.add(Entry(10))
+            c.add(Entry(20))
+            c.add(Entry(12))
+            Console.WriteLine(c.count())
+            Console.WriteLine(c.drainSum())
+            Console.WriteLine(c.count())
+            """;
+
+        Assert.Equal("3\n42\n0\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void ListOfUserType_AddIndexCount_EmitsAndRuns()
+    {
+        // Exercises a second constructed BCL generic (List[T]) member-access
+        // family (Add / indexer / Count) over a same-compilation user type.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            class Item {
+                var Id int32
+                init(id int32) {
+                    Id = id
+                }
+            }
+
+            class Bag {
+                let items List[Item] = List[Item]()
+
+                func push(i Item) {
+                    items.Add(i)
+                }
+
+                func first() Item {
+                    return items[0]
+                }
+
+                func size() int32 {
+                    return items.Count
+                }
+            }
+
+            var b = Bag()
+            b.push(Item(7))
+            b.push(Item(9))
+            var head = b.first()
+            Console.WriteLine(head.Id)
+            Console.WriteLine(b.size())
+            """;
+
+        Assert.Equal("7\n2\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1100_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1100GenericMethodUserTypeArgTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1100GenericMethodUserTypeArgTests.cs
@@ -1,0 +1,112 @@
+// <copyright file="Issue1100GenericMethodUserTypeArgTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1100 (binding facet): a generic method invoked on a constructed BCL
+/// generic receiver whose type argument is a same-compilation user type must
+/// recover the symbolic substituted result type instead of erasing it to
+/// <c>object</c>. For <c>Queue[Entry]</c> (with <c>Entry</c> declared in the
+/// same compilation), <c>q.Dequeue()</c> must bind to <c>Entry</c> so that an
+/// <c>Entry</c>-typed target assigns without <c>GS0155</c>, and
+/// <c>q.Enqueue(e)</c> must accept an <c>Entry</c> argument.
+/// </summary>
+public class Issue1100GenericMethodUserTypeArgTests
+{
+    [Fact]
+    public void Dequeue_OnQueueOfUserType_BindsToUserType_NotObject()
+    {
+        // Before the fix the generic method return type T erased to `object`,
+        // so assigning `q.Dequeue()` to an `Entry`-typed local reported GS0155
+        // ("Cannot convert type 'object' to 'Entry'").
+        var source = @"
+import System.Collections.Generic
+
+class Entry { }
+
+class C {
+    let q Queue[Entry] = Queue[Entry]()
+
+    func drain() {
+        let x Entry = q.Dequeue()
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Message.Contains("GS0155"));
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void Enqueue_OnQueueOfUserType_AcceptsUserTypeArgument()
+    {
+        // The by-T parameter of Enqueue must accept an `Entry` argument rather
+        // than erasing to `object` and rejecting the call.
+        var source = @"
+import System.Collections.Generic
+
+class Entry { }
+
+class C {
+    let q Queue[Entry] = Queue[Entry]()
+
+    func add(e Entry) {
+        q.Enqueue(e)
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void EnqueueDequeueCount_RoundTrip_OnQueueOfUserType_Binds()
+    {
+        // Full round trip exercising Enqueue (by-T parameter), Count, and
+        // Dequeue (T return) on a same-compilation user type argument.
+        var source = @"
+import System.Collections.Generic
+
+class Entry {
+    var Value int32
+}
+
+class C {
+    let q Queue[Entry] = Queue[Entry]()
+
+    func add(e Entry) {
+        q.Enqueue(e)
+    }
+
+    func drainSum() int32 {
+        var total = 0
+        while q.Count > 0 {
+            let x = q.Dequeue()
+            total = total + x.Value
+        }
+        return total
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
Fixes #1100

## Root cause

Emitting a member access on a constructed BCL generic whose type argument is a
**same-compilation user type** — e.g. `Queue[Entry]` (`.Enqueue` / `.Dequeue` /
`.Count`) with `Entry` declared in the same assembly — aborted compilation with:

```
GS9998: NotSupportedException: TypeBuilder generic instantiation does not
support resolving members. Use TypeBuilder.GetMethod instead.
```

gsharp's emitter is `ReflectionMetadataEmitter` (System.Reflection.Metadata),
not `System.Reflection.Emit`. But **binding runs during `Compilation.Emit()`**,
and the `TypeBuilderInstantiation` reached there: a constructed generic delegate
closed (via the host-runtime open `Func<>`/`Action<>` definition) over a type
loaded by the reference resolver's `MetadataLoadContext` materialises as a
`System.Reflection.Emit.TypeBuilderInstantiation`. Every reflection probe against
that instantiation throws `NotSupportedException`. `Conversion` classification
probed it **directly** — `GetMethod("Invoke")`, `IsEnum` (→ `IsSubclassOf`),
`IsInterface` — so the first probe threw a fatal `GS9998` that aborted the entire
assembly emit, masking all other diagnostics.

A second, related defect: a generic method invoked on a constructed generic
receiver whose type arg is a same-compilation user type **erased its `T`
return/parameter to `object`**, so `Queue[Entry].Dequeue()` failed to bind to an
`Entry` target (`GS0155`) — preventing a self-contained repro from reaching emit.

## Fix

- **`Conversion.IsFunctionToDelegateConvertible`** resolves the delegate `Invoke`
  signature crash-safely via a new `TryGetDelegateInvokeSignature` helper: it
  catches the `NotSupportedException` and recovers `Invoke` from the **open
  generic definition**, substituting type arguments by position — never resolving
  a member off the instantiation.
- **`Conversion.IsEnumLikeType` / `IsInterfaceLikeType`** guard their `IsEnum` /
  `IsInterface` reflection predicates against `NotSupportedException` (a
  constructed generic delegate is never an enum or interface).
- **`ExpressionBinder.ResolveInstanceReturnTypeFromReceiver`** keeps the symbolic
  projection of a generic method's substituted result type when it references a
  same-compilation user type (not only an in-scope type parameter), so
  `Queue[Entry].Dequeue()` binds to `Entry` (not `object`) and
  `Queue[Entry].Enqueue(e)` accepts an `Entry`.
- **`ControlFlowGraph`** handles `BoundNodeKind.FixedStatement` as an opaque
  fall-through statement in both CFG builders — a second previously-masked fatal
  `GS9998` ("Unexpected statement: FixedStatement") that the corpus hit once the
  TypeBuilder abort was removed.

## Tests

- `test/Compiler.Tests/Emit/Issue1100GenericMemberOnUserTypeArgEmitTests.cs` —
  compiles, **IL-verifies and runs** the minimal `Queue[Entry]` (Enqueue/Dequeue/
  Count) and `List[Item]` shapes end to end.
- `test/Core.Tests/CodeAnalysis/Binding/Issue1100GenericMethodUserTypeArgTests.cs`
  — asserts `Queue[Entry].Dequeue()` binds to `Entry` (not `object`) and
  `Enqueue(Entry)` is accepted.

## Verification

**Oahu.Decrypt migrate (deterministic gate):**

| | fatal GS9998 | TypeBuilder | outcome |
|---|---|---|---|
| **Before** | 1 (`ChapterQueue.gs`) | yes | whole assembly emit aborts; all other diagnostics suppressed |
| **After** | **0** | **0** | binding completes |

Before — the only reported line:
```
ChapterQueue.gs(1,1,1,1): error GS9998: NotSupportedException: TypeBuilder generic instantiation does not support resolving members. Use TypeBuilder.GetMethod instead.
```

After — the fatal abort is gone. ~1413 diagnostics now surface; these are
**pre-existing, unrelated cs2gs translator defects** that were masked behind the
fatal abort (none reference TypeBuilder / function types / generic-method
erasure), e.g.:
- `GS0270` — `x as int64` (mis-translated numeric value-type casts)
- `GS0159` — `Cannot find function WriteUInt32BE` / `ReadUInt32BE` / `ReadBlock` (missing helper funcs)
- `GS0157` — `Cannot find type base`
- `GS0158` — `Cannot find member Length` / `Mdia` (member-access translation gaps)

These are out of scope for #1100 (each is a separate cs2gs translation issue) and
are tracked as follow-ups.

- **Standalone minimal repro** (`Queue[Entry]` Enqueue/Dequeue/Count with a full
  framework reference set): binds **and** emits cleanly (`Wrote …`).
- **Full Core.Tests:** 3827 passed, 1 skipped, 0 failed.
- **Emit/binder regression tests** pass; delegate/conversion emit subset (157
  tests incl. `Issue908` delegate covariance) green.
