### PR TITLE
Fix #1139: inline out-var visible in enclosing scope for qualified static calls

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -206,6 +206,7 @@ public sealed class Binder
             conversions,
             bindExpression: syntax => expressions.BindExpression(syntax),
             bindRefArgumentExpression: (refSyntax, parameter) => expressions.BindRefArgumentExpression(refSyntax, parameter),
+            tryRebindInlineOutVarPlaceholder: (boundArg, slotSyntax, resolvedParameter, substitutedPointeeType) => expressions.TryRebindInlineOutVarPlaceholder(boundArg, slotSyntax, resolvedParameter, substitutedPointeeType),
             bindTypeClause: BindTypeClause,
             lookupType: LookupType,
             reportObsoleteUseIfApplicable: ReportObsoleteUseIfApplicable,

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -1742,6 +1742,29 @@ internal sealed partial class ExpressionBinder
             for (var i = 0; i < permutedArgs.Length; i++)
             {
                 var paramType = method.Parameters[i].Type;
+
+                // ADR-0060 / issue #1139: an inline-decl `out var n` / `out let
+                // n` / `out _` was bound with TypeSymbol.Error in the first
+                // pass (before the static method was resolved) and never
+                // declared a local. Now that overload resolution has chosen the
+                // method — and the method type-argument substitution is known —
+                // re-bind it (via the shared helper used by the instance path)
+                // so the synthesized local is typed from the resolved
+                // (substituted) out-parameter pointee type and leaks into the
+                // enclosing block scope. The out-var arg always sits in the
+                // fixed-parameter region, so permutedArgs[i] / ce.Arguments[i] /
+                // method.Parameters[i] line up. This must run BEFORE the
+                // open-type-parameter shortcut so generic static out-parameters
+                // (`func G[T](out r T)`) are handled too.
+                var slotSyntax = i < ce.Arguments.Count ? ce.Arguments[i] : null;
+                var substitutedPointeeType = substitution != null ? Binder.SubstituteType(paramType, substitution) : paramType;
+                var reboundOutVar = TryRebindInlineOutVarPlaceholder(permutedArgs[i], slotSyntax, method.Parameters[i], substitutedPointeeType);
+                if (reboundOutVar != null)
+                {
+                    convertedArgs.Add(reboundOutVar);
+                    continue;
+                }
+
                 if (paramType is TypeParameterSymbol)
                 {
                     convertedArgs.Add(permutedArgs[i]);

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -1269,6 +1269,57 @@ internal sealed partial class ExpressionBinder
         return new BoundAddressOfExpression(null, operand);
     }
 
+    /// <summary>
+    /// ADR-0060 / issues #1133, #1139: re-binds a first-pass inline out-var
+    /// placeholder once overload resolution has chosen the callee. An inline
+    /// <c>out var n</c> / <c>out let n</c> / <c>out _</c> argument is bound in
+    /// the first pass (before the parameter/method is known) to a
+    /// <see cref="BoundAddressOfExpression"/> wrapping a
+    /// <see cref="BoundErrorExpression"/> that declares <em>no</em> local. Now
+    /// that the resolved out-parameter (and its substituted pointee type) is
+    /// known, re-bind via <see cref="BindRefArgumentExpression"/> so the
+    /// synthesized local is typed correctly and leaks into the enclosing block
+    /// scope. Shared by the user-instance path
+    /// (<see cref="OverloadResolver.BindUserInstanceCall"/>) and the qualified
+    /// static path (<c>BindUserTypeStaticCall</c>) so both behave identically.
+    /// </summary>
+    /// <param name="boundArg">The first-pass bound argument that may be an
+    /// inline out-var placeholder.</param>
+    /// <param name="slotSyntax">The argument syntax at this position (may be a
+    /// named-argument wrapper).</param>
+    /// <param name="resolvedParameter">The resolved out-parameter this argument
+    /// binds to.</param>
+    /// <param name="substitutedPointeeType">The (already-substituted) pointee
+    /// type the synthesized local should carry.</param>
+    /// <returns>The rebound address-of expression when <paramref name="boundArg"/>
+    /// is an inline out-var placeholder; otherwise <see langword="null"/> so the
+    /// caller keeps its normal conversion path.</returns>
+    internal BoundExpression TryRebindInlineOutVarPlaceholder(
+        BoundExpression boundArg,
+        ExpressionSyntax slotSyntax,
+        ParameterSymbol resolvedParameter,
+        TypeSymbol substitutedPointeeType)
+    {
+        if (boundArg is not BoundAddressOfExpression inlineOutAddr
+            || inlineOutAddr.Operand.Type != TypeSymbol.Error)
+        {
+            return null;
+        }
+
+        var unwrappedSlotSyntax = slotSyntax != null ? OverloadResolver.UnwrapNamedArgumentValue(slotSyntax) : null;
+        if (unwrappedSlotSyntax is not RefArgumentExpressionSyntax inlineOutRefArg
+            || !inlineOutRefArg.IsInlineDeclaration
+            || inlineOutRefArg.DeclaredType != null)
+        {
+            return null;
+        }
+
+        var rebindParameter = ReferenceEquals(substitutedPointeeType, resolvedParameter.Type)
+            ? resolvedParameter
+            : new ParameterSymbol(resolvedParameter.Name, substitutedPointeeType, refKind: RefKind.Out);
+        return BindRefArgumentExpression(inlineOutRefArg, rebindParameter);
+    }
+
     private BoundExpression BindIndexAssignmentExpression(IndexAssignmentExpressionSyntax syntax)
     {
         var name = syntax.TargetIdentifier.Text;

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -112,6 +112,7 @@ internal sealed class OverloadResolver
 
     private readonly Func<ExpressionSyntax, BoundExpression> bindExpression;
     private readonly Func<RefArgumentExpressionSyntax, ParameterSymbol, BoundExpression> bindRefArgumentExpression;
+    private readonly Func<BoundExpression, ExpressionSyntax, ParameterSymbol, TypeSymbol, BoundExpression> tryRebindInlineOutVarPlaceholder;
     private readonly Func<TypeClauseSyntax, TypeSymbol> bindTypeClause;
     private readonly Func<string, TypeSymbol> lookupType;
     private readonly Action<TextLocation, Symbol, string> reportObsoleteUseIfApplicable;
@@ -150,6 +151,10 @@ internal sealed class OverloadResolver
     /// <param name="bindRefArgumentExpression">Callback to bind a
     /// <see cref="RefArgumentExpressionSyntax"/> against a known parameter
     /// symbol (or <c>null</c> in the first, parameter-unknown, pass).</param>
+    /// <param name="tryRebindInlineOutVarPlaceholder">Callback that re-binds a
+    /// first-pass inline out-var placeholder once the callee/parameter is
+    /// resolved, returning the rebound expression (or <c>null</c> when the
+    /// argument is not an inline out-var placeholder).</param>
     /// <param name="bindTypeClause">Callback to bind a
     /// <see cref="TypeClauseSyntax"/> to a <see cref="TypeSymbol"/>.</param>
     /// <param name="lookupType">Callback to resolve a bare type name to a
@@ -215,6 +220,7 @@ internal sealed class OverloadResolver
         ConversionClassifier conversions,
         Func<ExpressionSyntax, BoundExpression> bindExpression,
         Func<RefArgumentExpressionSyntax, ParameterSymbol, BoundExpression> bindRefArgumentExpression,
+        Func<BoundExpression, ExpressionSyntax, ParameterSymbol, TypeSymbol, BoundExpression> tryRebindInlineOutVarPlaceholder,
         Func<TypeClauseSyntax, TypeSymbol> bindTypeClause,
         Func<string, TypeSymbol> lookupType,
         Action<TextLocation, Symbol, string> reportObsoleteUseIfApplicable,
@@ -241,6 +247,7 @@ internal sealed class OverloadResolver
         this.conversions = conversions ?? throw new ArgumentNullException(nameof(conversions));
         this.bindExpression = bindExpression ?? throw new ArgumentNullException(nameof(bindExpression));
         this.bindRefArgumentExpression = bindRefArgumentExpression ?? throw new ArgumentNullException(nameof(bindRefArgumentExpression));
+        this.tryRebindInlineOutVarPlaceholder = tryRebindInlineOutVarPlaceholder ?? throw new ArgumentNullException(nameof(tryRebindInlineOutVarPlaceholder));
         this.bindTypeClause = bindTypeClause ?? throw new ArgumentNullException(nameof(bindTypeClause));
         this.lookupType = lookupType ?? throw new ArgumentNullException(nameof(lookupType));
         this.reportObsoleteUseIfApplicable = reportObsoleteUseIfApplicable ?? throw new ArgumentNullException(nameof(reportObsoleteUseIfApplicable));
@@ -3985,16 +3992,11 @@ internal sealed class OverloadResolver
                 && inlineOutAddr.Operand.Type == TypeSymbol.Error)
             {
                 var slotSyntax = i < permutedSyntax.Length ? permutedSyntax[i] : null;
-                var unwrappedSlotSyntax = slotSyntax != null ? UnwrapNamedArgumentValue(slotSyntax) : null;
-                if (unwrappedSlotSyntax is RefArgumentExpressionSyntax inlineOutRefArg
-                    && inlineOutRefArg.IsInlineDeclaration
-                    && inlineOutRefArg.DeclaredType == null)
+                var pointeeType = substitution != null ? substituteType(paramType, substitution) : paramType;
+                var reboundOutVar = tryRebindInlineOutVarPlaceholder(permutedArguments[i], slotSyntax, parameter, pointeeType);
+                if (reboundOutVar != null)
                 {
-                    var pointeeType = substitution != null ? substituteType(paramType, substitution) : paramType;
-                    var rebindParameter = ReferenceEquals(pointeeType, parameter.Type)
-                        ? parameter
-                        : new ParameterSymbol(parameter.Name, pointeeType, refKind: RefKind.Out);
-                    convertedArgs.Add(bindRefArgumentExpression(inlineOutRefArg, rebindParameter));
+                    convertedArgs.Add(reboundOutVar);
                     continue;
                 }
             }

--- a/test/Compiler.Tests/Emit/Issue1139OutVarStaticCallEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1139OutVarStaticCallEmitTests.cs
@@ -1,0 +1,226 @@
+// <copyright file="Issue1139OutVarStaticCallEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1139 (follow-up to #1133): an inline <c>out var n</c> (and
+/// <c>out let n</c> / <c>out _</c>) declaration at a <em>qualified static</em>
+/// (<c>shared</c>) method call site (<c>C.G(out var y)</c>) was accepted but the
+/// declared local never leaked into the enclosing block scope, so a later read
+/// failed with <c>GS0125</c>. The instance path was fixed by #1137; the static
+/// path (<c>BindUserTypeStaticCall</c>) never re-bound the first-pass
+/// placeholder. These tests compile, IL-verify, and actually run the shape
+/// end-to-end so the leaked local both binds and carries the right value at
+/// runtime.
+/// </summary>
+public class Issue1139OutVarStaticCallEmitTests
+{
+    [Fact]
+    public void QualifiedStatic_OutVar_Compiles_And_Runs()
+    {
+        // The headline repro: `C.G(out var y)` on a qualified static method must
+        // declare `y` in the enclosing scope and return 5.
+        var source = """
+            package P
+            import System
+
+            class C {
+                shared {
+                    func G(out x int32) { x = 5 }
+                    func F() int32 {
+                        C.G(out var y)
+                        return y
+                    }
+                }
+            }
+
+            Console.WriteLine(C.F())
+            """;
+
+        Assert.Equal("5\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void CrossTypeQualifiedStatic_OutVar_Compiles_And_Runs()
+    {
+        // `Other.G(out var y)` from a different type must leak `y` too.
+        var source = """
+            package P
+            import System
+
+            class Other {
+                shared {
+                    func G(out x int32) { x = 7 }
+                }
+            }
+
+            class C {
+                shared {
+                    func F() int32 {
+                        Other.G(out var y)
+                        return y
+                    }
+                }
+            }
+
+            Console.WriteLine(C.F())
+            """;
+
+        Assert.Equal("7\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void QualifiedStatic_OutLet_ReadOnlyLocal_Compiles_And_Runs()
+    {
+        // `out let y` declares a read-only local; reading it is fine.
+        var source = """
+            package P
+            import System
+
+            class C {
+                shared {
+                    func G(out x int32) { x = 11 }
+                    func F() int32 {
+                        C.G(out let y)
+                        return y
+                    }
+                }
+            }
+
+            Console.WriteLine(C.F())
+            """;
+
+        Assert.Equal("11\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void QualifiedStatic_OutDiscard_Compiles_And_Runs()
+    {
+        // `out _` discards the result; no name leaks into the enclosing scope.
+        var source = """
+            package P
+            import System
+
+            class C {
+                shared {
+                    func G(out x int32) { x = 5 }
+                    func F() int32 {
+                        C.G(out _)
+                        return 42
+                    }
+                }
+            }
+
+            Console.WriteLine(C.F())
+            """;
+
+        Assert.Equal("42\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void GenericQualifiedStatic_OutVar_Compiles_And_Runs()
+    {
+        // A generic static out-parameter (`func M[T](seed T, out result T)`)
+        // must bind the out-var local as the substituted pointee type (int32)
+        // and run.
+        var source = """
+            package P
+            import System
+
+            class C {
+                shared {
+                    func M[T](seed T, out result T) { result = seed }
+                    func F() int32 {
+                        C.M[int32](9, out var y)
+                        return y
+                    }
+                }
+            }
+
+            Console.WriteLine(C.F())
+            """;
+
+        Assert.Equal("9\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1139_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1139OutVarStaticCallBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1139OutVarStaticCallBinderTests.cs
@@ -1,0 +1,260 @@
+// <copyright file="Issue1139OutVarStaticCallBinderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1139 / ADR-0060 (follow-up to #1133): an inline <c>out var n</c> (and
+/// <c>out let n</c> / <c>out _</c>) declaration at a <em>qualified static</em>
+/// (<c>shared</c>) method call site (<c>C.G(out var y)</c>) was accepted but
+/// never declared the local in the enclosing block scope, so a subsequent read
+/// of <c>n</c> failed with <c>GS0125</c>. The instance path
+/// (<c>BindUserInstanceCall</c>) was fixed by #1137; the static path
+/// (<c>BindUserTypeStaticCall</c>) never re-bound the first-pass placeholder.
+/// These tests cover the qualified static call, a cross-type-qualified call,
+/// the read-only (<c>out let</c>) and discard (<c>out _</c>) forms, and a
+/// generic static out-parameter, plus regression guards.
+/// </summary>
+public class Issue1139OutVarStaticCallBinderTests
+{
+    [Fact]
+    public void QualifiedStatic_OutVar_DeclaresLocalInEnclosingScope_NoGS0125()
+    {
+        // Exact repro from the issue.
+        const string source = @"
+package p
+class C {
+    shared {
+        func G(out x int32) { x = 5 }
+        func F() int32 {
+            C.G(out var y)
+            return y
+        }
+    }
+}
+";
+        var diagnostics = GetDiagnostics(source).ToList();
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0125");
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void CrossTypeQualifiedStatic_OutVar_DeclaresLocalInEnclosingScope_NoGS0125()
+    {
+        const string source = @"
+package p
+class Other {
+    shared {
+        func G(out x int32) { x = 5 }
+    }
+}
+class C {
+    shared {
+        func F() int32 {
+            Other.G(out var y)
+            return y
+        }
+    }
+}
+";
+        var diagnostics = GetDiagnostics(source).ToList();
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0125");
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void QualifiedStatic_OutLet_DeclaresReadOnlyLocal_ReadIsFine()
+    {
+        const string source = @"
+package p
+class C {
+    shared {
+        func G(out x int32) { x = 5 }
+        func F() int32 {
+            C.G(out let y)
+            return y
+        }
+    }
+}
+";
+        var diagnostics = GetDiagnostics(source).ToList();
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void QualifiedStatic_OutLet_AssigningAfterwards_ReportsReadOnly()
+    {
+        const string source = @"
+package p
+class C {
+    shared {
+        func G(out x int32) { x = 5 }
+        func F() int32 {
+            C.G(out let y)
+            y = 9
+            return y
+        }
+    }
+}
+";
+        var diagnostics = GetDiagnostics(source).ToList();
+        Assert.Contains(diagnostics, d => d.Id == "GS0127");
+    }
+
+    [Fact]
+    public void QualifiedStatic_OutDiscard_DoesNotLeakName()
+    {
+        const string source = @"
+package p
+class C {
+    shared {
+        func G(out x int32) { x = 5 }
+        func F() int32 {
+            C.G(out _)
+            return _
+        }
+    }
+}
+";
+        var diagnostics = GetDiagnostics(source).ToList();
+        Assert.Contains(diagnostics, d => d.Id == "GS0125");
+    }
+
+    [Fact]
+    public void QualifiedStatic_OutDiscard_AloneCompiles()
+    {
+        const string source = @"
+package p
+class C {
+    shared {
+        func G(out x int32) { x = 5 }
+        func F() int32 {
+            C.G(out _)
+            return 1
+        }
+    }
+}
+";
+        var diagnostics = GetDiagnostics(source).ToList();
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void GenericQualifiedStatic_OutVar_BindsSubstitutedType_NoDiagnostics()
+    {
+        // The out-var local must bind as the substituted parameter pointee
+        // type (int32 here), not the open type parameter `T`.
+        const string source = @"
+package p
+class C {
+    shared {
+        func M[T](seed T, out result T) { result = seed }
+        func F() int32 {
+            C.M[int32](7, out var y)
+            return y
+        }
+    }
+}
+";
+        var diagnostics = GetDiagnostics(source).ToList();
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0125");
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void QualifiedStatic_PreDeclaredOutLocal_StillCompiles()
+    {
+        // Regression guard: the existing pre-declared form must keep working.
+        const string source = @"
+package p
+class C {
+    shared {
+        func G(out x int32) { x = 5 }
+        func F() int32 {
+            var y int32
+            C.G(out y)
+            return y
+        }
+    }
+}
+";
+        var diagnostics = GetDiagnostics(source).ToList();
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void QualifiedStatic_NormalCallWithoutOutVar_StillBinds()
+    {
+        // No-regression: a normal qualified static call without an out-var
+        // still binds cleanly.
+        const string source = @"
+package p
+class C {
+    shared {
+        func G(x int32) int32 { return x + 1 }
+        func F() int32 {
+            return C.G(4)
+        }
+    }
+}
+";
+        var diagnostics = GetDiagnostics(source).ToList();
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void QualifiedStatic_UnknownMethod_StillReportsDiagnostic()
+    {
+        // No-regression: an unknown qualified static method still reports a
+        // diagnostic (the inline-out-var rebind must not swallow it).
+        const string source = @"
+package p
+class C {
+    shared {
+        func F() int32 {
+            C.Missing(out var y)
+            return y
+        }
+    }
+}
+";
+        var diagnostics = GetDiagnostics(source).ToList();
+        Assert.NotEmpty(diagnostics);
+    }
+
+    [Fact]
+    public void InstanceForm_OutVar_StillWorks_Regression1137()
+    {
+        // Regression guard for #1137: the instance path must keep working after
+        // the shared-helper refactor.
+        const string source = @"
+package p
+class C {
+    func G(out x int32) { x = 5 }
+    func F() int32 {
+        G(out var y)
+        return y
+    }
+}
+";
+        var diagnostics = GetDiagnostics(source).ToList();
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0125");
+        Assert.Empty(diagnostics);
+    }
+
+    private static IEnumerable<Diagnostic> GetDiagnostics(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new GSharp.Core.CodeAnalysis.Compilation.Compilation(tree);
+        using var peStream = new System.IO.MemoryStream();
+        return compilation.Emit(peStream).Diagnostics;
+    }
+}


### PR DESCRIPTION
Fixes #1139.

Follow-up to #1133 (fixed for instance calls by #1137). An inline `out var n` / `out let n` / `out _` declaration on a **qualified static** (`shared`) method call (`C.G(out var y)`) was accepted but never declared the local into the enclosing block scope, so a later read failed with `GS0125: Variable 'n' doesn't exist`.

## Root cause
In the first-pass argument-binding loop, an inline out-var argument is bound to a placeholder `BoundAddressOfExpression` wrapping a `BoundErrorExpression` that declares **no** local (the parameter/type is unknown before overload resolution). The instance path (`OverloadResolver.BindUserInstanceCall`) re-bound that placeholder once the method was resolved (#1133/#1137), but `BindUserTypeStaticCall` (in `ExpressionBinder.Access.cs`) never did — its per-position conversion loop passed the placeholder straight to `BindCallArgumentWithRefKind`, so the synthesized local was never declared into the enclosing scope.

## Fix (shared-helper refactor)
- Extracted a shared helper `TryRebindInlineOutVarPlaceholder(BoundExpression boundArg, ExpressionSyntax slotSyntax, ParameterSymbol resolvedParameter, TypeSymbol substitutedPointeeType)` next to `BindRefArgumentExpression` in `ExpressionBinder.Assignments.cs`. Given a first-pass placeholder + the argument syntax + resolved out-parameter + substituted pointee type, it re-binds via `BindRefArgumentExpression` with a parameter carrying the substituted type (reusing the resolved parameter when the type is unchanged), or returns `null` so the caller keeps its normal conversion path. It unwraps named-argument wrappers via `OverloadResolver.UnwrapNamedArgumentValue` for parity with the instance path.
- **Static path**: `BindUserTypeStaticCall` now calls the helper in its conversion loop, before the open-type-parameter shortcut and before `BindCallArgumentWithRefKind`, computing the substituted pointee type the same way `expectedType` is computed.
- **Instance path**: `OverloadResolver.BindUserInstanceCall` now calls the **same** helper (wired in via a new `tryRebindInlineOutVarPlaceholder` delegate, assigned in `Binder.cs` alongside the existing `bindRefArgumentExpression` delegate) instead of its inlined copy, removing the duplication. Behavior is identical — verified by re-running the #1133 instance tests.

`out let` → read-only local; `out _` → discard (no name leak); generic static out-params (`func G[T](out r T)`) bind the local as the substituted type.

## Tests
- `test/Core.Tests/CodeAnalysis/Binding/Issue1139OutVarStaticCallBinderTests.cs` (11 tests): qualified static `C.G(out var y)`; cross-type `Other.G(out var y)`; `out let` (read ok / GS0127 on later assign); `out _` discard (GS0125 on use, alone compiles); generic static out-param substituted type; pre-declared control; normal qualified static call; unknown qualified static method still diagnoses; instance-form #1137 regression guard.
- `test/Compiler.Tests/Emit/Issue1139OutVarStaticCallEmitTests.cs` (5 tests): compile + IL-verify + run for qualified static, cross-type-qualified, `out let`, `out _`, and generic static out-param, asserting the leaked local's runtime value.

All Issue1139 tests pass; #1133 (binder + emit), `OutVar`, and static-call (`Issue940`/`Issue951`/`StaticCall`) regression slices and the coverage-matrix golden test stay green. No new `SyntaxKind`/`BoundNodeKind`.

## Out of scope
A bare sibling-static call `G(out var y)` (no `C.` qualifier) is a separate pre-existing limitation (bare sibling static calls fail with `GS0130` even without out params) and is not addressed here.
