### PR TITLE
Fix #1132: allow member writes through let reference-type locals

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -253,6 +253,41 @@ internal sealed partial class ExpressionBinder
     }
 
     /// <summary>
+    /// Issue #1132: returns <see langword="true"/> when the receiver
+    /// <paramref name="type"/> of a dotted member write is a reference type, in
+    /// which case mutating one of its members mutates the heap object rather
+    /// than the (possibly read-only) binding. A nullable reference type is
+    /// unwrapped first so a smart-cast / annotated reference receiver is also
+    /// treated as a reference, while a nullable value type (<c>int32?</c>) stays
+    /// a value type and remains rejected.
+    /// </summary>
+    /// <param name="type">The receiver variable's type.</param>
+    /// <returns><see langword="true"/> when the receiver is a reference type.</returns>
+    private static bool ReceiverTypeIsReference(TypeSymbol type)
+    {
+        var underlying = type is NullableTypeSymbol nullable ? nullable.UnderlyingType : type;
+        return Binder.IsReferenceTypeForConstraint(underlying);
+    }
+
+    /// <summary>
+    /// Issue #1132: returns <see langword="true"/> when a member write through
+    /// <paramref name="receiver"/> must be rejected because the receiver is a
+    /// read-only (e.g. <c>let</c>) local of a <em>value</em> type — mutating one
+    /// of its members would mutate the value stored in the read-only slot. A
+    /// reference-type receiver (mutating the heap object) and the enclosing
+    /// <c>this</c> are both exempt.
+    /// </summary>
+    /// <param name="receiver">The bound receiver of the member write.</param>
+    /// <returns><see langword="true"/> when the member write must be rejected.</returns>
+    private bool ReceiverBlocksValueTypeMemberWrite(BoundExpression receiver)
+    {
+        return receiver is BoundVariableExpression bve
+            && bve.Variable.IsReadOnly
+            && !ReceiverVariableIsThis(bve.Variable)
+            && !ReceiverTypeIsReference(bve.Variable.Type);
+    }
+
+    /// <summary>
     /// Issue #947: returns <see langword="true"/> when the bound
     /// <paramref name="receiver"/> denotes the enclosing function's <c>this</c>
     /// (a <see langword="null"/> receiver is an implicit <c>this</c>).
@@ -577,6 +612,16 @@ internal sealed partial class ExpressionBinder
                     Diagnostics.ReportProtectedMemberInaccessible(syntax.FieldIdentifier.Location, prop.Name, propDeclaringType.Name);
                 }
 
+                // Issue #1132: writing a property of a read-only value-type
+                // receiver mutates the value in the read-only slot — reject it
+                // (a reference-type receiver mutates the heap object and the
+                // enclosing `this` are both exempt via ReceiverVariableIsThis /
+                // ReceiverTypeIsReference).
+                if (variable.IsReadOnly && !ReceiverVariableIsThis(variable) && !ReceiverTypeIsReference(variable.Type))
+                {
+                    Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, receiverName);
+                }
+
                 var propConverted = conversions.BindConversion(syntax.Value.Location, value, prop.Type);
                 var propReceiver = implicitFieldReceiverExpr ?? new BoundVariableExpression(null, variable);
                 EnforceInitOnlyAssignment(prop, propReceiver, syntax.EqualsToken.Location);
@@ -629,7 +674,12 @@ internal sealed partial class ExpressionBinder
         // Issue #947: a read-only field of `this` may be assigned inside the
         // declaring type's constructor; in that case the receiver being `this`
         // (which is itself read-only) must not block the field write.
-        if (variable.IsReadOnly && !receiverIsThisField)
+        // Issue #1132: `let` communicates immutability of the *binding* only
+        // (shallow / readonly-reference semantics). For a reference-type
+        // receiver, `b.Field = v` mutates the heap object, not the binding, so
+        // it must be allowed; only value-type receivers (where the field write
+        // would mutate the value stored in the read-only slot) stay rejected.
+        if (variable.IsReadOnly && !receiverIsThisField && !ReceiverTypeIsReference(variable.Type))
         {
             Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, receiverName);
         }
@@ -935,6 +985,14 @@ internal sealed partial class ExpressionBinder
                 Diagnostics.ReportCannotAssign(syntax.OperatorToken.Location, memberName);
             }
 
+            // Issue #1132: compound-mutating a field of a read-only value-type
+            // receiver mutates the value in the read-only slot — reject it.
+            // Reference-type receivers and `this` are exempt.
+            if (ReceiverBlocksValueTypeMemberWrite(boundReceiver))
+            {
+                Diagnostics.ReportCannotAssign(syntax.OperatorToken.Location, memberName);
+            }
+
             var leftRead = new BoundFieldAccessExpression(null, boundReceiver, declaringType, field);
             var op = BoundBinaryOperator.Bind(baseOpSyntaxKind, field.Type, boundRhs.Type);
             if (op == null)
@@ -955,6 +1013,13 @@ internal sealed partial class ExpressionBinder
             {
                 Diagnostics.ReportCannotAssign(syntax.OperatorToken.Location, memberName);
                 return new BoundErrorExpression(null);
+            }
+
+            // Issue #1132: compound-mutating a property of a read-only value-type
+            // receiver mutates the value in the read-only slot — reject it.
+            if (ReceiverBlocksValueTypeMemberWrite(boundReceiver))
+            {
+                Diagnostics.ReportCannotAssign(syntax.OperatorToken.Location, memberName);
             }
 
             var leftRead = new BoundPropertyAccessExpression(null, boundReceiver, structSym, prop);

--- a/test/Compiler.Tests/Emit/Issue1132LetReferenceFieldWriteEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1132LetReferenceFieldWriteEmitTests.cs
@@ -1,0 +1,147 @@
+// <copyright file="Issue1132LetReferenceFieldWriteEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1132: a member write through a <c>let</c> reference-type local
+/// mutates the heap object, not the (read-only) binding, so it must compile
+/// AND emit correctly. These tests compile+run a snippet to prove the heap
+/// mutation actually happens at runtime, not just that it binds.
+/// </summary>
+public class Issue1132LetReferenceFieldWriteEmitTests
+{
+    [Fact]
+    public void LetClassLocal_FieldWrite_MutatesHeapObject()
+    {
+        // Acceptance #6: `let b = Box{}; b.Value = 5` mutates the heap object.
+        var source = """
+            package p
+            import System
+
+            class Box { var Value int32 = 0 }
+
+            func makeAndMutate() int32 {
+                let b = Box{ }
+                b.Value = 5
+                return b.Value
+            }
+
+            public var result = makeAndMutate()
+            """;
+
+        Assert.Equal(5, RunAndGetIntResult(source));
+    }
+
+    [Fact]
+    public void LetClassLocal_CompoundAndIncrement_MutatesHeapObject()
+    {
+        // Acceptance #6: compound `+=` and `++` through a `let` class local.
+        var source = """
+            package p
+            import System
+
+            class Counter { var Value int32 = 0 }
+
+            func count() int32 {
+                let c = Counter{ }
+                c.Value += 4
+                c.Value++
+                return c.Value
+            }
+
+            public var result = count()
+            """;
+
+        Assert.Equal(5, RunAndGetIntResult(source));
+    }
+
+    [Fact]
+    public void LetClassLocal_PropertyWrite_MutatesHeapObject()
+    {
+        // Acceptance #6: property write through a `let` class local.
+        var source = """
+            package p
+            import System
+
+            class Box {
+                var _v int32 = 0
+                prop Value int32 {
+                    get { return _v }
+                    set { _v = value }
+                }
+            }
+
+            func makeAndMutate() int32 {
+                let b = Box{ }
+                b.Value = 5
+                return b.Value
+            }
+
+            public var result = makeAndMutate()
+            """;
+
+        Assert.Equal(5, RunAndGetIntResult(source));
+    }
+
+    private static int RunAndGetIntResult(string source)
+    {
+        var assembly = CompileToAssembly(source, target: "exe");
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var entry = program.GetMethod(
+            "<Main>$",
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+        var resultField = program.GetField(
+            "result",
+            BindingFlags.Public | BindingFlags.Static);
+
+        entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { System.Array.Empty<string>() });
+        return (int)resultField!.GetValue(null)!;
+    }
+
+    private static Assembly CompileToAssembly(string source, string target)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1132_emit_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:" + target,
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+        IlVerifier.Verify(outPath);
+
+        var bytes = File.ReadAllBytes(outPath);
+        return Assembly.Load(bytes);
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1132LetReferenceFieldWriteBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1132LetReferenceFieldWriteBinderTests.cs
@@ -1,0 +1,259 @@
+// <copyright file="Issue1132LetReferenceFieldWriteBinderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1132: <c>let</c> communicates immutability of the <em>binding</em>
+/// (shallow / readonly-reference semantics). Writing a field or property of a
+/// <em>reference-type</em> object held by a <c>let</c> local mutates the heap
+/// object, not the binding, so it must be allowed; only the binding itself
+/// (<c>b = other</c>) and member writes through a <em>value-type</em> <c>let</c>
+/// local (which would mutate the value in the read-only slot) stay rejected
+/// with <c>GS0127</c>.
+/// </summary>
+public class Issue1132LetReferenceFieldWriteBinderTests
+{
+    [Fact]
+    public void LetClassLocal_FieldWrite_Allowed()
+    {
+        // Acceptance #1: `let b = Box{}; b.Value = 5` (class receiver).
+        const string source = """
+            package p
+            class Box { var Value int32 = 0 }
+            class C {
+                func F() int32 {
+                    let b = Box{ }
+                    b.Value = 5
+                    return b.Value
+                }
+            }
+            """;
+
+        Assert.DoesNotContain(Bind(source), d => d.Id == "GS0127");
+    }
+
+    [Fact]
+    public void LetClassLocal_PropertyWrite_Allowed()
+    {
+        // Acceptance #2: property write through a `let` class local.
+        const string source = """
+            package p
+            class Box {
+                var _v int32 = 0
+                prop Value int32 {
+                    get { return _v }
+                    set { _v = value }
+                }
+            }
+            class C {
+                func F() int32 {
+                    let b = Box{ }
+                    b.Value = 5
+                    return b.Value
+                }
+            }
+            """;
+
+        Assert.DoesNotContain(Bind(source), d => d.Id == "GS0127");
+    }
+
+    [Fact]
+    public void LetClassLocal_CompoundFieldWrite_Allowed()
+    {
+        // Acceptance #3: `let b = Counter{}; b.Value += 1` (class receiver).
+        const string source = """
+            package p
+            class Counter { var Value int32 = 0 }
+            class C {
+                func F() int32 {
+                    let b = Counter{ }
+                    b.Value += 1
+                    return b.Value
+                }
+            }
+            """;
+
+        Assert.DoesNotContain(Bind(source), d => d.Id == "GS0127");
+    }
+
+    [Fact]
+    public void LetClassLocal_IncrementFieldWrite_Allowed()
+    {
+        // Acceptance #3: `let b = Counter{}; b.Value++` (class receiver).
+        const string source = """
+            package p
+            class Counter { var Value int32 = 0 }
+            class C {
+                func F() int32 {
+                    let b = Counter{ }
+                    b.Value++
+                    return b.Value
+                }
+            }
+            """;
+
+        Assert.DoesNotContain(Bind(source), d => d.Id == "GS0127");
+    }
+
+    [Fact]
+    public void LetStructLocal_FieldWrite_Rejected()
+    {
+        // Acceptance #4: a value-type (struct) receiver stays rejected.
+        const string source = """
+            package p
+            struct S { var Value int32 }
+            class C {
+                func F() int32 {
+                    let s = S{ Value: 1 }
+                    s.Value = 5
+                    return s.Value
+                }
+            }
+            """;
+
+        Assert.Contains(Bind(source), d => d.Id == "GS0127");
+    }
+
+    [Fact]
+    public void LetStructLocal_PropertyWrite_Rejected()
+    {
+        // Acceptance #4: struct property write through a `let` struct local.
+        const string source = """
+            package p
+            struct S {
+                var _v int32
+                prop Value int32 {
+                    get { return _v }
+                    set { _v = value }
+                }
+            }
+            class C {
+                func F() int32 {
+                    let s = S{ }
+                    s.Value = 5
+                    return s.Value
+                }
+            }
+            """;
+
+        Assert.Contains(Bind(source), d => d.Id == "GS0127");
+    }
+
+    [Fact]
+    public void LetStructLocal_CompoundFieldWrite_Rejected()
+    {
+        // Acceptance #4: struct compound write through a `let` struct local.
+        const string source = """
+            package p
+            struct S { var Value int32 }
+            class C {
+                func F() int32 {
+                    let s = S{ Value: 1 }
+                    s.Value += 1
+                    return s.Value
+                }
+            }
+            """;
+
+        Assert.Contains(Bind(source), d => d.Id == "GS0127");
+    }
+
+    [Fact]
+    public void LetStructLocal_IncrementFieldWrite_Rejected()
+    {
+        // Acceptance #4: struct increment through a `let` struct local.
+        const string source = """
+            package p
+            struct S { var Value int32 }
+            class C {
+                func F() int32 {
+                    let s = S{ Value: 1 }
+                    s.Value++
+                    return s.Value
+                }
+            }
+            """;
+
+        Assert.Contains(Bind(source), d => d.Id == "GS0127");
+    }
+
+    [Fact]
+    public void LetClassLocal_Rebind_Rejected()
+    {
+        // Acceptance #5: direct rebinding of a `let` class local stays rejected.
+        const string source = """
+            package p
+            class Box { var Value int32 = 0 }
+            class C {
+                func F() int32 {
+                    let b = Box{ }
+                    b = Box{ }
+                    return b.Value
+                }
+            }
+            """;
+
+        Assert.Contains(Bind(source), d => d.Id == "GS0127");
+    }
+
+    [Fact]
+    public void LetStructLocal_Rebind_Rejected()
+    {
+        // Acceptance #5: direct rebinding of a `let` struct local stays rejected.
+        const string source = """
+            package p
+            struct S { var Value int32 }
+            class C {
+                func F() int32 {
+                    let s = S{ Value: 1 }
+                    s = S{ Value: 2 }
+                    return s.Value
+                }
+            }
+            """;
+
+        Assert.Contains(Bind(source), d => d.Id == "GS0127");
+    }
+
+    [Fact]
+    public void VarClassLocal_FieldWrite_StillAllowed()
+    {
+        // Acceptance #7 (no regression): `var b` field writes are unaffected.
+        const string source = """
+            package p
+            class Box { var Value int32 = 0 }
+            class C {
+                func F() int32 {
+                    var b = Box{ }
+                    b.Value = 5
+                    return b.Value
+                }
+            }
+            """;
+
+        Assert.DoesNotContain(Bind(source), d => d.Id == "GS0127");
+    }
+
+    private static ImmutableArray<GSharp.Core.CodeAnalysis.Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var globalScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+        if (globalScope.Diagnostics.Any())
+        {
+            return globalScope.Diagnostics;
+        }
+
+        var program = Binder.BindProgram(globalScope);
+        return program.Diagnostics.ToImmutableArray();
+    }
+}


### PR DESCRIPTION
## Problem
Assigning to a field/property of a **reference-type** object held by a `let` local was wrongly rejected with `GS0127: Variable 'b' is read-only and cannot be assigned to`. Per the spec, `let` communicates immutability of the **binding** (shallow / readonly-reference, like Kotlin `val` / C# `readonly`). For a reference-type local, `b.Field = x` mutates the **heap object**, not the binding, so it must be allowed. `var b` already compiled; `let b` did not.

Found migrating Oahu via cs2gs (#914): e.g. `ChunkOffsetList list = new(...); list.chunkOffsets64 = new(...);` — `list` is a class, never reassigned, so the translator emits `let list`, but the field write was rejected.

## Root cause
`ExpressionBinder.Assignments.cs` applied the read-only-receiver guard (`GS0127`) to **any** read-only receiver variable in the dotted field-write path, regardless of whether the receiver was a value type or a reference type.

## Fix
Exempt **reference-type** receivers from the read-only-receiver guard using the existing `Binder.IsReferenceTypeForConstraint` helper (unwrapping a `NullableTypeSymbol` first, so a nullable reference receiver is also exempt while a nullable value type stays rejected). Applied consistently to:
- the dotted **field-write** path,
- the user-struct **property-write** path,
- the chained **compound-assignment** (`+=`) field & property paths.

Increment/decrement (`b.Field++`) already desugar through the field-write path and inherit the fix.

**Deliberately left rejected (unchanged):** direct rebind `b = other`, bare compound `b += x` (line 780), bare `b++`, value-type (struct) member writes through a `let` local, static/readonly-field enforcement, and `in`/`ref`/`out` paths. `this`-receiver writes inside constructors/methods are unchanged.

## Tests
- `Issue1132LetReferenceFieldWriteBinderTests` (11 tests): field/property/compound/increment writes through a `let` **class** local are allowed; the same through a `let` **struct** local stay rejected; direct rebind of both stays rejected; `var` field write unaffected.
- `Issue1132LetReferenceFieldWriteEmitTests` (3 tests): compile **and run** prove the heap mutation emits correctly (field, compound+increment, property all yield `5`).

Regression: Core.Tests `Assignment|ReadOnly|Let|Field|Struct|Increment|Compound|Property|Protected` slices (1039 tests) and Compiler.Tests `Assignment|Field|Struct|Increment|Compound|Property|Let` emit slices (609 tests) all pass. Full Release build: 0 warnings / 0 errors.

Fixes #1132