### PR TITLE
Fix #1133: inline out-var declaration visible in enclosing scope for user instance calls

### DIFF
--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -3953,7 +3953,37 @@ internal sealed class OverloadResolver
         var convertedArgs = ImmutableArray.CreateBuilder<BoundExpression>(permutedArguments.Length);
         for (var i = 0; i < permutedArguments.Length; i++)
         {
-            var paramType = method.Parameters[i + parameterOffset].Type;
+            var parameter = method.Parameters[i + parameterOffset];
+            var paramType = parameter.Type;
+
+            // ADR-0060 / issue #1133: an inline-decl `out var n` / `out let n` /
+            // `out _` was bound with TypeSymbol.Error in the first pass (from
+            // BindCallExpression, before the method was resolved) and never
+            // declared a local. Now that overload resolution has chosen the
+            // method — and the receiver / method type-argument substitution is
+            // known — re-bind it so the synthesized local is typed from the
+            // resolved (substituted) out-parameter pointee type and leaks into
+            // the enclosing block scope. This mirrors the free-function path
+            // and the imported-method RebindInlineOutVarArguments helper, and
+            // must run BEFORE the open-type-parameter shortcut below so generic
+            // out-parameters (`func M[T](out result T)`) are handled too.
+            if (permutedArguments[i] is BoundAddressOfExpression inlineOutAddr
+                && inlineOutAddr.Operand.Type == TypeSymbol.Error)
+            {
+                var slotSyntax = i < permutedSyntax.Length ? permutedSyntax[i] : null;
+                var unwrappedSlotSyntax = slotSyntax != null ? UnwrapNamedArgumentValue(slotSyntax) : null;
+                if (unwrappedSlotSyntax is RefArgumentExpressionSyntax inlineOutRefArg
+                    && inlineOutRefArg.IsInlineDeclaration
+                    && inlineOutRefArg.DeclaredType == null)
+                {
+                    var pointeeType = substitution != null ? substituteType(paramType, substitution) : paramType;
+                    var rebindParameter = ReferenceEquals(pointeeType, parameter.Type)
+                        ? parameter
+                        : new ParameterSymbol(parameter.Name, pointeeType, refKind: RefKind.Out);
+                    convertedArgs.Add(bindRefArgumentExpression(inlineOutRefArg, rebindParameter));
+                    continue;
+                }
+            }
 
             // An argument bound to an open type parameter is left untouched —
             // the emitter boxes value types at the call boundary (the parameter

--- a/test/Compiler.Tests/Emit/Issue1133OutVarUserInstanceEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1133OutVarUserInstanceEmitTests.cs
@@ -1,0 +1,218 @@
+// <copyright file="Issue1133OutVarUserInstanceEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1133: an inline <c>out var n</c> (and <c>out let n</c> / <c>out _</c>)
+/// declaration at a <em>user instance method</em> call site was accepted but the
+/// declared local never leaked into the enclosing block scope, so a later read
+/// failed with <c>GS0125</c>. The free-function and imported-method paths already
+/// re-bound the first-pass placeholder once overload resolution had chosen the
+/// callee; <c>BindUserInstanceCall</c> did not. These tests compile, IL-verify,
+/// and actually run the shape end-to-end so the leaked local both binds and
+/// carries the right value at runtime.
+/// </summary>
+public class Issue1133OutVarUserInstanceEmitTests
+{
+    [Fact]
+    public void ImplicitThis_OutVar_Compiles_And_Runs()
+    {
+        // The headline repro: `G(out var y)` on an implicit-`this` instance
+        // method must declare `y` in the enclosing scope and return 5.
+        var source = """
+            package P
+            import System
+
+            class C {
+                func G(out x int32) { x = 5 }
+                func F() int32 {
+                    G(out var y)
+                    return y
+                }
+            }
+
+            var c = C()
+            Console.WriteLine(c.F())
+            """;
+
+        Assert.Equal("5\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void ExplicitReceiver_OutVar_Compiles_And_Runs()
+    {
+        // `c.G(out var y)` on an explicit receiver must leak `y` too.
+        var source = """
+            package P
+            import System
+
+            class C {
+                func G(out x int32) { x = 7 }
+            }
+
+            class D {
+                func F(c C) int32 {
+                    c.G(out var y)
+                    return y
+                }
+            }
+
+            var c = C()
+            var d = D()
+            Console.WriteLine(d.F(c))
+            """;
+
+        Assert.Equal("7\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void OutLet_ReadOnlyLocal_Compiles_And_Runs()
+    {
+        // `out let y` declares a read-only local; reading it is fine.
+        var source = """
+            package P
+            import System
+
+            class C {
+                func G(out x int32) { x = 11 }
+                func F() int32 {
+                    G(out let y)
+                    return y
+                }
+            }
+
+            var c = C()
+            Console.WriteLine(c.F())
+            """;
+
+        Assert.Equal("11\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void OutDiscard_Compiles_And_Runs()
+    {
+        // `out _` discards the result; no name leaks into the enclosing scope.
+        var source = """
+            package P
+            import System
+
+            class C {
+                func G(out x int32) { x = 5 }
+                func F() int32 {
+                    G(out _)
+                    return 42
+                }
+            }
+
+            var c = C()
+            Console.WriteLine(c.F())
+            """;
+
+        Assert.Equal("42\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void GenericOutParameter_OutVar_Compiles_And_Runs()
+    {
+        // A generic out-parameter (`func M[T](seed T, out result T)`) must bind
+        // the out-var local as the substituted pointee type (int32) and run.
+        var source = """
+            package P
+            import System
+
+            class C {
+                func M[T](seed T, out result T) { result = seed }
+                func F() int32 {
+                    M[int32](9, out var y)
+                    return y
+                }
+            }
+
+            var c = C()
+            Console.WriteLine(c.F())
+            """;
+
+        Assert.Equal("9\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1133_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1133OutVarEnclosingScopeBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1133OutVarEnclosingScopeBinderTests.cs
@@ -1,0 +1,180 @@
+// <copyright file="Issue1133OutVarEnclosingScopeBinderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1133 / ADR-0060: an inline <c>out var n</c> (and <c>out let n</c> /
+/// <c>out _</c>) declaration at a <em>user instance method</em> call site was
+/// accepted but never declared the local in the enclosing block scope, so a
+/// subsequent read of <c>n</c> failed with <c>GS0125</c>. The free-function and
+/// imported-method paths already re-bound the first-pass placeholder; the
+/// user-instance path (<c>BindUserInstanceCall</c>) did not. These tests cover
+/// implicit-<c>this</c> and explicit-receiver calls, the read-only (<c>out
+/// let</c>) and discard (<c>out _</c>) forms, and a generic out-parameter.
+/// </summary>
+public class Issue1133OutVarEnclosingScopeBinderTests
+{
+    [Fact]
+    public void ImplicitThis_OutVar_DeclaresLocalInEnclosingScope_NoGS0125()
+    {
+        // Exact repro from the issue.
+        const string source = @"
+package p
+class C {
+    func G(out x int32) { x = 5 }
+    func F() int32 {
+        G(out var y)
+        return y
+    }
+}
+";
+        var diagnostics = GetDiagnostics(source).ToList();
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0125");
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void ExplicitReceiver_OutVar_DeclaresLocalInEnclosingScope_NoGS0125()
+    {
+        const string source = @"
+package p
+class C {
+    func G(out x int32) { x = 5 }
+}
+class D {
+    func F(c C) int32 {
+        c.G(out var y)
+        return y
+    }
+}
+";
+        var diagnostics = GetDiagnostics(source).ToList();
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0125");
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void OutLet_DeclaresReadOnlyLocal_ReadIsFine()
+    {
+        const string source = @"
+package p
+class C {
+    func G(out x int32) { x = 5 }
+    func F() int32 {
+        G(out let y)
+        return y
+    }
+}
+";
+        var diagnostics = GetDiagnostics(source).ToList();
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void OutLet_AssigningAfterwards_ReportsReadOnly()
+    {
+        const string source = @"
+package p
+class C {
+    func G(out x int32) { x = 5 }
+    func F() int32 {
+        G(out let y)
+        y = 9
+        return y
+    }
+}
+";
+        var diagnostics = GetDiagnostics(source).ToList();
+        Assert.Contains(diagnostics, d => d.Id == "GS0127");
+    }
+
+    [Fact]
+    public void OutDiscard_DoesNotLeakName()
+    {
+        const string source = @"
+package p
+class C {
+    func G(out x int32) { x = 5 }
+    func F() int32 {
+        G(out _)
+        return _
+    }
+}
+";
+        var diagnostics = GetDiagnostics(source).ToList();
+        Assert.Contains(diagnostics, d => d.Id == "GS0125");
+    }
+
+    [Fact]
+    public void OutDiscard_AloneCompiles()
+    {
+        const string source = @"
+package p
+class C {
+    func G(out x int32) { x = 5 }
+    func F() int32 {
+        G(out _)
+        return 1
+    }
+}
+";
+        var diagnostics = GetDiagnostics(source).ToList();
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void GenericOutParameter_OutVar_BindsSubstitutedType_NoDiagnostics()
+    {
+        // The out-var local must bind as the substituted parameter pointee
+        // type (int32 here), not the open type parameter `T`.
+        const string source = @"
+package p
+class C {
+    func M[T](seed T, out result T) { result = seed }
+    func F() int32 {
+        M[int32](7, out var y)
+        return y
+    }
+}
+";
+        var diagnostics = GetDiagnostics(source).ToList();
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0125");
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void Control_PreDeclaredOutLocal_StillCompiles()
+    {
+        // Regression guard: the existing pre-declared form must keep working.
+        const string source = @"
+package p
+class C {
+    func G(out x int32) { x = 5 }
+    func F() int32 {
+        var y int32
+        G(out y)
+        return y
+    }
+}
+";
+        var diagnostics = GetDiagnostics(source).ToList();
+        Assert.Empty(diagnostics);
+    }
+
+    private static IEnumerable<Diagnostic> GetDiagnostics(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new GSharp.Core.CodeAnalysis.Compilation.Compilation(tree);
+        using var peStream = new System.IO.MemoryStream();
+        return compilation.Emit(peStream).Diagnostics;
+    }
+}


### PR DESCRIPTION
Fixes #1133

## Problem
An inline `out var n` (and `out let n` / `out _`) declaration at a **user instance method** call site was accepted, but the declared local was not visible in the enclosing scope. A subsequent read failed with `GS0125: Variable 'n' doesn't exist`.

```gsharp
class C {
    func G(out x int32) { x = 5 }
    func F() int32 {
        G(out var y)
        return y          // was GS0125
    }
}
```

This affected both implicit-`this` calls (`G(out var y)`) and explicit-receiver calls (`obj.M(out var y)`). The free-function path and imported-CLR-method path already worked.

## Root cause
On the first binding pass (before overload resolution), an inline out-var argument is bound to a placeholder `BoundAddressOfExpression` wrapping a `BoundErrorExpression` and intentionally declares no local. The free-function path (`OverloadResolver`) and the imported-method path (`RebindInlineOutVarArguments`) both re-bind this placeholder once the callee parameter type is known, declaring the local into the active enclosing scope. **`BindUserInstanceCall` never performed that rebind**, so the local for user instance calls was never declared.

## Fix
In `BindUserInstanceCall`'s per-argument conversion loop, before the open-type-parameter shortcut and the normal ref-kind conversion, detect the inline out-var placeholder (a `BoundAddressOfExpression` whose operand type is `TypeSymbol.Error`, matched to an inline-declaration `RefArgumentExpressionSyntax` with no explicit type) and re-bind it via the same `bindRefArgumentExpression` delegate the free-function/imported paths use. The pointee type is substituted through the receiver / method type-argument map, so generic out-parameters (`func M[T](out result T)`) bind the local as the substituted type. The first-pass placeholder behavior and the free-function / imported paths are unchanged.

## Tests added
**`Issue1133OutVarEnclosingScopeBinderTests`** (binder/semantic):
- `ImplicitThis_OutVar_DeclaresLocalInEnclosingScope_NoGS0125`
- `ExplicitReceiver_OutVar_DeclaresLocalInEnclosingScope_NoGS0125`
- `OutLet_DeclaresReadOnlyLocal_ReadIsFine`
- `OutLet_AssigningAfterwards_ReportsReadOnly` (GS0127)
- `OutDiscard_DoesNotLeakName` (GS0125 on `_`)
- `OutDiscard_AloneCompiles`
- `GenericOutParameter_OutVar_BindsSubstitutedType_NoDiagnostics`
- `Control_PreDeclaredOutLocal_StillCompiles` (regression guard)

**`Issue1133OutVarUserInstanceEmitTests`** (compile + IL-verify + run):
- `ImplicitThis_OutVar_Compiles_And_Runs` → 5
- `ExplicitReceiver_OutVar_Compiles_And_Runs` → 7
- `OutLet_ReadOnlyLocal_Compiles_And_Runs` → 11
- `OutDiscard_Compiles_And_Runs` → 42
- `GenericOutParameter_OutVar_Compiles_And_Runs` → 9

Coverage: `out var`, `out let`, `out _`, and generic out-parameters are all covered. No new SyntaxKind/BoundNodeKind, so no coverage-matrix changes.

## Validation
- Build: clean (0 warnings, 0 errors).
- New tests: 8 binder + 5 emit, all pass.
- Regression slices all green: `OutVar`, `RefArgument`, `RefKind`, `OverloadResolution`, `Issue977`, `Issue1107`.
