### PR TITLE
Resolve namespace-qualified attribute names (Fixes #1206)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -7406,15 +7406,31 @@ internal sealed class DeclarationBinder
         var nameLocation = GetAnnotationNameLocation(annotation);
         nameIsExact = true;
 
-        // The dotted form (e.g. `System.Obsolete`) is not yet routed through
-        // LookupType — fall back to a CLR walk by full name. v1 keeps
-        // resolution focused on the single-identifier form; dotted names
-        // remain a follow-up.
-        var direct = lookupType(name);
-        TypeSymbol suffixed = null;
-        if (!string.IsNullOrEmpty(name) && !name.EndsWith("Attribute", StringComparison.Ordinal))
+        // Issue #1206: resolve the verbatim name and the C#-style
+        // `<simple-name>Attribute` suffixed name. The suffix is appended to the
+        // final simple-name segment only — for a qualified name `Ns.Foo` the
+        // candidate is `Ns.FooAttribute`, never `Ns.FooAttribute` with a doubled
+        // `Attribute`, and a name whose simple part already ends in `Attribute`
+        // is not suffixed at all. Both the simple-identifier form (honoring
+        // imports/aliases via LookupType) and the dotted/qualified form (resolved
+        // by full name against the reference set, the same machinery used for
+        // qualified type references such as `System.IntPtr`) are supported.
+        var direct = ResolveAttributeName(name);
+
+        var simpleName = name;
+        var dotIndex = string.IsNullOrEmpty(name) ? -1 : name.LastIndexOf('.');
+        if (dotIndex >= 0)
         {
-            suffixed = lookupType(name + "Attribute");
+            simpleName = name.Substring(dotIndex + 1);
+        }
+
+        TypeSymbol suffixed = null;
+        if (!string.IsNullOrEmpty(simpleName) && !simpleName.EndsWith("Attribute", StringComparison.Ordinal))
+        {
+            var suffixedName = dotIndex >= 0
+                ? string.Concat(name.Substring(0, dotIndex + 1), simpleName, "Attribute")
+                : simpleName + "Attribute";
+            suffixed = ResolveAttributeName(suffixedName);
         }
 
         if (direct != null && IsAttributeType(direct) && suffixed != null && IsAttributeType(suffixed))
@@ -7436,6 +7452,33 @@ internal sealed class DeclarationBinder
         }
 
         Diagnostics.ReportAttributeTypeNotFound(nameLocation, name);
+        return null;
+    }
+
+    // Issue #1206: resolves a (possibly dotted) attribute name to a TypeSymbol.
+    // The simple-identifier form goes through LookupType so imports and aliases
+    // are honored; the qualified/dotted form (e.g. `System.Obsolete`,
+    // `System.Runtime.InteropServices.DllImport`) is resolved by full name
+    // against the reference set — the same resolution used for qualified type
+    // references elsewhere (e.g. `System.IntPtr`).
+    private TypeSymbol ResolveAttributeName(string name)
+    {
+        if (string.IsNullOrEmpty(name))
+        {
+            return null;
+        }
+
+        var resolved = lookupType(name);
+        if (resolved != null)
+        {
+            return resolved;
+        }
+
+        if (name.IndexOf('.') >= 0 && scope.References.TryResolveType(name, out var clrType) && clrType != null)
+        {
+            return TypeSymbol.FromClrType(clrType);
+        }
+
         return null;
     }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1206QualifiedAttributeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1206QualifiedAttributeTests.cs
@@ -1,0 +1,128 @@
+// <copyright file="Issue1206QualifiedAttributeTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Regression coverage for issue #1206: namespace-qualified attribute names
+/// (e.g. <c>@System.Obsolete</c>, <c>@System.ObsoleteAttribute</c>,
+/// <c>@System.Runtime.InteropServices.DllImport</c>) must resolve without an
+/// <c>import</c>, mirroring how qualified type references resolve. The resolver
+/// must split <c>Ns.Name</c> and resolve the type by full name, append the
+/// <c>Attribute</c> suffix to the final simple-name segment only (never produce
+/// a doubled <c>...AttributeAttribute</c>), and the type-identity-based
+/// P/Invoke detection must recognise the qualified <c>@DllImport</c>.
+/// </summary>
+public class Issue1206QualifiedAttributeTests
+{
+    [Fact]
+    public void Qualified_Obsolete_Resolves_Without_Import()
+    {
+        var globalScope = BindSource("@System.Obsolete(\"x\")\nfunc Helper() {\n}\n");
+        var helper = globalScope.Functions.Single(f => f.Name == "Helper");
+
+        var attr = Assert.Single(helper.Attributes);
+        Assert.Equal("System.ObsoleteAttribute", attr.AttributeType.Name);
+        Assert.DoesNotContain(GetBinderDiagnostics(globalScope), d => d.Id == "GS0198");
+    }
+
+    [Fact]
+    public void Qualified_ObsoleteAttribute_Resolves_Without_Double_Suffix()
+    {
+        // The explicit `Attribute` suffix must NOT produce
+        // `System.ObsoleteAttributeAttribute`.
+        var globalScope = BindSource("@System.ObsoleteAttribute(\"x\")\nfunc Helper() {\n}\n");
+        var helper = globalScope.Functions.Single(f => f.Name == "Helper");
+
+        var attr = Assert.Single(helper.Attributes);
+        Assert.Equal("System.ObsoleteAttribute", attr.AttributeType.Name);
+        Assert.DoesNotContain(GetBinderDiagnostics(globalScope), d => d.Id == "GS0198");
+    }
+
+    [Fact]
+    public void Unqualified_Obsolete_Still_Resolves_With_Import()
+    {
+        var globalScope = BindSource("import System\n@Obsolete(\"x\")\nfunc Helper() {\n}\n");
+        var helper = globalScope.Functions.Single(f => f.Name == "Helper");
+
+        var attr = Assert.Single(helper.Attributes);
+        Assert.Equal("System.ObsoleteAttribute", attr.AttributeType.Name);
+        Assert.DoesNotContain(GetBinderDiagnostics(globalScope), d => d.Id == "GS0198");
+    }
+
+    [Fact]
+    public void Qualified_Unknown_Attribute_Still_Reports_GS0198()
+    {
+        var globalScope = BindSource("@System.DoesNotExistAnywhere\nfunc Helper() {\n}\n");
+
+        Assert.Contains(GetBinderDiagnostics(globalScope), d => d.Id == "GS0198");
+    }
+
+    [Fact]
+    public void Qualified_DllImport_Is_Recognised_As_PInvoke()
+    {
+        const string source = @"
+package P
+
+unsafe class C {
+    shared {
+        @System.Runtime.InteropServices.DllImport(""kernel32"", SetLastError: true)
+        func ReadFile(handle System.IntPtr, pBuffer *void, n int32, pRead *int32, ov int32) bool;
+    }
+}
+";
+        var globalScope = BindSource(source);
+
+        var fn = GetAllFunctions(globalScope).Single(f => f.Name == "ReadFile");
+        Assert.True(fn.IsPInvoke);
+        Assert.NotNull(fn.PInvokeMetadata);
+        Assert.Equal("kernel32", fn.PInvokeMetadata.LibraryName);
+        Assert.True(fn.PInvokeMetadata.SetLastError);
+
+        // Neither the unresolved-attribute (GS0198) nor the bodyless-without-
+        // DllImport (GS0325) diagnostic may appear.
+        Assert.DoesNotContain(GetBinderDiagnostics(globalScope), d => d.Id is "GS0198" or "GS0325");
+    }
+
+    private static IEnumerable<GSharp.Core.CodeAnalysis.Symbols.FunctionSymbol> GetAllFunctions(BoundGlobalScope scope)
+    {
+        foreach (var fn in scope.Functions)
+        {
+            yield return fn;
+        }
+
+        foreach (var type in scope.Structs)
+        {
+            foreach (var fn in type.Methods)
+            {
+                yield return fn;
+            }
+
+            foreach (var fn in type.StaticMethods)
+            {
+                yield return fn;
+            }
+        }
+    }
+
+    private static BoundGlobalScope BindSource(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        return Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+    }
+
+    private static IEnumerable<GSharp.Core.CodeAnalysis.Diagnostic> GetBinderDiagnostics(BoundGlobalScope scope)
+    {
+        return scope.Diagnostics;
+    }
+}


### PR DESCRIPTION
Fixes #1206.

## Root cause
`gsc` could not resolve a fully-qualified (namespace-qualified) attribute name. `@System.Obsolete`, `@System.ObsoleteAttribute`, and `@System.Runtime.InteropServices.DllImport` all reported `GS0198` even for core BCL attributes; only the unqualified short form (with an `import`) resolved.

Two defects in `DeclarationBinder.ResolveAttributeType`:
1. **Dotted names never resolved.** Qualified names were handed verbatim to `LookupType`, which only handles simple identifiers (honoring imports/aliases) and never resolves a `Ns.Name` type by full name. The dotted form was a documented "follow-up" gap.
2. **Double `Attribute` suffix.** The `Attribute` suffix was appended to the whole name, so `@System.ObsoleteAttribute` produced `System.ObsoleteAttributeAttribute`.

## Fix
- New `ResolveAttributeName` helper resolves a (possibly dotted) name via `LookupType` first, then by full name against the reference set (`scope.References.TryResolveType`) for dotted names — the same machinery used for qualified type references like `System.IntPtr`.
- The `Attribute` suffix is now appended to the **final simple-name segment only**: `Ns.Foo` → tries `Ns.Foo` and `Ns.FooAttribute`; a name already ending in `Attribute` is not suffixed.
- **P/Invoke detection needed no change:** `KnownAttributes.FindDllImport`/`IsDllImport` already match by resolved CLR type identity (`DllImportAttribute`), not the literal token. Once the qualified attribute resolves, the bodyless `;`-terminated static extern is accepted and emits a valid `ImplMap` row (verified: `module=kernel32`, `SetLastError`).

## Repros now passing (all compile, `/target:library`)
```gsharp
package p
@System.Obsolete("x")
class C { func F() int32 { return 1 } }
```
```gsharp
package p
@System.ObsoleteAttribute("x")
class C { func F() int32 { return 1 } }
```
```gsharp
package p
unsafe class C {
    shared {
        @System.Runtime.InteropServices.DllImport("kernel32", SetLastError: true)
        func ReadFile(handle System.IntPtr, pBuffer *void, n int32, pRead *int32, ov int32) bool;
    }
}
```
The qualified `DllImport` extern previously failed with `GS0198` + `GS0325`; both now clear and the method is recognized as a P/Invoke with valid metadata.

## Tests
- New `Issue1206QualifiedAttributeTests` (5 tests): qualified Obsolete, double-suffix case, unqualified path still works, qualified unknown-attribute still reports GS0198, and the qualified DllImport P/Invoke scenario.
- Core.Tests: **4220 passed**, 1 skipped.
- Extensions.Tests: **104 passed**.
- Narrowed Compiler.Tests (`Attribute|PInvoke|DllImport`): **45 passed**.
- Full `GSharp.sln -c Release -graph`: 0 errors, 0 warnings.