### PR TITLE
Refs #914: cs2gs coerce non-int32 array/indexer index to int32

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue914IndexCoercionTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue914IndexCoercionTranslationTests.cs
@@ -1,0 +1,184 @@
+// <copyright file="Issue914IndexCoercionTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Translation tests for the array/indexer element-access index coercion defect
+/// discovered migrating <c>Oahu.Decrypt</c> (issue #914). G# array and indexer
+/// element access require an <c>int32</c> index; C# accepts any integral index
+/// and only widens the narrow kinds (<c>byte</c>, <c>sbyte</c>, <c>short</c>,
+/// <c>ushort</c>, <c>char</c>) to <c>int</c>. The wider/unsigned kinds
+/// (<c>uint</c>, <c>long</c>, <c>ulong</c>, <c>nint</c>, <c>nuint</c>) do not
+/// implicitly convert, so they must be coerced via the conversion-call form
+/// (<c>int32(i)</c>) (otherwise gsc reports GS0156).
+/// </summary>
+public class Issue914IndexCoercionTranslationTests
+{
+    /// <summary>
+    /// A <c>uint</c> array index is coerced to <c>int32</c>.
+    /// </summary>
+    [Fact]
+    public void ArrayIndex_UintIndex_CoercesToInt32()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public int Get(int[] arr, uint i) => arr[i];
+    }
+}");
+
+        Assert.Contains("arr[int32(i)]", printed);
+    }
+
+    /// <summary>
+    /// A <c>long</c> array index is coerced to <c>int32</c>.
+    /// </summary>
+    [Fact]
+    public void ArrayIndex_LongIndex_CoercesToInt32()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public int Get(int[] arr, long i) => arr[i];
+    }
+}");
+
+        Assert.Contains("arr[int32(i)]", printed);
+    }
+
+    /// <summary>
+    /// A computed <c>uint</c> index expression (<c>chunk - 1u</c>) is coerced to
+    /// <c>int32</c> as a whole.
+    /// </summary>
+    [Fact]
+    public void ArrayIndex_UintExpression_CoercesToInt32()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public int Get(int[] table, uint chunk) => table[chunk - 1u];
+    }
+}");
+
+        Assert.Contains("int32(", printed);
+        Assert.Contains("chunk", printed);
+    }
+
+    /// <summary>
+    /// An <c>int</c> array index already matches <c>int32</c>; no conversion call
+    /// is added.
+    /// </summary>
+    [Fact]
+    public void ArrayIndex_IntIndex_NoCoercion()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public int Get(int[] arr, int i) => arr[i];
+    }
+}");
+
+        Assert.Contains("arr[i]", printed);
+        Assert.DoesNotContain("int32(i)", printed);
+    }
+
+    /// <summary>
+    /// A <c>Dictionary&lt;string, T&gt;</c> lookup is keyed by the string; the
+    /// index must not be wrapped.
+    /// </summary>
+    [Fact]
+    public void DictionaryIndex_StringKey_NoCoercion()
+    {
+        string printed = TranslateUnit(@"
+using System.Collections.Generic;
+namespace Demo
+{
+    public class C
+    {
+        public int Get(Dictionary<string, int> map, string k) => map[k];
+    }
+}");
+
+        Assert.DoesNotContain("int32(", printed);
+    }
+
+    /// <summary>
+    /// A <c>Dictionary&lt;uint, T&gt;</c> lookup is keyed by <c>uint</c>; the
+    /// index must not be coerced to <c>int32</c> (the indexer parameter is
+    /// <c>uint</c>, not <c>int32</c>).
+    /// </summary>
+    [Fact]
+    public void DictionaryIndex_UintKey_NoCoercion()
+    {
+        string printed = TranslateUnit(@"
+using System.Collections.Generic;
+namespace Demo
+{
+    public class C
+    {
+        public int Get(Dictionary<uint, int> map, uint k) => map[k];
+    }
+}");
+
+        Assert.DoesNotContain("int32(k)", printed);
+    }
+
+    /// <summary>
+    /// A from-end index (<c>span[^1]</c>, a <c>System.Index</c>) goes through the
+    /// dedicated lowering and must not gain a spurious <c>int32(...)</c> wrap.
+    /// </summary>
+    [Fact]
+    public void SpanFromEndIndex_NoSpuriousCoercion()
+    {
+        string printed = TranslateUnit(@"
+using System;
+namespace Demo
+{
+    public class C
+    {
+        public int Last(Span<int> span) => span[^1];
+    }
+}");
+
+        Assert.DoesNotContain("int32(", printed);
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -3268,6 +3268,84 @@ public sealed class CSharpToGSharpTranslator
             return length;
         }
 
+        // G# array/indexer element access requires an `int32` index. C# accepts any
+        // integral index and implicitly widens the narrow ones (`byte`, `sbyte`,
+        // `short`, `ushort`, `char`) to `int`, but the wider/unsigned kinds
+        // (`uint`, `long`, `ulong`, `nint`, `nuint`) do NOT implicitly convert to
+        // `int32`, so gsc rejects them with GS0156. When the indexed target's index
+        // type is `int32` (an array, or an indexer whose single parameter is
+        // `int32` — e.g. `List<T>`/`Span<T>`/`IReadOnlyList<T>`) and the C# index
+        // expression has a non-`int32` integral type that does not widen, wrap the
+        // index in the conversion-call form `int32(<index>)`. Dictionary/other
+        // indexers whose key type is not `int32`, `System.Index`/`System.Range`
+        // indices, and indices already `int`/narrower are left untouched.
+        private GExpression CoerceIndexToInt32(
+            ElementAccessExpressionSyntax elementAccess, GExpression index)
+        {
+            if (elementAccess.ArgumentList.Arguments.Count != 1)
+            {
+                return index;
+            }
+
+            if (!this.IndexerTargetTypeIsInt32(elementAccess))
+            {
+                return index;
+            }
+
+            ExpressionSyntax indexSyntax = elementAccess.ArgumentList.Arguments[0].Expression;
+            ITypeSymbol indexType = this.context.GetTypeInfo(indexSyntax).Type;
+            if (indexType != null &&
+                IsNonNullableValueType(indexType) &&
+                IsIntegerNotWideningToInt32(indexType))
+            {
+                ITypeSymbol int32Type =
+                    this.context.Compilation.GetSpecialType(SpecialType.System_Int32);
+                return this.CoerceOperandTo(index, int32Type);
+            }
+
+            return index;
+        }
+
+        // Reports whether the element-access target indexes by `int32`: a C# array,
+        // or a type whose bound indexer takes a single `int32` parameter (such as
+        // `List<T>`, `Span<T>`, `IReadOnlyList<T>`). A `Dictionary<TKey, T>` or any
+        // other indexer keyed by a non-`int32` type returns false.
+        private bool IndexerTargetTypeIsInt32(ElementAccessExpressionSyntax elementAccess)
+        {
+            ITypeSymbol receiverType = this.context.GetTypeInfo(elementAccess.Expression).Type;
+            if (receiverType is IArrayTypeSymbol)
+            {
+                return true;
+            }
+
+            if (this.context.GetSymbolInfo(elementAccess).Symbol is IPropertySymbol
+                    { IsIndexer: true, Parameters.Length: 1 } indexer)
+            {
+                return indexer.Parameters[0].Type.SpecialType == SpecialType.System_Int32;
+            }
+
+            return false;
+        }
+
+        // Reports whether `type` is an integral type that does NOT implicitly widen
+        // to `int32` in C# — `uint`/`uint32`, `long`/`int64`, `ulong`/`uint64`,
+        // `nint`, and `nuint`. The narrow integrals (`byte`, `sbyte`, `short`,
+        // `ushort`, `char`) and `int` itself widen to/are `int32` and return false.
+        private static bool IsIntegerNotWideningToInt32(ITypeSymbol type)
+        {
+            switch (type.SpecialType)
+            {
+                case SpecialType.System_UInt32:
+                case SpecialType.System_Int64:
+                case SpecialType.System_UInt64:
+                case SpecialType.System_IntPtr:
+                case SpecialType.System_UIntPtr:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
         // C# `a ?? b` where `a` is a nullable numeric: G# requires `b` to match
         // the underlying numeric type of `a`, otherwise GS0129. Coerce the right
         // operand to the left's underlying (non-nullable) type when they differ.
@@ -4723,7 +4801,9 @@ public sealed class CSharpToGSharpTranslator
                     }
 
                     GExpression index = elementAccess.ArgumentList.Arguments.Count > 0
-                        ? this.TranslateExpression(elementAccess.ArgumentList.Arguments[0].Expression)
+                        ? this.CoerceIndexToInt32(
+                            elementAccess,
+                            this.TranslateExpression(elementAccess.ArgumentList.Arguments[0].Expression))
                         : new IdentifierExpression("nil");
                     return new IndexExpression(
                         this.TranslateReceiverWithNullForgiveness(elementAccess.Expression),


### PR DESCRIPTION
## Problem

G# array/indexer element access requires an `int32` index. C# allows `int`, `uint`, `long`, `ulong`, `nint`, `nuint` indices and only the narrow integral kinds (`byte`, `sbyte`, `short`, `ushort`, `char`) implicitly widen to `int`. The wider/unsigned kinds (`uint`, `long`, `ulong`, `nint`, `nuint`) do **not** implicitly convert to `int32`, so `gsc` rejects the emitted access:

```
error GS0156: Cannot convert type 'uint32' to 'int32'. An explicit conversion exists (are you missing a cast?)
```

Real `Oahu.Decrypt` sites: `frameSizes[i]` / `AscSampleRates[samplingFrequencyIndex]` (uint index), `table[chunk - 1u]` (uint index expression).

## Fix

When translating a C# element-access whose index expression has a non-widening integral type (`uint`/`long`/`ulong`/`nint`/`nuint`) **and** the indexed target's index type is `int32` (a C# array, or an indexer whose single parameter is `int32`, e.g. `List<T>`/`Span<T>`/`IReadOnlyList<T>`), wrap the index in the conversion-call form `int32(<index>)`, reusing the existing `CoerceOperandTo` helper (translator-only change).

### Precise wrap condition
Wrap iff **all** hold:
- The receiver is an array, **or** the bound indexer is a single-parameter indexer whose parameter `SpecialType == System_Int32`.
- The index expression's type is non-nullable and one of `UInt32`/`Int64`/`UInt64`/`IntPtr`/`UIntPtr`.

### Excluded (left untouched)
- Indices already `int`/`int32` and narrow integrals that widen to int.
- `System.Index` / `System.Range` (`^n`, `a..b`) — handled by the existing range/from-end lowering.
- Indexers keyed by a non-`int32` type (e.g. `Dictionary<uint,T>`, `Dictionary<string,T>`) — the indexer parameter type is checked, so the key is not wrapped.

## Tests
Adds `Issue914IndexCoercionTranslationTests` (7 tests): uint/long array indices, a computed `table[chunk - 1u]` expression, plus negative controls — `int` index (no wrap), string- and uint-keyed dictionary lookups (no wrap), and a span from-end index `span[^1]` (no spurious wrap). All 281 cs2gs tests pass.

## Corpus before/after
- **Oahu.Decrypt:** total errors **128 → 124**, `GS0156` **4 → 0**, no new errors.
- **Oahu.Foundation:** translate still **PASS** (no regression; the one remaining unrelated `GS0156` is a pre-existing `System.Version`→`string` case, out of scope).