### PR TITLE
cs2gs: preserve explicit local type when it differs from initializer (Refs #914)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/LocalExplicitTypePreservationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/LocalExplicitTypePreservationTests.cs
@@ -1,0 +1,161 @@
+// <copyright file="LocalExplicitTypePreservationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Translator-fidelity tests for preserving the explicit declared type of a C#
+/// local that has an initializer of a different natural type (an implicit
+/// conversion). cs2gs normally relies on G# inference for an initialized local,
+/// but when the developer wrote an explicit type that widens the initializer
+/// (e.g. <c>long startSample = 0;</c> where <c>0</c> is <c>int</c>), G# would
+/// re-infer the narrower natural type and later operations such as
+/// <c>startSample += sum/* int64 */</c> fail with GS0129. The type clause must be
+/// preserved so the binding keeps the developer's intended type. When the
+/// declared type and the initializer's natural type match, the clause is omitted
+/// (idiomatic inference). The #1072 nullability promotion still applies.
+/// </summary>
+public class LocalExplicitTypePreservationTests
+{
+    [Fact]
+    public void LongLocalInitializedFromIntLiteral_PreservesInt64Type()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public long F()
+        {
+            long startSample = 0;
+            startSample += 1L;
+            return startSample;
+        }
+    }
+}");
+
+        Assert.Contains("var startSample int64 = 0", printed);
+    }
+
+    [Fact]
+    public void IntLocalInitializedFromIntLiteral_OmitsTypeClause()
+    {
+        // Declared type matches the initializer's natural type: rely on inference.
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public int F()
+        {
+            int x = 0;
+            x += 1;
+            return x;
+        }
+    }
+}");
+
+        Assert.Contains("var x = 0", printed);
+        Assert.DoesNotContain("var x int32 = 0", printed);
+    }
+
+    [Fact]
+    public void DoubleLocalInitializedFromIntLiteral_PreservesFloat64Type()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public double F()
+        {
+            double ratio = 1;
+            return ratio;
+        }
+    }
+}");
+
+        Assert.Contains("let ratio float64 =", printed);
+    }
+
+    [Fact]
+    public void NullableReferenceLocalInitializedFromConcrete_PreservesNullableInterfaceType()
+    {
+        // The declared type (IBox) differs from the initializer's natural type
+        // (Box), so the explicit type is preserved; because the local is later
+        // null-assigned it is also promoted to nullable (#1072).
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public interface IBox { }
+    public class Box : IBox { }
+    public class C
+    {
+        public void F()
+        {
+            IBox b = new Box();
+            b = null!;
+            System.Console.WriteLine(b);
+        }
+    }
+}");
+
+        Assert.Contains("b IBox?", printed);
+    }
+
+    [Fact]
+    public void ForLoopHeader_StillTranslates()
+    {
+        // For-loop initializers also route through TranslateLocalDeclaration; the
+        // declared type matches the literal's natural type so the header stays
+        // idiomatic.
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public int F()
+        {
+            int total = 0;
+            for (int i = 0; i < 3; i++)
+            {
+                total += i;
+            }
+            return total;
+        }
+    }
+}");
+
+        Assert.Contains("for var i = 0", printed);
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -3028,20 +3028,46 @@ public sealed class CSharpToGSharpTranslator
 
                 // A type clause is required when there is no initializer (it names
                 // the zero/default value, spec §Bindings). With an initializer the
-                // type is inferred (ADR-0115 §B.3).
+                // type is normally inferred (ADR-0115 §B.3) — but when the C#
+                // developer wrote an explicit type that differs from the
+                // initializer's natural type (an implicit conversion, e.g.
+                // `long startSample = 0;` where `0` is `int`), G# would re-infer
+                // the narrower natural type and later operations (e.g. `+=` with an
+                // `int64` value) fail with GS0129. In that case preserve the
+                // developer's declared type so the binding keeps the intended type.
                 GTypeReference type = null;
-                if (initializer == null && hasExplicitType)
+                if (hasExplicitType)
                 {
-                    ITypeSymbol typeSymbol = this.context.GetTypeInfo(declaration.Type).Type;
-                    type = typeSymbol != null
-                        ? this.typeMapper.Map(typeSymbol, this.context, declaration.Type.GetLocation())
-                        : null;
+                    bool emitType = initializer == null;
+                    ITypeSymbol declaredType = this.context.GetTypeInfo(declaration.Type).Type;
 
-                    // Issue #1072: a non-nullable reference/array local that is
-                    // null-checked or null-assigned in its scope is really nullable.
-                    if (this.context.GetDeclaredSymbol(declarator) is ILocalSymbol localSymbol)
+                    if (!emitType && initializer != null && declaredType != null)
                     {
-                        type = this.PromoteIfUsedAsNullable(type, localSymbol);
+                        // Preserve the explicit type only when it differs from the
+                        // initializer's natural type (an implicit conversion). When
+                        // they match, omit the clause and rely on inference — the
+                        // idiomatic common case.
+                        ITypeSymbol naturalType =
+                            this.context.GetTypeInfo(declarator.Initializer.Value).Type;
+                        if (naturalType == null
+                            || !SymbolEqualityComparer.Default.Equals(declaredType, naturalType))
+                        {
+                            emitType = true;
+                        }
+                    }
+
+                    if (emitType)
+                    {
+                        type = declaredType != null
+                            ? this.typeMapper.Map(declaredType, this.context, declaration.Type.GetLocation())
+                            : null;
+
+                        // Issue #1072: a non-nullable reference/array local that is
+                        // null-checked or null-assigned in its scope is really nullable.
+                        if (this.context.GetDeclaredSymbol(declarator) is ILocalSymbol localSymbol)
+                        {
+                            type = this.PromoteIfUsedAsNullable(type, localSymbol);
+                        }
                     }
                 }
 


### PR DESCRIPTION
Refs #914

## Problem
cs2gs dropped the explicit declared type of a C# local whenever the declaration had an initializer, relying on G# inference. When the developer used an explicit type that differs from the initializer's natural type (an implicit widening conversion), G# inferred the narrower natural type and later operations failed with GS0129.

Example (`Mpeg4/Chunks/ChunkEntryList.cs`):
```csharp
long startSample = 0;                              // explicit long; 0 is int
startSample += entry.FrameDurations.Sum(d => d);   // Sum() returns long
```
Previously emitted `var startSample = 0` (inferred int32), so `int32 += int64` => GS0129. Now emits `var startSample int64 = 0`.

## Fix
In `TranslateLocalDeclaration`, the explicit type clause is now preserved when the C# local has an explicit (non-`var`) type **and** an initializer **and** the declared type differs from the initializer's natural type (an implicit conversion), per Roslyn semantic info:

```
hasExplicitType && initializer != null && declaredType != null
  && (naturalType == null || !SymbolEqualityComparer.Default.Equals(declaredType, naturalType))
```

When declared type and natural type match, the clause is omitted (idiomatic inference, unchanged). The existing #1072 nullability promotion (`PromoteIfUsedAsNullable`) is applied on this new path too.

## Scoping
The general "any differing type" rule was kept (no narrowing needed) — it fixed the int64 cluster without regressing Foundation or Decrypt. For-loop headers (`for var i = 0; ...`) still translate correctly because there the declared type matches the literal's natural type, so no clause is added.

## Verification
- cs2gs tests: 262 passing (5 new in `LocalExplicitTypePreservationTests.cs`).
- Oahu **Decrypt**: 235 -> **227** (GS0129 cluster + downstream cascades dropped).
- Oahu **Foundation**: 16 -> **16** (no regression).