### PR TITLE
Switch-expression best-common-type across arms (#1112)

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -128,7 +128,7 @@ IDs may be given as `GS0001`, `0001`, or the bare integer `1`; all three forms a
 | GS0176 | Error | Switch expression is missing a `default` arm. | A `switch` expression that cannot be proven exhaustive and has no `default`. |
 | GS0177 | Error | Switch expression on enum is not exhaustive. | One or more enum members not covered and no `default` arm. |
 | GS0178 | Error | Switch statement on enum is not exhaustive. | One or more enum members not covered and no `default` arm. |
-| GS0179 | Error | Switch expression arm type mismatch. | Different arms of a `switch` expression produce incompatible types. |
+| GS0179 | Error | Switch expression arm type mismatch. | The arms of a `switch` expression have no best-common-type (shared base class/interface) and no usable target type — e.g. unrelated types like `string` + `int32`. |
 | GS0180 | Error | Accessibility modifier not allowed here. | `pub` or `priv` used on a local variable or inside a function body. |
 | GS0181 | Error | Base class is not open. | Inheriting from a class that was not declared `open`. |
 | GS0182 | Error | Method is overridable; `override` required. | Redefining an `open` method without the `override` keyword. |

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.SwitchExpr.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.SwitchExpr.cs
@@ -25,6 +25,9 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 internal sealed partial class ExpressionBinder
 {
     private BoundExpression BindSwitchExpression(SwitchExpressionSyntax syntax)
+        => BindSwitchExpression(syntax, targetType: null);
+
+    private BoundExpression BindSwitchExpression(SwitchExpressionSyntax syntax, TypeSymbol targetType)
     {
         var discriminant = BindExpression(syntax.Expression);
         var switchType = discriminant.Type;
@@ -107,11 +110,45 @@ internal sealed partial class ExpressionBinder
             Diagnostics.ReportSwitchExpressionMissingDefault(syntax.SwitchKeyword.Location);
         }
 
-        var resultType = boundArmBuilders[0].Result.Type;
+        // Issue #1112: compute the result type using a best-common-type
+        // (least-upper-bound) procedure across ALL arm types rather than
+        // forcing every arm to match the first arm's type. When no common
+        // type exists but a declared target type is supplied (a `let x T = …`
+        // initializer or a `return` in a function with a declared return
+        // type), fall back to target-typing the arms.
+        var armTypes = boundArmBuilders.Select(a => a.Result.Type);
+        var resultType = ComputeSwitchResultType(armTypes);
+
+        if ((resultType == null || IsObjectOrValueType(resultType))
+            && targetType != null
+            && targetType != TypeSymbol.Error
+            && AllArmsConvertTo(boundArmBuilders, targetType))
+        {
+            resultType = targetType;
+        }
+
+        if (resultType == null)
+        {
+            // No best-common-type and no usable target type: anchor on the
+            // first arm's type so the per-arm loop below reports the GS0179
+            // mismatch diagnostic against it (preserving prior behavior).
+            resultType = boundArmBuilders[0].Result.Type;
+        }
+
         var arms = ImmutableArray.CreateBuilder<BoundSwitchExpressionArm>(boundArmBuilders.Count);
         foreach (var arm in boundArmBuilders)
         {
             var result = arm.Result;
+
+            // Issue #1018 precedent: a throw-expression arm has the bottom
+            // (`never`) type — it yields no value to convert, so leave it
+            // unwrapped (mirroring ConvertConditionalBranch).
+            if (result.Type == TypeSymbol.Never)
+            {
+                arms.Add(new BoundSwitchExpressionArm(null, arm.Pattern, arm.Guard, result));
+                continue;
+            }
+
             var conversion = Conversion.Classify(result.Type, resultType);
             if (!conversion.Exists || conversion.IsExplicit)
             {
@@ -139,5 +176,245 @@ internal sealed partial class ExpressionBinder
             Diagnostics);
 
         return new BoundSwitchExpression(null, discriminant, boundArms, resultType);
+    }
+
+    /// <summary>
+    /// Issue #1112: computes the best-common-type (least-upper-bound) across a
+    /// set of switch-expression arm result types, using the following ordered
+    /// rules (mirroring the ternary <c>ComputeConditionalCommonType</c>
+    /// procedure but generalized to N arms):
+    /// <list type="number">
+    ///   <item><description><c>never</c> arms (throw-expressions) do not constrain the result; <c>nil</c> arms only require a reference/nullable result, which the per-arm conversion verifies.</description></item>
+    ///   <item><description>Identity — all constraining arms already share one type.</description></item>
+    ///   <item><description>Pairwise dominance — an arm type to which every other arm implicitly converts (preserves numeric widening and the "one arm IS the common base" case), with the numeric tie-break when several mutually convert.</description></item>
+    ///   <item><description>Shared supertype — the most-derived class or interface to which EVERY arm implicitly converts. <c>object</c>/<c>System.ValueType</c> are never valid results, so unrelated arms (e.g. <c>string</c> + <c>int32</c>) have no common type.</description></item>
+    /// </list>
+    /// Returns <see langword="null"/> when no common type exists.
+    /// </summary>
+    private static TypeSymbol ComputeSwitchResultType(IEnumerable<TypeSymbol> armTypesEnumerable)
+    {
+        var armTypes = armTypesEnumerable.ToList();
+        if (armTypes.Count == 0)
+        {
+            return null;
+        }
+
+        if (armTypes.Any(t => t == TypeSymbol.Error))
+        {
+            return TypeSymbol.Error;
+        }
+
+        // never/nil sentinels do not constrain the common type (mirroring
+        // ComputeConditionalCommonType). A nil arm only needs the chosen
+        // result to be reference/nullable-compatible, which the per-arm
+        // conversion pass verifies separately.
+        var hasNull = armTypes.Any(t => t == TypeSymbol.Null);
+        var constraining = armTypes.Where(t => t != TypeSymbol.Never && t != TypeSymbol.Null).ToList();
+
+        if (constraining.Count == 0)
+        {
+            // Every arm is a throw (never) or nil. Prefer nil when present so
+            // the result stays reference-compatible; otherwise the bottom type.
+            return hasNull ? TypeSymbol.Null : TypeSymbol.Never;
+        }
+
+        // Rule 1: identity — all constraining arms already share one type.
+        var first = constraining[0];
+        if (constraining.All(t => ReferenceEquals(t, first)))
+        {
+            return first;
+        }
+
+        // Rule 2: pairwise dominance — an arm type to which every other arm
+        // implicitly converts. Preserves numeric widening (ADR-0037) and the
+        // case where one arm literally IS the shared base type.
+        TypeSymbol dominator = null;
+        foreach (var candidate in constraining)
+        {
+            if (!AllConvertTo(constraining, candidate))
+            {
+                continue;
+            }
+
+            if (dominator == null)
+            {
+                dominator = candidate;
+            }
+            else
+            {
+                // Several mutually-convertible dominators (e.g. numeric
+                // primitives): prefer the wider via the numeric tie-break.
+                var widened = TryNumericTieBreak(dominator, candidate);
+                dominator = widened ?? dominator;
+            }
+        }
+
+        if (dominator != null)
+        {
+            return dominator;
+        }
+
+        // Rule 3: shared supertype LUB — the most-derived class or interface
+        // (excluding object/ValueType) to which every arm implicitly converts.
+        // The candidate pool is the ordered supertype set (most-derived first)
+        // of the first user-type arm; AllConvertTo enforces the intersection
+        // against all other arms.
+        foreach (var arm in constraining)
+        {
+            if (arm is not StructSymbol && arm is not InterfaceSymbol)
+            {
+                continue;
+            }
+
+            foreach (var candidate in EnumerateSupertypes(arm))
+            {
+                if (IsObjectOrValueType(candidate))
+                {
+                    continue;
+                }
+
+                if (AllConvertTo(constraining, candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            break;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> when every type in <paramref name="types"/>
+    /// implicitly converts (including identity) to <paramref name="target"/>.
+    /// </summary>
+    private static bool AllConvertTo(IEnumerable<TypeSymbol> types, TypeSymbol target)
+    {
+        foreach (var t in types)
+        {
+            if (ReferenceEquals(t, target))
+            {
+                continue;
+            }
+
+            // never/nil are implicitly convertible to any reference/nullable
+            // target; Conversion.Classify already encodes the never rule, and
+            // a nil sentinel widens to any reference/nullable type.
+            if (t == TypeSymbol.Never)
+            {
+                continue;
+            }
+
+            if (!Conversion.Classify(t, target).IsImplicit)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> when every switch arm implicitly
+    /// converts to <paramref name="target"/> (used for target-typing fallback).
+    /// </summary>
+    private static bool AllArmsConvertTo(
+        IEnumerable<(SwitchExpressionArmSyntax Syntax, BoundPattern Pattern, BoundExpression Guard, BoundExpression Result)> arms,
+        TypeSymbol target)
+        => AllConvertTo(arms.Select(a => a.Result.Type), target);
+
+    /// <summary>
+    /// Enumerates the supertype set of a user type — itself, its transitive
+    /// base classes, its imported CLR base class, and its transitive (and
+    /// inherited) interfaces — ordered most-derived first so the first match
+    /// found by the LUB search is the most specific shared supertype. Only
+    /// user-declared <see cref="StructSymbol"/> classes and
+    /// <see cref="InterfaceSymbol"/> interfaces contribute a non-trivial set;
+    /// primitive/imported types contribute only themselves, which keeps
+    /// unrelated value-type arms (e.g. <c>string</c> + <c>int32</c>) without a
+    /// common type.
+    /// </summary>
+    private static IEnumerable<TypeSymbol> EnumerateSupertypes(TypeSymbol type)
+    {
+        var seen = new HashSet<TypeSymbol>();
+        var ordered = new List<TypeSymbol>();
+
+        void Add(TypeSymbol t)
+        {
+            if (t != null && seen.Add(t))
+            {
+                ordered.Add(t);
+            }
+        }
+
+        if (type is StructSymbol s && s.IsClass)
+        {
+            // Self + user base-class chain (most-derived first).
+            for (var c = s; c != null; c = c.BaseClass)
+            {
+                Add(c);
+            }
+
+            // Imported CLR base class (e.g. a G# class extending a CLR type).
+            Add(s.ImportedBaseType);
+
+            // Transitive user interfaces and imported CLR interfaces from the
+            // whole class chain.
+            for (var c = s; c != null; c = c.BaseClass)
+            {
+                foreach (var iface in c.Interfaces)
+                {
+                    foreach (var baseIface in iface.SelfAndAllBaseInterfaces())
+                    {
+                        Add(baseIface);
+                    }
+                }
+
+                foreach (var clrIface in c.ImplementedClrInterfaces)
+                {
+                    Add(clrIface);
+                }
+            }
+        }
+        else if (type is InterfaceSymbol i)
+        {
+            foreach (var baseIface in i.SelfAndAllBaseInterfaces())
+            {
+                Add(baseIface);
+            }
+        }
+        else
+        {
+            Add(type);
+        }
+
+        return ordered;
+    }
+
+    /// <summary>
+    /// Issue #1112: <c>object</c> and <c>System.ValueType</c> are never valid
+    /// best-common-type results — when the only shared supertype is one of
+    /// these, the arms are treated as having no common type.
+    /// </summary>
+    private static bool IsObjectOrValueType(TypeSymbol type)
+    {
+        if (type == null)
+        {
+            return true;
+        }
+
+        if (ReferenceEquals(type, TypeSymbol.Object))
+        {
+            return true;
+        }
+
+        var clr = type.ClrType;
+        if (clr == null)
+        {
+            return false;
+        }
+
+        return clr.IsSameAs(typeof(object)) || clr.IsSameAs(typeof(System.ValueType));
     }
 }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -168,6 +168,19 @@ internal sealed partial class ExpressionBinder
             return BindStackAllocExpression(stackAlloc, targetType);
         }
 
+        // Issue #1112: thread the declared target type into a switch-expression
+        // so its arms can be target-typed when no best-common-type exists
+        // across them (e.g. `let x object = switch …` or a `return switch …`
+        // into a wider declared return type). When a best-common-type does
+        // exist it wins, and the outer conversion below is then identity.
+        if (syntax is SwitchExpressionSyntax switchSyntax)
+        {
+            var boundSwitch = BindSwitchExpression(switchSyntax, targetType);
+            return targetType == null
+                ? boundSwitch
+                : conversions.BindConversion(syntax.Location, boundSwitch, targetType);
+        }
+
         return conversions.BindConversion(syntax, targetType);
     }
 

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.cs
@@ -708,6 +708,14 @@ internal sealed class StatementBinder
                 variableType = type;
                 convertedInitializer = new BoundDefaultExpression(defaultInit, variableType);
             }
+            else if (type != null && syntax.Initializer is SwitchExpressionSyntax)
+            {
+                // Issue #1112: a `let x T = switch …` declaration target-types
+                // the switch arms against the declared type, so arms that share
+                // no best-common-type but all convert to T still bind.
+                variableType = type;
+                convertedInitializer = bindExpressionWithTargetType(syntax.Initializer, type);
+            }
             else
             {
                 var initializer = bindExpression(syntax.Initializer);
@@ -3613,7 +3621,22 @@ internal sealed class StatementBinder
         }
         else
         {
-            expression = syntax.Expression == null ? null : bindExpression(syntax.Expression);
+            if (syntax.Expression is SwitchExpressionSyntax switchReturn
+                && function != null
+                && !function.IsReturnTypeInferred
+                && function.Type != TypeSymbol.Void
+                && function.Type != TypeSymbol.Error)
+            {
+                // Issue #1112: a `return switch …` in a function with a declared
+                // return type target-types the switch arms against that type,
+                // so arms with no best-common-type but a common conversion to
+                // the return type still bind.
+                expression = bindExpressionWithTargetType(switchReturn, function.Type);
+            }
+            else
+            {
+                expression = syntax.Expression == null ? null : bindExpression(syntax.Expression);
+            }
         }
 
         // Issue #490 (ADR-0060 follow-up): validate the `return ref` / `return` form

--- a/test/Compiler.Tests/Emit/Issue1112SwitchBestCommonTypeEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1112SwitchBestCommonTypeEmitTests.cs
@@ -1,0 +1,277 @@
+// <copyright file="Issue1112SwitchBestCommonTypeEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1112: a switch-expression no longer forces every arm to produce the
+/// exact same type. The result type is the best-common-type (least-upper-bound)
+/// across all arm types — the shared base class or interface. These tests
+/// compile, ilverify, and RUN the repro to prove the upcast arms dispatch
+/// correctly at runtime.
+/// </summary>
+public class Issue1112SwitchBestCommonTypeEmitTests
+{
+    [Fact]
+    public void EndToEnd_SiblingSubtypes_SwitchBindsToBaseAndDispatches()
+    {
+        // The repro: each arm produces a distinct subtype of Base; the switch
+        // result type is the shared base class Base. Virtual dispatch on the
+        // upcast value resolves to the runtime subtype's override.
+        var source = """
+            package p
+
+            open class Base {
+                open func Name() string { return "base" }
+            }
+            class A : Base {
+                override func Name() string { return "a" }
+            }
+            class B : Base {
+                override func Name() string { return "b" }
+            }
+
+            class Factory {
+                func PickLet(s string) Base {
+                    let box = switch s {
+                        case "a": A()
+                        case "b": B()
+                        default: A()
+                    }
+                    return box
+                }
+                func PickReturn(s string) Base {
+                    return switch s {
+                        case "a": A()
+                        case "b": B()
+                        default: A()
+                    }
+                }
+            }
+
+            func Main() {
+                let f = Factory()
+                System.Console.WriteLine(f.PickReturn("a").Name())
+                System.Console.WriteLine(f.PickReturn("b").Name())
+                System.Console.WriteLine(f.PickLet("a").Name())
+                System.Console.WriteLine(f.PickLet("b").Name())
+                System.Console.WriteLine(f.PickReturn("z").Name())
+            }
+            """;
+        var output = CompileAndRun(source);
+        Assert.Equal("a\nb\na\nb\na\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_SharedInterface_SwitchBindsToInterfaceAndDispatches()
+    {
+        // Arms implement a common interface (no shared base beyond object); the
+        // switch result type is the interface and dispatch resolves correctly.
+        var source = """
+            package p
+
+            interface IShape { func Kind() string; }
+            class Circle : IShape { func Kind() string { return "circle" } }
+            class Square : IShape { func Kind() string { return "square" } }
+
+            class Picker {
+                func Pick(s string) IShape {
+                    return switch s {
+                        case "c": Circle()
+                        default: Square()
+                    }
+                }
+            }
+
+            func Main() {
+                let p = Picker()
+                System.Console.WriteLine(p.Pick("c").Kind())
+                System.Console.WriteLine(p.Pick("s").Kind())
+            }
+            """;
+        var output = CompileAndRun(source);
+        Assert.Equal("circle\nsquare\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_NeverArm_DoesNotConstrainAndDispatches()
+    {
+        // A throw-expression arm has the bottom (never) type; it does not
+        // constrain the best-common-type, which is the shared base Base.
+        var source = """
+            package p
+
+            open class Base { open func Name() string { return "base" } }
+            class A : Base { override func Name() string { return "a" } }
+            class B : Base { override func Name() string { return "b" } }
+
+            class Factory {
+                func Pick(s string) Base {
+                    return switch s {
+                        case "a": A()
+                        case "b": throw System.Exception("boom")
+                        default: B()
+                    }
+                }
+            }
+
+            func Main() {
+                let f = Factory()
+                System.Console.WriteLine(f.Pick("a").Name())
+                System.Console.WriteLine(f.Pick("z").Name())
+            }
+            """;
+        var output = CompileAndRun(source);
+        Assert.Equal("a\nb\n", output);
+    }
+
+    [Fact]
+    public void Library_SwitchBestCommonType_PassesIlVerify()
+    {
+        // ilverify is invoked unconditionally by CompileLibrary; an unsound
+        // upcast or a missing conversion would fail verification here.
+        var source = """
+            package p
+
+            open class Base { open func Name() string { return "base" } }
+            class A : Base { override func Name() string { return "a" } }
+            class B : Base { override func Name() string { return "b" } }
+
+            class Factory {
+                func Pick(s string) Base {
+                    return switch s { case "a": A() case "b": B() default: A() }
+                }
+            }
+            """;
+
+        var dllPath = CompileLibrary(source);
+        TryCleanup(dllPath);
+    }
+
+    private static string CompileLibrary(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1112_lib_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        var args = new[]
+        {
+            "/out:" + outPath,
+            "/target:library",
+            "/targetframework:net10.0",
+            srcPath,
+        };
+
+        RunCompiler(args);
+        IlVerifier.Verify(outPath);
+        return outPath;
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1112_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            RunCompiler(args);
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static void RunCompiler(string[] args)
+    {
+        using var stdoutWriter = new StringWriter();
+        using var stderrWriter = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(stdoutWriter);
+        Console.SetError(stderrWriter);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+    }
+
+    private static void TryCleanup(string dllPath)
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(dllPath);
+            if (dir != null && Directory.Exists(dir))
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+        catch
+        {
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/SwitchExpressionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/SwitchExpressionTests.cs
@@ -64,6 +64,154 @@ let label = switch v { case 1: ""one"" default: 2 }
         Assert.Contains(diagnostics, d => d.Message.Contains("All switch-expression arms must produce the same type", System.StringComparison.Ordinal));
     }
 
+    // Issue #1112: sibling subtypes that share a common base class produce a
+    // switch whose result type is the shared base, not a GS0179 mismatch.
+    [Fact]
+    public void SwitchExpression_SiblingSubtypes_SharedBaseClass_BindsToBase()
+    {
+        var scope = BindGlobalScope(@"
+open class Base {}
+class A : Base {}
+class B : Base {}
+let box = switch ""a"" { case ""a"": A() case ""b"": B() default: A() }
+");
+
+        Assert.DoesNotContain(scope.Diagnostics, d => d.Id == "GS0179");
+        Assert.Equal("Base", scope.Variables.Single(v => v.Name == "box").Type.Name);
+    }
+
+    // Issue #1112: arms whose types share only a common interface produce a
+    // switch whose result type is that interface.
+    [Fact]
+    public void SwitchExpression_SharedInterface_BindsToInterface()
+    {
+        var scope = BindGlobalScope(@"
+interface IShape { func Area() float64; }
+class Circle : IShape { func Area() float64 { return 3.14 } }
+class Square : IShape { func Area() float64 { return 4.0 } }
+let shape = switch ""c"" { case ""c"": Circle() default: Square() }
+");
+
+        Assert.DoesNotContain(scope.Diagnostics, d => d.Id == "GS0179");
+        Assert.Equal("IShape", scope.Variables.Single(v => v.Name == "shape").Type.Name);
+    }
+
+    // Issue #1112: one arm literally IS the common base — the dominance rule
+    // keeps the base as the result type.
+    [Fact]
+    public void SwitchExpression_ArmIsTheBase_BindsToBase()
+    {
+        var scope = BindGlobalScope(@"
+open class Base {}
+class A : Base {}
+let box = switch ""a"" { case ""a"": A() default: Base() }
+");
+
+        Assert.DoesNotContain(scope.Diagnostics, d => d.Id == "GS0179");
+        Assert.Equal("Base", scope.Variables.Single(v => v.Name == "box").Type.Name);
+    }
+
+    // Issue #1112: the full repro program (PickLet + PickReturn) compiles with
+    // no diagnostics under best-common-type alone.
+    [Fact]
+    public void SwitchExpression_Issue1112Repro_CompilesClean()
+    {
+        var diagnostics = Bind(@"
+package p
+
+open class Base {
+    open func Name() string { return ""base"" }
+}
+class A : Base {
+    override func Name() string { return ""a"" }
+}
+class B : Base {
+    override func Name() string { return ""b"" }
+}
+
+class Factory {
+    func PickLet(s string) Base {
+        let box = switch s {
+            case ""a"": A()
+            case ""b"": B()
+            default: A()
+        }
+        return box
+    }
+    func PickReturn(s string) Base {
+        return switch s {
+            case ""a"": A()
+            case ""b"": B()
+            default: A()
+        }
+    }
+}
+");
+
+        Assert.Empty(diagnostics);
+    }
+
+    // Issue #1112: numeric widening across arms is preserved (int8 + int32 →
+    // int32 via the dominance / numeric tie-break rule).
+    [Fact]
+    public void SwitchExpression_NumericWidening_PicksWiderType()
+    {
+        var scope = BindGlobalScope(@"
+let a int8 = 1
+let n = switch ""x"" { case ""x"": a default: 1000 }
+");
+
+        Assert.DoesNotContain(scope.Diagnostics, d => d.Id == "GS0179");
+        Assert.Equal(TypeSymbol.Int32, scope.Variables.Single(v => v.Name == "n").Type);
+    }
+
+    // Issue #1112: target-typing — when no best-common-type exists but every
+    // arm converts to a declared target type, the arms are target-typed.
+    [Fact]
+    public void SwitchExpression_TargetTypedToObject_Binds()
+    {
+        var scope = BindGlobalScope(@"
+let s = ""a""
+let x object = switch s { case ""a"": ""s"" default: 1 }
+");
+
+        Assert.DoesNotContain(scope.Diagnostics, d => d.Id == "GS0179");
+        Assert.Equal(TypeSymbol.Object, scope.Variables.Single(v => v.Name == "x").Type);
+    }
+
+    // Issue #1112: a never (throw-expression) arm does not constrain the
+    // common type — the result is the sibling arms' shared base.
+    [Fact]
+    public void SwitchExpression_NeverArm_DoesNotConstrainCommonType()
+    {
+        var diagnostics = Bind(@"
+import System
+
+open class Base {}
+class A : Base {}
+class B : Base {}
+func pick(s string) Base {
+    return switch s { case ""a"": A() case ""b"": throw Exception(""boom"") default: B() }
+}
+");
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0179");
+        Assert.Empty(diagnostics);
+    }
+
+    // Issue #1112: unrelated arm types with no declared target type still
+    // report GS0179 — object/ValueType are never a valid common type.
+    [Fact]
+    public void SwitchExpression_UnrelatedTypes_NoTarget_StillDiagnoses()
+    {
+        var diagnostics = Bind(@"
+let v = 1
+let label = switch v { case 1: ""one"" default: 2 }
+");
+
+        Assert.Contains(diagnostics, d => d.Id == "GS0179");
+    }
+
     [Fact]
     public void SwitchExpression_CaseValueTypeMismatch_Diagnoses()
     {

--- a/website/docs/ref/diagnostics.md
+++ b/website/docs/ref/diagnostics.md
@@ -136,7 +136,7 @@ IDs may be given as `GS0001`, `0001`, or the bare integer `1`; all three forms a
 | GS0176 | Error | Switch expression is missing a `default` arm. | A `switch` expression that cannot be proven exhaustive and has no `default`. |
 | GS0177 | Error | Switch expression on enum is not exhaustive. | One or more enum members not covered and no `default` arm. |
 | GS0178 | Error | Switch statement on enum is not exhaustive. | One or more enum members not covered and no `default` arm. |
-| GS0179 | Error | Switch expression arm type mismatch. | Different arms of a `switch` expression produce incompatible types. |
+| GS0179 | Error | Switch expression arm type mismatch. | The arms of a `switch` expression have no best-common-type (shared base class/interface) and no usable target type — e.g. unrelated types like `string` + `int32`. |
 | GS0180 | Error | Accessibility modifier not allowed here. | `pub` or `priv` used on a local variable or inside a function body. |
 | GS0181 | Error | Base class is not open. | Inheriting from a class that was not declared `open`. |
 | GS0182 | Error | Method is overridable; `override` required. | Redefining an `open` method without the `override` keyword. |

--- a/website/docs/ref/spec.md
+++ b/website/docs/ref/spec.md
@@ -763,6 +763,8 @@ Each element lowers against a fresh local seeded by the constructor call: a **ba
 
 Switch expressions use `:` between the pattern and the arm value (per ADR-0074 / issue #714). The legacy `->` arm separator is still accepted as a one-release migration aid but emits warning `GS0302`. Switch expressions require coverage or a default arm as enforced by diagnostics.
 
+The result type of a switch-expression is the **best-common-type** (least-upper-bound) across all arm values (issue #1112), not merely the first arm's type. It is chosen by: identity (all arms already share one type); pairwise dominance (an arm type to which every other arm implicitly converts — preserving numeric widening and the case where one arm is the shared base); otherwise the most-derived shared supertype — base class or interface — to which every arm implicitly converts. `object`/`System.ValueType` are never a valid common type, so unrelated arms (e.g. `string` + `int32`) have none. A `never`-typed (throw-expression) arm does not constrain the common type and a `nil` arm only requires a reference/nullable result. When no best-common-type exists but the switch appears as a `let x T = …` initializer or as a `return` in a function with a declared return type, the arms are target-typed to `T` when they all convert to it. When neither a common type nor a usable target type exists, the arms are rejected with `GS0179`.
+
 ```gsharp
 let description = switch value {
 case 0: "zero"


### PR DESCRIPTION
## Summary

A G# switch-expression previously inferred its result type from the **first** arm (`boundArmBuilders[0].Result.Type`) and rejected any later arm whose type differed with `GS0179`, even when all arms shared a common base class or interface.

This replaces the "first arm wins" logic with a **best-common-type (least-upper-bound)** computation across **all** arm result types.

`Fixes #1112`

## Best-common-type rules (`ComputeSwitchResultType`)

1. **Identity** — all arms already share one type (current behavior preserved).
2. **Pairwise dominance** — an arm type to which every other arm implicitly converts. Preserves numeric widening (with the existing numeric tie-break) and the case where one arm literally **is** the shared base.
3. **Shared supertype (the core enhancement)** — the most-derived class or interface, enumerated from a user-type arm's transitive base classes + transitive/inherited interfaces (most-derived first), to which **every** arm implicitly converts.
4. **`never` / `nil` sentinels** — a `never`-typed (throw-expression) arm does not constrain the common type and is left unwrapped at emit; a `nil` arm only requires a reference/nullable result.

**`object` / `System.ValueType` exclusion:** these are never a valid common type, so unrelated arms (e.g. `string` + `int32`) still have no common type and keep reporting `GS0179`.

All convertibility uses `Conversion.Classify`, keeping reference/interface/numeric rules consistent with the rest of the binder.

## Target-typing (implemented)

In addition to LUB, the declared target type is threaded into the switch so that, when **no** best-common-type exists but every arm converts to the target, the arms are target-typed:

- `let x T = switch …` (variable declaration with an explicit type)
- `return switch …` in a function with a declared (non-inferred) return type
- any target-typed expression position (`BindExpression(syntax, targetType)`)

The two repro methods compile under **LUB alone** (`PickReturn`'s arms LUB to `Base`; `PickLet` infers `Base` then `return box` is `Base`→`Base`); target-typing broadens coverage (e.g. `let x object = switch … { string / int }`).

## Files changed

- `src/Core/CodeAnalysis/Binding/ExpressionBinder.SwitchExpr.cs` — LUB result-type computation + helpers (`ComputeSwitchResultType`, `AllConvertTo`, `AllArmsConvertTo`, `EnumerateSupertypes`, `IsObjectOrValueType`); per-arm loop leaves `never` arms unwrapped; new target-typed overload.
- `src/Core/CodeAnalysis/Binding/ExpressionBinder.cs` — thread the target type into a switch-expression in the target-typed `BindExpression` overload.
- `src/Core/CodeAnalysis/Binding/StatementBinder.cs` — target-type a switch in `let x T = …` and `return switch …`.
- `docs/diagnostics.md`, `website/docs/ref/diagnostics.md` — refine the `GS0179` description.
- `website/docs/ref/spec.md` — document the switch-expression best-common-type rule.
- `test/Core.Tests/CodeAnalysis/Binding/SwitchExpressionTests.cs` — new binding tests.
- `test/Compiler.Tests/Emit/Issue1112SwitchBestCommonTypeEmitTests.cs` — new end-to-end emit tests.

## Tests added

Binding: sibling subtypes → base, shared interface → interface, arm-is-base, numeric widening, target-typing to `object`, `never` arm does not constrain, the full repro (PickLet + PickReturn) compiles clean, and the preserved `string` + `int32` → `GS0179` negative.

Emit (compile + ilverify + run): sibling subtypes dispatch via the base, shared-interface dispatch, `never`-arm program, and an ilverify-only library.

## Verification

- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release --no-build --filter "FullyQualifiedName~SwitchExpression"` → 84 passed.
- Full `Core.Tests` → 3858 passed, 1 skipped, 0 failed.
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Release --no-build --filter "FullyQualifiedName~Issue1112" -- xUnit.MaxParallelThreads=2` → 4 passed.
- Emit sanity batches (Switch/Conditional/IfExpression/Throw → 63 passed; Return/Variable/Inheritance/Polymorph → 199 passed).
- The must-preserve `string` + `int32` `GS0179` test still passes; the two repro methods compile clean.

Target-typing was implemented in addition to best-common-type (LUB).
