### PR TITLE
Fix #1157: adapt integer-literal switch-case labels to a narrow/unsigned governing type

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
@@ -1304,7 +1304,7 @@ internal sealed partial class ExpressionBinder
     // issue #1144: the ten G# integer primitive types (signed + unsigned,
     // including the native-int pair). Membership mirrors the integral sets in
     // BoundBinaryOperator.
-    private static bool IsIntegerType(TypeSymbol type)
+    internal static bool IsIntegerType(TypeSymbol type)
     {
         return type == TypeSymbol.Int8 || type == TypeSymbol.Int16 || type == TypeSymbol.Int32
             || type == TypeSymbol.Int64 || type == TypeSymbol.NInt
@@ -1314,7 +1314,7 @@ internal sealed partial class ExpressionBinder
 
     // issue #1144: true when the boxed literal value is a compile-time constant
     // INTEGER (excludes char/bool/float/decimal/string/enum, which never adapt).
-    private static bool IsIntegerLiteralValue(object value)
+    internal static bool IsIntegerLiteralValue(object value)
     {
         return value is sbyte or byte or short or ushort or int or uint or long or ulong or nint or nuint;
     }
@@ -1326,7 +1326,7 @@ internal sealed partial class ExpressionBinder
     // InferType) to EXACTLY the target type. Native ints are range-tested
     // conservatively as int64 (nint) / uint64 (nuint) so the result is stable
     // regardless of the host process pointer width.
-    private static bool TryAdaptIntegerLiteral(object value, TypeSymbol target, out object converted)
+    internal static bool TryAdaptIntegerLiteral(object value, TypeSymbol target, out object converted)
     {
         converted = null;
         BigInteger v = value switch

--- a/src/Core/CodeAnalysis/Binding/PatternBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/PatternBinder.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Numerics;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 
@@ -165,6 +166,25 @@ internal sealed class PatternBinder
     private BoundPattern BindConstantPattern(ConstantPatternSyntax syntax, TypeSymbol discriminantType)
     {
         var expression = bindExpression(syntax.Expression);
+
+        // Issue #1157: adapt a constant integer LITERAL case label that fits the
+        // discriminant's integer type to that type, mirroring the constant
+        // adaptation #1144 restored for binary operators. Without this, a literal
+        // like `0` (typed int32) on a `uint8` switch is a narrowing conversion and
+        // would be rejected with GS0171 even though it clearly fits. A nullable
+        // discriminant targets its underlying type; out-of-range labels are left
+        // untouched so the existing GS0171 path still fires.
+        var adaptTarget = discriminantType is NullableTypeSymbol nullableTarget
+            ? nullableTarget.UnderlyingType
+            : discriminantType;
+        if (ExpressionBinder.IsIntegerType(adaptTarget)
+            && expression.Type != adaptTarget
+            && TryGetConstantIntegerLiteralValue(expression, out var literalValue)
+            && ExpressionBinder.TryAdaptIntegerLiteral(literalValue, adaptTarget, out var adaptedValue))
+        {
+            expression = new BoundLiteralExpression(syntax.Expression, adaptedValue);
+        }
+
         var conversion = Conversion.Classify(expression.Type, discriminantType);
         if (!conversion.Exists || conversion.IsExplicit)
         {
@@ -191,6 +211,76 @@ internal sealed class PatternBinder
         }
 
         return new BoundConstantPattern(syntax, discriminantType, value);
+    }
+
+    // Issue #1157: extract a compile-time constant INTEGER literal value from a
+    // case-label expression. Accepts a bare integer literal or a unary `+` / `-`
+    // applied to one (e.g. `case -1`), so a negative literal label can adapt to a
+    // signed governing type. Named constants and other non-literal expressions are
+    // deliberately excluded — only literal labels participate in adaptation.
+    private static bool TryGetConstantIntegerLiteralValue(BoundExpression expression, out object value)
+    {
+        switch (expression)
+        {
+            case BoundLiteralExpression lit when ExpressionBinder.IsIntegerLiteralValue(lit.Value):
+                value = lit.Value;
+                return true;
+
+            case BoundUnaryExpression unary
+                when unary.Op.Kind == BoundUnaryOperatorKind.Identity
+                    && TryGetConstantIntegerLiteralValue(unary.Operand, out var positive):
+                value = positive;
+                return true;
+
+            case BoundUnaryExpression unary
+                when unary.Op.Kind == BoundUnaryOperatorKind.Negation
+                    && TryGetConstantIntegerLiteralValue(unary.Operand, out var operand):
+                return TryNegateIntegerLiteral(operand, out value);
+        }
+
+        value = null;
+        return false;
+    }
+
+    // Issue #1157: negate a boxed integer literal, re-boxing into the narrowest of
+    // int64 / uint64 that holds the result. The boxed type only feeds
+    // ExpressionBinder.TryAdaptIntegerLiteral (which range-checks via BigInteger),
+    // so any integer carrier with the correct value suffices.
+    private static bool TryNegateIntegerLiteral(object value, out object negated)
+    {
+        var result = -ToBigInteger(value);
+        if (result >= long.MinValue && result <= long.MaxValue)
+        {
+            negated = (long)result;
+            return true;
+        }
+
+        if (result >= ulong.MinValue && result <= ulong.MaxValue)
+        {
+            negated = (ulong)result;
+            return true;
+        }
+
+        negated = null;
+        return false;
+    }
+
+    private static BigInteger ToBigInteger(object value)
+    {
+        return value switch
+        {
+            sbyte s => s,
+            byte b => b,
+            short s => s,
+            ushort u => u,
+            int i => i,
+            uint u => u,
+            long l => l,
+            ulong u => u,
+            nint n => (long)n,
+            nuint n => (ulong)n,
+            _ => default,
+        };
     }
 
     private BoundPattern BindTypePattern(TypePatternSyntax syntax, TypeSymbol discriminantType, bool allowBindings)

--- a/test/Compiler.Tests/Emit/Issue1157SwitchCaseLiteralAdaptationEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1157SwitchCaseLiteralAdaptationEmitTests.cs
@@ -1,0 +1,124 @@
+// <copyright file="Issue1157SwitchCaseLiteralAdaptationEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1157: end-to-end emit + execution test proving a constant integer
+/// literal case label adapts to a narrow / unsigned governing type and the
+/// correct switch-expression arm is selected at runtime. Mirrors the #1144
+/// emit harness: each program compiles via <c>gsc</c>, is IL-verified, and is
+/// run under <c>dotnet exec</c> with its runtime output asserted.
+/// </summary>
+public class Issue1157SwitchCaseLiteralAdaptationEmitTests
+{
+    [Fact]
+    public void UInt8SwitchExpression_LiteralLabelsAdapt_DispatchesCorrectArm()
+    {
+        var source = """
+            package main
+            import System
+
+            func F(b uint8) int32 {
+                return switch b {
+                    case 0: 10
+                    case 1: 20
+                    default: 30
+                }
+            }
+
+            func run() {
+                Console.WriteLine(F(uint8(1)))
+                Console.WriteLine(F(uint8(7)))
+                Console.WriteLine(F(uint8(0)))
+            }
+
+            run()
+            """;
+
+        // case 1 -> 20, no match -> default 30, case 0 -> 10
+        Assert.Equal("20\n30\n10\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1157_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath, null, Array.Empty<string>());
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+                // ignored
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1157SwitchCaseLiteralAdaptationTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1157SwitchCaseLiteralAdaptationTests.cs
@@ -1,0 +1,184 @@
+// <copyright file="Issue1157SwitchCaseLiteralAdaptationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1157: a constant integer LITERAL case label adapts to a narrow /
+/// unsigned governing (discriminant) type when its value is representable
+/// there — the switch-case-label analogue of the binary-operator constant
+/// adaptation restored by #1144. A label that does NOT fit the governing
+/// type still errors with GS0171, and non-integer discriminants (string,
+/// enum) are unaffected.
+/// </summary>
+public class Issue1157SwitchCaseLiteralAdaptationTests
+{
+    // ── The exact repro: switch-EXPRESSION over uint8 ──────────────────
+
+    [Fact]
+    public void SwitchExpression_UInt8_LiteralLabelsAdapt_NoDiagnostics()
+    {
+        var source = Wrap(@"func F(b uint8) int32 {
+        return switch b {
+            case 0: 10
+            case 1: 20
+            default: 30
+        }
+    }");
+        Assert.Empty(Errors(source));
+    }
+
+    // ── switch-STATEMENT over uint8 routes through the same path ────────
+
+    [Fact]
+    public void SwitchStatement_UInt8_LiteralLabelsAdapt_NoDiagnostics()
+    {
+        var source = Wrap(@"func F(b uint8) {
+        switch b {
+            case 0 { var a = 1 }
+            case 1 { var c = 2 }
+            default { var d = 3 }
+        }
+    }");
+        Assert.Empty(Errors(source));
+    }
+
+    // ── Other narrow / unsigned governing types ────────────────────────
+
+    [Theory]
+    [InlineData("uint8", "0", "1")]
+    [InlineData("uint16", "0", "1000")]
+    [InlineData("int16", "0", "100")]
+    [InlineData("int8", "0", "100")]
+    [InlineData("uint32", "0", "40000")]
+    [InlineData("uint64", "0", "1")]
+    public void SwitchExpression_NarrowGoverningType_FittingLabels_NoDiagnostics(
+        string type, string a, string b)
+    {
+        var source = Wrap(@"func F(v " + type + @") int32 {
+        return switch v {
+            case " + a + @": 10
+            case " + b + @": 20
+            default: 30
+        }
+    }");
+        Assert.Empty(Errors(source));
+    }
+
+    // ── Negative literal fits int8 but not uint8 ───────────────────────
+
+    [Fact]
+    public void SwitchExpression_Int8_NegativeLiteralFits_NoDiagnostics()
+    {
+        var source = Wrap(@"func F(v int8) int32 {
+        return switch v {
+            case -1: 10
+            default: 30
+        }
+    }");
+        Assert.Empty(Errors(source));
+    }
+
+    [Fact]
+    public void SwitchExpression_UInt8_NegativeLiteralDoesNotFit_GS0171()
+    {
+        var source = Wrap(@"func F(v uint8) int32 {
+        return switch v {
+            case -1: 10
+            default: 30
+        }
+    }");
+        Assert.Contains(Errors(source), d => d.Id == "GS0171");
+    }
+
+    // ── Out-of-range label still errors ────────────────────────────────
+
+    [Fact]
+    public void SwitchExpression_UInt8_OutOfRangeLiteral_StillErrorsGS0171()
+    {
+        var source = Wrap(@"func F(b uint8) int32 {
+        return switch b {
+            case 300: 10
+            default: 30
+        }
+    }");
+        Assert.Contains(Errors(source), d => d.Id == "GS0171");
+    }
+
+    // ── Nullable discriminant adapts to underlying then widens ─────────
+
+    [Fact]
+    public void SwitchExpression_NullableUInt8_LiteralLabelAdapts_NoDiagnostics()
+    {
+        var source = Wrap(@"func F(b uint8?) int32 {
+        return switch b {
+            case 0: 10
+            case 1: 20
+            default: 30
+        }
+    }");
+        Assert.Empty(Errors(source));
+    }
+
+    // ── Non-integer discriminants unaffected ───────────────────────────
+
+    [Fact]
+    public void SwitchExpression_String_LiteralLabel_StillWorks()
+    {
+        var source = Wrap(@"func F(s string) int32 {
+        return switch s {
+            case ""hi"": 10
+            case ""bye"": 20
+            default: 30
+        }
+    }");
+        Assert.Empty(Errors(source));
+    }
+
+    [Fact]
+    public void SwitchExpression_Enum_StillWorks()
+    {
+        var source = @"
+package p
+enum Color { Red, Green, Blue }
+class C {
+    func F(c Color) int32 {
+        return switch c {
+            case Color.Red: 10
+            case Color.Green: 20
+            default: 30
+        }
+    }
+}
+";
+        Assert.Empty(Errors(source));
+    }
+
+    private static string Wrap(string member)
+    {
+        return @"
+package p
+class C {
+    " + member + @"
+}
+";
+    }
+
+    private static IReadOnlyList<Diagnostic> Errors(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new GSharp.Core.CodeAnalysis.Compilation.Compilation(tree);
+        using var peStream = new System.IO.MemoryStream();
+        return compilation.Emit(peStream).Diagnostics
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .ToList();
+    }
+}


### PR DESCRIPTION
Fixes #1157

## Root cause
A `switch` whose governing value is a narrow/unsigned integer type (`uint8`, `uint16`, …) rejected integer-LITERAL case labels with GS0171. Both switch-expression arms and switch-statement cases bind constant labels through `PatternBinder.BindConstantPattern`. A label literal like `0`/`1` binds as a `BoundLiteralExpression` of type `int32`; `Conversion.Classify(int32, uint8)` is a narrowing (non-implicit) conversion, so `!Exists || IsExplicit` triggered GS0171 even though the literal clearly fits.

## Fix
This is the switch-case-label analogue of the binary-operator constant adaptation #1144 restored (`uint8 == 0`, `uint8 | 4`). In `BindConstantPattern`, immediately after binding the label expression and **before** the `Conversion.Classify` check, a constant integer literal label that FITS the discriminant's integer type is adapted to that type, reusing the #1144 helpers (visibility relaxed `private static` -> `internal static`): `IsIntegerType`, `IsIntegerLiteralValue`, `TryAdaptIntegerLiteral`. After adaptation the existing conversion becomes identity (non-nullable) or implicit `T -> T?` (nullable), so the existing success path and nullable-comparison logic handle both unchanged.

- **Nullable discriminant** (`uint8?`): adapts to the underlying type, then widens.
- **Negated literal** (`case -1`): folded so it adapts to a signed governing type (`int8`) while still erroring on an unsigned one (`uint8`).
- **Out-of-range** (`case 300` on `uint8`): `TryAdaptIntegerLiteral` returns false, the literal is left untouched, and the existing GS0171 path still fires.
- **Non-integer discriminants** (string, enum, char, bool, float, user types): unaffected via the `IsIntegerType(adaptTarget)` guard.

The change is purely in the binder; the adapted literal carries the discriminant's CLR type and the existing switch emit handles it.

## Tests
- **`Issue1157SwitchCaseLiteralAdaptationTests`** (binder): the exact repro (switch-expression over `uint8`), switch-statement over `uint8`, narrow/unsigned governing types (`uint16`/`int16`/`int8`/`uint32`/`uint64`), negative literal fitting `int8` but not `uint8` (GS0171), out-of-range `case 300` still GS0171, nullable `uint8?`, and unaffected `string`/`enum` discriminants.
- **`Issue1157SwitchCaseLiteralAdaptationEmitTests`** (emit/exec): compiles + runs a `uint8` switch-expression and asserts runtime arm dispatch (input 1 -> 20, input 7 -> default 30, input 0 -> 10).
- Existing #1144 binder/emit tests and the broader switch/pattern suites remain green; full `Core.Tests` passes (4016 passed, 1 skipped).
