### PR TITLE
Construct generic classes with explicit init constructors (Fixes #1214)

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -190,7 +190,7 @@ Issue #306 covers user class constructor flow — explicit `init(...)` construct
 | GS0214 | Error | Class `{base}` has no accessible constructor that takes `{N}` argument(s). | `init() : base(1, 2)` when the base only declares `init()`. |
 | GS0215 | Error | Class `{name}` cannot declare both a primary constructor and an explicit `init` constructor. | `class Customer(id int32) { init(name string) { } }`. |
 | GS0216 | Error | Class `{name}` declares multiple `init` constructors; only a single explicit constructor is supported. | Two `init(...)` declarations in the same class body. |
-| GS0217 | Error | Generic class `{name}` with an explicit `init` constructor cannot be constructed; generic explicit constructors are not supported. | `class Box[T] { init(x T) { } }` then `Box[int32](42)`. |
+| GS0217 | _Retired_ | Previously: generic class with an explicit `init` constructor cannot be constructed. Generic classes with explicit `init(...)` constructors are now supported (issue #1214); this diagnostic is no longer emitted. | — |
 
 ### Delegate conversion diagnostics (GS0218)
 

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -1994,10 +1994,22 @@ internal sealed class OverloadResolver
     /// </summary>
     private BoundExpression BindExplicitConstructorCallExpression(CallExpressionSyntax syntax, StructSymbol classType)
     {
+        // Issue #1214: a generic class declaring an explicit `init(...)`
+        // constructor is constructed at a closed type (`Box[int32](5, "x")`).
+        // Resolve the type arguments — supplied explicitly or inferred from the
+        // value arguments against the constructor's parameter list — and close
+        // the definition before binding. The closed type's explicit
+        // constructor surfaces through EffectiveExplicitConstructors (the open
+        // definition's constructor table), with parameter types substituted via
+        // GetConstructorParameterTypesForConstruction; the emitter references
+        // the `.ctor` through a MemberRef parented at the construction's
+        // TypeSpec (ResolveUserCtorTokenForExplicit).
         if (syntax.TypeArgumentList != null || classType.IsGenericDefinition)
         {
-            Diagnostics.ReportGenericExplicitConstructorUnsupported(syntax.Identifier.Location, classType.Name);
-            return new BoundErrorExpression(syntax);
+            if (!TryCloseGenericExplicitConstructorType(syntax, classType, out classType))
+            {
+                return new BoundErrorExpression(syntax);
+            }
         }
 
         // Issue #343: pre-validate named-argument layout (positional precedes
@@ -2011,7 +2023,9 @@ internal sealed class OverloadResolver
         // bind the arguments first, then pick the constructor whose signature
         // best matches the call. With a single constructor the existing
         // single-overload diagnostics (wrong arity) still fire below.
-        var ctorOverloads = classType.ExplicitConstructors;
+        // Issue #1214: for a closed generic construction, the constructor table
+        // lives on the open definition (EffectiveExplicitConstructors).
+        var ctorOverloads = classType.EffectiveExplicitConstructors;
         var boundArgumentsBuilder = ImmutableArray.CreateBuilder<BoundExpression>(syntax.Arguments.Count);
         for (var ai = 0; ai < syntax.Arguments.Count; ai++)
         {
@@ -2037,7 +2051,7 @@ internal sealed class OverloadResolver
         ConstructorSymbol selectedCtor;
         if (ctorOverloads.Length <= 1)
         {
-            selectedCtor = classType.ExplicitConstructor;
+            selectedCtor = ctorOverloads.Length == 1 ? ctorOverloads[0] : classType.ExplicitConstructor;
         }
         else
         {
@@ -2080,6 +2094,13 @@ internal sealed class OverloadResolver
         }
 
         var parameters = selectedCtor.Parameters;
+
+        // Issue #1214: for a closed generic construction, surface the
+        // constructor's parameter types with the construction's type arguments
+        // substituted (`init(v T)` on `Box[int32]` → `init(v int32)`), so the
+        // per-position conversion below targets the concrete argument types.
+        // For a non-generic or open type these equal the declared types.
+        var effectiveParamTypes = classType.GetConstructorParameterTypesForConstruction(selectedCtor);
 
         // ADR-0101 follow-up / issue #812: a constructor's last parameter
         // may be variadic. The arity check accepts any count >= the fixed
@@ -2151,7 +2172,11 @@ internal sealed class OverloadResolver
             // slice-typed argument so the per-position conversion loop
             // below sees exactly `parameters.Length` arguments.
             var variadicParam = parameters[parameters.Length - 1];
-            var sliceType = (SliceTypeSymbol)variadicParam.Type;
+
+            // Issue #1214: use the (possibly type-argument-substituted) slice
+            // type so a generic variadic init (`init(xs ...T)` on `Box[int32]`)
+            // packs into `[]int32`, matching the concrete argument types.
+            var sliceType = (SliceTypeSymbol)effectiveParamTypes[parameters.Length - 1];
             var elementType = sliceType.ElementType;
             var trailingCount = requestedArgCount - fixedCtorParamCount;
             var passThrough = trailingCount == 1
@@ -2240,14 +2265,19 @@ internal sealed class OverloadResolver
             var argument = boundArguments[i];
             var parameter = parameters[i];
 
+            // Issue #1214: target the type-argument-substituted parameter type
+            // for a closed generic construction (equal to parameter.Type for a
+            // non-generic/open type).
+            var paramType = effectiveParamTypes[i];
+
             // ADR-0055 Tier 4 (#369): re-lower an interpolated-string argument
             // targeting an IFormattable/FormattableString parameter.
             if (i < parameterSyntax.Length
                 && parameterSyntax[i] != null
                 && parameterSyntax[i] is InterpolatedStringExpressionSyntax interpolatedCtorArg
-                && isFormattableStringTargetType(parameter.Type))
+                && isFormattableStringTargetType(paramType))
             {
-                convertedArguments.Add(bindInterpolatedStringAsFormattable(interpolatedCtorArg, parameter.Type));
+                convertedArguments.Add(bindInterpolatedStringAsFormattable(interpolatedCtorArg, paramType));
                 continue;
             }
 
@@ -2259,7 +2289,7 @@ internal sealed class OverloadResolver
             if (parameter.RefKind != RefKind.None && argument is BoundAddressOfExpression addrCtor)
             {
                 var pointee = addrCtor.Operand?.Type;
-                if (pointee == parameter.Type || pointee == TypeSymbol.Error || parameter.Type == TypeSymbol.Error)
+                if (pointee == paramType || pointee == TypeSymbol.Error || paramType == TypeSymbol.Error)
                 {
                     convertedArguments.Add(argument);
                     continue;
@@ -2268,7 +2298,7 @@ internal sealed class OverloadResolver
             else if (parameter.RefKind != RefKind.None && argument is BoundConditionalAddressExpression condAddrCtor)
             {
                 var pointee = condAddrCtor.PointeeType;
-                if (pointee == parameter.Type || pointee == TypeSymbol.Error || parameter.Type == TypeSymbol.Error)
+                if (pointee == paramType || pointee == TypeSymbol.Error || paramType == TypeSymbol.Error)
                 {
                     convertedArguments.Add(argument);
                     continue;
@@ -2278,17 +2308,17 @@ internal sealed class OverloadResolver
             var argLocation = i < parameterSyntax.Length && parameterSyntax[i] != null
                 ? parameterSyntax[i].Location
                 : syntax.Identifier.Location;
-            if (argument.Type != parameter.Type
-                && !Conversion.Classify(argument.Type, parameter.Type).IsImplicit)
+            if (argument.Type != paramType
+                && !Conversion.Classify(argument.Type, paramType).IsImplicit)
             {
                 // Issue #889: arrow/func literal → void-returning delegate.
-                if (TryConvertLiteralArgumentToVoidDelegate(argument, parameter.Type, argLocation, out var voidDelegateArg))
+                if (TryConvertLiteralArgumentToVoidDelegate(argument, paramType, argLocation, out var voidDelegateArg))
                 {
                     convertedArguments.Add(voidDelegateArg);
                     continue;
                 }
 
-                if (conversions.TryApplyUserDefinedImplicitArgumentConversion(argument, parameter.Type, out var convertedArg))
+                if (conversions.TryApplyUserDefinedImplicitArgumentConversion(argument, paramType, out var convertedArg))
                 {
                     convertedArguments.Add(convertedArg);
                     continue;
@@ -2296,7 +2326,7 @@ internal sealed class OverloadResolver
 
                 if (argument.Type != TypeSymbol.Error)
                 {
-                    Diagnostics.ReportWrongArgumentType(argLocation, parameter.Name, parameter.Type, argument.Type);
+                    Diagnostics.ReportWrongArgumentType(argLocation, parameter.Name, paramType, argument.Type);
                 }
 
                 hasErrors = true;
@@ -2304,7 +2334,7 @@ internal sealed class OverloadResolver
             }
             else
             {
-                convertedArguments.Add(conversions.BindConversion(argLocation, argument, parameter.Type));
+                convertedArguments.Add(conversions.BindConversion(argLocation, argument, paramType));
             }
         }
 
@@ -2314,6 +2344,109 @@ internal sealed class OverloadResolver
         }
 
         return new BoundConstructorCallExpression(syntax, classType, convertedArguments.ToImmutable(), selectedCtor);
+    }
+
+    /// <summary>
+    /// Issue #1214: closes a generic class that declares an explicit
+    /// <c>init(...)</c> constructor for a construction call <c>Box[int32](args)</c>.
+    /// Resolves the type arguments — taken from an explicit <c>[…]</c> list or
+    /// inferred from the value arguments against the constructor's parameter
+    /// list (first-seen-wins, mirroring the primary-constructor path in
+    /// <see cref="BindConstructorCallExpression"/>) — validates the arity and
+    /// constraints, then yields the constructed closed <see cref="StructSymbol"/>.
+    /// Returns <see langword="false"/> after reporting a diagnostic when the type
+    /// arguments cannot be resolved.
+    /// </summary>
+    private bool TryCloseGenericExplicitConstructorType(
+        CallExpressionSyntax syntax,
+        StructSymbol classType,
+        out StructSymbol constructed)
+    {
+        constructed = classType;
+
+        if (!classType.IsGenericDefinition)
+        {
+            // A type-argument list on a non-generic class is a usage error.
+            if (syntax.TypeArgumentList != null)
+            {
+                Diagnostics.ReportWrongTypeArgumentCount(syntax.TypeArgumentList.Location, classType.Name, 0, syntax.TypeArgumentList.Arguments.Count);
+                return false;
+            }
+
+            return true;
+        }
+
+        var tps = classType.TypeParameters;
+        var substitution = new Dictionary<TypeParameterSymbol, TypeSymbol>();
+        if (syntax.TypeArgumentList != null)
+        {
+            var explicitArgs = syntax.TypeArgumentList.Arguments;
+            if (explicitArgs.Count != tps.Length)
+            {
+                Diagnostics.ReportWrongTypeArgumentCount(syntax.TypeArgumentList.Location, classType.Name, tps.Length, explicitArgs.Count);
+                return false;
+            }
+
+            for (var i = 0; i < explicitArgs.Count; i++)
+            {
+                var ta = bindTypeClause(explicitArgs[i]);
+                if (ta == null)
+                {
+                    return false;
+                }
+
+                substitution[tps[i]] = ta;
+            }
+        }
+        else
+        {
+            // Infer the type arguments from the value arguments against the
+            // (first) explicit constructor's parameter list. The open-definition
+            // constructor parameter types reference the class type parameters,
+            // so binding each argument and unifying drives inference.
+            var ctorOverloads = classType.EffectiveExplicitConstructors;
+            var ctorParams = ctorOverloads.IsDefaultOrEmpty
+                ? ImmutableArray<ParameterSymbol>.Empty
+                : ctorOverloads[0].Parameters;
+
+            for (var i = 0; i < syntax.Arguments.Count && i < ctorParams.Length; i++)
+            {
+                var argSyntax = UnwrapNamedArgumentValue(syntax.Arguments[i]);
+                var preBound = bindExpression(argSyntax);
+                inferTypeArguments(ctorParams[i].Type, preBound.Type, substitution);
+            }
+
+            foreach (var tp in tps)
+            {
+                if (!substitution.ContainsKey(tp))
+                {
+                    Diagnostics.ReportTypeArgumentInferenceFailed(syntax.Identifier.Location, classType.Name, tp.Name);
+                    return false;
+                }
+            }
+        }
+
+        var constraintLocation = syntax.TypeArgumentList != null
+            ? syntax.TypeArgumentList.Location
+            : syntax.Identifier.Location;
+        foreach (var tp in tps)
+        {
+            var typeArg = substitution[tp];
+            if (!satisfiesConstraint(typeArg, tp))
+            {
+                Diagnostics.ReportTypeArgumentDoesNotSatisfyConstraint(constraintLocation, tp.Name, typeArg, describeConstraint(tp));
+                return false;
+            }
+        }
+
+        var typeArgs = ImmutableArray.CreateBuilder<TypeSymbol>(tps.Length);
+        foreach (var tp in tps)
+        {
+            typeArgs.Add(substitution[tp]);
+        }
+
+        constructed = StructSymbol.Construct(classType, typeArgs.MoveToImmutable());
+        return true;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -1380,14 +1380,6 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
         Report(location, "GS0216", $"Class '{className}' declares multiple 'init' constructors; only a single explicit constructor is supported.");
     }
 
-    /// <summary>Reports construction of a generic class that declares an explicit <c>init(...)</c> constructor, which is not yet supported (issue #306).</summary>
-    /// <param name="location">The text location of the construction call.</param>
-    /// <param name="className">The class name.</param>
-    public void ReportGenericExplicitConstructorUnsupported(TextLocation location, string className)
-    {
-        Report(location, "GS0217", $"Generic class '{className}' with an explicit 'init' constructor cannot be constructed; generic explicit constructors are not supported.");
-    }
-
     /// <summary>Reports a method that overrides a base method without using <c>override</c>. ADR-0017.</summary>
     /// <param name="location">The text location of the offending declaration.</param>
     /// <param name="baseTypeName">The base type name.</param>

--- a/test/Compiler.Tests/Emit/Issue1214GenericExplicitInitCtorEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1214GenericExplicitInitCtorEmitTests.cs
@@ -1,0 +1,188 @@
+// <copyright file="Issue1214GenericExplicitInitCtorEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1214: end-to-end emit tests proving a generic class that declares an
+/// explicit <c>init(...)</c> constructor can be constructed at a closed type
+/// (<c>Box[int32](5, "x")</c>). The explicit <c>.ctor</c> is emitted once on the
+/// erased generic <c>TypeDef</c>; the construction call site references it
+/// through a <c>MemberRef</c> parented at the construction's <c>TypeSpec</c>
+/// (<see cref="GSharp.CodeAnalysis.Emit.ReflectionMetadataEmitter"/>'s
+/// <c>ResolveUserCtorTokenForExplicit</c>). Each test compiles via <c>gsc</c>,
+/// runs <c>ilverify</c>, executes the produced assembly, and asserts that the
+/// constructor actually ran (its argument round-trips through the instance) —
+/// which can only hold when the ctor is correctly emitted and invoked.
+/// </summary>
+public class Issue1214GenericExplicitInitCtorEmitTests
+{
+    [Fact]
+    public void GenericClass_ExplicitInitCtor_FieldsFromInitParams_RoundTrip()
+    {
+        var source = """
+            package Probe
+            import System
+
+            class Box[T] {
+                let value T
+                var label string
+                init(v T, l string) {
+                    value = v
+                    label = l
+                }
+                func Get() T { return value }
+                func Label() string { return label }
+            }
+
+            let b = Box[int32](5, "x")
+            Console.WriteLine(b.Get())
+            Console.WriteLine(b.Label())
+            """;
+
+        var output = CompileAndRun(source);
+
+        // 5 proves the `value = v` field assignment in the constructor ran and
+        // the int32 argument round-tripped through the `!0` slot; "x" proves the
+        // second (string) init parameter was passed and stored correctly.
+        Assert.Equal("5\nx\n", output);
+    }
+
+    [Fact]
+    public void GenericClass_ExplicitInitCtor_TwoInstantiations_PerConstructionWorks()
+    {
+        var source = """
+            package Probe
+            import System
+
+            class Box[T] {
+                let value T
+                init(v T) {
+                    value = v
+                }
+                func Get() T { return value }
+            }
+
+            let i = Box[int32](42)
+            let s = Box[string]("hello")
+            Console.WriteLine(i.Get())
+            Console.WriteLine(s.Get())
+            """;
+
+        var output = CompileAndRun(source);
+
+        // Two distinct closed constructions (Box[int32] and Box[string]) each
+        // newobj the SAME erased .ctor through a per-construction TypeSpec
+        // MemberRef; 42 and hello prove both arguments were passed and stored.
+        Assert.Equal("42\nhello\n", output);
+    }
+
+    [Fact]
+    public void GenericClass_ExplicitInitCtor_TypeParameterReturn_RoundTrip()
+    {
+        var source = """
+            package Probe
+            import System
+
+            open class Mp4Operation[TOutput] {
+                let label string
+                init(name string) {
+                    label = name
+                }
+                func Name() string { return label }
+            }
+
+            func Make() Mp4Operation[int32] {
+                return Mp4Operation[int32]("clip")
+            }
+
+            let op = Make()
+            Console.WriteLine(op.Name())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("clip\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1214_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+                // ignored
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1214GenericExplicitInitCtorTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1214GenericExplicitInitCtorTests.cs
@@ -1,0 +1,211 @@
+// <copyright file="Issue1214GenericExplicitInitCtorTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1214: a generic class that declares an explicit <c>init(...)</c>
+/// constructor can be constructed at a closed type (<c>Box[int32](5, "x")</c>).
+/// Previously the binder reported GS0217 ("generic explicit constructors are not
+/// supported") and refused to bind such a construction. The fix closes the
+/// generic definition (resolving type arguments explicitly or by inference) and
+/// binds against the explicit constructor's type-argument-substituted parameter
+/// list. These tests assert the construction binds cleanly, that GS0217 no
+/// longer fires, and that the surrounding diagnostics (arity, argument type,
+/// constraints) still behave for the generic case.
+/// </summary>
+public class Issue1214GenericExplicitInitCtorTests
+{
+    [Fact]
+    public void GenericClass_ExplicitInitCtor_ConstructsAtClosedType_CompilesCleanly()
+    {
+        // The minimal #1214 repro: explicit init on a generic class, constructed
+        // through a closed `Mp4Operation[int32]`.
+        var source = """
+            package p
+            open class Mp4Operation[TOutput] {
+                init(name string) { }
+            }
+            func Make() Mp4Operation[int32] {
+                return Mp4Operation[int32]("x")
+            }
+            """;
+
+        var diagnostics = Diagnose(source);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void NonGenericClass_ExplicitInitCtor_StillCompilesCleanly()
+    {
+        // Control: the identical shape with a NON-generic class must keep working.
+        var source = """
+            package p
+            open class Op {
+                init(name string) { }
+            }
+            func MakeOk() Op {
+                return Op("x")
+            }
+            """;
+
+        var diagnostics = Diagnose(source);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void GenericClass_ExplicitInitCtor_NoLongerReportsGs0217()
+    {
+        var source = """
+            package p
+            class Box[T] {
+                let value T
+                init(v T) { value = v }
+            }
+            func Use() {
+                let b = Box[int32](5)
+            }
+            """;
+
+        var diagnostics = Diagnose(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0217");
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void GenericClass_ExplicitInitCtor_FieldsFromTypeParameterAndString_CompilesCleanly()
+    {
+        var source = """
+            package p
+            class Box[T] {
+                let value T
+                var label string
+                init(v T, l string) {
+                    value = v
+                    label = l
+                }
+                func Get() T { return value }
+            }
+            func Use() int32 {
+                let b = Box[int32](5, "x")
+                return b.Get()
+            }
+            """;
+
+        var diagnostics = Diagnose(source);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void GenericClass_ExplicitInitCtor_WrongArgumentType_ReportsDiagnostic()
+    {
+        // A type argument that closes `T` to int32 means passing a string for the
+        // `T` parameter must be a wrong-argument-type error, not GS0217.
+        var source = """
+            package p
+            class Box[T] {
+                let value T
+                init(v T) { value = v }
+            }
+            func Use() {
+                let b = Box[int32]("x")
+            }
+            """;
+
+        var diagnostics = Diagnose(source);
+
+        Assert.NotEmpty(diagnostics);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0217");
+    }
+
+    [Fact]
+    public void GenericClass_ExplicitInitCtor_WrongArity_ReportsDiagnostic()
+    {
+        var source = """
+            package p
+            class Box[T] {
+                let value T
+                init(v T) { value = v }
+            }
+            func Use() {
+                let b = Box[int32](5, 6)
+            }
+            """;
+
+        var diagnostics = Diagnose(source);
+
+        Assert.NotEmpty(diagnostics);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0217");
+    }
+
+    [Fact]
+    public void GenericClass_ExplicitInitCtor_WrongTypeArgumentCount_ReportsDiagnostic()
+    {
+        var source = """
+            package p
+            class Box[T] {
+                let value T
+                init(v T) { value = v }
+            }
+            func Use() {
+                let b = Box[int32, string](5)
+            }
+            """;
+
+        var diagnostics = Diagnose(source);
+
+        Assert.NotEmpty(diagnostics);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0217");
+    }
+
+    [Fact]
+    public void GenericClass_ExplicitInitCtor_InferredTypeArguments_CompilesCleanly()
+    {
+        // No explicit `[…]`: the type argument is inferred from the value
+        // argument against the constructor's parameter list.
+        var source = """
+            package p
+            class Box[T] {
+                let value T
+                init(v T) { value = v }
+                func Get() T { return value }
+            }
+            func Use() int32 {
+                let b = Box(5)
+                return b.Get()
+            }
+            """;
+
+        var diagnostics = Diagnose(source);
+
+        Assert.Empty(diagnostics);
+    }
+
+    private static ImmutableArray<Diagnostic> Diagnose(string source)
+    {
+        // Bind the full program (function bodies included) so that a
+        // construction expression inside a function body is actually bound and
+        // any diagnostic surfaces. BindGlobalScope alone only binds signatures
+        // and declaration-level constructs (e.g. `: base(...)`), not bodies.
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return result.Diagnostics;
+    }
+}


### PR DESCRIPTION
Fixes #1214.

## Why GS0217 existed
Constructing a generic class that declared an explicit `init(...)` constructor (`Mp4Operation[int32]("x")`) failed with **GS0217**: *"Generic class '<Name>' with an explicit 'init' constructor cannot be constructed; generic explicit constructors are not supported."* The guard lived in `BindExplicitConstructorCallExpression` (`OverloadResolver.cs`) and returned a `BoundErrorExpression` for any generic explicit-ctor construction. The non-generic form (`Op("x")`) and generic **primary**-constructor classes worked; only an explicit `init` on a *generic* class was blocked.

## Root cause / what was missing
The binder never closed the generic definition for the explicit-ctor path, and bound argument conversions against the open `init` parameter list (where a parameter typed `T` is a `TypeParameterSymbol`), so `int32 -> T` failed. The **emit** side was already complete: `ResolveUserCtorTokenForExplicit` emits the `.ctor` once on the erased generic `TypeDef` and, for a constructed type, references it through a **MemberRef parented at the construction's `TypeSpec`** (`EncodeTypeSymbol` encodes `T` params as `!0`). The only blocker was the binder guard.

## Bind support added
In `BindExplicitConstructorCallExpression`:
- New helper `TryCloseGenericExplicitConstructorType` resolves type arguments — from an explicit `[…]` list, or **inferred** from the value arguments against the constructor's parameter list (first-seen-wins, mirroring the primary-constructor path) — validates arity and constraints, and calls `StructSymbol.Construct`.
- The explicit constructor is resolved through `EffectiveExplicitConstructors` (a constructed symbol carries no own ctor table — those live on the open definition, issue #1087).
- Arguments are bound/converted against the **type-argument-substituted** parameter types via `GetConstructorParameterTypesForConstruction` (`init(v T)` on `Box[int32]` becomes `init(v int32)`), so the closed-type conversions, diagnostics, and the variadic slice element type are all concrete.
- The `BoundConstructorCallExpression` carries the constructed `StructType` plus the definition `ConstructorSymbol`; the emitter references the `.ctor` through the per-construction `TypeSpec`.

The unused **GS0217** diagnostic is removed and marked _Retired_ in `docs/diagnostics.md`.

## Repros (compile + run after fix)
- `Mp4Operation[int32]("x")` — compiles; non-generic control `Op("x")` still compiles.
- `Box[int32](5, "x")` with `init(v T, l string)` setting `value = v` / `label = l` — `Get()` returns **5** and the string field round-trips.

## Emit round-trip (per-construction)
New `Issue1214GenericExplicitInitCtorEmitTests` compiles via `gsc`, runs `IlVerifier.Verify`, executes, and asserts: the int32 init arg round-trips (`Get()` == 5, label == "x"); **two distinct instantiations** `Box[int32](42)` and `Box[string]("hello")` each `newobj` the erased `.ctor` through their own `TypeSpec` MemberRef and round-trip; and a closed-type return (`Mp4Operation[int32]`).

## Tests
- `test/Core.Tests/.../Issue1214GenericExplicitInitCtorTests.cs` — **8 binder tests** (closed-type construction binds cleanly; GS0217 no longer fires; wrong arg type / wrong arity / wrong type-arg count still report; type-argument inference; non-generic control).
- `test/Compiler.Tests/Emit/Issue1214GenericExplicitInitCtorEmitTests.cs` — **3 emit/execution tests**.
- Full `Core.Tests` (4252 passed), `Extensions.Tests` (104 passed), narrowed `Compiler.Tests` Generic/Constructor/Ctor/Issue1214 filter (269 passed). Full `GSharp.sln -graph` build: 0 warnings, 0 errors.
