### PR TITLE
Refs #914: cs2gs qualify bare static field/property references through owning type

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/StaticMemberQualificationTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/StaticMemberQualificationTranslationTests.cs
@@ -1,0 +1,89 @@
+// <copyright file="StaticMemberQualificationTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// A C# extension method on a <c>static class</c> translates to a top-level
+/// receiver-clause <c>func</c>, but a private <c>static</c> field of that class
+/// stays in the class's <c>shared { }</c> block. A bare reference to that field
+/// from the lifted <c>func</c> body has no implicit type scope at top level, so it
+/// must be qualified through the owning type (<c>Ec3Extensions.FfAc3ChannelsTab</c>),
+/// mirroring the bare static-call rule (ADR-0115 §B.18). Without qualification gsc
+/// reports GS0125 (name not in scope).
+/// </summary>
+public class StaticMemberQualificationTranslationTests
+{
+    private const string ExtensionSource = @"
+namespace Corpus.StaticMember
+{
+    public struct Sub
+    {
+        public byte Acmod { get; init; }
+    }
+
+    public static class Ec3Extensions
+    {
+        private static readonly byte[] FfAc3ChannelsTab = [2, 1, 2, 3];
+
+        public static int ChannelCount(this Sub indSub)
+            => FfAc3ChannelsTab[(byte)indSub.Acmod];
+    }
+}
+";
+
+    [Fact]
+    public void StaticFieldReferenced_FromLiftedExtensionFunc_IsQualified()
+    {
+        string rendered = TranslateAndPrint(ExtensionSource);
+
+        Assert.Contains("Ec3Extensions.FfAc3ChannelsTab", rendered, StringComparison.Ordinal);
+    }
+
+    private const string SiblingSource = @"
+namespace Corpus.StaticMember
+{
+    public class Holder
+    {
+        private static readonly int Tab = 5;
+
+        public static int Read()
+        {
+            return Tab;
+        }
+    }
+}
+";
+
+    [Fact]
+    public void StaticFieldReferenced_FromSiblingSharedMethod_IsQualified()
+    {
+        string rendered = TranslateAndPrint(SiblingSource);
+
+        Assert.Contains("Holder.Tab", rendered, StringComparison.Ordinal);
+    }
+
+    private static string TranslateAndPrint(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", source) });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        return GSharpPrinter.Print(unit);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -5508,6 +5508,25 @@ public sealed class CSharpToGSharpTranslator
                 }
             }
 
+            // A C# bare sibling static field/property reference (`FfAc3ChannelsTab`)
+            // carries an implicit type qualifier. A G# top-level `func` (e.g. a
+            // lifted extension method whose former `static class` keeps the field
+            // in a `shared { }` block) or `shared` body has no implicit type scope,
+            // so the reference must be qualified through the owning type
+            // (`Ec3Extensions.FfAc3ChannelsTab`) — the field/property analog of the
+            // bare static-call rule (ADR-0115 §B.18). Without this the binder reports
+            // GS0125 (the name is not in scope at top level).
+            if (this.context.GetSymbolInfo(identifier).Symbol is
+                    { IsStatic: true, Kind: SymbolKind.Field or SymbolKind.Property } staticMember &&
+                staticMember.ContainingType is { TypeKind: TypeKind.Class or TypeKind.Struct } owner &&
+                !owner.IsImplicitlyDeclared &&
+                !SymbolEqualityComparer.Default.Equals(owner.OriginalDefinition, this.entryType?.OriginalDefinition))
+            {
+                return new MemberAccessExpression(
+                    new IdentifierExpression(owner.Name),
+                    identifier.Identifier.Text);
+            }
+
             return new IdentifierExpression(SanitizeIdentifier(identifier.Identifier.Text));
         }
 


### PR DESCRIPTION
## Summary
A C# extension method on a `static class` translates to a top-level receiver-clause `func`, but a private `static` field of that class stays in the class's `shared { }` block. A bare reference to that field from the lifted `func` body has no implicit type scope at top level, so gsc reports **GS0125** (name not in scope).

This qualifies bare `static` field/property references through the owning type (e.g. `FfAc3ChannelsTab` → `Ec3Extensions.FfAc3ChannelsTab`), mirroring the existing bare static-**call** rule (ADR-0115 §B.18, `Geometry.Round`).

## Impact (Oahu.Decrypt)
- Clears the GS0125 on `Ec3Extensions.ChannelCount` (reads `FfAc3ChannelsTab`) and the analogous reference in `Ac4Extensions`.
- `Ec3Extensions.gs` now compiles clean; `Ac4Extensions.gs` progresses past binding (a distinct pre-existing latent numeric `+=` GS0129 is unmasked — separate concern).

## Tests
- New `StaticMemberQualificationTranslationTests` (lifted-extension + sibling-shared cases).
- Full cs2gs suite: 294 pass, no regressions.