### PR TITLE
Fix #1139: inline out-var visible in enclosing scope for qualified static calls

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -1742,6 +1742,33 @@ internal sealed partial class ExpressionBinder
             for (var i = 0; i < permutedArgs.Length; i++)
             {
                 var paramType = method.Parameters[i].Type;
+
+                // ADR-0060 / issue #1139: an inline-decl `out var n` /
+                // `out let n` / `out _` at a qualified static (`C.G(...)`) call
+                // site was bound with TypeSymbol.Error in the first pass
+                // (before the static overload was resolved) and never declared
+                // a local — the same gap #1137 fixed for user instance calls.
+                // Now that the method is selected (and any generic substitution
+                // is known) re-bind it so the synthesized local is typed from
+                // the resolved (substituted) out-parameter pointee type and
+                // leaks into the enclosing block scope. Must run BEFORE the
+                // open-type-parameter shortcut below so generic out-parameters
+                // (`func G[T](out result T)`) are handled too.
+                if (permutedArgs[i] is BoundAddressOfExpression inlineOutAddr
+                    && inlineOutAddr.Operand.Type == TypeSymbol.Error
+                    && i < ce.Arguments.Count
+                    && OverloadResolver.UnwrapNamedArgumentValue(ce.Arguments[i]) is RefArgumentExpressionSyntax inlineOutRefArg
+                    && inlineOutRefArg.IsInlineDeclaration
+                    && inlineOutRefArg.DeclaredType == null)
+                {
+                    var pointeeType = substitution != null ? Binder.SubstituteType(paramType, substitution) : paramType;
+                    var rebindParameter = ReferenceEquals(pointeeType, method.Parameters[i].Type)
+                        ? method.Parameters[i]
+                        : new ParameterSymbol(method.Parameters[i].Name, pointeeType, refKind: RefKind.Out);
+                    convertedArgs.Add(BindRefArgumentExpression(inlineOutRefArg, rebindParameter));
+                    continue;
+                }
+
                 if (paramType is TypeParameterSymbol)
                 {
                     convertedArgs.Add(permutedArgs[i]);

--- a/test/Compiler.Tests/Emit/Issue1139StaticOutVarEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1139StaticOutVarEmitTests.cs
@@ -1,0 +1,152 @@
+// <copyright file="Issue1139StaticOutVarEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1139 (follow-up to #1133): an inline <c>out var n</c> declaration at a
+/// <em>qualified static</em> call site (<c>C.G(out var n)</c>) was bound with
+/// <c>TypeSymbol.Error</c> before overload resolution and never leaked the local
+/// into the enclosing scope, so a later read failed with <c>GS0125</c>. #1137
+/// fixed the user-instance path; this verifies the qualified-static path
+/// (<c>BindUserTypeStaticCall</c>) compiles, IL-verifies, and runs end-to-end.
+/// </summary>
+public class Issue1139StaticOutVarEmitTests
+{
+    [Fact]
+    public void QualifiedStatic_OutVar_Compiles_And_Runs()
+    {
+        // The headline repro: `C.G(out var y)` in an `if` condition must declare
+        // `y` in the enclosing scope and return 13.
+        var source = """
+            package P
+            import System
+
+            class C {
+                shared {
+                    func G(out x int32) bool {
+                        x = 13
+                        return true
+                    }
+                }
+                func F() int32 {
+                    if C.G(out var y) {
+                        return y
+                    }
+                    return 0
+                }
+            }
+
+            var c = C()
+            Console.WriteLine(c.F())
+            """;
+
+        Assert.Equal("13\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void QualifiedStatic_GenericOutParameter_OutVar_Compiles_And_Runs()
+    {
+        // A generic out-parameter on a static method must bind the out-var local
+        // as the substituted pointee type (int32) and run.
+        var source = """
+            package P
+            import System
+
+            class C {
+                shared {
+                    func M[T](seed T, out result T) { result = seed }
+                }
+                func F() int32 {
+                    C.M[int32](21, out var y)
+                    return y
+                }
+            }
+
+            var c = C()
+            Console.WriteLine(c.F())
+            """;
+
+        Assert.Equal("21\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1139_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1139StaticOutVarBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1139StaticOutVarBinderTests.cs
@@ -1,0 +1,199 @@
+// <copyright file="Issue1139StaticOutVarBinderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1139 / ADR-0060 (follow-up to #1133): an inline <c>out var n</c>
+/// (and <c>out let n</c> / <c>out _</c>) declaration at a <em>qualified static</em>
+/// call site (<c>C.G(out var n)</c>) was bound with <c>TypeSymbol.Error</c> on the
+/// first pass — before the static overload was resolved — and never declared the
+/// local in the enclosing block scope, so a subsequent read of <c>n</c> failed with
+/// <c>GS0125</c>. #1137 fixed the user-instance path
+/// (<c>BindUserInstanceCall</c>); this covers the qualified-static path
+/// (<c>BindUserTypeStaticCall</c>). Tests cover <c>out var</c>, the read-only
+/// (<c>out let</c>) and discard (<c>out _</c>) forms, and a generic
+/// out-parameter where the local must bind as the substituted pointee type.
+/// </summary>
+public class Issue1139StaticOutVarBinderTests
+{
+    [Fact]
+    public void QualifiedStatic_OutVar_DeclaresLocalInEnclosingScope_NoGS0125()
+    {
+        const string source = @"
+package p
+class C {
+    shared {
+        func G(out x int32) bool {
+            x = 13
+            return true
+        }
+    }
+    func F() int32 {
+        if C.G(out var y) {
+            return y
+        }
+        return 0
+    }
+}
+";
+        var diagnostics = GetDiagnostics(source).ToList();
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0125");
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void QualifiedStatic_OutVar_SimpleStatement_NoDiagnostics()
+    {
+        const string source = @"
+package p
+class C {
+    shared {
+        func G(out x int32) { x = 5 }
+    }
+    func F() int32 {
+        C.G(out var y)
+        return y
+    }
+}
+";
+        var diagnostics = GetDiagnostics(source).ToList();
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0125");
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void QualifiedStatic_OutLet_DeclaresReadOnlyLocal_ReadIsFine()
+    {
+        const string source = @"
+package p
+class C {
+    shared {
+        func G(out x int32) { x = 5 }
+    }
+    func F() int32 {
+        C.G(out let y)
+        return y
+    }
+}
+";
+        var diagnostics = GetDiagnostics(source).ToList();
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void QualifiedStatic_OutLet_AssigningAfterwards_ReportsReadOnly()
+    {
+        const string source = @"
+package p
+class C {
+    shared {
+        func G(out x int32) { x = 5 }
+    }
+    func F() int32 {
+        C.G(out let y)
+        y = 9
+        return y
+    }
+}
+";
+        var diagnostics = GetDiagnostics(source).ToList();
+        Assert.Contains(diagnostics, d => d.Id == "GS0127");
+    }
+
+    [Fact]
+    public void QualifiedStatic_OutDiscard_DoesNotLeakName()
+    {
+        const string source = @"
+package p
+class C {
+    shared {
+        func G(out x int32) { x = 5 }
+    }
+    func F() int32 {
+        C.G(out _)
+        return _
+    }
+}
+";
+        var diagnostics = GetDiagnostics(source).ToList();
+        Assert.Contains(diagnostics, d => d.Id == "GS0125");
+    }
+
+    [Fact]
+    public void QualifiedStatic_OutDiscard_AloneCompiles()
+    {
+        const string source = @"
+package p
+class C {
+    shared {
+        func G(out x int32) { x = 5 }
+    }
+    func F() int32 {
+        C.G(out _)
+        return 1
+    }
+}
+";
+        var diagnostics = GetDiagnostics(source).ToList();
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void QualifiedStatic_GenericOutParameter_OutVar_BindsSubstitutedType_NoDiagnostics()
+    {
+        // The out-var local must bind as the substituted parameter pointee
+        // type (int32 here), not the open type parameter `T`.
+        const string source = @"
+package p
+class C {
+    shared {
+        func M[T](seed T, out result T) { result = seed }
+    }
+    func F() int32 {
+        C.M[int32](7, out var y)
+        return y
+    }
+}
+";
+        var diagnostics = GetDiagnostics(source).ToList();
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0125");
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void QualifiedStatic_Control_PreDeclaredOutLocal_StillCompiles()
+    {
+        const string source = @"
+package p
+class C {
+    shared {
+        func G(out x int32) { x = 5 }
+    }
+    func F() int32 {
+        var y int32
+        C.G(out y)
+        return y
+    }
+}
+";
+        var diagnostics = GetDiagnostics(source).ToList();
+        Assert.Empty(diagnostics);
+    }
+
+    private static IEnumerable<Diagnostic> GetDiagnostics(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new GSharp.Core.CodeAnalysis.Compilation.Compilation(tree);
+        using var peStream = new System.IO.MemoryStream();
+        return compilation.Emit(peStream).Diagnostics;
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1139 (follow-up to #1133 / ADR-0060).

An inline-decl `out var n` / `out let n` / `out _` at a **qualified static** call site (`C.G(out var n)`) was bound with `TypeSymbol.Error` on the first pass — before the static overload was resolved — and never declared the local in the enclosing block scope, so a subsequent read of `n` failed with `GS0125`. PR #1137 fixed this for user **instance** calls (`BindUserInstanceCall`); this lands the same treatment for the qualified-static path (`BindUserTypeStaticCall`).

## Change

`src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs` — `BindUserTypeStaticCall`'s per-position conversion loop now detects a first-pass inline out-var placeholder (`BoundAddressOfExpression` whose operand is `TypeSymbol.Error`, backed by a `RefArgumentExpressionSyntax` inline declaration with no explicit declared type) and re-binds it via `BindRefArgumentExpression` once the static overload is selected. The synthesized local is typed from the resolved (substituted) out-parameter pointee type and leaks into the enclosing block scope. The re-bind runs **before** the open-type-parameter shortcut so generic out-parameters (`func M[T](..., out result T)`) are handled too.

## Tests

- **`Issue1139StaticOutVarBinderTests`** (8): `out var` in an `if` and as a simple statement; `out let` read-only local (and `GS0127` when reassigned); `out _` discard (compiles alone; `GS0125` when read); generic out-parameter substituted type; pre-declared-local control.
- **`Issue1139StaticOutVarEmitTests`** (2): end-to-end compile + IL-verify + run, asserting the leaked local carries the right value (13; generic 21).

## Validation

- `dotnet build GSharp.sln -c Release -graph` → 0 Warning(s) 0 Error(s).
- Targeted tests: binder 8 passed, emit 2 passed.
- Standalone gsc repros: `C.G(out var y)` → "Wrote x.dll"; `out _` then read `_` → `GS0125` (correct); user `#1136` Object-member fix (#1140, already on main) still resolves.

Refs #914
