### PR TITLE
Fixes #1103: extension functions on imported/primitive receivers callable with instance syntax

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -1812,6 +1812,24 @@ public sealed class Binder
             foreach (var f in previous.Functions)
             {
                 scope.TryDeclareFunction(f);
+
+                // Issue #1103: extension functions are folded into
+                // BoundGlobalScope.Functions (so free-function call syntax
+                // `Ext(receiver, …)` resolves through normal overload
+                // resolution). They must ALSO be re-registered as extension
+                // functions on the rebuilt body-binding scope, otherwise
+                // member/instance call syntax `receiver.Ext(…)` inside a
+                // function/method body finds no candidate (the scope walked at
+                // the call site carries an empty extension table) and reports
+                // GS0159. This is independent of the receiver type — it was
+                // previously masked only because top-level call sites are bound
+                // in the same pass that declares the extension, and because
+                // package-owned struct receivers also register the function as
+                // an instance method on the struct.
+                if (f.IsExtension)
+                {
+                    scope.TryDeclareExtensionFunction(f);
+                }
             }
 
             foreach (var v in previous.Variables)

--- a/src/Core/CodeAnalysis/Binding/BoundScope.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundScope.cs
@@ -265,10 +265,13 @@ public sealed class BoundScope
     /// <remarks>
     /// Two lookup paths are tried, in order:
     /// <list type="number">
-    /// <item><description><b>Exact-match fast path</b> — reference-equality on the
-    /// declared receiver type. This is sufficient for non-generic receivers
-    /// (<c>(self string)</c>, <c>(self int32)</c>) and for already-closed
-    /// receiver spellings.</description></item>
+    /// <item><description><b>Exact / structural receiver match</b> — a
+    /// reference-equality fast path (sufficient for primitive singletons and
+    /// already-interned imported symbols) backed by a STRUCTURAL CLR-type
+    /// comparison (issue #1103) so an imported/BCL or primitive receiver still
+    /// matches when the declaration-site and call-site symbols are distinct
+    /// <see cref="ImportedTypeSymbol"/> instances wrapping the same CLR type.
+    /// See <see cref="ExtensionReceiverMatches"/>.</description></item>
     /// <item><description><b>Generic-receiver unification (issue #773)</b> —
     /// an extension whose receiver type references its own function-level
     /// type parameters (e.g. <c>func (self sequence[T]) FirstOrNil[T]() T?</c>
@@ -290,7 +293,7 @@ public sealed class BoundScope
         {
             foreach (var ext in extensionFunctions)
             {
-                if (ext.Name == name && ext.ExtensionReceiverType == receiverType)
+                if (ext.Name == name && ExtensionReceiverMatches(ext.ExtensionReceiverType, receiverType))
                 {
                     function = ext;
                     return true;
@@ -899,6 +902,133 @@ public sealed class BoundScope
         }
 
         return symbols.Values.OfType<TSymbol>().ToImmutableArray();
+    }
+
+    /// <summary>
+    /// Issue #1103: determines whether an extension function declared with
+    /// receiver type <paramref name="declared"/> applies to a call-site
+    /// receiver of type <paramref name="callSite"/>.
+    /// </summary>
+    /// <remarks>
+    /// Reference equality is the fast path and is sufficient for the common
+    /// case where both spellings resolve to the same interned symbol
+    /// (primitive singletons such as <c>int32</c>/<c>string</c>, or an
+    /// <see cref="ImportedTypeSymbol"/> served from its per-CLR-<see cref="Type"/>
+    /// cache). It is, however, NOT sufficient for an imported/BCL receiver
+    /// whose declaration-site and call-site symbols are DISTINCT
+    /// <see cref="ImportedTypeSymbol"/> instances wrapping the same logical CLR
+    /// type — this happens when the two <see cref="Type"/> objects originate
+    /// from different reflection/metadata-load contexts and are therefore not
+    /// reference-equal, so the cache hands out distinct symbols. For those we
+    /// fall back to a STRUCTURAL comparison of the underlying CLR type
+    /// (<see cref="ClrTypeUtilities.IsSameAs(Type, Type)"/>, which compares by
+    /// <see cref="Type.FullName"/> and recurses through constructed generics /
+    /// arrays), so <c>func (s Stream) …</c> matches a <c>Stream</c> receiver and
+    /// <c>func (l List[int32]) …</c> matches a <c>List[int32]</c> receiver. When
+    /// either side carries SYMBOLIC type arguments (a #313 erased generic whose
+    /// closed CLR shape is projected onto <c>object</c>) the symbolic arguments
+    /// are compared too, so <c>List[A]</c> never matches <c>List[B]</c>. Because
+    /// the comparison is rooted in CLR-type identity, two different imported
+    /// types (or an imported type vs. a user type, whose <c>ClrType</c> is
+    /// <see langword="null"/> while being compiled) never collide.
+    /// </remarks>
+    /// <param name="declared">The declared extension receiver type.</param>
+    /// <param name="callSite">The static type of the call-site receiver.</param>
+    /// <returns><c>true</c> when both denote the same receiver type.</returns>
+    private static bool ExtensionReceiverMatches(TypeSymbol declared, TypeSymbol callSite)
+    {
+        if (ReferenceEquals(declared, callSite))
+        {
+            return true;
+        }
+
+        if (declared is null || callSite is null
+            || ReferenceEquals(declared, TypeSymbol.Error)
+            || ReferenceEquals(callSite, TypeSymbol.Error))
+        {
+            return false;
+        }
+
+        // Structural CLR-type identity. A null ClrType means a
+        // same-compilation user type / interface / open generic; those are
+        // identified by reference (handled above) — never by CLR identity —
+        // so a user receiver can never collide with an imported one here.
+        if (declared.ClrType is null || callSite.ClrType is null
+            || !ClrTypeUtilities.IsSameAs(declared.ClrType, callSite.ClrType))
+        {
+            return false;
+        }
+
+        // For constructed generics whose closed CLR shape is type-erased to
+        // `object` (symbolic arguments, e.g. `List[A]` for a same-compilation
+        // user type `A`), the ClrType comparison above is not discriminating —
+        // require the symbolic type arguments to agree as well so `List[A]`
+        // does not spuriously match `List[B]`.
+        if (declared is ImportedTypeSymbol declaredImported
+            && callSite is ImportedTypeSymbol callSiteImported
+            && (declaredImported.HasSubstitutableTypeArgument || callSiteImported.HasSubstitutableTypeArgument))
+        {
+            return ImportedTypeArgumentsMatch(declaredImported, callSiteImported);
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Issue #1103: compares the symbolic type arguments of two constructed
+    /// imported generics for structural identity, recovering same-compilation
+    /// user-type arguments whose <see cref="TypeSymbol.ClrType"/> has erased to
+    /// <c>object</c> (or is <see langword="null"/>). Same-compilation symbols
+    /// are reference-equal; distinct user types differ by reference / name so a
+    /// genuine mismatch (e.g. <c>List[A]</c> vs. <c>List[B]</c>) is rejected.
+    /// </summary>
+    /// <param name="declared">The declared receiver generic.</param>
+    /// <param name="callSite">The call-site receiver generic.</param>
+    /// <returns><c>true</c> when the open definitions and every type argument agree.</returns>
+    private static bool ImportedTypeArgumentsMatch(ImportedTypeSymbol declared, ImportedTypeSymbol callSite)
+    {
+        if (!ClrTypeUtilities.IsSameAs(declared.OpenDefinition, callSite.OpenDefinition))
+        {
+            return false;
+        }
+
+        if (declared.TypeArguments.IsDefaultOrEmpty || callSite.TypeArguments.IsDefaultOrEmpty
+            || declared.TypeArguments.Length != callSite.TypeArguments.Length)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < declared.TypeArguments.Length; i++)
+        {
+            var a = declared.TypeArguments[i];
+            var b = callSite.TypeArguments[i];
+            if (ReferenceEquals(a, b))
+            {
+                continue;
+            }
+
+            if (a is null || b is null)
+            {
+                return false;
+            }
+
+            // Concrete arguments compare by CLR identity; erased
+            // same-compilation user-type arguments (null ClrType) compare by
+            // reference (handled above) or by name as a last resort.
+            if (a.ClrType != null && b.ClrType != null)
+            {
+                if (!ClrTypeUtilities.IsSameAs(a.ClrType, b.ClrType))
+                {
+                    return false;
+                }
+            }
+            else if (!string.Equals(a.Name, b.Name, StringComparison.Ordinal))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /// <summary>

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1103ExtensionImportedReceiverTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1103ExtensionImportedReceiverTests.cs
@@ -1,0 +1,239 @@
+// <copyright file="Issue1103ExtensionImportedReceiverTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1103 / ADR-0019. An extension function whose receiver type is an
+/// imported/BCL or primitive CLR type must be callable with instance/member
+/// syntax <c>receiver.ExtMethod(args)</c> from inside a function or method
+/// body — not only as a free function <c>ExtMethod(receiver, args)</c> and not
+/// only from a top-level statement.
+///
+/// Two gaps combined to produce GS0159 "Cannot find function":
+/// <list type="number">
+/// <item><description>Extension functions were folded into
+/// <c>BoundGlobalScope.Functions</c> but were re-registered on the rebuilt
+/// body-binding scope only as plain functions, so the call-site extension
+/// table was empty for any call inside a function/method body
+/// (<c>CreateParentScope</c>).</description></item>
+/// <item><description><see cref="BoundScope.TryLookupExtensionFunction"/>
+/// matched the declared receiver against the call-site receiver by reference
+/// equality, which is not robust for imported types whose declaration- and
+/// call-site symbols can be distinct instances wrapping the same CLR
+/// type.</description></item>
+/// </list>
+/// Top-level calls and package-owned struct receivers masked the first gap
+/// (top-level statements are bound in the declaration pass; struct receivers
+/// also register the function as an instance method on the struct), which is
+/// why existing extension tests passed while real migrations failed.
+/// </summary>
+public class Issue1103ExtensionImportedReceiverTests
+{
+    [Fact]
+    public void ImportedBclReferenceReceiver_InMethodBody_Binds()
+    {
+        const string source = @"
+package Issue1103.Bcl
+import System.IO
+
+func (stream Stream) ReadU32() uint32 {
+    return uint32(5)
+}
+
+class C {
+    func UseFree(file Stream) uint32 {
+        return ReadU32(file)
+    }
+    func UseInstance(file Stream) uint32 {
+        return file.ReadU32()
+    }
+}
+";
+        var diagnostics = Bind(source);
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void PrimitiveReceiver_InMethodBody_Binds_And_Executes()
+    {
+        const string source = @"
+package Issue1103.Prim
+import System
+
+func (n int32) Doubled() int32 {
+    return n * 2
+}
+
+class C {
+    func UseInt(x int32) int32 {
+        return x.Doubled()
+    }
+}
+
+var c = C()
+c.UseInt(21)
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void ImportedBclReferenceReceiver_InMethodBody_Executes()
+    {
+        const string source = @"
+package Issue1103.BclExec
+import System
+import System.IO
+
+func (stream Stream) ReadU32() int32 {
+    return 5
+}
+
+class C {
+    func UseInstance(file Stream) int32 {
+        return file.ReadU32()
+    }
+}
+
+var c = C()
+var m = MemoryStream()
+c.UseInstance(m)
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(5, result.Value);
+    }
+
+    [Fact]
+    public void ClosedGenericImportedReceiver_InMethodBody_Binds_And_Executes()
+    {
+        const string source = @"
+package Issue1103.Gen
+import System.Collections.Generic
+
+func (l List[int32]) SumAll() int32 {
+    var total = 0
+    for x in l {
+        total = total + x
+    }
+    return total
+}
+
+class C {
+    func Use(items List[int32]) int32 {
+        return items.SumAll()
+    }
+}
+
+var c = C()
+var nums = List[int32]()
+nums.Add(1)
+nums.Add(2)
+nums.Add(3)
+c.Use(nums)
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(6, result.Value);
+    }
+
+    [Fact]
+    public void PackageOwnedStructReceiver_InMethodBody_StillBinds()
+    {
+        const string source = @"
+package Issue1103.Struct
+
+struct Point {
+    var X int32
+    var Y int32
+}
+
+func (p Point) Sum() int32 {
+    return p.X + p.Y
+}
+
+class C {
+    func Use(p Point) int32 {
+        return p.Sum()
+    }
+}
+";
+        // Only the expected ADR-0079 GS0314 owned-receiver warning may appear;
+        // no GS0159 'cannot find function' error.
+        var diagnostics = Bind(source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0159");
+    }
+
+    [Fact]
+    public void NoOverMatch_DifferentImportedReceiver_StillReportsGS0159()
+    {
+        const string source = @"
+package Issue1103.NoOverMatch
+import System.IO
+
+func (stream Stream) ReadU32() uint32 {
+    return uint32(5)
+}
+
+class C {
+    func Use(w TextWriter) uint32 {
+        return w.ReadU32()
+    }
+}
+";
+        var diagnostics = Bind(source);
+        Assert.Contains(diagnostics, d => d.Id == "GS0159");
+    }
+
+    [Fact]
+    public void OpenGenericReceiverUnification_InMethodBody_StillBinds_And_Executes()
+    {
+        const string source = @"
+package Issue1103.OpenGen
+import System
+import System.Collections.Generic
+
+func (self IEnumerable[T]) MyFirst[T any](fb T) T {
+    return fb
+}
+
+class C {
+    func Use(items []int32) int32 {
+        return items.MyFirst(99)
+    }
+}
+
+var c = C()
+c.Use([]int32{10, 20, 30})
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(99, result.Value);
+    }
+
+    private static IEnumerable<Diagnostic> Bind(string source)
+    {
+        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(syntaxTree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>()).Diagnostics.ToList();
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(syntaxTree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue1103ExtensionImportedReceiverEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue1103ExtensionImportedReceiverEmitTests.cs
@@ -1,0 +1,97 @@
+// <copyright file="Issue1103ExtensionImportedReceiverEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #1103. End-to-end (compile → load → reflective invoke) proof that an
+/// extension function on an imported/BCL or primitive receiver dispatches when
+/// called with instance/member syntax <c>receiver.ExtMethod(args)</c> from
+/// inside a method body. Prior to the fix these call sites reported GS0159.
+/// </summary>
+public class Issue1103ExtensionImportedReceiverEmitTests
+{
+    [Fact]
+    public void PrimitiveReceiver_InstanceCall_InMethodBody_Executes()
+    {
+        const string source = @"package Issue1103.PrimEmit
+
+import System
+
+func (n int32) Doubled() int32 {
+    return n * 2
+}
+
+class C {
+    public func UseInt(x int32) int32 {
+        return x.Doubled()
+    }
+}
+";
+        var asm = CompileToAssembly(source, "Issue1103.PrimEmit");
+
+        var cType = asm.GetTypes().Single(t => t.Name == "C");
+        var instance = System.Activator.CreateInstance(cType);
+        var useInt = cType.GetMethod("UseInt", BindingFlags.Public | BindingFlags.Instance);
+        Assert.NotNull(useInt);
+
+        var result = useInt!.Invoke(instance, new object[] { 21 });
+        Assert.Equal(42, result);
+    }
+
+    [Fact]
+    public void ImportedBclReceiver_InstanceCall_InMethodBody_Executes()
+    {
+        const string source = @"package Issue1103.BclEmit
+
+import System
+import System.IO
+
+func (stream Stream) ReadU32() int32 {
+    return 5
+}
+
+class C {
+    public func UseInstance(file Stream) int32 {
+        return file.ReadU32()
+    }
+}
+";
+        var asm = CompileToAssembly(source, "Issue1103.BclEmit");
+
+        var cType = asm.GetTypes().Single(t => t.Name == "C");
+        var instance = System.Activator.CreateInstance(cType);
+        var useInstance = cType.GetMethod("UseInstance", BindingFlags.Public | BindingFlags.Instance);
+        Assert.NotNull(useInstance);
+
+        using var ms = new MemoryStream();
+        var result = useInstance!.Invoke(instance, new object[] { ms });
+        Assert.Equal(5, result);
+    }
+
+    private static Assembly CompileToAssembly(string source, string contextName)
+    {
+        using var peStream = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Emit(peStream);
+
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(contextName, isCollectible: false);
+        return loadContext.LoadFromStream(peStream);
+    }
+}


### PR DESCRIPTION
## Summary
An extension function (receiver-clause `func`, ADR-0019) whose receiver is an imported/BCL or primitive CLR type could not be invoked with instance/member syntax `receiver.ExtMethod(args)` from inside a function/method body — the binder reported **GS0159: Cannot find function**. Free-function syntax `ExtMethod(receiver, args)` and package-owned struct receivers worked fine. This blocks faithful migration of idiomatic C# (extension methods on `Stream`, `byte[]`, `int`, ...).

The minimal repro from the issue now binds and runs:
```gsharp
func (stream Stream) ReadU32() uint32 { return uint32(5) }
func (n int32) Doubled() int32 { return n * 2 }
class C {
    func UseInstance(file Stream) uint32 { return file.ReadU32() } // was GS0159
    func UseInt(x int32) int32 { return x.Doubled() }             // was GS0159
}
```

## Root cause (two gaps)
1. **Scope re-registration (primary).** Extension functions are folded into `BoundGlobalScope.Functions` (`Binder.cs`) so free-call overload resolution can find them. But when the body-binding parent scope is rebuilt in `CreateParentScope`, those functions were re-declared **only as plain functions** (`TryDeclareFunction`), never as extensions (`TryDeclareExtensionFunction`). So every body-binding scope had an empty extension table and `TryLookupExtensionFunction` returned nothing → GS0159. This was masked because top-level call sites are bound in the *same* pass that declares the extension, and package-owned struct receivers are *also* registered as struct instance methods.
2. **Reference-equality match.** `BoundScope.TryLookupExtensionFunction` matched the declared receiver against the call-site receiver by reference equality, which is not robust for imported types whose declaration- and call-site symbols can be distinct `ImportedTypeSymbol` instances wrapping the same CLR type (e.g. across metadata-load contexts).

## Fix
- **`Binder.CreateParentScope`**: also re-register `IsExtension` functions via `TryDeclareExtensionFunction` (in addition to `TryDeclareFunction`), so member syntax resolves in body scopes while free-call syntax keeps working.
- **`BoundScope.TryLookupExtensionFunction`**: compare receivers structurally via a new `ExtensionReceiverMatches` helper — a reference-equality fast path backed by CLR-type identity (`ClrTypeUtilities.IsSameAs`, `FullName`-based and cross-context safe), plus symbolic type-argument comparison for erased constructed generics so `List[A]` never matches `List[B]`. User types (null `ClrType`) are matched only by reference, so a user receiver never collides with an imported one and two different imported types never collide. The open-generic unification branch (#773 / #775 constraint ranking) is left **unchanged**.

## Tests
- **`Issue1103ExtensionImportedReceiverTests`** (binder + interpreter): imported BCL reference receiver in a method body; primitive receiver (bind + execute → 42); closed-generic `List[int32]` receiver (bind + execute → 6); package-owned struct receiver still binds (no GS0159); negative over-match (extension on `Stream` not found for `TextWriter` → still GS0159); open-generic `IEnumerable[T]` unification in a method body still binds + executes.
- **`Issue1103ExtensionImportedReceiverEmitTests`** (compile → load → reflective invoke): primitive and imported-BCL instance-syntax calls dispatch and return the correct value.

## Verification
- Full `Core.Tests`: 3840 passed, 1 skipped.
- `Compiler.Tests` extension/receiver/overload slice: 123 passed.
- Targeted extension/receiver/overload/#773/#775/#792 slice: 308 passed.
- No new node kinds; pure binder lookup + scope-reconstruction logic.
