### PR TITLE
Fixes #1287: accept all non-nullable value types for the struct constraint

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -3884,14 +3884,9 @@ public sealed class Binder
             return !structSym.IsClass;
         }
 
-        if (type == TypeSymbol.Int32 || type == TypeSymbol.Bool)
+        if (type.ClrType is { } primitiveClr)
         {
-            return true;
-        }
-
-        if (type is ImportedTypeSymbol it && it.ClrType is { } clr)
-        {
-            return clr.IsValueType && !NullableLifting.IsValueTypeNullableClr(clr);
+            return primitiveClr.IsValueType && !NullableLifting.IsValueTypeNullableClr(primitiveClr);
         }
 
         return false;

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue775ClassStructConstraintTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue775ClassStructConstraintTests.cs
@@ -68,6 +68,54 @@ First[string](""hi"")
         Assert.NotEmpty(result.Diagnostics);
     }
 
+    [Theory]
+    [InlineData("int32")]
+    [InlineData("uint32")]
+    [InlineData("uint16")]
+    [InlineData("uint8")]
+    [InlineData("int64")]
+    [InlineData("float64")]
+    [InlineData("char")]
+    [InlineData("bool")]
+    [InlineData("nint")]
+    public void StructConstraint_PrimitiveValueTypeArgument_Accepted(string primitive)
+    {
+        // Issue #1287: every non-nullable CLR value type — not just int32/bool —
+        // must satisfy the `struct` constraint. None of these should report
+        // GS0152.
+        var source = $@"
+func First[T struct](x T) T {{ return x }}
+func Use(v {primitive}) {primitive} {{ return First[{primitive}](v) }}
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0152");
+    }
+
+    [Fact]
+    public void StructConstraint_UserStructArgument_Accepted()
+    {
+        var source = @"
+struct S { prop A int32 { get; init; } }
+func First[T struct](x T) T { return x }
+func Use(v S) S { return First[S](v) }
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0152");
+    }
+
+    [Fact]
+    public void StructConstraint_ReferenceTypeArgument_ReportsGS0152()
+    {
+        // Issue #1287: reference-type primitives (e.g. string) must still be
+        // rejected by the `struct` constraint.
+        var source = @"
+func First[T struct](x T) T { return x }
+func Use(v string) string { return First[string](v) }
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0152");
+    }
+
     [Fact]
     public void NewConstraint_DefaultCtorTypeArgument_Accepted()
     {


### PR DESCRIPTION
## Root cause
`Binder.IsNonNullableValueTypeForConstraint` (src/Core/CodeAnalysis/Binding/Binder.cs) hardcoded only two primitives:

```csharp
if (type == TypeSymbol.Int32 || type == TypeSymbol.Bool)
{
    return true;
}
```

Every other primitive `TypeSymbol` carries a real CLR `ClrType` (e.g. `new TypeSymbol("uint32", typeof(uint))`) but fell through to `return false`, so `[T struct]` wrongly rejected `uint32`, `uint16`, `uint8`, `int64`, `float64`, `char`, `nint`, etc. with **GS0152**, even though they are all non-nullable value types.

## Fix
Generalize the check to accept any `TypeSymbol` whose `ClrType` is a non-nullable value type. This also subsumes the prior `ImportedTypeSymbol` value-type branch:

```csharp
if (type.ClrType is { } primitiveClr)
{
    return primitiveClr.IsValueType && !NullableLifting.IsValueTypeNullableClr(primitiveClr);
}
```

The earlier `TypeParameterSymbol`, `NullableTypeSymbol`, and `StructSymbol` branches remain ordered first (source `StructSymbol`s may have a null `ClrType`). Reference-type primitives like `string`/`object` still return false (`string.IsValueType == false`).

## Before / after repro
```gsharp
package p
class C {
  func MyStruct[T struct](x T) T { return x }
  func Use(v uint32) uint32 { return MyStruct[uint32](v) }
}
```
- **Before:** `error GS0152: Type argument 'uint32' for type parameter 'T' does not satisfy the 'struct' constraint.`
- **After:** compiles with zero diagnostics. Verified with standalone `gsc` for int32, uint32, uint16, uint8, int64, float64, char, bool, nint, and a user struct — all compile; `string` still correctly reports GS0152.

## Tests
Added to `test/Core.Tests/CodeAnalysis/Binding/Issue775ClassStructConstraintTests.cs`:
- A `[Theory]` asserting each primitive value type (int32/uint32/uint16/uint8/int64/float64/char/bool/nint) satisfies `[T struct]` with no GS0152.
- A user-struct positive test.
- A negative test asserting a reference type (`string`) still reports GS0152.

Full `Core.Tests` suite passes: **4459 passed, 1 skipped**. Full solution builds clean (0 warnings / 0 errors).