### PR TITLE
Fix non-nullable T to U? when U is a base class or interface of T (#1121)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -238,6 +238,25 @@ public sealed class Conversion
             {
                 return Conversion.Implicit;
             }
+
+            // Issue #1121: a non-nullable T is implicitly convertible to U?
+            // whenever T is implicitly convertible to its underlying U. This
+            // combines a reference upcast (to a base class or an implemented
+            // interface of T) with nullable wrapping into a single implicit
+            // conversion — a non-null reference is always a valid U?. For a
+            // reference-type underlying U the nullable wrap is a representation
+            // no-op, so we defer to the full implicit-conversion classification
+            // of `T → U` (identity, reference/upcast, interface implementation,
+            // boxing-to-object). Restricted to reference-like underlying targets
+            // so numeric nullable lifting (e.g. int32 → int64?) is unaffected.
+            if (IsReferenceLikeTarget(toNullable.UnderlyingType))
+            {
+                var underlyingConversion = Classify(from, toNullable.UnderlyingType);
+                if (underlyingConversion.Exists && underlyingConversion.IsImplicit)
+                {
+                    return Conversion.Implicit;
+                }
+            }
         }
 
         // Phase 3.C.2: nil literal is never assignable to a non-nullable type.
@@ -909,6 +928,29 @@ public sealed class Conversion
         {
             return false;
         }
+    }
+
+    private static bool IsReferenceLikeTarget(TypeSymbol type)
+    {
+        if (type is InterfaceSymbol)
+        {
+            return true;
+        }
+
+        if (type is StructSymbol { IsClass: true })
+        {
+            return true;
+        }
+
+        // Imported / CLR-backed types are reference-like when the CLR backing
+        // is a class or interface (not a value type, pointer, or by-ref). User
+        // value structs carry a null ClrType during binding and fall through.
+        if (type?.ClrType is { } clrBacking)
+        {
+            return !clrBacking.IsValueType && !clrBacking.IsPointer && !clrBacking.IsByRef;
+        }
+
+        return false;
     }
 
     private static bool IsInterfaceLikeType(TypeSymbol type)

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1121NonNullableToNullableBaseConversionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1121NonNullableToNullableBaseConversionTests.cs
@@ -1,0 +1,148 @@
+// <copyright file="Issue1121NonNullableToNullableBaseConversionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1121: a non-nullable value of type <c>T</c> must be implicitly
+/// convertible to <c>U?</c> when <c>U</c> is a base class or implemented
+/// interface of <c>T</c> — the conversion combines a reference upcast with
+/// nullable wrapping. Previously <c>Conversion.Classify</c> only accepted a
+/// nullable target whose underlying type was identical to the source, so the
+/// <c>T → U?</c> combination was rejected with <c>GS0155</c>.
+///
+/// These tests assert the positive base-class and interface cases (argument
+/// passing, assignment, return, and transitive base interface), that the
+/// pre-existing <c>T → T?</c> and plain <c>T → U</c> upcasts still bind, and
+/// that an unrelated type to <c>U?</c> still fails with <c>GS0155</c>.
+/// </summary>
+public class Issue1121NonNullableToNullableBaseConversionTests
+{
+    [Fact]
+    public void NonNullableClass_To_NullableInterface_AsArgument_Binds()
+    {
+        var source = @"
+interface IBox {}
+class StsdBox : IBox {}
+
+func TakeIface(p IBox?) {}
+
+TakeIface(StsdBox{})
+";
+        Assert.Empty(Evaluate(source).Diagnostics);
+    }
+
+    [Fact]
+    public void NonNullableDerived_To_NullableBase_AsArgument_Binds()
+    {
+        var source = @"
+open class Base {}
+class Derived : Base {}
+
+func TakeBase(p Base?) {}
+
+TakeBase(Derived{})
+";
+        Assert.Empty(Evaluate(source).Diagnostics);
+    }
+
+    [Fact]
+    public void NonNullableDerived_To_NullableBase_Assignment_Binds()
+    {
+        var source = @"
+open class Base {}
+class Derived : Base {}
+
+var b Base? = Derived{}
+";
+        Assert.Empty(Evaluate(source).Diagnostics);
+    }
+
+    [Fact]
+    public void NonNullableDerived_To_NullableBase_Return_Binds()
+    {
+        var source = @"
+open class Base {}
+class Derived : Base {}
+
+func Make() Base? {
+    return Derived{}
+}
+
+Make()
+";
+        Assert.Empty(Evaluate(source).Diagnostics);
+    }
+
+    [Fact]
+    public void NonNullableClass_To_NullableTransitiveBaseInterface_Binds()
+    {
+        var source = @"
+interface IBase {}
+interface IDerived : IBase {}
+class Impl : IDerived {}
+
+func TakeBase(p IBase?) {}
+
+TakeBase(Impl{})
+";
+        Assert.Empty(Evaluate(source).Diagnostics);
+    }
+
+    [Fact]
+    public void NonNullable_To_SameNullable_StillBinds()
+    {
+        var source = @"
+class StsdBox {}
+
+func Take(p StsdBox?) {}
+
+Take(StsdBox{})
+";
+        Assert.Empty(Evaluate(source).Diagnostics);
+    }
+
+    [Fact]
+    public void NonNullableDerived_To_NonNullableBase_StillBinds()
+    {
+        var source = @"
+open class Base {}
+class Derived : Base {}
+
+func Take(p Base) {}
+
+Take(Derived{})
+";
+        Assert.Empty(Evaluate(source).Diagnostics);
+    }
+
+    [Fact]
+    public void Unrelated_To_NullableInterface_StillReportsGS0155()
+    {
+        var source = @"
+interface IBox {}
+class Unrelated {}
+
+var b IBox? = Unrelated{}
+";
+        var result = Evaluate(source);
+        Assert.NotEmpty(result.Diagnostics);
+        Assert.Contains(result.Diagnostics, d => d.Message.Contains("Cannot convert type"));
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
## Root cause
`Conversion.Classify` accepted a nullable target `U?` only when the source was the `nil` literal, a matching nullable, or **exactly** `U`'s underlying type. It never ran the full implicit-conversion classification for a non-nullable source, so a combined **reference upcast + nullable wrap** (`T -> U?`, where `U` is a base class or implemented interface of `T`) was rejected with `GS0155` -- even though each step alone (`T -> T?` and `T -> U`) was already legal.

## Fix
When the target is a nullable `U?` and the source is a non-nullable `T`, classify `T -> U` using the existing implicit-conversion logic (identity, reference/upcast, interface implementation, boxing-to-object). If that is implicit, `T -> U?` is implicit too. For a reference-type underlying `U` the nullable wrap is a representation no-op.

A new `IsReferenceLikeTarget` guard restricts the arm to reference-like underlying targets (interfaces, classes, CLR reference types) so numeric nullable lifting (e.g. `int32 -> int64?`) is unaffected. Centralizing this in the classifier makes it apply to **all** implicit-conversion contexts: argument passing, `return`, assignment, and variable initialization.

## Tests
`Issue1121NonNullableToNullableBaseConversionTests` covers:
- Positive: non-nullable class -> nullable interface (argument), derived -> nullable base (argument/assignment/return), and transitive base-interface.
- Regression: `T -> T?` and plain `T -> U` upcasts still bind.
- Negative: an unrelated type -> `U?` still reports `GS0155`.

Full `Core.Tests` suite: **3863 passed, 1 skipped, 0 failed**. Standalone `gsc` repro from the issue now compiles (both calls).

Fixes #1121
