### PR TITLE
Resolve settable prop members in composite literals (Fixes #1211)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundFieldInitializer.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundFieldInitializer.cs
@@ -10,7 +10,11 @@ using GSharp.Core.CodeAnalysis.Symbols;
 namespace GSharp.Core.CodeAnalysis.Binding;
 
 /// <summary>
-/// A single <c>FieldName: value</c> initializer inside a struct composite literal.
+/// A single <c>FieldName: value</c> initializer inside a struct/class composite
+/// literal. The targeted member is either a <see cref="FieldSymbol"/> (a
+/// <c>var</c> member) or, since issue #1211, a settable
+/// <see cref="PropertySymbol"/> (a <c>prop</c> auto-property with a
+/// <c>set</c>/<c>init</c> accessor).
 /// </summary>
 public sealed class BoundFieldInitializer
 {
@@ -20,7 +24,31 @@ public sealed class BoundFieldInitializer
         Value = value;
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BoundFieldInitializer"/>
+    /// class targeting a settable property (issue #1211): an auto-property with
+    /// a <c>set</c> or <c>init</c> accessor. The emitter lowers this to a call
+    /// to the property's setter/init accessor instead of a <c>stfld</c>.
+    /// </summary>
+    /// <param name="property">The targeted property.</param>
+    /// <param name="value">The value to assign.</param>
+    public BoundFieldInitializer(PropertySymbol property, BoundExpression value)
+    {
+        Property = property;
+        Value = value;
+    }
+
+    /// <summary>Gets the targeted field, or <see langword="null"/> when this initializer targets a property.</summary>
     public FieldSymbol Field { get; }
 
+    /// <summary>Gets the targeted property, or <see langword="null"/> when this initializer targets a field.</summary>
+    public PropertySymbol Property { get; }
+
     public BoundExpression Value { get; }
+
+    /// <summary>Gets the name of the targeted member (field or property).</summary>
+    public string MemberName => Field != null ? Field.Name : Property.Name;
+
+    /// <summary>Gets the declared type of the targeted member (field or property).</summary>
+    public TypeSymbol MemberType => Field != null ? Field.Type : Property.Type;
 }

--- a/src/Core/CodeAnalysis/Binding/BoundNodePrinter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundNodePrinter.cs
@@ -1297,7 +1297,7 @@ public static class BoundNodePrinter
             }
 
             var init = node.Initializers[i];
-            writer.WriteIdentifier(init.Field.Name);
+            writer.WriteIdentifier(init.MemberName);
             writer.WritePunctuation(SyntaxKind.ColonToken);
             writer.WriteSpace();
             init.Value.WriteTo(writer);

--- a/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -1447,7 +1447,11 @@ public abstract class BoundTreeRewriter
 
             if (builder != null)
             {
-                builder.Add(newValue == init.Value ? init : new BoundFieldInitializer(init.Field, newValue));
+                builder.Add(newValue == init.Value
+                    ? init
+                    : (init.Field != null
+                        ? new BoundFieldInitializer(init.Field, newValue)
+                        : new BoundFieldInitializer(init.Property, newValue)));
             }
         }
 

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
@@ -515,13 +515,22 @@ internal sealed partial class ExpressionBinder
                 // consistent with Phase 4.1 call-site inference).
                 foreach (var initSyntax in syntax.Initializers)
                 {
-                    if (!TypeMemberModel.TryGetFieldIncludingInherited(structSymbol, initSyntax.FieldIdentifier.Text, MemberQuery.Instance(MemberKinds.Field), out var field, out _))
+                    TypeSymbol memberType;
+                    if (TypeMemberModel.TryGetFieldIncludingInherited(structSymbol, initSyntax.FieldIdentifier.Text, MemberQuery.Instance(MemberKinds.Field), out var field, out _))
+                    {
+                        memberType = field.Type;
+                    }
+                    else if (TypeMemberModel.TryGetProperty(structSymbol, initSyntax.FieldIdentifier.Text, out var property))
+                    {
+                        memberType = property.Type;
+                    }
+                    else
                     {
                         continue;
                     }
 
                     var valueExpr = BindExpression(initSyntax.Value);
-                    Binder.InferTypeArguments(field.Type, valueExpr.Type, substitution);
+                    Binder.InferTypeArguments(memberType, valueExpr.Type, substitution);
                 }
 
                 foreach (var tp in tps)
@@ -567,10 +576,29 @@ internal sealed partial class ExpressionBinder
         foreach (var initSyntax in syntax.Initializers)
         {
             var fieldName = initSyntax.FieldIdentifier.Text;
-            if (!TypeMemberModel.TryGetFieldIncludingInherited(structSymbol, fieldName, MemberQuery.Instance(MemberKinds.Field), out var field, out _))
+
+            // Issue #1211: a composite literal targets `var` fields AND settable
+            // `prop` auto-properties (a property with a `set` or `init`
+            // accessor). Resolve fields first, then fall back to properties so
+            // both `class C { var X int32 }` and `class C { prop X int32 { get;
+            // init; } }` accept `C{X: ...}`.
+            var hasField = TypeMemberModel.TryGetFieldIncludingInherited(structSymbol, fieldName, MemberQuery.Instance(MemberKinds.Field), out var field, out _);
+            PropertySymbol property = null;
+            if (!hasField)
             {
-                Diagnostics.ReportUnableToFindMember(initSyntax.FieldIdentifier.Location, fieldName);
-                continue;
+                if (!TypeMemberModel.TryGetProperty(structSymbol, fieldName, out property))
+                {
+                    Diagnostics.ReportUnableToFindMember(initSyntax.FieldIdentifier.Location, fieldName);
+                    continue;
+                }
+
+                // A get-only property (no `set` and no `init` accessor) cannot
+                // be assigned in a composite literal — keep it diagnosed.
+                if (!property.HasSetter)
+                {
+                    Diagnostics.ReportCannotAssign(initSyntax.FieldIdentifier.Location, fieldName);
+                    continue;
+                }
             }
 
             if (!seenFieldNames.Add(fieldName))
@@ -579,9 +607,12 @@ internal sealed partial class ExpressionBinder
                 continue;
             }
 
+            var memberType = hasField ? field.Type : property.Type;
             var valueExpr = BindExpression(initSyntax.Value);
-            valueExpr = conversions.BindConversion(initSyntax.Value.Location, valueExpr, field.Type);
-            inits.Add(new BoundFieldInitializer(field, valueExpr));
+            valueExpr = conversions.BindConversion(initSyntax.Value.Location, valueExpr, memberType);
+            inits.Add(hasField
+                ? new BoundFieldInitializer(field, valueExpr)
+                : new BoundFieldInitializer(property, valueExpr));
         }
 
         // Issue #948: a value-type (struct / data struct) composite literal

--- a/src/Core/CodeAnalysis/Emit/ClosureEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ClosureEmitter.cs
@@ -462,7 +462,7 @@ internal sealed class ClosureEmitter
                     this.TryAdd(sl.StructType);
                     foreach (var init in sl.Initializers)
                     {
-                        this.TryAdd(init.Field.Type);
+                        this.TryAdd(init.MemberType);
                     }
 
                     break;

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
@@ -1002,6 +1002,18 @@ internal sealed partial class MethodBodyEmitter
 
             foreach (var init in literal.Initializers)
             {
+                // Issue #1211: a `prop` member is set through its setter/init
+                // accessor (`dup; <value>; callvirt set_X`) rather than a stfld.
+                if (init.Property != null)
+                {
+                    var setterHandle = this.ResolveStructLiteralSetter(literal.StructType, init.Property, isGeneric);
+                    this.il.OpCode(ILOpCode.Dup);
+                    this.EmitExpression(init.Value);
+                    this.il.OpCode(ILOpCode.Callvirt);
+                    this.il.Token(setterHandle);
+                    continue;
+                }
+
                 EntityHandle fieldHandle;
                 if (isGeneric)
                 {
@@ -1042,6 +1054,19 @@ internal sealed partial class MethodBodyEmitter
         // For each initializer: ldloca slot; <emit value>; stfld fieldHandle.
         foreach (var init in literal.Initializers)
         {
+            // Issue #1211: a `prop` member on a value type is set through its
+            // setter/init accessor (`ldloca slot; <value>; call set_X`). The
+            // managed-pointer receiver means a non-virtual `call`.
+            if (init.Property != null)
+            {
+                var setterHandle = this.ResolveStructLiteralSetter(literal.StructType, init.Property, isGeneric);
+                this.il.LoadLocalAddress(slot);
+                this.EmitExpression(init.Value);
+                this.il.OpCode(ILOpCode.Call);
+                this.il.Token(setterHandle);
+                continue;
+            }
+
             EntityHandle fieldHandle;
             if (isGeneric)
             {
@@ -1065,6 +1090,27 @@ internal sealed partial class MethodBodyEmitter
 
         // Leave the constructed struct value on the stack.
         this.il.LoadLocal(slot);
+    }
+
+    /// <summary>
+    /// Issue #1211: resolves the setter/init accessor MethodDef (or
+    /// TypeSpec-parented MemberRef for a constructed generic) for a property
+    /// targeted by a composite-literal initializer.
+    /// </summary>
+    private EntityHandle ResolveStructLiteralSetter(StructSymbol structType, PropertySymbol property, bool isGeneric)
+    {
+        if (isGeneric)
+        {
+            return this.outer.ResolveUserPropertyAccessorToken(structType, property, wantSetter: true);
+        }
+
+        if (this.outer.cache.PropertyAccessorHandles.TryGetValue(property, out var handles) && handles.Setter.HasValue)
+        {
+            return handles.Setter.Value;
+        }
+
+        throw new InvalidOperationException(
+            $"Property '{property.Name}' has no emitted setter MethodDef.");
     }
 
     private void EmitNullConditionalAccess(BoundNullConditionalAccessExpression nc)

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -1171,6 +1171,31 @@ public sealed class Evaluator
 
         foreach (var init in node.Initializers)
         {
+            // Issue #1211: a composite-literal entry may target a settable
+            // property. For an auto-property store into its backing field; for
+            // a computed property run the setter body with `this` = sv.
+            if (init.Property != null)
+            {
+                if (init.Property.IsAutoProperty && init.Property.BackingField != null)
+                {
+                    sv.Fields[init.Property.BackingField.Name] = EvaluateExpression(init.Value);
+                }
+                else if (init.Property.SetterSymbol != null && program.Functions.TryGetValue(init.Property.SetterSymbol, out var setterBody))
+                {
+                    var value = EvaluateExpression(init.Value);
+                    var frame = new Dictionary<Symbols.VariableSymbol, object>
+                    {
+                        [init.Property.SetterSymbol.ThisParameter] = sv,
+                        [init.Property.SetterSymbol.Parameters[0]] = value,
+                    };
+                    locals.Push(frame);
+                    EvaluateFunctionBody(setterBody);
+                    locals.Pop();
+                }
+
+                continue;
+            }
+
             sv.Fields[init.Field.Name] = EvaluateExpression(init.Value);
         }
 

--- a/test/Compiler.Tests/Emit/Issue1211CompositeLiteralPropEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1211CompositeLiteralPropEmitTests.cs
@@ -1,0 +1,167 @@
+// <copyright file="Issue1211CompositeLiteralPropEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1211: end-to-end emit tests proving a composite literal
+/// <c>T{Field: value}</c> assigns settable <c>prop</c> auto-property members
+/// by calling the property's setter/init accessor (not a <c>stfld</c>). Each
+/// test compiles via <c>gsc</c>, runs <c>ilverify</c>, executes the produced
+/// assembly, and asserts the property values round-trip — which can only hold
+/// if the setter/init accessor actually ran.
+/// </summary>
+public class Issue1211CompositeLiteralPropEmitTests
+{
+    [Fact]
+    public void ClassCompositeLiteral_GetInitAndGetSetProps_RoundTrip()
+    {
+        var source = """
+            package Probe
+            import System
+
+            class C {
+                prop TrackId int32 { get; init; }
+                prop Name string { get; set }
+                var Count int32
+            }
+
+            var c = C{TrackId: 7, Name: "abc", Count: 5}
+            Console.WriteLine(c.TrackId)
+            Console.WriteLine(c.Name)
+            Console.WriteLine(c.Count)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("7\nabc\n5\n", output);
+    }
+
+    [Fact]
+    public void StructCompositeLiteral_GetInitAndGetSetProps_RoundTrip()
+    {
+        var source = """
+            package Probe
+            import System
+
+            struct P {
+                prop X int32 { get; init; }
+                prop Y int32 { get; set }
+                var Z int32
+            }
+
+            var p = P{X: 1, Y: 2, Z: 3}
+            Console.WriteLine(p.X)
+            Console.WriteLine(p.Y)
+            Console.WriteLine(p.Z)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("1\n2\n3\n", output);
+    }
+
+    [Fact]
+    public void ClassCompositeLiteral_InheritedProperty_RoundTrip()
+    {
+        var source = """
+            package Probe
+            import System
+
+            open class Base {
+                prop Id int32 { get; init; }
+            }
+
+            class Derived : Base {
+                prop Extra int32 { get; set }
+            }
+
+            var d = Derived{Id: 5, Extra: 6}
+            Console.WriteLine(d.Id)
+            Console.WriteLine(d.Extra)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("5\n6\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1211_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+                // ignored
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1211CompositeLiteralPropBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1211CompositeLiteralPropBinderTests.cs
@@ -1,0 +1,120 @@
+// <copyright file="Issue1211CompositeLiteralPropBinderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1211: a composite literal <c>T{Field: value}</c> must resolve and
+/// assign settable <c>prop</c> auto-property members (a property with a
+/// <c>set</c> or an <c>init</c> accessor) — not just <c>var</c> fields. A
+/// get-only property is still not settable, so targeting it stays a diagnostic.
+/// </summary>
+public class Issue1211CompositeLiteralPropBinderTests
+{
+    [Fact]
+    public void CompositeLiteral_GetInitProperty_Binds()
+    {
+        var source = @"
+class C { prop TrackId int32 { get; init; } }
+let c = C{TrackId: 7}
+c.TrackId
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(7, result.Value);
+    }
+
+    [Fact]
+    public void CompositeLiteral_GetSetProperty_Binds()
+    {
+        var source = @"
+class C { prop Count int32 { get; set } }
+let c = C{Count: 9}
+c.Count
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(9, result.Value);
+    }
+
+    [Fact]
+    public void CompositeLiteral_MixedPropAndVar_Binds()
+    {
+        var source = @"
+class E { prop Name int32 { get; set } var Count int32 }
+let e = E{Name: 3, Count: 4}
+e.Name + e.Count
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(7, result.Value);
+    }
+
+    [Fact]
+    public void CompositeLiteral_InheritedProperty_Binds()
+    {
+        var source = @"
+open class Base { prop Id int32 { get; init; } }
+class Derived : Base { prop Extra int32 { get; set } }
+let d = Derived{Id: 5, Extra: 6}
+d.Id + d.Extra
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(11, result.Value);
+    }
+
+    [Fact]
+    public void CompositeLiteral_StructProperty_Binds()
+    {
+        var source = @"
+struct P { prop X int32 { get; init; } prop Y int32 { get; set } var Z int32 }
+let p = P{X: 1, Y: 2, Z: 3}
+p.X + p.Y + p.Z
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(6, result.Value);
+    }
+
+    [Fact]
+    public void CompositeLiteral_GetOnlyProperty_IsDiagnosed()
+    {
+        var source = @"
+class C { prop Ro int32 { get; } }
+let c = C{Ro: 1}
+c.Ro
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Message.Contains("read-only"));
+    }
+
+    [Fact]
+    public void CompositeLiteral_UnknownMember_IsDiagnosed()
+    {
+        var source = @"
+class C { prop Name int32 { get; set } }
+let c = C{Missing: 1}
+c.Name
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Message.Contains("Cannot find member"));
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
## Summary
A composite literal `T{Field: value}` (ADR-0115; C# `new T { Field = value }`) only resolved `var` field members — `prop` auto-property members reported `GS0158: Cannot find member`. Both `{ get; set }` and `{ get; init; }` properties failed. This was the highest-leverage gap blocking the Oahu.Decrypt migration.

## Root cause
- The composite-literal binder (`BindStructLiteralExpression`) resolved each `Field: value` entry **only** via `TypeMemberModel.TryGetFieldIncludingInherited`, so properties were never found.
- The emitter (`EmitStructLiteral`) only knew how to emit `stfld` field stores.

## Bind changes
- Member lookup now falls back to `TypeMemberModel.TryGetProperty` when no `var` field matches.
- A **settable** property (`HasSetter` — i.e. a `set` **or** an `init` accessor) binds to a property-targeted `BoundFieldInitializer`.
- A **get-only** property (`{ get; }`, no set/init) stays diagnosed as read-only (**GS0127**) — not silently allowed.
- An unknown member still reports **GS0158**.
- Generic type-argument inference for `Foo[T]{...}` now also considers property member types.

## Emit changes
- `BoundFieldInitializer` now carries either a `FieldSymbol` **or** a `PropertySymbol` (with `MemberName`/`MemberType` helpers).
- `EmitStructLiteral` lowers a property entry to the property **setter/init accessor** call instead of a `stfld`:
  - class literal: `newobj ctor; (dup; <value>; callvirt set_X)` per prop
  - struct literal: `ldloca slot; <value>; call set_X` per prop (managed-pointer receiver → non-virtual `call`)
- The setter handle is resolved through the same path as `EmitPropertyAssignment` (`PropertyAccessorHandles` / `ResolveUserPropertyAccessorToken` for constructed generics).
- The interpreter (`Evaluator`) stores into the auto-property backing field (or runs the setter body for computed props).

Covered consistently for **class and struct** composite literals, **get/set + get/init** accessors, **mixed prop+var**, and **inherited** properties.

## Repros now passing
```gsharp
class C { prop TrackId uint32 { get; init; } }
class E { prop Name string { get; set } var Count int32 }
func Make()  C { return C{TrackId: uint32(1)} }   // was GS0158, now compiles
func Make3() E { return E{Name: "a", Count: 2} }  // mixed prop+var, now compiles
```

## Tests
- **Core.Tests** — `Issue1211CompositeLiteralPropBinderTests` (7 tests): get/init binds, get/set binds, mixed prop+var, inherited prop, struct prop, **get-only diagnosed (read-only)**, unknown member diagnosed.
- **Compiler.Tests/Emit** — `Issue1211CompositeLiteralPropEmitTests` (3 tests): class get/init+get/set+var, struct get/init+get/set+var, inherited prop — each compiles, runs **ilverify**, executes, and asserts the values **round-trip** (proving the setter/init accessor actually runs).

### Verification
- `dotnet build GSharp.sln -c Release -graph` → 0 errors.
- `dotnet test test/Core.Tests` → 4235 passed.
- `dotnet test test/Extensions.Tests` → 104 passed.
- Narrowed `Compiler.Tests` (`ObjectInitializer|CompositeLiteral|StructLiteral|Issue1211`) → 11 passed.

No new `BoundNodeKind`/`SyntaxKind` or top-level samples, so no coverage-matrix / refactoring-baseline tripwires apply.

Fixes #1211