### PR TITLE
cs2gs: honor nullable annotation on type-parameter types (T?) (#1072)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue1072NullCheckedAsNullableTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1072NullCheckedAsNullableTranslationTests.cs
@@ -170,6 +170,27 @@ namespace Demo
         Assert.DoesNotContain("x int32?", printed);
     }
 
+    [Fact]
+    public void NullableTypeParameterReturn_RendersNullableType()
+    {
+        // A `T?` return on a method whose type parameter is interface-constrained
+        // (`where T : IBox`) reports `IsReferenceType == false` in Roslyn, so the
+        // `?` must be honoured via the type-parameter path or it is silently
+        // dropped and `let x = GetChild<T>()` infers a non-nullable `T`, breaking
+        // the subsequent `x == nil` guard at the call site (issue #1072 cascade).
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public interface IBox { }
+    public class Box : IBox
+    {
+        public T? GetChild<T>() where T : IBox => default;
+    }
+}");
+
+        Assert.Contains("GetChild[T IBox]() T?", printed);
+    }
+
     private static string TranslateUnit(string source)
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
@@ -101,7 +101,16 @@ public sealed class CSharpTypeMapper
             return WithNullable(underlying, true);
         }
 
-        bool nullableReference = type.NullableAnnotation == NullableAnnotation.Annotated && type.IsReferenceType;
+        // A `T?`-annotated type also covers an annotated type parameter (`T?`
+        // where `T : IFoo` / unconstrained). Such a parameter reports
+        // `IsReferenceType == false` (an interface/unconstrained type parameter is
+        // not provably a reference type), so it must be recognised explicitly or
+        // the `?` is silently dropped and the nullable return/field no longer
+        // type-checks against `== nil`. A `T : struct` parameter's `T?` is modelled
+        // by Roslyn as `Nullable<T>` and is handled above, so an annotated
+        // ITypeParameterSymbol here is always the nullable-reference-like form.
+        bool nullableReference = type.NullableAnnotation == NullableAnnotation.Annotated
+            && (type.IsReferenceType || type is ITypeParameterSymbol);
         GTypeReference mapped = this.MapCore(type, context, location);
         return nullableReference ? WithNullable(mapped, true) : mapped;
     }


### PR DESCRIPTION
## What

Honor the nullable annotation on a **type-parameter** type (`T?`) when mapping C# types to G#. Previously `CSharpTypeMapper.Map` gated nullability on `type.IsReferenceType`, which is `false` for an interface-constrained or unconstrained type parameter (Roslyn cannot prove such a `T` is a reference type). As a result a C# `T? GetChild<T>() where T : IBox` was rendered as G# `func GetChild[T IBox]() T` — the `?` was silently dropped.

## Why it matters (Oahu / #1072 cascade)

`Box.GetChild<T>()` / `BaseDescriptor.GetChild<T>()` genuinely return `T?`. With the `?` dropped, `let x = box.GetChild[MvexBox]()` inferred a non-nullable `MvexBox`, so the faithful `if x != nil { … }` guard failed to type-check (`GS0129: '!=' is not defined for types 'MvexBox' and 'nil'`), and downstream member accesses cascaded. This is the root of a broad nullability cascade in `Oahu.Decrypt`.

A `T : struct` parameter's `T?` is modelled by Roslyn as `Nullable<T>` and is already handled earlier in `Map`, so an annotated `ITypeParameterSymbol` reaching this point is always the nullable-reference-like form — making the fix safe.

## Change

`tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs`: extend the nullable-reference predicate to also fire for `type is ITypeParameterSymbol` when `NullableAnnotation == Annotated`. The existing `WithNullable` already carries the flag onto the `NamedTypeReference` that a type parameter maps to. Interacts correctly with the merged flow-`!!` pass (#1148): a now-`T?` local that is guarded gets `x!!.Member` at flow-proven-non-null sites.

## Verification

- Build: 0 errors.
- cs2gs tests: **216 pass** (+1 new `NullableTypeParameterReturn_RendersNullableType`, asserting `GetChild[T IBox]() T?`).
- Standalone gsc: `func GetChild[T IBox]() T?` + `let x = GetChild[Box]()` + `if x == nil { return }` + `x!!` compiles (`Wrote x.dll`).
- **Oahu.Decrypt: 396 → 392** (net −4); the `MvexBox`/`BtrtBox` `!= nil`/`== nil` `GS0129` errors are gone; translate stage still PASS. The residual movement in `GS0159` is downstream LINQ-on-nullable-receiver, tracked by the open integer-widening / overload issues (#1150) and unrelated to this mapping fix.

Refs #914, Refs #1072
