### PR TITLE
Fix #1244: recognize generic derived override of type-parameter-using abstract member

### DIFF
--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -906,6 +906,7 @@ public sealed class StructSymbol : TypeSymbol
                         continue;
                     }
 
+                    var candidateSubst = levels[kk].Subst;
                     foreach (var candidate in derivedCls.Methods)
                     {
                         if (candidate.IsAbstract)
@@ -913,7 +914,7 @@ public sealed class StructSymbol : TypeSymbol
                             continue;
                         }
 
-                        if (AbstractMethodSatisfiedBy(abstractMethod, subst, candidate))
+                        if (AbstractMethodSatisfiedBy(abstractMethod, subst, candidate, candidateSubst))
                         {
                             implemented = true;
                             break;
@@ -1265,7 +1266,8 @@ public sealed class StructSymbol : TypeSymbol
     private static bool AbstractMethodSatisfiedBy(
         FunctionSymbol abstractMethod,
         Dictionary<TypeParameterSymbol, TypeSymbol> subst,
-        FunctionSymbol candidate)
+        FunctionSymbol candidate,
+        Dictionary<TypeParameterSymbol, TypeSymbol> candidateSubst)
     {
         if (!string.Equals(abstractMethod.Name, candidate.Name, System.StringComparison.Ordinal))
         {
@@ -1296,7 +1298,18 @@ public sealed class StructSymbol : TypeSymbol
             var baseType = subst != null
                 ? SubstituteTypeForConstruction(baseParams[i].Type, subst)
                 : baseParams[i].Type;
-            if (!DeclarationBinder.TypeSignaturesEquivalent(baseType, derivedParams[i].Type))
+
+            // Issue #1244: the override is declared on a (possibly still-generic)
+            // derived class whose own type parameters are distinct symbols from the
+            // base's — even when same-named. Substitute the candidate's parameter
+            // types with the derived level's construction map so a signature using
+            // the derived class type parameter (e.g. Der[T].Handle(T)) unifies with
+            // the substituted abstract signature (Base[T].Handle(T) -> Handle(int32)).
+            var derivedType = candidateSubst != null
+                ? SubstituteTypeForConstruction(derivedParams[i].Type, candidateSubst)
+                : derivedParams[i].Type;
+
+            if (!DeclarationBinder.TypeSignaturesEquivalent(baseType, derivedType))
             {
                 return false;
             }

--- a/test/Compiler.Tests/Emit/Issue1244GenericAbstractOverrideEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1244GenericAbstractOverrideEmitTests.cs
@@ -1,0 +1,180 @@
+// <copyright file="Issue1244GenericAbstractOverrideEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1244: a GENERIC derived class whose <c>override</c> of an abstract base
+/// member uses the class type parameter (<c>Der[T] : Base[T]</c> overriding
+/// <c>Handle(x T) int32</c>) must be recognized as implementing the abstract, so a
+/// concrete leaf (<c>Leaf : Der[int32]</c>) is fully instantiable (no GS0386/GS0387)
+/// and emits a correct vtable. These tests drive the real end-to-end emit pipeline:
+/// they construct the leaf, run the program, and verify the emitted IL with
+/// <c>ilverify</c> — proving the override slot is laid out correctly, not merely the
+/// diagnostic.
+/// </summary>
+public class Issue1244GenericAbstractOverrideEmitTests
+{
+    [Fact]
+    public void CanonicalGenericDerivedOverride_LeafConstructsAndRuns()
+    {
+        // The canonical #1244 case: ONLY Der[T]'s type-parameter-using override
+        // closes Base[T].Handle; Leaf adds no override. Before the fix this failed
+        // with GS0387 (Leaf wrongly considered abstract) so it could not be emitted
+        // at all. Now it constructs, runs, and the IL verifies.
+        var source = """
+            package p
+            open class Base[T] {
+                open func Handle(x T) int32;
+            }
+            open class Der[T] : Base[T] {
+                override func Handle(x T) int32 { return 0 }
+            }
+            class Leaf : Der[int32] {
+                func Plain() int32 { return 42 }
+            }
+            func Main() {
+                let leaf Leaf = Leaf()
+                System.Console.WriteLine(leaf.Plain())
+            }
+            """;
+
+        Assert.Equal("42\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void GenericHierarchyOverride_DispatchesOverriddenValueAtRuntime()
+    {
+        // Proves runtime vtable dispatch in the same generic hierarchy: Der[T]
+        // declares an open override of the type-parameter-using abstract, and the
+        // concrete Leaf overrides it again with a concrete signature. Invoking the
+        // member must reach Leaf's override and return its value.
+        var source = """
+            package p
+            open class Base[T] {
+                open func Handle(x T) int32;
+            }
+            open class Der[T] : Base[T] {
+                open override func Handle(x T) int32 { return -1 }
+            }
+            class Leaf : Der[int32] {
+                override func Handle(x int32) int32 { return x + 1 }
+            }
+            func Main() {
+                let leaf Leaf = Leaf()
+                System.Console.WriteLine(leaf.Handle(41))
+            }
+            """;
+
+        Assert.Equal("42\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void ThreeLevelGenericChain_LeafConstructsAndRuns()
+    {
+        // FilterBase[T] -> TransformBase[TIn, TOut] (generic derived overriding the
+        // type-parameter-using abstract Handle(x TIn)) -> AacFilter (overriding the
+        // remaining abstract Perform). The substitution composes across every hop;
+        // the concrete leaf constructs and runs, and the IL verifies.
+        var source = """
+            package p
+            open class FilterBase[T] {
+                protected open func Handle(x T) int32;
+            }
+            open class TransformBase[TIn, TOut] : FilterBase[TIn] {
+                protected override func Handle(x TIn) int32 { return 0 }
+                protected open func Perform(x TIn) TOut;
+            }
+            open class AacFilter : TransformBase[int32, int32] {
+                protected override func Perform(x int32) int32 { return x + 5 }
+                func Run(x int32) int32 { return x + 5 }
+            }
+            func Main() {
+                let f AacFilter = AacFilter()
+                System.Console.WriteLine(f.Run(37))
+            }
+            """;
+
+        Assert.Equal("42\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1244_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1244GenericAbstractOverrideBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1244GenericAbstractOverrideBinderTests.cs
@@ -1,0 +1,139 @@
+// <copyright file="Issue1244GenericAbstractOverrideBinderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1244: a generic derived class's <c>override</c> of an abstract member
+/// whose signature uses the class type parameter (<c>Der[T] : Base[T]</c> with
+/// <c>override func Handle(x T) int32</c>) must be recognized as implementing the
+/// abstract member, so the derived class — and every concrete leaf below it — is
+/// fully concrete. The completeness check substitutes BOTH the base abstract
+/// signature (with the constructed base's type arguments) AND the candidate
+/// override's signature (with the derived level's construction map) before
+/// comparing; otherwise the derived class's own type parameter (a distinct symbol
+/// from the base's, even when same-named) fails to unify and the leaf is wrongly
+/// treated as still-abstract (GS0387 / GS0386).
+/// </summary>
+public class Issue1244GenericAbstractOverrideBinderTests
+{
+    [Fact]
+    public void GenericDerivedOverridesTypeParamAbstract_LeafIsConcrete_NoDiagnostic()
+    {
+        var source = @"
+open class Base[T] {
+    open func Handle(x T) int32;
+}
+open class Der[T] : Base[T] {
+    override func Handle(x T) int32 { return 0 }
+}
+class Leaf : Der[int32] {
+}
+class C {
+    func Make() Leaf { return Leaf() }
+}
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0387");
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0386");
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void GenericDerivedOverride_RenamedTypeParam_NoDiagnostic()
+    {
+        // Param-name renaming is irrelevant: Der[U] : Base[U] with override
+        // Handle(x U) must match identically to the same-named-T case.
+        var source = @"
+open class Base[T] {
+    open func Handle(x T) int32;
+}
+open class Der[U] : Base[U] {
+    override func Handle(x U) int32 { return 0 }
+}
+class Leaf : Der[int32] {
+}
+class C {
+    func Make() Leaf { return Leaf() }
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void ThreeLevelGenericChain_AllConcrete_NoDiagnostic()
+    {
+        var source = @"
+import System.Threading.Tasks
+open class FilterBase[T] {
+    protected open func Handle(x T) Task;
+}
+open class TransformBase[TIn, TOut] : FilterBase[TIn] {
+    protected override async func Handle(x TIn) { }
+    protected open func Perform(x TIn) TOut;
+}
+open class AacFilter : TransformBase[int32, int32] {
+    protected override func Perform(x int32) int32 { return x }
+}
+class C {
+    func Make() AacFilter { return AacFilter() }
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void GenericDerivedMissingOverride_StillDiagnosticGS0387()
+    {
+        // Negative: Der[T] does NOT override the type-parameter-using abstract
+        // member, so Leaf must still be reported as not implementing it.
+        var source = @"
+open class Base[T] {
+    open func Handle(x T) int32;
+}
+open class Der[T] : Base[T] {
+}
+class Leaf : Der[int32] {
+}
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0387");
+    }
+
+    [Fact]
+    public void GenericDerivedOverrideWrongType_StillDiagnosticGS0387()
+    {
+        // Negative: the override's parameter type does not match the substituted
+        // abstract signature, so the abstract remains unimplemented.
+        var source = @"
+open class Base[T] {
+    open func Handle(x T) int32;
+}
+open class Der[T] : Base[T] {
+    override func Handle(x int64) int32 { return 0 }
+}
+class Leaf : Der[int32] {
+}
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0387");
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
## Bug (#1244)

A **generic derived class's `override` of an abstract member (`open func ... ;`) whose signature uses the class type parameter was NOT recognized as implementing the abstract member.** The derived class and every concrete leaf below it were wrongly treated as still-abstract, producing `GS0387 'X' does not implement inherited abstract member` and, at construction sites, `GS0386 Cannot create an instance of the abstract type 'X'`.

Canonical failing repro (now compiles cleanly):

```gsharp
package p
open class Base[T]() { open func Handle(x T) int32; }
open class Der[T] : Base[T] { override func Handle(x T) int32 { return 0 } }
class Leaf : Der[int32] { }
class C { func Make() Leaf { return Leaf() } }
```

## Root cause

The abstract-implementation completeness check in `StructSymbol.GetUnimplementedAbstractMethods` substituted the **base** abstract signature with the constructed base's type arguments, but compared it against the candidate override's parameter types **without substituting the candidate**. A generic derived class's override is declared in terms of the derived class's *own* type parameter — a distinct symbol from the base's even when same-named — and that signature is shared **unsubstituted** on the constructed symbol (`CreateConstructed` calls `SetMethods(definition.Methods)`). So `Der[T].Handle(T_der)` never unified with the substituted abstract `Base[T].Handle(int32)`, and the abstract was deemed unimplemented.

## Fix

`AbstractMethodSatisfiedBy` now also substitutes the **candidate** override's parameter types using the candidate level's construction map (already composed across every hop of the inheritance chain by the existing level-walk). This makes `Der[T].Handle(T)` match `Base[T].Handle(T)` under the `Der[T] : Base[T]` mapping, and the `Leaf` / `AacFilter` closures resolve correctly. The change is general (no repro special-casing).

Guardrails preserved:
- A genuinely missing override still yields `GS0387`.
- A signature that does not match after substitution (e.g. `override Handle(x int64)`) still yields `GS0387`.

Single source change: `src/Core/CodeAnalysis/Symbols/StructSymbol.cs`.

## Tests added

**Binder/diagnostic** — `test/Core.Tests/CodeAnalysis/Binding/Issue1244GenericAbstractOverrideBinderTests.cs`:
- canonical generic derived override → no diagnostics
- renamed type parameter (`Der[U] : Base[U]`) → no diagnostics
- 3-level chain (`FilterBase[T]` → `TransformBase[TIn,TOut]` → `AacFilter`, incl. `async` override) → no diagnostics
- negative: generic derived missing the override → still `GS0387`
- negative: wrong-type override → still `GS0387`

**Emit/execution** — `test/Compiler.Tests/Emit/Issue1244GenericAbstractOverrideEmitTests.cs` (real Program.Main compile → `ilverify` → exec):
- canonical case (only `Der[T]`'s generic override closes the abstract) constructs the leaf and runs
- generic hierarchy where the override dispatches the overridden value at runtime (returns 42)
- non-async 3-level chain constructs and runs

## Verification

- `dotnet build GSharp.sln -c Release -graph` → 0 errors, 0 warnings
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release` → 4305 passed, 1 skipped, 0 failed
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Release --no-build --filter "FullyQualifiedName~Issue1244GenericAbstractOverrideEmitTests" -- xUnit.MaxParallelThreads=2` → 3 passed
- Standalone `gsc` recompile of the minimal repro now succeeds.

### Out of scope (pre-existing, unrelated limitations observed while writing emit tests)
Independent of this fix, generic-derived hierarchies have separate emit/lookup limitations: implicit upcast of a generic-derived instance to a constructed base ref (`GS0155`), calling an inherited *generic* method on a leaf (InvalidProgram IL), member-lookup ambiguity (`GS0266`) when a constructed generic surfaces both inherited-abstract and override slots, and async-generic state-machine IL. The emit tests dispatch through paths that avoid these so they exercise the #1244 fix cleanly; the unrelated limitations are not addressed here.

Fixes #1244
