### PR TITLE
Bind `?` on an array clause to the element type (Fixes #1212)

### DIFF
--- a/docs/adr/0084-gsharp-extensions-optional-sequences.md
+++ b/docs/adr/0084-gsharp-extensions-optional-sequences.md
@@ -215,7 +215,7 @@ hatch under `src/Sdk/Gsharp.Extensions/*.cs` works today.
   combinations are recognised by the parser and the function
   retains its extension-method status. The binder + emit pipeline
   also accept call-site dispatch when the receiver is *closed*
-  (concrete) — `string?`, `(int32, string)`, `[]int32?`,
+  (concrete) — `string?`, `(int32, string)`, `([]int32)?`,
   `map[string,int32]`. **Binder-side closed by
   [issue #773](https://github.com/DavidObando/gsharp/issues/773).**
   `BoundScope.TryLookupExtensionFunction` now falls back to

--- a/samples/NullConditionalIndexing.gs
+++ b/samples/NullConditionalIndexing.gs
@@ -12,12 +12,12 @@ import System.Collections.Generic
 
 var calls int32 = 0
 
-func bump() []int32? {
+func bump() ([]int32)? {
     calls = calls + 1
     return []int32{7, 8, 9}
 }
 
-func nilBump() []int32? {
+func nilBump() ([]int32)? {
     calls = calls + 1
     return nil
 }
@@ -25,11 +25,11 @@ func nilBump() []int32? {
 func main() {
     // 1. Slice receiver. The first read indexes a live slice; the second
     // reads through a nil slice and short-circuits to nil.
-    var live []int32? = []int32{10, 20, 30}
+    var live ([]int32)? = []int32{10, 20, 30}
     var first = live?[1]
     Console.WriteLine(first)
 
-    var missing []int32? = nil
+    var missing ([]int32)? = nil
     var firstMissing = missing?[0]
     if firstMissing == nil {
         Console.WriteLine("nil-slice")

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -2148,6 +2148,16 @@ public sealed class Binder
         if (syntax.IsTuple)
         {
             // Phase 4.5: tuple type clause `(T1, T2, ...)`.
+            // Issue #1212: a *single* parenthesized type `(T)` is a grouping,
+            // not a tuple. It exists so a nullable array reference can be
+            // spelled `([]T)?` — the parentheses bind the array shape before
+            // the outer `?` (applied by BindTypeClause) wraps the whole array
+            // in a NullableTypeSymbol. Bind the lone element and return it.
+            if (syntax.TupleElements.Count == 1)
+            {
+                return BindTypeClause(syntax.TupleElements[0]);
+            }
+
             if (syntax.TupleElements.Count < 2)
             {
                 Diagnostics.ReportUnexpectedToken(syntax.CloseParenToken.Location, syntax.CloseParenToken.Kind, SyntaxKind.IdentifierToken);
@@ -2506,6 +2516,18 @@ public sealed class Binder
             return element;
         }
 
+        // Issue #1212: a trailing `?` on an array/slice clause (`[]T?`,
+        // `[N]T?`) binds to the *element* type, yielding an array whose
+        // elements are nullable (`Slice(Nullable(T))` / `Array(Nullable(T))`).
+        // This is orthogonal to a *nullable array reference* (the whole array
+        // possibly nil), which is spelled `([]T)?` and handled by the outer
+        // `NullableTypeSymbol` wrap in BindTypeClause. Element-nullable arrays
+        // remain indexable (the array itself is non-nil), reading/writing `T?`.
+        if (syntax.IsNullable)
+        {
+            element = NullableTypeSymbol.Get(element);
+        }
+
         if (syntax.IsSlice)
         {
             return SliceTypeSymbol.Get(element);
@@ -2524,6 +2546,15 @@ public sealed class Binder
     {
         var bound = BindNonNullableTypeClause(syntax);
         if (bound == null || !syntax.IsNullable)
+        {
+            return bound;
+        }
+
+        // Issue #1212: for an array/slice clause the trailing `?` is consumed
+        // by ApplyArraySuffix and applied to the element type; do not also wrap
+        // the whole array. Every other clause shape (`T?`, `map[K,V]?`,
+        // `chan T?`, the parenthesized `([]T)?` group, …) wraps the whole type.
+        if (syntax.IsArray)
         {
             return bound;
         }

--- a/src/Core/CodeAnalysis/Symbols/ArrayTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ArrayTypeSymbol.cs
@@ -21,7 +21,7 @@ public sealed class ArrayTypeSymbol : TypeSymbol
     private static readonly ConcurrentDictionary<(TypeSymbol Element, int Length), ArrayTypeSymbol> Cache = new();
 
     private ArrayTypeSymbol(TypeSymbol elementType, int length)
-        : base($"[{length}]{elementType.Name}", elementType.ClrType?.MakeArrayType())
+        : base($"[{length}]{elementType.Name}", NullableLifting.GetEffectiveClrType(elementType)?.MakeArrayType())
     {
         ElementType = elementType;
         Length = length;

--- a/src/Core/CodeAnalysis/Symbols/SliceTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/SliceTypeSymbol.cs
@@ -25,7 +25,7 @@ public sealed class SliceTypeSymbol : TypeSymbol
     private static readonly ConcurrentDictionary<TypeSymbol, SliceTypeSymbol> Cache = new();
 
     private SliceTypeSymbol(TypeSymbol elementType)
-        : base($"[]{elementType.Name}", elementType.ClrType?.MakeArrayType())
+        : base($"[]{elementType.Name}", NullableLifting.GetEffectiveClrType(elementType)?.MakeArrayType())
     {
         ElementType = elementType;
     }

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -7350,6 +7350,29 @@ public class Parser
         }
 
         var elementType = MatchToken(SyntaxKind.IdentifierToken);
+
+        // Issue #1212: an element-nullable array literal `[]T?{ … }` /
+        // `[N]T?{ … }`. The `?` binds to the element identifier, so route the
+        // element through a nullable-suffixed type clause (mirroring the
+        // nested-element path) instead of the bare-identifier fast path.
+        if (Current.Kind == SyntaxKind.QuestionToken)
+        {
+            var questionToken = MatchToken(SyntaxKind.QuestionToken);
+            var elementClause = new TypeClauseSyntax(syntaxTree, openBracketToken: null, lengthToken: null, closeBracketToken: null, elementType, questionToken);
+            var nullableOpenBrace = MatchToken(SyntaxKind.OpenBraceToken);
+            var nullableElements = ParseArrayInitializerElements();
+            var nullableCloseBrace = MatchToken(SyntaxKind.CloseBraceToken);
+            return new ArrayCreationExpressionSyntax(
+                syntaxTree,
+                openBracket,
+                length,
+                closeBracket,
+                elementClause,
+                nullableOpenBrace,
+                nullableElements,
+                nullableCloseBrace);
+        }
+
         var openBrace = MatchToken(SyntaxKind.OpenBraceToken);
         var elements = ParseArrayInitializerElements();
         var closeBrace = MatchToken(SyntaxKind.CloseBraceToken);

--- a/test/Compiler.Tests/Emit/Issue1154NullableWideningOverloadEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1154NullableWideningOverloadEmitTests.cs
@@ -16,7 +16,7 @@ namespace GSharp.Compiler.Tests.Emit;
 /// overload that needs an implicit nullable-widening conversion (T → T?) when
 /// a second, wholly non-applicable overload (e.g. <c>F(string)</c>) also
 /// exists — without a spurious GS0266 ambiguity. This test proves the selected
-/// <c>F([]uint8?)</c> overload actually runs: a non-null array argument flows
+/// <c>F(([]uint8)?)</c> overload actually runs: a non-null array argument flows
 /// into the nullable-array overload body and produces its distinctive output.
 /// </summary>
 public class Issue1154NullableWideningOverloadEmitTests
@@ -32,7 +32,7 @@ public class Issue1154NullableWideningOverloadEmitTests
             class C {
                 shared { func Make() []uint8 { var r = []uint8{uint8(10), uint8(20), uint8(30)} return r } }
                 func F(a string) string { return "string-overload" }
-                func F(a []uint8?) string {
+                func F(a ([]uint8)?) string {
                     if a == nil { return "null" }
                     return "bytes-overload:" + a.Length.ToString()
                 }

--- a/test/Compiler.Tests/Emit/Issue1212NullableElementArrayIndexEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1212NullableElementArrayIndexEmitTests.cs
@@ -1,0 +1,160 @@
+// <copyright file="Issue1212NullableElementArrayIndexEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1212 — emit/execution coverage for indexing an array/slice whose
+/// element type is nullable (<c>[]T?</c>). Each test compiles via in-process
+/// <c>gsc</c>, IL-verifies the emitted PE, and runs it under <c>dotnet exec</c>,
+/// asserting captured stdout. Both a nullable *value*-element array
+/// (<c>[]int32?</c>, backed by <c>Nullable&lt;int32&gt;[]</c>) and a nullable
+/// *reference*-element array (<c>[]object?</c>, backed by <c>object[]</c>) are
+/// written (including a nil and a value) and read back, proving the emitted
+/// <c>ldelem</c>/<c>stelem</c> round-trip the nullable element correctly.
+/// </summary>
+public class Issue1212NullableElementArrayIndexEmitTests
+{
+    [Fact]
+    public void NullableValueElementSlice_WriteReadRoundTrips()
+    {
+        var source = """
+            package Test
+            import System
+
+            func main() {
+                var a []int32? = []int32?{nil, 7, nil}
+                a[0] = 42
+                if a[0] == nil { Console.WriteLine("nil") } else { Console.WriteLine(a[0]!!) }
+                if a[1] == nil { Console.WriteLine("nil") } else { Console.WriteLine(a[1]!!) }
+                if a[2] == nil { Console.WriteLine("nil") } else { Console.WriteLine(a[2]!!) }
+            }
+
+            main()
+            """;
+
+        Assert.Equal("42\n7\nnil\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void NullableReferenceElementSlice_WriteReadRoundTrips()
+    {
+        var source = """
+            package Test
+            import System
+
+            func main() {
+                var a []object? = []object?{nil, "hi"}
+                a[0] = "set"
+                if a[0] == nil { Console.WriteLine("nil") } else { Console.WriteLine(a[0]!!) }
+                if a[1] == nil { Console.WriteLine("nil") } else { Console.WriteLine(a[1]!!) }
+            }
+
+            main()
+            """;
+
+        Assert.Equal("set\nhi\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void NullableValueElementSlice_WriteNil_ReadsBackNil()
+    {
+        var source = """
+            package Test
+            import System
+
+            func main() {
+                var a []int32? = []int32?{1, 2, 3}
+                a[1] = nil
+                Console.WriteLine(a.Length)
+                if a[1] == nil {
+                    Console.WriteLine("cleared")
+                } else {
+                    Console.WriteLine("kept")
+                }
+                Console.WriteLine(a[2]!!)
+            }
+
+            main()
+            """;
+
+        Assert.Equal("3\ncleared\n3\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1212_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed (exit {compileExit}):\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"sample exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue710NullConditionalIndexingEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue710NullConditionalIndexingEmitTests.cs
@@ -27,7 +27,7 @@ public class Issue710NullConditionalIndexingEmitTests
             import System
 
             func main() {
-                var a []int32? = nil
+                var a ([]int32)? = nil
                 var x = a?[0]
                 if x == nil {
                     Console.WriteLine("nil")
@@ -50,7 +50,7 @@ public class Issue710NullConditionalIndexingEmitTests
             import System
 
             func main() {
-                var a []int32? = []int32{10, 20, 30}
+                var a ([]int32)? = []int32{10, 20, 30}
                 var x = a?[1]
                 Console.WriteLine(x)
             }
@@ -149,12 +149,12 @@ public class Issue710NullConditionalIndexingEmitTests
             var receiverCalls int32 = 0
             var indexCalls int32 = 0
 
-            func getSlice() []int32? {
+            func getSlice() ([]int32)? {
                 receiverCalls = receiverCalls + 1
                 return []int32{7, 8, 9}
             }
 
-            func getNilSlice() []int32? {
+            func getNilSlice() ([]int32)? {
                 receiverCalls = receiverCalls + 1
                 return nil
             }
@@ -197,7 +197,7 @@ public class Issue710NullConditionalIndexingEmitTests
             import System
 
             class Holder {
-                var Data []int32?
+                var Data ([]int32)?
             }
 
             func main() {

--- a/test/Compiler.Tests/Emit/Issue751RichReceiverEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue751RichReceiverEmitTests.cs
@@ -68,7 +68,7 @@ public class Issue751RichReceiverEmitTests
             package P
             import System
 
-            func (self []int32?) FirstOrZero() int32 {
+            func (self ([]int32)?) FirstOrZero() int32 {
                 if self == nil {
                     return 0
                 }
@@ -78,8 +78,8 @@ public class Issue751RichReceiverEmitTests
                 return self[0]
             }
 
-            var present []int32? = []int32{10, 20}
-            var absent []int32? = nil
+            var present ([]int32)? = []int32{10, 20}
+            var absent ([]int32)? = nil
             Console.WriteLine(present.FirstOrZero())
             Console.WriteLine(absent.FirstOrZero())
             """;

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1154NullableWideningOverloadTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1154NullableWideningOverloadTests.cs
@@ -31,14 +31,14 @@ public class Issue1154NullableWideningOverloadTests
     [Fact]
     public void Repro_NullableWidening_UniqueApplicable_BindsWithoutGS0266()
     {
-        // REPRO: F(string), F([]uint8?); arg is non-nullable []uint8.
-        // Only F([]uint8?) is applicable ([]uint8 -> []uint8? implicit widening).
+        // REPRO: F(string), F(([]uint8)?); arg is non-nullable []uint8.
+        // Only F(([]uint8)?) is applicable ([]uint8 -> ([]uint8)? implicit widening).
         const string source = @"
 package p
 class C {
     shared { func Make() []uint8 { var r []uint8 return r } }
     func F(a string) { F(C.Make()) }
-    func F(a []uint8?) { var n = 1 }
+    func F(a ([]uint8)?) { var n = 1 }
 }
 ";
         var compilation = Compile(source);
@@ -78,12 +78,12 @@ class C {
     [Fact]
     public void VariantB_NullableWideningOnly_StillBinds()
     {
-        // F([]uint8?) only; arg []uint8 -> nullable widening applicable.
+        // F(([]uint8)?) only; arg []uint8 -> nullable widening applicable.
         const string source = @"
 package p
 class C {
     shared { func Make() []uint8 { var r []uint8 return r } }
-    func F(a []uint8?) { F(C.Make()) }
+    func F(a ([]uint8)?) { F(C.Make()) }
 }
 ";
         var compilation = Compile(source);
@@ -100,13 +100,13 @@ class C {
     [Fact]
     public void VariantC_ExactNullableMatch_StillBinds()
     {
-        // F(string), F([]uint8?); arg is []uint8? -> exact match to T?.
+        // F(string), F(([]uint8)?); arg is ([]uint8)? -> exact match to T?.
         const string source = @"
 package p
 class C {
-    shared { func Make() []uint8? { var r []uint8? return r } }
+    shared { func Make() ([]uint8)? { var r ([]uint8)? return r } }
     func F(a string) { F(C.Make()) }
-    func F(a []uint8?) { var n = 1 }
+    func F(a ([]uint8)?) { var n = 1 }
 }
 ";
         var compilation = Compile(source);

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1212NullableElementArrayIndexTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1212NullableElementArrayIndexTests.cs
@@ -1,0 +1,127 @@
+// <copyright file="Issue1212NullableElementArrayIndexTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1212: indexing an array/slice whose *element* type is nullable
+/// (<c>[]T?</c> / <c>[N]T?</c>) must bind as ordinary element access yielding
+/// <c>T?</c> (read) and accepting <c>T?</c> (write). The trailing <c>?</c>
+/// binds to the element, leaving the array itself non-nil and indexable. A
+/// genuinely nullable array reference (the whole array possibly nil) is spelled
+/// <c>([]T)?</c> and still requires a null check (<c>!!</c>) before indexing.
+/// </summary>
+public class Issue1212NullableElementArrayIndexTests
+{
+    [Fact]
+    public void NullableReferenceElementSlice_IsIndexable_ForRead()
+    {
+        var diagnostics = Bind("""
+            package p
+            func F(a []object?) object? { return a[0] }
+            """);
+        Assert.Empty(diagnostics.Where(d => d.IsError));
+    }
+
+    [Fact]
+    public void NullableValueElementSlice_IsIndexable_ForRead()
+    {
+        var diagnostics = Bind("""
+            package p
+            func G(a []int32?) int32? { return a[0] }
+            """);
+        Assert.Empty(diagnostics.Where(d => d.IsError));
+    }
+
+    [Fact]
+    public void NonNullableElementSlice_StillIndexable()
+    {
+        var diagnostics = Bind("""
+            package p
+            func H(a []object) object { return a[0] }
+            """);
+        Assert.Empty(diagnostics.Where(d => d.IsError));
+    }
+
+    [Fact]
+    public void NullableElementSlice_IndexResult_IsNullableElementType()
+    {
+        // `a[0]` on `[]int32?` yields `int32?`; assigning it to a non-nullable
+        // `int32` return must be rejected, proving the read result is nullable.
+        var diagnostics = Bind("""
+            package p
+            func F(a []int32?) int32 { return a[0] }
+            """);
+        Assert.Contains(diagnostics, d => d.IsError);
+    }
+
+    [Fact]
+    public void NullableElementSlice_IndexedWrite_AcceptsNullableElement()
+    {
+        var diagnostics = Bind("""
+            package p
+            func W(a []object?, x object?) { a[0] = x }
+            func V(a []int32?, x int32?) { a[0] = x }
+            """);
+        Assert.Empty(diagnostics.Where(d => d.IsError));
+    }
+
+    [Fact]
+    public void NullableElementFixedArray_IsIndexable()
+    {
+        var diagnostics = Bind("""
+            package p
+            func F(a [3]int32?) int32? { return a[0] }
+            """);
+        Assert.Empty(diagnostics.Where(d => d.IsError));
+    }
+
+    [Fact]
+    public void WholeNullableArray_RequiresNullCheck_BeforeIndexing()
+    {
+        // `([]int32)?` is a nullable array *reference*; indexing it directly is
+        // rejected with GS0116 (the array may be nil).
+        var diagnostics = Bind("""
+            package p
+            func F(a ([]int32)?) int32 { return a[0] }
+            """);
+        Assert.Contains(diagnostics, d => d.Id == "GS0116");
+    }
+
+    [Fact]
+    public void WholeNullableArray_IsIndexable_AfterNullForgiving()
+    {
+        var diagnostics = Bind("""
+            package p
+            func F(a ([]int32)?) int32 { return a!![0] }
+            """);
+        Assert.Empty(diagnostics.Where(d => d.IsError));
+    }
+
+    private static ImmutableArray<Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        if (tree.Diagnostics.Any(d => d.IsError))
+        {
+            return tree.Diagnostics;
+        }
+
+        var globalScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+        if (globalScope.Diagnostics.Any(d => d.IsError))
+        {
+            return globalScope.Diagnostics;
+        }
+
+        var program = Binder.BindProgram(globalScope);
+        return program.Diagnostics.ToImmutableArray();
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue710NullConditionalIndexingBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue710NullConditionalIndexingBindingTests.cs
@@ -28,7 +28,7 @@ public class Issue710NullConditionalIndexingBindingTests
         var diagnostics = Bind("""
             package P
             func F() {
-                var a []int32? = nil
+                var a ([]int32)? = nil
                 var x = a?[0]
             }
             """);
@@ -52,12 +52,12 @@ public class Issue710NullConditionalIndexingBindingTests
     [Fact]
     public void Result_Is_Nullable_Form_Of_Element_Type()
     {
-        // `a?[0]` where a is `[]int32?` (slice of int32, nullable slice)
+        // `a?[0]` where a is `([]int32)?` (slice of int32, nullable slice)
         // should give `int32?` for the read result.
         var program = BindProgramFor("""
             package P
             func F() int32? {
-                var a []int32? = nil
+                var a ([]int32)? = nil
                 return a?[0]
             }
             """);
@@ -72,7 +72,7 @@ public class Issue710NullConditionalIndexingBindingTests
         var diagnostics = Bind("""
             package P
             class Holder {
-                var Data []int32?
+                var Data ([]int32)?
             }
             func F() {
                 var h Holder? = Holder{Data: []int32{1, 2, 3}}
@@ -115,7 +115,7 @@ public class Issue710NullConditionalIndexingBindingTests
         var diagnostics = Bind("""
             package P
             func F() {
-                var a []int32? = nil
+                var a ([]int32)? = nil
                 a?[0] = 1
             }
             """);
@@ -128,7 +128,7 @@ public class Issue710NullConditionalIndexingBindingTests
         var diagnostics = Bind("""
             package P
             func F() {
-                var a []int32? = nil
+                var a ([]int32)? = nil
                 a?[0] += 1
             }
             """);
@@ -143,7 +143,7 @@ public class Issue710NullConditionalIndexingBindingTests
         var diagnostics = Bind("""
             package P
             func F() {
-                var a []int32? = nil
+                var a ([]int32)? = nil
                 a?[0] ??= 1
             }
             """);

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue751RichReceiverBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue751RichReceiverBinderTests.cs
@@ -82,7 +82,7 @@ p.Tag() + ""|"" + q.Tag()
     public void NullableArray_Receiver_Dispatches_Via_DotSyntax()
     {
         var source = @"
-func (self []int32?) FirstOrZero() int32 {
+func (self ([]int32)?) FirstOrZero() int32 {
     if self == nil {
         return 0
     }
@@ -92,8 +92,8 @@ func (self []int32?) FirstOrZero() int32 {
     return self[0]
 }
 
-var present []int32? = []int32{10, 20}
-var absent []int32? = nil
+var present ([]int32)? = []int32{10, 20}
+var absent ([]int32)? = nil
 present.FirstOrZero() + absent.FirstOrZero()
 ";
         var result = Evaluate(source);

--- a/test/Interpreter.Tests/Issue710NullConditionalIndexingInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue710NullConditionalIndexingInterpreterTests.cs
@@ -22,7 +22,7 @@ public class Issue710NullConditionalIndexingInterpreterTests
     public void Slice_NullReceiver_YieldsNil()
     {
         var source = """
-            var a []int32? = nil
+            var a ([]int32)? = nil
             var x = a?[0]
             if x == nil {
                 Console.WriteLine("nil")
@@ -39,7 +39,7 @@ public class Issue710NullConditionalIndexingInterpreterTests
     public void Slice_NonNullReceiver_YieldsLiftedValue()
     {
         var source = """
-            var a []int32? = []int32{10, 20, 30}
+            var a ([]int32)? = []int32{10, 20, 30}
             var x = a?[1]
             Console.WriteLine(x)
             """;
@@ -107,12 +107,12 @@ public class Issue710NullConditionalIndexingInterpreterTests
             var receiverCalls int32 = 0
             var indexCalls int32 = 0
 
-            func getSlice() []int32? {
+            func getSlice() ([]int32)? {
                 receiverCalls = receiverCalls + 1
                 return []int32{7, 8, 9}
             }
 
-            func getNilSlice() []int32? {
+            func getNilSlice() ([]int32)? {
                 receiverCalls = receiverCalls + 1
                 return nil
             }
@@ -153,7 +153,7 @@ public class Issue710NullConditionalIndexingInterpreterTests
     {
         var source = """
             class Holder {
-                var Data []int32?
+                var Data ([]int32)?
             }
 
             func main() {

--- a/test/Interpreter.Tests/Issue751RichReceiverInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue751RichReceiverInterpreterTests.cs
@@ -53,7 +53,7 @@ public class Issue751RichReceiverInterpreterTests
     public void NullableArray_Receiver_Dispatches()
     {
         var source = """
-            func (self []int32?) FirstOrZero() int32 {
+            func (self ([]int32)?) FirstOrZero() int32 {
                 if self == nil {
                     return 0
                 }
@@ -63,8 +63,8 @@ public class Issue751RichReceiverInterpreterTests
                 return self[0]
             }
 
-            var present []int32? = []int32{10, 20}
-            var absent []int32? = nil
+            var present ([]int32)? = []int32{10, 20}
+            var absent ([]int32)? = nil
             Console.WriteLine(present.FirstOrZero())
             Console.WriteLine(absent.FirstOrZero())
             """;


### PR DESCRIPTION
Fixes #1212.

## Root cause
Indexing an array/slice whose element type is nullable (`[]T?`, `[N]T?`) was rejected with `GS0116: Type '[]T?' is not indexable`. When binding a type clause, the trailing `?` on an array clause was applied to the **whole array** (producing `Nullable(Slice(T))`), not to the element. The index-expression element-type resolver (`GetIndexElementType`) unwraps slice/array symbols, so it saw a `NullableTypeSymbol` wrapper instead of a slice/array and returned `null` → GS0116. Both nullable reference-element (`[]object?`) and nullable value-element (`[]int32?`) arrays were affected; `[]T` indexed fine.

## The fix — indexability of nullable element types
- **`?` on an array/slice clause binds to the element.** `ApplyArraySuffix` now wraps the element in `NullableTypeSymbol` before building the slice/array, yielding `Slice(Nullable(T))` / `Array(Nullable(T))`. `BindTypeClause` no longer double-wraps the whole array for array clauses. The element being nullable is now orthogonal to the array's indexability.
- **Result/element type.** `GetIndexElementType` returns the slice/array element, now `T?`, so `a[i]` **reads** `T?` and **writes** `T?` — exactly as `[]T` reads/writes `T`.
- **Whole-nullable-array guard preserved.** A genuinely nullable array *reference* (the whole array possibly nil) is spelled `([]T)?` and still reports `GS0116` on a bare `a[i]`, requiring `!!` (or `?[`) first. A single parenthesized type `(T)` is now treated as a **grouping** (it previously errored as a 1-tuple), so `([]T)?` parses and binds to `Nullable(Slice(T))`.
- **Backing CLR type.** `SliceTypeSymbol`/`ArrayTypeSymbol` build their array CLR type from the *effective* element type, so `[]int32?` is `Nullable<int32>[]` (holds nil value elements) while `[]object?` stays `object[]`.
- **Literals.** The composite-array-literal parser accepts a trailing `?` on the element (`[]T?{ … }`).

## Emit round-trip
Indexing `[]T?` emits the same `ldelem`/`stelem` as `[]T`, with the element type being the nullable representation: `Nullable<int32>` (a struct → typed `ldelem`/`stelem`) for value elements, and `object` (`ldelem.ref`/`stelem.ref`) for reference elements. A new emit/execution test builds `[]int32?` and `[]object?`, writes elements (including a nil and a value), reads them back, and asserts the values round-trip; IL is verified with `IlVerifier.Verify`.

## Read + write
- read: `func F(a []object?) object? { return a[0] }`, `func G(a []int32?) int32? { return a[0] }`
- write: `a[0] = x` where `a : []T?`, `x : T?`
- `([]T)?` still needs `!!`: bare `a[0]` → GS0116; `a!![0]` compiles.

## Tests
- **Binder** (`Issue1212NullableElementArrayIndexTests`, 8 tests): `[]T?` indexable yielding `T?` (ref + value), non-nullable `[]T` still works, read result is nullable, indexed write accepts `T?`, `[N]T?` indexable, `([]T)?` needs `!!`.
- **Emit/execution** (`Issue1212NullableElementArrayIndexEmitTests`, 3 tests): nullable value- and reference-element slices write/read round-trip, including writing nil.
- Migrated existing nullable-*slice* usages (#710 / #751 / #1154 tests + `samples/NullConditionalIndexing.gs`) to the `([]T)?` spelling.
- Full Core.Tests (4252), Extensions.Tests (104), Interpreter.Tests (321), narrowed Compiler.Tests (`Array|Index|Nullable|Issue1212`, 364), and `GSharp.sln -graph` all green.
