### PR TITLE
Fix #1283: apply user-defined implicit conversion operators at target-typed positions

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -432,6 +432,25 @@ internal sealed class ConversionClassifier
                 return new BoundCallExpression(null, userConvOp, ImmutableArray.Create(converted));
             }
 
+            // Issue #1283: lifted user-defined conversion to a nullable target.
+            // When the target is `U?` and the source `T` has a user-defined
+            // op_Implicit (or op_Explicit at an explicit position) producing the
+            // underlying `U`, apply the operator and then nullable-wrap the
+            // result (`U` -> `U?`). The recursive BindConversion call performs
+            // the standard nullable-wrap; it cannot recurse into a second
+            // user-defined operator because the produced value already has type
+            // `U`, the nullable's underlying type.
+            if (type is NullableTypeSymbol nullableTarget
+                && nullableTarget.UnderlyingType != expression.Type
+                && TryResolveUserDefinedSymbolConversion(expression.Type, nullableTarget.UnderlyingType, allowExplicit, out var liftedConvOp))
+            {
+                var liftedArg = liftedConvOp.Parameters.Length == 1
+                    ? BindConversion(diagnosticLocation, expression, liftedConvOp.Parameters[0].Type, allowExplicit)
+                    : expression;
+                var producedUnderlying = new BoundCallExpression(null, liftedConvOp, ImmutableArray.Create(liftedArg));
+                return BindConversion(diagnosticLocation, producedUnderlying, type, allowExplicit);
+            }
+
             // Stream E: fall back to a user-defined op_Implicit (and
             // op_Explicit when allowed) on either source or target CLR type.
             if (expression.Type?.ClrType != null && type?.ClrType != null

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -1272,6 +1272,15 @@ internal sealed class DeclarationBinder
         // BindProgram by walking StructSymbol.Methods. For value-type receivers
         // the emitter synthesizes a by-ref `this`, identical to the
         // receiver-clause owned-struct method lowering.
+        // Issue #1283: in-body user-defined conversion operators
+        // (`func operator implicit/explicit (x T) U` declared directly inside a
+        // struct/class body) are modelled exactly like the free-function form —
+        // a static `op_Implicit` / `op_Explicit` special-name method on the
+        // owning type. They are collected here and registered AFTER the
+        // shared-block static methods are installed (which replaces the static
+        // method table), so an in-body operator coexists with a `shared` block.
+        var pendingConversionOperators = new List<(FunctionDeclarationSyntax Syntax, ImmutableArray<ParameterSymbol> Parameters, TypeSymbol ReturnType, Accessibility Accessibility, ImmutableArray<BoundAttribute> Attributes)>();
+
         if (!syntax.Methods.IsDefaultOrEmpty)
         {
             var methodsBuilder = ImmutableArray.CreateBuilder<FunctionSymbol>();
@@ -1385,6 +1394,29 @@ internal sealed class DeclarationBinder
                     var methodAccessibility = resolveAccessibility(methodSyntax.AccessibilityModifier);
                     var methodParameters = parameters.ToImmutable();
                     var methodReturnRefKind = ValidateReturnRefKind(methodSyntax, returnType);
+
+                    // Issue #1283: a conversion operator declared in the body is
+                    // not an instance method — defer it to the static
+                    // `op_Implicit` / `op_Explicit` registration below, reusing
+                    // the same machinery as the free-function form so the
+                    // conversion is recognised and applied at every target-typed
+                    // position.
+                    if (methodSyntax.IsConversionOperator)
+                    {
+                        var conversionAttributes = ImmutableArray<BoundAttribute>.Empty;
+                        if (!methodSyntax.Annotations.IsDefaultOrEmpty)
+                        {
+                            conversionAttributes = BindAttributes(
+                                methodSyntax.Annotations,
+                                AttributeTargetKind.Method,
+                                Binder.FunctionDeclarationAllowedTargets,
+                                "a method declaration",
+                                System.AttributeTargets.Method);
+                        }
+
+                        pendingConversionOperators.Add((methodSyntax, methodParameters, returnType, methodAccessibility, conversionAttributes));
+                        continue;
+                    }
 
                     // Issue #1071: the effective async flag (mirrors
                     // FunctionSymbol.IsAsync below) so override / shadow matching
@@ -2508,6 +2540,22 @@ internal sealed class DeclarationBinder
             }
 
             structSymbol.SetStaticEvents(staticEventsBuilder.ToImmutable());
+        }
+
+        // Issue #1283: register in-body conversion operators as static
+        // `op_Implicit` / `op_Explicit` methods now that the static-method table
+        // (which a `shared` block REPLACES via SetStaticMethods above) is final.
+        // BindConversionOperatorDeclaration appends via AddStaticMethods, so the
+        // operator coexists with any `shared`-block statics.
+        foreach (var conversionOperator in pendingConversionOperators)
+        {
+            BindConversionOperatorDeclaration(
+                conversionOperator.Syntax,
+                conversionOperator.Parameters,
+                conversionOperator.ReturnType,
+                conversionOperator.Accessibility,
+                package,
+                conversionOperator.Attributes);
         }
 
         // Issue #1070: consolidated field-initializer binding. Every static member

--- a/test/Compiler.Tests/Emit/Issue1283ImplicitConversionEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1283ImplicitConversionEmitTests.cs
@@ -1,0 +1,185 @@
+// <copyright file="Issue1283ImplicitConversionEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1283: a user-defined <c>func operator implicit (x T) U</c> declared
+/// inside a struct/class body must be applied IMPLICITLY wherever a target type
+/// is expected — at return, <c>let</c>/<c>var</c> init with an explicit type,
+/// field/property store, and argument passing. Each site emits a
+/// <c>call U op_Implicit(T)</c> around the source value, exactly like the
+/// explicit type-call cast form <c>U(x)</c>. These tests compile a program that
+/// exercises every position, verify the emitted IL, and assert the runtime
+/// output proves the conversion ran.
+/// </summary>
+public class Issue1283ImplicitConversionEmitTests
+{
+    [Fact]
+    public void InBodyImplicit_AppliedAtEveryTargetTypedPosition_EmitsAndRuns()
+    {
+        var source = """
+            package P
+            import System
+
+            struct Meters {
+                var V int32
+                func operator implicit (v int32) Meters {
+                    return Meters{V: v}
+                }
+            }
+
+            class C {
+                var P Meters
+                func Take(m Meters) {
+                    Console.WriteLine(m.V)
+                }
+                func Ret() Meters {
+                    return 5
+                }
+                func F(n int32) {
+                    let a Meters = n
+                    Console.WriteLine(a.V)
+                    var b Meters
+                    b = n
+                    Console.WriteLine(b.V)
+                    this.P = n
+                    Console.WriteLine(this.P.V)
+                    this.Take(n)
+                }
+            }
+
+            let c = C{ }
+            Console.WriteLine(c.Ret().V)
+            c.F(7)
+            """;
+
+        Assert.Equal("5\n7\n7\n7\n7\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void InBodyImplicit_OnDataClass_AppliedAtAssignment_EmitsAndRuns()
+    {
+        var source = """
+            package P
+            import System
+
+            data class Meters {
+                var V int32
+                func operator implicit (v int32) Meters {
+                    return Meters{V: v}
+                }
+            }
+
+            let m Meters = 42
+            Console.WriteLine(m.V)
+            """;
+
+        Assert.Equal("42\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void InBodyImplicit_FromVariableOperand_AppliedAtArgument_EmitsAndRuns()
+    {
+        var source = """
+            package P
+            import System
+
+            struct Meters {
+                var V int32
+                func operator implicit (v int32) Meters {
+                    return Meters{V: v}
+                }
+            }
+
+            func show(m Meters) {
+                Console.WriteLine(m.V)
+            }
+
+            let n = 11
+            show(n)
+            """;
+
+        Assert.Equal("11\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1283_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new System.Collections.Generic.List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+
+            // (a) Static verification: the emitted IL must be valid.
+            IlVerifier.Verify(outPath);
+
+            // (b) Dynamic verification: the emitted code must execute.
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/ConversionOperatorTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ConversionOperatorTests.cs
@@ -138,6 +138,104 @@ func operator explicit (b Box) int32 {
         Assert.Contains(result.Diagnostics, d => d.Id == "GS0395");
     }
 
+    [Fact]
+    public void InBodyImplicitConversion_AppliedAtAssignment_BindsAndEvaluates()
+    {
+        // Issue #1283: a conversion operator declared INSIDE the struct body
+        // (rather than as a free function) is registered as a static
+        // op_Implicit and applied implicitly at a target-typed position.
+        var source = @"
+struct Meters {
+    var v int32
+    func operator implicit (n int32) Meters {
+        return Meters{v: n}
+    }
+}
+
+var m Meters = 5
+var got = m.v
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(5, result.Value);
+    }
+
+    [Fact]
+    public void InBodyImplicitConversion_AppliedAtReturn_BindsAndEvaluates()
+    {
+        var source = @"
+struct Meters {
+    var v int32
+    func operator implicit (n int32) Meters {
+        return Meters{v: n}
+    }
+}
+
+func make() Meters {
+    return 9
+}
+
+var got = make().v
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(9, result.Value);
+    }
+
+    [Fact]
+    public void InBodyExplicitConversion_NotAppliedImplicitly_ReportsGS0155()
+    {
+        // Issue #1283: op_Explicit must STILL require the explicit U(x) form.
+        // An explicit-only in-body operator at an implicit position errors.
+        var source = @"
+struct Meters {
+    var v int32
+    func operator explicit (n int32) Meters {
+        return Meters{v: n}
+    }
+}
+
+var m Meters = 5
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0155");
+    }
+
+    [Fact]
+    public void InBodyExplicitConversion_AppliedAtCast_BindsAndEvaluates()
+    {
+        var source = @"
+struct Meters {
+    var v int32
+    func operator explicit (n int32) Meters {
+        return Meters{v: n}
+    }
+}
+
+var m = Meters(5)
+var got = m.v
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(5, result.Value);
+    }
+
+    [Fact]
+    public void ImplicitConversion_NoOperator_ReportsGS0155()
+    {
+        // A source type with NO implicit user conversion to the target still
+        // reports GS0155 — real errors are not suppressed by the new lookup.
+        var source = @"
+struct Meters {
+    var v int32
+}
+
+var m Meters = 5
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0155");
+    }
+
     private static EvaluationResult Evaluate(string source)
     {
         var tree = SyntaxTree.Parse(SourceText.From(source));


### PR DESCRIPTION
## Issue
#1283 — a user-defined `func operator implicit (x T) U` declared **inside a struct / data-class body** was never applied implicitly. Every target-typed site (assignment, `let`/`var` init with an explicit type, field/property store, argument passing, return) reported GS0155 `Cannot convert type 'T' to 'U'`. Even the explicit type-call form `U(x)` failed in that case. The spec (`website/docs/ref/spec.md:403`, ADR-0120 / #1017) promises implicit conversions are applied automatically wherever a target type is expected.

## Root cause
The free-function form `func operator implicit (c T) U` is registered as a static `op_Implicit` on the owning type and is correctly consulted by the conversion classifier. But **in-body** member declarations are bound by a struct/class instance-method loop that never checked `methodSyntax.IsConversionOperator`. The operator was silently treated as a malformed instance method named `op_Implicit`, so it never landed in the owning type's `StaticMethods` table the classifier searches — hence GS0155 everywhere, including `U(x)`.

## Change
- **`DeclarationBinder.BindStructDeclarationBodyCore`**: detect in-body conversion operators, defer them, and register each via the existing `BindConversionOperatorDeclaration` (static `op_Implicit`/`op_Explicit` on the owning type) **after** the shared-block static-method table is installed (which replaces it), so an in-body operator coexists with a `shared` block. This reuses the exact same lookup + bound-call + emit machinery as the free-function form, so each site emits `call U op_Implicit(T)` around the source value — identical to the explicit `U(x)` form.
- **`ConversionClassifier.BindConversion`**: add a lifted user-defined conversion to a nullable target `U?` (apply the operator producing `U`, then nullable-wrap via a recursive standard conversion; at most one user-op, no recursion into a second).

### Semantics preserved
- `op_Explicit` is still **not** applied implicitly (still requires `U(x)`).
- A source with no implicit user conversion still reports GS0155.
- User-op lookup runs only when no standard conversion exists, so overload resolution is unperturbed.
- Imported-CLR `op_Implicit` (Span, ADR-0056) path is untouched — not regressed.

### Nullable target status
The lifted `T -> U?` **classification** now works (no GS0155). However, emit of a **nullable user-defined struct** (`U?` as a field/local) is an independent, pre-existing emitter limitation (`Nullable user-defined struct is not yet supported by the emitter`) that fails even for an identity `U -> U?` store with no conversion. So the binder applies the lifted conversion correctly, but end-to-end emit of `U?` user-struct targets remains blocked upstream of this change. The non-nullable `U` case works fully (compile + IL-verified exec).

## Tests
- `test/Core.Tests` `ConversionOperatorTests`: in-body implicit applied at assignment/return; explicit-only NOT applied implicitly (GS0155); explicit cast still works; missing operator still GS0155.
- `test/Compiler.Tests/Emit/Issue1283ImplicitConversionEmitTests`: IL-verified exec proving the conversion runs at return, let-init, field/property store, and argument positions, on `struct` and `data class`, from literal and variable operands.

Verification: standalone repro compiles (no GS0155); `dotnet build GSharp.sln -c Release -graph` -> 0/0; all Core.Tests pass (4413, incl. coverage-matrix golden — no enum changes); narrow Compiler.Tests filters `~Conversion` (42), `~Operator` (93), `~Emit.Issue` (1401), and `~Issue1283` (3) all green.

Fixes #1283
