### PR TITLE
cs2gs: numeric coercion (conversion-call), extended promotion, and negated-guard binding (Refs #914)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue914NumericCoercionTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue914NumericCoercionTranslationTests.cs
@@ -1,0 +1,259 @@
+// <copyright file="Issue914NumericCoercionTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Translation tests for the three numeric/guard translator defects discovered
+/// migrating <c>Oahu.Decrypt</c> (issue #914):
+/// (1) numeric coercion to a non-nullable value type must use the
+/// conversion-call form <c>T(x)</c>, not <c>(x as T)</c> (GS0270);
+/// (2) numeric promotion must extend to bitwise / null-coalescing / char /
+/// compound-assignment operands (GS0129);
+/// (3) a negated type-pattern guard (<c>is not T t</c>) must keep its binding
+/// available after the <c>if</c> via a hoisted nullable local (GS0157).
+/// </summary>
+public class Issue914NumericCoercionTranslationTests
+{
+    /// <summary>
+    /// Task 1: coercing a constant operand to a non-nullable value type emits the
+    /// conversion-call form <c>uint8(1)</c> (not the GS0270-rejected
+    /// <c>(1 as uint8)</c>).
+    /// </summary>
+    [Fact]
+    public void NumericCoercion_NonNullableValueTarget_UsesConversionCallForm()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public bool F(byte b) => b > 1;
+    }
+}");
+
+        Assert.Contains("uint8(1)", printed);
+        Assert.DoesNotContain("as uint8", printed);
+    }
+
+    /// <summary>
+    /// Task 1 guard: a nullable value-type target keeps the <c>as</c> form, which
+    /// G# accepts (<c>(2 as uint16?)</c>).
+    /// </summary>
+    [Fact]
+    public void NumericCoercion_NullableValueTarget_KeepsAsForm()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class Entry { public ushort ChannelCount { get; set; } }
+
+    public class C
+    {
+        public bool IsStereo(Entry? e) => e?.ChannelCount == 2;
+    }
+}");
+
+        Assert.Contains("(2 as uint16?)", printed);
+    }
+
+    /// <summary>
+    /// Task 2: a bitwise operator over differing numeric operands is promoted, so
+    /// the constant operand is retyped via the conversion-call form
+    /// (<c>a &amp; uint32(255)</c>).
+    /// </summary>
+    [Fact]
+    public void BitwiseOperator_DifferingNumericOperands_Promoted()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public uint B(uint a) => a & 0xFF;
+    }
+}");
+
+        Assert.Contains("& uint32(", printed);
+        Assert.DoesNotContain("as uint32", printed);
+    }
+
+    /// <summary>
+    /// Task 2: null-coalescing over a nullable numeric coerces the right operand
+    /// to the left operand's underlying numeric type (<c>x ?? uint32(0)</c>).
+    /// </summary>
+    [Fact]
+    public void NullCoalescing_NullableNumeric_CoercesRightToUnderlying()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public uint N(uint? x) => x ?? 0;
+    }
+}");
+
+        Assert.Contains("?? uint32(0)", printed);
+    }
+
+    /// <summary>
+    /// Task 2: null-coalescing over non-numeric operands is left untouched (no
+    /// spurious numeric conversion is inserted).
+    /// </summary>
+    [Fact]
+    public void NullCoalescing_NonNumericOperands_NotPerturbed()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public string N(string? a, string b) => a ?? b;
+    }
+}");
+
+        Assert.Contains("a ?? b", printed);
+    }
+
+    /// <summary>
+    /// Task 2: a char operand participates in promotion; comparing a byte with a
+    /// char literal coerces the char to the byte's numeric type
+    /// (<c>b == uint8('A')</c>).
+    /// </summary>
+    [Fact]
+    public void CharOperand_InComparison_Promoted()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public bool Ch(byte b) => b == 'A';
+    }
+}");
+
+        Assert.Contains("uint8(", printed);
+        Assert.Contains("'A'", printed);
+    }
+
+    /// <summary>
+    /// Task 2: a compound numeric assignment with a differing RHS numeric type
+    /// coerces the RHS to the LHS type (<c>total += int64(count)</c>).
+    /// </summary>
+    [Fact]
+    public void CompoundAssignment_DifferingNumericRhs_Coerced()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public long T(int count)
+        {
+            long total = 0;
+            total += count;
+            return total;
+        }
+    }
+}");
+
+        Assert.Contains("total += int64(count)", printed);
+    }
+
+    /// <summary>
+    /// Task 3: a negated type-pattern guard (<c>is not T t</c>) is lowered to a
+    /// hoisted nullable local plus a nil-guard, so the binder <c>t</c> stays in
+    /// scope (and smart-casts) after the <c>if</c>.
+    /// </summary>
+    [Fact]
+    public void NegatedTypePatternGuard_HoistsBindingPastIf()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class TrunBox { public int DoThing() => 1; }
+
+    public class C
+    {
+        public int G(object box)
+        {
+            if (box is not TrunBox trun)
+            {
+                throw new System.InvalidOperationException();
+            }
+
+            return trun.DoThing();
+        }
+    }
+}");
+
+        Assert.Contains("let trun TrunBox? = box as TrunBox", printed);
+        Assert.Contains("if trun == nil", printed);
+        Assert.Contains("trun.DoThing()", printed);
+    }
+
+    /// <summary>
+    /// Task 3: a negated type-pattern guard over a property-path receiver
+    /// (<c>child.Header is not T t</c>) hoists the receiver into the local, which
+    /// G# cannot smart-cast in place.
+    /// </summary>
+    [Fact]
+    public void NegatedTypePatternGuard_PropertyPathReceiver_HoistsLocal()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class Header { }
+    public class TrunBox : Header { public int DoThing() => 1; }
+    public class Child { public Header Box { get; set; } }
+
+    public class C
+    {
+        public int G(Child child)
+        {
+            if (child.Box is not TrunBox trun)
+            {
+                return 0;
+            }
+
+            return trun.DoThing();
+        }
+    }
+}");
+
+        Assert.Contains("let trun TrunBox? = child.Box as TrunBox", printed);
+        Assert.Contains("if trun == nil", printed);
+        Assert.Contains("trun.DoThing()", printed);
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -2654,7 +2654,7 @@ public sealed class CSharpToGSharpTranslator
                     };
 
                 case IfStatementSyntax ifStatement:
-                    return new[] { this.TranslateIf(ifStatement) };
+                    return this.TranslateIfStatements(ifStatement).ToArray();
 
                 case WhileStatementSyntax whileStatement:
                     return new[]
@@ -2788,6 +2788,16 @@ public sealed class CSharpToGSharpTranslator
             string op = binary.OperatorToken.Text;
             GExpression right = this.TranslateExpression(binary.Right);
 
+            // C# null-coalescing `a ?? b`: the left is a nullable numeric, the
+            // right must match the left's *underlying* (non-nullable) numeric type
+            // (a `??` is not a symmetric arithmetic promotion of both sides). Only
+            // apply this when both sides are numeric; mixed reference cases such as
+            // `Task<T>? ?? Task` flow through unchanged.
+            if (op == "??")
+            {
+                return this.TranslateNullCoalescing(binary, left, right);
+            }
+
             if (!IsNumericPromotionOperator(op))
             {
                 return new BinaryExpression(left, op, right);
@@ -2849,13 +2859,102 @@ public sealed class CSharpToGSharpTranslator
             return new BinaryExpression(left, op, right);
         }
 
-        // Emits `(expr as T)` where T is the canonical G# form of `targetType`,
-        // making the C# implicit numeric promotion explicit for the G# binder.
+        // For a compound numeric assignment `x OP= y` (`+= -= *= /= %= &= |= ^=`),
+        // G# requires the RHS to share the LHS's numeric type; a mismatched RHS is
+        // coerced to the LHS type via the conversion-call form (e.g. `x += int64(y)`).
+        // A nullable RHS is coerced through the LHS's underlying numeric type.
+        private GExpression CoerceCompoundAssignmentRhs(
+            AssignmentExpressionSyntax assignment, GExpression rhs)
+        {
+            if (assignment.IsKind(SyntaxKind.SimpleAssignmentExpression))
+            {
+                return rhs;
+            }
+
+            ITypeSymbol leftType = this.context.GetTypeInfo(assignment.Left).Type;
+            ITypeSymbol rightType = this.context.GetTypeInfo(assignment.Right).Type;
+
+            if (TryGetNumericKind(leftType, out SpecialType leftUnderlying) &&
+                TryGetNumericKind(rightType, out SpecialType rightUnderlying) &&
+                leftUnderlying != rightUnderlying)
+            {
+                return this.CoerceOperandTo(rhs, UnwrapNullable(leftType));
+            }
+
+            return rhs;
+        }
+
+        // C# `a ?? b` where `a` is a nullable numeric: G# requires `b` to match
+        // the underlying numeric type of `a`, otherwise GS0129. Coerce the right
+        // operand to the left's underlying (non-nullable) type when they differ.
+        // Non-numeric coalescing (reference types, tasks) is left untouched.
+        private GExpression TranslateNullCoalescing(
+            BinaryExpressionSyntax binary, GExpression left, GExpression right)
+        {
+            ITypeSymbol leftType = this.context.GetTypeInfo(binary.Left).Type;
+            ITypeSymbol rightType = this.context.GetTypeInfo(binary.Right).Type;
+
+            if (TryGetNumericKind(leftType, out SpecialType leftUnderlying) &&
+                TryGetNumericKind(rightType, out SpecialType rightUnderlying) &&
+                leftUnderlying != rightUnderlying)
+            {
+                ITypeSymbol leftUnderlyingType = UnwrapNullable(leftType);
+                right = this.CoerceOperandTo(right, leftUnderlyingType);
+            }
+
+            return new BinaryExpression(left, "??", right);
+        }
+
+        // Unwraps `System.Nullable<T>` to its underlying `T`; other types pass
+        // through unchanged.
+        private static ITypeSymbol UnwrapNullable(ITypeSymbol type)
+        {
+            if (type is INamedTypeSymbol named &&
+                named.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T &&
+                named.TypeArguments.Length == 1)
+            {
+                return named.TypeArguments[0];
+            }
+
+            return type;
+        }
+
+        // non-nullable value type target (e.g. `uint8`, `int32`) G# rejects
+        // `(expr as T)` with GS0270 ("the 'as' operator requires the target type to
+        // be a reference type or a nullable value type"); the canonical G# form is
+        // the width-bearing conversion-call `T(expr)`. Only a reference type or a
+        // nullable value type target (where `as` is valid) keeps the `as` form.
         private GExpression CoerceOperandTo(GExpression expression, ITypeSymbol targetType)
         {
+            if (IsNonNullableValueType(targetType))
+            {
+                GTypeReference conversionTarget = this.typeMapper.Map(
+                    targetType, this.context, Location.None);
+                return new ConversionExpression(conversionTarget, expression);
+            }
+
             GTypeReference target = this.typeMapper.Map(targetType, this.context, Location.None);
             return new ParenthesizedExpression(
                 new BinaryExpression(expression, "as", new TypeExpression(target)));
+        }
+
+        // Reports whether `type` is a value type that is not `System.Nullable<T>`,
+        // i.e. a target for which G#'s `as` operator is invalid (GS0270) and the
+        // conversion-call form must be used instead.
+        private static bool IsNonNullableValueType(ITypeSymbol type)
+        {
+            if (type == null || !type.IsValueType)
+            {
+                return false;
+            }
+
+            if (type is INamedTypeSymbol named &&
+                named.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T)
+            {
+                return false;
+            }
+
+            return true;
         }
 
         private static bool IsNumericPromotionOperator(string op)
@@ -2873,6 +2972,9 @@ public sealed class CSharpToGSharpTranslator
                 case "*":
                 case "/":
                 case "%":
+                case "&":
+                case "|":
+                case "^":
                     return true;
                 default:
                     return false;
@@ -2880,9 +2982,9 @@ public sealed class CSharpToGSharpTranslator
         }
 
         // Reports whether `type` is a numeric primitive (unwrapping Nullable<T>) and
-        // yields its underlying special type. `bool`/`char`/`string` are excluded:
-        // they do not participate in C# implicit numeric promotion in a way that
-        // needs a G# conversion here.
+        // yields its underlying special type. `char` is included because C# promotes
+        // it to `int` in arithmetic/comparison/bitwise contexts, so a mismatched
+        // `uint8 == 'A'` needs a G# conversion here. `bool`/`string` are excluded.
         private static bool TryGetNumericKind(ITypeSymbol type, out SpecialType underlying)
         {
             underlying = SpecialType.None;
@@ -2900,6 +3002,7 @@ public sealed class CSharpToGSharpTranslator
 
             switch (type.SpecialType)
             {
+                case SpecialType.System_Char:
                 case SpecialType.System_SByte:
                 case SpecialType.System_Byte:
                 case SpecialType.System_Int16:
@@ -3026,11 +3129,13 @@ public sealed class CSharpToGSharpTranslator
             {
                 case AssignmentExpressionSyntax assignment:
                     string op = assignment.OperatorToken.Text;
+                    GExpression assignRhs = this.CoerceConstantToUnsigned(
+                        assignment.Right,
+                        this.TranslateExpression(assignment.Right));
+                    assignRhs = this.CoerceCompoundAssignmentRhs(assignment, assignRhs);
                     return new AssignmentStatement(
                         this.TranslateExpression(assignment.Left),
-                        this.CoerceConstantToUnsigned(
-                            assignment.Right,
-                            this.TranslateExpression(assignment.Right)),
+                        assignRhs,
                         op);
 
                 case PostfixUnaryExpressionSyntax postfix
@@ -3341,6 +3446,136 @@ public sealed class CSharpToGSharpTranslator
                 IndexExpression => true,
                 BinaryExpression binary => EndsWithIndexExpression(binary.Right),
                 _ => false,
+            };
+        }
+
+        /// <summary>
+        /// Translates an <c>if</c> statement into one or more G# statements. A C#
+        /// negated type-pattern guard with a designation (<c>if (x is not T t) {
+        /// throw/return; }</c>) needs the binder <c>t</c> to remain in scope *after*
+        /// the <c>if</c> (the then-block exits), and a property-path receiver cannot
+        /// be smart-cast — so it is lowered to a hoisted nullable local plus a
+        /// nil-guard (<see cref="TryBuildNegatedGuardHoist"/>). Every other form maps
+        /// to the single-statement <see cref="TranslateIf"/>.
+        /// </summary>
+        private IEnumerable<GStatement> TranslateIfStatements(IfStatementSyntax ifStatement)
+        {
+            if (this.TryBuildNegatedGuardHoist(ifStatement, out IReadOnlyList<GStatement> hoisted))
+            {
+                return hoisted;
+            }
+
+            return new[] { this.TranslateIf(ifStatement) };
+        }
+
+        /// <summary>
+        /// Lowers a C# negated type-pattern guard <c>if (receiver is not T t) {
+        /// … }</c> to the smart-cast-friendly G# form below.
+        /// <code>
+        /// let t T? = receiver as T
+        /// if t == nil { … }
+        /// </code>
+        /// The binder <c>t</c> becomes a real hoisted local that survives past the
+        /// <c>if</c> (so later <c>t.Member</c> uses bind to it under G#'s Kotlin-style
+        /// smart cast), and a property-path receiver (<c>child.Header</c>) is
+        /// evaluated once into the local. Only applies when the whole condition is a
+        /// negated declaration/recursive type-pattern with a single-variable
+        /// designation over a reference (non-value) target type, where
+        /// <c>as T</c> + nil-guard is valid.
+        /// </summary>
+        private bool TryBuildNegatedGuardHoist(
+            IfStatementSyntax ifStatement, out IReadOnlyList<GStatement> result)
+        {
+            result = null;
+
+            if (ifStatement.Condition is not IsPatternExpressionSyntax isPattern ||
+                isPattern.Pattern is not UnaryPatternSyntax notPattern ||
+                !notPattern.IsKind(SyntaxKind.NotPattern))
+            {
+                return false;
+            }
+
+            TypeSyntax typeSyntax;
+            VariableDesignationSyntax designation;
+            switch (notPattern.Pattern)
+            {
+                case DeclarationPatternSyntax declaration:
+                    typeSyntax = declaration.Type;
+                    designation = declaration.Designation;
+                    break;
+
+                case RecursivePatternSyntax { Type: { } recursiveType } recursive
+                    when recursive.PropertyPatternClause is null or { Subpatterns.Count: 0 }:
+                    typeSyntax = recursiveType;
+                    designation = recursive.Designation;
+                    break;
+
+                default:
+                    return false;
+            }
+
+            if (designation is not SingleVariableDesignationSyntax single)
+            {
+                return false;
+            }
+
+            // The hoisted `as T` + `== nil` guard is only valid when T is a
+            // reference type (or nullable value type); a non-nullable value-type
+            // target keeps the existing then-block binding behaviour.
+            ITypeSymbol targetSymbol = this.context.GetTypeInfo(typeSyntax).Type;
+            if (targetSymbol == null || targetSymbol.IsValueType)
+            {
+                return false;
+            }
+
+            string localName = SanitizeIdentifier(single.Identifier.Text);
+            GExpression receiver = this.TranslateExpression(isPattern.Expression);
+            GTypeReference targetType = this.MapTypeSyntax(typeSyntax);
+
+            // `let t T? = receiver as T` — the local is declared nullable so the
+            // `== nil` guard and the subsequent smart cast both type-check, while the
+            // `as` cast keeps its non-nullable reference target (a nullable `as T?`
+            // target is rejected at emit time).
+            var hoist = new LocalDeclarationStatement(
+                BindingKind.Let,
+                localName,
+                MakeNullable(targetType),
+                new BinaryExpression(receiver, "as", new TypeExpression(targetType)));
+
+            // `if t == nil { <then> }` reproduces the negated guard: when the cast
+            // fails the local is nil, so the original then-block runs.
+            GExpression guard = new BinaryExpression(
+                new IdentifierExpression(localName), "==", LiteralExpression.Null());
+            BlockStatement then = this.TranslateStatementAsBlock(ifStatement.Statement);
+
+            GStatement elseBranch = null;
+            if (ifStatement.Else != null)
+            {
+                elseBranch = ifStatement.Else.Statement is IfStatementSyntax elseIf
+                    ? this.TranslateIf(elseIf)
+                    : this.TranslateStatementAsBlock(ifStatement.Else.Statement);
+            }
+
+            result = new GStatement[] { hoist, new IfStatement(guard, then, elseBranch) };
+            return true;
+        }
+
+        // Returns a nullable (`T?`) copy of a type reference, preserving the
+        // concrete reference kind (named/array/pointer/tuple). Used when hoisting a
+        // negated type-pattern guard local so the `== nil` test type-checks.
+        private static GTypeReference MakeNullable(GTypeReference reference)
+        {
+            return reference switch
+            {
+                NamedTypeReference named =>
+                    new NamedTypeReference(named.Name, named.TypeArguments) { IsNullable = true },
+                ArrayTypeReference array =>
+                    new ArrayTypeReference(array.ElementType) { IsNullable = true },
+                PointerTypeReference pointer =>
+                    new PointerTypeReference(pointer.ElementType) { IsNullable = true },
+                TupleTypeReference tuple =>
+                    new TupleTypeReference(tuple.ElementTypes) { IsNullable = true },
+                _ => reference,
             };
         }
 


### PR DESCRIPTION
Translator-only fixes for three cs2gs (C#→G#) defects discovered while migrating the `Oahu.Decrypt` project. These account for the bulk (~380) of the remaining compile errors. All changes are in `tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs`; no `src/Core` (G# compiler) changes.

## Task 1 — GS0270: numeric coercion uses conversion-call form, not `as`
**Root cause:** `CoerceOperandTo` emitted `(expr as T)`. G# rejects `as` when the target is a non-nullable value type (`uint8`, `int32`, …) with GS0270.
**Fix:** For a non-nullable value-type target, emit the canonical conversion-call `T(expr)` via the existing `ConversionExpression` node. Reference types and nullable value types (e.g. `uint16?`) keep the valid `as` form (new `IsNonNullableValueType` helper).

## Task 2 — GS0129: extend numeric promotion
**Root cause:** Promotion only ran for `== != < <= > >= + - * / %`; several other numeric expressions reached G# with mismatched operand types.
**Fix:**
- **Bitwise** `& | ^` added to `IsNumericPromotionOperator` (existing promotion logic applies).
- **Null-coalescing `??`** (`TranslateNullCoalescing`): coerce the right operand to the **left**'s underlying (non-nullable) numeric type; numeric-only — reference/`Task` coalescing is untouched.
- **char** included in `TryGetNumericKind` (C# promotes char to int), so `uint8 == 'A'` → `uint8(...)`.
- **Compound assignment** `+= -= *= /= %= &= |= ^=` (`CoerceCompoundAssignmentRhs`): a differing-typed RHS is coerced to the LHS numeric type via the conversion-call form (`total += int64(count)`); nullable RHS coerced through the underlying type.

## Task 3 — GS0157: negated type-pattern guard binding lost after the `if`
**Root cause:** `TranslateIf` removed all pattern bindings registered by the condition after the then-block. For a negated guard `if (x is not T t) { throw/return; }` the binder `t` is used **after** the `if`; also a property-path receiver can't be smart-cast in place.
**Fix:** New `TryBuildNegatedGuardHoist` lowers the whole-condition `is not T t` form (declaration or simple recursive type-pattern, reference target) to a hoisted nullable local plus a nil-guard:
```
let t T? = receiver as T
if t == nil { … }
```
`t` becomes a real local that survives the `if` and smart-casts afterwards; the receiver is evaluated once. `TranslateIf` callers now route through `TranslateIfStatements` (returns `IEnumerable<GStatement>`). Non-reference targets fall back to the prior behaviour.

## Verification
- Build: `dotnet build GSharp.sln -c Release -graph` → 0 Warnings / 0 Errors.
- cs2gs tests: **194 passed** (185 existing + 9 new in `Issue914NumericCoercionTranslationTests`).
- Each generated G# form was compiled standalone through `gsc` (with the full framework ref set) and emits successfully — including `b > uint8(1)`, `a & uint32(255)`, `x ?? uint32(0)`, `b == uint8('A')`, `total += int64(count)`, and the hoisted `let trun T? = … as T` / `if trun == nil { … }` guard (both simple-local and property-path receivers).

## Out of scope
`[]uint8 == nil` (array-vs-null) is intentionally left for separate nullability work.

Refs #914