### PR TITLE
Fix #1151: unify nil + value-type if/switch-expression branches to T?

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
@@ -880,15 +880,18 @@ internal sealed partial class ExpressionBinder
 
         // Nil/null compatibility: when one arm is the null sentinel and the
         // other is non-null, pick the non-null. The conversion machinery
-        // accepts the trivial null → reference/nullable widening.
+        // accepts the trivial null → reference/nullable widening. Issue #1151:
+        // when the other arm is a non-nullable value type `T`, the unified type
+        // must be `T?` so the value arm is lifted and the nil arm becomes the
+        // null `T?` (reference and already-nullable arms are left unchanged).
         if (left == TypeSymbol.Null)
         {
-            return right;
+            return LiftForNilArm(right);
         }
 
         if (right == TypeSymbol.Null)
         {
-            return left;
+            return LiftForNilArm(left);
         }
 
         var leftToRight = Conversion.Classify(left, right);
@@ -924,6 +927,26 @@ internal sealed partial class ExpressionBinder
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Issue #1151: lifts a non-nullable value type to its nullable form when it
+    /// is unified with a <c>nil</c> arm in an if/switch-expression. A value type
+    /// <c>T</c> becomes <c>T?</c> so the value arm can be lifted and the nil arm
+    /// can become the null <c>T?</c>. Reference types already legally hold
+    /// <c>nil</c>, and already-nullable types are idempotent, so both are
+    /// returned unchanged.
+    /// </summary>
+    /// <param name="type">The non-nil arm's type.</param>
+    /// <returns><c>T?</c> for a non-nullable value type <c>T</c>; otherwise <paramref name="type"/>.</returns>
+    private static TypeSymbol LiftForNilArm(TypeSymbol type)
+    {
+        if (type is not NullableTypeSymbol && type?.ClrType is { IsValueType: true })
+        {
+            return NullableTypeSymbol.Get(type);
+        }
+
+        return type;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.SwitchExpr.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.SwitchExpr.cs
@@ -127,7 +127,12 @@ internal sealed partial class ExpressionBinder
             }
             else if (!conversion.IsIdentity)
             {
-                result = new BoundConversionExpression(null, resultType, result);
+                // Issue #1151: route the materialised conversion through
+                // BindConversion so value-type `nil → T?` arms are lowered to a
+                // BoundDefaultExpression (the verifiable Nullable<T> default),
+                // matching the if-expression path. The Conversion.Classify check
+                // above still governs the GS0179 arm-mismatch diagnostic.
+                result = conversions.BindConversion(arm.Syntax.Result.Location, result, resultType);
             }
 
             arms.Add(new BoundSwitchExpressionArm(null, arm.Pattern, arm.Guard, result));
@@ -221,11 +226,18 @@ internal sealed partial class ExpressionBinder
         }
 
         // Drop the trivial bottom / null-sentinel types — they convert to any
-        // reference target and never constrain the common type.
+        // reference target and never constrain the common type. Issue #1151:
+        // remember whether a `nil` arm was present so a value-type common type
+        // can be lifted to its nullable form below.
         var significant = new List<TypeSymbol>(armTypes.Count);
+        var hasNullArm = false;
         foreach (var t in armTypes)
         {
-            if (t != TypeSymbol.Never && t != TypeSymbol.Null)
+            if (t == TypeSymbol.Null)
+            {
+                hasNullArm = true;
+            }
+            else if (t != TypeSymbol.Never)
             {
                 significant.Add(t);
             }
@@ -248,20 +260,32 @@ internal sealed partial class ExpressionBinder
             }
         }
 
+        TypeSymbol common;
         if (allSame)
         {
-            return first;
+            common = first;
         }
-
-        foreach (var candidate in EnumerateSupertypeCandidates(first))
+        else
         {
-            if (AllArmsImplicitlyConvertTo(significant, candidate))
+            common = null;
+            foreach (var candidate in EnumerateSupertypeCandidates(first))
             {
-                return candidate;
+                if (AllArmsImplicitlyConvertTo(significant, candidate))
+                {
+                    common = candidate;
+                    break;
+                }
             }
         }
 
-        return null;
+        // Issue #1151: when a `nil` arm was present and the common type of the
+        // remaining arms is a non-nullable value type `T`, unify to `T?`.
+        if (common != null && hasNullArm)
+        {
+            common = LiftForNilArm(common);
+        }
+
+        return common;
     }
 
     /// <summary>

--- a/test/Compiler.Tests/Emit/Issue1151NullableBranchUnifyEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1151NullableBranchUnifyEmitTests.cs
@@ -1,0 +1,215 @@
+// <copyright file="Issue1151NullableBranchUnifyEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1151: end-to-end CLR emit coverage for unifying a value-type arm and
+/// a <c>nil</c> arm of an <c>if</c>/<c>switch</c>-expression to <c>T?</c>. The
+/// emitted nullable must round-trip: the present branch yields a
+/// <c>Nullable&lt;T&gt;</c> with a value, and the <c>nil</c> branch yields the
+/// missing-value <c>Nullable&lt;T&gt;</c> (lowered to a <c>default(T?)</c> temp
+/// slot), and ilverify must accept the assembly.
+/// </summary>
+public class Issue1151NullableBranchUnifyEmitTests
+{
+    [Fact]
+    public void EndToEnd_IfExpression_ValueTypeAndNil_RoundTrips()
+    {
+        var source = """
+            package Probe
+            import System
+
+            class Box {
+                func F(present bool) int32? {
+                    let x = if present { 5 } else { nil }
+                    return x
+                }
+            }
+
+            func Main() {
+                var b = Box()
+                Console.WriteLine(Describe(b.F(true)))
+                Console.WriteLine(Describe(b.F(false)))
+            }
+
+            func Describe(v int32?) int32 {
+                return v ?? -1
+            }
+            """;
+        var output = CompileAndRun(source);
+        Assert.Equal("5\n-1\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_IfExpression_TargetTyped_ValueTypeAndNil_RoundTrips()
+    {
+        var source = """
+            package Probe
+            import System
+
+            class Box {
+                func G(present bool) int32? {
+                    let x int32? = if present { 5 } else { nil }
+                    return x
+                }
+            }
+
+            func Main() {
+                var b = Box()
+                Console.WriteLine(Describe(b.G(true)))
+                Console.WriteLine(Describe(b.G(false)))
+            }
+
+            func Describe(v int32?) int32 {
+                return v ?? -1
+            }
+            """;
+        var output = CompileAndRun(source);
+        Assert.Equal("5\n-1\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_SwitchExpression_ValueTypeAndNil_RoundTrips()
+    {
+        var source = """
+            package Probe
+            import System
+
+            class Box {
+                func S(present bool) int32? {
+                    let x = switch present { case true: 42 default: nil }
+                    return x
+                }
+            }
+
+            func Main() {
+                var b = Box()
+                Console.WriteLine(Describe(b.S(true)))
+                Console.WriteLine(Describe(b.S(false)))
+            }
+
+            func Describe(v int32?) int32 {
+                return v ?? -1
+            }
+            """;
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n-1\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_Mpeg4StyleUInt32AndNil_RoundTrips()
+    {
+        var source = """
+            package Probe
+            import System
+
+            class Reader {
+                func Field(present bool) uint32? {
+                    let v = if present { 123u } else { nil }
+                    return v
+                }
+            }
+
+            func Main() {
+                var r = Reader()
+                Console.WriteLine(Describe(r.Field(true)))
+                Console.WriteLine(Describe(r.Field(false)))
+            }
+
+            func Describe(v uint32?) uint32 {
+                return v ?? 999u
+            }
+            """;
+        var output = CompileAndRun(source);
+        Assert.Equal("123\n999\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_nil1151_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1151NullableBranchUnifyTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1151NullableBranchUnifyTests.cs
@@ -1,0 +1,178 @@
+// <copyright file="Issue1151NullableBranchUnifyTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1151: an <c>if</c>/<c>switch</c>-expression whose branches are a
+/// value type <c>T</c> and <c>nil</c> must unify to <c>T?</c> — both when the
+/// result type is inferred and when it is explicitly target-typed to <c>T?</c>.
+/// The value arm is lifted to <c>T?</c> and the <c>nil</c> arm becomes the null
+/// <c>T?</c>, mirroring C#'s target-typed conditional. Reference-type and
+/// already-nullable arms are left unchanged (never double-wrapped).
+/// </summary>
+public class Issue1151NullableBranchUnifyTests
+{
+    [Fact]
+    public void IfExpression_ValueTypeAndNil_Inferred_UnifiesToNullable()
+    {
+        var scope = BindGlobalScope(@"
+let x = if true { 5 } else { nil }
+");
+
+        Assert.Empty(scope.Diagnostics);
+        var x = scope.Variables.Single(v => v.Name == "x").Type;
+        var nullable = Assert.IsType<NullableTypeSymbol>(x);
+        Assert.Equal(TypeSymbol.Int32, nullable.UnderlyingType);
+    }
+
+    [Fact]
+    public void IfExpression_ValueTypeAndNil_TargetTyped_BindsCleanly()
+    {
+        var scope = BindGlobalScope(@"
+let x int32? = if true { 5 } else { nil }
+");
+
+        Assert.Empty(scope.Diagnostics);
+        var x = scope.Variables.Single(v => v.Name == "x").Type;
+        var nullable = Assert.IsType<NullableTypeSymbol>(x);
+        Assert.Equal(TypeSymbol.Int32, nullable.UnderlyingType);
+    }
+
+    [Fact]
+    public void SwitchExpression_ValueTypeAndNil_Inferred_UnifiesToNullable()
+    {
+        var scope = BindGlobalScope(@"
+let x = switch true { case true: 5 default: nil }
+");
+
+        Assert.Empty(scope.Diagnostics);
+        var x = scope.Variables.Single(v => v.Name == "x").Type;
+        var nullable = Assert.IsType<NullableTypeSymbol>(x);
+        Assert.Equal(TypeSymbol.Int32, nullable.UnderlyingType);
+    }
+
+    [Fact]
+    public void SwitchExpression_ValueTypeAndNil_TargetTyped_BindsCleanly()
+    {
+        var scope = BindGlobalScope(@"
+let x int32? = switch true { case true: 5 default: nil }
+");
+
+        Assert.Empty(scope.Diagnostics);
+        var x = scope.Variables.Single(v => v.Name == "x").Type;
+        var nullable = Assert.IsType<NullableTypeSymbol>(x);
+        Assert.Equal(TypeSymbol.Int32, nullable.UnderlyingType);
+    }
+
+    [Fact]
+    public void IssueRepro_FAndG_BindWithNoDiagnostics()
+    {
+        var diagnostics = Bind(@"
+package p
+class C {
+    func F(present bool) int32? {
+        let x = if present { 5 } else { nil }
+        return x
+    }
+    func G(present bool) int32? {
+        let x int32? = if present { 5 } else { nil }
+        return x
+    }
+}
+");
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void IfExpression_NullableReferenceAndNil_NotDoubleWrapped()
+    {
+        // Regression guard: a `string?` arm unified with `nil` stays `string?`
+        // (NullableTypeSymbol.Get is idempotent) — it must NOT become
+        // `string??`. Reference types are left untouched by the value-type lift.
+        var scope = BindGlobalScope(@"
+let s string? = ""hi""
+let x = if true { s } else { nil }
+");
+
+        Assert.Empty(scope.Diagnostics);
+        var x = scope.Variables.Single(v => v.Name == "x").Type;
+        var nullable = Assert.IsType<NullableTypeSymbol>(x);
+        Assert.Equal(TypeSymbol.String, nullable.UnderlyingType);
+        Assert.IsNotType<NullableTypeSymbol>(nullable.UnderlyingType);
+    }
+
+    [Fact]
+    public void IfExpression_Mpeg4StyleUInt32AndNil_UnifiesToNullable()
+    {
+        // The MPEG-4 optional-field pattern from the issue: a uint32 value arm
+        // and a nil arm infer uint32?.
+        var scope = BindGlobalScope(@"
+let d = if true { 7u } else { nil }
+");
+
+        Assert.Empty(scope.Diagnostics);
+        var d = scope.Variables.Single(v => v.Name == "d").Type;
+        var nullable = Assert.IsType<NullableTypeSymbol>(d);
+        Assert.Equal(TypeSymbol.UInt32, nullable.UnderlyingType);
+    }
+
+    [Fact]
+    public void SwitchExpression_GenuineTypeMismatch_StillDiagnoses_GS0179()
+    {
+        // The fix must NOT suppress the pre-existing arm-mismatch diagnostic
+        // for genuinely incompatible arms.
+        var diagnostics = Bind(@"
+let x = switch true { case true: 5 default: ""x"" }
+");
+
+        Assert.Contains(diagnostics, d => d.Id == "GS0179");
+    }
+
+    [Fact]
+    public void IfExpression_GenuineTypeMismatch_StillDiagnoses_GS0263()
+    {
+        // Two incompatible value/reference arms (no nil) still have no common
+        // type and report GS0263.
+        var diagnostics = Bind(@"
+let x = if true { 5 } else { ""x"" }
+");
+
+        Assert.Contains(diagnostics, d => d.Id == "GS0263");
+    }
+
+    private static ImmutableArray<Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        if (tree.Diagnostics.Any())
+        {
+            return tree.Diagnostics;
+        }
+
+        var globalScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+        if (globalScope.Diagnostics.Any())
+        {
+            return globalScope.Diagnostics;
+        }
+
+        var program = Binder.BindProgram(globalScope);
+        return program.Diagnostics.ToImmutableArray();
+    }
+
+    private static BoundGlobalScope BindGlobalScope(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        return Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+    }
+}


### PR DESCRIPTION
Fixes #1151

## Root cause
The compiler binds `let x T = <init>` initializers without threading the declared target type into the if/switch-expression value binder, so both the inferred case (`let x = ...`) and the explicitly target-typed case (`let x int32? = ...`) rely on the if/switch-expression's *internal* inferred common type. That inference picked the bare value type `T` for a `nil` + `T` pair, and converting the `nil` arm to non-nullable `T` then failed (GS0155 for `if`, GS0179 for `switch`).

## Fix
The inferred common-type computation now unifies a `nil` arm with a non-nullable value-type arm to `T?` in **both** paths:

- **if-expression** — `ComputeConditionalCommonType` (`ExpressionBinder.Operators.cs`) lifts a non-nullable value type to its nullable form via a new `LiftForNilArm` helper when the sibling arm is the `nil` sentinel. Reference types (which the binder treats as non-nullable; nil already does not convert to them) and already-nullable types are returned unchanged, so nothing is double-wrapped.
- **switch-expression** — `ComputeBestCommonType` (`ExpressionBinder.SwitchExpr.cs`) tracks whether a `nil` arm was present and lifts a value-type common type to `T?`. The arm materialisation now routes through `BindConversion` so a value-type `nil -> T?` arm is lowered to a `BoundDefaultExpression` (the verifiable `Nullable<T>` default), matching the if-expression path. The existing `Conversion.Classify` check still governs the GS0179 arm-mismatch diagnostic.

This mirrors C#'s target-typed conditional (`int? x = cond ? 5 : null;`). The general `cond ? a : b` ternary shares `ComputeConditionalCommonType` and benefits too. The pre-existing arm-mismatch diagnostics (GS0179 / GS0263) still fire for genuinely incompatible arms.

### Out of scope
A bare `default` arm binds to `TypeSymbol.Error` (not the `nil` sentinel), so it is not part of this nil-unification and is intentionally left unchanged. A bare non-nullable *reference* literal arm + `nil` (e.g. `if c { "a" } else { nil }`) remains a separate non-nullable-reference concern (pre-existing on main; `string` needs `string?`).

## Tests added
- `Issue1151NullableBranchUnifyTests` (Core.Tests, 9 tests) — inferred + target-typed `if`/`switch` unify to `int32?`/`uint32?`, the exact issue repro (`F`/`G`) binds clean, nullable-reference arm is not double-wrapped, and GS0179/GS0263 still fire for real mismatches.
- `Issue1151NullableBranchUnifyEmitTests` (Compiler.Tests, 4 tests) — end-to-end emit + run proving the unified `T?` round-trips for `if`, target-typed `if`, `switch`, and the MPEG-4-style `uint32?` pattern (ilverify clean).

Full `Core.Tests` (3996 passed) and the broad Switch/Conditional/IfExpression/Nullable `Compiler.Tests` suite (200 passed) are green; the solution builds with 0 errors.