### PR TITLE
cs2gs: apply !! to null-forgiven call arguments

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/ForEachNullForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/ForEachNullForgivenessTranslationTests.cs
@@ -73,6 +73,36 @@ namespace Demo
         Assert.DoesNotContain("offsets!!", printed);
     }
 
+    [Fact]
+    public void NullCheckedFieldAsArgument_AssertsArgument()
+    {
+        string printed = TranslateUnit(@"
+#nullable enable
+namespace Demo
+{
+    public class C
+    {
+        private string? text;
+        private static int Len(string s) => s.Length;
+        public int M()
+        {
+            if (text == null)
+            {
+                return 0;
+            }
+            else
+            {
+                return Len(text);
+            }
+        }
+    }
+}");
+
+        // The `string?` field is flow-proven non-null in the else branch and is
+        // passed to a `string` parameter, so the argument carries `!!`.
+        Assert.Contains("Len(text!!)", printed);
+    }
+
     private static string TranslateUnit(string source)
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -5447,6 +5447,19 @@ public sealed class CSharpToGSharpTranslator
                 return new UnaryExpression("&", this.TranslateExpression(argument.Expression));
             }
 
+            // A declared-nullable reference argument that C# flow analysis has
+            // narrowed to non-null (e.g. a `string?` field read inside an
+            // `if (field == null) … else …` guard) is passed by value, but G#
+            // smart-casts narrow only LOCALS — the field/property keeps its `T?`
+            // type, so a non-null `T` parameter rejects it (GS0156). The existing
+            // receiver null-forgiveness pass already gates on flow-proven non-null
+            // AND a declared-nullable reference symbol, so asserting `!!` here is
+            // always runtime-safe and widens cleanly to a `T?` parameter too.
+            if (this.ReceiverNeedsNullForgiveness(argument.Expression))
+            {
+                return new NonNullAssertionExpression(this.TranslateExpression(argument.Expression));
+            }
+
             // OD-T2: a C# integer literal implicitly converted to an unsigned
             // parameter (e.g. `base(4)` where the parameter is `byte`) must be
             // emitted as a typed G# literal (`uint8(4)`); G# performs no implicit


### PR DESCRIPTION
## Summary
Extends the existing flow-state null-forgiveness pass from **receivers** to **call arguments**.

A declared-nullable reference argument — e.g. a `string?` field read inside an `if (field == null) … else …` guard — that C# flow analysis narrows to non-null is passed by value, but G# smart-casts narrow only **locals**. The field/property keeps its `T?` type, so a non-null `T` parameter rejects it (GS0156).

Routing the argument through `ReceiverNeedsNullForgiveness` (which already gates on flow-proven-non-null **and** a declared-nullable reference symbol) emits `!!`. This is always runtime-safe (the value is provably non-null at that site) and widens cleanly to a `T?` parameter as well, so it never over-restricts.

## Impact
Oahu.Decrypt (e.g. `TEXTFrame`'s `string? Text` passed to `Frame.IsUnicode(string)` / `Frame.UnicodeLength(string)` inside an `if (Text == null) … else …`):
- `GS0156`: **17 → 7**
- compile errors: **301 → 293** (translate stage stays PASS)

## Tests
- `ForEachNullForgivenessTranslationTests.NullCheckedFieldAsArgument_AssertsArgument` (new): a `string?` field flow-proven non-null in the else branch and passed to a `string` parameter carries `!!`.
- Full cs2gs suite: **233 pass**.

Refs #914
