### PR TITLE
Fix #1112: switch-expression best-common-type and target-typing

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.SwitchExpr.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.SwitchExpr.cs
@@ -25,6 +25,9 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 internal sealed partial class ExpressionBinder
 {
     private BoundExpression BindSwitchExpression(SwitchExpressionSyntax syntax)
+        => BindSwitchExpression(syntax, targetType: null);
+
+    private BoundExpression BindSwitchExpression(SwitchExpressionSyntax syntax, TypeSymbol targetType)
     {
         var discriminant = BindExpression(syntax.Expression);
         var switchType = discriminant.Type;
@@ -107,7 +110,7 @@ internal sealed partial class ExpressionBinder
             Diagnostics.ReportSwitchExpressionMissingDefault(syntax.SwitchKeyword.Location);
         }
 
-        var resultType = boundArmBuilders[0].Result.Type;
+        var resultType = ComputeSwitchExpressionResultType(boundArmBuilders, targetType);
         var arms = ImmutableArray.CreateBuilder<BoundSwitchExpressionArm>(boundArmBuilders.Count);
         foreach (var arm in boundArmBuilders)
         {
@@ -139,5 +142,152 @@ internal sealed partial class ExpressionBinder
             Diagnostics);
 
         return new BoundSwitchExpression(null, discriminant, boundArms, resultType);
+    }
+
+    /// <summary>
+    /// Issue #1112: computes the switch-expression result type. When a target
+    /// type is available (C#-style target-typing from an enclosing typed local,
+    /// function return type, or argument context) and every arm is implicitly
+    /// convertible to it, the target type is used. Otherwise the best common
+    /// type (least-upper-bound) across the arm types is computed by walking the
+    /// base-class chain and implemented interfaces, falling back to
+    /// <c>object</c>. When no common type exists the first arm's type is kept so
+    /// the existing GS0179 arm-mismatch diagnostic fires for the offending arms.
+    /// </summary>
+    private static TypeSymbol ComputeSwitchExpressionResultType(
+        IReadOnlyList<(SwitchExpressionArmSyntax Syntax, BoundPattern Pattern, BoundExpression Guard, BoundExpression Result)> arms,
+        TypeSymbol targetType)
+    {
+        var armTypes = new List<TypeSymbol>(arms.Count);
+        foreach (var arm in arms)
+        {
+            armTypes.Add(arm.Result.Type);
+        }
+
+        // Target-typing: honor an explicit target when every arm converts to it.
+        if (targetType != null
+            && targetType != TypeSymbol.Error
+            && targetType != TypeSymbol.Void
+            && AllArmsImplicitlyConvertTo(armTypes, targetType))
+        {
+            return targetType;
+        }
+
+        var common = ComputeBestCommonType(armTypes);
+        return common ?? armTypes[0];
+    }
+
+    private static bool AllArmsImplicitlyConvertTo(IReadOnlyList<TypeSymbol> armTypes, TypeSymbol candidate)
+    {
+        foreach (var armType in armTypes)
+        {
+            if (armType == TypeSymbol.Error
+                || armType == TypeSymbol.Never
+                || armType == TypeSymbol.Null)
+            {
+                // The bottom (`never`) and null-sentinel types convert to any
+                // reference/nullable target; an error arm is already diagnosed.
+                continue;
+            }
+
+            var conversion = Conversion.Classify(armType, candidate);
+            if (!conversion.IsImplicit)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Computes the best common type (least-upper-bound) across the supplied
+    /// arm types. Candidates are enumerated from the most-derived "anchor" arm
+    /// type — itself, then its base-class chain, then its implemented
+    /// interfaces, then <c>object</c> — and the first candidate to which every
+    /// arm is implicitly convertible is returned. Returns <see langword="null"/>
+    /// when no common type can be found.
+    /// </summary>
+    private static TypeSymbol ComputeBestCommonType(IReadOnlyList<TypeSymbol> armTypes)
+    {
+        // Any error arm short-circuits to Error so callers suppress further
+        // diagnostics.
+        foreach (var t in armTypes)
+        {
+            if (t == TypeSymbol.Error)
+            {
+                return TypeSymbol.Error;
+            }
+        }
+
+        // Drop the trivial bottom / null-sentinel types — they convert to any
+        // reference target and never constrain the common type.
+        var significant = new List<TypeSymbol>(armTypes.Count);
+        foreach (var t in armTypes)
+        {
+            if (t != TypeSymbol.Never && t != TypeSymbol.Null)
+            {
+                significant.Add(t);
+            }
+        }
+
+        if (significant.Count == 0)
+        {
+            return null;
+        }
+
+        // Fast path: all arms already share the same type.
+        var first = significant[0];
+        var allSame = true;
+        for (var i = 1; i < significant.Count; i++)
+        {
+            if (!ReferenceEquals(significant[i], first))
+            {
+                allSame = false;
+                break;
+            }
+        }
+
+        if (allSame)
+        {
+            return first;
+        }
+
+        foreach (var candidate in EnumerateSupertypeCandidates(first))
+        {
+            if (AllArmsImplicitlyConvertTo(significant, candidate))
+            {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Enumerates the candidate supertypes of <paramref name="type"/> ordered
+    /// most-specific first: the type itself, its base-class chain, then its
+    /// directly implemented interfaces. Mirroring C# best-common-type, this
+    /// deliberately does NOT invent <c>object</c> as a candidate — when arms
+    /// share no common base/interface the result is left unresolved so the
+    /// arm-mismatch diagnostic (GS0179) fires (an explicit target type can
+    /// still unify to a wider type, including <c>object</c>).
+    /// </summary>
+    private static IEnumerable<TypeSymbol> EnumerateSupertypeCandidates(TypeSymbol type)
+    {
+        yield return type;
+
+        if (type is StructSymbol structSymbol)
+        {
+            for (var baseClass = structSymbol.BaseClass; baseClass != null; baseClass = baseClass.BaseClass)
+            {
+                yield return baseClass;
+            }
+
+            foreach (var iface in structSymbol.Interfaces)
+            {
+                yield return iface;
+            }
+        }
     }
 }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -168,6 +168,16 @@ internal sealed partial class ExpressionBinder
             return BindStackAllocExpression(stackAlloc, targetType);
         }
 
+        // Issue #1112: a switch-expression honors the target type (C#-style
+        // target-typing) — bind it with the target so the result type can be
+        // the target when every arm is implicitly convertible to it, then run
+        // the standard conversion to shape/validate the overall result.
+        if (syntax is SwitchExpressionSyntax switchExpr)
+        {
+            var boundSwitch = BindSwitchExpression(switchExpr, targetType);
+            return conversions.BindConversion(syntax.Location, boundSwitch, targetType);
+        }
+
         return conversions.BindConversion(syntax, targetType);
     }
 

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.cs
@@ -3613,7 +3613,22 @@ internal sealed class StatementBinder
         }
         else
         {
-            expression = syntax.Expression == null ? null : bindExpression(syntax.Expression);
+            // Issue #1112: a `return switch { … }` honors the function's
+            // declared return type as the switch-expression target type so the
+            // result type can unify to the return type (C#-style target-typing)
+            // before the conversion below.
+            if (syntax.Expression is SwitchExpressionSyntax
+                && function != null
+                && !function.IsReturnTypeInferred
+                && function.Type != TypeSymbol.Void
+                && function.Type != TypeSymbol.Error)
+            {
+                expression = bindExpressionWithTargetType(syntax.Expression, function.Type);
+            }
+            else
+            {
+                expression = syntax.Expression == null ? null : bindExpression(syntax.Expression);
+            }
         }
 
         // Issue #490 (ADR-0060 follow-up): validate the `return ref` / `return` form

--- a/test/Compiler.Tests/Emit/Issue1112SwitchExprCommonTypeEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1112SwitchExprCommonTypeEmitTests.cs
@@ -1,0 +1,218 @@
+// <copyright file="Issue1112SwitchExprCommonTypeEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1112: end-to-end CLR emit coverage for switch-expression
+/// best-common-type / target-typing. A switch-expression whose arms produce
+/// different derived types (sharing a common base class or interface) must
+/// unify to that base/interface, both when the result is inferred into a
+/// local and when it is returned directly from a typed function. The emitted
+/// switch must produce a value statically typed as the common type so the
+/// stack slot / local is uniform, and ilverify must accept the assembly.
+/// </summary>
+public class Issue1112SwitchExprCommonTypeEmitTests
+{
+    [Fact]
+    public void EndToEnd_CommonBaseClass_LetInference_RunsAndDispatchesVirtually()
+    {
+        var source = """
+            package Probe
+            import System
+
+            open class Base {
+                open func Name() string { return "base" }
+            }
+            class A : Base {
+                override func Name() string { return "a" }
+            }
+            class B : Base {
+                override func Name() string { return "b" }
+            }
+
+            class Factory {
+                func PickLet(s string) Base {
+                    let box = switch s {
+                        case "a": A()
+                        case "b": B()
+                        default: A()
+                    }
+                    return box
+                }
+            }
+
+            func Main() {
+                var f = Factory()
+                Console.WriteLine(f.PickLet("a").Name())
+                Console.WriteLine(f.PickLet("b").Name())
+                Console.WriteLine(f.PickLet("z").Name())
+            }
+            """;
+        var output = CompileAndRun(source);
+        Assert.Equal("a\nb\na\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_CommonBaseClass_DirectReturn_RunsAndDispatchesVirtually()
+    {
+        var source = """
+            package Probe
+            import System
+
+            open class Base {
+                open func Name() string { return "base" }
+            }
+            class A : Base {
+                override func Name() string { return "a" }
+            }
+            class B : Base {
+                override func Name() string { return "b" }
+            }
+
+            class Factory {
+                func PickReturn(s string) Base {
+                    return switch s {
+                        case "a": A()
+                        case "b": B()
+                        default: A()
+                    }
+                }
+            }
+
+            func Main() {
+                var f = Factory()
+                Console.WriteLine(f.PickReturn("a").Name())
+                Console.WriteLine(f.PickReturn("b").Name())
+                Console.WriteLine(f.PickReturn("z").Name())
+            }
+            """;
+        var output = CompileAndRun(source);
+        Assert.Equal("a\nb\na\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_CommonInterface_RunsAndDispatchesVirtually()
+    {
+        var source = """
+            package Probe
+            import System
+
+            interface IShape {
+                func Area() float64;
+            }
+            class Sq : IShape {
+                func Area() float64 { return 4.0 }
+            }
+            class Ci : IShape {
+                func Area() float64 { return 3.0 }
+            }
+
+            class Factory {
+                func Pick(s string) IShape {
+                    let box = switch s {
+                        case "sq": Sq()
+                        default: Ci()
+                    }
+                    return box
+                }
+            }
+
+            func Main() {
+                var f = Factory()
+                Console.WriteLine(f.Pick("sq").Area())
+                Console.WriteLine(f.Pick("ci").Area())
+            }
+            """;
+        var output = CompileAndRun(source);
+        Assert.Equal("4\n3\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_sw1112_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/SwitchExpressionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/SwitchExpressionTests.cs
@@ -64,6 +64,119 @@ let label = switch v { case 1: ""one"" default: 2 }
         Assert.Contains(diagnostics, d => d.Message.Contains("All switch-expression arms must produce the same type", System.StringComparison.Ordinal));
     }
 
+    // Issue #1112: a class hierarchy used to exercise best-common-type and
+    // target-typing across switch-expression arms.
+    private const string ShapeHierarchy = @"
+open class Base {
+    open func Name() string { return ""base"" }
+}
+class A : Base {
+    override func Name() string { return ""a"" }
+}
+class B : Base {
+    override func Name() string { return ""b"" }
+}
+interface IShape {
+    func Area() float64;
+}
+class Sq : IShape {
+    func Area() float64 { return 4.0 }
+}
+class Ci : IShape {
+    func Area() float64 { return 3.0 }
+}
+";
+
+    [Fact]
+    public void SwitchExpression_CommonBaseClass_LetInference_Compiles()
+    {
+        // Issue #1112: arms produce A and B which share base class Base; the
+        // switch-expression result type should be the best common type Base,
+        // so `let box = …` infers Base and returning it as Base succeeds.
+        var diagnostics = Bind(ShapeHierarchy + @"
+func Pick(s string) Base {
+    let box = switch s {
+        case ""a"": A()
+        case ""b"": B()
+        default: A()
+    }
+    return box
+}
+");
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void SwitchExpression_CommonBaseClass_DirectReturn_Compiles()
+    {
+        // Issue #1112: `return switch { … }` unifies the A/B arms to Base
+        // (best common type and/or the function-return target type).
+        var diagnostics = Bind(ShapeHierarchy + @"
+func Pick(s string) Base {
+    return switch s {
+        case ""a"": A()
+        case ""b"": B()
+        default: A()
+    }
+}
+");
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void SwitchExpression_CommonInterface_LetInference_Compiles()
+    {
+        // Issue #1112: arms produce Sq and Ci which share interface IShape; the
+        // best common type is IShape.
+        var diagnostics = Bind(ShapeHierarchy + @"
+func Pick(s string) IShape {
+    let box = switch s {
+        case ""a"": Sq()
+        default: Ci()
+    }
+    return box
+}
+");
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void SwitchExpression_TargetTypedLocal_Compiles()
+    {
+        // Issue #1112: an explicitly-typed local supplies the target type the
+        // switch-expression unifies to.
+        var diagnostics = Bind(ShapeHierarchy + @"
+func Pick(s string) Base {
+    let box Base = switch s {
+        case ""a"": A()
+        default: B()
+    }
+    return box
+}
+");
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void SwitchExpression_CommonBaseClass_ResultTypeIsBase()
+    {
+        // Issue #1112: the inferred local type is the best common type Base.
+        var scope = BindGlobalScope(ShapeHierarchy + @"
+let box = switch ""x"" {
+    case ""a"": A()
+    case ""b"": B()
+    default: A()
+}
+");
+
+        Assert.Empty(scope.Diagnostics);
+        Assert.Equal("Base", scope.Variables.Single(v => v.Name == "box").Type.Name);
+    }
+
     [Fact]
     public void SwitchExpression_CaseValueTypeMismatch_Diagnoses()
     {


### PR DESCRIPTION
## Root cause
`BindSwitchExpression` inferred the switch-expression result type from the **first arm only** (`resultType = boundArmBuilders[0].Result.Type`) and then required every other arm to be implicitly convertible to that exact type. When arms produced different derived types that share a common base class / interface (e.g. `A()` and `B()` both deriving from `Base`), the second arm failed conversion and `GS0179` fired — even when the expression was assigned/returned into the shared base type.

## Fix
The result type is now the **best common type** (least-upper-bound) across all arm types:

- `ComputeSwitchExpressionResultType` first honors an available **target type** (typed local, function return type, argument context) when every arm is implicitly convertible to it (C#-style target-typing).
- Otherwise `ComputeBestCommonType` enumerates the anchor arm's supertype candidates — itself, its base-class chain, then its implemented interfaces — and returns the most-derived candidate to which **every** arm is implicitly convertible (using the existing `Conversion.Classify` machinery). Mirroring C# best-common-type, `object` is not auto-invented, so genuinely incompatible arms (e.g. `string`/`int`) still produce `GS0179`.
- Each arm is wrapped in the required implicit conversion so emit yields a uniformly-typed value (the local/stack slot is the common type).

Wiring:
- `ExpressionBinder.cs`: a target-typed `switch` expression routes through the new `BindSwitchExpression(syntax, targetType)` overload (covers typed locals and typed arguments).
- `StatementBinder.cs`: `return switch { … }` passes the function's declared return type as the target.

## Tests
- `SwitchExpressionTests`: best-common-type (base class & interface), inferred-let, direct-return, target-typed local, and result-type assertions. Existing `string`/`int` mismatch test still expects `GS0179`.
- `Issue1112SwitchExprCommonTypeEmitTests`: end-to-end compile + ilverify + run of the issue repro (let-inference, direct-return, common-interface) asserting correct virtual dispatch output.

Validation:
- `dotnet build GSharp.sln -c Release -graph` → 0 Warning(s) 0 Error(s).
- `dotnet test test/Core.Tests` → 3855 passed, 1 skipped, 0 failed.
- `dotnet test test/Compiler.Tests --filter Issue1112` → 3 passed.
- Standalone gsc repro compiles: `Wrote /tmp/sw1112.dll`.

No new `SyntaxKind`/`BoundNodeKind` were introduced (coverage matrix unchanged).

Fixes #1112