### PR TITLE
cs2gs: coerce array-creation length to int32 for AllocateArray

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue914ArrayLengthCoercionTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue914ArrayLengthCoercionTranslationTests.cs
@@ -1,0 +1,106 @@
+// <copyright file="Issue914ArrayLengthCoercionTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Translation tests for the array-creation length coercion defect discovered
+/// migrating <c>Oahu.Decrypt</c> (issue #914). C# array-creation expressions
+/// accept any integral length (<c>new T[uint]</c>, <c>new T[long]</c>, …), but
+/// the emitted <c>System.GC.AllocateArray[T]</c> takes an <c>int32</c>; a
+/// non-<c>int32</c> numeric length must be coerced via the conversion-call form
+/// (<c>int32(n)</c>) so the allocation binds (otherwise gsc reports GS0159
+/// "Cannot find function AllocateArray").
+/// </summary>
+public class Issue914ArrayLengthCoercionTranslationTests
+{
+    /// <summary>
+    /// A <c>uint</c> length is coerced to <c>int32</c> via the conversion-call
+    /// form so <c>System.GC.AllocateArray[T]</c> binds.
+    /// </summary>
+    [Fact]
+    public void ArrayCreation_UintLength_CoercesToInt32()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class S { public int X; }
+
+    public class C
+    {
+        public S[] Make(uint n) => new S[n];
+    }
+}");
+
+        Assert.Contains("System.GC.AllocateArray[S](int32(n))", printed);
+    }
+
+    /// <summary>
+    /// A <c>long</c> length is likewise coerced to <c>int32</c>.
+    /// </summary>
+    [Fact]
+    public void ArrayCreation_LongLength_CoercesToInt32()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public byte[] Make(long n) => new byte[n];
+    }
+}");
+
+        Assert.Contains("int32(n)", printed);
+    }
+
+    /// <summary>
+    /// An <c>int</c> length is already <c>int32</c>; no conversion call is added.
+    /// </summary>
+    [Fact]
+    public void ArrayCreation_IntLength_NoCoercion()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class S { public int X; }
+
+    public class C
+    {
+        public S[] Make(int n) => new S[n];
+    }
+}");
+
+        Assert.Contains("System.GC.AllocateArray[S](n)", printed);
+        Assert.DoesNotContain("int32(n)", printed);
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -3246,6 +3246,28 @@ public sealed class CSharpToGSharpTranslator
             return count;
         }
 
+        // C# array-creation lengths accept any integral type (`new T[uint]`,
+        // `new T[long]`, …), but the emitted `System.GC.AllocateArray[T]` takes an
+        // `int32`. Coerce a non-`int32` numeric length to int32 via the
+        // conversion-call form so the allocation binds (avoids GS0159). A nullable
+        // or non-numeric length is left unchanged.
+        private GExpression CoerceLengthToInt32(
+            ExpressionSyntax lengthSyntax, GExpression length)
+        {
+            ITypeSymbol lengthType = this.context.GetTypeInfo(lengthSyntax).Type;
+            if (lengthType != null &&
+                IsNonNullableValueType(lengthType) &&
+                TryGetNumericKind(lengthType, out SpecialType underlying) &&
+                underlying != SpecialType.System_Int32)
+            {
+                ITypeSymbol int32Type =
+                    this.context.Compilation.GetSpecialType(SpecialType.System_Int32);
+                return this.CoerceOperandTo(length, int32Type);
+            }
+
+            return length;
+        }
+
         // C# `a ?? b` where `a` is a nullable numeric: G# requires `b` to match
         // the underlying numeric type of `a`, otherwise GS0129. Coerce the right
         // operand to the left's underlying (non-nullable) type when they differ.
@@ -5083,13 +5105,22 @@ public sealed class CSharpToGSharpTranslator
             // `new T[n]` (runtime/constant length, no initializer) → the canonical
             // zero-initialised allocation `System.GC.AllocateArray[T](n)`, which
             // returns a `T[]` of length `n` (the Go-style `make([]T, n)` form is a
-            // documented gsc gap, ADR-0083).
-            GExpression length = creation.Type.RankSpecifiers.Count > 0 &&
+            // documented gsc gap, ADR-0083). C# accepts any integral length
+            // (`uint`/`long`/…); `GC.AllocateArray[T]` takes an `int32`, so a
+            // non-`int32` numeric length is coerced via the conversion-call form
+            // (`int32(n)`) to avoid GS0159 (no matching overload).
+            GExpression length;
+            if (creation.Type.RankSpecifiers.Count > 0 &&
                 creation.Type.RankSpecifiers[0].Sizes.Count > 0 &&
                 creation.Type.RankSpecifiers[0].Sizes[0] is { } sizeExpr &&
-                !sizeExpr.IsKind(SyntaxKind.OmittedArraySizeExpression)
-                ? this.TranslateExpression(sizeExpr)
-                : LiteralExpression.Int("0");
+                !sizeExpr.IsKind(SyntaxKind.OmittedArraySizeExpression))
+            {
+                length = this.CoerceLengthToInt32(sizeExpr, this.TranslateExpression(sizeExpr));
+            }
+            else
+            {
+                length = LiteralExpression.Int("0");
+            }
 
             return new InvocationExpression(
                 new MemberAccessExpression(


### PR DESCRIPTION
## Problem

C# array-creation expressions accept any integral length (`new T[uint]`, `new T[long]`, …), but the cs2gs translator emits `System.GC.AllocateArray[T](n)` for `new T[n]`, and `GC.AllocateArray[T]` takes an `int32`. G# does not implicitly convert `uint32`/`int64`/etc. to `int32`, so gsc rejected the emitted code with:

```
error GS0159: Cannot find function AllocateArray.
```

This surfaced migrating **Oahu.Decrypt** — `TrunBox`, `StscBox`, `Dec3Box`, `IStszBox` all do `new SampleInfo[sampleCount]` where `sampleCount` is a `uint` (e.g. `uint sampleCount = file.ReadUInt32BE();`).

## Fix

Coerce a non-`int32` numeric array length to `int32` via the conversion-call form `int32(n)` (new `CoerceLengthToInt32` helper, mirroring the existing `CoerceShiftCountToInt32`). A length already typed `int32` is left unchanged; nullable/non-numeric lengths are untouched.

Before: `System.GC.AllocateArray[SampleInfo](sampleCount)` → GS0159
After:  `System.GC.AllocateArray[SampleInfo](int32(sampleCount))` → binds.

This reduced the Oahu.Decrypt `AllocateArray` GS0159 cluster from 5 to 1 (the remaining one is an unrelated cascade from a static-member-on-type-parameter access).

## Tests

New `Issue914ArrayLengthCoercionTranslationTests` (uint→int32, long→int32, int→no-coercion). Full `Cs2Gs.Tests` suite: 274 passed.

Refs #914.