### PR TITLE
Fixes #864: update outdated lexical-structure guide

### DIFF
--- a/website/docs/guide/lexical-structure.md
+++ b/website/docs/guide/lexical-structure.md
@@ -10,15 +10,26 @@ This guide explains the tokens G# recognizes today. For the normative grammar, s
 
 ## Source text and comments
 
-G# source is Unicode text. Whitespace separates tokens but is otherwise insignificant outside literals. Use `//` for line comments and `/* ... */` for block comments. Block comments do not nest. The compiler lexer supports block comments even though some older editor documentation is behind the implementation.
+G# source is Unicode text. Line terminators are LF, CR, or CRLF. Whitespace separates tokens but is otherwise insignificant outside literals. Use `//` for line comments and `/* ... */` for block comments; block comments do not nest, and an unterminated block comment is a lexical diagnostic. Documentation comments begin with `///`: consecutive `///` lines are concatenated and attached to the following declaration, where they are parsed as Markdown and lowered to CLR XML doc.
 
 ## Identifiers and keywords
 
 Identifiers start with a Unicode letter or `_` and continue with Unicode letters, digits, or `_`. The lexer uses .NET Unicode classification, so non-ASCII letters are accepted.
 
-Reserved keywords include declarations (`package`, `import`, `type`, `func`, `var`, `let`, `const`), control flow (`if`, `else`, `for`, `switch`, `case`, `default`, `break`, `continue`, `return`), concurrency (`go`, `chan`, `select`, `scope`), exceptions (`try`, `catch`, `finally`, `throw`), and modifiers such as `public`, `internal`, `private`, `open`, `override`, and `sealed`.
+The reserved keywords may not be used as identifiers. The complete set is:
 
-Some words are contextual: `data`, `inline`, `prop`, `event`, `shared`, `init`, `get`, `set`, `add`, `remove`, `raise`, `in`, `out`, `yield`, `with`, `typeof`, `nameof`, and `make` are identifiers except in the syntax positions that give them special meaning.
+- Declarations: `package`, `import`, `using`, `type`, `func`, `operator`, `var`, `let`, `const`
+- Type and member kinds: `class`, `struct`, `interface`, `enum`, `map`, `sequence`, `chan`
+- Control flow: `if`, `else`, `for`, `while`, `do`, `switch`, `case`, `default`, `fallthrough`, `break`, `continue`, `goto`, `guard`, `range`, `return`
+- Pattern and cast: `is`, `as`
+- Concurrency: `go`, `select`, `scope`, `defer`, `async`, `await`
+- Exceptions: `try`, `catch`, `finally`, `throw`
+- Access and inheritance modifiers: `public`, `internal`, `protected`, `private`, `open`, `override`, `sealed`
+- Literals: `true`, `false`, `nil`
+
+A few of these are reserved but have no surface form yet — most notably `while`, which has no loop statement; write `for condition { ... }` instead.
+
+Some words are contextual: `data`, `inline`, `prop`, `event`, `shared`, `init`, `get`, `set`, `add`, `remove`, `raise`, `in`, `out`, `yield`, `with`, `unsafe`, `fixed`, `typeof`, `nameof`, and `make` are ordinary identifiers except in the syntax positions that give them special meaning.
 
 ## Numeric literals
 
@@ -26,13 +37,13 @@ Use explicit prefixes for non-decimal integers: `0x` for hexadecimal, `0o` for o
 
 Integer suffixes are case-insensitive: `L` for `int64`, `U` for `uint32`, and `UL` or `LU` for `uint64`. Unsuffixed decimal integers are `int32`; unsuffixed non-decimal values fitting `uint32` are bit-cast to `int32` for compatibility.
 
-Floating literals are decimal only. Valid forms include `1.5`, `.5`, `1e10`, and `1.5e-3`. The current lexer does not treat `1.` as a float because the dot would conflict with member access. Floating suffixes are `F` for `float32`, `D` for `float64`, and `M` for `decimal`.
+Floating literals are decimal only. Valid forms include `1.5`, `.5`, `1e10`, and `1.5e-3`. The current lexer does not treat `1.` as a float because the dot would conflict with member access; a digit must follow the dot. Unsuffixed floating literals are `float64`. Floating suffixes are case-insensitive: `F` for `float32`, `D` for `float64`, and `M` for `decimal`.
 
 
 ## Characters and strings
 
-A character literal is one UTF-16 code unit or escape in single quotes. Supported escapes include common C-style escapes, hex escapes, and Unicode escapes constrained to one code unit. 
-Normal strings are double-quoted. In the implementation snapshot, doubled quotes produce a literal quote; backslash escapes are not interpreted by the normal string lexer. Raw strings are backtick-delimited, can span lines, normalize CR and CRLF to LF, and do not process escapes or interpolation. 
+A character literal is one UTF-16 code unit or escape in single quotes. Supported escapes are the C-style escapes (`\'`, `\"`, `\\`, `\0`, `\a`, `\b`, `\f`, `\n`, `\r`, `\t`, `\v`), hex escapes (`\x` with one to four hex digits), and Unicode escapes (`\u` with exactly four hex digits, `\U` with exactly eight hex digits constrained to a single code unit).
+Normal strings are double-quoted and interpret the same backslash escapes as character literals, so a literal double quote is written `\"`. There is no doubled-quote (`""`) escaping. Raw strings are backtick-delimited, can span lines, normalize CR and CRLF to LF, cannot contain a backtick, and do not process escapes or interpolation.
 Interpolated strings are sigil-free: holes live inside ordinary double-quoted strings rather than behind a C#-style `$"…"` prefix. A hole is `$name` (a single identifier) or a braced `${expression}`, optionally with an alignment and format clause, `${expr,alignment:format}`. Use `$$` for a literal dollar sign; there is no `{{`/`}}` brace escaping. The braced-hole scanner is delimiter-aware — it balances brackets, skips nested string and char literals and comments, and allows the expression to span lines — so `${dict["k"]}`, `${cond ? "a" : "b"}`, and multiline holes all work. Holes are real code: hover, go-to-definition, find-references, completion, and signature help all work inside `${…}`.
 
 ```gsharp title="samples/InterpolatedString.gs"
@@ -48,6 +59,6 @@ Console.WriteLine("$$ stays literal")
 
 ## Operators and punctuation
 
-G# includes compact operators plus CLR-oriented additions: null assertion `!!`, null-conditional access `?.`, null-conditional indexing `?[`, null coalescing `??`, null-coalescing compound assignment `??=`, channel receive and send `<-`, switch-expression arrows `->`, and annotations introduced by `@`. Compound assignment exists for arithmetic, bitwise, bit-clear, and shift operators.
+G# includes compact operators plus CLR-oriented additions: non-null assertion `!!`, null-conditional access `?.`, null-conditional indexing `?[`, null coalescing `??`, null-coalescing compound assignment `??=`, channel receive and send `<-`, the lambda and function-type arrow `->`, and annotations introduced by `@`. The `->` arrow introduces a lambda body (`(x int32) -> x * 2`, or the bare single-parameter `x -> x * 2`) and the function-type clause (`(T1, T2) -> R`); switch-expression and switch-statement arms use a colon `:`. Compound assignment exists for arithmetic, bitwise, bit-clear, and shift operators.
 
-`while`, `null`, `nameof`, `typeof`, and `make` are not all keywords. `while` and `null` are not implemented language forms; use `for condition { ... }` and `nil`.
+`while`, `null`, `nameof`, `typeof`, and `make` are not all keywords. `while` is a reserved word with no loop form — use `for condition { ... }`. `null` is not a keyword at all: it is an ordinary identifier, and the null literal is `nil`. `nameof`, `typeof`, and `make` are contextual identifiers.


### PR DESCRIPTION
Fixes #864

The lexical-structure guide (`website/docs/guide/lexical-structure.md`) was very outdated. This audits every claim against the current lexer (`src/Core/CodeAnalysis/Syntax/Lexer.cs`, `SyntaxFacts.cs`) and the spec (`website/docs/ref/spec.md`) and corrects the inaccuracies.

### Corrections
- **Reserved keywords** — the old list was materially incomplete (only ~30 words). Replaced with the full authoritative set from `SyntaxFacts.GetKeywordKind`, grouped by role. Now includes `class`, `struct`, `interface`, `enum`, `is`, `as`, `async`, `await`, `defer`, `do`, `guard`, `goto`, `fallthrough`, `range`, `sequence`, `operator`, `using`, `map`, `nil`, `true`, `false`, `protected`, and `while`.
- **`->` operator** — was described as the "switch-expression arrow". Per ADR-0074/0075 it is the **lambda operator** and the **function-type arrow** (`(x int32) -> x*2`, `(T1, T2) -> R`); switch arms now use a colon `:`.
- **`while` / `null`** — `while` is reserved but has no loop form (use `for cond {}`); `null` is **not** a keyword at all (ordinary identifier) — the null literal is `nil`.
- **Normal strings** — corrected to the true lexer behavior: normal double-quoted strings interpret the same backslash escapes as char literals (a literal quote is `\"`), and there is **no** doubled-quote escaping.
- **Hedge cleanup** — removed stale "implementation snapshot" / "behind the implementation" phrasing; added line terminators, doc comments, and the default float type (`float64`).
- **Contextual identifiers** — added `unsafe` and `fixed` (ADR-0122).

### Scope
- Edited **only** `website/docs/guide/lexical-structure.md`.
- `versioned_docs/version-0.2/...` and all `src/` files untouched. `docs/lexical.md` needed no change (it delegates the keyword list to `SyntaxFacts` and contained none of the wrong claims).
- Front-matter, headings, section structure, and the `samples/InterpolatedString.gs` code block preserved.