### PR TITLE
Fixes #1181: surface imported base-interface members on user interface receivers

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -2204,6 +2204,42 @@ internal sealed partial class ExpressionBinder
                         return new BoundPropertyAccessExpression(null, receiver, null, ifaceProp);
                     }
 
+                    // Issue #1181: a user interface that extends an imported/BCL
+                    // interface (e.g. `interface IBox : ICollection`) inherits
+                    // that interface's properties/fields/methods. Mirror the
+                    // imported-base-class fallback above by probing the
+                    // transitive imported base interfaces so `b.Count`
+                    // (b : IBox) resolves and emits a verifiable
+                    // `callvirt get_Count`. The receiver carries an
+                    // InterfaceImpl row to each imported base interface, so a
+                    // CLR member access on it is verifiable.
+                    var ifaceMemberName = ne.IdentifierToken.Text;
+                    foreach (var clrBaseIface in MemberLookup.GetTransitiveClrBaseInterfaces(ifaceSym))
+                    {
+                        var clrProp = ClrTypeUtilities.SafeGetProperty(clrBaseIface, ifaceMemberName, BindingFlags.Public | BindingFlags.Instance);
+                        if (clrProp != null && clrProp.GetIndexParameters().Length == 0 && clrProp.CanRead)
+                        {
+                            return new BoundClrPropertyAccessExpression(null, receiver, clrProp, TypeSymbol.FromClrType(clrProp.PropertyType));
+                        }
+
+                        var clrFld = ClrTypeUtilities.SafeGetField(clrBaseIface, ifaceMemberName, BindingFlags.Public | BindingFlags.Instance);
+                        if (clrFld != null)
+                        {
+                            return new BoundClrPropertyAccessExpression(null, receiver, clrFld, TypeSymbol.FromClrType(clrFld.FieldType));
+                        }
+                    }
+
+                    // Issue #1181: an inherited imported-base-interface method
+                    // named in method-group position (e.g. `b.Dispose` passed
+                    // to a delegate) is captured against the bound receiver.
+                    foreach (var clrBaseIface in MemberLookup.GetTransitiveClrBaseInterfaces(ifaceSym))
+                    {
+                        if (TryBindClrMethodGroup(receiver, clrBaseIface, wantStatic: false, ifaceMemberName, out var ifaceClrGroup))
+                        {
+                            return ifaceClrGroup;
+                        }
+                    }
+
                     Diagnostics.ReportUnableToFindMember(ne.Location, ne.IdentifierToken.Text);
                 }
                 else if (receiver != null && receiver.Type is TupleTypeSymbol tupleSym)

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -2579,6 +2579,18 @@ internal sealed partial class ExpressionBinder
                 return userPathExt;
             }
 
+            // Issue #1181: a user interface that extends an imported/BCL
+            // interface (e.g. `interface IBox : IDisposable`) inherits that
+            // interface's members. After user-declared interface members and
+            // extension lookups fail, resolve the call against the transitive
+            // imported base interfaces so `b.Dispose()` (b : IBox) binds and
+            // emits a verifiable `callvirt IDisposable::Dispose`.
+            if (receiver != null && receiver.Type is InterfaceSymbol importedBaseIfaceRecv
+                && TryBindInterfaceImportedBaseInstanceCall(receiver, importedBaseIfaceRecv, methodName, arguments, ce, out var importedBaseIfaceCall, explicitTypeArgs, typeArgSymbols, argumentNames))
+            {
+                return importedBaseIfaceCall;
+            }
+
             Diagnostics.ReportUnableToFindFunction(ce.Location, methodName);
             return new BoundErrorExpression(null);
         }
@@ -2639,6 +2651,7 @@ internal sealed partial class ExpressionBinder
         var candidates = ClrTypeUtilities.SafeGetMethodsIncludingInterfaces(clrType, System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public)
             .Where(m => m.Name == methodName)
             .ToList();
+
         if (candidates.Count > 0)
         {
             var argTypes = new System.Type[arguments.Length];
@@ -3112,6 +3125,105 @@ internal sealed partial class ExpressionBinder
         {
             return false;
         }
+
+        return TryResolveAndBindClrInstanceCall(receiver, candidates, importedBaseClr, methodName, arguments, ce, out result, explicitTypeArgs, typeArgSymbols, argumentNames);
+    }
+
+    /// <summary>
+    /// Issue #1181: resolves an instance method call against the imported/BCL
+    /// base interfaces of a user interface receiver. A user interface
+    /// <c>interface IBox : IDisposable</c> has a null <c>ClrType</c>, so the
+    /// regular imported-instance walks find nothing; this projects every
+    /// transitive imported base interface's public instance methods onto the
+    /// receiver (matching how user-base-interface members are surfaced) and
+    /// runs the shared overload resolution. The emitted
+    /// <see cref="BoundImportedInstanceCallExpression"/> dispatches via
+    /// <c>callvirt</c> on the imported interface method, which is verifiable
+    /// because <c>IBox</c> carries an InterfaceImpl row to each imported base.
+    /// Runs only after user member-table lookup fails, so user-declared
+    /// interface members keep priority.
+    /// </summary>
+    /// <param name="receiver">The interface-typed receiver expression.</param>
+    /// <param name="interfaceSymbol">The user interface symbol of the receiver.</param>
+    /// <param name="methodName">The invoked method name.</param>
+    /// <param name="arguments">The bound call arguments.</param>
+    /// <param name="ce">The call syntax (for diagnostics/locations).</param>
+    /// <param name="result">The bound call on success, or an error node on ambiguity.</param>
+    /// <param name="explicitTypeArgs">Explicit CLR type arguments, when present.</param>
+    /// <param name="typeArgSymbols">Explicit symbolic type arguments, when present.</param>
+    /// <param name="argumentNames">Named-argument labels, when present.</param>
+    /// <returns>True when the call resolved (or reported a precise ambiguity).</returns>
+    internal bool TryBindInterfaceImportedBaseInstanceCall(
+        BoundExpression receiver,
+        InterfaceSymbol interfaceSymbol,
+        string methodName,
+        ImmutableArray<BoundExpression> arguments,
+        CallExpressionSyntax ce,
+        out BoundExpression result,
+        System.Type[] explicitTypeArgs = null,
+        ImmutableArray<TypeSymbol> typeArgSymbols = default,
+        ImmutableArray<string> argumentNames = default)
+    {
+        result = null;
+
+        var clrBases = MemberLookup.GetTransitiveClrBaseInterfaces(interfaceSymbol);
+        if (clrBases.Count == 0)
+        {
+            return false;
+        }
+
+        var candidates = new List<MethodInfo>();
+        foreach (var clrBase in clrBases)
+        {
+            foreach (var m in ClrTypeUtilities.SafeGetMethods(clrBase, BindingFlags.Instance | BindingFlags.Public))
+            {
+                if (string.Equals(m.Name, methodName, System.StringComparison.Ordinal)
+                    && !MemberLookup.HasSameSignature(candidates, m))
+                {
+                    candidates.Add(m);
+                }
+            }
+        }
+
+        if (candidates.Count == 0)
+        {
+            return false;
+        }
+
+        return TryResolveAndBindClrInstanceCall(receiver, candidates, importedBaseClr: clrBases[0], methodName, arguments, ce, out result, explicitTypeArgs, typeArgSymbols, argumentNames);
+    }
+
+    /// <summary>
+    /// Issue #296 / #1181: shared overload-resolution + bound-call construction
+    /// core for an imported-instance method call against a pre-collected
+    /// <paramref name="candidates"/> set. Factored out of
+    /// <see cref="TryBindInheritedClrInstanceCall"/> so the inherited-base-class
+    /// path and the user-interface imported-base path share one implementation.
+    /// </summary>
+    /// <param name="receiver">The receiver expression.</param>
+    /// <param name="candidates">The candidate CLR methods.</param>
+    /// <param name="importedBaseClr">A representative CLR type for named-argument diagnostics.</param>
+    /// <param name="methodName">The invoked method name.</param>
+    /// <param name="arguments">The bound call arguments.</param>
+    /// <param name="ce">The call syntax.</param>
+    /// <param name="result">The bound call on success.</param>
+    /// <param name="explicitTypeArgs">Explicit CLR type arguments, when present.</param>
+    /// <param name="typeArgSymbols">Explicit symbolic type arguments, when present.</param>
+    /// <param name="argumentNames">Named-argument labels, when present.</param>
+    /// <returns>True when the call resolved (or reported a precise ambiguity).</returns>
+    private bool TryResolveAndBindClrInstanceCall(
+        BoundExpression receiver,
+        IReadOnlyList<MethodInfo> candidates,
+        System.Type importedBaseClr,
+        string methodName,
+        ImmutableArray<BoundExpression> arguments,
+        CallExpressionSyntax ce,
+        out BoundExpression result,
+        System.Type[] explicitTypeArgs,
+        ImmutableArray<TypeSymbol> typeArgSymbols,
+        ImmutableArray<string> argumentNames)
+    {
+        result = null;
 
         var argTypes = new System.Type[arguments.Length];
         var hasUserClassArg = false;

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -198,6 +198,122 @@ internal sealed class MemberLookup
     }
 
     /// <summary>
+    /// Issue #1181: collects the transitive closure of imported/BCL base
+    /// interfaces declared on <paramref name="interfaceSymbol"/> or on any of
+    /// its user base interfaces. A user interface
+    /// <c>interface IBox : System.IDisposable</c> records <c>IDisposable</c> in
+    /// <see cref="InterfaceSymbol.BaseClrInterfaces"/>; this walk surfaces that
+    /// CLR interface plus every interface IT extends (e.g.
+    /// <c>IEnumerable&lt;T&gt;</c> → <c>IEnumerable</c>) so the binder and the
+    /// language server can project the inherited CLR members onto an
+    /// <c>IBox</c>-typed receiver. The result is deduplicated structurally via
+    /// <see cref="ClrTypeUtilities.AreSame"/> (FullName-based, robust across
+    /// metadata-load contexts).
+    /// </summary>
+    /// <param name="interfaceSymbol">The user interface whose imported base interfaces to collect.</param>
+    /// <returns>The transitive CLR base interface <see cref="Type"/>s, each appearing once.</returns>
+    public static IReadOnlyList<Type> GetTransitiveClrBaseInterfaces(InterfaceSymbol interfaceSymbol)
+    {
+        if (interfaceSymbol == null)
+        {
+            return Array.Empty<Type>();
+        }
+
+        var result = new List<Type>();
+
+        void AddClr(Type clr)
+        {
+            if (clr == null || !clr.IsInterface)
+            {
+                return;
+            }
+
+            foreach (var existing in result)
+            {
+                if (ClrTypeUtilities.AreSame(existing, clr))
+                {
+                    return;
+                }
+            }
+
+            result.Add(clr);
+
+            foreach (var transitive in ClrTypeUtilities.SafeGetInterfaces(clr))
+            {
+                AddClr(transitive);
+            }
+        }
+
+        // A user base interface may itself extend a CLR interface, so walk the
+        // whole user interface hierarchy (this-first) and harvest each level's
+        // imported base interfaces.
+        foreach (var iface in interfaceSymbol.SelfAndAllBaseInterfaces())
+        {
+            if (iface.BaseClrInterfaces.IsDefaultOrEmpty)
+            {
+                continue;
+            }
+
+            foreach (var clrBase in iface.BaseClrInterfaces)
+            {
+                if (clrBase?.ClrType is Type clrType)
+                {
+                    AddClr(clrType);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Issue #1181: returns whether <paramref name="candidate"/> already has a
+    /// same-name, same-parameter-types entry in <paramref name="existing"/>
+    /// (structural CLR comparison via <see cref="ClrTypeUtilities.AreSame"/>).
+    /// Used to dedupe imported base-interface methods projected onto a user
+    /// interface receiver so a signature surfaced by two related interfaces
+    /// (e.g. <c>IEnumerable&lt;T&gt;</c> and <c>IEnumerable</c>) is not added
+    /// twice into an overload set.
+    /// </summary>
+    /// <param name="existing">The methods collected so far.</param>
+    /// <param name="candidate">The candidate method to test.</param>
+    /// <returns>True when a structurally-equal signature is already present.</returns>
+    public static bool HasSameSignature(IReadOnlyList<MethodInfo> existing, MethodInfo candidate)
+    {
+        foreach (var m in existing)
+        {
+            if (!string.Equals(m.Name, candidate.Name, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var existingParams = m.GetParameters();
+            var candidateParams = candidate.GetParameters();
+            if (existingParams.Length != candidateParams.Length)
+            {
+                continue;
+            }
+
+            var match = true;
+            for (var i = 0; i < existingParams.Length; i++)
+            {
+                if (!ClrTypeUtilities.AreSame(existingParams[i].ParameterType, candidateParams[i].ParameterType))
+                {
+                    match = false;
+                    break;
+                }
+            }
+
+            if (match)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Returns the G# field on <paramref name="structSymbol"/> that satisfies
     /// the property contract of <paramref name="clrProp"/>: same name, the
     /// field's type's CLR projection matches the property's PropertyType, and

--- a/src/LanguageServer/HoverComputer.cs
+++ b/src/LanguageServer/HoverComputer.cs
@@ -8,6 +8,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using GSharp.Core.CodeAnalysis.Binding;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Symbols.Display;
@@ -2086,7 +2087,45 @@ public static class CompletionComputer
             return;
         }
 
+        if (type is InterfaceSymbol interfaceType)
+        {
+            AddInterfaceInstanceMembers(items, seen, interfaceType);
+            return;
+        }
+
         AddClrMembers(items, seen, type?.ClrType, staticMembers: false);
+    }
+
+    private static void AddInterfaceInstanceMembers(List<CompletionItem> items, HashSet<string> seen, InterfaceSymbol interfaceType)
+    {
+        // ADR-0112: enumerate user-declared interface members (this interface
+        // and its user base interfaces) through the canonical layer.
+        foreach (var member in TypeMemberModel.EnumerateMembers(
+                     interfaceType,
+                     MemberQuery.Instance(MemberKinds.Property | MemberKinds.Event | MemberKinds.Method)))
+        {
+            switch (member)
+            {
+                case PropertySymbol property:
+                    AddItem(items, seen, property.Name, CompletionItemKind.Property, $"{property.Name}: {property.Type?.Name}");
+                    break;
+                case EventSymbol @event:
+                    AddItem(items, seen, @event.Name, CompletionItemKind.Event, @event.Name);
+                    break;
+                case FunctionSymbol method:
+                    AddItem(items, seen, method.Name, CompletionItemKind.Method, HoverComputer.FormatSymbol(method));
+                    break;
+            }
+        }
+
+        // Issue #1181: a user interface that extends an imported/BCL interface
+        // also surfaces that interface's (and its transitive CLR bases')
+        // members on an interface-typed receiver — keep the completion surface
+        // consistent with the binder's member resolution.
+        foreach (var clrBaseIface in MemberLookup.GetTransitiveClrBaseInterfaces(interfaceType))
+        {
+            AddClrMembers(items, seen, clrBaseIface, staticMembers: false);
+        }
     }
 
     private static void AddStructInstanceMembers(List<CompletionItem> items, HashSet<string> seen, StructSymbol structType)

--- a/test/Compiler.Tests/Emit/Issue1181InterfaceImportedBaseMembersEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1181InterfaceImportedBaseMembersEmitTests.cs
@@ -1,0 +1,194 @@
+// <copyright file="Issue1181InterfaceImportedBaseMembersEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1181: a user-defined interface that extends a BCL/imported interface
+/// surfaces the imported interface's members on user-interface-typed receivers.
+/// These tests give end-to-end CLR emit + ilverify coverage and confirm that a
+/// call to an inherited imported member (e.g. <c>IDisposable.Dispose</c>)
+/// dispatches correctly at runtime when invoked through the user interface.
+/// </summary>
+public class Issue1181InterfaceImportedBaseMembersEmitTests
+{
+    [Fact]
+    public void EndToEnd_ImportedBaseInterfaceMethod_DispatchesThroughUserInterface()
+    {
+        // IBox extends System.IDisposable. Calling b.Dispose() through an
+        // IBox-typed parameter must dispatch to Box's implementation.
+        var source = """
+            package p
+            import System
+            interface IBox : IDisposable { prop N int32 { get; } }
+            class Box : IBox {
+                prop N int32 { get; init; }
+                func Dispose() { Console.WriteLine("disposed") }
+            }
+            func Use(b IBox) { b.Dispose() }
+            func Main() { Use(Box()) }
+            """;
+        var output = CompileAndRun(source);
+        Assert.Equal("disposed\n", output);
+    }
+
+    [Fact]
+    public void Library_ImportedBaseInterfaceProperty_ReadThroughUserInterface_PassesIlVerify()
+    {
+        // IBox extends System.Collections.ICollection; reading b.Count through
+        // an IBox-typed reference must emit verifiable IL (a `callvirt
+        // get_Count` on the IBox receiver, which carries an InterfaceImpl row
+        // to ICollection).
+        var source = """
+            package p
+            import System.Collections
+            interface IBox : ICollection { prop N int32 { get; } }
+            func Use(b IBox) int32 { return b.Count }
+            """;
+        var dllPath = CompileLibrary(source);
+        TryCleanup(dllPath);
+    }
+
+    [Fact]
+    public void Library_TransitiveGenericEnumerableThroughUserInterface_PassesIlVerify()
+    {
+        // IEnumerable<int32> transitively extends the non-generic IEnumerable;
+        // GetEnumerator surfaced through the user interface must emit
+        // verifiable IL.
+        var source = """
+            package p
+            import System.Collections.Generic
+            interface IBox : IEnumerable[int32] { prop N int32 { get; } }
+            func Use(b IBox) { let e = b.GetEnumerator() }
+            """;
+        var dllPath = CompileLibrary(source);
+        TryCleanup(dllPath);
+    }
+
+    private static string CompileLibrary(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1181_lib_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        var args = new[]
+        {
+            "/out:" + outPath,
+            "/target:library",
+            "/targetframework:net10.0",
+            srcPath,
+        };
+
+        RunCompiler(args);
+        IlVerifier.Verify(outPath);
+        return outPath;
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1181_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            RunCompiler(args);
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static void RunCompiler(string[] args)
+    {
+        using var stdoutWriter = new StringWriter();
+        using var stderrWriter = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(stdoutWriter);
+        Console.SetError(stderrWriter);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+    }
+
+    private static void TryCleanup(string dllPath)
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(dllPath);
+            if (dir != null && Directory.Exists(dir))
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+        catch
+        {
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1181InterfaceImportedBaseMembersTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1181InterfaceImportedBaseMembersTests.cs
@@ -1,0 +1,157 @@
+// <copyright file="Issue1181InterfaceImportedBaseMembersTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1181: a user-defined interface that extends a BCL/imported interface
+/// must surface that interface's inherited members (and the transitive closure
+/// of any CLR interface it extends) on values typed as the user interface —
+/// exactly as it already does for members inherited from a user base interface.
+/// Previously member lookup only walked user base interfaces, so
+/// <c>interface IBox : IDisposable</c> failed to expose <c>Dispose()</c> with
+/// GS0159 / GS0158. The binder now projects the imported base interfaces'
+/// CLR members onto the user-interface receiver.
+/// </summary>
+public class Issue1181InterfaceImportedBaseMembersTests
+{
+    [Fact]
+    public void ImportedBaseInterfaceMethod_CalledThroughUserInterface_Binds()
+    {
+        const string source = """
+            package p
+            import System
+            interface IBox : IDisposable { prop N int32 }
+            func Use(b IBox) { b.Dispose() }
+            """;
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void ImportedBaseInterfaceMethod_NonGenericEnumerable_Binds()
+    {
+        const string source = """
+            package p
+            import System.Collections
+            interface IBox : IEnumerable { prop N int32 }
+            func Use(b IBox) { let e = b.GetEnumerator() }
+            """;
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void ImportedBaseInterfaceMethod_TransitiveGenericEnumerable_Binds()
+    {
+        // IEnumerable<int32> transitively extends the non-generic IEnumerable;
+        // GetEnumerator must be surfaced through the whole CLR interface chain.
+        const string source = """
+            package p
+            import System.Collections.Generic
+            interface IBox : IEnumerable[int32] { prop N int32 }
+            func Use(b IBox) { let e = b.GetEnumerator() }
+            """;
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void ImportedBaseInterfaceProperty_ReadThroughUserInterface_Binds()
+    {
+        // System.Collections.ICollection declares the Count property.
+        const string source = """
+            package p
+            import System.Collections
+            interface IBox : ICollection { prop N int32 }
+            func Use(b IBox) int32 { return b.Count }
+            """;
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void ImportedBaseInterfaceMethod_ReachedThroughUserBaseInterface_Binds()
+    {
+        // The imported base interface is declared on a user base interface; the
+        // member must still be surfaced two hops away.
+        const string source = """
+            package p
+            import System
+            interface IBase : IDisposable {}
+            interface IBox : IBase { prop N int32 }
+            func Use(b IBox) { b.Dispose() }
+            """;
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void UserBaseInterfaceMember_StillBinds()
+    {
+        // Control: a member inherited from a USER base interface must keep
+        // working unchanged.
+        const string source = """
+            package p
+            interface IBase { func Close(); }
+            interface IBox : IBase { prop N int32 }
+            func Use(b IBox) { b.Close() }
+            """;
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void ImportedInterfaceMember_CalledOnImportedInterfaceDirectly_StillBinds()
+    {
+        // Control: calling the inherited member on the BCL interface type
+        // directly must keep working.
+        const string source = """
+            package p
+            import System
+            func Use(b IDisposable) { b.Dispose() }
+            """;
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void AbsentMethod_ThroughUserInterfaceExtendingImportedBase_ReportsGS0159()
+    {
+        // A genuinely-absent method must still surface "Cannot find function".
+        const string source = """
+            package p
+            import System
+            interface IBox : IDisposable { prop N int32 }
+            func Use(b IBox) { b.NoSuchMethod() }
+            """;
+        Assert.Contains(Bind(source), d => d.Id == "GS0159");
+    }
+
+    [Fact]
+    public void AbsentProperty_ThroughUserInterfaceExtendingImportedBase_ReportsGS0158()
+    {
+        const string source = """
+            package p
+            import System.Collections
+            interface IBox : ICollection { prop N int32 }
+            func Use(b IBox) int32 { return b.NoSuchProperty }
+            """;
+        Assert.Contains(Bind(source), d => d.Id == "GS0158");
+    }
+
+    private static IReadOnlyList<Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+
+        // BoundProgram fully binds function bodies (where member access is
+        // resolved), surfacing body-level diagnostics such as GS0158/GS0159 —
+        // GlobalScope.Diagnostics only covers declaration-level binding.
+        return compilation.GlobalScope.Diagnostics
+            .Concat(compilation.BoundProgram.Diagnostics)
+            .ToList();
+    }
+}

--- a/test/LanguageServer.Tests/CompletionHandlerTests.cs
+++ b/test/LanguageServer.Tests/CompletionHandlerTests.cs
@@ -192,6 +192,22 @@ public class CompletionHandlerTests
     }
 
     [Fact]
+    public void ComputeCompletions_AfterDotOnUserInterfaceExtendingImportedInterface_OffersInheritedClrMembers()
+    {
+        // Issue #1181: a user interface extending a BCL interface must surface
+        // the imported base interface's members (and the user-declared members)
+        // on an interface-typed receiver — consistent with the binder.
+        const string source = "package p\nimport System\ninterface IBox : IDisposable { prop N int32 }\nfunc use(b IBox) {\nb.\n}\n";
+        var content = LanguageServerTestHelpers.Content(source);
+
+        var items = CompletionComputer.ComputeCompletions(content, After(source, "b."));
+
+        Assert.Contains(items, i => i.Label == "Dispose" && i.Kind == CompletionItemKind.Method);
+        Assert.Contains(items, i => i.Label == "N" && i.Kind == CompletionItemKind.Property);
+        Assert.DoesNotContain(items, i => i.Kind == CompletionItemKind.Keyword);
+    }
+
+    [Fact]
     public void ComputeCompletions_AfterDotOnParenthesizedExpression_InsideFunction_UsesParameters()
     {
         const string source = "func add(a int32, b int32) {\n(a + b).\n}\n";


### PR DESCRIPTION
Fixes #1181.

## Problem
A user-defined interface that **extends a BCL/imported interface** did not surface the inherited members when a member was invoked on a value typed as the user interface. Member lookup failed:

```gsharp
package p
import System
interface IBox : IDisposable { prop N int32 }
func Use(b IBox) { b.Dispose() }   // was: GS0159 Cannot find function Dispose.
```

Extending a **user** base interface, and calling the member on the imported interface type **directly**, both already worked — so the gap was specifically the imported base interface's members not being projected through the deriving user interface (the interface-inheritance analog of #1103).

## Root cause
User-interface member resolution walked only the *user* base interfaces (`InterfaceSymbol.BaseInterfaces` via `SelfAndAllBaseInterfaces()`) and ignored the imported CLR base interfaces recorded in `InterfaceSymbol.BaseClrInterfaces`. The canonical pure layer (`TypeMemberModel`, ADR-0112) intentionally excludes CLR reflection, so the imported base interfaces' members were never projected onto the receiver — even though the emitter already emits an `InterfaceImpl` row from the user interface to each imported base, making a `callvirt` against the inherited member verifiable.

## Fix
- `MemberLookup.GetTransitiveClrBaseInterfaces` walks the user interface hierarchy and harvests each level's `BaseClrInterfaces` plus their transitive CLR interface bases (e.g. `IEnumerable<T>` → `IEnumerable`), deduped structurally via `ClrTypeUtilities.AreSame` (FullName-based, robust across metadata-load contexts).
- The method-call binder resolves an interface receiver's call against these imported base interfaces (`TryBindInterfaceImportedBaseInstanceCall`, sharing the resolution core extracted from the #296 inherited-base-class path) **after** user member-table lookup fails — so user-declared members keep priority and a verifiable `callvirt` is emitted.
- The member-access binder mirrors this for inherited imported properties/fields and method groups.
- The language-server completion surface enumerates the same inherited imported members for interface receivers, keeping it consistent with the binder.

## Tests
- **Binder** (`Issue1181InterfaceImportedBaseMembersTests`): `IDisposable.Dispose`, non-generic `IEnumerable.GetEnumerator`, transitive generic `IEnumerable[int32]`, `ICollection.Count` property, imported base reached through a user base interface, plus controls (user-base-interface member, direct BCL-interface call) and negative GS0158/GS0159 cases.
- **Emit** (`Issue1181InterfaceImportedBaseMembersEmitTests`): end-to-end `Dispose` dispatch through the user interface (runtime output asserted), ilverify coverage for the generic-transitive and property-access cases.
- **Language server** (`CompletionHandlerTests`): completion after `.` on a user-interface receiver offers the inherited `Dispose` and the user-declared property.

## Verification
- `dotnet build GSharp.sln -c Release -graph` → 0 warnings / 0 errors.
- `dotnet test test/Core.Tests` → 4117 passed.
- Compiler interface emit tests → 183 passed; new `~Issue1181` → 3 passed.
- `dotnet test test/LanguageServer.Tests` → 365 passed.
