### PR TITLE
Fix #1144: constant integer literal adapts to operand integer type in binary expressions

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Numerics;
 using System.Reflection;
 using System.Text;
 using GSharp.Core.CodeAnalysis.Lowering;
@@ -1070,6 +1071,40 @@ internal sealed partial class ExpressionBinder
 
         var boundOperator = BoundBinaryOperator.Bind(syntax.OperatorToken.Kind, boundLeft.Type, boundRight.Type);
 
+        // issue #1144: constant integer-literal adaptation (C#-style
+        // constant-expression conversion). When exactly one operand is a
+        // compile-time constant integer literal and the OTHER operand is a
+        // (non-literal) integer type, the literal implicitly adapts to that
+        // integer type provided its value is representable there. This makes
+        // `a + 1` (a: uint32) bind as `uint32 + uint32` without touching the
+        // general conversion path — conversions between two TYPED integer
+        // operands still require an explicit cast. An OUT-OF-RANGE literal is
+        // NOT adapted, so the GS0129 path below still reports an error (the
+        // value is never silently wrapped/truncated). Placed before the
+        // nullable mixed-mode lifts so it takes precedence for the
+        // non-nullable integer-literal case (lifts don't apply there anyway).
+        if (boundOperator == null)
+        {
+            if (boundLeft is BoundLiteralExpression leftLit
+                && IsIntegerLiteralValue(leftLit.Value)
+                && boundRight is not BoundLiteralExpression
+                && IsIntegerType(boundRight.Type)
+                && TryAdaptIntegerLiteral(leftLit.Value, boundRight.Type, out var adaptedLeftValue))
+            {
+                boundLeft = new BoundLiteralExpression(boundLeft.Syntax, adaptedLeftValue);
+                boundOperator = BoundBinaryOperator.Bind(syntax.OperatorToken.Kind, boundLeft.Type, boundRight.Type);
+            }
+            else if (boundRight is BoundLiteralExpression rightLit
+                && IsIntegerLiteralValue(rightLit.Value)
+                && boundLeft is not BoundLiteralExpression
+                && IsIntegerType(boundLeft.Type)
+                && TryAdaptIntegerLiteral(rightLit.Value, boundLeft.Type, out var adaptedRightValue))
+            {
+                boundRight = new BoundLiteralExpression(boundRight.Syntax, adaptedRightValue);
+                boundOperator = BoundBinaryOperator.Bind(syntax.OperatorToken.Kind, boundLeft.Type, boundRight.Type);
+            }
+        }
+
         // PR N-4 / §6.1 / C# §7.3.7: mixed-mode lift. When one operand is
         // a value-type Nullable<T> and the other is its underlying T, lift
         // T to T? via the existing implicit conversion and re-bind. The
@@ -1209,5 +1244,144 @@ internal sealed partial class ExpressionBinder
         }
 
         return new BoundBinaryExpression(null, boundLeft, boundOperator, boundRight);
+    }
+
+    // issue #1144: the ten G# integer primitive types (signed + unsigned,
+    // including the native-int pair). Membership mirrors the integral sets in
+    // BoundBinaryOperator.
+    private static bool IsIntegerType(TypeSymbol type)
+    {
+        return type == TypeSymbol.Int8 || type == TypeSymbol.Int16 || type == TypeSymbol.Int32
+            || type == TypeSymbol.Int64 || type == TypeSymbol.NInt
+            || type == TypeSymbol.UInt8 || type == TypeSymbol.UInt16 || type == TypeSymbol.UInt32
+            || type == TypeSymbol.UInt64 || type == TypeSymbol.NUInt;
+    }
+
+    // issue #1144: true when the boxed literal value is a compile-time constant
+    // INTEGER (excludes char/bool/float/decimal/string/enum, which never adapt).
+    private static bool IsIntegerLiteralValue(object value)
+    {
+        return value is sbyte or byte or short or ushort or int or uint or long or ulong or nint or nuint;
+    }
+
+    // issue #1144: try to adapt a constant integer literal to the target integer
+    // type. Uses BigInteger as a wide, sign-agnostic carrier so the full uint64
+    // range is handled, and range-checks against the target's min/max before
+    // producing a boxed value whose CLR type maps (via BoundLiteralExpression's
+    // InferType) to EXACTLY the target type. Native ints are range-tested
+    // conservatively as int64 (nint) / uint64 (nuint) so the result is stable
+    // regardless of the host process pointer width.
+    private static bool TryAdaptIntegerLiteral(object value, TypeSymbol target, out object converted)
+    {
+        converted = null;
+        BigInteger v = value switch
+        {
+            sbyte s => s,
+            byte b => b,
+            short s => s,
+            ushort u => u,
+            int i => i,
+            uint u => u,
+            long l => l,
+            ulong u => u,
+            nint n => (long)n,
+            nuint n => (ulong)n,
+            _ => default,
+        };
+
+        BigInteger min;
+        BigInteger max;
+        if (target == TypeSymbol.Int8)
+        {
+            min = sbyte.MinValue;
+            max = sbyte.MaxValue;
+        }
+        else if (target == TypeSymbol.UInt8)
+        {
+            min = byte.MinValue;
+            max = byte.MaxValue;
+        }
+        else if (target == TypeSymbol.Int16)
+        {
+            min = short.MinValue;
+            max = short.MaxValue;
+        }
+        else if (target == TypeSymbol.UInt16)
+        {
+            min = ushort.MinValue;
+            max = ushort.MaxValue;
+        }
+        else if (target == TypeSymbol.Int32)
+        {
+            min = int.MinValue;
+            max = int.MaxValue;
+        }
+        else if (target == TypeSymbol.UInt32)
+        {
+            min = uint.MinValue;
+            max = uint.MaxValue;
+        }
+        else if (target == TypeSymbol.Int64 || target == TypeSymbol.NInt)
+        {
+            min = long.MinValue;
+            max = long.MaxValue;
+        }
+        else if (target == TypeSymbol.UInt64 || target == TypeSymbol.NUInt)
+        {
+            min = ulong.MinValue;
+            max = ulong.MaxValue;
+        }
+        else
+        {
+            return false;
+        }
+
+        if (v < min || v > max)
+        {
+            return false;
+        }
+
+        if (target == TypeSymbol.Int8)
+        {
+            converted = (sbyte)v;
+        }
+        else if (target == TypeSymbol.UInt8)
+        {
+            converted = (byte)v;
+        }
+        else if (target == TypeSymbol.Int16)
+        {
+            converted = (short)v;
+        }
+        else if (target == TypeSymbol.UInt16)
+        {
+            converted = (ushort)v;
+        }
+        else if (target == TypeSymbol.Int32)
+        {
+            converted = (int)v;
+        }
+        else if (target == TypeSymbol.UInt32)
+        {
+            converted = (uint)v;
+        }
+        else if (target == TypeSymbol.Int64)
+        {
+            converted = (long)v;
+        }
+        else if (target == TypeSymbol.UInt64)
+        {
+            converted = (ulong)v;
+        }
+        else if (target == TypeSymbol.NInt)
+        {
+            converted = (nint)(long)v;
+        }
+        else
+        {
+            converted = (nuint)(ulong)v;
+        }
+
+        return true;
     }
 }

--- a/test/Compiler.Tests/Emit/Issue1144LiteralIntAdaptEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1144LiteralIntAdaptEmitTests.cs
@@ -1,0 +1,199 @@
+// <copyright file="Issue1144LiteralIntAdaptEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1144: end-to-end emit + execution tests proving a constant integer
+/// literal operand of a binary operator adapts to the OTHER operand's integer
+/// type and is emitted with that type. Each program compiles via <c>gsc</c>,
+/// is IL-verified, and runs under <c>dotnet exec</c> with its runtime values
+/// asserted — including an unsigned-arithmetic check to confirm the literal is
+/// emitted as the unsigned operand type (not int32).
+/// </summary>
+public class Issue1144LiteralIntAdaptEmitTests
+{
+    [Fact]
+    public void UInt32Increment_LiteralAdapts_AndRuns()
+    {
+        var source = """
+            package main
+            import System
+
+            func F(a uint32) uint32 { return a + 1 }
+
+            func run() {
+                Console.WriteLine(F(uint32(10)))
+            }
+
+            run()
+            """;
+
+        Assert.Equal("11\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void UInt8BitwiseOr_LiteralAdapts_AndRuns()
+    {
+        var source = """
+            package main
+            import System
+
+            func G(b uint8) int32 { return int32(b | 4) }
+
+            func run() {
+                Console.WriteLine(G(uint8(1)))
+            }
+
+            run()
+            """;
+
+        // 1 | 4 == 5
+        Assert.Equal("5\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void UInt8Equality_LiteralAdapts_AndRuns()
+    {
+        var source = """
+            package main
+            import System
+
+            func H(c uint8) bool { return c == 0 }
+
+            func run() {
+                Console.WriteLine(H(uint8(0)))
+                Console.WriteLine(H(uint8(5)))
+            }
+
+            run()
+            """;
+
+        Assert.Equal("True\nFalse\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void UInt32Wrap_LiteralEmittedAsUnsigned_NotInt32()
+    {
+        // If the literal `1` were emitted as int32 and the addition performed
+        // as signed int32, `0xFFFFFFFF + 1` would overflow into a negative
+        // int32. Adapting the literal to uint32 makes this wrap to 0 as
+        // unsigned arithmetic — proving the emitted operand type.
+        var source = """
+            package main
+            import System
+
+            func F(a uint32) uint32 { return a + 1 }
+
+            func run() {
+                var max = 4294967295U
+                Console.WriteLine(F(max))
+            }
+
+            run()
+            """;
+
+        Assert.Equal("0\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void Int64Operand_LiteralAdapts_AndRuns()
+    {
+        var source = """
+            package main
+            import System
+
+            func F(l int64) int64 { return l + 1 }
+
+            func run() {
+                Console.WriteLine(F(9223372036854775806L))
+            }
+
+            run()
+            """;
+
+        Assert.Equal("9223372036854775807\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1144_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath, null, Array.Empty<string>());
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+                // ignored
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1144LiteralIntAdaptBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1144LiteralIntAdaptBinderTests.cs
@@ -1,0 +1,189 @@
+// <copyright file="Issue1144LiteralIntAdaptBinderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1144: a constant integer literal operand of a binary operator
+/// adapts to the OTHER operand's integer type when its value is
+/// representable there (C#-style constant-expression conversion). This is
+/// local to binary-expression binding: conversions between two TYPED
+/// integer operands still require an explicit cast, and an out-of-range
+/// literal still errors (never silently wraps).
+///
+/// The result TYPE of each positive case is asserted indirectly but
+/// precisely via the enclosing function's declared return type: if the
+/// binary expression did not bind to the expected integer/bool type the
+/// implicit `return` conversion would surface a diagnostic.
+/// </summary>
+public class Issue1144LiteralIntAdaptBinderTests
+{
+    // ── Arithmetic: uint32 operand + int literal → uint32 ──────────────
+
+    [Theory]
+    [InlineData("a + 1")]
+    [InlineData("a - 1")]
+    [InlineData("a * 2")]
+    [InlineData("a / 2")]
+    [InlineData("a % 2")]
+    public void Arithmetic_UInt32OperandWithIntLiteral_BindsToUInt32(string expr)
+    {
+        var source = Wrap("func F(a uint32) uint32 { return " + expr + " }");
+        Assert.Empty(Errors(source));
+    }
+
+    // ── Bitwise: uint8 operand | int literal → uint8 ───────────────────
+
+    [Theory]
+    [InlineData("b | 4")]
+    [InlineData("b & 4")]
+    [InlineData("b ^ 4")]
+    public void Bitwise_UInt8OperandWithIntLiteral_BindsToUInt8(string expr)
+    {
+        var source = Wrap("func F(b uint8) uint8 { return " + expr + " }");
+        Assert.Empty(Errors(source));
+    }
+
+    // ── Comparison: uint8 operand vs int literal → bool ────────────────
+
+    [Theory]
+    [InlineData("c == 0")]
+    [InlineData("c != 0")]
+    [InlineData("c < 10")]
+    [InlineData("c >= 1")]
+    public void Comparison_UInt8OperandWithIntLiteral_BindsToBool(string expr)
+    {
+        var source = Wrap("func F(c uint8) bool { return " + expr + " }");
+        Assert.Empty(Errors(source));
+    }
+
+    // ── Literal on the LEFT adapts too ─────────────────────────────────
+
+    [Fact]
+    public void LiteralOnLeft_Arithmetic_BindsToUInt32()
+    {
+        var source = Wrap("func F(a uint32) uint32 { return 1 + a }");
+        Assert.Empty(Errors(source));
+    }
+
+    [Fact]
+    public void LiteralOnLeft_Comparison_BindsToBool()
+    {
+        var source = Wrap("func F(c uint8) bool { return 0 == c }");
+        Assert.Empty(Errors(source));
+    }
+
+    // ── Each of the ten integer target types ───────────────────────────
+
+    [Theory]
+    [InlineData("int8")]
+    [InlineData("uint8")]
+    [InlineData("int16")]
+    [InlineData("uint16")]
+    [InlineData("int32")]
+    [InlineData("uint32")]
+    [InlineData("int64")]
+    [InlineData("uint64")]
+    [InlineData("nint")]
+    [InlineData("nuint")]
+    public void AllIntegerTargetTypes_LiteralAdapts(string type)
+    {
+        var source = Wrap("func F(v " + type + ") " + type + " { return v + 1 }");
+        Assert.Empty(Errors(source));
+    }
+
+    [Fact]
+    public void Int64Operand_WithIntLiteral_BindsToInt64()
+    {
+        var source = Wrap("func F(l int64) int64 { return l + 1 }");
+        Assert.Empty(Errors(source));
+    }
+
+    // ── Negative cases: must STILL error ───────────────────────────────
+
+    [Fact]
+    public void OutOfRangeLiteral_UInt8_StillErrorsGS0129()
+    {
+        var source = Wrap("func F(c uint8) bool { return c == 999 }");
+        Assert.Contains(Errors(source), d => d.Id == "GS0129");
+    }
+
+    [Fact]
+    public void NegativeLiteral_NotRepresentableInUInt32_StillErrorsGS0129()
+    {
+        var source = Wrap("func F(a uint32) uint32 { return a + -1 }");
+        Assert.Contains(Errors(source), d => d.Id == "GS0129");
+    }
+
+    [Fact]
+    public void TwoTypedIntegerOperands_StillErrorsGS0129()
+    {
+        // No literal involved: uint8 + int32 between two typed locals still
+        // requires an explicit cast (general conversion path untouched).
+        var source = Wrap(@"func F(x uint8, y int32) int32 {
+        return int32(x + y)
+    }");
+        Assert.Contains(Errors(source), d => d.Id == "GS0129");
+    }
+
+    [Fact]
+    public void TypedVariableNarrowing_StillErrorsGS0156()
+    {
+        // Proves the general numeric-conversion path is untouched: assigning
+        // a (typed int32) literal-initialized value to a uint8 still needs a
+        // cast. `let a uint8 = 4` narrows int32 -> uint8 and reports GS0156.
+        var source = Wrap("func F() { let a uint8 = 4 }");
+        Assert.Contains(Errors(source), d => d.Id == "GS0156");
+    }
+
+    // ── Regression: pre-existing behaviour preserved ───────────────────
+
+    [Fact]
+    public void TwoIntLiterals_StillBindToInt32()
+    {
+        var source = Wrap("func F() int32 { return 1 + 2 }");
+        Assert.Empty(Errors(source));
+    }
+
+    [Fact]
+    public void ExplicitCastWorkaround_StillCompiles()
+    {
+        var source = Wrap("func F(a uint32) uint32 { return a + uint32(1) }");
+        Assert.Empty(Errors(source));
+    }
+
+    [Fact]
+    public void ShiftWithIntRhs_StillCompiles()
+    {
+        var source = Wrap("func F(a uint32) uint32 { return a << 8 }");
+        Assert.Empty(Errors(source));
+    }
+
+    private static string Wrap(string member)
+    {
+        return @"
+package p
+class C {
+    " + member + @"
+}
+";
+    }
+
+    private static IReadOnlyList<Diagnostic> Errors(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new GSharp.Core.CodeAnalysis.Compilation.Compilation(tree);
+        using var peStream = new System.IO.MemoryStream();
+        return compilation.Emit(peStream).Diagnostics
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .ToList();
+    }
+}

--- a/website/docs/ref/spec.md
+++ b/website/docs/ref/spec.md
@@ -155,7 +155,7 @@ The predeclared primitive and special type names are `bool`, `uint8`, `int8`, `i
 
 ### Numeric types
 
-Integral types are `int8`, `uint8`, `int16`, `uint16`, `int32`, `uint32`, `int64`, `uint64`, `nint`, and `nuint`. Floating and decimal types are `float32`, `float64`, and `decimal`. Operators are defined per primitive type rather than by implicit cross-type promotion. Widening numeric conversions follow the implemented conversion lattice; other numeric primitive pairs require explicit conversion.
+Integral types are `int8`, `uint8`, `int16`, `uint16`, `int32`, `uint32`, `int64`, `uint64`, `nint`, and `nuint`. Floating and decimal types are `float32`, `float64`, and `decimal`. Operators are defined per primitive type rather than by implicit cross-type promotion. Widening numeric conversions follow the implemented conversion lattice; other numeric primitive pairs require explicit conversion. As an exception, when one operand of a binary operator is a constant integer literal and the other operand is an integer type, the literal adapts to that integer type if its value is representable there (C#-style constant-expression conversion); so `a + 1` with `a` of type `uint32` binds as `uint32 + uint32`. A constant whose value is out of range for the target type, or a conversion between two typed integer operands, still requires an explicit cast.
 
 ### String and character types
 


### PR DESCRIPTION
Fixes #1144

## Root cause
G# gives every untyped decimal integer literal the intrinsic type `int32`, and binary operators are defined **only for matching operand types** with no implicit cross-type promotion (spec §Numeric types). So `a + 1` (a: `uint32`) binds left=`uint32`, right=`int32` literal, `BoundBinaryOperator.Bind` finds no `(uint32,int32)` arm, and reports **GS0129**. The same affected `flags | 0x04`, `b == 0`, etc. — the single largest error category when migrating real decoder/codec code via cs2gs (#914).

## Fix
Add a constant-expression adaptation step **local to `BindBinaryExpression`** (`ExpressionBinder.Operators.cs`), triggered only when the initial `BoundBinaryOperator.Bind` returns null and placed before the nullable mixed-mode lifts:

- When exactly one operand is a compile-time **constant integer literal** and the **other** operand is a (non-literal) integer type, adapt the literal to that integer type **iff its value is representable there**, build an adapted `BoundLiteralExpression` (whose `Type` becomes the target via `InferType`), and re-bind. `a + 1` then binds as `uint32 + uint32` → `uint32`.
- Range is checked with `BigInteger` (sign-agnostic, full uint64 range). Native ints are range-tested conservatively as int64 (`nint`) / uint64 (`nuint`) so results are stable across host pointer widths.
- **Out-of-range** literals are NOT adapted → the existing **GS0129** path still fires (never silently wraps/truncates).
- Conversions between **two typed integer operands** still require an explicit cast, and the general numeric-conversion path (`Conversion.cs` / `ConversionClassifier.cs`) is **untouched** — `let a uint8 = 4` still reports GS0156.

## Tests
- `test/Core.Tests/.../Issue1144LiteralIntAdaptBinderTests.cs` (32 cases): arithmetic/bitwise/comparison adaptation, literal on either side, all ten integer target types, plus negatives — `c == 999` (out of range) GS0129, `a + -1` GS0129, two typed operands GS0129, `let a uint8 = 4` GS0156, and regressions (`1 + 2` → int32, explicit-cast workaround, `a << 8`).
- `test/Compiler.Tests/Emit/Issue1144LiteralIntAdaptEmitTests.cs` (5 cases): compile + IL-verify + run, asserting runtime values including an **unsigned-wrap** check (`uint32(0xFFFFFFFF) + 1 == 0`) that proves the literal is emitted as the unsigned operand type.

## Spec
Updated `website/docs/ref/spec.md` (Numeric types) to document constant integer-literal adaptation while keeping typed-to-typed conversions cast-required.