### PR TITLE
Resolve composite literals on imported reference-type classes (Fixes #1199)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
@@ -466,6 +466,21 @@ internal sealed partial class ExpressionBinder
             var preferredArity = syntax.TypeArgumentList != null ? syntax.TypeArgumentList.Arguments.Count : -1;
             if (!scope.TryLookupTypeAlias(typeName, preferredArity, out var resolvedType) || !(resolvedType is StructSymbol resolvedStruct))
             {
+                // Issue #1199: a composite literal `T{Field: value}` also targets
+                // an IMPORTED reference-type class (a BCL class such as
+                // `System.Text.Json.JsonSerializerOptions`). These resolve through
+                // the import table — not `TryLookupTypeAlias`, which only surfaces
+                // user-declared types — so route the literal through the same
+                // imported-class lookup that the constructor-call path uses and
+                // lower it to a C#-style object-initializer (construct via the
+                // parameterless ctor, then assign each named member).
+                if (syntax.TypeArgumentList == null
+                    && scope.TryLookupImportedClass(typeName, declaration: null, out var importedClass)
+                    && importedClass.ClassType is { IsValueType: false, IsGenericTypeDefinition: false })
+                {
+                    return BindImportedClassLiteralExpression(syntax, importedClass.ClassType);
+                }
+
                 Diagnostics.ReportUnableToFindType(syntax.TypeIdentifier.Location, typeName);
                 return new BoundErrorExpression(null);
             }
@@ -640,6 +655,97 @@ internal sealed partial class ExpressionBinder
         }
 
         return new BoundStructLiteralExpression(null, structSymbol, inits.ToImmutable());
+    }
+
+    /// <summary>
+    /// Issue #1199: binds a composite literal <c>T{Member: value, ...}</c> on an
+    /// IMPORTED reference-type class (e.g. <c>JsonSerializerOptions{WriteIndented:
+    /// true}</c>). It lowers to the same shape as the object-initializer suffix
+    /// (<c>T(){ Member = value }</c>, ADR-0117 / issue #569): construct the
+    /// instance via its public parameterless constructor into a synthetic local,
+    /// assign each named settable property/field through that local, and yield
+    /// the local. Reusing existing bound nodes (<see
+    /// cref="BoundClrConstructorCallExpression"/>,
+    /// <see cref="BoundClrPropertyAssignmentExpression"/>) means emit and the
+    /// interpreter both work without a new bound-node kind.
+    /// </summary>
+    private BoundExpression BindImportedClassLiteralExpression(StructLiteralExpressionSyntax syntax, Type clrType)
+    {
+        // The object-initializer lowering needs a constructed instance; require a
+        // public parameterless constructor (the C# object-initializer contract).
+        var parameterlessCtor = ClrTypeUtilities
+            .SafeGetConstructors(clrType, BindingFlags.Public | BindingFlags.Instance)
+            .FirstOrDefault(c => c.GetParameters().Length == 0);
+        if (parameterlessCtor == null)
+        {
+            Diagnostics.ReportUnableToFindType(syntax.TypeIdentifier.Location, syntax.TypeIdentifier.Text);
+            foreach (var initSyntax in syntax.Initializers)
+            {
+                _ = BindExpression(initSyntax.Value);
+            }
+
+            return new BoundErrorExpression(null);
+        }
+
+        var resultType = TypeSymbol.FromClrType(clrType);
+        BoundExpression construction = new BoundClrConstructorCallExpression(
+            syntax,
+            clrType,
+            parameterlessCtor,
+            ImmutableArray<BoundExpression>.Empty,
+            resultType);
+
+        var tempName = "$implit" + System.Threading.Interlocked.Increment(ref binderCtx.SyntheticLocalCounter).ToString(System.Globalization.CultureInfo.InvariantCulture);
+        var tempVar = new LocalVariableSymbol(tempName, isReadOnly: true, resultType);
+        scope.TryDeclareVariable(tempVar);
+
+        var statements = ImmutableArray.CreateBuilder<BoundStatement>();
+        statements.Add(new BoundVariableDeclaration(syntax, tempVar, construction));
+
+        var seen = new HashSet<string>();
+        foreach (var initSyntax in syntax.Initializers)
+        {
+            var memberName = initSyntax.FieldIdentifier.Text;
+            if (!seen.Add(memberName))
+            {
+                Diagnostics.ReportSymbolAlreadyDeclared(initSyntax.FieldIdentifier.Location, memberName);
+                continue;
+            }
+
+            // Resolve a public instance property (non-indexer) or field on the
+            // imported CLR type. A settable member binds to a CLR property/field
+            // assignment; a get-only/read-only member stays diagnosed (GS0127).
+            MemberInfo member = ClrTypeUtilities.SafeGetPropertyIncludingInterfaces(clrType, memberName, BindingFlags.Public | BindingFlags.Instance);
+            if (member is PropertyInfo idxProp && idxProp.GetIndexParameters().Length != 0)
+            {
+                member = null;
+            }
+
+            member ??= ClrTypeUtilities.SafeGetFieldIncludingInterfaces(clrType, memberName, BindingFlags.Public | BindingFlags.Instance);
+            if (member == null)
+            {
+                Diagnostics.ReportUnableToFindMember(initSyntax.FieldIdentifier.Location, memberName);
+                _ = BindExpression(initSyntax.Value);
+                continue;
+            }
+
+            if (!TryGetWritableClrMember(member, out _, out var targetSymbol, out _))
+            {
+                Diagnostics.ReportCannotAssign(initSyntax.FieldIdentifier.Location, memberName);
+                _ = BindExpression(initSyntax.Value);
+                continue;
+            }
+
+            var value = BindExpression(initSyntax.Value);
+            var converted = conversions.BindConversion(initSyntax.Value.Location, value, targetSymbol);
+            var receiverExpr = new BoundVariableExpression(initSyntax, tempVar);
+            statements.Add(new BoundExpressionStatement(
+                initSyntax,
+                new BoundClrPropertyAssignmentExpression(initSyntax, receiverExpr, member, converted, targetSymbol)));
+        }
+
+        var resultExpr = new BoundVariableExpression(syntax, tempVar);
+        return new BoundBlockExpression(syntax, statements.ToImmutable(), resultExpr);
     }
 
     private BoundExpression BindTupleLiteralExpression(TupleLiteralExpressionSyntax syntax)

--- a/test/Compiler.Tests/Emit/Issue1199ImportedCompositeLiteralEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1199ImportedCompositeLiteralEmitTests.cs
@@ -1,0 +1,132 @@
+// <copyright file="Issue1199ImportedCompositeLiteralEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1199: end-to-end emit tests proving a composite literal
+/// <c>T{Member: value}</c> on an IMPORTED reference-type class (a BCL class)
+/// constructs the instance via its parameterless constructor and assigns each
+/// named settable member through its CLR property setter / field — the C#
+/// object-initializer lowering. Each test compiles via <c>gsc</c>, runs
+/// <c>ilverify</c>, executes the produced assembly, and asserts the member value
+/// round-trips, which can only hold if the setter actually ran.
+/// </summary>
+public class Issue1199ImportedCompositeLiteralEmitTests
+{
+    [Fact]
+    public void ImportedClassCompositeLiteral_SettableProperty_RoundTrips()
+    {
+        var source = """
+            package Probe
+            import System
+            import System.Text
+
+            var sb = StringBuilder{Capacity: 128}
+            Console.WriteLine(sb.Capacity)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("128\n", output);
+    }
+
+    [Fact]
+    public void ImportedClassCompositeLiteral_MultipleMembers_RoundTrip()
+    {
+        var source = """
+            package Probe
+            import System
+            import System.Text
+
+            var sb = StringBuilder{Capacity: 64}
+            sb.Append("hi")
+            Console.WriteLine(sb.Capacity)
+            Console.WriteLine(sb.ToString())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("64\nhi\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1199_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+                // ignored
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1199ImportedCompositeLiteralBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1199ImportedCompositeLiteralBinderTests.cs
@@ -1,0 +1,96 @@
+// <copyright file="Issue1199ImportedCompositeLiteralBinderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1199: a composite literal <c>T{Member: value}</c> must also resolve
+/// and assign settable members on an IMPORTED reference-type class (a BCL
+/// class such as <c>System.Text.StringBuilder</c>) — exactly the cases that
+/// already work in constructor-call position. A read-only / get-only member is
+/// still not settable, and an unknown member is still diagnosed.
+/// </summary>
+public class Issue1199ImportedCompositeLiteralBinderTests
+{
+    [Fact]
+    public void ImportedClassLiteral_SettableProperty_BindsAndEvaluates()
+    {
+        var source = @"
+import System.Text
+
+let sb = StringBuilder{Capacity: 128}
+sb.Capacity
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(128, result.Value);
+    }
+
+    [Fact]
+    public void ImportedClassLiteral_NoInitializers_Binds()
+    {
+        var source = @"
+import System.Text
+
+let sb = StringBuilder{}
+sb.Capacity
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void ImportedClassLiteral_GetOnlyMember_IsDiagnosed()
+    {
+        var source = @"
+import System.Text
+
+let sb = StringBuilder{MaxCapacity: 5}
+sb.MaxCapacity
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Message.Contains("read-only"));
+    }
+
+    [Fact]
+    public void ImportedClassLiteral_UnknownMember_IsDiagnosed()
+    {
+        var source = @"
+import System.Text
+
+let sb = StringBuilder{Missing: 5}
+sb.Capacity
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Message.Contains("Cannot find member"));
+    }
+
+    [Fact]
+    public void ImportedClassLiteral_DuplicateMember_IsDiagnosed()
+    {
+        var source = @"
+import System.Text
+
+let sb = StringBuilder{Capacity: 16, Capacity: 32}
+sb.Capacity
+";
+        var result = Evaluate(source);
+        Assert.NotEmpty(result.Diagnostics);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
Fixes #1199

## Problem
A G# composite literal `T{Member: value}` on an **imported reference-type class** (a BCL class such as `System.Text.Json.JsonSerializerOptions` or `System.Text.StringBuilder`) failed type resolution with `GS0157: Cannot find type T. Are you missing an import?` — even though the very same type resolves fine in constructor-call or variable-declaration position.

```
package p
import System.Text.Json
class C {
  func F() JsonSerializerOptions {
    return JsonSerializerOptions{WriteIndented: true}   // GS0157 before this fix
  }
}
```

## Root cause
`BindStructLiteralExpression` (in `ExpressionBinder.Literals.cs`) resolved the literal's type **only** via `scope.TryLookupTypeAlias(...) is StructSymbol`, which surfaces user-declared types only. Imported CLR classes are resolved through the import table — `scope.TryLookupImportedClass`, exactly what the constructor-call path (`TryBindClrConstructorCall`) uses. The literal path never consulted that table, so it reported GS0157.

## Fix
When the `StructSymbol` lookup fails, the literal binder now falls back to the imported-class lookup. An imported **reference-type** class (`!IsValueType`, not an open generic) is lowered to the same shape as the existing object-initializer suffix `T(){ Member = value }` (issue #569 / ADR-0117):

1. construct via the public parameterless constructor into a synthetic local (`BoundClrConstructorCallExpression`),
2. assign each named settable property/field through a `BoundClrPropertyAssignmentExpression`,
3. yield the local (`BoundBlockExpression`).

This reuses existing bound nodes, so emit and the interpreter both work with **no new bound-node kind**. Settable members bind and emit the CLR property setter / `stfld`; get-only members stay diagnosed (GS0127) and unknown members GS0158.

This mirrors the user-class composite-literal fix from #1211/#1215, but for imported types (member resolution uses the imported type's CLR property setters / fields).

## Scope / non-regressions
- Imported **value types** are intentionally excluded (guarded by `IsValueType: false`); they still produce GS0157 as before — struct-literal semantics are unchanged.
- The imported-struct construction path (#1163) and the user-class composite-literal path (#1211) are untouched and verified green.

## Tests
- **Binder (Core.Tests):** settable property binds and evaluates, empty literal, get-only diagnosed, unknown member diagnosed, duplicate diagnosed.
- **Emit (Compiler.Tests, with ilverify):** round-trip tests compiling `StringBuilder{Capacity: 128}`, running the produced assembly, and asserting `sb.Capacity == 128` — which can only hold if the CLR setter actually ran.

Standalone `gsc` now emits the original repro (`JsonSerializerOptions{WriteIndented: true}`) successfully.
