### PR TITLE
Fix #1218: resolve inherited System.Enum/ValueType/Object members on enum values

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -443,6 +443,21 @@ public sealed class Conversion
             return Conversion.Implicit;
         }
 
+        // Issue #1218: an enum value boxes implicitly to its CLR reference base
+        // types — System.Object, System.ValueType, and System.Enum. An
+        // EnumSymbol carries no ClrType during binding (the enum is still being
+        // compiled), so the general object-boxing rule above cannot fire. This
+        // makes inherited Enum/ValueType/Object members callable on enum values
+        // (e.g. passing an enum to System.Enum.HasFlag(System.Enum)); the
+        // emitter lowers the conversion to a single `box <Enum>`.
+        if (from is EnumSymbol && to?.ClrType is System.Type enumBoxTarget
+            && (enumBoxTarget.IsSameAs(typeof(object))
+                || enumBoxTarget.IsSameAs(typeof(System.ValueType))
+                || enumBoxTarget.IsSameAs(typeof(System.Enum))))
+        {
+            return Conversion.Implicit;
+        }
+
         // ADR-0045 explicit unbox: `(T)objectValue` for any value-type T.
         if (from?.ClrType.IsSameAs(typeof(object)) == true && to?.ClrType != null && to.ClrType.IsValueType)
         {

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -2386,6 +2386,21 @@ internal sealed partial class ExpressionBinder
 
                     Diagnostics.ReportUnableToFindMember(ne.Location, ne.IdentifierToken.Text);
                 }
+                else if (receiver != null && receiver.Type is EnumSymbol)
+                {
+                    // Issue #1218: an inherited System.Enum / ValueType / Object
+                    // instance member (HasFlag/ToString/GetHashCode/Equals/GetType)
+                    // named in method-group position on an enum value. Capture it
+                    // as a CLR method group over typeof(System.Enum) so it resolves
+                    // against a target delegate signature; the emitter boxes the
+                    // value-type receiver into the delegate Target.
+                    if (TryBindClrMethodGroup(receiver, typeof(System.Enum), wantStatic: false, ne.IdentifierToken.Text, out var enumClrGroup))
+                    {
+                        return enumClrGroup;
+                    }
+
+                    Diagnostics.ReportUnableToFindMember(ne.Location, ne.IdentifierToken.Text);
+                }
                 else if (receiver != null && receiver.Type is InterfaceSymbol ifaceSym)
                 {
                     // Issue #1068: read a property declared on the static

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -2573,6 +2573,19 @@ internal sealed partial class ExpressionBinder
                 return inheritedCall;
             }
 
+            // Issue #1218: an enum value is a CLR value type whose base chain is
+            // System.Enum -> System.ValueType -> System.Object. Its inherited
+            // instance members (Enum.HasFlag, Object/ValueType ToString /
+            // GetHashCode / Equals, Object.GetType) are callable on enum values.
+            // Resolve against typeof(System.Enum); SafeGetMethods walks the base
+            // types so all inherited members are found, and the helper returns
+            // false for any name Enum/Object does not define (still GS0159).
+            if (receiver != null && receiver.Type is EnumSymbol
+                && TryBindInheritedClrInstanceCall(receiver, typeof(System.Enum), methodName, arguments, ce, out var enumInheritedCall, explicitTypeArgs, typeArgSymbols, argumentNames, mapEnumArgumentsToBaseClr: true))
+            {
+                return enumInheritedCall;
+            }
+
             // Issue #294: imported [Extension] method dispatched with instance
             // (receiver) syntax, when the receiver carries a CLR type even
             // though its symbol is a user/interface shape.
@@ -3194,7 +3207,8 @@ internal sealed partial class ExpressionBinder
         out BoundExpression result,
         System.Type[] explicitTypeArgs = null,
         ImmutableArray<TypeSymbol> typeArgSymbols = default,
-        ImmutableArray<string> argumentNames = default)
+        ImmutableArray<string> argumentNames = default,
+        bool mapEnumArgumentsToBaseClr = false)
     {
         result = null;
 
@@ -3204,7 +3218,7 @@ internal sealed partial class ExpressionBinder
             return false;
         }
 
-        return TryResolveAndBindClrInstanceCall(receiver, candidates, importedBaseClr, methodName, arguments, ce, out result, explicitTypeArgs, typeArgSymbols, argumentNames);
+        return TryResolveAndBindClrInstanceCall(receiver, candidates, importedBaseClr, methodName, arguments, ce, out result, explicitTypeArgs, typeArgSymbols, argumentNames, mapEnumArgumentsToBaseClr);
     }
 
     /// <summary>
@@ -3288,6 +3302,7 @@ internal sealed partial class ExpressionBinder
     /// <param name="explicitTypeArgs">Explicit CLR type arguments, when present.</param>
     /// <param name="typeArgSymbols">Explicit symbolic type arguments, when present.</param>
     /// <param name="argumentNames">Named-argument labels, when present.</param>
+    /// <param name="mapEnumArgumentsToBaseClr">When <see langword="true"/>, enum-typed arguments resolve as the inherited base CLR type (<c>System.Enum</c>) instead of their erased underlying primitive, so members such as <c>HasFlag(System.Enum)</c> match.</param>
     /// <returns>True when the call resolved (or reported a precise ambiguity).</returns>
     private bool TryResolveAndBindClrInstanceCall(
         BoundExpression receiver,
@@ -3299,7 +3314,8 @@ internal sealed partial class ExpressionBinder
         out BoundExpression result,
         System.Type[] explicitTypeArgs,
         ImmutableArray<TypeSymbol> typeArgSymbols,
-        ImmutableArray<string> argumentNames)
+        ImmutableArray<string> argumentNames,
+        bool mapEnumArgumentsToBaseClr = false)
     {
         result = null;
 
@@ -3307,6 +3323,17 @@ internal sealed partial class ExpressionBinder
         var hasUserClassArg = false;
         for (var i = 0; i < arguments.Length; i++)
         {
+            // Issue #1218: when resolving an inherited call against System.Enum
+            // (e.g. HasFlag(System.Enum)), an enum-typed argument is the boxed
+            // System.Enum the parameter expects. The default mapping erases an
+            // enum to its underlying int32 (issue #661), which would not match a
+            // System.Enum parameter, so map it to the base CLR type instead.
+            if (mapEnumArgumentsToBaseClr && arguments[i].Type is EnumSymbol)
+            {
+                argTypes[i] = importedBaseClr;
+                continue;
+            }
+
             // Issue #530: use GetEffectiveArgumentClrType (see instance method path).
             // Issue #533: allow null (nil literal) through.
             // Issue #658: use overload-resolution variant for user classes.

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
@@ -281,6 +281,21 @@ internal sealed partial class MethodBodyEmitter
             return;
         }
 
+        // Issue #1218: a value-type value (notably an enum) converting to one of
+        // its CLR reference base types — System.ValueType or System.Enum — boxes
+        // to a proper object reference. This mirrors the `object`/interface box
+        // above and lets inherited Enum/ValueType members receive the boxed
+        // receiver/argument (e.g. an enum passed to System.Enum.HasFlag).
+        if (ReflectionMetadataEmitter.IsValueTypeSymbol(from)
+            && to?.ClrType is System.Type valueBoxTarget
+            && (valueBoxTarget.IsSameAs(typeof(System.ValueType))
+                || valueBoxTarget.IsSameAs(typeof(System.Enum))))
+        {
+            this.il.OpCode(ILOpCode.Box);
+            this.il.Token(this.outer.GetElementTypeToken(from));
+            return;
+        }
+
         // ADR-0087 §3 R4: after R2 a value of `T` lives in a real type slot
         // (VAR/MVAR), not an erased `object`. Where the binder still emits a
         // BoundConversionExpression bridging `T → object` (e.g. passing a

--- a/test/Compiler.Tests/Emit/Issue1218EnumMemberEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1218EnumMemberEmitTests.cs
@@ -1,0 +1,179 @@
+// <copyright file="Issue1218EnumMemberEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1218: inherited System.Enum / System.ValueType / System.Object
+/// instance members must emit and run on enum values. An enum is a CLR value
+/// type whose base chain is System.Enum -&gt; System.ValueType -&gt;
+/// System.Object, so its inherited members (Enum.HasFlag,
+/// Object/ValueType ToString / GetHashCode / Equals, Object.GetType) resolve to
+/// real CLR MethodInfos. The value-type receiver is boxed before the
+/// <c>callvirt</c>; for HasFlag the enum argument is additionally boxed to
+/// System.Enum. These tests compile a program that exercises each member,
+/// statically verify the IL, and assert the runtime output. G# enums get
+/// sequential values (Red=0, Green=1, Blue=2) with no explicit-value or
+/// <c>[Flags]</c> syntax, so HasFlag is exercised with single-flag equality
+/// semantics (Green.HasFlag(Green) is true, Green.HasFlag(Blue) is false).
+/// </summary>
+public class Issue1218EnumMemberEmitTests
+{
+    [Fact]
+    public void EnumReceiver_HasFlag_BoxesArgumentAndRuns()
+    {
+        var source = """
+            package P
+            import System
+
+            enum Color { Red, Green, Blue }
+
+            Console.WriteLine(Color.Green.HasFlag(Color.Green))
+            Console.WriteLine(Color.Green.HasFlag(Color.Blue))
+            Console.WriteLine(Color.Blue.HasFlag(Color.Green))
+            """;
+
+        Assert.Equal("True\nFalse\nFalse\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EnumReceiver_ToStringAndGetType_BoxAndRun()
+    {
+        var source = """
+            package P
+            import System
+
+            enum Color { Red, Green, Blue }
+
+            Console.WriteLine(Color.Green.ToString())
+            Console.WriteLine(Color.Green.GetType().Name)
+            """;
+
+        Assert.Equal("Green\nColor\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EnumReceiver_EqualsAndGetHashCode_BoxAndRun()
+    {
+        var source = """
+            package P
+            import System
+
+            enum Color { Red, Green, Blue }
+
+            Console.WriteLine(Color.Green.Equals(Color.Green))
+            Console.WriteLine(Color.Green.Equals(Color.Blue))
+            Console.WriteLine(Color.Green.GetHashCode() == Color.Green.GetHashCode())
+            Console.WriteLine(Color.Green.GetHashCode() == Color.Blue.GetHashCode())
+            """;
+
+        Assert.Equal("True\nFalse\nTrue\nFalse\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EnumReceiver_HasFlagThroughClassMethod_EmitsAndRuns()
+    {
+        // Mirrors the original repro from issue #1218: HasFlag invoked through a
+        // class method whose parameter is the enum type. Verifies the binder
+        // resolves the inherited member on a parameter-typed receiver (not only
+        // on a `Type.Member` literal) and that it emits and runs.
+        var source = """
+            package P
+            import System
+
+            enum Color { Red, Green, Blue }
+
+            class C {
+                func Test(a Color, b Color) bool {
+                    return a.HasFlag(b)
+                }
+            }
+
+            let c = C{ }
+            Console.WriteLine(c.Test(Color.Blue, Color.Blue))
+            Console.WriteLine(c.Test(Color.Blue, Color.Green))
+            """;
+
+        Assert.Equal("True\nFalse\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1218_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new System.Collections.Generic.List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+
+            // (a) Static verification: the emitted IL must be valid.
+            IlVerifier.Verify(outPath);
+
+            // (b) Dynamic verification: the emitted code must execute.
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1218

Enum values in G# could not call inherited `System.Enum` instance members such as `HasFlag`, nor inherited `System.Object`/`System.ValueType` members (`ToString`, `GetHashCode`, `Equals`, `GetType`). Calling them reported `GS0159: Cannot find function HasFlag.`

## Root cause
An `EnumSymbol` receiver carries no `ClrType` (the enum is still being compiled), so member-call binding routed it into the null-`ClrType` fallback in `ExpressionBinder.Calls.cs`, which had no enum case and fell straight through to `GS0159`. This is the enum analog of issue #1136 (which fixed the same gap for user class/struct receivers by falling back to `typeof(object)`).

## Fix (mirrors the #1136 approach)
- **`ExpressionBinder.Calls.cs`** — an `EnumSymbol` receiver now resolves the call against `typeof(System.Enum)`. `SafeGetMethods` walks the CLR base chain (`Enum` -> `ValueType` -> `Object`) so every inherited member is found; the helper returns `false` for unknown names so `GS0159` still fires for genuinely undefined methods. Enum-typed arguments map to `System.Enum` (instead of their erased `int32`) so `HasFlag(System.Enum)` overload-resolves.
- **`ExpressionBinder.Access.cs`** — an inherited member named in method-group position on an enum value binds as a CLR method group over `System.Enum`.
- **`Conversion.cs`** — an enum value boxes implicitly to its reference base types (`Object`/`ValueType`/`Enum`); the `EnumSymbol` has no `ClrType`, so the existing object-boxing rule could not fire.
- **`MethodBodyEmitter.Conversions.cs`** — emit `box <Enum>` when a value-type value converts to `System.ValueType`/`System.Enum`, so the `HasFlag` enum argument is boxed. The receiver box+`callvirt` path already handled value-type receivers calling reference-base methods.

## Tests
`test/Compiler.Tests/Emit/Issue1218EnumMemberEmitTests.cs` (4 tests) compile, IL-verify, and run:
- `HasFlag` with single-flag equality semantics (G# enums get sequential values `Red=0, Green=1, Blue=2` — no explicit-value or `[Flags]` syntax), including `HasFlag` through a class-method parameter (the original repro shape).
- `ToString`, `GetType().Name`, `Equals`, `GetHashCode` on enum values.

## Verification
- `dotnet build GSharp.sln -c Release -graph` — 0 errors.
- Standalone `gsc` on the issue repro now prints `Wrote` and runs correctly at runtime (`Color.Green.HasFlag(Color.Green) == true`, `.HasFlag(Color.Blue) == false`, `ToString() == "Green"`, `GetType().Name == "Color"`).
- `test/Core.Tests` — 4252 passed.
- `test/Compiler.Tests` enum + issue-1136 filter — 134 passed; conversion/box filter — 57 passed; new tests — 4 passed.
- `test/Extensions.Tests` — 104 passed.
