### PR TITLE
cs2gs: render block-bodied lambdas as func literals (#914)

### DIFF
--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/GExpression.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/GExpression.cs
@@ -530,8 +530,11 @@ public sealed class ParenthesizedExpression : GExpression
 }
 
 /// <summary>
-/// An arrow lambda <c>(x int32) -&gt; body</c> (ADR-0074). The body is either
-/// a single expression or a brace-delimited block.
+/// A lambda (ADR-0074). An expression body renders as the arrow form
+/// <c>(x int32) -&gt; expr</c> (an expression-block); a block body renders as the
+/// function-literal form <c>func (x int32) RetType { … }</c> (a statement-block),
+/// which handles control flow and supplies an explicit <see cref="ReturnType"/> for
+/// value-returning literals.
 /// </summary>
 public sealed class LambdaExpression : GExpression
 {
@@ -542,16 +545,25 @@ public sealed class LambdaExpression : GExpression
     /// <param name="expressionBody">The single-expression body, when present.</param>
     /// <param name="blockBody">The block body, when present.</param>
     /// <param name="isAsync">Whether the lambda is asynchronous.</param>
+    /// <param name="returnType">
+    /// The explicit return type for a block (func-literal) body, or
+    /// <see langword="null"/> when the block returns no value (void) or the body is
+    /// an expression. A block-bodied lambda renders as the G# function-literal form
+    /// <c>func (params) RetType { … }</c>; the return type is required so a
+    /// value-returning literal is not inferred as <c>void</c>.
+    /// </param>
     public LambdaExpression(
         IReadOnlyList<Parameter> parameters,
         GExpression expressionBody = null,
         BlockStatement blockBody = null,
-        bool isAsync = false)
+        bool isAsync = false,
+        GTypeReference returnType = null)
     {
         Parameters = parameters ?? new List<Parameter>();
         ExpressionBody = expressionBody;
         BlockBody = blockBody;
         IsAsync = isAsync;
+        ReturnType = returnType;
     }
 
     /// <summary>Gets the lambda parameters.</summary>
@@ -565,6 +577,12 @@ public sealed class LambdaExpression : GExpression
 
     /// <summary>Gets a value indicating whether the lambda is asynchronous.</summary>
     public bool IsAsync { get; }
+
+    /// <summary>
+    /// Gets the explicit return type for a block (func-literal) body, or
+    /// <see langword="null"/> when the block is void or the body is an expression.
+    /// </summary>
+    public GTypeReference ReturnType { get; }
 }
 
 /// <summary>

--- a/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
@@ -537,8 +537,16 @@ public static class GSharpPrinter
 
         if (lambda.BlockBody != null)
         {
+            // A block body is a STATEMENT block, so it must render as the G#
+            // function-literal form `func (params) RetType { … }` rather than the
+            // arrow form `(params) -> { … }` (whose body is an expression-block).
+            // The explicit return type is required for value-returning literals so
+            // they are not inferred as void; a void block omits it.
+            var retClause = lambda.ReturnType != null
+                ? " " + RenderTypeReference(lambda.ReturnType)
+                : string.Empty;
             var sb = new StringBuilder();
-            sb.Append($"{asyncPrefix}({parameters}) -> {{");
+            sb.Append($"{asyncPrefix}func ({parameters}){retClause} {{");
             foreach (var statement in lambda.BlockBody.Statements)
             {
                 sb.Append('\n');

--- a/tools/cs2gs/Cs2Gs.Tests/BlockLambdaFuncLiteralTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/BlockLambdaFuncLiteralTranslationTests.cs
@@ -1,0 +1,133 @@
+// <copyright file="BlockLambdaFuncLiteralTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Translator-fidelity tests (refs #914): a block-bodied C# lambda
+/// must render as the G# function-literal form <c>func (params) RetType { … }</c>
+/// (a STATEMENT block), not the arrow form <c>(params) -&gt; { … }</c> (whose body
+/// is an EXPRESSION-block). The arrow body misbinds control-flow statements — a
+/// non-trailing <c>if</c> without <c>else</c> is rejected by gsc as a value-position
+/// if (<c>GS0276</c>). A value-returning literal also needs an EXPLICIT return type,
+/// otherwise the literal is inferred void and <c>return expr</c> fails (<c>GS0122</c>);
+/// a void (Action) lambda omits the return type. Expression-bodied lambdas stay arrow.
+/// </summary>
+public class BlockLambdaFuncLiteralTranslationTests
+{
+    [Fact]
+    public void VoidBlockLambda_WithIfWithoutElse_RendersFuncLiteralWithoutReturnType()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    using System;
+
+    public class C
+    {
+        public void F()
+        {
+            Action<int> g = d =>
+            {
+                if (d > 0)
+                {
+                    H(d);
+                }
+
+                H(d);
+            };
+            g(1);
+        }
+
+        private void H(int x)
+        {
+        }
+    }
+}");
+
+        Assert.Contains("func (d int32) {", printed);
+        Assert.DoesNotContain("(d int32) -> {", printed);
+    }
+
+    [Fact]
+    public void ValueReturningBlockLambda_RendersFuncLiteralWithReturnType()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    using System;
+
+    public class C
+    {
+        public int F()
+        {
+            Func<int, int> f = x =>
+            {
+                if (x > 0)
+                {
+                    return x + 1;
+                }
+
+                return 0;
+            };
+            return f(1);
+        }
+    }
+}");
+
+        Assert.Contains("func (x int32) int32 {", printed);
+        Assert.DoesNotContain("(x int32) -> {", printed);
+    }
+
+    [Fact]
+    public void ExpressionBodiedLambda_StaysArrow()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    using System;
+
+    public class C
+    {
+        public int F()
+        {
+            Func<int, int> f = x => x + 1;
+            return f(1);
+        }
+    }
+}");
+
+        Assert.Contains("(x int32) -> x + 1", printed);
+        Assert.DoesNotContain("func (x int32)", printed);
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -3578,21 +3578,30 @@ public sealed class CSharpToGSharpTranslator
 
             bool isAsync = localFunction.Modifiers.Any(m => m.IsKind(SyntaxKind.AsyncKeyword));
 
+            // A local function renders as a `func` literal too, so a value-returning
+            // one needs an explicit return type (else the literal is inferred void
+            // and `return expr` is rejected). The declared symbol carries the real
+            // return type / void-ness; the async unwrap mirrors method `func`s.
+            GTypeReference returnType = this.context.GetDeclaredSymbol(localFunction) is IMethodSymbol localSymbol
+                ? this.MapDelegateLikeReturnType(localSymbol, isAsync, localFunction.ReturnType.GetLocation())
+                : null;
+
             LambdaExpression lambda;
             if (localFunction.Body != null)
             {
-                lambda = new LambdaExpression(parameters, blockBody: this.WithParameterShadows(localFunction, this.TranslateBlock(localFunction.Body)), isAsync: isAsync);
+                lambda = new LambdaExpression(parameters, blockBody: this.WithParameterShadows(localFunction, this.TranslateBlock(localFunction.Body)), isAsync: isAsync, returnType: returnType);
             }
             else if (localFunction.ExpressionBody != null)
             {
                 lambda = new LambdaExpression(
                     parameters,
                     blockBody: new BlockStatement(this.TranslateExpressionStatements(localFunction.ExpressionBody.Expression).ToList()),
-                    isAsync: isAsync);
+                    isAsync: isAsync,
+                    returnType: returnType);
             }
             else
             {
-                lambda = new LambdaExpression(parameters, blockBody: new BlockStatement(new List<GStatement>()), isAsync: isAsync);
+                lambda = new LambdaExpression(parameters, blockBody: new BlockStatement(new List<GStatement>()), isAsync: isAsync, returnType: returnType);
             }
 
             return new LocalFunctionStatement(localFunction.Identifier.Text, lambda);
@@ -5748,23 +5757,71 @@ public sealed class CSharpToGSharpTranslator
 
             if (lambda.Body is BlockSyntax block)
             {
-                return new LambdaExpression(parameters, blockBody: this.TranslateBlock(block), isAsync: isAsync);
+                return new LambdaExpression(
+                    parameters,
+                    blockBody: this.TranslateBlock(block),
+                    isAsync: isAsync,
+                    returnType: this.MapLambdaReturnType(lambda));
             }
 
             if (lambda.Body is AssignmentExpressionSyntax)
             {
                 // An assignment is statement-only in G#; an assignment-bodied lambda
-                // (`o => x = f()`) becomes a block-bodied lambda `o -> { x = f() }`.
+                // (`o => x = f()`) becomes a block-bodied lambda. An assignment has no
+                // value, so the resulting func literal is void (no return type).
                 return new LambdaExpression(
                     parameters,
                     blockBody: new BlockStatement(this.TranslateExpressionStatements((ExpressionSyntax)lambda.Body).ToList()),
-                    isAsync: isAsync);
+                    isAsync: isAsync,
+                    returnType: null);
             }
 
             return new LambdaExpression(
                 parameters,
                 expressionBody: this.TranslateExpression((ExpressionSyntax)lambda.Body),
                 isAsync: isAsync);
+        }
+
+        // Computes the explicit return type for a block-bodied lambda's G#
+        // function-literal form. Returns null when the lambda yields no value (a
+        // C# statement/Action lambda, or an `async` lambda returning a bare
+        // `Task`), in which case the literal is rendered void; otherwise maps the
+        // inferred result type (unwrapping `Task<T>` for `async`, mirroring
+        // MapReturnType for methods). A null result also covers the case where the
+        // symbol is unavailable, leaving the literal void (the conservative form).
+        private GTypeReference MapLambdaReturnType(AnonymousFunctionExpressionSyntax lambda)
+        {
+            if (this.context.GetSymbolInfo(lambda).Symbol is not IMethodSymbol symbol)
+            {
+                return null;
+            }
+
+            Location location = lambda.GetLocation();
+            return this.MapDelegateLikeReturnType(symbol, symbol.IsAsync, location);
+        }
+
+        // Shared mapping of a method/lambda result type into a G# func return type,
+        // applying the `async` unwrap rule: a G# `async func` declares the UNWRAPPED
+        // result, so C# `async Task` → null (void) and `async Task<T>` → `T`.
+        private GTypeReference MapDelegateLikeReturnType(IMethodSymbol symbol, bool isAsync, Location location)
+        {
+            if (symbol.ReturnsVoid)
+            {
+                return null;
+            }
+
+            ITypeSymbol returnType = symbol.ReturnType;
+
+            if (isAsync &&
+                returnType is INamedTypeSymbol { Name: "Task" } task &&
+                task.ContainingNamespace?.ToDisplayString() == "System.Threading.Tasks")
+            {
+                return task.IsGenericType
+                    ? this.typeMapper.Map(task.TypeArguments[0], this.context, location)
+                    : null;
+            }
+
+            return this.typeMapper.Map(returnType, this.context, location);
         }
 
         private Parameter MapLambdaParameter(ParameterSyntax parameter)


### PR DESCRIPTION
## Problem

cs2gs rendered every block-bodied C# lambda using the G# **arrow** form
`(params) -> { ... }`. Per the G# spec an arrow lambda's `{ ... }` body is an
**expression-block** — its trailing expression (or a `return`) supplies the lambda
value — so gsc treats control-flow statements inside it as value-position. A
non-trailing `if` **without** `else` is rejected with `GS0276` ("An if-expression
in value position must have an 'else' branch"), and trailing void statements
misbind. This broke essentially every multi-statement C# statement/Action lambda
and any value-returning block lambda containing an `if`-without-`else`.

## Fix

The G# **function-literal** form `func (params) RetType { ... }` is a **statement
block** and handles control flow correctly. Block-bodied lambdas (and the
block-bodied lambdas used for local functions / assignment-bodied lambdas) now
render as the `func` literal form. **Expression-bodied** lambdas (`x => expr`) are
unchanged and stay arrow `(x) -> expr` (canonical).

A `func` literal needs an **explicit return type** when it returns a value;
without it the literal is inferred **void** and `return expr` fails with `GS0122`:

- **void** block lambda  → `func (params) { stmts }` (no return type)
- **value** block lambda → `func (params) RetType { stmts }` (explicit return type)

The return type comes from the lambda's Roslyn method symbol
(`ReturnsVoid`/`ReturnType`), applying the same `async` unwrap as method `func`s
(`async Task` → void, `async Task<T>` → `T`).

## Changes

- **Cs2Gs.CodeModel** (`GExpression.cs`): `LambdaExpression` gains an optional
  `ReturnType` (null = void / expression body).
- **GSharpPrinter** (`RenderLambda`): block body prints `func (params) RetType { ... }`
  (async spelling `async func (...)`); the expression-body branch is unchanged.
- **CSharpToGSharpTranslator**: `TranslateLambda`, the assignment-bodied lambda case,
  and `TranslateLocalFunction` plumb the computed return type through the new
  `MapLambdaReturnType` / `MapDelegateLikeReturnType` helpers.

## Goldens

No existing test golden/fixture used the arrow-block form (`) -> {`), so **none
changed**. Added `Issue1159BlockLambdaFuncLiteralTranslationTests` (void Action
lambda with `if`-without-else → `func (...) {`; value-returning block lambda →
`func (...) RetType {`; expression-bodied lambda stays `-> `). Suite **217 → 220**,
all green.

## Oahu.Decrypt corpus (vs 392 baseline)

- Translate stage still **PASSES**.
- Total compile errors **392 → 389**; `GS0276` dropped to **0** (net improvement).
- 38 block lambdas now emit the `func` literal form; **zero** arrow-block lambdas remain.
- Standalone gsc round-trips of the void and value-returning `func`-literal repros both compile.

Refs #914
