### PR TITLE
cs2gs: do not apply !! inside nameof arguments

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/ForEachNullForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/ForEachNullForgivenessTranslationTests.cs
@@ -103,6 +103,36 @@ namespace Demo
         Assert.Contains("Len(text!!)", printed);
     }
 
+    [Fact]
+    public void NullCheckedFieldInNameOf_NotAsserted()
+    {
+        string printed = TranslateUnit(@"
+#nullable enable
+namespace Demo
+{
+    public class C
+    {
+        private string? text;
+        public string M()
+        {
+            if (text == null)
+            {
+                return string.Empty;
+            }
+            else
+            {
+                return nameof(text) + text.Length;
+            }
+        }
+    }
+}");
+
+        // `nameof` requires a name reference; `nameof(text!!)` would be rejected
+        // (GS0190), so the null-forgiveness pass must skip nameof arguments.
+        Assert.Contains("nameof(text)", printed);
+        Assert.DoesNotContain("nameof(text!!)", printed);
+    }
+
     private static string TranslateUnit(string source)
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -5455,7 +5455,9 @@ public sealed class CSharpToGSharpTranslator
             // receiver null-forgiveness pass already gates on flow-proven non-null
             // AND a declared-nullable reference symbol, so asserting `!!` here is
             // always runtime-safe and widens cleanly to a `T?` parameter too.
-            if (this.ReceiverNeedsNullForgiveness(argument.Expression))
+            // `nameof(x)` takes a name reference, not a value, so `nameof(x!!)`
+            // is rejected (GS0190) — never assert inside a `nameof` argument.
+            if (!IsNameOfArgument(argument) && this.ReceiverNeedsNullForgiveness(argument.Expression))
             {
                 return new NonNullAssertionExpression(this.TranslateExpression(argument.Expression));
             }
@@ -5467,6 +5469,16 @@ public sealed class CSharpToGSharpTranslator
             return this.CoerceConstantToUnsigned(
                 argument.Expression,
                 this.TranslateExpression(argument.Expression));
+        }
+
+        // `nameof(x)` takes a name reference, not a value, so its argument must
+        // never be wrapped in a `!!` non-null assertion (GS0190).
+        private static bool IsNameOfArgument(ArgumentSyntax argument)
+        {
+            return argument.Parent?.Parent is InvocationExpressionSyntax
+            {
+                Expression: IdentifierNameSyntax { Identifier.Text: "nameof" },
+            };
         }
 
         private GExpression TranslateObjectCreation(ObjectCreationExpressionSyntax creation)


### PR DESCRIPTION
## Summary
Follow-up to #1178. The argument null-forgiveness pass wrapped flow-proven non-null nullable arguments in `!!`, but `nameof(x)` takes a **name reference**, not a value — `nameof(x!!)` is rejected with **GS0190** ("The argument to 'nameof' must be a name reference"). This skips the assertion when the argument belongs to a `nameof` invocation.

## Impact
Oahu.Decrypt: clears **16 GS0190**; compile errors **262 → 246**.

## Tests
- `ForEachNullForgivenessTranslationTests.NullCheckedFieldInNameOf_NotAsserted` (new): a flow-narrowed `string?` field inside `nameof` keeps the bare name.
- Full cs2gs suite passes.

Refs #914
