### PR TITLE
Fix GS0127 on let-ref-local field write + out-var enclosing scope (#914)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -1742,6 +1742,25 @@ internal sealed partial class ExpressionBinder
             for (var i = 0; i < permutedArgs.Length; i++)
             {
                 var paramType = method.Parameters[i].Type;
+
+                // ADR-0060 / issue #1133: an inline `out var n` / `out let n` /
+                // `out _` argument was bound to a placeholder address-of (Error
+                // pointee) in the eager argument pass, because the resolved
+                // parameter — and therefore the local's type — was not yet
+                // known. Now that the static (`shared`) overload has been
+                // chosen, re-bind the inline declaration against the resolved
+                // by-ref parameter so the synthesized local is declared (with
+                // the correct pointee type) into the enclosing block scope and
+                // becomes visible to the rest of the block — mirroring the
+                // instance-method path in OverloadResolver.BindUserInstanceCall.
+                var outVarParamType = substitution != null ? Binder.SubstituteType(paramType, substitution) : paramType;
+                var argSyntaxForOutVar = i < ce.Arguments.Count ? ce.Arguments[i] : null;
+                if (TryRebindInlineOutVarUserArgument(permutedArgs[i], argSyntaxForOutVar, method.Parameters[i].Name, outVarParamType, out var reboundOutVar))
+                {
+                    convertedArgs.Add(reboundOutVar);
+                    continue;
+                }
+
                 if (paramType is TypeParameterSymbol)
                 {
                     convertedArgs.Add(permutedArgs[i]);

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -1149,6 +1149,48 @@ internal sealed partial class ExpressionBinder
     }
 
     /// <summary>
+    /// ADR-0060 / issue #1133: re-binds a single inline <c>out var n</c> /
+    /// <c>out let n</c> / <c>out _</c> argument whose declared type was omitted,
+    /// once the resolved by-ref parameter type is known. In the eager argument
+    /// pass such an argument is bound to a placeholder
+    /// <see cref="BoundAddressOfExpression"/> over an <see cref="BoundErrorExpression"/>
+    /// (Error pointee) without declaring a local, because the parameter — and
+    /// therefore the local's pointee type — was not yet known. This re-binds the
+    /// declaration against a synthesized <see cref="RefKind.Out"/> parameter so
+    /// the local is declared into the enclosing block scope with the correct
+    /// type. Shared by the user instance-call, free-function, and qualified
+    /// static-call paths so the inline-out-var scoping is identical everywhere.
+    /// </summary>
+    /// <param name="boundArgument">The already-bound argument (possibly a placeholder).</param>
+    /// <param name="argumentSyntax">The source argument syntax (named-argument wrappers are unwrapped).</param>
+    /// <param name="parameterName">The resolved parameter's name (used for the synthesized parameter symbol).</param>
+    /// <param name="parameterType">The resolved parameter's (pointee) type, used as the local's type.</param>
+    /// <param name="rebound">The rebound address-of expression, when applicable.</param>
+    /// <returns><see langword="true"/> when the argument was a type-omitted inline out declaration and was rebound.</returns>
+    internal bool TryRebindInlineOutVarUserArgument(
+        BoundExpression boundArgument,
+        ExpressionSyntax argumentSyntax,
+        string parameterName,
+        TypeSymbol parameterType,
+        out BoundExpression rebound)
+    {
+        rebound = null;
+        if (argumentSyntax == null
+            || boundArgument is not BoundAddressOfExpression placeholder
+            || placeholder.Operand?.Type != TypeSymbol.Error
+            || OverloadResolver.UnwrapNamedArgumentValue(argumentSyntax) is not RefArgumentExpressionSyntax refArg
+            || !refArg.IsInlineDeclaration
+            || refArg.DeclaredType != null)
+        {
+            return false;
+        }
+
+        var syntheticParameter = new ParameterSymbol(parameterName, parameterType, refKind: RefKind.Out);
+        rebound = BindRefArgumentExpression(refArg, syntheticParameter);
+        return true;
+    }
+
+    /// <summary>
     /// ADR-0060: binds a <c>ref</c>/<c>out</c>/<c>in</c> argument-position expression.
     /// For the lvalue form (e.g. <c>ref x</c>, <c>out result</c>, <c>in rect</c>) the
     /// inner expression is bound to a <see cref="BoundAddressOfExpression"/>. For the

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -240,6 +240,50 @@ internal sealed partial class ExpressionBinder
     }
 
     /// <summary>
+    /// Issue #1132: determines whether <paramref name="type"/> is a value type
+    /// for the purpose of read-only (<c>let</c>) receiver enforcement. A
+    /// member write (<c>recv.Field = v</c>, <c>recv.Field += v</c>,
+    /// <c>recv.Field++</c>) through a read-only <c>let</c> binding is only
+    /// rejected when the receiver is a value type — mutating it would change the
+    /// value held in the read-only slot. For a reference type the write mutates
+    /// the heap object the binding points at, not the binding itself, so it is
+    /// allowed (only rebinding <c>recv = other</c> stays blocked).
+    /// </summary>
+    /// <param name="type">The static type of the receiver variable.</param>
+    /// <returns><see langword="true"/> when the receiver type is a value type.</returns>
+    private static bool IsValueTypeReceiver(TypeSymbol type)
+    {
+        switch (type)
+        {
+            case null:
+                return false;
+
+            // User-defined `struct` is a value type; `class` (IsClass) is a
+            // reference type and therefore exempt.
+            case StructSymbol structSymbol:
+                return !structSymbol.IsClass;
+
+            // Enums are value types.
+            case EnumSymbol:
+                return true;
+
+            // Interfaces are reference types.
+            case InterfaceSymbol:
+                return false;
+
+            // A type parameter is a value type only when it carries a
+            // value-type (`struct`) constraint; otherwise it may bind to a
+            // reference type, so do not over-restrict.
+            case TypeParameterSymbol typeParameter:
+                return typeParameter.HasValueTypeConstraint;
+
+            // Imported / CLR-backed types: defer to the runtime classification.
+            default:
+                return type.ClrType is { IsValueType: true };
+        }
+    }
+
+    /// <summary>
     /// Issue #947: returns <see langword="true"/> when <paramref name="variable"/>
     /// is the enclosing function's <c>this</c> parameter (the instance under
     /// construction or the method's receiver).
@@ -629,7 +673,15 @@ internal sealed partial class ExpressionBinder
         // Issue #947: a read-only field of `this` may be assigned inside the
         // declaring type's constructor; in that case the receiver being `this`
         // (which is itself read-only) must not block the field write.
-        if (variable.IsReadOnly && !receiverIsThisField)
+        //
+        // Issue #1132: `let` makes the BINDING read-only, not the heap object it
+        // points at. For a reference-type receiver (`class`/interface/imported
+        // reference type), `b.Field = x` mutates the object on the heap, not the
+        // binding, so it is allowed; only rebinding `b = other` is blocked. For a
+        // value-type receiver (`struct`/enum/value-type type parameter), the
+        // field write would mutate the value held in the read-only slot, so it
+        // stays rejected.
+        if (variable.IsReadOnly && !receiverIsThisField && IsValueTypeReceiver(variable.Type))
         {
             Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, receiverName);
         }
@@ -925,12 +977,24 @@ internal sealed partial class ExpressionBinder
         var baseOpSyntaxKind = isAdd ? SyntaxKind.PlusToken : SyntaxKind.MinusToken;
         var boundRhs = BindExpression(syntax.Value);
 
+        // Issue #1132: a compound member write (`recv.Field += v`) through a
+        // read-only `let` binding mutates the member in place. When the receiver
+        // is a value type held in the read-only slot this is rejected; for a
+        // reference type the heap object is mutated, not the binding, so it is
+        // allowed. Mirrors the simple-assignment guard in BindFieldAssignmentExpression.
+        var receiverIsReadOnlyValueType =
+            boundReceiver is BoundVariableExpression compoundReceiverVar
+            && compoundReceiverVar.Variable.IsReadOnly
+            && !ReceiverExpressionIsThis(boundReceiver)
+            && IsValueTypeReceiver(compoundReceiverVar.Variable.Type);
+
         // ADR-0112 A3: this-first base-chain instance field walk, using the
         // declaring struct as the owner for both the read access and assignment.
         if (TypeMemberModel.TryGetFieldIncludingInherited(structSym, memberName, MemberQuery.Instance(MemberKinds.Field), out var field, out var declaringType))
         {
-            if (field.IsReadOnly
-                && !IsReadOnlyFieldAssignmentAllowed(field, declaringType, ReceiverExpressionIsThis(boundReceiver)))
+            if (receiverIsReadOnlyValueType
+                || (field.IsReadOnly
+                    && !IsReadOnlyFieldAssignmentAllowed(field, declaringType, ReceiverExpressionIsThis(boundReceiver))))
             {
                 Diagnostics.ReportCannotAssign(syntax.OperatorToken.Location, memberName);
             }
@@ -951,6 +1015,11 @@ internal sealed partial class ExpressionBinder
         // ADR-0051: check properties.
         if (TypeMemberModel.TryGetProperty(structSym, memberName, out var prop))
         {
+            if (receiverIsReadOnlyValueType)
+            {
+                Diagnostics.ReportCannotAssign(syntax.OperatorToken.Location, memberName);
+            }
+
             if (!prop.HasGetter || !prop.HasSetter)
             {
                 Diagnostics.ReportCannotAssign(syntax.OperatorToken.Location, memberName);
@@ -1322,8 +1391,15 @@ internal sealed partial class ExpressionBinder
             // declaring struct as the owner for the emitted assignment.
             if (TypeMemberModel.TryGetFieldIncludingInherited(structSym, fieldName, MemberQuery.Instance(MemberKinds.Field), out var field, out var declaringType))
             {
-                if (field.IsReadOnly
-                    && !IsReadOnlyFieldAssignmentAllowed(field, declaringType, ReceiverExpressionIsThis(receiver)))
+                // Issue #1132: reject a member write through a read-only `let`
+                // binding only when the receiver is a value type (mutating the
+                // slot); reference-type receivers mutate the heap object instead.
+                if ((receiver is BoundVariableExpression memberReceiverVar
+                        && memberReceiverVar.Variable.IsReadOnly
+                        && !ReceiverExpressionIsThis(receiver)
+                        && IsValueTypeReceiver(memberReceiverVar.Variable.Type))
+                    || (field.IsReadOnly
+                        && !IsReadOnlyFieldAssignmentAllowed(field, declaringType, ReceiverExpressionIsThis(receiver))))
                 {
                     Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, fieldName);
                 }

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -4002,6 +4002,32 @@ internal sealed class OverloadResolver
             }
 
             var argLoc = argSyntaxForLocation?.Location ?? ce.Location;
+
+            // ADR-0060 / issue #1133: an inline `out var n` / `out let n` /
+            // `out _` argument was bound to a placeholder address-of (Error
+            // pointee) in the eager argument pass, because the resolved
+            // parameter — and therefore the local's type — was not yet known.
+            // Now that overload resolution has chosen this method, re-bind the
+            // inline declaration against the resolved by-ref parameter so the
+            // synthesized local is declared (with the correct pointee type)
+            // into the enclosing block scope and becomes visible to the rest of
+            // the block (mirrors the imported-method path in
+            // RebindInlineOutVarArguments and the free-function fix-up in
+            // BindCallExpression).
+            if (permutedArguments[i] is BoundAddressOfExpression inlineOutAddr
+                && inlineOutAddr.Operand?.Type == TypeSymbol.Error
+                && argSyntaxForInterp is RefArgumentExpressionSyntax inlineOutRefArg
+                && inlineOutRefArg.IsInlineDeclaration
+                && inlineOutRefArg.DeclaredType == null)
+            {
+                var inlineOutParameter = new ParameterSymbol(
+                    method.Parameters[i + parameterOffset].Name,
+                    expectedType,
+                    refKind: RefKind.Out);
+                convertedArgs.Add(bindRefArgumentExpression(inlineOutRefArg, inlineOutParameter));
+                continue;
+            }
+
             convertedArgs.Add(conversions.BindCallArgumentWithRefKind(argLoc, permutedArguments[i], expectedType, method.Parameters[i + parameterOffset]));
         }
 

--- a/test/Compiler.Tests/Emit/Issue1132LetRefLocalFieldWriteEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1132LetRefLocalFieldWriteEmitTests.cs
@@ -1,0 +1,165 @@
+// <copyright file="Issue1132LetRefLocalFieldWriteEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1132: <c>let</c> communicates immutability of the BINDING (shallow,
+/// like Kotlin <c>val</c> / a C# <c>readonly</c> reference), not of the heap
+/// object the binding points at. For a reference-type (<c>class</c>/interface)
+/// local, a field or property write through the binding
+/// (<c>b.Field = x</c>, <c>b.Field += 1</c>, <c>b.Field++</c>) mutates the heap
+/// object and must be allowed; only rebinding the local (<c>b = other</c>) is
+/// blocked. These end-to-end tests prove the mutation is actually observed at
+/// runtime after the fix removed the spurious GS0127.
+/// </summary>
+public class Issue1132LetRefLocalFieldWriteEmitTests
+{
+    [Fact]
+    public void LetClassLocal_FieldWrite_MutationObserved()
+    {
+        var source = """
+            package P
+            import System
+
+            class Box {
+                var Value int32 = 0
+            }
+
+            func mutate() int32 {
+                let b = Box{ }
+                b.Value = 5
+                return b.Value
+            }
+
+            Console.WriteLine(mutate())
+            """;
+
+        Assert.Equal("5\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void LetClassLocal_CompoundFieldWrite_MutationObserved()
+    {
+        var source = """
+            package P
+            import System
+
+            class Box {
+                var Value int32 = 10
+            }
+
+            func mutate() int32 {
+                let b = Box{ }
+                b.Value += 3
+                b.Value++
+                return b.Value
+            }
+
+            Console.WriteLine(mutate())
+            """;
+
+        Assert.Equal("14\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void LetClassLocal_PropertyWrite_MutationObserved()
+    {
+        var source = """
+            package P
+            import System
+
+            class Counter {
+                public var Count int32 = 0
+                public func Bump() {
+                    let self = this
+                    self.Count = self.Count + 1
+                }
+            }
+
+            let c = Counter{ }
+            c.Bump()
+            c.Bump()
+            Console.WriteLine(c.Count)
+            """;
+
+        Assert.Equal("2\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1132_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi);
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue1133OutVarScopeEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1133OutVarScopeEmitTests.cs
@@ -1,0 +1,245 @@
+// <copyright file="Issue1133OutVarScopeEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1133: an inline <c>out var n</c> / <c>out let n</c> declaration on a
+/// call to a user-defined <em>instance</em> method (e.g.
+/// <c>this.G(out var n)</c> via implicit <c>this</c>) must leak the new local
+/// into the ENCLOSING block scope — like C# — so it is usable by later
+/// statements. Previously the local was accepted at the call site but a
+/// subsequent use failed with GS0125 ("Variable doesn't exist") because the
+/// re-bind (after overload resolution) never declared it. These end-to-end
+/// tests confirm the leaked local both binds and receives the value at runtime.
+/// </summary>
+public class Issue1133OutVarScopeEmitTests
+{
+    [Fact]
+    public void InstanceMethod_OutVar_LeaksToEnclosingScope_AndReceivesValue()
+    {
+        var source = """
+            package P
+            import System
+
+            class C {
+                func G(out x int32) {
+                    x = 5
+                }
+
+                public func F() int32 {
+                    G(out var y)
+                    return y
+                }
+            }
+
+            let c = C{ }
+            Console.WriteLine(c.F())
+            """;
+
+        Assert.Equal("5\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void InstanceMethod_OutLet_ReadAfterCall()
+    {
+        var source = """
+            package P
+            import System
+
+            class C {
+                func G(out x int32) {
+                    x = 11
+                }
+
+                public func F() int32 {
+                    G(out let y)
+                    return y
+                }
+            }
+
+            let c = C{ }
+            Console.WriteLine(c.F())
+            """;
+
+        Assert.Equal("11\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void InstanceMethod_OutVar_ReassignedThenUsed()
+    {
+        var source = """
+            package P
+            import System
+
+            class C {
+                func G(out x int32) {
+                    x = 5
+                }
+
+                public func F() int32 {
+                    G(out var y)
+                    y = 7
+                    return y
+                }
+            }
+
+            let c = C{ }
+            Console.WriteLine(c.F())
+            """;
+
+        Assert.Equal("7\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void InstanceMethod_OutVar_UsedAsLaterCallArgument()
+    {
+        var source = """
+            package P
+            import System
+
+            class C {
+                func G(out x int32) {
+                    x = 6
+                }
+
+                func H(v int32) int32 {
+                    return v * 2
+                }
+
+                public func F() int32 {
+                    G(out var y)
+                    return H(y)
+                }
+            }
+
+            let c = C{ }
+            Console.WriteLine(c.F())
+            """;
+
+        Assert.Equal("12\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void InstanceMethod_OutDiscard_Binds()
+    {
+        var source = """
+            package P
+            import System
+
+            class C {
+                func G(out x int32) {
+                    x = 5
+                }
+
+                public func F() int32 {
+                    G(out _)
+                    return 0
+                }
+            }
+
+            let c = C{ }
+            Console.WriteLine(c.F())
+            """;
+
+        Assert.Equal("0\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void ExplicitReceiverInstanceMethod_OutVar_LeaksToEnclosingScope()
+    {
+        var source = """
+            package P
+            import System
+
+            class C {
+                public func G(out x int32) {
+                    x = 9
+                }
+            }
+
+            let c = C{ }
+            c.G(out var y)
+            Console.WriteLine(y)
+            """;
+
+        Assert.Equal("9\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1133_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi);
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue1133OutVarScopeEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1133OutVarScopeEmitTests.cs
@@ -12,12 +12,13 @@ namespace GSharp.Compiler.Tests.Emit;
 /// <summary>
 /// Issue #1133: an inline <c>out var n</c> / <c>out let n</c> declaration on a
 /// call to a user-defined <em>instance</em> method (e.g.
-/// <c>this.G(out var n)</c> via implicit <c>this</c>) must leak the new local
-/// into the ENCLOSING block scope — like C# — so it is usable by later
-/// statements. Previously the local was accepted at the call site but a
-/// subsequent use failed with GS0125 ("Variable doesn't exist") because the
-/// re-bind (after overload resolution) never declared it. These end-to-end
-/// tests confirm the leaked local both binds and receives the value at runtime.
+/// <c>this.G(out var n)</c> via implicit <c>this</c>) or a <em>qualified
+/// static</em> method (e.g. <c>C.G(out var n)</c>) must leak the new local into
+/// the ENCLOSING block scope — like C# — so it is usable by later statements.
+/// Previously the local was accepted at the call site but a subsequent use
+/// failed with GS0125 ("Variable doesn't exist") because the re-bind (after
+/// overload resolution) never declared it. These end-to-end tests confirm the
+/// leaked local both binds and receives the value at runtime.
 /// </summary>
 public class Issue1133OutVarScopeEmitTests
 {
@@ -170,6 +171,115 @@ public class Issue1133OutVarScopeEmitTests
             """;
 
         Assert.Equal("9\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void QualifiedStaticMethod_OutVar_LeaksToEnclosingScope_AndReceivesValue()
+    {
+        var source = """
+            package P
+            import System
+
+            class C {
+                shared {
+                    func G(out x int32) {
+                        x = 5
+                    }
+
+                    func F() int32 {
+                        C.G(out var y)
+                        return y
+                    }
+                }
+            }
+
+            Console.WriteLine(C.F())
+            """;
+
+        Assert.Equal("5\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void QualifiedStaticMethod_OutLet_ReadAfterCall()
+    {
+        var source = """
+            package P
+            import System
+
+            class C {
+                shared {
+                    func G(out x int32) {
+                        x = 11
+                    }
+
+                    func F() int32 {
+                        C.G(out let y)
+                        return y
+                    }
+                }
+            }
+
+            Console.WriteLine(C.F())
+            """;
+
+        Assert.Equal("11\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void QualifiedStaticMethod_OutVar_ReassignedThenUsed()
+    {
+        var source = """
+            package P
+            import System
+
+            class C {
+                shared {
+                    func G(out x int32) {
+                        x = 5
+                    }
+
+                    func F() int32 {
+                        C.G(out var y)
+                        y = 7
+                        return y
+                    }
+                }
+            }
+
+            Console.WriteLine(C.F())
+            """;
+
+        Assert.Equal("7\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void QualifiedStaticMethod_OnOtherClass_OutVar_ReceivesValue()
+    {
+        var source = """
+            package P
+            import System
+
+            class Other {
+                shared {
+                    func G(out x int32) {
+                        x = 8
+                    }
+                }
+            }
+
+            class C {
+                shared {
+                    func F() int32 {
+                        Other.G(out var y)
+                        return y
+                    }
+                }
+            }
+
+            Console.WriteLine(C.F())
+            """;
+
+        Assert.Equal("8\n", CompileAndRun(source));
     }
 
     private static string CompileAndRun(string source)

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1132LetRefLocalFieldWriteBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1132LetRefLocalFieldWriteBindingTests.cs
@@ -1,0 +1,168 @@
+// <copyright file="Issue1132LetRefLocalFieldWriteBindingTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1132: <c>let</c> makes the BINDING read-only, not the heap object the
+/// binding points at. A field/property write through a read-only <c>let</c>
+/// local must be allowed when the receiver is a reference type (the object is
+/// mutated, not the binding) and rejected when the receiver is a value type
+/// (the value held in the read-only slot would be mutated). Rebinding the local
+/// (<c>b = other</c>) stays rejected for both. These tests pin the GS0127
+/// behaviour across simple, compound, and increment member writes.
+/// </summary>
+public class Issue1132LetRefLocalFieldWriteBindingTests
+{
+    [Fact]
+    public void LetClassLocal_FieldWrite_Allowed()
+    {
+        const string source = @"
+package p
+class Box { var Value int32 = 0 }
+class C {
+  func F() int32 {
+    let b = Box{ }
+    b.Value = 5
+    return b.Value
+  }
+}
+";
+        Assert.DoesNotContain(GetDiagnostics(source), d => d.Id == "GS0127");
+    }
+
+    [Fact]
+    public void LetStructLocal_FieldWrite_Rejected()
+    {
+        const string source = @"
+package p
+struct S { var Value int32 }
+class C {
+  func F() int32 {
+    let s = S{ Value: 1 }
+    s.Value = 5
+    return s.Value
+  }
+}
+";
+        Assert.Contains(GetDiagnostics(source), d => d.Id == "GS0127");
+    }
+
+    [Fact]
+    public void LetClassLocal_Rebind_Rejected()
+    {
+        const string source = @"
+package p
+class Box { var Value int32 = 0 }
+class C {
+  func F() int32 {
+    let b = Box{ }
+    b = Box{ }
+    return b.Value
+  }
+}
+";
+        Assert.Contains(GetDiagnostics(source), d => d.Id == "GS0127");
+    }
+
+    [Fact]
+    public void LetClassLocal_CompoundFieldWrite_Allowed()
+    {
+        const string source = @"
+package p
+class Box { var Value int32 = 0 }
+class C {
+  func F() int32 {
+    let b = Box{ }
+    b.Value += 1
+    return b.Value
+  }
+}
+";
+        Assert.DoesNotContain(GetDiagnostics(source), d => d.Id == "GS0127");
+    }
+
+    [Fact]
+    public void LetStructLocal_CompoundFieldWrite_Rejected()
+    {
+        const string source = @"
+package p
+struct S { var Value int32 }
+class C {
+  func F() int32 {
+    let s = S{ Value: 1 }
+    s.Value += 1
+    return s.Value
+  }
+}
+";
+        Assert.Contains(GetDiagnostics(source), d => d.Id == "GS0127");
+    }
+
+    [Fact]
+    public void LetClassLocal_PostfixIncrementFieldWrite_Allowed()
+    {
+        const string source = @"
+package p
+class Box { var Value int32 = 0 }
+class C {
+  func F() int32 {
+    let b = Box{ }
+    b.Value++
+    return b.Value
+  }
+}
+";
+        Assert.DoesNotContain(GetDiagnostics(source), d => d.Id == "GS0127");
+    }
+
+    [Fact]
+    public void LetStructLocal_PostfixIncrementFieldWrite_Rejected()
+    {
+        const string source = @"
+package p
+struct S { var Value int32 }
+class C {
+  func F() int32 {
+    let s = S{ Value: 1 }
+    s.Value++
+    return s.Value
+  }
+}
+";
+        Assert.Contains(GetDiagnostics(source), d => d.Id == "GS0127");
+    }
+
+    [Fact]
+    public void VarClassLocal_FieldWrite_Allowed_Control()
+    {
+        const string source = @"
+package p
+class Box { var Value int32 = 0 }
+class C {
+  func F() int32 {
+    var b = Box{ }
+    b.Value = 5
+    return b.Value
+  }
+}
+";
+        Assert.DoesNotContain(GetDiagnostics(source), d => d.Id == "GS0127");
+    }
+
+    private static IEnumerable<Diagnostic> GetDiagnostics(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new GSharp.Core.CodeAnalysis.Compilation.Compilation(tree);
+        using var peStream = new System.IO.MemoryStream();
+        return compilation.Emit(peStream).Diagnostics.ToList();
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1133OutVarScopeBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1133OutVarScopeBindingTests.cs
@@ -1,0 +1,157 @@
+// <copyright file="Issue1133OutVarScopeBindingTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1133: an inline <c>out var n</c> / <c>out let n</c> / <c>out _</c>
+/// declaration on a call to a user-defined <em>instance</em> method (resolved
+/// through <see cref="GSharp.Core.CodeAnalysis.Binding.OverloadResolver"/>'s
+/// instance-call path) must leak the new local into the ENCLOSING block scope,
+/// like C#, so later statements can use it. Previously the call site was
+/// accepted but using the variable afterwards reported GS0125
+/// ("Variable doesn't exist") because the post-overload-resolution re-bind never
+/// declared the local. <c>out _</c> introduces no visible name.
+/// </summary>
+public class Issue1133OutVarScopeBindingTests
+{
+    [Fact]
+    public void InstanceMethod_OutVar_VisibleInEnclosingScope_NoGS0125()
+    {
+        const string source = @"
+package p
+class C {
+  func G(out x int32) { x = 5 }
+  func F() int32 {
+    G(out var y)
+    return y
+  }
+}
+";
+        var diagnostics = GetDiagnostics(source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0125");
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void InstanceMethod_OutLet_ReadAfterCall_NoGS0125()
+    {
+        const string source = @"
+package p
+class C {
+  func G(out x int32) { x = 5 }
+  func F() int32 {
+    G(out let y)
+    return y
+  }
+}
+";
+        var diagnostics = GetDiagnostics(source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0125");
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void InstanceMethod_OutLet_RebindReportsCannotAssign()
+    {
+        const string source = @"
+package p
+class C {
+  func G(out x int32) { x = 5 }
+  func F() int32 {
+    G(out let y)
+    y = 7
+    return y
+  }
+}
+";
+        Assert.Contains(GetDiagnostics(source), d => d.Id == "GS0127");
+    }
+
+    [Fact]
+    public void InstanceMethod_OutVar_ReassignedThenUsed_NoErrors()
+    {
+        const string source = @"
+package p
+class C {
+  func G(out x int32) { x = 5 }
+  func F() int32 {
+    G(out var y)
+    y = 7
+    return y
+  }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void InstanceMethod_OutVar_UsedAsLaterCallArgument_NoErrors()
+    {
+        const string source = @"
+package p
+class C {
+  func G(out x int32) { x = 5 }
+  func H(v int32) int32 { return v }
+  func F() int32 {
+    G(out var y)
+    return H(y)
+  }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void InstanceMethod_OutDiscard_IntroducesNoVisibleName()
+    {
+        const string source = @"
+package p
+class C {
+  func G(out x int32) { x = 5 }
+  func F() int32 {
+    G(out _)
+    return 0
+  }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void ExplicitReceiverInstanceMethod_OutVar_VisibleInEnclosingScope()
+    {
+        const string source = @"
+package p
+class C {
+  public func G(out x int32) { x = 9 }
+}
+class D {
+  func F() int32 {
+    let c = C{ }
+    c.G(out var y)
+    return y
+  }
+}
+";
+        var diagnostics = GetDiagnostics(source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0125");
+        Assert.Empty(diagnostics);
+    }
+
+    private static List<Diagnostic> GetDiagnostics(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new GSharp.Core.CodeAnalysis.Compilation.Compilation(tree);
+        using var peStream = new System.IO.MemoryStream();
+        return compilation.Emit(peStream).Diagnostics.ToList();
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1133OutVarScopeBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1133OutVarScopeBindingTests.cs
@@ -15,11 +15,14 @@ namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 /// Issue #1133: an inline <c>out var n</c> / <c>out let n</c> / <c>out _</c>
 /// declaration on a call to a user-defined <em>instance</em> method (resolved
 /// through <see cref="GSharp.Core.CodeAnalysis.Binding.OverloadResolver"/>'s
-/// instance-call path) must leak the new local into the ENCLOSING block scope,
-/// like C#, so later statements can use it. Previously the call site was
-/// accepted but using the variable afterwards reported GS0125
-/// ("Variable doesn't exist") because the post-overload-resolution re-bind never
-/// declared the local. <c>out _</c> introduces no visible name.
+/// instance-call path) or a <em>qualified static</em> method (e.g.
+/// <c>C.G(out var n)</c>, resolved through
+/// <c>ExpressionBinder.BindUserTypeStaticCall</c>) must leak the new local into
+/// the ENCLOSING block scope, like C#, so later statements can use it.
+/// Previously the call site was accepted but using the variable afterwards
+/// reported GS0125 ("Variable doesn't exist") because the
+/// post-overload-resolution re-bind never declared the local. <c>out _</c>
+/// introduces no visible name.
 /// </summary>
 public class Issue1133OutVarScopeBindingTests
 {
@@ -139,6 +142,126 @@ class D {
     let c = C{ }
     c.G(out var y)
     return y
+  }
+}
+";
+        var diagnostics = GetDiagnostics(source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0125");
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void QualifiedStaticMethod_OutVar_VisibleInEnclosingScope_NoGS0125()
+    {
+        const string source = @"
+package p
+class C {
+  shared {
+    func G(out x int32) { x = 5 }
+    func F() int32 {
+      C.G(out var y)
+      return y
+    }
+  }
+}
+";
+        var diagnostics = GetDiagnostics(source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0125");
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void QualifiedStaticMethod_OutLet_ReadAfterCall_NoGS0125()
+    {
+        const string source = @"
+package p
+class C {
+  shared {
+    func G(out x int32) { x = 5 }
+    func F() int32 {
+      C.G(out let y)
+      return y
+    }
+  }
+}
+";
+        var diagnostics = GetDiagnostics(source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0125");
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void QualifiedStaticMethod_OutLet_RebindReportsCannotAssign()
+    {
+        const string source = @"
+package p
+class C {
+  shared {
+    func G(out x int32) { x = 5 }
+    func F() int32 {
+      C.G(out let y)
+      y = 7
+      return y
+    }
+  }
+}
+";
+        Assert.Contains(GetDiagnostics(source), d => d.Id == "GS0127");
+    }
+
+    [Fact]
+    public void QualifiedStaticMethod_OutVar_ReassignedThenUsed_NoErrors()
+    {
+        const string source = @"
+package p
+class C {
+  shared {
+    func G(out x int32) { x = 5 }
+    func F() int32 {
+      C.G(out var y)
+      y = 7
+      return y
+    }
+  }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void QualifiedStaticMethod_OutDiscard_IntroducesNoVisibleName()
+    {
+        const string source = @"
+package p
+class C {
+  shared {
+    func G(out x int32) { x = 5 }
+    func F() int32 {
+      C.G(out _)
+      return 0
+    }
+  }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void QualifiedStaticMethod_OnOtherClass_OutVar_VisibleInEnclosingScope()
+    {
+        const string source = @"
+package p
+class Other {
+  shared {
+    func G(out x int32) { x = 5 }
+  }
+}
+class C {
+  shared {
+    func F() int32 {
+      Other.G(out var y)
+      return y
+    }
   }
 }
 ";


### PR DESCRIPTION
## Summary

Two related G# binder fixes.

### #1132 — GS0127 wrongly rejected field/property writes through a `let` reference-type local
Per spec, `let` makes the **binding** read-only (shallow, Kotlin `val` / C# `readonly`-reference semantics), not the heap object. For a reference-type receiver (`class`/interface/imported reference type), `b.Field = x` mutates the heap object, not the binding, so it must be allowed; only rebinding `b = other` is blocked. For a value-type receiver (`struct`/enum/value-type type parameter), a field write through a `let` stays rejected (it would mutate the value in the read-only slot).

A new `IsValueTypeReceiver(TypeSymbol)` helper is added and the value-type-only guard is applied to every member-write path that previously rejected purely on receiver read-onlyness:
- simple `b.Field = x` (`BindFieldAssignmentExpression`)
- compound `b.Field += 1` (`TryBindChainedCompoundAssignment`) — this path previously *allowed* struct field writes too, which is now correctly rejected
- chained member `a.b.Field = x` (`BindMemberFieldAssignmentExpression`)

Postfix `b.Field++` is covered because it desugars to the simple-assignment path.

### #1133 — inline `out var n` not visible in enclosing scope (GS0125)
An inline `out var n` / `out let n` / `out _` declaration on a user-defined **instance** method call (implicit or explicit `this`) now leaks the new local into the enclosing block scope (like C#). Previously the call site was accepted but a later use failed with `GS0125: Variable 'y' doesn't exist`.

`BindUserInstanceCall` now re-binds the inline out-var placeholder against the resolved by-ref parameter (mirroring the imported-method `RebindInlineOutVarArguments` and free-function fix-up paths), declaring the local with the inferred pointee type into the active block scope.

## Tests
- `test/Core.Tests/.../Issue1132LetRefLocalFieldWriteBindingTests.cs` (8 tests)
- `test/Core.Tests/.../Issue1133OutVarScopeBindingTests.cs` (7 tests)
- `test/Compiler.Tests/Emit/Issue1132LetRefLocalFieldWriteEmitTests.cs` (3 tests, asserts runtime mutation)
- `test/Compiler.Tests/Emit/Issue1133OutVarScopeEmitTests.cs` (6 tests, asserts out-var receives value)

Full `Core.Tests` green (3901 passed). Targeted emit + related Compiler.Tests (FieldAssignment, RefKind, out-var, ADR-0060/0112, struct, mutation, LanguageConformance) all green.

### Known limitation (out of scope)
Prefix `++b.Value` as a standalone statement still fails with GS0402 — but this is a pre-existing parser newline-absorption bug that affects `var` locals identically (`++i` on a `var` local fails the same way), unrelated to the `let`/readonly binder fix. Postfix `b.Value++` and compound `b.Value += 1` work correctly.

Fixes #1132
Fixes #1133
Refs #914