### PR TITLE
Fix #1136: resolve inherited System.Object members on user class/struct instances

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -2018,6 +2018,17 @@ internal sealed partial class ExpressionBinder
                         return instanceUserGroup;
                     }
 
+                    // Issue #1136: an inherited System.Object instance member
+                    // (GetType/ToString/GetHashCode/Equals) named in method-group
+                    // position. When the user type declares no explicit imported
+                    // base, fall back to typeof(object) so the member is captured
+                    // as a CLR method group resolvable against a target delegate.
+                    var inheritedMgClr = structSym.ImportedBaseType?.ClrType ?? typeof(object);
+                    if (TryBindClrMethodGroup(receiver, inheritedMgClr, wantStatic: false, ne.IdentifierToken.Text, out var inheritedClrGroup))
+                    {
+                        return inheritedClrGroup;
+                    }
+
                     Diagnostics.ReportUnableToFindMember(ne.Location, ne.IdentifierToken.Text);
                 }
                 else if (receiver != null && receiver.Type is InterfaceSymbol ifaceSym)

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -2558,8 +2558,14 @@ internal sealed partial class ExpressionBinder
             // base CLR type so inherited members are callable on the derived
             // GSharp instance. Inherited instance members take precedence over
             // imported extension methods.
+            // Issue #1136: when the user class/struct declares no explicit
+            // imported base, every .NET type still inherits System.Object's
+            // instance members (GetType/ToString/GetHashCode/Equals). Fall back
+            // to typeof(object) so those resolve. TryBindInheritedClrInstanceCall
+            // returns false for any name Object does not define, so unknown
+            // methods still report GS0159 below.
             if (receiver != null && receiver.Type is StructSymbol inheritedDerived
-                && inheritedDerived.ImportedBaseType?.ClrType is System.Type inheritedBaseClr
+                && (inheritedDerived.ImportedBaseType?.ClrType ?? typeof(object)) is System.Type inheritedBaseClr
                 && TryBindInheritedClrInstanceCall(receiver, inheritedBaseClr, methodName, arguments, ce, out var inheritedCall, explicitTypeArgs, typeArgSymbols, argumentNames))
             {
                 return inheritedCall;

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -2652,6 +2652,20 @@ internal sealed class OverloadResolver
                     var implicitReceiver = new BoundVariableExpression(null, getCurrentFunction().ThisParameter);
                     return BindUserInstanceCall(implicitReceiver, implicitMethod, boundArguments.ToImmutable(), syntax, argumentNames);
                 }
+
+                // Issue #1136: a bare (implicit-`this`) call such as `GetType()`
+                // inside an instance method must resolve as `this.GetType()`
+                // against the universally-inherited System.Object members when
+                // no sibling user method matches. Falls back to typeof(object)
+                // (or the explicit imported base if present); the helper returns
+                // false for any name Object does not define, so the GS0130 path
+                // below still fires for genuinely undefined functions.
+                var implicitBaseClr = implicitReceiverStruct.ImportedBaseType?.ClrType ?? typeof(object);
+                var implicitReceiverExpr = new BoundVariableExpression(null, getCurrentFunction().ThisParameter);
+                if (tryBindInheritedClrInstanceCall(implicitReceiverExpr, implicitBaseClr, syntax.Identifier.Text, boundArguments.ToImmutable(), syntax, out var implicitInheritedCall, null, default, argumentNames))
+                {
+                    return implicitInheritedCall;
+                }
             }
 
             // ADR-0085 / ADR-0090 implicit `this` inside an interface default

--- a/test/Compiler.Tests/Emit/Issue1136ObjectMemberEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1136ObjectMemberEmitTests.cs
@@ -1,0 +1,224 @@
+// <copyright file="Issue1136ObjectMemberEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1136: inherited System.Object instance members must emit and run on
+/// user class AND struct instances that declare no explicit imported base. A
+/// reference-type (class) receiver dispatches via <c>callvirt</c>; a value-type
+/// (struct) receiver whose inherited method is declared on a reference base
+/// (System.Object) is boxed before the <c>callvirt</c>. These tests compile a
+/// program that exercises GetType()/ToString()/GetHashCode()/Equals() on both
+/// shapes, plus bare implicit-<c>this</c> GetType(), verify the IL, and assert
+/// the runtime output. A user ToString() override must still take precedence.
+/// </summary>
+public class Issue1136ObjectMemberEmitTests
+{
+    [Fact]
+    public void ClassReceiver_ObjectMembers_EmitAndRun()
+    {
+        var source = """
+            package P
+            import System
+
+            class C { }
+
+            let c = C{ }
+            Console.WriteLine(c.GetType().Name)
+            Console.WriteLine(c.Equals(c))
+            Console.WriteLine(c.GetHashCode() == c.GetHashCode())
+            """;
+
+        Assert.Equal("C\nTrue\nTrue\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void BareImplicitThis_GetType_EmitsAndRuns()
+    {
+        var source = """
+            package P
+            import System
+
+            class C {
+                func Name() string { return GetType().Name }
+            }
+
+            let c = C{ }
+            Console.WriteLine(c.Name())
+            """;
+
+        Assert.Equal("C\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void StructReceiver_GetHashCodeAndGetType_BoxAndRun()
+    {
+        // The value-type receiver is boxed before callvirt for GetType() and
+        // GetHashCode() (declared on System.Object). Two structurally-equal
+        // structs hash equal and compare equal through the default value-type
+        // semantics. Structs are built in locals (not top-level initonly
+        // statics) so the receiver address is taken from a verifiable slot.
+        var source = """
+            package P
+            import System
+
+            struct S { var X int32 }
+
+            func Report() string {
+                let a = S{ X: 5 }
+                let b = S{ X: 5 }
+                let name = a.GetType().Name
+                let eq = a.Equals(b)
+                let hashEq = a.GetHashCode() == b.GetHashCode()
+                return name + " " + eq.ToString() + " " + hashEq.ToString()
+            }
+
+            Console.WriteLine(Report())
+            """;
+
+        Assert.Equal("S True True\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void UserToStringOverride_TakesPrecedence_AtRuntime()
+    {
+        var source = """
+            package P
+            import System
+
+            class C {
+                func ToString() string { return "custom-C" }
+            }
+
+            let c = C{ }
+            Console.WriteLine(c.ToString())
+            """;
+
+        Assert.Equal("custom-C\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EqualsAcrossUserClassInstances_EmitsAndRuns()
+    {
+        var source = """
+            package P
+            import System
+
+            class C { }
+
+            let a = C{ }
+            let b = C{ }
+            Console.WriteLine(a.Equals(b))
+            Console.WriteLine(a.Equals(a))
+            """;
+
+        Assert.Equal("False\nTrue\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void MethodGroup_InheritedToString_ConvertsToDelegateAndRuns()
+    {
+        // A bare `obj.ToString` (method-group position) on a user class with no
+        // explicit imported base resolves the inherited System.Object.ToString
+        // and converts to a delegate. The user override still takes precedence.
+        var source = """
+            package P
+            import System
+
+            class C { func ToString() string { return "custom-C" } }
+            class D { }
+
+            func Use(f () -> string) string { return f() }
+
+            let c = C{ }
+            let d = D{ }
+            let f () -> string = c.ToString
+            let g () -> string = d.ToString
+            Console.WriteLine(Use(f))
+            Console.WriteLine(Use(g))
+            """;
+
+        Assert.Equal("custom-C\nP.D\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1136_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new System.Collections.Generic.List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+
+            // (a) Static verification: the emitted IL must be valid.
+            IlVerifier.Verify(outPath);
+
+            // (b) Dynamic verification: the emitted code must execute.
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1136ObjectMemberBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1136ObjectMemberBinderTests.cs
@@ -1,0 +1,198 @@
+// <copyright file="Issue1136ObjectMemberBinderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1136: inherited <see cref="object"/> instance members
+/// (<c>GetType()</c>, <c>ToString()</c>, <c>GetHashCode()</c>,
+/// <c>Equals(object)</c>) must be callable on user <c>class</c>/<c>struct</c>
+/// instances even when the user type declares no explicit imported base. The
+/// binder's inherited-CLR fallback previously only fired when
+/// <c>StructSymbol.ImportedBaseType</c> was set; it now falls back to
+/// <c>typeof(object)</c> so the universally-inherited members resolve in
+/// <c>this.M()</c>, <c>receiver.M()</c>, and bare implicit-<c>this</c> (<c>M()</c>)
+/// positions. The return types are validated through explicit type annotations
+/// (<c>System.Type</c>/<c>string</c>/<c>int32</c>/<c>bool</c>): a mismatch would
+/// surface a conversion diagnostic. Method bodies are bound (and their
+/// diagnostics captured) without being executed, so these tests are pure binder
+/// coverage independent of the tree interpreter.
+/// </summary>
+public class Issue1136ObjectMemberBinderTests
+{
+    [Fact]
+    public void ThisReceiver_ObjectMembers_BindWithCorrectTypes_OnClass()
+    {
+        var source = @"
+import System
+class C {
+    func F() int32 {
+        let h int32 = this.GetHashCode()
+        let s string = this.ToString()
+        let t Type = this.GetType()
+        let e bool = this.Equals(this)
+        return h
+    }
+}
+";
+        AssertNoErrors(Evaluate(source));
+    }
+
+    [Fact]
+    public void LocalReceiver_ObjectMembers_BindOnClassInstance()
+    {
+        var source = @"
+import System
+class C { }
+class D {
+    func F() string {
+        let c = C{ }
+        let t Type = c.GetType()
+        let s string = c.ToString()
+        return s
+    }
+}
+";
+        AssertNoErrors(Evaluate(source));
+    }
+
+    [Fact]
+    public void BareImplicitThis_GetType_ResolvesAsThisGetType()
+    {
+        var source = @"
+class C {
+    func F() string {
+        return GetType().Name
+    }
+}
+";
+        AssertNoErrors(Evaluate(source));
+    }
+
+    [Fact]
+    public void StructReceiver_GetHashCode_BindsOnValueType()
+    {
+        var source = @"
+struct S { let X int32 }
+class C {
+    func F() int32 {
+        let s = S{ X: 1 }
+        return s.GetHashCode()
+    }
+}
+";
+        AssertNoErrors(Evaluate(source));
+    }
+
+    [Fact]
+    public void StructReceiver_ObjectMembers_BindWithCorrectTypes()
+    {
+        var source = @"
+import System
+struct S { let X int32 }
+class C {
+    func F() int32 {
+        let a = S{ X: 1 }
+        let b = S{ X: 1 }
+        let h int32 = a.GetHashCode()
+        let s string = a.ToString()
+        let t Type = a.GetType()
+        let e bool = a.Equals(b)
+        return h
+    }
+}
+";
+        AssertNoErrors(Evaluate(source));
+    }
+
+    [Fact]
+    public void UnknownMethod_StillReportsGS0159()
+    {
+        var source = @"
+class C {
+    func F() {
+        let x = this.NoSuchMethod()
+    }
+}
+";
+        var diagnostics = Evaluate(source).Diagnostics;
+        Assert.Contains(diagnostics, d => d.Message.Contains("NoSuchMethod"));
+    }
+
+    [Fact]
+    public void UserToStringOverride_TakesPrecedenceOverInheritedMember()
+    {
+        // A user-declared `func ToString() string` must win over the inherited
+        // System.Object.ToString(); the interpreter executes the user method.
+        var source = @"
+class C {
+    func ToString() string { return ""custom"" }
+}
+let c = C{ }
+c.ToString()
+";
+        var result = Evaluate(source);
+        AssertNoErrors(result);
+        Assert.Equal("custom", result.Value);
+    }
+
+    [Fact]
+    public void ExplicitImportedBase_StillResolvesInheritedMembers()
+    {
+        // Control: a user class with an explicit imported CLR base must keep
+        // resolving members against its actual base (and Object transitively).
+        var source = @"
+import System
+class MyErr : Exception {
+    func F() int32 {
+        let h int32 = this.GetHashCode()
+        let s string = this.ToString()
+        return h
+    }
+}
+";
+        AssertNoErrors(Evaluate(source));
+    }
+
+    [Fact]
+    public void MethodGroup_InheritedObjectMember_BindsOnClassReceiver()
+    {
+        // ADR-0112 method-group position: a bare `obj.ToString` (no call) on a
+        // user class with no explicit imported base captures the inherited
+        // System.Object.ToString as a CLR method group convertible to a delegate.
+        var source = @"
+class C { }
+func Use(f () -> string) string { return f() }
+class D {
+    func F() string {
+        let c = C{ }
+        let f () -> string = c.ToString
+        return Use(f)
+    }
+}
+";
+        AssertNoErrors(Evaluate(source));
+    }
+
+    private static void AssertNoErrors(EvaluationResult result)
+    {
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
Fixes #1136

## Problem
Inherited `System.Object` instance members — `GetType()`, `ToString()`, `GetHashCode()`, `Equals(object)` — were **not callable** on user `class`/`struct` instances that declare no override. `this.M()` / `receiver.M()` failed with `GS0159`; a bare `GetType()` failed with `GS0130`. These members are inherited by every .NET type, so they must resolve.

## Root cause
The binder's inherited-CLR fallback (issue #296) only fired when the user type had an **explicit imported base** (`StructSymbol.ImportedBaseType?.ClrType != null`). A plain `class C {}` / `struct S {}` has `ImportedBaseType == null`, so the universally-inherited `System.Object` members were never consulted.

The fix makes the fallbacks consult `typeof(object)` when there is no explicit imported base. `TryBindInheritedClrInstanceCall` returns `false` for any name `Object` does not define, so unknown methods still report `GS0159` (no over-resolution), and a user-declared override still takes precedence (the fallback runs after user-method lookup).

The **emitter already boxes value-type receivers** before `callvirt` for reference-base methods, so the struct path works through the existing box+callvirt path with **no emit change**.

## Lookup paths fixed
- **Call position** (`this.M()` / `c.M()`): `ExpressionBinder.Calls.cs` inherited-CLR fallback now uses `ImportedBaseType?.ClrType ?? typeof(object)`.
- **Bare implicit-`this`** (`M()`): `OverloadResolver.cs` routes through the existing `tryBindInheritedClrInstanceCall` callback with `typeof(object)` before reporting `GS0130`.
- **Method-group position** (`obj.ToString`): `ExpressionBinder.Access.cs` falls back to a CLR method group over `typeof(object)` via `TryBindClrMethodGroup`.

## Files changed
- `src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs` — call-position Object fallback.
- `src/Core/CodeAnalysis/Binding/OverloadResolver.cs` — bare implicit-`this` Object fallback.
- `src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs` — method-group Object fallback.
- `test/Core.Tests/CodeAnalysis/Binding/Issue1136ObjectMemberBinderTests.cs` — 9 binder tests.
- `test/Compiler.Tests/Emit/Issue1136ObjectMemberEmitTests.cs` — 6 emit/execution tests.

## Tests
**Binder (9):** `this`/local/struct receivers bind the four members with correct return types (`System.Type`/`string`/`int32`/`bool`); bare `GetType().Name`; method-group position; `obj.NoSuchMethod()` still `GS0159`; user `ToString` override precedence; explicit imported CLR base control.

**Emit/execution (6):** class + struct receivers emit, pass IL verification, and run — `GetType().Name == "C"`/`"S"`, `Equals`, `GetHashCode` equality, box+callvirt for structs, bare implicit-`this` `GetType()`, method-group conversion, and `ToString` override precedence.

All targeted tests pass; nearby regression slices (`Issue296`, `ClrBase`, `Adr0112`, method-group, full Binding suite — 2272 tests) remain green. Full solution builds clean.

## Notes
- No new `SyntaxKind`/`BoundNodeKind` (reuses `BoundImportedInstanceCallExpression` / `BoundClrMethodGroupExpression`), so no coverage-matrix changes.
- Tree-interpreter limitation: a non-emitted user instance is a `StructValue` with no real CLR `Type`, so executing these Object calls through the interpreter (e.g. `GetType()` returning the user type) is a larger separate effort; execution coverage is provided via the emit tests. Binder tests bind method bodies without executing them, validating resolution + types independent of the interpreter.
