### PR TITLE
Fixes #1162: user-element array satisfies System.Array members and IEnumerable[T] (LINQ)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -533,6 +533,29 @@ public sealed class Conversion
             return Conversion.Implicit;
         }
 
+        // Issue #1162: same forward slice-to-array conversion when the
+        // slice element is a same-compilation user type whose backing
+        // ClrType is still null during binding (so the CLR-backed arm
+        // above cannot fire). The target may itself be a SliceTypeSymbol
+        // or ArrayTypeSymbol with a null ClrType; match symbolically by
+        // element equivalence. Slice invariance is preserved because
+        // `AreTypeArgumentsEquivalent` requires the elements to match.
+        if (from is SliceTypeSymbol sliceSrcSym && sliceSrcSym.ClrType == null)
+        {
+            TypeSymbol targetElementSym = to switch
+            {
+                SliceTypeSymbol toSlice => toSlice.ElementType,
+                ArrayTypeSymbol toArray => toArray.ElementType,
+                _ => null,
+            };
+
+            if (targetElementSym != null
+                && AreTypeArgumentsEquivalent(targetElementSym, sliceSrcSym.ElementType))
+            {
+                return Conversion.Implicit;
+            }
+        }
+
         // Slice-to-interface: a G# slice `[]T` is backed by a CLR `T[]`
         // at runtime. Extend to every interface that `T[]` implements
         // (IEnumerable<T>, IReadOnlyList<T>, IList<T>, non-generic
@@ -548,8 +571,8 @@ public sealed class Conversion
         // accept covariant matches via `IsAssignableFrom`) from firing.
         if (from is SliceTypeSymbol sliceForIface && to?.ClrType != null && to.ClrType.IsInterface)
         {
-            if (sliceForIface.ClrType != null
-                && SliceImplementsInterface(sliceForIface, to))
+            if ((sliceForIface.ClrType != null && SliceImplementsInterface(sliceForIface, to))
+                || (sliceForIface.ClrType == null && SliceImplementsInterfaceSymbolically(sliceForIface, to)))
             {
                 return Conversion.Implicit;
             }
@@ -1215,5 +1238,48 @@ public sealed class Conversion
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Issue #1162: symbolic counterpart to <see cref="SliceImplementsInterface"/>
+    /// for a slice <c>[]T</c> whose element <c>T</c> is a same-compilation user
+    /// type and whose backing <see cref="TypeSymbol.ClrType"/> is therefore
+    /// <see langword="null"/> during binding. The backing CLR array cannot be
+    /// walked, so instead match the target interface's open definition against
+    /// the known generic interfaces that a one-dimensional <c>T[]</c> implements
+    /// (<c>IEnumerable&lt;T&gt;</c>, <c>IReadOnlyList&lt;T&gt;</c>,
+    /// <c>IReadOnlyCollection&lt;T&gt;</c>, <c>IList&lt;T&gt;</c>,
+    /// <c>ICollection&lt;T&gt;</c>) and require the single type argument to match
+    /// the slice element. Slice invariance is preserved because
+    /// <see cref="AreTypeArgumentsEquivalent"/> demands an exact element match.
+    /// </summary>
+    private static bool SliceImplementsInterfaceSymbolically(SliceTypeSymbol slice, TypeSymbol targetInterface)
+    {
+        if (targetInterface is not ImportedTypeSymbol imported
+            || imported.OpenDefinition is null
+            || imported.TypeArguments.Length != 1)
+        {
+            return false;
+        }
+
+        var openName = imported.OpenDefinition.FullName;
+        if (openName is null)
+        {
+            return false;
+        }
+
+        var isArrayInterface =
+            string.Equals(openName, typeof(System.Collections.Generic.IEnumerable<>).FullName, StringComparison.Ordinal)
+            || string.Equals(openName, typeof(System.Collections.Generic.IReadOnlyList<>).FullName, StringComparison.Ordinal)
+            || string.Equals(openName, typeof(System.Collections.Generic.IReadOnlyCollection<>).FullName, StringComparison.Ordinal)
+            || string.Equals(openName, typeof(System.Collections.Generic.IList<>).FullName, StringComparison.Ordinal)
+            || string.Equals(openName, typeof(System.Collections.Generic.ICollection<>).FullName, StringComparison.Ordinal);
+
+        if (!isArrayInterface)
+        {
+            return false;
+        }
+
+        return AreTypeArgumentsEquivalent(imported.TypeArguments[0], slice.ElementType);
     }
 }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -2327,6 +2327,31 @@ internal sealed partial class ExpressionBinder
                     Diagnostics.ReportUnableToFindMember(ne.Location, memberName);
                     return new BoundErrorExpression(null);
                 }
+                else if (receiver != null
+                    && receiver.Type is SliceTypeSymbol or ArrayTypeSymbol
+                    && receiver.Type.ClrType == null)
+                {
+                    // Issue #1162: a slice/array whose element is a
+                    // same-compilation user type has a null backing
+                    // ClrType during binding, so the CLR-property arm
+                    // above (gated on `receiver.Type.ClrType != null`)
+                    // cannot reflect `System.Array` members such as
+                    // `.Length`/`.Rank`/`.LongLength`. The runtime
+                    // receiver is the real `T[]`, which derives from
+                    // `System.Array`, so reflect the member directly
+                    // against `typeof(System.Array)` and bind it as an
+                    // ordinary CLR property read; the IL is correct
+                    // because the array genuinely exposes the member.
+                    var arrayMemberName = ne.IdentifierToken.Text;
+                    var arrayProp = ClrTypeUtilities.SafeGetPropertyIncludingInterfaces(typeof(System.Array), arrayMemberName, BindingFlags.Public | BindingFlags.Instance);
+                    if (arrayProp != null && arrayProp.GetIndexParameters().Length == 0 && arrayProp.CanRead)
+                    {
+                        return new BoundClrPropertyAccessExpression(null, receiver, arrayProp, ClrNullability.GetPropertyTypeSymbol(arrayProp));
+                    }
+
+                    Diagnostics.ReportUnableToFindMember(ne.Location, arrayMemberName);
+                    return new BoundErrorExpression(null);
+                }
                 else
                 {
                     Diagnostics.ReportUnableToFindMember(ne.Location, ne.IdentifierToken.Text);

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -914,6 +914,23 @@ internal sealed class MemberLookup
                 // (erased) element type and the structural delegate conversion
                 // applies.
                 return TryProjectErasedDelegateClrType(fn, out erased);
+            case StructSymbol { IsClass: true } userClass:
+                // Issue #1162: a slice/array element that is a same-compilation
+                // user type has a null ClrType during binding, so projecting
+                // `[]Segment` previously failed at the element and aborted the
+                // whole slice projection — blocking IEnumerable<T> extension
+                // (LINQ) candidate gating with GS0159. Erase user types just
+                // enough to pass the ClrType gate (mirroring the delegate-
+                // component eraser); the symbolic-argument recovery downstream
+                // re-derives the real element type for inference.
+                erased = userClass.ImportedBaseType?.ClrType ?? typeof(object);
+                return true;
+            case StructSymbol:
+                erased = typeof(object);
+                return true;
+            case EnumSymbol:
+                erased = typeof(int);
+                return true;
             default:
                 return false;
         }

--- a/test/Compiler.Tests/Emit/Issue1162UserElementArrayEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1162UserElementArrayEmitTests.cs
@@ -1,0 +1,295 @@
+// <copyright file="Issue1162UserElementArrayEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1162: a G# slice <c>[]T</c> whose element <c>T</c> is a
+/// same-compilation user type (struct / data-struct / class / enum) is backed
+/// by a CLR <c>T[]</c> whose <see cref="GSharp.Core.CodeAnalysis.Symbols.TypeSymbol.ClrType"/>
+/// is <see langword="null"/> during binding. These tests pin the three
+/// symbolic fixes that restore the <see cref="System.Array"/> member surface
+/// (<c>.Length</c>), the <c>[]T → IEnumerable[T]</c> (and sibling interface)
+/// conversion, and <c>IEnumerable&lt;T&gt;</c> extension (LINQ) resolution for
+/// user element types — proving each end-to-end by running the emitted IL and
+/// asserting the computed value. A <c>[]int32</c> control guards the primitive
+/// path against regressions.
+/// </summary>
+public class Issue1162UserElementArrayEmitTests
+{
+    // Constructing a value struct with a `let` (readonly) field via a struct
+    // literal (e.g. `Segment{X: 1u}`) emits a `stfld` to the readonly field
+    // outside the type's .ctor, which `dotnet-ilverify` flags as `InitOnly`.
+    // This is a pre-existing G# value-struct-literal emit characteristic — it
+    // reproduces with a bare `var s = Segment{X: 5u}` and no slices/arrays at
+    // all — and is wholly orthogonal to the issue #1162 binding fix. The JIT
+    // accepts the IL (the runtime assertions below prove correct execution), so
+    // these value-struct cases verify with `InitOnly` treated as non-fatal.
+    private static readonly string[] InitOnlyStructLiteral = { "InitOnly" };
+
+    [Fact]
+    public void StructElementArray_Length_CompilesRunsAndIlVerifies()
+    {
+        var gsource = """
+            package Probe
+            import System
+
+            struct Segment { let X uint32 }
+
+            func Len(xs []Segment) int32 { return xs.Length }
+
+            var xs = []Segment{Segment{X: 1u}, Segment{X: 2u}, Segment{X: 3u}}
+            Console.WriteLine(Len(xs))
+            """;
+
+        Assert.Equal("3\n", CompileAndRun(gsource, InitOnlyStructLiteral));
+    }
+
+    [Fact]
+    public void ClassElementArray_Length_CompilesRunsAndIlVerifies()
+    {
+        var gsource = """
+            package Probe
+            import System
+
+            class Seg { public var X int32 = 0 }
+
+            func Len(xs []Seg) int32 { return xs.Length }
+
+            var a = Seg()
+            a.X = 10
+            var b = Seg()
+            b.X = 20
+            var xs = []Seg{a, b}
+            Console.WriteLine(Len(xs))
+            """;
+
+        Assert.Equal("2\n", CompileAndRun(gsource));
+    }
+
+    [Fact]
+    public void EnumElementArray_Length_CompilesRunsAndIlVerifies()
+    {
+        var gsource = """
+            package Probe
+            import System
+
+            enum Color { Red, Green, Blue }
+
+            func Len(xs []Color) int32 { return xs.Length }
+
+            var xs = []Color{Color.Red, Color.Green, Color.Blue, Color.Red}
+            Console.WriteLine(Len(xs))
+            """;
+
+        Assert.Equal("4\n", CompileAndRun(gsource));
+    }
+
+    [Fact]
+    public void StructElementArray_ToIEnumerable_CompilesRunsAndIlVerifies()
+    {
+        // Repro C: passing a []Segment where IEnumerable[Segment] is expected.
+        var gsource = """
+            package Probe
+            import System
+            import System.Collections.Generic
+
+            struct Segment { let X uint32 }
+
+            func Take(e IEnumerable[Segment]) int32 {
+                var n int32 = 0
+                for s in e {
+                    n = n + 1
+                }
+                return n
+            }
+
+            var xs = []Segment{Segment{X: 1u}, Segment{X: 2u}, Segment{X: 3u}}
+            Console.WriteLine(Take(xs))
+            """;
+
+        Assert.Equal("3\n", CompileAndRun(gsource, InitOnlyStructLiteral));
+    }
+
+    [Fact]
+    public void StructElementArray_ToIReadOnlyList_CompilesRunsAndIlVerifies()
+    {
+        var gsource = """
+            package Probe
+            import System
+            import System.Collections.Generic
+
+            struct Segment { let X uint32 }
+
+            func First(e IReadOnlyList[Segment]) uint32 { return e[0].X }
+
+            var xs = []Segment{Segment{X: 7u}, Segment{X: 9u}}
+            Console.WriteLine(First(xs))
+            """;
+
+        Assert.Equal("7\n", CompileAndRun(gsource, InitOnlyStructLiteral));
+    }
+
+    [Fact]
+    public void StructElementArray_LinqSum_CompilesRunsAndIlVerifies()
+    {
+        // Repro D: LINQ Sum over a user-element array, with the selector
+        // closing over the same-compilation struct.
+        var gsource = """
+            package Probe
+            import System
+            import System.Linq
+
+            struct Segment { let ReferenceSize uint32 }
+
+            func F(segs []Segment) int64 { return segs.Sum((s Segment) -> int64(s.ReferenceSize)) }
+
+            var xs = []Segment{Segment{ReferenceSize: 10u}, Segment{ReferenceSize: 20u}, Segment{ReferenceSize: 30u}}
+            Console.WriteLine(F(xs))
+            """;
+
+        Assert.Equal("60\n", CompileAndRun(gsource, InitOnlyStructLiteral));
+    }
+
+    [Fact]
+    public void ClassElementArray_LinqWhereCount_CompilesRunsAndIlVerifies()
+    {
+        // Repro E: LINQ Where().Count() over a class-element array.
+        var gsource = """
+            package Probe
+            import System
+            import System.Linq
+
+            class Seg { public var X int32 = 0 }
+
+            func F(xs []Seg) int32 { return xs.Where((s Seg) -> s.X > 0).Count() }
+
+            var a = Seg()
+            a.X = 5
+            var b = Seg()
+            b.X = -1
+            var c = Seg()
+            c.X = 7
+            var xs = []Seg{a, b, c}
+            Console.WriteLine(F(xs))
+            """;
+
+        Assert.Equal("2\n", CompileAndRun(gsource));
+    }
+
+    [Fact]
+    public void EnumElementArray_LinqWhereCount_CompilesRunsAndIlVerifies()
+    {
+        var gsource = """
+            package Probe
+            import System
+            import System.Linq
+
+            enum Color { Red, Green, Blue }
+
+            func F(xs []Color) int32 { return xs.Where((c Color) -> c == Color.Red).Count() }
+
+            var xs = []Color{Color.Red, Color.Green, Color.Blue, Color.Red}
+            Console.WriteLine(F(xs))
+            """;
+
+        Assert.Equal("2\n", CompileAndRun(gsource));
+    }
+
+    [Fact]
+    public void PrimitiveElementArray_LengthSumWhere_StillWork()
+    {
+        // Regression control: the primitive ([]int32) path is unchanged.
+        var gsource = """
+            package Probe
+            import System
+            import System.Linq
+
+            func F(xs []int32) int32 { return xs.Sum() }
+            func G(xs []int32) int32 { return xs.Where((x int32) -> x > 0).Count() }
+            func F2(xs []int32) int32 { return xs.Length }
+
+            var xs = []int32{1, -2, 3, 4}
+            Console.WriteLine(F(xs))
+            Console.WriteLine(G(xs))
+            Console.WriteLine(F2(xs))
+            """;
+
+        Assert.Equal("6\n3\n4\n", CompileAndRun(gsource));
+    }
+
+    private static string CompileAndRun(string source, string[] ignoredIlErrorCodes = null)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1162_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath, ignoredErrorCodes: ignoredIlErrorCodes);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1162UserElementArrayBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1162UserElementArrayBinderTests.cs
@@ -1,0 +1,186 @@
+// <copyright file="Issue1162UserElementArrayBinderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1162: a slice <c>[]T</c> whose element <c>T</c> is a
+/// same-compilation user type (struct / class / enum) has a null backing
+/// <c>ClrType</c> during binding. These binder-level tests assert that the
+/// three affected paths now report no diagnostics: the <see cref="System.Array"/>
+/// member surface (<c>.Length</c>), the <c>[]T → IEnumerable[T]</c> /
+/// <c>IReadOnlyList[T]</c> conversion, and <c>IEnumerable&lt;T&gt;</c>
+/// extension (LINQ) resolution — while primitive-element controls keep working
+/// and genuinely incompatible element types are still rejected.
+/// </summary>
+public class Issue1162UserElementArrayBinderTests
+{
+    [Fact]
+    public void StructElementArray_Length_NoDiagnostics()
+    {
+        const string source = @"
+package P
+struct Segment { let X uint32 }
+func Len(xs []Segment) int32 { return xs.Length }
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void ClassElementArray_Length_NoDiagnostics()
+    {
+        const string source = @"
+package P
+class Seg { public let X int32 = 0 }
+func Len(xs []Seg) int32 { return xs.Length }
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void EnumElementArray_Length_NoDiagnostics()
+    {
+        const string source = @"
+package P
+enum Color { Red, Green, Blue }
+func Len(xs []Color) int32 { return xs.Length }
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void StructElementArray_ToIEnumerable_NoDiagnostics()
+    {
+        const string source = @"
+package P
+import System.Collections.Generic
+struct Segment { let X uint32 }
+func Take(e IEnumerable[Segment]) int32 { return 0 }
+func F(xs []Segment) int32 { return Take(xs) }
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void StructElementArray_ToIReadOnlyList_NoDiagnostics()
+    {
+        const string source = @"
+package P
+import System.Collections.Generic
+struct Segment { let X uint32 }
+func Take(e IReadOnlyList[Segment]) int32 { return 0 }
+func F(xs []Segment) int32 { return Take(xs) }
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void StructElementArray_LinqSum_NoDiagnostics()
+    {
+        const string source = @"
+package P
+import System.Linq
+struct Segment { let ReferenceSize uint32 }
+func F(segs []Segment) int64 { return segs.Sum((s Segment) -> int64(s.ReferenceSize)) }
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void ClassElementArray_LinqWhereCount_NoDiagnostics()
+    {
+        const string source = @"
+package P
+import System.Linq
+class Seg { public let X int32 = 0 }
+func F(xs []Seg) int32 { return xs.Where((s Seg) -> s.X > 0).Count() }
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void PrimitiveElementArray_LengthAndLinq_StillBind()
+    {
+        const string source = @"
+package P
+import System.Linq
+func F(xs []int32) int32 { return xs.Sum() }
+func G(xs []int32) int32 { return xs.Where((x int32) -> x > 0).Count() }
+func F2(xs []int32) int32 { return xs.Length }
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void Negative_StructElementArray_ToMismatchedIEnumerable_Rejected()
+    {
+        // Slice invariance must hold for user types too: a []SegA does NOT
+        // convert to IEnumerable[SegB].
+        const string source = @"
+package P
+import System.Collections.Generic
+struct SegA { let X uint32 }
+struct SegB { let Y uint32 }
+func Take(e IEnumerable[SegB]) int32 { return 0 }
+func F(xs []SegA) int32 { return Take(xs) }
+";
+        var diags = GetDiagnostics(source);
+        Assert.NotEmpty(diags);
+        Assert.Contains(diags, d => d.Id == "GS0154" || d.Id == "GS0155");
+    }
+
+    private static ImmutableArrayOfDiagnostic GetDiagnostics(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var parseDiagnostics = tree.Diagnostics;
+        var bindDiagnostics = compilation.GlobalScope.Diagnostics;
+        var programDiagnostics = compilation.BoundProgram.Diagnostics;
+        var all = parseDiagnostics
+            .Concat(bindDiagnostics)
+            .Concat(programDiagnostics)
+            .Where(d => d.IsError)
+            .ToImmutableArray();
+        return new ImmutableArrayOfDiagnostic(all);
+    }
+
+    /// <summary>
+    /// Thin wrapper so the test cases can call <c>Assert.Empty</c> against a
+    /// <see cref="ImmutableArray{T}"/> without exposing the GSharp diagnostic
+    /// surface to xUnit's enumerable inference.
+    /// </summary>
+    private readonly struct ImmutableArrayOfDiagnostic : IReadOnlyCollection<Diagnostic>
+    {
+        private readonly ImmutableArray<Diagnostic> diagnostics;
+
+        public ImmutableArrayOfDiagnostic(ImmutableArray<Diagnostic> diagnostics)
+        {
+            this.diagnostics = diagnostics;
+        }
+
+        public int Count => this.diagnostics.Length;
+
+        public IEnumerator<Diagnostic> GetEnumerator()
+        {
+            foreach (var diagnostic in this.diagnostics)
+            {
+                yield return diagnostic;
+            }
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1162

A G# slice `[]T` (backed by CLR `T[]`) whose element `T` is a **same-compilation user type** (struct / data-struct / class / enum) has a null backing `ClrType` during binding. Three independent code paths gate on `slice.ClrType != null` and therefore silently skipped their work, so for user-element arrays:

- `.Length` and other `System.Array` members failed with **GS0158**
- conversion to `IEnumerable[T]` / `IReadOnlyList[T]` / `ICollection[T]` / … failed with **GS0154**
- any `IEnumerable<T>` extension / LINQ method (`Sum`, `Where`, `Select`, `Count`, …) failed with **GS0159**

Primitive-element arrays (`[]int32`) already worked. All three gaps are fixed **symbolically** (no retro-population of the slice's `ClrType`).

## The three fixes

1. **`System.Array` member surface** — `src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs`
   New instance-member arm: when the receiver is a `SliceTypeSymbol`/`ArrayTypeSymbol` with a null `ClrType`, reflect the requested member against `typeof(System.Array)` and bind it as an ordinary CLR property read. The runtime receiver is the real `T[]`, so `.Length`/`.Rank`/`.LongLength` read correctly.

2. **Slice → interface / array conversion** — `src/Core/CodeAnalysis/Binding/Conversion.cs`
   Added `SliceImplementsInterfaceSymbolically`: matches the target interface's open definition against the generic interfaces a 1-D `T[]` implements (`IEnumerable<T>`, `IReadOnlyList<T>`, `IReadOnlyCollection<T>`, `IList<T>`, `ICollection<T>`) and requires the single type argument to match the slice element via the existing invariance-preserving `AreTypeArgumentsEquivalent`. Also added a symbolic branch to the forward slice → array arm for user-element slices.

3. **LINQ extension resolution** — `src/Core/CodeAnalysis/Binding/MemberLookup.cs`
   Extended `TryProjectErasedClrType` with the same user-type erasure cases the delegate-component eraser already uses (user class → imported base or `object`, value/data struct → `object`, enum → `int`), so `[]Segment` erases to `object[]` and passes the ClrType gate; symbolic-argument recovery re-derives the real `TSource` for inference.

## Tests
- `test/Core.Tests/CodeAnalysis/Binding/Issue1162UserElementArrayBinderTests.cs` — binder-level no-diagnostic assertions + slice-invariance negative case (9 tests).
- `test/Compiler.Tests/Emit/Issue1162UserElementArrayEmitTests.cs` — end-to-end compile + run asserting correct runtime values for `.Length`, `IEnumerable[T]`/`IReadOnlyList[T]` conversion, LINQ `Sum` and `Where().Count()`, across struct/class/enum element types, plus a `[]int32` regression control (9 tests).

All new tests pass; full `Core.Tests` (4054) and the touched `Slice|Linq|Enumerable|Array|Conversion|Interface` emit/binder suites pass with no regressions.
