### PR TITLE
cs2gs: mark subclassed/abstract record (data class) as open (GS0181)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/DataClassOpenTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/DataClassOpenTranslationTests.cs
@@ -1,0 +1,78 @@
+// <copyright file="DataClassOpenTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// A C# <c>record</c> (G# <c>data class</c>) that is subclassed must be declared
+/// <c>open</c> in G#; otherwise gsc rejects the derived type with GS0181
+/// ("Class '…' is not open"). Mirrors the plain-class openness logic for the
+/// <c>DataClass</c> kind.
+/// </summary>
+public class DataClassOpenTranslationTests
+{
+    private const string Source = @"
+namespace Corpus.DataOpen
+{
+    public record Message(int Type, string Text);
+
+    public record Message<T>(int Type, string Text, T Custom) : Message(Type, Text);
+
+    public abstract record Shape(int Sides);
+}
+";
+
+    [Fact]
+    public void SubclassedRecord_IsForcedOpen()
+    {
+        CompilationUnit unit = Translate();
+        TypeDeclaration message = unit.Members
+            .OfType<TypeDeclaration>()
+            .Single(t => t.Name == "Message" && (t.TypeParameters == null || t.TypeParameters.Count == 0));
+
+        Assert.Equal(TypeDeclarationKind.DataClass, message.Kind);
+        Assert.True(message.IsOpen);
+    }
+
+    [Fact]
+    public void AbstractRecord_IsForcedOpen()
+    {
+        CompilationUnit unit = Translate();
+        TypeDeclaration shape = unit.Members.OfType<TypeDeclaration>().Single(t => t.Name == "Shape");
+
+        Assert.Equal(TypeDeclarationKind.DataClass, shape.Kind);
+        Assert.True(shape.IsOpen);
+    }
+
+    [Fact]
+    public void SubclassedRecord_RendersOpenDataClass()
+    {
+        CompilationUnit unit = Translate();
+        string rendered = GSharpPrinter.Print(unit);
+        Assert.Contains("open data class Message", rendered, StringComparison.Ordinal);
+    }
+
+    private static CompilationUnit Translate()
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Message.cs", Source) });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        return new CSharpToGSharpTranslator().TranslateDocument(document, context);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -904,17 +904,26 @@ public sealed class CSharpToGSharpTranslator
             // `sealed` class that carries `protected override` members (it overrides
             // an abstract/virtual protected base) therefore still maps to `open`;
             // G# has no `sealed` modifier so the sealedness is dropped (ADR-0115 §B.4).
+            // A C# `record` (G# `data class`) is reference-typed and may be
+            // subclassed (e.g. `record Derived : Base`); like a plain class it must
+            // be declared `open` in G# to permit subclassing (GS0181) or to carry a
+            // `protected` member (GS0380). `data struct`/`struct`/`interface` are
+            // excluded (value types are not subclassable; interfaces are open by
+            // nature).
+            bool isOpenableKind = kind == TypeDeclarationKind.Class
+                || kind == TypeDeclarationKind.DataClass;
             bool isOpen = symbol != null &&
-                kind == TypeDeclarationKind.Class &&
+                isOpenableKind &&
                 !symbol.IsStatic &&
                 ((!symbol.IsSealed && this.subclassedBases.Contains(symbol.OriginalDefinition))
                     || HasProtectedMember(symbol));
 
             // G# has no `abstract` class modifier (the keyword is not recognized by
             // the parser); a C# `abstract class`/`abstract record` therefore maps to
-            // an `open class` — subclassable but without enforced non-instantiation
-            // (ADR-0115 §B.4). The abstractness is intentionally dropped.
-            bool wasAbstract = symbol != null && symbol.IsAbstract && kind == TypeDeclarationKind.Class;
+            // an `open class`/`open data class` — subclassable but without enforced
+            // non-instantiation (ADR-0115 §B.4). The abstractness is intentionally
+            // dropped.
+            bool wasAbstract = symbol != null && symbol.IsAbstract && isOpenableKind;
             if (wasAbstract)
             {
                 this.context.Report(new TranslationDiagnostic(


### PR DESCRIPTION
## Problem
A C# `record` maps to a G# `data class`. When such a record is **subclassed** (e.g. `record Derived : Base`) or is **abstract**, the emitted `data class` was not declared `open`, so gsc rejected the derived type with `GS0181: Class '…' is not open`.

## Fix
The translator's openness gate (`isOpen`/`wasAbstract`) previously required `kind == TypeDeclarationKind.Class`. Extended it to also cover `TypeDeclarationKind.DataClass`, so a subclassed or abstract record renders as `open data class`. `subclassedBases` already captures record bases (records are `TypeKind.Class`); the printer already emits `open` before any kind keyword. `data struct`/`struct`/`interface` remain excluded (value types aren't subclassable; interfaces are open by nature).

## Verification
- New `DataClassOpenTranslationTests` (3 tests): subclassed record forced open, abstract record forced open, renders `open data class`.
- Full cs2gs suite: **251 pass**.
- Oahu.Foundation: `InteractionMessage` record hierarchy now renders `open data class InteractionMessage`; GS0181 cleared (34→33).

Refs #914