### PR TITLE
Fixes #1182: accept value-type default(T) / T() as an optional-parameter default

### DIFF
--- a/docs/adr/0063-method-overloading-and-optional-parameters.md
+++ b/docs/adr/0063-method-overloading-and-optional-parameters.md
@@ -76,14 +76,14 @@ parameter = identifier ellipsis? type_clause ('=' constant_expression)?
 
 In v1, an optional parameter must satisfy all of the following:
 
-1. Its default value is a compile-time constant representable in CLR parameter metadata: numeric literal, `bool`, `char`, `string`, enum constant, or `nil` for a nullable/reference-compatible parameter.
+1. Its default value is a compile-time constant representable in CLR parameter metadata: numeric literal, `bool`, `char`, `string`, enum constant, `nil` for a nullable/reference-compatible parameter, or a value-type `default(T)` / zero-value `T()` (issue #1182) — the type's all-zero value.
 2. It is not marked `ref`, `out`, or `in`.
 3. It is not variadic (`...`).
 4. It is not the receiver parameter of a receiver method or extension function.
 
 Optional and required parameters may therefore be interleaved. A call is applicable if every required parameter receives an argument and every unsupplied parameter is optional.
 
-These restrictions are deliberate. They preserve faithful CLR emission (`Optional`/`HasDefault` plus a Constant row) while keeping omitted-argument lowering purely compile-time. Non-constant defaults, defaults that reference earlier parameters, and `default(T)`-style generalized expressions are deferred.
+These restrictions are deliberate. They preserve faithful CLR emission (`Optional`/`HasDefault` plus a Constant row) while keeping omitted-argument lowering purely compile-time. A value-type `default(T)` (and the equivalent zero-value `T()` form) is also accepted (issue #1182): primitive defaults emit their typed-zero Constant, while arbitrary value types (BCL or user `data struct`) and `Nullable<T>` emit a nullref Constant and materialize the all-zero value at omitted call sites via a `BoundDefaultExpression` (`initobj` in IL), matching C#. Non-constant defaults, defaults that reference earlier parameters, and other generalized expressions remain deferred.
 
 ### 4. Call-site semantics
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -426,7 +426,7 @@ ADR-0063 lifts the v0 "one declaration per name" rule, so G# user functions can 
 Cause/fix examples:
 
 - **GS0264** — two `func F(x int32) {}` declarations, or two declarations that differ only in return type. Fix: change the parameter list (different types, arity, or ref-kinds); return type alone is not a distinguishing signature.
-- **GS0265** — a default-value expression that is not constant, a parameter whose default depends on another parameter, an optional parameter preceding a required one without all trailing parameters also optional, or an optional ref/out parameter. Fix: use a compile-time-constant default, place optional parameters at the end of the list, and avoid combining `ref`/`out` with defaults.
+- **GS0265** — a default-value expression that is not constant, a parameter whose default depends on another parameter, an optional parameter preceding a required one without all trailing parameters also optional, or an optional ref/out parameter. Fix: use a compile-time-constant default, place optional parameters at the end of the list, and avoid combining `ref`/`out` with defaults. A value-type `default(T)` (and the zero-value `T()` form) is accepted and materializes the type's all-zero value at omitted call sites, matching C#.
 - **GS0266** — `Greet("ada")` when both `Greet(string)` and `Greet(name string)` are visible via different paths. Fix: rename one, change one signature, or use a named argument that only one overload accepts.
 - **GS0267** — `Greet(42)` when only `Greet(string)` is declared. Fix: pass a value of the expected type, or add an overload covering the new argument shape.
 

--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -1505,9 +1505,18 @@ internal sealed class ConversionClassifier
         {
             value = lit.Value;
         }
+        else if (inner is BoundDefaultExpression def)
+        {
+            // Issue #1182: a value-type `default(T)` (and the zero-value `T()`
+            // form, which the binder also lowers to a BoundDefaultExpression for
+            // value types with no surfaced parameterless constructor) is a valid
+            // compile-time constant — the type's all-zero value. Accept it and
+            // record a constant the call site can materialize, mirroring C#.
+            return TryExtractValueTypeDefaultConstant(def, parameterType, out value, out reason);
+        }
         else
         {
-            reason = "the default value must be a compile-time constant (numeric, bool, char, string, enum, or nil).";
+            reason = "the default value must be a compile-time constant (numeric, bool, char, string, enum, nil, or a value-type default(T)).";
             return false;
         }
 
@@ -1546,5 +1555,153 @@ internal sealed class ConversionClassifier
                 value = null;
                 return false;
         }
+    }
+
+    // Issue #1182: extracts the constant default for a value-type `default(T)` /
+    // zero-value `T()` optional default. The written `default(T)` must denote the
+    // parameter's own type. Primitive value types (numeric / bool / char) are
+    // recorded as their typed zero — identical to `= 0` — so a CLR Constant row is
+    // emitted; arbitrary value types (e.g. TimeSpan, user structs) and Nullable<T>
+    // record <see langword="null"/>, which the call site materializes as the
+    // all-zero value via a BoundDefaultExpression and the metadata encodes as a
+    // nullref Constant (matching C# `T x = default`).
+    private static bool TryExtractValueTypeDefaultConstant(BoundDefaultExpression def, TypeSymbol parameterType, out object value, out string reason)
+    {
+        value = null;
+        reason = null;
+
+        var paramUnderlying = parameterType is NullableTypeSymbol pn ? pn.UnderlyingType : parameterType;
+        var defUnderlying = def.Type is NullableTypeSymbol dn ? dn.UnderlyingType : def.Type;
+
+        // The written `default(T)` / `T()` must denote the parameter's own type;
+        // no implicit conversion of a value-type default is supported.
+        if (!DefaultTypeMatchesParameter(defUnderlying, paramUnderlying))
+        {
+            reason = $"the default value 'default({def.Type?.Name})' does not match the parameter type '{parameterType.Name}'.";
+            return false;
+        }
+
+        // Nullable<T> or reference-type parameter: the default is the missing value
+        // (nil), already representable as a nullref Constant and materialized as nil.
+        if (parameterType is NullableTypeSymbol || !IsValueTypeForDefault(paramUnderlying))
+        {
+            value = null;
+            return true;
+        }
+
+        // Primitive value types are CLR Constant-table representable as their typed
+        // zero — emit the same constant as the `= 0` form.
+        if (TryGetPrimitiveZero(paramUnderlying, out var primitiveZero))
+        {
+            value = primitiveZero;
+            return true;
+        }
+
+        // Arbitrary value type (TimeSpan, user struct, enum, tuple): materialized at
+        // the call site via BoundDefaultExpression; metadata Constant is nullref.
+        value = null;
+        return true;
+    }
+
+    // Issue #1182: the written `default(T)` / `T()` must denote the same type as the
+    // parameter. Symbol identity covers the common case (including user value types
+    // whose <see cref="TypeSymbol.ClrType"/> is null pre-emit); the CLR full-name and
+    // name fallbacks cover imported types and re-resolved symbol instances.
+    private static bool DefaultTypeMatchesParameter(TypeSymbol defType, TypeSymbol paramType)
+    {
+        if (defType == null || paramType == null)
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(defType, paramType) || Equals(defType, paramType))
+        {
+            return true;
+        }
+
+        var defClr = defType.ClrType;
+        var paramClr = paramType.ClrType;
+        if (defClr != null && paramClr != null)
+        {
+            return string.Equals(defClr.FullName, paramClr.FullName, System.StringComparison.Ordinal);
+        }
+
+        return string.Equals(defType.Name, paramType.Name, System.StringComparison.Ordinal);
+    }
+
+    // Issue #1182: recognises value-type parameter symbols whose all-zero default is a
+    // valid optional default — including user `data struct` / enum / tuple symbols that
+    // carry no CLR backing type before emit.
+    private static bool IsValueTypeForDefault(TypeSymbol type)
+    {
+        if (type is StructSymbol s && !s.IsClass)
+        {
+            return true;
+        }
+
+        if (type is EnumSymbol || type is TupleTypeSymbol)
+        {
+            return true;
+        }
+
+        return type?.ClrType is { IsValueType: true };
+    }
+
+    // Issue #1182: returns the typed CLR zero for a primitive value-type symbol so a
+    // `default(T)` optional default emits the same CLR Constant row as `= 0`.
+    private static bool TryGetPrimitiveZero(TypeSymbol type, out object zero)
+    {
+        zero = null;
+
+        if (type == TypeSymbol.Bool)
+        {
+            zero = false;
+        }
+        else if (type == TypeSymbol.Int8)
+        {
+            zero = (sbyte)0;
+        }
+        else if (type == TypeSymbol.UInt8)
+        {
+            zero = (byte)0;
+        }
+        else if (type == TypeSymbol.Int16)
+        {
+            zero = (short)0;
+        }
+        else if (type == TypeSymbol.UInt16)
+        {
+            zero = (ushort)0;
+        }
+        else if (type == TypeSymbol.Int32)
+        {
+            zero = 0;
+        }
+        else if (type == TypeSymbol.UInt32)
+        {
+            zero = 0u;
+        }
+        else if (type == TypeSymbol.Int64)
+        {
+            zero = 0L;
+        }
+        else if (type == TypeSymbol.UInt64)
+        {
+            zero = 0UL;
+        }
+        else if (type == TypeSymbol.Float32)
+        {
+            zero = 0f;
+        }
+        else if (type == TypeSymbol.Float64)
+        {
+            zero = 0d;
+        }
+        else if (type == TypeSymbol.Char)
+        {
+            zero = '\0';
+        }
+
+        return zero != null;
     }
 }

--- a/src/Core/CodeAnalysis/Symbols/ParameterSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ParameterSymbol.cs
@@ -73,7 +73,9 @@ public sealed class ParameterSymbol : LocalVariableSymbol
     /// Only meaningful when <see cref="HasExplicitDefaultValue"/> is <see langword="true"/>.
     /// Value kinds: numeric primitive, <see cref="bool"/>, <see cref="char"/>,
     /// <see cref="string"/>, enum constant (carried as its underlying integral value),
-    /// or <see langword="null"/> for a nullable/reference parameter.
+    /// or <see langword="null"/> for a nullable/reference parameter or a value-type
+    /// <c>default(T)</c> / <c>T()</c> default (issue #1182), whose all-zero value is
+    /// materialized at the call site via a <see cref="Binding.BoundDefaultExpression"/>.
     /// </summary>
     public object ExplicitDefaultValue { get; private set; }
 
@@ -94,7 +96,7 @@ public sealed class ParameterSymbol : LocalVariableSymbol
     /// once by the binder when the parameter syntax includes a <c>= constant</c> clause
     /// and the constant has passed all ADR-0063 §3 restrictions.
     /// </summary>
-    /// <param name="value">The encoded constant default. May be <see langword="null"/> to represent the source-level <c>nil</c> default.</param>
+    /// <param name="value">The encoded constant default. May be <see langword="null"/> to represent the source-level <c>nil</c> default or a value-type <c>default(T)</c> / <c>T()</c> all-zero default (issue #1182).</param>
     public void SetExplicitDefaultValue(object value)
     {
         HasExplicitDefaultValue = true;

--- a/test/Compiler.Tests/Emit/Issue1182ValueTypeDefaultOptionalParameterEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1182ValueTypeDefaultOptionalParameterEmitTests.cs
@@ -1,0 +1,170 @@
+// <copyright file="Issue1182ValueTypeDefaultOptionalParameterEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1182 — emit + IL-verify coverage for a value-type <c>default(T)</c>
+/// (and the zero-value <c>T()</c> form) used as an optional-parameter default.
+/// When the argument is omitted at a call site, the emitter must materialize
+/// the type's all-zero value (verifiable IL), matching C#.
+///
+/// Covers a BCL value type (<c>TimeSpan</c>), a primitive (<c>int32</c>), and a
+/// user <c>data struct</c>, plus a regression guard that an explicitly-supplied
+/// argument still overrides the default.
+/// </summary>
+public class Issue1182ValueTypeDefaultOptionalParameterEmitTests
+{
+    [Fact]
+    public void Primitive_DefaultOf_Omitted_MaterializesZero()
+    {
+        var source = """
+            package Probe
+
+            func F(x int32 = default(int32)) int32 {
+                return x
+            }
+
+            public var result = F()
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal(0, GetField<int>(assembly, "result"));
+    }
+
+    [Fact]
+    public void Primitive_DefaultOf_Supplied_OverridesDefault()
+    {
+        var source = """
+            package Probe
+
+            func F(x int32 = default(int32)) int32 {
+                return x
+            }
+
+            public var result = F(42)
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal(42, GetField<int>(assembly, "result"));
+    }
+
+    [Fact]
+    public void BclValueType_DefaultOf_Omitted_MaterializesAllZero()
+    {
+        var source = """
+            package Probe
+            import System
+
+            func F(t TimeSpan = default(TimeSpan)) int64 {
+                return t.Ticks
+            }
+
+            public var result = F()
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal(0L, GetField<long>(assembly, "result"));
+    }
+
+    [Fact]
+    public void BclValueType_ZeroValueConstructorForm_Omitted_MaterializesAllZero()
+    {
+        var source = """
+            package Probe
+            import System
+
+            class C {
+                var T TimeSpan
+                init(t TimeSpan = TimeSpan()) { T = t }
+            }
+
+            public var result = C().T.Ticks
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal(0L, GetField<long>(assembly, "result"));
+    }
+
+    [Fact]
+    public void UserStruct_DefaultOf_Omitted_MaterializesAllZero()
+    {
+        var source = """
+            package Probe
+
+            data struct Point {
+                var X int32
+                var Y int32
+            }
+
+            func F(p Point = default(Point)) int32 {
+                return p.X + p.Y
+            }
+
+            public var result = F()
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal(0, GetField<int>(assembly, "result"));
+    }
+
+    private static Assembly CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1182_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+        IlVerifier.Verify(outPath);
+
+        var bytes = File.ReadAllBytes(outPath);
+        var assembly = Assembly.Load(bytes);
+
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+        entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+
+        return assembly;
+    }
+
+    private static T GetField<T>(Assembly assembly, string name)
+    {
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var resultField = program.GetField(name, BindingFlags.Public | BindingFlags.Static);
+        return (T)resultField!.GetValue(null)!;
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1182ValueTypeDefaultOptionalParameterTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1182ValueTypeDefaultOptionalParameterTests.cs
@@ -1,0 +1,162 @@
+// <copyright file="Issue1182ValueTypeDefaultOptionalParameterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1182 — a value-type <c>default(T)</c> (and the equivalent zero-value
+/// <c>T()</c> form) is a valid compile-time constant and must be accepted as an
+/// optional-parameter default, materializing the type's all-zero value when the
+/// argument is omitted at a call site (matching C#). Previously rejected with
+/// GS0265. Covers BCL value types (<c>TimeSpan</c>), primitives
+/// (<c>default(int32)</c>), user <c>data struct</c>s, the existing accepted
+/// controls (numeric literal, <c>nil</c>), and a type-mismatch rejection.
+/// </summary>
+public class Issue1182ValueTypeDefaultOptionalParameterTests
+{
+    [Fact]
+    public void BclValueType_DefaultOf_AcceptedAsOptionalDefault()
+    {
+        var source = @"
+import System
+class C { init(t TimeSpan = default(TimeSpan)) {} }
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void BclValueType_ZeroValueConstructorForm_AcceptedAsOptionalDefault()
+    {
+        var source = @"
+import System
+class C { init(t TimeSpan = TimeSpan()) {} }
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void Primitive_DefaultOf_AcceptedAsOptionalDefault()
+    {
+        var source = @"
+func F(x int32 = default(int32)) int32 { return x }
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void UserStruct_DefaultOf_AcceptedAsOptionalDefault()
+    {
+        var source = @"
+data struct Point { var X int32 var Y int32 }
+func F(p Point = default(Point)) int32 { return p.X }
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void Primitive_DefaultOf_OmittedAtCallSite_MaterializesZero()
+    {
+        var source = @"
+func F(x int32 = default(int32)) int32 { return x }
+let r = F()
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(0, result.Value);
+    }
+
+    [Fact]
+    public void UserStruct_DefaultOf_OmittedAtCallSite_MaterializesAllZero()
+    {
+        var source = @"
+data struct Point { var X int32 var Y int32 }
+func F(p Point = default(Point)) int32 { return p.X + p.Y }
+let r = F()
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(0, result.Value);
+    }
+
+    [Fact]
+    public void Primitive_DefaultOf_SuppliedAtCallSite_OverridesDefault()
+    {
+        var source = @"
+func F(x int32 = default(int32)) int32 { return x }
+let r = F(7)
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(7, result.Value);
+    }
+
+    [Fact]
+    public void TypeMismatchedValueTypeDefault_DiagnosesGS0265()
+    {
+        var source = @"
+import System
+class C { init(t TimeSpan = default(int32)) {} }
+";
+        var result = Evaluate(source);
+        AssertHasDiagnosticId(result.Diagnostics, "GS0265");
+    }
+
+    [Fact]
+    public void NumericLiteralDefault_StillAccepted()
+    {
+        var source = @"
+func F(x int32 = 5) int32 { return x }
+let r = F()
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(5, result.Value);
+    }
+
+    [Fact]
+    public void NilDefault_StillAccepted()
+    {
+        var source = @"
+class C { init(s string? = nil) {} }
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void NonConstantValueTypeExpressionDefault_StillDiagnosesGS0265()
+    {
+        // A real parameterless construction with side effects is not a constant.
+        var source = @"
+func F(x int32 = 1 + 2) int32 { return x }
+";
+        var result = Evaluate(source);
+        AssertHasDiagnosticId(result.Diagnostics, "GS0265");
+    }
+
+    private static void AssertHasDiagnosticId(ImmutableArray<Diagnostic> diagnostics, string id)
+    {
+        Assert.Contains(diagnostics, d => d.Id == id);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
Fixes #1182.

## Problem
An optional parameter whose default is a value-type `default(T)` (e.g. `TimeSpan t = default(TimeSpan)`) — or the equivalent zero-value `T()` form, or `default(int32)` — was rejected by `gsc` with **GS0265** ("the default value must be a compile-time constant"). A value-type `default(T)` *is* a compile-time constant (the all-zero value) and should be a valid optional-parameter default, as it is in C#.

## Root cause
The optional-default validation in `ConversionClassifier.TryExtractConstantDefault` only accepted a `BoundLiteralExpression` of a numeric/bool/char/string/enum/nil constant. A value-type `default(T)` and the zero-value `T()` form both bind to a `BoundDefaultExpression`, which fell into the `else` branch and produced GS0265.

## Fix
- The binder now accepts a `BoundDefaultExpression` whose type matches the parameter:
  - **Primitive value types** (`default(int32)`, etc.) record their typed zero — identical to `= 0`, so a normal CLR Constant row is emitted.
  - **Arbitrary value types** (BCL like `TimeSpan`, user `data struct`, enums, tuples) and `Nullable<T>` record `null`, which the call site materializes as the all-zero value via a `BoundDefaultExpression` (`initobj` in IL) and the metadata encodes as a nullref Constant — exactly how C# emits `T x = default`.
  - A **type-mismatched** `default(T)` (e.g. `TimeSpan t = default(int32)`) is still rejected with GS0265.
- User `data struct` types whose `ClrType` is null before emit are handled via symbol-based value-type detection and type matching.
- Both the tree interpreter (`Evaluator`) and the IL emitter already materialize `BoundDefaultExpression` for value types, so the omitted-argument lowering needed no change.

## Tests
- **Binder/diagnostic** (`test/Core.Tests/.../Issue1182ValueTypeDefaultOptionalParameterTests.cs`): `default(TimeSpan)`, `TimeSpan()`, `default(int32)`, and `default(Point)` (user struct) are accepted; omitted call sites materialize the all-zero value in the interpreter; supplied arguments override; type-mismatch yields GS0265; numeric-literal and `nil` controls still pass.
- **Emit/execution** (`test/Compiler.Tests/Emit/Issue1182ValueTypeDefaultOptionalParameterEmitTests.cs`): IL-verified (`IlVerifier.Verify`) end-to-end runs that omit the optional argument and assert the materialized default is all-zero for a BCL value type (`TimeSpan`), a primitive (`int32`), and a user `data struct` (`Point`), plus a supplied-override guard.

## Validation
- `dotnet build GSharp.sln -c Release -graph` → 0 warnings / 0 errors.
- `dotnet test test/Core.Tests` → 4128 passed, 1 skipped.
- New binder tests: 11 passed. New emit tests: 5 passed. Related regression tests (Issue936 optional params, Issue524 default ctor, DataStructInterop): 18 passed.

## Docs
Updated ADR-0063 and `docs/diagnostics.md` (GS0265) to note value-type `default(T)` / `T()` is now accepted.
