### PR TITLE
Bind and emit event references for in-type raising (Fixes #1213)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -365,6 +365,30 @@ public sealed class Binder
                                 }
                             }
                         }
+
+                        // Issue #1213: expose a field-like event of the
+                        // *declaring* type as a bare name inside its own method
+                        // bodies, bound to the event's private backing delegate
+                        // field. This lets the canonical raise pattern
+                        // `MyEvent?.Invoke(args)` resolve, exactly as C# compiles
+                        // it to a read of the backing field. Only the type that
+                        // declares the event may raise it (a base class event is
+                        // intentionally not surfaced here), so this is restricted
+                        // to `t == receiverStruct`. A bare `MyEvent += handler`
+                        // still routes to the event-subscription path, which is
+                        // checked first in BindBareEventOrCompoundAssignment.
+                        if (ReferenceEquals(t, receiverStruct) && !t.Events.IsDefaultOrEmpty)
+                        {
+                            foreach (var evt in t.Events)
+                            {
+                                if (evt.IsFieldLike
+                                    && evt.BackingField != null
+                                    && seenMembers.Add(evt.Name))
+                                {
+                                    scope.TryDeclareVariable(new ImplicitFieldVariableSymbol(function.ThisParameter, t, evt.BackingField));
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -857,6 +857,35 @@ internal sealed partial class ExpressionBinder
         type is StructSymbol or EnumSymbol or InterfaceSymbol;
 
     /// <summary>
+    /// Issue #1213: whether the function currently being bound belongs to
+    /// <paramref name="type"/> (or a type derived from it). Used to gate
+    /// in-type resolution of a field-like event to its private backing
+    /// delegate field, matching C# (an event name in expression position is
+    /// only valid inside the declaring type).
+    /// </summary>
+    private bool IsWithinType(StructSymbol type)
+    {
+        if (type == null)
+        {
+            return false;
+        }
+
+        var enclosingType = (this.function?.ReceiverType as StructSymbol)
+            ?? (this.function?.StaticOwnerType as StructSymbol);
+
+        for (var t = enclosingType; t != null; t = t.BaseClass)
+        {
+            if (ReferenceEquals(t, type)
+                || (t.Declaration != null && ReferenceEquals(t.Declaration, type.Declaration)))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Issue #1069: whether <paramref name="name"/> resolves to a user-defined
     /// type whose enclosing type is <paramref name="container"/>.
     /// </summary>
@@ -1024,6 +1053,18 @@ internal sealed partial class ExpressionBinder
         var whenNotNull = BindAccessorStep(captureRef, null, rightPart);
 
         scope = scope.Parent;
+
+        // Issue #1213: a null-conditional invocation whose access produces no
+        // value — the canonical event-raise form `evt?.Invoke(args)` where the
+        // delegate returns `void` — is itself a `void` statement. Do not wrap
+        // `void` in a nullable result type; that would force the emitter to
+        // push a `null` on the nil branch with nothing to match it on the
+        // not-null branch (a stack-imbalance). The emitter special-cases a
+        // `void`-typed null-conditional to a plain null-guarded call.
+        if (ReferenceEquals(whenNotNull.Type, TypeSymbol.Void))
+        {
+            return new BoundNullConditionalAccessExpression(null, receiver, capture, whenNotNull, TypeSymbol.Void, resultSlot: null);
+        }
 
         var resultType = whenNotNull.Type is NullableTypeSymbol ? whenNotNull.Type : (TypeSymbol)NullableTypeSymbol.Get(whenNotNull.Type);
 
@@ -2282,6 +2323,24 @@ internal sealed partial class ExpressionBinder
                         }
 
                         return ApplyMemberNarrowing(new BoundPropertyAccessExpression(null, receiver, structSym, prop));
+                    }
+
+                    // Issue #1213: an `event` member referenced in expression
+                    // position (e.g. `this.MyEvent?.Invoke(args)`) binds to its
+                    // private backing delegate field, mirroring how C# compiles
+                    // a raise of a field-like event to a read of the backing
+                    // field. Restricted to access from inside the declaring type
+                    // (the backing field is private); cross-type reads continue
+                    // to fall through to the existing member-lookup diagnostics
+                    // so the `+=`/`-=` subscription path is unaffected.
+                    if (IsWithinType(structSym))
+                    {
+                        var evt = structSym.Events.FirstOrDefault(e =>
+                            e.Name == ne.IdentifierToken.Text && e.IsFieldLike && e.BackingField != null);
+                        if (evt != null)
+                        {
+                            return ApplyMemberNarrowing(new BoundFieldAccessExpression(null, receiver, structSym, evt.BackingField));
+                        }
                     }
 
                     // Issue #296: a GSharp class inheriting an imported CLR base

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
@@ -1115,6 +1115,25 @@ internal sealed partial class MethodBodyEmitter
 
     private void EmitNullConditionalAccess(BoundNullConditionalAccessExpression nc)
     {
+        // Issue #1213: a `void`-typed null-conditional (e.g. the event-raise
+        // form `evt?.Invoke(args)` where the delegate returns `void`) leaves no
+        // value on the stack. Emit a plain null-guarded access: evaluate the
+        // receiver into the capture, skip the access when null, otherwise run
+        // the (value-less) access. Neither branch pushes a result, so the stack
+        // stays balanced (the generic path below would push a `null` on the nil
+        // branch with no matching value on the not-null branch).
+        if (ReferenceEquals(nc.Type, Symbols.TypeSymbol.Void))
+        {
+            this.EmitExpression(nc.Receiver);
+            this.EmitStoreVariable(nc.Capture);
+            this.EmitLoadVariable(nc.Capture);
+            var endVoid = this.il.DefineLabel();
+            this.il.Branch(ILOpCode.Brfalse, endVoid);
+            this.EmitExpression(nc.WhenNotNull);
+            this.il.MarkLabel(endVoid);
+            return;
+        }
+
         // Phase 3.C.3b / ADR-0001: evaluate the receiver once into a
         // synthetic capture local. If the captured value is null, leave
         // null on the stack and skip the access; otherwise evaluate the

--- a/test/Compiler.Tests/Emit/Issue1213EventInvokeEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1213EventInvokeEmitTests.cs
@@ -1,0 +1,193 @@
+// <copyright file="Issue1213EventInvokeEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1213: an <c>event</c> member declared on a class must be referenceable
+/// in expression position (bare and <c>this.</c>-qualified) inside the declaring
+/// type so the canonical raise pattern <c>MyEvent?.Invoke(args)</c> binds and
+/// emits. Inside the type an event read resolves to its private backing delegate
+/// field; the null-conditional invoke lowers to a null-check plus a delegate
+/// <c>Invoke</c>. These tests prove the emitted IL verifies and runs: a null
+/// backing field makes the raise a safe no-op, and a subscribed handler is
+/// invoked with the raised arguments.
+/// </summary>
+public class Issue1213EventInvokeEmitTests
+{
+    [Fact]
+    public void BareEventRaise_NullBackingField_IsSafeNoOp()
+    {
+        var source = """
+            package MyLib
+
+            class Counter {
+                event Bumped (int32) -> void
+                func Raise(n int32) { Bumped?.Invoke(n) }
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var counterType = assembly.GetTypes().Single(t => t.Name == "Counter");
+        var instance = Activator.CreateInstance(counterType)!;
+
+        // No handler subscribed: the backing delegate field is null, so raising
+        // must be a no-op rather than throwing a NullReferenceException.
+        var raise = counterType.GetMethod("Raise")!;
+        var ex = Record.Exception(() => raise.Invoke(instance, new object[] { 5 }));
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void BareEventRaise_WithHandler_InvokesHandler()
+    {
+        var source = """
+            package MyLib
+
+            class Counter {
+                event Bumped (int32) -> void
+                func Raise(n int32) { Bumped?.Invoke(n) }
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var counterType = assembly.GetTypes().Single(t => t.Name == "Counter");
+        var instance = Activator.CreateInstance(counterType)!;
+
+        int total = 0;
+        var ev = counterType.GetEvent("Bumped")!;
+        Action<int> handler = n => total += n;
+        ev.AddEventHandler(instance, handler);
+
+        counterType.GetMethod("Raise")!.Invoke(instance, new object[] { 7 });
+        Assert.Equal(7, total);
+    }
+
+    [Fact]
+    public void QualifiedEventRaise_WithHandler_InvokesHandler()
+    {
+        var source = """
+            package MyLib
+
+            class Counter {
+                event Bumped (int32) -> void
+                func RaiseQualified(n int32) { this.Bumped?.Invoke(n) }
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var counterType = assembly.GetTypes().Single(t => t.Name == "Counter");
+        var instance = Activator.CreateInstance(counterType)!;
+
+        int total = 0;
+        var ev = counterType.GetEvent("Bumped")!;
+        Action<int> handler = n => total += n;
+        ev.AddEventHandler(instance, handler);
+
+        counterType.GetMethod("RaiseQualified")!.Invoke(instance, new object[] { 3 });
+        Assert.Equal(3, total);
+    }
+
+    [Fact]
+    public void EventNilCheck_ReflectsSubscriptionState()
+    {
+        var source = """
+            package MyLib
+
+            class Counter {
+                event Bumped (int32) -> void
+                func HasSub() bool { return Bumped != nil }
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var counterType = assembly.GetTypes().Single(t => t.Name == "Counter");
+        var instance = Activator.CreateInstance(counterType)!;
+        var hasSub = counterType.GetMethod("HasSub")!;
+
+        Assert.False((bool)hasSub.Invoke(instance, null)!);
+
+        var ev = counterType.GetEvent("Bumped")!;
+        Action<int> handler = _ => { };
+        ev.AddEventHandler(instance, handler);
+
+        Assert.True((bool)hasSub.Invoke(instance, null)!);
+    }
+
+    [Fact]
+    public void MultiArgVoidEventRaise_PassesAllArguments()
+    {
+        var source = """
+            package MyLib
+
+            class Emitter {
+                event Notify (int32, string) -> void
+                func Fire(n int32, s string) { Notify?.Invoke(n, s) }
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var emitterType = assembly.GetTypes().Single(t => t.Name == "Emitter");
+        var instance = Activator.CreateInstance(emitterType)!;
+
+        int seenInt = 0;
+        string seenStr = null;
+        var ev = emitterType.GetEvent("Notify")!;
+        Action<int, string> handler = (n, s) =>
+        {
+            seenInt = n;
+            seenStr = s;
+        };
+        ev.AddEventHandler(instance, handler);
+
+        emitterType.GetMethod("Fire")!.Invoke(instance, new object[] { 42, "hi" });
+        Assert.Equal(42, seenInt);
+        Assert.Equal("hi", seenStr);
+    }
+
+    private static Assembly CompileToAssembly(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1213_emit_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+        IlVerifier.Verify(outPath);
+
+        var bytes = File.ReadAllBytes(outPath);
+        return Assembly.Load(bytes);
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1213EventInvokeBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1213EventInvokeBinderTests.cs
@@ -1,0 +1,119 @@
+// <copyright file="Issue1213EventInvokeBinderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1213: an <c>event</c> member can be declared on a class but could not
+/// be referenced or invoked in expression position. A bare reference reported
+/// <c>GS0125</c> ("Variable 'X' doesn't exist") and a <c>this.</c>-qualified
+/// reference reported <c>GS0158</c> ("Cannot find member"). Inside the declaring
+/// type, an event must bind to its private backing delegate field so the
+/// canonical raise pattern <c>MyEvent?.Invoke(args)</c> resolves and emits.
+/// </summary>
+public class Issue1213EventInvokeBinderTests
+{
+    [Fact]
+    public void BareEventReference_NullConditionalInvoke_Binds()
+    {
+        const string source = """
+            package p
+            class C {
+                event ChapterRead (object?, int32) -> void
+                func Fire(x int32) { ChapterRead?.Invoke(this, x) }
+            }
+            """;
+
+        var diagnostics = Bind(source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0125");
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0158");
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void QualifiedEventReference_NullConditionalInvoke_Binds()
+    {
+        const string source = """
+            package p
+            class C {
+                event ChapterRead (object?, int32) -> void
+                func Fire(x int32) { this.ChapterRead?.Invoke(this, x) }
+            }
+            """;
+
+        var diagnostics = Bind(source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0125");
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0158");
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void EventReference_DirectInvoke_AfterNilCheck_Binds()
+    {
+        const string source = """
+            package p
+            class C {
+                event ChapterRead (object?, int32) -> void
+                func Fire(x int32) {
+                    if ChapterRead != nil {
+                        ChapterRead.Invoke(this, x)
+                    }
+                }
+            }
+            """;
+
+        var diagnostics = Bind(source);
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void VoidDelegateEvent_NoArgs_Binds()
+    {
+        const string source = """
+            package p
+            class C {
+                event Ping () -> void
+                func FirePing() { Ping?.Invoke() }
+            }
+            """;
+
+        var diagnostics = Bind(source);
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void MultiArgEvent_NullConditionalInvoke_Binds()
+    {
+        const string source = """
+            package p
+            class C {
+                event Multi (int32, string, bool) -> void
+                func FireMulti(n int32, s string, b bool) { this.Multi?.Invoke(n, s, b) }
+            }
+            """;
+
+        var diagnostics = Bind(source);
+        Assert.Empty(diagnostics);
+    }
+
+    private static ImmutableArray<GSharp.Core.CodeAnalysis.Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var globalScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+        if (globalScope.Diagnostics.Any())
+        {
+            return globalScope.Diagnostics;
+        }
+
+        var program = Binder.BindProgram(globalScope);
+        return program.Diagnostics.ToImmutableArray();
+    }
+}


### PR DESCRIPTION
Fixes #1213.

## What existed
Field-like `event` members already **declare** correctly on a class: the binder synthesizes a private backing delegate field plus `add_`/`remove_`/(optional) `raise_` accessors and emits the `EventDef`/`EventMap`/`MethodSemantics` rows (ADR-0052). Cross-type `+=`/`-=` subscription works via `BoundEventSubscriptionExpression`.

## The bug
An event could not be **referenced or invoked** in expression position. A bare reference reported `GS0125: Variable 'X' doesn't exist`; a `this.`-qualified reference reported `GS0158: Cannot find member`. So the faithful raise mapping `MyEvent?.Invoke(this, args)` did not bind.

## The read/reference fix
Mirroring how C# compiles a raise of a field-like event to a read of its private backing field, an event referenced **inside its declaring type** now binds to that backing delegate field:

- **Bare name** (`src/Core/CodeAnalysis/Binding/Binder.cs`): the declaring type's field-like events are exposed as implicit `this`-field bare names alongside fields/properties. `+=`/`-=` still routes to the event-subscription path (checked first in `BindBareEventOrCompoundAssignment`), so subscription is unaffected.
- **`this.`-qualified** (`src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs`): the struct-receiver member-access path resolves a field-like event of the type to a backing-field read, gated to in-type access (the backing field is private) via a new `IsWithinType` helper. Cross-type reads fall through to the existing diagnostics.

The backing field's type is the event's declared delegate signature (a `FunctionTypeSymbol`, e.g. `(object?, int32) -> void`), so `?.Invoke(args)`, direct `.Invoke(args)`, and `!= nil` resolve through the existing delegate machinery.

## Emit lowering fix
Raising a `void` event (`evt?.Invoke(args)`) exposed a pre-existing stack-imbalance in the null-conditional lowering: the generic path pushed `ldnull` on the nil branch with no matching value on the not-null branch (the `Invoke` returns `void`). The binder now types a value-less null-conditional as `void`, and `EmitNullConditionalAccess` special-cases it to a plain null-guarded call (`MethodBodyEmitter.Expressions.cs`). The emitted IL now passes `IlVerifier`/`ilverify`.

## Scope covered
In-type raising: `evt?.Invoke(args)` (bare and `this.`-qualified), direct `evt.Invoke(args)` after a `!= nil` guard, and `evt != nil` — for `void` and multi-arg delegate events. Cross-type `+=`/`-=` subscription is unchanged.

## Repros (now compile, `/target:library`)
```gsharp
package p
class C {
    event ChapterRead (object?, int32) -> void
    func Fire(x int32) { ChapterRead?.Invoke(this, x) }       // was GS0125
    func Fire2(x int32) { this.ChapterRead?.Invoke(this, x) } // was GS0158
}
```

## Tests
- `test/Core.Tests/CodeAnalysis/Binding/Issue1213EventInvokeBinderTests.cs` — 5 binder tests (bare + qualified reference, direct invoke after nil-check, void no-arg, multi-arg) assert clean binding.
- `test/Compiler.Tests/Emit/Issue1213EventInvokeEmitTests.cs` — 5 emit/execution tests prove the IL verifies, a null backing field makes the raise a safe no-op, and a subscribed handler is invoked with the raised arguments (bare + qualified + multi-arg), and `!= nil` reflects subscription state.

No new `SyntaxKind`/`BoundNodeKind` and no new top-level samples, so coverage-matrix and refactoring baselines are untouched.

## Verification
- `dotnet build GSharp.sln -c Release -graph` — 0 errors.
- Standalone `gsc` compiles both repros, void and multi-arg events; emitted IL passes `ilverify`.
- `dotnet test test/Core.Tests` — 4244 passed, 1 skipped.
- `dotnet test test/Extensions.Tests` — 104 passed.
- `dotnet test test/Compiler.Tests --filter Event|Issue1213|Delegate|NullConditional` — 92 passed.
