### PR TITLE
Refs #914: translate conversion-operator bodies + coerce implicit numeric args

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue914NumericCoercionTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue914NumericCoercionTranslationTests.cs
@@ -444,6 +444,62 @@ namespace Demo
         Assert.Contains("Mode == (12 as uint8?)", printed);
     }
 
+    /// <summary>
+    /// A C# conversion operator with a block body must keep that body when
+    /// translated. The body switch in <c>TranslateBodyCore</c> previously had no
+    /// arm for <c>ConversionOperatorDeclarationSyntax</c>, so the operator was
+    /// emitted with an empty block (silently dropping the conversion logic, which
+    /// also yielded GS0100 "not all code paths return a value").
+    /// </summary>
+    [Fact]
+    public void ConversionOperator_BlockBody_IsTranslated()
+    {
+        string printed = TranslateUnit(@"
+using System;
+namespace Demo
+{
+    public readonly struct Meters
+    {
+        public Meters(int value) { Value = value; }
+        public int Value { get; }
+
+        public static implicit operator Meters(int value)
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
+            return new Meters(value);
+        }
+    }
+}");
+        Assert.Contains("func operator implicit", printed);
+        Assert.Contains("ThrowIfNegative", printed);
+        Assert.Contains("return Meters", printed);
+    }
+
+    /// <summary>
+    /// An argument whose declared numeric type differs from the type C# implicitly
+    /// converted it to at the call site (here a <c>ushort</c> constant passed where
+    /// generic inference selected <c>int</c>) must carry that conversion explicitly,
+    /// since G# performs no implicit numeric promotion at the call site (an
+    /// un-coerced operand defeats generic inference → GS0159).
+    /// </summary>
+    [Fact]
+    public void Argument_ImplicitNumericConversion_EmitsExplicitConversion()
+    {
+        string printed = TranslateUnit(@"
+using System;
+namespace Demo
+{
+    public class C
+    {
+        public void M(int x)
+        {
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(x, ushort.MaxValue);
+        }
+    }
+}");
+        Assert.Contains("int32(UInt16.MaxValue)", printed);
+    }
+
     private static string TranslateUnit(string source)
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -2567,6 +2567,7 @@ public sealed class CSharpToGSharpTranslator
             {
                 MethodDeclarationSyntax method => method.ParameterList,
                 OperatorDeclarationSyntax op => op.ParameterList,
+                ConversionOperatorDeclarationSyntax conversion => conversion.ParameterList,
                 ConstructorDeclarationSyntax ctor => ctor.ParameterList,
                 LocalFunctionStatementSyntax localFunction => localFunction.ParameterList,
                 _ => null,
@@ -2629,6 +2630,19 @@ public sealed class CSharpToGSharpTranslator
                     if (op.ExpressionBody != null)
                     {
                         return this.WrapExpressionBody(op.ExpressionBody.Expression, isVoid: false);
+                    }
+
+                    break;
+
+                case ConversionOperatorDeclarationSyntax conversion:
+                    if (conversion.Body != null)
+                    {
+                        return this.TranslateBlock(conversion.Body);
+                    }
+
+                    if (conversion.ExpressionBody != null)
+                    {
+                        return this.WrapExpressionBody(conversion.ExpressionBody.Expression, isVoid: false);
                     }
 
                     break;
@@ -5995,13 +6009,46 @@ public sealed class CSharpToGSharpTranslator
                 return new NonNullAssertionExpression(this.TranslateExpression(argument.Expression));
             }
 
-            // OD-T2: a C# integer literal implicitly converted to an unsigned
-            // parameter (e.g. `base(4)` where the parameter is `byte`) must be
-            // emitted as a typed G# literal (`uint8(4)`); G# performs no implicit
-            // signed→unsigned constant conversion at the call site (GS0214/GS0156).
-            return this.CoerceConstantToUnsigned(
+            // A C# argument whose declared numeric type differs from the type C#
+            // implicitly converted it to at the call site (e.g. a `ushort` constant
+            // passed where generic inference selected `int`, or a signed literal
+            // passed to an unsigned parameter) must carry that conversion explicitly:
+            // G# performs no implicit numeric promotion at the call site, and an
+            // un-coerced operand defeats generic inference (GS0159) or rejects the
+            // parameter (GS0156/GS0214). Honor Roslyn's converted type when both the
+            // source and converted types are numeric primitives that differ.
+            return this.CoerceNumericArgumentToConverted(
                 argument.Expression,
                 this.TranslateExpression(argument.Expression));
+        }
+
+        // Coerce an argument expression to the numeric type C# implicitly converted
+        // it to at the call site, when that converted type differs from the
+        // expression's own numeric type. This generalizes signed→unsigned constant
+        // coercion to any numeric widening/retyping (e.g. `uint16`→`int32`) that C#
+        // applies implicitly but G# does not.
+        private GExpression CoerceNumericArgumentToConverted(ExpressionSyntax expression, GExpression translated)
+        {
+            // A numeric literal is already retyped to its C# converted type by the
+            // literal-translation path (a float-promoted literal becomes a float
+            // literal `30.0`, ADR-0115 §B.12), so re-wrapping it here would double
+            // up the conversion. Constant signed→unsigned literal retyping is still
+            // applied below for integer targets.
+            if (expression is LiteralExpressionSyntax literal &&
+                literal.IsKind(SyntaxKind.NumericLiteralExpression))
+            {
+                return this.CoerceConstantToUnsigned(expression, translated);
+            }
+
+            TypeInfo info = this.context.GetTypeInfo(expression);
+            if (TryGetNumericKind(info.Type, out SpecialType sourceUnderlying) &&
+                TryGetNumericKind(info.ConvertedType, out SpecialType convertedUnderlying) &&
+                sourceUnderlying != convertedUnderlying)
+            {
+                return this.CoerceOperandTo(translated, info.ConvertedType);
+            }
+
+            return translated;
         }
 
         // `nameof(x)` takes a name reference, not a value, so its argument must


### PR DESCRIPTION
## Summary
Two cs2gs translator fixes discovered while migrating `Oahu.Decrypt` toward an error-free idiomatic G# translation (issue #914).

### 1. Conversion-operator block bodies were silently dropped
`TranslateBodyCore` had a switch over body owners but **no arm for `ConversionOperatorDeclarationSyntax`**, so a C# `public static implicit operator T(U x) { ... }` fell through to the empty-block default. The emitted G# `func operator implicit` had an empty body — losing all the conversion logic and producing **GS0100** ("not all code paths return a value"). Added arms for both block and expression bodies, and added `ConversionOperatorDeclarationSyntax` to `WithParameterShadows` so reassigned operator parameters shadow correctly.

### 2. Implicit numeric conversion on arguments is now made explicit
An argument whose declared numeric type differs from the type C# implicitly converted it to at the call site — e.g. a `ushort` constant passed to `ArgumentOutOfRangeException.ThrowIfGreaterThan(int, ushort.MaxValue)` where generic inference selects `int` — is now emitted with the explicit G# conversion (`int32(UInt16.MaxValue)`). G# performs no implicit numeric promotion at the call site, so an un-coerced operand defeats generic inference (**GS0159**) or rejects the parameter. New helper `CoerceNumericArgumentToConverted` honors Roslyn's `ConvertedType`, generalizing the prior signed→unsigned constant coercion. Numeric **literals** are deferred to the existing literal-translation path (which already retypes float-promoted literals like `30`→`30.0`) to avoid double-wrapping.

## Impact
- Oahu.Decrypt **124 → 122** compile errors (IAppleData `TrackNumber`/`DiskNumber` conversion operators now compile clean; GS0100 + 4× GS0159 cleared).
- Oahu.Foundation **translate=PASS** (no regression).

## Tests
- 2 new regression tests in `Issue914NumericCoercionTranslationTests`.
- Full solution build: 0 warnings / 0 errors.
- cs2gs tests: **286 passed**.

Refs #914