### PR TITLE
Fix #1255: lift nullable reference upcast T? → U?

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -280,6 +280,29 @@ public sealed class Conversion
                     }
                 }
 
+                // Issue #1255: lifted nullable reference upcast — `T? → U?` is an
+                // implicit conversion whenever the underlying `T → U` is an
+                // implicit reference/interface upcast (T derives from or
+                // implements U). This mirrors the non-null #1121 rule (`T → U?`)
+                // for the nullable-source case so the two stay consistent. For
+                // reference-type underlyings a nullable wrapper shares the CLR
+                // representation of the bare reference (null stays null, a
+                // non-null value reference-upcasts), so this is a representation-
+                // preserving no-op conversion — never boxing or wrapping. The
+                // value-type underlying case is handled by the lifted numeric
+                // rule above and intentionally excluded here. Note this never
+                // makes `T? → U` (non-nullable target, handled below) implicit,
+                // so the narrowing null-dropping conversion still errors.
+                if (IsReferenceLikeTarget(fromNullable.UnderlyingType)
+                    && IsReferenceLikeTarget(toNullable.UnderlyingType))
+                {
+                    var underlyingConversion = Classify(fromNullable.UnderlyingType, toNullable.UnderlyingType);
+                    if (underlyingConversion.Exists && underlyingConversion.IsImplicit)
+                    {
+                        return Conversion.Implicit;
+                    }
+                }
+
                 return Conversion.None;
             }
 

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
@@ -189,6 +189,21 @@ internal sealed partial class MethodBodyEmitter
             return;
         }
 
+        // Issue #1255: lifted nullable reference upcast `T? -> U?` where U is a
+        // base class or implemented interface of T. Both sides are reference-
+        // type Nullable<T>, which share the underlying reference's CLR
+        // representation, so the upcast (and null propagation) is metadata-only —
+        // the reference already on the stack is a valid U?. This mirrors the
+        // `T -> U?` (#1121) and `T -> U` reference upcasts as a no-op.
+        if (from is NullableTypeSymbol fromRefNullable
+            && to is NullableTypeSymbol toRefNullable
+            && !ReflectionMetadataEmitter.IsValueTypeNullable(fromRefNullable)
+            && !ReflectionMetadataEmitter.IsValueTypeNullable(toRefNullable)
+            && IsReferenceCompatible(fromRefNullable.UnderlyingType, toRefNullable.UnderlyingType))
+        {
+            return;
+        }
+
         // Phase 3 exit: widening to a nullable reference type (`T` -> `T?`)
         // is metadata-only because reference nullability shares the CLR
         // representation. The same applies to narrowing back via `!!`.

--- a/test/Compiler.Tests/Emit/Issue1255NullableRefUpcastEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1255NullableRefUpcastEmitTests.cs
@@ -1,0 +1,241 @@
+// <copyright file="Issue1255NullableRefUpcastEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1255: a nullable→nullable implicit reference conversion <c>T? -> U?</c>
+/// (where <c>T</c> derives from or implements <c>U</c>) must bind AND emit. Both
+/// sides share the underlying reference's CLR representation, so the upcast is a
+/// metadata-only no-op (null stays null, a non-null value reference-upcasts).
+/// These tests prove a real value round-trips through a nullable base/interface
+/// slot and that null is preserved without an NRE on the upcast itself.
+/// </summary>
+public class Issue1255NullableRefUpcastEmitTests
+{
+    [Fact]
+    public void NullableClassUpcast_NonNullValue_RoundTrips()
+    {
+        var source = """
+            package Test
+            import System
+
+            open class Base { func Tag() int32 { return 5 } }
+            class Derived : Base { func Extra() int32 { return 9 } }
+
+            func Read(b Base?) int32 {
+                if b != nil {
+                    return b.Tag()
+                }
+                return -1
+            }
+
+            let d Derived? = Derived()
+            Console.WriteLine(Read(d))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("5\n", output);
+    }
+
+    [Fact]
+    public void NullableClassUpcast_NullValue_StaysNull()
+    {
+        var source = """
+            package Test
+            import System
+
+            open class Base { func Tag() int32 { return 5 } }
+            class Derived : Base { func Extra() int32 { return 9 } }
+
+            func Read(b Base?) int32 {
+                if b != nil {
+                    return b.Tag()
+                }
+                return -1
+            }
+
+            let d Derived? = nil
+            Console.WriteLine(Read(d))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("-1\n", output);
+    }
+
+    [Fact]
+    public void NullableInterfaceUpcast_NonNullValue_RoundTrips()
+    {
+        var source = """
+            package Test
+            import System
+
+            interface IBox { func Size() int32; }
+            class AppleListBox : IBox { func Size() int32 { return 42 } }
+
+            func Read(box IBox?) int32 {
+                if box != nil {
+                    return box.Size()
+                }
+                return -1
+            }
+
+            let a AppleListBox? = AppleListBox()
+            Console.WriteLine(Read(a))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void NullableInterfaceUpcast_NullValue_StaysNull()
+    {
+        var source = """
+            package Test
+            import System
+
+            interface IBox { func Size() int32; }
+            class AppleListBox : IBox { func Size() int32 { return 42 } }
+
+            func Read(box IBox?) int32 {
+                if box != nil {
+                    return box.Size()
+                }
+                return -1
+            }
+
+            let a AppleListBox? = nil
+            Console.WriteLine(Read(a))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("-1\n", output);
+    }
+
+    [Fact]
+    public void NullableClassUpcast_LetTarget_RoundTrips()
+    {
+        var source = """
+            package Test
+            import System
+
+            open class Base { func Tag() int32 { return 5 } }
+            class Derived : Base {}
+
+            let d Derived? = Derived()
+            let b Base? = d
+            Console.WriteLine(b != nil)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var (exitCode, stdout, stderr) = CompileAndRunRaw(source);
+        Assert.True(
+            exitCode == 0,
+            $"gsc failed (exit {exitCode}):\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout;
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) CompileAndRunRaw(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1255_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+            };
+
+            foreach (var reference in TrustedPlatformAssemblies())
+            {
+                args.Add("/reference:" + reference);
+            }
+
+            args.Add("/nowarn:GS9100");
+            args.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            if (compileExit != 0)
+            {
+                return (compileExit, compileOut.ToString(), compileErr.ToString());
+            }
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+
+            return (proc.ExitCode, stdout.Replace("\r\n", "\n"), stderr.Replace("\r\n", "\n"));
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static IEnumerable<string> TrustedPlatformAssemblies()
+    {
+        var tpa = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        if (string.IsNullOrEmpty(tpa))
+        {
+            yield break;
+        }
+
+        foreach (var path in tpa.Split(Path.PathSeparator))
+        {
+            if (!string.IsNullOrWhiteSpace(path) && File.Exists(path))
+            {
+                yield return path;
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1255NullableToNullableRefUpcastConversionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1255NullableToNullableRefUpcastConversionTests.cs
@@ -1,0 +1,155 @@
+// <copyright file="Issue1255NullableToNullableRefUpcastConversionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1255: a nullable value of type <c>T?</c> must be implicitly convertible
+/// to <c>U?</c> when <c>U</c> is a base class or implemented interface of <c>T</c>
+/// — the lifted reference upcast maps null to null and reference-upcasts a
+/// non-null value (representation-preserving). Previously <c>Conversion.Classify</c>
+/// only lifted the non-null source case (<c>T → U?</c>, issue #1121) and rejected
+/// <c>T? → U?</c> with <c>GS0155</c> (<c>GS0154</c> in argument position).
+///
+/// These tests assert the positive base-class and interface cases in both
+/// argument and let-target positions, that the narrowing <c>T? → U</c>
+/// (non-nullable target) still errors, that the #1121 <c>T → U?</c> control still
+/// binds, and that an unrelated <c>T? → U?</c> still fails.
+/// </summary>
+public class Issue1255NullableToNullableRefUpcastConversionTests
+{
+    [Fact]
+    public void NullableDerived_To_NullableBase_AsArgument_Binds()
+    {
+        var source = @"
+open class Base {}
+class Derived : Base {}
+
+func TakeBase(p Base?) {}
+
+func F(x Derived?) { TakeBase(x) }
+";
+        Assert.Empty(Evaluate(source).Diagnostics);
+    }
+
+    [Fact]
+    public void NullableConcrete_To_NullableInterface_AsArgument_Binds()
+    {
+        var source = @"
+interface IBox {}
+class AppleListBox : IBox {}
+
+func Take(parent IBox?) {}
+
+func F(x AppleListBox?) { Take(x) }
+";
+        Assert.Empty(Evaluate(source).Diagnostics);
+    }
+
+    [Fact]
+    public void NullableDerived_To_NullableBase_LetTarget_Binds()
+    {
+        var source = @"
+open class Base {}
+class Derived : Base {}
+
+func F(x Derived?) {
+    let b Base? = x
+}
+";
+        Assert.Empty(Evaluate(source).Diagnostics);
+    }
+
+    [Fact]
+    public void NullableConcrete_To_NullableInterface_LetTarget_Binds()
+    {
+        var source = @"
+interface IBox {}
+class AppleListBox : IBox {}
+
+func F(x AppleListBox?) {
+    let b IBox? = x
+}
+";
+        Assert.Empty(Evaluate(source).Diagnostics);
+    }
+
+    [Fact]
+    public void NullableConcrete_To_NullableTransitiveBaseInterface_Binds()
+    {
+        var source = @"
+interface IBase {}
+interface IDerived : IBase {}
+class Impl : IDerived {}
+
+func TakeBase(p IBase?) {}
+
+func F(x Impl?) { TakeBase(x) }
+";
+        Assert.Empty(Evaluate(source).Diagnostics);
+    }
+
+    [Fact]
+    public void NullableDerived_To_NonNullableBase_StillReportsGS0155()
+    {
+        var source = @"
+open class Base {}
+class Derived : Base {}
+
+func TakeBase(p Base) {}
+
+func F(x Derived?) { TakeBase(x) }
+";
+        var result = Evaluate(source);
+        Assert.NotEmpty(result.Diagnostics);
+        Assert.Contains(
+            result.Diagnostics,
+            d => d.Message.Contains("Cannot convert") || d.Message.Contains("requires a value of type"));
+    }
+
+    [Fact]
+    public void NonNullableDerived_To_NullableBase_StillBinds_Control()
+    {
+        var source = @"
+open class Base {}
+class Derived : Base {}
+
+func TakeBase(p Base?) {}
+
+TakeBase(Derived{})
+";
+        Assert.Empty(Evaluate(source).Diagnostics);
+    }
+
+    [Fact]
+    public void UnrelatedNullable_To_NullableInterface_StillReportsGS0155()
+    {
+        var source = @"
+interface IBox {}
+class Unrelated {}
+
+func F(x Unrelated?) {
+    let b IBox? = x
+}
+";
+        var result = Evaluate(source);
+        Assert.NotEmpty(result.Diagnostics);
+        Assert.Contains(result.Diagnostics, d => d.Message.Contains("Cannot convert"));
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}

--- a/website/docs/ref/spec.md
+++ b/website/docs/ref/spec.md
@@ -169,7 +169,7 @@ Integral types are `int8`, `uint8`, `int16`, `uint16`, `int32`, `uint32`, `int64
 
 ### Object and nil
 
-`object` is the universal upper bound. Values backed by CLR types and user value types can implicitly convert or box to `object`; explicit conversions can unbox to CLR value types. Nullable types are written by appending `?` to a type clause. `nil` converts implicitly to nullable types but not to non-nullable types. Postfix `!!` asserts non-null and `??` is null coalescing.
+`object` is the universal upper bound. Values backed by CLR types and user value types can implicitly convert or box to `object`; explicit conversions can unbox to CLR value types. Nullable types are written by appending `?` to a type clause. `nil` converts implicitly to nullable types but not to non-nullable types. A reference upcast lifts through nullable annotations: when `U` is a base class or implemented interface of `T`, both `T → U?` (issue #1121) and `T? → U?` (issue #1255) are implicit reference conversions — for reference types a nullable annotation shares the underlying reference representation, so the lifted upcast is a metadata-only no-op that maps `nil` to `nil` and reference-upcasts a non-null value. The narrowing `T? → U` (dropping the nullable annotation) is not implicit and still requires `!!`. Postfix `!!` asserts non-null and `??` is null coalescing.
 
 ### Arrays and slices
 


### PR DESCRIPTION
## Bug

A nullable→nullable implicit reference conversion `T? → U?` (where `T` derives from or implements `U`) was wrongly rejected with **GS0155** (and **GS0154** in argument position), even though `T → U?` (#1121) and `T → U` already work.

```gsharp
package p
interface IBox {}
class AppleListBox : IBox {}
class C {
  func Take(parent IBox?) {}
  func F(x AppleListBox?) { Take(x) }   // was GS0155
}
```

## Root cause

In `Conversion.Classify`, the `from is NullableTypeSymbol` branch only handled identity (matching underlyings) and lifted value-type numeric widening, then returned `None`. It never lifted the reference upcast when **both** source and target were nullable reference/interface types.

## Fix

- **`Conversion.cs`**: when both underlyings are reference-like (`IsReferenceLikeTarget`), classify on the underlying types — `T? → U?` is implicit whenever `underlying(T) → underlying(U)` is an implicit reference/interface upcast. Mirrors the #1121 non-null rule. Value-type nullable conversions unchanged; narrowing `T? → U` (non-nullable target) still errors.
- **`MethodBodyEmitter.Conversions.cs`**: a reference-type `T? → U?` upcast is representation-preserving, emitted as a metadata-only no-op through the existing `IsReferenceCompatible` reference-upcast path (null stays null).

## Guardrails

- `T? → U` (nullable→non-null narrowing) still errors.
- Value-type nullable conversions unchanged.
- `T → U?` and `T → U` controls still bind.

## Tests

- **Core.Tests**: positive `Derived?→Base?` / `Concrete?→IFace?` in argument and let-target positions, transitive base interface; negative `Derived?→Base` errors; control `Derived→Base?` binds.
- **Compiler.Tests/Emit**: exec round-trip of a non-null value through a nullable base/interface slot, and null-stays-null, for class and interface hierarchies.
- **spec.md**: documented the lifted nullable reference conversion.

Fixes #1255