### PR TITLE
Fix #1232: implicit numeric ergonomics (shift widening/semantics, value-if width, == literals)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -4183,6 +4183,16 @@ internal sealed class DeclarationBinder
             };
         }
 
+        // Issue #1232: fold `<<`/`>>` with C#/CLR shift semantics. The shift
+        // count is masked by the LEFT operand's width (32-bit types → count &
+        // 0x1F, 64-bit types → count & 0x3F) and right-shift uses the operand's
+        // actual signedness (arithmetic for signed, logical for unsigned), so
+        // the compile-time result matches the runtime `shl`/`shr` emission.
+        if (kind is BoundBinaryOperatorKind.ShiftLeft or BoundBinaryOperatorKind.ShiftRight)
+        {
+            return FoldShift(kind, left, right);
+        }
+
         if (!TryToInt64(left, out var li) || !TryToInt64(right, out var ri))
         {
             return null;
@@ -4195,13 +4205,50 @@ internal sealed class DeclarationBinder
             BoundBinaryOperatorKind.Product => li * ri,
             BoundBinaryOperatorKind.Quotient when ri != 0 => li / ri,
             BoundBinaryOperatorKind.Remainder when ri != 0 => li % ri,
-            BoundBinaryOperatorKind.ShiftLeft => li << (int)ri,
-            BoundBinaryOperatorKind.ShiftRight => li >> (int)ri,
             BoundBinaryOperatorKind.BitwiseAnd => li & ri,
             BoundBinaryOperatorKind.BitwiseOr => li | ri,
             BoundBinaryOperatorKind.BitwiseXor => li ^ ri,
             _ => (object)null,
         };
+    }
+
+    /// <summary>
+    /// Issue #1232: folds a left/right shift over two constant operands using
+    /// the same semantics the runtime emits (bare CLR <c>shl</c>/<c>shr</c>). The shift
+    /// count is masked by the left operand's CLR width and the operation is
+    /// computed in the left operand's actual type so masking, wrap-around and
+    /// sign-extension exactly match C#. C# promotes operands narrower than
+    /// <c>int</c> to <c>int</c> (32-bit, mask 0x1F); <c>uint</c> is 32-bit;
+    /// <c>long</c>/<c>ulong</c> are 64-bit (mask 0x3F). 32-bit results are
+    /// widened back to <see cref="long"/> to preserve the Int64 return-shape the
+    /// other folded arithmetic ops use; 64-bit results keep their CLR type so
+    /// downstream narrowing to the declared const field type stays correct.
+    /// </summary>
+    private static object FoldShift(BoundBinaryOperatorKind kind, object left, object right)
+    {
+        if (!TryToInt64(right, out var rawCount))
+        {
+            return null;
+        }
+
+        var is64 = left is long or ulong;
+        var count = (int)(rawCount & (is64 ? 0x3F : 0x1F));
+        var isLeft = kind == BoundBinaryOperatorKind.ShiftLeft;
+
+        switch (left)
+        {
+            case long l:
+                return isLeft ? l << count : l >> count;
+            case ulong ul:
+                return isLeft ? ul << count : ul >> count;
+            case uint u:
+                return (long)(isLeft ? u << count : u >> count);
+            case int or short or sbyte or byte or ushort or char:
+                var i = System.Convert.ToInt32(left, System.Globalization.CultureInfo.InvariantCulture);
+                return (long)(isLeft ? i << count : i >> count);
+            default:
+                return null;
+        }
     }
 
     private static bool TryToInt64(object value, out long result)

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
@@ -661,6 +661,8 @@ internal sealed partial class ExpressionBinder
             return new BoundErrorExpression(null);
         }
 
+        TryAdaptConditionalIntegerLiteralArm(ref whenTrue, ref whenFalse);
+
         var resultType = ComputeConditionalResultType(whenTrue.Type, whenFalse.Type, targetType);
         if (resultType == null)
         {
@@ -727,6 +729,8 @@ internal sealed partial class ExpressionBinder
         {
             return new BoundErrorExpression(null);
         }
+
+        TryAdaptConditionalIntegerLiteralArm(ref whenTrue, ref whenFalse);
 
         var resultType = ComputeConditionalResultType(whenTrue.Type, whenFalse.Type, targetType);
         if (resultType == null)
@@ -918,6 +922,38 @@ internal sealed partial class ExpressionBinder
         // (c) Best-common-type (least-upper-bound) fallback: unify sibling
         // subtypes to their shared base/interface.
         return ComputeBestCommonType(new[] { left, right });
+    }
+
+    /// <summary>
+    /// Issue #1232: value-producing if/conditional ergonomics. When exactly one
+    /// branch is a compile-time constant integer literal and the OTHER branch is
+    /// a (non-literal) integer-typed expression, adapt the literal to that
+    /// integer type when its value is representable there — mirroring the
+    /// constant-integer-literal adaptation that <c>BindBinaryExpression</c>
+    /// performs for binary operands (#1144). This lets idiomatic forms such as
+    /// <c>if cond { someUint32 } else { 0 }</c> (and the equivalent
+    /// <c>cond ? someUint32 : 0</c>) unify on the wider arm's type without an
+    /// explicit cast on the <c>0</c>, exactly as C# does. An out-of-range literal
+    /// is left unchanged so the no-common-type path still reports GS0263.
+    /// </summary>
+    private void TryAdaptConditionalIntegerLiteralArm(ref BoundExpression whenTrue, ref BoundExpression whenFalse)
+    {
+        if (whenTrue is BoundLiteralExpression trueLit
+            && IsIntegerLiteralValue(trueLit.Value)
+            && whenFalse is not BoundLiteralExpression
+            && IsIntegerType(whenFalse.Type)
+            && TryAdaptIntegerLiteral(trueLit.Value, whenFalse.Type, out var adaptedTrue))
+        {
+            whenTrue = new BoundLiteralExpression(whenTrue.Syntax, adaptedTrue);
+        }
+        else if (whenFalse is BoundLiteralExpression falseLit
+            && IsIntegerLiteralValue(falseLit.Value)
+            && whenTrue is not BoundLiteralExpression
+            && IsIntegerType(whenTrue.Type)
+            && TryAdaptIntegerLiteral(falseLit.Value, whenTrue.Type, out var adaptedFalse))
+        {
+            whenFalse = new BoundLiteralExpression(whenFalse.Syntax, adaptedFalse);
+        }
     }
 
     /// <summary>
@@ -1330,6 +1366,29 @@ internal sealed partial class ExpressionBinder
                 boundRight = new BoundLiteralExpression(boundRight.Syntax, adaptedRightValue);
                 boundOperator = BoundBinaryOperator.Bind(operatorKind, boundLeft.Type, boundRight.Type);
             }
+        }
+
+        // Issue #1232: shift-count widening. C# allows the shift COUNT (the RHS
+        // of `<<` / `>>` / `<<=` / `>>=`) to be any integer that implicitly
+        // converts to `int` (sbyte/byte/short/ushort/char), promoting it to
+        // int32; the left operand alone determines the result type. G#'s shift
+        // operators take an `int32` count, so a narrower-order count previously
+        // produced GS0129. When the count's integer type implicitly widens to
+        // int32, widen it and re-bind rather than erroring. Counts that do NOT
+        // implicitly convert to int32 (uint32/int64/uint64/nint/nuint) still
+        // error — matching C#, which also rejects those count types. This must
+        // run BEFORE the generic directional widening below, which would
+        // otherwise widen the count to the LEFT operand's type and leave the
+        // shift unbound.
+        if (boundOperator == null
+            && (operatorKind == SyntaxKind.ShiftLeftToken || operatorKind == SyntaxKind.ShiftRightToken)
+            && IsIntegerType(boundLeft.Type)
+            && (IsIntegerType(boundRight.Type) || boundRight.Type == TypeSymbol.Char)
+            && boundRight.Type != TypeSymbol.Int32
+            && Conversion.Classify(boundRight.Type, TypeSymbol.Int32).IsImplicit)
+        {
+            boundRight = conversions.BindConversion(rightLocation, boundRight, TypeSymbol.Int32);
+            boundOperator = BoundBinaryOperator.Bind(operatorKind, boundLeft.Type, boundRight.Type);
         }
 
         // Issue #1150: directional implicit integer widening between two TYPED

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
@@ -527,12 +527,10 @@ internal sealed partial class MethodBodyEmitter
                 this.il.OpCode(isUnsigned ? ILOpCode.Rem_un : ILOpCode.Rem);
                 break;
             case BoundBinaryOperatorKind.ShiftLeft:
-                this.EmitShiftWithGoSemanticsGuard(ILOpCode.Shl, b.Left.Type);
+                this.il.OpCode(ILOpCode.Shl);
                 break;
             case BoundBinaryOperatorKind.ShiftRight:
-                this.EmitShiftWithGoSemanticsGuard(
-                    isUnsigned ? ILOpCode.Shr_un : ILOpCode.Shr,
-                    b.Left.Type);
+                this.il.OpCode(isUnsigned ? ILOpCode.Shr_un : ILOpCode.Shr);
                 break;
             case BoundBinaryOperatorKind.BitwiseAnd:
                 this.il.OpCode(ILOpCode.And);
@@ -741,89 +739,14 @@ internal sealed partial class MethodBodyEmitter
         }
     }
 
-    // Issue #421 (P2-2): IL `shl`/`shr`/`shr_un` mask the shift count to
-    // the low log2(stack-width) bits (5 for i4, 6 for i8). G# follows Go
-    // semantics, where a shift count >= the operand's natural width
-    // yields zero. Without this guard, `int32(1) << 33` would produce 2
-    // under the CLR mask but should produce 0 in Go. Emit a runtime
-    // check `count >= width` and substitute zero when the count is
-    // out-of-range; otherwise emit the normal shift opcode.
-    //
-    // Stack on entry: [value, count(i4)]; stack on exit: [result].
-    // For signed right shift this simplification (zero instead of
-    // sign-extension to all-ones for negative values) matches the
-    // documented G# behavior — interpreter and emitter agree on it.
-    private void EmitShiftWithGoSemanticsGuard(ILOpCode shiftOp, TypeSymbol leftType)
-    {
-        var zeroLabel = this.il.DefineLabel();
-        var endLabel = this.il.DefineLabel();
-
-        this.il.OpCode(ILOpCode.Dup);
-        this.EmitTypeBitWidth(leftType);
-        this.il.Branch(ILOpCode.Bge_un, zeroLabel);
-        this.il.OpCode(shiftOp);
-        this.il.Branch(ILOpCode.Br, endLabel);
-
-        this.il.MarkLabel(zeroLabel);
-        this.il.OpCode(ILOpCode.Pop);
-        this.il.OpCode(ILOpCode.Pop);
-        this.EmitZeroForShiftResult(leftType);
-
-        this.il.MarkLabel(endLabel);
-    }
-
-    private void EmitTypeBitWidth(TypeSymbol t)
-    {
-        if (t == TypeSymbol.Int8 || t == TypeSymbol.UInt8)
-        {
-            this.il.LoadConstantI4(8);
-        }
-        else if (t == TypeSymbol.Int16 || t == TypeSymbol.UInt16 || t == TypeSymbol.Char)
-        {
-            this.il.LoadConstantI4(16);
-        }
-        else if (t == TypeSymbol.Int32 || t == TypeSymbol.UInt32)
-        {
-            this.il.LoadConstantI4(32);
-        }
-        else if (t == TypeSymbol.Int64 || t == TypeSymbol.UInt64)
-        {
-            this.il.LoadConstantI4(64);
-        }
-        else if (t == TypeSymbol.NInt || t == TypeSymbol.NUInt)
-        {
-            // Width is sizeof(IntPtr) * 8, determined at IL runtime so
-            // 32-bit and 64-bit hosts both produce Go-correct results.
-            this.il.OpCode(ILOpCode.Sizeof);
-            this.il.Token(this.outer.GetTypeReference(typeof(IntPtr)));
-            this.il.LoadConstantI4(8);
-            this.il.OpCode(ILOpCode.Mul);
-        }
-        else
-        {
-            // Fallback (shouldn't reach here for non-integer types since
-            // shifts are only bound on integer operands).
-            this.il.LoadConstantI4(32);
-        }
-    }
-
-    private void EmitZeroForShiftResult(TypeSymbol t)
-    {
-        if (t == TypeSymbol.Int64 || t == TypeSymbol.UInt64)
-        {
-            this.il.LoadConstantI8(0);
-        }
-        else if (t == TypeSymbol.NInt || t == TypeSymbol.NUInt)
-        {
-            this.il.LoadConstantI4(0);
-            this.il.OpCode(ILOpCode.Conv_i);
-        }
-        else
-        {
-            this.il.LoadConstantI4(0);
-        }
-    }
-
+    // Issue #1232: G# shift semantics now match C#/CLR. The IL `shl`/`shr`/
+    // `shr_un` opcodes mask the shift count to the low log2(stack-width) bits
+    // (5 for an i4 stack slot — covering int32/uint32 and the sub-i4 types
+    // promoted to i4 — and 6 for i8). Native-int operands mask to the runtime
+    // pointer width. This is exactly C#'s behavior (`x << count` masks `count`
+    // by `& 0x1F` for 32-bit operands and `& 0x3F` for 64-bit operands), so the
+    // bare opcode is emitted directly with no count-range guard. (G# previously
+    // followed Go, substituting zero when the count was >= the operand width.)
     private bool TryEmitDecimalBinary(BoundBinaryOperatorKind kind)
     {
         string opName = kind switch

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -2533,41 +2533,15 @@ public sealed class Evaluator
     };
 
     // Issue #421 (P2-2): Go semantics for shift operations. The C# `<<` and
-    // `>>` operators mask the shift count to log2(width) low bits, matching
-    // ECMA-335 `shl`/`shr`. G# follows Go, where a shift count >= the
-    // operand's natural width yields zero. Match the emitter's behavior so
-    // interpreter results agree with compiled output.
-    private static int BitWidthOf(object l) => l switch
-    {
-        sbyte _ => 8,
-        byte _ => 8,
-        short _ => 16,
-        ushort _ => 16,
-        int _ => 32,
-        uint _ => 32,
-        long _ => 64,
-        ulong _ => 64,
-        nint _ => IntPtr.Size * 8,
-        nuint _ => IntPtr.Size * 8,
-        _ => 32,
-    };
-
-    private static object ZeroOfShape(object l) => l switch
-    {
-        sbyte _ => (sbyte)0,
-        byte _ => (byte)0,
-        short _ => (short)0,
-        ushort _ => (ushort)0,
-        int _ => 0,
-        uint _ => 0u,
-        long _ => 0L,
-        ulong _ => 0UL,
-        nint _ => (nint)0,
-        nuint _ => (nuint)0,
-        _ => 0,
-    };
-
-    private static object NumericShl(object l, int r) => (r < 0 || r >= BitWidthOf(l)) ? ZeroOfShape(l) : l switch
+    // Issue #1232: G# shift semantics match C#/CLR. C#'s `<<`/`>>` operators
+    // mask the shift count by the operand's stack width (`& 0x1F` for 32-bit
+    // operands — including the sub-i4 types, which C# evaluates as int — and
+    // `& 0x3F` for 64-bit operands); native-int operands mask to the runtime
+    // pointer width. C#'s own `<<`/`>>` (used below) applies exactly this
+    // masking, so the count is shifted directly with no range guard, matching
+    // the emitter's bare `shl`/`shr` opcodes. (G# previously followed Go,
+    // substituting zero when the count was >= the operand width.)
+    private static object NumericShl(object l, int r) => l switch
     {
         int li => li << r,
         long li => li << r,
@@ -2582,7 +2556,7 @@ public sealed class Evaluator
         _ => throw new InvalidOperationException($"Unsupported << on {l?.GetType()}"),
     };
 
-    private static object NumericShr(object l, int r) => (r < 0 || r >= BitWidthOf(l)) ? ZeroOfShape(l) : l switch
+    private static object NumericShr(object l, int r) => l switch
     {
         int li => li >> r,
         long li => li >> r,

--- a/test/Compiler.Tests/Emit/PrimitiveOperatorEmitTests.cs
+++ b/test/Compiler.Tests/Emit/PrimitiveOperatorEmitTests.cs
@@ -33,17 +33,19 @@ public class PrimitiveOperatorEmitTests
     [InlineData("int64", "1L << 10", "1024")]
     [InlineData("int64", "1024L >> 2", "256")]
 
-    // Issue #421 (P2-2): Go semantics — count >= width yields 0 (not CLR's masked shift).
-    [InlineData("int32", "1 << 33", "0")]
-    [InlineData("int32", "1 << 32", "0")]
-    [InlineData("int32", "100 >> 32", "0")]
-    [InlineData("uint32", "uint32(1) << 32", "0")]
-    [InlineData("uint32", "uint32(100) >> 64", "0")]
-    [InlineData("int64", "1L << 64", "0")]
-    [InlineData("int64", "1L << 100", "0")]
-    [InlineData("int64", "1024L >> 64", "0")]
-    [InlineData("uint64", "uint64(1) << 64", "0")]
-    [InlineData("uint64", "uint64(1024) >> 64", "0")]
+    // Issue #1232: shift count masking matches C#/CLR — the count is masked by
+    // the operand's stack width (`& 0x1F` for 32-bit operands, `& 0x3F` for
+    // 64-bit operands), not Go's "count >= width yields 0".
+    [InlineData("int32", "1 << 33", "2")]
+    [InlineData("int32", "1 << 32", "1")]
+    [InlineData("int32", "100 >> 32", "100")]
+    [InlineData("uint32", "uint32(1) << 32", "1")]
+    [InlineData("uint32", "uint32(100) >> 64", "100")]
+    [InlineData("int64", "1L << 64", "1")]
+    [InlineData("int64", "1L << 100", "68719476736")]
+    [InlineData("int64", "1024L >> 64", "1024")]
+    [InlineData("uint64", "uint64(1) << 64", "1")]
+    [InlineData("uint64", "uint64(1024) >> 64", "1024")]
 
     // Boundary: shift by exactly width-1 still works normally.
     [InlineData("int32", "1 << 31", "-2147483648")]
@@ -57,6 +59,42 @@ public class PrimitiveOperatorEmitTests
     public void Long_Operators_ProduceExpectedValue(string _, string expr, string expected)
     {
         Assert.Equal(expected + "\n", CompileAndRun(BuildSource(expr)));
+    }
+
+    // Issue #1232: a narrower-order integer shift count is implicitly widened to
+    // int32, and the shift runs with C#/CLR masking — end-to-end.
+    [Fact]
+    public void Shift_NarrowOrderCount_WidensAndRuns()
+    {
+        var src = """
+            package P
+            import System
+
+            func Shl(value uint32, count uint8) uint32 {
+                return value << count
+            }
+
+            Console.WriteLine(Shl(uint32(1), uint8(4)))
+            """;
+        Assert.Equal("16\n", CompileAndRun(src));
+    }
+
+    // Issue #1232: a value-producing if whose arms are a uint32 and the literal
+    // `0` unifies on uint32 without an explicit cast on the `0`.
+    [Fact]
+    public void ValueIf_Uint32AndZeroLiteral_RunsWithoutCast()
+    {
+        var src = """
+            package P
+            import System
+
+            func Pick(cond bool, u uint32) uint32 {
+                return if cond { u } else { 0 }
+            }
+
+            Console.WriteLine(Pick(false, uint32(7)))
+            """;
+        Assert.Equal("0\n", CompileAndRun(src));
     }
 
     [Theory]

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1232NumericErgonomicsBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1232NumericErgonomicsBinderTests.cs
@@ -1,0 +1,207 @@
+// <copyright file="Issue1232NumericErgonomicsBinderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1232: implicit numeric ergonomics aligning G# with C#.
+///
+/// (1) Shift-count widening — the RHS of <c>&lt;&lt;</c> / <c>&gt;&gt;</c> /
+///     <c>&lt;&lt;=</c> / <c>&gt;&gt;=</c> may be any integer that implicitly
+///     converts to <c>int32</c> (sbyte/byte/short/ushort/char); G# widens it to
+///     int32 instead of reporting GS0129. The result type stays the left
+///     operand's type. Counts that do NOT implicitly convert to int32
+///     (uint32/int64/...) still error, matching C#.
+///
+/// (2) Value-producing <c>if</c> / conditional arms — an in-range constant
+///     integer literal arm adapts to the other arm's integer type, so
+///     <c>if cond { someUint32 } else { 0 }</c> binds without an explicit cast.
+///
+/// (3) <c>==</c> (and comparison) numeric-literal ergonomics — idiomatic
+///     comparisons such as <c>someUint8 == 11</c> bind via implicit widening +
+///     in-range literal adaptation (regression coverage; nullable operands are a
+///     deliberate gap tracked by #1236).
+/// </summary>
+public class Issue1232NumericErgonomicsBinderTests
+{
+    // ── (1) Shift-count widening ───────────────────────────────────────
+
+    [Theory]
+    [InlineData("int8")]
+    [InlineData("uint8")]
+    [InlineData("int16")]
+    [InlineData("uint16")]
+    public void ShiftLeft_NarrowOrderCount_WidensToInt32(string countType)
+    {
+        var source = Wrap("func F(value uint32, count " + countType + ") uint32 { return value << count }");
+        Assert.Empty(Errors(source));
+    }
+
+    [Theory]
+    [InlineData("int8")]
+    [InlineData("uint8")]
+    [InlineData("int16")]
+    [InlineData("uint16")]
+    public void ShiftRight_NarrowOrderCount_WidensToInt32(string countType)
+    {
+        var source = Wrap("func F(value uint32, count " + countType + ") uint32 { return value >> count }");
+        Assert.Empty(Errors(source));
+    }
+
+    [Fact]
+    public void Shift_CharCount_WidensToInt32()
+    {
+        var source = Wrap("func F(value uint32, count char) uint32 { return value << count }");
+        Assert.Empty(Errors(source));
+    }
+
+    [Fact]
+    public void Shift_SubI4LeftOperand_NarrowCount_Compiles()
+    {
+        // The left operand's type is preserved; the count widens to int32.
+        var source = Wrap("func F(value uint8, count uint8) uint8 { return value << count }");
+        Assert.Empty(Errors(source));
+    }
+
+    [Fact]
+    public void CompoundShiftLeft_NarrowCount_WidensToInt32()
+    {
+        var source = Wrap(@"func F(value uint32, count uint8) uint32 {
+        var v = value
+        v <<= count
+        return v
+    }");
+        Assert.Empty(Errors(source));
+    }
+
+    [Fact]
+    public void CompoundShiftRight_NarrowCount_WidensToInt32()
+    {
+        var source = Wrap(@"func F(value uint32, count uint16) uint32 {
+        var v = value
+        v >>= count
+        return v
+    }");
+        Assert.Empty(Errors(source));
+    }
+
+    // Counts that do NOT implicitly convert to int32 still error (C# also
+    // rejects a uint/long/... shift count).
+    [Theory]
+    [InlineData("uint32")]
+    [InlineData("int64")]
+    [InlineData("uint64")]
+    public void Shift_NonWideningCount_StillErrorsGS0129(string countType)
+    {
+        var source = Wrap("func F(value uint32, count " + countType + ") uint32 { return value << count }");
+        Assert.Contains(Errors(source), d => d.Id == "GS0129");
+    }
+
+    // ── (2) Value-producing if / conditional arms ──────────────────────
+
+    [Fact]
+    public void ValueIf_Uint32ThenZeroElse_AdaptsLiteralArm()
+    {
+        var source = Wrap("func F(cond bool, u uint32) uint32 { return if cond { u } else { 0 } }");
+        Assert.Empty(Errors(source));
+    }
+
+    [Fact]
+    public void ValueIf_ZeroThenUint32Else_AdaptsLiteralArm()
+    {
+        var source = Wrap("func F(cond bool, u uint32) uint32 { return if cond { 0 } else { u } }");
+        Assert.Empty(Errors(source));
+    }
+
+    [Fact]
+    public void Ternary_Uint32AndZero_AdaptsLiteralArm()
+    {
+        var source = Wrap("func F(cond bool, u uint32) uint32 { return cond ? u : 0 }");
+        Assert.Empty(Errors(source));
+    }
+
+    [Theory]
+    [InlineData("uint8")]
+    [InlineData("int16")]
+    [InlineData("uint16")]
+    [InlineData("uint64")]
+    public void ValueIf_LiteralArm_AdaptsAcrossIntegerTypes(string type)
+    {
+        var source = Wrap("func F(cond bool, v " + type + ") " + type + " { return if cond { v } else { 0 } }");
+        Assert.Empty(Errors(source));
+    }
+
+    [Fact]
+    public void ValueIf_TypedArmsThatWiden_StillUnify()
+    {
+        // Directional widening across typed arms (uint16 widens to uint32).
+        var source = Wrap("func F(cond bool, a uint16, b uint32) uint32 { return if cond { a } else { b } }");
+        Assert.Empty(Errors(source));
+    }
+
+    [Fact]
+    public void ValueIf_OutOfRangeLiteralArm_StillErrors()
+    {
+        // 999 is not representable in uint8, so it is NOT silently adapted. The
+        // arms unify to int32 (uint8 widens to int32, like C#'s common type),
+        // and returning that int32 where uint8 is expected still errors — the
+        // out-of-range literal never wraps.
+        var source = Wrap("func F(cond bool, v uint8) uint8 { return if cond { v } else { 999 } }");
+        Assert.NotEmpty(Errors(source));
+    }
+
+    // ── (3) == / comparison numeric-literal ergonomics ─────────────────
+
+    [Theory]
+    [InlineData("c == 11")]
+    [InlineData("c != 11")]
+    [InlineData("c < 11")]
+    [InlineData("c >= 11")]
+    public void Comparison_Uint8WithIntLiteral_Compiles(string expr)
+    {
+        var source = Wrap("func F(c uint8) bool { return " + expr + " }");
+        Assert.Empty(Errors(source));
+    }
+
+    [Fact]
+    public void Equality_Uint32WithZeroLiteral_Compiles()
+    {
+        var source = Wrap("func F(u uint32) bool { return u == 0 }");
+        Assert.Empty(Errors(source));
+    }
+
+    [Fact]
+    public void Equality_MixedWidthNonNullable_WidensImplicitly()
+    {
+        var source = Wrap("func F(a uint16, b uint32) bool { return a == b }");
+        Assert.Empty(Errors(source));
+    }
+
+    private static string Wrap(string member)
+    {
+        return @"
+package p
+class C {
+    " + member + @"
+}
+";
+    }
+
+    private static IReadOnlyList<Diagnostic> Errors(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new GSharp.Core.CodeAnalysis.Compilation.Compilation(tree);
+        using var peStream = new System.IO.MemoryStream();
+        return compilation.Emit(peStream).Diagnostics
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .ToList();
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue1232ConstShiftFoldingEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue1232ConstShiftFoldingEmitTests.cs
@@ -1,0 +1,182 @@
+// <copyright file="Issue1232ConstShiftFoldingEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #1232: compile-time constant folding of <c>&lt;&lt;</c>/<c>&gt;&gt;</c>
+/// must match the C#/CLR runtime shift semantics the same change aligned the
+/// emitter to (bare <c>shl</c>/<c>shr</c>, i.e. the count is masked by the LEFT
+/// operand's width — 32-bit types mask the count with 0x1F, 64-bit types with
+/// 0x3F — and right-shift uses the operand's actual signedness). These
+/// end-to-end emit+run tests prove the folded compile-time values equal what C#
+/// produces at runtime, rather than the previous Int64-only fold that masked
+/// every shift count with 0x3F and lost the operand width.
+/// </summary>
+public class Issue1232ConstShiftFoldingEmitTests
+{
+    [Fact]
+    public void Int32ConstShiftLeft_CountExceeds32_MasksWith0x1F()
+    {
+        // C#: `(int)(1 << 33)` == `1 << (33 & 0x1F)` == `1 << 1` == 2.
+        // The old Int64 fold produced `1L << 33` == 8589934592 (masked 0x3F).
+        const string Source = @"package P
+class C {
+    shared {
+        const X int32 = 1 << 33
+    }
+}
+func main() int32 {
+    return C.X
+}
+";
+        var (asm, ctx) = CompileToAssembly(Source, nameof(Int32ConstShiftLeft_CountExceeds32_MasksWith0x1F));
+        try
+        {
+            Assert.Equal(2, GetProgramMethod(asm, "main").Invoke(null, null));
+        }
+        finally
+        {
+            ctx.Unload();
+        }
+    }
+
+    [Fact]
+    public void Int64ConstShiftLeft_CountExceeds64_MasksWith0x3F()
+    {
+        // C#: `1L << 100` == `1L << (100 & 0x3F)` == `1L << 36` == 68719476736.
+        const string Source = @"package P
+class C {
+    shared {
+        const X int64 = 1L << 100
+    }
+}
+func main() int64 {
+    return C.X
+}
+";
+        var (asm, ctx) = CompileToAssembly(Source, nameof(Int64ConstShiftLeft_CountExceeds64_MasksWith0x3F));
+        try
+        {
+            Assert.Equal(68719476736L, GetProgramMethod(asm, "main").Invoke(null, null));
+        }
+        finally
+        {
+            ctx.Unload();
+        }
+    }
+
+    [Fact]
+    public void UInt32ConstShiftRight_LogicalShift_FoldsToCorrectValue()
+    {
+        // C#: `0xFFFFFFFFu >> 1` (logical) == 0x7FFFFFFF == 2147483647.
+        const string Source = @"package P
+class C {
+    shared {
+        const X uint32 = 0xFFFFFFFFu >> 1
+    }
+}
+func main() uint32 {
+    return C.X
+}
+";
+        var (asm, ctx) = CompileToAssembly(Source, nameof(UInt32ConstShiftRight_LogicalShift_FoldsToCorrectValue));
+        try
+        {
+            Assert.Equal(0x7FFFFFFFu, GetProgramMethod(asm, "main").Invoke(null, null));
+        }
+        finally
+        {
+            ctx.Unload();
+        }
+    }
+
+    [Fact]
+    public void UInt64ConstShiftRight_LogicalShift_FoldsToCorrectValue()
+    {
+        // C#: `0xFFFFFFFFFFFFFFFFul >> 1` (logical) == 0x7FFFFFFFFFFFFFFF.
+        const string Source = @"package P
+class C {
+    shared {
+        const X uint64 = 0xFFFFFFFFFFFFFFFFul >> 1
+    }
+}
+func main() uint64 {
+    return C.X
+}
+";
+        var (asm, ctx) = CompileToAssembly(Source, nameof(UInt64ConstShiftRight_LogicalShift_FoldsToCorrectValue));
+        try
+        {
+            Assert.Equal(0x7FFFFFFFFFFFFFFFUL, GetProgramMethod(asm, "main").Invoke(null, null));
+        }
+        finally
+        {
+            ctx.Unload();
+        }
+    }
+
+    [Fact]
+    public void Int32ConstShiftRight_NegativeArithmetic_MasksWith0x1F()
+    {
+        // C#: `(int)(-8 >> 33)` == `-8 >> (33 & 0x1F)` == `-8 >> 1` == -4
+        // (arithmetic, sign-extending). The old Int64 fold produced
+        // `-8L >> 33` == -1.
+        const string Source = @"package P
+class C {
+    shared {
+        const X int32 = -8 >> 33
+    }
+}
+func main() int32 {
+    return C.X
+}
+";
+        var (asm, ctx) = CompileToAssembly(Source, nameof(Int32ConstShiftRight_NegativeArithmetic_MasksWith0x1F));
+        try
+        {
+            Assert.Equal(-4, GetProgramMethod(asm, "main").Invoke(null, null));
+        }
+        finally
+        {
+            ctx.Unload();
+        }
+    }
+
+    private static (Assembly asm, AssemblyLoadContext ctx) CompileToAssembly(string source, string contextName)
+    {
+        using var peStream = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Emit(peStream);
+
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(contextName, isCollectible: true);
+        var asm = loadContext.LoadFromStream(peStream);
+        return (asm, loadContext);
+    }
+
+    private static MethodInfo GetProgramMethod(Assembly asm, string name)
+    {
+        var programType = asm.GetTypes().FirstOrDefault(t => t.Name == "<Program>");
+        Assert.NotNull(programType);
+        var method = programType!.GetMethod(name, BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        return method!;
+    }
+}

--- a/test/Interpreter.Tests/PrimitiveInterpreterTests.cs
+++ b/test/Interpreter.Tests/PrimitiveInterpreterTests.cs
@@ -30,15 +30,16 @@ public class PrimitiveInterpreterTests
     [InlineData("1L << 10", "1024")]
     [InlineData("1024L >> 2", "256")]
 
-    // Issue #421 (P2-2): Go semantics — count >= width yields 0.
-    [InlineData("1 << 33", "0")]
-    [InlineData("1 << 32", "0")]
-    [InlineData("100 >> 32", "0")]
-    [InlineData("1L << 64", "0")]
-    [InlineData("1L << 100", "0")]
-    [InlineData("1024L >> 64", "0")]
-    [InlineData("uint32(1) << 32", "0")]
-    [InlineData("uint64(1) << 64", "0")]
+    // Issue #1232: shift count masking matches C#/CLR (`& 0x1F` for 32-bit
+    // operands, `& 0x3F` for 64-bit operands), not Go's "count >= width = 0".
+    [InlineData("1 << 33", "2")]
+    [InlineData("1 << 32", "1")]
+    [InlineData("100 >> 32", "100")]
+    [InlineData("1L << 64", "1")]
+    [InlineData("1L << 100", "68719476736")]
+    [InlineData("1024L >> 64", "1024")]
+    [InlineData("uint32(1) << 32", "1")]
+    [InlineData("uint64(1) << 64", "1")]
 
     // Boundary: shift by exactly width-1 still works normally.
     [InlineData("1 << 31", "-2147483648")]

--- a/tools/cs2gs/Cs2Gs.Tests/Issue914NumericCoercionTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue914NumericCoercionTranslationTests.cs
@@ -237,13 +237,13 @@ namespace Demo
     }
 
     /// <summary>
-    /// A shift count of a non-<c>int32</c> integral (here <c>byte</c>, which C#
-    /// implicitly widens to <c>int</c>) is wrapped as <c>int32(count)</c> so the
-    /// shift binds in G# (which requires an <c>int32</c> shift count; a
-    /// <c>uint8</c>/<c>uint32</c> count is GS0129).
+    /// Issue #1232: a shift count of a narrower-order integral (here <c>byte</c>,
+    /// which C# implicitly widens to <c>int</c>) is emitted idiomatically — gsc now
+    /// implicitly widens the count to <c>int32</c>, so no <c>int32(count)</c> wrap
+    /// is produced.
     /// </summary>
     [Fact]
-    public void Shift_NonInt32Count_WrapsInInt32Conversion()
+    public void Shift_NonInt32Count_LeftIdiomatic()
     {
         string printed = TranslateUnit(@"
 namespace Demo
@@ -254,7 +254,8 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("value << int32(count)", printed);
+        Assert.Contains("value << count", printed);
+        Assert.DoesNotContain("int32(count)", printed);
     }
 
     /// <summary>
@@ -278,12 +279,14 @@ namespace Demo
     }
 
     /// <summary>
-    /// A compound shift-assignment <c>value &lt;&lt;= count</c> coerces the count to
-    /// <c>int32</c>, NOT to the left operand's numeric type (the previous behavior
-    /// wrongly emitted <c>uint32(count)</c>, yielding GS0129).
+    /// Issue #1232: a compound shift-assignment <c>value &lt;&lt;= count</c> with a
+    /// narrower-order count is emitted idiomatically (no count coercion). gsc widens
+    /// the count to <c>int32</c>; the translator must NOT coerce it to the left
+    /// operand's numeric type (which previously produced the GS0129-rejected
+    /// <c>uint32(count)</c>).
     /// </summary>
     [Fact]
-    public void CompoundShiftAssignment_NonInt32Count_CoercesCountToInt32()
+    public void CompoundShiftAssignment_NonInt32Count_LeftIdiomatic()
     {
         string printed = TranslateUnit(@"
 namespace Demo
@@ -298,18 +301,19 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("value <<= int32(count)", printed);
+        Assert.Contains("value <<= count", printed);
+        Assert.DoesNotContain("int32(count)", printed);
         Assert.DoesNotContain("uint32(count)", printed);
     }
 
     /// <summary>
-    /// A ternary whose arms are differing numeric primitives coerces the diverging
-    /// arm to the conditional's non-nullable numeric result type (G# has no implicit
-    /// numeric promotion; mismatched arms are GS0263). Here C#'s common type of
-    /// <c>1u</c> and <c>0</c> is <c>uint</c>, so the <c>0</c> arm becomes <c>uint32(0)</c>.
+    /// Issue #1232: a ternary whose arms are differing numeric primitives where one
+    /// arm is an in-range constant literal is emitted idiomatically — gsc now adapts
+    /// the literal to the other arm's type, so `b ? 1u : 0` translates to
+    /// <c>if b { 1u } else { 0 }</c> with no <c>uint32(0)</c> cast.
     /// </summary>
     [Fact]
-    public void Ternary_DivergingNumericArms_CoercesToResultType()
+    public void Ternary_DivergingNumericArms_LeftIdiomatic()
     {
         string printed = TranslateUnit(@"
 namespace Demo
@@ -320,7 +324,8 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("uint32(0)", printed);
+        Assert.Contains("if b { 1u } else { 0 }", printed);
+        Assert.DoesNotContain("uint32(0)", printed);
     }
 
     /// <summary>

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -3119,16 +3119,11 @@ public sealed class CSharpToGSharpTranslator
                 return this.TranslateNullCoalescing(binary, left, right);
             }
 
-            // C# shifts (`<<` / `>>`) take the result type from the left operand and
-            // allow any integral count; G# requires the shift count (RHS) to be
-            // `int32` (a `uint32`/`uint8`/... count yields GS0129). Coerce the count
-            // to int32 when it isn't already.
-            if (op == "<<" || op == ">>")
-            {
-                return new BinaryExpression(
-                    left, op, this.CoerceShiftCountToInt32(binary.Right, right));
-            }
-
+            // Issue #1232: G# now matches C#'s shift-count ergonomics — gsc
+            // implicitly widens a narrower-order integer shift count to int32 —
+            // so `<<` / `>>` translate straight through with no count coercion.
+            // (`<<` / `>>` are not numeric-promotion operators, so they fall
+            // through to the plain binary form below.)
             if (!IsNumericPromotionOperator(op))
             {
                 return new BinaryExpression(left, op, right);
@@ -3202,13 +3197,16 @@ public sealed class CSharpToGSharpTranslator
                 return rhs;
             }
 
-            // Compound shift (`<<=` / `>>=`): the RHS is a shift count, which G#
-            // requires to be `int32` — NOT the LHS numeric type. Coerce the count to
-            // int32 (e.g. `value <<= n` where `n` is `uint32` → `value <<= int32(n)`).
+            // Issue #1232: compound shift (`<<=` / `>>=`). The RHS is a shift
+            // count, NOT the LHS numeric type — gsc now implicitly widens a
+            // narrower-order integer count to int32, so the count needs no
+            // coercion. Return it unchanged (and, crucially, skip the LHS-type
+            // numeric promotion below, which would wrongly coerce the count to
+            // the LHS type, e.g. `uint32(count)` → GS0129).
             if (assignment.IsKind(SyntaxKind.LeftShiftAssignmentExpression) ||
                 assignment.IsKind(SyntaxKind.RightShiftAssignmentExpression))
             {
-                return this.CoerceShiftCountToInt32(assignment.Right, rhs);
+                return rhs;
             }
 
             ITypeSymbol leftType = this.context.GetTypeInfo(assignment.Left).Type;
@@ -3222,28 +3220,6 @@ public sealed class CSharpToGSharpTranslator
             }
 
             return rhs;
-        }
-
-        // G# requires a shift count (the RHS of `<<` / `>>` / `<<=` / `>>=`) to be
-        // `int32`; C# infers the shift result from the left operand and accepts any
-        // integral count. Coerce a non-`int32` numeric count to int32 via the
-        // conversion-call form so the shift binds (avoids GS0129). A nullable or
-        // non-numeric count is left unchanged.
-        private GExpression CoerceShiftCountToInt32(
-            ExpressionSyntax countSyntax, GExpression count)
-        {
-            ITypeSymbol countType = this.context.GetTypeInfo(countSyntax).Type;
-            if (countType != null &&
-                IsNonNullableValueType(countType) &&
-                TryGetNumericKind(countType, out SpecialType underlying) &&
-                underlying != SpecialType.System_Int32)
-            {
-                ITypeSymbol int32Type =
-                    this.context.Compilation.GetSpecialType(SpecialType.System_Int32);
-                return this.CoerceOperandTo(count, int32Type);
-            }
-
-            return count;
         }
 
         // C# array-creation lengths accept any integral type (`new T[uint]`,
@@ -3368,11 +3344,15 @@ public sealed class CSharpToGSharpTranslator
         }
 
         // C# ternary `cond ? a : b` lowers to the G# value-position `if` expression.
-        // When both arms are numeric primitives whose types differ from the
-        // conditional's overall (non-nullable) numeric result type, G# has no
-        // implicit numeric promotion and reports GS0263 ("branches have no common
-        // result type"). Coerce each diverging arm to the result type via the
-        // conversion-call form (e.g. `cond ? 1u : 0` → `if cond { 1u } else { uint32(0) }`).
+        // Issue #1232: gsc now matches C#'s numeric ergonomics for conditional arms
+        // — it adapts an in-range constant integer literal arm and implicitly widens
+        // a narrower typed arm to the other arm's type. So a coercion is only needed
+        // for the residual case G# still cannot unify on its own: when C#'s common
+        // result type is STRICTLY WIDER than BOTH arm types (e.g. `cond ? u16 : i16`
+        // whose C# common type is `int`, which equals neither arm). There we coerce
+        // both diverging arms to the result type via the conversion-call form. The
+        // idiomatic `cond ? 1u : 0` now translates to `if cond { 1u } else { 0 }`
+        // (no cast on the `0`), letting gsc adapt the literal.
         private GExpression TranslateConditionalExpression(
             ConditionalExpressionSyntax conditional)
         {
@@ -3388,17 +3368,12 @@ public sealed class CSharpToGSharpTranslator
                 IsNonNullableValueType(resultType) &&
                 TryGetNumericKind(resultType, out SpecialType resultUnderlying) &&
                 TryGetNumericKind(trueType, out SpecialType trueUnderlying) &&
-                TryGetNumericKind(falseType, out SpecialType falseUnderlying))
+                TryGetNumericKind(falseType, out SpecialType falseUnderlying) &&
+                resultUnderlying != trueUnderlying &&
+                resultUnderlying != falseUnderlying)
             {
-                if (trueUnderlying != resultUnderlying)
-                {
-                    whenTrue = this.CoerceOperandTo(whenTrue, resultType);
-                }
-
-                if (falseUnderlying != resultUnderlying)
-                {
-                    whenFalse = this.CoerceOperandTo(whenFalse, resultType);
-                }
+                whenTrue = this.CoerceOperandTo(whenTrue, resultType);
+                whenFalse = this.CoerceOperandTo(whenFalse, resultType);
             }
 
             return new IfExpression(condition, whenTrue, whenFalse);


### PR DESCRIPTION
Fixes #1232.

Brings G# numeric ergonomics in line with C# and reverts the cs2gs gymnastics introduced by #1228.

## gsc changes
- **Shift-count widening**: narrow-order integer shift counts (int8/uint8/int16/uint16/char) are now implicitly widened to int32 instead of erroring GS0129, matching C# where the count operand is an int. Counts that do not implicitly convert to int32 (uint32/int64/uint64/nint/nuint) still error, as in C#.
- **Shift semantics**: `<<`, `>>`, `<<=`, `>>=` now follow C#/CLR count masking (e.g. `1 << 33 == 2`, `1L << 100 == 68719476736`) instead of the prior Go-style "count >= width -> 0" behavior. The special-case guards were removed from both the IL emitter and the interpreter, since the bare CLR `shl`/`shr` opcodes (and C#'s own operators in the interpreter) already mask the count.
- **Value-producing if/conditional**: an in-range integer literal arm is now adapted to the other arm's wider numeric type (e.g. `if cond { someUint32 } else { 0 }`) via the existing literal-adaptation + widening lattice, instead of forcing explicit casts.
- **`==` / comparison literal ergonomics**: covered by existing implicit widening + in-range literal adaptation; added regression tests.

## cs2gs changes
Reverted the #1228 gymnastics now that gsc accepts the idiomatic forms: removed `CoerceShiftCountToInt32`, shifts pass through unchanged, dropped compound-shift RHS coercion, and conditional arms are only coerced when the result type differs from both arm types.

## Tests
- New `Issue1232NumericErgonomicsBinderTests` (30 tests) covering shift-count widening, value-if/ternary literal adaptation, and `==`/comparison ergonomics.
- Updated shift emit/interpreter InlineData to C# masked results; added end-to-end facts for narrow-order shift count and value-if.
- Rewrote cs2gs Issue914 shift/ternary tests to assert idiomatic output.
- Full Core.Tests pass; targeted Compiler.Tests filters (shift/conditional/numeric/nullable/enum/comparison) pass.

## Out of scope
Nullable-operand numeric widening remains a deliberate gap, tracked separately as #1236.
