### PR TITLE
cs2gs: emit non-null assertion (!!) for flow-proven nullable receivers

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/NullableFlowForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/NullableFlowForgivenessTranslationTests.cs
@@ -1,0 +1,182 @@
+// <copyright file="NullableFlowForgivenessTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Translator-fidelity tests for the nullable-flow non-null assertion rule
+/// (issue #914, GS0158 / GS0116): C# narrows a guarded nullable property/field
+/// chain to non-null with flow analysis (<c>if (o.Child == null) return;</c>),
+/// but G# follows Kotlin-style smart-casts that narrow only local variables,
+/// never property/field-access chains. So a member or element access whose
+/// receiver is a <em>declared</em>-nullable reference that Roslyn has
+/// flow-proven non-null is emitted with G#'s postfix non-null assertion
+/// (<c>recv!!.Member</c> / <c>recv!![i]</c>), re-establishing the fact the guard
+/// already proved. The negative tests pin the precision guards so a stray
+/// assertion is never emitted on an unguarded, static, or already-asserted
+/// receiver.
+/// </summary>
+public class NullableFlowForgivenessTranslationTests
+{
+    [Fact]
+    public void GuardedNullableProperty_MemberAccess_EmitsNonNullAssertion()
+    {
+        string printed = TranslateUnit(@"
+#nullable enable
+namespace Demo
+{
+    public class Inner { public int Value; }
+    public class Outer { public Inner? Child => null; }
+    public class C
+    {
+        public int F(Outer o)
+        {
+            if (o.Child == null) return 0;
+            return o.Child.Value;
+        }
+    }
+}");
+
+        Assert.Contains("o.Child!!.Value", printed);
+    }
+
+    [Fact]
+    public void GuardedNullableField_ElementAccess_EmitsNonNullAssertion()
+    {
+        string printed = TranslateUnit(@"
+#nullable enable
+namespace Demo
+{
+    public class C
+    {
+        private int[]? arr;
+        public int F()
+        {
+            if (arr == null) return 0;
+            return arr[0];
+        }
+    }
+}");
+
+        Assert.Contains("arr!![0]", printed);
+    }
+
+    [Fact]
+    public void UnguardedNullableProperty_MemberAccess_DoesNotAssert()
+    {
+        string printed = TranslateUnit(@"
+#nullable enable
+namespace Demo
+{
+    public class Inner { public int Value; }
+    public class Outer { public Inner? Child => null; }
+    public class C
+    {
+        public int F(Outer o)
+        {
+            return o.Child.Value;
+        }
+    }
+}");
+
+        // No guard means the flow state is MayBeNull, so no `!!` is emitted.
+        Assert.DoesNotContain("!!", printed);
+        Assert.Contains("o.Child.Value", printed);
+    }
+
+    [Fact]
+    public void NonNullableProperty_MemberAccess_DoesNotAssert()
+    {
+        string printed = TranslateUnit(@"
+#nullable enable
+namespace Demo
+{
+    public class Inner { public int Value; }
+    public class Outer { public Inner Child => new Inner(); }
+    public class C
+    {
+        public int F(Outer o)
+        {
+            return o.Child.Value;
+        }
+    }
+}");
+
+        // The receiver is declared non-nullable, so it never needs an assertion.
+        Assert.DoesNotContain("!!", printed);
+        Assert.Contains("o.Child.Value", printed);
+    }
+
+    [Fact]
+    public void StaticMemberAccess_DoesNotAssert()
+    {
+        string printed = TranslateUnit(@"
+#nullable enable
+namespace Demo
+{
+    public class C
+    {
+        public int F()
+        {
+            return System.Environment.ProcessId;
+        }
+    }
+}");
+
+        Assert.DoesNotContain("!!", printed);
+    }
+
+    [Fact]
+    public void AlreadyNullForgiving_MemberAccess_DoesNotDoubleAssert()
+    {
+        string printed = TranslateUnit(@"
+#nullable enable
+namespace Demo
+{
+    public class Inner { public int Value; }
+    public class Outer { public Inner? Child => null; }
+    public class C
+    {
+        public int F(Outer o)
+        {
+            return o.Child!.Value;
+        }
+    }
+}");
+
+        // The C# null-forgiving `expr!` already lowers to a single `!!`; the
+        // flow-forgiveness rule must not stack a second assertion onto it.
+        Assert.Contains("o.Child!!.Value", printed);
+        Assert.DoesNotContain("!!!", printed);
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -4174,7 +4174,7 @@ public sealed class CSharpToGSharpTranslator
                         // faithful `Slice(start, length)` / `Slice(start)` call the
                         // C# range indexer itself lowers to (ADR-0115 §B).
                         return this.TranslateRangeSlice(
-                            this.TranslateExpression(elementAccess.Expression),
+                            this.TranslateReceiverWithNullForgiveness(elementAccess.Expression),
                             sliceRange);
                     }
 
@@ -4182,7 +4182,7 @@ public sealed class CSharpToGSharpTranslator
                         ? this.TranslateExpression(elementAccess.ArgumentList.Arguments[0].Expression)
                         : new IdentifierExpression("nil");
                     return new IndexExpression(
-                        this.TranslateExpression(elementAccess.Expression),
+                        this.TranslateReceiverWithNullForgiveness(elementAccess.Expression),
                         index);
 
                 case SimpleLambdaExpressionSyntax simpleLambda:
@@ -4974,7 +4974,7 @@ public sealed class CSharpToGSharpTranslator
             // Member access on a bare-identifier element access (`values[i].M`)
             // previously hit a G# parser ambiguity (#942); that gap is now fixed,
             // so the construct translates through the normal member-access path.
-            GExpression target = this.TranslateExpression(member.Expression);
+            GExpression target = this.TranslateReceiverWithNullForgiveness(member.Expression);
             string memberName = member.Name.Identifier.Text;
 
             // A C# tuple element access (`item.Name`, `item.Price`) lowers to the
@@ -4990,6 +4990,98 @@ public sealed class CSharpToGSharpTranslator
             }
 
             return new MemberAccessExpression(target, SanitizeIdentifier(memberName));
+        }
+
+        /// <summary>
+        /// Translates a member- or element-access <paramref name="recv"/> receiver,
+        /// wrapping it in G#'s postfix non-null assertion (<c>recv!!</c>) when the
+        /// receiver is <em>declared</em> nullable (a <c>T?</c> reference type or
+        /// nullable array) yet Roslyn's nullable <em>flow</em> analysis has proven
+        /// it non-null at this site (e.g. after a guard such as
+        /// <c>if (o.Child == null) return;</c>).
+        /// </summary>
+        /// <remarks>
+        /// C# uses flow-sensitive null analysis, so a guarded nullable property or
+        /// field chain reads as non-null afterwards. G# follows Kotlin-style
+        /// smart-casts that narrow only <em>local</em> variables, never
+        /// property/field-access chains, so emitting <c>Moov.TextTrack.Mdia</c>
+        /// where <c>TextTrack</c> is <c>TrakBox?</c> is rejected with GS0158 (member
+        /// access on a <c>T?</c> receiver) or GS0116 (indexing a <c>T?</c> receiver).
+        /// Reusing Roslyn's own proof, the assertion <c>!!</c> re-establishes the
+        /// non-null fact the guard already proved (#914). The assertion is harmless
+        /// on an already-non-null receiver, but the predicate below stays precise to
+        /// keep the output faithful.
+        /// </remarks>
+        /// <param name="recv">The immediate receiver expression (left of the
+        /// <c>.</c> or <c>[</c>).</param>
+        /// <returns>The translated receiver, wrapped in
+        /// <see cref="NonNullAssertionExpression"/> when flow-proven non-null.</returns>
+        private GExpression TranslateReceiverWithNullForgiveness(ExpressionSyntax recv)
+        {
+            GExpression translated = this.TranslateExpression(recv);
+
+            if (this.ReceiverNeedsNullForgiveness(recv))
+            {
+                return new NonNullAssertionExpression(translated);
+            }
+
+            return translated;
+        }
+
+        /// <summary>
+        /// Determines whether <paramref name="recv"/> is a declared-nullable
+        /// reference receiver that Roslyn's flow analysis has narrowed to non-null,
+        /// and therefore needs a G# <c>!!</c> assertion (see
+        /// <see cref="TranslateReceiverWithNullForgiveness"/>).
+        /// </summary>
+        private bool ReceiverNeedsNullForgiveness(ExpressionSyntax recv)
+        {
+            // `expr!` already lowers to a `NonNullAssertionExpression`; never
+            // double-assert. `this`/`base`, a null literal, and a `?.` conditional
+            // access receiver are handled by their own paths and are not
+            // declared-nullable property/field chains.
+            if (recv is PostfixUnaryExpressionSyntax { RawKind: (int)SyntaxKind.SuppressNullableWarningExpression }
+                or ThisExpressionSyntax
+                or BaseExpressionSyntax
+                or LiteralExpressionSyntax
+                or ConditionalAccessExpressionSyntax)
+            {
+                return false;
+            }
+
+            // Flow analysis must have proven the receiver non-null at this site.
+            if (this.context.GetTypeInfo(recv).Nullability.FlowState != NullableFlowState.NotNull)
+            {
+                return false;
+            }
+
+            ISymbol symbol = this.context.GetSymbolInfo(recv).Symbol;
+
+            // Static member access (`Type.StaticMember`) and namespace-qualified
+            // names carry a type/namespace receiver, not a value: never assert.
+            if (symbol is ITypeSymbol or INamespaceSymbol or null)
+            {
+                return false;
+            }
+
+            // Inspect the receiver's *declared* type. The flow-collapsed
+            // `Nullability.Annotation` reports NotAnnotated once flow proves
+            // non-null, so it cannot distinguish a declared `T?` from a `T`; the
+            // declaring symbol's type is the reliable source.
+            ITypeSymbol declared = symbol switch
+            {
+                IPropertySymbol property => property.Type,
+                IFieldSymbol field => field.Type,
+                ILocalSymbol local => local.Type,
+                IParameterSymbol parameter => parameter.Type,
+                IMethodSymbol method => method.ReturnType,
+                _ => null,
+            };
+
+            // Focus on the GS0158/GS0116 cases: nullable reference types and
+            // nullable arrays. Nullable value types (`int?`) take the `.Value`/
+            // `.HasValue` path and are left untouched.
+            return declared is { IsReferenceType: true, NullableAnnotation: NullableAnnotation.Annotated };
         }
 
         private GExpression TranslateInvocation(InvocationExpressionSyntax invocation)


### PR DESCRIPTION
## Summary

C# uses flow-sensitive null analysis: after a guard such as `if (o.Child == null) return;` (or `throw`/`continue`/`break`, or an `is not T t` early-exit) a later `o.Child.Member` access reads as non-null. G# follows **Kotlin-style smart-casts that narrow only LOCAL variables, never property/field-access chains**, so the translator's emitted member/element access on a `T?` property or field chain is rejected by `gsc`:

- `error GS0158: Cannot find member <X>.` — member access on a `T?` receiver
- `error GS0116: Type '...?' is not indexable.` — element/indexer access on a `T?` receiver

This is the largest error category migrating **Oahu.Decrypt**.

## The fix

Leverage Roslyn's own nullable flow analysis to re-establish the fact the C# guard already proved. When translating a member access (`recv.Member`) or an element/indexer access (`recv[i]`), if the receiver `recv` is **declared** nullable (a `T?` reference type or nullable array) **but** Roslyn's nullable **flow state** for `recv` at that site is `NotNull`, wrap the translated receiver in G#'s postfix non-null assertion — emitting `recv!!.Member` / `recv!![i]` (the `NonNullAssertionExpression` node).

Implementation notes:

- The decision is centralized in one helper, `TranslateReceiverWithNullForgiveness`, called from the `MemberAccessExpressionSyntax` path and from the `ElementAccessExpressionSyntax` / `TranslateRangeSlice` receiver paths.
- **Flow state** comes from `GetTypeInfo(recv).Nullability.FlowState == NotNull`.
- **Declared nullability** is read from the receiver's *symbol* type (`IPropertySymbol`/`IFieldSymbol`/`ILocalSymbol`/`IParameterSymbol`/`IMethodSymbol`), **not** `Nullability.Annotation` — that property is flow-collapsed (reports `NotAnnotated` once flow proves non-null) and cannot distinguish a declared `T?` from a `T`.

## Precision guards (no stray `!!`)

Never assert when the receiver is:

- already a C# null-forgiving `expr!` (`SuppressNullableWarningExpression`) — avoids a double `!!`;
- `this` / `base`, a null literal, or any literal;
- a static / namespace-qualified member access (`Type.StaticMember`) — receiver is a type, not a value;
- a `?.` conditional-access receiver.

Nullable **value** types (`int?`) take the `.Value` / `.HasValue` path and are left untouched; only reference-type `T?` and nullable arrays (the GS0158/GS0116 cases) are asserted.

## Verification

- Solution builds clean (`0 Error(s)`).
- All cs2gs tests pass: **208** (202 baseline + 6 new). New `NullableFlowForgivenessTranslationTests` cover the guarded member-access positive (`o.Child!!.Value`), the guarded nullable-field indexer positive (`arr!![0]`), and negatives (unguarded access, non-nullable receiver, static access, already-`!` — no double `!!`).
- Standalone `gsc` repro confirms a guarded `Inner?` property accessed via `!!` compiles, and the unguarded form reproduces `GS0158`.
- **Oahu.Decrypt migration** (translate stage still passes): total compile errors **509 → 445**; **GS0158 150 → 96**; **GS0116 19 → 9**. No new error categories introduced.

Refs #914
