### PR TITLE
Fix unsafe class modifier composition (#1202) and static shared-block externs (#1203)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -1368,6 +1368,19 @@ public sealed class Binder
                     continue;
                 }
 
+                // ADR-0086 / issue #1203: a bodyless `shared`-block method (a
+                // static `@DllImport` P/Invoke extern) has no managed body to
+                // bind. Register an empty synthetic block so the emitter still
+                // mints a MethodDef handle (it routes P/Invokes through the
+                // ImplMap path and writes no IL body) and skip body binding,
+                // which would otherwise dereference the null `Declaration.Body`
+                // and crash with GS9998 (the static-path analogue of issue #987).
+                if (method.Declaration.Body == null)
+                {
+                    functionBodies.Add(method, new BoundBlockStatement(method.Declaration, ImmutableArray<BoundStatement>.Empty));
+                    continue;
+                }
+
                 BindStructMethodBody(cache, dirtyTrees, parentScope, method, structSym, functionBodies, diagnostics);
             }
         }

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -2189,6 +2189,23 @@ internal sealed class DeclarationBinder
 
                     Binder.AttachDocumentation(methodSymbol, methodSyntax);
 
+                    // ADR-0086 / issue #1203: a `shared`-block method may be a
+                    // static P/Invoke (`@DllImport ... func F(...) R;`). Resolve
+                    // and attach the PInvokeMetadata so the body-binder skips the
+                    // (absent) body and the emitter writes the ImplMap row. A
+                    // bodyless `shared` method that is NOT a P/Invoke is reported
+                    // with GS0325, mirroring the top-level free-function path.
+                    var isStaticPInvoke = PInvokeBinder.TryAttachPInvokeMetadata(methodSymbol, methodSyntax, Diagnostics);
+                    if (!isStaticPInvoke && methodSyntax.HasSemicolonBody)
+                    {
+                        Diagnostics.ReportSemicolonBodyRequiresDllImport(methodSyntax.Identifier.Location, methodSymbol.Name);
+                    }
+
+                    if (!isStaticPInvoke)
+                    {
+                        PInvokeBinder.ReportMarshalAsOnNonPInvokeFunction(methodSyntax, Diagnostics);
+                    }
+
                     // ADR-0063 §11: detect duplicate-signature within the static block.
                     var hasDupSig = false;
                     foreach (var existingMethod in staticMethodsBuilder)

--- a/src/Core/CodeAnalysis/Binding/PInvokeBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/PInvokeBinder.cs
@@ -88,11 +88,11 @@ internal static class PInvokeBinder
             diagnostics.ReportDllImportInvalidFunctionShape(identifierLocation, function.Name, "instance methods are not supported");
         }
 
-        if (function.IsStatic)
-        {
-            diagnostics.ReportDllImportInvalidFunctionShape(identifierLocation, function.Name, "members of 'shared' blocks are not supported");
-        }
-
+        // ADR-0086 / issue #1203: a P/Invoke declared inside a class's
+        // `shared { }` block (function.IsStatic) is the canonical G# spelling
+        // of a C# `static extern [DllImport]` member. The CLR represents every
+        // P/Invoke as a static method, so a `shared`-block extern is precisely
+        // the supported shape — it is no longer rejected here.
         if (function.ReturnRefKind != RefKind.None)
         {
             diagnostics.ReportDllImportInvalidFunctionShape(identifierLocation, function.Name, "ref-returning functions are not supported");

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -264,15 +264,15 @@ public class Parser
         }
 
         // ADR-0122 / issue #1014: an optional `unsafe` contextual modifier may
-        // precede `func`, `class`, or `struct` (with or without an
-        // accessibility modifier). It introduces an unsafe context in which
-        // unmanaged raw pointers (`*T`) and raw-pointer operations are legal.
+        // precede `func` (with or without an accessibility / async modifier).
+        // It introduces an unsafe context in which unmanaged raw pointers
+        // (`*T`) and raw-pointer operations are legal. The `unsafe` class/struct
+        // modifier (issue #1202) is handled inside ParseAggregateDeclaration so
+        // it composes with `open`/`sealed`/etc. in any order.
         SyntaxToken unsafeModifier = null;
         if (Current.Kind == SyntaxKind.IdentifierToken && Current.Text == "unsafe"
             && (Peek(1).Kind == SyntaxKind.FuncKeyword
-                || Peek(1).Kind == SyntaxKind.AsyncKeyword
-                || Peek(1).Kind == SyntaxKind.ClassKeyword
-                || Peek(1).Kind == SyntaxKind.StructKeyword))
+                || Peek(1).Kind == SyntaxKind.AsyncKeyword))
         {
             unsafeModifier = NextToken();
         }
@@ -313,30 +313,12 @@ public class Parser
         else if (TryDetectAggregateDeclarationHead())
         {
             // ADR-0078 / issue #718: the canonical declaration head is
-            //   [visibility]? [open|sealed]? [data]? [inline]? (class|struct|enum|interface) Name ...
+            //   [visibility]? [unsafe]? [open|sealed]? [data]? [inline]? (class|struct|enum|interface) Name ...
             // The aggregate-kind keyword IS the declaration keyword — no leading
-            // `type`. Drop into the new aggregate parser path.
-            if (unsafeModifier != null)
-            {
-                this.unsafeDepth++;
-            }
-
-            try
-            {
-                member = ParseAggregateDeclaration(accessibilityModifier);
-            }
-            finally
-            {
-                if (unsafeModifier != null)
-                {
-                    this.unsafeDepth--;
-                }
-            }
-
-            if (unsafeModifier != null && member is StructDeclarationSyntax unsafeAggregate)
-            {
-                unsafeAggregate.UnsafeModifier = unsafeModifier;
-            }
+            // `type`. Drop into the new aggregate parser path. A leading
+            // `unsafe` modifier (issue #1202) is consumed inside
+            // ParseAggregateDeclaration so it composes with the other modifiers.
+            member = ParseAggregateDeclaration(accessibilityModifier);
         }
         else if (Current.Kind == SyntaxKind.TypeKeyword)
         {
@@ -570,7 +552,10 @@ public class Parser
                 continue;
             }
 
-            if (k.Kind == SyntaxKind.IdentifierToken && (k.Text == "data" || k.Text == "inline" || k.Text == "ref"))
+            // ADR-0122 / issue #1202: `unsafe` composes with the other class
+            // modifiers (in any order), establishing an unsafe context for the
+            // whole aggregate. Treat it like the other contextual modifiers.
+            if (k.Kind == SyntaxKind.IdentifierToken && (k.Text == "data" || k.Text == "inline" || k.Text == "ref" || k.Text == "unsafe"))
             {
                 // Bail out if the same contextual modifier appears twice — we are
                 // not in a declaration head; let the legacy / statement parser
@@ -600,11 +585,26 @@ public class Parser
         SyntaxToken dataKeyword = null;
         SyntaxToken inlineKeyword = null;
         SyntaxToken refModifier = null;
+        SyntaxToken unsafeModifier = null;
 
         // Collect modifiers in any order. Re-issuing of a modifier is reported
         // as an unexpected token but parsing continues for recovery.
         while (true)
         {
+            // ADR-0122 / issue #1202: `unsafe` composes with the other class
+            // modifiers in any order (e.g. `unsafe open class`, `open unsafe
+            // class`). It is a contextual identifier keyword.
+            if (Current.Kind == SyntaxKind.IdentifierToken && Current.Text == "unsafe")
+            {
+                if (unsafeModifier != null)
+                {
+                    Diagnostics.ReportUnexpectedToken(Current.Location, Current.Kind, SyntaxKind.ClassKeyword);
+                }
+
+                unsafeModifier = NextToken();
+                continue;
+            }
+
             if (Current.Kind == SyntaxKind.OpenKeyword)
             {
                 if (openModifier != null)
@@ -749,6 +749,11 @@ public class Parser
                     Diagnostics.ReportUnexpectedToken(refModifier.Location, SyntaxKind.IdentifierToken, SyntaxKind.EnumKeyword);
                 }
 
+                if (unsafeModifier != null)
+                {
+                    Diagnostics.ReportUnexpectedToken(unsafeModifier.Location, SyntaxKind.IdentifierToken, SyntaxKind.EnumKeyword);
+                }
+
                 break;
 
             case SyntaxKind.InterfaceKeyword:
@@ -770,6 +775,11 @@ public class Parser
                 if (refModifier != null)
                 {
                     Diagnostics.ReportUnexpectedToken(refModifier.Location, SyntaxKind.IdentifierToken, SyntaxKind.InterfaceKeyword);
+                }
+
+                if (unsafeModifier != null)
+                {
+                    Diagnostics.ReportUnexpectedToken(unsafeModifier.Location, SyntaxKind.IdentifierToken, SyntaxKind.InterfaceKeyword);
                 }
 
                 break;
@@ -800,10 +810,26 @@ public class Parser
         }
 
         // class / struct path.
-        var structDecl = ParseStructDeclarationNew(accessibilityModifier, dataKeyword, inlineKeyword, openModifier, sealedModifier, refModifier, aggregateKeyword, identifier);
-        structDecl.TypeParameterList = typeParameterList;
-        structDecl.RefModifier = refModifier;
-        return structDecl;
+        if (unsafeModifier != null)
+        {
+            this.unsafeDepth++;
+        }
+
+        try
+        {
+            var structDecl = ParseStructDeclarationNew(accessibilityModifier, dataKeyword, inlineKeyword, openModifier, sealedModifier, refModifier, aggregateKeyword, identifier);
+            structDecl.TypeParameterList = typeParameterList;
+            structDecl.RefModifier = refModifier;
+            structDecl.UnsafeModifier = unsafeModifier;
+            return structDecl;
+        }
+        finally
+        {
+            if (unsafeModifier != null)
+            {
+                this.unsafeDepth--;
+            }
+        }
     }
 
     /// <summary>

--- a/test/Compiler.Tests/Emit/Issue1203SharedExternEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1203SharedExternEmitTests.cs
@@ -1,0 +1,116 @@
+// <copyright file="Issue1203SharedExternEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// End-to-end emit coverage for ADR-0086 / issue #1203: a static
+/// <c>@DllImport</c> extern declared inside a class's <c>shared { }</c> block
+/// (the C# <c>static extern</c> equivalent) lowers to a CLR <c>Static</c> +
+/// <c>PinvokeImpl</c> method with an <c>ImplMap</c> row. The bodyless static
+/// member used to crash the compiler with GS9998; this pins the emitted
+/// metadata, including the raw-pointer parameters allowed by the enclosing
+/// <c>unsafe</c> class.
+/// </summary>
+public class Issue1203SharedExternEmitTests
+{
+    [Fact]
+    public void StaticDllImportExtern_InUnsafeClass_EmitsPinvokeImplMethod()
+    {
+        const string source = """
+            package p
+            import System.Runtime.InteropServices
+
+            unsafe class C {
+                shared {
+                    @DllImport("kernel32", SetLastError: true)
+                    func ReadFile(handle System.IntPtr, pBuffer *void, n int32, pRead *int32, ov int32) bool;
+                }
+            }
+            """;
+
+        var tempDir = Directory.CreateTempSubdirectory("gs_shared_extern_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+            CompileOrThrow(srcPath, outPath, target: "library");
+
+            using var pe = new PEReader(File.OpenRead(outPath));
+            var md = pe.GetMetadataReader();
+
+            var foundPInvoke = false;
+            foreach (var h in md.MethodDefinitions)
+            {
+                var m = md.GetMethodDefinition(h);
+                if (md.GetString(m.Name) != "ReadFile")
+                {
+                    continue;
+                }
+
+                foundPInvoke = true;
+                Assert.True((m.Attributes & System.Reflection.MethodAttributes.Static) == System.Reflection.MethodAttributes.Static);
+                Assert.True((m.Attributes & System.Reflection.MethodAttributes.PinvokeImpl) == System.Reflection.MethodAttributes.PinvokeImpl);
+
+                var import = m.GetImport();
+                Assert.False(import.Module.IsNil);
+                Assert.Equal("kernel32", md.GetString(md.GetModuleReference(import.Module).Name));
+                Assert.Equal("ReadFile", md.GetString(import.Name));
+                Assert.True((import.Attributes & System.Reflection.MethodImportAttributes.SetLastError) == System.Reflection.MethodImportAttributes.SetLastError);
+
+                var declaringType = md.GetString(md.GetTypeDefinition(m.GetDeclaringType()).Name);
+                Assert.Equal("C", declaringType);
+            }
+
+            Assert.True(foundPInvoke, "expected an emitted static P/Invoke method named ReadFile on class C");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    private static void CompileOrThrow(string srcPath, string outPath, string target)
+    {
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:" + target,
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1203SharedExternBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1203SharedExternBinderTests.cs
@@ -1,0 +1,118 @@
+// <copyright file="Issue1203SharedExternBinderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// ADR-0086 / issue #1203: a bodyless function inside a class's
+/// <c>shared { }</c> static block is the canonical G# spelling of a C#
+/// <c>static extern [DllImport]</c> member. Previously the static-member path
+/// dereferenced the null <c>Declaration.Body</c> and crashed the compiler with
+/// a GS9998 NullReferenceException. These tests pin that a static
+/// <c>@DllImport</c> extern now binds as a P/Invoke and that a bodyless static
+/// method without <c>@DllImport</c> reports GS0325 instead of crashing.
+/// </summary>
+public class Issue1203SharedExternBinderTests
+{
+    [Fact]
+    public void StaticDllImportExtern_BindsAsPInvoke()
+    {
+        const string source = @"
+package p
+import System.Runtime.InteropServices
+
+class C {
+    shared {
+        @DllImport(""kernel32"", SetLastError: true)
+        func ReadFile(handle System.IntPtr, n int32) bool;
+    }
+}
+";
+        var globalScope = BindSource(source);
+        var structSym = globalScope.Structs.Single(s => s.Name == "C");
+        var method = structSym.StaticMethods.Single(m => m.Name == "ReadFile");
+
+        Assert.True(method.IsPInvoke);
+        Assert.NotNull(method.PInvokeMetadata);
+        Assert.Equal("kernel32", method.PInvokeMetadata.LibraryName);
+        Assert.True(method.PInvokeMetadata.SetLastError);
+    }
+
+    [Fact]
+    public void BodylessStaticFunc_WithoutDllImport_ReportsGS0325_DoesNotCrash()
+    {
+        const string source = @"
+package p
+class C {
+    shared {
+        func F(x int32) bool;
+    }
+}
+";
+        var diagnostics = GetEmitDiagnostics(source);
+        Assert.Contains(diagnostics, d => d.Id == "GS0325");
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS9998");
+    }
+
+    [Fact]
+    public void StaticDllImportExtern_DoesNotCrash_NoGS9998()
+    {
+        const string source = @"
+package p
+import System.Runtime.InteropServices
+
+class C {
+    shared {
+        @DllImport(""kernel32"")
+        func GetTickCount() int32;
+    }
+}
+";
+        var diagnostics = GetEmitDiagnostics(source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS9998");
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0325");
+    }
+
+    [Fact]
+    public void StaticDllImportExtern_InUnsafeClass_WithPointerParams_Binds()
+    {
+        const string source = @"
+package p
+import System.Runtime.InteropServices
+
+unsafe class C {
+    shared {
+        @DllImport(""kernel32"", SetLastError: true)
+        func ReadFile(handle System.IntPtr, pBuffer *void, n int32, pRead *int32, ov int32) bool;
+    }
+}
+";
+        var diagnostics = GetEmitDiagnostics(source);
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+    }
+
+    private static BoundGlobalScope BindSource(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        return Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+    }
+
+    private static IEnumerable<Diagnostic> GetEmitDiagnostics(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new GSharp.Core.CodeAnalysis.Compilation.Compilation(tree);
+        using var peStream = new System.IO.MemoryStream();
+        return compilation.Emit(peStream).Diagnostics;
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue1202UnsafeClassModifierParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue1202UnsafeClassModifierParserTests.cs
@@ -1,0 +1,69 @@
+// <copyright file="Issue1202UnsafeClassModifierParserTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Syntax;
+
+/// <summary>
+/// ADR-0122 / issue #1202: the <c>unsafe</c> class modifier must compose with
+/// the other aggregate modifiers (<c>open</c>/<c>sealed</c>/visibility) in any
+/// order. Previously only a SOLE leading <c>unsafe class</c> parsed; combining
+/// it with <c>open</c> tripped the statement parser (GS0285/GS0125) and
+/// aborted the declaration. These tests pin that <c>unsafe</c> is a first-class
+/// member of the class modifier set.
+/// </summary>
+public class Issue1202UnsafeClassModifierParserTests
+{
+    [Fact]
+    public void UnsafeOpenClass_Parses_WithoutDiagnostics()
+    {
+        const string source = "package p\nunsafe open class C { private var pBuffer *void }\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+    }
+
+    [Fact]
+    public void OpenUnsafeClass_Parses_WithoutDiagnostics()
+    {
+        const string source = "package p\nopen unsafe class C { private var pBuffer *void }\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+    }
+
+    [Fact]
+    public void UnsafeClass_SoleModifier_StillParses()
+    {
+        const string source = "package p\nunsafe class C { private var pBuffer *void }\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+    }
+
+    [Theory]
+    [InlineData("package p\nunsafe open class C { }\n")]
+    [InlineData("package p\nopen unsafe class C { }\n")]
+    [InlineData("package p\npublic unsafe open class C { }\n")]
+    [InlineData("package p\nunsafe sealed class C { }\n")]
+    [InlineData("package p\nsealed unsafe class C { }\n")]
+    public void UnsafeComposesWithClassModifiers_MarksNodeUnsafe(string source)
+    {
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var root = (CompilationUnitSyntax)tree.Root;
+        var classDecl = root.Members.OfType<StructDeclarationSyntax>().Single();
+        Assert.True(classDecl.IsUnsafe);
+    }
+
+    [Fact]
+    public void UnsafeOnInterface_ReportsDiagnostic()
+    {
+        // `unsafe` is only valid on a class/struct head, not an interface.
+        const string source = "package p\nunsafe interface I { }\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.NotEmpty(tree.Diagnostics);
+    }
+}


### PR DESCRIPTION
## Summary

Two G# **compiler** fixes that unblock faithful Win32 P/Invoke interop migration (follow-ups to #1014). Both are in `src/` only.

### Fixes #1202 — `unsafe` class modifier could not combine with `open` (or other modifiers)

`unsafe class C` parsed, but `unsafe open class C` and `open unsafe class C` failed: the parser special-cased a *sole* leading `unsafe` keyword that only folded into `func`/`async`/`class`/`struct`. Anything else dropped through to the statement parser, producing `GS0285` + `GS0125` and cascading spurious GS9006/GS0198/GS0243 in the body.

`unsafe` is now a first-class member of the aggregate modifier set:
- recognised in `TryDetectAggregateDeclarationHead`, and
- consumed in `ParseAggregateDeclaration` alongside `open`/`sealed`/`data`/`inline`/`ref` **in any order**, establishing an unsafe context for the whole class.

It is rejected on `enum`/`interface` heads with an unexpected-token diagnostic.

### Fixes #1203 — bodyless func inside a `shared { }` block crashed with GS9998 (NullReferenceException)

A bodyless (abstract/extern) function inside a `shared { }` static block — the pattern for static `[DllImport]` externs — crashed the compiler. The static-member body-binding loop unconditionally dereferenced `method.Declaration.Body` (null for a bodyless extern), unlike the instance path which already guards it (issue #987).

The static `shared`-block path now:
- resolves `@DllImport`/`@LibraryImport` metadata via `PInvokeBinder.TryAttachPInvokeMetadata`, and reports `GS0325` for a bodyless `shared` method **without** `@DllImport` (mirroring the top-level free-function path);
- registers an empty synthetic block for bodyless static methods so the emitter mints the P/Invoke `MethodDef` (ImplMap, no IL body) instead of binding a null body.

`PInvokeBinder` no longer rejects static (`shared`-block) P/Invokes — the CLR represents every P/Invoke as a static method, so a `shared`-block `@DllImport` extern is precisely the supported shape.

## Repros now passing

```gsharp
// #1202 — both orderings compile
package p
unsafe open class C { private var pBuffer *void }
```

```gsharp
// #1203 minimal — no longer crashes; emits a clean GS0325
package p
class C { shared { func F(x int32) bool; } }
```

```gsharp
// Real Oahu scenario — compiles to a valid static P/Invoke
package p
import System.Runtime.InteropServices
unsafe class C {
    shared {
        @DllImport("kernel32", SetLastError: true)
        func ReadFile(handle System.IntPtr, pBuffer *void, n int32, pRead *int32, ov int32) bool;
    }
}
```

The emitted `C.ReadFile` is `Public, Static, HideBySig, PinvokeImpl` (PreserveSig) with an ImplMap row: `entry=ReadFile module=kernel32 SetLastError`.

## Files changed

- `src/Core/CodeAnalysis/Syntax/Parser.cs` — `unsafe` composes with class modifiers in any order (#1202).
- `src/Core/CodeAnalysis/Binding/Binder.cs` — guard bodyless static methods in the `shared`-block body-bind loop (#1203 NRE root cause).
- `src/Core/CodeAnalysis/Binding/DeclarationBinder.cs` — attach P/Invoke metadata + `GS0325` for `shared`-block methods (#1203).
- `src/Core/CodeAnalysis/Binding/PInvokeBinder.cs` — allow static (`shared`-block) P/Invokes (#1203).
- Tests: `Issue1202UnsafeClassModifierParserTests`, `Issue1203SharedExternBinderTests`, `Issue1203SharedExternEmitTests`.

## Validation

- Full solution build: 0 errors.
- Core.Tests: 4215 passed (+13 new).
- Extensions.Tests: 104 passed.
- Compiler.Tests (`~PInvoke|~Shared|~DllImport`, `~Unsafe`, new emit test): all passed.

Fixes #1202
Fixes #1203
