### PR TITLE
Fix #1154: exclude non-convertible candidates from user-call overload applicability

### DIFF
--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -648,6 +648,37 @@ internal sealed class OverloadResolver
             }
         }
 
+        // Issue #1154: arity/name applicability (Phase 1) does not check whether
+        // each argument is type-convertible to the corresponding parameter. Per
+        // C# §11.6.4.2 a candidate is NOT applicable when any argument has no
+        // implicit conversion to its parameter type. Without this filter a
+        // wholly-inapplicable overload (e.g. F(string) for a []uint8 argument)
+        // can tie — and thus be reported ambiguous (GS0266) — with the unique
+        // genuinely-applicable overload that merely needs an implicit
+        // nullable/reference widening (e.g. []uint8 -> []uint8?). Drop such
+        // non-convertible candidates here, conservatively (see skips below), so
+        // the unique applicable overload is selected without a spurious GS0266.
+        if (applicable.Count > 1 && !HasNamedArguments(argumentNames))
+        {
+            var convertible = new List<FunctionSymbol>(applicable.Count);
+            foreach (var cand in applicable)
+            {
+                if (IsConvertibilityApplicable(cand, argumentCount, boundArguments))
+                {
+                    convertible.Add(cand);
+                }
+            }
+
+            // Mirror the #1124 pattern: only adopt the narrowed set when it
+            // leaves at least one candidate. An empty result means the call is
+            // genuinely unsatisfiable; keep the prior list so the pre-existing
+            // diagnostics (no-applicable-overload / ambiguity) are preserved.
+            if (convertible.Count > 0)
+            {
+                applicable = convertible;
+            }
+        }
+
         if (applicable.Count == 0)
         {
             return null;
@@ -709,6 +740,101 @@ internal sealed class OverloadResolver
         }
 
         return best;
+    }
+
+    /// <summary>
+    /// Issue #1154: returns <see langword="true"/> when <paramref name="argumentNames"/>
+    /// carries any non-null positional name. When named arguments are present the
+    /// positional index→parameter mapping used by the convertibility filter is
+    /// unreliable, so the filter is skipped entirely for that call.
+    /// </summary>
+    private static bool HasNamedArguments(ImmutableArray<string> argumentNames)
+    {
+        if (argumentNames.IsDefault)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < argumentNames.Length; i++)
+        {
+            if (argumentNames[i] != null)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Issue #1154: convertibility-aware applicability. Returns
+    /// <see langword="true"/> when every positional argument actually supplied
+    /// is implicitly convertible to the corresponding parameter type of
+    /// <paramref name="candidate"/>. Conservatively treats a candidate as
+    /// convertible (does NOT reject) for situations where the positional
+    /// index→parameter mapping or the parameter type is unreliable: generic
+    /// candidates (their parameter types may contain unsubstituted method type
+    /// parameters — handled by the #1124 inference filter), the variadic tail,
+    /// by-ref/out/in parameters, and unknown argument/parameter types.
+    /// </summary>
+    private bool IsConvertibilityApplicable(
+        FunctionSymbol candidate,
+        int argumentCount,
+        ImmutableArray<BoundExpression>.Builder boundArguments)
+    {
+        // Generic candidates may carry unsubstituted method type parameters in
+        // their signature; rely on the existing #1124 inference filter instead.
+        if (candidate.IsGeneric)
+        {
+            return true;
+        }
+
+        var parameterOffset = candidate.ExplicitReceiverParameter == null ? 0 : 1;
+        var paramLen = candidate.Parameters.Length - parameterOffset;
+        var isVariadic = paramLen > 0 && candidate.Parameters[candidate.Parameters.Length - 1].IsVariadic;
+        var fixedParamCount = isVariadic ? paramLen - 1 : paramLen;
+
+        var count = Math.Min(argumentCount, paramLen);
+        for (var i = 0; i < count && i < boundArguments.Count; i++)
+        {
+            // The variadic tail binds its element(s) elsewhere; do not reject.
+            if (isVariadic && i >= fixedParamCount)
+            {
+                continue;
+            }
+
+            var parameter = candidate.Parameters[i + parameterOffset];
+
+            // By-ref/out/in parameters have their own exact-type rules.
+            if (parameter.RefKind != RefKind.None)
+            {
+                continue;
+            }
+
+            var argType = boundArguments[i]?.Type;
+            var paramType = parameter.Type;
+
+            // Unknown argument or parameter type — be conservative, do not reject.
+            if (argType == null || paramType == null)
+            {
+                continue;
+            }
+
+            var conversion = Conversion.Classify(argType, paramType);
+            if (conversion.Exists && (conversion.IsImplicit || conversion.IsIdentity))
+            {
+                continue;
+            }
+
+            if (conversions.TryApplyUserDefinedImplicitArgumentConversion(boundArguments[i], paramType, out _))
+            {
+                continue;
+            }
+
+            return false;
+        }
+
+        return true;
     }
 
     /// <summary>

--- a/test/Compiler.Tests/Emit/Issue1154NullableWideningOverloadEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1154NullableWideningOverloadEmitTests.cs
@@ -1,0 +1,149 @@
+// <copyright file="Issue1154NullableWideningOverloadEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1154: overload resolution must select the unique applicable
+/// overload that needs an implicit nullable-widening conversion (T → T?) when
+/// a second, wholly non-applicable overload (e.g. <c>F(string)</c>) also
+/// exists — without a spurious GS0266 ambiguity. This test proves the selected
+/// <c>F([]uint8?)</c> overload actually runs: a non-null array argument flows
+/// into the nullable-array overload body and produces its distinctive output.
+/// </summary>
+public class Issue1154NullableWideningOverloadEmitTests
+{
+    [Fact]
+    public void NullableWideningOverload_NonNullArray_RunsNullableOverloadBody()
+    {
+        var source = """
+            package P
+
+            import System
+
+            class C {
+                shared { func Make() []uint8 { var r = []uint8{uint8(10), uint8(20), uint8(30)} return r } }
+                func F(a string) string { return "string-overload" }
+                func F(a []uint8?) string {
+                    if a == nil { return "null" }
+                    return "bytes-overload:" + a.Length.ToString()
+                }
+                func Run() string { return F(C.Make()) }
+            }
+
+            let c = C()
+            Console.WriteLine(c.Run())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("bytes-overload:3\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var (exitCode, stdout, stderr) = CompileAndRunRaw(source);
+        Assert.True(
+            exitCode == 0,
+            $"exited {exitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout;
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) CompileAndRunRaw(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1154_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+            };
+
+            foreach (var bcl in BclReferences.Value)
+            {
+                args.Add("/r:" + bcl);
+            }
+
+            args.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            return (proc.ExitCode, stdout.Replace("\r\n", "\n"), stderr.Replace("\r\n", "\n"));
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static readonly Lazy<IReadOnlyList<string>> BclReferences = new(() =>
+    {
+        var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location);
+        if (string.IsNullOrEmpty(runtimeDir) || !Directory.Exists(runtimeDir))
+        {
+            return Array.Empty<string>();
+        }
+
+        return Directory.EnumerateFiles(runtimeDir, "*.dll", SearchOption.TopDirectoryOnly)
+            .Where(p =>
+            {
+                var name = Path.GetFileName(p);
+                return name.StartsWith("System.", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "mscorlib.dll", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "netstandard.dll", StringComparison.OrdinalIgnoreCase);
+            })
+            .ToList();
+    });
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1154NullableWideningOverloadTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1154NullableWideningOverloadTests.cs
@@ -1,0 +1,216 @@
+// <copyright file="Issue1154NullableWideningOverloadTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1154. Overload resolution must not report a spurious GS0266
+/// ambiguity when an argument needs an implicit nullable-widening conversion
+/// (T → T?) to match the ONLY applicable candidate while a second, wholly
+/// non-applicable overload (e.g. F(string) for a []uint8 argument) also exists.
+/// Phase-1 arity/name applicability is convertibility-unaware, so the
+/// non-applicable overload used to tie with — and thus be reported ambiguous
+/// against — the unique applicable nullable-widening overload. A
+/// convertibility-aware filter now excludes non-convertible candidates so the
+/// unique applicable overload binds without a diagnostic, while genuine
+/// ambiguity and genuine no-applicable-overload cases still report.
+/// </summary>
+public class Issue1154NullableWideningOverloadTests
+{
+    [Fact]
+    public void Repro_NullableWidening_UniqueApplicable_BindsWithoutGS0266()
+    {
+        // REPRO: F(string), F([]uint8?); arg is non-nullable []uint8.
+        // Only F([]uint8?) is applicable ([]uint8 -> []uint8? implicit widening).
+        const string source = @"
+package p
+class C {
+    shared { func Make() []uint8 { var r []uint8 return r } }
+    func F(a string) { F(C.Make()) }
+    func F(a []uint8?) { var n = 1 }
+}
+";
+        var compilation = Compile(source);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
+        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+
+        var selected = FindCall(compilation, "F", "F");
+        Assert.NotNull(selected);
+        var param = selected.Parameters.Last();
+        Assert.IsType<NullableTypeSymbol>(param.Type);
+    }
+
+    [Fact]
+    public void VariantA_ExactMatch_StillBinds()
+    {
+        // F(string), F([]uint8); arg []uint8 -> exact match to F([]uint8).
+        const string source = @"
+package p
+class C {
+    shared { func Make() []uint8 { var r []uint8 return r } }
+    func F(a string) { F(C.Make()) }
+    func F(a []uint8) { var n = 1 }
+}
+";
+        var compilation = Compile(source);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
+        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+
+        var selected = FindCall(compilation, "F", "F");
+        Assert.NotNull(selected);
+        var param = selected.Parameters.Last();
+        Assert.IsNotType<NullableTypeSymbol>(param.Type);
+    }
+
+    [Fact]
+    public void VariantB_NullableWideningOnly_StillBinds()
+    {
+        // F([]uint8?) only; arg []uint8 -> nullable widening applicable.
+        const string source = @"
+package p
+class C {
+    shared { func Make() []uint8 { var r []uint8 return r } }
+    func F(a []uint8?) { F(C.Make()) }
+}
+";
+        var compilation = Compile(source);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
+        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+
+        var selected = FindCall(compilation, "F", "F");
+        Assert.NotNull(selected);
+        var param = selected.Parameters.Last();
+        Assert.IsType<NullableTypeSymbol>(param.Type);
+    }
+
+    [Fact]
+    public void VariantC_ExactNullableMatch_StillBinds()
+    {
+        // F(string), F([]uint8?); arg is []uint8? -> exact match to T?.
+        const string source = @"
+package p
+class C {
+    shared { func Make() []uint8? { var r []uint8? return r } }
+    func F(a string) { F(C.Make()) }
+    func F(a []uint8?) { var n = 1 }
+}
+";
+        var compilation = Compile(source);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
+        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+
+        var selected = FindCall(compilation, "F", "F");
+        Assert.NotNull(selected);
+        var param = selected.Parameters.Last();
+        Assert.IsType<NullableTypeSymbol>(param.Type);
+    }
+
+    [Fact]
+    public void GenuineAmbiguity_StillReportsGS0266()
+    {
+        // Argument `Both` converts (implicitly) to both IA and IB equally; the
+        // two non-generic overloads genuinely tie. Must still report GS0266.
+        const string source = @"
+package p
+interface IA {}
+interface IB {}
+class Both : IA, IB {}
+class Factory {
+    shared {
+        func Take(x IA) int32 { return 1 }
+        func Take(x IB) int32 { return 2 }
+    }
+}
+class C {
+    func G(b Both) {
+        let x = Factory.Take(b)
+    }
+}
+";
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0266");
+    }
+
+    [Fact]
+    public void NoApplicableOverload_StillReports_NotGS0266()
+    {
+        // F(string) only; arg []uint8 -> no applicable overload. Must report a
+        // diagnostic (not GS0266, not a crash).
+        const string source = @"
+package p
+class C {
+    shared { func Make() []uint8 { var r []uint8 return r } }
+    func F(a string) { F(C.Make()) }
+}
+";
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree) { IsLibrary = true };
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.NotEmpty(result.Diagnostics);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
+    }
+
+    private static Compilation Compile(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        return new Compilation(tree) { IsLibrary = true };
+    }
+
+    private static FunctionSymbol FindCall(Compilation compilation, string functionName, string callName)
+        => FindCalls(compilation, functionName, callName).FirstOrDefault();
+
+    private static List<FunctionSymbol> FindCalls(Compilation compilation, string functionName, string callName)
+    {
+        var collector = new CallCollector(callName);
+        foreach (var body in compilation.BoundProgram.Functions.Values)
+        {
+            collector.Visit(body);
+        }
+
+        return collector.Collected;
+    }
+
+    private sealed class CallCollector : BoundTreeWalker
+    {
+        private readonly string callName;
+
+        public CallCollector(string callName)
+        {
+            this.callName = callName;
+        }
+
+        public List<FunctionSymbol> Collected { get; } = new();
+
+        public override void VisitExpression(BoundExpression node)
+        {
+            switch (node)
+            {
+                case BoundCallExpression call when call.Function.Name == callName:
+                    Collected.Add(call.Function);
+                    break;
+                case BoundUserInstanceCallExpression instanceCall when instanceCall.Method.Name == callName:
+                    Collected.Add(instanceCall.Method);
+                    break;
+            }
+
+            base.VisitExpression(node);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1154.

## Root cause
User-call overload resolution (`SelectBestUserOverloadCore` in `OverloadResolver.cs`) reported a spurious **GS0266** ambiguity when an argument needed an implicit nullable-widening conversion (`T -> T?`) to match the *only* applicable candidate while a second, wholly non-applicable overload also existed.

Phase-1 applicability only checked **arity + named-argument names**, not whether each argument is type-convertible to the corresponding parameter. So for the repro:

```gsharp
class C {
    shared { func Make() []uint8 { var r []uint8 return r } }
    func F(a string) { F(C.Make()) }   // arg is non-nullable []uint8
    func F(a []uint8?) { var n = 1 }
}
```

`F(string)` was wrongly kept "applicable" for a `[]uint8` argument. Phase-2 scoring only rewards *exact* type matches (`-10`), so neither `F(string)` nor `F([]uint8?)` (which needs a nullable wrap) scored a bonus, producing a tie and GS0266. Per C# 11.6.4.2, a candidate is not applicable when an argument has no implicit conversion to its parameter type.

## Fix
Add a **convertibility-aware applicability filter** after the existing arity/name applicability and the #1124 generic filter, before Phase-2 scoring. A candidate is excluded when any supplied positional argument has no implicit / identity / user-defined-implicit conversion to its parameter type.

The filter is conservative, mirroring the #1124 pattern:
- only adopted when it leaves at least one candidate (never empties the set);
- **skips** generic candidates (rely on #1124 inference filter), the variadic tail, by-ref/out/in parameters, unknown argument/parameter types, and any call with **named arguments** (positional mapping unreliable).

This removes `F(string)` from the applicable set, leaving `F([]uint8?)` as the unique applicable overload, bound with **no diagnostic**. Genuine ambiguity (GS0266) and genuine no-applicable-overload cases still report. The fix lives in `SelectBestUserOverloadCore`, which all user-call entry points (`SelectBestInstanceOverload`, `SelectUnifiedInstanceStaticOverload`, same-named self-calls) route through.

## Tests
**Added**
- `test/Core.Tests/CodeAnalysis/Binding/Issue1154NullableWideningOverloadTests.cs` (6 tests): REPRO binds to `F([]uint8?)` with no GS0266; Variant A (exact `[]uint8`); Variant B (nullable-widening only); Variant C (exact `[]uint8?`); genuine ambiguity still GS0266; genuine no-applicable-overload still reported (not GS0266).
- `test/Compiler.Tests/Emit/Issue1154NullableWideningOverloadEmitTests.cs` (1 test): emit/exec proving the selected `[]uint8?` overload body actually runs for a non-null array.

**Preserved (all green):** full Core.Tests (4002 passed), plus OverloadResolutionTests, OverloadAndOptionalParameterTests, Issue1124/Issue1147/Issue687/Issue814 (131 passed in the focused overload/binding filter).
