### PR TITLE
Smart-cast nullable var to non-null after non-null assignment (#1123)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundAssignmentExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundAssignmentExpression.cs
@@ -18,11 +18,18 @@ public sealed class BoundAssignmentExpression : BoundExpression
     /// <param name="syntax">The originating syntax.</param>
     /// <param name="variable">The variable symbol.</param>
     /// <param name="expression">The expression.</param>
-    public BoundAssignmentExpression(SyntaxNode syntax, VariableSymbol variable, BoundExpression expression)
+    /// <param name="assignedValueType">The static type of the right-hand side
+    /// value <em>before</em> any conversion to the variable's declared type.
+    /// Issue #1123: the statement binder consults this to decide whether an
+    /// assignment of a non-nullable value narrows a nullable <c>var</c> local
+    /// for subsequent reads. <see langword="null"/> falls back to
+    /// <see cref="Expression"/>'s (post-conversion) type.</param>
+    public BoundAssignmentExpression(SyntaxNode syntax, VariableSymbol variable, BoundExpression expression, TypeSymbol assignedValueType = null)
         : base(syntax)
     {
         Variable = variable;
         Expression = expression;
+        AssignedValueType = assignedValueType ?? expression.Type;
     }
 
     /// <inheritdoc/>
@@ -40,4 +47,12 @@ public sealed class BoundAssignmentExpression : BoundExpression
     /// Gets the expression.
     /// </summary>
     public BoundExpression Expression { get; }
+
+    /// <summary>
+    /// Gets the static type of the right-hand side value before conversion to
+    /// the variable's declared type (issue #1123). Used by the statement binder
+    /// to drive assignment-based smart-cast narrowing of nullable <c>var</c>
+    /// locals.
+    /// </summary>
+    public TypeSymbol AssignedValueType { get; }
 }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -138,7 +138,7 @@ internal sealed partial class ExpressionBinder
 
         var convertedExpression = conversions.BindConversion(syntax.Expression.Location, boundExpression, variable.Type);
 
-        return new BoundAssignmentExpression(null, variable, convertedExpression);
+        return new BoundAssignmentExpression(null, variable, convertedExpression, boundExpression.Type);
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.cs
@@ -354,6 +354,15 @@ internal sealed class StatementBinder
                 // narrowing from the current frame so subsequent reads in this
                 // block see the variable at its declared (nullable) type again.
                 InvalidateNarrowingsForAssignedVariables(statementSyntax);
+
+                // Issue #1123: assignment-based smart cast. After invalidation
+                // (which clears any stale narrowing on the assigned variable),
+                // re-narrow a nullable `var` local that was just assigned a
+                // statically non-nullable value, so subsequent reads in this
+                // block — and nested blocks — see the non-nullable type until a
+                // later mutation invalidates it again. Runs last so it wins over
+                // the invalidation pass for the same statement.
+                ApplyAssignmentNarrowing(statement, memberNotNullFrame);
             }
         }
         finally
@@ -556,6 +565,108 @@ internal sealed class StatementBinder
                 persistentFrame[kv.Key] = kv.Value;
             }
         }
+    }
+
+    /// <summary>
+    /// Issue #1123: assignment-based smart cast. When the bound statement is a
+    /// plain <c>x = rhs</c> assignment whose target is a nullable <c>var</c>
+    /// local and whose right-hand side is statically a <em>non-nullable</em>
+    /// value assignable to the local's underlying type, record a narrowing of
+    /// <c>x</c> to that underlying non-nullable type in
+    /// <paramref name="persistentFrame"/>. Mirrors the post-guard narrowing of
+    /// <see cref="ApplyEarlyExitNarrowings"/>: the entry persists for the rest
+    /// of the enclosing block (and into nested blocks) until
+    /// <see cref="InvalidateNarrowingsForAssignedVariables"/> clears it on a
+    /// subsequent mutation. Called after invalidation so the fresh narrowing
+    /// supersedes the clearing pass for this same statement.
+    /// </summary>
+    private void ApplyAssignmentNarrowing(BoundStatement statement, Dictionary<VariableSymbol, TypeSymbol> persistentFrame)
+    {
+        if (statement is not BoundExpressionStatement { Expression: BoundAssignmentExpression assign })
+        {
+            return;
+        }
+
+        // Narrow locals only — never parameters, fields, or read-only `let`
+        // locals (a `let` cannot be reassigned, so it never reaches here with a
+        // re-narrowable shape anyway). This matches the receiver-stability rule
+        // the type-test smart cast applies to `var` locals.
+        if (assign.Variable is not LocalVariableSymbol local || local.IsReadOnly)
+        {
+            return;
+        }
+
+        if (local.Type is not NullableTypeSymbol nullable)
+        {
+            return;
+        }
+
+        var assignedType = assign.AssignedValueType;
+        if (assignedType == null || assignedType == TypeSymbol.Error)
+        {
+            return;
+        }
+
+        // A possibly-null right-hand side does not narrow (invalidation already
+        // cleared any prior narrowing). Only a statically non-nullable value
+        // proves the local is non-null after the assignment.
+        if (assignedType is NullableTypeSymbol)
+        {
+            return;
+        }
+
+        // Issue #1123 is scoped to reference (and interface) types. Nullable
+        // value types (`int32?` → `int32`) are excluded: the existing narrowed-
+        // read emit path does not unwrap `Nullable<T>` to its underlying value
+        // for a `var`-local read, so a narrowed value-type read produces
+        // unverifiable IL. Reference nullability is purely an annotation, so a
+        // narrowed reference read needs no special emit.
+        var underlying = nullable.UnderlyingType;
+        if (!IsReferenceLikeType(underlying))
+        {
+            return;
+        }
+
+        // The right-hand side must be implicitly convertible to the local's
+        // underlying non-nullable type. The assignment itself already proved the
+        // value converts to the nullable declared type; this guards the value
+        // narrowing to the underlying type (e.g. excludes shapes where the only
+        // conversion to the bare underlying type would be explicit).
+        var conversion = Conversion.Classify(assignedType, underlying);
+        if (!conversion.Exists || !conversion.IsImplicit)
+        {
+            return;
+        }
+
+        persistentFrame[local] = underlying;
+    }
+
+    /// <summary>
+    /// Issue #1123: whether <paramref name="type"/> is a reference-like type —
+    /// an interface, a user class, or a CLR-backed class/interface. User value
+    /// structs (null <c>ClrType</c> during binding, <c>IsClass == false</c>)
+    /// and CLR value types / pointers / by-refs are excluded. Mirrors the
+    /// reference-likeness rule the conversion classifier uses for nullable
+    /// reference targets.
+    /// </summary>
+    private static bool IsReferenceLikeType(TypeSymbol type)
+    {
+        if (type is InterfaceSymbol)
+        {
+            return true;
+        }
+
+        if (type is StructSymbol structSymbol)
+        {
+            return structSymbol.IsClass;
+        }
+
+        if (type?.ClrType is { } clrBacking)
+        {
+            return !clrBacking.IsValueType && !clrBacking.IsPointer && !clrBacking.IsByRef;
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/test/Compiler.Tests/Emit/Issue1123SmartCastOnAssignmentEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1123SmartCastOnAssignmentEmitTests.cs
@@ -1,0 +1,221 @@
+// <copyright file="Issue1123SmartCastOnAssignmentEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1123: Kotlin-style smart cast that narrows a nullable <c>var</c>
+/// local to its non-nullable underlying type after it is assigned a
+/// statically non-nullable value. These tests prove the narrowed read both
+/// binds (member dispatch resolves) and emits/runs correctly — the call
+/// dispatches to the expected member and the program produces the expected
+/// output.
+/// </summary>
+public class Issue1123SmartCastOnAssignmentEmitTests
+{
+    [Fact]
+    public void Assignment_NarrowsNullableRefLocal_DispatchesCall()
+    {
+        // The minimal repro from the issue, run end-to-end: `x` is `E?`,
+        // assigned a non-nullable `E`, then `x.M()` must dispatch.
+        var source = """
+            package Test
+            import System
+
+            class E { func M() int32 { return 42 } }
+
+            func F(fresh E) int32 {
+                var x E? = nil
+                x = fresh
+                return x.M()
+            }
+
+            Console.WriteLine(F(E()))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void Assignment_NarrowingReachesNestedBlock()
+    {
+        var source = """
+            package Test
+            import System
+
+            class E { func M() int32 { return 7 } }
+
+            func F(fresh E) int32 {
+                var x E? = nil
+                x = fresh
+                if true {
+                    return x.M()
+                }
+                return 0
+            }
+
+            Console.WriteLine(F(E()))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("7\n", output);
+    }
+
+    [Fact]
+    public void Assignment_NarrowsToMostDerivedAssignedValue_DispatchesVirtual()
+    {
+        // `x` is declared `Base?`; after `x = Derived()` the value is provably
+        // a non-null Base. Virtual dispatch must reach the Derived override.
+        var source = """
+            package Test
+            import System
+
+            open class Base { open func M() int32 { return 1 } }
+            class Derived : Base { override func M() int32 { return 99 } }
+
+            func F(d Derived) int32 {
+                var x Base? = nil
+                x = d
+                return x.M()
+            }
+
+            Console.WriteLine(F(Derived()))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("99\n", output);
+    }
+
+    [Fact]
+    public void Assignment_NullableValueType_NotNarrowed_ScopedToReferenceTypes()
+    {
+        // Issue #1123 is scoped to reference types: nullable value types
+        // (`int32?`) are intentionally NOT narrowed on assignment because the
+        // narrowed-read emit path does not unwrap `Nullable<T>`. Reading the
+        // value type directly still requires an explicit unwrap (e.g. a nil
+        // guard), so a bare arithmetic read here must fail to compile.
+        var source = """
+            package Test
+            import System
+
+            func F(n int32) int32 {
+                var x int32? = nil
+                x = n
+                return x + 1
+            }
+
+            Console.WriteLine(F(41))
+            """;
+
+        var (exitCode, _, _) = CompileAndRunRaw(source);
+        Assert.NotEqual(0, exitCode);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var (exitCode, stdout, stderr) = CompileAndRunRaw(source);
+        Assert.True(
+            exitCode == 0,
+            $"gsc failed (exit {exitCode}):\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout;
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) CompileAndRunRaw(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1123_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+            };
+
+            foreach (var reference in TrustedPlatformAssemblies())
+            {
+                args.Add("/reference:" + reference);
+            }
+
+            args.Add("/nowarn:GS9100");
+            args.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            if (compileExit != 0)
+            {
+                return (compileExit, compileOut.ToString(), compileErr.ToString());
+            }
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+
+            return (proc.ExitCode, stdout.Replace("\r\n", "\n"), stderr.Replace("\r\n", "\n"));
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static IEnumerable<string> TrustedPlatformAssemblies()
+    {
+        var tpa = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        if (string.IsNullOrEmpty(tpa))
+        {
+            yield break;
+        }
+
+        foreach (var path in tpa.Split(Path.PathSeparator))
+        {
+            if (!string.IsNullOrWhiteSpace(path) && File.Exists(path))
+            {
+                yield return path;
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1123AssignmentSmartCastBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1123AssignmentSmartCastBinderTests.cs
@@ -1,0 +1,187 @@
+// <copyright file="Issue1123AssignmentSmartCastBinderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1123 — Kotlin-style smart cast that narrows a nullable <c>var</c>
+/// local to its non-nullable underlying type after the local is assigned a
+/// statically non-nullable value. Mirrors the existing <c>if x is T</c> /
+/// nil-guard smart-cast flow analysis, extended to assignment. Covers:
+/// positive narrowing (straight-line and into nested blocks), re-narrowing,
+/// the invalidation rules (reassigning to a possibly-null value clears the
+/// narrowing), and a negative control (no narrowing without the assignment).
+/// </summary>
+public class Issue1123AssignmentSmartCastBinderTests
+{
+    [Fact]
+    public void Assignment_OfNonNullValue_NarrowsNullableLocal()
+    {
+        // The minimal repro from the issue.
+        var result = Evaluate(@"
+class E { func M() int32 { return 1 } }
+class C {
+    func F(fresh E) int32 {
+        var x E? = nil
+        x = fresh
+        return x.M()
+    }
+}
+");
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void Assignment_Narrowing_ReachesNestedBlock()
+    {
+        var result = Evaluate(@"
+class E { func M() int32 { return 1 } }
+class C {
+    func F(fresh E) int32 {
+        var x E? = nil
+        x = fresh
+        if true {
+            return x.M()
+        }
+        return 0
+    }
+}
+");
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void Assignment_Narrowing_ReachesStraightLineStatements()
+    {
+        var result = Evaluate(@"
+class E { func M() int32 { return 1 } }
+class C {
+    func F(fresh E) int32 {
+        var x E? = nil
+        x = fresh
+        var a = x.M()
+        var b = x.M()
+        return a + b
+    }
+}
+");
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void Assignment_Narrowing_ToDerivedAssignedValue()
+    {
+        var result = Evaluate(@"
+open class Base { open func M() int32 { return 1 } }
+class Derived : Base { override func M() int32 { return 2 } }
+class C {
+    func F(d Derived) int32 {
+        var x Base? = nil
+        x = d
+        return x.M()
+    }
+}
+");
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void Assignment_ReassignToPossiblyNull_ClearsNarrowing()
+    {
+        // Re-assigning `x` to a possibly-null value drops the narrowing, so the
+        // subsequent member access fails again.
+        var result = Evaluate(@"
+class E { func M() int32 { return 1 } }
+class C {
+    func F(fresh E, maybe E?) int32 {
+        var x E? = nil
+        x = fresh
+        x = maybe
+        return x.M()
+    }
+}
+");
+
+        Assert.Contains(result.Diagnostics, d => d.Message.Contains("M", System.StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Assignment_ReNarrows_AfterPossiblyNullThenNonNull()
+    {
+        // A possibly-null assignment clears the narrowing; a following non-null
+        // assignment re-establishes it.
+        var result = Evaluate(@"
+class E { func M() int32 { return 1 } }
+class C {
+    func F(fresh E, maybe E?) int32 {
+        var x E? = nil
+        x = maybe
+        x = fresh
+        return x.M()
+    }
+}
+");
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void NoAssignment_NegativeControl_DoesNotNarrow()
+    {
+        // Without the narrowing assignment, the member access on `E?` fails.
+        var result = Evaluate(@"
+class E { func M() int32 { return 1 } }
+class C {
+    func F() int32 {
+        var x E? = nil
+        return x.M()
+    }
+}
+");
+
+        Assert.Contains(result.Diagnostics, d => d.Message.Contains("M", System.StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Assignment_NarrowingDoesNotEscapeBlock_AfterReassign()
+    {
+        // After re-assigning `x` to a possibly-null value the narrowing is gone
+        // for the rest of the block, including nested blocks.
+        var result = Evaluate(@"
+class E { func M() int32 { return 1 } }
+class C {
+    func F(fresh E, maybe E?) int32 {
+        var x E? = nil
+        x = fresh
+        x = maybe
+        if true {
+            return x.M()
+        }
+        return 0
+    }
+}
+");
+
+        Assert.Contains(result.Diagnostics, d => d.Message.Contains("M", System.StringComparison.Ordinal));
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(syntaxTree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
## Root cause
G# applied Kotlin-style smart casts after type tests (`if x is T`) and nil-guards, but assigning a statically non-nullable value to a nullable `var` local did **not** narrow the local. After `x = <non-null T>`, a subsequent `x.Member`/`x.Method()` failed with `GS0159` as if `x` were still `T?`.

## Fix
Extend the existing flow-narrowing infrastructure to assignment:

- `BoundAssignmentExpression` now records the **pre-conversion** RHS type (`AssignedValueType`).
- The block-statement binder runs a new `ApplyAssignmentNarrowing` pass **after** the existing assignment-invalidation step. When a `var` local of nullable reference type is assigned a statically non-nullable value implicitly convertible to its underlying type, the local is narrowed to that underlying type in the **same persistent per-block narrowing frame** the nil-guard early-exit lift uses.
- The narrowing therefore reaches across straight-line statements and into nested blocks until invalidated.

## Invalidation
Reuses the existing `var`-local mechanism — `InvalidateNarrowingsForAssignedVariables` clears the narrowing on a later mutation (covering ref/out and lambda-capture invalidation), and re-narrows when the new RHS is itself non-null.

## Scope / deferred
Reference (and interface) types only. Nullable **value** types (`int32?` → `int32`) are intentionally excluded: the narrowed-read emit path does not unwrap `Nullable<T>` for a var-local read, which would produce unverifiable IL. This is documented with a value-type negative-control test.

## Tests
- `Issue1123AssignmentSmartCastBinderTests` (Core.Tests): positive narrowing (straight-line + nested block), narrowing to a derived assigned value, re-narrowing after possibly-null then non-null, reassignment-clears-narrowing invalidation, and a negative control.
- `Issue1123SmartCastOnAssignmentEmitTests` (Compiler.Tests/Emit): compiles **and runs** the repro asserting correct dispatch (including virtual dispatch to the assigned derived value) + value-type scope negative control.
- Full Core.Tests suite: **3871 passed, 1 skipped, 0 failed**.

Fixes #1123