### PR TITLE
Fix #1270: evaluate expression-bodied property accessors

### DIFF
--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -2821,6 +2821,17 @@ public class Parser
                 {
                     body = ParseBlockStatement();
                 }
+                else if (IsAccessorExpressionBodyArrow())
+                {
+                    // Issue #1270: an expression-bodied accessor `get => e` /
+                    // `set => e`. Desugar at parse time into an equivalent block
+                    // body so binding and emit reuse the existing accessor-body
+                    // path: a getter becomes `{ return e }` and a setter/init
+                    // becomes `{ e }` (an expression statement). Without this the
+                    // `=> e` tokens were silently skipped, leaving a body-less
+                    // accessor that returned the type's default value.
+                    body = ParseAccessorExpressionBody(accessorKeyword.Text == "get");
+                }
                 else if (Current.Kind == SyntaxKind.SemicolonToken)
                 {
                     semicolon = NextToken();
@@ -2849,6 +2860,49 @@ public class Parser
         }
 
         return accessors.ToImmutable();
+    }
+
+    // Issue #1270: detect the start of an expression-bodied accessor arrow
+    // `=>`. The lexer produces `=>` as adjacent `=` (EqualsToken) and `>`
+    // (GreaterToken) tokens, so a fat arrow is the pair with no intervening
+    // characters. Requiring adjacency avoids misreading a stray `= >`.
+    private bool IsAccessorExpressionBodyArrow()
+        => Current.Kind == SyntaxKind.EqualsToken
+            && Peek(1).Kind == SyntaxKind.GreaterToken
+            && Current.Position + (Current.Text?.Length ?? 0) == Peek(1).Position;
+
+    // Issue #1270: parse the `=> expr` tail of an expression-bodied accessor and
+    // synthesize an equivalent block body. A getter lowers to `{ return expr }`;
+    // a setter/init lowers to `{ expr }` (an expression statement). The
+    // synthesized braces reuse the arrow's source position so diagnostics and
+    // spans remain anchored at the accessor.
+    private BlockStatementSyntax ParseAccessorExpressionBody(bool isGetter)
+    {
+        var equalsToken = NextToken();
+        var greaterToken = NextToken();
+        var arrowPosition = equalsToken.Position;
+
+        var expression = ParseExpression();
+
+        var openBrace = new SyntaxToken(syntaxTree, SyntaxKind.OpenBraceToken, arrowPosition, "{", null);
+        var closeBrace = new SyntaxToken(syntaxTree, SyntaxKind.CloseBraceToken, greaterToken.Position, "}", null);
+
+        StatementSyntax statement;
+        if (isGetter)
+        {
+            var returnKeyword = new SyntaxToken(syntaxTree, SyntaxKind.ReturnKeyword, arrowPosition, "return", null);
+            statement = new ReturnStatementSyntax(syntaxTree, returnKeyword, expression);
+        }
+        else
+        {
+            statement = new ExpressionStatementSyntax(syntaxTree, expression);
+        }
+
+        return new BlockStatementSyntax(
+            syntaxTree,
+            openBrace,
+            ImmutableArray.Create(statement),
+            closeBrace);
     }
 
     private FieldDeclarationSyntax ParseFieldDeclaration()

--- a/test/Compiler.Tests/Emit/Issue1270ExpressionBodiedAccessorEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1270ExpressionBodiedAccessorEmitTests.cs
@@ -1,0 +1,213 @@
+// <copyright file="Issue1270ExpressionBodiedAccessorEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1270: an expression-bodied property getter <c>prop P T { get => e }</c>
+/// silently returned the type's default value instead of evaluating <c>e</c> —
+/// the IL verified and ran but yielded the wrong value with no diagnostic. The
+/// parser dropped the <c>=> e</c> tokens, leaving a body-less accessor.
+///
+/// The fix desugars an expression-bodied accessor at parse time: a getter becomes
+/// <c>{ return e }</c> and a setter/init becomes <c>{ e }</c>. These end-to-end
+/// emit tests compile, ilverify, execute, and assert the runtime values for both
+/// instance and static getters (with constant, field, computed, and conditional
+/// bodies), an expression-bodied setter, and the block-bodied controls.
+/// </summary>
+public class Issue1270ExpressionBodiedAccessorEmitTests
+{
+    [Fact]
+    public void ExpressionBodiedGetters_InstanceAndStatic_EvaluateExpression()
+    {
+        var source = """
+            package p
+            import System
+            class C {
+                prop R int32 { get => 5 }
+                prop S int32 { get { return 5 } }
+                shared {
+                    prop P int32 { get => 7 }
+                    prop Q int32 { get { return 7 } }
+                }
+            }
+            let c = C()
+            Console.WriteLine(c.R)
+            Console.WriteLine(c.S)
+            Console.WriteLine(C.P)
+            Console.WriteLine(C.Q)
+            """;
+
+        Assert.Equal("5\n5\n7\n7\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void ExpressionBodiedGetter_NonConstantFieldSum_EvaluatesAtRuntime()
+    {
+        var source = """
+            package p
+            import System
+            class C {
+                let a int32
+                let b int32
+                prop Sum int32 { get => this.a + this.b }
+                init(x int32, y int32) {
+                    this.a = x
+                    this.b = y
+                }
+            }
+            let c = C(3, 4)
+            Console.WriteLine(c.Sum)
+            """;
+
+        Assert.Equal("7\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void ExpressionBodiedGetter_ReadInLargerExpression_EvaluatesEachAccess()
+    {
+        var source = """
+            package p
+            import System
+            class C {
+                let n int32
+                prop Doubled int32 { get => this.n * 2 }
+                init(v int32) {
+                    this.n = v
+                }
+            }
+            let c = C(6)
+            Console.WriteLine(c.Doubled + c.Doubled + 1)
+            """;
+
+        Assert.Equal("25\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void ExpressionBodiedGetter_ConditionalAndMethodCallBody_Evaluates()
+    {
+        var source = """
+            package p
+            import System
+            class C {
+                let n int32
+                prop Label string { get => this.n > 10 ? "big" : "small" }
+                prop Text string { get => this.n.ToString() }
+                init(v int32) {
+                    this.n = v
+                }
+            }
+            let c = C(42)
+            Console.WriteLine(c.Label)
+            Console.WriteLine(c.Text)
+            """;
+
+        Assert.Equal("big\n42\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void ExpressionBodiedSetter_RunsAssignmentExpression()
+    {
+        var source = """
+            package p
+            import System
+            class C {
+                var w int32
+                prop W int32 { get => this.w  set => this.w = value }
+            }
+            let c = C()
+            c.W = 42
+            Console.WriteLine(c.W)
+            """;
+
+        Assert.Equal("42\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1270_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Syntax/PropertyParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/PropertyParserTests.cs
@@ -245,4 +245,55 @@ public class PropertyParserTests
         var propDecl = structDecl.Properties.Single();
         Assert.True(propDecl.Accessors.Single(a => a.IsInit).IsInit);
     }
+
+    [Fact]
+    public void ParsesExpressionBodiedGetter_NoDiagnostics()
+    {
+        // Issue #1270: `prop P T { get => e }` is an expression-bodied getter.
+        const string source = "package P\nclass Foo {\n  prop X int32 { get => 5 }\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+    }
+
+    [Fact]
+    public void ExpressionBodiedGetter_DesugarsToBlockWithReturn()
+    {
+        // Issue #1270: the parser desugars `get => e` into a synthesized block
+        // `{ return e }` so binding/emit reuse the existing accessor-body path.
+        const string source = "package P\nclass Foo {\n  prop X int32 { get => 5 }\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var structDecl = tree.Root.Members.OfType<StructDeclarationSyntax>().Single();
+        var accessor = structDecl.Properties.Single().Accessors.Single();
+        Assert.True(accessor.IsGetter);
+        Assert.NotNull(accessor.Body);
+        var statement = Assert.Single(accessor.Body.Statements);
+        Assert.IsType<ReturnStatementSyntax>(statement);
+    }
+
+    [Fact]
+    public void ExpressionBodiedSetter_DesugarsToBlockWithExpressionStatement()
+    {
+        // Issue #1270: a `set => e` desugars to `{ e }` (an expression
+        // statement), NOT an implicit return, because the setter is void.
+        const string source = "package P\nclass Foo {\n  var n int32\n  prop X int32 { get => this.n  set => this.n = value }\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var structDecl = tree.Root.Members.OfType<StructDeclarationSyntax>().Single();
+        var setter = structDecl.Properties.Single().Accessors.Single(a => a.IsSetter);
+        Assert.NotNull(setter.Body);
+        var statement = Assert.Single(setter.Body.Statements);
+        Assert.IsType<ExpressionStatementSyntax>(statement);
+    }
+
+    [Fact]
+    public void ParsesExpressionBodiedGetterOnInterface_NoDiagnostics()
+    {
+        // Issue #1270: default interface getter via expression body.
+        const string source = "package P\ninterface I {\n  prop X int32 { get => 5 }\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+    }
 }


### PR DESCRIPTION
## Bug

An **expression-bodied property getter** `prop P T { get => <expr> }` silently returned the type's **default value** (e.g. `0`) at runtime instead of evaluating `<expr>` — with **no compile diagnostic**. The IL verified and ran but produced the wrong value. The block-body form `get { return <expr> }` worked. The defect affected **both static and instance** properties.

### Repro (before)
```gsharp
package p
import System
class C {
  prop R int32 { get => 5 }
  prop S int32 { get { return 5 } }
  shared {
    prop P int32 { get => 7 }
    prop Q int32 { get { return 7 } }
  }
}
let c = C()
Console.WriteLine(c.R)   // 0  (WRONG, expected 5)
Console.WriteLine(c.S)   // 5  (correct)
Console.WriteLine(C.P)   // 0  (WRONG, expected 7)
Console.WriteLine(C.Q)   // 7  (correct)
```
Before: `0 / 5 / 0 / 7`. After: `5 / 5 / 7 / 7`.

## Root cause

`ParsePropertyAccessors` in `Parser.cs` only handled a `{ ... }` block body or a `;`/bare accessor. The `=> e` arrow form was never recognized, so the `=>` and expression tokens were silently consumed by the unknown-token skip loop. The accessor was left **body-less**, which made the property behave like an auto/bare accessor returning the backing default value — no diagnostic, wrong runtime result.

## Fix

Parse the `=> e` expression-body form for accessors and desugar it **at parse time** into the equivalent block body, so binding and emit reuse the existing accessor-body path (the general root cause — not a type-specific special case):

- getter `get => e` → `{ return e }`
- setter/init `set => e` → `{ e }` (an expression statement, since the accessor is void)

The fat arrow `=>` is recognized as adjacent `=`/`>` tokens.

## Tests

- `test/Compiler.Tests/Emit/Issue1270ExpressionBodiedAccessorEmitTests.cs` — end-to-end compile → `IlVerifier.Verify` → exec → assert for: instance & static `get => expr`, non-constant field sum `get => a + b`, get-only computed read used inside a larger expression, conditional / method-call bodies, an expression-bodied setter, plus block-body controls.
- `test/Core.Tests/CodeAnalysis/Syntax/PropertyParserTests.cs` — parser tests asserting the desugaring (getter → `ReturnStatement`, setter → `ExpressionStatement`) and clean parse on a class and an interface.

## Status

- **Getters: fully fixed** (instance + static, constant and non-constant bodies).
- **Setters: also handled** — `set => e` now runs its assignment expression correctly (covered by a test).
- Interface *default-implementation* getters with bodies remain unsupported by the binder (no DIM support); this is a pre-existing limitation independent of this change.

Fixes #1270
