### PR TITLE
Raise inherited events from derived classes (Fixes #1221)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -366,18 +366,20 @@ public sealed class Binder
                             }
                         }
 
-                        // Issue #1213: expose a field-like event of the
-                        // *declaring* type as a bare name inside its own method
-                        // bodies, bound to the event's private backing delegate
+                        // Issue #1213 / #1221: expose a field-like event of the
+                        // receiver type *or any base class* as a bare name inside
+                        // method bodies, bound to the event's backing delegate
                         // field. This lets the canonical raise pattern
                         // `MyEvent?.Invoke(args)` resolve, exactly as C# compiles
-                        // it to a read of the backing field. Only the type that
-                        // declares the event may raise it (a base class event is
-                        // intentionally not surfaced here), so this is restricted
-                        // to `t == receiverStruct`. A bare `MyEvent += handler`
-                        // still routes to the event-subscription path, which is
-                        // checked first in BindBareEventOrCompoundAssignment.
-                        if (ReferenceEquals(t, receiverStruct) && !t.Events.IsDefaultOrEmpty)
+                        // it to a read of the backing field. Issue #1213 enabled
+                        // this for the declaring type; issue #1221 extends it to
+                        // derived types so an inherited event can be raised from a
+                        // derived class (the inheritance walk binds to the base
+                        // type `t` that declares the field). A bare
+                        // `MyEvent += handler` still routes to the event-
+                        // subscription path, which is checked first in
+                        // BindBareEventOrCompoundAssignment.
+                        if (!t.Events.IsDefaultOrEmpty)
                         {
                             foreach (var evt in t.Events)
                             {

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -2325,21 +2325,30 @@ internal sealed partial class ExpressionBinder
                         return ApplyMemberNarrowing(new BoundPropertyAccessExpression(null, receiver, structSym, prop));
                     }
 
-                    // Issue #1213: an `event` member referenced in expression
-                    // position (e.g. `this.MyEvent?.Invoke(args)`) binds to its
-                    // private backing delegate field, mirroring how C# compiles
-                    // a raise of a field-like event to a read of the backing
+                    // Issue #1213 / #1221: an `event` member referenced in
+                    // expression position (e.g. `this.MyEvent?.Invoke(args)`)
+                    // binds to its backing delegate field, mirroring how C#
+                    // compiles a raise of a field-like event to a read of the
+                    // backing field. Issue #1213 enabled this for an event
+                    // declared on the receiver type; issue #1221 walks the base
+                    // chain so an event inherited from a base class can be raised
+                    // from a derived type — the field access targets the base
+                    // type that declares the (now `family`/protected) backing
                     // field. Restricted to access from inside the declaring type
-                    // (the backing field is private); cross-type reads continue
-                    // to fall through to the existing member-lookup diagnostics
-                    // so the `+=`/`-=` subscription path is unaffected.
+                    // or a derived type (`IsWithinType`); cross-type reads
+                    // continue to fall through to the existing member-lookup
+                    // diagnostics so the `+=`/`-=` subscription path is
+                    // unaffected.
                     if (IsWithinType(structSym))
                     {
-                        var evt = structSym.Events.FirstOrDefault(e =>
-                            e.Name == ne.IdentifierToken.Text && e.IsFieldLike && e.BackingField != null);
-                        if (evt != null)
+                        for (var evtDeclType = structSym; evtDeclType != null; evtDeclType = evtDeclType.BaseClass)
                         {
-                            return ApplyMemberNarrowing(new BoundFieldAccessExpression(null, receiver, structSym, evt.BackingField));
+                            var evt = evtDeclType.Events.FirstOrDefault(e =>
+                                e.Name == ne.IdentifierToken.Text && e.IsFieldLike && e.BackingField != null);
+                            if (evt != null)
+                            {
+                                return ApplyMemberNarrowing(new BoundFieldAccessExpression(null, receiver, evtDeclType, evt.BackingField));
+                            }
                         }
                     }
 

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -2816,6 +2816,67 @@ internal sealed class OverloadResolver
         return true;
     }
 
+    /// <summary>
+    /// Issue #1213 / #1221: lowers a call through a delegate/function-typed
+    /// variable to a <see cref="BoundIndirectCallExpression"/>, with two
+    /// event-raise refinements when the variable is the implicit backing-field
+    /// of a field-like event (an <see cref="ImplicitFieldVariableSymbol"/>):
+    /// <list type="bullet">
+    /// <item><description>The callee is loaded as a field read on <c>this</c>
+    /// (e.g. <c>ldfld Base::Changed</c>) — including the backing field declared
+    /// on a base class, so an inherited event can be raised from a derived type
+    /// — rather than a (non-existent) local slot.</description></item>
+    /// <item><description>The conditional raise form <c>Ev?(args)</c> on a
+    /// <c>void</c> delegate is guarded by a null check (a
+    /// <see cref="BoundNullConditionalAccessExpression"/>), so raising an event
+    /// with no subscribers is a safe no-op, mirroring <c>Ev?.Invoke(args)</c>.
+    /// </description></item>
+    /// </list>
+    /// </summary>
+    private BoundExpression BuildIndirectDelegateCall(
+        CallExpressionSyntax syntax,
+        VariableSymbol variable,
+        FunctionTypeSymbol fnType,
+        ImmutableArray<BoundExpression> args)
+    {
+        if (variable is ImplicitFieldVariableSymbol implicitField)
+        {
+            if (syntax.NullableQuestionToken != null
+                && ReferenceEquals(fnType.ReturnType, TypeSymbol.Void))
+            {
+                var captureName = "$ncap_" + (++binderCtx.NullConditionalCaptureCounter)
+                    .ToString(System.Globalization.CultureInfo.InvariantCulture);
+                var capture = new LocalVariableSymbol(captureName, isReadOnly: true, type: implicitField.Field.Type);
+                var invoke = new BoundIndirectCallExpression(null, new BoundVariableExpression(null, capture), fnType, args);
+                return new BoundNullConditionalAccessExpression(
+                    syntax,
+                    BuildImplicitFieldLoad(implicitField),
+                    capture,
+                    invoke,
+                    TypeSymbol.Void,
+                    resultSlot: null);
+            }
+
+            return new BoundIndirectCallExpression(null, BuildImplicitFieldLoad(implicitField), fnType, args);
+        }
+
+        return new BoundIndirectCallExpression(null, new BoundVariableExpression(null, variable), fnType, args);
+    }
+
+    /// <summary>
+    /// Issue #1213 / #1221: loads an <see cref="ImplicitFieldVariableSymbol"/>
+    /// (the implicit <c>this</c>-field exposed for a bare field/event name) as
+    /// a field read on its declaring type. The declaring type carried by the
+    /// symbol may be a base class, producing the correct base field token when
+    /// the access originates from a derived method.
+    /// </summary>
+    private static BoundExpression BuildImplicitFieldLoad(ImplicitFieldVariableSymbol implicitField) =>
+        new BoundFieldAccessExpression(
+            null,
+            new BoundVariableExpression(null, implicitField.Receiver),
+            implicitField.StructType,
+            implicitField.Field);
+
     public BoundExpression BindCallExpression(CallExpressionSyntax syntax)
     {
         // ADR-0065 §2: a bare `init(args)` call inside a constructor body is
@@ -3216,7 +3277,7 @@ internal sealed class OverloadResolver
                 convertedArgs.Add(conversions.BindConversion(argLoc, fnPermutedArgs[i], fnType.ParameterTypes[i]));
             }
 
-            return new BoundIndirectCallExpression(null, new BoundVariableExpression(null, variable), fnType, convertedArgs.MoveToImmutable());
+            return BuildIndirectDelegateCall(syntax, variable, fnType, convertedArgs.MoveToImmutable());
         }
 
         // ADR-0059 / issue #255: direct call syntax `h(args)` on a variable
@@ -3290,7 +3351,7 @@ internal sealed class OverloadResolver
                 convertedNamedArgs.Add(conversions.BindConversion(argLoc, ndPermutedArgs[i], namedDelegateSym.Parameters[i].Type));
             }
 
-            return new BoundIndirectCallExpression(null, new BoundVariableExpression(null, namedDelegateVar), namedDelegateSym.EquivalentFunctionType, convertedNamedArgs.MoveToImmutable());
+            return BuildIndirectDelegateCall(syntax, namedDelegateVar, namedDelegateSym.EquivalentFunctionType, convertedNamedArgs.MoveToImmutable());
         }
 
         // #325: a variable whose type is a CLR delegate (e.g. `Func[int32,
@@ -3302,7 +3363,9 @@ internal sealed class OverloadResolver
             && delegateVar.Type?.ClrType is System.Type delegateClrType
             && ClrTypeUtilities.IsDelegateType(delegateClrType))
         {
-            var receiver = new BoundVariableExpression(null, delegateVar);
+            var receiver = delegateVar is ImplicitFieldVariableSymbol clrImplicitField
+                ? BuildImplicitFieldLoad(clrImplicitField)
+                : (BoundExpression)new BoundVariableExpression(null, delegateVar);
             if (tryBindInheritedClrInstanceCall(receiver, delegateClrType, "Invoke", boundArguments.ToImmutable(), syntax, out var invokeCall, null, default, argumentNames))
             {
                 return invokeCall;

--- a/src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs
@@ -264,8 +264,18 @@ internal sealed class TypeDefEmitter
 
             var sigBlob = new BlobBuilder();
             this.encodeTypeSymbol(new BlobEncoder(sigBlob).FieldSignature(), ev.Type);
+
+            // Issue #1221: emit the field-like event's backing delegate field as
+            // `family` (protected) rather than `private`. C# keeps the backing
+            // field private and forbids raising a base-class event from a derived
+            // class, but G# semantics (and the Oahu corpus) require an inherited
+            // event to be raisable from a derived type. A derived method raises
+            // the event by reading this backing field on `this`, which a private
+            // field would reject at runtime (FieldAccessException); `family`
+            // grants the necessary derived-class (and cross-assembly subclass)
+            // access while still hiding the field from unrelated types.
             var backingHandle = this.emitCtx.Metadata.AddFieldDefinition(
-                attributes: FieldAttributes.Private,
+                attributes: FieldAttributes.Family,
                 name: this.emitCtx.Metadata.GetOrAddString(ev.BackingField.Name),
                 signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
             if (firstField.IsNil)

--- a/test/Compiler.Tests/Emit/EventEmitTests.cs
+++ b/test/Compiler.Tests/Emit/EventEmitTests.cs
@@ -57,7 +57,12 @@ public class EventEmitTests
         var button = assembly.GetTypes().Single(t => t.Name == "MyButton");
         var backingField = button.GetField("Click", BindingFlags.NonPublic | BindingFlags.Instance);
         Assert.NotNull(backingField);
-        Assert.True(backingField!.IsPrivate);
+
+        // Issue #1221: the field-like event backing field is emitted as
+        // `family` (protected) rather than `private` so an inherited event can
+        // be raised from a derived class (the derived method reads this field on
+        // `this`). It remains inaccessible to unrelated types.
+        Assert.True(backingField!.IsFamily);
     }
 
     [Fact]

--- a/test/Compiler.Tests/Emit/Issue1221InheritedEventRaiseEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1221InheritedEventRaiseEmitTests.cs
@@ -1,0 +1,212 @@
+// <copyright file="Issue1221InheritedEventRaiseEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1221 (follow-up to #1213): an <c>event</c> declared on a base class
+/// must be raisable from a derived class. Raising an inherited event
+/// (<c>Changed?(args)</c> / <c>Changed?.Invoke(args)</c>) from a derived method
+/// loads the base type's backing delegate field on <c>this</c>, null-checks it,
+/// and invokes it. The backing field is emitted as <c>family</c> (protected) so
+/// the derived-class read verifies and runs. These tests prove the emitted IL
+/// verifies and runs: a derived raise reaches a subscribed handler, a multi-level
+/// (grandparent) event raises from a grandchild, and a null backing field makes
+/// the raise a safe no-op.
+/// </summary>
+public class Issue1221InheritedEventRaiseEmitTests
+{
+    [Fact]
+    public void DerivedRaisesInheritedEvent_WithHandler_InvokesHandler()
+    {
+        var source = """
+            package MyLib
+
+            open class Base {
+                event Changed (int32) -> void
+            }
+
+            class Derived : Base {
+                func RaiseFromDerived(v int32) { Changed?(v) }
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var derivedType = assembly.GetTypes().Single(t => t.Name == "Derived");
+        var instance = Activator.CreateInstance(derivedType)!;
+
+        int observed = 0;
+        var ev = derivedType.GetEvent("Changed")!;
+        Action<int> handler = v => observed = v;
+        ev.AddEventHandler(instance, handler);
+
+        derivedType.GetMethod("RaiseFromDerived")!.Invoke(instance, new object[] { 42 });
+        Assert.Equal(42, observed);
+    }
+
+    [Fact]
+    public void DerivedRaisesInheritedEvent_NullBackingField_IsSafeNoOp()
+    {
+        var source = """
+            package MyLib
+
+            open class Base {
+                event Changed (int32) -> void
+            }
+
+            class Derived : Base {
+                func RaiseFromDerived(v int32) { Changed?(v) }
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var derivedType = assembly.GetTypes().Single(t => t.Name == "Derived");
+        var instance = Activator.CreateInstance(derivedType)!;
+
+        // No handler subscribed: the inherited backing delegate field is null,
+        // so raising must be a no-op rather than throwing a
+        // NullReferenceException (or a FieldAccessException for the base field).
+        var raise = derivedType.GetMethod("RaiseFromDerived")!;
+        var ex = Record.Exception(() => raise.Invoke(instance, new object[] { 5 }));
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void GrandchildRaisesGrandparentEvent_WithHandler_InvokesHandler()
+    {
+        var source = """
+            package MyLib
+
+            open class A {
+                event Changed (int32) -> void
+            }
+
+            open class B : A {
+            }
+
+            class C : B {
+                func RaiseFromC(v int32) { Changed?(v) }
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var cType = assembly.GetTypes().Single(t => t.Name == "C");
+        var instance = Activator.CreateInstance(cType)!;
+
+        int observed = 0;
+        var ev = cType.GetEvent("Changed")!;
+        Action<int> handler = v => observed = v;
+        ev.AddEventHandler(instance, handler);
+
+        cType.GetMethod("RaiseFromC")!.Invoke(instance, new object[] { 99 });
+        Assert.Equal(99, observed);
+    }
+
+    [Fact]
+    public void DerivedRaisesInheritedEvent_QualifiedInvokeForm_InvokesHandler()
+    {
+        var source = """
+            package MyLib
+
+            open class Base {
+                event Changed (int32) -> void
+            }
+
+            class Derived : Base {
+                func RaiseFromDerived(v int32) { this.Changed?.Invoke(v) }
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var derivedType = assembly.GetTypes().Single(t => t.Name == "Derived");
+        var instance = Activator.CreateInstance(derivedType)!;
+
+        int observed = 0;
+        var ev = derivedType.GetEvent("Changed")!;
+        Action<int> handler = v => observed = v;
+        ev.AddEventHandler(instance, handler);
+
+        derivedType.GetMethod("RaiseFromDerived")!.Invoke(instance, new object[] { 7 });
+        Assert.Equal(7, observed);
+    }
+
+    [Fact]
+    public void BaseAndDerivedRaiseSameInheritedEvent_BothReachHandler()
+    {
+        var source = """
+            package MyLib
+
+            open class Base {
+                event Changed (int32) -> void
+                func RaiseFromBase(v int32) { Changed?(v) }
+            }
+
+            class Derived : Base {
+                func RaiseFromDerived(v int32) { Changed?(v) }
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var derivedType = assembly.GetTypes().Single(t => t.Name == "Derived");
+        var instance = Activator.CreateInstance(derivedType)!;
+
+        int observed = 0;
+        var ev = derivedType.GetEvent("Changed")!;
+        Action<int> handler = v => observed = v;
+        ev.AddEventHandler(instance, handler);
+
+        // The same-type raise (declared on Base) and the inherited raise (from
+        // Derived) both bind to the one backing field and reach the handler.
+        derivedType.GetMethod("RaiseFromBase")!.Invoke(instance, new object[] { 11 });
+        Assert.Equal(11, observed);
+
+        derivedType.GetMethod("RaiseFromDerived")!.Invoke(instance, new object[] { 22 });
+        Assert.Equal(22, observed);
+    }
+
+    private static Assembly CompileToAssembly(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1221_emit_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+        IlVerifier.Verify(outPath);
+
+        var bytes = File.ReadAllBytes(outPath);
+        return Assembly.Load(bytes);
+    }
+}


### PR DESCRIPTION
Fixes #1221

Follow-up to #1213 (PR #1219). An `event` declared on a base class could be raised from within the declaring type but **not** from a derived class. The bare raise `Changed?(v)` reported `GS0130: Function 'Changed' doesn't exist.` and the qualified `this.Changed?.Invoke(v)` reported `GS0158: Cannot find member Changed.` inside a derived method — even though G# semantics (and the Oahu corpus the translator targets) require an inherited event to be raisable from derived types.

## Root cause
#1213 made event raising work, but gated three in-type resolution points to the *declaring* type only. For a derived class the receiver type is the derived type, so the inherited event was never surfaced/resolved, and the backing delegate field was emitted `private` (inaccessible from a derived method at runtime).

## Fix
Extend each gate to walk the self-and-base-class chain, and make the backing field reachable from derived types:

- **Bare-name exposure** (`Binder.cs`): expose a field-like event of the receiver type *or any base class* as an implicit `this`-field bare name. The inheritance walk already iterated the base chain; the event branch's `t == receiverStruct` restriction is removed.
- **Qualified read** (`ExpressionBinder.Access.cs`): `this.Ev` now searches the base chain for the declaring type and targets that type's backing field (correct base field token).
- **Delegate-call lowering** (`OverloadResolver.cs`): a bare event call resolves to an `ImplicitFieldVariableSymbol`; the new `BuildIndirectDelegateCall` loads it as a field read on `this` (the previous `BoundVariableExpression` had no local slot — the same emit failure the same-type `Ev?(v)` form also hit), and the conditional raise `Ev?(args)` on a `void` delegate is guarded by a null check so a no-subscriber raise is a safe no-op, matching `Ev?.Invoke(args)`.
- **Backing-field accessibility** (`TypeDefEmitter.cs`): field-like event backing fields are emitted `family` (protected) instead of `private`, granting derived-class and cross-assembly-subclass access while still hiding them from unrelated types.

Raising an unrelated type's event (not in the base chain) still errors with `GS0130`, so events are not made globally raisable.

## Tests
- New `test/Compiler.Tests/Emit/Issue1221InheritedEventRaiseEmitTests.cs`: derived raise reaches a subscribed handler, multi-level grandparent->grandchild raise, qualified `?.Invoke` form, base+derived both raising the one backing field, and null-backing no-op. Each compiles, IL-verifies (`IlVerifier`), and runs.
- Updated `EventEmitTests.FieldLikeEvent_HasBackingField` to assert the now-`family` backing field.

## Verification
- `dotnet build GSharp.sln -c Release -graph` — 0 errors/warnings.
- Standalone `gsc` compiles the issue repro (base + derived raise) to a verifiable DLL; a reflection harness confirms a derived raise reaches the handler with the raised value and a no-subscriber raise is a no-op.
- `test/Core.Tests` — all 4257 pass.
- Compiler.Tests event/delegate/inherit emit slices pass (47 event tests, 173 delegate/inherit/func tests).
