### PR TITLE
Fix #1248: substitute derived type arguments when classifying generic base upcast

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -580,12 +580,9 @@ public sealed class Conversion
 
             if (to is StructSymbol toClass && toClass.IsClass)
             {
-                for (var c = fromClass.BaseClass; c != null; c = c.BaseClass)
+                if (DerivesFromConstructed(fromClass, toClass))
                 {
-                    if (c == toClass)
-                    {
-                        return Conversion.Implicit;
-                    }
+                    return Conversion.Implicit;
                 }
             }
         }
@@ -810,6 +807,115 @@ public sealed class Conversion
         for (var i = 0; i < from.TypeArguments.Length; i++)
         {
             if (!AreTypeArgumentsEquivalent(from.TypeArguments[i], to.TypeArguments[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Issue #1248: determines whether a (possibly constructed generic) class
+    /// <paramref name="fromClass"/> implicitly upcasts to a constructed generic
+    /// base class <paramref name="toClass"/> by walking the inheritance chain
+    /// while substituting type arguments at each level.
+    /// <para>
+    /// A base-type reference is declared in terms of the derived class's OWN
+    /// type parameters (e.g. <c>TransformBase[TIn, TOut] : FilterBase[TIn]</c>),
+    /// and a constructed instance keeps that base reference unsubstituted
+    /// (<see cref="StructSymbol.BaseClass"/> is the open definition's base). A
+    /// naive reference-equality walk therefore compares <c>FilterBase[TIn]</c>
+    /// against the target <c>FilterBase[int32]</c> and fails. This walk threads
+    /// a substitution map mapping each class's declaration type parameters onto
+    /// the concrete type arguments seen at the most-derived level, composing the
+    /// map down every hop, so the base reference is fully substituted before the
+    /// comparison. Handles multi-level chains (concrete leaf → generic mid →
+    /// generic base), type-parameter renaming, and partial type-parameter flow
+    /// (only some of the derived's parameters reaching the base). A wrong type
+    /// argument or an unrelated definition still fails (GS0155).
+    /// </para>
+    /// </summary>
+    private static bool DerivesFromConstructed(StructSymbol fromClass, StructSymbol toClass)
+    {
+        // Maps each visited class's declaration type parameters onto concrete
+        // type arguments resolved in fromClass's context, composed across hops.
+        Dictionary<TypeParameterSymbol, TypeSymbol> running = null;
+
+        for (var c = fromClass; c != null; c = c.BaseClass)
+        {
+            // The most-derived class itself is the identity case (handled by the
+            // caller); only its base chain is an upcast target.
+            if (!ReferenceEquals(c, fromClass) && MatchesConstructedTarget(c, toClass, running))
+            {
+                return true;
+            }
+
+            // Extend the running map with this class's own declaration
+            // parameters -> (resolved) arguments, so a deeper base whose type
+            // arguments reference these parameters can be substituted.
+            if (c.Definition != null
+                && !c.TypeArguments.IsDefaultOrEmpty
+                && !c.Definition.TypeParameters.IsDefaultOrEmpty)
+            {
+                var defParams = c.Definition.TypeParameters;
+                var count = Math.Min(defParams.Length, c.TypeArguments.Length);
+                for (var i = 0; i < count; i++)
+                {
+                    var arg = c.TypeArguments[i];
+                    if (arg is TypeParameterSymbol tpArg && running != null
+                        && running.TryGetValue(tpArg, out var resolved))
+                    {
+                        arg = resolved;
+                    }
+
+                    running ??= new Dictionary<TypeParameterSymbol, TypeSymbol>();
+                    running[defParams[i]] = arg;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Issue #1248: tests whether a base-chain class <paramref name="c"/>, after
+    /// substituting its type arguments through <paramref name="running"/>, denotes
+    /// the same constructed type as <paramref name="toClass"/>.
+    /// </summary>
+    private static bool MatchesConstructedTarget(
+        StructSymbol c,
+        StructSymbol toClass,
+        Dictionary<TypeParameterSymbol, TypeSymbol> running)
+    {
+        if (!ReferenceEquals(c.Definition, toClass.Definition))
+        {
+            return false;
+        }
+
+        // Non-generic class along the chain: definition identity is sufficient.
+        if (c.TypeArguments.IsDefaultOrEmpty && toClass.TypeArguments.IsDefaultOrEmpty)
+        {
+            return true;
+        }
+
+        if (c.TypeArguments.IsDefaultOrEmpty
+            || toClass.TypeArguments.IsDefaultOrEmpty
+            || c.TypeArguments.Length != toClass.TypeArguments.Length)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < c.TypeArguments.Length; i++)
+        {
+            var arg = c.TypeArguments[i];
+            if (arg is TypeParameterSymbol tp && running != null
+                && running.TryGetValue(tp, out var resolved))
+            {
+                arg = resolved;
+            }
+
+            if (!AreTypeArgumentsEquivalent(arg, toClass.TypeArguments[i]))
             {
                 return false;
             }

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
@@ -462,9 +462,18 @@ internal sealed partial class MethodBodyEmitter
 
         if (a is StructSymbol aClass && b is StructSymbol bClass && aClass.IsClass && bClass.IsClass)
         {
-            for (var c = aClass; c != null; c = c.BaseClass)
+            // Issue #1248: a constructed generic class's base-type reference is
+            // declared with the derived class's own type parameters (e.g.
+            // `TransformBase[TIn, TOut] : FilterBase[TIn]`) and is kept
+            // unsubstituted on the constructed symbol, so reference equality
+            // against the constructed target (`FilterBase[int32]`) fails. The
+            // upcast is a no-op reference conversion at the IL level regardless
+            // of type arguments, and the binder already validated argument
+            // compatibility, so matching by generic definition along the base
+            // chain correctly recognises it.
+            for (var c = aClass.BaseClass; c != null; c = c.BaseClass)
             {
-                if (c == bClass)
+                if (c == bClass || ReferenceEquals(c.Definition, bClass.Definition))
                 {
                     return true;
                 }

--- a/test/Compiler.Tests/Emit/Issue1248GenericUpcastEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1248GenericUpcastEmitTests.cs
@@ -1,0 +1,169 @@
+// <copyright file="Issue1248GenericUpcastEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1248: a generic class instance must upcast to its constructed generic base
+/// class when the base type argument is one of the derived class's OWN type
+/// parameters (<c>TransformBase[TIn, TOut] : FilterBase[TIn]</c>). These tests drive
+/// the real end-to-end emit pipeline: they construct the derived instance, upcast it
+/// to the base type, invoke a base method at runtime to prove correct dispatch, and
+/// verify the emitted IL with <c>ilverify</c> — proving the upcast lowers to a valid
+/// no-op reference conversion, not merely that the binder accepts it.
+/// </summary>
+public class Issue1248GenericUpcastEmitTests
+{
+    [Fact]
+    public void TwoLevelGenericUpcast_PassesAsBaseParameterAndDispatches()
+    {
+        // TransformBase[int32, int32] is upcast to FilterBase[int32] when passed
+        // to Take; the base method Tag is invoked through the base-typed reference.
+        var source = """
+            package p
+            open class FilterBase[T]() {
+                open func Tag() int32 { return 7 }
+            }
+            open class TransformBase[TIn, TOut] : FilterBase[TIn] { }
+            class C {
+                func Take(f FilterBase[int32]) int32 { return f.Tag() }
+                func Run() int32 {
+                    var x = TransformBase[int32, int32]()
+                    return Take(x)
+                }
+            }
+            func Main() {
+                let c C = C()
+                System.Console.WriteLine(c.Run())
+            }
+            """;
+
+        Assert.Equal("7\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void TwoLevelGenericUpcast_OverriddenBaseMethodDispatchesThroughBaseSlot()
+    {
+        // The derived class overrides the base method; invoking it through the
+        // upcast base-typed local must reach the override (vtable dispatch).
+        var source = """
+            package p
+            open class FilterBase[T]() {
+                open func Tag() int32 { return 1 }
+            }
+            open class TransformBase[TIn, TOut] : FilterBase[TIn] {
+                override func Tag() int32 { return 42 }
+            }
+            func Main() {
+                let f FilterBase[int32] = TransformBase[int32, int32]()
+                System.Console.WriteLine(f.Tag())
+            }
+            """;
+
+        Assert.Equal("42\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void ConcreteLeafBelowGenericIntermediate_UpcastsAndDispatches()
+    {
+        // FilterBase[T] -> TransformBase[TIn, TOut] : FilterBase[TIn] ->
+        // LosslessFilter : TransformBase[int32, int32]. The concrete leaf upcasts
+        // to FilterBase[int32] across two hops and the base method dispatches.
+        var source = """
+            package p
+            open class FilterBase[T]() {
+                open func Tag() int32 { return 5 }
+            }
+            open class TransformBase[TIn, TOut] : FilterBase[TIn] {
+                override func Tag() int32 { return 99 }
+            }
+            class LosslessFilter : TransformBase[int32, int32] { }
+            func Main() {
+                let f FilterBase[int32] = LosslessFilter()
+                System.Console.WriteLine(f.Tag())
+            }
+            """;
+
+        Assert.Equal("99\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1248_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1248GenericUpcastBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1248GenericUpcastBinderTests.cs
@@ -1,0 +1,220 @@
+// <copyright file="Issue1248GenericUpcastBinderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1248: an instance of a generic class must be recognized as implicitly
+/// convertible to its (constructed) generic base class when the base type argument
+/// is one of the derived class's OWN type parameters
+/// (<c>TransformBase[TIn, TOut] : FilterBase[TIn]</c>). The implicit reference
+/// upcast <c>Derived[...] -&gt; Base[...]</c> must be classified by substituting the
+/// derived instance's type arguments along the base chain before comparing against
+/// the target, instead of comparing the unsubstituted base reference
+/// (<c>FilterBase[TIn]</c>) against the target (<c>FilterBase[int32]</c>) and
+/// failing with GS0155. Wrong type arguments and unrelated types must still fail.
+/// </summary>
+public class Issue1248GenericUpcastBinderTests
+{
+    [Fact]
+    public void TwoLevelGenericUpcast_ParameterPassing_NoDiagnostic()
+    {
+        var source = @"
+open class FilterBase[T]() { }
+open class TransformBase[TIn, TOut] : FilterBase[TIn] { }
+class C {
+    func Take(f FilterBase[int32]) { }
+    func G() {
+        var x = TransformBase[int32, int32]()
+        Take(x)
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0155");
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void TwoLevelGenericUpcast_LocalInitialization_NoDiagnostic()
+    {
+        var source = @"
+open class FilterBase[T]() { }
+open class TransformBase[TIn, TOut] : FilterBase[TIn] { }
+class C {
+    func G() {
+        var f FilterBase[int32] = TransformBase[int32, int32]()
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void TwoLevelGenericUpcast_Assignment_NoDiagnostic()
+    {
+        var source = @"
+open class FilterBase[T]() { }
+open class TransformBase[TIn, TOut] : FilterBase[TIn] { }
+class C {
+    func G() {
+        var f FilterBase[int32] = FilterBase[int32]()
+        f = TransformBase[int32, int32]()
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void ConcreteLeafBelowGenericIntermediate_Upcast_NoDiagnostic()
+    {
+        var source = @"
+open class FilterBase[T]() { }
+open class TransformBase[TIn, TOut] : FilterBase[TIn] { }
+class LosslessFilter : TransformBase[int32, int32] { }
+class C {
+    func G() {
+        var f FilterBase[int32] = LosslessFilter()
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void TypeParameterRenaming_ThreeLevelChain_Upcast_NoDiagnostic()
+    {
+        // Renaming the flowing type parameter at every hop must not matter:
+        // Leaf[Z] : Mid[Z], Mid[A] : FilterBase[A].
+        var source = @"
+open class FilterBase[T]() { }
+open class Mid[A] : FilterBase[A] { }
+open class Leaf[Z] : Mid[Z] { }
+class C {
+    func Take(f FilterBase[int32]) { }
+    func G() {
+        var x = Leaf[int32]()
+        Take(x)
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void PartialTypeParameterFlow_OnlyOneParameterReachesBase_NoDiagnostic()
+    {
+        // Only TIn flows to FilterBase; TOut is unused by the base. The upcast
+        // must still succeed regardless of the TOut argument.
+        var source = @"
+open class FilterBase[T]() { }
+open class TransformBase[TIn, TOut] : FilterBase[TIn] { }
+class C {
+    func Take(f FilterBase[int32]) { }
+    func G() {
+        var x = TransformBase[int32, string]()
+        Take(x)
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void WrongTypeArgument_StillDiagnosticGS0155()
+    {
+        // Negative: TransformBase[int64, int64] is NOT a FilterBase[int32].
+        var source = @"
+open class FilterBase[T]() { }
+open class TransformBase[TIn, TOut] : FilterBase[TIn] { }
+class C {
+    func Take(f FilterBase[int32]) { }
+    func G() {
+        var x = TransformBase[int64, int64]()
+        Take(x)
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0155");
+    }
+
+    [Fact]
+    public void WrongTypeArgument_FlowingParameter_StillDiagnosticGS0155()
+    {
+        // Negative: the FLOWING parameter is wrong (string instead of int32),
+        // even though the non-flowing TOut happens to be int32.
+        var source = @"
+open class FilterBase[T]() { }
+open class TransformBase[TIn, TOut] : FilterBase[TIn] { }
+class C {
+    func Take(f FilterBase[int32]) { }
+    func G() {
+        var x = TransformBase[string, int32]()
+        Take(x)
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0155");
+    }
+
+    [Fact]
+    public void UnrelatedType_StillDiagnosticGS0155()
+    {
+        // Negative: an unrelated class is not a FilterBase at all.
+        var source = @"
+open class FilterBase[T]() { }
+class Unrelated { }
+class C {
+    func Take(f FilterBase[int32]) { }
+    func G() {
+        Take(Unrelated())
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0155");
+    }
+
+    [Fact]
+    public void DirectOneLevelGenericUpcast_StillWorks_NoDiagnostic()
+    {
+        // Control / regression: a one-level derived class that directly closes the
+        // generic base with a concrete argument already worked and must keep working.
+        var source = @"
+open class FilterBase[T]() { }
+class LosslessFilter : FilterBase[int32] { }
+class C {
+    func Take(f FilterBase[int32]) { }
+    func G() {
+        Take(LosslessFilter())
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
## Bug

An instance of a generic class is not recognized as implicitly convertible to its (constructed) generic base class when the base type argument is one of the derived class's OWN type parameters. The implicit upcast `Derived[…] → Base[…]` fails with `GS0155: Cannot convert type 'Derived' to 'Base'`.

```gsharp
package p
open class FilterBase[T]() { }
open class TransformBase[TIn, TOut] : FilterBase[TIn] { }
class C {
  func Take(f FilterBase[int32]) { }
  func G() {
    var x = TransformBase[int32, int32]()
    Take(x)        // GS0155 before fix
  }
}
```

Also failed for a concrete leaf below the generic intermediate:

```gsharp
class LosslessFilter : TransformBase[int32, int32] { }
var f FilterBase[int32] = LosslessFilter()   // GS0155 before fix
```

`TransformBase[int32,int32]` derives from `FilterBase[int32]` (substituting `TIn := int32`), so it IS a `FilterBase[int32]`.

## Root cause

The implicit reference-conversion classifier (`Conversion.Classify`) walked the derived class's base chain comparing each base by **reference equality** (`c == toClass`). A constructed generic keeps its base-type reference **unsubstituted** (`StructSymbol.BaseClass` is the open definition's base), so the walk compared `FilterBase[TIn]` — with `TIn` still the derived's type-parameter symbol — against the target `FilterBase[int32]` and never matched.

The emitter's `MethodBodyEmitter.IsReferenceCompatible` had the identical reference-equality walk, so even once the classifier was fixed, emit failed with *"Conversion … is not yet supported by the emitter."*

This is the same type-parameter-substitution-along-the-base-chain family as #1244, but a distinct code path (the conversion/subtyping classifier + emitter reference-compatibility check).

## Fix

- **`Conversion.Classify`** (`src/Core/CodeAnalysis/Binding/Conversion.cs`): replaced the reference-equality base-chain walk with `DerivesFromConstructed`, which threads a substitution map mapping each class's declaration type parameters onto the concrete type arguments at the most-derived level, composing the map down every hop, then compares the fully-substituted base reference (definition + substituted type arguments via `AreTypeArgumentsEquivalent`) against the target. Handles multi-level chains, type-parameter renaming, and partial type-parameter flow. Wrong type arguments / unrelated definitions still fail (GS0155). Reuses the per-level substitution-composition pattern from #1244.
- **`MethodBodyEmitter.IsReferenceCompatible`** (`src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs`): recognise the upcast by matching the generic definition along the base chain (the upcast is a no-op reference conversion at the IL level regardless of type arguments, and the binder already validated argument compatibility), starting the walk at the base class so a class is never matched against itself by definition.

## Tests

- `test/Core.Tests/.../Issue1248GenericUpcastBinderTests.cs`: 2-level upcast (param passing, local init, assignment), concrete-leaf-below-generic-intermediate, type-parameter renaming (3 levels), partial type-parameter flow, the direct one-level control case, and negatives (wrong flowing/non-flowing argument, unrelated type) still GS0155.
- `test/Compiler.Tests/Emit/Issue1248GenericUpcastEmitTests.cs`: end-to-end emit/exec tests constructing the derived instance, upcasting to the base type, invoking a base method at runtime (including overridden vtable dispatch through the base slot), verified with `ilverify`.

## Verification

- `dotnet build GSharp.sln -c Release -graph` → 0 warnings / 0 errors
- `dotnet test test/Core.Tests` → Passed 4315, Skipped 1, Failed 0
- `dotnet test test/Compiler.Tests --filter Issue1248GenericUpcastEmitTests -- xUnit.MaxParallelThreads=2` → Passed 3
- Both minimal repros now compile; all negative cases still report GS0155.

Fixes #1248
