### PR TITLE
Fixes #1100: recover same-compilation user element type for BCL generic member access

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -1176,7 +1176,74 @@ internal sealed partial class ExpressionBinder
         }
 
         var mapped = MemberLookup.MapOpenClrTypeToSymbolic(openReturn, imp.OpenDefinition, imp.TypeArguments);
-        return TypeSymbol.ContainsTypeParameter(mapped) ? mapped : null;
+
+        // Issue #794 surfaced this override when the projection still contains
+        // an in-scope type parameter. Issue #1100 extends it to a
+        // same-compilation user type argument: when the receiver is e.g.
+        // `Queue[Entry]` and `Entry` is a class/struct still being compiled,
+        // the closed CLR shape erased `T` to `object`, so a member call
+        // returning `T` (e.g. `Queue<T>.Dequeue()`) would otherwise surface as
+        // `object` and lose the `Entry` identity (GS0155 at the call site).
+        // The symbolic projection recovers it.
+        return TypeSymbol.ContainsTypeParameter(mapped) || TypeSymbol.ContainsSameCompilationUserType(mapped)
+            ? mapped
+            : null;
+    }
+
+    /// <summary>
+    /// Issue #1100: the by-ref-parameter counterpart of
+    /// <see cref="ResolveInstanceReturnTypeFromReceiver"/>. When a call is
+    /// dispatched against a receiver whose <see cref="ImportedTypeSymbol"/>
+    /// carries symbolic type arguments (e.g. <c>Dictionary[K, V]</c>),
+    /// substitute the open declaring type's parameter pointee type using the
+    /// receiver's symbolic arguments. Without this an inline <c>out var</c>
+    /// argument against a generic by-ref parameter (e.g. the <c>out TValue</c>
+    /// of <c>Dictionary&lt;K, V&gt;.TryGetValue</c>) would bind from the
+    /// type-erased closed shape (<c>out object</c>), losing the symbolic
+    /// projection (the user element type). Returns <see langword="null"/> when
+    /// no override is needed so callers keep their existing pointee derivation.
+    /// </summary>
+    /// <param name="receiverType">The receiver's static type symbol.</param>
+    /// <param name="closedMethod">The closed method selected by overload resolution.</param>
+    /// <param name="paramIndex">The zero-based parameter position to recover.</param>
+    /// <returns>The override pointee type symbol, or <see langword="null"/>.</returns>
+    private static TypeSymbol ResolveInstanceParameterPointeeTypeFromReceiver(
+        TypeSymbol receiverType,
+        System.Reflection.MethodInfo closedMethod,
+        int paramIndex)
+    {
+        if (receiverType is not ImportedTypeSymbol imp
+            || imp.OpenDefinition == null
+            || imp.TypeArguments.IsDefaultOrEmpty
+            || closedMethod == null
+            || paramIndex < 0)
+        {
+            return null;
+        }
+
+        var openMethod = TryGetOpenInstanceMethod(imp.OpenDefinition, closedMethod);
+        if (openMethod == null)
+        {
+            return null;
+        }
+
+        var openParameters = openMethod.GetParameters();
+        if (paramIndex >= openParameters.Length)
+        {
+            return null;
+        }
+
+        var openParamType = openParameters[paramIndex].ParameterType;
+        var openPointee = openParamType.IsByRef ? openParamType.GetElementType() : openParamType;
+        if (openPointee == null)
+        {
+            return null;
+        }
+
+        var mapped = MemberLookup.MapOpenClrTypeToSymbolic(openPointee, imp.OpenDefinition, imp.TypeArguments);
+        return TypeSymbol.ContainsTypeParameter(mapped) || TypeSymbol.ContainsSameCompilationUserType(mapped)
+            ? mapped
+            : null;
     }
 
     /// <summary>
@@ -2088,12 +2155,14 @@ internal sealed partial class ExpressionBinder
     /// <param name="arguments">The bound arguments (with placeholder out-var entries).</param>
     /// <param name="resolvedMethod">The chosen imported method (constructed if generic).</param>
     /// <param name="parameterMapping">The source-argument → parameter-position mapping; default for positional calls.</param>
+    /// <param name="receiverType">The receiver's static type (for symbolic by-ref-parameter recovery); may be <see langword="null"/>.</param>
     /// <returns>The argument vector with inline out-var placeholders rebound.</returns>
     private ImmutableArray<BoundExpression> RebindInlineOutVarArguments(
         CallExpressionSyntax ce,
         ImmutableArray<BoundExpression> arguments,
         System.Reflection.MethodInfo resolvedMethod,
-        ImmutableArray<int> parameterMapping)
+        ImmutableArray<int> parameterMapping,
+        TypeSymbol receiverType = null)
     {
         ImmutableArray<BoundExpression>.Builder rebuilt = null;
         System.Reflection.ParameterInfo[] parameters = null;
@@ -2113,7 +2182,16 @@ internal sealed partial class ExpressionBinder
 
             var clrParameterType = parameters[paramIndex].ParameterType;
             var pointeeClr = clrParameterType.IsByRef ? clrParameterType.GetElementType() : clrParameterType;
-            var pointeeType = TypeSymbol.FromClrType(pointeeClr);
+
+            // Issue #1100: when the by-ref parameter's pointee is a type-level
+            // generic parameter on the receiver (e.g. `Dictionary[string,
+            // Entry].TryGetValue(string, out TValue)`), the resolved CLR method
+            // erased `TValue` to `object`, so the out-var local would bind as
+            // `object` and member access on it (`found.V`) would fail. Recover
+            // the symbolic pointee type from the receiver's symbolic type
+            // arguments (mirroring `ResolveInstanceReturnTypeFromReceiver`).
+            var pointeeType = ResolveInstanceParameterPointeeTypeFromReceiver(receiverType, resolvedMethod, paramIndex)
+                ?? TypeSymbol.FromClrType(pointeeClr);
             var syntheticParameter = new ParameterSymbol(
                 parameters[paramIndex].Name ?? "value",
                 pointeeType,
@@ -2611,7 +2689,7 @@ internal sealed partial class ExpressionBinder
                             // any inline `out var`/`out let`/`out _` placeholders
                             // against the resolved by-ref parameter so the new
                             // local is declared with the inferred pointee type.
-                            arguments = RebindInlineOutVarArguments(ce, arguments, resolution.Best, resolution.ParameterMapping);
+                            arguments = RebindInlineOutVarArguments(ce, arguments, resolution.Best, resolution.ParameterMapping, receiver?.Type);
                             var instSymbolicArgs = MemberLookup.BuildSymbolicArgTypeVector(receiver?.Type, ImmutableArray.CreateRange(arguments.Select(a => a?.Type)));
                             var instSymbolicTypeArgs = MemberLookup.BuildSymbolicMethodTypeArgs(resolution.Best, typeArgSymbols, instSymbolicArgs);
                             var instTypeArgSymbolsForCall = !instSymbolicTypeArgs.IsDefault ? instSymbolicTypeArgs : typeArgSymbols;

--- a/test/Compiler.Tests/Emit/Issue1100BclGenericUserArgEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1100BclGenericUserArgEmitTests.cs
@@ -1,0 +1,305 @@
+// <copyright file="Issue1100BclGenericUserArgEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1100: member access (method call returning <c>T</c>, method call
+/// taking <c>T</c>, property access) on a constructed BCL generic
+/// (<c>Queue[Entry]</c>, <c>List[Entry]</c>, <c>Dictionary[string, Entry]</c>)
+/// whose type argument is a <em>same-compilation</em> user
+/// <c>class</c>/<c>data struct</c>.
+/// <para>
+/// Binder facet (the standalone-reproducible symptom): a generic member whose
+/// open signature returns the type-level parameter <c>T</c> — e.g.
+/// <c>Queue&lt;T&gt;.Dequeue()</c> — was typed from the type-erased closed
+/// shape (<c>Queue&lt;object&gt;.Dequeue() → object</c>), so
+/// <c>var x Entry = q.Dequeue()</c> was rejected with
+/// <c>GS0155 ("Cannot convert type 'object' to 'Entry'")</c>. The recovery in
+/// <c>ResolveInstanceReturnTypeFromReceiver</c> only fired when the recovered
+/// projection still contained an in-scope type parameter (#794); it now also
+/// fires when the projection is a same-compilation user type (mirroring the
+/// generic-method counterpart fixed for #903), so <c>Dequeue()</c> surfaces
+/// the real <c>Entry</c> element type.
+/// </para>
+/// <para>
+/// Emit facet: once binding recovers the user element type, the call's
+/// MemberRef parent is the symbolic <c>Queue&lt;Entry&gt;</c> instantiation
+/// (encoded via the open definition rather than resolving members off the
+/// erased closed shape — #649/#671/#832/#903), and the post-call
+/// erasure-widening is short-circuited so no spurious <c>unbox.any</c> /
+/// <c>castclass</c> is emitted. These tests compile, IL-verify, and actually
+/// run programs exercising the shape end-to-end.
+/// </para>
+/// </summary>
+public class Issue1100BclGenericUserArgEmitTests
+{
+    [Fact]
+    public void QueueOfUserClass_EnqueueDequeueCount_Compiles_And_Runs()
+    {
+        // The headline repro from the issue's "minimal shape": a `Queue[Entry]`
+        // where `Entry` is a same-compilation user class. `Dequeue()` must
+        // surface `Entry` (not erased `object`) so `var x Entry = q.Dequeue()`
+        // binds without GS0155, and the program must emit and run correctly.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            class Entry { var V int32 }
+
+            class C {
+                private let q Queue[Entry] = Queue[Entry]()
+                func Add(e Entry) { q.Enqueue(e) }
+                func Drain() int32 {
+                    var sum = 0
+                    while q.Count > 0 {
+                        var x Entry = q.Dequeue()
+                        sum = sum + x.V
+                    }
+                    return sum
+                }
+            }
+
+            var c = C()
+            var a = Entry()
+            a.V = 40
+            c.Add(a)
+            var b = Entry()
+            b.V = 2
+            c.Add(b)
+            Console.WriteLine(c.Drain())
+            """;
+
+        Assert.Equal("42\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void QueueOfUserDataStruct_EnqueueDequeueCount_Compiles_And_Runs()
+    {
+        // Value-type user argument: `Dequeue()` returns a raw `Item` struct,
+        // so the emitter must NOT widen the (erased `object`) return with a
+        // spurious `unbox.any` — that would be ilverify-rejected and crash.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            data struct Item(Name string, Price int32)
+
+            class C {
+                private let q Queue[Item] = Queue[Item]()
+                func Add(i Item) { q.Enqueue(i) }
+                func Total() int32 {
+                    var sum = 0
+                    while q.Count > 0 {
+                        var x Item = q.Dequeue()
+                        sum = sum + x.Price
+                    }
+                    return sum
+                }
+            }
+
+            var c = C()
+            c.Add(Item{Name: "a", Price: 40})
+            c.Add(Item{Name: "b", Price: 2})
+            Console.WriteLine(c.Total())
+            """;
+
+        Assert.Equal("42\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void ListOfUserClass_AddIndexerForInCount_Compiles_And_Runs()
+    {
+        // `List[Entry]`: `Add(T)` (param), indexer read (`list[i] → Entry`),
+        // `for-in` element type recovery, and `Count`.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            class Entry { var V int32 }
+
+            class C {
+                private let l List[Entry] = List[Entry]()
+                func Add(e Entry) { l.Add(e) }
+                func SumViaIndexer() int32 {
+                    var sum = 0
+                    var i = 0
+                    while i < l.Count {
+                        var x Entry = l[i]
+                        sum = sum + x.V
+                        i = i + 1
+                    }
+                    return sum
+                }
+                func SumViaForIn() int32 {
+                    var sum = 0
+                    for item in l { sum = sum + item.V }
+                    return sum
+                }
+            }
+
+            var c = C()
+            var a = Entry()
+            a.V = 10
+            c.Add(a)
+            var b = Entry()
+            b.V = 32
+            c.Add(b)
+            Console.WriteLine(c.SumViaIndexer())
+            Console.WriteLine(c.SumViaForIn())
+            """;
+
+        Assert.Equal("42\n42\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void DictionaryOfUserValue_WriteReadIndexer_Compiles_And_Runs()
+    {
+        // `Dictionary[string, Entry]`: indexer write (`d[k] = e`), indexer read
+        // recovering the `Entry` value type, and `TryGetValue` out-parameter.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            class Entry { var V int32 }
+
+            class C {
+                private let d Dictionary[string, Entry] = Dictionary[string, Entry]()
+                func Put(key string, e Entry) { d[key] = e }
+                func Get(key string) int32 {
+                    var got Entry = d[key]
+                    return got.V
+                }
+                func TryGet(key string) int32 {
+                    var ok = d.TryGetValue(key, out var found)
+                    if ok { return found.V }
+                    return -1
+                }
+            }
+
+            var c = C()
+            var a = Entry()
+            a.V = 42
+            c.Put("k", a)
+            Console.WriteLine(c.Get("k"))
+            Console.WriteLine(c.TryGet("k"))
+            Console.WriteLine(c.TryGet("missing"))
+            """;
+
+        Assert.Equal("42\n42\n-1\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void QueueOfUserClass_DequeueReturnedFromMethod_Compiles_And_Runs()
+    {
+        // A method whose declared return type IS the user type and whose body
+        // returns `q.Dequeue()` directly — the binder must recover `Entry` for
+        // the return without an intervening local annotation (GS0155 guard).
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            class Entry { var V int32 }
+
+            class C {
+                private let q Queue[Entry] = Queue[Entry]()
+                func Add(e Entry) { q.Enqueue(e) }
+                func Next() Entry { return q.Dequeue() }
+            }
+
+            var c = C()
+            var a = Entry()
+            a.V = 7
+            c.Add(a)
+            var n = c.Next()
+            Console.WriteLine(n.V)
+            """;
+
+        Assert.Equal("7\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1100_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Emitting a member access on a constructed BCL generic whose type argument is a **same-compilation** user `class`/`data struct` (e.g. `Queue[Entry]`, `List[Entry]`, `Dictionary[string, Entry]`) lost the user element type. A generic member whose open signature mentions the type-level parameter `T` was projected from the **type-erased** closed shape, so:

- `var x Entry = q.Dequeue()` → **GS0155** ("Cannot convert type 'object' to 'Entry'"), because `Queue<T>.Dequeue()` surfaced as `object`.
- `d.TryGetValue(k, out var found); found.V` → **GS0158** ("Cannot find member V"), because the `out TValue` of `Dictionary<K,V>.TryGetValue` typed `found` as `object`.

In a full multi-file compile where the result is left erased, the downstream emit could not resolve members against the symbolic instantiation and aborted with **GS9998** (`NotSupportedException` from the constructed-generic member-resolution path). This blocked faithful cs2gs migration of any code using BCL generic collections parameterised by a same-compilation user type (the last error blocking Oahu.Decrypt).

## Root cause

The binder's erasure-recovery overrides only kept the symbolic projection when it still contained an **in-scope type parameter** (#794). For a same-compilation user type argument the projection is the user type itself (no type parameter), so the override was skipped and the erased `object` was used:

- `ExpressionBinder.Calls.cs` — `ResolveInstanceReturnTypeFromReceiver` gated its result on `ContainsTypeParameter(mapped)` only.
- `ExpressionBinder.Calls.cs` — `RebindInlineOutVarArguments` (#977) typed the out-var directly from the erased CLR pointee (`out object`).

## Fix

**Binder** (`src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs`):
- `ResolveInstanceReturnTypeFromReceiver` now also keeps the projection when it references a same-compilation user type (`TypeSymbol.ContainsSameCompilationUserType`), mirroring the generic-method counterpart added for #903. This recovers `Queue<T>.Dequeue() → Entry`.
- New `ResolveInstanceParameterPointeeTypeFromReceiver` recovers the symbolic pointee for a generic by-ref parameter; `RebindInlineOutVarArguments` threads the receiver type and uses it so `out var` against `Dictionary[K, V].TryGetValue` binds the user value type instead of `object`.

**Emit**: no change required. Once binding recovers the user element type, the existing symbolic-container MemberRef machinery (#649 / #671 / #832 / #903) already parents the call/ctor/field reference at the symbolic generic instantiation — encoded from the **open** definition rather than resolving members off the erased closed shape — and short-circuits the post-call erasure-widening (`TryGetSymbolicSubstitutedInstanceMethodReturn`, which already recognises `ArgIsSymbolicUserDefined`). The program therefore emits, IL-verifies and runs correctly.

## Tests

Added `test/Compiler.Tests/Emit/Issue1100BclGenericUserArgEmitTests.cs` — five tests that compile, IL-verify and **execute**:
- `Queue[Entry]` (user class) — Enqueue (param `T`), Dequeue (return `T`), Count.
- `Queue[Item]` (user `data struct`) — value-type element (no spurious `unbox.any`).
- `List[Entry]` — Add, indexer read, for-in element type, Count.
- `Dictionary[string, Entry]` — indexer write/read and `TryGetValue` out-var.
- `Queue[Entry].Dequeue()` returned directly from a method whose declared return type is the user type.

### Results
- New tests: **5 passed**.
- `Issue968 / Issue939 / Issue903 / Issue977 / Issue794 / Issue832`: **40 passed**.
- `~Generic` emit tests: **180 passed**.
- Collection/Dictionary/Queue/for-in emit tests: **91 passed**.
- `Emit.Issue9xx / Emit.Issue10xx`: **383 passed**.
- Full `Core.Tests`: **3828 passed, 1 skipped**.

No regressions observed.
