### PR TITLE
Fix #1240: parameter shadows same-named instance field/property

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -341,6 +341,20 @@ public sealed class Binder
                         {
                             foreach (var fld in t.Fields)
                             {
+                                // Issue #1240: a method/constructor parameter named
+                                // like an instance field shadows that field for bare
+                                // (unqualified) access — matching C# semantics and the
+                                // parameter > instance member > static member precedence
+                                // already enforced for static members below. The field
+                                // remains reachable as `this.<field>`. Without this
+                                // guard the field's pseudo-variable is seeded first and
+                                // TryDeclareVariable silently drops the later parameter,
+                                // so the parameter is wrongly ignored.
+                                if (paramNames.Contains(fld.Name))
+                                {
+                                    continue;
+                                }
+
                                 if (seenMembers.Add(fld.Name))
                                 {
                                     scope.TryDeclareVariable(new ImplicitFieldVariableSymbol(function.ThisParameter, t, fld));
@@ -356,6 +370,14 @@ public sealed class Binder
                                 // CLR name `Item` but is not accessible by bare name —
                                 // it is reached only through `this[i]` index access.
                                 if (prop.IsIndexer)
+                                {
+                                    continue;
+                                }
+
+                                // Issue #1240: a parameter named like an instance
+                                // property shadows that property for bare access; the
+                                // property stays reachable as `this.<property>`.
+                                if (paramNames.Contains(prop.Name))
                                 {
                                     continue;
                                 }
@@ -386,6 +408,7 @@ public sealed class Binder
                             {
                                 if (evt.IsFieldLike
                                     && evt.BackingField != null
+                                    && !paramNames.Contains(evt.Name)
                                     && seenMembers.Add(evt.Name))
                                 {
                                     scope.TryDeclareVariable(new ImplicitFieldVariableSymbol(function.ThisParameter, t, evt.BackingField));

--- a/test/Compiler.Tests/Emit/Issue1240ParameterShadowsFieldEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1240ParameterShadowsFieldEmitTests.cs
@@ -1,0 +1,145 @@
+// <copyright file="Issue1240ParameterShadowsFieldEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1240 — emit + IL-verify coverage proving that a method/constructor
+/// parameter named like an instance field (or property) shadows that member for
+/// unqualified (bare) reads, matching C# semantics. The member remains reachable
+/// via <c>this.</c>. These tests execute the emitted IL and assert that the
+/// PARAMETER value is the one observed, not the field/property value.
+/// </summary>
+public class Issue1240ParameterShadowsFieldEmitTests
+{
+    [Fact]
+    public void Method_BareParam_ShadowsField_ReturnsParameter()
+    {
+        var source = """
+            package Probe
+
+            class C {
+                var iv int32
+                init() {
+                    iv = 100
+                }
+                func M(iv int32) int32 {
+                    return iv
+                }
+            }
+
+            public var result = C().M(7)
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal(7, GetField<int>(assembly, "result"));
+    }
+
+    [Fact]
+    public void Method_ThisField_AndBareParam_AreDistinct()
+    {
+        // `this.iv` (field = 100) + bare `iv` (parameter = 7) = 107.
+        var source = """
+            package Probe
+
+            class C {
+                var iv int32
+                init() {
+                    iv = 100
+                }
+                func M(iv int32) int32 {
+                    return this.iv + iv
+                }
+            }
+
+            public var result = C().M(7)
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal(107, GetField<int>(assembly, "result"));
+    }
+
+    [Fact]
+    public void Constructor_BareParam_ShadowsField_AssignsFromParameter()
+    {
+        // `this.iv = iv` stores the parameter into the field; Get() reads it back.
+        var source = """
+            package Probe
+
+            class C {
+                var iv int32
+                init(iv int32) {
+                    this.iv = iv
+                }
+                func Get() int32 {
+                    return this.iv
+                }
+            }
+
+            public var result = C(5).Get()
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal(5, GetField<int>(assembly, "result"));
+    }
+
+    private static Assembly CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1240_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+        IlVerifier.Verify(outPath);
+
+        var bytes = File.ReadAllBytes(outPath);
+        var assembly = Assembly.Load(bytes);
+
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+        entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+
+        return assembly;
+    }
+
+    private static T GetField<T>(Assembly assembly, string name)
+    {
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var resultField = program.GetField(name, BindingFlags.Public | BindingFlags.Static);
+        return (T)resultField!.GetValue(null)!;
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1240ParameterShadowsFieldTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1240ParameterShadowsFieldTests.cs
@@ -1,0 +1,167 @@
+// <copyright file="Issue1240ParameterShadowsFieldTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1240: a method/constructor parameter whose name collides with an
+/// instance field (or property) must shadow that member for unqualified (bare)
+/// references inside the body — matching C# semantics and the
+/// <c>parameter &gt; instance member &gt; static member</c> precedence already
+/// enforced for static members. The member remains reachable via <c>this.</c>.
+///
+/// Before the fix, the field's pseudo-variable was seeded into the method scope
+/// first and <c>TryDeclareVariable</c> silently dropped the later parameter, so
+/// the parameter was wrongly ignored — a latent correctness bug that also
+/// surfaced as a spurious GS0129 when field and parameter types differed (e.g.
+/// non-nullable field vs nullable parameter).
+/// </summary>
+public class Issue1240ParameterShadowsFieldTests
+{
+    [Fact]
+    public void Constructor_NullableParam_ShadowsNonNullableField_NoDiagnostics()
+    {
+        // Faithful repro from the issue: the field is non-nullable []uint8 while
+        // the parameter is nullable []uint8?. Bare `iv` must bind to the
+        // PARAMETER, so `iv == nil` typechecks; binding to the field would emit
+        // GS0129 ('==' not defined for '[]uint8' and 'nil').
+        var source = @"
+package p
+class C {
+    private let iv []uint8
+    init(iv []uint8?) {
+        if iv == nil { throw System.ArgumentException(""x"") }
+        this.iv = iv!!
+    }
+    func M(iv []uint8?) bool {
+        return iv == nil
+    }
+}
+";
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void Method_Param_ShadowsField_ParameterValueUsed()
+    {
+        // Same-type field and parameter so the body compiles either way; the
+        // returned value proves the PARAMETER (7), not the field (100), is read.
+        var source = @"
+class C {
+    var iv int32
+    init() {
+        iv = 100
+    }
+    func M(iv int32) int32 {
+        return iv
+    }
+}
+
+var c = C()
+var r = c.M(7)
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(7, result.Value);
+    }
+
+    [Fact]
+    public void Method_QualifiedThisField_StillResolvesToField()
+    {
+        // `this.iv` is unaffected by parameter shadowing: it reads the field
+        // (100) while bare `iv` reads the parameter (7) → 107.
+        var source = @"
+class C {
+    var iv int32
+    init() {
+        iv = 100
+    }
+    func M(iv int32) int32 {
+        return this.iv + iv
+    }
+}
+
+var c = C()
+var r = c.M(7)
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(107, result.Value);
+    }
+
+    [Fact]
+    public void Constructor_Param_ShadowsField_AssignsFieldFromParameter()
+    {
+        // `this.iv = iv` writes the field from the parameter; a later read of
+        // `this.iv` returns the stored field value (the parameter that was
+        // passed in), proving the bare `iv` on the right-hand side was the
+        // PARAMETER, not the (default-zero) field.
+        var source = @"
+class C {
+    var iv int32
+    init(iv int32) {
+        this.iv = iv
+    }
+    func Get() int32 {
+        return this.iv
+    }
+}
+
+var c = C(5)
+var r = c.Get()
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(5, result.Value);
+    }
+
+    [Fact]
+    public void Method_Param_ShadowsProperty_ParameterValueUsed()
+    {
+        // Parameters must shadow instance properties too (not just fields).
+        var source = @"
+class C {
+    var _v int32
+    prop Value int32 {
+        get { return _v }
+        set(x) { _v = x }
+    }
+    init() {
+        _v = 100
+    }
+    func M(Value int32) int32 {
+        return Value
+    }
+}
+
+var c = C()
+var r = c.M(42)
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    private static System.Collections.Immutable.ImmutableArray<Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>()).Diagnostics;
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
## Summary
Fixes #1240. A method/constructor **parameter** named like a class **field** (or property) did not shadow that member for unqualified references inside the body. A bare name bound to the FIELD instead of the PARAMETER — a name-resolution correctness bug. When field and parameter types differed (e.g. non-nullable field vs nullable parameter) it also surfaced as a spurious `GS0129`.

### Repro (failed before)
```gsharp
package p
class C {
  private let iv []uint8
  init(iv []uint8?) {
    if iv == nil { throw System.ArgumentException("x") }  // GS0129 before fix
    this.iv = iv!!
  }
  func M(iv []uint8?) bool {
    return iv == nil                                       // GS0129 before fix
  }
}
```

## Root cause
When seeding a method/constructor body scope (`Binder.cs`), the binder declared an `ImplicitFieldVariableSymbol` (and `ImplicitPropertyVariableSymbol` / field-like event backing field) for every instance member **before** declaring the parameters. Parameters and these member pseudo-variables share the same body scope, and `BoundScope.TryDeclareSymbol` silently skips a name already present. So a parameter colliding with an instance field/property was silently dropped, and bare references bound to the member.

Static members already enforced `parameter > instance > static` precedence via a `paramNames` guard; the instance field/property/event seeding did not.

## Fix
Skip seeding an instance field/property/field-like-event pseudo-variable when its name matches a parameter, so the later-declared parameter occupies the name and wins for bare (unqualified) access. Qualified `this.<member>` access is unaffected and still resolves to the member.

## Tests
- `test/Core.Tests/.../Issue1240ParameterShadowsFieldTests.cs` — binder/eval: the exact nullable-param vs non-nullable-field repro (no diagnostics), parameter value used (not field), `this.field` still resolves to field, parameter shadows property.
- `test/Compiler.Tests/Emit/Issue1240ParameterShadowsFieldEmitTests.cs` — IL-verified execution proving the PARAMETER value is observed at runtime.

## Verification
- New Core.Tests filter: 5 passed.
- New Compiler.Tests Emit filter: 3 passed (`xUnit.MaxParallelThreads=2`).
- Full `dotnet test test/Core.Tests/Core.Tests.csproj -c Release`: 4268 passed, 1 skipped, 0 failed.
- `dotnet build GSharp.sln -c Release -graph`: 0 warnings, 0 errors.