### PR TITLE
cs2gs: preserve nullable annotation on local declarations

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue914NumericCoercionTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue914NumericCoercionTranslationTests.cs
@@ -388,6 +388,39 @@ namespace Demo
         Assert.DoesNotContain("?(x)", printed);
     }
 
+    /// <summary>
+    /// A nullable-enabled local declaration (`Box? t1 = null`) keeps its `?` in the
+    /// emitted G# type. The local symbol's flow annotation is honored (not the bare
+    /// type-syntax info, which drops `?`), so the binding is `var t1 Box? = nil` and
+    /// later `t1 = nil` / `t1 == nil` type-check.
+    /// </summary>
+    [Fact]
+    public void NullableLocal_AnnotatedReference_KeepsNullableType()
+    {
+        string printed = TranslateUnit(@"
+#nullable enable
+namespace Demo
+{
+    public class Box { }
+    public class C
+    {
+        Box Source() => new Box();
+        public Box? M(bool flag)
+        {
+            Box? t1 = null;
+            if (flag)
+            {
+                t1 = Source();
+                Use(t1);
+            }
+            return t1;
+        }
+        void Use(Box b) { }
+    }
+}");
+        Assert.Contains("var t1 Box? = nil", printed);
+    }
+
     private static string TranslateUnit(string source)
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -3039,18 +3039,29 @@ public sealed class CSharpToGSharpTranslator
                 if (hasExplicitType)
                 {
                     bool emitType = initializer == null;
-                    ITypeSymbol declaredType = this.context.GetTypeInfo(declaration.Type).Type;
+
+                    // Prefer the local symbol's type: it carries the flow
+                    // nullable annotation (`SttsBox?`), whereas
+                    // `GetTypeInfo(declaration.Type)` reports the bare type and
+                    // silently drops the `?`, so a nullable-enabled local would
+                    // be rendered non-nullable and later `= nil`/`== nil` fail.
+                    ITypeSymbol declaredType =
+                        (this.context.GetDeclaredSymbol(declarator) as ILocalSymbol)?.Type
+                        ?? this.context.GetTypeInfo(declaration.Type).Type;
 
                     if (!emitType && initializer != null && declaredType != null)
                     {
                         // Preserve the explicit type only when it differs from the
                         // initializer's natural type (an implicit conversion). When
                         // they match, omit the clause and rely on inference — the
-                        // idiomatic common case.
+                        // idiomatic common case. A declared nullable reference
+                        // (`Box?`) whose initializer is non-null would infer the
+                        // narrower non-null type, so always emit it to keep the `?`.
                         ITypeSymbol naturalType =
                             this.context.GetTypeInfo(declarator.Initializer.Value).Type;
                         if (naturalType == null
-                            || !SymbolEqualityComparer.Default.Equals(declaredType, naturalType))
+                            || !SymbolEqualityComparer.Default.Equals(declaredType, naturalType)
+                            || IsAnnotatedNullableReference(declaredType))
                         {
                             emitType = true;
                         }
@@ -4412,6 +4423,13 @@ public sealed class CSharpToGSharpTranslator
         // is used as nullable in its scope (issue #1072). Value types and
         // already-nullable types are left untouched: this pass only covers
         // reference-type/array null-comparison and null-assignment.
+        // True for a `T?`-annotated reference type, array, or (interface/
+        // unconstrained) type parameter — the forms whose `?` the G# type mapper
+        // preserves and which inference over a non-null initializer would drop.
+        private static bool IsAnnotatedNullableReference(ITypeSymbol type) =>
+            type is { NullableAnnotation: NullableAnnotation.Annotated }
+                && (type.IsReferenceType || type is ITypeParameterSymbol);
+
         private GTypeReference PromoteIfUsedAsNullable(GTypeReference type, ISymbol symbol)
         {
             if (type == null || type.IsNullable)


### PR DESCRIPTION
## Summary
A nullable-enabled C# local declaration such as `SttsBox? t1 = null;` was translated to the **non-nullable** `var t1 SttsBox = nil`, silently dropping the `?`. Later `t1 = nil` / `t1 == nil` / `t1 != nil` uses then failed with `GS0155`/`GS0129` (`nil` not convertible to `SttsBox`; operator `==` not defined for `SttsBox` and `nil`).

Two causes in `TranslateLocalDeclaration`:
1. The declared type was read via `GetTypeInfo(declaration.Type).Type`, which reports the bare symbol **without** the flow nullable annotation.
2. The type clause was omitted whenever the declared type 'matched' the initializer's natural type — but `SymbolEqualityComparer.Default` ignores nullability, so a `Box?` declared with a non-null (or untyped `null`) initializer fell back to inference and lost the `?`.

### Fix
- Read the declared type from the **local symbol** (`GetDeclaredSymbol(declarator).Type`), which carries `NullableAnnotation.Annotated`.
- Force emitting the type clause when the declared type is an annotated nullable reference / array / type-parameter, so inference over a non-null initializer can't narrow away the `?`.

The G# type mapper already preserves `?` on reference types; it simply never received the annotated symbol on this path.

## Impact
- Oahu.Decrypt: **194 → 181** compile errors (GS0129 26→21, GS0155 24→19, GS0158 39→36).
- Oahu.Foundation: translate **PASS**, compile **8** (no change/regression).

## Tests
- +1 regression test (`NullableLocal_AnnotatedReference_KeepsNullableType`). Full suite **270 pass**.

Refs #914.