### PR TITLE
Fix #1254: emit inherited generic-base members against the constructed base

### DIFF
--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Calls.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Calls.cs
@@ -178,10 +178,25 @@ internal sealed partial class MethodBodyEmitter
         // at the constructed TypeSpec via <see cref="ResolveUserInterfaceInstanceMethodToken"/>.
         var receiverIface = call.Receiver.Type as InterfaceSymbol;
 
+        // Issue #1254: an inherited instance method declared on a generic base
+        // type, invoked through a (non-generic) derived receiver, must be
+        // referenced via a MemberRef parented at the CONSTRUCTED base TypeSpec
+        // (e.g. `Base`1<int32>`) — never the bare MethodDef on the open generic
+        // definition, which the runtime rejects with "the containing type is
+        // not fully instantiated". The `isGenericReceiver` branch already covers
+        // the case where the receiver itself is the generic type.
+        var inheritedGenericBase = !isGenericReceiver
+            ? this.ResolveInheritedGenericBase(call.Receiver.Type as StructSymbol, call.Method)
+            : null;
+
         EntityHandle methodHandle;
         if (isGenericReceiver)
         {
             methodHandle = this.outer.ResolveUserInstanceMethodToken(receiverType, call.Method);
+        }
+        else if (inheritedGenericBase != null)
+        {
+            methodHandle = this.outer.ResolveUserInstanceMethodToken(inheritedGenericBase, call.Method);
         }
         else if (receiverIface != null
             && ReflectionMetadataEmitter.IsUserGenericInterfaceReference(receiverIface))
@@ -222,6 +237,45 @@ internal sealed partial class MethodBodyEmitter
         // ADR-0087 §3 R3+R4: after R2, a user-instance call returns the
         // method's reified signature (substituted at the TypeSpec / MethodSpec
         // level). No erasure-widening is required at the call boundary.
+    }
+
+    // Issue #1254: returns the constructed generic base instantiation that
+    // declares an inherited <paramref name="method"/>, when the call's receiver
+    // inherits it from a generic base (e.g. `Derived : Base[int32]` calling an
+    // inherited `Base.Hello()`). Returns null when the method is not inherited
+    // from a generic base — including when the receiver itself is the declaring
+    // type or the declaring type is non-generic.
+    private StructSymbol ResolveInheritedGenericBase(StructSymbol receiver, FunctionSymbol method)
+    {
+        if (receiver == null || method == null)
+        {
+            return null;
+        }
+
+        if (!this.outer.cache.MethodHandles.ContainsKey(method))
+        {
+            return null;
+        }
+
+        var declaring = method.ReceiverType as StructSymbol;
+        if (declaring == null)
+        {
+            return null;
+        }
+
+        var declaringDef = declaring.Definition ?? declaring;
+        if (declaringDef.TypeParameters.IsDefaultOrEmpty)
+        {
+            return null;
+        }
+
+        // Not inherited — the receiver itself declares the method.
+        if (ReferenceEquals(receiver.Definition ?? receiver, declaringDef))
+        {
+            return null;
+        }
+
+        return receiver.FindConstructedGenericBase(def => ReferenceEquals(def, declaringDef));
     }
 
     // ADR-0087 R5 / issue #765: bridges from a substituted FunctionSymbol on
@@ -647,7 +701,28 @@ internal sealed partial class MethodBodyEmitter
         // Resolve the MethodDef of the base implementation. For a non-generic
         // base this is the bare MethodDef row; for a constructed generic base
         // it is a MemberRef parented at the base TypeSpec.
-        var methodToken = this.outer.ResolveUserInstanceMethodToken(call.BaseClass, call.Method);
+        // Issue #1254: when the base is named by its OPEN generic definition
+        // (no type arguments) — as it is for an inherited method whose
+        // declaring type is generic — resolve the CONSTRUCTED base
+        // instantiation from the receiver's hierarchy so the MemberRef is
+        // parented at e.g. `Base`1<int32>` rather than the open `Base`1<!0>`
+        // (which the runtime rejects with BadImageFormat / "not fully
+        // instantiated").
+        var baseClass = call.BaseClass;
+        if (baseClass != null
+            && baseClass.TypeArguments.IsDefaultOrEmpty
+            && !baseClass.TypeParameters.IsDefaultOrEmpty
+            && call.Receiver.Type is StructSymbol baseReceiver)
+        {
+            var baseDef = baseClass.Definition ?? baseClass;
+            var constructedBase = baseReceiver.FindConstructedGenericBase(d => ReferenceEquals(d, baseDef));
+            if (constructedBase != null)
+            {
+                baseClass = constructedBase;
+            }
+        }
+
+        var methodToken = this.outer.ResolveUserInstanceMethodToken(baseClass, call.Method);
 
         // Issue #986: non-virtual `call`, NOT `callvirt`. callvirt would
         // re-dispatch through the v-table and re-enter the derived override.

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
@@ -404,6 +404,13 @@ internal sealed partial class MethodBodyEmitter
         var containing = fa.StructType;
         bool isGeneric = ReflectionMetadataEmitter.IsUserGenericTypeReference(containing);
 
+        // Issue #1254: an inherited field declared on a generic base type but
+        // accessed through a (non-generic) derived receiver must be read via a
+        // MemberRef parented at the constructed base TypeSpec.
+        var inheritedFieldBase = isGeneric
+            ? null
+            : ResolveInheritedGenericBaseForField(fa.Receiver?.Type as StructSymbol, fa.Field);
+
         EntityHandle fieldHandle;
         if (fa.InterfaceType != null)
         {
@@ -415,6 +422,10 @@ internal sealed partial class MethodBodyEmitter
         else if (isGeneric)
         {
             fieldHandle = this.outer.ResolveFieldToken(containing, fa.Field);
+        }
+        else if (inheritedFieldBase != null)
+        {
+            fieldHandle = this.outer.GetUserStructFieldRef(inheritedFieldBase, fa.Field);
         }
         else if (this.outer.cache.StructFieldDefs.TryGetValue(fa.Field, out var defHandle))
         {
@@ -500,6 +511,13 @@ internal sealed partial class MethodBodyEmitter
         var containing = fas.StructType;
         bool isGeneric = ReflectionMetadataEmitter.IsUserGenericTypeReference(containing);
 
+        // Issue #1254: inherited field on a generic base via a non-generic
+        // derived receiver — write through a MemberRef parented at the
+        // constructed base TypeSpec.
+        var inheritedFieldBase = isGeneric
+            ? null
+            : ResolveInheritedGenericBaseForField(fas.Receiver?.Type as StructSymbol, fas.Field);
+
         EntityHandle fieldHandle;
         if (fas.InterfaceType != null)
         {
@@ -510,6 +528,10 @@ internal sealed partial class MethodBodyEmitter
         else if (isGeneric)
         {
             fieldHandle = this.outer.ResolveFieldToken(containing, fas.Field);
+        }
+        else if (inheritedFieldBase != null)
+        {
+            fieldHandle = this.outer.GetUserStructFieldRef(inheritedFieldBase, fas.Field);
         }
         else if (this.outer.cache.StructFieldDefs.TryGetValue(fas.Field, out var defHandle))
         {
@@ -665,9 +687,12 @@ internal sealed partial class MethodBodyEmitter
         // parameter is read with the substitution applied. The non-generic case
         // keeps using the plain accessor MethodDef.
         EntityHandle getterHandle;
-        if (ReflectionMetadataEmitter.IsUserGenericTypeReference(access.StructType))
+        var getterContainer = ReflectionMetadataEmitter.IsUserGenericTypeReference(access.StructType)
+            ? access.StructType
+            : ResolveInheritedGenericBaseForProperty(access.Receiver?.Type as StructSymbol, access.Property);
+        if (getterContainer != null)
         {
-            getterHandle = this.outer.ResolveUserPropertyAccessorToken(access.StructType, access.Property, wantSetter: false);
+            getterHandle = this.outer.ResolveUserPropertyAccessorToken(getterContainer, access.Property, wantSetter: false);
         }
         else if (this.outer.cache.PropertyAccessorHandles.TryGetValue(access.Property, out var handles) && handles.Getter.HasValue)
         {
@@ -730,9 +755,12 @@ internal sealed partial class MethodBodyEmitter
         // Issue #989: route generic constructed receivers through the
         // TypeSpec-parented MemberRef (mirrors EmitPropertyAccess).
         EntityHandle setterHandle;
-        if (ReflectionMetadataEmitter.IsUserGenericTypeReference(assn.StructType))
+        var setterContainer = ReflectionMetadataEmitter.IsUserGenericTypeReference(assn.StructType)
+            ? assn.StructType
+            : ResolveInheritedGenericBaseForProperty(assn.Receiver?.Type as StructSymbol, assn.Property);
+        if (setterContainer != null)
         {
-            setterHandle = this.outer.ResolveUserPropertyAccessorToken(assn.StructType, assn.Property, wantSetter: true);
+            setterHandle = this.outer.ResolveUserPropertyAccessorToken(setterContainer, assn.Property, wantSetter: true);
         }
         else if (this.outer.cache.PropertyAccessorHandles.TryGetValue(assn.Property, out var handles) && handles.Setter.HasValue)
         {
@@ -1417,5 +1445,68 @@ internal sealed partial class MethodBodyEmitter
         {
             this.il.OpCode(ILOpCode.Stind_ref);
         }
+    }
+
+    // Issue #1254: when an inherited property is accessed through a (non-generic)
+    // derived receiver but the property is declared on a generic base type, the
+    // accessor must be referenced via a MemberRef parented at the CONSTRUCTED
+    // base TypeSpec. Returns that constructed base, or null when the property is
+    // not inherited from a generic base.
+    private static StructSymbol ResolveInheritedGenericBaseForProperty(StructSymbol receiver, PropertySymbol property)
+    {
+        if (receiver == null || property == null)
+        {
+            return null;
+        }
+
+        return receiver.FindConstructedGenericBase(def => DefDeclaresProperty(def, property));
+    }
+
+    private static bool DefDeclaresProperty(StructSymbol def, PropertySymbol property)
+    {
+        var set = property.IsStatic ? def.StaticProperties : def.Properties;
+        if (set.IsDefaultOrEmpty)
+        {
+            return false;
+        }
+
+        foreach (var candidate in set)
+        {
+            if (candidate.Name == property.Name && candidate.IsIndexer == property.IsIndexer)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // Issue #1254: the field analogue of ResolveInheritedGenericBaseForProperty.
+    private static StructSymbol ResolveInheritedGenericBaseForField(StructSymbol receiver, FieldSymbol field)
+    {
+        if (receiver == null || field == null)
+        {
+            return null;
+        }
+
+        return receiver.FindConstructedGenericBase(def => DefDeclaresField(def, field));
+    }
+
+    private static bool DefDeclaresField(StructSymbol def, FieldSymbol field)
+    {
+        if (def.Fields.IsDefaultOrEmpty)
+        {
+            return false;
+        }
+
+        foreach (var candidate in def.Fields)
+        {
+            if (candidate.Name == field.Name)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -597,6 +597,7 @@ internal sealed class ReflectionMetadataEmitter
             this.GetTypeReference,
             this.GetUserStructTypeSpec,
             this.ResolveConstructedBaseParameterlessCtorToken,
+            this.ResolveConstructedBaseExplicitCtorToken,
             this.customAttrEncoder.NextParameterHandle,
             this.customAttrEncoder.EmitUserAttributes,
             this.customAttrEncoder.EmitIsReadOnlyAttributeOnParameter,
@@ -7080,6 +7081,57 @@ internal sealed class ReflectionMetadataEmitter
                     }
                 });
         return this.GetUserStructMethodRef(structType, primaryDef, ".ctor", sigBlob);
+    }
+
+    /// <summary>
+    /// Issue #1254: resolves the base-constructor token for an explicit
+    /// <c>: base(args)</c> initializer whose base is a CONSTRUCTED generic user
+    /// class (e.g. <c>Derived : Base[int32]</c> chaining to <c>Base</c>'s
+    /// primary or an explicit <c>init(...)</c> ctor). The base ctor's MethodDef
+    /// is keyed by the open definition, so a bare token is invalid for a generic
+    /// type; a MemberRef parented at the constructed base's TypeSpec is emitted
+    /// with the open ctor's signature (type-parameter slots encode as VAR).
+    /// </summary>
+    internal EntityHandle ResolveConstructedBaseExplicitCtorToken(StructSymbol constructedBase, ConstructorSymbol ctor)
+    {
+        if (ctor == null || !this.cache.ExplicitCtorHandles.TryGetValue(ctor, out var ctorDef))
+        {
+            return this.ResolveConstructedBaseParameterlessCtorToken(constructedBase);
+        }
+
+        var function = ctor.Function;
+
+        // The receiver `this` is not part of the encoded parameter list. It may
+        // or may not appear in Function.Parameters, so count (and emit) only the
+        // non-receiver parameters rather than assuming a fixed offset.
+        var paramCount = 0;
+        foreach (var p in function.Parameters)
+        {
+            if (!ReferenceEquals(p, function.ThisParameter))
+            {
+                paramCount++;
+            }
+        }
+
+        var sigBlob = new BlobBuilder();
+        new BlobEncoder(sigBlob)
+            .MethodSignature(isInstanceMethod: true)
+            .Parameters(
+                paramCount,
+                r => r.Void(),
+                ps =>
+                {
+                    foreach (var p in function.Parameters)
+                    {
+                        if (ReferenceEquals(p, function.ThisParameter))
+                        {
+                            continue;
+                        }
+
+                        EncodeTypeSymbol(ps.AddParameter().Type(isByRef: p.RefKind != RefKind.None), p.Type);
+                    }
+                });
+        return this.GetUserStructMethodRef(constructedBase, ctorDef, ".ctor", sigBlob);
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs
@@ -93,6 +93,7 @@ internal sealed class TypeDefEmitter
     private readonly Func<Type, TypeReferenceHandle> getTypeReference;
     private readonly Func<StructSymbol, EntityHandle> getUserStructTypeSpec;
     private readonly Func<StructSymbol, EntityHandle> resolveConstructedBaseCtorToken;
+    private readonly Func<StructSymbol, ConstructorSymbol, EntityHandle> resolveConstructedBaseExplicitCtorToken;
     private readonly Func<ParameterHandle> nextParameterHandle;
     private readonly Action<EntityHandle, Symbol, AttributeTargetKind> emitUserAttributes;
     private readonly Action<ParameterHandle> emitIsReadOnlyAttributeOnParameter;
@@ -114,6 +115,7 @@ internal sealed class TypeDefEmitter
         Func<Type, TypeReferenceHandle> getTypeReference,
         Func<StructSymbol, EntityHandle> getUserStructTypeSpec,
         Func<StructSymbol, EntityHandle> resolveConstructedBaseCtorToken,
+        Func<StructSymbol, ConstructorSymbol, EntityHandle> resolveConstructedBaseExplicitCtorToken,
         Func<ParameterHandle> nextParameterHandle,
         Action<EntityHandle, Symbol, AttributeTargetKind> emitUserAttributes,
         Action<ParameterHandle> emitIsReadOnlyAttributeOnParameter,
@@ -134,6 +136,7 @@ internal sealed class TypeDefEmitter
         this.getTypeReference = getTypeReference ?? throw new ArgumentNullException(nameof(getTypeReference));
         this.getUserStructTypeSpec = getUserStructTypeSpec ?? throw new ArgumentNullException(nameof(getUserStructTypeSpec));
         this.resolveConstructedBaseCtorToken = resolveConstructedBaseCtorToken ?? throw new ArgumentNullException(nameof(resolveConstructedBaseCtorToken));
+        this.resolveConstructedBaseExplicitCtorToken = resolveConstructedBaseExplicitCtorToken ?? throw new ArgumentNullException(nameof(resolveConstructedBaseExplicitCtorToken));
         this.nextParameterHandle = nextParameterHandle ?? throw new ArgumentNullException(nameof(nextParameterHandle));
         this.emitUserAttributes = emitUserAttributes ?? throw new ArgumentNullException(nameof(emitUserAttributes));
         this.emitIsReadOnlyAttributeOnParameter = emitIsReadOnlyAttributeOnParameter ?? throw new ArgumentNullException(nameof(emitIsReadOnlyAttributeOnParameter));
@@ -1593,6 +1596,20 @@ internal sealed class TypeDefEmitter
         }
 
         var gsharpBase = init.GSharpBaseType;
+
+        // Issue #1254: when the base is a CONSTRUCTED generic user class, the
+        // base ctor's MethodDef is keyed by the open definition and a bare token
+        // is invalid for a generic type. Emit a MemberRef parented at the
+        // constructed base's TypeSpec for the selected ctor (primary or explicit
+        // `init(...)`), mirroring the parameter-less #1055 path.
+        var constructedGenericBase =
+            (classSym.BaseClass != null && !classSym.BaseClass.TypeArguments.IsDefaultOrEmpty)
+                ? classSym.BaseClass
+                : ((gsharpBase != null && !gsharpBase.TypeArguments.IsDefaultOrEmpty) ? gsharpBase : null);
+        if (constructedGenericBase != null)
+        {
+            return this.resolveConstructedBaseExplicitCtorToken(constructedGenericBase, init.GSharpConstructor);
+        }
 
         // Issue #1060: when the base initializer resolved to a specific explicit
         // `init(...)` constructor on the GSharp base class, target that exact

--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -1018,6 +1018,82 @@ public sealed class StructSymbol : TypeSymbol
     }
 
     /// <summary>
+    /// Issue #1254: finds the constructed generic base instantiation in this
+    /// type's base-class chain whose definition satisfies
+    /// <paramref name="declaringDefinitionPredicate"/>, composing the
+    /// type-argument substitution across each inheritance hop so the returned
+    /// symbol carries fully-resolved type arguments in this type's context.
+    /// </summary>
+    /// <remarks>
+    /// A deeper base's type arguments are expressed in terms of a shallower
+    /// base's type parameters (e.g. for <c>Derived : Mid[int32] : Base[T]</c>
+    /// the <c>Base</c> instantiation is written <c>Base[Mid.T]</c>), so each
+    /// argument is resolved through the running substitution accumulated from
+    /// the more-derived levels. Looking up <c>Base</c> therefore yields the
+    /// fully-closed <c>Base[int32]</c>. Returns <see langword="null"/> when no
+    /// matching generic base exists. The walk includes the receiver itself.
+    /// </remarks>
+    /// <param name="declaringDefinitionPredicate">Predicate matched against each ancestor's definition (or itself when non-generic).</param>
+    /// <returns>The constructed generic base instantiation, or null.</returns>
+    public StructSymbol FindConstructedGenericBase(Func<StructSymbol, bool> declaringDefinitionPredicate)
+    {
+        if (declaringDefinitionPredicate == null)
+        {
+            return null;
+        }
+
+        Dictionary<TypeParameterSymbol, TypeSymbol> running = null;
+        for (var c = this; c != null; c = c.BaseClass)
+        {
+            // Compose this level's type-argument mapping into the running
+            // substitution before testing the predicate so a matching base's
+            // arguments are already resolved in this type's context.
+            var cDef = c.Definition ?? c;
+            if (c.Definition != null
+                && !c.TypeArguments.IsDefaultOrEmpty
+                && !c.Definition.TypeParameters.IsDefaultOrEmpty)
+            {
+                var defParams = c.Definition.TypeParameters;
+                var count = System.Math.Min(defParams.Length, c.TypeArguments.Length);
+                for (var i = 0; i < count; i++)
+                {
+                    var arg = c.TypeArguments[i];
+                    if (arg is TypeParameterSymbol tpArg && running != null && running.TryGetValue(tpArg, out var resolved))
+                    {
+                        arg = resolved;
+                    }
+
+                    running ??= new Dictionary<TypeParameterSymbol, TypeSymbol>();
+                    running[defParams[i]] = arg;
+                }
+            }
+
+            if (cDef.TypeParameters.IsDefaultOrEmpty || !declaringDefinitionPredicate(cDef))
+            {
+                continue;
+            }
+
+            var tps = cDef.TypeParameters;
+            var args = ImmutableArray.CreateBuilder<TypeSymbol>(tps.Length);
+            foreach (var tp in tps)
+            {
+                if (running != null && running.TryGetValue(tp, out var concrete))
+                {
+                    args.Add(concrete);
+                }
+                else
+                {
+                    args.Add(tp);
+                }
+            }
+
+            return Construct(cDef, args.MoveToImmutable());
+        }
+
+        return null;
+    }
+
+    /// <summary>
     /// Issue #1087: gets the parameter types of <paramref name="constructor"/>
     /// as observed on this (possibly constructed) symbol. For a constructed
     /// closed generic type, the open-definition constructor's parameter types

--- a/test/Compiler.Tests/Emit/Issue1254GenericBaseEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1254GenericBaseEmitTests.cs
@@ -1,0 +1,357 @@
+// <copyright file="Issue1254GenericBaseEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1254: calling a member that is INHERITED from a generic base class
+/// through a derived receiver must emit a metadata token whose containing type
+/// is the CONSTRUCTED base instantiation (e.g. <c>Base`1&lt;int32&gt;</c>), not the
+/// open generic definition (<c>Base`1</c>). Emitting against the open definition
+/// produces IL that statically verifies but throws at runtime:
+/// <c>InvalidOperationException: ... not fully instantiated</c>.
+/// <para>
+/// Every test both statically verifies the emitted assembly via
+/// <see cref="IlVerifier.Verify"/> AND executes it, asserting the printed
+/// result, so a token bound to the open definition is caught either way.
+/// </para>
+/// </summary>
+public class Issue1254GenericBaseEmitTests
+{
+    [Fact]
+    public void InheritedMethod_IgnoringTypeParam_ViaDerivedReceiver_EmitsAndRuns()
+    {
+        // The minimal repro from #1254: the inherited method's signature does
+        // not mention T, so the only unresolved thing is the containing-type
+        // instantiation.
+        var source = """
+            package P
+            import System
+
+            open class Base[T] {
+                func Hello() int32 { return 42 }
+            }
+
+            class Derived : Base[int32] {
+            }
+
+            let d = Derived()
+            Console.WriteLine(d.Hello())
+            """;
+
+        Assert.Equal("42\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void InheritedMethod_UsingTypeParam_ViaDerivedReceiver_EmitsAndRuns()
+    {
+        // The inherited method's parameter and return both use T, which is
+        // substituted to int32 by the constructed base.
+        var source = """
+            package P
+            import System
+
+            open class Base[T] {
+                func Echo(x T) T { return x }
+            }
+
+            class Derived : Base[int32] {
+            }
+
+            let d = Derived()
+            Console.WriteLine(d.Echo(7))
+            """;
+
+        Assert.Equal("7\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void InheritedField_ViaDerivedReceiver_EmitsAndRuns()
+    {
+        var source = """
+            package P
+            import System
+
+            open class Base[T] {
+                let Value int32 = 99
+            }
+
+            class Derived : Base[int32] {
+            }
+
+            let d = Derived()
+            Console.WriteLine(d.Value)
+            """;
+
+        Assert.Equal("99\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void InheritedAutoProperty_GetAndSet_ViaDerivedReceiver_EmitsAndRuns()
+    {
+        var source = """
+            package P
+            import System
+
+            open class Base[T] {
+                prop Item T
+            }
+
+            class Derived : Base[int32] {
+            }
+
+            let d = Derived()
+            d.Item = 8
+            Console.WriteLine(d.Item)
+            """;
+
+        Assert.Equal("8\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void InheritedProperty_Get_ViaDerivedReceiver_EmitsAndRuns()
+    {
+        var source = """
+            package P
+            import System
+
+            open class Base[T] {
+                var backing T
+                prop Item T {
+                    get { return this.backing }
+                }
+            }
+
+            class Derived : Base[int32] {
+            }
+
+            let d = Derived()
+            Console.WriteLine(d.Item)
+            """;
+
+        Assert.Equal("0\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void InheritedMethod_MultiLevelGenericBaseChain_EmitsAndRuns()
+    {
+        // Derived : Mid[int32] : Base[T] — the type argument must be threaded
+        // through each hop of the base chain.
+        var source = """
+            package P
+            import System
+
+            open class Base[T] {
+                func Hello() int32 { return 42 }
+            }
+
+            open class Mid[T] : Base[T] {
+            }
+
+            class Derived : Mid[int32] {
+            }
+
+            let d = Derived()
+            Console.WriteLine(d.Hello())
+            """;
+
+        Assert.Equal("42\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void InheritedMethod_UsingTypeParam_MultiLevelChain_EmitsAndRuns()
+    {
+        var source = """
+            package P
+            import System
+
+            open class Base[T] {
+                func Pick(a T, b T) T { return a }
+            }
+
+            open class Mid[T] : Base[T] {
+            }
+
+            class Derived : Mid[int32] {
+            }
+
+            let d = Derived()
+            Console.WriteLine(d.Pick(9, 4))
+            """;
+
+        Assert.Equal("9\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void BaseDotMethod_IntoGenericBase_FromNonGenericDerived_EmitsAndRuns()
+    {
+        var source = """
+            package P
+            import System
+
+            open class Base[T] {
+                open func Hello() int32 { return 42 }
+            }
+
+            class Derived : Base[int32] {
+                func Call() int32 { return base.Hello() }
+            }
+
+            let d = Derived()
+            Console.WriteLine(d.Call())
+            """;
+
+        Assert.Equal("42\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void BaseDotProperty_IntoGenericBase_FromNonGenericDerived_EmitsAndRuns()
+    {
+        var source = """
+            package P
+            import System
+
+            open class Base[T] {
+                open prop Tag int32 {
+                    get { return 13 }
+                }
+            }
+
+            class Derived : Base[int32] {
+                func Read() int32 { return base.Tag }
+            }
+
+            let d = Derived()
+            Console.WriteLine(d.Read())
+            """;
+
+        Assert.Equal("13\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void BaseConstructorChaining_IntoGenericBasePrimaryCtor_EmitsAndRuns()
+    {
+        var source = """
+            package P
+            import System
+
+            open class Base[T](stored T) {
+            }
+
+            class Derived : Base[int32] {
+                init() : base(66) {
+                }
+            }
+
+            let d = Derived()
+            Console.WriteLine(d.stored)
+            """;
+
+        Assert.Equal("66\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void InheritedMethod_GenericDerived_EmitsAndRuns()
+    {
+        // Derived[U] : Base[U] — the derived type is itself generic and forwards
+        // its own type parameter to the base.
+        var source = """
+            package P
+            import System
+
+            open class Base[T] {
+                func Hello() int32 { return 42 }
+            }
+
+            class Derived[U] : Base[U] {
+            }
+
+            let d = Derived[int32]()
+            Console.WriteLine(d.Hello())
+            """;
+
+        Assert.Equal("42\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1254_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new System.Collections.Generic.List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+
+            // (a) Static verification: the emitted IL must be valid.
+            IlVerifier.Verify(outPath);
+
+            // (b) Dynamic verification: the emitted code must execute. This is
+            // what catches a token bound to the open generic definition, which
+            // verifies statically but throws "not fully instantiated" at run.
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
## Bug

Calling a member **inherited from a generic base class** (e.g. `Base[T]`) through a derived receiver emitted IL that statically verified but **crashed at runtime**:

```
System.InvalidOperationException: Could not execute the method because either the method itself
or the containing type is not fully instantiated.
```

Minimal repro (compiles, crashed at runtime, now prints `42`):

```gsharp
package p
import System

open class Base[T] {
  func Hello() int32 { return 42 }
}

class Derived : Base[int32] {
}

let d = Derived()
Console.WriteLine(d.Hello())
```

## Root cause

For an inherited member, the emitter resolved the metadata token against the **open** generic base definition (``Base`1``) instead of the **constructed** base instantiation supplied by the derived type (``Base`1<int32>``). A bare `MethodDef`/`FieldDef` on the open definition names a containing type that is not fully instantiated, which the runtime rejects. `IlVerifier` does not catch it because it is a metadata-token problem, not an IL-stream problem — so it only surfaced at execution. This is the **emit-side** counterpart of the bind-time generic-substitution fixes (#1244 / #1248 / #1250).

## Fix

Added `StructSymbol.FindConstructedGenericBase`, which walks the derived type's base chain composing the running type-argument substitution across each hop (needed because constructed types do not substitute their `BaseClass`) and returns the first matching constructed generic base.

The emitter now routes inherited members through that constructed base, so each token becomes a **MemberRef parented at the constructed TypeSpec** (via the existing `GetUserStructMethodRef` / `ResolveUserPropertyAccessorToken` / `GetUserStructFieldRef` paths):

- inherited instance methods via a derived receiver (`EmitUserInstanceCall`);
- `base.M()` / `base.Prop` into a generic base from a non-generic derived member (`EmitBaseClassCall`, property access);
- inherited property get/set and field read/write (`MethodBodyEmitter.MemberAccess`);
- base-constructor chaining into a generic base's primary or explicit ctor (`TypeDefEmitter.GetBaseInitializerCtorToken` + `ReflectionMetadataEmitter.ResolveConstructedBaseExplicitCtorToken`), counting only non-receiver parameters when encoding the signature.

General fix: works for any base type-arg arity, multi-level generic base chains (`Derived : Mid[int32] : Base[T]`), members whose signature uses `T`, and the generic-derived case (`Derived[U] : Base[U]`). No name special-casing; no new `SyntaxKind`/`BoundNodeKind`.

## Tests

`test/Compiler.Tests/Emit/Issue1254GenericBaseEmitTests.cs` — 11 emit tests, each `IlVerifier.Verify`s the assembly **and** executes it and asserts stdout: inherited method ignoring/using `T`, inherited field, inherited auto-property get/set and property get, multi-level chain, `base.M()`/`base.Prop`, base-ctor chaining, and generic-derived.

### Verification
- `dotnet build GSharp.sln -c Release -graph` → 0 errors / 0 warnings
- `dotnet test test/Core.Tests` → 4362 passed, 1 skipped, 0 failed
- `Issue1254` emit tests → 11 passed
- Regression: `~Generic` (210 passed), `~Adr0112` (10 passed)

Fixes #1254
