### PR TITLE
Smart-cast nullable local to non-null after non-null assignment (#1123)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/StatementBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.cs
@@ -354,6 +354,17 @@ internal sealed class StatementBinder
                 // narrowing from the current frame so subsequent reads in this
                 // block see the variable at its declared (nullable) type again.
                 InvalidateNarrowingsForAssignedVariables(statementSyntax);
+
+                // Issue #1123: Kotlin-style assignment smart cast. Runs AFTER
+                // invalidation so the stale narrowing for the assigned variable
+                // is first cleared, then re-added only when the assigned value
+                // is statically non-null. This means a reassignment to a
+                // nullable/`nil` value naturally invalidates the narrowing
+                // (cleared and not re-added), while `x = <non-null T>` narrows
+                // `x` to the assigned value's static non-null type for
+                // subsequent reads in this block (and nested blocks) until it is
+                // reassigned or otherwise invalidated.
+                ApplyAssignmentNarrowings(statement, memberNotNullFrame);
             }
         }
         finally
@@ -439,6 +450,169 @@ internal sealed class StatementBinder
         {
             frame[fieldVar] = nullable.UnderlyingType;
         }
+    }
+
+    /// <summary>
+    /// Issue #1123: Kotlin-style assignment smart cast. When a statement assigns
+    /// a statically non-null value to a nullable local/parameter
+    /// (<c>var x T?; x = &lt;non-null T&gt;</c>), narrows <paramref name="frame"/>
+    /// so subsequent reads of the variable see its non-nullable (RHS-static)
+    /// type. Runs immediately after
+    /// <see cref="InvalidateNarrowingsForAssignedVariables"/>, so a reassignment
+    /// to a nullable / <c>nil</c> value leaves the narrowing cleared and
+    /// un-readded (i.e. invalidated). Handles the single
+    /// <see cref="BoundAssignmentExpression"/> form as well as the multi-
+    /// assignment lowering, whose per-target assignments live inside a
+    /// synthesized <see cref="BoundBlockStatement"/>.
+    /// </summary>
+    private void ApplyAssignmentNarrowings(BoundStatement statement, Dictionary<VariableSymbol, TypeSymbol> frame)
+    {
+        switch (statement)
+        {
+            case BoundExpressionStatement { Expression: BoundAssignmentExpression assignment }:
+                NarrowAssignedVariableIfNonNull(assignment, frame);
+                break;
+
+            // The multi-assignment statement (`a, b = x, y`) lowers to a
+            // synthesized block of per-target `BoundExpressionStatement`s.
+            // Only descend into that specific lowering — never into arbitrary
+            // user blocks, whose narrowings must not leak into the enclosing
+            // frame.
+            case BoundBlockStatement block when block.Syntax is MultiAssignmentStatementSyntax:
+                foreach (var inner in block.Statements)
+                {
+                    if (inner is BoundExpressionStatement { Expression: BoundAssignmentExpression innerAssignment })
+                    {
+                        NarrowAssignedVariableIfNonNull(innerAssignment, frame);
+                    }
+                }
+
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Issue #1123: adds a smart-cast narrowing for a single assignment when its
+    /// target is a narrowable nullable local/parameter and the assigned value is
+    /// statically non-null and implicitly convertible to the target's underlying
+    /// type. The narrowed type is the value's own static non-null type (Kotlin
+    /// behaviour), which may be more specific than the declared underlying type.
+    /// </summary>
+    private void NarrowAssignedVariableIfNonNull(BoundAssignmentExpression assignment, Dictionary<VariableSymbol, TypeSymbol> frame)
+    {
+        var variable = assignment.Variable;
+
+        // ADR-0069 stability: narrow locals and parameters only — never fields,
+        // properties, or globals whose value can change under aliasing.
+        if (variable is not (LocalVariableSymbol or ParameterSymbol))
+        {
+            return;
+        }
+
+        // The declared type must be nullable `T?` to have anything to narrow.
+        if (variable.Type is not NullableTypeSymbol declaredNullable)
+        {
+            return;
+        }
+
+        var declaredUnderlying = declaredNullable.UnderlyingType;
+
+        // Recover the assigned value's static type. BindAssignmentExpression
+        // wraps the RHS in an implicit conversion to the declared (nullable)
+        // type, so peel that single nullable-wrapping conversion to see the
+        // value's non-null static type (`T → T?`).
+        var assignedType = UnwrapAssignedValueType(assignment.Expression);
+
+        // Only narrow when the assigned value is statically non-null and
+        // meaningful: not nullable, not the `nil` sentinel, not an error/void.
+        if (assignedType is null or NullableTypeSymbol
+            || assignedType == TypeSymbol.Null
+            || assignedType == TypeSymbol.Error
+            || assignedType == TypeSymbol.Void
+            || assignedType == TypeSymbol.Never)
+        {
+            return;
+        }
+
+        // Issue #1123: scope assignment narrowing to reference-like targets.
+        // A value-type nullable read (`int32? → int32`) needs the emitter to
+        // strip the `Nullable<T>` wrapper, but the narrowed-read emit path
+        // (EmitNarrowingCastIfNeeded) treats a value-type nullable strip as a
+        // representation no-op — which is unsound when the read flows straight
+        // into arithmetic/return (it leaves a `Nullable<T>` where a `T` is
+        // expected). This is a pre-existing emit limitation shared by the
+        // `if x != nil { … }` value-type narrowing; until the emit path lifts
+        // value-type nullables, narrowing only reference-like targets keeps the
+        // generated IL verifiable. Reference nullables share T's CLR
+        // representation, so the narrowed read is a no-op or a `castclass`.
+        if (!IsReferenceLikeNarrowTarget(declaredUnderlying) || !IsReferenceLikeNarrowTarget(assignedType))
+        {
+            return;
+        }
+
+        // Guard: the value's non-null type must be implicitly convertible to the
+        // declared underlying type. This always holds because the assignment
+        // already type-checked, but assert it so the narrowing can never be
+        // unsound (e.g. if the unwrap ever surfaces an unrelated type).
+        var conversion = Conversion.Classify(assignedType, declaredUnderlying);
+        if (!conversion.Exists || !conversion.IsImplicit)
+        {
+            return;
+        }
+
+        frame[variable] = assignedType;
+    }
+
+    /// <summary>
+    /// Issue #1123: returns the static type of an assigned value, peeling the
+    /// single implicit nullable-wrapping conversion that
+    /// <c>BindAssignmentExpression</c> inserts when storing a non-null value into
+    /// a nullable slot (`T → T?`). Identity assignments (nullable → nullable)
+    /// are returned unwrapped by the conversion binder, so their type already
+    /// reflects the source.
+    /// </summary>
+    private static TypeSymbol UnwrapAssignedValueType(BoundExpression value)
+    {
+        if (value is BoundConversionExpression conversion
+            && conversion.Type is NullableTypeSymbol
+            && conversion.Expression.Type is not NullableTypeSymbol)
+        {
+            return conversion.Expression.Type;
+        }
+
+        return value.Type;
+    }
+
+    /// <summary>
+    /// Issue #1123: a type is a sound assignment-narrowing target when its CLR
+    /// representation is a reference (class or interface). Reference nullables
+    /// (`T?` where T is a class/interface) share T's representation, so a
+    /// narrowed read is a representation no-op or a verifiable <c>castclass</c>.
+    /// Value types are excluded because the narrowed-read emit path does not yet
+    /// strip the <c>Nullable&lt;T&gt;</c> wrapper. Mirrors
+    /// <c>Conversion.IsReferenceLikeTarget</c>.
+    /// </summary>
+    private static bool IsReferenceLikeNarrowTarget(TypeSymbol type)
+    {
+        if (type is InterfaceSymbol)
+        {
+            return true;
+        }
+
+        if (type is StructSymbol { IsClass: true })
+        {
+            return true;
+        }
+
+        // Imported / CLR-backed types are reference-like when the CLR backing
+        // is a class or interface (not a value type, pointer, or by-ref). User
+        // value structs carry a null ClrType during binding and fall through.
+        if (type?.ClrType is { } clrBacking)
+        {
+            return !clrBacking.IsValueType && !clrBacking.IsPointer && !clrBacking.IsByRef;
+        }
+
+        return false;
     }
 
     private BoundTryStatement BuildCleanupTryStatement(ImmutableArray<BoundStatement> protectedStatements, BoundExpression cleanup)

--- a/test/Compiler.Tests/Emit/Issue1123AssignmentSmartCastEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1123AssignmentSmartCastEmitTests.cs
@@ -1,0 +1,167 @@
+// <copyright file="Issue1123AssignmentSmartCastEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1123 — Kotlin-style assignment smart cast emit coverage. After a
+/// nullable local is assigned a statically non-null reference value, a
+/// subsequent member access binds and emits against the assigned value's
+/// non-null (possibly more-derived) type. Each test compiles via in-process
+/// <c>gsc</c>, IL-verifies the emitted PE (so the narrowed read's
+/// <c>castclass</c>/no-op is well-formed), and runs it under
+/// <c>dotnet exec</c>, asserting captured stdout.
+/// </summary>
+public class Issue1123AssignmentSmartCastEmitTests
+{
+    private const string Hierarchy = """
+        package Test
+        import System
+
+        class E { func M() int32 { return 42 } }
+
+        open class Animal {
+            var Name string
+            open func Describe() string { return Name }
+        }
+
+        class Dog : Animal {
+            override func Describe() string { return Name + " (dog)" }
+            func Bark() string { return Name + ":woof" }
+        }
+
+        """;
+
+    [Fact]
+    public void AssignmentSmartCast_NarrowsNullableLocalToNonNull_AndRuns()
+    {
+        var source = Hierarchy + """
+            func Run(fresh E) int32 {
+                var x E? = nil
+                x = fresh
+                return x.M()
+            }
+
+            Console.WriteLine(Run(E{}))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void AssignmentSmartCast_NarrowsToAssignedDerivedType_CallsDerivedMember()
+    {
+        // Kotlin narrows to the assigned value's static type: assigning a `Dog`
+        // to an `Animal?` local lets the `Dog`-only `Bark()` bind and emit.
+        var source = Hierarchy + """
+            func Run(d Dog) string {
+                var a Animal? = nil
+                a = d
+                return a.Bark()
+            }
+
+            Console.WriteLine(Run(Dog{Name: "Rex"}))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("Rex:woof\n", output);
+    }
+
+    [Fact]
+    public void AssignmentSmartCast_NarrowingReachesIntoNestedBlock()
+    {
+        var source = Hierarchy + """
+            func Run(fresh E, flag bool) int32 {
+                var x E? = nil
+                x = fresh
+                if flag {
+                    return x.M()
+                }
+                return 0
+            }
+
+            Console.WriteLine(Run(E{}, true))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1123_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed (exit {compileExit}):\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"sample exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1123AssignmentSmartCastBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1123AssignmentSmartCastBinderTests.cs
@@ -1,0 +1,229 @@
+// <copyright file="Issue1123AssignmentSmartCastBinderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1123 — Kotlin-style assignment smart cast. After a nullable local
+/// (<c>var x T?</c>) is assigned a statically non-null value, subsequent reads
+/// see <c>x</c> at the assigned value's non-null type until the variable is
+/// reassigned to a possibly-null value or otherwise invalidated. Binder-level
+/// coverage for the narrowing, its reach, the invalidation-on-reassignment
+/// behaviour, and the reference-only scope.
+/// </summary>
+public class Issue1123AssignmentSmartCastBinderTests
+{
+    private const string Hierarchy = @"
+class E { func M() int32 { return 1 } }
+open class Animal {
+    var Name string
+    open func Describe() string { return Name }
+}
+class Dog : Animal {
+    override func Describe() string { return ""Dog"" }
+    func Bark() string { return ""woof"" }
+}
+";
+
+    [Fact]
+    public void Assignment_NarrowsNullableLocalToNonNull()
+    {
+        // The repro: after `x = fresh`, `x` is `E`, so `x.M()` binds.
+        var result = Evaluate(Hierarchy + @"
+func Run(fresh E) int32 {
+    var x E? = nil
+    x = fresh
+    return x.M()
+}
+Run(E{})
+");
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void WithoutAssignment_NullableMemberAccessStillReported()
+    {
+        // Control: without the assignment narrowing, `x.M()` on an `E?` fails.
+        var result = Evaluate(Hierarchy + @"
+func Run() int32 {
+    var x E? = nil
+    return x.M()
+}
+");
+
+        Assert.NotEmpty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void Assignment_NarrowsToAssignedStaticType_DerivedMember()
+    {
+        // Kotlin narrows to the assigned value's static type. Assigning a `Dog`
+        // to an `Animal?` local lets a `Dog`-only member bind.
+        var result = Evaluate(Hierarchy + @"
+func Run(d Dog) string {
+    var a Animal? = nil
+    a = d
+    return a.Bark()
+}
+Run(Dog{Name: ""Rex""})
+");
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void Reassignment_ToNil_InvalidatesNarrowing()
+    {
+        // `x = fresh` narrows, but `x = nil` drops the narrowing, so the
+        // following `x.M()` is rejected again.
+        var result = Evaluate(Hierarchy + @"
+func Run(fresh E) int32 {
+    var x E? = nil
+    x = fresh
+    x = nil
+    return x.M()
+}
+");
+
+        Assert.NotEmpty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void Reassignment_ToNullableValue_InvalidatesNarrowing()
+    {
+        // Reassigning another possibly-null value (an `E?` parameter) also
+        // invalidates the narrowing.
+        var result = Evaluate(Hierarchy + @"
+func Run(fresh E, maybe E?) int32 {
+    var x E? = nil
+    x = fresh
+    x = maybe
+    return x.M()
+}
+");
+
+        Assert.NotEmpty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void Narrowing_AvailableBeforeReassignment()
+    {
+        // The narrowing is in effect for statements preceding the invalidating
+        // reassignment.
+        var result = Evaluate(Hierarchy + @"
+func Run(fresh E) int32 {
+    var x E? = nil
+    x = fresh
+    var n int32 = x.M()
+    x = nil
+    return n
+}
+Run(E{})
+");
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void Narrowing_ReachesIntoNestedBlock()
+    {
+        // The narrowing holds into a subsequent nested block.
+        var result = Evaluate(Hierarchy + @"
+func Run(fresh E, flag bool) int32 {
+    var x E? = nil
+    x = fresh
+    if flag {
+        return x.M()
+    }
+    return 0
+}
+Run(E{}, true)
+");
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void Narrowing_HoldsAcrossStraightLineStatements()
+    {
+        var result = Evaluate(Hierarchy + @"
+func Run(fresh E) int32 {
+    var x E? = nil
+    x = fresh
+    var a int32 = x.M()
+    var b int32 = x.M()
+    return a + b
+}
+Run(E{})
+");
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void ValueTypeNullable_NotNarrowed_ScopedToReferenceTypes()
+    {
+        // Issue #1123: value-type nullable narrowing is intentionally scoped
+        // out (the narrowed-read emit path does not strip `Nullable<T>`), so
+        // `n` stays `int32?` and the arithmetic is rejected.
+        var result = Evaluate(@"
+func Run() int32 {
+    var n int32? = nil
+    n = 5
+    return n + 1
+}
+");
+
+        Assert.NotEmpty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void AssignedNullable_DoesNotNarrow()
+    {
+        // Assigning a possibly-null value never narrows.
+        var result = Evaluate(Hierarchy + @"
+func Run(maybe E?) int32 {
+    var x E? = nil
+    x = maybe
+    return x.M()
+}
+");
+
+        Assert.NotEmpty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void MultiAssignment_NarrowsEachTargetToNonNull()
+    {
+        // The multi-assignment lowering (`x, y = a, b`) narrows each nullable
+        // target assigned a non-null value.
+        var result = Evaluate(Hierarchy + @"
+func Run(a E, b E) int32 {
+    var x E? = nil
+    var y E? = nil
+    x, y = a, b
+    return x.M() + y.M()
+}
+Run(E{}, E{})
+");
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(syntaxTree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
Fixes #1123

## Root cause
G# applied Kotlin-style smart casts after `is` type tests and nil-guards, but **not** after a nullable local (`var x T?`) is *assigned* a statically non-null value. After `x = <non-null T>`, a subsequent `x.Member` / `x.Method()` failed with `GS0159` as if `x` were still `T?`.

The per-statement flow loop in `BindBlockStatements` (`StatementBinder.cs`) only ever *dropped* `x`'s narrowing on assignment (`InvalidateNarrowingsForAssignedVariables`); it never re-added a non-null narrowing.

## Fix
Added a new `ApplyAssignmentNarrowings` step, wired **immediately after** `InvalidateNarrowingsForAssignedVariables`:

1. invalidation runs first -> clears any stale narrowing for the assigned variable,
2. the new step re-adds a narrowing **only when the assigned value is statically non-null**.

So reassignment to a nullable / `nil` value naturally invalidates the narrowing (cleared and not re-added).

`NarrowAssignedVariableIfNonNull` narrows when:
- the target is a narrowable local/parameter (ADR-0069 stability rules — `LocalVariableSymbol`/`ParameterSymbol` only),
- its declared type is a `NullableTypeSymbol` (`T?`),
- the assigned value is statically non-null (not nullable, not the `nil` sentinel, not error/void/never) — recovered by peeling the implicit `T -> T?` conversion that `BindAssignmentExpression` inserts, and
- the value's non-null type is implicitly convertible to the declared underlying type.

The narrowed type is the value's **own static non-null type** (Kotlin behaviour), so assigning a `Dog` to an `Animal?` local lets `Dog`-only members bind. The narrowing lives in the persistent block frame, so it reaches across straight-line code and into nested blocks until invalidated. The multi-assignment lowering (`x, y = a, b`) is also covered.

## Scope: reference types (hard requirement) + value types intentionally scoped out
Value-type nullable narrowing (`int32? -> int32`) is **intentionally excluded**. The narrowed-read emit path (`EmitNarrowingCastIfNeeded`) treats a value-type nullable strip as a representation no-op, which leaves a `Nullable<T>` on the stack where a `T` is expected when the read flows into arithmetic/return — producing unverifiable IL (a runtime bus error). I verified this is a **pre-existing** emit limitation: the existing `if x != nil { return n + 1 }` value-type narrowing crashes the same way today. Rather than introduce unsound IL, `IsReferenceLikeNarrowTarget` restricts assignment narrowing to reference-like targets (class/interface), where a narrowed read is a representation no-op or a verifiable `castclass`. A binder test documents the value-type behaviour (`n` stays `int32?`).

## Tests
**Binder (`Core.Tests` — `Issue1123AssignmentSmartCastBinderTests`):**
- repro narrows (`var x E? = nil; x = fresh; return x.M()`),
- narrowing to the assigned **derived** type (`Animal?` <- `Dog`, calls `Bark()`),
- invalidation on `nil` reassignment and on reassignment to another nullable value,
- narrowing available before the invalidating reassignment,
- reach into a nested block and across straight-line statements,
- multi-assignment (`x, y = a, b`),
- value-type scope-out.

**Emit (`Compiler.Tests` — `Issue1123AssignmentSmartCastEmitTests`):** IL-verifies + runs the repro (returns 42), the derived-type case (`Rex:woof`), and the nested-block reach (42).

## Validation
- `dotnet build GSharp.sln -c Release` — clean (0 warnings/errors).
- Repro now emits with no `GS0159` and returns 1/42 at runtime; `x = fresh; x = nil; x.M()` still reports the nullable-member error.
- `Core.Tests`: full project green (3873 passed). Smart-cast/narrowing filter (incl. #700/#708/#712/new #1123): 106 passed.
- `Compiler.Tests` emit: `Issue1123` 3 passed; smart-cast/narrowing regression (`Issue700SmartCast`/`Issue712FlowNarrowing`/`Issue708`): 18 passed.

No new `SyntaxKind`/`BoundNodeKind` and no new sample file — binder-only change, so no coverage-matrix/baseline regeneration needed.
