### PR TITLE
cs2gs: construct imported/BCL structs via constructor call, not struct literal

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/ImportedStructConstructionTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/ImportedStructConstructionTranslationTests.cs
@@ -1,0 +1,110 @@
+// <copyright file="ImportedStructConstructionTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Translator-fidelity tests for the construction of value types. A
+/// <em>source-defined</em> <c>struct</c> / <c>data struct</c> has no callable
+/// constructor surface in G# and is built with a struct literal
+/// (<c>T{Field: value, ...}</c>). An <em>imported / BCL</em> struct (e.g.
+/// <see cref="System.Guid"/>) is also <c>SpecialType.None</c> yet DOES expose
+/// real constructors that G# can call directly (<c>Guid(bytes, true)</c>), so a
+/// positional <c>new Guid(...)</c> must be rendered as a constructor call — not
+/// zipped into a bogus struct literal over the type's <em>properties</em>
+/// (which produced the invalid <c>Guid{Variant: ..., Version: ...}</c> → GS0157).
+/// </summary>
+public class ImportedStructConstructionTranslationTests
+{
+    [Fact]
+    public void ImportedStruct_PositionalNew_RendersConstructorCall()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public System.Guid Make(byte[] bytes) => new System.Guid(bytes, true);
+    }
+}");
+
+        Assert.Contains("Guid(bytes, true)", printed);
+        Assert.DoesNotContain("Guid{", printed);
+    }
+
+    [Fact]
+    public void ImportedStruct_TargetTypedNew_RendersConstructorCall()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public System.Guid Make(byte[] bytes)
+        {
+            System.Guid g = new(bytes, true);
+            return g;
+        }
+    }
+}");
+
+        Assert.Contains("Guid(bytes, true)", printed);
+        Assert.DoesNotContain("Guid{", printed);
+    }
+
+    [Fact]
+    public void SourceStruct_PositionalNew_StillRendersStructLiteral()
+    {
+        // Regression guard: a source-defined value aggregate keeps the canonical
+        // G# struct-literal form (no callable ctor surface in G#).
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public struct Point
+    {
+        public int X { get; }
+        public int Y { get; }
+        public Point(int x, int y) { X = x; Y = y; }
+    }
+
+    public class C
+    {
+        public Point Make() => new Point(1, 2);
+    }
+}");
+
+        Assert.Contains("Point{", printed);
+        Assert.Contains("X: 1", printed);
+        Assert.Contains("Y: 2", printed);
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -5498,13 +5498,19 @@ public sealed class CSharpToGSharpTranslator
                 return new CompositeLiteralExpression(type, fieldInitializers);
             }
 
-            // A value aggregate (`struct` / `data struct`) has no callable
-            // constructor surface in G#: it is constructed with a struct literal
-            // `T{Field: value, ...}` (spec §Struct literals). Map the positional C#
-            // `new T(a, b)` to that literal by zipping the arguments with the
-            // type's settable instance members in declaration order (ADR-0115 §B.4).
+            // A source-defined value aggregate (`struct` / `data struct`) has no
+            // callable constructor surface in G#: it is constructed with a struct
+            // literal `T{Field: value, ...}` (spec §Struct literals). Map the
+            // positional C# `new T(a, b)` to that literal by zipping the arguments
+            // with the type's settable instance members in declaration order
+            // (ADR-0115 §B.4). Imported/BCL structs (e.g. `Guid`, `DateTime`,
+            // `Span<T>` — all `SpecialType.None`) DO expose real constructors that
+            // G# can call directly (`Guid(bytes, true)`), so they must fall through
+            // to a constructor call rather than be zipped into a bogus literal over
+            // the type's *properties*.
             if (typeSymbol is INamedTypeSymbol { TypeKind: TypeKind.Struct, SpecialType: SpecialType.None } valueType &&
                 !valueType.IsTupleType &&
+                !valueType.DeclaringSyntaxReferences.IsEmpty &&
                 arguments.Count > 0)
             {
                 List<string> targetNames = OrderedValueMemberNames(valueType);
@@ -5932,10 +5938,12 @@ public sealed class CSharpToGSharpTranslator
                     .Select(a => this.TranslateArgument(a))
                     .ToList();
 
-            // A value aggregate is constructed with a composite literal; a reference
-            // type with a call on the (bracketed-generic) type name.
+            // A source-defined value aggregate is constructed with a composite
+            // literal; a reference type — or an imported/BCL struct with a real
+            // constructor — with a call on the (bracketed-generic) type name.
             if (typeSymbol is INamedTypeSymbol { TypeKind: TypeKind.Struct, SpecialType: SpecialType.None } valueType &&
                 !valueType.IsTupleType &&
+                !valueType.DeclaringSyntaxReferences.IsEmpty &&
                 creation.Initializer == null)
             {
                 List<string> targetNames = OrderedValueMemberNames(valueType);


### PR DESCRIPTION
## Summary

A source-defined `struct` / `data struct` has no callable constructor surface in G# and is constructed with a struct literal (`T{Field: value, ...}`). The translator applied that struct-literal zip to **any** struct with `SpecialType.None` — but imported/BCL structs such as `System.Guid`, `DateTime` and `Span<T>` are **also** `SpecialType.None`, and they DO expose real constructors that G# can call directly (`Guid(bytes, true)`).

The old code zipped `new Guid(bytes, true)` onto `Guid`'s **properties** (`Variant`, `Version`, …), emitting the invalid `Guid{Variant: file.ReadBlock(16), Version: true}` → **GS0157 `Cannot find type Guid`**.

## Fix

Gate the struct-literal zip on the struct being **source-defined** (`!valueType.DeclaringSyntaxReferences.IsEmpty`) in both object-creation paths (explicit `new T(...)` and target-typed `new(...)`). Imported/BCL structs now fall through to a constructor call (`Guid(bytes, true)`), which gsc accepts. Source-defined structs keep the canonical struct-literal form.

## Validation

- `Oahu.Decrypt`: 371 → **356** compile errors; all `Guid` GS0157 cleared. Translate stage still PASS.
- cs2gs tests: **223 pass** (+3 new in `ImportedStructConstructionTranslationTests` covering imported-struct ctor call, target-typed `new`, and a source-struct literal regression guard).

Refs #914
