### PR TITLE
cs2gs: rewrite delegate Invoke to native G# call

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue914NumericCoercionTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue914NumericCoercionTranslationTests.cs
@@ -323,6 +323,71 @@ namespace Demo
         Assert.Contains("uint32(0)", printed);
     }
 
+    /// <summary>
+    /// A direct delegate/event <c>Invoke(...)</c> is rewritten to G#'s native
+    /// invocation form (<c>d(args)</c>); G# has no <c>Delegate.Invoke</c> member.
+    /// </summary>
+    [Fact]
+    public void DelegateInvoke_IdentifierReceiver_RewritesToNativeCall()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        private System.Action<int> handler;
+        public void Raise(int x) => handler.Invoke(x);
+    }
+}");
+
+        Assert.Contains("handler(x)", printed);
+        Assert.DoesNotContain(".Invoke(x)", printed);
+    }
+
+    /// <summary>
+    /// A null-conditional delegate invocation with a simple identifier receiver
+    /// renders as G#'s <c>d?(args)</c> (the parser disambiguates <c>name?(</c> as a
+    /// null-conditional invoke).
+    /// </summary>
+    [Fact]
+    public void NullConditionalInvoke_IdentifierReceiver_RewritesToNullConditionalCall()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        private System.Action<int> handler;
+        public void Raise(int x) => handler?.Invoke(x);
+    }
+}");
+
+        Assert.Contains("handler?(x)", printed);
+        Assert.DoesNotContain(".Invoke(x)", printed);
+    }
+
+    /// <summary>
+    /// A null-conditional delegate invocation whose receiver is a call (its text ends
+    /// in <c>)</c>) keeps the explicit <c>?.Invoke(...)</c>: G# would parse
+    /// <c>GetHandler()?(args)</c> as the ternary operator, so the rewrite is skipped.
+    /// </summary>
+    [Fact]
+    public void NullConditionalInvoke_CallReceiver_KeepsExplicitInvoke()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        private System.Action<int> GetHandler() => null;
+        public void Raise(int x) => GetHandler()?.Invoke(x);
+    }
+}");
+
+        Assert.Contains("GetHandler()?.Invoke(x)", printed);
+        Assert.DoesNotContain("?(x)", printed);
+    }
+
     private static string TranslateUnit(string source)
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -5600,6 +5600,21 @@ public sealed class CSharpToGSharpTranslator
             GExpression target;
             IReadOnlyList<GTypeReference> typeArguments = null;
 
+            // C# delegate/event invocation `d.Invoke(args)` / `d?.Invoke(args)` maps
+            // to G#'s direct function-call form `d(args)` / `d?(args)`: G# invokes a
+            // function-typed value (delegate field or event) directly and has no
+            // `.Invoke` member (`.Invoke` would be GS0159). Detected via the
+            // delegate's synthesized `Invoke` method (MethodKind.DelegateInvoke).
+            if (this.context.GetSymbolInfo(invocation).Symbol is IMethodSymbol
+                    { MethodKind: MethodKind.DelegateInvoke }
+                && TryGetDelegateInvokeReceiver(invocation.Expression, out GExpression invokeTarget))
+            {
+                var invokeArguments = invocation.ArgumentList.Arguments
+                    .Select(a => this.TranslateArgument(a))
+                    .ToList();
+                return new InvocationExpression(invokeTarget, invokeArguments, null);
+            }
+
             // A C# extension method whose receiver is an enum is emitted as a
             // plain static helper (a receiver clause is rejected on enums,
             // GS0103). Rewrite the call `x.M(args)` to the positional form
@@ -5673,6 +5688,56 @@ public sealed class CSharpToGSharpTranslator
                 .ToList();
 
             return new InvocationExpression(target, arguments, typeArguments);
+        }
+
+        // Resolves the receiver of a delegate/event `.Invoke(...)` call to the value
+        // that G# invokes directly. `d.Invoke(...)` → `d`; the null-conditional
+        // `d?.Invoke(...)` form reaches here as a member-binding whose receiver is the
+        // conditional-receiver placeholder (so the enclosing `?.` renders `d?(...)`).
+        // The null-conditional rewrite is only applied when the conditional-access
+        // receiver is a simple identifier/member/`this` expression: G# parses
+        // `complexExpr?(args)` (e.g. a call or index receiver ending in `)`/`]`) as
+        // the ternary operator (`expr ? a : b`), so those keep the explicit `.Invoke`.
+        private bool TryGetDelegateInvokeReceiver(
+            ExpressionSyntax callee, out GExpression receiver)
+        {
+            switch (callee)
+            {
+                case MemberAccessExpressionSyntax member
+                    when member.Name.Identifier.Text == "Invoke":
+                    receiver = this.TranslateExpression(member.Expression);
+                    return true;
+
+                case MemberBindingExpressionSyntax binding
+                    when binding.Name.Identifier.Text == "Invoke"
+                        && IsSimpleConditionalInvokeReceiver(binding):
+                    receiver = new ConditionalReceiverExpression();
+                    return true;
+
+                default:
+                    receiver = null;
+                    return false;
+            }
+        }
+
+        // Reports whether the conditional-access receiver enclosing a `?.Invoke(...)`
+        // member-binding is a form G# can null-conditionally invoke as `recv?(args)`
+        // without colliding with the ternary operator — i.e. an identifier, a member
+        // access, or `this` (its last token is an identifier), but NOT a call/index/
+        // parenthesized receiver (whose trailing `)`/`]` makes `recv?(` parse as a
+        // ternary condition).
+        private static bool IsSimpleConditionalInvokeReceiver(
+            MemberBindingExpressionSyntax binding)
+        {
+            if (binding.Parent is not InvocationExpressionSyntax invocation ||
+                invocation.Parent is not ConditionalAccessExpressionSyntax conditional)
+            {
+                return false;
+            }
+
+            return conditional.Expression is IdentifierNameSyntax
+                or MemberAccessExpressionSyntax
+                or ThisExpressionSyntax;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
C# expresses delegate/event invocation as `d.Invoke(args)` (and `d?.Invoke(args)`). G# invokes delegates directly (`d(args)`) and has **no** `Delegate.Invoke` member, so the unmodified translation produced `GS0159: Cannot find function 'Invoke'` across Oahu (events, progress callbacks, continuations).

This teaches the translator to detect a `MethodKind.DelegateInvoke` callee and emit the native G# form:
- `d.Invoke(args)` → `d(args)`
- `d?.Invoke(args)` → `d?(args)`

### Ternary-ambiguity guard
The null-conditional rewrite is **gated to simple identifier / member / `this` receivers**. G# parses `complexExpr?(args)` — where the receiver is a call or index ending in `)`/`]` — as the **ternary operator** (`expr ? a : b`), yielding `GS0005: expected <ColonToken>`. Such call-receiver forms keep the explicit `?.Invoke` (which round-trips cleanly), e.g. `ToStringFunc[T]()?.Invoke(val)`.

## Impact
- Oahu.Decrypt: **201 → 194** compile errors (all `.Invoke` GS0159 cleared, correct forms generated).
- Oahu.Foundation: translate still **PASS** (no regression; the call-receiver guard prevents the round-trip break).

## Tests
- +3 unit tests (identifier rewrite, null-conditional identifier rewrite, call-receiver guard). Full suite **269 pass**.

Refs #914.