### PR TITLE
Fix #1158: unify if/conditional sibling arms via best-common-type and target-typing

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
@@ -599,6 +599,9 @@ internal sealed partial class ExpressionBinder
     }
 
     private BoundExpression BindConditionalExpression(ConditionalExpressionSyntax syntax)
+        => BindConditionalExpression(syntax, targetType: null);
+
+    private BoundExpression BindConditionalExpression(ConditionalExpressionSyntax syntax, TypeSymbol targetType)
     {
         var condition = BindExpression(syntax.Condition, TypeSymbol.Bool);
 
@@ -648,7 +651,7 @@ internal sealed partial class ExpressionBinder
             return new BoundErrorExpression(null);
         }
 
-        var resultType = ComputeConditionalCommonType(whenTrue.Type, whenFalse.Type);
+        var resultType = ComputeConditionalResultType(whenTrue.Type, whenFalse.Type, targetType);
         if (resultType == null)
         {
             Diagnostics.ReportConditionalNoCommonResultType(
@@ -674,6 +677,9 @@ internal sealed partial class ExpressionBinder
     /// are lowered to <see cref="BoundBlockExpression"/> wrapping the final value.
     /// </summary>
     private BoundExpression BindIfExpression(IfExpressionSyntax syntax)
+        => BindIfExpression(syntax, targetType: null);
+
+    private BoundExpression BindIfExpression(IfExpressionSyntax syntax, TypeSymbol targetType)
     {
         // An if-expression in value position must have an else branch.
         if (syntax.ElseExpression == null)
@@ -692,7 +698,7 @@ internal sealed partial class ExpressionBinder
             return new BoundErrorExpression(null);
         }
 
-        var resultType = ComputeConditionalCommonType(whenTrue.Type, whenFalse.Type);
+        var resultType = ComputeConditionalResultType(whenTrue.Type, whenFalse.Type, targetType);
         if (resultType == null)
         {
             Diagnostics.ReportConditionalNoCommonResultType(
@@ -829,6 +835,47 @@ internal sealed partial class ExpressionBinder
         }
 
         return BindExpression(bodySyntax, canBeVoid: true);
+    }
+
+    /// <summary>
+    /// Issue #1158: computes the conditional/if-expression result type using the
+    /// same target-typing + best-common-type machinery as switch-expressions, in
+    /// the following priority order (first non-null wins):
+    /// <list type="number">
+    ///   <item><description>Target-typing — when an explicit, valid target type is supplied and BOTH arms implicitly convert to it (C# 9+ target-typed conditional).</description></item>
+    ///   <item><description>The existing pairwise <see cref="ComputeConditionalCommonType"/> (identity, never/null lift, one-way implicit, ADR-0037 numeric tie-break).</description></item>
+    ///   <item><description>Best-common-type (least-upper-bound) across the two arms — unifies sibling subtypes to their shared base/interface.</description></item>
+    /// </list>
+    /// Returns <see langword="null"/> only when none of the three yield a type, so
+    /// the caller reports GS0263.
+    /// </summary>
+    /// <param name="left">The true-arm type.</param>
+    /// <param name="right">The false-arm type.</param>
+    /// <param name="targetType">The optional target type (C#-style target-typing), or <see langword="null"/>.</param>
+    /// <returns>The chosen result type, or <see langword="null"/>.</returns>
+    private static TypeSymbol ComputeConditionalResultType(TypeSymbol left, TypeSymbol right, TypeSymbol targetType)
+    {
+        // (a) Target-typing: honor an explicit, valid target when both arms
+        // implicitly convert to it.
+        if (targetType != null
+            && targetType != TypeSymbol.Error
+            && targetType != TypeSymbol.Void
+            && AllArmsImplicitlyConvertTo(new[] { left, right }, targetType))
+        {
+            return targetType;
+        }
+
+        // (b) Existing pairwise common type (identity, never/null, one-way
+        // implicit, numeric tie-break). DO NOT alter this method's behavior.
+        var pairwise = ComputeConditionalCommonType(left, right);
+        if (pairwise != null)
+        {
+            return pairwise;
+        }
+
+        // (c) Best-common-type (least-upper-bound) fallback: unify sibling
+        // subtypes to their shared base/interface.
+        return ComputeBestCommonType(new[] { left, right });
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -178,6 +178,22 @@ internal sealed partial class ExpressionBinder
             return conversions.BindConversion(syntax.Location, boundSwitch, targetType);
         }
 
+        // Issue #1158: an if-expression and a ternary conditional likewise honor
+        // the target type (C# 9+ target-typed conditional) — bind with the
+        // target so sibling arms can unify to it, then run the standard
+        // conversion to shape/validate the overall result.
+        if (syntax is IfExpressionSyntax ifExpr)
+        {
+            var boundIf = BindIfExpression(ifExpr, targetType);
+            return conversions.BindConversion(syntax.Location, boundIf, targetType);
+        }
+
+        if (syntax is ConditionalExpressionSyntax conditionalExpr)
+        {
+            var boundConditional = BindConditionalExpression(conditionalExpr, targetType);
+            return conversions.BindConversion(syntax.Location, boundConditional, targetType);
+        }
+
         return conversions.BindConversion(syntax, targetType);
     }
 

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.cs
@@ -819,6 +819,23 @@ internal sealed class StatementBinder
                 variableType = type;
                 convertedInitializer = new BoundDefaultExpression(defaultInit, variableType);
             }
+            else if (type != null
+                && (syntax.Initializer is IfExpressionSyntax
+                    || syntax.Initializer is ConditionalExpressionSyntax
+                    || syntax.Initializer is SwitchExpressionSyntax))
+            {
+                // Issue #1158: when a typed local is initialised with an
+                // if-/conditional-/switch-expression, thread the declared type
+                // into the binder as the target type so sibling arms can unify
+                // to it (C# 9+ target-typed conditional/switch), including a
+                // target that is wider than the arms' natural least-upper-bound
+                // (e.g. `object` or a shared interface). The conversion below is
+                // identity for the chosen target; a genuine mismatch still
+                // reports the regular conversion diagnostic.
+                variableType = type;
+                var initializer = bindExpressionWithTargetType(syntax.Initializer, type);
+                convertedInitializer = conversions.BindConversion(syntax.Initializer.Location, initializer, variableType);
+            }
             else
             {
                 var initializer = bindExpression(syntax.Initializer);
@@ -3724,11 +3741,13 @@ internal sealed class StatementBinder
         }
         else
         {
-            // Issue #1112: a `return switch { … }` honors the function's
-            // declared return type as the switch-expression target type so the
-            // result type can unify to the return type (C#-style target-typing)
-            // before the conversion below.
-            if (syntax.Expression is SwitchExpressionSyntax
+            // Issue #1112 / #1158: a `return switch { … }`, `return if … `, or
+            // `return cond ? … : …` honors the function's declared return type
+            // as the target type so the result type can unify to the return type
+            // (C#-style target-typing) before the conversion below.
+            if ((syntax.Expression is SwitchExpressionSyntax
+                    || syntax.Expression is IfExpressionSyntax
+                    || syntax.Expression is ConditionalExpressionSyntax)
                 && function != null
                 && !function.IsReturnTypeInferred
                 && function.Type != TypeSymbol.Void

--- a/test/Compiler.Tests/Emit/Issue1158ConditionalSiblingUnifyEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1158ConditionalSiblingUnifyEmitTests.cs
@@ -1,0 +1,153 @@
+// <copyright file="Issue1158ConditionalSiblingUnifyEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1158: end-to-end CLR emit coverage for unifying two sibling-subtype
+/// arms of an <c>if</c>/conditional-expression to their shared base type. The
+/// upcast must be a no-op reference conversion, so the value flowing out of the
+/// conditional keeps its concrete runtime type per the branch taken.
+/// </summary>
+public class Issue1158ConditionalSiblingUnifyEmitTests
+{
+    [Fact]
+    public void EndToEnd_IfExpression_SiblingArms_PreservesConcreteType()
+    {
+        var source = """
+            package Probe
+            import System
+
+            open class Box { }
+            class Co64Box : Box { }
+            class StcoBox : Box { }
+
+            func PickIf(b bool) Box {
+                let x = Co64Box()
+                let y = StcoBox()
+                return if b { x } else { y }
+            }
+
+            func Main() {
+                Console.WriteLine(PickIf(true).GetType().Name)
+                Console.WriteLine(PickIf(false).GetType().Name)
+            }
+            """;
+        var output = CompileAndRun(source);
+        Assert.Equal("Co64Box\nStcoBox\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_Ternary_SiblingArms_PreservesConcreteType()
+    {
+        var source = """
+            package Probe
+            import System
+
+            open class Box { }
+            class Co64Box : Box { }
+            class StcoBox : Box { }
+
+            func PickTern(b bool) Box {
+                let x = Co64Box()
+                let y = StcoBox()
+                return b ? x : y
+            }
+
+            func Main() {
+                Console.WriteLine(PickTern(true).GetType().Name)
+                Console.WriteLine(PickTern(false).GetType().Name)
+            }
+            """;
+        var output = CompileAndRun(source);
+        Assert.Equal("Co64Box\nStcoBox\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_cond1158_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1158ConditionalSiblingUnifyTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1158ConditionalSiblingUnifyTests.cs
@@ -1,0 +1,331 @@
+// <copyright file="Issue1158ConditionalSiblingUnifyTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1158: an <c>if</c>/conditional-expression whose two arms are sibling
+/// subtypes sharing a common base (or interface) must unify to that common
+/// supertype (best-common-type), and an explicit target type must drive the
+/// conversion (C# 9+ target-typed conditional) — matching the switch-expression
+/// machinery (#1112/#1151). These tests cover both the <c>if</c>-expression and
+/// the ternary <c>?:</c> form, and confirm the existing one-way, numeric and
+/// nil behaviors are unchanged.
+/// </summary>
+public class Issue1158ConditionalSiblingUnifyTests
+{
+    // Sibling subtypes of a shared base, a base/derived pair, and two classes
+    // sharing only an interface (no common non-object base).
+    private const string Hierarchy = @"
+open class Box { }
+class Co64Box : Box { }
+class StcoBox : Box { }
+open class Animal { }
+class Dog : Animal { }
+interface IShape { }
+class Sq : IShape { }
+class Ci : IShape { }
+class Unrelated { }
+";
+
+    [Fact]
+    public void ReproF_ReturnIfExpression_SiblingArms_ReturnTypeBox_NoDiagnostics()
+    {
+        // Issue repro F: both arms are siblings of Box; the declared return type
+        // Box is the target the arms unify to.
+        var diagnostics = Bind(Hierarchy + @"
+func F(b bool, x Co64Box, y StcoBox) Box {
+    return if b { x } else { y }
+}
+");
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void ReproG_LetTypedBox_IfExpression_SiblingArms_NoDiagnostics()
+    {
+        // Issue repro G: an explicitly-typed local Box supplies the target type.
+        var diagnostics = Bind(Hierarchy + @"
+func G(b bool, x Co64Box, y StcoBox) {
+    let r Box = if b { x } else { y }
+}
+");
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void Ternary_SiblingArms_ReturnTypeBox_NoDiagnostics()
+    {
+        var diagnostics = Bind(Hierarchy + @"
+func F(b bool, x Co64Box, y StcoBox) Box {
+    return b ? x : y
+}
+");
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void Ternary_SiblingArms_LetTypedBox_NoDiagnostics()
+    {
+        var diagnostics = Bind(Hierarchy + @"
+func G(b bool, x Co64Box, y StcoBox) {
+    let r Box = b ? x : y
+}
+");
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void NoTarget_IfExpression_SiblingArms_InfersBox()
+    {
+        // No declared target: the best-common-type (LUB) fallback unifies the
+        // two siblings to their shared base Box.
+        var scope = BindGlobalScope(Hierarchy + @"
+let b = true
+let x = Co64Box()
+let y = StcoBox()
+let r = if b { x } else { y }
+");
+
+        Assert.Empty(scope.Diagnostics);
+        Assert.Equal("Box", scope.Variables.Single(v => v.Name == "r").Type.Name);
+    }
+
+    [Fact]
+    public void NoTarget_Ternary_SiblingArms_InfersBox()
+    {
+        var scope = BindGlobalScope(Hierarchy + @"
+let b = true
+let x = Co64Box()
+let y = StcoBox()
+let r = b ? x : y
+");
+
+        Assert.Empty(scope.Diagnostics);
+        Assert.Equal("Box", scope.Variables.Single(v => v.Name == "r").Type.Name);
+    }
+
+    [Fact]
+    public void NoTarget_IfExpression_CommonInterfaceArms_InfersIShape()
+    {
+        // Sq and Ci share only the interface IShape (no common non-object base);
+        // the LUB enumerates interfaces and unifies to IShape.
+        var scope = BindGlobalScope(Hierarchy + @"
+let b = true
+let x = Sq()
+let y = Ci()
+let r = if b { x } else { y }
+");
+
+        Assert.Empty(scope.Diagnostics);
+        Assert.Equal("IShape", scope.Variables.Single(v => v.Name == "r").Type.Name);
+    }
+
+    [Fact]
+    public void NoTarget_Ternary_CommonInterfaceArms_InfersIShape()
+    {
+        var scope = BindGlobalScope(Hierarchy + @"
+let b = true
+let x = Sq()
+let y = Ci()
+let r = b ? x : y
+");
+
+        Assert.Empty(scope.Diagnostics);
+        Assert.Equal("IShape", scope.Variables.Single(v => v.Name == "r").Type.Name);
+    }
+
+    [Fact]
+    public void TargetTyped_LetIShape_CommonInterfaceArms_NoDiagnostics()
+    {
+        var diagnostics = Bind(Hierarchy + @"
+func H(b bool, x Sq, y Ci) {
+    let r IShape = if b { x } else { y }
+}
+");
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void BaseDerived_IfExpression_TargetAnimal_NoDiagnostics()
+    {
+        // One arm IS the base (Animal); the existing one-way implicit path keeps
+        // working unchanged.
+        var diagnostics = Bind(Hierarchy + @"
+func B(b bool, d Dog, a Animal) Animal {
+    return if b { d } else { a }
+}
+");
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void BaseDerived_NoTarget_InfersAnimal()
+    {
+        var scope = BindGlobalScope(Hierarchy + @"
+let b = true
+let d = Dog()
+let a = Animal()
+let r = if b { d } else { a }
+");
+
+        Assert.Empty(scope.Diagnostics);
+        Assert.Equal("Animal", scope.Variables.Single(v => v.Name == "r").Type.Name);
+    }
+
+    [Fact]
+    public void Numeric_IfExpression_Int32AndInt64_StillUnifiesToInt64()
+    {
+        // Guard: ADR-0037 numeric tie-break behavior is unchanged — an int32 and
+        // an int64 arm unify to int64 (issue #1150's surface is untouched).
+        var scope = BindGlobalScope(Hierarchy + @"
+let b = true
+let i32v int32 = 5
+let i64v int64 = 5
+let r = if b { i32v } else { i64v }
+");
+
+        Assert.Empty(scope.Diagnostics);
+        Assert.Equal(TypeSymbol.Int64, scope.Variables.Single(v => v.Name == "r").Type);
+    }
+
+    [Fact]
+    public void Numeric_Ternary_Int32AndInt64_StillUnifiesToInt64()
+    {
+        var scope = BindGlobalScope(Hierarchy + @"
+let b = true
+let i32v int32 = 5
+let i64v int64 = 5
+let r = b ? i32v : i64v
+");
+
+        Assert.Empty(scope.Diagnostics);
+        Assert.Equal(TypeSymbol.Int64, scope.Variables.Single(v => v.Name == "r").Type);
+    }
+
+    [Fact]
+    public void Unrelated_NoTarget_IfExpression_StillReportsGS0263()
+    {
+        // Two unrelated user classes share only object; with NO target type the
+        // best-common-type (which deliberately excludes object) yields none, so
+        // GS0263 still fires.
+        var diagnostics = Bind(Hierarchy + @"
+func U(b bool, x Box, y Unrelated) {
+    let r = if b { x } else { y }
+}
+");
+
+        Assert.Contains(diagnostics, d => d.Id == "GS0263");
+    }
+
+    [Fact]
+    public void Unrelated_ObjectTarget_IfExpression_NoDiagnostics()
+    {
+        // string and int32 share only object. With NO target the conditional is
+        // GS0263, but an explicit `object` target drives both arms' implicit
+        // conversion to object (target-typing), so it binds cleanly.
+        var diagnostics = Bind(Hierarchy + @"
+func O(b bool, s string, n int32) {
+    let r object = if b { s } else { n }
+}
+");
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void Unrelated_ObjectTarget_NoTarget_StillReportsGS0263()
+    {
+        // The same string/int32 pair WITHOUT a target still reports GS0263.
+        var diagnostics = Bind(Hierarchy + @"
+func O(b bool, s string, n int32) {
+    let r = if b { s } else { n }
+}
+");
+
+        Assert.Contains(diagnostics, d => d.Id == "GS0263");
+    }
+
+    [Fact]
+    public void Unrelated_ObjectTarget_Ternary_NoDiagnostics()
+    {
+        var diagnostics = Bind(Hierarchy + @"
+func O(b bool, s string, n int32) {
+    let r object = b ? s : n
+}
+");
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void NilArm_NullableReferenceArm_IfExpression_UnifiesToNullable()
+    {
+        // A nullable-reference arm (`string?`) unified with a `nil` arm stays
+        // `string?` — unchanged from the existing nil/null handling.
+        var scope = BindGlobalScope(Hierarchy + @"
+let b = true
+let s string? = ""hi""
+let r = if b { s } else { nil }
+");
+
+        Assert.Empty(scope.Diagnostics);
+        var nullable = Assert.IsType<NullableTypeSymbol>(scope.Variables.Single(v => v.Name == "r").Type);
+        Assert.Equal(TypeSymbol.String, nullable.UnderlyingType);
+    }
+
+    [Fact]
+    public void NilArm_NullableReferenceArm_Ternary_UnifiesToNullable()
+    {
+        var scope = BindGlobalScope(Hierarchy + @"
+let b = true
+let s string? = ""hi""
+let r = b ? s : nil
+");
+
+        Assert.Empty(scope.Diagnostics);
+        var nullable = Assert.IsType<NullableTypeSymbol>(scope.Variables.Single(v => v.Name == "r").Type);
+        Assert.Equal(TypeSymbol.String, nullable.UnderlyingType);
+    }
+
+    private static ImmutableArray<Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        if (tree.Diagnostics.Any())
+        {
+            return tree.Diagnostics;
+        }
+
+        var globalScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+        if (globalScope.Diagnostics.Any())
+        {
+            return globalScope.Diagnostics;
+        }
+
+        var program = Binder.BindProgram(globalScope);
+        return program.Diagnostics.ToImmutableArray();
+    }
+
+    private static BoundGlobalScope BindGlobalScope(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        return Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+    }
+}


### PR DESCRIPTION
Fixes #1158

## Root cause

An `if`/conditional-expression whose two arms are **sibling subtypes** sharing a common base (or interface) was rejected with **GS0263**, even when an explicit target type both arms convert to was available. Both the if-expression and ternary forms routed their result-type decision through one pairwise helper (`ComputeConditionalCommonType`) that only unified arms when one arm was directly assignable from the other — it neither computed the arms' common base/interface nor consulted the target type.

## Fix

Reuse the switch-expression machinery (#1112/#1151). Both forms now compute the result type in this priority order (first non-null wins):

1. **Target-typing** — when a valid target type is supplied and both arms implicitly convert to it (`AllArmsImplicitlyConvertTo`), use the target (C# 9+ target-typed conditional).
2. **Existing pairwise** `ComputeConditionalCommonType` — identity, `never`/`null` lift, one-way implicit, and the ADR-0037 numeric tie-break (**unchanged**).
3. **Best-common-type** (`ComputeBestCommonType`, least-upper-bound) fallback — siblings unify to their shared base/interface.

GS0263 is reported only when all three yield null.

The target type is threaded into if/conditional binding, mirroring the switch path:
- `BindExpression(syntax, targetType)` intercepts `IfExpressionSyntax`/`ConditionalExpressionSyntax`.
- `BindReturnStatement` honors the declared return type for `return if ...` / `return cond ? ... : ...`.
- `BindVariableDeclaration` passes a typed local's declared type as the target for if/conditional/switch initializers (honoring targets wider than the arms' natural LUB, e.g. `object` or a shared interface).

`ComputeConditionalCommonType` / `TryNumericTieBreak` and all numeric/integer-widening behavior (#1150's surface) are **untouched**. Base/derived, nil, and throw-branch (`never`) cases keep working via the existing pairwise path.

## Tests

**New:**
- `Issue1158ConditionalSiblingUnifyTests` (binder, 19 tests): repro F (`return if` -> `Box`), repro G (`let r Box = if`), ternary (return + let), no-target sibling LUB (infers `Box`), common-interface LUB (infers `IShape`) + target-typed `let r IShape`, base/derived (`Dog`/`Animal`) preserved, numeric `int32`/`int64` -> `int64` preserved (if + ternary), two unrelated types -> still GS0263 without a target but OK with an explicit `object` target, and nil-arm + `string?` -> `string?`.
- `Issue1158ConditionalSiblingUnifyEmitTests` (emit/exec, 2 tests): a `Box`-returning function using `return if`/ternary runs and the returned object's concrete runtime type matches the branch taken (`Co64Box`/`StcoBox`).

**Preserved (green):** full `Core.Tests` (4035 passed), all conditional/if-expression/ternary/switch/#1151/#1018 binder tests (286), and the conditional/switch/#1151/#521 emit subset (72).
