### PR TITLE
Fix generic-type reference in expression position (#1209)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundCallExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundCallExpression.cs
@@ -63,6 +63,16 @@ public sealed class BoundCallExpression : BoundExpression
     public override TypeSymbol Type => ReturnType ?? Function.Type;
 
     /// <summary>
+    /// Gets, for issue #1209, the constructed generic user type when a
+    /// static (<c>shared</c>) method is dispatched on a constructed generic user
+    /// type (<c>Box[int32].Make()</c>), so the emitter parents the call at the
+    /// construction's <c>TypeSpec</c> (mirroring the static-field and
+    /// static-property paths). <see langword="null"/> for ordinary calls and for
+    /// non-generic static receivers (which use the bare accessor <c>MethodDef</c>).
+    /// </summary>
+    public StructSymbol StaticGenericOwnerType { get; internal set; }
+
+    /// <summary>
     /// Gets the function symbol.
     /// </summary>
     public FunctionSymbol Function { get; }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -757,15 +757,37 @@ internal sealed partial class ExpressionBinder
                 return new BoundErrorExpression(null);
             }
         }
-        else if (leftPart is IndexExpressionSyntax genericIfaceIndex
-            && !genericIfaceIndex.IsNullConditional
-            && TryResolveConstructedGenericInterfaceReceiver(genericIfaceIndex, out var constructedInterface))
+        else if (leftPart is IndexExpressionSyntax genericTypeIndex
+            && !genericTypeIndex.IsNullConditional
+            && TryResolveConstructedGenericTypeReceiver(
+                genericTypeIndex,
+                out var constructedStruct,
+                out var constructedInterface,
+                out var constructedImported))
         {
-            // ADR-0089 / issue #1030: `IBox[int32].StaticField` — qualified
-            // access to a *constructed generic* interface's static field. The
-            // closed construction is carried so emit parents the field at the
-            // construction's TypeSpec and the interpreter keys per construction.
-            userInterfaceSymbol = constructedInterface;
+            // Issue #1209 (extends ADR-0089 / issue #1030): a generic-type
+            // reference with explicit type arguments used in expression /
+            // member-access receiver position — `Box[int32].Default`,
+            // `ArrayPool[uint8].Shared`, `Comparer[int32].Default`. The parser
+            // shapes `Name[Arg]` as an index expression; when `Name` is NOT a
+            // value but IS a generic type definition of matching arity (user
+            // class/struct, user interface, or imported CLR generic), bind the
+            // whole `Name[Arg]` as the constructed generic *type* receiver
+            // rather than as element access. The closed construction is carried
+            // so static-member access (and static method calls) resolve against
+            // the construction.
+            if (constructedInterface != null)
+            {
+                userInterfaceSymbol = constructedInterface;
+            }
+            else if (constructedStruct != null)
+            {
+                userStructSymbol = constructedStruct;
+            }
+            else
+            {
+                classSymbol = constructedImported;
+            }
         }
         else if (leftPart is AccessorExpressionSyntax qualifiedNestedType
             && !qualifiedNestedType.IsNullConditional
@@ -1505,6 +1527,122 @@ internal sealed partial class ExpressionBinder
     }
 
     /// <summary>
+    /// Issue #1209: resolves a <c>Name[TypeArg]</c> index-expression receiver
+    /// that appears in expression / member-access position to the constructed
+    /// generic *type* it names — a user class/struct, a user interface, or an
+    /// imported CLR generic type — so qualified static-member access
+    /// (<c>Box[int32].Default</c>, <c>ArrayPool[uint8].Shared</c>) and static
+    /// method calls bind against the construction rather than as element access.
+    /// <para>
+    /// Disambiguation rule (avoids breaking genuine indexing such as
+    /// <c>arr[i]</c> / <c>dict[key]</c>): the target must be a simple name that
+    /// does NOT resolve to a value/variable in scope, AND must resolve to a
+    /// generic type definition (user generic class/struct/interface, or imported
+    /// CLR generic) whose arity matches the bracketed type-argument count, AND
+    /// the bracket contents must parse as type arguments. When the name resolves
+    /// to a value, this returns <c>false</c> and the caller binds element access
+    /// as before.
+    /// </para>
+    /// </summary>
+    /// <param name="index">The candidate <c>Name[TypeArg]</c> receiver.</param>
+    /// <param name="constructedStruct">The constructed generic class/struct on success.</param>
+    /// <param name="constructedInterface">The constructed generic interface on success.</param>
+    /// <param name="constructedImported">The constructed imported CLR generic type on success.</param>
+    /// <returns>Whether a constructed generic type receiver was resolved.</returns>
+    private bool TryResolveConstructedGenericTypeReceiver(
+        IndexExpressionSyntax index,
+        out StructSymbol constructedStruct,
+        out InterfaceSymbol constructedInterface,
+        out ImportedClassSymbol constructedImported)
+    {
+        constructedStruct = null;
+        constructedInterface = null;
+        constructedImported = null;
+
+        if (index.Target is not NameExpressionSyntax targetName)
+        {
+            return false;
+        }
+
+        var name = targetName.IdentifierToken.Text;
+
+        // Genuine indexing (`arr[i]`, `dict[key]`) requires the target to name a
+        // value. Only when the name is NOT a value do we consider the
+        // constructed-generic-type interpretation.
+        if (scope.TryLookupSymbol(name) is VariableSymbol)
+        {
+            return false;
+        }
+
+        // Gate on the name actually naming a generic type definition before
+        // binding the bracket contents as type arguments, so that we never emit
+        // spurious type diagnostics for a non-generic-type target.
+        var arity = FlattenCommaList(index.Index).Count();
+        var userGenericDef = scope.TryLookupTypeAlias(name, out var alias)
+            && ((alias is StructSymbol sDef && sDef.IsGenericDefinition && sDef.TypeParameters.Length == arity)
+                || (alias is InterfaceSymbol iDef && iDef.IsGenericDefinition && iDef.TypeParameters.Length == arity));
+        Type openClrType = null;
+        var clrGenericDef = !userGenericDef
+            && scope.TryLookupImportedGenericClass(name, arity, out openClrType);
+
+        if (!userGenericDef && !clrGenericDef)
+        {
+            return false;
+        }
+
+        if (!TryBindTypeArgumentExpressions(index.Index, out var typeArgs)
+            || typeArgs.Length != arity)
+        {
+            return false;
+        }
+
+        if (userGenericDef)
+        {
+            switch (alias)
+            {
+                case StructSymbol structDef:
+                    constructedStruct = StructSymbol.Construct(structDef, typeArgs);
+                    return true;
+                case InterfaceSymbol ifaceDef:
+                    constructedInterface = InterfaceSymbol.Construct(ifaceDef, typeArgs);
+                    return true;
+            }
+        }
+
+        // Imported CLR generic type: close the open generic definition over the
+        // CLR types of the bound type arguments (e.g. ArrayPool`1 + byte ->
+        // ArrayPool<byte>) and surface it as an imported class so the existing
+        // static-member / static-call binding path resolves members against the
+        // closed construction.
+        var clrArgs = new Type[typeArgs.Length];
+        for (var i = 0; i < typeArgs.Length; i++)
+        {
+            var clr = NullableTypeSymbol.GetEffectiveClrType(typeArgs[i]);
+            if (clr == null)
+            {
+                return false;
+            }
+
+            // Project the host CLR type argument onto the resolver's reference
+            // set so it shares the open type's load context (its
+            // MetadataLoadContext when references are supplied via /reference:),
+            // which MakeGenericType requires (mirrors Binder.BindGenericClrType).
+            clrArgs[i] = scope.References.MapClrTypeToReferences(clr);
+        }
+
+        try
+        {
+            var closed = openClrType.MakeGenericType(clrArgs);
+            constructedImported = new ImportedClassSymbol(closed, index);
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
     /// ADR-0089 / issue #1030: binds the type-argument expression(s) of a
     /// generic-interface index receiver (<c>int32</c> in <c>IBox[int32]</c>) to
     /// <see cref="TypeSymbol"/>s. Supports a single argument or a comma list
@@ -1922,28 +2060,35 @@ internal sealed partial class ExpressionBinder
                 convertedArgs.Add(conversions.BindCallArgumentWithRefKind(argLoc, permutedArgs[i], expectedType, method.Parameters[i]));
             }
 
+            // Issue #1209: when the static call dispatches on a constructed
+            // generic user type, carry the construction so the emitter parents
+            // the call at the construction's TypeSpec (a bare MethodDef token is
+            // invalid for a method of a generic type). Null for non-generic
+            // receivers leaves the ordinary MethodDef path unchanged.
+            var staticGenericOwner = structSym.Definition != null ? structSym : null;
+
             if (substitution != null)
             {
                 var substitutedReturn = Binder.SubstituteType(method.Type, substitution);
                 if (method.IsAsync && !isAsyncIteratorReturnType(method.Type))
                 {
                     substitutedReturn = lambdas.WrapAsTask(substitutedReturn);
-                    return new BoundCallExpression(null, method, convertedArgs.ToImmutable(), substitutedReturn);
+                    return new BoundCallExpression(null, method, convertedArgs.ToImmutable(), substitutedReturn) { StaticGenericOwnerType = staticGenericOwner };
                 }
 
                 if (!ReferenceEquals(substitutedReturn, method.Type))
                 {
-                    return new BoundCallExpression(null, method, convertedArgs.ToImmutable(), substitutedReturn);
+                    return new BoundCallExpression(null, method, convertedArgs.ToImmutable(), substitutedReturn) { StaticGenericOwnerType = staticGenericOwner };
                 }
             }
 
             if (method.IsAsync && !isAsyncIteratorReturnType(method.Type))
             {
                 var asyncReturn = lambdas.WrapAsTask(method.Type);
-                return new BoundCallExpression(null, method, convertedArgs.ToImmutable(), asyncReturn);
+                return new BoundCallExpression(null, method, convertedArgs.ToImmutable(), asyncReturn) { StaticGenericOwnerType = staticGenericOwner };
             }
 
-            return new BoundCallExpression(null, method, convertedArgs.ToImmutable());
+            return new BoundCallExpression(null, method, convertedArgs.ToImmutable()) { StaticGenericOwnerType = staticGenericOwner };
         }
 
         Diagnostics.ReportUnableToFindMember(ce.Location, methodName);

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
@@ -146,7 +146,17 @@ internal sealed partial class MethodBodyEmitter
                 // would carry MVAR slots and fail ilverify against the
                 // concrete argument types.
                 EntityHandle callTokenToEmit = fnHandle;
-                if (call.Function.IsGeneric && !call.Function.TypeParameters.IsDefaultOrEmpty)
+                if (call.StaticGenericOwnerType != null
+                    && ReflectionMetadataEmitter.IsUserGenericTypeReference(call.StaticGenericOwnerType))
+                {
+                    // Issue #1209: a `shared` (static) method called on a
+                    // constructed generic user type (`Box[int32].Make()`) must
+                    // be referenced through a MemberRef parented at the
+                    // construction's TypeSpec; a bare MethodDef token is invalid
+                    // for a method of a generic type.
+                    callTokenToEmit = this.outer.ResolveUserStaticMethodToken(call.StaticGenericOwnerType, call.Function);
+                }
+                else if (call.Function.IsGeneric && !call.Function.TypeParameters.IsDefaultOrEmpty)
                 {
                     callTokenToEmit = this.outer.BuildMethodSpecForGenericCall(fnHandle, call);
                 }

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -6804,6 +6804,32 @@ internal sealed class ReflectionMetadataEmitter
     }
 
     /// <summary>
+    /// Issue #1209: resolves the token for a call to a user <c>shared</c>
+    /// (static) method whose declaring type is a constructed generic user type
+    /// (<c>Box[int32].Make()</c>). A bare <c>MethodDef</c> token is invalid for a
+    /// method of a generic type, so a <c>MemberRef</c> parented at the
+    /// construction's <c>TypeSpec</c> is emitted (mirroring the static-field and
+    /// static-property paths). The MemberRef signature is the open static method
+    /// signature (no <c>this</c>) produced by <see cref="EncodeOpenMethodSignature"/>.
+    /// </summary>
+    internal EntityHandle ResolveUserStaticMethodToken(StructSymbol containingType, FunctionSymbol method)
+    {
+        if (!this.cache.MethodHandles.TryGetValue(method, out var openDef)
+            && !this.cache.FunctionHandles.TryGetValue(method, out openDef))
+        {
+            throw new InvalidOperationException(
+                $"Static method '{method.Name}' has no emitted handle.");
+        }
+
+        if (!IsUserGenericTypeReference(containingType))
+        {
+            return openDef;
+        }
+
+        return this.GetUserStructMethodRef(containingType, openDef, method.Name, this.EncodeOpenMethodSignature(method));
+    }
+
+    /// <summary>
     /// Issue #989: resolves the right token for a call to a user property's
     /// get/set accessor. For a non-generic containing type returns the bare
     /// accessor <c>MethodDef</c>; for a constructed generic containing type
@@ -6874,9 +6900,14 @@ internal sealed class ReflectionMetadataEmitter
         var indexParams = property.Parameters.IsDefaultOrEmpty
             ? ImmutableArray<ParameterSymbol>.Empty
             : property.Parameters;
+
+        // Issue #1209: a static (`shared`) property accessor on a generic user
+        // type has no `this` — the MemberRef signature must NOT set HASTHIS, or
+        // the runtime fails to bind the accessor (MissingMethodException).
+        var isInstanceAccessor = !property.IsStatic;
         if (wantSetter)
         {
-            new BlobEncoder(sigBlob).MethodSignature(isInstanceMethod: true)
+            new BlobEncoder(sigBlob).MethodSignature(isInstanceMethod: isInstanceAccessor)
                 .Parameters(
                     indexParams.Length + 1,
                     r => r.Void(),
@@ -6892,7 +6923,7 @@ internal sealed class ReflectionMetadataEmitter
         }
         else
         {
-            new BlobEncoder(sigBlob).MethodSignature(isInstanceMethod: true)
+            new BlobEncoder(sigBlob).MethodSignature(isInstanceMethod: isInstanceAccessor)
                 .Parameters(
                     indexParams.Length,
                     r => EncodeTypeSymbol(r.Type(), property.Type),

--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -1156,6 +1156,19 @@ public sealed class StructSymbol : TypeSymbol
 
         constructed.SetMethods(definition.Methods);
 
+        // Issue #1209: a constructed generic class/struct must surface the open
+        // definition's static members so a qualified static reference on the
+        // construction (`Box[int32].Default`, `Box[int32].Make()`) resolves the
+        // same way as on the definition. G# erases generic type parameters to
+        // System.Object at emit (ADR-0004), so the static members live on the
+        // single erased type and can be shared with the definition by symbol
+        // identity (no per-construction substitution at emit). The constructed
+        // symbol is still carried as the owner of the bound access so member
+        // resolution and diagnostics see the closed type.
+        constructed.SetStaticMethods(definition.StaticMethods);
+        constructed.SetStaticFields(definition.StaticFields);
+        constructed.SetConstFields(definition.ConstFields);
+
         // Issue #989: a generic auto-property (or computed property) whose type
         // mentions the class type parameter must resolve on a constructed
         // instance with `T` substituted — exactly like instance fields above.

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1209GenericTypeExprTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1209GenericTypeExprTests.cs
@@ -1,0 +1,163 @@
+// <copyright file="Issue1209GenericTypeExprTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1209 — a generic-type reference with explicit type arguments used in
+/// expression / member-access receiver position (<c>Box[int32].Default</c>,
+/// <c>Comparer[int32].Default</c>) must bind as the constructed generic type,
+/// not as element access on a variable (which previously produced
+/// <c>GS0125 Variable 'Box' doesn't exist</c>). The disambiguation must NOT
+/// regress genuine indexing (<c>arr[i]</c>, <c>dict[key]</c>), which still
+/// binds as element access because the target resolves to a value.
+/// </summary>
+public class Issue1209GenericTypeExprTests
+{
+    [Fact]
+    public void UserGenericStaticField_BindsAsConstructedType()
+    {
+        var source = @"
+class Box[T] {
+  shared {
+    let Default int32 = 0
+  }
+}
+
+func F() int32 {
+  return Box[int32].Default
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void UserGenericStaticProperty_BindsAsConstructedType()
+    {
+        var source = @"
+class Box[T] {
+  shared {
+    prop Value int32 { get { return 11 } }
+  }
+}
+
+func F() int32 {
+  return Box[int32].Value
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void UserGenericStaticMethod_BindsAsConstructedType()
+    {
+        var source = @"
+class Box[T] {
+  shared {
+    func Make() int32 { return 7 }
+  }
+}
+
+func F() int32 {
+  return Box[int32].Make()
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void BclGenericStaticMember_Comparer_BindsAsConstructedType()
+    {
+        var source = @"
+import System.Collections.Generic
+
+func F() int32 {
+  return Comparer[int32].Default.Compare(1, 2)
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void ArrayIndexing_StillBindsAsElementAccess()
+    {
+        var source = @"
+func F() int32 {
+  var a = [3]int32{10, 20, 30}
+  a[0] = 99
+  return a[1]
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void DictionaryIndexing_StillBindsAsElementAccess()
+    {
+        var source = @"
+import System.Collections.Generic
+
+func F() int32 {
+  var d = map[string,int32]{}
+  d[""a""] = 1
+  return d[""a""]
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void IndexingWithVariableSubscript_StillBindsAsElementAccess()
+    {
+        var source = @"
+func F() int32 {
+  var a = [3]int32{10, 20, 30}
+  var sum = 0
+  for var i = 0; i < a.Length; i++ {
+    sum = sum + a[i]
+  }
+
+  return sum
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void UnknownGenericTypeReference_StillReportsDiagnostic()
+    {
+        // A name that is neither a value nor a known generic type must not be
+        // silently accepted as a constructed generic receiver.
+        var source = @"
+func F() int32 {
+  return Nope[int32].Default
+}
+";
+        var result = Evaluate(source);
+        Assert.NotEmpty(result.Diagnostics);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
Fixes #1209

## Root cause
A generic-type reference with explicit type arguments used in **expression / member-access receiver position** — `Box[int32].Default`, `ArrayPool[uint8].Shared`, `Comparer[int32].Default`, `Box[int32].Make()` — was bound as **element access** (indexing) on a variable named like the type. The accessor binder saw the parser-produced `Name[Arg]` index shape and committed to element access, reporting `GS0125: Variable 'Box' doesn't exist` (and `Variable 'int32' doesn't exist`).

## Disambiguation rule implemented (binder-side)
In `ExpressionBinder.BindAccessorExpression`, when the member-access receiver is a `Name[Arg]` index expression, treat it as a **constructed generic type** receiver instead of element access **only when ALL** of the following hold (new helper `TryResolveConstructedGenericTypeReceiver`):

1. The target is a simple name that does **NOT** resolve to a value/variable in scope (`scope.TryLookupSymbol(name) is not VariableSymbol`).
2. The name resolves to a **generic type definition of matching arity** — a user generic class/struct, a user generic interface, or an imported CLR generic (`TryLookupTypeAlias` / `TryLookupImportedGenericClass`).
3. The bracket contents parse as **type arguments**.

When the name resolves to a value, the helper returns early and the caller binds element access exactly as before. This preserves genuine indexing: `arr[i]`, `dict[key]`, `list[0]`, and C-style `for` loops with `a[i] = ...` all still bind as element access (the target is a value).

For imported CLR generics, the host type arguments are projected onto the resolver's reference set via `MapClrTypeToReferences` before `MakeGenericType` (same load context, mirroring `Binder.BindGenericClrType`).

## Static-member emit on constructed generic user types
- `StructSymbol.CreateConstructed` now carries the definition's static methods/fields/const fields onto the construction (valid under G# type erasure, ADR-0004), so static references resolve on `Box[int32]`.
- Static **property** accessor signatures no longer hard-code `HASTHIS` (`EncodeOpenPropertyAccessorSignature` uses `!property.IsStatic`).
- Static **method** calls on a generic owner are routed through a TypeSpec-parented `MemberRef` (`ResolveUserStaticMethodToken`) via a new `BoundCallExpression.StaticGenericOwnerType`; a bare `MethodDef` token is invalid for a method of a generic type.

## Repros now passing (compile, `/target:library`/`exe`, and run)
- User generic static **field**: `Box[int32].Default` → 42
- User generic static **property**: `Box[int32].Value` → 11
- User generic static **method**: `Box[int32].Make()` → 7
- BCL generics: `ArrayPool[uint8].Shared`, `MemoryPool[uint8].Shared`, `Comparer[int32].Default` (and `.Compare(1,2)` → -1)

## Indexing confirmed still working (no regression)
- Array indexing read/write `a[0] = 99; a[1]`, C-style `for` loop `a[i]`, dictionary `d["a"] = 1; d["a"]` — all bind as element access and run correctly.

## Tests
- New `test/Core.Tests/CodeAnalysis/Binding/Issue1209GenericTypeExprTests.cs` (8 tests): static field/property/method on user generic, BCL `Comparer` static member, plus guard tests that array/dict/variable-subscript indexing still bind as element access and that an unknown generic-type name still reports a diagnostic.
- Core.Tests: **4228 passed**, 1 skipped.
- Extensions.Tests: **104 passed**.
- Compiler.Tests (narrowed `~Generic|~Index`, MaxParallelThreads=2): **274 passed**.
- Full `dotnet build GSharp.sln -c Release -graph`: **0 errors**. Coverage-matrix golden: passes (no new SyntaxKind/BoundNodeKind).