### PR TITLE
Refs #914: cs2gs coerce each mismatched ternary numeric arm independently

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue914NumericCoercionTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue914NumericCoercionTranslationTests.cs
@@ -324,8 +324,31 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("if b { 1u } else { 0 }", printed);
-        Assert.DoesNotContain("uint32(0)", printed);
+        // The 1u arm already matches the uint32 result type; the int32 literal 0
+        // arm must be coerced independently to uint32 so gsc does not reject the
+        // conditional with GS0263 (G# has no implicit cross-type numeric promotion
+        // and does not adapt an integer literal in a ternary arm to a sibling
+        // arm's unsigned type).
+        Assert.Contains("if b { 1u } else { uint32(0) }", printed);
+    }
+
+    /// <summary>
+    /// When the <em>first</em> arm is the mismatched one, it is the arm that gets
+    /// coerced; the already-matching arm is left untouched.
+    /// </summary>
+    [Fact]
+    public void Ternary_DivergingNumericArms_CoercesMismatchedTrueArm()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public uint F(bool b) => b ? 0 : 1u;
+    }
+}");
+
+        Assert.Contains("if b { uint32(0) } else { 1u }", printed);
     }
 
     /// <summary>

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -3378,16 +3378,27 @@ public sealed class CSharpToGSharpTranslator
             ITypeSymbol trueType = this.context.GetTypeInfo(conditional.WhenTrue).Type;
             ITypeSymbol falseType = this.context.GetTypeInfo(conditional.WhenFalse).Type;
 
+            // When C# computed a single numeric conditional type but an arm has a
+            // different numeric type (e.g. `cond ? 1u : 0`, whose `0` is `int32`
+            // while the result is `uint32`), coerce each mismatched arm to the
+            // result type: G# requires both arms to share a type (GS0263) and does
+            // no implicit promotion. Each arm is coerced independently so a ternary
+            // with only one mismatched arm is still aligned.
             if (resultType != null &&
                 IsNonNullableValueType(resultType) &&
-                TryGetNumericKind(resultType, out SpecialType resultUnderlying) &&
-                TryGetNumericKind(trueType, out SpecialType trueUnderlying) &&
-                TryGetNumericKind(falseType, out SpecialType falseUnderlying) &&
-                resultUnderlying != trueUnderlying &&
-                resultUnderlying != falseUnderlying)
+                TryGetNumericKind(resultType, out SpecialType resultUnderlying))
             {
-                whenTrue = this.CoerceOperandTo(whenTrue, resultType);
-                whenFalse = this.CoerceOperandTo(whenFalse, resultType);
+                if (TryGetNumericKind(trueType, out SpecialType trueUnderlying) &&
+                    trueUnderlying != resultUnderlying)
+                {
+                    whenTrue = this.CoerceOperandTo(whenTrue, resultType);
+                }
+
+                if (TryGetNumericKind(falseType, out SpecialType falseUnderlying) &&
+                    falseUnderlying != resultUnderlying)
+                {
+                    whenFalse = this.CoerceOperandTo(whenFalse, resultType);
+                }
             }
 
             return new IfExpression(condition, whenTrue, whenFalse);


### PR DESCRIPTION
## Summary
cs2gs translator fix (no `src/` changes). A C# conditional with a single numeric result type but one divergent arm type—e.g. `cond ? 1u : 0` (the `0` is `int32`, the result `uint32`)—was only coerced when **both** arms differed from the result type. When one arm already matched, the other was left mismatched, so gsc rejected the emitted G# `if` expression with **GS0263** (G# requires both arms to share a type and does no implicit cross-type numeric promotion).

Now each arm is coerced independently to the result type when its numeric kind differs.

## Impact
- Oahu.Decrypt: **123 → 121** (clears the AudioSpecificConfig `? 1u : 0` ternary GS0263).
- Foundation: unchanged.
- 287 cs2gs tests pass (+1 regression test for the mismatched-true-arm case; updated the existing diverging-arms test to the now-correct `uint32(0)` expectation).

Refs #914.