### PR TITLE
cs2gs: widen field/property type to T? when initializer is nullable (#1072)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue1072FieldInitNullableTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1072FieldInitNullableTests.cs
@@ -1,0 +1,147 @@
+// <copyright file="Issue1072FieldInitNullableTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Translator-fidelity tests for the issue #1072 field/property INITIALIZER form:
+/// when a field or property whose declared type is a non-nullable reference type is
+/// initialized from an expression that yields a nullable value (a <c>?.</c>
+/// conditional access, a <c>?? nullableFallback</c> coalesce, or a member declared
+/// <c>T?</c>), the emitted G# declared type must be widened to <c>T?</c>; otherwise
+/// gsc rejects the initializer with <c>GS0156: Cannot convert type 'T?' to 'T'</c>.
+/// The negative tests pin the precision guard: a provably non-null initializer keeps
+/// its non-nullable <c>T</c> type.
+/// </summary>
+public class Issue1072FieldInitNullableTests
+{
+    [Fact]
+    public void StaticGetOnlyProperty_ConditionalAccessInitializer_RendersNullableType()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public static string Name { get; } = Get()?.ToString();
+        private static object Get() => null;
+    }
+}");
+
+        Assert.Contains("let Name string? =", printed);
+    }
+
+    [Fact]
+    public void StaticGetOnlyProperty_NonNullInitializer_KeepsNonNullableType()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public static string Name { get; } = ""hello"";
+    }
+}");
+
+        Assert.Contains("let Name string =", printed);
+        Assert.DoesNotContain("let Name string? =", printed);
+    }
+
+    [Fact]
+    public void StaticGetOnlyProperty_CoalesceWithNonNullFallback_KeepsNonNullableType()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public static string Name { get; } = Get()?.ToString() ?? ""fallback"";
+        private static object Get() => null;
+    }
+}");
+
+        Assert.Contains("let Name string =", printed);
+        Assert.DoesNotContain("let Name string? =", printed);
+    }
+
+    [Fact]
+    public void StaticGetOnlyProperty_CoalesceWithNullableFallback_RendersNullableType()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public static string Name { get; } = Get()?.ToString() ?? Maybe();
+        private static object Get() => null;
+        private static string? Maybe() => null;
+    }
+}");
+
+        Assert.Contains("let Name string? =", printed);
+    }
+
+    [Fact]
+    public void InstanceField_ConditionalAccessInitializer_RendersNullableType()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        private readonly string s = Get()?.ToString();
+        private static object Get() => null;
+    }
+}");
+
+        Assert.Contains("let s string? =", printed);
+    }
+
+    [Fact]
+    public void StaticField_NullableMemberInitializer_RendersNullableType()
+    {
+        // `AssemblyName.Name` is declared `string?` in BCL metadata, so the
+        // initializer is nullable even though the consuming nullable context is off.
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public static string Title { get; } =
+            System.Reflection.Assembly.GetEntryAssembly().GetName().Name;
+    }
+}");
+
+        Assert.Contains("let Title string? =", printed);
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -1523,6 +1523,14 @@ public sealed class CSharpToGSharpTranslator
                     initializer = this.CoerceConstantToUnsigned(
                         declarator.Initializer.Value,
                         this.TranslateExpression(declarator.Initializer.Value));
+
+                    // Issue #1072: a non-nullable reference field whose initializer
+                    // is nullable (e.g. `?.`-access) is rendered `T?`.
+                    if (symbol != null)
+                    {
+                        type = this.PromoteIfInitializerNullable(
+                            type, symbol.Type, declarator.Initializer.Value);
+                    }
                 }
                 else if (symbol != null &&
                     this.staticFieldInitializers.TryGetValue(symbol, out GExpression staticLifted))
@@ -1819,6 +1827,15 @@ public sealed class CSharpToGSharpTranslator
             GExpression initializer = this.CoerceConstantToUnsigned(
                 node.Initializer.Value,
                 this.TranslateExpression(node.Initializer.Value));
+
+            // Issue #1072: a non-nullable reference static auto-property whose
+            // initializer is nullable (e.g. `GetAttribute<...>()?.Member`) is
+            // rendered `T?` so the initializer assignment type-checks.
+            if (symbol != null)
+            {
+                type = this.PromoteIfInitializerNullable(
+                    type, symbol.Type, node.Initializer.Value);
+            }
 
             // A mutable static auto-property (`{ get; set; }` / `{ get; private set; }`)
             // becomes a `var` field; an immutable get-only one becomes a `let` field.
@@ -4299,6 +4316,97 @@ public sealed class CSharpToGSharpTranslator
             }
 
             return this.IsPromotedToNullableReference(symbol) ? MakeNullable(type) : type;
+        }
+
+        // Issue #1072 (field/property initializer form): when a field or property is
+        // emitted with an explicit declared type plus an initializer whose
+        // Roslyn-inferred type is nullable (e.g. the value comes from a `?.`
+        // conditional access or a method returning `T?`), widen the emitted declared
+        // type to `T?`. Otherwise gsc rejects the initializer with
+        // `GS0156: Cannot convert type 'T?' to 'T'`. We always key off the Roslyn
+        // `TypeInfo` of the FULL initializer expression (so a `?? nonNullFallback`
+        // that Roslyn proves non-null stays `T`). Value types and already-nullable
+        // declared types are left untouched.
+        private GTypeReference PromoteIfInitializerNullable(
+            GTypeReference type,
+            ITypeSymbol declaredType,
+            ExpressionSyntax initializer)
+        {
+            if (type == null || type.IsNullable || initializer == null)
+            {
+                return type;
+            }
+
+            if (declaredType is not { IsReferenceType: true }
+                || declaredType.NullableAnnotation == NullableAnnotation.Annotated)
+            {
+                return type;
+            }
+
+            return this.IsNullableInitializer(initializer) ? MakeNullable(type) : type;
+        }
+
+        // Determines whether <paramref name="expression"/> (a field/property
+        // initializer) yields a nullable reference value. Because the migrated
+        // corpus typically compiles with the nullable context DISABLED, flow
+        // nullability is unavailable, so this combines (a) syntactic forms that
+        // introduce null (`a?.b`, `a ?? nullableFallback`, `cond ? a : b`) with
+        // (b) the bound symbol's DECLARED nullable annotation, which survives in
+        // BCL/source metadata regardless of the consuming nullable context
+        // (e.g. `AssemblyName.Name` and `Path.GetFileNameWithoutExtension(...)`
+        // are declared `string?`). `x!` suppresses nullability.
+        private bool IsNullableInitializer(ExpressionSyntax expression)
+        {
+            if (expression == null)
+            {
+                return false;
+            }
+
+            switch (expression)
+            {
+                case ParenthesizedExpressionSyntax paren:
+                    return this.IsNullableInitializer(paren.Expression);
+
+                case PostfixUnaryExpressionSyntax suppress
+                    when suppress.IsKind(SyntaxKind.SuppressNullableWarningExpression):
+                    return false;
+
+                // `a?.b` / `a?[i]`: conditional access yields a nullable result.
+                case ConditionalAccessExpressionSyntax:
+                    return true;
+
+                // `a ?? b`: nullable iff the `b` fallback is itself nullable.
+                case BinaryExpressionSyntax coalesce
+                    when coalesce.IsKind(SyntaxKind.CoalesceExpression):
+                    return this.IsNullableInitializer(coalesce.Right);
+
+                // `cond ? a : b`: nullable iff either branch is nullable.
+                case ConditionalExpressionSyntax ternary:
+                    return this.IsNullableInitializer(ternary.WhenTrue)
+                        || this.IsNullableInitializer(ternary.WhenFalse);
+            }
+
+            // Flow nullability when the nullable context happens to be enabled.
+            TypeInfo info = this.context.GetTypeInfo(expression);
+            if (info.Nullability.Annotation == NullableAnnotation.Annotated)
+            {
+                return true;
+            }
+
+            // Otherwise consult the bound symbol's declared annotation.
+            ISymbol symbol = this.context.GetSymbolInfo(expression).Symbol;
+            ITypeSymbol symbolType = symbol switch
+            {
+                IMethodSymbol m => m.ReturnType,
+                IPropertySymbol p => p.Type,
+                IFieldSymbol f => f.Type,
+                ILocalSymbol l => l.Type,
+                IParameterSymbol pr => pr.Type,
+                _ => null,
+            };
+
+            return symbolType is { IsReferenceType: true }
+                && symbolType.NullableAnnotation == NullableAnnotation.Annotated;
         }
 
         // Issue #1072: true when <paramref name="symbol"/> is a parameter/field/local


### PR DESCRIPTION
## Summary

Implements the #1072 nullability rule for **field / property initializers**: when cs2gs emits a field or get-only/static auto-property whose declared type is a **non-nullable reference type** but whose **initializer yields a nullable value**, the emitted G# declared type is widened to `T?` instead of `T`. This follows the user rule "if C# allows a nullable value for a field, that field should be `T?` rather than `T`" — prefer `T?` over `nil!!`.

Previously cs2gs emitted e.g.:
```
let AssemblyProduct string = GetAttribute[AssemblyProductAttribute]()?.Product
```
which failed `GS0156: Cannot convert type 'string?' to 'string'`. It now emits:
```
let AssemblyProduct string? = GetAttribute[AssemblyProductAttribute]()?.Product
```

## How it detects nullability

The migrated corpus typically compiles with the nullable context **disabled**, so Roslyn flow-nullability is unavailable. Detection therefore combines:
- syntactic null-introducing forms: `a?.b` conditional access, `a ?? nullableFallback` (nullable iff the fallback is nullable), `cond ? a : b` (nullable iff either branch is);
- the bound symbol's **declared** nullable annotation, which survives in BCL/source metadata regardless of the consuming nullable context (e.g. `AssemblyName.Name` and `Path.GetFileNameWithoutExtension(...)` are declared `string?`).

A provably non-null initializer (`?? "literal"`, plain literal) keeps its non-nullable `T`. Value types and already-nullable declared types are untouched. Applied to both static (`shared`) and instance fields and to static get-only auto-property → field lowerings.

## Measured error deltas (Oahu corpus)

| Project | Before | After |
|---|---|---|
| Oahu.Foundation | 23 | **16** |
| Oahu.Decrypt | 246 | **235** |

In Foundation, all 7 `string? -> string` GS0156 errors in `Auxiliary/ApplEnv.cs` (the `?.`, `??`, and `.Name` initializers) clear. Neither project's error count rose.

## Tests

Added `Cs2Gs.Tests/Issue1072FieldInitNullableTests.cs` covering: `?.`-initialized field → `T?`, non-null initializer stays `T`, `?? nonNullFallback` stays `T`, `?? nullableFallback` → `T?`, instance field, and nullable-member (`AssemblyName.Name`) initializer. Full cs2gs suite: **257 passing**.

Refs #914