### PR TITLE
Fix #1250: substitute constructed-generic member types on generic receivers

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -3536,6 +3536,55 @@ public sealed class Binder
                 : type;
         }
 
+        // Issue #1250: a member-signature type that is itself a constructed
+        // generic G# user class (e.g. `Holder[T]` on `Box[T]`) must have its
+        // own type arguments substituted with the receiver's type-argument map
+        // so `Holder[T]` surfaces as `Holder[int32]` on `Box[int32]`. Without
+        // this branch the constructed type's arguments stay parametric and the
+        // bound member binds with `T` still open, failing argument/return/
+        // assignment conversions (GS0155 "Cannot convert 'Holder' to 'Holder'").
+        // Recurses so nested generics (`Holder[Holder[T]]`,
+        // `Dictionary[K, List[V]]`) are substituted too.
+        if (type is StructSymbol ss
+            && ss.Definition != null
+            && !ReferenceEquals(ss.Definition, ss)
+            && !ss.TypeArguments.IsDefaultOrEmpty)
+        {
+            var newStructArgs = ImmutableArray.CreateBuilder<TypeSymbol>(ss.TypeArguments.Length);
+            var structChanged = false;
+            foreach (var arg in ss.TypeArguments)
+            {
+                var substituted = SubstituteType(arg, substitution);
+                structChanged |= !ReferenceEquals(substituted, arg);
+                newStructArgs.Add(substituted);
+            }
+
+            return structChanged
+                ? StructSymbol.Construct(ss.Definition, newStructArgs.MoveToImmutable())
+                : type;
+        }
+
+        // Issue #1250: same recursion for a constructed generic user interface
+        // type appearing in a member signature (`IBox[T]` → `IBox[int32]`).
+        if (type is InterfaceSymbol ifaceType
+            && ifaceType.Definition != null
+            && !ReferenceEquals(ifaceType.Definition, ifaceType)
+            && !ifaceType.TypeArguments.IsDefaultOrEmpty)
+        {
+            var newIfaceArgs = ImmutableArray.CreateBuilder<TypeSymbol>(ifaceType.TypeArguments.Length);
+            var ifaceChanged = false;
+            foreach (var arg in ifaceType.TypeArguments)
+            {
+                var substituted = SubstituteType(arg, substitution);
+                ifaceChanged |= !ReferenceEquals(substituted, arg);
+                newIfaceArgs.Add(substituted);
+            }
+
+            return ifaceChanged
+                ? InterfaceSymbol.Construct(ifaceType.Definition, newIfaceArgs.MoveToImmutable())
+                : type;
+        }
+
         if (type is ImportedTypeSymbol it && it.HasTypeParameterArgument)
         {
             // #313: substitute a generic type parameterized by an in-scope type

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -4650,24 +4650,49 @@ internal sealed class OverloadResolver
 
     private static Dictionary<TypeParameterSymbol, TypeSymbol> TryBuildReceiverSubstitution(TypeSymbol receiverType)
     {
-        if (receiverType is StructSymbol s
-            && !s.TypeArguments.IsDefaultOrEmpty
-            && s.Definition != null
-            && !ReferenceEquals(s.Definition, s))
+        if (receiverType is not StructSymbol start)
         {
-            var defTps = s.Definition.TypeParameters;
-            if (!defTps.IsDefaultOrEmpty && defTps.Length == s.TypeArguments.Length)
+            return null;
+        }
+
+        // Issue #1250: an inherited method's signature is declared in terms of
+        // its declaring class's type parameters (e.g. `LinkTo(next FilterBase[TOut])`
+        // on `TransformBase[TIn, TOut]`). When the method is reached through a
+        // derived receiver (`AudioFilter : TransformBase[FrameEntry, FrameEntry]`),
+        // the substitution must compose every hop of the base chain so the
+        // inherited type parameters (TIn/TOut) resolve to the concrete arguments
+        // seen at the most-derived level. Walk the chain accumulating each
+        // class's declaration-parameter -> (resolved) argument mappings, exactly
+        // like Conversion.DerivesFromConstructed threads its map for subtyping.
+        Dictionary<TypeParameterSymbol, TypeSymbol> map = null;
+        for (var c = start; c != null; c = c.BaseClass)
+        {
+            if (c.Definition == null
+                || ReferenceEquals(c.Definition, c)
+                || c.TypeArguments.IsDefaultOrEmpty
+                || c.Definition.TypeParameters.IsDefaultOrEmpty)
             {
-                var map = new Dictionary<TypeParameterSymbol, TypeSymbol>(defTps.Length);
-                for (var i = 0; i < defTps.Length; i++)
+                continue;
+            }
+
+            var defTps = c.Definition.TypeParameters;
+            var count = System.Math.Min(defTps.Length, c.TypeArguments.Length);
+            for (var i = 0; i < count; i++)
+            {
+                var arg = c.TypeArguments[i];
+
+                // Resolve an argument that is itself one of a more-derived
+                // class's type parameters through the running map.
+                if (arg is TypeParameterSymbol tpArg && map != null && map.TryGetValue(tpArg, out var resolved))
                 {
-                    map[defTps[i]] = s.TypeArguments[i];
+                    arg = resolved;
                 }
 
-                return map;
+                map ??= new Dictionary<TypeParameterSymbol, TypeSymbol>();
+                map[defTps[i]] = arg;
             }
         }
 
-        return null;
+        return map;
     }
 }

--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -1328,6 +1328,30 @@ public sealed class StructSymbol : TypeSymbol
             return subst.TryGetValue(tp, out var concrete) ? concrete : type;
         }
 
+        // Issue #1250: a member type that is itself a constructed generic G#
+        // user class (e.g. a field/property/primary-ctor parameter typed
+        // `Holder[T]` on `Box[T]`) must have its own type arguments substituted
+        // so it surfaces as `Holder[int32]` on `Box[int32]`. Recurses so nested
+        // generics (`Holder[Holder[T]]`, `Dictionary[K, List[V]]`) work too.
+        if (type is StructSymbol ss
+            && ss.Definition != null
+            && !ReferenceEquals(ss.Definition, ss)
+            && !ss.TypeArguments.IsDefaultOrEmpty)
+        {
+            var substitutedStructArgs = ImmutableArray.CreateBuilder<TypeSymbol>(ss.TypeArguments.Length);
+            var structChanged = false;
+            for (var i = 0; i < ss.TypeArguments.Length; i++)
+            {
+                var substituted = SubstituteTypeForConstruction(ss.TypeArguments[i], subst);
+                substitutedStructArgs.Add(substituted);
+                structChanged |= !ReferenceEquals(substituted, ss.TypeArguments[i]);
+            }
+
+            return structChanged
+                ? StructSymbol.Construct(ss.Definition, substitutedStructArgs.MoveToImmutable())
+                : type;
+        }
+
         if (type is InterfaceSymbol iface && !iface.TypeArguments.IsDefaultOrEmpty)
         {
             var substitutedArgs = ImmutableArray.CreateBuilder<TypeSymbol>(iface.TypeArguments.Length);

--- a/test/Compiler.Tests/Emit/Issue1250GenericMemberSubstitutionEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1250GenericMemberSubstitutionEmitTests.cs
@@ -1,0 +1,185 @@
+// <copyright file="Issue1250GenericMemberSubstitutionEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1250: end-to-end CLR emit + ilverify coverage for accessing a member
+/// whose signature uses a constructed generic type built on the class's type
+/// parameter (e.g. <c>Holder[T]</c> on <c>Box[T]</c>) through a constructed
+/// generic receiver (<c>Box[int32]</c>). These tests round-trip a value through
+/// such members (parameter + return), proving the substituted signature binds,
+/// the IL verifies, and the program produces the right runtime result.
+/// </summary>
+public class Issue1250GenericMemberSubstitutionEmitTests
+{
+    [Fact]
+    public void EndToEnd_PutAndGetConstructedGenericMember_RoundTripsValue()
+    {
+        var source = """
+            package p
+            class Holder[T]() {
+              var Value T
+            }
+            class Box[T]() {
+              var Item Holder[T] = Holder[T]()
+              func Put(x Holder[T]) { this.Item = x }
+              func Get() Holder[T] { return this.Item }
+            }
+            func Main() {
+              var h = Holder[int32]()
+              h.Value = 42
+              var b = Box[int32]()
+              b.Put(h)
+              var read = b.Get()
+              System.Console.WriteLine(read.Value)
+            }
+            """;
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void Library_ConstructedGenericMemberSignatures_PassIlVerify()
+    {
+        var source = """
+            package p
+            class Holder[T]() { var Value T }
+            class Box[T]() {
+              var Item Holder[T] = Holder[T]()
+              func Put(x Holder[T]) { this.Item = x }
+              func Get() Holder[T] { return this.Item }
+            }
+            """;
+
+        var dllPath = CompileLibrary(source);
+        TryCleanup(dllPath);
+    }
+
+    private static string CompileLibrary(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1250_lib_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        var args = new[]
+        {
+            "/out:" + outPath,
+            "/target:library",
+            "/targetframework:net10.0",
+            srcPath,
+        };
+
+        RunCompiler(args);
+        IlVerifier.Verify(outPath);
+        return outPath;
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1250_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            RunCompiler(args);
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static void RunCompiler(string[] args)
+    {
+        using var stdoutWriter = new StringWriter();
+        using var stderrWriter = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(stdoutWriter);
+        Console.SetError(stderrWriter);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+    }
+
+    private static void TryCleanup(string dllPath)
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(dllPath);
+            if (dir != null && Directory.Exists(dir))
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+        catch
+        {
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1250GenericMemberSubstitutionBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1250GenericMemberSubstitutionBinderTests.cs
@@ -1,0 +1,269 @@
+// <copyright file="Issue1250GenericMemberSubstitutionBinderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1250: when a member is accessed through a constructed generic receiver,
+/// a member-signature type that is itself a constructed generic type using the
+/// class's type parameter (e.g. <c>Holder[T]</c> on <c>Box[T]</c>) must be
+/// substituted with the receiver's type arguments (<c>Holder[int32]</c> on
+/// <c>Box[int32]</c>). Before the fix only bare type parameters (<c>T</c>) and
+/// arrays of type parameters (<c>[]T</c>) were substituted; constructed generic
+/// member types were left open and bound with <c>T</c> still free, failing
+/// argument/return/assignment conversions with GS0155 ("Cannot convert type
+/// 'Holder' to 'Holder'"). The recursion must also handle nested generics,
+/// arrays/nullables of generics, multiple type parameters, and inherited methods
+/// (composing the base-chain mapping), while still rejecting wrong type arguments.
+/// </summary>
+public class Issue1250GenericMemberSubstitutionBinderTests
+{
+    [Fact]
+    public void ConstructedGenericParameter_NoDiagnostic()
+    {
+        var source = @"
+class Holder[T]() { }
+class Box[T]() { func Put(x Holder[T]) { } }
+class C {
+    func G(h Holder[int32]) {
+        var b = Box[int32]()
+        b.Put(h)
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void ConstructedGenericReturn_NoDiagnostic()
+    {
+        var source = @"
+class Holder[T]() { }
+class Box[T]() { func Get() Holder[T] { return Holder[T]() } }
+class C {
+    func G() Holder[int32] {
+        var b = Box[int32]()
+        return b.Get()
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void ConstructedGenericField_NoDiagnostic()
+    {
+        var source = @"
+class Holder[T]() { }
+class Box[T]() { var Item Holder[T] = Holder[T]() }
+class C {
+    func G() Holder[int32] {
+        var b = Box[int32]()
+        return b.Item
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void ConstructedGenericProperty_NoDiagnostic()
+    {
+        var source = @"
+class Holder[T]() { }
+class Box[T]() { prop Item Holder[T] { get; set; } }
+class C {
+    func G(h Holder[int32]) {
+        var b = Box[int32]()
+        b.Item = h
+        var read Holder[int32] = b.Item
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void NestedConstructedGeneric_NoDiagnostic()
+    {
+        var source = @"
+class Holder[T]() { }
+class Box[T]() { func Put(x Holder[Holder[T]]) { } }
+class C {
+    func G(h Holder[Holder[int32]]) {
+        var b = Box[int32]()
+        b.Put(h)
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void ArrayOfConstructedGeneric_NoDiagnostic()
+    {
+        var source = @"
+class Holder[T]() { }
+class Box[T]() { func Put(x []Holder[T]) { } }
+class C {
+    func G(h []Holder[int32]) {
+        var b = Box[int32]()
+        b.Put(h)
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void NullableConstructedGeneric_NoDiagnostic()
+    {
+        var source = @"
+class Holder[T]() { }
+class Box[T]() { func Put(x Holder[T]?) { } }
+class C {
+    func G(h Holder[int32]?) {
+        var b = Box[int32]()
+        b.Put(h)
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void MultipleTypeParameters_NoDiagnostic()
+    {
+        var source = @"
+class Pair[K, V]() { }
+class Map[K, V]() { func Put(x Pair[K, V]) { } }
+class C {
+    func G(p Pair[int32, string]) {
+        var m = Map[int32, string]()
+        m.Put(p)
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void InheritedMethodConstructedGenericParameter_NoDiagnostic()
+    {
+        // The constructed-generic parameter type `FilterBase[TOut]` is on an
+        // INHERITED method; substitution must compose the inheritance mapping
+        // TOut -> FrameEntry from the base chain
+        // AudioFilter : TransformBase[FrameEntry, FrameEntry].
+        var source = @"
+open class FilterBase[T]() { }
+open class TransformBase[TIn, TOut] : FilterBase[TIn] {
+    func LinkTo(next FilterBase[TOut]) { }
+}
+class FrameEntry { }
+class AudioFilter : TransformBase[FrameEntry, FrameEntry] { }
+class C {
+    func G(arg FilterBase[FrameEntry]) {
+        var f = AudioFilter()
+        f.LinkTo(arg)
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void BareTypeParameterParameter_StillWorks_NoDiagnostic()
+    {
+        // Control / regression: a bare `T` parameter already substituted today.
+        var source = @"
+class Box[T]() { func Put(x T) { } }
+class C {
+    func G() {
+        var b = Box[int32]()
+        b.Put(5)
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void ArrayOfTypeParameterParameter_StillWorks_NoDiagnostic()
+    {
+        // Control / regression: a `[]T` parameter already substituted today.
+        var source = @"
+class Box[T]() { func Put(x []T) { } }
+class C {
+    func G(arr []int32) {
+        var b = Box[int32]()
+        b.Put(arr)
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void WrongTypeArgument_StillDiagnosticGS0155()
+    {
+        // Negative: Box[int32].Put expects Holder[int32]; passing Holder[string]
+        // must still fail even though the display name 'Holder' matches.
+        var source = @"
+class Holder[T]() { }
+class Box[T]() { func Put(x Holder[T]) { } }
+class C {
+    func G(h Holder[string]) {
+        var b = Box[int32]()
+        b.Put(h)
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0155");
+    }
+
+    [Fact]
+    public void WrongTypeArgument_Return_StillDiagnosticGS0155()
+    {
+        // Negative: Box[int32].Get returns Holder[int32], not Holder[string].
+        var source = @"
+class Holder[T]() { }
+class Box[T]() { func Get() Holder[T] { return Holder[T]() } }
+class C {
+    func G() Holder[string] {
+        var b = Box[int32]()
+        return b.Get()
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0155");
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
## Bug

When a member is accessed through a **constructed generic receiver**, a member-signature type that is itself a **constructed generic type using the class's type parameter** (e.g. `Holder[T]` on `Box[T]`) was **not** substituted with the receiver's type arguments. The member bound with the type parameter left open, so argument/return/assignment conversions failed with `GS0155: Cannot convert type 'Holder' to 'Holder'` (same display name; one side still carries the open `T`).

Bare type-parameter types (`T`) and arrays of type parameters (`[]T`) were already substituted — only nested/constructed generic member types were missed.

## Root cause

Both type-parameter substitution visitors —
- `Binder.SubstituteType` (call/access-site path for method parameter & return types), and
- `StructSymbol.SubstituteTypeForConstruction` (field / property / primary-constructor path)

— recursed into bare type parameters, arrays, slices, nullables, tuples, function types, and imported CLR generics, but **neither had a recursive case for a constructed generic *G# user type*** (`StructSymbol` / `InterfaceSymbol` carrying `TypeArguments`). A `Holder[T]` was therefore returned unchanged instead of becoming `Holder[int32]`.

## Fix

- **`Binder.SubstituteType`** and **`StructSymbol.SubstituteTypeForConstruction`**: add a recursive case for a constructed generic `StructSymbol` / `InterfaceSymbol` (`Definition != null && !ReferenceEquals(Definition, self) && TypeArguments` non-empty). Their type arguments are substituted recursively and the type rebuilt via `StructSymbol.Construct` / `InterfaceSymbol.Construct`. This composes naturally with arrays, nullables, nested generics (`Holder[Holder[T]]`), and multiple type parameters (`Pair[K, V]`).
- **`OverloadResolver.TryBuildReceiverSubstitution`**: now walks the receiver's base chain composing each hop's declaration-parameter to argument map (mirroring `Conversion.DerivesFromConstructed` from #1248), so an **inherited** method whose signature uses the declaring class's type parameter (`LinkTo(next FilterBase[TOut])` on `TransformBase[TIn, TOut]`, reached through `AudioFilter : TransformBase[FrameEntry, FrameEntry]`) substitutes `TOut` to `FrameEntry` correctly.

Wrong type arguments still fail `GS0155` (guardrail preserved).

## Files changed

- `src/Core/CodeAnalysis/Binding/Binder.cs`
- `src/Core/CodeAnalysis/Binding/OverloadResolver.cs`
- `src/Core/CodeAnalysis/Symbols/StructSymbol.cs`
- `test/Core.Tests/CodeAnalysis/Binding/Issue1250GenericMemberSubstitutionBinderTests.cs` (new)
- `test/Compiler.Tests/Emit/Issue1250GenericMemberSubstitutionEmitTests.cs` (new)

## Tests

**Binder/conversion** (13 cases): parameter, return, field, property, nested generic, array-of-generic, nullable-generic, multiple type parameters, inherited-method form, bare-`T` / `[]T` controls, and negative (wrong-arg) cases for both parameter and return.

**Emit/execution**: end-to-end `Box[int32].Put`/`Get` runtime round-trip (prints `42`) + a library ilverify case.

## Verification

- `dotnet build GSharp.sln -c Release -graph` -> 0 warnings / 0 errors
- `dotnet test test/Core.Tests` -> 4328 passed, 0 failed, 1 skipped
- `dotnet test test/Compiler.Tests --filter Issue1250GenericMemberSubstitutionEmitTests -- xUnit.MaxParallelThreads=2` -> 2 passed
- All minimal repros (param/return/field) compile; bare-`T`/`[]T` controls compile; wrong-arg negative still GS0155.

## Deferred (out of scope)

The inherited `LinkTo` form is covered as a **binder (compile) test** and binds correctly. An end-to-end *runtime* execution of an inherited method declared on a generic base, reached through a non-generic derived receiver, currently throws `InvalidOperationException: ... not fully instantiated` at runtime. This is a **pre-existing emit limitation unrelated to this substitution fix** — it reproduces even for an inherited method with a non-generic signature (`func Hello() int32`) and no `Holder[T]`-style parameter. The emit/execution test here therefore uses the `Box[int32].Put`/`Get` form.

Fixes #1250
