### PR TITLE
cs2gs: coerce shift counts to int32 and align ternary numeric arms (Refs #914)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue914NumericCoercionTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue914NumericCoercionTranslationTests.cs
@@ -236,6 +236,93 @@ namespace Demo
         Assert.Contains("trun.DoThing()", printed);
     }
 
+    /// <summary>
+    /// A shift count of a non-<c>int32</c> integral (here <c>byte</c>, which C#
+    /// implicitly widens to <c>int</c>) is wrapped as <c>int32(count)</c> so the
+    /// shift binds in G# (which requires an <c>int32</c> shift count; a
+    /// <c>uint8</c>/<c>uint32</c> count is GS0129).
+    /// </summary>
+    [Fact]
+    public void Shift_NonInt32Count_WrapsInInt32Conversion()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public uint F(uint value, byte count) => value << count;
+    }
+}");
+
+        Assert.Contains("value << int32(count)", printed);
+    }
+
+    /// <summary>
+    /// A shift whose count is already <c>int32</c> is left unchanged (no redundant
+    /// conversion).
+    /// </summary>
+    [Fact]
+    public void Shift_Int32Count_LeftUnchanged()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public uint F(uint value, int count) => value << count;
+    }
+}");
+
+        Assert.Contains("value << count", printed);
+        Assert.DoesNotContain("int32(count)", printed);
+    }
+
+    /// <summary>
+    /// A compound shift-assignment <c>value &lt;&lt;= count</c> coerces the count to
+    /// <c>int32</c>, NOT to the left operand's numeric type (the previous behavior
+    /// wrongly emitted <c>uint32(count)</c>, yielding GS0129).
+    /// </summary>
+    [Fact]
+    public void CompoundShiftAssignment_NonInt32Count_CoercesCountToInt32()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public uint F(uint value, byte count)
+        {
+            value <<= count;
+            return value;
+        }
+    }
+}");
+
+        Assert.Contains("value <<= int32(count)", printed);
+        Assert.DoesNotContain("uint32(count)", printed);
+    }
+
+    /// <summary>
+    /// A ternary whose arms are differing numeric primitives coerces the diverging
+    /// arm to the conditional's non-nullable numeric result type (G# has no implicit
+    /// numeric promotion; mismatched arms are GS0263). Here C#'s common type of
+    /// <c>1u</c> and <c>0</c> is <c>uint</c>, so the <c>0</c> arm becomes <c>uint32(0)</c>.
+    /// </summary>
+    [Fact]
+    public void Ternary_DivergingNumericArms_CoercesToResultType()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public uint F(bool b) => b ? 1u : 0;
+    }
+}");
+
+        Assert.Contains("uint32(0)", printed);
+    }
+
     private static string TranslateUnit(string source)
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -3108,6 +3108,16 @@ public sealed class CSharpToGSharpTranslator
                 return this.TranslateNullCoalescing(binary, left, right);
             }
 
+            // C# shifts (`<<` / `>>`) take the result type from the left operand and
+            // allow any integral count; G# requires the shift count (RHS) to be
+            // `int32` (a `uint32`/`uint8`/... count yields GS0129). Coerce the count
+            // to int32 when it isn't already.
+            if (op == "<<" || op == ">>")
+            {
+                return new BinaryExpression(
+                    left, op, this.CoerceShiftCountToInt32(binary.Right, right));
+            }
+
             if (!IsNumericPromotionOperator(op))
             {
                 return new BinaryExpression(left, op, right);
@@ -3181,6 +3191,15 @@ public sealed class CSharpToGSharpTranslator
                 return rhs;
             }
 
+            // Compound shift (`<<=` / `>>=`): the RHS is a shift count, which G#
+            // requires to be `int32` — NOT the LHS numeric type. Coerce the count to
+            // int32 (e.g. `value <<= n` where `n` is `uint32` → `value <<= int32(n)`).
+            if (assignment.IsKind(SyntaxKind.LeftShiftAssignmentExpression) ||
+                assignment.IsKind(SyntaxKind.RightShiftAssignmentExpression))
+            {
+                return this.CoerceShiftCountToInt32(assignment.Right, rhs);
+            }
+
             ITypeSymbol leftType = this.context.GetTypeInfo(assignment.Left).Type;
             ITypeSymbol rightType = this.context.GetTypeInfo(assignment.Right).Type;
 
@@ -3192,6 +3211,28 @@ public sealed class CSharpToGSharpTranslator
             }
 
             return rhs;
+        }
+
+        // G# requires a shift count (the RHS of `<<` / `>>` / `<<=` / `>>=`) to be
+        // `int32`; C# infers the shift result from the left operand and accepts any
+        // integral count. Coerce a non-`int32` numeric count to int32 via the
+        // conversion-call form so the shift binds (avoids GS0129). A nullable or
+        // non-numeric count is left unchanged.
+        private GExpression CoerceShiftCountToInt32(
+            ExpressionSyntax countSyntax, GExpression count)
+        {
+            ITypeSymbol countType = this.context.GetTypeInfo(countSyntax).Type;
+            if (countType != null &&
+                IsNonNullableValueType(countType) &&
+                TryGetNumericKind(countType, out SpecialType underlying) &&
+                underlying != SpecialType.System_Int32)
+            {
+                ITypeSymbol int32Type =
+                    this.context.Compilation.GetSpecialType(SpecialType.System_Int32);
+                return this.CoerceOperandTo(count, int32Type);
+            }
+
+            return count;
         }
 
         // C# `a ?? b` where `a` is a nullable numeric: G# requires `b` to match
@@ -3213,6 +3254,43 @@ public sealed class CSharpToGSharpTranslator
             }
 
             return new BinaryExpression(left, "??", right);
+        }
+
+        // C# ternary `cond ? a : b` lowers to the G# value-position `if` expression.
+        // When both arms are numeric primitives whose types differ from the
+        // conditional's overall (non-nullable) numeric result type, G# has no
+        // implicit numeric promotion and reports GS0263 ("branches have no common
+        // result type"). Coerce each diverging arm to the result type via the
+        // conversion-call form (e.g. `cond ? 1u : 0` → `if cond { 1u } else { uint32(0) }`).
+        private GExpression TranslateConditionalExpression(
+            ConditionalExpressionSyntax conditional)
+        {
+            GExpression condition = this.TranslateExpression(conditional.Condition);
+            GExpression whenTrue = this.TranslateExpression(conditional.WhenTrue);
+            GExpression whenFalse = this.TranslateExpression(conditional.WhenFalse);
+
+            ITypeSymbol resultType = this.context.GetTypeInfo(conditional).Type;
+            ITypeSymbol trueType = this.context.GetTypeInfo(conditional.WhenTrue).Type;
+            ITypeSymbol falseType = this.context.GetTypeInfo(conditional.WhenFalse).Type;
+
+            if (resultType != null &&
+                IsNonNullableValueType(resultType) &&
+                TryGetNumericKind(resultType, out SpecialType resultUnderlying) &&
+                TryGetNumericKind(trueType, out SpecialType trueUnderlying) &&
+                TryGetNumericKind(falseType, out SpecialType falseUnderlying))
+            {
+                if (trueUnderlying != resultUnderlying)
+                {
+                    whenTrue = this.CoerceOperandTo(whenTrue, resultType);
+                }
+
+                if (falseUnderlying != resultUnderlying)
+                {
+                    whenFalse = this.CoerceOperandTo(whenFalse, resultType);
+                }
+            }
+
+            return new IfExpression(condition, whenTrue, whenFalse);
         }
 
         // Unwraps `System.Nullable<T>` to its underlying `T`; other types pass
@@ -4627,10 +4705,7 @@ public sealed class CSharpToGSharpTranslator
                     // A C# ternary `cond ? a : b` maps to the canonical G#
                     // value-position `if` expression `if cond { a } else { b }`
                     // (ADR-0064, sample IfExpression.gs; ADR-0115 §B).
-                    return new IfExpression(
-                        this.TranslateExpression(conditional.Condition),
-                        this.TranslateExpression(conditional.WhenTrue),
-                        this.TranslateExpression(conditional.WhenFalse));
+                    return this.TranslateConditionalExpression(conditional);
 
                 case QueryExpressionSyntax query:
                     return this.TranslateQuery(query);


### PR DESCRIPTION
## Summary
Two numeric-coercion translator gaps surfaced migrating `Oahu.Decrypt` (Refs #914). G# has no implicit numeric promotion, so the translator must emit explicit conversions that C# performs implicitly.

### 1. Shift counts must be `int32`
G# requires the RHS of `<<` / `>>` / `<<=` / `>>=` to be `int32`. C# infers the shift result from the left operand and accepts any integral count (implicitly widening `byte`/`short`/`char` to `int`).

- `TranslateBinaryExpression` now coerces a non-`int32` shift count to `int32` via the conversion-call form: `value << int32(count)`.
- `CoerceCompoundAssignmentRhs` no longer coerces a shift count to the **LHS** numeric type (which produced `value <<= uint32(count)` → GS0129); shift counts now route through the same int32 coercion.

### 2. Ternary numeric arms must share a type
A C# ternary `cond ? a : b` maps to the canonical G# value-position `if`. When the arms are differing numeric primitives (e.g. `cond ? 1u : 0`), G# reports GS0263 ("branches have no common result type"). `TranslateConditionalExpression` now coerces each diverging arm to the conditional's non-nullable numeric result type → `if cond { 1u } else { uint32(0) }`.

## Impact
- `Oahu.Decrypt`: **206 → 201** compile errors.
- `Oahu.Foundation`: unchanged (no regression).
- cs2gs translator tests: **266 pass** (262 + 4 new in `Issue914NumericCoercionTranslationTests`).

## Tests
New cases: non-int32 shift count wraps to `int32(count)`; int32 count left unchanged; compound shift count coerces to int32 (not `uint32`); diverging ternary numeric arms coerce to the result type.
