### PR TITLE
Fix #1268: static-virtual interface members through generic interface constraints

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -4414,13 +4414,29 @@ internal sealed partial class ExpressionBinder
                     // emitted as `constrained. !!T  call I::get_Prop()`.
                     var propName = ne.IdentifierToken.Text;
                     PropertySymbol slotProp = null;
+                    InterfaceSymbol slotIface = null;
                     foreach (var iface in tpSym.InterfaceConstraint.SelfAndAllBaseInterfaces())
                     {
-                        foreach (var candidate in iface.Properties)
+                        // Issue #1268: a constructed generic interface
+                        // constraint (e.g. `T : IData[int32]` or the
+                        // self-referential `T : IData[T]`) does not surface
+                        // its declared static-virtual *properties* on the
+                        // constructed instance — only methods are
+                        // substituted onto it. Walk the open definition's
+                        // property table so the slot is found regardless of
+                        // whether the constraint is open or constructed; the
+                        // getter resolved here is the open definition's
+                        // static-virtual accessor (keyed in the emitter's
+                        // MethodHandles), and the constructed interface is
+                        // retained for type-argument substitution / emit.
+                        var defIface = iface.Definition ?? iface;
+                        defIface.EnsureMembersResolved();
+                        foreach (var candidate in defIface.Properties)
                         {
                             if (candidate.IsStatic && candidate.Name == propName)
                             {
                                 slotProp = candidate;
+                                slotIface = iface;
                                 break;
                             }
                         }
@@ -4438,7 +4454,7 @@ internal sealed partial class ExpressionBinder
                         return new BoundErrorExpression(null);
                     }
 
-                    var propType = SubstituteThroughConstructedInterface(slotProp.Type, tpSym.InterfaceConstraint);
+                    var propType = SubstituteThroughConstructedInterface(slotProp.Type, slotIface);
 
                     return new BoundConstrainedStaticCallExpression(
                         ne,

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Calls.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Calls.cs
@@ -633,11 +633,35 @@ internal sealed partial class MethodBodyEmitter
         // both shapes via TypeParameterSymbol.IsMethodTypeParameter.
         var typeParamToken = this.outer.GetElementTypeToken(call.TypeParameter);
 
-        // Resolve the interface static-virtual MethodDef handle. The
+        // Resolve the interface static-virtual member handle. The
         // BoundConstrainedStaticCallExpression carries the *interface
         // slot* FunctionSymbol; MethodHandles maps interface slots to
         // their planned MethodDef rows.
-        if (!this.outer.cache.MethodHandles.TryGetValue(call.InterfaceMethod, out var slotHandle))
+        //
+        // Issue #1268: when the constraint is a constructed generic
+        // interface (e.g. `T : IData[int32]` or the self-referential
+        // `T : IData[T]`), the bound slot is either the substituted
+        // static method on the constructed instance (methods) or the open
+        // definition's static-virtual property getter (properties).
+        // Neither is keyed in `cache.MethodHandles` against the
+        // *constructed* interface, so the target must be encoded as a
+        // MemberRef parented at the constructed interface's TypeSpec — the
+        // same way constructed-generic instance interface calls are emitted
+        // (ADR-0087 R5 / issue #765). Resolve back to the open definition
+        // slot and parent the MemberRef at the constructed TypeSpec.
+        var constraintIface = call.TypeParameter.InterfaceConstraint;
+        EntityHandle slotHandle;
+        if (constraintIface != null
+            && ReflectionMetadataEmitter.IsUserGenericInterfaceReference(constraintIface))
+        {
+            var openSlot = ResolveOpenInterfaceMethod(constraintIface, call.InterfaceMethod);
+            slotHandle = this.outer.ResolveUserInterfaceInstanceMethodToken(constraintIface, openSlot);
+        }
+        else if (this.outer.cache.MethodHandles.TryGetValue(call.InterfaceMethod, out var slotDef))
+        {
+            slotHandle = slotDef;
+        }
+        else
         {
             throw new InvalidOperationException(
                 $"Static-virtual interface method '{call.InterfaceMethod.Name}' has no emitted handle.");

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -9751,12 +9751,26 @@ internal sealed class ReflectionMetadataEmitter
                 continue;
             }
 
+            // Issue #1268: when the implemented interface is a constructed
+            // generic (e.g. `TrackNumber : IData[TrackNumber]`), its
+            // `StaticMethods` are substituted instances that are NOT keyed in
+            // `MethodHandles`; only the open definition's slots are. Resolve
+            // each substituted slot back to its open counterpart for the
+            // MethodDef lookup, and parent the MethodImpl's declaration at the
+            // constructed interface's TypeSpec (a MemberRef) so the runtime can
+            // pair the override against `IData`1<TrackNumber>::Method`.
+            var isGenericIface = IsUserGenericInterfaceReference(iface);
             foreach (var slot in iface.StaticMethods)
             {
-                if (!this.cache.MethodHandles.TryGetValue(slot, out var slotHandle))
+                var openSlot = ResolveOpenInterfaceStaticMethod(iface, slot);
+                if (!this.cache.MethodHandles.TryGetValue(openSlot, out var slotDefHandle))
                 {
                     continue;
                 }
+
+                EntityHandle slotHandle = isGenericIface
+                    ? this.ResolveUserInterfaceInstanceMethodToken(iface, openSlot)
+                    : slotDefHandle;
 
                 FunctionSymbol implMatch = null;
                 foreach (var candidate in structSymbol.GetStaticMethods(slot.Name))
@@ -9784,6 +9798,42 @@ internal sealed class ReflectionMetadataEmitter
     }
 
     /// <summary>
+    /// Issue #1268: maps a (possibly substituted) static-virtual method slot
+    /// on a constructed generic interface back to its open declaration on the
+    /// interface definition. Returns <paramref name="slot"/> unchanged when the
+    /// interface is not a constructed instance, or when no open counterpart is
+    /// found.
+    /// </summary>
+    private static FunctionSymbol ResolveOpenInterfaceStaticMethod(InterfaceSymbol iface, FunctionSymbol slot)
+    {
+        var def = iface.Definition ?? iface;
+        if (ReferenceEquals(def, iface))
+        {
+            return slot;
+        }
+
+        var constructedStatics = iface.StaticMethods;
+        var defStatics = def.StaticMethods;
+        for (var i = 0; i < constructedStatics.Length; i++)
+        {
+            if (ReferenceEquals(constructedStatics[i], slot) && i < defStatics.Length)
+            {
+                return defStatics[i];
+            }
+        }
+
+        foreach (var m in defStatics)
+        {
+            if (m.Name == slot.Name && m.Parameters.Length == slot.Parameters.Length)
+            {
+                return m;
+            }
+        }
+
+        return slot;
+    }
+
+    /// <summary>
     /// ADR-0089 / issue #1019: emit <c>MethodImpl</c> rows pairing the
     /// implementer's static property accessor methods (<c>get_Name</c> /
     /// <c>set_Name</c>) to the matching static-virtual interface property
@@ -9807,12 +9857,20 @@ internal sealed class ReflectionMetadataEmitter
 
         foreach (var iface in structSymbol.Interfaces)
         {
-            if (iface.Properties.IsDefaultOrEmpty)
+            // Issue #1268: a constructed generic interface does not surface its
+            // declared properties on the constructed instance (only methods are
+            // substituted) — walk the open definition's property table so the
+            // static-virtual property slots are found, and parent the
+            // MethodImpl declaration at the constructed TypeSpec for generic
+            // interfaces.
+            var defIface = iface.Definition ?? iface;
+            if (defIface.Properties.IsDefaultOrEmpty)
             {
                 continue;
             }
 
-            foreach (var slotProp in iface.Properties)
+            var isGenericIface = IsUserGenericInterfaceReference(iface);
+            foreach (var slotProp in defIface.Properties)
             {
                 if (!slotProp.IsStatic)
                 {
@@ -9843,12 +9901,18 @@ internal sealed class ReflectionMetadataEmitter
 
                 if (slotProp.HasGetter && slotAccessors.Getter.HasValue && implAccessors.Getter.HasValue)
                 {
-                    this.emitCtx.Metadata.AddMethodImplementation(implTypeDef, implAccessors.Getter.Value, slotAccessors.Getter.Value);
+                    EntityHandle getterDecl = isGenericIface && slotProp.GetterSymbol != null
+                        ? this.ResolveUserInterfaceInstanceMethodToken(iface, slotProp.GetterSymbol)
+                        : slotAccessors.Getter.Value;
+                    this.emitCtx.Metadata.AddMethodImplementation(implTypeDef, implAccessors.Getter.Value, getterDecl);
                 }
 
                 if (slotProp.HasSetter && slotAccessors.Setter.HasValue && implAccessors.Setter.HasValue)
                 {
-                    this.emitCtx.Metadata.AddMethodImplementation(implTypeDef, implAccessors.Setter.Value, slotAccessors.Setter.Value);
+                    EntityHandle setterDecl = isGenericIface && slotProp.SetterSymbol != null
+                        ? this.ResolveUserInterfaceInstanceMethodToken(iface, slotProp.SetterSymbol)
+                        : slotAccessors.Setter.Value;
+                    this.emitCtx.Metadata.AddMethodImplementation(implTypeDef, implAccessors.Setter.Value, setterDecl);
                 }
             }
         }

--- a/test/Compiler.Tests/Emit/Issue1268StaticVirtualGenericInterfaceEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1268StaticVirtualGenericInterfaceEmitTests.cs
@@ -1,0 +1,239 @@
+// <copyright file="Issue1268StaticVirtualGenericInterfaceEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// ADR-0089 / issue #1268 — end-to-end emit + execution of static-virtual
+/// interface members dispatched through a type parameter whose constraint is a
+/// *constructed generic* interface (the self-referential
+/// <c>T : IData[T]</c> shape used by generic-math-style code). Validates that:
+/// <list type="bullet">
+///   <item>the consumer's <c>constrained. !!T  call</c> targets a MemberRef
+///   parented at the constructed interface's TypeSpec (issue #1268 emit fix);</item>
+///   <item>the implementer's <c>MethodImpl</c> rows pair its static override
+///   against the constructed-interface slot, so the runtime resolves the body
+///   (no <c>TypeLoadException</c>);</item>
+///   <item>both static-virtual methods and get-only / get-set properties work.</item>
+/// </list>
+/// Each test compiles a concrete implementer, IL-verifies, executes, and
+/// asserts the runtime value produced by the implementer's body.
+/// </summary>
+public class Issue1268StaticVirtualGenericInterfaceEmitTests
+{
+    [Fact]
+    public void StaticVirtualMethod_ThroughSelfReferentialGenericConstraint_RunsAndReturnsExpected()
+    {
+        var source = """
+            package Probe
+            import System
+
+            interface IData[TData IData[TData]] {
+                shared {
+                    func Size() int32;
+                }
+            }
+
+            struct TrackNumber : IData[TrackNumber] {
+                shared {
+                    func Size() int32 { return 11 }
+                }
+            }
+
+            func Use[T IData[T]](w T) int32 {
+                return T.Size()
+            }
+
+            func Main() {
+                Console.WriteLine(Use(TrackNumber{}))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("11\n", output);
+    }
+
+    [Fact]
+    public void StaticVirtualGetOnlyProperty_ThroughSelfReferentialGenericConstraint_RunsAndReturnsExpected()
+    {
+        var source = """
+            package Probe
+            import System
+
+            interface IData[TData IData[TData]] {
+                shared {
+                    prop SizeInBytes int32 { get; }
+                }
+            }
+
+            struct TrackNumber : IData[TrackNumber] {
+                shared {
+                    prop SizeInBytes int32 { get { return 7 } }
+                }
+            }
+
+            func Use[T IData[T]](w T) int32 {
+                return T.SizeInBytes
+            }
+
+            func Main() {
+                Console.WriteLine(Use(TrackNumber{}))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("7\n", output);
+    }
+
+    [Fact]
+    public void StaticVirtualGetSetProperty_ThroughSelfReferentialGenericConstraint_RunsAndReturnsExpected()
+    {
+        var source = """
+            package Probe
+            import System
+
+            interface IData[TData IData[TData]] {
+                shared {
+                    prop Tag int32 { get; set }
+                }
+            }
+
+            struct TrackNumber : IData[TrackNumber] {
+                shared {
+                    prop Tag int32 { get { return 42 } set { } }
+                }
+            }
+
+            func Use[T IData[T]](w T) int32 {
+                return T.Tag
+            }
+
+            func Main() {
+                Console.WriteLine(Use(TrackNumber{}))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void StaticVirtualMember_ThroughNonSelfReferentialGenericConstraint_RunsAndReturnsExpected()
+    {
+        var source = """
+            package Probe
+            import System
+
+            interface IData[X] {
+                shared {
+                    func Size() int32;
+                }
+            }
+
+            struct TrackNumber : IData[int32] {
+                shared {
+                    func Size() int32 { return 99 }
+                }
+            }
+
+            func Use[T IData[int32]](w T) int32 {
+                return T.Size()
+            }
+
+            func Main() {
+                Console.WriteLine(Use(TrackNumber{}))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("99\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1268_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath, ignoredErrorCodes: IlVerifier.KnownIssues.StaticVirtualInterface);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1268StaticVirtualGenericInterfaceTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1268StaticVirtualGenericInterfaceTests.cs
@@ -1,0 +1,130 @@
+// <copyright file="Issue1268StaticVirtualGenericInterfaceTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// ADR-0089 / issue #1268 — static-virtual interface members accessed through a
+/// type parameter (<c>T.Member</c>) whose constraint is a *constructed generic*
+/// interface (<c>T : IData[int32]</c> or the self-referential
+/// <c>T : IData[T]</c>). Prior issues (#755/#865/#1019/#1030/#1031) implemented
+/// the feature for non-generic interface constraints; the generic-constraint
+/// case reported GS0333 for properties (the constructed-interface property slot
+/// was never searched). These tests pin that the binder now resolves both
+/// static-virtual properties and methods through a generic interface
+/// constraint.
+/// </summary>
+public class Issue1268StaticVirtualGenericInterfaceTests
+{
+    [Fact]
+    public void StaticVirtualProperty_ThroughGenericConstraint_Binds()
+    {
+        var source = @"
+package p
+interface IData[X] {
+  shared {
+    prop SizeInBytes int32 { get; }
+  }
+}
+func Use[T IData[int32]]() int32 { return T.SizeInBytes }
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void StaticVirtualProperty_ThroughSelfReferentialConstraint_Binds()
+    {
+        var source = @"
+package p
+interface IData[TData IData[TData]] {
+  shared {
+    prop SizeInBytes int32 { get; }
+  }
+}
+func Use[T IData[T]]() int32 { return T.SizeInBytes }
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void GetSetStaticVirtualProperty_ThroughSelfReferentialConstraint_Binds()
+    {
+        var source = @"
+package p
+interface IData[TData IData[TData]] {
+  shared {
+    prop Tag int32 { get; set }
+  }
+}
+func Use[T IData[T]]() int32 { return T.Tag }
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void StaticVirtualMethod_ThroughGenericConstraint_Binds()
+    {
+        var source = @"
+package p
+interface IData[X] {
+  shared {
+    func Size() int32;
+  }
+}
+func Use[T IData[int32]]() int32 { return T.Size() }
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void StaticVirtualMethod_ThroughSelfReferentialConstraint_Binds()
+    {
+        var source = @"
+package p
+interface IData[TData IData[TData]] {
+  shared {
+    func Size() int32;
+  }
+}
+func Use[T IData[T]]() int32 { return T.Size() }
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void UnknownStaticVirtualMember_ThroughGenericConstraint_StillReportsGS0333()
+    {
+        var source = @"
+package p
+interface IData[X] {
+  shared {
+    prop SizeInBytes int32 { get; }
+  }
+}
+func Use[T IData[int32]]() int32 { return T.Missing }
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0333");
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
## Bug

Static-virtual interface members (ADR-0089) accessed through a type parameter `T.Member` work when the constraint interface is **non-generic**, but break when the constraint is a **constructed/generic** interface (`T : IData[int32]` or the self-referential `T : IData[T]`):

- `T.SizeInBytes` (static-virtual **property**) → binder `GS0333` ("no constraint that declares a static-virtual member").
- `T.Size()` (static-virtual **method**) → emit `GS9998 InvalidOperationException: ... has no emitted handle`.
- Even after those, a concrete implementer (`TrackNumber : IData[TrackNumber]`) threw `TypeLoadException` at runtime (missing `MethodImpl`).

The non-generic constraint controls (`T : IData`) continued to work.

## Root cause

1. **Binder (GS0333, properties).** A constructed generic interface only substitutes its *method* tables onto the constructed instance — `Properties` stays empty. The property slot lookup iterated the constructed instance's `Properties`, so it found nothing. (The method path already bound.)
2. **Emitter (GS9998, methods).** `EmitConstrainedStaticCall` looked up the bound slot directly in `MethodHandles`. For a constructed interface that slot is the *substituted* member, which is not keyed there — only the open definition's slot is.
3. **Emitter (implementer MethodImpl).** `EmitStaticVirtualMethodImpls` / `EmitStaticVirtualPropertyMethodImpls` keyed on the constructed interface's substituted members and its empty `Properties`, so no `MethodImpl` row was emitted → runtime `TypeLoadException`.

## Fix

1. Binder property lookup walks the **open definition's** property table (`iface.Definition.Properties`) for both open and constructed constraints, keeping the constructed interface for type-argument substitution — taking the same route the method path already used.
2. `EmitConstrainedStaticCall`: when the constraint is a constructed generic interface, resolve back to the open slot and emit a **MemberRef parented at the constructed interface's TypeSpec** (existing ADR-0087 R5 machinery), covering both methods and the property getter (a static-virtual method under the hood).
3. The two implementer-side `MethodImpl` emitters resolve the open slot, read the open definition's property table, and parent the `MethodImpl` declaration at the constructed-interface TypeSpec for generic interfaces.

No special-casing of arity; handles type-argument substitution, self-referential constraints, and both methods and get-only / get-set properties. **Both** the property-bind gap and the method/property-emit gap are fully fixed — bind, IL-verify, and run.

## Tests

- `test/Core.Tests/CodeAnalysis/Binding/Issue1268StaticVirtualGenericInterfaceTests.cs` — property/method through `IData[int32]` and self-referential `IData[T]`, get-only and get-set, plus a negative GS0333 case.
- `test/Compiler.Tests/Emit/Issue1268StaticVirtualGenericInterfaceEmitTests.cs` — compile a concrete implementer, IL-verify, execute, and assert the runtime value for method, get-only property, get-set property, and a non-self-referential generic constraint.

### Verification
- `dotnet build GSharp.sln -c Release -graph` → 0 errors / 0 warnings.
- `dotnet test test/Core.Tests` → 4395 passed.
- Filtered `Compiler.Tests`: `Issue1268` (4), `StaticVirtual` (13), `Issue1019|1030|765|985` (17), `Interface` (184) all pass.

Fixes #1268