### PR TITLE
cs2gs: render C# discard `_ = expr` and multi-init/multi-incrementor for-loops

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/BodyTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/BodyTranslationTests.cs
@@ -127,6 +127,35 @@ public class BodyTranslationTests
         Assert.Contains("for var i = 1; i <= 3; i++ {", body);
     }
 
+    /// <summary>C# statement-level discard <c>_ = expr;</c> has no G# discard target
+    /// (<c>_ = e</c> → GS0125), so it lowers to a bare expression statement of the
+    /// RHS (issue #914).</summary>
+    [Fact]
+    public void DiscardAssignment_EmitsBareRightHandSide()
+    {
+        string body = GetMethodBody("_ = n.ToString();");
+        Assert.Contains("n.ToString()", body);
+        Assert.DoesNotContain("_ =", body);
+    }
+
+    /// <summary>A C-style <c>for</c> with multiple declarators/initializers or
+    /// multiple incrementors cannot fit G#'s single-init, single-incrementor
+    /// <c>for</c>, so it lowers to a block + <c>while</c> running every init once up
+    /// front and every incrementor at the end of each iteration (issue #914).</summary>
+    [Fact]
+    public void MultiInitMultiIncrementorFor_LowersToBlockWhile()
+    {
+        string body = GetMethodBody(
+            "for (int f = 0, start = 0; f < 3; start += f, f++) { n = n + start; }");
+
+        Assert.Contains("var f = 0", body);
+        Assert.Contains("var start = 0", body);
+        Assert.Contains("while f < 3 {", body);
+        Assert.Contains("start += f", body);
+        Assert.Contains("f++", body);
+        Assert.DoesNotContain("for ", body);
+    }
+
     /// <summary>C# <c>foreach (var x in xs)</c> maps to the G# <c>for x in xs</c>
     /// (<see cref="ForInStatement"/>).</summary>
     [Fact]

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -3240,6 +3240,16 @@ public sealed class CSharpToGSharpTranslator
             if (expression is AssignmentExpressionSyntax assignment &&
                 assignment.IsKind(SyntaxKind.SimpleAssignmentExpression))
             {
+                if (assignment.Left is IdentifierNameSyntax { Identifier.ValueText: "_" })
+                {
+                    // C# statement-level discard `_ = e` (Roslyn parses the `_`
+                    // target as an IdentifierNameSyntax). G# has no discard target
+                    // (`_ = e` → GS0125), so drop the assignment and emit just the
+                    // RHS as statement(s); `_ = a = b`, `_ = x ?? throw E`, and
+                    // `_ = await ...` flow through the RHS translation (issue #914).
+                    return this.TranslateExpressionStatements(assignment.Right);
+                }
+
                 if (TryGetCoalesceThrow(assignment.Right, out ExpressionSyntax coalesceValue, out ThrowExpressionSyntax coalesceThrow))
                 {
                     // `target = x ?? throw E` → evaluate x once, throw when nil,
@@ -3913,6 +3923,20 @@ public sealed class CSharpToGSharpTranslator
 
         private GStatement TranslateForStatement(ForStatementSyntax forStatement)
         {
+            int declaratorCount = forStatement.Declaration?.Variables.Count ?? 0;
+
+            // G#'s `for` carries a SINGLE init clause and a SINGLE incrementor, so
+            // a C-style `for` with multiple declarators/initializers or multiple
+            // incrementors cannot be represented directly. Lower those to a block
+            // + `while` so every init runs once up front and every incrementor runs
+            // at the end of each iteration (issue #914).
+            if (declaratorCount > 1 ||
+                forStatement.Initializers.Count > 1 ||
+                forStatement.Incrementors.Count > 1)
+            {
+                return this.LowerForToWhile(forStatement);
+            }
+
             GStatement initializer = null;
             if (forStatement.Declaration != null)
             {
@@ -3937,6 +3961,51 @@ public sealed class CSharpToGSharpTranslator
                 condition,
                 incrementor,
                 this.TranslateStatementAsBlock(forStatement.Statement));
+        }
+
+        /// <summary>
+        /// Lowers a C-style <c>for</c> that has more than one initializer/declarator
+        /// or more than one incrementor — neither of which fits G#'s single-init,
+        /// single-incrementor <c>for</c> — into an equivalent block + <c>while</c>:
+        /// all inits run once before the loop, the body runs each iteration, then
+        /// every incrementor runs at the end of the body (issue #914).
+        /// </summary>
+        /// <remarks>
+        /// Fidelity caveat: in C# the incrementors also run when the body executes a
+        /// loop-targeting <c>continue</c>; in this while-lowering the trailing
+        /// incrementors are SKIPPED on <c>continue</c>. The decoder loops this fix
+        /// targets do not use a loop-level <c>continue</c>, so the lowering is
+        /// faithful for them; a warning would be required to generalise this.
+        /// </remarks>
+        private GStatement LowerForToWhile(ForStatementSyntax forStatement)
+        {
+            var outer = new List<GStatement>();
+
+            if (forStatement.Declaration != null)
+            {
+                outer.AddRange(this.TranslateLocalDeclaration(forStatement.Declaration, isConst: false));
+            }
+
+            foreach (ExpressionSyntax init in forStatement.Initializers)
+            {
+                outer.AddRange(this.TranslateExpressionStatements(init));
+            }
+
+            GExpression condition = forStatement.Condition == null
+                ? LiteralExpression.Bool(true)
+                : GuardBlockCondition(this.TranslateExpression(forStatement.Condition));
+
+            var bodyStatements = new List<GStatement>(
+                this.TranslateStatementAsBlock(forStatement.Statement).Statements);
+
+            foreach (ExpressionSyntax inc in forStatement.Incrementors)
+            {
+                bodyStatements.AddRange(this.TranslateExpressionStatements(inc));
+            }
+
+            outer.Add(new WhileStatement(condition, new BlockStatement(bodyStatements)));
+
+            return new BlockStatement(outer);
         }
 
         private bool IsLocalReassigned(ILocalSymbol local)


### PR DESCRIPTION
## Summary
Fixes two confirmed `cs2gs` translator defects that emitted invalid G# for real C# decoder code (issue #914).

### Defect 1 — C# discard `_ = expr;`
A statement-level discard `_ = e` (Roslyn parses the `_` target as an `IdentifierNameSyntax`) was emitted verbatim, which G# rejects with `GS0125: Variable '_' doesn't exist`. The translator now detects a pure `_` LHS at the top of the `SimpleAssignmentExpression` handling and emits **just the RHS** as expression statement(s) via `TranslateExpressionStatements(assignment.Right)`, so `_ = SomeCall()`, `_ = a = b`, and `_ = x ?? throw E` all flow correctly through the existing RHS translation. The `out _` discard designation (a different syntax) is untouched.

### Defect 2 — C-style `for` with multiple declarators/initializers or incrementors
G#'s `for` carries a **single** init clause and a **single** incrementor, so the translator silently dropped extra declarators/initializers and extra incrementors. This produced `GS0125` (undefined loop variables like `f` / `beginIndex`) and `GS0005` (an incrementor ending in an indexer right before `{`, e.g. `start += chunk.FrameSizes[f] {`, mis-parsed as a composite literal).

A `for` with `>1` declarator/initializer **or** `>1` incrementor now lowers to a block + `while`:
```
{
    <init0>
    <init1>
    ...
    while <condition> {   // literal `true` when the condition is omitted
        <body...>
        <inc0>
        <inc1>
        ...
    }
}
```
The common single-init/single-incrementor `for` still maps cleanly to G#'s `for`.

### Continue caveat
In C# the incrementors also run on a loop-targeting `continue`; this while-lowering skips the trailing incrementors on `continue`. The Decrypt loops targeted here (ChunkReader, SidxBox) do **not** use a loop-level `continue`, so the lowering is faithful for them. This is documented in a code comment on `LowerForToWhile`.

## Verification
- `dotnet build GSharp.sln -c Release -graph` → **0 Error(s)**.
- `Cs2Gs.Tests`: **202 passed** (200 existing + 2 new), 0 failed. New tests: `DiscardAssignment_EmitsBareRightHandSide` and `MultiInitMultiIncrementorFor_LowersToBlockWhile` in `BodyTranslationTests`.
- Standalone `gsc` repro of the expected output shapes (bare discard call; block+while loop) compiles: `Wrote /tmp/x.dll`.
- Oahu.Decrypt migration: **translate stage still passes**; total compile errors **526 → 509**. The targeted `Variable '_'` (×6), `Variable 'f'`, `Variable 'beginIndex'` `GS0125` messages and all `GS0005` parse errors are **gone** (`GS0005` count 0). Remaining errors are unrelated (events, static fields, generic `T`, `.Count`/`.Sum`/`.Remove` member resolution).

Refs #914
