### PR TITLE
Fix #1124: exclude uninferable generic overload from applicable set

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -1518,7 +1518,7 @@ internal sealed partial class ExpressionBinder
         var staticMethodGroup = TypeMemberModel.GetMethods(structSym, methodName, MemberQuery.Static(MemberKinds.Method));
         if (!staticMethodGroup.IsDefaultOrEmpty)
         {
-            var method = overloads.SelectInstanceOverloadOrReport(staticMethodGroup, arguments, ce, methodName, argumentNames: default);
+            var method = overloads.SelectInstanceOverloadOrReport(staticMethodGroup, arguments, ce, methodName, argumentNames: default, hasExplicitTypeArgs: ce.TypeArgumentList != null);
             if (method == null)
             {
                 return new BoundErrorExpression(null);

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -2435,7 +2435,7 @@ internal sealed partial class ExpressionBinder
 
                 if (ifaceOverloads.Length > 0)
                 {
-                    var ifaceMethod = overloads.SelectInstanceOverloadOrReport(ifaceOverloads, arguments, ce, methodName, argumentNames);
+                    var ifaceMethod = overloads.SelectInstanceOverloadOrReport(ifaceOverloads, arguments, ce, methodName, argumentNames, ce.TypeArgumentList != null);
                     if (ifaceMethod == null)
                     {
                         return new BoundErrorExpression(null);
@@ -2456,7 +2456,7 @@ internal sealed partial class ExpressionBinder
                 var tpOverloads = TypeMemberModel.GetMethods(tpRecv.InterfaceConstraint, methodName, MemberQuery.Instance(MemberKinds.Method));
                 if (tpOverloads.Length > 0)
                 {
-                    var tpIfaceMethod = overloads.SelectInstanceOverloadOrReport(tpOverloads, arguments, ce, methodName, argumentNames);
+                    var tpIfaceMethod = overloads.SelectInstanceOverloadOrReport(tpOverloads, arguments, ce, methodName, argumentNames, ce.TypeArgumentList != null);
                     if (tpIfaceMethod == null)
                     {
                         return new BoundErrorExpression(null);
@@ -2484,7 +2484,7 @@ internal sealed partial class ExpressionBinder
                 var tpClassOverloads = TypeMemberModel.GetMethods(tpClassConstraint, methodName, MemberQuery.Instance(MemberKinds.Method));
                 if (tpClassOverloads.Length > 0)
                 {
-                    var tpClassMethod = overloads.SelectInstanceOverloadOrReport(tpClassOverloads, arguments, ce, methodName, argumentNames);
+                    var tpClassMethod = overloads.SelectInstanceOverloadOrReport(tpClassOverloads, arguments, ce, methodName, argumentNames, ce.TypeArgumentList != null);
                     if (tpClassMethod == null)
                     {
                         return new BoundErrorExpression(null);
@@ -2512,7 +2512,7 @@ internal sealed partial class ExpressionBinder
                 var userOverloads = TypeMemberModel.GetMethods(userClass, methodName, MemberQuery.Instance(MemberKinds.Method));
                 if (userOverloads.Length > 0)
                 {
-                    var userMethod = overloads.SelectInstanceOverloadOrReport(userOverloads, arguments, ce, methodName, argumentNames);
+                    var userMethod = overloads.SelectInstanceOverloadOrReport(userOverloads, arguments, ce, methodName, argumentNames, ce.TypeArgumentList != null);
                     if (userMethod == null)
                     {
                         return new BoundErrorExpression(null);
@@ -2585,7 +2585,7 @@ internal sealed partial class ExpressionBinder
             var priorityOverloads = TypeMemberModel.GetMethods(userClassPriority, methodName, MemberQuery.Instance(MemberKinds.Method));
             if (priorityOverloads.Length > 0)
             {
-                var userMethodPriority = overloads.SelectInstanceOverloadOrReport(priorityOverloads, arguments, ce, methodName, argumentNames);
+                var userMethodPriority = overloads.SelectInstanceOverloadOrReport(priorityOverloads, arguments, ce, methodName, argumentNames, ce.TypeArgumentList != null);
                 if (userMethodPriority == null)
                 {
                     return new BoundErrorExpression(null);
@@ -2863,7 +2863,7 @@ internal sealed partial class ExpressionBinder
                     continue;
                 }
 
-                var selected = this.overloads.SelectInstanceOverloadOrReport(defaultsOnly.ToImmutable(), arguments, ce, methodName, argumentNames);
+                var selected = this.overloads.SelectInstanceOverloadOrReport(defaultsOnly.ToImmutable(), arguments, ce, methodName, argumentNames, ce.TypeArgumentList != null);
                 if (selected != null)
                 {
                     return selected;
@@ -3923,7 +3923,7 @@ internal sealed partial class ExpressionBinder
         }
 
         var arguments = boundArguments.ToImmutable();
-        var method = overloads.SelectInstanceOverloadOrReport(baseOverloads, arguments, ce, methodName, argumentNames);
+        var method = overloads.SelectInstanceOverloadOrReport(baseOverloads, arguments, ce, methodName, argumentNames, ce.TypeArgumentList != null);
         if (method == null)
         {
             return new BoundErrorExpression(null);

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -452,14 +452,15 @@ internal sealed class OverloadResolver
         ImmutableArray<BoundExpression> arguments,
         CallExpressionSyntax ce,
         string methodName,
-        ImmutableArray<string> argumentNames)
+        ImmutableArray<string> argumentNames,
+        bool hasExplicitTypeArgs = false)
     {
         if (overloads.Length <= 1)
         {
             return overloads.Length == 1 ? overloads[0] : null;
         }
 
-        var selected = SelectBestInstanceOverload(overloads, arguments.Length, argumentNames, arguments, out var ambiguous);
+        var selected = SelectBestInstanceOverload(overloads, arguments.Length, argumentNames, arguments, out var ambiguous, hasExplicitTypeArgs);
         if (selected != null)
         {
             return selected;
@@ -482,9 +483,10 @@ internal sealed class OverloadResolver
         int argumentCount,
         ImmutableArray<string> argumentNames,
         ImmutableArray<BoundExpression>.Builder boundArguments,
-        out bool ambiguous)
+        out bool ambiguous,
+        bool hasExplicitTypeArgs = false)
     {
-        return SelectBestUserOverloadCore(candidates, argumentCount, argumentNames, boundArguments, out ambiguous);
+        return SelectBestUserOverloadCore(candidates, argumentCount, argumentNames, boundArguments, out ambiguous, hasExplicitTypeArgs);
     }
 
     /// <summary>
@@ -498,7 +500,8 @@ internal sealed class OverloadResolver
         int argumentCount,
         ImmutableArray<string> argumentNames,
         ImmutableArray<BoundExpression> boundArguments,
-        out bool ambiguous)
+        out bool ambiguous,
+        bool hasExplicitTypeArgs = false)
     {
         ambiguous = false;
         if (candidates.Length == 0)
@@ -513,7 +516,7 @@ internal sealed class OverloadResolver
 
         var builder = ImmutableArray.CreateBuilder<BoundExpression>(boundArguments.Length);
         builder.AddRange(boundArguments);
-        return SelectBestUserOverloadCore(candidates, argumentCount, argumentNames, builder, out ambiguous);
+        return SelectBestUserOverloadCore(candidates, argumentCount, argumentNames, builder, out ambiguous, hasExplicitTypeArgs);
     }
 
     private FunctionSymbol SelectBestUserOverloadCore(
@@ -521,7 +524,8 @@ internal sealed class OverloadResolver
         int argumentCount,
         ImmutableArray<string> argumentNames,
         ImmutableArray<BoundExpression>.Builder boundArguments,
-        out bool ambiguous)
+        out bool ambiguous,
+        bool hasExplicitTypeArgs = false)
     {
         ambiguous = false;
 
@@ -532,6 +536,39 @@ internal sealed class OverloadResolver
             if (IsApplicableUserCallable(cand, argumentCount, argumentNames))
             {
                 applicable.Add(cand);
+            }
+        }
+
+        // Issue #1124: a generic candidate invoked WITHOUT explicit type
+        // arguments is applicable only when ALL of its type parameters can be
+        // inferred from the supplied argument types — exactly as C# excludes a
+        // candidate whose type inference fails. Dropping such candidates before
+        // the tie/ambiguity determination lets a non-generic (or successfully
+        // inferred) sibling resolve unambiguously instead of surfacing GS0266.
+        // Symmetrically, when explicit type arguments ARE supplied, a
+        // non-generic candidate cannot accept them, so C# removes it from the
+        // candidate set; that leaves the generic overload to resolve. In both
+        // directions the exclusion is guarded so that it only applies when at
+        // least one candidate survives, preserving the existing single-candidate
+        // diagnostics (e.g. type-argument-inference-failure for a lone
+        // uninferable generic) rather than a misleading "no applicable overload".
+        if (applicable.Count > 1)
+        {
+            var filtered = new List<FunctionSymbol>();
+            foreach (var cand in applicable)
+            {
+                var keep = hasExplicitTypeArgs
+                    ? cand.IsGeneric
+                    : AllTypeParametersInferable(cand, boundArguments);
+                if (keep)
+                {
+                    filtered.Add(cand);
+                }
+            }
+
+            if (filtered.Count > 0 && filtered.Count < applicable.Count)
+            {
+                applicable = filtered;
             }
         }
 
@@ -660,6 +697,51 @@ internal sealed class OverloadResolver
                 {
                     return false;
                 }
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Issue #1124: returns true when the candidate is non-generic, or when it
+    /// is generic and every one of its type parameters can be inferred from the
+    /// supplied argument types via the same left-to-right unification used by
+    /// the call binder. A generic candidate whose type parameter(s) appear only
+    /// in the return type / a constraint (never in a parameter) is therefore
+    /// reported as not inferable, so it can be excluded from the applicable set
+    /// when no explicit type arguments were supplied at the call site.
+    /// </summary>
+    private static bool AllTypeParametersInferable(FunctionSymbol candidate, ImmutableArray<BoundExpression>.Builder boundArguments)
+    {
+        if (!candidate.IsGeneric)
+        {
+            return true;
+        }
+
+        // A static/top-level candidate carries no explicit receiver parameter,
+        // so argument index maps directly to parameter index. An instance
+        // candidate may carry a leading receiver parameter that has no matching
+        // argument; skip it via the same offset used by the scoring loop.
+        var parameterOffset = candidate.ExplicitReceiverParameter == null ? 0 : 1;
+        var paramLen = candidate.Parameters.Length - parameterOffset;
+        var substitution = new Dictionary<TypeParameterSymbol, TypeSymbol>();
+        for (var i = 0; i < paramLen && i < boundArguments.Count; i++)
+        {
+            var argType = boundArguments[i]?.Type;
+            if (argType == null)
+            {
+                continue;
+            }
+
+            Binder.InferTypeArguments(candidate.Parameters[i + parameterOffset].Type, argType, substitution);
+        }
+
+        foreach (var tp in candidate.TypeParameters)
+        {
+            if (!substitution.ContainsKey(tp))
+            {
+                return false;
             }
         }
 
@@ -2529,7 +2611,7 @@ internal sealed class OverloadResolver
                 var implicitOverloads = TypeMemberModel.GetMethods(implicitReceiverStruct, syntax.Identifier.Text, MemberQuery.Instance(MemberKinds.Method));
                 if (implicitOverloads.Length > 0)
                 {
-                    var implicitMethod = SelectInstanceOverloadOrReport(implicitOverloads, boundArguments.ToImmutable(), syntax, syntax.Identifier.Text, argumentNames);
+                    var implicitMethod = SelectInstanceOverloadOrReport(implicitOverloads, boundArguments.ToImmutable(), syntax, syntax.Identifier.Text, argumentNames, syntax.TypeArgumentList != null);
                     if (implicitMethod == null)
                     {
                         return new BoundErrorExpression(null);
@@ -2560,7 +2642,7 @@ internal sealed class OverloadResolver
 
                 if (implicitIfaceOverloads.Length > 0)
                 {
-                    var implicitIfaceMethod = SelectInstanceOverloadOrReport(implicitIfaceOverloads, boundArguments.ToImmutable(), syntax, syntax.Identifier.Text, argumentNames);
+                    var implicitIfaceMethod = SelectInstanceOverloadOrReport(implicitIfaceOverloads, boundArguments.ToImmutable(), syntax, syntax.Identifier.Text, argumentNames, syntax.TypeArgumentList != null);
                     if (implicitIfaceMethod == null)
                     {
                         return new BoundErrorExpression(null);
@@ -2589,7 +2671,7 @@ internal sealed class OverloadResolver
 
                 if (implicitStaticOverloads.Length > 0)
                 {
-                    var implicitStaticMethod = SelectInstanceOverloadOrReport(implicitStaticOverloads, boundArguments.ToImmutable(), syntax, syntax.Identifier.Text, argumentNames);
+                    var implicitStaticMethod = SelectInstanceOverloadOrReport(implicitStaticOverloads, boundArguments.ToImmutable(), syntax, syntax.Identifier.Text, argumentNames, syntax.TypeArgumentList != null);
                     if (implicitStaticMethod == null)
                     {
                         return new BoundErrorExpression(null);
@@ -2825,7 +2907,7 @@ internal sealed class OverloadResolver
         var overloadSet = Scope.TryLookupFunctions(syntax.Identifier.Text);
         if (overloadSet.Length > 1)
         {
-            var selected = SelectBestUserOverload(overloadSet, syntax.Arguments.Count, argumentNames, boundArguments, out var overloadAmbiguous);
+            var selected = SelectBestUserOverload(overloadSet, syntax.Arguments.Count, argumentNames, boundArguments, out var overloadAmbiguous, syntax.TypeArgumentList != null);
             if (selected == null)
             {
                 if (overloadAmbiguous)

--- a/test/Compiler.Tests/Emit/Issue1124UninferableGenericOverloadEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1124UninferableGenericOverloadEmitTests.cs
@@ -1,0 +1,157 @@
+// <copyright file="Issue1124UninferableGenericOverloadEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1124: end-to-end CLR emit + ilverify + run coverage for a method
+/// group containing a generic overload whose type parameter cannot be inferred
+/// (it appears only in the return type / constraint) alongside a non-generic
+/// overload with a matching parameter list. A call without explicit type
+/// arguments must resolve to the non-generic overload (previously GS0266
+/// ambiguity), while a call with explicit type arguments must resolve to the
+/// generic overload. Both forms must emit a verifiable assembly that runs.
+/// </summary>
+public class Issue1124UninferableGenericOverloadEmitTests
+{
+    // Acceptance criterion 5: a program using the non-generic resolution
+    // (Factory.Make(5, b)) compiles to a runnable assembly and produces the
+    // non-generic overload's behavior (it returns a Box whose Tag() is "box").
+    [Fact]
+    public void EndToEnd_NoExplicitTypeArgs_RunsNonGenericOverload()
+    {
+        var source = """
+            package Probe
+            import System
+            interface IBox { func Tag() string; }
+            class Box : IBox { func Tag() string { return "box" } }
+            class Factory {
+                shared {
+                    func Make[T Box](file int32, parent IBox?) T { return default(T) }
+                    func Make(file int32, parent IBox?) IBox { return Box() }
+                }
+            }
+            func Main() {
+                var b IBox = Box()
+                let child = Factory.Make(5, b)
+                Console.WriteLine(child.Tag())
+            }
+            """;
+        var output = CompileAndRun(source);
+        Assert.Equal("box\n", output);
+    }
+
+    // Acceptance criterion 2 (emit): a call WITH explicit type arguments selects
+    // the generic overload and the program emits a verifiable assembly that runs.
+    [Fact]
+    public void EndToEnd_ExplicitTypeArg_RunsGenericOverload()
+    {
+        var source = """
+            package Probe
+            import System
+            interface IBox {}
+            class Box : IBox {}
+            class Factory {
+                shared {
+                    func Make[T Box](file int32, parent IBox?) T { return default(T) }
+                    func Make(file int32, parent IBox?) IBox { return Box() }
+                }
+            }
+            func Main() {
+                var b IBox = Box()
+                var made Box = Factory.Make[Box](5, b)
+                Console.WriteLine("ok")
+            }
+            """;
+        var output = CompileAndRun(source);
+        Assert.Equal("ok\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1124_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1124UninferableGenericOverloadBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1124UninferableGenericOverloadBinderTests.cs
@@ -1,0 +1,193 @@
+// <copyright file="Issue1124UninferableGenericOverloadBinderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1124: when a method group contains a generic overload whose type
+/// parameter cannot be inferred from the arguments (it appears only in the
+/// return type / a constraint) alongside a non-generic overload with a matching
+/// parameter list, a call WITHOUT explicit type arguments was reported as
+/// ambiguous (GS0266). C# excludes the generic candidate from the applicable
+/// set because type inference fails for it, leaving the non-generic overload as
+/// the unique best match. The binder now drops a generic candidate whose type
+/// parameters are not all inferable (when no explicit type arguments are
+/// supplied) before the ambiguity determination, and symmetrically excludes a
+/// non-generic candidate when explicit type arguments ARE supplied (they can
+/// only apply to a generic method).
+/// </summary>
+public class Issue1124UninferableGenericOverloadBinderTests
+{
+    private const string FactoryPreamble = """
+        package t
+        interface IBox {}
+        class Box : IBox {}
+        class Factory {
+            shared {
+                func Make[T Box](file int32, parent IBox?) T { return default(T) }
+                func Make(file int32, parent IBox?) IBox { return Box() }
+            }
+        }
+        """;
+
+    // Acceptance criterion 1: the repro compiles with NO diagnostics — the
+    // uninferable generic Make[T] is excluded and the non-generic Make resolves.
+    [Fact]
+    public void StaticCall_NoExplicitTypeArgs_ResolvesNonGeneric_NoDiagnostics()
+    {
+        var source = FactoryPreamble + """
+
+            class C {
+                func G(b IBox) {
+                    let child = Factory.Make(5, b)
+                }
+            }
+            """;
+        Assert.Empty(Bind(source));
+    }
+
+    // Acceptance criterion 1 (distinguishing): the resolved overload returns
+    // IBox (the non-generic), proven by it satisfying an IBox-typed return.
+    [Fact]
+    public void StaticCall_NoExplicitTypeArgs_ResultIsNonGenericIBox()
+    {
+        var source = FactoryPreamble + """
+
+            class C {
+                func G(b IBox) IBox { return Factory.Make(5, b) }
+            }
+            """;
+        Assert.Empty(Bind(source));
+    }
+
+    // Acceptance criterion 1 (negative distinguishing): the non-generic result
+    // is IBox, NOT Box, so flowing it into a Box-typed return is a conversion
+    // error (GS0155) — and crucially NOT the old GS0266 ambiguity.
+    [Fact]
+    public void StaticCall_NoExplicitTypeArgs_ResultNotBox_ReportsConversionNotAmbiguity()
+    {
+        var source = FactoryPreamble + """
+
+            class C {
+                func G(b IBox) Box { return Factory.Make(5, b) }
+            }
+            """;
+        var diagnostics = Bind(source);
+        Assert.Contains(diagnostics, d => d.Id == "GS0155");
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0266");
+    }
+
+    // Acceptance criterion 2: with explicit [Box], the generic overload is
+    // selected (its return type T=Box satisfies the Box-typed return).
+    [Fact]
+    public void StaticCall_ExplicitTypeArg_ResolvesGeneric_NoDiagnostics()
+    {
+        var source = FactoryPreamble + """
+
+            class C {
+                func G(b IBox) Box { return Factory.Make[Box](5, b) }
+            }
+            """;
+        Assert.Empty(Bind(source));
+    }
+
+    // Acceptance criterion 3: a generic overload whose type parameter IS
+    // inferable from the arguments is still selectable without explicit type
+    // args, even alongside a non-generic sibling of different arity.
+    [Fact]
+    public void StaticCall_InferableGeneric_StillSelectable_NoDiagnostics()
+    {
+        const string source = """
+            package t
+            class Factory {
+                shared {
+                    func Id[T](x T) T { return x }
+                    func Id(a int32, b int32) int32 { return a }
+                }
+            }
+            class C { func G() int32 { return Factory.Id(7) } }
+            """;
+        Assert.Empty(Bind(source));
+    }
+
+    // Acceptance criterion 4: a lone generic overload with an uninferable type
+    // parameter and no non-generic sibling still reports the dedicated
+    // type-argument-inference-failure diagnostic (GS0151), NOT a misleading
+    // "no applicable overload" or ambiguity.
+    [Fact]
+    public void StaticCall_LoneUninferableGeneric_ReportsInferenceFailure()
+    {
+        const string source = """
+            package t
+            interface IBox {}
+            class Box : IBox {}
+            class Factory {
+                shared {
+                    func Make[T Box](file int32, parent IBox?) T { return default(T) }
+                }
+            }
+            class C {
+                func G(b IBox) {
+                    let child = Factory.Make(5, b)
+                }
+            }
+            """;
+        var diagnostics = Bind(source);
+        Assert.Contains(diagnostics, d => d.Id == "GS0151");
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0266");
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0144");
+    }
+
+    // Centralized-fix coverage: the same rule applies to TOP-LEVEL function
+    // overload groups, not only static class methods.
+    [Fact]
+    public void TopLevelFunctions_ExcludeUninferableGeneric_NoExplicitTypeArgs()
+    {
+        const string source = """
+            package t
+            interface IBox {}
+            class Box : IBox {}
+            func Make[T Box](file int32, parent IBox?) T { return default(T) }
+            func Make(file int32, parent IBox?) IBox { return Box() }
+            func G(b IBox) IBox { return Make(5, b) }
+            """;
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void TopLevelFunctions_ExplicitTypeArg_ResolvesGeneric()
+    {
+        const string source = """
+            package t
+            interface IBox {}
+            class Box : IBox {}
+            func Make[T Box](file int32, parent IBox?) T { return default(T) }
+            func Make(file int32, parent IBox?) IBox { return Box() }
+            func H(b IBox) Box { return Make[Box](5, b) }
+            """;
+        Assert.Empty(Bind(source));
+    }
+
+    private static IReadOnlyList<Diagnostic> Bind(string source)
+    {
+        // Include method-body diagnostics (overload resolution, conversions,
+        // type-argument inference) which are produced by BindProgram, not only
+        // the declaration-level diagnostics on the global scope.
+        var resolver = ReferenceResolver.Default();
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var globalScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree), resolver);
+        var program = Binder.BindProgram(globalScope, resolver);
+        return globalScope.Diagnostics.AddRange(program.Diagnostics).ToList();
+    }
+}


### PR DESCRIPTION
## Problem

When a method group has both a **generic** overload whose type parameter cannot be inferred from the arguments (the type parameter appears only in the return type / a constraint, never in a parameter) and a **non-generic** overload with a matching parameter list, calling it **without explicit type arguments** was reported as ambiguous (GS0266) instead of resolving to the non-generic overload.

Minimal repro (previously `GS0266`, now compiles clean):

```gsharp
package p
interface IBox {}
class Box : IBox {}
class Factory {
    shared {
        func Make[T Box](file int32, parent IBox?) T { return default(T) }
        func Make(file int32, parent IBox?) IBox { return Box() }
    }
}
class C {
    func G(b IBox) {
        let child = Factory.Make(5, b)   // now resolves to non-generic Make(int32, IBox?) IBox
    }
}
```

## Root cause

`OverloadResolver.SelectBestUserOverloadCore` Phase 1 applicability (`IsApplicableUserCallable`) only checked arity + named-argument compatibility. It never considered whether a generic candidate's type parameters could be inferred, so both `Make[T]` and `Make` survived to Phase 2, tied on score, and were reported as ambiguous — whereas C# excludes the generic candidate because type inference fails for it.

## Fix

Centralized in `SelectBestUserOverloadCore` (covers static, instance, and top-level user-method overload groups). After Phase 1, when more than one candidate is applicable, apply the C# rule:

- **No explicit type arguments**: drop generic candidates whose type parameters cannot **all** be inferred from the supplied argument types (new helper `AllTypeParametersInferable`, reusing `Binder.InferTypeArguments`).
- **Explicit type arguments present** (`Make[Box](…)`): drop non-generic candidates (they cannot accept type arguments), leaving the generic overload to resolve. (This also fixes a pre-existing `GS0266` on the explicit-arg form.)

The exclusion is **guarded** so it only applies when at least one candidate survives — preserving the existing single-candidate diagnostics, e.g. the type-argument-inference-failure `GS0151` for a *lone* uninferable generic with no sibling.

A `hasExplicitTypeArgs` signal is threaded from the call sites (`ce`/`syntax.TypeArgumentList != null`) through `SelectInstanceOverloadOrReport`, `SelectBestInstanceOverload`, `SelectBestUserOverload`, and the core (added with a safe default so existing callers compile).

## Tests

- **`Issue1124UninferableGenericOverloadBinderTests`** (binder): no-explicit-arg resolves to non-generic with no diagnostics; return-type distinguishing checks (result is `IBox`, not `Box`, and not `GS0266`); explicit `[Box]` selects the generic; an inferable generic (`Id[T](x T) T`) is still selectable; a lone uninferable generic still reports `GS0151`; top-level-function path.
- **`Issue1124UninferableGenericOverloadEmitTests`** (emit): end-to-end compile + ilverify + run for both the non-generic and explicit-generic resolutions.

## Validation

- `dotnet build GSharp.sln -c Release` — clean (0 warnings, 0 errors).
- New binder tests: 8/8 passed. New emit tests: 2/2 passed.
- Regression slices: Core.Tests `~Overload|~Generic` 396/396, `~Call|~Method|~Static|~Function` 746/746; Compiler.Tests `~Generic` 179/179, `~Overload|~GenericMethod|~StaticMethod` 72/72 — all passed.

Fixes #1124
