### PR TITLE
Fix #1238: target-type conditional/switch call arguments

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -205,6 +205,7 @@ public sealed class Binder
             memberLookup,
             conversions,
             bindExpression: syntax => expressions.BindExpression(syntax),
+            bindExpressionWithTargetType: (syntax, targetType) => expressions.BindExpression(syntax, targetType),
             bindRefArgumentExpression: (refSyntax, parameter) => expressions.BindRefArgumentExpression(refSyntax, parameter),
             tryRebindInlineOutVarPlaceholder: (boundArg, slotSyntax, resolvedParameter, substitutedPointeeType) => expressions.TryRebindInlineOutVarPlaceholder(boundArg, slotSyntax, resolvedParameter, substitutedPointeeType),
             bindTypeClause: BindTypeClause,

--- a/src/Core/CodeAnalysis/Binding/BinderContext.cs
+++ b/src/Core/CodeAnalysis/Binding/BinderContext.cs
@@ -57,6 +57,20 @@ internal sealed class BinderContext
     public int NullConditionalCaptureCounter;
 
     /// <summary>
+    /// Issue #1238: set transiently by the argument-binding loops just before
+    /// eagerly binding a top-level conditional (<c>if</c>/<c>else</c>),
+    /// ternary, or <c>switch</c>-expression argument that has no target type
+    /// yet. When set, those branchy binders suppress a no-common-type
+    /// unification failure (instead of reporting it) and return a placeholder
+    /// carrying the original syntax, so the argument can be re-bound with the
+    /// resolved parameter type as its target once overload resolution picks the
+    /// applicable method/constructor. The flag is read-and-cleared by the
+    /// branchy binder so nested sub-expressions bind with normal (non-deferred)
+    /// semantics.
+    /// </summary>
+    public bool DeferTargetlessConditional;
+
+    /// <summary>
     /// Counter used to allocate unique synthetic-local names for general
     /// binder-introduced temporaries. Mutated in place by callers via
     /// <see cref="System.Threading.Interlocked.Increment(ref int)"/>.

--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -273,6 +273,26 @@ internal sealed class ConversionClassifier
     /// <returns>The shaped bound expression.</returns>
     public BoundExpression BindConversion(TextLocation diagnosticLocation, BoundExpression expression, TypeSymbol type, bool allowExplicit = false)
     {
+        // Issue #1238: a deferred target-typed conditional/if/switch argument
+        // placeholder (a BoundErrorExpression retaining the branchy syntax,
+        // produced when the branches could not unify without a target type).
+        // Re-bind the retained syntax against the now-known target so each
+        // branch is target-typed (e.g. a `nil` arm widens to the parameter's
+        // nullable type). When the target is missing/in error, re-bind without
+        // a target so the original no-common-type diagnostic — suppressed at the
+        // deferral point — surfaces. This is the central finalization path that
+        // covers every call/constructor argument site routed through
+        // BindConversion.
+        if (ExpressionBinder.IsDeferredBranchyArgumentPlaceholder(expression, out var branchySyntax))
+        {
+            if (type == null || type == TypeSymbol.Error || type == TypeSymbol.Void)
+            {
+                return bindExpression(branchySyntax);
+            }
+
+            return bindExpressionWithTargetType(branchySyntax, type);
+        }
+
         // Issue #1018: a throw-expression has the bottom (`never`) type and is
         // implicitly convertible to any target. Return it unwrapped — there is
         // no value to convert, and wrapping it in a BoundConversionExpression

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -1244,7 +1244,7 @@ internal sealed partial class ExpressionBinder
             var argSyntax = OverloadResolver.UnwrapNamedArgumentValue(argument);
             boundArguments.Add(argSyntax is RefArgumentExpressionSyntax refArg
                 ? BindRefArgumentExpression(refArg, parameter: null)
-                : BindExpression(argSyntax));
+                : BindArgumentDeferringBranchy(argSyntax));
         }
 
         var arguments = boundArguments.ToImmutable();

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -2289,7 +2289,7 @@ internal sealed partial class ExpressionBinder
             }
             else
             {
-                boundArguments.Add(BindExpression(inner));
+                boundArguments.Add(BindArgumentDeferringBranchy(inner));
             }
 
             argSlot++;

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
@@ -603,6 +603,16 @@ internal sealed partial class ExpressionBinder
 
     private BoundExpression BindConditionalExpression(ConditionalExpressionSyntax syntax, TypeSymbol targetType)
     {
+        // Issue #1238: when this conditional is a bare call/constructor argument
+        // whose target parameter type is not yet known, the argument-binding
+        // loop set DeferTargetlessConditional so a no-common-type unification
+        // failure (e.g. a `nil`/narrower arm that needs the parameter's nullable
+        // type to widen) is deferred rather than reported here. Consume the flag
+        // immediately so nested sub-expressions bind with normal semantics.
+        var deferOnFailure = targetType == null && binderCtx.DeferTargetlessConditional;
+        binderCtx.DeferTargetlessConditional = false;
+        var diagMark = Diagnostics.Count;
+
         var condition = BindExpression(syntax.Condition, TypeSymbol.Bool);
 
         // ADR-0100 / issue #795: a bare `default` branch takes its type
@@ -654,6 +664,12 @@ internal sealed partial class ExpressionBinder
         var resultType = ComputeConditionalResultType(whenTrue.Type, whenFalse.Type, targetType);
         if (resultType == null)
         {
+            if (deferOnFailure)
+            {
+                Diagnostics.TruncateTo(diagMark);
+                return new BoundErrorExpression(syntax);
+            }
+
             Diagnostics.ReportConditionalNoCommonResultType(
                 syntax.Location,
                 whenTrue.Type?.Name ?? "?",
@@ -665,6 +681,12 @@ internal sealed partial class ExpressionBinder
         var convertedFalse = ConvertConditionalBranch(syntax.WhenFalse.Location, whenFalse, resultType);
         if (convertedTrue is BoundErrorExpression || convertedFalse is BoundErrorExpression)
         {
+            if (deferOnFailure)
+            {
+                Diagnostics.TruncateTo(diagMark);
+                return new BoundErrorExpression(syntax);
+            }
+
             return new BoundErrorExpression(null);
         }
 
@@ -681,6 +703,14 @@ internal sealed partial class ExpressionBinder
 
     private BoundExpression BindIfExpression(IfExpressionSyntax syntax, TypeSymbol targetType)
     {
+        // Issue #1238: defer a no-common-type unification failure when this
+        // if-expression is a bare argument awaiting its parameter target type
+        // (see BindConditionalExpression for the full rationale). Consume the
+        // flag immediately so nested sub-expressions bind normally.
+        var deferOnFailure = targetType == null && binderCtx.DeferTargetlessConditional;
+        binderCtx.DeferTargetlessConditional = false;
+        var diagMark = Diagnostics.Count;
+
         // An if-expression in value position must have an else branch.
         if (syntax.ElseExpression == null)
         {
@@ -701,6 +731,12 @@ internal sealed partial class ExpressionBinder
         var resultType = ComputeConditionalResultType(whenTrue.Type, whenFalse.Type, targetType);
         if (resultType == null)
         {
+            if (deferOnFailure)
+            {
+                Diagnostics.TruncateTo(diagMark);
+                return new BoundErrorExpression(syntax);
+            }
+
             Diagnostics.ReportConditionalNoCommonResultType(
                 syntax.Location,
                 whenTrue.Type?.Name ?? "?",
@@ -712,6 +748,12 @@ internal sealed partial class ExpressionBinder
         var convertedFalse = ConvertConditionalBranch(syntax.ElseExpression.Location, whenFalse, resultType);
         if (convertedTrue is BoundErrorExpression || convertedFalse is BoundErrorExpression)
         {
+            if (deferOnFailure)
+            {
+                Diagnostics.TruncateTo(diagMark);
+                return new BoundErrorExpression(syntax);
+            }
+
             return new BoundErrorExpression(null);
         }
 

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.SwitchExpr.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.SwitchExpr.cs
@@ -29,6 +29,14 @@ internal sealed partial class ExpressionBinder
 
     private BoundExpression BindSwitchExpression(SwitchExpressionSyntax syntax, TypeSymbol targetType)
     {
+        // Issue #1238: when this switch-expression is an eagerly-bound call
+        // argument with no target type yet, defer a no-common-type unification
+        // failure (instead of reporting GS0179) so the argument can be re-bound
+        // against the resolved parameter type. The flag is read-and-cleared up
+        // front so nested sub-expressions bind with normal semantics.
+        var deferOnFailure = targetType == null && binderCtx.DeferTargetlessConditional;
+        binderCtx.DeferTargetlessConditional = false;
+
         var discriminant = BindExpression(syntax.Expression);
         var switchType = discriminant.Type;
 
@@ -111,6 +119,8 @@ internal sealed partial class ExpressionBinder
         }
 
         var resultType = ComputeSwitchExpressionResultType(boundArmBuilders, targetType);
+        var diagMark = Diagnostics.Count;
+        var anyArmFailed = false;
         var arms = ImmutableArray.CreateBuilder<BoundSwitchExpressionArm>(boundArmBuilders.Count);
         foreach (var arm in boundArmBuilders)
         {
@@ -121,6 +131,7 @@ internal sealed partial class ExpressionBinder
                 if (result.Type != TypeSymbol.Error && resultType != TypeSymbol.Error)
                 {
                     Diagnostics.ReportSwitchExpressionArmTypeMismatch(arm.Syntax.Result.Location, result.Type, resultType);
+                    anyArmFailed = true;
                 }
 
                 result = new BoundErrorExpression(null);
@@ -139,6 +150,17 @@ internal sealed partial class ExpressionBinder
         }
 
         var boundArms = arms.ToImmutable();
+
+        // Issue #1238: a deferred argument switch-expression whose arms could not
+        // unify without a target — suppress the GS0179 diagnostics and return a
+        // syntax-carrying placeholder so the caller can re-bind against the
+        // resolved parameter type.
+        if (anyArmFailed && deferOnFailure)
+        {
+            Diagnostics.TruncateTo(diagMark);
+            return new BoundErrorExpression(syntax);
+        }
+
         ExhaustivenessAnalyzer.AnalyzeSwitchExpression(
             syntax.SwitchKeyword.Location,
             switchType,

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -811,6 +811,73 @@ internal sealed partial class ExpressionBinder
             or BoundDereferenceExpression;
     }
 
+    /// <summary>
+    /// Issue #1238: returns true when <paramref name="syntax"/> (after peeling
+    /// any enclosing parentheses) is a target-typeable branchy expression — an
+    /// <c>if</c>/<c>else</c> expression, a ternary conditional, or a
+    /// <c>switch</c>-expression. Such an expression, when used directly as a
+    /// call/constructor argument, must be (re)bound with the corresponding
+    /// parameter type as its target so each branch is target-typed (mirroring
+    /// the <c>return</c>/typed-<c>let</c> paths).
+    /// </summary>
+    internal static bool IsTargetTypedBranchyArgumentSyntax(SyntaxNode syntax)
+    {
+        while (syntax is ParenthesizedExpressionSyntax parenthesized)
+        {
+            syntax = parenthesized.Expression;
+        }
+
+        return syntax is IfExpressionSyntax
+            or ConditionalExpressionSyntax
+            or SwitchExpressionSyntax;
+    }
+
+    /// <summary>
+    /// Issue #1238: detects a deferred branchy-argument placeholder produced by
+    /// the if/conditional/switch binders when they could not unify their
+    /// branches without a target type. The placeholder is a
+    /// <see cref="BoundErrorExpression"/> that retains the original branchy
+    /// syntax so the argument-conversion loops can re-bind it against the
+    /// resolved parameter type.
+    /// </summary>
+    internal static bool IsDeferredBranchyArgumentPlaceholder(BoundExpression expression, out ExpressionSyntax branchySyntax)
+    {
+        if (expression is BoundErrorExpression { Syntax: ExpressionSyntax syntax }
+            && IsTargetTypedBranchyArgumentSyntax(syntax))
+        {
+            branchySyntax = syntax;
+            return true;
+        }
+
+        branchySyntax = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Issue #1238: binds a (named-argument-unwrapped) call argument value,
+    /// deferring a no-common-type unification failure when the value is a
+    /// target-typeable branchy expression (so it can be re-bound against the
+    /// resolved parameter type). See <see cref="BinderContext.DeferTargetlessConditional"/>.
+    /// </summary>
+    internal BoundExpression BindArgumentDeferringBranchy(ExpressionSyntax inner)
+    {
+        if (!IsTargetTypedBranchyArgumentSyntax(inner))
+        {
+            return BindExpression(inner);
+        }
+
+        var previous = binderCtx.DeferTargetlessConditional;
+        binderCtx.DeferTargetlessConditional = true;
+        try
+        {
+            return BindExpression(inner);
+        }
+        finally
+        {
+            binderCtx.DeferTargetlessConditional = previous;
+        }
+    }
+
     private static bool TryGetTaskElementType(TypeSymbol type, out TypeSymbol element)
     {
         element = null;

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -111,6 +111,7 @@ internal sealed class OverloadResolver
     private readonly ConversionClassifier conversions;
 
     private readonly Func<ExpressionSyntax, BoundExpression> bindExpression;
+    private readonly Func<ExpressionSyntax, TypeSymbol, BoundExpression> bindExpressionWithTargetType;
     private readonly Func<RefArgumentExpressionSyntax, ParameterSymbol, BoundExpression> bindRefArgumentExpression;
     private readonly Func<BoundExpression, ExpressionSyntax, ParameterSymbol, TypeSymbol, BoundExpression> tryRebindInlineOutVarPlaceholder;
     private readonly Func<TypeClauseSyntax, TypeSymbol> bindTypeClause;
@@ -149,6 +150,10 @@ internal sealed class OverloadResolver
     /// chosen.</param>
     /// <param name="bindExpression">Callback to re-bind a sub-expression
     /// through the still-on-Binder expression-binding entry point.</param>
+    /// <param name="bindExpressionWithTargetType">Issue #1238: callback that
+    /// (re)binds an expression with an explicit target type, used to finalize a
+    /// deferred target-typed conditional/if/switch argument against its resolved
+    /// parameter type.</param>
     /// <param name="bindRefArgumentExpression">Callback to bind a
     /// <see cref="RefArgumentExpressionSyntax"/> against a known parameter
     /// symbol (or <c>null</c> in the first, parameter-unknown, pass).</param>
@@ -225,6 +230,7 @@ internal sealed class OverloadResolver
         MemberLookup memberLookup,
         ConversionClassifier conversions,
         Func<ExpressionSyntax, BoundExpression> bindExpression,
+        Func<ExpressionSyntax, TypeSymbol, BoundExpression> bindExpressionWithTargetType,
         Func<RefArgumentExpressionSyntax, ParameterSymbol, BoundExpression> bindRefArgumentExpression,
         Func<BoundExpression, ExpressionSyntax, ParameterSymbol, TypeSymbol, BoundExpression> tryRebindInlineOutVarPlaceholder,
         Func<TypeClauseSyntax, TypeSymbol> bindTypeClause,
@@ -253,6 +259,7 @@ internal sealed class OverloadResolver
         this.memberLookup = memberLookup ?? throw new ArgumentNullException(nameof(memberLookup));
         this.conversions = conversions ?? throw new ArgumentNullException(nameof(conversions));
         this.bindExpression = bindExpression ?? throw new ArgumentNullException(nameof(bindExpression));
+        this.bindExpressionWithTargetType = bindExpressionWithTargetType ?? throw new ArgumentNullException(nameof(bindExpressionWithTargetType));
         this.bindRefArgumentExpression = bindRefArgumentExpression ?? throw new ArgumentNullException(nameof(bindRefArgumentExpression));
         this.tryRebindInlineOutVarPlaceholder = tryRebindInlineOutVarPlaceholder ?? throw new ArgumentNullException(nameof(tryRebindInlineOutVarPlaceholder));
         this.bindTypeClause = bindTypeClause ?? throw new ArgumentNullException(nameof(bindTypeClause));
@@ -1030,6 +1037,72 @@ internal sealed class OverloadResolver
         => argument is NamedArgumentExpressionSyntax named ? named.Expression : argument;
 
     /// <summary>
+    /// Issue #1238: eagerly binds a (named-argument-unwrapped) call/constructor
+    /// argument value. When the argument is a target-typeable branchy
+    /// expression (<c>if</c>/<c>else</c>, ternary, or <c>switch</c>-expression)
+    /// the <see cref="BinderContext.DeferTargetlessConditional"/> flag is set so
+    /// a no-common-type unification failure is deferred (the binder returns a
+    /// placeholder retaining the syntax) instead of being reported prematurely
+    /// without the parameter's target type. The deferred placeholder is later
+    /// re-bound by <see cref="FinalizeBranchyArgument"/> (or centrally by
+    /// <c>ConversionClassifier.BindConversion</c>) once the applicable
+    /// parameter type is known.
+    /// </summary>
+    /// <param name="inner">The unwrapped argument value syntax.</param>
+    /// <returns>The eagerly-bound argument (a deferred placeholder when a
+    /// branchy argument could not unify without a target).</returns>
+    private BoundExpression BindOverloadArgumentValue(ExpressionSyntax inner)
+    {
+        if (!ExpressionBinder.IsTargetTypedBranchyArgumentSyntax(inner))
+        {
+            return bindExpression(inner);
+        }
+
+        var previous = binderCtx.DeferTargetlessConditional;
+        binderCtx.DeferTargetlessConditional = true;
+        try
+        {
+            return bindExpression(inner);
+        }
+        finally
+        {
+            binderCtx.DeferTargetlessConditional = previous;
+        }
+    }
+
+    /// <summary>
+    /// Issue #1238: finalizes a deferred branchy-argument placeholder (produced
+    /// by <see cref="BindOverloadArgumentValue"/>) once the resolved parameter
+    /// type is known. The retained branchy syntax is re-bound with
+    /// <paramref name="expectedType"/> as its target so each branch is
+    /// target-typed (e.g. a <c>nil</c> arm widens to the parameter's nullable
+    /// type). When no usable target is available the syntax is re-bound without
+    /// a target so the original no-common-type diagnostic — suppressed at the
+    /// deferral point — surfaces. Non-placeholder arguments are returned
+    /// unchanged.
+    /// </summary>
+    /// <param name="argument">The (possibly placeholder) bound argument.</param>
+    /// <param name="expectedType">The resolved parameter target type.</param>
+    /// <returns>The finalized argument.</returns>
+    private BoundExpression FinalizeBranchyArgument(BoundExpression argument, TypeSymbol expectedType)
+    {
+        if (!ExpressionBinder.IsDeferredBranchyArgumentPlaceholder(argument, out var branchySyntax))
+        {
+            return argument;
+        }
+
+        if (expectedType != null
+            && expectedType != TypeSymbol.Error
+            && expectedType != TypeSymbol.Void
+            && !TypeSymbol.ContainsTypeParameter(expectedType))
+        {
+            return bindExpressionWithTargetType(branchySyntax, expectedType);
+        }
+
+        return bindExpression(branchySyntax);
+    }
+
+    /// <summary>
     /// Issue #343: pre-validates the layout of call arguments — positional
     /// arguments must precede all named arguments, and no two named arguments
     /// may share the same name. Reports the corresponding diagnostic
@@ -1664,7 +1737,7 @@ internal sealed class OverloadResolver
         foreach (var argument in syntax.Arguments)
         {
             // Issue #343: bind the value behind any named-argument wrapper.
-            boundArguments.Add(bindExpression(UnwrapNamedArgumentValue(argument)));
+            boundArguments.Add(BindOverloadArgumentValue(UnwrapNamedArgumentValue(argument)));
         }
 
         // ADR-0101 follow-up / issue #819: a primary constructor may declare a
@@ -1925,6 +1998,14 @@ internal sealed class OverloadResolver
             var argument = boundArguments[i];
             var parameter = parameters[i];
 
+            // Issue #1238: re-bind a deferred target-typed conditional argument
+            // against the constructor parameter type before the convertibility
+            // checks below.
+            if (ExpressionBinder.IsDeferredBranchyArgumentPlaceholder(argument, out _))
+            {
+                boundArguments[i] = argument = FinalizeBranchyArgument(argument, parameter.Type);
+            }
+
             // ADR-0055 Tier 4 (#369): an interpolated-string argument targeting an
             // IFormattable/FormattableString constructor parameter lowers to
             // FormattableStringFactory.Create rather than an eager string.
@@ -2044,7 +2125,7 @@ internal sealed class OverloadResolver
             }
             else
             {
-                boundArgumentsBuilder.Add(bindExpression(argument));
+                boundArgumentsBuilder.Add(BindOverloadArgumentValue(argument));
             }
         }
 
@@ -2264,6 +2345,14 @@ internal sealed class OverloadResolver
         {
             var argument = boundArguments[i];
             var parameter = parameters[i];
+
+            // Issue #1238: re-bind a deferred target-typed conditional argument
+            // against the constructor parameter type before the convertibility
+            // checks below.
+            if (ExpressionBinder.IsDeferredBranchyArgumentPlaceholder(argument, out _))
+            {
+                boundArguments[i] = argument = FinalizeBranchyArgument(argument, effectiveParamTypes[i]);
+            }
 
             // Issue #1214: target the type-argument-substituted parameter type
             // for a closed generic construction (equal to parameter.Type for a
@@ -2645,6 +2734,14 @@ internal sealed class OverloadResolver
             var parameter = parameters[i];
             var argument = boundArgs[i];
             var argLocation = parameterSyntax[i]?.Location ?? syntax.Identifier.Location;
+
+            // Issue #1238: re-bind a deferred target-typed conditional argument
+            // against the constructor parameter type before the error/convert
+            // checks below.
+            if (ExpressionBinder.IsDeferredBranchyArgumentPlaceholder(argument, out _))
+            {
+                argument = FinalizeBranchyArgument(argument, parameter.Type);
+            }
 
             if (argument.Type == TypeSymbol.Error)
             {
@@ -3032,7 +3129,7 @@ internal sealed class OverloadResolver
             }
             else
             {
-                boundArgument = bindExpression(argSyntax);
+                boundArgument = BindOverloadArgumentValue(argSyntax);
             }
 
             boundArguments.Add(boundArgument);
@@ -3623,7 +3720,16 @@ internal sealed class OverloadResolver
             var parameter = function.Parameters[i];
             var expectedType = substitution != null ? substituteType(parameter.Type, substitution) : parameter.Type;
 
-            // Issue #951: a deferred un-typed arrow lambda argument is now
+            // Issue #1238: a deferred target-typed conditional/if/switch
+            // argument is re-bound here against the resolved parameter type so
+            // each branch is target-typed before the convertibility checks
+            // below (which would otherwise reject the suppressed-error
+            // placeholder).
+            if (ExpressionBinder.IsDeferredBranchyArgumentPlaceholder(argument, out _))
+            {
+                boundArguments[i] = argument = FinalizeBranchyArgument(argument, expectedType);
+            }
+
             // bound against the resolved parameter's delegate target so its
             // omitted parameter type(s) and inferred return type are filled in
             // from the parameter shape (e.g. `func F(f Func[int32, int32])`

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -18,6 +18,35 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
 {
     private readonly List<Diagnostic> diagnostics = new List<Diagnostic>();
 
+    /// <summary>
+    /// Gets the number of diagnostics currently held in the bag. Used together
+    /// with <see cref="TruncateTo"/> to discard speculative diagnostics emitted
+    /// while binding an expression that is subsequently re-bound (e.g. issue
+    /// #1238 target-typed conditional arguments).
+    /// </summary>
+    public int Count => diagnostics.Count;
+
+    /// <summary>
+    /// Removes every diagnostic added after the bag reached <paramref name="count"/>
+    /// entries, restoring it to an earlier marked state. Used to roll back the
+    /// speculative diagnostics produced while eagerly binding an expression that
+    /// will be re-bound against a now-known target type.
+    /// </summary>
+    /// <param name="count">The diagnostic count to truncate back to. Values
+    /// outside the current range are clamped.</param>
+    public void TruncateTo(int count)
+    {
+        if (count < 0)
+        {
+            count = 0;
+        }
+
+        if (count < diagnostics.Count)
+        {
+            diagnostics.RemoveRange(count, diagnostics.Count - count);
+        }
+    }
+
     /// <inheritdoc/>
     public IEnumerator<Diagnostic> GetEnumerator() => diagnostics.GetEnumerator();
 

--- a/test/Compiler.Tests/Emit/Issue1238ConditionalArgumentTargetTypingEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1238ConditionalArgumentTargetTypingEmitTests.cs
@@ -1,0 +1,199 @@
+// <copyright file="Issue1238ConditionalArgumentTargetTypingEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1238: end-to-end CLR emit coverage for target-typed conditional /
+/// switch-expression CALL ARGUMENTS. An <c>if</c>/<c>else</c>, ternary, or
+/// switch-expression passed directly as an argument must be target-typed to the
+/// corresponding parameter type so a <c>nil</c> (or narrower) branch widens to
+/// the parameter's nullable type — matching the behavior already present in
+/// <c>return</c> / typed-<c>let</c> positions. The emitted program must run and
+/// produce the expected values for both the nil and non-nil branches, and
+/// ilverify must accept the assembly.
+/// </summary>
+public class Issue1238ConditionalArgumentTargetTypingEmitTests
+{
+    [Fact]
+    public void EndToEnd_IfExpressionArgument_NilBranch_RunsCorrectly()
+    {
+        var source = """
+            package Probe
+            import System
+
+            class C {
+                func Describe(data string?) string {
+                    if data == nil {
+                        return "none"
+                    }
+                    return data!!
+                }
+                func Run(s string?) string {
+                    return Describe(if s == nil { nil } else { s!! })
+                }
+            }
+
+            func Main() {
+                var c = C()
+                Console.WriteLine(c.Run(nil))
+                Console.WriteLine(c.Run("hi"))
+            }
+            """;
+        var output = CompileAndRun(source);
+        Assert.Equal("none\nhi\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_SwitchExpressionArgument_NilArm_RunsCorrectly()
+    {
+        var source = """
+            package Probe
+            import System
+
+            class C {
+                func Describe(data string?) string {
+                    if data == nil {
+                        return "none"
+                    }
+                    return data!!
+                }
+                func Run(n int32) string {
+                    return Describe(switch n { case 0: nil default: "val" })
+                }
+            }
+
+            func Main() {
+                var c = C()
+                Console.WriteLine(c.Run(0))
+                Console.WriteLine(c.Run(7))
+            }
+            """;
+        var output = CompileAndRun(source);
+        Assert.Equal("none\nval\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_ConstructorArgument_IfExpressionNilBranch_RunsCorrectly()
+    {
+        var source = """
+            package Probe
+            import System
+
+            class Holder {
+                let value string?
+                init(v string?) {
+                    this.value = v
+                }
+                func Text() string {
+                    if this.value == nil {
+                        return "empty"
+                    }
+                    return this.value!!
+                }
+            }
+
+            class C {
+                func Make(s string?) Holder {
+                    return Holder(if s == nil { nil } else { s!! })
+                }
+            }
+
+            func Main() {
+                var c = C()
+                Console.WriteLine(c.Make(nil).Text())
+                Console.WriteLine(c.Make("ok").Text())
+            }
+            """;
+        var output = CompileAndRun(source);
+        Assert.Equal("empty\nok\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_cond1238_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1238ConditionalArgumentTargetTypingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1238ConditionalArgumentTargetTypingTests.cs
@@ -1,0 +1,202 @@
+// <copyright file="Issue1238ConditionalArgumentTargetTypingTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1238: an <c>if</c>/<c>else</c> (conditional), ternary, or
+/// switch-expression used directly as a CALL ARGUMENT must be target-typed to
+/// the corresponding parameter type — the same target-typing path already used
+/// for <c>return</c> statements and typed <c>let</c>. Previously the argument's
+/// branches were unified in isolation, so a <c>nil</c> (or narrower) branch
+/// failed to widen to the parameter's nullable type with GS0155. These tests
+/// pin the fixed behavior for call, constructor, and nested-call arguments,
+/// and confirm genuine no-common-type errors are still reported.
+/// </summary>
+public class Issue1238ConditionalArgumentTargetTypingTests
+{
+    private static System.Collections.Immutable.ImmutableArray<GSharp.Core.CodeAnalysis.Diagnostic> EmitDiagnostics(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        using var peStream = new System.IO.MemoryStream();
+        return compilation.Emit(peStream).Diagnostics;
+    }
+
+    [Fact]
+    public void IfExpressionArgument_NilBranch_TargetTypedToParameter()
+    {
+        const string Source = @"package Issue1238.IfArg
+
+class C {
+    func Sink(data string?) { }
+    func Call(s string?) {
+        Sink(if s == nil { nil } else { s!! })
+    }
+}
+";
+        Assert.Empty(EmitDiagnostics(Source).Where(d => d.IsError));
+    }
+
+    [Fact]
+    public void IfExpressionArgument_AmongOtherArguments_TargetTypedToParameter()
+    {
+        const string Source = @"package Issue1238.IfArgMulti
+
+import System.Text
+
+class C {
+    func Sink(name string, data []uint8?) { }
+    func Call(data string?) {
+        Sink(""x"", if data == nil { nil } else { Encoding.UTF8.GetBytes(data!!) })
+    }
+}
+";
+        Assert.Empty(EmitDiagnostics(Source).Where(d => d.IsError));
+    }
+
+    [Fact]
+    public void TernaryArgument_NilBranch_TargetTypedToParameter()
+    {
+        const string Source = @"package Issue1238.TernaryArg
+
+class C {
+    func Sink(data string?) { }
+    func Call(s string?) {
+        Sink(s == nil ? nil : s!!)
+    }
+}
+";
+        Assert.Empty(EmitDiagnostics(Source).Where(d => d.IsError));
+    }
+
+    [Fact]
+    public void SwitchExpressionArgument_NilArm_TargetTypedToParameter()
+    {
+        const string Source = @"package Issue1238.SwitchArg
+
+class C {
+    func Sink(data string?) { }
+    func Call(n int32) {
+        Sink(switch n { case 0: nil default: ""x"" })
+    }
+}
+";
+        Assert.Empty(EmitDiagnostics(Source).Where(d => d.IsError));
+    }
+
+    [Fact]
+    public void ConstructorArgument_IfExpressionNilBranch_TargetTypedToParameter()
+    {
+        const string Source = @"package Issue1238.CtorArg
+
+class Holder {
+    init(name string, data string?) { }
+}
+
+class C {
+    func Make(s string?) Holder {
+        return Holder(""n"", if s == nil { nil } else { s!! })
+    }
+}
+";
+        Assert.Empty(EmitDiagnostics(Source).Where(d => d.IsError));
+    }
+
+    [Fact]
+    public void NestedCallArgument_IfExpressionNilBranch_TargetTypedToParameter()
+    {
+        const string Source = @"package Issue1238.NestedArg
+
+class C {
+    func Sink(data string?) { }
+    func Wrap(s string?) string? { return s }
+    func Call(s string?) {
+        Sink(Wrap(if s == nil { nil } else { s!! }))
+    }
+}
+";
+        Assert.Empty(EmitDiagnostics(Source).Where(d => d.IsError));
+    }
+
+    [Fact]
+    public void ReturnAndTypedLetPositions_StillBindCleanly()
+    {
+        // Regression guard: the positions that already worked must keep working.
+        const string Source = @"package Issue1238.AlreadyOk
+
+import System.Text
+
+class C {
+    func R(data string?) []uint8? {
+        return if data == nil { nil } else { Encoding.UTF8.GetBytes(data!!) }
+    }
+    func L(data string?) []uint8? {
+        let r []uint8? = if data == nil { nil } else { Encoding.UTF8.GetBytes(data!!) }
+        return r
+    }
+    func Sink(data []uint8?) { }
+    func PlainNil() { Sink(nil) }
+}
+";
+        Assert.Empty(EmitDiagnostics(Source).Where(d => d.IsError));
+    }
+
+    [Fact]
+    public void OverloadResolution_WithIfExpressionArgument_NotRegressed()
+    {
+        // The if-expression arms unify naturally to int32 and must still select
+        // the int32 overload (defer path is not engaged for a clean unification).
+        const string Source = @"package Issue1238.Overload
+
+class C {
+    func F(x int32) string { return ""int"" }
+    func F(x string) string { return ""str"" }
+    func Pick(b bool) string {
+        return F(if b { 1 } else { 2 })
+    }
+}
+";
+        Assert.Empty(EmitDiagnostics(Source).Where(d => d.IsError));
+    }
+
+    [Fact]
+    public void GenuineNoCommonTypeArgument_StillReportsError()
+    {
+        // Neither branch is convertible to the other or to the parameter type;
+        // the error must surface (not be swallowed by the defer mechanism).
+        const string Source = @"package Issue1238.BadArg
+
+class C {
+    func Sink(data string?) { }
+    func Call(b bool) {
+        Sink(if b { 1 } else { 2 })
+    }
+}
+";
+        Assert.Contains(EmitDiagnostics(Source), d => d.IsError && d.Id == "GS0155");
+    }
+
+    [Fact]
+    public void UntypedLetWithNoCommonType_StillReportsError()
+    {
+        // Outside argument position the defer flag is never set, so an untyped
+        // local with mismatched branches keeps reporting immediately.
+        const string Source = @"package Issue1238.UntypedLet
+
+class C {
+    func Call(b bool) {
+        let x = if b { 1 } else { ""s"" }
+    }
+}
+";
+        Assert.Contains(EmitDiagnostics(Source), d => d.IsError && d.Id == "GS0263");
+    }
+}


### PR DESCRIPTION
Fixes #1238.

## Root cause
An `if`/`else`, ternary, or `switch`-expression used directly as a **call argument** was bound eagerly during overload resolution **without a target type**. With no target the branches were unified in isolation, so a `nil` (or otherwise narrower) branch could not widen to the parameter's nullable type and the binder reported `GS0155` (or `GS0179` for switch). The identical expression compiled cleanly in `return` / typed-`let` positions, which already thread an expected type into branch binding.

```gsharp
func Sink2(data string?) { }
func Call2(s string?) {
    Sink2(if s == nil { nil } else { s!! })   // was: GS0155 Cannot convert 'nil' to 'string'
}
```

## Fix — defer then rebind
- When a branchy argument is eagerly bound before its parameter type is known, a transient `BinderContext.DeferTargetlessConditional` flag is set.
- The if/conditional/switch binders read-and-clear the flag and, on a no-common-type unification failure, **truncate the speculative diagnostics** and return a `BoundErrorExpression` placeholder that **retains the original branchy syntax** (instead of reporting).
- Once overload resolution selects the applicable method/constructor, the placeholder is **re-bound against the resolved parameter type** — centrally in `ConversionClassifier.BindConversion` and explicitly in the argument-conversion loops that short-circuit on an error-typed argument — so each branch is target-typed exactly as in the return/let paths.

The defer flag is only set during argument eager binding, so value/statement and untyped-`let` contexts still report no-common-type errors immediately, and a genuinely unconvertible argument still surfaces its diagnostic after rebind. The success path is unchanged, preserving the natural argument type for overload resolution.

Covers free-function, instance, constructor, color-color, and nested-call arguments, plus if/ternary and switch-expression forms.

## Files changed
- `BinderContext.cs` — `DeferTargetlessConditional` flag.
- `DiagnosticBag.cs` — `Count` + `TruncateTo` for rolling back speculative diagnostics.
- `ExpressionBinder.Operators.cs` — defer-on-failure in `BindConditionalExpression` / `BindIfExpression`.
- `ExpressionBinder.SwitchExpr.cs` — defer-on-failure in `BindSwitchExpression`.
- `ExpressionBinder.cs` — `IsTargetTypedBranchyArgumentSyntax`, `IsDeferredBranchyArgumentPlaceholder`, `BindArgumentDeferringBranchy` helpers.
- `OverloadResolver.cs` — `bindExpressionWithTargetType` plumbing, `BindOverloadArgumentValue`, `FinalizeBranchyArgument`; wired into call/ctor eager + conversion loops.
- `ConversionClassifier.cs` — central placeholder finalization in `BindConversion`.
- `ExpressionBinder.Access.cs` / `ExpressionBinder.Calls.cs` — eager loops defer branchy args.
- `Binder.cs` — pass `bindExpressionWithTargetType` to `OverloadResolver`.

## Tests
- `test/Core.Tests/.../Issue1238ConditionalArgumentTargetTypingTests.cs` (10 tests): if/ternary/switch/ctor/nested arguments, return+let regression guard, overload-resolution guard, and genuine-error cases (`GS0155`/`GS0263` still reported).
- `test/Compiler.Tests/Emit/Issue1238ConditionalArgumentTargetTypingEmitTests.cs` (3 tests): end-to-end emit/execution for if and switch arguments (nil + non-nil branches) and a constructor argument.

### Verification
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release` -> 4263 passed, 0 failed.
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Release --filter "FullyQualifiedName~Issue1238ConditionalArgumentTargetTypingEmitTests" -- xUnit.MaxParallelThreads=2` -> 3 passed.
- `dotnet build GSharp.sln -c Release -graph` -> 0 errors.
