### PR TITLE
cs2gs: coerce numeric literals in is-pattern lowering

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue914NumericCoercionTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue914NumericCoercionTranslationTests.cs
@@ -421,6 +421,29 @@ namespace Demo
         Assert.Contains("var t1 Box? = nil", printed);
     }
 
+    /// <summary>
+    /// A C# constant `or` pattern on a nullable numeric (`b is 11 or 12`) lowers to
+    /// equality tests whose literals are retyped to the receiver's numeric type, so
+    /// the result type-checks under G#'s no-implicit-promotion rule (a bare
+    /// `b == 11` of `uint8?` vs `int32` is GS0129).
+    /// </summary>
+    [Fact]
+    public void ConstantOrPattern_NullableNumericReceiver_RetypesLiterals()
+    {
+        string printed = TranslateUnit(@"
+#nullable enable
+namespace Demo
+{
+    public class C
+    {
+        public byte? Mode { get; set; }
+        public bool M() => Mode is 11 or 12 or 13;
+    }
+}");
+        Assert.Contains("Mode == (11 as uint8?)", printed);
+        Assert.Contains("Mode == (12 as uint8?)", printed);
+    }
+
     private static string TranslateUnit(string source)
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -4856,10 +4856,12 @@ public sealed class CSharpToGSharpTranslator
         private GExpression TranslateIsPattern(IsPatternExpressionSyntax isPattern)
         {
             GExpression receiver = this.TranslateExpression(isPattern.Expression);
-            return this.TranslatePatternTest(receiver, isPattern.Pattern);
+            ITypeSymbol receiverType = this.context.GetTypeInfo(isPattern.Expression).Type;
+            return this.TranslatePatternTest(receiver, isPattern.Pattern, receiverType);
         }
 
-        private GExpression TranslatePatternTest(GExpression receiver, PatternSyntax pattern)
+        private GExpression TranslatePatternTest(
+            GExpression receiver, PatternSyntax pattern, ITypeSymbol receiverType = null)
         {
             switch (pattern)
             {
@@ -4871,18 +4873,26 @@ public sealed class CSharpToGSharpTranslator
                 case ConstantPatternSyntax constant:
                     // `x is 0` / `x is "moov"` / `x is true`. G# `is` only tests a
                     // type, so a constant pattern lowers to an equality test
-                    // (ADR-0115 §B).
+                    // (ADR-0115 §B). A numeric literal is retyped to the receiver's
+                    // type so `uint8? is 11` → `b == (11 as uint8?)` (G# has no
+                    // implicit numeric promotion: a bare `b == 11` is GS0129).
                     return new BinaryExpression(
                         receiver,
                         "==",
-                        this.TranslateExpression(constant.Expression));
+                        this.CoercePatternConstant(
+                            constant.Expression,
+                            this.TranslateExpression(constant.Expression),
+                            receiverType));
 
                 case RelationalPatternSyntax relational:
-                    // `x is > 0` → `x > 0`.
+                    // `x is > 0` → `x > 0` (with the same numeric retyping).
                     return new BinaryExpression(
                         receiver,
                         relational.OperatorToken.Text,
-                        this.TranslateExpression(relational.Expression));
+                        this.CoercePatternConstant(
+                            relational.Expression,
+                            this.TranslateExpression(relational.Expression),
+                            receiverType));
 
                 case DeclarationPatternSyntax declaration:
                     // `x is T t` → the boolean test `x is T`; the binder `t` is a
@@ -4910,7 +4920,7 @@ public sealed class CSharpToGSharpTranslator
                     return this.TranslateRecursivePatternTest(receiver, recursive);
 
                 case UnaryPatternSyntax unary when unary.IsKind(SyntaxKind.NotPattern):
-                    return this.TranslateNotPatternTest(receiver, unary.Pattern);
+                    return this.TranslateNotPatternTest(receiver, unary.Pattern, receiverType);
 
                 case BinaryPatternSyntax binaryPattern
                     when binaryPattern.OperatorToken.IsKind(SyntaxKind.OrKeyword)
@@ -4919,13 +4929,13 @@ public sealed class CSharpToGSharpTranslator
                     // `x is A and B` → `(x is A) && (x is B)`.
                     bool isOr = binaryPattern.OperatorToken.IsKind(SyntaxKind.OrKeyword);
                     return new BinaryExpression(
-                        this.TranslatePatternTest(receiver, binaryPattern.Left),
+                        this.TranslatePatternTest(receiver, binaryPattern.Left, receiverType),
                         isOr ? "||" : "&&",
-                        this.TranslatePatternTest(receiver, binaryPattern.Right));
+                        this.TranslatePatternTest(receiver, binaryPattern.Right, receiverType));
 
                 case ParenthesizedPatternSyntax parenthesized:
                     return new ParenthesizedExpression(
-                        this.TranslatePatternTest(receiver, parenthesized.Pattern));
+                        this.TranslatePatternTest(receiver, parenthesized.Pattern, receiverType));
 
                 default:
                     this.context.ReportUnsupported(
@@ -4935,7 +4945,8 @@ public sealed class CSharpToGSharpTranslator
             }
         }
 
-        private GExpression TranslateNotPatternTest(GExpression receiver, PatternSyntax inner)
+        private GExpression TranslateNotPatternTest(
+            GExpression receiver, PatternSyntax inner, ITypeSymbol receiverType = null)
         {
             switch (inner)
             {
@@ -4945,11 +4956,14 @@ public sealed class CSharpToGSharpTranslator
                     return new BinaryExpression(receiver, "!=", LiteralExpression.Null());
 
                 case ConstantPatternSyntax constant:
-                    // `x is not 6` → `x != 6`.
+                    // `x is not 6` → `x != 6` (with numeric retyping to the receiver).
                     return new BinaryExpression(
                         receiver,
                         "!=",
-                        this.TranslateExpression(constant.Expression));
+                        this.CoercePatternConstant(
+                            constant.Expression,
+                            this.TranslateExpression(constant.Expression),
+                            receiverType));
 
                 case RecursivePatternSyntax { Type: null } emptyRecursive
                     when emptyRecursive.PropertyPatternClause is null or { Subpatterns.Count: 0 }:
@@ -4982,8 +4996,36 @@ public sealed class CSharpToGSharpTranslator
                     // General negation: `!( <inner test> )`.
                     return new UnaryExpression(
                         "!",
-                        new ParenthesizedExpression(this.TranslatePatternTest(receiver, inner)));
+                        new ParenthesizedExpression(
+                            this.TranslatePatternTest(receiver, inner, receiverType)));
             }
+        }
+
+        // Retypes a constant/relational pattern's literal operand to the receiver's
+        // numeric type so the lowered `==`/`!=`/`<`… comparison type-checks. G# has
+        // no implicit numeric promotion, so `uint8? is 11` lowered to `b == 11`
+        // (where `11` is `int32`) is GS0129; coercing the literal yields the
+        // accepted `b == (11 as uint8?)`. Mirrors the constant branch of
+        // <see cref="TranslateBinaryExpression"/>. Non-numeric receivers/literals
+        // (string/enum/type tests) are left untouched.
+        private GExpression CoercePatternConstant(
+            ExpressionSyntax constantSyntax, GExpression constant, ITypeSymbol receiverType)
+        {
+            if (receiverType == null)
+            {
+                return constant;
+            }
+
+            ITypeSymbol constantType = this.context.GetTypeInfo(constantSyntax).Type;
+            if (TryGetNumericKind(receiverType, out SpecialType receiverUnderlying) &&
+                TryGetNumericKind(constantType, out SpecialType constantUnderlying) &&
+                receiverUnderlying != constantUnderlying &&
+                this.context.SemanticModel.GetConstantValue(constantSyntax).HasValue)
+            {
+                return this.CoerceOperandTo(constant, receiverType);
+            }
+
+            return constant;
         }
 
         private GExpression TranslateRecursivePatternTest(GExpression receiver, RecursivePatternSyntax recursive)


### PR DESCRIPTION
## Summary
A C# constant or relational `is` pattern on a numeric receiver lowers to a comparison (`x is 11` → `x == 11`, `x is > 0` → `x > 0`), but the literal retained its `int32` type. G# has no implicit numeric promotion, so a nullable/narrow receiver produced `GS0129`:

```
// C#:  DsiPresentationChMode is 11 or 12 or 13 or 14   (field is byte?)
// was: b == 11 || b == 12 || ...      → GS0129 (uint8? vs int32)
// now: b == (11 as uint8?) || ...     → compiles
```

`TranslatePatternTest` / `TranslateNotPatternTest` now thread the receiver's type and retype a numeric literal to it via the existing `CoerceOperandTo` (the same retyping `TranslateBinaryExpression`'s constant branch already does for `==`/`<`/…). The coercion only fires for numeric receiver + numeric constant literal of a different underlying kind; string / enum / `bool` / type-test patterns are untouched, and `or`/`and`/`not`/parenthesized patterns thread the receiver type through.

## Impact
- Oahu.Decrypt: **181 → 177** compile errors (GS0129 21→17).
- Oahu.Foundation: translate **PASS**, compile **8** (no regression).

## Tests
- +1 regression test (`ConstantOrPattern_NullableNumericReceiver_RetypesLiterals`). Full suite **271 pass**.

Refs #914.