### PR TITLE
Fix extension instance-call dispatch on imported/primitive CLR receivers (#1103)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -1812,6 +1812,21 @@ public sealed class Binder
             foreach (var f in previous.Functions)
             {
                 scope.TryDeclareFunction(f);
+
+                // Issue #1103: extension functions are flattened into
+                // BoundGlobalScope.Functions (Binder.BindGlobalScope merges
+                // GetDeclaredExtensionFunctions into Functions) so free-call
+                // syntax resolves them as ordinary functions. When a follow-up
+                // pass rehydrates the previous global scope (the body-binding
+                // pass binds member/function bodies against this rebuilt
+                // scope), the extension registry must be repopulated too —
+                // otherwise member-syntax dispatch (`receiver.Ext()`) via
+                // BoundScope.TryLookupExtensionFunction finds nothing and the
+                // call reports GS0159 even though the free-call form binds.
+                if (f.IsExtension)
+                {
+                    scope.TryDeclareExtensionFunction(f);
+                }
             }
 
             foreach (var v in previous.Variables)

--- a/src/Core/CodeAnalysis/Binding/BoundScope.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundScope.cs
@@ -290,7 +290,7 @@ public sealed class BoundScope
         {
             foreach (var ext in extensionFunctions)
             {
-                if (ext.Name == name && ext.ExtensionReceiverType == receiverType)
+                if (ext.Name == name && ReceiverMatches(ext.ExtensionReceiverType, receiverType))
                 {
                     function = ext;
                     return true;
@@ -755,6 +755,43 @@ public sealed class BoundScope
     /// <returns>The composite storage key.</returns>
     private static string MangleArity(string name, int arity)
         => arity <= 0 ? name : name + "`" + arity.ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+    /// <summary>
+    /// Determines whether an extension's declared receiver type matches the
+    /// static type of the call receiver.
+    /// </summary>
+    /// <remarks>
+    /// Package-owned user struct/class/interface receivers are interned, so
+    /// reference equality matches them exactly (and must remain the primary
+    /// check so two distinct user types never collide). Imported/BCL and
+    /// primitive receivers, however, are not interned: the
+    /// <see cref="FunctionSymbol.ExtensionReceiverType"/> captured at the
+    /// extension declaration and the receiver's type symbol at the call site
+    /// can be distinct <c>ImportedTypeSymbol</c> instances (or symbols
+    /// materialised through a <see cref="System.Reflection.MetadataLoadContext"/>)
+    /// that wrap the same logical CLR type (issue #1103). For those we fall
+    /// back to an exact structural CLR-type identity comparison via
+    /// <see cref="ClrTypeUtilities.IsSameAs"/> — exact identity, never
+    /// assignability, so genuinely different types do not match.
+    /// </remarks>
+    /// <param name="declaredReceiverType">The extension's declared receiver type.</param>
+    /// <param name="receiverType">The static type of the call receiver.</param>
+    /// <returns><c>true</c> when the receiver types match.</returns>
+    private static bool ReceiverMatches(TypeSymbol declaredReceiverType, TypeSymbol receiverType)
+    {
+        if (declaredReceiverType == receiverType)
+        {
+            return true;
+        }
+
+        if (declaredReceiverType?.ClrType is Type declaredClr
+            && receiverType?.ClrType is Type receiverClr)
+        {
+            return declaredClr.IsSameAs(receiverClr);
+        }
+
+        return false;
+    }
 
     /// <summary>
     /// Issue #1080: returns the enclosing type of a (possibly nested) user type

--- a/test/Compiler.Tests/Emit/Issue1103ExtensionInstanceCallEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1103ExtensionInstanceCallEmitTests.cs
@@ -1,0 +1,243 @@
+// <copyright file="Issue1103ExtensionInstanceCallEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1103: a receiver-clause extension function (ADR-0019) whose receiver
+/// type is an imported/BCL or primitive CLR type must be invokable with
+/// instance/member syntax (<c>receiver.Ext(args)</c>), not only as a free
+/// function (<c>Ext(receiver, args)</c>).
+/// <para>
+/// The defect had two causes. (1) Extension functions are flattened into
+/// <c>BoundGlobalScope.Functions</c> so free-call syntax resolves them, but the
+/// follow-up body-binding pass rebuilt its lookup scope without re-registering
+/// them as extensions, so <c>BoundScope.TryLookupExtensionFunction</c> found
+/// nothing inside function/method bodies. (2) Even when present, the receiver
+/// match used reference equality on the receiver type symbol, which fails for
+/// imported CLR types because the declaration-site and call-site symbols are
+/// distinct <c>ImportedTypeSymbol</c> instances wrapping the same CLR type. Both
+/// made member-syntax calls report <c>GS0159 Cannot find function</c> while the
+/// equivalent free-call form bound fine.
+/// </para>
+/// These tests prove that instance-syntax extension calls on a BCL type
+/// (<c>System.Text.StringBuilder</c>) and on a primitive (<c>int32</c>) compile,
+/// IL-verify, and produce the correct runtime results from inside class methods,
+/// free functions, and top-level statements.
+/// </summary>
+public class Issue1103ExtensionInstanceCallEmitTests
+{
+    [Fact]
+    public void Int32Extension_InstanceSyntax_InsideClassMethod()
+    {
+        var source = """
+            package P
+            import System
+
+            func (n int32) Doubled() int32 {
+                return n * 2
+            }
+
+            class Calc {
+                func Run(x int32) int32 {
+                    return x.Doubled()
+                }
+            }
+
+            let c = Calc()
+            Console.WriteLine(c.Run(21))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void BclExtension_InstanceSyntax_InsideFreeFunction()
+    {
+        // StringBuilder is an imported BCL type: the declaration-site and
+        // call-site receiver symbols are distinct ImportedTypeSymbol instances,
+        // so the receiver match must be structural (CLR-type identity).
+        var source = """
+            package P
+            import System
+            import System.Text
+
+            func (sb StringBuilder) AppendBang() StringBuilder {
+                return sb.Append("!")
+            }
+
+            func buildShout(word string) string {
+                let sb = StringBuilder()
+                sb.Append(word)
+                sb.AppendBang()
+                sb.AppendBang()
+                return sb.ToString()
+            }
+
+            Console.WriteLine(buildShout("hi"))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("hi!!\n", output);
+    }
+
+    [Fact]
+    public void Int32Extension_InstanceSyntax_AtTopLevel()
+    {
+        var source = """
+            package P
+            import System
+
+            func (n int32) Tripled() int32 {
+                return n * 3
+            }
+
+            let x int32 = 14
+            Console.WriteLine(x.Tripled())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void Extension_FreeCallForm_Control_StillCompiles()
+    {
+        // Control: the same extension invoked as a free function must keep
+        // working (this path always bound; it must not regress).
+        var source = """
+            package P
+            import System
+
+            func (n int32) Doubled() int32 {
+                return n * 2
+            }
+
+            func compute(x int32) int32 {
+                return Doubled(x)
+            }
+
+            Console.WriteLine(compute(21))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void BclAndPrimitiveExtensions_InstanceSyntax_InOneProgram()
+    {
+        // Instance-call forms of imported and primitive receiver extensions all
+        // bind and run within the same compilation, from class-method bodies.
+        var source = """
+            package P
+            import System
+            import System.Text
+
+            func (sb StringBuilder) AppendBang() StringBuilder {
+                return sb.Append("!")
+            }
+
+            func (n int32) Doubled() int32 {
+                return n * 2
+            }
+
+            class Worker {
+                func Shout(word string) string {
+                    let sb = StringBuilder()
+                    sb.Append(word)
+                    return sb.AppendBang().ToString()
+                }
+
+                func Twice(n int32) int32 {
+                    return n.Doubled()
+                }
+            }
+
+            let w = Worker()
+            Console.WriteLine(w.Shout("go"))
+            Console.WriteLine(w.Twice(50))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("go!\n100\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1103_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi);
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1103ExtensionInstanceCallTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1103ExtensionInstanceCallTests.cs
@@ -1,0 +1,145 @@
+// <copyright file="Issue1103ExtensionInstanceCallTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1103. A receiver-clause extension (ADR-0019) on an imported/BCL or
+/// primitive CLR type must bind with instance/member syntax
+/// (<c>receiver.Ext()</c>) and not only as a free function
+/// (<c>Ext(receiver)</c>).
+/// <para>
+/// Two defects produced <c>GS0159 Cannot find function</c> on the member-syntax
+/// form: (1) the body-binding pass rebuilt its lookup scope from the previous
+/// global scope without re-registering the flattened extension functions as
+/// extensions, so <see cref="BoundScope.TryLookupExtensionFunction"/> found
+/// nothing inside any function/method body; and (2) the receiver match compared
+/// the declared and call-site receiver type symbols by reference, which fails
+/// for imported CLR types whose symbols are distinct instances wrapping the same
+/// CLR type. The match is now structural (CLR-type identity) with reference
+/// equality kept as the fast path for interned user types.
+/// </para>
+/// </summary>
+public class Issue1103ExtensionInstanceCallTests
+{
+    [Fact]
+    public void PrimitiveExtension_InstanceSyntax_InsideFunctionBody_Binds()
+    {
+        const string source = @"
+package P
+
+func (n int32) Doubled() int32 {
+    return n * 2
+}
+
+func run(x int32) int32 {
+    return x.Doubled()
+}
+
+run(21)
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void PrimitiveExtension_InstanceSyntax_InsideClassMethod_Binds()
+    {
+        const string source = @"
+package P
+
+func (n int32) Doubled() int32 {
+    return n * 2
+}
+
+class Calc {
+    func Run(x int32) int32 {
+        return x.Doubled()
+    }
+}
+
+var c = Calc()
+c.Run(21)
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void PrimitiveExtension_InstanceSyntax_AtTopLevel_Binds()
+    {
+        const string source = @"
+package P
+
+func (n int32) Doubled() int32 {
+    return n * 2
+}
+
+var x int32 = 21
+x.Doubled()
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void Extension_FreeCallForm_InsideFunctionBody_Control_StillBinds()
+    {
+        // Control: the free-call form always bound; it must keep working.
+        const string source = @"
+package P
+
+func (n int32) Doubled() int32 {
+    return n * 2
+}
+
+func run(x int32) int32 {
+    return Doubled(x)
+}
+
+run(21)
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void PrimitiveExtension_InstanceSyntax_InsideFunctionBody_NoGS0159()
+    {
+        const string source = @"
+package P
+
+func (n int32) Doubled() int32 {
+    return n * 2
+}
+
+func run(x int32) int32 {
+    return x.Doubled()
+}
+
+run(5)
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Message.Contains("Cannot find function"));
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
## Summary

A receiver-clause extension function (ADR-0019) whose receiver type is an **imported/BCL or primitive CLR type** could not be invoked with instance/member syntax `receiver.Ext(args)` — the binder reported `GS0159: Cannot find function`. The same extension bound fine as a free function `Ext(receiver, args)`, and instance syntax worked when the receiver was a package-owned struct/class (those extensions are merged into the type's member list).

## Root cause

Two defects combined:

1. **Extension registry not rehydrated.** Extension functions are flattened into `BoundGlobalScope.Functions` (so the free-call form resolves them as ordinary functions). When a follow-up pass rebuilds its lookup scope from the previous global scope (`CreateParentScope`, used to bind member/function bodies), it re-declared those functions only via `TryDeclareFunction` and never re-registered them as extensions. So `extensionFunctions` was empty in every body-binding scope and `TryLookupExtensionFunction` found nothing — member-syntax dispatch inside any function/method body fell through to `GS0159`.

2. **Reference-equality receiver match.** `BoundScope.TryLookupExtensionFunction` matched candidates by reference equality on the receiver type symbol. For imported CLR types the declaration-site `ExtensionReceiverType` and the call-site `receiver.Type` are distinct `ImportedTypeSymbol` instances wrapping the same CLR type (imported type symbols are not interned), so `==` missed even once the registry was populated.

## Fix

- `CreateParentScope` re-registers flattened extension functions via `TryDeclareExtensionFunction` when rehydrating the previous global scope.
- `TryLookupExtensionFunction` now matches via a new `ReceiverMatches` helper: reference equality first (fast path for interned user types), then exact structural CLR-type identity (`ClrTypeUtilities.IsSameAs`) when both sides expose a non-null `ClrType`. Exact identity, not assignability — genuinely different types never match. The open-generic receiver unification branch and its constraint ranking are untouched.

## Tests

- `Issue1103ExtensionInstanceCallEmitTests` — compiles, IL-verifies and runs instance-syntax extension calls on a BCL type (`System.Text.StringBuilder`) and a primitive (`int32`) from class methods, free functions and top-level statements, asserting correct runtime results.
- `Issue1103ExtensionInstanceCallTests` — binder-level assertions that `GS0159` is no longer reported.

## Verification

- Minimal repro from the issue now compiles + emits + runs.
- Full `Core.Tests`: 3836 passed, 0 failed.
- `Issue1103` Emit tests: 5 passed. Extension/Receiver regression filters: Core.Tests 202 passed, Compiler.Tests 92 passed.

Fixes #1103
