### PR TITLE
Fix #1129: support string indexing s[i] -> char via get_Chars

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -2438,6 +2438,18 @@ internal sealed partial class ExpressionBinder
             return new BoundIndexExpression(null, target, index, element);
         }
 
+        // Issue #1129: `string` is the primitive `TypeSymbol.String` (not an
+        // `ImportedTypeSymbol`), so it matches none of the indexer-resolution
+        // branches below. Model `s[i]` against .NET's `String` indexer
+        // (`char this[int]` / `get_Chars(int)`), yielding a `char`. The index is
+        // converted to int32 exactly like array indexing. Emit already lowers a
+        // `BoundIndexExpression` whose target is `string` to `get_Chars` (#537).
+        if (target.Type == TypeSymbol.String)
+        {
+            var index = ConvertIndex(TypeSymbol.Int32);
+            return new BoundIndexExpression(null, target, index, TypeSymbol.Char);
+        }
+
         // Phase 4 exit: CLR indexer read on an imported reference type
         // (e.g. `d["k"]` on Dictionary[string, int]). Pick a public
         // instance indexer (a `PropertyInfo` whose `GetIndexParameters()`

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -1014,6 +1014,14 @@ public sealed class Evaluator
             return DefaultValue(mapType.ValueType);
         }
 
+        // Issue #1129: `s[i]` on a string reads the char at position `i` via
+        // the .NET String indexer (`get_Chars`), matching the emit lowering.
+        if (node.Target.Type == TypeSymbol.String && target is string str)
+        {
+            var charIndex = (int)EvaluateExpression(node.Index);
+            return str[charIndex];
+        }
+
         var arr = (System.Array)target;
         var index = (int)EvaluateExpression(node.Index);
         return arr.GetValue(index);

--- a/test/Compiler.Tests/Emit/Issue1129StringIndexerEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1129StringIndexerEmitTests.cs
@@ -1,0 +1,164 @@
+// <copyright file="Issue1129StringIndexerEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1129: indexing a <c>string</c> with <c>s[i]</c> was rejected with
+/// GS0116. .NET's <c>string</c> exposes <c>char this[int]</c>
+/// (<c>get_Chars</c>), so <c>s[i]</c> yields the <c>char</c> at that position.
+/// The binder now maps <c>string[int]</c> to a <c>BoundIndexExpression</c> with
+/// a <c>char</c> result; emit already lowered that node to
+/// <c>System.String.get_Chars(int)</c> (issue #537). These tests compile and
+/// run real programs end-to-end.
+/// </summary>
+public class Issue1129StringIndexerEmitTests
+{
+    [Fact]
+    public void StringIndex_ByConstant_YieldsCharCode()
+    {
+        // Acceptance criteria #2: end-to-end `s[1]` of "ABCD" is 'B' = 66.
+        var source = """
+            package P
+            import System
+
+            var s = "ABCD"
+            let c = s[1]
+            Console.WriteLine(int32(c))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("66\n", output);
+    }
+
+    [Fact]
+    public void StringIndex_FirstChar_YieldsCharCode()
+    {
+        var source = """
+            package P
+            import System
+
+            var s = "ABCD"
+            Console.WriteLine(int32(s[0]))
+            """;
+
+        var output = CompileAndRun(source);
+
+        // 'A' = 65
+        Assert.Equal("65\n", output);
+    }
+
+    [Fact]
+    public void StringIndex_ByVariable_YieldsCharCode()
+    {
+        // Acceptance criteria #3: indexing with a non-constant int variable.
+        var source = """
+            package P
+            import System
+
+            var s = "ABCD"
+            var i = 2
+            Console.WriteLine(int32(s[i]))
+            """;
+
+        var output = CompileAndRun(source);
+
+        // 'C' = 67
+        Assert.Equal("67\n", output);
+    }
+
+    [Fact]
+    public void StringIndex_PrintedAsChar()
+    {
+        var source = """
+            package P
+            import System
+
+            var s = "ABCD"
+            Console.WriteLine(s[3])
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("D\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1129_").FullName;
+        try
+        {
+            return CompileAndRunImpl(source, tempDir);
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static string CompileAndRunImpl(string source, string tempDir)
+    {
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        var args = new List<string>
+        {
+            "/out:" + outPath,
+            "/target:exe",
+            "/targetframework:net10.0",
+            srcPath,
+        };
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args.ToArray());
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+        IlVerifier.Verify(outPath);
+
+        var psi = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = tempDir,
+        };
+        psi.ArgumentList.Add("exec");
+        psi.ArgumentList.Add("--runtimeconfig");
+        psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+        psi.ArgumentList.Add(outPath);
+
+        using var proc = Process.Start(psi);
+        var stdout = proc.StandardOutput.ReadToEnd();
+        var stderr = proc.StandardError.ReadToEnd();
+        Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+        Assert.True(
+            proc.ExitCode == 0,
+            $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+        return stdout.Replace("\r\n", "\n");
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/ArrayTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ArrayTests.cs
@@ -53,9 +53,19 @@ public class ArrayTests
     }
 
     [Fact]
-    public void IndexExpression_OnNonArray_Diagnosed()
+    public void IndexExpression_OnString_ReturnsChar()
     {
-        var diagnostics = Bind("let s = \"hello\"\nlet c = s[0]\n");
+        // Issue #1129: `string` is now indexable; `s[i]` yields the char at
+        // position `i` (via .NET's String.get_Chars). 'h' = 104.
+        var result = Evaluate("let s = \"hello\"\nint32(s[0])");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(104, result.Value);
+    }
+
+    [Fact]
+    public void IndexExpression_OnNonIndexable_Diagnosed()
+    {
+        var diagnostics = Bind("let x = 5\nlet c = x[0]\n");
         Assert.Contains(diagnostics, d => d.Message.Contains("not indexable"));
     }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1129StringIndexerBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1129StringIndexerBinderTests.cs
@@ -1,0 +1,134 @@
+// <copyright file="Issue1129StringIndexerBinderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1129: indexing a <c>string</c> with <c>s[i]</c> was rejected with
+/// GS0116 "Type 'string' is not indexable." In C#/.NET <c>string</c> exposes
+/// <c>char this[int]</c> (<c>get_Chars</c>), so <c>s[i]</c> yields the
+/// <c>char</c> at that position. The binder now maps <c>string[int]</c> to a
+/// <c>BoundIndexExpression</c> with a <c>char</c> result; string WRITE
+/// (<c>s[i] = c</c>) remains rejected because .NET strings are immutable.
+/// </summary>
+public class Issue1129StringIndexerBinderTests
+{
+    [Fact]
+    public void StringIndex_ReadByConstant_NoDiagnostics()
+    {
+        // Acceptance criteria #1: the repro binds with no diagnostics.
+        var result = Evaluate("let s = \"ABCD\"\ns[1]");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal('B', result.Value);
+    }
+
+    [Fact]
+    public void StringIndex_ReadByConstant_FirstChar()
+    {
+        var result = Evaluate("let s = \"ABCD\"\nint32(s[0])");
+        Assert.Empty(result.Diagnostics);
+
+        // 'A' = 65
+        Assert.Equal(65, result.Value);
+    }
+
+    [Fact]
+    public void StringIndex_ReadByVariable_NoDiagnostics()
+    {
+        // Acceptance criteria #3: indexing with a non-constant int variable.
+        var result = Evaluate("let s = \"ABCD\"\nlet i = 2\ns[i]");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal('C', result.Value);
+    }
+
+    [Fact]
+    public void StringIndex_ResultIsChar()
+    {
+        // The bound element/result type must be `char` so downstream
+        // numeric/char handling (e.g. int32(c)) works.
+        var diagnostics = GetDiagnostics(
+            "package p\nclass C {\n    func F(s string) char {\n        return s[0]\n    }\n}");
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void StringIndex_ResultUsedAsChar_AssignsToCharTyped()
+    {
+        var diagnostics = GetDiagnostics(
+            "package p\nclass C {\n    func F(s string, i int32) char {\n        return s[i]\n    }\n}");
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void StringIndex_WriteStillRejected()
+    {
+        // Acceptance criteria #4: .NET strings are immutable, so s[i] = c
+        // must still report GS0116.
+        var diagnostics = GetDiagnostics(
+            "package p\nclass C {\n    func F(s string) {\n        s[0] = 'x'\n    }\n}");
+        Assert.NotEmpty(diagnostics);
+        Assert.Contains(diagnostics, d => d.Contains("not indexable"));
+    }
+
+    [Fact]
+    public void StringSlice_StillWorks()
+    {
+        // Acceptance criteria #5: no regression to string slicing.
+        var result = Evaluate("let s = \"abcdef\"\ns[1..3]");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("bc", result.Value);
+    }
+
+    [Fact]
+    public void StringFromEndIndex_StillWorks()
+    {
+        // Acceptance criteria #5: no regression to from-end indexing on string.
+        var result = Evaluate("let s = \"ABCD\"\ns[^1]");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal('D', result.Value);
+    }
+
+    [Fact]
+    public void StringLength_StillWorks()
+    {
+        // Acceptance criteria #5: no regression to s.Length.
+        var result = Evaluate("let s = \"ABCD\"\ns.Length");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(4, result.Value);
+    }
+
+    [Fact]
+    public void ArrayIndex_StillWorks()
+    {
+        // Acceptance criteria #5: no regression to array indexing.
+        var result = Evaluate("var xs = [3]int32{10, 20, 30}\nxs[1]");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(20, result.Value);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+
+    private static string[] GetDiagnostics(string source)
+    {
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(source)));
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream);
+        return result.Diagnostics.Where(d => d.IsError).Select(d => d.Message).ToArray();
+    }
+}


### PR DESCRIPTION
## Problem
Indexing a `string` with `s[i]` was rejected with `GS0116: Type 'string' is not indexable`, even though .NET's `string` exposes `char this[int]` (`get_Chars`). `s.Length` already worked, so strings were only partially BCL-modeled. Surfaced migrating Oahu via cs2gs (~34 GS0116).

## Root cause
Binder-only gap. `string` is the primitive `TypeSymbol.String`, not an `ImportedTypeSymbol`, so the index-read path in `ExpressionBinder.Access.cs` matched none of its indexer-resolution branches (map / array element / CLR indexer / user struct indexer) and fell through to `ReportTypeNotIndexable`. Emit already supported it: a `BoundIndexExpression` with `Target.Type == TypeSymbol.String` lowers to `System.String.get_Chars(int)` (added by #537).

## Fix
- `ExpressionBinder.Access.cs`: after the array-element check in the index-read binder, map `string[int]` to a `BoundIndexExpression` with the index converted to `int32` (same as arrays) and a `char` result type. Routed as a plain `BoundIndexExpression` so the existing emit fast-path (`get_Chars`) applies.
- `Evaluator.cs`: teach the interpreter to read string chars, since the node now binds for strings (previously it cast to `System.Array` and would crash).

String WRITE (`s[i] = c`) is intentionally left rejected because .NET strings are immutable. String slicing (`s[a..b]`) and from-end indexing (`s[^1]`) are unchanged.

## Tests
- `Issue1129StringIndexerBinderTests` — read by const/var, `char` result, write still GS0116, no regression to slice/from-end/Length/array.
- `Issue1129StringIndexerEmitTests` — compile + run end-to-end (e.g. `s[1]` of "ABCD" = 'B' = 66).
- Updated `ArrayTests`, which previously asserted the old buggy GS0116 for string indexing.

All focused + regression slices pass: Core.Tests 426 (Index|String|Slice), Compiler.Tests 219 (Index|String). Release build clean (0 warnings / 0 errors).

Fixes #1129
