### PR TITLE
cs2gs: hoist C# local functions called before declaration

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/LocalFunctionHoistTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/LocalFunctionHoistTranslationTests.cs
@@ -1,0 +1,117 @@
+// <copyright file="LocalFunctionHoistTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Translator-fidelity tests for C# local functions. C# local functions are
+/// hoisted (callable before their lexical declaration), but G# renders them as
+/// <c>let name = func(...)</c> bindings, which are not hoisted and cannot be
+/// forward-referenced (GS0130). When a local function is called before its
+/// declaration, the translator moves its declaration to the top of the block —
+/// unless it captures a sibling local declared in the same block (G# closures
+/// require captured locals to already be in scope at the binding point).
+/// </summary>
+public class LocalFunctionHoistTranslationTests
+{
+    [Fact]
+    public void LocalFunctionCalledBeforeDeclaration_IsHoistedToTop()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public int Field;
+        public void M(int input)
+        {
+            if (input > 0)
+            {
+                Helper(input);
+            }
+            else
+            {
+                Helper(0);
+            }
+
+            void Helper(int x)
+            {
+                Field = x;
+            }
+        }
+    }
+}");
+
+        // The `let Helper = func ...` binding must precede the first call site.
+        int declIndex = printed.IndexOf("let Helper", StringComparison.Ordinal);
+        int callIndex = printed.IndexOf("Helper(input)", StringComparison.Ordinal);
+        Assert.True(declIndex >= 0, "Local function should be emitted as a let binding.\n" + printed);
+        Assert.True(callIndex >= 0, "Call site should be present.\n" + printed);
+        Assert.True(
+            declIndex < callIndex,
+            "Local function declaration must be hoisted above its first use.\n" + printed);
+    }
+
+    [Fact]
+    public void LocalFunctionCapturingSiblingLocal_IsNotHoisted()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public int M()
+        {
+            int seed = 5;
+            int result = Helper();
+
+            int Helper()
+            {
+                return seed + 1;
+            }
+
+            return result;
+        }
+    }
+}");
+
+        // Hoisting would move `let Helper` above `let seed`, breaking the capture,
+        // so the declaration must stay after the sibling local it captures.
+        int seedIndex = printed.IndexOf("let seed", StringComparison.Ordinal);
+        int declIndex = printed.IndexOf("let Helper", StringComparison.Ordinal);
+        Assert.True(seedIndex >= 0 && declIndex >= 0, "Both bindings should be present.\n" + printed);
+        Assert.True(
+            seedIndex < declIndex,
+            "Local function capturing a sibling local must not be hoisted above it.\n" + printed);
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -2606,12 +2606,115 @@ public sealed class CSharpToGSharpTranslator
         private BlockStatement TranslateBlock(BlockSyntax block)
         {
             var statements = new List<GStatement>();
-            foreach (StatementSyntax statement in block.Statements)
+            foreach (StatementSyntax statement in this.HoistCallBeforeDeclLocalFunctions(block))
             {
                 statements.AddRange(this.TranslateStatement(statement));
             }
 
             return new BlockStatement(statements);
+        }
+
+        // C# local functions are hoisted (callable before their lexical
+        // declaration), but G# renders them as `let name = func(...)` bindings,
+        // which are NOT hoisted and cannot be forward-referenced (GS0130/GS0125).
+        // When a local function is called before its declaration within a block,
+        // move its declaration to the top of the block — but only when it is safe
+        // to do so (it must not capture a sibling local declared in the same
+        // block, since G# closures require captured locals to already be in scope
+        // at the binding point).
+        private IReadOnlyList<StatementSyntax> HoistCallBeforeDeclLocalFunctions(BlockSyntax block)
+        {
+            SyntaxList<StatementSyntax> statements = block.Statements;
+            var localFunctions = statements.OfType<LocalFunctionStatementSyntax>().ToList();
+            if (localFunctions.Count == 0)
+            {
+                return statements;
+            }
+
+            var toHoist = new List<LocalFunctionStatementSyntax>();
+            foreach (LocalFunctionStatementSyntax localFunction in localFunctions)
+            {
+                int declIndex = statements.IndexOf(localFunction);
+                if (this.context.GetDeclaredSymbol(localFunction) is not IMethodSymbol funcSymbol)
+                {
+                    continue;
+                }
+
+                bool usedBeforeDeclaration = false;
+                for (int i = 0; i < declIndex && !usedBeforeDeclaration; i++)
+                {
+                    usedBeforeDeclaration = statements[i]
+                        .DescendantNodes()
+                        .OfType<IdentifierNameSyntax>()
+                        .Any(id => id.Identifier.Text == localFunction.Identifier.Text
+                            && SymbolEqualityComparer.Default.Equals(
+                                this.context.GetSymbolInfo(id).Symbol, funcSymbol));
+                }
+
+                if (!usedBeforeDeclaration)
+                {
+                    continue;
+                }
+
+                if (this.CapturesSiblingBlockLocal(localFunction, block))
+                {
+                    continue;
+                }
+
+                toHoist.Add(localFunction);
+            }
+
+            if (toHoist.Count == 0)
+            {
+                return statements;
+            }
+
+            var reordered = new List<StatementSyntax>(toHoist);
+            foreach (StatementSyntax statement in statements)
+            {
+                if (!toHoist.Contains(statement))
+                {
+                    reordered.Add(statement);
+                }
+            }
+
+            return reordered;
+        }
+
+        // Returns true when the local function references a local variable that is
+        // declared directly within the given block (a sibling), which would make
+        // hoisting the function to the top of that block unsafe. References to the
+        // enclosing method's parameters, outer-scope locals, or the function's own
+        // locals/parameters are fine — those remain in scope at the top.
+        private bool CapturesSiblingBlockLocal(LocalFunctionStatementSyntax localFunction, BlockSyntax block)
+        {
+            foreach (IdentifierNameSyntax id in localFunction.DescendantNodes().OfType<IdentifierNameSyntax>())
+            {
+                if (this.context.GetSymbolInfo(id).Symbol is not ILocalSymbol local)
+                {
+                    continue;
+                }
+
+                foreach (SyntaxReference reference in local.DeclaringSyntaxReferences)
+                {
+                    SyntaxNode declaration = reference.GetSyntax();
+
+                    // A local declared inside the function's own body is safe.
+                    if (localFunction.Span.Contains(declaration.Span))
+                    {
+                        continue;
+                    }
+
+                    // A local declared (directly or nested) within this block but
+                    // outside the function is a sibling capture — unsafe to hoist.
+                    if (block.Span.Contains(declaration.Span))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
 
         private IEnumerable<GStatement> TranslateFixedStatement(FixedStatementSyntax node)


### PR DESCRIPTION
## Summary
C# local functions are **hoisted** (callable before their lexical declaration), but G# renders them as `let name = func(...)` bindings, which are **not** hoisted and cannot be forward-referenced (GS0130/GS0125). When a local function is called before its declaration within a block, this change moves its declaration to the top of the block.

The reorder is **conservative**: a local function is only hoisted when it is *used before its declaration* AND it does **not** capture a sibling local declared in the same block (G# closures require captured locals to already be in scope at the binding point — verified: forward-referencing a later local yields GS0125). Functions capturing only the enclosing method's parameters, outer-scope locals, fields, or their own locals are safely hoisted.

## Motivation
Oahu.Decrypt's `MetadataItems.SetCoverArt` declares an `EditOrAdd` local function at the **end** of the method but calls it 3× earlier in an if/else chain. cs2gs preserved source order, so the calls preceded the `let EditOrAdd = func(...)` binding → GS0130 "Function 'EditOrAdd' doesn't exist".

Decrypt compile errors: **306 → 301** (translate stage stays PASS).

## Tests
- `LocalFunctionHoistTranslationTests` (new): hoists a call-before-decl local function above its first use; does NOT hoist one that captures a sibling local.
- Full cs2gs suite: **232 pass**.

Refs #914
