### PR TITLE
Fix #1159: resolve unqualified enclosing-instance members inside lambda bodies

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -115,6 +115,31 @@ internal sealed partial class ExpressionBinder
     private FunctionSymbol function => getCurrentFunction();
 #pragma warning restore SA1300
 
+    /// <summary>
+    /// Issue #1159: returns the implicit-<c>this</c> parameter that an
+    /// unqualified instance-member reference should bind against. For a direct
+    /// instance method body this is the enclosing function's own
+    /// <see cref="FunctionSymbol.ThisParameter"/>. Inside a lambda body the
+    /// enclosing function is a synthetic <see cref="FunctionSymbol"/> with no
+    /// receiver, so we fall back to the <c>this</c> still visible in the
+    /// current lexical scope — the enclosing instance method's <c>this</c>,
+    /// which the lambda's child scope inherits and which capture analysis
+    /// already captures into the display class (mirroring explicit
+    /// <c>this.X</c> and bare field/property reads). In a static context no
+    /// <c>this</c> is in scope, so this returns <see langword="null"/> and the
+    /// bare-name method-group path stays unchanged.
+    /// </summary>
+    private ParameterSymbol GetEffectiveThisParameter()
+    {
+        var current = getCurrentFunction();
+        if (current?.ThisParameter != null)
+        {
+            return current.ThisParameter;
+        }
+
+        return scope.TryLookupSymbol("this") as ParameterSymbol;
+    }
+
     private BoundExpression BindExpressionWithNarrowing(ExpressionSyntax syntax, Dictionary<VariableSymbol, TypeSymbol> frame)
     {
         if (frame == null)
@@ -819,18 +844,22 @@ internal sealed partial class ExpressionBinder
         // null-receiver group. This mirrors how the event-subscription path
         // already resolves bare `this`-instance handlers, generalized to any
         // value (delegate-conversion) context.
+        // Issue #1159: `effThis` is the enclosing instance method's `this`
+        // even when this bare name sits inside a lambda body, so an unqualified
+        // instance method group resolves and captures `this`.
         var enclosing = this.function;
+        var effThis = GetEffectiveThisParameter();
+        if (effThis != null && effThis.Type is StructSymbol thisStruct)
+        {
+            var instanceMethods = TypeMemberModel.GetMethods(thisStruct, name, MemberQuery.Instance(MemberKinds.Method));
+            if (TryBuildUserMethodGroup(new BoundVariableExpression(null, effThis), instanceMethods, out methodGroup))
+            {
+                return true;
+            }
+        }
+
         if (enclosing != null)
         {
-            if (enclosing.ThisParameter != null && enclosing.ReceiverType is StructSymbol thisStruct)
-            {
-                var instanceMethods = TypeMemberModel.GetMethods(thisStruct, name, MemberQuery.Instance(MemberKinds.Method));
-                if (TryBuildUserMethodGroup(new BoundVariableExpression(null, enclosing.ThisParameter), instanceMethods, out methodGroup))
-                {
-                    return true;
-                }
-            }
-
             var enclosingType = (enclosing.ReceiverType as StructSymbol) ?? (enclosing.StaticOwnerType as StructSymbol);
             if (enclosingType != null)
             {

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -283,6 +283,32 @@ internal sealed class OverloadResolver
     private BoundScope Scope => binderCtx.RootScope;
 
     /// <summary>
+    /// Issue #1159: returns the implicit-<c>this</c> parameter that an
+    /// unqualified instance-member reference should bind against. For a direct
+    /// instance method (or interface default method) body this is the enclosing
+    /// function's own <see cref="FunctionSymbol.ThisParameter"/>. Inside a
+    /// lambda body the enclosing function is a synthetic
+    /// <see cref="FunctionSymbol"/> with no receiver, so we fall back to the
+    /// <c>this</c> that is still visible in the current lexical scope — the
+    /// enclosing instance method's <c>this</c>, which the lambda's child scope
+    /// inherits and which capture analysis already captures into the display
+    /// class (mirroring how explicit <c>this.X</c> and bare field/property
+    /// reads already work and capture). In a static context no <c>this</c> is
+    /// in scope, so this returns <see langword="null"/> and unqualified
+    /// resolution stays unchanged.
+    /// </summary>
+    private ParameterSymbol GetEffectiveThisParameter()
+    {
+        var current = getCurrentFunction();
+        if (current?.ThisParameter != null)
+        {
+            return current.ThisParameter;
+        }
+
+        return Scope.TryLookupSymbol("this") as ParameterSymbol;
+    }
+
+    /// <summary>
     /// Issue #506: synthesises C#-style <c>params T[]</c> expansion for a CLR
     /// call site that won overload resolution in expanded form. The trailing
     /// positional arguments (those mapped to the final <c>params</c> parameter)
@@ -2825,8 +2851,13 @@ internal sealed class OverloadResolver
             // Implicit `this`: if we are inside an instance method body and the
             // name matches a sibling method on the receiver type, dispatch via
             // `this.<method>(args)` automatically.
-            if (getCurrentFunction()?.ThisParameter != null
-                && getCurrentFunction().ReceiverType is StructSymbol implicitReceiverStruct)
+            // Issue #1159: `effThis` is the enclosing instance method's `this`
+            // even when this call sits inside a lambda body (whose synthetic
+            // enclosing function carries no receiver), so unqualified
+            // enclosing-instance member calls resolve and capture `this`.
+            var effThis = GetEffectiveThisParameter();
+            if (effThis != null
+                && effThis.Type is StructSymbol implicitReceiverStruct)
             {
                 // Issue #1147 (Facet B): an unqualified same-named call inside an
                 // instance method resolves against the COMBINED instance + static
@@ -2866,7 +2897,7 @@ internal sealed class OverloadResolver
                         return new BoundCallExpression(null, implicitMethod, convertedSelfStaticArgs.MoveToImmutable());
                     }
 
-                    var implicitReceiver = new BoundVariableExpression(null, getCurrentFunction().ThisParameter);
+                    var implicitReceiver = new BoundVariableExpression(null, effThis);
                     return BindUserInstanceCall(implicitReceiver, implicitMethod, boundArguments.ToImmutable(), syntax, argumentNames);
                 }
 
@@ -2878,7 +2909,7 @@ internal sealed class OverloadResolver
                 // false for any name Object does not define, so the GS0130 path
                 // below still fires for genuinely undefined functions.
                 var implicitBaseClr = implicitReceiverStruct.ImportedBaseType?.ClrType ?? typeof(object);
-                var implicitReceiverExpr = new BoundVariableExpression(null, getCurrentFunction().ThisParameter);
+                var implicitReceiverExpr = new BoundVariableExpression(null, effThis);
                 if (tryBindInheritedClrInstanceCall(implicitReceiverExpr, implicitBaseClr, syntax.Identifier.Text, boundArguments.ToImmutable(), syntax, out var implicitInheritedCall, null, default, argumentNames))
                 {
                     return implicitInheritedCall;
@@ -2893,8 +2924,8 @@ internal sealed class OverloadResolver
             // inside the interface see both the public surface and the
             // private helpers; external callers go through the receiver-typed
             // path which does its own GS0334 check.
-            if (getCurrentFunction()?.ThisParameter != null
-                && getCurrentFunction().ReceiverType is InterfaceSymbol implicitReceiverIface)
+            if (effThis != null
+                && effThis.Type is InterfaceSymbol implicitReceiverIface)
             {
                 var implicitIfaceOverloads = TypeMemberModel.GetMethods(implicitReceiverIface, syntax.Identifier.Text, MemberQuery.Instance(MemberKinds.Method));
                 var implicitPrivateIfaceOverloads = implicitReceiverIface.GetPrivateMethods(syntax.Identifier.Text);
@@ -2911,7 +2942,7 @@ internal sealed class OverloadResolver
                         return new BoundErrorExpression(null);
                     }
 
-                    var implicitReceiver = new BoundVariableExpression(null, getCurrentFunction().ThisParameter);
+                    var implicitReceiver = new BoundVariableExpression(null, effThis);
                     return BindUserInstanceCall(implicitReceiver, implicitIfaceMethod, boundArguments.ToImmutable(), syntax, argumentNames);
                 }
             }

--- a/test/Compiler.Tests/Emit/Issue1159LambdaThisCaptureEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1159LambdaThisCaptureEmitTests.cs
@@ -1,0 +1,161 @@
+// <copyright file="Issue1159LambdaThisCaptureEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1159: a lambda body that makes an unqualified call to an
+/// enclosing-instance method must capture <c>this</c> and dispatch through it
+/// at runtime, producing the same value as an explicit <c>this.</c> call. These
+/// end-to-end emit tests prove the captured receiver is actually used (not just
+/// that the program compiles): the called instance method reads an instance
+/// field, so a wrong/absent receiver would yield an incorrect value.
+/// </summary>
+public class Issue1159LambdaThisCaptureEmitTests
+{
+    [Fact]
+    public void FuncLiteralLambda_CapturesThis_AndCallsInstanceMethod()
+    {
+        var source = """
+            package P
+            import System
+
+            class C {
+                var state int32 = 10
+                func Bump(x int32) int32 { return x + state }
+                func Run() {
+                    let g = func (d int32) int32 { return Bump(d) }
+                    Console.WriteLine(g(5))
+                }
+            }
+
+            let c = C{ }
+            c.Run()
+            """;
+
+        Assert.Equal("15\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void ArrowLambda_CapturesThis_AndCallsInstanceMethod()
+    {
+        var source = """
+            package P
+            import System
+
+            class C {
+                var state int32 = 100
+                func Bump(x int32) int32 { return x + state }
+                func Run() {
+                    let g = (d int32) -> Bump(d)
+                    Console.WriteLine(g(7))
+                }
+            }
+
+            let c = C{ }
+            c.Run()
+            """;
+
+        Assert.Equal("107\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void NestedLambda_CapturesThis_AndCallsInstanceMethod()
+    {
+        var source = """
+            package P
+            import System
+
+            class C {
+                var state int32 = 20
+                func Bump(x int32) int32 { return x + state }
+                func Run() {
+                    let g = func (d int32) int32 {
+                        let inner = func (e int32) int32 { return Bump(e) }
+                        return inner(d)
+                    }
+                    Console.WriteLine(g(3))
+                }
+            }
+
+            let c = C{ }
+            c.Run()
+            """;
+
+        Assert.Equal("23\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1159_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1159LambdaEnclosingInstanceMemberBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1159LambdaEnclosingInstanceMemberBinderTests.cs
@@ -1,0 +1,216 @@
+// <copyright file="Issue1159LambdaEnclosingInstanceMemberBinderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1159: an unqualified reference to an enclosing-instance member from
+/// inside a lambda / closure body must resolve (capturing <c>this</c>) just as
+/// it does when written directly in the method body or with an explicit
+/// <c>this.</c> receiver. Previously the unqualified call path
+/// (<c>H(d)</c> → GS0130) and the method-group-as-value path
+/// (<c>let fn = H</c> → GS0125) keyed off the lambda's synthetic enclosing
+/// function (which carries no receiver) instead of the enclosing instance
+/// method's <c>this</c> still visible in lexical scope. Both lambda forms
+/// (<c>func (…) { … }</c> and <c>(…) -&gt; …</c>) and nested lambdas are
+/// covered. Static-context behavior is unchanged: a genuinely-undefined name
+/// still reports its diagnostic.
+/// </summary>
+public class Issue1159LambdaEnclosingInstanceMemberBinderTests
+{
+    [Fact]
+    public void UnqualifiedInstanceCall_InFuncLiteralLambda_Resolves()
+    {
+        var source = @"
+class C {
+    func H(x int32) { }
+    func F() {
+        let g = func (d int32) {
+            H(d)
+        }
+        g(1)
+    }
+}
+";
+        AssertNoErrors(Evaluate(source));
+    }
+
+    [Fact]
+    public void UnqualifiedInstanceCall_InArrowLambda_Resolves()
+    {
+        var source = @"
+class C {
+    func H(x int32) { }
+    func F() {
+        let g = (d int32) -> H(d)
+        g(1)
+    }
+}
+";
+        AssertNoErrors(Evaluate(source));
+    }
+
+    [Fact]
+    public void UnqualifiedInstanceCall_ValueReturningArrowLambda_Resolves()
+    {
+        var source = @"
+class C {
+    func H(x int32) int32 { return x }
+    func F() {
+        let g = (d int32) -> H(d)
+        let r int32 = g(1)
+    }
+}
+";
+        AssertNoErrors(Evaluate(source));
+    }
+
+    [Fact]
+    public void InstanceMethodGroupAsValue_InLambda_Resolves()
+    {
+        var source = @"
+class C {
+    func H(x int32) { }
+    func F() {
+        let g = func (d int32) {
+            let fn = H
+            fn(d)
+        }
+        g(1)
+    }
+}
+";
+        AssertNoErrors(Evaluate(source));
+    }
+
+    [Fact]
+    public void UnqualifiedInstanceCall_InNestedLambda_Resolves()
+    {
+        var source = @"
+class C {
+    func H(x int32) { }
+    func F() {
+        let g = func (d int32) {
+            let inner = func (e int32) {
+                H(e)
+            }
+            inner(d)
+        }
+        g(1)
+    }
+}
+";
+        AssertNoErrors(Evaluate(source));
+    }
+
+    [Fact]
+    public void ExplicitThisCall_InLambda_StillResolves()
+    {
+        // Control: the explicit `this.` receiver path already worked and must
+        // keep working unchanged.
+        var source = @"
+class C {
+    func H(x int32) { }
+    func F() {
+        let g = func (d int32) {
+            this.H(d)
+        }
+        g(1)
+    }
+}
+";
+        AssertNoErrors(Evaluate(source));
+    }
+
+    [Fact]
+    public void DirectUnqualifiedInstanceCall_StillResolves()
+    {
+        // Control: a non-lambda unqualified instance call must remain unaffected.
+        var source = @"
+class C {
+    func H(x int32) { }
+    func F() { H(1) }
+}
+";
+        AssertNoErrors(Evaluate(source));
+    }
+
+    [Fact]
+    public void UndefinedName_InLambda_InInstanceMethod_StillReportsGS0130()
+    {
+        // The implicit-`this` fallback must not invent a resolution for a name
+        // that no enclosing instance member defines.
+        var source = @"
+class C {
+    func F() {
+        let g = func (d int32) {
+            Nope(d)
+        }
+        g(1)
+    }
+}
+";
+        var diagnostics = Evaluate(source).Diagnostics;
+        Assert.Contains(diagnostics, d => d.IsError && d.Message.Contains("Nope"));
+    }
+
+    [Fact]
+    public void UndefinedName_InLambda_InStaticMethod_StillReportsGS0130()
+    {
+        // Static context: no `this` is in scope, so the effective-`this`
+        // lookup yields null and resolution stays unchanged (still errors).
+        var source = @"
+class C {
+    shared {
+        func F() {
+            let g = func (d int32) {
+                Nope(d)
+            }
+            g(1)
+        }
+    }
+}
+";
+        var diagnostics = Evaluate(source).Diagnostics;
+        Assert.Contains(diagnostics, d => d.IsError && d.Message.Contains("Nope"));
+    }
+
+    [Fact]
+    public void UnqualifiedFieldRead_InLambda_StillResolves()
+    {
+        // Control: bare instance field reads already resolved through the
+        // implicit-member scope symbols; this must remain unaffected.
+        var source = @"
+class C {
+    var state int32 = 10
+    func F() int32 {
+        let g = func (d int32) int32 { return state + d }
+        return g(5)
+    }
+}
+";
+        AssertNoErrors(Evaluate(source));
+    }
+
+    private static void AssertNoErrors(EvaluationResult result)
+    {
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
## Summary

An unqualified reference to an enclosing-instance member from inside a lambda / closure body was not resolved: `gsc` reported `GS0130` ("Function 'X' doesn't exist") for unqualified instance calls and `GS0125` ("Variable 'X' doesn't exist") for instance method-groups used as values. The same member resolved when called directly in the method body or with an explicit `this.` receiver.

### Root cause

A lambda body binds against a synthetic `FunctionSymbol` (created in `LambdaBinder`) that has no `ReceiverType`/`ThisParameter`. The unqualified-call path (`OverloadResolver`) and the method-group-as-value path (`ExpressionBinder`) keyed their implicit-`this` resolution directly off `getCurrentFunction()`, so they failed inside a lambda. Field/property reads and explicit `this.X` already worked because they resolve the enclosing method's `this` through lexical scope (which the lambda's child scope inherits and capture analysis already handles).

### Fix

Resolve the implicit-`this` from the enclosing `this` **visible in the current lexical scope** when the enclosing function carries none. A new private helper `GetEffectiveThisParameter()` returns `getCurrentFunction().ThisParameter` when present, otherwise `scope.TryLookupSymbol("this") as ParameterSymbol`. This reuses the exact symbol that capture analysis captures into the display class, so no changes to `LambdaBinder`, the synthetic symbol, or the emitter are needed. The fix lives at the resolution sites, so it automatically covers both lambda forms (`func (...){...}` and the arrow form) and nested lambdas. In static contexts no `this` is in scope, so behavior is unchanged.

### Changed files
- `src/Core/CodeAnalysis/Binding/OverloadResolver.cs` — add `GetEffectiveThisParameter()`; the unqualified-call struct/class and interface-default-method branches now gate on and build receivers from the effective `this`.
- `src/Core/CodeAnalysis/Binding/ExpressionBinder.cs` — add `GetEffectiveThisParameter()`; the bare-name instance method-group branch now uses the effective `this`.
- `test/Core.Tests/CodeAnalysis/Binding/Issue1159LambdaEnclosingInstanceMemberBinderTests.cs` — binder coverage (both lambda forms, method-group value, nested, controls, negative/static).
- `test/Compiler.Tests/Emit/Issue1159LambdaThisCaptureEmitTests.cs` — end-to-end emit tests proving `this` is captured and used at runtime.

### Verification
- Issue minimal repro compiles clean (no GS0130).
- Method-group-as-value in a lambda compiles (no GS0125).
- Both lambda forms + value-returning variant + nested lambdas compile.
- Runtime exec proves `this` capture: a lambda calling an unqualified instance method that reads an instance field returns the correct value (15).
- Regressions: static-context undefined name still errors; explicit `this.X`, bare field reads, and direct (non-lambda) instance calls unaffected.
- Core.Tests: 4045 passed. Compiler.Tests lambda/closure/capture + instance/interface/method-group slices: 345 passed.

Out of scope (pre-existing limitation, not a closure regression): unqualified static `shared`-sibling calls inside a lambda — left unchanged.

Fixes #1159
