### PR TITLE
Refs #914: cs2gs render parameterless/target-typed source-struct construction as struct literal

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/ImportedStructConstructionTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/ImportedStructConstructionTranslationTests.cs
@@ -87,6 +87,67 @@ namespace Demo
         Assert.Contains("Y: 2", printed);
     }
 
+    /// <summary>
+    /// A parameterless <c>new T()</c> on a source-defined value <c>struct</c>
+    /// must render as the empty struct literal <c>T{}</c> — a value struct has
+    /// no callable constructor surface in G#, so emitting a <c>T()</c> call
+    /// would surface as GS0130 ("function 'T' doesn't exist").
+    /// </summary>
+    [Fact]
+    public void SourceStruct_ParameterlessNew_RendersEmptyStructLiteral()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public struct ChunkFrames
+    {
+        public uint FirstFrameIndex { get; init; }
+        public uint NumberOfFrames { get; init; }
+    }
+
+    public class C
+    {
+        public ChunkFrames Make() => new ChunkFrames();
+    }
+}");
+
+        Assert.Contains("ChunkFrames{}", printed);
+        Assert.DoesNotContain("ChunkFrames()", printed);
+    }
+
+    /// <summary>
+    /// A target-typed <c>new() { Field = value, ... }</c> on a source value
+    /// <c>struct</c> must render as the struct literal <c>T{Field: value, ...}</c>;
+    /// previously the target-typed object initializer was silently dropped, emitting
+    /// a bare <c>T()</c> call (GS0130).
+    /// </summary>
+    [Fact]
+    public void SourceStruct_TargetTypedNewWithInitializer_RendersStructLiteral()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public readonly record struct ChunkFrames
+    {
+        public uint FirstFrameIndex { get; init; }
+        public uint NumberOfFrames { get; init; }
+    }
+
+    public class C
+    {
+        public ChunkFrames Make(uint a, uint b)
+        {
+            ChunkFrames result = new() { FirstFrameIndex = a, NumberOfFrames = b };
+            return result;
+        }
+    }
+}");
+
+        Assert.Contains("FirstFrameIndex: a", printed);
+        Assert.Contains("NumberOfFrames: b", printed);
+        Assert.DoesNotContain("ChunkFrames()", printed);
+    }
+
     private static string TranslateUnit(string source)
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -6059,7 +6059,7 @@ public sealed class CSharpToGSharpTranslator
             // target carries any constructor arguments, matching
             // `new(StringComparer.OrdinalIgnoreCase){ ... }`.
             if (creation.Initializer != null &&
-                this.TryTranslateCollectionInitializer(creation, type, arguments, out GExpression collectionInitializer))
+                this.TryTranslateCollectionInitializer(creation.Initializer, type, arguments, out GExpression collectionInitializer))
             {
                 return collectionInitializer;
             }
@@ -6071,25 +6071,7 @@ public sealed class CSharpToGSharpTranslator
                 creation.Initializer.IsKind(SyntaxKind.ObjectInitializerExpression) &&
                 !hasCtorArgs)
             {
-                var fieldInitializers = new List<FieldInitializer>();
-                foreach (ExpressionSyntax element in creation.Initializer.Expressions)
-                {
-                    if (element is AssignmentExpressionSyntax assignment &&
-                        assignment.Left is IdentifierNameSyntax name)
-                    {
-                        fieldInitializers.Add(new FieldInitializer(
-                            name.Identifier.Text,
-                            this.TranslateExpression(assignment.Right)));
-                    }
-                    else
-                    {
-                        this.context.ReportUnsupported(
-                            element,
-                            "object-initializer element is not a simple `Field = value` assignment; no canonical G# struct-literal form yet (ADR-0115 §B.11).");
-                    }
-                }
-
-                return new CompositeLiteralExpression(type, fieldInitializers);
+                return this.BuildObjectInitializerLiteral(creation.Initializer, type);
             }
 
             // A source-defined value aggregate (`struct` / `data struct`) has no
@@ -6104,9 +6086,17 @@ public sealed class CSharpToGSharpTranslator
             // the type's *properties*.
             if (typeSymbol is INamedTypeSymbol { TypeKind: TypeKind.Struct, SpecialType: SpecialType.None } valueType &&
                 !valueType.IsTupleType &&
-                !valueType.DeclaringSyntaxReferences.IsEmpty &&
-                arguments.Count > 0)
+                !valueType.DeclaringSyntaxReferences.IsEmpty)
             {
+                // A parameterless `new T()` on a source value struct has no callable
+                // constructor surface in G# either; the default (zero-initialised)
+                // value is the empty struct literal `T{}`. Emitting a `T()` call here
+                // would surface as GS0130 ("function 'T' doesn't exist").
+                if (arguments.Count == 0)
+                {
+                    return new CompositeLiteralExpression(type, new List<FieldInitializer>());
+                }
+
                 List<string> targetNames = OrderedValueMemberNames(valueType);
                 if (targetNames.Count == arguments.Count)
                 {
@@ -6120,7 +6110,7 @@ public sealed class CSharpToGSharpTranslator
                 }
             }
 
-            return BuildConstruction(type, arguments, creation);
+            return BuildConstruction(type, arguments);
         }
 
         /// <summary>
@@ -6128,7 +6118,7 @@ public sealed class CSharpToGSharpTranslator
         /// a call on the type name carrying any bracket type arguments
         /// (<c>List[int32](...)</c>, ADR-0115 §B.7).
         /// </summary>
-        private static GExpression BuildConstruction(GTypeReference type, IReadOnlyList<GExpression> arguments, ObjectCreationExpressionSyntax creation)
+        private static GExpression BuildConstruction(GTypeReference type, IReadOnlyList<GExpression> arguments)
         {
             if (type is NamedTypeReference named)
             {
@@ -6141,7 +6131,7 @@ public sealed class CSharpToGSharpTranslator
                     typeArguments);
             }
 
-            return new InvocationExpression(new IdentifierExpression(creation.Type.ToString()), arguments);
+            return new InvocationExpression(new IdentifierExpression(type.ToString()), arguments);
         }
 
         /// <summary>
@@ -6155,19 +6145,47 @@ public sealed class CSharpToGSharpTranslator
             typeName == "object" ? "System.Object" : typeName;
 
         /// <summary>
+        /// Builds the canonical G# struct literal <c>T{Field: value, ...}</c> from a
+        /// C# object initializer (<c>{ Field = value, ... }</c>), used by both the
+        /// explicit (<c>new T { ... }</c>) and target-typed (<c>new() { ... }</c>)
+        /// construction paths (spec §Struct literals; ADR-0115 §B.11).
+        /// </summary>
+        private GExpression BuildObjectInitializerLiteral(InitializerExpressionSyntax initializer, GTypeReference type)
+        {
+            var fieldInitializers = new List<FieldInitializer>();
+            foreach (ExpressionSyntax element in initializer.Expressions)
+            {
+                if (element is AssignmentExpressionSyntax assignment &&
+                    assignment.Left is IdentifierNameSyntax name)
+                {
+                    fieldInitializers.Add(new FieldInitializer(
+                        name.Identifier.Text,
+                        this.TranslateExpression(assignment.Right)));
+                }
+                else
+                {
+                    this.context.ReportUnsupported(
+                        element,
+                        "object-initializer element is not a simple `Field = value` assignment; no canonical G# struct-literal form yet (ADR-0115 §B.11).");
+                }
+            }
+
+            return new CompositeLiteralExpression(type, fieldInitializers);
+        }
+
+        /// <summary>
         /// Attempts to translate a C# collection initializer into a canonical G#
         /// collection initializer (ADR-0117). Returns <see langword="false"/> when
         /// the initializer is not a collection initializer (e.g. a plain object
         /// initializer), leaving the caller's other mappings to apply.
         /// </summary>
         private bool TryTranslateCollectionInitializer(
-            ObjectCreationExpressionSyntax creation,
+            InitializerExpressionSyntax initializer,
             GTypeReference type,
             IReadOnlyList<GExpression> arguments,
             out GExpression result)
         {
             result = null;
-            InitializerExpressionSyntax initializer = creation.Initializer;
 
             bool isCollectionInitializer = initializer.IsKind(SyntaxKind.CollectionInitializerExpression);
             bool isIndexedObjectInitializer = initializer.IsKind(SyntaxKind.ObjectInitializerExpression) &&
@@ -6223,7 +6241,7 @@ public sealed class CSharpToGSharpTranslator
                 }
             }
 
-            GExpression construction = BuildConstruction(type, arguments, creation);
+            GExpression construction = BuildConstruction(type, arguments);
             result = new CollectionInitializerExpression(construction, elements);
             return true;
         }
@@ -6516,6 +6534,25 @@ public sealed class CSharpToGSharpTranslator
                     .Select(a => this.TranslateArgument(a))
                     .ToList();
 
+            bool hasCtorArgs = arguments.Count > 0;
+
+            // A target-typed `new() { ... }` carries the same initializer forms as
+            // an explicit `new T() { ... }`; without this the initializer was
+            // silently dropped, emitting a bare `T()` call (GS0130 for value
+            // structs, lost members otherwise).
+            if (creation.Initializer != null &&
+                this.TryTranslateCollectionInitializer(creation.Initializer, type, arguments, out GExpression collectionInitializer))
+            {
+                return collectionInitializer;
+            }
+
+            if (creation.Initializer != null &&
+                creation.Initializer.IsKind(SyntaxKind.ObjectInitializerExpression) &&
+                !hasCtorArgs)
+            {
+                return this.BuildObjectInitializerLiteral(creation.Initializer, type);
+            }
+
             // A source-defined value aggregate is constructed with a composite
             // literal; a reference type — or an imported/BCL struct with a real
             // constructor — with a call on the (bracketed-generic) type name.
@@ -6524,8 +6561,15 @@ public sealed class CSharpToGSharpTranslator
                 !valueType.DeclaringSyntaxReferences.IsEmpty &&
                 creation.Initializer == null)
             {
+                // Parameterless target-typed `new()` on a source value struct → empty
+                // struct literal `T{}` (no callable constructor surface in G#).
+                if (arguments.Count == 0)
+                {
+                    return new CompositeLiteralExpression(type, new List<FieldInitializer>());
+                }
+
                 List<string> targetNames = OrderedValueMemberNames(valueType);
-                if (targetNames.Count == arguments.Count && arguments.Count > 0)
+                if (targetNames.Count == arguments.Count)
                 {
                     var fieldInitializers = new List<FieldInitializer>();
                     for (int i = 0; i < arguments.Count; i++)


### PR DESCRIPTION
## Summary
cs2gs translator fix (no `src/` changes). A source-defined value `struct` has no callable constructor surface in G#, so it must be built with a struct literal. Two construction forms were mis-rendered as a bare `T()` call → **GS0130** ("function 'T' doesn't exist"):

1. **Parameterless** `new T()` on a source struct emitted `T()` instead of the empty struct literal `T{}`.
2. **Target-typed** `new() { Field = value, ... }` on a source struct **silently dropped the object initializer** and emitted `T()` — the implicit-object-creation path never handled initializers at all.

### Refactor
- Extracted `BuildObjectInitializerLiteral(initializer, type)`, shared by the explicit (`new T { ... }`) and target-typed (`new() { ... }`) paths.
- `TryTranslateCollectionInitializer` now takes the `InitializerExpressionSyntax` directly (was `ObjectCreationExpressionSyntax`), so both paths reuse collection-initializer handling. `BuildConstruction` no longer needs the `creation` node (falls back to `type.ToString()`).

## Impact
- Oahu.Decrypt: clears the StscBox `ChunkFrames` GS0130 (`new() { FirstFrameIndex = ..., NumberOfFrames = ... }`); **123 → 122** off origin/main.
- Foundation: unchanged (8).
- 288 cs2gs tests pass (+2 regression tests: parameterless `new T()` → `T{}`, and target-typed `new() { ... }` → struct literal).

Refs #914.