### PR TITLE
Fix #1188: allow overloading of extension functions

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundScope.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundScope.cs
@@ -235,11 +235,24 @@ public sealed class BoundScope
     /// <summary>
     /// Tries to declare an extension function (Phase 3.B.6 / ADR-0019). Extension
     /// functions live outside the normal symbol table because their identity is
-    /// the pair (receiverType, name): two extensions with the same name but
-    /// different receivers are legal.
+    /// the triple (receiverType, name, signature).
     /// </summary>
+    /// <remarks>
+    /// Issue #1188: extension functions support overloading exactly like ordinary
+    /// methods and free functions. Two extensions that share a (receiver, name)
+    /// pair but differ in parameter signature (by arity, parameter type, or
+    /// generic arity) are legal overloads and both are registered. A collision is
+    /// reported only when a candidate is overload-identical to an existing one
+    /// (same name, same receiver type, same callable parameter signature). The
+    /// receiver type participates in identity through the synthetic receiver slot
+    /// at <c>Parameters[0]</c> (extension functions never set
+    /// <see cref="FunctionSymbol.ExplicitReceiverParameter"/>, so
+    /// <see cref="FunctionSignaturesEqual"/> compares the receiver type too): two
+    /// extensions with the same name and parameter list but different receiver
+    /// types remain independent.
+    /// </remarks>
     /// <param name="function">The extension function symbol. Must have <see cref="FunctionSymbol.IsExtension"/> set.</param>
-    /// <returns>True if the extension was registered; false if an identical (receiver, name) pair already exists in this scope.</returns>
+    /// <returns>True if the extension was registered; false if an overload-identical (receiver, name, signature) extension already exists in this scope.</returns>
     public bool TryDeclareExtensionFunction(FunctionSymbol function)
     {
         if (extensionFunctions == null)
@@ -249,7 +262,8 @@ public sealed class BoundScope
 
         foreach (var existing in extensionFunctions)
         {
-            if (existing.Name == function.Name && existing.ExtensionReceiverType == function.ExtensionReceiverType)
+            if (FunctionSignaturesEqual(existing, function)
+                && ExtensionTypeParameterConstraintsEqual(existing, function))
             {
                 return false;
             }
@@ -360,6 +374,61 @@ public sealed class BoundScope
         }
 
         return Parent?.TryLookupExtensionFunction(receiverType, name, out function) ?? false;
+    }
+
+    /// <summary>
+    /// Issue #1188: returns every extension-function overload visible from this
+    /// scope (walking parent scopes) that matches the (receiverType, name) pair.
+    /// Extension functions support overloading, so a single call site may have
+    /// several candidates differing only by parameter signature; the caller runs
+    /// these through normal overload resolution to pick the best one.
+    /// </summary>
+    /// <remarks>
+    /// Both dispatch paths used by <see cref="TryLookupExtensionFunction"/> are
+    /// honoured: the reference-equality receiver fast path (issue #1103) and the
+    /// generic-receiver unification fallback (issue #773 / #775). Candidates are
+    /// returned in declaration order, innermost scope first.
+    /// </remarks>
+    /// <param name="receiverType">The static type of the call receiver.</param>
+    /// <param name="name">The method name at the call site.</param>
+    /// <returns>The matching extension overloads, or an empty array when none match.</returns>
+    public ImmutableArray<FunctionSymbol> TryLookupExtensionFunctions(TypeSymbol receiverType, string name)
+    {
+        ImmutableArray<FunctionSymbol>.Builder builder = null;
+        for (var s = this; s != null; s = s.Parent)
+        {
+            if (s.extensionFunctions == null)
+            {
+                continue;
+            }
+
+            foreach (var ext in s.extensionFunctions)
+            {
+                if (ext.Name != name)
+                {
+                    continue;
+                }
+
+                var matches = ReceiverMatches(ext.ExtensionReceiverType, receiverType);
+                if (!matches
+                    && !ext.TypeParameters.IsDefaultOrEmpty
+                    && ext.ExtensionReceiverType != null
+                    && ext.ExtensionReceiverType != TypeSymbol.Error
+                    && ReceiverMentionsAnyTypeParameter(ext.ExtensionReceiverType, ext.TypeParameters)
+                    && TryUnifyAndCheckConstraints(ext, receiverType, out _))
+                {
+                    matches = true;
+                }
+
+                if (matches)
+                {
+                    builder ??= ImmutableArray.CreateBuilder<FunctionSymbol>();
+                    builder.Add(ext);
+                }
+            }
+        }
+
+        return builder == null ? ImmutableArray<FunctionSymbol>.Empty : builder.ToImmutable();
     }
 
     /// <summary>Gets the extension functions declared in this scope (Phase 3.B.6).</summary>
@@ -982,6 +1051,52 @@ public sealed class BoundScope
 
     private static ImmutableArray<ParameterSymbol> SigCallableParameters(FunctionSymbol f)
         => f.ExplicitReceiverParameter == null ? f.Parameters : f.Parameters.RemoveAt(0);
+
+    /// <summary>
+    /// Issue #1188 / #775: compares the type-parameter constraints of two
+    /// extension functions for overload-identity purposes. Two extensions that
+    /// share a name, receiver type, and callable parameter signature are still
+    /// distinct overloads when their generic type parameters carry different
+    /// constraints (e.g. <c>FirstOrNil[T class]()</c> vs
+    /// <c>FirstOrNil[T struct]()</c>), because receiver-constraint dispatch
+    /// disambiguates them at the call site. Returns <see langword="true"/> only
+    /// when every type parameter carries equivalent class/struct/new() and
+    /// interface/base constraints.
+    /// </summary>
+    /// <param name="a">First extension function.</param>
+    /// <param name="b">Second extension function.</param>
+    /// <returns>Whether the two functions' type-parameter constraints match.</returns>
+    private static bool ExtensionTypeParameterConstraintsEqual(FunctionSymbol a, FunctionSymbol b)
+    {
+        var aTp = a.TypeParameters.IsDefault ? ImmutableArray<TypeParameterSymbol>.Empty : a.TypeParameters;
+        var bTp = b.TypeParameters.IsDefault ? ImmutableArray<TypeParameterSymbol>.Empty : b.TypeParameters;
+        if (aTp.Length != bTp.Length)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < aTp.Length; i++)
+        {
+            var x = aTp[i];
+            var y = bTp[i];
+            if (x.HasValueTypeConstraint != y.HasValueTypeConstraint
+                || x.HasReferenceTypeConstraint != y.HasReferenceTypeConstraint
+                || x.HasDefaultConstructorConstraint != y.HasDefaultConstructorConstraint
+                || x.Constraint != y.Constraint)
+            {
+                return false;
+            }
+
+            var xRef = x.ConstraintReferenceType?.Name;
+            var yRef = y.ConstraintReferenceType?.Name;
+            if (!string.Equals(xRef, yRef, StringComparison.Ordinal))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
 
     private static bool SigTypesEquivalent(TypeSymbol x, TypeSymbol y, FunctionSymbol fx, FunctionSymbol fy)
     {

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -5234,9 +5234,16 @@ internal sealed class DeclarationBinder
             {
                 function.IsExtension = true;
                 function.ExtensionReceiverType = receiverType;
+
+                // Issue #1188: extension functions overload like ordinary
+                // methods and free functions. A collision now means a genuine
+                // duplicate signature (same receiver type, name, and callable
+                // parameters) — report it as a duplicate-overload-signature
+                // error to match the method/free-function path rather than a
+                // generic redeclaration.
                 if (function.Declaration.Identifier.Text != null && !scope.TryDeclareExtensionFunction(function))
                 {
-                    Diagnostics.ReportSymbolAlreadyDeclared(syntax.Identifier.Location, function.Name);
+                    Diagnostics.ReportDuplicateOverloadSignature(syntax.Identifier.Location, function.Name, Binder.FormatOverloadSignature(function));
                 }
 
                 return;

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -2546,10 +2546,12 @@ internal sealed partial class ExpressionBinder
             }
 
             // Phase 3.B.6 / ADR-0019: extension function fallback for
-            // user-type receivers (struct/class/interface).
-            if (receiver != null && scope.TryLookupExtensionFunction(receiver.Type, methodName, out var userExtFn))
+            // user-type receivers (struct/class/interface). Issue #1188:
+            // extension functions overload, so select the best matching
+            // overload across all (receiver, name) candidates.
+            if (TryBindExtensionFunctionOverload(receiver, methodName, arguments, ce, argumentNames, out var userExtResult))
             {
-                return overloads.BindExtensionFunctionCall(receiver, userExtFn, arguments, ce, argumentNames);
+                return userExtResult;
             }
 
             // Issue #296: a GSharp class inheriting an imported CLR base class
@@ -2766,9 +2768,11 @@ internal sealed partial class ExpressionBinder
 
         // Phase 3.B.6 / ADR-0019: extension function fallback. After all
         // instance/static lookups fail, try matching by (receiverType, name).
-        if (receiver != null && scope.TryLookupExtensionFunction(receiver.Type, methodName, out var extFn))
+        // Issue #1188: extension functions overload, so select the best
+        // matching overload across all (receiver, name) candidates.
+        if (TryBindExtensionFunctionOverload(receiver, methodName, arguments, ce, argumentNames, out var extResult))
         {
-            return overloads.BindExtensionFunctionCall(receiver, extFn, arguments, ce, argumentNames);
+            return extResult;
         }
 
         // Issue #294: BCL/library [Extension] method dispatched with instance
@@ -2791,6 +2795,80 @@ internal sealed partial class ExpressionBinder
 
         Diagnostics.ReportUnableToFindFunction(ce.Location, methodName);
         return new BoundErrorExpression(null);
+    }
+
+    /// <summary>
+    /// Issue #1188: resolves an instance-syntax call <c>receiver.Method(args)</c>
+    /// against the user-defined extension functions visible from the current
+    /// scope, supporting overloading. Collects every extension overload matching
+    /// the (receiver type, name) pair and selects the single best applicable one
+    /// through the standard overload-resolution machinery before delegating to
+    /// <see cref="OverloadResolver.BindExtensionFunctionCall"/>.
+    /// </summary>
+    /// <remarks>
+    /// Extension function symbols carry their receiver in <c>Parameters[0]</c> and
+    /// never set <see cref="FunctionSymbol.ExplicitReceiverParameter"/>, so user
+    /// arguments line up against <c>Parameters[1..]</c>. To reuse the existing
+    /// instance-overload selector (which keys parameter alignment off
+    /// <c>ExplicitReceiverParameter</c>) the receiver is prepended as the first
+    /// positional argument; this makes the candidate's synthetic receiver slot
+    /// participate in applicability/convertibility ranking and in generic receiver
+    /// inference exactly as <see cref="OverloadResolver.BindExtensionFunctionCall"/>
+    /// does once a candidate is chosen.
+    /// </remarks>
+    /// <param name="receiver">The bound call receiver.</param>
+    /// <param name="methodName">The invoked method name.</param>
+    /// <param name="arguments">The bound user arguments (excluding the receiver).</param>
+    /// <param name="ce">The originating call syntax.</param>
+    /// <param name="argumentNames">The named-argument layout, or default.</param>
+    /// <param name="result">The bound call, when an extension overload matched.</param>
+    /// <returns><see langword="true"/> when at least one extension overload matched the (receiver, name) pair.</returns>
+    private bool TryBindExtensionFunctionOverload(
+        BoundExpression receiver,
+        string methodName,
+        ImmutableArray<BoundExpression> arguments,
+        CallExpressionSyntax ce,
+        ImmutableArray<string> argumentNames,
+        out BoundExpression result)
+    {
+        result = null;
+        if (receiver == null)
+        {
+            return false;
+        }
+
+        var candidates = scope.TryLookupExtensionFunctions(receiver.Type, methodName);
+        if (candidates.IsDefaultOrEmpty)
+        {
+            return false;
+        }
+
+        var selected = candidates[0];
+        if (candidates.Length > 1)
+        {
+            var allArguments = ImmutableArray.CreateBuilder<BoundExpression>(arguments.Length + 1);
+            allArguments.Add(receiver);
+            allArguments.AddRange(arguments);
+
+            var allNames = argumentNames;
+            if (!argumentNames.IsDefault)
+            {
+                var namesBuilder = ImmutableArray.CreateBuilder<string>(argumentNames.Length + 1);
+                namesBuilder.Add(null);
+                namesBuilder.AddRange(argumentNames);
+                allNames = namesBuilder.ToImmutable();
+            }
+
+            selected = overloads.SelectInstanceOverloadOrReport(candidates, allArguments.ToImmutable(), ce, methodName, allNames);
+            if (selected == null)
+            {
+                result = new BoundErrorExpression(null);
+                return true;
+            }
+        }
+
+        result = overloads.BindExtensionFunctionCall(receiver, selected, arguments, ce, argumentNames);
+        return true;
     }
 
     /// <summary>

--- a/test/Compiler.Tests/Emit/Issue1188ExtensionOverloadEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1188ExtensionOverloadEmitTests.cs
@@ -1,0 +1,191 @@
+// <copyright file="Issue1188ExtensionOverloadEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1188: extension functions (ADR-0019) support overloading exactly like
+/// ordinary class methods and free functions. Two extension functions that share
+/// a (receiver type, name) pair but differ in parameter signature — by arity, by
+/// parameter type, or by generic arity — must coexist and dispatch to the correct
+/// overload through the standard overload-resolution machinery. Extensions whose
+/// receiver types differ stay independent.
+/// <para>
+/// The defect was that the extension-function declaration table was keyed by
+/// <c>(receiver type, name)</c> and rejected any second extension with the same
+/// name and receiver, reporting <c>GS0102 '&lt;name&gt;' is already declared</c>.
+/// </para>
+/// These tests prove that overloaded extension calls compile, IL-verify, and
+/// produce the correct runtime results.
+/// </summary>
+public class Issue1188ExtensionOverloadEmitTests
+{
+    [Fact]
+    public void Extension_Overload_ByArity_ResolvesCorrectOverload()
+    {
+        var source = """
+            package P
+            import System
+
+            func (s string) Do(x int32) string {
+                return "one"
+            }
+
+            func (s string) Do(x int32, y int32) string {
+                return "two"
+            }
+
+            Console.WriteLine("hi".Do(1))
+            Console.WriteLine("hi".Do(1, 2))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("one\ntwo\n", output);
+    }
+
+    [Fact]
+    public void Extension_Overload_ByParameterType_ResolvesCorrectOverload()
+    {
+        var source = """
+            package P
+            import System
+
+            func (s string) Tag(x int32) string {
+                return "int"
+            }
+
+            func (s string) Tag(x string) string {
+                return "str"
+            }
+
+            Console.WriteLine("hi".Tag(1))
+            Console.WriteLine("hi".Tag("x"))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("int\nstr\n", output);
+    }
+
+    [Fact]
+    public void Extension_Overload_GenericArityVariant_ResolvesCorrectOverload()
+    {
+        var source = """
+            package P
+            import System
+
+            func (s string) Pick(x int32) string {
+                return "concrete"
+            }
+
+            func (s string) Pick[T](item T) string {
+                return "generic"
+            }
+
+            Console.WriteLine("hi".Pick(1))
+            Console.WriteLine("hi".Pick[string]("x"))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("concrete\ngeneric\n", output);
+    }
+
+    [Fact]
+    public void Extension_Overload_DifferentReceiverTypes_StayIndependent()
+    {
+        var source = """
+            package P
+            import System
+
+            func (s string) Kind(x int32) string {
+                return "string-recv"
+            }
+
+            func (n int32) Kind(x int32) string {
+                return "int-recv"
+            }
+
+            Console.WriteLine("hi".Kind(1))
+            Console.WriteLine((5).Kind(1))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("string-recv\nint-recv\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1188_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi);
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/ExtensionFunctionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ExtensionFunctionTests.cs
@@ -188,6 +188,132 @@ n.Echo[int32, string](42)
         Assert.NotEmpty(result.Diagnostics);
     }
 
+    [Fact]
+    public void Extension_Overload_ByArity_ResolvesCorrectOverload()
+    {
+        var source = @"
+func (s string) Do(x int32) string {
+    return ""one""
+}
+
+func (s string) Do(x int32, y int32) string {
+    return ""two""
+}
+
+var a = ""hi"".Do(1)
+var b = ""hi"".Do(1, 2)
+a + b
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("onetwo", result.Value);
+    }
+
+    [Fact]
+    public void Extension_Overload_ByParameterType_ResolvesCorrectOverload()
+    {
+        var source = @"
+func (s string) Tag(x int32) string {
+    return ""int""
+}
+
+func (s string) Tag(x string) string {
+    return ""str""
+}
+
+var a = ""hi"".Tag(1)
+var b = ""hi"".Tag(""x"")
+a + b
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("intstr", result.Value);
+    }
+
+    [Fact]
+    public void Extension_Overload_GenericArityVariant_ResolvesCorrectOverload()
+    {
+        var source = @"
+func (s string) Pick(x int32) string {
+    return ""concrete""
+}
+
+func (s string) Pick[T](item T) string {
+    return ""generic""
+}
+
+var a = ""hi"".Pick(1)
+var b = ""hi"".Pick[string](""x"")
+a + b
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("concretegeneric", result.Value);
+    }
+
+    [Fact]
+    public void Extension_Overload_DifferentReceiverTypes_StayIndependent()
+    {
+        var source = @"
+func (s string) Kind(x int32) string {
+    return ""string-recv""
+}
+
+func (n int32) Kind(x int32) string {
+    return ""int-recv""
+}
+
+var a = ""hi"".Kind(1)
+var b = (5).Kind(1)
+a + b
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("string-recvint-recv", result.Value);
+    }
+
+    [Fact]
+    public void Extension_Overload_SameReceiverDifferentSignatures_DeclareWithoutError()
+    {
+        var source = @"
+func (s string) Do(x int32) string {
+    return s
+}
+
+func (s string) Do(x int32, y int32) string {
+    return s
+}
+
+func (s string) Do[T](item T) string {
+    return s
+}
+
+var a = ""hi"".Do(1)
+a
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void Extension_DuplicateSignature_ReportsError()
+    {
+        var source = @"
+func (s string) Do(x int32) string {
+    return s
+}
+
+func (s string) Do(y int32) string {
+    return s
+}
+
+var a = ""hi"".Do(1)
+a
+";
+        var result = Evaluate(source);
+        Assert.NotEmpty(result.Diagnostics);
+    }
+
     private static EvaluationResult Evaluate(string source)
     {
         var syntaxTree = SyntaxTree.Parse(SourceText.From(source));


### PR DESCRIPTION
## Summary

Extension functions (ADR-0019) could not be overloaded. Two extension functions sharing a `(receiver type, name)` pair but differing only by parameter signature collided with `GS0102: '<name>' is already declared`, even though ordinary class-method and free-function overloading already worked.

```gsharp
package p
func (s string) Do(x int32) string { return s }
func (s string) Do(x int32, y int32) string { return s }
// previously: error GS0102: 'Do' is already declared.
```

## Root cause

- `BoundScope.TryDeclareExtensionFunction` keyed the extension-declaration table by `(receiver type, name)` and rejected any second extension with the same name and receiver, ignoring the parameter signature.
- The instance-syntax call path (`recv.Do(args)`) resolved extensions via `TryLookupExtensionFunction`, which returned only the **first** match instead of running overload resolution over all candidates.

## Fix

- **`TryDeclareExtensionFunction`** now rejects only genuine duplicates — overload-identical extensions (same name, receiver, callable parameter signature, *and* type-parameter constraints). Extension functions never set `ExplicitReceiverParameter`, so the synthetic receiver in `Parameters[0]` participates in signature identity, keeping different receiver types independent. Constraint-disambiguated generic overloads (#775, e.g. `[T class]` vs `[T struct]`) remain distinct.
- **`BoundScope.TryLookupExtensionFunctions`** (new) returns every matching overload — exact-receiver matches plus generic-receiver-unification candidates (#773/#775) — across the scope chain.
- **The instance-syntax call binder** (`ExpressionBinder.Calls.cs`) now collects all candidates and selects the best via the existing instance-overload resolver, reusing it by prepending the receiver as the first positional argument (so user arguments align with `Parameters[1..]`, exactly as `BindExtensionFunctionCall` does once a candidate is chosen). This preserves generic receiver/argument inference and convertibility ranking.
- A genuine duplicate now reports the standard `GS0264` duplicate-overload-signature diagnostic, matching the method/free-function path.

The #1103 reference-equality fix for imported/BCL/primitive receivers is preserved (the new plural lookup reuses the same `ReceiverMatches` and generic-unify logic).

## Tests

- **Core.Tests** `ExtensionFunctionTests`: overload by arity, by parameter type, generic-arity variant (`Pick[T](T)` vs `Pick(int32)`), different-receiver independence, multi-overload declaration, and the genuine-duplicate diagnostic.
- **Compiler.Tests** `Issue1188ExtensionOverloadEmitTests`: emit + IL-verify + run for arity / parameter-type / generic-arity / different-receiver overloads.

## Validation

- Full build `dotnet build GSharp.sln -c Release -graph`: **0 errors, 0 warnings**.
- `dotnet test test/Core.Tests`: **4189 passed, 1 skipped, 0 failed**.
- `dotnet test test/Compiler.Tests --filter Extension`: all pass (incl. new emit tests, IL-verified).
- Standalone `gsc` confirms the repro compiles and each call site resolves to the correct overload at runtime.

Fixes #1188