### PR TITLE
Fix #1153: emit native G# coalesce-throw (x ?? throw e) in cs2gs

### DIFF
--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/GExpression.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/GExpression.cs
@@ -882,13 +882,12 @@ public sealed class ConditionalAccessExpression : GExpression
 
 /// <summary>
 /// A C# <c>throw</c> expression used in value position (<c>a ?? throw e</c>,
-/// <c>cond ? a : throw e</c>, a <c>switch</c> arm value). G# models <c>throw</c>
-/// as a statement only (spec §If expressions), so the canonical faithful form
-/// lowers the throw to an if-expression whose then-branch is a block that runs
-/// the <c>throw</c> statement and supplies an (unreachable) tail of the result
-/// type: <c>if true { throw e\n default(T) } else { default(T) }</c>. This shape
-/// is a primary expression and therefore valid in every value position
-/// (ADR-0115 §B).
+/// <c>cond ? a : throw e</c>, a <c>switch</c> arm value). G# supports
+/// throw-as-expression natively (issue #1153), so it renders as a bare
+/// <c>throw e</c> in coalesce-RHS, switch-arm, and ternary positions. In the one
+/// position gsc rejects a bare throw — the sole trailing value of an
+/// if-expression block branch (GS0277) — it is emitted as a throw STATEMENT
+/// followed by a value-producing typed tail: <c>throw e\n default(T)</c>.
 /// </summary>
 public sealed class ThrowExpression : GExpression
 {
@@ -897,9 +896,9 @@ public sealed class ThrowExpression : GExpression
     /// </summary>
     /// <param name="operand">The thrown exception value.</param>
     /// <param name="resultType">
-    /// The type the surrounding expression position expects, used for the
-    /// unreachable <c>default(T)</c> tail. May be <see langword="null"/> when no
-    /// type is resolvable, in which case a bare <c>default</c> is emitted.
+    /// The type the surrounding if-expression block branch expects, used for the
+    /// value-producing <c>default(T)</c> tail. May be <see langword="null"/> when
+    /// no type is resolvable, in which case a bare <c>default</c> is emitted.
     /// </param>
     public ThrowExpression(GExpression operand, GTypeReference resultType)
     {
@@ -910,6 +909,6 @@ public sealed class ThrowExpression : GExpression
     /// <summary>Gets the thrown exception value.</summary>
     public GExpression Operand { get; }
 
-    /// <summary>Gets the result type used for the unreachable tail.</summary>
+    /// <summary>Gets the result type used for the if-expression block branch tail.</summary>
     public GTypeReference ResultType { get; }
 }

--- a/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
@@ -437,14 +437,10 @@ public static class GSharpPrinter
                 return $"if {RenderExpression(ifExpression.Condition, indent)} {{ {RenderBranchValue(ifExpression.ThenExpression, indent)} }} else {{ {RenderBranchValue(ifExpression.ElseExpression, indent)} }}";
 
             case ThrowExpression throwExpression:
-                // G# has no throw-expression: lower to an if-expression whose
-                // then-branch block runs the `throw` statement and supplies an
-                // unreachable typed tail (spec §If expressions). The shape is a
-                // primary expression, so it is valid in every value position.
-                var throwTail = throwExpression.ResultType == null
-                    ? "default"
-                    : $"default({RenderType(throwExpression.ResultType)})";
-                return $"if true {{ throw {RenderExpression(throwExpression.Operand, indent)}\n{Indent(indent + 1)}{throwTail} }} else {{ {throwTail} }}";
+                // G# supports throw-as-expression natively: render the bare
+                // `throw <operand>` form, valid in coalesce-RHS, switch-arm,
+                // and ternary expression positions (issue #1153).
+                return $"throw {RenderExpression(throwExpression.Operand, indent)}";
 
             case OutArgumentExpression outArgument:
                 return $"{outArgument.Keyword} {outArgument.Name}";
@@ -483,6 +479,18 @@ public static class GSharpPrinter
         if (expression is SwitchExpression)
         {
             return $"({RenderExpression(expression, indent)})";
+        }
+
+        // A bare throw-expression is not accepted as the sole trailing value of
+        // an if-expression block branch (gsc GS0277). Emit the throw as a
+        // STATEMENT followed by a value-producing typed tail so the branch block
+        // ends with a value-producing expression (issue #1153).
+        if (expression is ThrowExpression throwExpression)
+        {
+            var throwTail = throwExpression.ResultType == null
+                ? "default"
+                : $"default({RenderType(throwExpression.ResultType)})";
+            return $"throw {RenderExpression(throwExpression.Operand, indent)}\n{Indent(indent + 1)}{throwTail}";
         }
 
         return RenderExpression(expression, indent);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue914TranslatorFidelityTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue914TranslatorFidelityTests.cs
@@ -129,7 +129,7 @@ namespace Demo
     // ---- Task 3: `x ?? throw E` ---------------------------------------------
 
     [Fact]
-    public void CoalesceThrow_InReturn_LoweredToNilGuard()
+    public void CoalesceThrow_InReturn_RendersNativeCoalesceThrow()
     {
         string printed = TranslateUnit(@"
 namespace Demo
@@ -141,10 +141,70 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("if __coalesce", printed);
-        Assert.Contains("== nil", printed);
-        Assert.Contains("throw InvalidOperationException", printed);
-        Assert.DoesNotContain("?? if", printed);
+        Assert.Contains("?? throw InvalidOperationException", printed);
+        Assert.DoesNotContain("__coalesce", printed);
+        Assert.DoesNotContain("if true {", printed);
+    }
+
+    [Fact]
+    public void CoalesceThrow_InLocalDeclaration_RendersNativeCoalesceThrow()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class E { }
+    public class C
+    {
+        public E F(E? x)
+        {
+            var r = x ?? throw new System.InvalidOperationException(""nil"");
+            return r;
+        }
+    }
+}");
+
+        Assert.Contains("?? throw InvalidOperationException", printed);
+        Assert.DoesNotContain("__coalesce", printed);
+        Assert.DoesNotContain("if true {", printed);
+    }
+
+    [Fact]
+    public void CoalesceThrow_InAssignment_RendersNativeCoalesceThrow()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class E { }
+    public class C
+    {
+        public E Field;
+        public void F(E? x)
+        {
+            Field = x ?? throw new System.InvalidOperationException(""nil"");
+        }
+    }
+}");
+
+        Assert.Contains("?? throw InvalidOperationException", printed);
+        Assert.DoesNotContain("__coalesce", printed);
+        Assert.DoesNotContain("if true {", printed);
+    }
+
+    [Fact]
+    public void CoalesceThrow_ValueTypeNullable_RendersNativeCoalesceThrow()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public int F(int? n) { return n ?? throw new System.InvalidOperationException(""nil""); }
+    }
+}");
+
+        Assert.Contains("?? throw InvalidOperationException", printed);
+        Assert.DoesNotContain("__coalesce", printed);
+        Assert.DoesNotContain("if true {", printed);
     }
 
     private static string TranslateUnit(string source)

--- a/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
@@ -46,12 +46,12 @@ namespace Demo
     }
 
     /// <summary>
-    /// A C# throw-expression on the right of <c>??</c> is lowered to the
-    /// uniform value-position form <c>if true { throw … default(T) } else {
-    /// default(T) }</c> (G# `throw` is statement-only; ADR-0115 §B).
+    /// A C# throw-expression on the right of <c>??</c> maps to G#'s native
+    /// throw-expression (<c>s ?? throw …</c>); G# supports throw-as-expression
+    /// directly (issue #1153), so no <c>if true { … }</c> lowering is needed.
     /// </summary>
     [Fact]
-    public void ThrowExpression_InNullCoalescing_LoweredToIfExpression()
+    public void ThrowExpression_InNullCoalescing_RendersNativeCoalesceThrow()
     {
         string printed = TranslateUnit(@"
 namespace Demo
@@ -62,17 +62,19 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("throw ", printed);
-        Assert.Contains("if true {", printed);
+        Assert.Contains("?? throw", printed);
+        Assert.DoesNotContain("if true {", printed);
     }
 
     /// <summary>
-    /// A C# throw-expression in a ternary branch (<c>cond ? v : throw e</c>) is
-    /// lowered through the same value-position throw form inside the G#
-    /// if-expression branch.
+    /// A C# throw-expression in a ternary branch (<c>cond ? v : throw e</c>)
+    /// becomes a G# if-expression branch. Because gsc rejects a bare throw as the
+    /// sole trailing value of an if-expression block branch (GS0277), the printer
+    /// emits the throw as a STATEMENT followed by a value-producing typed tail
+    /// (<c>else { throw … default(T) }</c>) — no <c>if true { … }</c> wrapper.
     /// </summary>
     [Fact]
-    public void ThrowExpression_InTernaryBranch_LoweredToIfExpression()
+    public void ThrowExpression_InTernaryBranch_RendersBlockSafeThrow()
     {
         string printed = TranslateUnit(@"
 namespace Demo
@@ -85,6 +87,7 @@ namespace Demo
 }");
 
         Assert.Contains("throw ", printed);
+        Assert.DoesNotContain("if true {", printed);
     }
 
     /// <summary>

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -322,10 +322,6 @@ public sealed class CSharpToGSharpTranslator
         // tuple-deconstruction assignments (`(a, b) = (x, y)`); ADR-0115 §B.
         private int deconCounter;
 
-        // Monotonic counter for synthesizing unique temporaries when lowering a
-        // null-coalescing-with-throw (`x ?? throw E`) to a nil-guard (issue #914).
-        private int coalesceThrowCounter;
-
         // When translating the body of a lifted owned-value-aggregate receiver
         // method (issue #938), the implicit `this.` of a bare instance-member
         // reference must be made explicit through the receiver name (`self.`),
@@ -2713,12 +2709,6 @@ public sealed class CSharpToGSharpTranslator
                     return this.TranslateFixedStatement(fixedStatement);
 
                 case ReturnStatementSyntax ret:
-                    if (ret.Expression != null
-                        && TryGetCoalesceThrow(ret.Expression, out ExpressionSyntax retValue, out ThrowExpressionSyntax retThrow))
-                    {
-                        return this.LowerCoalesceThrow(retValue, retThrow, r => new ReturnStatement(r));
-                    }
-
                     return new[]
                     {
                         (GStatement)new ReturnStatement(
@@ -2838,21 +2828,6 @@ public sealed class CSharpToGSharpTranslator
                     {
                         type = this.PromoteIfUsedAsNullable(type, localSymbol);
                     }
-                }
-
-                // `let r = x ?? throw E` → evaluate x once, throw when nil, then
-                // bind r to the non-null value (issue #914). Emitted in place of the
-                // (invalid) inline throw-in-expression form.
-                if (!isConst && !isUsing && declarator.Initializer != null
-                    && TryGetCoalesceThrow(declarator.Initializer.Value, out ExpressionSyntax coalesceValue, out ThrowExpressionSyntax coalesceThrow))
-                {
-                    BindingKind declBinding = binding;
-                    string declName = SanitizeIdentifier(declarator.Identifier.Text);
-                    results.AddRange(this.LowerCoalesceThrow(
-                        coalesceValue,
-                        coalesceThrow,
-                        r => new LocalDeclarationStatement(declBinding, declName, type: null, r)));
-                    continue;
                 }
 
                 results.Add(new LocalDeclarationStatement(
@@ -3274,17 +3249,6 @@ public sealed class CSharpToGSharpTranslator
                     return this.TranslateExpressionStatements(assignment.Right);
                 }
 
-                if (TryGetCoalesceThrow(assignment.Right, out ExpressionSyntax coalesceValue, out ThrowExpressionSyntax coalesceThrow))
-                {
-                    // `target = x ?? throw E` → evaluate x once, throw when nil,
-                    // then assign the non-null value (issue #914).
-                    GExpression target = this.TranslateExpression(assignment.Left);
-                    return this.LowerCoalesceThrow(
-                        coalesceValue,
-                        coalesceThrow,
-                        r => new AssignmentStatement(target, r, assignment.OperatorToken.Text));
-                }
-
                 if (this.TryGetDeconstructionTargets(assignment.Left, out BindingKind binding, out IReadOnlyList<string> names))
                 {
                     // `var (a, b) = e` → `let (a, b) = e` (spec §Tuples).
@@ -3366,69 +3330,6 @@ public sealed class CSharpToGSharpTranslator
             }
 
             return statements;
-        }
-
-        // Detects the C# `value ?? throw E` shape (a coalesce whose right operand is
-        // a throw expression), unwrapping enclosing parentheses on either side.
-        private static bool TryGetCoalesceThrow(
-            ExpressionSyntax expression,
-            out ExpressionSyntax value,
-            out ThrowExpressionSyntax throwExpression)
-        {
-            value = null;
-            throwExpression = null;
-
-            ExpressionSyntax unwrapped = expression;
-            while (unwrapped is ParenthesizedExpressionSyntax parenthesized)
-            {
-                unwrapped = parenthesized.Expression;
-            }
-
-            if (unwrapped is not BinaryExpressionSyntax binary
-                || !binary.IsKind(SyntaxKind.CoalesceExpression))
-            {
-                return false;
-            }
-
-            ExpressionSyntax right = binary.Right;
-            while (right is ParenthesizedExpressionSyntax parenthesizedRight)
-            {
-                right = parenthesizedRight.Expression;
-            }
-
-            if (right is not ThrowExpressionSyntax thrown)
-            {
-                return false;
-            }
-
-            value = binary.Left;
-            throwExpression = thrown;
-            return true;
-        }
-
-        // Lowers a C# `value ?? throw E` (statement position) to the faithful G#
-        // nil-guard form: evaluate the value once into a temp, throw when it is nil,
-        // then feed the (now non-null, smart-cast) temp to <paramref name="useResult"/>
-        // which forms the enclosing return/declaration/assignment (issue #914).
-        private IEnumerable<GStatement> LowerCoalesceThrow(
-            ExpressionSyntax value,
-            ThrowExpressionSyntax throwExpression,
-            Func<GExpression, GStatement> useResult)
-        {
-            string temp = $"__coalesce{this.coalesceThrowCounter++}";
-            return new[]
-            {
-                (GStatement)new LocalDeclarationStatement(
-                    BindingKind.Let, temp, type: null, this.TranslateExpression(value)),
-                new IfStatement(
-                    new BinaryExpression(new IdentifierExpression(temp), "==", LiteralExpression.Null()),
-                    new BlockStatement(new GStatement[]
-                    {
-                        new ThrowStatement(this.TranslateExpression(throwExpression.Expression)),
-                    }),
-                    elseBranch: null),
-                useResult(new IdentifierExpression(temp)),
-            };
         }
 
         private static List<PostfixUnaryExpressionSyntax> CollectEmbeddedPostfix(ExpressionSyntax expression)
@@ -4459,8 +4360,8 @@ public sealed class CSharpToGSharpTranslator
 
                 case ThrowExpressionSyntax throwExpression:
                     // `a ?? throw e`, `cond ? a : throw e`, a `switch` arm value.
-                    // G# `throw` is a statement only; lower to a typed
-                    // if-expression that runs the throw (ADR-0115 §B).
+                    // G# supports throw-as-expression natively (issue #1153);
+                    // map it directly to a G# throw-expression.
                     return new ThrowExpression(
                         this.TranslateExpression(throwExpression.Expression),
                         this.ResolveExpressionType(throwExpression));


### PR DESCRIPTION
Fixes #1153

## Root cause
The cs2gs migration tool lowered C# `exp ?? throw e` into a hand-rolled nil-guard (`let __coalesceN = …; if __coalesceN == nil { throw E }; …`) and rendered every throw-expression as a clunky `if true { throw … default(T) } else { default(T) }`. Both were built on the now-outdated assumption that **G# has no throw-expression**.

**gsc already fully supports throw-as-expression — no compiler change is needed.** Verified by probe: `return x ?? throw Exception("nil")` (reference and value-type-nullable), ternary/switch-arm throws all compile and round-trip. The only restriction is that a *bare* throw is rejected as the sole trailing value of an if-expression block branch (GS0277).

## Fix (cs2gs only)
- **Printer** (`GSharpPrinter.cs`): `ThrowExpression` now renders as a bare `throw e` — valid in coalesce-RHS, switch-arm, and ternary positions. `RenderBranchValue` gains a `ThrowExpression` case that emits the throw as a STATEMENT followed by a value-producing typed tail (`throw e\n default(T)`) so an if-expression block branch stays valid under GS0277.
- **Translator** (`CSharpToGSharpTranslator.cs`): removed the statement-level nil-guard expansion (`LowerCoalesceThrow`, `TryGetCoalesceThrow`, `coalesceThrowCounter`) and its three interception sites (return, local declaration, assignment). `x ?? throw E` now falls through to its natural `BinaryExpression(left, "??", ThrowExpression)` translation, producing the clean 1:1 form. The `_ = x ?? throw E` discard path is unaffected.
- Updated `GExpression.ThrowExpression` doc comment to reflect native support.

### Before / After (`return x ?? throw E`)
Before: `let __coalesce0 = x` / `if __coalesce0 == nil { throw … }` / `return __coalesce0`
After:  `return x ?? throw InvalidOperationException("nil")`

## Tests
- `Issue914TranslatorFidelityTests`: rewrote `CoalesceThrow_InReturn_*` → `CoalesceThrow_InReturn_RendersNativeCoalesceThrow`; added `CoalesceThrow_InLocalDeclaration_RendersNativeCoalesceThrow`, `CoalesceThrow_InAssignment_RendersNativeCoalesceThrow`, `CoalesceThrow_ValueTypeNullable_RendersNativeCoalesceThrow`.
- `OahuDecryptTranslationTests`: `ThrowExpression_InNullCoalescing_RendersNativeCoalesceThrow` and `ThrowExpression_InTernaryBranch_RendersBlockSafeThrow` (updated assertions + doc comments).
- All assertions keep round-trip validation (printed G# compiled through gsc). Full cs2gs suite: 223/223 passing. `dotnet build GSharp.sln --configuration Release` clean (0 errors).