### PR TITLE
cs2gs: render null-checked reference params/fields as T? (#1072)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue1072NullCheckedAsNullableTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1072NullCheckedAsNullableTranslationTests.cs
@@ -1,0 +1,193 @@
+// <copyright file="Issue1072NullCheckedAsNullableTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Translator-fidelity tests for issue #1072: G# follows Kotlin-style nullability
+/// safety, so a `nil` comparison or `nil` assignment is only legal on a nullable
+/// type. A C# parameter/field/local DECLARED non-nullable (`T`) but defensively
+/// compared against <c>null</c> (<c>== null</c> / <c>!= null</c>) or assigned
+/// <c>null</c> / <c>null!</c> is in truth nullable, so the faithful G# rendering of
+/// its type clause is the nullable <c>T?</c> (otherwise gsc rejects the guard with
+/// <c>GS0129</c>). The negative tests pin the precision guard so a parameter/field
+/// that is never null-checked nor null-assigned keeps its non-nullable type.
+/// </summary>
+public class Issue1072NullCheckedAsNullableTranslationTests
+{
+    [Fact]
+    public void NullCheckedReferenceParameter_RendersNullableType()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public void F(string s)
+        {
+            if (s == null) throw new System.ArgumentException(""s"");
+            System.Console.WriteLine(s.Length);
+        }
+    }
+}");
+
+        Assert.Contains("F(s string?)", printed);
+    }
+
+    [Fact]
+    public void NullCheckedArrayParameter_RendersNullableType()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public C(byte[] key)
+        {
+            if (key == null || key.Length != 16) throw new System.ArgumentException(""key"");
+        }
+    }
+}");
+
+        Assert.Contains("key []uint8?", printed);
+    }
+
+    [Fact]
+    public void IsNullPatternCheckedArrayParameter_RendersNullableType()
+    {
+        // `key is null` (constant pattern) is the C# pattern form of a null
+        // comparison; it must promote the parameter to nullable just like `==`.
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public C(byte[] iv)
+        {
+            if (iv is null || iv.Length != 16) throw new System.ArgumentException(""iv"");
+        }
+    }
+}");
+
+        Assert.Contains("iv []uint8?", printed);
+    }
+
+    [Fact]
+    public void NullAssignedReferenceField_RendersNullableType()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        private string name = null!;
+        public void Reset() { name = null!; }
+    }
+}");
+
+        Assert.Contains("name string?", printed);
+    }
+
+    [Fact]
+    public void NullComparedReferenceField_RendersNullableType()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        private object box = new object();
+        public bool HasBox() => box != null;
+    }
+}");
+
+        Assert.Contains("box object?", printed);
+    }
+
+    [Fact]
+    public void NeverNullCheckedReferenceParameter_StaysNonNullable()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public int F(string s)
+        {
+            return s.Length;
+        }
+    }
+}");
+
+        Assert.Contains("F(s string)", printed);
+        Assert.DoesNotContain("s string?", printed);
+    }
+
+    [Fact]
+    public void NeverNullCheckedReferenceField_StaysNonNullable()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        private string name = ""x"";
+        public int Len() => name.Length;
+    }
+}");
+
+        Assert.Contains("name string", printed);
+        Assert.DoesNotContain("name string?", printed);
+    }
+
+    [Fact]
+    public void NullCheckedValueParameter_StaysNonNullable()
+    {
+        // Value types are out of scope for this pass: an `int` compared to null is
+        // a C# nullable-value scenario handled elsewhere, not a reference promotion.
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public void F(int x)
+        {
+            System.Console.WriteLine(x);
+        }
+    }
+}");
+
+        Assert.Contains("F(x int32)", printed);
+        Assert.DoesNotContain("x int32?", printed);
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -1487,6 +1487,14 @@ public sealed class CSharpToGSharpTranslator
                     ? this.typeMapper.Map(symbol.Type, this.context, declarator.GetLocation())
                     : new NamedTypeReference(CSharpTypeMapper.UnsupportedPlaceholderType);
 
+                // Issue #1072: a non-nullable reference/array field that is
+                // null-checked or null-assigned anywhere in the declaring type is
+                // really nullable; render it `T?` so the `== nil` guard type-checks.
+                if (symbol != null)
+                {
+                    type = this.PromoteIfUsedAsNullable(type, symbol);
+                }
+
                 // T2: a field initializer (ADR-0115 §B.3) comes either from a
                 // constructor assignment independent of the constructor parameters
                 // (lifted out of the dropped `init`) or from a C# field initializer.
@@ -2253,6 +2261,15 @@ public sealed class CSharpToGSharpTranslator
 
             GTypeReference type = this.typeMapper.Map(parameterType, this.context, symbol.Locations.FirstOrDefault());
 
+            // Issue #1072: a non-nullable reference/array parameter that is
+            // null-checked or null-assigned in the method body is really nullable;
+            // render it `T?` so the `== nil` guard type-checks (variadic params are
+            // never null-compared as a whole, so they are excluded).
+            if (!variadic)
+            {
+                type = this.PromoteIfUsedAsNullable(type, symbol);
+            }
+
             GExpression defaultValue = null;
             if (symbol.HasExplicitDefaultValue)
             {
@@ -2814,6 +2831,13 @@ public sealed class CSharpToGSharpTranslator
                     type = typeSymbol != null
                         ? this.typeMapper.Map(typeSymbol, this.context, declaration.Type.GetLocation())
                         : null;
+
+                    // Issue #1072: a non-nullable reference/array local that is
+                    // null-checked or null-assigned in its scope is really nullable.
+                    if (this.context.GetDeclaredSymbol(declarator) is ILocalSymbol localSymbol)
+                    {
+                        type = this.PromoteIfUsedAsNullable(type, localSymbol);
+                    }
                 }
 
                 // `let r = x ?? throw E` → evaluate x once, throw when nil, then
@@ -4088,6 +4112,163 @@ public sealed class CSharpToGSharpTranslator
             return false;
         }
 
+        // Issue #1072: G# follows Kotlin-style nullability, so `nil`-safety is
+        // enforced by the static type, not by a `!!`-on-`nil` escape hatch. A C#
+        // symbol DECLARED non-nullable (`T`) but defensively compared against
+        // `null` (`== null` / `!= null`) or assigned `null` / `null!` is, in
+        // truth, nullable: faithfully it must render `T?` so the `== nil`/`!= nil`
+        // guard type-checks (gsc only permits `== nil` on a nullable operand,
+        // otherwise GS0129). Returns true when <paramref name="symbol"/> is used
+        // that way anywhere in <paramref name="scope"/>.
+        private bool IsUsedAsNullable(ISymbol symbol, SyntaxNode scope)
+        {
+            if (symbol == null || scope == null)
+            {
+                return false;
+            }
+
+            // The scope is scanned with the current document's semantic model, so a
+            // node from another syntax tree (e.g. an inherited field declared in a
+            // different file) cannot be queried here — `GetSymbolInfo` would throw
+            // "Syntax node is not within syntax tree". Such a symbol is promoted (if
+            // applicable) while its own document is translated; skip it here.
+            if (scope.SyntaxTree != this.context.SemanticModel.SyntaxTree)
+            {
+                return false;
+            }
+
+            foreach (SyntaxNode node in scope.DescendantNodes())
+            {
+                switch (node)
+                {
+                    case BinaryExpressionSyntax binary
+                        when binary.IsKind(SyntaxKind.EqualsExpression)
+                            || binary.IsKind(SyntaxKind.NotEqualsExpression):
+                        if ((IsNullLiteral(binary.Right) && this.BindsTo(binary.Left, symbol))
+                            || (IsNullLiteral(binary.Left) && this.BindsTo(binary.Right, symbol)))
+                        {
+                            return true;
+                        }
+
+                        break;
+
+                    case AssignmentExpressionSyntax assignment
+                        when assignment.IsKind(SyntaxKind.SimpleAssignmentExpression)
+                            && this.BindsTo(assignment.Left, symbol)
+                            && IsNullOrSuppressedNull(assignment.Right):
+                        return true;
+
+                    case IsPatternExpressionSyntax isPattern
+                        when this.BindsTo(isPattern.Expression, symbol)
+                            && IsNullConstantPattern(isPattern.Pattern):
+                        return true;
+
+                    case VariableDeclaratorSyntax declarator
+                        when declarator.Initializer != null
+                            && IsNullOrSuppressedNull(declarator.Initializer.Value)
+                            && SymbolEqualityComparer.Default.Equals(
+                                this.context.GetDeclaredSymbol(declarator), symbol):
+                        return true;
+                }
+            }
+
+            return false;
+        }
+
+        // Promotes <paramref name="type"/> to its nullable (`T?`) form when the
+        // symbol it renders is declared as a non-nullable reference/array type yet
+        // is used as nullable in its scope (issue #1072). Value types and
+        // already-nullable types are left untouched: this pass only covers
+        // reference-type/array null-comparison and null-assignment.
+        private GTypeReference PromoteIfUsedAsNullable(GTypeReference type, ISymbol symbol)
+        {
+            if (type == null || type.IsNullable)
+            {
+                return type;
+            }
+
+            return this.IsPromotedToNullableReference(symbol) ? MakeNullable(type) : type;
+        }
+
+        // Issue #1072: true when <paramref name="symbol"/> is a parameter/field/local
+        // whose DECLARED type is a non-nullable reference (or array) but which is
+        // null-checked or null-assigned in its scope, so the translator renders it
+        // `T?`. This is the single source of truth shared by the type-rendering paths
+        // (param/field/local) and the `!!` non-null-assertion pass
+        // (<see cref="ReceiverNeedsNullForgiveness"/>) so a promoted receiver still
+        // gets its flow-proven `recv!!.Member` assertion.
+        private bool IsPromotedToNullableReference(ISymbol symbol)
+        {
+            ITypeSymbol declared = symbol switch
+            {
+                IFieldSymbol f => f.Type,
+                ILocalSymbol l => l.Type,
+                IParameterSymbol p => p.Type,
+                _ => null,
+            };
+
+            if (declared is not { IsReferenceType: true }
+                || declared.NullableAnnotation == NullableAnnotation.Annotated)
+            {
+                return false;
+            }
+
+            return this.IsUsedAsNullable(symbol, this.GetNullabilityScope(symbol));
+        }
+
+        // The syntax region a symbol's null usage is searched in: the whole
+        // enclosing method for a parameter, the whole declaring type for a field,
+        // and the enclosing method body block for a local.
+        private SyntaxNode GetNullabilityScope(ISymbol symbol)
+        {
+            switch (symbol)
+            {
+                case IParameterSymbol parameter:
+                    return parameter.ContainingSymbol?
+                        .DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax();
+
+                case IFieldSymbol field:
+                    return field.ContainingType?
+                        .DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax();
+
+                case ILocalSymbol local:
+                    SyntaxNode declaration = local
+                        .DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax();
+                    return declaration?.Ancestors().LastOrDefault(a => a is BlockSyntax);
+
+                default:
+                    return null;
+            }
+        }
+
+        // `x is null` / `x is not null` constant pattern (the C# pattern form of a
+        // null comparison, which the translator lowers to `== nil` / `!= nil`).
+        private static bool IsNullConstantPattern(PatternSyntax pattern)
+        {
+            if (pattern is UnaryPatternSyntax unary && unary.IsKind(SyntaxKind.NotPattern))
+            {
+                pattern = unary.Pattern;
+            }
+
+            return pattern is ConstantPatternSyntax constant && IsNullLiteral(constant.Expression);
+        }
+
+        private static bool IsNullLiteral(ExpressionSyntax expression) =>
+            expression is LiteralExpressionSyntax literal
+                && literal.IsKind(SyntaxKind.NullLiteralExpression);
+
+        // `null` or `null!` (a SuppressNullableWarning over a null literal).
+        private static bool IsNullOrSuppressedNull(ExpressionSyntax expression)
+        {
+            if (expression is PostfixUnaryExpressionSyntax suppress
+                && suppress.IsKind(SyntaxKind.SuppressNullableWarningExpression))
+            {
+                expression = suppress.Operand;
+            }
+
+            return IsNullLiteral(expression);
+        }
+
         private GExpression TranslateExpression(ExpressionSyntax expression)
         {
             switch (expression)
@@ -5081,7 +5262,17 @@ public sealed class CSharpToGSharpTranslator
             // Focus on the GS0158/GS0116 cases: nullable reference types and
             // nullable arrays. Nullable value types (`int?`) take the `.Value`/
             // `.HasValue` path and are left untouched.
-            return declared is { IsReferenceType: true, NullableAnnotation: NullableAnnotation.Annotated };
+            if (declared is not { IsReferenceType: true })
+            {
+                return false;
+            }
+
+            // A declared-nullable receiver (`T?`) flow-proven non-null needs `!!`.
+            // A declared non-null receiver that this pass PROMOTED to `T?`
+            // (issue #1072: null-checked param/field/local) is rendered nullable
+            // too, so its flow-proven uses need the same assertion for consistency.
+            return declared.NullableAnnotation == NullableAnnotation.Annotated
+                || this.IsPromotedToNullableReference(symbol);
         }
 
         private GExpression TranslateInvocation(InvocationExpressionSyntax invocation)


### PR DESCRIPTION
## What

Per the issue #1072 guidance, **G# follows Kotlin-style nullability safety**, so
`nil!!` is not a substitute for a correct static type: `== nil` / `!= nil` is only
defined on a *nullable* operand. A C# parameter/field/local DECLARED non-nullable
(`T`) but actually **used as nullable** — defensively compared against `null`
(`== null` / `!= null`, including the `is null` / `is not null` pattern forms), or
assigned `null` / `null!` — must be rendered as the nullable G# type `T?`, not `T`.
Otherwise gsc rejects the defensive guard with `GS0129: Binary operator '=='/'!=' is
not defined for types '<T>' and 'nil'`.

## How

- New `IsUsedAsNullable(ISymbol, scope)` scans the symbol's scope for: a `== null` /
  `!= null` binary comparison, an `is null` / `is not null` constant pattern, a
  simple assignment of `null` / `null!`, or a variable initializer of `null` /
  `null!` that binds to the symbol (reusing the existing `BindsTo` helper).
- `IsPromotedToNullableReference(ISymbol)` is the single source of truth: it
  restricts promotion to **reference types and arrays** whose declared
  `NullableAnnotation` is not already `Annotated` (value types and already-`T?`
  symbols are left untouched), then defers to `IsUsedAsNullable`.
- The parameter (`MapParameter`), field (`TranslateField`), and explicit-type local
  (`TranslateLocalDeclaration`) type-rendering paths call `MakeNullable` when the
  predicate holds.

### Interaction with the FlowState `!!` pass

The just-merged `TranslateReceiverWithNullForgiveness` pass emits `recv!!.Member`
where Roslyn flow-proves a *declared-nullable* receiver non-null. Promoting a
declared **non-null** symbol to `T?` makes its declared annotation `NotAnnotated`,
so that pass would not fire and `key.Length` on a promoted `key` would become
`GS0158`. `ReceiverNeedsNullForgiveness` now also fires for symbols this pass
promotes, so a promoted `key` correctly emits `key!!.Length` — consistent with the
`if (key is null) throw` guard that already proved it non-null.

### Precision guards

- Only reference types / arrays are promoted; value types are out of scope.
- Symbols already declared `T?` are left alone (no double promotion).
- Cross-syntax-tree symbols (e.g. an inherited field declared in another file) are
  skipped in the scope scan to avoid Roslyn's "Syntax node is not within syntax
  tree" — such a symbol is promoted while its own document is translated.

## Decrypt corpus (before → after)

- Total gsc errors: **417 → 414** (net **−3**); translate stage still **passes**.
- `[]uint8 == nil` `GS0129`: **7 → 1**; targeted `==`/`!= nil` GS0129 count dropped.
- The faithful `T?` promotion of overloaded `SetDecryptionKey(byte[] …)` params
  surfaces a *separate* gsc nullable-overload-resolution quirk (`GS0266` ambiguous,
  +3) plus +1 conversion; these are outweighed by the `nil`-guard fixes, so the net
  is a reduction. The remaining `nil` cases are inferred `var` locals initialised
  from nullable-returning methods (`let x = GetChild[T]()`), which carry no explicit
  type clause and are a distinct concern from declared non-nullable symbols.

Refs #914, Refs #1072
