### PR TITLE
Fixes #1107: recover out-var pointee type for generic by-ref params over same-compilation user-type args

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -1190,6 +1190,64 @@ internal sealed partial class ExpressionBinder
     }
 
     /// <summary>
+    /// Issue #1107: the by-ref-parameter counterpart of
+    /// <see cref="ResolveInstanceReturnTypeFromReceiver"/>. When a call is
+    /// dispatched against a receiver whose <see cref="ImportedTypeSymbol"/>
+    /// carries symbolic type arguments (e.g. <c>Dictionary[K, V]</c>),
+    /// substitute the open declaring type's parameter pointee type using the
+    /// receiver's symbolic arguments. Without this an inline <c>out var</c>
+    /// argument against a generic by-ref parameter (e.g. the <c>out TValue</c>
+    /// of <c>Dictionary&lt;K, V&gt;.TryGetValue</c>) would bind from the
+    /// type-erased closed shape (<c>out object</c>), losing the symbolic
+    /// projection (the same-compilation user element type) and reporting
+    /// <c>GS0158</c> on a subsequent member access of the out-var local.
+    /// Returns <see langword="null"/> when no override is needed so callers keep
+    /// their existing pointee derivation.
+    /// </summary>
+    /// <param name="receiverType">The receiver's static type symbol.</param>
+    /// <param name="closedMethod">The closed method selected by overload resolution.</param>
+    /// <param name="paramIndex">The zero-based parameter position to recover.</param>
+    /// <returns>The override pointee type symbol, or <see langword="null"/>.</returns>
+    private static TypeSymbol ResolveInstanceParameterPointeeTypeFromReceiver(
+        TypeSymbol receiverType,
+        System.Reflection.MethodInfo closedMethod,
+        int paramIndex)
+    {
+        if (receiverType is not ImportedTypeSymbol imp
+            || imp.OpenDefinition == null
+            || imp.TypeArguments.IsDefaultOrEmpty
+            || closedMethod == null
+            || paramIndex < 0)
+        {
+            return null;
+        }
+
+        var openMethod = TryGetOpenInstanceMethod(imp.OpenDefinition, closedMethod);
+        if (openMethod == null)
+        {
+            return null;
+        }
+
+        var openParameters = openMethod.GetParameters();
+        if (paramIndex >= openParameters.Length)
+        {
+            return null;
+        }
+
+        var openParamType = openParameters[paramIndex].ParameterType;
+        var openPointee = openParamType.IsByRef ? openParamType.GetElementType() : openParamType;
+        if (openPointee == null)
+        {
+            return null;
+        }
+
+        var mapped = MemberLookup.MapOpenClrTypeToSymbolic(openPointee, imp.OpenDefinition, imp.TypeArguments);
+        return TypeSymbol.ContainsTypeParameter(mapped) || TypeSymbol.ContainsSameCompilationUserType(mapped)
+            ? mapped
+            : null;
+    }
+
+    /// <summary>
     /// Locates the open-generic-definition counterpart of <paramref name="closedMethod"/>
     /// on <paramref name="openDefinition"/>. Match is by metadata token + module,
     /// which is stable for methods on a constructed generic type (the
@@ -2098,12 +2156,14 @@ internal sealed partial class ExpressionBinder
     /// <param name="arguments">The bound arguments (with placeholder out-var entries).</param>
     /// <param name="resolvedMethod">The chosen imported method (constructed if generic).</param>
     /// <param name="parameterMapping">The source-argument → parameter-position mapping; default for positional calls.</param>
+    /// <param name="receiverType">The receiver's static type (for symbolic by-ref-parameter recovery); may be <see langword="null"/>.</param>
     /// <returns>The argument vector with inline out-var placeholders rebound.</returns>
     private ImmutableArray<BoundExpression> RebindInlineOutVarArguments(
         CallExpressionSyntax ce,
         ImmutableArray<BoundExpression> arguments,
         System.Reflection.MethodInfo resolvedMethod,
-        ImmutableArray<int> parameterMapping)
+        ImmutableArray<int> parameterMapping,
+        TypeSymbol receiverType = null)
     {
         ImmutableArray<BoundExpression>.Builder rebuilt = null;
         System.Reflection.ParameterInfo[] parameters = null;
@@ -2123,7 +2183,16 @@ internal sealed partial class ExpressionBinder
 
             var clrParameterType = parameters[paramIndex].ParameterType;
             var pointeeClr = clrParameterType.IsByRef ? clrParameterType.GetElementType() : clrParameterType;
-            var pointeeType = TypeSymbol.FromClrType(pointeeClr);
+
+            // Issue #1107: when the by-ref parameter's pointee is a type-level
+            // generic parameter on the receiver (e.g. `Dictionary[string,
+            // Entry].TryGetValue(string, out TValue)`), the resolved CLR method
+            // erased `TValue` to `object`, so the out-var local would bind as
+            // `object` and member access on it (`found.V`) would fail (GS0158).
+            // Recover the symbolic pointee type from the receiver's symbolic
+            // type arguments (mirroring `ResolveInstanceReturnTypeFromReceiver`).
+            var pointeeType = ResolveInstanceParameterPointeeTypeFromReceiver(receiverType, resolvedMethod, paramIndex)
+                ?? TypeSymbol.FromClrType(pointeeClr);
             var syntheticParameter = new ParameterSymbol(
                 parameters[paramIndex].Name ?? "value",
                 pointeeType,
@@ -2621,7 +2690,7 @@ internal sealed partial class ExpressionBinder
                             // any inline `out var`/`out let`/`out _` placeholders
                             // against the resolved by-ref parameter so the new
                             // local is declared with the inferred pointee type.
-                            arguments = RebindInlineOutVarArguments(ce, arguments, resolution.Best, resolution.ParameterMapping);
+                            arguments = RebindInlineOutVarArguments(ce, arguments, resolution.Best, resolution.ParameterMapping, receiver?.Type);
                             var instSymbolicArgs = MemberLookup.BuildSymbolicArgTypeVector(receiver?.Type, ImmutableArray.CreateRange(arguments.Select(a => a?.Type)));
                             var instSymbolicTypeArgs = MemberLookup.BuildSymbolicMethodTypeArgs(resolution.Best, typeArgSymbols, instSymbolicArgs);
                             var instTypeArgSymbolsForCall = !instSymbolicTypeArgs.IsDefault ? instSymbolicTypeArgs : typeArgSymbols;

--- a/test/Compiler.Tests/Emit/Issue1107OutVarUserTypeErasureEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1107OutVarUserTypeErasureEmitTests.cs
@@ -1,0 +1,172 @@
+// <copyright file="Issue1107OutVarUserTypeErasureEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1107: an inline <c>out var</c> argument bound against a generic by-ref
+/// parameter whose pointee is a type-level type parameter — e.g. the
+/// <c>out TValue</c> of <c>Dictionary&lt;TKey, TValue&gt;.TryGetValue</c> — was
+/// typed from the type-erased closed CLR shape (<c>out object</c>) when the
+/// receiver's generic argument is a <em>same-compilation</em> user type. The
+/// out-var local therefore bound as <c>object</c> and any subsequent member
+/// access on it failed with <c>GS0158</c>.
+/// <para>
+/// This is the by-ref-parameter counterpart of the generic-method return-type
+/// erasure fixed for #1100 (PR #1102): the return path was recovered in
+/// <c>ResolveInstanceReturnTypeFromReceiver</c>, but the by-ref parameter path
+/// in <c>RebindInlineOutVarArguments</c> (#977) still derived the out-var
+/// pointee from the erased closed shape. The new
+/// <c>ResolveInstanceParameterPointeeTypeFromReceiver</c> re-projects the open
+/// declaring type's parameter pointee through the receiver's symbolic type
+/// arguments, recovering the user element type. These tests compile, IL-verify,
+/// and actually run the shape end-to-end.
+/// </para>
+/// </summary>
+public class Issue1107OutVarUserTypeErasureEmitTests
+{
+    [Fact]
+    public void DictionaryOfUserClass_TryGetValueOutVar_Compiles_And_Runs()
+    {
+        // The headline repro: `Dictionary[string, Entry].TryGetValue(key, out var
+        // found)` must bind `found` as `Entry` (not erased `object`) so the
+        // subsequent `found.V` resolves (no GS0158), and the program runs.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            class Entry { var V int32 }
+
+            class C {
+                private let d Dictionary[string, Entry] = Dictionary[string, Entry]()
+                func Put(key string, e Entry) { d[key] = e }
+                func TryGet(key string) int32 {
+                    var ok = d.TryGetValue(key, out var found)
+                    if ok { return found.V }
+                    return -1
+                }
+            }
+
+            var c = C()
+            var a = Entry()
+            a.V = 42
+            c.Put("k", a)
+            Console.WriteLine(c.TryGet("k"))
+            Console.WriteLine(c.TryGet("missing"))
+            """;
+
+        Assert.Equal("42\n-1\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void DictionaryOfUserDataStruct_TryGetValueOutVar_Compiles_And_Runs()
+    {
+        // Value-type user argument: `found` must bind as the `Item` struct (not
+        // `object`), so `found.Price` resolves and no spurious unbox is emitted.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            data struct Item(Name string, Price int32)
+
+            class C {
+                private let d Dictionary[string, Item] = Dictionary[string, Item]()
+                func Put(key string, i Item) { d[key] = i }
+                func TryTotal(key string) int32 {
+                    var ok = d.TryGetValue(key, out var found)
+                    if ok { return found.Price }
+                    return -1
+                }
+            }
+
+            var c = C()
+            c.Put("a", Item{Name: "a", Price: 42})
+            Console.WriteLine(c.TryTotal("a"))
+            Console.WriteLine(c.TryTotal("missing"))
+            """;
+
+        Assert.Equal("42\n-1\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1107_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1107

## Root cause

An inline `out var` argument bound against a generic by-ref parameter whose pointee is a **type-level type parameter** — e.g. the `out TValue` of `Dictionary<TKey, TValue>.TryGetValue` — was typed from the **type-erased closed CLR shape** (`out object`) when the receiver's generic argument is a **same-compilation user type**. The out-var local therefore bound as `object`, and a subsequent member access on it failed with `GS0158`:

```gsharp
class Entry { var V int32 }
// ...
var ok = d.TryGetValue(key, out var found)
if ok { return found.V }   // GS0158: `found` bound as `object`, not `Entry`
```

This is the **by-ref-parameter counterpart** of the generic-method **return-type** erasure fixed for #1100 (PR #1102). That PR recovered the return path in `ExpressionBinder.ResolveInstanceReturnTypeFromReceiver`, but the by-ref parameter path in `RebindInlineOutVarArguments` (#977) still derived the out-var pointee straight from the erased closed shape:

```csharp
var pointeeClr = clrParameterType.IsByRef ? clrParameterType.GetElementType() : clrParameterType;
var pointeeType = TypeSymbol.FromClrType(pointeeClr);   // erased to object
```

## Fix

- Add `ResolveInstanceParameterPointeeTypeFromReceiver`, mirroring `ResolveInstanceReturnTypeFromReceiver`: it maps the **open** declaring type's parameter pointee through the receiver's symbolic type arguments (`MemberLookup.MapOpenClrTypeToSymbolic`) and keeps the projection when it contains an in-scope type parameter **or** a same-compilation user type.
- Thread the receiver type into `RebindInlineOutVarArguments` and prefer the recovered pointee, falling back to the existing CLR derivation when no override is needed.

## Tests

`test/Compiler.Tests/Emit/Issue1107OutVarUserTypeErasureEmitTests.cs` — compiles, **IL-verifies, and runs** `Dictionary[string, Entry].TryGetValue(key, out var found)` over both a user `class` and a user `data struct`, asserting `found.V` / `found.Price` resolve and the program produces the expected output.

## Verification

- New tests: 2 passed.
- Regression slices on the touched paths: `~Issue977|~Issue1100|~OutVar|~TryGetValue` (Compiler.Tests) 10 passed; `~Generic` (Compiler.Tests) 177 passed; `~OutVar|~Issue977|~Issue1100|~GenericMethod` (Core.Tests) 46 passed.
- Full Release build clean.

## Context

Discovered while validating the #1100 fix (PR #1102 landed the return-type half independently). This completes the same family for the `out var` parameter path, which blocks faithful cs2gs migration of the very common `Dictionary.TryGetValue(key, out var value)` pattern over same-compilation user types.
