### PR TITLE
Fix #1147: Color Color rule + unify instance/static overloads for unqualified calls

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -226,7 +226,8 @@ public sealed class Binder
             satisfiesConstraint: SatisfiesConstraint,
             describeConstraint: DescribeConstraint,
             getCurrentFunction: () => this.function,
-            bindLambdaWithTarget: (syntax, targetType) => lambdas.BindLambdaExpression(syntax, targetType));
+            bindLambdaWithTarget: (syntax, targetType) => lambdas.BindLambdaExpression(syntax, targetType),
+            bindUserTypeStaticCall: (structSym, ce) => expressions.BindUserTypeStaticCall(structSym, ce));
         patterns = new PatternBinder(
             binderCtx,
             conversions,

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -562,6 +562,28 @@ internal sealed partial class ExpressionBinder
                 return BindBaseClassPropertyRead(basePropName, leftName.Location, explicitBaseType: null, selectorLocation: leftName.Location);
             }
 
+            // Issue #1147 (Facet A — "Color Color" + unified overload
+            // resolution): when the receiver name binds to BOTH an in-scope
+            // value AND a same-named user struct/class, and the right-hand side
+            // is a CALL to a method declared as BOTH an instance and a static
+            // (`shared`) overload, neither the value nor the type interpretation
+            // is correct on its own. Resolve the call against the COMBINED
+            // instance + static overload set (C# §12.8.7.1) and route by the
+            // selected method's IsStatic: an instance overload binds the VALUE
+            // as the receiver; a static overload binds against the TYPE. This is
+            // strictly scoped to the both-buckets-non-empty case, so a
+            // static-only member name still falls through to the #687 type path
+            // below and an instance-only name still falls through to the
+            // value/instance path — both unchanged.
+            if (variableHit != null
+                && rightPart is CallExpressionSyntax colorColorCall
+                && TryResolveColorColorType(name, leftName, out _, out var unifiedColorStruct, out _)
+                && unifiedColorStruct != null
+                && TryBindColorColorUnifiedCall(unifiedColorStruct, leftName, colorColorCall, out var unifiedColorResult))
+            {
+                return unifiedColorResult;
+            }
+
             // Issue #687 (Option A — C#-style "color color"): when an identifier
             // resolves to both a value (field/local/parameter) AND a same-named
             // type in scope, prefer the type interpretation if the right-hand
@@ -1089,6 +1111,92 @@ internal sealed partial class ExpressionBinder
     }
 
     /// <summary>
+    /// Issue #1147 (Facet A): finalizes a "Color Color" member-access CALL whose
+    /// receiver name binds to BOTH a value (an in-scope property/field/local/
+    /// parameter) and a same-named user struct/class (<paramref name="structSym"/>),
+    /// when the invoked method name is declared as BOTH an instance and a static
+    /// (<c>shared</c>) overload. The call is resolved against the unified
+    /// instance + static overload set and routed by the selected method's
+    /// <see cref="FunctionSymbol.IsStatic"/>:
+    /// <list type="bullet">
+    /// <item>instance overload → the value is bound as the receiver and the call
+    /// is dispatched as an ordinary instance call;</item>
+    /// <item>static overload → the call is bound as a static member call on the
+    /// type.</item>
+    /// </list>
+    /// Returns <see langword="false"/> (leaving <paramref name="result"/> unset)
+    /// when the method name is not declared in BOTH buckets, so the existing #687
+    /// type path (static-only) and the value/instance path (instance-only) keep
+    /// their current behavior unchanged.
+    /// </summary>
+    private bool TryBindColorColorUnifiedCall(
+        StructSymbol structSym,
+        NameExpressionSyntax leftName,
+        CallExpressionSyntax ce,
+        out BoundExpression result)
+    {
+        result = null;
+        var methodName = ce.Identifier.Text;
+
+        var instanceGroup = TypeMemberModel.GetMethods(structSym, methodName, MemberQuery.Instance(MemberKinds.Method));
+        var staticGroup = TypeMemberModel.GetMethods(structSym, methodName, MemberQuery.Static(MemberKinds.Method));
+
+        // Only intercept the genuinely-ambiguous case: the name is declared as
+        // BOTH an instance and a static overload. Otherwise defer to the existing
+        // paths so behavior is unchanged.
+        if (instanceGroup.IsDefaultOrEmpty || staticGroup.IsDefaultOrEmpty)
+        {
+            return false;
+        }
+
+        if (!overloads.TryAnalyzeCallArgumentLayout(ce.Arguments, out _, out var argumentNames))
+        {
+            result = new BoundErrorExpression(null);
+            return true;
+        }
+
+        var boundArguments = ImmutableArray.CreateBuilder<BoundExpression>(ce.Arguments.Count);
+        foreach (var argument in ce.Arguments)
+        {
+            var argSyntax = OverloadResolver.UnwrapNamedArgumentValue(argument);
+            boundArguments.Add(argSyntax is RefArgumentExpressionSyntax refArg
+                ? BindRefArgumentExpression(refArg, parameter: null)
+                : BindExpression(argSyntax));
+        }
+
+        var arguments = boundArguments.ToImmutable();
+        var unified = instanceGroup.AddRange(staticGroup);
+        var method = overloads.SelectInstanceOverloadOrReport(unified, arguments, ce, methodName, argumentNames);
+        if (method == null)
+        {
+            result = new BoundErrorExpression(null);
+            return true;
+        }
+
+        if (method.IsStatic)
+        {
+            // Static overload selected: bind as a static member call on the type
+            // (re-resolves the static group, applying optional/variadic/generic
+            // fidelity through the shared static-call finalizer).
+            result = BindUserTypeStaticCall(structSym, ce);
+            return true;
+        }
+
+        // Instance overload selected: materialize the value (property / field /
+        // local / parameter) as the receiver and dispatch the instance call with
+        // the already-bound arguments.
+        var receiver = BindNameExpression(leftName);
+        if (receiver is BoundErrorExpression)
+        {
+            result = receiver;
+            return true;
+        }
+
+        result = overloads.BindUserInstanceCall(receiver, method, arguments, ce, argumentNames);
+        return true;
+    }
+
+    /// <summary>
     /// Issue #687 (Option A): inspects the right-hand side of an accessor chain
     /// to determine whether it would bind as a static member (field, property,
     /// event, nested type, or method) of the supplied type. Used to decide
@@ -1475,7 +1583,7 @@ internal sealed partial class ExpressionBinder
         return new BoundErrorExpression(null);
     }
 
-    private BoundExpression BindUserTypeStaticCall(StructSymbol structSym, CallExpressionSyntax ce)
+    internal BoundExpression BindUserTypeStaticCall(StructSymbol structSym, CallExpressionSyntax ce)
     {
         var methodName = ce.Identifier.Text;
 

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -133,6 +133,7 @@ internal sealed class OverloadResolver
     private readonly Func<TypeParameterSymbol, string> describeConstraint;
     private readonly Func<FunctionSymbol> getCurrentFunction;
     private readonly Func<LambdaExpressionSyntax, FunctionTypeSymbol, BoundExpression> bindLambdaWithTarget;
+    private readonly Func<StructSymbol, CallExpressionSyntax, BoundExpression> bindUserTypeStaticCall;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="OverloadResolver"/>
@@ -214,6 +215,11 @@ internal sealed class OverloadResolver
     /// arrow-lambda syntax against a target <see cref="FunctionTypeSymbol"/>,
     /// used to target-type a deferred un-typed arrow-lambda argument from the
     /// resolved parameter's delegate shape. May be <see langword="null"/>.</param>
+    /// <param name="bindUserTypeStaticCall">Issue #1147: callback that finalizes
+    /// a <c>Type.Method(args)</c> static (<c>shared</c>) user call against a
+    /// resolved struct/class, used by the unqualified implicit-<c>this</c> path
+    /// when unified instance+static overload resolution selects a static sibling.
+    /// May be <see langword="null"/>.</param>
     public OverloadResolver(
         BinderContext binderCtx,
         MemberLookup memberLookup,
@@ -240,7 +246,8 @@ internal sealed class OverloadResolver
         Func<TypeSymbol, TypeParameterSymbol, bool> satisfiesConstraint,
         Func<TypeParameterSymbol, string> describeConstraint,
         Func<FunctionSymbol> getCurrentFunction,
-        Func<LambdaExpressionSyntax, FunctionTypeSymbol, BoundExpression> bindLambdaWithTarget = null)
+        Func<LambdaExpressionSyntax, FunctionTypeSymbol, BoundExpression> bindLambdaWithTarget = null,
+        Func<StructSymbol, CallExpressionSyntax, BoundExpression> bindUserTypeStaticCall = null)
     {
         this.binderCtx = binderCtx ?? throw new ArgumentNullException(nameof(binderCtx));
         this.memberLookup = memberLookup ?? throw new ArgumentNullException(nameof(memberLookup));
@@ -268,6 +275,7 @@ internal sealed class OverloadResolver
         this.describeConstraint = describeConstraint ?? throw new ArgumentNullException(nameof(describeConstraint));
         this.getCurrentFunction = getCurrentFunction ?? throw new ArgumentNullException(nameof(getCurrentFunction));
         this.bindLambdaWithTarget = bindLambdaWithTarget;
+        this.bindUserTypeStaticCall = bindUserTypeStaticCall;
     }
 
     private DiagnosticBag Diagnostics => binderCtx.Diagnostics;
@@ -487,6 +495,53 @@ internal sealed class OverloadResolver
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Issue #1147: builds the <em>unified</em> instance + static (<c>shared</c>)
+    /// method group for <paramref name="structSym"/>.<paramref name="methodName"/>
+    /// and selects the single best applicable overload across BOTH buckets,
+    /// reporting the standard ambiguity / no-applicable-overload diagnostics. This
+    /// implements C#'s combined instance+static overload resolution that both the
+    /// "Color Color" receiver-disambiguation (ECMA-334 §12.8.7.1) and an
+    /// unqualified same-named call inside an instance method reduce to. The
+    /// selected method's <see cref="FunctionSymbol.IsStatic"/> tells the caller
+    /// whether to finalize the call as an instance or a static dispatch.
+    /// </summary>
+    /// <param name="structSym">The user struct/class whose method group is searched.</param>
+    /// <param name="methodName">The invoked method name.</param>
+    /// <param name="arguments">The already-bound call arguments.</param>
+    /// <param name="ce">The originating call syntax (for diagnostic locations / type-arg arity).</param>
+    /// <param name="argumentNames">The named-argument layout, or default.</param>
+    /// <param name="hasCandidates">Set to <see langword="true"/> when the union
+    /// was non-empty. When this is <see langword="false"/> the caller should fall
+    /// through to its existing not-found path so a genuinely-undefined name still
+    /// reports GS0130.</param>
+    /// <returns>The selected overload, or <see langword="null"/> (after a
+    /// diagnostic) when the non-empty union had no applicable overload.</returns>
+    public FunctionSymbol SelectUnifiedInstanceStaticOverload(
+        StructSymbol structSym,
+        string methodName,
+        ImmutableArray<BoundExpression> arguments,
+        CallExpressionSyntax ce,
+        ImmutableArray<string> argumentNames,
+        out bool hasCandidates)
+    {
+        var instanceGroup = TypeMemberModel.GetMethods(structSym, methodName, MemberQuery.Instance(MemberKinds.Method));
+        var staticGroup = TypeMemberModel.GetMethods(structSym, methodName, MemberQuery.Static(MemberKinds.Method));
+        var unified = instanceGroup.IsDefaultOrEmpty
+            ? staticGroup
+            : staticGroup.IsDefaultOrEmpty
+                ? instanceGroup
+                : instanceGroup.AddRange(staticGroup);
+
+        hasCandidates = !unified.IsDefaultOrEmpty;
+        if (!hasCandidates)
+        {
+            return null;
+        }
+
+        return SelectInstanceOverloadOrReport(unified, arguments, ce, methodName, argumentNames);
     }
 
     private FunctionSymbol SelectBestUserOverload(
@@ -2647,13 +2702,42 @@ internal sealed class OverloadResolver
             if (getCurrentFunction()?.ThisParameter != null
                 && getCurrentFunction().ReceiverType is StructSymbol implicitReceiverStruct)
             {
-                var implicitOverloads = TypeMemberModel.GetMethods(implicitReceiverStruct, syntax.Identifier.Text, MemberQuery.Instance(MemberKinds.Method));
-                if (implicitOverloads.Length > 0)
+                // Issue #1147 (Facet B): an unqualified same-named call inside an
+                // instance method resolves against the COMBINED instance + static
+                // (`shared`) overload set of the enclosing type — mirroring C#'s
+                // unified overload resolution — instead of seeing only instance
+                // overloads. The selected method's IsStatic routes emission.
+                var implicitMethod = SelectUnifiedInstanceStaticOverload(
+                    implicitReceiverStruct,
+                    syntax.Identifier.Text,
+                    boundArguments.ToImmutable(),
+                    syntax,
+                    argumentNames,
+                    out var implicitHasCandidates);
+                if (implicitHasCandidates)
                 {
-                    var implicitMethod = SelectInstanceOverloadOrReport(implicitOverloads, boundArguments.ToImmutable(), syntax, syntax.Identifier.Text, argumentNames);
                     if (implicitMethod == null)
                     {
                         return new BoundErrorExpression(null);
+                    }
+
+                    if (implicitMethod.IsStatic)
+                    {
+                        // Resolved to a same-named static sibling: finalize as a
+                        // static user call (full optional/variadic/generic
+                        // fidelity via the shared static-call finalizer).
+                        if (bindUserTypeStaticCall != null)
+                        {
+                            return bindUserTypeStaticCall(implicitReceiverStruct, syntax);
+                        }
+
+                        var convertedSelfStaticArgs = ImmutableArray.CreateBuilder<BoundExpression>(syntax.Arguments.Count);
+                        for (var ai = 0; ai < syntax.Arguments.Count; ai++)
+                        {
+                            convertedSelfStaticArgs.Add(conversions.BindConversion(syntax.Arguments[ai].Location, boundArguments[ai], implicitMethod.Parameters[ai].Type));
+                        }
+
+                        return new BoundCallExpression(null, implicitMethod, convertedSelfStaticArgs.MoveToImmutable());
                     }
 
                     var implicitReceiver = new BoundVariableExpression(null, getCurrentFunction().ThisParameter);

--- a/test/Compiler.Tests/Emit/Issue1147ColorColorAndStaticOverloadEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1147ColorColorAndStaticOverloadEmitTests.cs
@@ -1,0 +1,212 @@
+// <copyright file="Issue1147ColorColorAndStaticOverloadEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1147: end-to-end emit + runtime validation that unified instance +
+/// static (<c>shared</c>) overload resolution selects — and runs — the correct
+/// overload for both facets:
+///
+/// <list type="bullet">
+/// <item><description>
+/// Facet A — the "Color Color" rule: a member-access receiver naming both a
+/// value and a same-named type binds the INSTANCE overload when applicable.
+/// </description></item>
+/// <item><description>
+/// Facet B — a bare unqualified call inside an instance method resolves against
+/// the combined instance + static overload set and dispatches the STATIC
+/// overload when that is the applicable one.
+/// </description></item>
+/// </list>
+///
+/// Each body returns a distinguishable sentinel so the runtime result proves
+/// which overload was selected.
+/// </summary>
+public class Issue1147ColorColorAndStaticOverloadEmitTests
+{
+    [Fact]
+    public void FacetA_ColorColor_SelectsInstanceOverload_AtRuntime()
+    {
+        var source = """
+            package p
+            import System
+            class Tag { }
+            class AppleListBox {
+                func GetTagString(name string) string? { return "instance:" + name }
+                shared {
+                    func GetTagString(tagBox Tag?) string? { return "static" }
+                }
+            }
+            class Owner {
+                prop AppleListBox AppleListBox {
+                    get { return AppleListBox() }
+                }
+                func Title() string? {
+                    return AppleListBox.GetTagString("title")
+                }
+            }
+            var o = Owner()
+            Console.WriteLine(o.Title())
+            """;
+
+        Assert.Equal("instance:title\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void FacetA_ColorColor_SelectsStaticOverload_AtRuntime()
+    {
+        // Passing a `Tag?` makes the static overload the only applicable one, so
+        // the static body must run even though the receiver is the property value.
+        var source = """
+            package p
+            import System
+            class Tag { }
+            class AppleListBox {
+                func GetTagString(name string) string? { return "instance:" + name }
+                shared {
+                    func GetTagString(tagBox Tag?) string? { return "static" }
+                }
+            }
+            class Owner {
+                prop AppleListBox AppleListBox {
+                    get { return AppleListBox() }
+                }
+                func MakeTag() Tag? { return nil }
+                func Title() string? {
+                    return AppleListBox.GetTagString(MakeTag())
+                }
+            }
+            var o = Owner()
+            Console.WriteLine(o.Title())
+            """;
+
+        Assert.Equal("static\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void FacetB_UnqualifiedCall_SelectsStaticOverload_AtRuntime()
+    {
+        // The instance `GetTagString(string)` body calls the bare unqualified
+        // `GetTagString(...)` with a `Tag?`; unified resolution must pick the
+        // static overload, so the static sentinel is returned at runtime.
+        var source = """
+            package p
+            import System
+            class Tag { }
+            class Box {
+                func GetTagString(name string) string? {
+                    return GetTagString(GetTagBox(name))
+                }
+                func GetTagBox(name string) Tag? { return nil }
+                shared {
+                    func GetTagString(tagBox Tag?) string? { return "static-overload" }
+                }
+            }
+            var b = Box()
+            Console.WriteLine(b.GetTagString("x"))
+            """;
+
+        Assert.Equal("static-overload\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void FacetB_UnqualifiedCall_SelectsInstanceOverload_AtRuntime()
+    {
+        // The same combined group with a `string` argument must run the INSTANCE
+        // overload.
+        var source = """
+            package p
+            import System
+            class Tag { }
+            class Box {
+                func Probe() string? {
+                    return GetTagString("name")
+                }
+                func GetTagString(name string) string? { return "instance:" + name }
+                shared {
+                    func GetTagString(tagBox Tag?) string? { return "static" }
+                }
+            }
+            var b = Box()
+            Console.WriteLine(b.Probe())
+            """;
+
+        Assert.Equal("instance:name\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1147_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi);
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1147ColorColorAndStaticOverloadTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1147ColorColorAndStaticOverloadTests.cs
@@ -1,0 +1,266 @@
+// <copyright file="Issue1147ColorColorAndStaticOverloadTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1147: unified instance + static (<c>shared</c>) overload resolution in
+/// two member-access scenarios.
+///
+/// <list type="bullet">
+/// <item><description>
+/// Facet A — the C# "Color Color" rule (ECMA-334 §12.8.7.1): a member-access
+/// receiver simple-name that binds to BOTH an in-scope value AND a same-named
+/// type prefers the VALUE (instance access) when an instance overload is
+/// applicable, instead of always doing static member resolution against the
+/// type.
+/// </description></item>
+/// <item><description>
+/// Facet B — a bare unqualified call inside an instance method resolves against
+/// the COMBINED instance + static overload set of the enclosing type, not only
+/// the instance overloads.
+/// </description></item>
+/// </list>
+/// </summary>
+public class Issue1147ColorColorAndStaticOverloadTests
+{
+    [Fact]
+    public void FacetA_ColorColor_InstanceOverloadApplicable_BindsInstanceCall()
+    {
+        // The receiver `AppleListBox` binds to both the property value and the
+        // same-named type. The string argument is applicable to the INSTANCE
+        // overload `GetTagString(string)`, not the static `GetTagString(Tag?)`,
+        // so the instance interpretation must win (no GS0155).
+        var source = """
+            package p
+            class Tag { }
+            class AppleListBox {
+                func GetTagString(name string) string? { return nil }
+                shared {
+                    func GetTagString(tagBox Tag?) string? { return nil }
+                }
+            }
+            class Owner {
+                prop AppleListBox AppleListBox {
+                    get { return AppleListBox() }
+                }
+                func Title() string? {
+                    return AppleListBox.GetTagString("title")
+                }
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void FacetA_ColorColor_OnlyStaticOverloadApplicable_BindsStaticCall()
+    {
+        // Same Color-Color receiver, but the argument (a `Tag?`) is applicable
+        // only to the STATIC overload `GetTagString(Tag?)`, so unified
+        // resolution must select the static overload and the call compiles.
+        var source = """
+            package p
+            class Tag { }
+            class AppleListBox {
+                func GetTagString(name string) string? { return nil }
+                shared {
+                    func GetTagString(tagBox Tag?) string? { return nil }
+                }
+            }
+            class Owner {
+                prop AppleListBox AppleListBox {
+                    get { return AppleListBox() }
+                }
+                func GetTag() Tag? { return nil }
+                func Title() string? {
+                    return AppleListBox.GetTagString(GetTag())
+                }
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void FacetA_ColorColor_InstanceOnlyMethod_StillBindsInstance()
+    {
+        // The method exists ONLY as an instance overload (no `shared` sibling).
+        // The Color-Color receiver must keep binding the value/instance call.
+        var source = """
+            package p
+            class AppleListBox {
+                func GetTagString(name string) string? { return nil }
+            }
+            class Owner {
+                prop AppleListBox AppleListBox {
+                    get { return AppleListBox() }
+                }
+                func Title() string? {
+                    return AppleListBox.GetTagString("title")
+                }
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void FacetB_UnqualifiedCall_SelectsStaticOverload()
+    {
+        // The bare unqualified call `GetTagString(GetTagBox(name))` passes a
+        // `Tag?` which is applicable only to the static overload. Unified
+        // instance + static resolution must select the static one (no GS0155).
+        var source = """
+            package p
+            class Tag { }
+            class Box {
+                func GetTagString(name string) string? {
+                    return GetTagString(GetTagBox(name))
+                }
+                func GetTagBox(name string) Tag? { return nil }
+                shared {
+                    func GetTagString(tagBox Tag?) string? { return nil }
+                }
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void FacetB_UnqualifiedCall_SelectsInstanceOverload()
+    {
+        // The same combined group, but a `string` argument is applicable only to
+        // the instance overload — it must still bind the instance call.
+        var source = """
+            package p
+            class Tag { }
+            class Box {
+                func Probe() string? {
+                    return GetTagString("name")
+                }
+                func GetTagString(name string) string? { return nil }
+                shared {
+                    func GetTagString(tagBox Tag?) string? { return nil }
+                }
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void FacetB_UnqualifiedCall_StaticOnlySibling_Resolves()
+    {
+        // A bare unqualified call inside an instance method that names a method
+        // declared ONLY as a `shared` sibling resolves against the static
+        // overload (mirrors C# resolving the combined set).
+        var source = """
+            package p
+            class Box {
+                func Probe() string? {
+                    return Helper("x")
+                }
+                shared {
+                    func Helper(name string) string? { return nil }
+                }
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void Guardrail_StaticNotReachableThroughOrdinaryInstance()
+    {
+        // `box` is an ordinary parameter whose name is NOT also a type, so the
+        // Color-Color rule does not apply. The static overload
+        // `GetTagString(Tag?)` must remain unreachable: the only candidate is the
+        // instance `GetTagString(string)`, so passing a `Tag?` fails to convert.
+        var source = """
+            package p
+            class Tag { }
+            class AppleListBox {
+                func GetTagString(name string) string? { return nil }
+                shared {
+                    func GetTagString(tagBox Tag?) string? { return nil }
+                }
+            }
+            class Owner {
+                func GetTag() Tag? { return nil }
+                func Title(box AppleListBox) string? {
+                    return box.GetTagString(GetTag())
+                }
+            }
+            """;
+
+        var diagnostics = Bind(source);
+        Assert.Contains(diagnostics, d => d.Message.Contains("Tag?") || d.Message.Contains("Tag"));
+    }
+
+    [Fact]
+    public void Guardrail_UndefinedUnqualifiedName_ReportsUndefinedFunction()
+    {
+        var source = """
+            package p
+            class Box {
+                func M() string? {
+                    return TotallyUndefined("x")
+                }
+            }
+            """;
+
+        var diagnostics = Bind(source);
+        Assert.Contains(diagnostics, d => d.Message.Contains("TotallyUndefined"));
+    }
+
+    [Fact]
+    public void Guardrail_UnqualifiedCall_ArgMatchesNeitherOverload_Errors()
+    {
+        // The argument `42` is applicable to neither the instance
+        // `GetTagString(string)` nor the static `GetTagString(Tag?)` overload —
+        // the call must be rejected, never silently mis-bound.
+        var source = """
+            package p
+            class Tag { }
+            class Box {
+                func GetTagString(name string) string? {
+                    return GetTagString(42)
+                }
+                shared {
+                    func GetTagString(tagBox Tag?) string? { return nil }
+                }
+            }
+            """;
+
+        Assert.NotEmpty(Bind(source));
+    }
+
+    private static ImmutableArray<Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        if (tree.Diagnostics.Any())
+        {
+            return tree.Diagnostics;
+        }
+
+        var globalScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+        if (globalScope.Diagnostics.Any())
+        {
+            return globalScope.Diagnostics;
+        }
+
+        var program = Binder.BindProgram(globalScope);
+        return program.Diagnostics.ToImmutableArray();
+    }
+}


### PR DESCRIPTION
Fixes #1147

Both facets reduce to **unified instance + static (`shared`) overload resolution** applied in two narrowly-scoped member-access binding sites. In each, the candidate set is the union of the type's instance methods and its same-named static methods; the existing overload selector runs once over the bound arguments, and emission is routed by whether the selected `FunctionSymbol.IsStatic`.

## Facet A — "Color Color" rule (ECMA-334 §12.8.7.1)
When a member-access receiver simple-name binds to **both** an in-scope value (property/field/local/parameter) **and** a same-named user struct/class, and the RHS is a **call** to a method declared as **both** an instance and a static overload, gsc previously committed to the **type** (static) interpretation whenever a static member of that name existed — rejecting an applicable instance overload (`GS0155`).

It now resolves the call against the combined instance+static set and routes by `IsStatic`:
- instance selected → the **value** is bound as the receiver (instance call);
- static selected → the call binds against the **type**.

Strictly scoped to the *both-buckets-non-empty* user-struct call case, so:
- **static-only** member names still take the existing #687 type path (unchanged);
- **instance-only** names still take the value/instance path (unchanged);
- imported-class and enum Color-Color paths are untouched (still gated by `RightPartLooksLikeStaticMember`).

## Facet B — unqualified call ignores same-named `shared` overloads
A bare unqualified call `Method(args)` inside an instance method only considered instance overloads. It now resolves against the **combined** instance + static overload set of the enclosing type; a selected static sibling is finalized through the shared static-call binder (full optional/variadic/generic fidelity).

## Design
- New `OverloadResolver.SelectUnifiedInstanceStaticOverload(structSym, name, args, ce, argumentNames, out hasCandidates)` builds the union method group via the ADR-0112 `TypeMemberModel` layer (`MemberQuery.Instance` ∪ `MemberQuery.Static`) and selects the best applicable overload with `SelectInstanceOverloadOrReport` (same GS0144/ambiguity/no-applicable diagnostics as instance methods). `hasCandidates=false` (empty union) lets the caller fall through to its not-found path.
- **Facet B site** (`OverloadResolver.BindCallExpression`, implicit-`this` branch): uses the unified selector; instance → existing `BindUserInstanceCall(this, …)`, static → a new `bindUserTypeStaticCall` delegate (wired to `ExpressionBinder.BindUserTypeStaticCall`) with an inline fixed-arity conversion fallback.
- **Facet A site** (`ExpressionBinder.Access.BindAccessorExpression`): new `TryBindColorColorUnifiedCall` fires only when both buckets are non-empty; instance → `BindNameExpression` materializes the value receiver + `BindUserInstanceCall` with the already-bound args, static → `BindUserTypeStaticCall`.

## Guardrails (all covered by tests)
- A static method is **still unreachable** through an ordinary (non-Color-Color) instance reference — the Facet A change is gated on the receiver name also naming a type. Proven by `Guardrail_StaticNotReachableThroughOrdinaryInstance`.
- Genuinely-undefined unqualified names still report **GS0130** (`Guardrail_UndefinedUnqualifiedName_ReportsUndefinedFunction`).
- A unqualified call whose argument matches neither bucket is still rejected, never silently mis-bound (`Guardrail_UnqualifiedCall_ArgMatchesNeitherOverload_Errors`).
- **#687 preserved**: `Issue687ColorColorTypeShadowingTests` (Core, 11) and `Issue687ColorColorEmitTests` (Compiler, 3) pass unchanged.

## Tests
- `test/Core.Tests/CodeAnalysis/Binding/Issue1147ColorColorAndStaticOverloadTests.cs` (9): Facet A instance/static/instance-only; Facet B static/instance/static-only; three guardrails.
- `test/Compiler.Tests/Emit/Issue1147ColorColorAndStaticOverloadEmitTests.cs` (4): emit + IL-verify + run, asserting the runtime sentinel proves the selected overload for both facets (instance vs static).

## Coverage matrix
Reuses existing call/accessor binding — no new `SyntaxKind`/`BoundNodeKind`; CoverageMatrix golden test passes unchanged.

## Verification
- Build clean (Release).
- Both standalone repros now compile (`Wrote …dll`, exit 0).
- Issue1147 Core (9) + Compiler (4) green; Issue687 Core (11) + Compiler (3) green; full Core suite (3966) green; Compiler `~Overload` (49), `~Static` (80), Core `~ColorColor/Overload/Call/Static/Interface/Member/Shared/Implicit/CoverageMatrix` all green.
