### PR TITLE
Fix cs2gs .gs filename collisions (#1189) and static auto-property initializers (#1190)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Pipeline/Cs2Gs.Pipeline.csproj
+++ b/tools/cs2gs/Cs2Gs.Pipeline/Cs2Gs.Pipeline.csproj
@@ -10,4 +10,8 @@
     <ProjectReference Include="..\Cs2Gs.CodeModel\Cs2Gs.CodeModel.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="GSharp.Cs2Gs.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/tools/cs2gs/Cs2Gs.Pipeline/EmittedFileNaming.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/EmittedFileNaming.cs
@@ -1,0 +1,134 @@
+// <copyright file="EmittedFileNaming.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Cs2Gs.Pipeline;
+
+/// <summary>
+/// Derives unique <c>.gs</c> output file names from C# source paths (issue #1189).
+/// Two C# documents that share a base name in different folders (e.g.
+/// <c>Types/Enums.cs</c> and <c>Diagnostics/Enums.cs</c>) would otherwise both map
+/// to <c>Enums.gs</c> and the second would silently overwrite the first, losing the
+/// translated code and producing spurious downstream <c>GS0113</c> diagnostics.
+/// </summary>
+internal static class EmittedFileNaming
+{
+    /// <summary>
+    /// Returns a <c>.gs</c> file name for <paramref name="sourceFilePath"/> that is
+    /// unique within <paramref name="usedNames"/> (compared case-insensitively, to
+    /// stay safe on case-insensitive macOS/Windows filesystems). When the plain base
+    /// name collides, containing directory segments are prepended deterministically
+    /// (<c>Types.Enums.gs</c>, <c>Diagnostics.Enums.gs</c>); if every directory
+    /// segment has been consumed and a collision still remains, a numeric counter is
+    /// appended. The chosen name is added to <paramref name="usedNames"/> before
+    /// returning, so callers can pass the same set through their document loop.
+    /// </summary>
+    /// <param name="sourceFilePath">The originating C# source file path.</param>
+    /// <param name="usedNames">
+    /// The set of <c>.gs</c> names already emitted in this run. Must be created with a
+    /// case-insensitive comparer (e.g. <see cref="StringComparer.OrdinalIgnoreCase"/>).
+    /// </param>
+    /// <returns>A unique <c>.gs</c> file name.</returns>
+    public static string UniqueGsFileName(string sourceFilePath, ISet<string> usedNames)
+    {
+        if (usedNames is null)
+        {
+            throw new ArgumentNullException(nameof(usedNames));
+        }
+
+        string baseName = SanitizeSegment(Path.GetFileNameWithoutExtension(sourceFilePath ?? string.Empty));
+        if (string.IsNullOrEmpty(baseName))
+        {
+            baseName = "File";
+        }
+
+        IReadOnlyList<string> dirSegments = DirectorySegmentsNearestFirst(sourceFilePath);
+
+        string candidate = baseName + ".gs";
+        int step = 0;
+        while (usedNames.Contains(candidate))
+        {
+            step++;
+            if (step <= dirSegments.Count)
+            {
+                // Prepend the nearest `step` directory segments, ordered outer→inner
+                // for readability (e.g. ["Types"] → "Types.Enums.gs").
+                IEnumerable<string> prefix = dirSegments.Take(step).Reverse();
+                candidate = string.Join(".", prefix) + "." + baseName + ".gs";
+            }
+            else
+            {
+                // Exhausted directory segments: fall back to a numeric counter on top
+                // of the fully-qualified prefix.
+                int counter = step - dirSegments.Count + 1;
+                string allDirs = dirSegments.Count > 0
+                    ? string.Join(".", dirSegments.Reverse()) + "."
+                    : string.Empty;
+                candidate = allDirs + baseName + "." + counter + ".gs";
+            }
+        }
+
+        usedNames.Add(candidate);
+        return candidate;
+    }
+
+    private static IReadOnlyList<string> DirectorySegmentsNearestFirst(string sourceFilePath)
+    {
+        if (string.IsNullOrEmpty(sourceFilePath))
+        {
+            return Array.Empty<string>();
+        }
+
+        string dir = Path.GetDirectoryName(sourceFilePath);
+        if (string.IsNullOrEmpty(dir))
+        {
+            return Array.Empty<string>();
+        }
+
+        // Split on both separators so the result is platform-independent.
+        string[] parts = dir.Split(
+            new[] { '/', '\\' },
+            StringSplitOptions.RemoveEmptyEntries);
+
+        var segments = new List<string>(parts.Length);
+        for (int i = parts.Length - 1; i >= 0; i--)
+        {
+            string sanitized = SanitizeSegment(parts[i]);
+            if (sanitized.Length == 0 || sanitized == "." || sanitized == "..")
+            {
+                continue;
+            }
+
+            segments.Add(sanitized);
+        }
+
+        return segments;
+    }
+
+    private static string SanitizeSegment(string segment)
+    {
+        if (string.IsNullOrEmpty(segment))
+        {
+            return string.Empty;
+        }
+
+        char[] chars = segment.ToCharArray();
+        for (int i = 0; i < chars.Length; i++)
+        {
+            char c = chars[i];
+            if (char.IsLetterOrDigit(c) || c == '_' || c == '-')
+            {
+                continue;
+            }
+
+            chars[i] = '_';
+        }
+
+        return new string(chars).Trim('_');
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Pipeline/TestParityStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TestParityStage.cs
@@ -211,6 +211,7 @@ public sealed class TestParityStage : IMigrationStage
             .ConfigureAwait(false);
 
         var files = new List<GsharpSourceFile>();
+        var usedGsFileNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (LoadedDocument document in project.Documents)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -241,7 +242,7 @@ public sealed class TestParityStage : IMigrationStage
                     (roundTrip.Errors.FirstOrDefault() ?? "unknown parse error"));
             }
 
-            string gsFileName = Path.GetFileNameWithoutExtension(document.FilePath) + ".gs";
+            string gsFileName = EmittedFileNaming.UniqueGsFileName(document.FilePath, usedGsFileNames);
             files.Add(new GsharpSourceFile(gsFileName, printed));
         }
 

--- a/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
@@ -45,6 +45,8 @@ public sealed class TranslateStage : IMigrationStage
         var artifacts = new List<TriageArtifact>();
         Directory.CreateDirectory(context.AppRunDir);
 
+        var usedGsFileNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
         foreach (LoadedDocument document in project.Documents)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -57,7 +59,7 @@ public sealed class TranslateStage : IMigrationStage
             CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, translationContext);
             string printed = GSharpPrinter.Print(unit);
 
-            string gsFileName = Path.GetFileNameWithoutExtension(document.FilePath) + ".gs";
+            string gsFileName = EmittedFileNaming.UniqueGsFileName(document.FilePath, usedGsFileNames);
             string gsPath = Path.Combine(context.AppRunDir, gsFileName);
             File.WriteAllText(gsPath, printed);
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1189FilenameCollisionTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1189FilenameCollisionTests.cs
@@ -1,0 +1,106 @@
+// <copyright file="Issue1189FilenameCollisionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #1189: emitted <c>.gs</c> file names must be unique within a run. Two C#
+/// sources that share a base name in different folders (e.g. <c>Types/Enums.cs</c>
+/// and <c>Diagnostics/Enums.cs</c>) previously both mapped to <c>Enums.gs</c>, so
+/// the second silently overwrote the first — losing the translated code and
+/// producing spurious downstream <c>GS0113 Type '…' doesn't exist</c> diagnostics.
+/// </summary>
+public class Issue1189FilenameCollisionTests
+{
+    private static HashSet<string> NewUsedSet() =>
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+    [Fact]
+    public void DistinctBaseNames_AreUnchanged()
+    {
+        HashSet<string> used = NewUsedSet();
+
+        string a = EmittedFileNaming.UniqueGsFileName("/proj/Foo.cs", used);
+        string b = EmittedFileNaming.UniqueGsFileName("/proj/Bar.cs", used);
+
+        Assert.Equal("Foo.gs", a);
+        Assert.Equal("Bar.gs", b);
+    }
+
+    [Fact]
+    public void CollidingBaseNames_AreDisambiguatedByDirectory()
+    {
+        HashSet<string> used = NewUsedSet();
+
+        string first = EmittedFileNaming.UniqueGsFileName("/proj/Types/Enums.cs", used);
+        string second = EmittedFileNaming.UniqueGsFileName("/proj/Diagnostics/Enums.cs", used);
+
+        Assert.Equal("Enums.gs", first);
+        Assert.Equal("Diagnostics.Enums.gs", second);
+        Assert.NotEqual(first, second);
+    }
+
+    [Fact]
+    public void CollisionsAreCaseInsensitive()
+    {
+        HashSet<string> used = NewUsedSet();
+
+        string first = EmittedFileNaming.UniqueGsFileName("/proj/Types/Enums.cs", used);
+        string second = EmittedFileNaming.UniqueGsFileName("/proj/other/enums.cs", used);
+
+        // The base names differ only by case but must still not collide on a
+        // case-insensitive filesystem.
+        Assert.NotEqual(
+            first.ToLowerInvariant(),
+            second.ToLowerInvariant());
+    }
+
+    [Fact]
+    public void RepeatedDirectoryAndBase_FallsBackToCounter()
+    {
+        HashSet<string> used = NewUsedSet();
+
+        // Three sources that share both the immediate directory name and base name
+        // (different roots). The first keeps the plain name, the second gains the
+        // directory prefix, and subsequent ones add more path and/or a counter.
+        string a = EmittedFileNaming.UniqueGsFileName("/a/Shared/Enums.cs", used);
+        string b = EmittedFileNaming.UniqueGsFileName("/b/Shared/Enums.cs", used);
+        string c = EmittedFileNaming.UniqueGsFileName("/c/Shared/Enums.cs", used);
+
+        var names = new HashSet<string>(new[] { a, b, c }, StringComparer.OrdinalIgnoreCase);
+        Assert.Equal(3, names.Count);
+        Assert.Equal("Enums.gs", a);
+    }
+
+    [Fact]
+    public void IsDeterministic()
+    {
+        string Run()
+        {
+            HashSet<string> used = NewUsedSet();
+            string x = EmittedFileNaming.UniqueGsFileName("/proj/Types/Enums.cs", used);
+            string y = EmittedFileNaming.UniqueGsFileName("/proj/Diagnostics/Enums.cs", used);
+            return x + "|" + y;
+        }
+
+        Assert.Equal(Run(), Run());
+    }
+
+    [Fact]
+    public void AllReturnedNames_AreRegisteredInTheSet()
+    {
+        HashSet<string> used = NewUsedSet();
+
+        string a = EmittedFileNaming.UniqueGsFileName("/proj/Types/Enums.cs", used);
+        string b = EmittedFileNaming.UniqueGsFileName("/proj/Diagnostics/Enums.cs", used);
+
+        Assert.Contains(a, used);
+        Assert.Contains(b, used);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1190StaticAutoPropertyTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1190StaticAutoPropertyTranslationTests.cs
@@ -1,0 +1,147 @@
+// <copyright file="Issue1190StaticAutoPropertyTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #1190: a C# <c>static</c> get-only auto-property with an inline
+/// initializer (<c>public static Version OSVersion { get; } = GetOsVersion();</c>)
+/// must become a static read-only backing field inside the <c>shared { }</c> block
+/// (<c>shared { let OSVersion Version = GetOsVersion() }</c>), preserving the
+/// initializer. Previously it was mis-translated to an invalid static
+/// <c>prop … { get; init; }</c> (GS0374) and the initializer was dropped, causing
+/// downstream <c>GS0113</c> diagnostics. A mutable
+/// (<c>{ get; private set; }</c>) static auto-property maps to a
+/// <c>shared var NAME T = expr</c> field instead.
+/// </summary>
+public class Issue1190StaticAutoPropertyTranslationTests
+{
+    private const string Source = @"
+namespace Corpus.Issue1190
+{
+    public class ApplEnv
+    {
+        public static string OSVersion { get; } = GetOsVersion();
+
+        public static string ApplName { get; private set; } = ""app"";
+
+        public static string Mutable { get; set; } = ""m"";
+
+        public static string Plain { get; }
+
+        public static string Computed { get { return ""c""; } }
+
+        private static string GetOsVersion()
+        {
+            return ""1.0"";
+        }
+    }
+}
+";
+
+    [Fact]
+    public void StaticGetOnlyWithInitializer_BecomesSharedLetField()
+    {
+        SharedBlock shared = SharedBlockOf("ApplEnv");
+
+        FieldDeclaration osVersion = shared.Members
+            .OfType<FieldDeclaration>()
+            .Single(f => f.Name == "OSVersion");
+
+        Assert.Equal(BindingKind.Let, osVersion.Binding);
+        Assert.NotNull(osVersion.Initializer);
+    }
+
+    [Fact]
+    public void StaticPrivateSetWithInitializer_BecomesSharedVarField()
+    {
+        SharedBlock shared = SharedBlockOf("ApplEnv");
+
+        FieldDeclaration applName = shared.Members
+            .OfType<FieldDeclaration>()
+            .Single(f => f.Name == "ApplName");
+
+        Assert.Equal(BindingKind.Var, applName.Binding);
+        Assert.NotNull(applName.Initializer);
+    }
+
+    [Fact]
+    public void StaticGetSetWithInitializer_BecomesSharedVarField()
+    {
+        SharedBlock shared = SharedBlockOf("ApplEnv");
+
+        FieldDeclaration mutable = shared.Members
+            .OfType<FieldDeclaration>()
+            .Single(f => f.Name == "Mutable");
+
+        Assert.Equal(BindingKind.Var, mutable.Binding);
+        Assert.NotNull(mutable.Initializer);
+    }
+
+    [Fact]
+    public void ConvertedStaticAutoProperties_DoNotEmitInitAccessor()
+    {
+        (CompilationUnit unit, _) = Translate();
+        string rendered = GSharpPrinter.Print(unit);
+
+        // The shared fields preserve their initializers and never use `init`.
+        Assert.Contains("let OSVersion", rendered, StringComparison.Ordinal);
+        Assert.Contains("var ApplName", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("OSVersion string { get; init; }", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("ApplName string { get; init; }", rendered, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void StaticAutoPropertyWithoutInitializer_KeepsPropertyForm()
+    {
+        SharedBlock shared = SharedBlockOf("ApplEnv");
+
+        // `Plain` has no initializer, so it is NOT converted to a backing field.
+        Assert.DoesNotContain(
+            shared.Members.OfType<FieldDeclaration>(),
+            f => f.Name == "Plain");
+    }
+
+    [Fact]
+    public void StaticComputedProperty_KeepsPropertyForm()
+    {
+        SharedBlock shared = SharedBlockOf("ApplEnv");
+
+        // A static property with a getter body is unaffected.
+        Assert.DoesNotContain(
+            shared.Members.OfType<FieldDeclaration>(),
+            f => f.Name == "Computed");
+    }
+
+    private static SharedBlock SharedBlockOf(string typeName)
+    {
+        (CompilationUnit unit, _) = Translate();
+        TypeDeclaration type = unit.Members.OfType<TypeDeclaration>().Single(t => t.Name == typeName);
+        return type.Members.OfType<SharedBlock>().Single();
+    }
+
+    private static (CompilationUnit Unit, TranslationContext Context) Translate()
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("ApplEnv.cs", Source) });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        return (unit, context);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -1281,6 +1281,16 @@ public sealed class CSharpToGSharpTranslator
                         break;
                     }
 
+                    // Issue #1190: a static auto-property with an inline initializer
+                    // maps to a static backing field in the `shared { }` block, since
+                    // a static G# `prop` cannot carry an `init` accessor (GS0374) and
+                    // there is no instance constructor to receive the initializer.
+                    if (this.TryTranslateStaticAutoPropertyField(property, out FieldDeclaration staticField))
+                    {
+                        yield return (staticField, true);
+                        break;
+                    }
+
                     yield return this.TranslateProperty(property);
                     break;
 
@@ -1745,6 +1755,75 @@ public sealed class CSharpToGSharpTranslator
             // to the instance-member list in VisitAggregate, which the parser
             // accepts directly in the type body).
             return (method, false);
+        }
+
+        /// <summary>
+        /// Issue #1190: a C# <c>static</c> auto-property with an inline initializer
+        /// (<c>public static Version OSVersion { get; } = GetOsVersion();</c>) has no
+        /// instance constructor to carry the initializer into (the OD-T1 path only
+        /// services instance properties), and a static G# <c>prop</c> cannot declare
+        /// an <c>init</c> accessor (GS0374). Such a property therefore maps to a
+        /// static read-only/mutable backing field inside the <c>shared { }</c> block,
+        /// preserving the initializer expression: a get-only property becomes a
+        /// <c>shared let NAME T = expr</c> field, and a mutable
+        /// (<c>{ get; private set; }</c> / <c>{ get; set; }</c>) property becomes a
+        /// <c>shared var NAME T = expr</c> field. It is accessed identically
+        /// (<c>Type.NAME</c>). A static auto-property without an initializer, or one
+        /// with a getter body, keeps its existing handling.
+        /// </summary>
+        private bool TryTranslateStaticAutoPropertyField(
+            PropertyDeclarationSyntax node,
+            out FieldDeclaration field)
+        {
+            field = null;
+
+            if (!node.Modifiers.Any(SyntaxKind.StaticKeyword) || node.Initializer == null)
+            {
+                return false;
+            }
+
+            // Auto-property: body-less, all accessors body-less, no expression body.
+            if (node.ExpressionBody != null || node.AccessorList == null)
+            {
+                return false;
+            }
+
+            IReadOnlyList<AccessorDeclarationSyntax> accessors = node.AccessorList.Accessors;
+            if (accessors.Any(a => a.Body != null || a.ExpressionBody != null))
+            {
+                return false;
+            }
+
+            bool hasGet = accessors.Any(a => a.IsKind(SyntaxKind.GetAccessorDeclaration));
+            if (!hasGet)
+            {
+                return false;
+            }
+
+            bool hasSet = accessors.Any(a => a.IsKind(SyntaxKind.SetAccessorDeclaration));
+
+            var symbol = this.context.GetDeclaredSymbol(node) as IPropertySymbol;
+            GTypeReference type = symbol != null
+                ? this.typeMapper.Map(symbol.Type, this.context, node.GetLocation())
+                : new NamedTypeReference(CSharpTypeMapper.UnsupportedPlaceholderType);
+
+            GExpression initializer = this.CoerceConstantToUnsigned(
+                node.Initializer.Value,
+                this.TranslateExpression(node.Initializer.Value));
+
+            // A mutable static auto-property (`{ get; set; }` / `{ get; private set; }`)
+            // becomes a `var` field; an immutable get-only one becomes a `let` field.
+            BindingKind binding = hasSet ? BindingKind.Var : BindingKind.Let;
+
+            field = new FieldDeclaration(
+                binding,
+                SanitizeIdentifier(node.Identifier.Text),
+                type,
+                initializer: initializer,
+                visibility: MapVisibility(symbol, this.context, node),
+                attributes: this.MapAttributes(node.AttributeLists));
+
+            return true;
         }
 
         private (GMember Member, bool IsStatic) TranslateProperty(PropertyDeclarationSyntax node)


### PR DESCRIPTION
## Summary

Fixes two cs2gs (C#→G# migration) bugs that caused translated G# to be lost or to fail to compile. Both are confined to `tools/cs2gs/`; the G# compiler (`src/`) is untouched.

### Bug #1189 — emitted `.gs` filename collision silently overwrites files
`TranslateStage` and `TestParityStage` derived the output `.gs` name from **only** the C# source base name:
```csharp
string gsFileName = Path.GetFileNameWithoutExtension(document.FilePath) + ".gs";
```
So two sources sharing a base name in different folders (e.g. `Types/Enums.cs` and `Diagnostics/Enums.cs`) both wrote `Enums.gs` — the second **silently overwrote** the first. The lost translation produced spurious downstream `GS0113 Type '…' doesn't exist`.

**Fix:** a new `EmittedFileNaming.UniqueGsFileName` helper makes emitted names unique within a run. On a collision (compared **case-insensitively** for macOS/Windows filesystems) it deterministically prepends containing directory segments (`Types.Enums.gs`, `Diagnostics.Enums.gs`), then adds more path and/or a numeric counter if needed. The same used-name set is threaded through the document loop so `GsPath` / `relativeGsPath` / `context.EmittedFiles` all use the disambiguated name and `CompileStage.MatchEmittedFile` still resolves diagnostics consistently. The identical fix is applied to `TestParityStage`.

### Bug #1190 — static get-only auto-property with initializer emits invalid `init` + drops initializer
```csharp
public static Version OSVersion { get; } = GetOsVersion();
```
was mis-translated to invalid G#:
```
shared { prop OSVersion Version { get; init; } }   // GS0374: init illegal on static; initializer dropped
```
The OD-T1 path moves a get-only auto-prop's initializer into the instance `init(...)` constructor, but a **static** property has no instance constructor, so the initializer was lost and `init` is illegal on a static `prop`.

**Fix:** a static auto-property **with an initializer** now becomes a static backing field inside the `shared { }` block, preserving the initializer expression:
```
shared { let OSVersion Version = GetOsVersion() }   // get-only  -> shared let
shared { var ApplName  string  = "app" }            // mutable   -> shared var
```
Get-only ⇒ `let`; mutable (`{ get; set; }` / `{ get; private set; }`) ⇒ `var`. Accessed identically as `Type.NAME`. Static auto-props **without** an initializer, or with a getter body, keep their existing handling. The chosen G# forms were verified to compile with `gsc`.

## Tests
- `Issue1189FilenameCollisionTests` — distinct names unchanged, collisions disambiguated by directory, case-insensitive collision handling, counter fallback, determinism, set registration.
- `Issue1190StaticAutoPropertyTranslationTests` — get-only→`let`, private-set→`var`, get/set→`var`, no `init` accessor emitted, no-initializer and getter-body cases unchanged.
- All **248** cs2gs tests pass.

## Oahu.Foundation end-to-end (before → after)
| metric | before | after |
|---|---|---|
| emitted `.gs` files | 44 | **48** |
| total `gsc` errors | 94 | **64** |
| `GS0374` | 16 | **0** |
| `GS0113` | 16 | **0** |

Remaining errors (`GS0102`, etc.) are unrelated pre-existing translator gaps outside the scope of these two fixes.

Fixes #1189
Fixes #1190
Refs #914
