### PR TITLE
Exclude uninferable generic overloads from source-method resolution (#1124)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -459,7 +459,12 @@ internal sealed class OverloadResolver
             return overloads.Length == 1 ? overloads[0] : null;
         }
 
-        var selected = SelectBestInstanceOverload(overloads, arguments.Length, argumentNames, arguments, out var ambiguous);
+        // Issue #1124: a call may carry an explicit method type-argument list
+        // (e.g. `Factory.Make[Box](...)`). Thread its arity into overload
+        // selection so generic candidates are filtered for applicability against
+        // either the explicit type arguments or, in their absence, type inference.
+        var explicitTypeArgCount = ce.TypeArgumentList?.Arguments.Count ?? 0;
+        var selected = SelectBestInstanceOverload(overloads, arguments.Length, argumentNames, arguments, out var ambiguous, explicitTypeArgCount);
         if (selected != null)
         {
             return selected;
@@ -482,9 +487,10 @@ internal sealed class OverloadResolver
         int argumentCount,
         ImmutableArray<string> argumentNames,
         ImmutableArray<BoundExpression>.Builder boundArguments,
-        out bool ambiguous)
+        out bool ambiguous,
+        int explicitTypeArgCount = 0)
     {
-        return SelectBestUserOverloadCore(candidates, argumentCount, argumentNames, boundArguments, out ambiguous);
+        return SelectBestUserOverloadCore(candidates, argumentCount, argumentNames, boundArguments, out ambiguous, explicitTypeArgCount);
     }
 
     /// <summary>
@@ -498,7 +504,8 @@ internal sealed class OverloadResolver
         int argumentCount,
         ImmutableArray<string> argumentNames,
         ImmutableArray<BoundExpression> boundArguments,
-        out bool ambiguous)
+        out bool ambiguous,
+        int explicitTypeArgCount = 0)
     {
         ambiguous = false;
         if (candidates.Length == 0)
@@ -513,7 +520,7 @@ internal sealed class OverloadResolver
 
         var builder = ImmutableArray.CreateBuilder<BoundExpression>(boundArguments.Length);
         builder.AddRange(boundArguments);
-        return SelectBestUserOverloadCore(candidates, argumentCount, argumentNames, builder, out ambiguous);
+        return SelectBestUserOverloadCore(candidates, argumentCount, argumentNames, builder, out ambiguous, explicitTypeArgCount);
     }
 
     private FunctionSymbol SelectBestUserOverloadCore(
@@ -521,7 +528,8 @@ internal sealed class OverloadResolver
         int argumentCount,
         ImmutableArray<string> argumentNames,
         ImmutableArray<BoundExpression>.Builder boundArguments,
-        out bool ambiguous)
+        out bool ambiguous,
+        int explicitTypeArgCount = 0)
     {
         ambiguous = false;
 
@@ -532,6 +540,49 @@ internal sealed class OverloadResolver
             if (IsApplicableUserCallable(cand, argumentCount, argumentNames))
             {
                 applicable.Add(cand);
+            }
+        }
+
+        // Issue #1124: a generic candidate whose method type parameters cannot be
+        // determined for the call is not applicable (C# §11.6.4.2 "if type
+        // inference fails, the method is not a candidate"). Without an explicit
+        // type-argument list this means every type parameter must be inferable
+        // from the argument types; with an explicit list it means the candidate
+        // must be generic of matching arity (a non-generic overload cannot accept
+        // type arguments). Dropping such candidates here prevents a uninferable
+        // generic overload from tying with — and thus being reported ambiguous
+        // (GS0266) against — an otherwise-unique non-generic best match.
+        if (applicable.Count > 1)
+        {
+            var filtered = new List<FunctionSymbol>(applicable.Count);
+            foreach (var cand in applicable)
+            {
+                if (explicitTypeArgCount > 0)
+                {
+                    if (cand.IsGeneric && cand.TypeParameters.Length == explicitTypeArgCount)
+                    {
+                        filtered.Add(cand);
+                    }
+                }
+                else if (cand.IsGeneric)
+                {
+                    if (AllMethodTypeParametersInferable(cand, boundArguments, argumentCount))
+                    {
+                        filtered.Add(cand);
+                    }
+                }
+                else
+                {
+                    filtered.Add(cand);
+                }
+            }
+
+            // Only adopt the filtered set when it leaves at least one candidate;
+            // an empty result means the call shape is genuinely unsatisfiable and
+            // the pre-existing diagnostics on the unfiltered set are preferable.
+            if (filtered.Count > 0)
+            {
+                applicable = filtered;
             }
         }
 
@@ -660,6 +711,69 @@ internal sealed class OverloadResolver
                 {
                     return false;
                 }
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Issue #1124: returns <see langword="true"/> when every method type
+    /// parameter of a generic candidate can be inferred from the supplied
+    /// argument types, mirroring the inference the binder performs once a
+    /// candidate is selected (see <c>BindUserTypeStaticCall</c> /
+    /// <c>InferTypeArguments</c>). Used to drop generic candidates whose type
+    /// arguments cannot be inferred so they do not participate in (and tie within)
+    /// overload ranking. Non-generic candidates trivially qualify.
+    /// </summary>
+    private bool AllMethodTypeParametersInferable(
+        FunctionSymbol candidate,
+        ImmutableArray<BoundExpression>.Builder boundArguments,
+        int argumentCount)
+    {
+        if (!candidate.IsGeneric)
+        {
+            return true;
+        }
+
+        var substitution = new Dictionary<TypeParameterSymbol, TypeSymbol>();
+        var parameterOffset = candidate.ExplicitReceiverParameter == null ? 0 : 1;
+        var paramLen = candidate.Parameters.Length - parameterOffset;
+        var isVariadic = paramLen > 0 && candidate.Parameters[candidate.Parameters.Length - 1].IsVariadic;
+        var fixedParamCount = isVariadic ? paramLen - 1 : paramLen;
+
+        var inferenceLimit = isVariadic ? fixedParamCount : Math.Min(argumentCount, paramLen);
+        for (var i = 0; i < inferenceLimit && i < boundArguments.Count; i++)
+        {
+            var argType = boundArguments[i]?.Type;
+            if (argType == null)
+            {
+                continue;
+            }
+
+            inferTypeArguments(candidate.Parameters[i + parameterOffset].Type, argType, substitution);
+        }
+
+        if (isVariadic && candidate.Parameters[candidate.Parameters.Length - 1].Type is SliceTypeSymbol variadicSlice)
+        {
+            for (var i = fixedParamCount; i < argumentCount && i < boundArguments.Count; i++)
+            {
+                var argType = boundArguments[i]?.Type;
+                if (argType == null)
+                {
+                    continue;
+                }
+
+                var source = argType is SliceTypeSymbol argSlice ? argSlice.ElementType : argType;
+                inferTypeArguments(variadicSlice.ElementType, source, substitution);
+            }
+        }
+
+        foreach (var tp in candidate.TypeParameters)
+        {
+            if (!substitution.ContainsKey(tp))
+            {
+                return false;
             }
         }
 
@@ -2825,7 +2939,7 @@ internal sealed class OverloadResolver
         var overloadSet = Scope.TryLookupFunctions(syntax.Identifier.Text);
         if (overloadSet.Length > 1)
         {
-            var selected = SelectBestUserOverload(overloadSet, syntax.Arguments.Count, argumentNames, boundArguments, out var overloadAmbiguous);
+            var selected = SelectBestUserOverload(overloadSet, syntax.Arguments.Count, argumentNames, boundArguments, out var overloadAmbiguous, syntax.TypeArgumentList?.Arguments.Count ?? 0);
             if (selected == null)
             {
                 if (overloadAmbiguous)

--- a/test/Compiler.Tests/Emit/Issue1124GenericUninferableOverloadEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1124GenericUninferableOverloadEmitTests.cs
@@ -1,0 +1,185 @@
+// <copyright file="Issue1124GenericUninferableOverloadEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1124: a method group containing a generic overload whose type
+/// parameter cannot be inferred from the arguments (it appears only in the
+/// return type / a constraint) alongside a non-generic overload with a matching
+/// parameter list must, for a call without explicit type arguments, exclude the
+/// generic candidate and bind the non-generic overload — previously this was
+/// wrongly reported as GS0266 ambiguous.
+/// <para>
+/// These tests compile, IL-verify, and run the minimal repro end to end. The
+/// non-generic overload returns a real <c>Box</c> (Tag = 99) while the generic
+/// overload returns <c>default(T)</c> (null), so the runtime output proves which
+/// overload was selected: the implicit call selects the non-generic overload
+/// (prints 99), and an explicit type-argument list selects the generic overload
+/// (returns null → prints -1).
+/// </para>
+/// </summary>
+public class Issue1124GenericUninferableOverloadEmitTests
+{
+    [Fact]
+    public void ImplicitCall_SelectsNonGenericOverload_EmitsAndRuns()
+    {
+        var source = """
+            package p
+            import System
+
+            interface IBox {
+                func Tag() int32;
+            }
+
+            class Box : IBox {
+                func Tag() int32 { return 99 }
+            }
+
+            class Factory {
+                shared {
+                    func Make[T Box](file int32, parent IBox?) T { return default(T) }
+                    func Make(file int32, parent IBox?) IBox { return Box() }
+                }
+            }
+
+            class C {
+                func runImplicit(b IBox) int32 {
+                    let child = Factory.Make(5, b)
+                    return child.Tag()
+                }
+            }
+
+            var c = C()
+            Console.WriteLine(c.runImplicit(Box()))
+            """;
+
+        Assert.Equal("99\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void ExplicitTypeArguments_SelectGenericOverload_EmitsAndRuns()
+    {
+        var source = """
+            package p
+            import System
+
+            interface IBox {
+                func Tag() int32;
+            }
+
+            class Box : IBox {
+                func Tag() int32 { return 99 }
+            }
+
+            class Factory {
+                shared {
+                    func Make[T Box](file int32, parent IBox?) T? { return default(T) }
+                    func Make(file int32, parent IBox?) IBox { return Box() }
+                }
+            }
+
+            class C {
+                func runImplicit(b IBox) int32 {
+                    let child = Factory.Make(5, b)
+                    return child.Tag()
+                }
+
+                func runExplicit(b IBox) int32 {
+                    let child = Factory.Make[Box](5, b)
+                    if child == nil {
+                        return -1
+                    }
+
+                    return child.Tag()
+                }
+            }
+
+            var c = C()
+            Console.WriteLine(c.runImplicit(Box()))
+            Console.WriteLine(c.runExplicit(Box()))
+            """;
+
+        Assert.Equal("99\n-1\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1124_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1124GenericUninferableOverloadTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1124GenericUninferableOverloadTests.cs
@@ -1,0 +1,182 @@
+// <copyright file="Issue1124GenericUninferableOverloadTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1124. When a method group contains a generic overload whose method
+/// type parameter cannot be inferred from the arguments (it appears only in the
+/// return type / a constraint) alongside a non-generic overload with a matching
+/// parameter list, a call without explicit type arguments must exclude the
+/// generic candidate (C# §11.6.4.2: type inference failure makes the method
+/// inapplicable) and bind the unique non-generic overload — not report GS0266
+/// ambiguity. Explicit type arguments must still select the generic overload,
+/// inferable generics must still participate, and genuinely ambiguous calls
+/// must still report GS0266.
+/// </summary>
+public class Issue1124GenericUninferableOverloadTests
+{
+    [Fact]
+    public void UninferableGeneric_PlusNonGeneric_ResolvesToNonGeneric_NoDiagnostics()
+    {
+        const string source = @"
+package p
+interface IBox {}
+class Box : IBox {}
+class Factory {
+    shared {
+        func Make[T Box](file int32, parent IBox?) T { return default(T) }
+        func Make(file int32, parent IBox?) IBox { return Box() }
+    }
+}
+class C {
+    func G(b IBox) {
+        let child = Factory.Make(5, b)
+    }
+}
+";
+        var compilation = Compile(source);
+        Assert.Empty(compilation.GlobalScope.Diagnostics);
+
+        var make = FindCall(compilation, "G", "Make");
+        Assert.NotNull(make);
+        Assert.False(make.Function.IsGeneric);
+    }
+
+    [Fact]
+    public void ExplicitTypeArguments_SelectGenericOverload()
+    {
+        const string source = @"
+package p
+interface IBox {}
+class Box : IBox {}
+class Factory {
+    shared {
+        func Make[T Box](file int32, parent IBox?) T { return default(T) }
+        func Make(file int32, parent IBox?) IBox { return Box() }
+    }
+}
+class C {
+    func G(b IBox) {
+        let child = Factory.Make[Box](5, b)
+    }
+}
+";
+        var compilation = Compile(source);
+        Assert.Empty(compilation.GlobalScope.Diagnostics);
+
+        var make = FindCall(compilation, "G", "Make");
+        Assert.NotNull(make);
+        Assert.True(make.Function.IsGeneric);
+    }
+
+    [Fact]
+    public void InferableGeneric_StillParticipates_NoDiagnostics()
+    {
+        // The generic overload's type parameter is inferable from the first
+        // argument, and a non-generic overload of a different arity exists. The
+        // two-argument call must bind the generic overload (T inferred from the
+        // argument); the one-argument call must bind the non-generic overload.
+        const string source = @"
+package p
+interface IBox {}
+class Box : IBox {}
+class Factory {
+    shared {
+        func Make[T Box](item T, file int32) T { return item }
+        func Make(file int32) IBox { return Box() }
+    }
+}
+class C {
+    func G(box Box) {
+        let a = Factory.Make(box, 5)
+        let b = Factory.Make(7)
+    }
+}
+";
+        var compilation = Compile(source);
+        Assert.Empty(compilation.GlobalScope.Diagnostics);
+
+        var calls = FindCalls(compilation, "G", "Make");
+        Assert.Equal(2, calls.Count);
+        Assert.Contains(calls, c => c.Function.IsGeneric);
+        Assert.Contains(calls, c => !c.Function.IsGeneric);
+    }
+
+    [Fact]
+    public void GenuineAmbiguity_BetweenNonGenericOverloads_StillReportsGS0266()
+    {
+        const string source = @"
+package p
+interface IA {}
+interface IB {}
+class Both : IA, IB {}
+class Factory {
+    shared {
+        func Take(x IA) int32 { return 1 }
+        func Take(x IB) int32 { return 2 }
+    }
+}
+class C {
+    func G(b Both) {
+        let x = Factory.Take(b)
+    }
+}
+";
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0266");
+    }
+
+    private static Compilation Compile(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        return new Compilation(tree) { IsLibrary = true };
+    }
+
+    private static BoundCallExpression FindCall(Compilation compilation, string functionName, string callName)
+        => FindCalls(compilation, functionName, callName).FirstOrDefault();
+
+    private static List<BoundCallExpression> FindCalls(Compilation compilation, string functionName, string callName)
+    {
+        var fn = compilation.BoundProgram.Functions.Keys.Single(f => f.Name == functionName);
+        var body = compilation.BoundProgram.Functions[fn];
+        var collector = new CallCollector(callName);
+        collector.Visit(body);
+        return collector.Collected;
+    }
+
+    private sealed class CallCollector : BoundTreeWalker
+    {
+        private readonly string callName;
+
+        public CallCollector(string callName)
+        {
+            this.callName = callName;
+        }
+
+        public List<BoundCallExpression> Collected { get; } = new();
+
+        public override void VisitExpression(BoundExpression node)
+        {
+            if (node is BoundCallExpression call && call.Function.Name == callName)
+            {
+                Collected.Add(call);
+            }
+
+            base.VisitExpression(node);
+        }
+    }
+}


### PR DESCRIPTION
## Root cause
The source-symbol overload resolver (`OverloadResolver.SelectBestUserOverloadCore`) filtered candidates only by **arity** and named-argument names — it never considered generic type-argument inference. So a generic overload whose type parameter cannot be inferred from the arguments (it appears only in the return type / a constraint, e.g. `Make[T Box](file int32, parent IBox?) T`) stayed in the applicable set, tied with a non-generic overload of the same parameter shape during ranking, and produced a false `GS0266` ambiguity. Explicit type arguments were likewise ignored by selection, so even `Factory.Make[Box](...)` tied and failed.

## Fix
After the arity-based applicability pass, drop generic candidates that cannot apply, matching C# 11.6.4.2 ("if type inference fails, the method is not a candidate"):

- **No explicit type arguments:** a generic candidate is kept only when *every* method type parameter is inferable from the argument types. This reuses the binder's own `InferTypeArguments` logic (threaded in via the existing `inferTypeArguments` delegate) so the applicability decision matches the inference performed downstream.
- **Explicit type-argument list present:** only generic candidates of matching arity are kept; non-generic overloads (which cannot accept type arguments) are excluded.

The explicit type-argument arity is threaded through `SelectInstanceOverloadOrReport` / `SelectBestInstanceOverload` / `SelectBestUserOverload` into the core. The filter only runs when more than one candidate is applicable and never empties the set (falls back to the unfiltered candidates so pre-existing diagnostics are preserved).

## Tests
- **Core.Tests** `Issue1124GenericUninferableOverloadTests`: uninferable-generic + non-generic resolves to the non-generic overload; explicit type args select the generic overload; an inferable generic still participates; a genuine ambiguity between two non-generic overloads still reports `GS0266`.
- **Compiler.Tests** `Issue1124GenericUninferableOverloadEmitTests`: compiles, IL-verifies and runs the repro end to end, observing which overload was selected (implicit call -> non-generic returns `Box` -> prints `99`; explicit `[Box]` -> generic returns `default(T)` null -> prints `-1`).

Full Core.Tests pass (3875 passed, 1 skipped); the Overload/Generic/Shared/Static Compiler.Tests subset (276) passes.

Fixes #1124
