### PR TITLE
cs2gs: apply !! to foreach iterable over a null-guarded nullable receiver

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/ForEachNullForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/ForEachNullForgivenessTranslationTests.cs
@@ -1,0 +1,96 @@
+// <copyright file="ForEachNullForgivenessTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Translator-fidelity tests for `foreach` over a nullable receiver. G#
+/// smart-casts narrow only LOCAL variables, not field/property chains, so a
+/// declared-nullable (or #1072-promoted) field iterated inside a null guard —
+/// which C# flow analysis proves non-null — must be rendered with an explicit
+/// <c>!!</c> on the iterable, otherwise gsc rejects `for x in field` with
+/// GS0116 ("is not indexable"). A plainly non-null iterable keeps no assertion.
+/// </summary>
+public class ForEachNullForgivenessTranslationTests
+{
+    [Fact]
+    public void ForEachOverNullCheckedField_AssertsIterable()
+    {
+        string printed = TranslateUnit(@"
+#nullable enable
+namespace Demo
+{
+    public class C
+    {
+        private uint[]? offsets;
+        public void Sum()
+        {
+            if (offsets != null)
+            {
+                foreach (var o in offsets)
+                {
+                    System.Console.WriteLine(o);
+                }
+            }
+        }
+    }
+}");
+
+        // The field is promoted to a nullable array and the guarded iteration
+        // asserts non-null on the iterable.
+        Assert.Contains("for o in offsets!!", printed);
+    }
+
+    [Fact]
+    public void ForEachOverNonNullField_NoAssertion()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        private uint[] offsets = new uint[4];
+        public void Sum()
+        {
+            foreach (var o in offsets)
+            {
+                System.Console.WriteLine(o);
+            }
+        }
+    }
+}");
+
+        Assert.Contains("for o in offsets ", printed);
+        Assert.DoesNotContain("offsets!!", printed);
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -2730,11 +2730,18 @@ public sealed class CSharpToGSharpTranslator
                     return new[] { this.TranslateForStatement(forStatement) };
 
                 case ForEachStatementSyntax forEach:
+                    // The iterable receiver gets the same nullable-narrowing `!!`
+                    // treatment as a member/element-access receiver: a declared-
+                    // nullable (or #1072-promoted) field/property iterated inside a
+                    // null guard is flow-proven non-null in C#, but G# smart-casts
+                    // narrow only locals, so `for x in field` over a `T?` field is
+                    // rejected (GS0116 "not indexable") without an explicit
+                    // `field!!`.
                     return new[]
                     {
                         (GStatement)new ForInStatement(
                             SanitizeIdentifier(forEach.Identifier.Text),
-                            this.TranslateExpression(forEach.Expression),
+                            this.TranslateReceiverWithNullForgiveness(forEach.Expression),
                             this.TranslateStatementAsBlock(forEach.Statement)),
                     };
 
@@ -6008,7 +6015,7 @@ public sealed class CSharpToGSharpTranslator
                 return new ForInStatement(
                     names[0],
                     names[1],
-                    this.TranslateExpression(node.Expression),
+                    this.TranslateReceiverWithNullForgiveness(node.Expression),
                     this.TranslateStatementAsBlock(node.Statement));
             }
 


### PR DESCRIPTION
## Summary

G# smart-casts narrow only **local** variables, not field/property chains. So a declared-nullable (or #1072-promoted) field iterated inside a null guard — which C# flow analysis proves non-null — is rejected by gsc as **GS0116 "is not indexable"** when the translator renders it as a bare `for x in field`:

```gsharp
// field: private offsets []uint32?
if offsets != nil {
    for o in offsets { ... }   // GS0116: []uint32? is not indexable
}
```

The faithful G# form is `for o in offsets!!`, exactly as the `!!` pass already does for member-access (`recv!!.Member`) and element-access (`recv!![i]`) receivers.

## Fix

Route the `foreach` iterable through the existing `TranslateReceiverWithNullForgiveness` pass for both the single-name (`foreach (var x in xs)`) and two-name destructuring (`foreach (var (a, b) in xs)`) forms. The pass only emits `!!` when Roslyn flow analysis has proven the nullable receiver non-null at that site, so a plainly non-null iterable is untouched.

## Validation

- `Oahu.Decrypt`: GS0116 **9 → 6** (the remaining 6 are non-foreach indexer cases with different roots).
- cs2gs tests: **228 pass** (+2 in `ForEachNullForgivenessTranslationTests`: a null-guarded nullable field asserts the iterable; a non-null field keeps no assertion). The positive test uses `#nullable enable` in the snippet so the in-memory harness performs the same flow analysis the real pipeline does for Oahu (`<Nullable>enable</Nullable>`).

Refs #914
