### PR TITLE
Fix inherited System.Object members + static out-var scope on user types (#914)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -1742,6 +1742,33 @@ internal sealed partial class ExpressionBinder
             for (var i = 0; i < permutedArgs.Length; i++)
             {
                 var paramType = method.Parameters[i].Type;
+
+                // ADR-0060 / issue #1139: an inline-decl `out var n` /
+                // `out let n` / `out _` at a qualified static (`C.G(...)`) call
+                // site was bound with TypeSymbol.Error in the first pass
+                // (before the static overload was resolved) and never declared
+                // a local — the same gap #1137 fixed for user instance calls.
+                // Now that the method is selected (and any generic substitution
+                // is known) re-bind it so the synthesized local is typed from
+                // the resolved (substituted) out-parameter pointee type and
+                // leaks into the enclosing block scope. Must run BEFORE the
+                // open-type-parameter shortcut below so generic out-parameters
+                // (`func G[T](out result T)`) are handled too.
+                if (permutedArgs[i] is BoundAddressOfExpression inlineOutAddr
+                    && inlineOutAddr.Operand.Type == TypeSymbol.Error
+                    && i < ce.Arguments.Count
+                    && OverloadResolver.UnwrapNamedArgumentValue(ce.Arguments[i]) is RefArgumentExpressionSyntax inlineOutRefArg
+                    && inlineOutRefArg.IsInlineDeclaration
+                    && inlineOutRefArg.DeclaredType == null)
+                {
+                    var pointeeType = substitution != null ? Binder.SubstituteType(paramType, substitution) : paramType;
+                    var rebindParameter = ReferenceEquals(pointeeType, method.Parameters[i].Type)
+                        ? method.Parameters[i]
+                        : new ParameterSymbol(method.Parameters[i].Name, pointeeType, refKind: RefKind.Out);
+                    convertedArgs.Add(BindRefArgumentExpression(inlineOutRefArg, rebindParameter));
+                    continue;
+                }
+
                 if (paramType is TypeParameterSymbol)
                 {
                     convertedArgs.Add(permutedArgs[i]);

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -2573,6 +2573,21 @@ internal sealed partial class ExpressionBinder
                 return userPathExt;
             }
 
+            // Issue #1136: every user class/struct inherits the System.Object
+            // instance members (GetType/ToString/GetHashCode/Equals) — value
+            // types via System.ValueType → System.Object. When the user type
+            // does not declare its own override of one of these, resolve the
+            // call against System.Object so the inherited member is callable
+            // on any user-type instance. The bound call is emitted as a
+            // (virtual) callvirt, so a user-declared override — which is found
+            // earlier via TypeMemberModel.GetMethods — still wins at runtime,
+            // and value-type receivers are boxed by the emitter.
+            if (receiver != null && receiver.Type is StructSymbol
+                && TryBindInheritedClrInstanceCall(receiver, typeof(object), methodName, arguments, ce, out var objectMemberCall, explicitTypeArgs, typeArgSymbols, argumentNames))
+            {
+                return objectMemberCall;
+            }
+
             Diagnostics.ReportUnableToFindFunction(ce.Location, methodName);
             return new BoundErrorExpression(null);
         }

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -2652,6 +2652,17 @@ internal sealed class OverloadResolver
                     var implicitReceiver = new BoundVariableExpression(null, getCurrentFunction().ThisParameter);
                     return BindUserInstanceCall(implicitReceiver, implicitMethod, boundArguments.ToImmutable(), syntax, argumentNames);
                 }
+
+                // Issue #1136: a bare implicit-`this` call to an inherited
+                // System.Object member (GetType/ToString/GetHashCode/Equals)
+                // that the receiver type does not declare itself resolves as
+                // `this.<member>(args)` against System.Object, mirroring the
+                // qualified-receiver fallback in ExpressionBinder.Calls.cs.
+                var implicitObjectReceiver = new BoundVariableExpression(null, getCurrentFunction().ThisParameter);
+                if (tryBindInheritedClrInstanceCall(implicitObjectReceiver, typeof(object), syntax.Identifier.Text, boundArguments.ToImmutable(), syntax, out var implicitObjectCall, null, default, argumentNames))
+                {
+                    return implicitObjectCall;
+                }
             }
 
             // ADR-0085 / ADR-0090 implicit `this` inside an interface default

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
@@ -242,10 +242,34 @@ internal sealed partial class MethodBodyEmitter
                         // Load the receiver value (not its address) and box it so
                         // the inherited reference-type method receives a proper
                         // object reference.
-                        this.EmitExpression(instCall.Receiver);
+                        var receiverIsStructThis = instCall.Receiver is BoundVariableExpression structThisBve
+                            && this.structThisParameter != null
+                            && ReferenceEquals(structThisBve.Variable, this.structThisParameter);
+
                         if (receiverIsManagedPointer)
                         {
+                            // An explicit `ref TStruct` receiver: the expression
+                            // yields the managed pointer; dereference to the
+                            // value before boxing.
+                            this.EmitExpression(instCall.Receiver);
                             this.EmitLoadIndirect(receiverType);
+                        }
+                        else if (receiverIsStructThis)
+                        {
+                            // Issue #1136: the struct `this` parameter — arg0
+                            // holds `ref TStruct`, so emitting it as a value
+                            // pushes the managed pointer. Load that pointer
+                            // (EmitInstanceReceiver yields arg0) and dereference
+                            // to the value before boxing; boxing the pointer
+                            // would produce invalid IL (StackUnexpected).
+                            this.EmitInstanceReceiver(instCall.Receiver);
+                            this.EmitLoadIndirect(receiverType);
+                        }
+                        else
+                        {
+                            // A by-value value-type receiver (local, field, or
+                            // rvalue) is materialized as the value directly.
+                            this.EmitExpression(instCall.Receiver);
                         }
 
                         this.il.OpCode(ILOpCode.Box);

--- a/test/Compiler.Tests/Emit/Issue1133OutVarUserInstanceEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1133OutVarUserInstanceEmitTests.cs
@@ -142,6 +142,31 @@ public class Issue1133OutVarUserInstanceEmitTests
         Assert.Equal("9\n", CompileAndRun(source));
     }
 
+    [Fact]
+    public void QualifiedStatic_OutVar_Compiles_And_Runs()
+    {
+        // Issue #1139: the qualified static (`C.G(out var y)`) path was missed
+        // by #1137. The leaked local must both bind and carry the runtime value.
+        var source = """
+            package P
+            import System
+
+            class C {
+                shared {
+                    func G(out x int32) { x = 13 }
+                    func F() int32 {
+                        C.G(out var y)
+                        return y
+                    }
+                }
+            }
+
+            Console.WriteLine(C.F())
+            """;
+
+        Assert.Equal("13\n", CompileAndRun(source));
+    }
+
     private static string CompileAndRun(string source)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_issue1133_emit_").FullName;

--- a/test/Compiler.Tests/Emit/Issue1136ObjectMembersEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1136ObjectMembersEmitTests.cs
@@ -1,0 +1,240 @@
+// <copyright file="Issue1136ObjectMembersEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1136: the inherited <see cref="object"/> instance members
+/// (<c>GetType</c>, <c>ToString</c>, <c>GetHashCode</c>, <c>Equals(object)</c>)
+/// were not callable on a user <c>class</c>/<c>struct</c> instance that does not
+/// declare its own override — <c>recv.GetType()</c> / <c>this.ToString()</c>
+/// failed with <c>GS0159</c> and a bare implicit-<c>this</c> <c>GetType()</c>
+/// with <c>GS0130</c>. Every .NET type inherits these from
+/// <see cref="object"/> (value types via <see cref="ValueType"/>), so the binder
+/// now resolves the call against <see cref="object"/> when no user method
+/// matches. The bound call is a (virtual) <c>callvirt</c>, so a user-declared
+/// override still wins at runtime and value-type receivers are boxed by the
+/// emitter. These tests compile, IL-verify, and run the shapes end-to-end.
+/// </summary>
+public class Issue1136ObjectMembersEmitTests
+{
+    [Fact]
+    public void GetTypeName_OnUserClassInstance_ReturnsTypeName()
+    {
+        var source = """
+            package P
+            import System
+
+            class C { }
+
+            var c = C()
+            Console.WriteLine(c.GetType().Name)
+            """;
+
+        Assert.Equal("C\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void DefaultToString_OnUserClassInstance_ReturnsFullTypeName()
+    {
+        var source = """
+            package P
+            import System
+
+            class C { }
+
+            var c = C()
+            Console.WriteLine(c.ToString())
+            """;
+
+        Assert.Equal("P.C\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void UserToStringOverride_IsDispatchedAtRuntime()
+    {
+        // A user-declared ToString() override is found earlier (via the user
+        // method bucket) and must win over the inherited Object member.
+        var source = """
+            package P
+            import System
+
+            class C {
+                func ToString() string { return "custom" }
+            }
+
+            var c = C()
+            Console.WriteLine(c.ToString())
+            """;
+
+        Assert.Equal("custom\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void ImplicitThis_InheritedObjectMembers_AreCallable()
+    {
+        // `this.GetHashCode()`, `this.ToString()`, `this.GetType()`,
+        // `this.Equals(this)`, and a bare implicit-`this` `GetType()`.
+        var source = """
+            package P
+            import System
+
+            class C {
+                func TypeName() string { return GetType().Name }
+                func F() string {
+                    let h = this.GetHashCode()
+                    let s = this.ToString()
+                    let t = this.GetType()
+                    let e = this.Equals(this)
+                    if e {
+                        return t.Name
+                    }
+                    return "no"
+                }
+            }
+
+            var c = C()
+            Console.WriteLine(c.F())
+            Console.WriteLine(c.TypeName())
+            """;
+
+        Assert.Equal("C\nC\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void Equals_OnUserClassInstances_UsesReferenceEquality()
+    {
+        var source = """
+            package P
+            import System
+
+            class C { }
+
+            var a = C()
+            var b = C()
+            Console.WriteLine(a.Equals(a))
+            Console.WriteLine(a.Equals(b))
+            """;
+
+        Assert.Equal("True\nFalse\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void GetHashCode_OnUserClassInstance_IsStable()
+    {
+        var source = """
+            package P
+            import System
+
+            class C { }
+
+            var c = C()
+            Console.WriteLine(c.GetHashCode() == c.GetHashCode())
+            """;
+
+        Assert.Equal("True\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void InheritedObjectMembers_OnValueTypeStruct_AreCallable()
+    {
+        // A value-type receiver invoking an inherited reference-type Object
+        // member must be boxed; the emitter handles this for the bound call.
+        var source = """
+            package P
+            import System
+
+            struct S {
+                var x int32
+                func Describe() string { return this.GetType().Name }
+            }
+
+            var s = S{ x: 3 }
+            Console.WriteLine(s.GetType().Name)
+            Console.WriteLine(s.Describe())
+            Console.WriteLine(s.Equals(s))
+            """;
+
+        Assert.Equal("S\nS\nTrue\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1136_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1133OutVarEnclosingScopeBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1133OutVarEnclosingScopeBinderTests.cs
@@ -170,6 +170,130 @@ class C {
         Assert.Empty(diagnostics);
     }
 
+    [Fact]
+    public void QualifiedStatic_OutVar_DeclaresLocalInEnclosingScope_NoGS0125()
+    {
+        // Issue #1139: the qualified static (`C.G(...)`) path was missed by
+        // #1137. The exact repro from the issue must declare `y` and read it.
+        const string source = @"
+package p
+class C {
+    shared {
+        func G(out x int32) { x = 5 }
+        func F() int32 {
+            C.G(out var y)
+            return y
+        }
+    }
+}
+";
+        var diagnostics = GetDiagnostics(source).ToList();
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0125");
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void QualifiedStatic_OutLet_ReadIsFine()
+    {
+        const string source = @"
+package p
+class C {
+    shared {
+        func G(out x int32) { x = 5 }
+        func F() int32 {
+            C.G(out let y)
+            return y
+        }
+    }
+}
+";
+        var diagnostics = GetDiagnostics(source).ToList();
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void QualifiedStatic_OutLet_AssigningAfterwards_ReportsReadOnly()
+    {
+        const string source = @"
+package p
+class C {
+    shared {
+        func G(out x int32) { x = 5 }
+        func F() int32 {
+            C.G(out let y)
+            y = 7
+            return y
+        }
+    }
+}
+";
+        var diagnostics = GetDiagnostics(source).ToList();
+        Assert.Contains(diagnostics, d => d.Id == "GS0127");
+    }
+
+    [Fact]
+    public void QualifiedStatic_OutDiscard_DoesNotLeakName()
+    {
+        const string source = @"
+package p
+class C {
+    shared {
+        func G(out x int32) { x = 5 }
+        func F() int32 {
+            C.G(out _)
+            return _
+        }
+    }
+}
+";
+        var diagnostics = GetDiagnostics(source).ToList();
+        Assert.Contains(diagnostics, d => d.Id == "GS0125");
+    }
+
+    [Fact]
+    public void QualifiedStatic_OutVar_ReassignedLater_Compiles()
+    {
+        const string source = @"
+package p
+class C {
+    shared {
+        func G(out x int32) { x = 5 }
+        func F() int32 {
+            C.G(out var y)
+            y = 9
+            return y
+        }
+    }
+}
+";
+        var diagnostics = GetDiagnostics(source).ToList();
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void CrossClassQualifiedStatic_OutVar_DeclaresLocal_NoGS0125()
+    {
+        const string source = @"
+package p
+class Other {
+    shared {
+        func G(out x int32) { x = 5 }
+    }
+}
+class C {
+    shared {
+        func F() int32 {
+            Other.G(out var y)
+            return y
+        }
+    }
+}
+";
+        var diagnostics = GetDiagnostics(source).ToList();
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0125");
+        Assert.Empty(diagnostics);
+    }
+
     private static IEnumerable<Diagnostic> GetDiagnostics(string source)
     {
         var tree = SyntaxTree.Parse(SourceText.From(source));

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1136ObjectMembersBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1136ObjectMembersBinderTests.cs
@@ -1,0 +1,133 @@
+// <copyright file="Issue1136ObjectMembersBinderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1136: the inherited <see cref="object"/> instance members
+/// (<c>GetType</c>, <c>ToString</c>, <c>GetHashCode</c>, <c>Equals(object)</c>)
+/// must be callable on a user <c>class</c>/<c>struct</c> instance that does not
+/// declare its own override. Previously a qualified call failed with
+/// <c>GS0159</c> and a bare implicit-<c>this</c> call with <c>GS0130</c>. A
+/// user-declared override must still resolve to the override.
+/// </summary>
+public class Issue1136ObjectMembersBinderTests
+{
+    [Fact]
+    public void ImplicitThis_InheritedObjectMembers_Resolve_NoDiagnostics()
+    {
+        const string source = @"
+package p
+class C {
+    func F() int32 {
+        let h = this.GetHashCode()
+        let s = this.ToString()
+        let t = this.GetType()
+        let e = this.Equals(this)
+        return h
+    }
+}
+";
+        var diagnostics = GetDiagnostics(source).ToList();
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void BareImplicitThis_GetType_Resolves_NoGS0130()
+    {
+        const string source = @"
+package p
+class C { func F() string { return GetType().Name } }
+";
+        var diagnostics = GetDiagnostics(source).ToList();
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0130");
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void ExplicitReceiver_InheritedObjectMembers_Resolve_NoGS0159()
+    {
+        const string source = @"
+package p
+class C { }
+class D {
+    func F() string {
+        let c = C{ }
+        let n = c.GetType().Name
+        return c.ToString()
+    }
+}
+";
+        var diagnostics = GetDiagnostics(source).ToList();
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0159");
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void ValueTypeStruct_InheritedObjectMembers_Resolve_NoDiagnostics()
+    {
+        const string source = @"
+package p
+struct S {
+    var x int32
+    func F() int32 {
+        let h = this.GetHashCode()
+        let s = this.ToString()
+        let t = this.GetType()
+        return h
+    }
+}
+";
+        var diagnostics = GetDiagnostics(source).ToList();
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void UserToStringOverride_StillResolves_NoDiagnostics()
+    {
+        // A user-declared ToString() override must still bind (the inherited
+        // fallback only fires when no user method matches).
+        const string source = @"
+package p
+class C {
+    func ToString() string { return ""custom"" }
+    func F() string { return this.ToString() }
+}
+";
+        var diagnostics = GetDiagnostics(source).ToList();
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void UnknownMethod_OnUserClass_StillReportsUnableToFind()
+    {
+        // Regression guard: a genuinely unknown method must still report
+        // GS0159 (the Object fallback must not mask real errors).
+        const string source = @"
+package p
+class C {
+    func F() int32 {
+        return this.NoSuchMethod()
+    }
+}
+";
+        var diagnostics = GetDiagnostics(source).ToList();
+        Assert.Contains(diagnostics, d => d.Id == "GS0159");
+    }
+
+    private static IEnumerable<Diagnostic> GetDiagnostics(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new GSharp.Core.CodeAnalysis.Compilation.Compilation(tree);
+        using var peStream = new System.IO.MemoryStream();
+        return compilation.Emit(peStream).Diagnostics;
+    }
+}


### PR DESCRIPTION
Fixes #1136

Fixes #1139

Refs #914