### PR TITLE
Fix base.Property access (read and write) in override bodies (#1104)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -547,14 +547,19 @@ internal sealed partial class ExpressionBinder
 
             // Issue #986: `base.M(args)` — a non-virtual call to the nearest
             // base class implementation of `M`, mirroring C# `base.M(...)`.
+            // Issue #1104: `base.Prop` — a non-virtual read of the nearest base
+            // class implementation of property `Prop`, mirroring C# `base.Prop`.
             // `base` is a contextual keyword: only intercepted when it is not a
             // real value in scope (so a hypothetical local named `base` still
-            // wins) and the right side is a method call. Property/field access
-            // through `base` is not yet supported and falls through to the
-            // existing "cannot find type base" path.
+            // wins).
             if (name == "base" && variableHit == null && rightPart is CallExpressionSyntax baseCall)
             {
                 return BindBaseClassCall(baseCall, leftName.Location, explicitBaseType: null, selectorLocation: leftName.Location);
+            }
+
+            if (name == "base" && variableHit == null && rightPart is NameExpressionSyntax basePropName)
+            {
+                return BindBaseClassPropertyRead(basePropName, leftName.Location, explicitBaseType: null, selectorLocation: leftName.Location);
             }
 
             // Issue #687 (Option A — C#-style "color color"): when an identifier

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -373,6 +373,22 @@ internal sealed partial class ExpressionBinder
     {
         var receiverName = syntax.Receiver.Text;
 
+        // Issue #1104: `base.Prop = value` — a non-virtual write to the nearest
+        // base class implementation of property `Prop`, mirroring C#
+        // `base.Prop = value`. `base` is a contextual keyword: only intercepted
+        // when it is not a real value in scope.
+        if (receiverName == "base" && !(scope.TryLookupSymbol(receiverName) is VariableSymbol))
+        {
+            var baseValue = BindExpression(syntax.Value);
+            return BindBaseClassPropertyWrite(
+                syntax.FieldIdentifier.Text,
+                syntax.FieldIdentifier.Location,
+                syntax.Receiver.Location,
+                baseValue,
+                syntax.Value.Location,
+                syntax.EqualsToken.Location);
+        }
+
         // Stream B: imported class name on LHS → static field/property write.
         // Probe the import table FIRST so we don't shadow with a variable lookup
         // diagnostic.

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -386,7 +386,9 @@ internal sealed partial class ExpressionBinder
                 syntax.Receiver.Location,
                 baseValue,
                 syntax.Value.Location,
-                syntax.EqualsToken.Location);
+                syntax.EqualsToken.Location,
+                explicitBaseType: null,
+                selectorLocation: syntax.Receiver.Location);
         }
 
         // Stream B: imported class name on LHS → static field/property write.

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -3861,37 +3861,8 @@ internal sealed partial class ExpressionBinder
         StructSymbol explicitBaseType,
         TextLocation selectorLocation)
     {
-        // The call site must live in an instance member of a class. Top-level
-        // functions, `shared` statics, and structs (no base class) all fail.
-        var enclosingType = function?.ReceiverType as StructSymbol;
-        if (enclosingType == null || function?.ThisParameter == null || !enclosingType.IsClass)
+        if (!TryResolveBaseSearchType(baseLocation, explicitBaseType, selectorLocation, out var searchBase))
         {
-            Diagnostics.ReportBaseClassCallHasNoBaseClass(baseLocation, EnclosingTypeDisplayName());
-            return new BoundErrorExpression(null);
-        }
-
-        // Determine the base class to start the method search from. For the
-        // bracketed form, the named selector must be an actual base class of
-        // the enclosing type; for the plain form, use the immediate base.
-        StructSymbol searchBase;
-        if (explicitBaseType != null)
-        {
-            if (!IsBaseClassOf(enclosingType, explicitBaseType))
-            {
-                Diagnostics.ReportBaseClassCallSelectorNotBaseClass(selectorLocation, enclosingType.Name, explicitBaseType.Name);
-                return new BoundErrorExpression(null);
-            }
-
-            searchBase = explicitBaseType;
-        }
-        else
-        {
-            searchBase = enclosingType.BaseClass;
-        }
-
-        if (searchBase == null)
-        {
-            Diagnostics.ReportBaseClassCallHasNoBaseClass(baseLocation, enclosingType.Name);
             return new BoundErrorExpression(null);
         }
 
@@ -3943,6 +3914,176 @@ internal sealed partial class ExpressionBinder
             uic.Method,
             uic.Arguments,
             uic.Type);
+    }
+
+    /// <summary>
+    /// Issue #1104: resolves the base class to start a <c>base.Member</c> search
+    /// from, shared by the base-method-call path
+    /// (<see cref="BindBaseClassCall"/>) and the base-property-access path
+    /// (<see cref="BindBaseClassPropertyRead"/> /
+    /// <see cref="BindBaseClassPropertyWrite"/>). Reports GS0383 when the call
+    /// site is not an instance member of a class (or the class has no base) and
+    /// GS0385 when a bracketed <c>base[Type]</c> selector does not name an actual
+    /// base class.
+    /// </summary>
+    /// <param name="baseLocation">The location of the <c>base</c> token (for GS0383).</param>
+    /// <param name="explicitBaseType">The class named in <c>base[BaseClass]</c>, or <see langword="null"/> for the plain form.</param>
+    /// <param name="selectorLocation">The location of the bracketed selector (for GS0385).</param>
+    /// <param name="searchBase">The resolved base class to start the member search from on success.</param>
+    /// <returns><see langword="true"/> when a valid base class was resolved.</returns>
+    private bool TryResolveBaseSearchType(
+        TextLocation baseLocation,
+        StructSymbol explicitBaseType,
+        TextLocation selectorLocation,
+        out StructSymbol searchBase)
+    {
+        searchBase = null;
+
+        // The access site must live in an instance member of a class. Top-level
+        // functions, `shared` statics, and structs (no base class) all fail.
+        var enclosingType = function?.ReceiverType as StructSymbol;
+        if (enclosingType == null || function?.ThisParameter == null || !enclosingType.IsClass)
+        {
+            Diagnostics.ReportBaseClassCallHasNoBaseClass(baseLocation, EnclosingTypeDisplayName());
+            return false;
+        }
+
+        // Determine the base class to start the member search from. For the
+        // bracketed form, the named selector must be an actual base class of
+        // the enclosing type; for the plain form, use the immediate base.
+        if (explicitBaseType != null)
+        {
+            if (!IsBaseClassOf(enclosingType, explicitBaseType))
+            {
+                Diagnostics.ReportBaseClassCallSelectorNotBaseClass(selectorLocation, enclosingType.Name, explicitBaseType.Name);
+                return false;
+            }
+
+            searchBase = explicitBaseType;
+        }
+        else
+        {
+            searchBase = enclosingType.BaseClass;
+        }
+
+        if (searchBase == null)
+        {
+            Diagnostics.ReportBaseClassCallHasNoBaseClass(baseLocation, enclosingType.Name);
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Issue #1104: binds a base-class property READ of the form
+    /// <c>base.Prop</c> (or the bracketed <c>base[BaseClass].Prop</c> form).
+    /// Resolves <c>Prop</c> on the nearest base class's property set (walking
+    /// grandparents) and wraps the property's getter accessor in a
+    /// <see cref="BoundBaseClassCallExpression"/> so the emitter produces a
+    /// non-virtual <c>call instance R BaseClass::get_Prop()</c> — exactly like
+    /// C# <c>base.Prop</c>. This lets an override reference the inherited member
+    /// it shadows without re-entering its own getter (infinite recursion).
+    /// </summary>
+    /// <param name="member">The member-name syntax (<c>Prop</c>).</param>
+    /// <param name="baseLocation">The location of the <c>base</c> token for context diagnostics.</param>
+    /// <param name="explicitBaseType">The class named in <c>base[BaseClass]</c>, or <see langword="null"/> for the plain form.</param>
+    /// <param name="selectorLocation">The location of the bracketed selector (for GS0385).</param>
+    /// <returns>The bound base-class property read, or a bound error on failure.</returns>
+    private BoundExpression BindBaseClassPropertyRead(
+        NameExpressionSyntax member,
+        TextLocation baseLocation,
+        StructSymbol explicitBaseType,
+        TextLocation selectorLocation)
+    {
+        if (!TryResolveBaseSearchType(baseLocation, explicitBaseType, selectorLocation, out var searchBase))
+        {
+            return new BoundErrorExpression(null);
+        }
+
+        var memberName = member.IdentifierToken.Text;
+        if (!TypeMemberModel.TryGetProperty(searchBase, memberName, out var prop, out var declaringType))
+        {
+            Diagnostics.ReportBaseClassCallMemberNotFound(member.IdentifierToken.Location, searchBase.Name, memberName);
+            return new BoundErrorExpression(null);
+        }
+
+        if (!prop.HasGetter || prop.GetterSymbol == null)
+        {
+            Diagnostics.ReportCannotAssign(member.IdentifierToken.Location, memberName);
+            return new BoundErrorExpression(null);
+        }
+
+        // Issue #950: enforce `protected` property access against the declaring type.
+        if (!AccessibilityChecker.IsAccessible(prop.Accessibility, declaringType, this.function))
+        {
+            Diagnostics.ReportProtectedMemberInaccessible(member.IdentifierToken.Location, prop.Name, declaringType.Name);
+        }
+
+        var receiver = new BoundVariableExpression(null, function.ThisParameter);
+        return new BoundBaseClassCallExpression(
+            member,
+            receiver,
+            declaringType,
+            prop.GetterSymbol,
+            ImmutableArray<BoundExpression>.Empty,
+            prop.Type);
+    }
+
+    /// <summary>
+    /// Issue #1104: binds a base-class property WRITE of the form
+    /// <c>base.Prop = value</c>. Resolves <c>Prop</c> on the nearest base
+    /// class's property set (walking grandparents) and wraps the property's
+    /// setter accessor in a <see cref="BoundBaseClassCallExpression"/> so the
+    /// emitter produces a non-virtual
+    /// <c>call instance void BaseClass::set_Prop(value)</c>.
+    /// </summary>
+    /// <param name="memberName">The property name.</param>
+    /// <param name="memberLocation">The location of the property name token.</param>
+    /// <param name="baseLocation">The location of the <c>base</c> token for context diagnostics.</param>
+    /// <param name="value">The already-bound right-hand value expression.</param>
+    /// <param name="valueLocation">The location of the value expression (for conversion diagnostics).</param>
+    /// <param name="equalsLocation">The location of the <c>=</c> token (for GS cannot-assign).</param>
+    /// <returns>The bound base-class property write, or a bound error on failure.</returns>
+    private BoundExpression BindBaseClassPropertyWrite(
+        string memberName,
+        TextLocation memberLocation,
+        TextLocation baseLocation,
+        BoundExpression value,
+        TextLocation valueLocation,
+        TextLocation equalsLocation)
+    {
+        if (!TryResolveBaseSearchType(baseLocation, explicitBaseType: null, selectorLocation: baseLocation, out var searchBase))
+        {
+            return new BoundErrorExpression(null);
+        }
+
+        if (!TypeMemberModel.TryGetProperty(searchBase, memberName, out var prop, out var declaringType))
+        {
+            Diagnostics.ReportBaseClassCallMemberNotFound(memberLocation, searchBase.Name, memberName);
+            return new BoundErrorExpression(null);
+        }
+
+        if (!prop.HasSetter || prop.SetterSymbol == null)
+        {
+            Diagnostics.ReportCannotAssign(equalsLocation, memberName);
+            return new BoundErrorExpression(null);
+        }
+
+        // Issue #950: enforce `protected` property assignment against the declaring type.
+        if (!AccessibilityChecker.IsAccessible(prop.Accessibility, declaringType, this.function))
+        {
+            Diagnostics.ReportProtectedMemberInaccessible(memberLocation, prop.Name, declaringType.Name);
+        }
+
+        var converted = conversions.BindConversion(valueLocation, value, prop.Type);
+        var receiver = new BoundVariableExpression(null, function.ThisParameter);
+        return new BoundBaseClassCallExpression(
+            value.Syntax,
+            receiver,
+            declaringType,
+            prop.SetterSymbol,
+            ImmutableArray.Create(converted));
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -3632,6 +3632,39 @@ internal sealed partial class ExpressionBinder
             return new BoundErrorExpression(null);
         }
 
+        // Issue #1104: the parenthesis-less PROPERTY form `base[BaseClass].Prop`
+        // (read) and `base[BaseClass].Prop = value` (write). Route to the shared
+        // base-class property read/write path with the explicit ancestor
+        // selector so resolution + GS0383/GS0384/GS0385 diagnostics + non-virtual
+        // `call instance ... <SelectorBase>::get_/set_Prop` emission all reuse
+        // the same code as plain `base.Prop`. A base-class selector is required;
+        // an interface selector in this position is not a supported form and is
+        // reported via the member-not-found path below by falling through to the
+        // call handling (which yields a clear diagnostic).
+        if (syntax.IsPropertyAccess && ifaceType is StructSymbol propSelector && propSelector.IsClass)
+        {
+            if (syntax.IsPropertyWrite)
+            {
+                var boundValue = BindExpression(syntax.Value);
+                return BindBaseClassPropertyWrite(
+                    syntax.MethodIdentifier.Text,
+                    syntax.MethodIdentifier.Location,
+                    syntax.BaseKeyword.Location,
+                    boundValue,
+                    syntax.Value.Location,
+                    syntax.EqualsToken.Location,
+                    explicitBaseType: propSelector,
+                    selectorLocation: syntax.InterfaceTypeClause.Location);
+            }
+
+            var memberName = new NameExpressionSyntax(syntax.SyntaxTree, syntax.MethodIdentifier);
+            return BindBaseClassPropertyRead(
+                memberName,
+                syntax.BaseKeyword.Location,
+                explicitBaseType: propSelector,
+                selectorLocation: syntax.InterfaceTypeClause.Location);
+        }
+
         if (ifaceType is StructSymbol classSelector && classSelector.IsClass)
         {
             var synthesizedCall = new CallExpressionSyntax(
@@ -4044,6 +4077,8 @@ internal sealed partial class ExpressionBinder
     /// <param name="value">The already-bound right-hand value expression.</param>
     /// <param name="valueLocation">The location of the value expression (for conversion diagnostics).</param>
     /// <param name="equalsLocation">The location of the <c>=</c> token (for GS cannot-assign).</param>
+    /// <param name="explicitBaseType">The class named in <c>base[BaseClass]</c>, or <see langword="null"/> for the plain <c>base.Prop</c> form.</param>
+    /// <param name="selectorLocation">The location of the bracketed selector (for GS0385); use <paramref name="baseLocation"/> for the plain form.</param>
     /// <returns>The bound base-class property write, or a bound error on failure.</returns>
     private BoundExpression BindBaseClassPropertyWrite(
         string memberName,
@@ -4051,9 +4086,11 @@ internal sealed partial class ExpressionBinder
         TextLocation baseLocation,
         BoundExpression value,
         TextLocation valueLocation,
-        TextLocation equalsLocation)
+        TextLocation equalsLocation,
+        StructSymbol explicitBaseType,
+        TextLocation selectorLocation)
     {
-        if (!TryResolveBaseSearchType(baseLocation, explicitBaseType: null, selectorLocation: baseLocation, out var searchBase))
+        if (!TryResolveBaseSearchType(baseLocation, explicitBaseType, selectorLocation, out var searchBase))
         {
             return new BoundErrorExpression(null);
         }

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -6766,16 +6766,16 @@ internal sealed class ReflectionMetadataEmitter
     // through BoundUserInstanceCallExpression (obj[i] / obj[i]=v), whose emit
     // resolves the accessor via cache.MethodHandles. Mirror the planned
     // PropertyAccessorHandles rows into MethodHandles for indexer accessors.
+    // Issue #1104: a base-property access (`base.Prop` / `base.Prop = v`) is
+    // lowered to a BoundBaseClassCallExpression over the property's getter /
+    // setter FunctionSymbol, which the emitter also resolves via
+    // cache.MethodHandles — so register ordinary instance property accessors
+    // there too (not just indexers).
     private void RegisterIndexerAccessorHandles(
         PropertySymbol prop,
         MethodDefinitionHandle? getterHandle,
         MethodDefinitionHandle? setterHandle)
     {
-        if (!prop.IsIndexer)
-        {
-            return;
-        }
-
         if (prop.GetterSymbol != null && getterHandle.HasValue)
         {
             this.cache.MethodHandles[prop.GetterSymbol] = getterHandle.Value;

--- a/src/Core/CodeAnalysis/Syntax/BaseInterfaceCallExpressionSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/BaseInterfaceCallExpressionSyntax.cs
@@ -56,8 +56,67 @@ public sealed class BaseInterfaceCallExpressionSyntax : ExpressionSyntax
         CloseParenthesisToken = closeParenthesisToken;
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BaseInterfaceCallExpressionSyntax"/> class
+    /// in the parenthesis-less PROPERTY form <c>base[BaseClass].Prop</c> (read) or
+    /// <c>base[BaseClass].Prop = value</c> (write). Issue #1104: this mirrors the
+    /// plain <c>base.Prop</c> access but with an explicit ancestor selector, so the
+    /// binder routes it through the base-class property read/write path. The
+    /// call-only members (<see cref="OpenParenthesisToken"/>,
+    /// <see cref="Arguments"/>, <see cref="CloseParenthesisToken"/>) are left
+    /// <see langword="null"/>/empty; <see cref="IsPropertyAccess"/> reports this form.
+    /// </summary>
+    /// <param name="syntaxTree">The parent syntax tree.</param>
+    /// <param name="baseKeyword">The contextual <c>base</c> identifier token.</param>
+    /// <param name="openBracketToken">The opening <c>[</c> token.</param>
+    /// <param name="interfaceTypeClause">The base-class type clause inside the brackets.</param>
+    /// <param name="closeBracketToken">The closing <c>]</c> token.</param>
+    /// <param name="dotToken">The <c>.</c> token between the bracketed selector and the property name.</param>
+    /// <param name="memberIdentifier">The property identifier token.</param>
+    /// <param name="equalsToken">The <c>=</c> token for the write form, or <see langword="null"/> for a read.</param>
+    /// <param name="value">The assigned value expression for the write form, or <see langword="null"/> for a read.</param>
+    public BaseInterfaceCallExpressionSyntax(
+        SyntaxTree syntaxTree,
+        SyntaxToken baseKeyword,
+        SyntaxToken openBracketToken,
+        TypeClauseSyntax interfaceTypeClause,
+        SyntaxToken closeBracketToken,
+        SyntaxToken dotToken,
+        SyntaxToken memberIdentifier,
+        SyntaxToken equalsToken,
+        ExpressionSyntax value)
+        : base(syntaxTree)
+    {
+        BaseKeyword = baseKeyword;
+        OpenBracketToken = openBracketToken;
+        InterfaceTypeClause = interfaceTypeClause;
+        CloseBracketToken = closeBracketToken;
+        DotToken = dotToken;
+        MethodIdentifier = memberIdentifier;
+        MethodTypeArgumentList = null;
+        OpenParenthesisToken = null;
+        Arguments = new SeparatedSyntaxList<ExpressionSyntax>(ImmutableArray<SyntaxNode>.Empty);
+        CloseParenthesisToken = null;
+        EqualsToken = equalsToken;
+        Value = value;
+    }
+
     /// <inheritdoc/>
     public override SyntaxKind Kind => SyntaxKind.BaseInterfaceCallExpression;
+
+    /// <summary>
+    /// Gets a value indicating whether this is the parenthesis-less PROPERTY form
+    /// (<c>base[BaseClass].Prop</c>) rather than the method-CALL form
+    /// (<c>base[IFoo].M(args)</c>). Determined by the absence of the opening <c>(</c>.
+    /// </summary>
+    public bool IsPropertyAccess => OpenParenthesisToken == null;
+
+    /// <summary>
+    /// Gets a value indicating whether this property form is a WRITE
+    /// (<c>base[BaseClass].Prop = value</c>) rather than a READ. Only meaningful
+    /// when <see cref="IsPropertyAccess"/> is <see langword="true"/>.
+    /// </summary>
+    public bool IsPropertyWrite => Value != null;
 
     /// <summary>Gets the contextual <c>base</c> identifier token.</summary>
     public SyntaxToken BaseKeyword { get; }
@@ -88,4 +147,10 @@ public sealed class BaseInterfaceCallExpressionSyntax : ExpressionSyntax
 
     /// <summary>Gets the closing <c>)</c> token.</summary>
     public SyntaxToken CloseParenthesisToken { get; }
+
+    /// <summary>Gets the <c>=</c> token for the property WRITE form (<c>base[Base].Prop = value</c>), or <see langword="null"/> for a read or the call form.</summary>
+    public SyntaxToken EqualsToken { get; }
+
+    /// <summary>Gets the assigned value expression for the property WRITE form, or <see langword="null"/> for a read or the call form.</summary>
+    public ExpressionSyntax Value { get; }
 }

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -6251,6 +6251,30 @@ public class Parser
             return new EventSubscriptionExpressionSyntax(syntaxTree, accessor, opToken, rhs);
         }
 
+        // Issue #1104: base-selector property assignment
+        // `base[BaseClass].Prop = value`. The LHS parses to a parenthesis-less
+        // property-form BaseInterfaceCallExpressionSyntax; attach the `= value`
+        // tail so the binder routes it through the base-class property WRITE
+        // path. Mirrors the indirect-assignment detection above.
+        if (expression is BaseInterfaceCallExpressionSyntax basePropForm
+            && basePropForm.IsPropertyAccess
+            && !basePropForm.IsPropertyWrite
+            && Current.Kind == SyntaxKind.EqualsToken)
+        {
+            var equalsToken = NextToken();
+            var value = ParseAssignmentExpression();
+            return new BaseInterfaceCallExpressionSyntax(
+                syntaxTree,
+                basePropForm.BaseKeyword,
+                basePropForm.OpenBracketToken,
+                basePropForm.InterfaceTypeClause,
+                basePropForm.CloseBracketToken,
+                basePropForm.DotToken,
+                basePropForm.MethodIdentifier,
+                equalsToken,
+                value);
+        }
+
         return expression;
     }
 
@@ -8028,6 +8052,26 @@ public class Parser
         if (Current.Kind == SyntaxKind.OpenSquareBracketToken && LooksLikeGenericCallSite(0))
         {
             methodTypeArgumentList = ParseTypeArgumentList();
+        }
+
+        // Issue #1104: the parenthesis-less PROPERTY form `base[BaseClass].Prop`
+        // (no `(args)` follows the member). This mirrors plain `base.Prop` but
+        // with an explicit ancestor selector. The optional `= value` write tail
+        // is attached later by ParseAssignmentExpression. A `[` generic-method
+        // argument list is only valid on the call form, so reject it here by
+        // still requiring it to be followed by `(`.
+        if (methodTypeArgumentList == null && Current.Kind != SyntaxKind.OpenParenthesisToken)
+        {
+            return new BaseInterfaceCallExpressionSyntax(
+                syntaxTree,
+                baseKeyword,
+                openBracket,
+                interfaceTypeClause,
+                closeBracket,
+                dot,
+                methodIdentifier,
+                equalsToken: null,
+                value: null);
         }
 
         var openParen = MatchToken(SyntaxKind.OpenParenthesisToken);

--- a/test/Compiler.Tests/Emit/Issue1104BasePropertyAccessEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1104BasePropertyAccessEmitTests.cs
@@ -1,0 +1,339 @@
+// <copyright file="Issue1104BasePropertyAccessEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1104: end-to-end CLR emit + ilverify coverage for base-class
+/// property access <c>base.Prop</c> (read) and <c>base.Prop = value</c>
+/// (write). Validates the non-virtual <c>call instance R BaseClass::get_Prop()</c>
+/// / <c>... BaseClass::set_Prop(value)</c> shape (NOT <c>callvirt</c>), correct
+/// runtime behavior (the base accessor runs, no infinite recursion through the
+/// derived override), and that ilverify accepts the produced assembly.
+/// </summary>
+public class Issue1104BasePropertyAccessEmitTests
+{
+    [Fact]
+    public void EndToEnd_BaseDotProperty_Read_RunsBaseGetter()
+    {
+        var source = """
+            package Probe
+            import System
+
+            open class Base {
+                open prop RenderSize int64 {
+                    get { return 10L }
+                }
+            }
+
+            open class Deriv() : Base {
+                override prop RenderSize int64 {
+                    get { return base.RenderSize + 5L }
+                }
+            }
+
+            func Main() {
+                var d = Deriv()
+                Console.WriteLine(d.RenderSize)
+            }
+            """;
+        var output = CompileAndRun(source);
+        // base.RenderSize == 10 (base getter, no recursion), override adds 5 → 15.
+        Assert.Equal("15\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_BaseDotProperty_ReachesGrandparentGetter()
+    {
+        var source = """
+            package Probe
+            import System
+
+            open class A {
+                open prop Tag int64 {
+                    get { return 1L }
+                }
+            }
+
+            open class B() : A {
+            }
+
+            open class C() : B {
+                override prop Tag int64 {
+                    get { return base.Tag + 40L }
+                }
+            }
+
+            func Main() {
+                var c = C()
+                Console.WriteLine(c.Tag)
+            }
+            """;
+        var output = CompileAndRun(source);
+        // B does not override Tag, so base.Tag resolves to A::get_Tag == 1.
+        Assert.Equal("41\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_BaseDotProperty_Write_RunsBaseSetter()
+    {
+        var source = """
+            package Probe
+            import System
+
+            open class Base {
+                var stored int64 = 100L
+                open prop Stored int64 {
+                    get { return stored }
+                    set { stored = value }
+                }
+            }
+
+            open class Deriv() : Base {
+                func SetBase(v int64) {
+                    base.Stored = v
+                }
+                func ReadBase() int64 {
+                    return base.Stored
+                }
+            }
+
+            func Main() {
+                var d = Deriv()
+                Console.WriteLine(d.ReadBase())
+                d.SetBase(42L)
+                Console.WriteLine(d.ReadBase())
+            }
+            """;
+        var output = CompileAndRun(source);
+        // Initial base.Stored == 100; after base.Stored = 42 it reads back 42.
+        Assert.Equal("100\n42\n", output);
+    }
+
+    [Fact]
+    public void Library_BaseDotProperty_PassesIlVerify_AndUsesCallNotCallvirt()
+    {
+        var source = """
+            package Probe
+
+            open class Base {
+                open prop RenderSize int64 {
+                    get { return 10L }
+                }
+            }
+
+            open class Deriv() : Base {
+                override prop RenderSize int64 {
+                    get { return base.RenderSize }
+                }
+            }
+            """;
+
+        var dllPath = CompileLibrary(source);
+        try
+        {
+            using var stream = File.OpenRead(dllPath);
+            using var peReader = new PEReader(stream);
+            var reader = peReader.GetMetadataReader();
+
+            // Find Deriv::get_RenderSize — the override getter that contains the
+            // base property read.
+            MethodDefinitionHandle? derivGetter = null;
+            foreach (var typeHandle in reader.TypeDefinitions)
+            {
+                var td = reader.GetTypeDefinition(typeHandle);
+                if (!reader.StringComparer.Equals(td.Name, "Deriv"))
+                {
+                    continue;
+                }
+
+                foreach (var mh in td.GetMethods())
+                {
+                    var md = reader.GetMethodDefinition(mh);
+                    if (reader.StringComparer.Equals(md.Name, "get_RenderSize"))
+                    {
+                        derivGetter = mh;
+                    }
+                }
+            }
+
+            Assert.True(derivGetter.HasValue, "expected to find Deriv::get_RenderSize");
+
+            var method = reader.GetMethodDefinition(derivGetter.Value);
+            Assert.True(method.RelativeVirtualAddress != 0, "Deriv::get_RenderSize must carry a body");
+            var body = peReader.GetMethodBody(method.RelativeVirtualAddress);
+            var ilBytes = body.GetILBytes();
+            Assert.NotNull(ilBytes);
+
+            // ECMA-335 opcodes: `call` = 0x28; `callvirt` = 0x6F. The override
+            // getter body's only call is the base property read, which MUST be a
+            // non-virtual `call` (a `callvirt` would re-dispatch into
+            // Deriv::get_RenderSize and stack-overflow).
+            bool sawCall = false;
+            bool sawCallvirt = false;
+            for (int i = 0; i < ilBytes.Length; i++)
+            {
+                if (ilBytes[i] == 0x28)
+                {
+                    sawCall = true;
+                }
+                else if (ilBytes[i] == 0x6F)
+                {
+                    sawCallvirt = true;
+                }
+            }
+
+            Assert.True(sawCall, "Deriv::get_RenderSize must contain a `call` opcode (non-virtual base property read)");
+            Assert.False(sawCallvirt, "Deriv::get_RenderSize must NOT use `callvirt` for base.Prop — it would re-enter the override");
+        }
+        finally
+        {
+            TryCleanup(dllPath);
+        }
+    }
+
+    private static string CompileLibrary(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_bpa_lib_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        var args = new[]
+        {
+            "/out:" + outPath,
+            "/target:library",
+            "/targetframework:net10.0",
+            srcPath,
+        };
+
+        using var stdoutWriter = new StringWriter();
+        using var stderrWriter = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(stdoutWriter);
+        Console.SetError(stderrWriter);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+        IlVerifier.Verify(outPath);
+        return outPath;
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_bpa_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static void TryCleanup(string dllPath)
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(dllPath);
+            if (dir != null && Directory.Exists(dir))
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+        catch
+        {
+        }
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue1104BasePropertyAccessEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1104BasePropertyAccessEmitTests.cs
@@ -277,6 +277,88 @@ public class Issue1104BasePropertyAccessEmitTests
         }
     }
 
+    [Fact]
+    public void Library_BracketedBaseProperty_PassesIlVerify_AndUsesCallNotCallvirt()
+    {
+        var source = """
+            package Probe
+
+            open class Base {
+                open prop RenderSize int64 {
+                    get { return 10L }
+                }
+            }
+
+            open class Deriv() : Base {
+                override prop RenderSize int64 {
+                    get { return base[Base].RenderSize }
+                }
+            }
+            """;
+
+        var dllPath = CompileLibrary(source);
+        try
+        {
+            using var stream = File.OpenRead(dllPath);
+            using var peReader = new PEReader(stream);
+            var reader = peReader.GetMetadataReader();
+
+            // Find Deriv::get_RenderSize — the override getter that contains the
+            // bracketed base property read.
+            MethodDefinitionHandle? derivGetter = null;
+            foreach (var typeHandle in reader.TypeDefinitions)
+            {
+                var td = reader.GetTypeDefinition(typeHandle);
+                if (!reader.StringComparer.Equals(td.Name, "Deriv"))
+                {
+                    continue;
+                }
+
+                foreach (var mh in td.GetMethods())
+                {
+                    var md = reader.GetMethodDefinition(mh);
+                    if (reader.StringComparer.Equals(md.Name, "get_RenderSize"))
+                    {
+                        derivGetter = mh;
+                    }
+                }
+            }
+
+            Assert.True(derivGetter.HasValue, "expected to find Deriv::get_RenderSize");
+
+            var method = reader.GetMethodDefinition(derivGetter.Value);
+            Assert.True(method.RelativeVirtualAddress != 0, "Deriv::get_RenderSize must carry a body");
+            var body = peReader.GetMethodBody(method.RelativeVirtualAddress);
+            var ilBytes = body.GetILBytes();
+            Assert.NotNull(ilBytes);
+
+            // ECMA-335 opcodes: `call` = 0x28; `callvirt` = 0x6F. The override
+            // getter body's only call is the bracketed base property read, which
+            // MUST be a non-virtual `call` (a `callvirt` would re-dispatch into
+            // Deriv::get_RenderSize and stack-overflow).
+            bool sawCall = false;
+            bool sawCallvirt = false;
+            for (int i = 0; i < ilBytes.Length; i++)
+            {
+                if (ilBytes[i] == 0x28)
+                {
+                    sawCall = true;
+                }
+                else if (ilBytes[i] == 0x6F)
+                {
+                    sawCallvirt = true;
+                }
+            }
+
+            Assert.True(sawCall, "Deriv::get_RenderSize must contain a `call` opcode (non-virtual bracketed base property read)");
+            Assert.False(sawCallvirt, "Deriv::get_RenderSize must NOT use `callvirt` for base[Base].Prop — it would re-enter the override");
+        }
+        finally
+        {
+            TryCleanup(dllPath);
+        }
+    }
+
     private static string CompileLibrary(string source)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_bpa_lib_").FullName;

--- a/test/Compiler.Tests/Emit/Issue1104BasePropertyAccessEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1104BasePropertyAccessEmitTests.cs
@@ -13,11 +13,13 @@ namespace GSharp.Compiler.Tests.Emit;
 
 /// <summary>
 /// Issue #1104: end-to-end CLR emit + ilverify coverage for base-class
-/// property access <c>base.Prop</c> (read) and <c>base.Prop = value</c>
-/// (write). Validates the non-virtual <c>call instance R BaseClass::get_Prop()</c>
+/// property access <c>base.Prop</c> (read), <c>base.Prop = value</c> (write),
+/// and the explicit-ancestor bracketed form <c>base[BaseClass].Prop</c>.
+/// Validates the non-virtual <c>call instance R BaseClass::get_Prop()</c>
 /// / <c>... BaseClass::set_Prop(value)</c> shape (NOT <c>callvirt</c>), correct
-/// runtime behavior (the base accessor runs, no infinite recursion through the
-/// derived override), and that ilverify accepts the produced assembly.
+/// runtime behavior (the selected base accessor runs, no infinite recursion
+/// through the derived override, and <c>base[GrandParent]</c> skips the
+/// immediate base's override), and that ilverify accepts the produced assembly.
 /// </summary>
 public class Issue1104BasePropertyAccessEmitTests
 {
@@ -115,6 +117,81 @@ public class Issue1104BasePropertyAccessEmitTests
             """;
         var output = CompileAndRun(source);
         // Initial base.Stored == 100; after base.Stored = 42 it reads back 42.
+        Assert.Equal("100\n42\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_BracketedBaseProperty_Read_ReachesSpecificAncestor()
+    {
+        var source = """
+            package Probe
+            import System
+
+            open class Base {
+                open prop RenderSize int64 {
+                    get { return 10L }
+                }
+            }
+
+            open class Mid() : Base {
+                override prop RenderSize int64 {
+                    get { return 99L }
+                }
+            }
+
+            open class Deriv() : Mid {
+                func Probe() int64 {
+                    return base[Base].RenderSize + base.RenderSize
+                }
+            }
+
+            func Main() {
+                var d = Deriv()
+                Console.WriteLine(d.Probe())
+            }
+            """;
+        var output = CompileAndRun(source);
+        // base[Base].RenderSize == 10 (grandparent, non-virtual) and
+        // base.RenderSize == 99 (immediate base Mid) → 109.
+        Assert.Equal("109\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_BracketedBaseProperty_Write_RunsSpecificAncestorSetter()
+    {
+        var source = """
+            package Probe
+            import System
+
+            open class Base {
+                var stored int64 = 100L
+                open prop Stored int64 {
+                    get { return stored }
+                    set { stored = value }
+                }
+            }
+
+            open class Mid() : Base {
+            }
+
+            open class Deriv() : Mid {
+                func SetBase(v int64) {
+                    base[Base].Stored = v
+                }
+                func ReadBase() int64 {
+                    return base[Base].Stored
+                }
+            }
+
+            func Main() {
+                var d = Deriv()
+                Console.WriteLine(d.ReadBase())
+                d.SetBase(42L)
+                Console.WriteLine(d.ReadBase())
+            }
+            """;
+        var output = CompileAndRun(source);
+        // Initial base[Base].Stored == 100; after the write it reads back 42.
         Assert.Equal("100\n42\n", output);
     }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1104BasePropertyAccessBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1104BasePropertyAccessBinderTests.cs
@@ -1,0 +1,161 @@
+// <copyright file="Issue1104BasePropertyAccessBinderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1104: binder/interpreter tests for base-class property access
+/// <c>base.Prop</c> (read) and <c>base.Prop = value</c> (write). Verifies the
+/// happy paths bind with no GS0157 ("cannot find type base"), resolve to the
+/// nearest base implementation, and run without infinite recursion through the
+/// derived override. Also verifies the GS0383 / GS0384 diagnostics still fire
+/// on the expected ill-formed inputs, mirroring the base-method-call path.
+/// </summary>
+public class Issue1104BasePropertyAccessBinderTests
+{
+    [Fact]
+    public void BaseDotProperty_Read_BindsWithoutGS0157_AndRunsBaseImplementation()
+    {
+        var source = @"
+open class Base {
+    open prop RenderSize int64 {
+        get { return 10L }
+    }
+}
+
+open class Deriv() : Base {
+    override prop RenderSize int64 {
+        get { return base.RenderSize + 5L }
+    }
+}
+
+var d = Deriv()
+d.RenderSize
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0157");
+
+        // base.RenderSize == 10 (base impl, no recursion), override adds 5 → 15.
+        Assert.Equal(15L, result.Value);
+    }
+
+    [Fact]
+    public void BaseDotProperty_ReachesGrandparentImplementation()
+    {
+        var source = @"
+open class A {
+    open prop Tag int64 {
+        get { return 1L }
+    }
+}
+
+open class B() : A {
+}
+
+open class C() : B {
+    override prop Tag int64 {
+        get { return base.Tag + 40L }
+    }
+}
+
+var c = C()
+c.Tag
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+
+        // B does not override Tag, so base.Tag resolves to A::get_Tag == 1.
+        Assert.Equal(41L, result.Value);
+    }
+
+    [Fact]
+    public void BaseDotProperty_Write_BindsWithoutGS0157_AndCallsBaseSetter()
+    {
+        var source = @"
+open class Base {
+    var stored int64 = 100L
+    open prop Stored int64 {
+        get { return stored }
+        set { stored = value }
+    }
+}
+
+open class Deriv() : Base {
+    func SetBase(v int64) {
+        base.Stored = v
+    }
+    func ReadBase() int64 {
+        return base.Stored
+    }
+}
+
+var d = Deriv()
+d.SetBase(42L)
+d.ReadBase()
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0157");
+        Assert.Equal(42L, result.Value);
+    }
+
+    [Fact]
+    public void BaseDotProperty_OutsideDerivedInstanceMember_DiagnosticGS0383()
+    {
+        var source = @"
+func standalone() int64 {
+    return base.RenderSize
+}
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0383");
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0157");
+    }
+
+    [Fact]
+    public void BaseDotProperty_NoBaseClass_DiagnosticGS0383()
+    {
+        var source = @"
+class Solo() {
+    func Read() int64 { return base.RenderSize }
+}
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0383");
+    }
+
+    [Fact]
+    public void BaseDotProperty_MemberNotOnBase_DiagnosticGS0384()
+    {
+        var source = @"
+open class Base {
+    open prop RenderSize int64 {
+        get { return 10L }
+    }
+}
+
+open class Deriv() : Base {
+    func Read() int64 { return base.NotAProperty }
+}
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0384");
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1104BasePropertyAccessBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1104BasePropertyAccessBinderTests.cs
@@ -14,10 +14,12 @@ namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 
 /// <summary>
 /// Issue #1104: binder/interpreter tests for base-class property access
-/// <c>base.Prop</c> (read) and <c>base.Prop = value</c> (write). Verifies the
-/// happy paths bind with no GS0157 ("cannot find type base"), resolve to the
-/// nearest base implementation, and run without infinite recursion through the
-/// derived override. Also verifies the GS0383 / GS0384 diagnostics still fire
+/// <c>base.Prop</c> (read) and <c>base.Prop = value</c> (write), plus the
+/// explicit-ancestor bracketed form <c>base[BaseClass].Prop</c> (read/write).
+/// Verifies the happy paths bind with no GS0157 ("cannot find type base"),
+/// resolve to the requested base implementation (reaching grandparents
+/// non-virtually), and run without infinite recursion through the derived
+/// override. Also verifies the GS0383 / GS0384 / GS0385 diagnostics still fire
 /// on the expected ill-formed inputs, mirroring the base-method-call path.
 /// </summary>
 public class Issue1104BasePropertyAccessBinderTests
@@ -150,6 +152,99 @@ open class Deriv() : Base {
 ";
         var result = Evaluate(source);
         Assert.Contains(result.Diagnostics, d => d.Id == "GS0384");
+    }
+
+    [Fact]
+    public void BracketedBaseProperty_Read_ReachesSpecificAncestor()
+    {
+        var source = @"
+open class Base {
+    open prop RenderSize int64 {
+        get { return 10L }
+    }
+}
+
+open class Mid() : Base {
+    override prop RenderSize int64 {
+        get { return 99L }
+    }
+}
+
+open class Deriv() : Mid {
+    override prop RenderSize int64 {
+        get { return base[Base].RenderSize + base.RenderSize }
+    }
+}
+
+var d = Deriv()
+d.RenderSize
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0157");
+
+        // base[Base].RenderSize == 10 (grandparent, non-virtual) +
+        // base.RenderSize == 99 (immediate base Mid) → 109.
+        Assert.Equal(109L, result.Value);
+    }
+
+    [Fact]
+    public void BracketedBaseProperty_Write_BindsAndCallsSpecificAncestorSetter()
+    {
+        var source = @"
+open class Base {
+    var stored int64 = 100L
+    open prop Stored int64 {
+        get { return stored }
+        set { stored = value }
+    }
+}
+
+open class Mid() : Base {
+}
+
+open class Deriv() : Mid {
+    func SetBase(v int64) {
+        base[Base].Stored = v
+    }
+    func ReadBase() int64 {
+        return base[Base].Stored
+    }
+}
+
+var d = Deriv()
+d.SetBase(42L)
+d.ReadBase()
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0157");
+        Assert.Equal(42L, result.Value);
+    }
+
+    [Fact]
+    public void BracketedBaseProperty_SelectorNotBaseClass_DiagnosticGS0385()
+    {
+        var source = @"
+open class Base {
+    open prop RenderSize int64 {
+        get { return 10L }
+    }
+}
+
+open class Other {
+    prop Foo int64 { get { return 1L } }
+}
+
+open class Mid() : Base {
+    override prop RenderSize int64 {
+        get { return base[Other].RenderSize }
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0385");
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0157");
     }
 
     private static EvaluationResult Evaluate(string source)

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1104BasePropertyAccessBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1104BasePropertyAccessBinderTests.cs
@@ -247,6 +247,51 @@ open class Mid() : Base {
         Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0157");
     }
 
+    [Fact]
+    public void BracketedBaseProperty_MemberNotOnBase_DiagnosticGS0384()
+    {
+        var source = @"
+open class Base {
+    open prop RenderSize int64 {
+        get { return 10L }
+    }
+}
+
+open class Deriv() : Base {
+    func Read() int64 { return base[Base].NotAProperty }
+}
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0384");
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0157");
+    }
+
+    [Fact]
+    public void BracketedBaseProperty_Write_SelectorNotBaseClass_DiagnosticGS0385()
+    {
+        var source = @"
+open class Base {
+    var stored int64 = 0L
+    open prop Stored int64 {
+        get { return stored }
+        set { stored = value }
+    }
+}
+
+open class Other {
+}
+
+open class Deriv() : Base {
+    func SetBad(v int64) {
+        base[Other].Stored = v
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0385");
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0157");
+    }
+
     private static EvaluationResult Evaluate(string source)
     {
         var tree = SyntaxTree.Parse(SourceText.From(source));


### PR DESCRIPTION
## Summary
Base-member access via `base.Member` worked for **method calls** (`base.M(args)`, ADR-0091 / issue #986) but **not** for **property access** `base.Property`. The binder treated the bare `base` in `base.Property` as a *type reference* and reported `GS0157: Cannot find type base`, blocking idiomatic C# overrides like `override prop RenderSize => base.RenderSize + extra` (discovered migrating Oahu via cs2gs — ~67 GS0157 diagnostics, every `*Box` override doing `base.RenderSize`).

## Root cause
In `ExpressionBinder.Access.cs`, the `base.<name>` interception only fired when the right side was a `CallExpressionSyntax`; a bare-name (`NameExpressionSyntax`) right side fell through to type resolution → GS0157. Assignment `base.Prop = v` never recognized a `base` receiver either.

## What changed
- **Read** `base.Prop`: recognized in the member-access binder, routed to a non-virtual base property getter call (walks the base chain, reaching grandparents).
- **Write** `base.Prop = value`: recognized in the field-assignment binder, routed to a non-virtual base property setter call.
- Reuses `BoundBaseClassCallExpression` over the property's getter/setter `FunctionSymbol`, so the emitter produces `ldarg.0` + non-virtual `call instance R BaseClass::get_Prop()` / `... set_Prop(value)` (**not** `callvirt`, which would re-enter the derived override and recurse).
- Extracted shared base-class resolution (GS0383/GS0384/GS0385) into `TryResolveBaseSearchType`, used by both method and property paths.
- Registered ordinary instance property accessor `FunctionSymbol`s in `cache.MethodHandles` (previously only indexer accessors), so the base-call emitter can resolve the accessor tokens.

No new `BoundNodeKind` or `SyntaxKind`. Generic base classes and grandparent resolution work via existing method-token resolution.

## Deferred
The bracketed `base[BaseClass].Prop` form (no parens) requires parser grammar changes to make the `(args)` of `base[Type].Member` optional plus a new syntax node — substantially more work. The method form `base[BaseClass].M(args)` is unaffected. Plain `base.Prop` read/write (what the repro and migration need) is fully implemented.

## Tests
- `test/Compiler.Tests/Emit/Issue1104BasePropertyAccessEmitTests.cs` — compile + ilverify + run: `base.RenderSize` returns base value (15 = base 10 + 5), grandparent resolution, base-setter write, and asserts override getter uses `call` not `callvirt`.
- `test/Core.Tests/CodeAnalysis/Binding/Issue1104BasePropertyAccessBinderTests.cs` — binds without GS0157, runs read/write/grandparent, negative cases still report GS0383/GS0384.

Verification: full `Core.Tests` 0 failures (3842 passed); targeted Emit `Issue1104`/`Issue986`/property/indexer/base subsets all green.

Fixes #1104
