### PR TITLE
Fix #1235: surface fields/properties on class/interface-constrained type parameters

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -2636,6 +2636,24 @@ internal sealed partial class ExpressionBinder
                     Diagnostics.ReportUnableToFindMember(ne.Location, arrayMemberName);
                     return new BoundErrorExpression(null);
                 }
+                else if (receiver != null && receiver.Type is TypeParameterSymbol tpRecv)
+                {
+                    // Issue #1235: a value whose static type is a type parameter
+                    // constrained to a class (or interface) exposes that
+                    // constraint's FULL instance member surface — fields and
+                    // properties, not only methods (instance method calls are
+                    // resolved through the constraint in ExpressionBinder.Calls).
+                    // Field reads lower to a `box !!T; ldfld` against the
+                    // constraint class; property reads dispatch through a
+                    // verifiable `box !!T; callvirt get_X` (see the emitter).
+                    var tpMember = BindTypeParameterInstanceMemberAccess(tpRecv, receiver, ne);
+                    if (tpMember != null)
+                    {
+                        return tpMember;
+                    }
+
+                    Diagnostics.ReportUnableToFindMember(ne.Location, ne.IdentifierToken.Text);
+                }
                 else
                 {
                     Diagnostics.ReportUnableToFindMember(ne.Location, ne.IdentifierToken.Text);
@@ -4262,6 +4280,83 @@ internal sealed partial class ExpressionBinder
         {
             Diagnostics.ReportValueTaskDirectGetResult(callSyntax.Identifier.Location);
         }
+    }
+
+    /// <summary>
+    /// Issue #1235: resolves an instance field/property read named on a
+    /// receiver whose static type is a <see cref="TypeParameterSymbol"/>,
+    /// against the type parameter's class constraint (including inherited
+    /// members) or interface constraint. Instance method <em>calls</em> are
+    /// handled separately in <c>ExpressionBinder.Calls</c>; this surfaces the
+    /// remaining member kinds (fields and properties) so a constrained type
+    /// parameter exposes its constraint's full instance member surface.
+    /// Returns <see langword="null"/> when no such member exists (so the caller
+    /// reports GS0158).
+    /// </summary>
+    /// <param name="tpRecv">The type-parameter receiver's type.</param>
+    /// <param name="receiver">The bound receiver expression.</param>
+    /// <param name="ne">The member-name syntax.</param>
+    /// <returns>The bound member access, or <see langword="null"/>.</returns>
+    private BoundExpression BindTypeParameterInstanceMemberAccess(
+        TypeParameterSymbol tpRecv,
+        BoundExpression receiver,
+        NameExpressionSyntax ne)
+    {
+        var memberName = ne.IdentifierToken.Text;
+
+        // Class constraint (issue #1056 surfaced methods; this adds the rest):
+        // fields and properties, walking the base chain of the constraint class.
+        if (tpRecv.ClassConstraint is StructSymbol classConstraint)
+        {
+            if (TypeMemberModel.TryGetFieldIncludingInherited(classConstraint, memberName, MemberQuery.Instance(MemberKinds.Field), out var field, out var fieldDeclaringType))
+            {
+                reportObsoleteUseIfApplicable(ne.IdentifierToken.Location, field, $"{fieldDeclaringType.Name}.{field.Name}");
+
+                if (!AccessibilityChecker.IsAccessible(field.Accessibility, fieldDeclaringType, this.function))
+                {
+                    Diagnostics.ReportProtectedMemberInaccessible(ne.IdentifierToken.Location, field.Name, fieldDeclaringType.Name);
+                }
+
+                return ApplyMemberNarrowing(new BoundFieldAccessExpression(null, receiver, fieldDeclaringType, field));
+            }
+
+            if (TypeMemberModel.TryGetProperty(classConstraint, memberName, out var prop, out var propDeclaringType))
+            {
+                if (!prop.HasGetter)
+                {
+                    Diagnostics.ReportCannotAssign(ne.Location, memberName);
+                    return new BoundErrorExpression(null);
+                }
+
+                if (!AccessibilityChecker.IsAccessible(prop.Accessibility, propDeclaringType, this.function))
+                {
+                    Diagnostics.ReportProtectedMemberInaccessible(ne.IdentifierToken.Location, prop.Name, propDeclaringType.Name);
+                }
+
+                return ApplyMemberNarrowing(new BoundPropertyAccessExpression(null, receiver, propDeclaringType, prop));
+            }
+        }
+
+        // Interface constraint: an instance property declared on the (non-generic)
+        // interface or any base interface. The getter dispatches through a
+        // verifiable `box !!T; callvirt I::get_X` in the emitter.
+        if (tpRecv.InterfaceConstraint is InterfaceSymbol interfaceConstraint
+            && !interfaceConstraint.IsGenericDefinition
+            && interfaceConstraint.TypeArguments.IsDefaultOrEmpty)
+        {
+            if (TypeMemberModel.TryGetProperty(interfaceConstraint, memberName, out var ifaceProp, out _))
+            {
+                if (!ifaceProp.HasGetter)
+                {
+                    Diagnostics.ReportCannotAssign(ne.Location, memberName);
+                    return new BoundErrorExpression(null);
+                }
+
+                return new BoundPropertyAccessExpression(null, receiver, null, ifaceProp);
+            }
+        }
+
+        return null;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
@@ -435,6 +435,23 @@ internal sealed partial class MethodBodyEmitter
             return;
         }
 
+        // Issue #1235: a field read on a receiver whose static type is a type
+        // parameter constrained to a class (`t.F` with `t : T`, `T : Base`).
+        // A reference-type-constrained `!!T` value is boxed (a no-op at runtime
+        // that yields the object reference typed as the constraint) so the
+        // verifier accepts the subsequent `ldfld` against the constraint class —
+        // the same shape the C# compiler emits for `t.field`.
+        if (fa.Receiver.Type is TypeParameterSymbol fieldReceiverTp)
+        {
+            this.EmitExpression(fa.Receiver);
+            this.il.OpCode(ILOpCode.Box);
+            this.il.Token(this.outer.GetElementTypeToken(fieldReceiverTp));
+            this.il.OpCode(ILOpCode.Ldfld);
+            this.il.Token(fieldHandle);
+            this.EmitNarrowingCastIfNeeded(fa.Field.Type, fa.NarrowedType);
+            return;
+        }
+
         // Class receivers are references: load the value (the ref) and ldfld.
         // For struct receivers, load by address when the receiver is a
         // simple variable (avoids a copy and is verifier-friendly); fall
@@ -666,6 +683,24 @@ internal sealed partial class MethodBodyEmitter
         if (access.Receiver == null)
         {
             this.il.OpCode(ILOpCode.Call);
+            this.il.Token(getterHandle);
+            this.EmitNarrowingCastIfNeeded(access.Property.Type, access.NarrowedType);
+            return;
+        }
+
+        // Issue #1235: a property read on a receiver whose static type is a type
+        // parameter constrained to a class or interface (`t.P` with `t : T`,
+        // `T : Base`). A reference-type-constrained `!!T` value is boxed (a
+        // runtime no-op yielding the object reference typed as the constraint)
+        // and the getter dispatched with `callvirt get_P` — the same verifiable
+        // shape the C# compiler emits for a property read through a type
+        // parameter.
+        if (access.Receiver.Type is TypeParameterSymbol tpReceiver)
+        {
+            this.EmitExpression(access.Receiver);
+            this.il.OpCode(ILOpCode.Box);
+            this.il.Token(this.outer.GetElementTypeToken(tpReceiver));
+            this.il.OpCode(ILOpCode.Callvirt);
             this.il.Token(getterHandle);
             this.EmitNarrowingCastIfNeeded(access.Property.Type, access.NarrowedType);
             return;

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -2033,23 +2033,52 @@ public sealed class Evaluator
 
         var receiverValue = EvaluateExpression(node.Receiver);
 
-        // Auto-property fallback: access backing field directly.
-        if (node.Property.IsAutoProperty && node.Property.BackingField != null)
+        // Issue #1235 / issue #1068: when the statically-bound property is
+        // declared on an interface (or, for a constrained type parameter, on the
+        // constraint type), resolve the concrete property implementation from
+        // the receiver's runtime type so the read dispatches virtually — the
+        // interpreter analogue of `callvirt get_X`. Walking the base chain also
+        // honours property overrides.
+        var property = node.Property;
+        if (receiverValue is StructValue concreteSv && concreteSv.StructType != null)
         {
-            if (receiverValue is StructValue sv && sv.Fields.TryGetValue(node.Property.BackingField.Name, out var value))
+            for (var t = concreteSv.StructType; t != null; t = t.BaseClass)
+            {
+                Symbols.PropertySymbol concrete = null;
+                foreach (var p in t.Properties)
+                {
+                    if (!p.IsIndexer && p.Name == property.Name)
+                    {
+                        concrete = p;
+                        break;
+                    }
+                }
+
+                if (concrete != null)
+                {
+                    property = concrete;
+                    break;
+                }
+            }
+        }
+
+        // Auto-property fallback: access backing field directly.
+        if (property.IsAutoProperty && property.BackingField != null)
+        {
+            if (receiverValue is StructValue sv && sv.Fields.TryGetValue(property.BackingField.Name, out var value))
             {
                 return value;
             }
 
-            return DefaultValue(node.Property.Type);
+            return DefaultValue(property.Type);
         }
 
         // Computed property: execute the bound getter body.
-        if (node.Property.GetterSymbol != null && program.Functions.TryGetValue(node.Property.GetterSymbol, out var getterBody))
+        if (property.GetterSymbol != null && program.Functions.TryGetValue(property.GetterSymbol, out var getterBody))
         {
             var frame = new Dictionary<Symbols.VariableSymbol, object>
             {
-                [node.Property.GetterSymbol.ThisParameter] = receiverValue,
+                [property.GetterSymbol.ThisParameter] = receiverValue,
             };
             locals.Push(frame);
             var result = EvaluateFunctionBody(getterBody);
@@ -2057,7 +2086,7 @@ public sealed class Evaluator
             return result;
         }
 
-        return DefaultValue(node.Property.Type);
+        return DefaultValue(property.Type);
     }
 
     private object EvaluatePropertyAssignmentExpression(BoundPropertyAssignmentExpression node)

--- a/test/Compiler.Tests/Emit/Issue1235TypeParameterClassMemberEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1235TypeParameterClassMemberEmitTests.cs
@@ -1,0 +1,217 @@
+// <copyright file="Issue1235TypeParameterClassMemberEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1235: end-to-end CLR emit + ilverify coverage for instance FIELD and
+/// PROPERTY access on a value whose static type is a type parameter constrained
+/// to a (user) class or interface. Methods already dispatched through the
+/// constraint (issue #1056); these tests validate that fields, (inherited)
+/// properties, and interface properties are surfaced too, that the emitted
+/// <c>box !!T; ldfld</c> / <c>box !!T; callvirt get_X</c> sequences pass
+/// ilverify, and that the reads return the right values at runtime.
+/// </summary>
+public class Issue1235TypeParameterClassMemberEmitTests
+{
+    [Fact]
+    public void EndToEnd_ClassConstraint_ReadsFieldPropertyMethodAndInherited()
+    {
+        var source = """
+            package p
+            open class GrandBase { prop Inherited int32 { get; set; } }
+            open class Base : GrandBase {
+              prop P int32 { get; set; }
+              var F2 int32
+              func Hello() int32 { return 42 }
+            }
+            open class C[T Base] {
+              func ReadProp(t T) int32 { return t.P }
+              func ReadField(t T) int32 { return t.F2 }
+              func CallMethod(t T) int32 { return t.Hello() }
+              func ReadInherited(t T) int32 { return t.Inherited }
+            }
+            func Main() {
+              var b = Base()
+              b.P = 7
+              b.F2 = 13
+              b.Inherited = 100
+              var c = C[Base]()
+              var sum = c.ReadProp(b) + c.ReadField(b) + c.CallMethod(b) + c.ReadInherited(b)
+              System.Console.WriteLine(sum)
+            }
+            """;
+        var output = CompileAndRun(source);
+        Assert.Equal("162\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_InterfaceConstraint_ReadsProperty()
+    {
+        var source = """
+            package p
+            interface IHasName { prop Name int32 { get; } }
+            open class Named : IHasName { prop Name int32 { get; set; } }
+            open class D[T IHasName] {
+              func ReadIfaceProp(t T) int32 { return t.Name }
+            }
+            func Main() {
+              var n = Named()
+              n.Name = 55
+              var d = D[Named]()
+              System.Console.WriteLine(d.ReadIfaceProp(n))
+            }
+            """;
+        var output = CompileAndRun(source);
+        Assert.Equal("55\n", output);
+    }
+
+    [Fact]
+    public void Library_ClassConstraintFieldAndPropertyReads_PassIlVerify()
+    {
+        // ilverify is invoked unconditionally by CompileLibrary; a bare ldfld /
+        // callvirt on the unboxed `!!T` value (missing the `box !!T`) would fail
+        // verification here with StackUnexpected.
+        var source = """
+            package p
+            open class Base {
+              prop P int32 { get; set; }
+              var F2 int32
+            }
+            open class C[T Base] {
+              func A(t T) int32 { return t.P }
+              func B(t T) int32 { return t.F2 }
+            }
+            """;
+
+        var dllPath = CompileLibrary(source);
+        TryCleanup(dllPath);
+    }
+
+    private static string CompileLibrary(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1235_lib_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        var args = new[]
+        {
+            "/out:" + outPath,
+            "/target:library",
+            "/targetframework:net10.0",
+            srcPath,
+        };
+
+        RunCompiler(args);
+        IlVerifier.Verify(outPath);
+        return outPath;
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1235_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            RunCompiler(args);
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static void RunCompiler(string[] args)
+    {
+        using var stdoutWriter = new StringWriter();
+        using var stderrWriter = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(stdoutWriter);
+        Console.SetError(stderrWriter);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+    }
+
+    private static void TryCleanup(string dllPath)
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(dllPath);
+            if (dir != null && Directory.Exists(dir))
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+        catch
+        {
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1235TypeParameterClassMemberTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1235TypeParameterClassMemberTests.cs
@@ -1,0 +1,124 @@
+// <copyright file="Issue1235TypeParameterClassMemberTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1235: a value whose static type is a type parameter constrained to a
+/// (user) class or interface exposes that constraint's FULL instance member
+/// surface — instance fields and properties, not only methods. Previously a
+/// field/property read (<c>t.F</c> / <c>t.P</c>) on a constrained type
+/// parameter reported GS0158 "Cannot find member" while method calls resolved
+/// correctly.
+/// </summary>
+public class Issue1235TypeParameterClassMemberTests
+{
+    [Fact]
+    public void ClassConstraint_PropertyRead_BindsAndReturnsValue()
+    {
+        var source = @"
+open class Base { prop P int32 { get; set; } }
+
+func ReadP[T Base](t T) int32 { return t.P }
+var b = Base()
+b.P = 7
+ReadP[Base](b)
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(7, result.Value);
+    }
+
+    [Fact]
+    public void ClassConstraint_FieldRead_BindsAndReturnsValue()
+    {
+        var source = @"
+open class Base { var F2 int32 }
+
+func ReadF[T Base](t T) int32 { return t.F2 }
+var b = Base()
+b.F2 = 13
+ReadF[Base](b)
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(13, result.Value);
+    }
+
+    [Fact]
+    public void ClassConstraint_MethodCall_StillBinds()
+    {
+        var source = @"
+open class Base { func Hello() int32 { return 42 } }
+
+func CallHello[T Base](t T) int32 { return t.Hello() }
+CallHello[Base](Base())
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void ClassConstraint_InheritedProperty_Binds()
+    {
+        var source = @"
+open class GrandBase { prop Inherited int32 { get; set; } }
+open class Base : GrandBase { }
+
+func ReadInherited[T Base](t T) int32 { return t.Inherited }
+var b = Base()
+b.Inherited = 100
+ReadInherited[Base](b)
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(100, result.Value);
+    }
+
+    [Fact]
+    public void InterfaceConstraint_PropertyRead_Binds()
+    {
+        var source = @"
+interface IHasName { prop Name int32 { get; } }
+open class Named : IHasName { prop Name int32 { get; set; } }
+
+func ReadName[T IHasName](t T) int32 { return t.Name }
+var n = Named()
+n.Name = 55
+ReadName[Named](n)
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(55, result.Value);
+    }
+
+    [Fact]
+    public void UnknownMemberOnTypeParameter_StillReportsGS0158()
+    {
+        var source = @"
+open class Base { var F2 int32 }
+
+func Bad[T Base](t T) int32 { return t.Missing }
+";
+        var result = Evaluate(source);
+        Assert.NotEmpty(result.Diagnostics);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0158");
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(syntaxTree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
## Summary
A value whose static type is a type parameter constrained to a class (`[T Base]`) correctly resolved instance **method** calls but reported **GS0158 "Cannot find member"** for instance **field** and **property** reads.

```gsharp
open class Base {
  prop P int32 { get; set; }
  var F2 int32
  func Hello() int32 { return 1 }
}
open class C[T Base] {
  func A(t T) int32 { return t.P }       // was GS0158 — now OK
  func B(t T) int32 { return t.F2 }      // was GS0158 — now OK
  func G(t T) int32 { return t.Hello() } // already OK
}
```

## Root cause
Member-access binding only had receiver branches for concrete `StructSymbol` / `InterfaceSymbol` / CLR receivers. A `TypeParameterSymbol` receiver matched none of them and fell through to the GS0158 path. Method calls already worked because `ExpressionBinder.Calls` dispatches through the type parameter's constraint, but the field/property read path had no equivalent.

## Fix
- **Binder** (`ExpressionBinder.Access`): add a `TypeParameterSymbol` receiver branch that resolves the member against the type parameter's class constraint (fields and properties, walking the constraint's base chain) and, for a non-generic interface constraint, the interface's properties.
- **Emitter** (`MethodBodyEmitter.MemberAccess`): a field/property read on a type-parameter receiver boxes the reference-constrained `!!T` value (a runtime no-op yielding the object reference typed as the constraint) and then `ldfld` / `callvirt get_X` against the constraint type — the same verifiable IL shape the C# compiler emits. Verified with `ilverify`.
- **Evaluator**: resolve the concrete property implementation from the receiver's runtime type so interface/constraint property reads dispatch virtually in the interpreter.

## Tests
- `test/Core.Tests` — binder/eval tests: class property, field, method, inherited property, interface-constraint property, and GS0158 negative case.
- `test/Compiler.Tests/Emit` — end-to-end compile + `ilverify` + execution tests (class constraint field/prop/method/inherited, interface property, library ilverify).

All new tests pass; full `dotnet build GSharp.sln -c Release -graph` is 0 errors; full Core.Tests (4263) pass.

Fixes #1235
