### PR TITLE
Fix #1274: unify conditional arms to an imported/BCL base class

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -646,6 +646,31 @@ public sealed class Conversion
                     return Conversion.Implicit;
                 }
             }
+
+            // Issue #1274: a G# class that (transitively) derives from an
+            // imported/BCL base class (e.g. `MyStream : System.IO.Stream`)
+            // implicitly upcasts to that imported base class — or any base of
+            // it. The user class carries no ClrType during binding, so the
+            // general #521 reference upcast above (which requires
+            // `from.ClrType != null`) cannot fire. Walk the user base chain and
+            // match the first imported base class (`ImportedBaseType`) by name
+            // against the target's CLR type using IsAssignableByName, which
+            // covers the full CLR base chain of the imported base.
+            if (to?.ClrType is Type toClrClass
+                && !toClrClass.IsInterface
+                && !toClrClass.IsValueType
+                && !toClrClass.IsPointer
+                && !toClrClass.IsByRef)
+            {
+                for (var c = fromClass; c != null; c = c.BaseClass)
+                {
+                    if (c.ImportedBaseType?.ClrType is Type importedBaseClr
+                        && ClrTypeUtilities.IsAssignableByName(toClrClass, importedBaseClr))
+                    {
+                        return Conversion.Implicit;
+                    }
+                }
+            }
         }
 
         // Issue #528: a G# slice `[]T` is backed by a CLR `T[]` at runtime

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.SwitchExpr.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.SwitchExpr.cs
@@ -330,6 +330,21 @@ internal sealed partial class ExpressionBinder
                 yield return baseClass;
             }
 
+            // Issue #1274: a user class's transitive base chain may end in an
+            // imported/BCL base class (e.g. `MyStream : System.IO.Stream`),
+            // recorded as `ImportedBaseType` rather than in the `BaseClass`
+            // chain. Surface that imported base as a candidate so two sibling
+            // subclasses of the same imported base unify to it. Walk the
+            // user-base chain to find the first class carrying an imported base.
+            for (var c = structSymbol; c != null; c = c.BaseClass)
+            {
+                if (c.ImportedBaseType != null)
+                {
+                    yield return c.ImportedBaseType;
+                    break;
+                }
+            }
+
             foreach (var iface in structSymbol.Interfaces)
             {
                 yield return iface;

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
@@ -524,6 +524,26 @@ internal sealed partial class MethodBodyEmitter
             }
         }
 
+        // Issue #1274: class → imported CLR base class upcast. A user class
+        // that (transitively) derives from an imported/BCL base class (e.g.
+        // `MyStream : System.IO.Stream`) has no ClrType during emit, so the
+        // general #521 rule below cannot match. Recognise the relation
+        // structurally through the user base chain's `ImportedBaseType` so the
+        // upcast emits as a no-op reference conversion.
+        if (a is StructSymbol srcClass3 && srcClass3.IsClass
+            && b?.ClrType is System.Type bClrClass
+            && !bClrClass.IsInterface && !bClrClass.IsValueType)
+        {
+            for (var c = srcClass3; c != null; c = c.BaseClass)
+            {
+                if (c.ImportedBaseType?.ClrType is System.Type importedBaseClr
+                    && ClrTypeUtilities.IsAssignableByName(bClrClass, importedBaseClr))
+                {
+                    return true;
+                }
+            }
+        }
+
         // Issue #323: any delegate-typed value (named/generic CLR delegate
         // such as Func[string]) widens to System.Delegate /
         // System.MulticastDelegate as a no-op reference upcast.

--- a/test/Compiler.Tests/Emit/Issue1274ConditionalImportedBaseUnifyEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1274ConditionalImportedBaseUnifyEmitTests.cs
@@ -1,0 +1,152 @@
+// <copyright file="Issue1274ConditionalImportedBaseUnifyEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1274: end-to-end CLR emit coverage for unifying conditional /
+/// if-expression arms to an imported/BCL base class. When one arm is an
+/// imported base (e.g. <c>System.Exception</c>) and the other a user-defined
+/// subclass — or when both arms are user subclasses of the same imported base —
+/// the best-common-type is the imported base. The upcast must be a no-op
+/// reference conversion, so the value flowing out of the conditional keeps its
+/// concrete runtime type per the branch taken.
+/// </summary>
+public class Issue1274ConditionalImportedBaseUnifyEmitTests
+{
+    [Fact]
+    public void EndToEnd_IfExpression_ImportedBaseVsUserSubclass_PreservesConcreteType()
+    {
+        var source = """
+            package Probe
+            import System
+
+            open class MyEx : Exception { }
+
+            func Pick(b bool, e Exception) Exception {
+                return if b { e } else { MyEx() }
+            }
+
+            func Main() {
+                let baseEx = Exception("base")
+                Console.WriteLine(Pick(true, baseEx).GetType().Name)
+                Console.WriteLine(Pick(false, baseEx).GetType().Name)
+            }
+            """;
+        var output = CompileAndRun(source);
+        Assert.Equal("Exception\nMyEx\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_IfExpression_TwoUserSubclassesOfImportedBase_PreservesConcreteType()
+    {
+        var source = """
+            package Probe
+            import System
+
+            open class MyExA : Exception { }
+            open class MyExB : Exception { }
+
+            func Pick(b bool) Exception {
+                let a = MyExA()
+                let b2 = MyExB()
+                return if b { a } else { b2 }
+            }
+
+            func Main() {
+                Console.WriteLine(Pick(true).GetType().Name)
+                Console.WriteLine(Pick(false).GetType().Name)
+            }
+            """;
+        var output = CompileAndRun(source);
+        Assert.Equal("MyExA\nMyExB\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_cond1274_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1274ConditionalImportedBaseUnifyTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1274ConditionalImportedBaseUnifyTests.cs
@@ -1,0 +1,155 @@
+// <copyright file="Issue1274ConditionalImportedBaseUnifyTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1274: a conditional / if-expression whose two arms are an
+/// imported/BCL base class and a user-defined subclass of it (or two user
+/// subclasses of the same imported base) must unify to the imported base via
+/// best-common-type — matching the user-defined-base behavior. The bug was that
+/// the best-common-type ancestor enumeration (and the conversion classifier)
+/// only walked a user type's user-defined base chain (<c>BaseClass</c>) and did
+/// not recognise the imported base recorded in
+/// <see cref="GSharp.Core.CodeAnalysis.Symbols.StructSymbol.ImportedBaseType"/>.
+/// The user-defined-base controls must keep working (no regression).
+/// </summary>
+public class Issue1274ConditionalImportedBaseUnifyTests
+{
+    private const string ImportedHierarchy = @"
+import System
+open class MyEx : Exception { }
+open class MyExA : Exception { }
+open class MyExB : Exception { }
+open class MyExDeep : MyExA { }
+";
+
+    private const string UserHierarchy = @"
+open class Animal { }
+class Dog : Animal { }
+class Cat : Animal { }
+";
+
+    [Fact]
+    public void ImportedBase_TrueArm_UserSubclass_FalseArm_Unifies_NoDiagnostics()
+    {
+        var diagnostics = Bind(ImportedHierarchy + @"
+func F(b bool, e Exception) Exception {
+    return if b { e } else { MyEx() }
+}
+");
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void ImportedBase_UserSubclass_TrueArm_ImportedBase_FalseArm_Unifies_NoDiagnostics()
+    {
+        var diagnostics = Bind(ImportedHierarchy + @"
+func F(b bool, e Exception) Exception {
+    return if b { MyEx() } else { e }
+}
+");
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void TwoUserSubclasses_OfSameImportedBase_UnifyToImportedBase_NoDiagnostics()
+    {
+        var diagnostics = Bind(ImportedHierarchy + @"
+func F(b bool, x MyExA, y MyExB) Exception {
+    return if b { x } else { y }
+}
+");
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void MultiLevelUserSubclass_VsImportedBase_UnifyToImportedBase_NoDiagnostics()
+    {
+        var diagnostics = Bind(ImportedHierarchy + @"
+func F(b bool, e Exception, d MyExDeep) Exception {
+    return if b { e } else { d }
+}
+");
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void MultiLevelUserSubclasses_OnlySharedAncestorIsImportedBase_NoDiagnostics()
+    {
+        var diagnostics = Bind(ImportedHierarchy + @"
+func F(b bool, d MyExDeep, y MyExB) Exception {
+    return if b { d } else { y }
+}
+");
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void Ternary_ImportedBase_VsUserSubclass_Unifies_NoDiagnostics()
+    {
+        var diagnostics = Bind(ImportedHierarchy + @"
+func F(b bool, e Exception) Exception {
+    return b ? e : MyEx()
+}
+");
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void Control_UserBase_VsUserSubclass_StillUnifies_NoDiagnostics()
+    {
+        var diagnostics = Bind(UserHierarchy + @"
+func F(b bool, a Animal, d Dog) Animal {
+    return if b { a } else { d }
+}
+");
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void Control_SiblingUserSubclasses_StillUnify_NoDiagnostics()
+    {
+        var diagnostics = Bind(UserHierarchy + @"
+func F(b bool, c Cat, d Dog) Animal {
+    return if b { c } else { d }
+}
+");
+
+        Assert.Empty(diagnostics);
+    }
+
+    private static ImmutableArray<Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        if (tree.Diagnostics.Any())
+        {
+            return tree.Diagnostics;
+        }
+
+        var globalScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+        if (globalScope.Diagnostics.Any())
+        {
+            return globalScope.Diagnostics;
+        }
+
+        var program = Binder.BindProgram(globalScope);
+        return program.Diagnostics.ToImmutableArray();
+    }
+}


### PR DESCRIPTION
## Bug
A conditional / if-expression whose two arms are a **BCL/imported base class** and a **user-defined subclass** of it failed best-common-type computation (GS0263), even when target-typed to that base. The analogous case with a user-defined base class worked fine.

```gsharp
package p
import System.IO
open class MyStream : Stream { }
func F(b bool, file Stream) Stream { return if b { file } else { MyStream() } }
// before: error GS0263: Conditional expression branches have no common result type — 'System.IO.Stream' vs 'MyStream'.
```

## Root cause
The best-common-type ancestor enumeration for conditional arms — and the conversion classifier itself — walked a user class's **user-defined** base chain (`StructSymbol.BaseClass`) only. A user class deriving from an imported/BCL base records that base in `StructSymbol.ImportedBaseType`, separate from `BaseClass`, so the imported ancestor was invisible. This produced two gaps:

1. A user subclass did not implicitly convert to its imported base (GS0155 / GS0263).
2. Best-common-type never offered the imported base as a unification candidate (so two sibling user subclasses of the same imported base also failed).

## Fix (general — no `Stream`/`Exception` special-casing)
- **`Conversion.cs`**: classify a user class to its imported CLR base class as an implicit reference upcast by walking the user base chain's `ImportedBaseType` and matching the target's CLR type via `ClrTypeUtilities.IsAssignableByName` (covers the full CLR base chain of the imported base).
- **`ExpressionBinder.SwitchExpr.cs`**: `EnumerateSupertypeCandidates` now surfaces the first `ImportedBaseType` found along the user base chain, so two sibling user subclasses of the same imported base unify to it.
- **`MethodBodyEmitter.cs`**: `IsReferenceCompatible` recognises the user-class to imported-base-class upcast so the emitter lowers it to a no-op reference conversion; the runtime value keeps its concrete type per branch taken.

## Tests
- **Binder** (`Issue1274ConditionalImportedBaseUnifyTests`): BCL base vs user subclass (both orders), two user subclasses of the same BCL base, multi-level subclasses, ternary form, plus user-base controls (regression).
- **Emit/exec** (`Issue1274ConditionalImportedBaseUnifyEmitTests`): the conditional compiles, IL-verifies, and at runtime returns the correct concrete object (`Exception` vs `MyEx`, `MyExA` vs `MyExB`) per branch.

Full solution build (0/0), full Core.Tests, and filtered Compiler.Tests (`~Conditional`, `~IfExpression`) all pass; standalone repros now compile.

Fixes #1274
