### PR TITLE
Fix #1239: compute best common type for null-coalescing operator

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundBinaryOperator.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundBinaryOperator.cs
@@ -178,6 +178,49 @@ public sealed class BoundBinaryOperator
                 var result = rightType is NullableTypeSymbol ? (TypeSymbol)NullableTypeSymbol.Get(leftUnderlying) : leftUnderlying;
                 return new BoundBinaryOperator(syntaxKind, BoundBinaryOperatorKind.NullCoalesce, leftType, rightType, result);
             }
+
+            // Issue #1239 / C# §12.15: best common type. When the underlyings
+            // differ but a valid implicit conversion exists between them, `??`
+            // computes the best common type instead of requiring an exact match:
+            //   * if the right operand implicitly converts to the left's non-null
+            //     type A0 (reference downcast target, numeric widening source),
+            //     the result is A0 (e.g. `int32? ?? uint16` → `int32`);
+            //   * otherwise, if A0 implicitly converts to the right operand's
+            //     type, the result is the right type (reference upcast / interface
+            //     implementation, e.g. `Foo? ?? IFoo` → `IFoo`, or numeric
+            //     widening, e.g. `int32? ?? int64` → `int64`).
+            // Restricted to a non-nullable right operand so the result is a plain
+            // (non-nullable) type; ExpressionBinder.BindBinaryExpression inserts
+            // the operand conversions required for correct emit/evaluation. A
+            // mismatched nullable right operand still falls through to GS0129
+            // (unchanged behaviour) because lifted nullable numeric conversions
+            // are not part of the implicit-conversion lattice.
+            if (rightType is not NullableTypeSymbol
+                && leftUnderlying != null
+                && rightUnderlying != null
+                && leftType != TypeSymbol.Error
+                && rightType != TypeSymbol.Error)
+            {
+                TypeSymbol common = null;
+                var rightToLeft = Conversion.Classify(rightUnderlying, leftUnderlying);
+                if (rightToLeft.Exists && rightToLeft.IsImplicit)
+                {
+                    common = leftUnderlying;
+                }
+                else
+                {
+                    var leftToRight = Conversion.Classify(leftUnderlying, rightUnderlying);
+                    if (leftToRight.Exists && leftToRight.IsImplicit)
+                    {
+                        common = rightUnderlying;
+                    }
+                }
+
+                if (common != null)
+                {
+                    return new BoundBinaryOperator(syntaxKind, BoundBinaryOperatorKind.NullCoalesce, leftType, rightType, common);
+                }
+            }
         }
 
         // PR N-4 / §6.1 / C# §7.3.7: lifted binary operators over a

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
@@ -1387,6 +1387,22 @@ internal sealed partial class ExpressionBinder
             return new BoundErrorExpression(null);
         }
 
+        // Issue #1239 / C# §12.15: when `??` computes a best common type that
+        // differs from the right operand's type (a reference upcast / interface
+        // implementation or a numeric widening), insert the implicit conversion
+        // on the right operand so both branches of the coalesce leave a value of
+        // the operator's result type. The left operand's non-null value is
+        // converted to the result type by the emitter / evaluator when the
+        // result widened the left's underlying numeric type (e.g.
+        // `int32? ?? int64` → `int64`); reference upcasts need no IL conversion
+        // because they are representation-preserving.
+        if (boundOperator.Kind == BoundBinaryOperatorKind.NullCoalesce
+            && boundRight.Type != boundOperator.Type
+            && boundRight.Type != TypeSymbol.Never)
+        {
+            boundRight = conversions.BindConversion(syntax.Right.Location, boundRight, boundOperator.Type);
+        }
+
         return new BoundBinaryExpression(null, boundLeft, boundOperator, boundRight);
     }
 

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
@@ -219,6 +219,16 @@ internal sealed partial class MethodBodyEmitter
                     this.il.LoadLocalAddress(slot);
                     this.il.OpCode(ILOpCode.Call);
                     this.il.Token(this.outer.wellKnown.GetNullableGetValueOrDefaultReference(innerClr));
+
+                    // Issue #1239: when the best common type widened the left's
+                    // underlying numeric type (e.g. `int32? ?? int64` → `int64`),
+                    // convert the unwrapped underlying value to the result type so
+                    // the non-null branch leaves a value of `b.Type` on the stack,
+                    // matching the (already-converted) right branch.
+                    if (b.Type != leftNullable.UnderlyingType)
+                    {
+                        this.TryEmitNumericConversion(leftNullable.UnderlyingType, b.Type);
+                    }
                 }
 
                 this.il.Branch(ILOpCode.Br, end);

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -2277,7 +2277,24 @@ public sealed class Evaluator
         if (b.Op.Kind == BoundBinaryOperatorKind.NullCoalesce)
         {
             var leftValue = EvaluateExpression(b.Left);
-            return leftValue ?? EvaluateExpression(b.Right);
+            if (leftValue != null)
+            {
+                // Issue #1239: when the best common type widened the left's
+                // underlying numeric type (e.g. `int32? ?? int64` → `int64`),
+                // convert the non-null left value to the result type. Reference
+                // results are representation-preserving and need no conversion.
+                var leftUnderlying = b.Left.Type is NullableTypeSymbol ln ? ln.UnderlyingType : b.Left.Type;
+                if (b.Type != leftUnderlying
+                    && b.Type?.ClrType is { IsValueType: true } resultClr
+                    && IsSupportedNumericClrType(resultClr))
+                {
+                    return UncheckedNumericConvert(leftValue, resultClr);
+                }
+
+                return leftValue;
+            }
+
+            return EvaluateExpression(b.Right);
         }
 
         var left = EvaluateExpression(b.Left);

--- a/test/Compiler.Tests/Emit/Issue1239CoalesceCommonTypeEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1239CoalesceCommonTypeEmitTests.cs
@@ -1,0 +1,278 @@
+// <copyright file="Issue1239CoalesceCommonTypeEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1239: the null-coalescing operator <c>a ?? b</c> must compute the
+/// C# §12.15 best common type rather than requiring both operands to share an
+/// exact type. When the right operand implicitly converts to the left's
+/// non-null type the result is that type; otherwise, when the left's non-null
+/// type implicitly converts to the right operand's type (a reference upcast /
+/// interface implementation or a numeric widening), the result is the right
+/// type. Both branches are emitted with the conversions required so the
+/// produced value matches the operator's result type.
+///
+/// Each test compiles via <c>gsc</c>, IL-verifies the produced PE, then executes
+/// it under <c>dotnet exec</c> and asserts on captured stdout.
+/// </summary>
+public class Issue1239CoalesceCommonTypeEmitTests
+{
+    [Fact]
+    public void RightImplementsInterface_ResultIsInterface()
+    {
+        var source = """
+            package P
+
+            import System
+
+            interface IFoo { func Bar() int32; }
+            class Foo : IFoo { func Bar() int32 { return 1 } }
+            class Baz : IFoo { func Bar() int32 { return 2 } }
+
+            func Pick(f Foo?, g IFoo) IFoo {
+                return f ?? g
+            }
+
+            let present Foo = Foo()
+            let g IFoo = Baz()
+            Console.WriteLine(Pick(present, g).Bar().ToString())
+            Console.WriteLine(Pick(nil, g).Bar().ToString())
+            """;
+
+        var output = CompileAndRun(source);
+
+        // Non-null left -> Foo.Bar() == 1; nil left -> Baz.Bar() == 2.
+        Assert.Equal("1\n2\n", output);
+    }
+
+    [Fact]
+    public void RightIsBaseClass_ResultIsBaseClass()
+    {
+        var source = """
+            package P
+
+            import System
+
+            open class Animal { open func Speak() int32 { return 10 } }
+            class Dog : Animal { override func Speak() int32 { return 20 } }
+
+            func Pick(d Dog?, a Animal) Animal {
+                return d ?? a
+            }
+
+            let dog Dog = Dog()
+            let baseAnimal Animal = Animal()
+            Console.WriteLine(Pick(dog, baseAnimal).Speak().ToString())
+            Console.WriteLine(Pick(nil, baseAnimal).Speak().ToString())
+            """;
+
+        var output = CompileAndRun(source);
+
+        // Non-null left -> Dog.Speak() == 20; nil left -> Animal.Speak() == 10.
+        Assert.Equal("20\n10\n", output);
+    }
+
+    [Fact]
+    public void NumericWidening_RightWidensToLeftUnderlying_ResultIsLeftType()
+    {
+        var source = """
+            package P
+
+            import System
+
+            func Coalesce(a int32?, b uint16) int32 {
+                return a ?? b
+            }
+
+            let seven uint16 = 7
+            Console.WriteLine(Coalesce(100, seven).ToString())
+            Console.WriteLine(Coalesce(nil, seven).ToString())
+            """;
+
+        var output = CompileAndRun(source);
+
+        // Non-null left -> 100 (int32); nil left -> 7 widened from uint16.
+        Assert.Equal("100\n7\n", output);
+    }
+
+    [Fact]
+    public void NumericWidening_LeftWidensToRight_ResultIsRightType()
+    {
+        var source = """
+            package P
+
+            import System
+
+            func Coalesce(a int32?, b int64) int64 {
+                return a ?? b
+            }
+
+            let big int64 = 9000000000
+            Console.WriteLine(Coalesce(100, big).ToString())
+            Console.WriteLine(Coalesce(nil, big).ToString())
+            """;
+
+        var output = CompileAndRun(source);
+
+        // Non-null left -> 100 widened to int64; nil left -> 9000000000.
+        Assert.Equal("100\n9000000000\n", output);
+    }
+
+    [Fact]
+    public void ExplicitTargetType_BindsThroughInterface()
+    {
+        var source = """
+            package P
+
+            import System
+
+            interface IFoo { func Bar() int32; }
+            class Foo : IFoo { func Bar() int32 { return 42 } }
+            class Baz : IFoo { func Bar() int32 { return 7 } }
+
+            func WithTarget(f Foo?, g IFoo) int32 {
+                let r IFoo = f ?? g
+                return r.Bar()
+            }
+
+            Console.WriteLine(WithTarget(Foo(), Baz()).ToString())
+            Console.WriteLine(WithTarget(nil, Baz()).ToString())
+            """;
+
+        var output = CompileAndRun(source);
+
+        Assert.Equal("42\n7\n", output);
+    }
+
+    [Fact]
+    public void SameType_StillWorks()
+    {
+        var source = """
+            package P
+
+            import System
+
+            class Foo { func Bar() int32 { return 5 } }
+
+            func Same(f Foo?, g Foo) Foo {
+                return f ?? g
+            }
+
+            Console.WriteLine(Same(Foo(), Foo()).Bar().ToString())
+            Console.WriteLine(Same(nil, Foo()).Bar().ToString())
+            """;
+
+        var output = CompileAndRun(source);
+
+        Assert.Equal("5\n5\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var (exitCode, stdout, stderr) = CompileAndRunRaw(source);
+        Assert.True(
+            exitCode == 0,
+            $"exited {exitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout;
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) CompileAndRunRaw(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1239_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+            };
+
+            foreach (var bcl in BclReferences.Value)
+            {
+                args.Add("/r:" + bcl);
+            }
+
+            args.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            return (proc.ExitCode, stdout.Replace("\r\n", "\n"), stderr.Replace("\r\n", "\n"));
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static readonly Lazy<IReadOnlyList<string>> BclReferences = new(() =>
+    {
+        var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location);
+        if (string.IsNullOrEmpty(runtimeDir) || !Directory.Exists(runtimeDir))
+        {
+            return Array.Empty<string>();
+        }
+
+        return Directory.EnumerateFiles(runtimeDir, "*.dll", SearchOption.TopDirectoryOnly)
+            .Where(p =>
+            {
+                var name = Path.GetFileName(p);
+                return name.StartsWith("System.", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "mscorlib.dll", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "netstandard.dll", StringComparison.OrdinalIgnoreCase);
+            })
+            .ToList();
+    });
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1239CoalesceCommonTypeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1239CoalesceCommonTypeTests.cs
@@ -1,0 +1,143 @@
+// <copyright file="Issue1239CoalesceCommonTypeTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1239: the null-coalescing operator <c>a ?? b</c> must compute the
+/// C# §12.15 best common type rather than requiring both operands to share an
+/// exact type. When the left's non-null type implicitly converts to the right
+/// operand's type (a reference upcast / interface implementation or a numeric
+/// widening) — or vice versa — <c>??</c> binds cleanly instead of reporting
+/// GS0129.
+/// </summary>
+public class Issue1239CoalesceCommonTypeTests
+{
+    private static ImmutableArray<Diagnostic> EmitDiagnostics(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        using var peStream = new MemoryStream();
+        return compilation.Emit(peStream).Diagnostics;
+    }
+
+    [Fact]
+    public void RightImplementsInterface_BindsToInterface()
+    {
+        const string Source = @"package Issue1239.Iface
+
+interface IFoo { func Bar() int32; }
+class Foo : IFoo { func Bar() int32 { return 1 } }
+class C {
+    func ToIface(f Foo?, g IFoo) IFoo { return f ?? g }
+}
+";
+        var diagnostics = EmitDiagnostics(Source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0129");
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void ExplicitTargetType_BindsToInterface()
+    {
+        const string Source = @"package Issue1239.Target
+
+interface IFoo { func Bar() int32; }
+class Foo : IFoo { func Bar() int32 { return 1 } }
+class C {
+    func WithTarget(f Foo?, g IFoo) IFoo {
+        let r IFoo = f ?? g
+        return r
+    }
+}
+";
+        var diagnostics = EmitDiagnostics(Source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0129");
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void RightIsBaseClass_BindsToBaseClass()
+    {
+        const string Source = @"package Issue1239.BaseClass
+
+open class Animal { func Speak() int32 { return 10 } }
+class Dog : Animal { }
+class C {
+    func Pick(d Dog?, a Animal) Animal { return d ?? a }
+}
+";
+        var diagnostics = EmitDiagnostics(Source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0129");
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void NumericWidening_RightWidensToLeft_BindsToLeftType()
+    {
+        const string Source = @"package Issue1239.NumWiden
+
+class C {
+    func Coalesce(a int32?, b uint16) int32 { return a ?? b }
+}
+";
+        var diagnostics = EmitDiagnostics(Source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0129");
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void NumericWidening_LeftWidensToRight_BindsToRightType()
+    {
+        const string Source = @"package Issue1239.NumWiden2
+
+class C {
+    func Coalesce(a int32?, b int64) int64 { return a ?? b }
+}
+";
+        var diagnostics = EmitDiagnostics(Source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0129");
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void SameType_StillBinds()
+    {
+        const string Source = @"package Issue1239.Same
+
+class Foo { func Bar() int32 { return 1 } }
+class C {
+    func Same(f Foo?, g Foo) Foo { return f ?? g }
+}
+";
+        var diagnostics = EmitDiagnostics(Source);
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void Unrelated_TypesStillReportError()
+    {
+        // Regression guard: when no implicit conversion exists in either
+        // direction, `??` still reports GS0129.
+        const string Source = @"package Issue1239.Unrelated
+
+class Foo { }
+class Bar { }
+class C {
+    func Bad(f Foo?, g Bar) Foo { return f ?? g }
+}
+";
+        var diagnostics = EmitDiagnostics(Source);
+        Assert.Contains(diagnostics, d => d.Id == "GS0129");
+    }
+}

--- a/test/Interpreter.Tests/Issue1239CoalesceCommonTypeInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue1239CoalesceCommonTypeInterpreterTests.cs
@@ -1,0 +1,86 @@
+// <copyright file="Issue1239CoalesceCommonTypeInterpreterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #1239: interpreter parity for the null-coalescing (<c>??</c>) best
+/// common type. When the left's non-null type implicitly converts to the right
+/// operand's type (a reference upcast / interface implementation or a numeric
+/// widening) — or vice versa — <c>??</c> evaluates to a value of the computed
+/// best common type, mirroring the emitted IL behaviour validated by
+/// <c>Issue1239CoalesceCommonTypeEmitTests</c>.
+/// </summary>
+public class Issue1239CoalesceCommonTypeInterpreterTests
+{
+    [Fact]
+    public void NumericWidening_RightWidensToLeftUnderlying_LeftPresent()
+    {
+        var source = """
+            let a int32? = 100
+            let b uint16 = 7
+            Console.WriteLine((a ?? b).ToString())
+            """;
+
+        Assert.Equal("100\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void NumericWidening_RightWidensToLeftUnderlying_LeftNil()
+    {
+        var source = """
+            let a int32? = nil
+            let b uint16 = 7
+            Console.WriteLine((a ?? b).ToString())
+            """;
+
+        Assert.Equal("7\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void NumericWidening_LeftWidensToRight_LeftPresent_ConvertsToResultType()
+    {
+        var source = """
+            let a int32? = 100
+            let b int64 = 9000000000
+            Console.WriteLine((a ?? b).ToString())
+            """;
+
+        Assert.Equal("100\n", RunSubmission(source));
+    }
+
+    [Fact]
+    public void NumericWidening_LeftWidensToRight_LeftNil()
+    {
+        var source = """
+            let a int32? = nil
+            let b int64 = 9000000000
+            Console.WriteLine((a ?? b).ToString())
+            """;
+
+        Assert.Equal("9000000000\n", RunSubmission(source));
+    }
+
+    private static string RunSubmission(string text)
+    {
+        using var outWriter = new StringWriter();
+        var prevOut = Console.Out;
+        Console.SetOut(outWriter);
+        try
+        {
+            var repl = new GSharpRepl();
+            repl.EvaluateSubmission(text);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+        }
+
+        return outWriter.ToString().Replace("\r\n", "\n");
+    }
+}


### PR DESCRIPTION
Fixes #1239.

## Root cause
The null-coalescing operator `??` only bound when the right operand's type **exactly** matched the left operand's non-null underlying type. `BoundBinaryOperator.Bind` required `leftUnderlying == rightUnderlying`, so when the right operand was a base class / implemented interface of the left's non-null type (a valid implicit conversion) — or a numeric type related through the widening lattice — it returned `null` and the binder reported `GS0129`, even when an explicit target type was supplied:

```
error GS0129: Binary operator '??' is not defined for types 'Foo?' and 'IFoo'.
```

## Fix
Implement the C# §12.15 best-common-type rule. For `a ?? b`, let `A0` be the non-nullable type of `a`:
- if an implicit conversion exists from `b` to `A0`, the result type is `A0` (e.g. `int32? ?? uint16` → `int32`);
- otherwise, if an implicit conversion exists from `A0` to `b`'s type, the result type is `b`'s type (`Foo? ?? IFoo` → `IFoo`, `Foo? ?? Base` → `Base`, `int32? ?? int64` → `int64`).

This reuses the existing implicit-conversion classifier (`Conversion.Classify` — reference/interface conversions plus the numeric widening lattice). The same-type case is unchanged, and a mismatched **nullable** right operand still reports `GS0129` (lifted nullable numeric conversions are not part of the implicit lattice), so there is no regression.

The binder inserts the implicit conversion on the right operand so both coalesce branches yield the operator's result type. For a numeric result that widened the left's underlying type (`int32? ?? int64` → `int64`), the emitter converts the unwrapped left value to the result type and the evaluator mirrors this; reference upcasts are representation-preserving and need no IL conversion.

### Files changed
- `src/Core/CodeAnalysis/Binding/BoundBinaryOperator.cs` — best-common-type arm for `??`.
- `src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs` — insert right-operand conversion to the result type.
- `src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs` — convert unwrapped left value for numeric widening results.
- `src/Core/CodeAnalysis/Evaluator.cs` — interpreter parity for numeric widening results.

## Tests
- `test/Core.Tests/.../Issue1239CoalesceCommonTypeTests.cs` — binder: interface/base-class/numeric (both directions) bind cleanly, same-type still binds, unrelated types still report GS0129.
- `test/Compiler.Tests/Emit/Issue1239CoalesceCommonTypeEmitTests.cs` — IL-verified execution tests for non-null vs nil left across all result-type shapes.
- `test/Interpreter.Tests/Issue1239CoalesceCommonTypeInterpreterTests.cs` — evaluator parity.

All Core.Tests (4280), the new Compiler.Tests filter, related coalesce emit suites, the interpreter tests, and `dotnet build GSharp.sln -c Release -graph` pass with 0 errors.
