### PR TITLE
Fix #1278: expression-bodied members via -> arrow

### DIFF
--- a/docs/adr/0131-expression-bodied-members.md
+++ b/docs/adr/0131-expression-bodied-members.md
@@ -1,0 +1,170 @@
+# ADR-0131: Expression-bodied members via the `->` arrow
+
+- **Status**: Accepted
+- **Date**: 2026-06-27
+- **Phase**: Phase 9 — language surface completeness
+- **Related**: ADR-0128 (arrow-lambda statement/block parity), ADR-0051 (property accessors), ADR-0118 (indexer members), ADR-0019 (receiver-clause functions), ADR-0035 (user operators), issue [#1017](https://github.com/DavidObando/gsharp/issues/1017) (conversion operators), issues [#1278](https://github.com/DavidObando/gsharp/issues/1278), [#1277](https://github.com/DavidObando/gsharp/issues/1277), [#1273](https://github.com/DavidObando/gsharp/issues/1273), [#1270](https://github.com/DavidObando/gsharp/issues/1270)
+
+## Context
+
+C# offers a concise *expression-bodied member* form using the fat arrow `=>`:
+a member whose body is a single expression is written `=> expr` instead of a
+`{ … }` block. It applies to methods, read-only properties, property
+get/set/init accessors, indexers, operators, user-defined conversion operators,
+constructors, finalizers, and local functions.
+
+G# already uses the arrow `->` (`RightArrowToken`) for **arrow lambdas**
+(`(x int32) -> x + 1`, ADR-0128). The C# fat arrow `=>` is **not** a G# token.
+Until now G# had **no** expression-bodied member form at all:
+
+- PR #1270 (issue #1270) briefly taught the parser to recognise and desugar
+  `get => e` / `set => e` expression-bodied **accessors**, but that used the C#
+  fat arrow and was a language-consistency mistake.
+- PR #1277 (issue #1273) reverted it: a property accessor body became a block
+  `{ }` or `;` (bare/auto accessor) only, and **any** other token after an
+  accessor — notably `=>` or `->` followed by an expression — produced a loud
+  `GS0005` ("expected `OpenBraceToken`"). That was the correct end-state *at the
+  time*, because there was no member expression-body feature.
+
+Issue #1278 now **introduces** that feature, using the G# arrow `->` (never the
+C# fat arrow `=>`). Because a member-declaration `->` appears in a position that
+is syntactically distinct from expression position (after a return type, a
+property type, or an accessor keyword), it is unambiguously an expression body
+and does not collide with arrow lambdas in expression position.
+
+## Decision
+
+### 1. Syntax — the `->` member expression body
+
+A member whose body is a single expression may be written `-> expr` in place of
+a `{ … }` block. The arrow is the existing `RightArrowToken` (`->`); the C# fat
+arrow `=>` remains a `GS0005` syntax error in every member position.
+
+The form is accepted at these parser sites (all already-existing nodes; **no new
+`SyntaxKind`**):
+
+- **Free functions / methods** — `ParseFunctionDeclaration`: after the optional
+  return-type clause, `->` introduces an expression body. Because operators
+  (`func (a T) operator + (b T) T`) and user-defined conversion operators
+  (`func operator implicit (x T) U`) route through the same method-declaration
+  path, they get the arrow form for free:
+  - `func Square(x int32) int32 -> x * x`
+  - `func (a V) operator + (b V) V -> V{x: a.x + b.x}`
+  - `func operator implicit (c Celsius) int32 -> c.degrees`
+- **Read-only properties** — `ParsePropertyDeclaration`: `prop Name T -> expr`
+  is a get-only computed property.
+- **Indexers** — `ParseIndexerDeclaration`: `prop this[i T] U -> expr` is a
+  get-only computed indexer (ADR-0118).
+- **Property accessors** — `ParsePropertyAccessors`: `get -> expr`,
+  `set -> expr`, and `init -> expr` inside an accessor list. A setter/init body
+  may use the implicit `value` parameter (or a named one via `set(name)`).
+
+### 2. Desugaring — parser-synthesized block bodies
+
+The arrow form is desugared **at parse time** into an equivalent block body so
+it reuses every downstream path (binding, type-checking, lowering, async, and
+emit) without a single new `BoundNodeKind`:
+
+- A body that **yields a value** — a non-void function/method, a read-only
+  property/indexer, or a `get` accessor — becomes `{ return expr }`.
+- A **value-less** body — a void function/method (no return type clause), or a
+  `set`/`init` accessor — becomes `{ expr }` (an expression statement),
+  mirroring C#'s expression-bodied void methods.
+
+`ParseArrowExpressionBody(asReturn)` consumes the `->` and the expression and
+synthesizes the brace/`return` tokens at the arrow's source position so
+diagnostics and spans stay anchored at the member. A property/indexer arrow is
+synthesized into a single get-only `PropertyAccessorSyntax`
+(`SynthesizeArrowGetAccessorList`). The discriminator between `return expr` and a
+bare expression statement is the **presence of a return type** (functions) or
+**getter vs setter** (accessors) — exactly the C# rule.
+
+No new `SyntaxKind` or `BoundNodeKind` is introduced; the coverage matrix and
+the `BoundNodeKind` exhaustiveness allowlists are unaffected.
+
+### 3. Member kinds — what is implemented, and what is consciously excluded
+
+The full C# expression-bodied member set, and G#'s decision for each:
+
+| C# member kind | G# `->` form | Status |
+| --- | --- | --- |
+| Method | `func F(...) T -> expr` | **Implemented** |
+| Free function | `func F(...) T -> expr` | **Implemented** |
+| Read-only property | `prop P T -> expr` | **Implemented** |
+| `get` accessor | `get -> expr` | **Implemented** |
+| `set` accessor | `set -> expr` | **Implemented** |
+| `init` accessor | `init -> expr` | **Implemented** |
+| Indexer | `prop this[i T] U -> expr` | **Implemented** |
+| Indexer accessor | `get -> expr` / `set -> expr` | **Implemented** |
+| Operator | `func (a T) operator + (b T) T -> expr` | **Implemented** |
+| Conversion operator | `func operator implicit (x T) U -> expr` | **Implemented** |
+| Constructor | — | **Excluded** (see below) |
+| Finalizer | — | **Excluded** (see below) |
+| Local function | — | **Excluded** (see below) |
+
+Consciously excluded, with reasons (not silent gaps):
+
+- **Constructors** (`init(...)`, ADR-0065). A constructor returns no value, so a
+  C# expression-bodied constructor `Ctor(x) => this.x = x;` is a single void
+  statement. G#'s constructor grammar (`init(params) [: base(args)] { … }`)
+  always takes a brace block, and a constructor body is frequently more than one
+  assignment, so a one-expression arrow buys little. The grammar would need a
+  dedicated `init(...) -> expr` production with no expressive gain over
+  `init(...) { expr }`. Excluded to keep the constructor grammar single-form;
+  `cs2gs` continues to translate C# expression-bodied constructors to the brace
+  form.
+- **Finalizers / destructors** (`deinit { … }`, ADR-0068). A finalizer is rare,
+  always void, and its body is a cleanup block; G# spells it `deinit { … }` with
+  no name or parameters. An arrow form adds surface area for a member that is
+  discouraged in idiomatic G#. Excluded.
+- **Local functions.** A local function inside a body already has the arrow
+  *lambda* form available (`let f = (x int32) -> x + 1`, ADR-0128), which is the
+  idiomatic G# spelling for a one-expression local callable. A second,
+  declaration-style `func f(x int32) int32 -> …` local form would duplicate it.
+  Excluded in favour of the existing arrow lambda.
+
+These exclusions are grammar/ergonomics decisions, not desugaring limitations:
+each excluded kind already has a natural brace (or lambda) spelling, and adding
+an arrow form would create redundant syntax.
+
+### 4. `cs2gs` translation
+
+The translator (`CSharpToGSharpTranslator`) maps C# expression-bodied members to
+the idiomatic G# arrow form instead of the block bodies it previously emitted. A
+C# `=> expr` member is translated through the existing body seam and then
+**folded** to an arrow when the result is a single inline-renderable statement
+(`TryFoldArrowBody`):
+
+- A value-returning body (`{ return expr }`) folds to `-> expr`.
+- A void body that is a single expression or assignment statement folds to
+  `-> expr` / `-> target = value`.
+- Bodies that needed extra statements — parameter shadows (a reassigned value
+  parameter, ADR-0115 §B), hoisted temporaries, a bare `=> throw e`, or an
+  `unsafe { }` wrap — do **not** fold and keep their block body, so the emitted
+  G# stays correct.
+
+Read-only properties and indexers fold to the **member-level** arrow
+(`prop Name T -> expr`); accessors fold per-accessor (`get -> e` / `set -> e`).
+The code-model nodes `MethodDeclaration`, `PropertyDeclaration`, and
+`PropertyAccessor` each gain an optional `GStatement ExpressionBody`, and
+`GSharpPrinter` renders it as `-> …`. A missing `IndexerDeclarationSyntax`
+expression-body case in the body seam was filled in as part of this change so
+expression-bodied indexers translate correctly.
+
+## Consequences
+
+- `func Square(x int32) int32 -> x * x`, `prop Name String -> "…"`,
+  `get -> field`, `set -> field = value`, expression-bodied indexers, operators,
+  and conversion operators all compile and run, desugaring to the block bodies
+  they would otherwise spell.
+- The issue #1273 / PR #1277 "loud rejection" is narrowed: a `->` after an
+  accessor (or after a return/property type) is now a valid expression body; the
+  C# fat arrow `=>` is **still** a `GS0005` syntax error in every member
+  position, and block `{ }`, `;`, and bare accessors keep working.
+- Arrow lambdas in expression position (`(x int32) -> x + 1`,
+  `func (x int32) { … }`) are unaffected — the member-declaration arrow lives in
+  a distinct syntactic position.
+- `cs2gs` emits idiomatic `->` members, replacing the block bodies it previously
+  produced for C# `=>` members (the deliverable of issue #1278).
+- No new `SyntaxKind`/`BoundNodeKind` was added; the coverage matrix and the
+  exhaustiveness allowlists are unaffected.

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -2627,6 +2627,25 @@ public class Parser
                 closeBrace);
         }
 
+        if (Current.Kind == SyntaxKind.RightArrowToken)
+        {
+            // Issue #1278 / ADR-0131: an expression-bodied read-only property
+            // `prop Name T -> expr`. Desugar into a single get-only accessor
+            // whose body returns the expression (`{ get { return expr } }`).
+            var (synthOpenBrace, getAccessor, synthCloseBrace) = SynthesizeArrowGetAccessorList();
+            return new PropertyDeclarationSyntax(
+                syntaxTree,
+                accessibilityModifier,
+                openModifier,
+                overrideModifier,
+                propKeyword,
+                identifier,
+                type,
+                synthOpenBrace,
+                ImmutableArray.Create(getAccessor),
+                synthCloseBrace);
+        }
+
         // Bare auto-property: prop Name Type
         return new PropertyDeclarationSyntax(
             syntaxTree,
@@ -2664,6 +2683,13 @@ public class Parser
             openBrace = MatchToken(SyntaxKind.OpenBraceToken);
             accessors = ParsePropertyAccessors();
             closeBrace = MatchToken(SyntaxKind.CloseBraceToken);
+        }
+        else if (Current.Kind == SyntaxKind.RightArrowToken)
+        {
+            // Issue #1278 / ADR-0131: an expression-bodied read-only indexer
+            // `prop this[i T] U -> expr`, desugared into a get-only accessor.
+            (openBrace, var getAccessor, closeBrace) = SynthesizeArrowGetAccessorList();
+            accessors = ImmutableArray.Create(getAccessor);
         }
 
         return new PropertyDeclarationSyntax(
@@ -2821,19 +2847,32 @@ public class Parser
                 {
                     body = ParseBlockStatement();
                 }
+                else if (Current.Kind == SyntaxKind.RightArrowToken)
+                {
+                    // Issue #1278 / ADR-0131: an expression-bodied accessor
+                    // `get -> expr` / `set -> expr` / `init -> expr`. Desugar
+                    // into an equivalent block body so binding and emit reuse
+                    // the existing accessor-body path: a getter lowers to
+                    // `{ return expr }` and a setter/init lowers to `{ expr }`
+                    // (an expression statement, typically an assignment using
+                    // the `set(name)` value parameter). Note: G# uses the `->`
+                    // arrow, never the C# fat arrow `=>`, which remains a
+                    // syntax error below.
+                    body = ParseArrowExpressionBody(asReturn: accessorKeyword.Text == "get");
+                }
                 else if (Current.Kind == SyntaxKind.SemicolonToken)
                 {
                     semicolon = NextToken();
                 }
                 else if (!IsAccessorListTerminator())
                 {
-                    // Issue #1273: a G# property accessor body is a block `{ }`
-                    // or `;` (bare/auto accessor) only. Unlike C#, G# has no
-                    // fat-arrow `=>` (or `->`) expression-bodied accessor form.
-                    // Anything else here (e.g. `get => e` or `get -> e`) is a
-                    // syntax error: report it loudly rather than silently
-                    // skipping the tokens, which previously left a body-less
-                    // accessor returning the type's default value.
+                    // Issue #1273: a G# property accessor body is a block `{ }`,
+                    // a `->` expression body (issue #1278), or `;` (bare/auto
+                    // accessor). Unlike C#, G# has no fat-arrow `=>`
+                    // expression-bodied accessor form. Anything else here (e.g.
+                    // `get => e`) is a syntax error: report it loudly rather
+                    // than silently skipping the tokens, which previously left a
+                    // body-less accessor returning the type's default value.
                     Diagnostics.ReportUnexpectedToken(Current.Location, Current.Kind, SyntaxKind.OpenBraceToken);
                     SkipMalformedAccessorBody();
                 }
@@ -2897,6 +2936,70 @@ public class Parser
         {
             NextToken();
         }
+    }
+
+    // Issue #1278 / ADR-0131: parse the `-> expr` tail of an expression-bodied
+    // member (free function, method, operator, conversion operator, property,
+    // indexer, or property accessor) and synthesize an equivalent block body so
+    // binding, lowering, async, and emit reuse the existing block-body path. A
+    // body that yields a value (a getter, or a non-void function/property)
+    // lowers to `{ return expr }` (asReturn == true); a value-less body (a void
+    // function/method, or a set/init accessor) lowers to `{ expr }`, an
+    // expression statement (asReturn == false). The synthesized braces reuse the
+    // arrow's source position so diagnostics and spans stay anchored at the
+    // member. G# spells this arrow `->` (RightArrowToken); the C# fat arrow `=>`
+    // is never accepted.
+    private BlockStatementSyntax ParseArrowExpressionBody(bool asReturn)
+    {
+        var arrowToken = MatchToken(SyntaxKind.RightArrowToken);
+        var arrowPosition = arrowToken.Position;
+
+        var expression = ParseExpression();
+
+        var openBrace = new SyntaxToken(syntaxTree, SyntaxKind.OpenBraceToken, arrowPosition, "{", null);
+        var closeBrace = new SyntaxToken(syntaxTree, SyntaxKind.CloseBraceToken, arrowPosition, "}", null);
+
+        StatementSyntax statement;
+        if (asReturn)
+        {
+            var returnKeyword = new SyntaxToken(syntaxTree, SyntaxKind.ReturnKeyword, arrowPosition, "return", null);
+            statement = new ReturnStatementSyntax(syntaxTree, returnKeyword, expression);
+        }
+        else
+        {
+            statement = new ExpressionStatementSyntax(syntaxTree, expression);
+        }
+
+        return new BlockStatementSyntax(
+            syntaxTree,
+            openBrace,
+            ImmutableArray.Create(statement),
+            closeBrace);
+    }
+
+    // Issue #1278 / ADR-0131: synthesize the accessor list for an
+    // expression-bodied read-only property or indexer `prop Name T -> expr`.
+    // Produces the equivalent of `{ get { return expr } }`: a single get-only
+    // accessor whose block body returns the expression, plus synthetic braces
+    // for the enclosing accessor list anchored at the arrow's position.
+    private (SyntaxToken OpenBrace, PropertyAccessorSyntax GetAccessor, SyntaxToken CloseBrace) SynthesizeArrowGetAccessorList()
+    {
+        var arrowPosition = Current.Position;
+        var body = ParseArrowExpressionBody(asReturn: true);
+
+        var getKeyword = new SyntaxToken(syntaxTree, SyntaxKind.IdentifierToken, arrowPosition, "get", null);
+        var getAccessor = new PropertyAccessorSyntax(
+            syntaxTree,
+            getKeyword,
+            openParenToken: null,
+            parameterIdentifier: null,
+            closeParenToken: null,
+            body,
+            semicolonToken: null);
+
+        var openBrace = new SyntaxToken(syntaxTree, SyntaxKind.OpenBraceToken, arrowPosition, "{", null);
+        var closeBrace = new SyntaxToken(syntaxTree, SyntaxKind.CloseBraceToken, arrowPosition, "}", null);
+        return (openBrace, getAccessor, closeBrace);
     }
 
     private FieldDeclarationSyntax ParseFieldDeclaration()
@@ -3015,6 +3118,19 @@ public class Parser
         {
             semicolonBody = NextToken();
             body = null;
+        }
+        else if (Current.Kind == SyntaxKind.RightArrowToken)
+        {
+            // Issue #1278 / ADR-0131: an expression-bodied function/method
+            // `func F(...) T -> expr`. Desugar at parse time into an equivalent
+            // block body so binding, lowering, async, and emit reuse the
+            // existing block-body path. A non-void function (return type
+            // present) lowers to `{ return expr }`; a void function (no return
+            // type clause) lowers to `{ expr }` (an expression statement),
+            // mirroring C#'s expression-bodied void methods. This single path
+            // also covers methods, operators (`func operator + ...`), and
+            // user-defined conversion operators (`func operator implicit ...`).
+            body = ParseArrowExpressionBody(asReturn: type != null);
         }
         else
         {

--- a/test/Compiler.Tests/Emit/Issue1278ArrowExpressionMemberEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1278ArrowExpressionMemberEmitTests.cs
@@ -1,0 +1,216 @@
+// <copyright file="Issue1278ArrowExpressionMemberEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1278 / ADR-0131: emit + run coverage for expression-bodied members
+/// using the G# arrow <c>-&gt;</c>. Each program declares an arrow-bodied
+/// member (function/method, read-only property, get/set accessors, indexer,
+/// operator, or conversion operator), runs it, and reads back an
+/// <c>int32 result</c> field, proving the desugared bodies emit and execute
+/// identically to their block-bodied equivalents.
+/// </summary>
+public class Issue1278ArrowExpressionMemberEmitTests
+{
+    [Fact]
+    public void FunctionArrowBody_RunsAndReturns()
+    {
+        var source = """
+            package P
+
+            func square(x int32) int32 -> x * x
+
+            public var result = square(9)
+            """;
+
+        Assert.Equal(81, RunAndGetIntResult(source));
+    }
+
+    [Fact]
+    public void VoidMethodArrowBody_ExecutesSideEffect()
+    {
+        // A void method expression body is an executed statement (a call that
+        // writes a field), proving the `{ expr }` desugar runs.
+        var source = """
+            package P
+
+            class Counter {
+                var n int32
+                func Bump() -> this.Add(5)
+                func Add(d int32) -> this.Set(this.n + d)
+                func Set(v int32) -> this.Store(v)
+                func Store(v int32) { this.n = v }
+            }
+
+            let c = Counter()
+            c.Bump()
+            c.Bump()
+            public var result = c.n
+            """;
+
+        Assert.Equal(10, RunAndGetIntResult(source));
+    }
+
+    [Fact]
+    public void ReadOnlyPropertyArrow_RunsAndReturns()
+    {
+        var source = """
+            package P
+
+            class Box {
+                var seed int32
+                prop Doubled int32 -> this.seed * 2
+            }
+
+            let b = Box()
+            b.seed = 21
+            public var result = b.Doubled
+            """;
+
+        Assert.Equal(42, RunAndGetIntResult(source));
+    }
+
+    [Fact]
+    public void AccessorArrows_RoundTripThroughField()
+    {
+        var source = """
+            package P
+
+            class Box {
+                var n int32
+                prop Value int32 {
+                    get -> this.n
+                    set -> this.n = value
+                }
+            }
+
+            let b = Box()
+            b.Value = 33
+            public var result = b.Value
+            """;
+
+        Assert.Equal(33, RunAndGetIntResult(source));
+    }
+
+    [Fact]
+    public void IndexerArrow_RunsAndReturns()
+    {
+        var source = """
+            package P
+
+            class Grid {
+                var data []int32
+                prop this[i int32] int32 -> this.data[i]
+            }
+
+            let g = Grid{data: []int32{10, 20, 30}}
+            public var result = g[2]
+            """;
+
+        Assert.Equal(30, RunAndGetIntResult(source));
+    }
+
+    [Fact]
+    public void OperatorArrow_RunsAndReturns()
+    {
+        var source = """
+            package P
+
+            struct V {
+                var x int32
+            }
+
+            func (a V) operator +(b V) V -> V{x: a.x + b.x}
+
+            let s = V{x: 4} + V{x: 38}
+            public var result = s.x
+            """;
+
+        Assert.Equal(42, RunAndGetIntResult(source));
+    }
+
+    [Fact]
+    public void ConversionOperatorArrow_RunsAndReturns()
+    {
+        var source = """
+            package P
+
+            struct Celsius {
+                var degrees int32
+            }
+
+            func operator implicit (c Celsius) int32 -> c.degrees
+
+            let c = Celsius{degrees: 99}
+            var d int32 = c
+            public var result = d
+            """;
+
+        Assert.Equal(99, RunAndGetIntResult(source));
+    }
+
+    private static int RunAndGetIntResult(string source)
+    {
+        var assembly = CompileToAssembly(source);
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var entry = program.GetMethod(
+            "<Main>$",
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+        var resultField = program.GetField(
+            "result",
+            BindingFlags.Public | BindingFlags.Static);
+
+        entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { System.Array.Empty<string>() });
+        return (int)resultField!.GetValue(null)!;
+    }
+
+    private static Assembly CompileToAssembly(string source)
+    {
+        var (exitCode, output, outPath) = CompileToFile(source);
+        Assert.True(exitCode == 0, $"gsc failed:\n{output}");
+        var bytes = File.ReadAllBytes(outPath);
+        return Assembly.Load(bytes);
+    }
+
+    private static (int ExitCode, string Output, string OutPath) CompileToFile(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1278_emit_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        var output = compileOut.ToString() + compileErr.ToString();
+        return (compileExit, output, outPath);
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1278ArrowExpressionMemberTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1278ArrowExpressionMemberTests.cs
@@ -1,0 +1,114 @@
+// <copyright file="Issue1278ArrowExpressionMemberTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1278 / ADR-0131: binder/interpreter coverage for expression-bodied
+/// members using the G# arrow <c>-&gt;</c>. The arrow forms desugar to the same
+/// block bodies they would otherwise spell, so they bind, type-check, and
+/// evaluate identically to their block-bodied equivalents.
+/// </summary>
+public class Issue1278ArrowExpressionMemberTests
+{
+    [Fact]
+    public void FunctionArrowBody_BindsAndEvaluates()
+    {
+        var source = @"
+func square(x int32) int32 -> x * x
+
+var r = square(7)
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(49, result.Value);
+    }
+
+    [Fact]
+    public void ReadOnlyPropertyArrow_BindsAndEvaluates()
+    {
+        var source = @"
+class Box {
+    var seed int32
+    prop Doubled int32 -> this.seed * 2
+}
+
+var b = Box()
+b.seed = 21
+var r = b.Doubled
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void AccessorArrows_RoundTripThroughField()
+    {
+        var source = @"
+class Box {
+    var n int32
+    prop Value int32 {
+        get -> this.n
+        set -> this.n = value
+    }
+}
+
+var b = Box()
+b.Value = 17
+var r = b.Value
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(17, result.Value);
+    }
+
+    [Fact]
+    public void ConversionOperatorArrow_BindsAndEvaluates()
+    {
+        var source = @"
+struct Celsius {
+    var degrees int32
+}
+
+func operator implicit (c Celsius) int32 -> c.degrees
+
+var c = Celsius{degrees: 36}
+var d int32 = c
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(36, result.Value);
+    }
+
+    [Fact]
+    public void TypeErrorInArrowBody_IsReported()
+    {
+        // The desugared body type-checks exactly like a block body: a string
+        // expression cannot satisfy an int32 return type.
+        var source = @"
+func bad(x int32) int32 -> ""nope""
+
+var r = bad(1)
+";
+        var result = Evaluate(source);
+        Assert.NotEmpty(result.Diagnostics);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue1278ArrowExpressionMemberParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue1278ArrowExpressionMemberParserTests.cs
@@ -1,0 +1,82 @@
+// <copyright file="Issue1278ArrowExpressionMemberParserTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Issue #1278 / ADR-0131: parser coverage for expression-bodied members using
+/// the G# lambda arrow <c>-&gt;</c> (never the C# fat arrow <c>=&gt;</c>). The
+/// arrow form is accepted in member-declaration position for functions/methods,
+/// read-only properties, indexers, property accessors, operators, and
+/// conversion operators, and desugars to a synthesized block body so it reuses
+/// the existing binding/emit paths. The fat arrow <c>=&gt;</c> remains a GS0005
+/// syntax error.
+/// </summary>
+public class Issue1278ArrowExpressionMemberParserTests
+{
+    [Fact]
+    public void FreeFunctionArrowBody_ParsesCleanly()
+    {
+        const string source = "package P\nfunc Square(x int32) int32 -> x * x\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+        var func = tree.Root.Members.OfType<FunctionDeclarationSyntax>().Single();
+        Assert.NotNull(func.Body);
+    }
+
+    [Fact]
+    public void VoidFunctionArrowBody_ParsesCleanly()
+    {
+        const string source = "package P\nimport System\nfunc Shout(s string) -> Console.WriteLine(s)\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+    }
+
+    [Fact]
+    public void MethodArrowBody_ParsesCleanly()
+    {
+        const string source = "package P\nclass C {\n  func Twice(x int32) int32 -> x + x\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+    }
+
+    [Fact]
+    public void OperatorArrowBody_ParsesCleanly()
+    {
+        const string source = "package P\nstruct V {\n  var x int32\n}\nfunc (a V) operator +(b V) V -> V{x: a.x + b.x}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+    }
+
+    [Fact]
+    public void ConversionOperatorArrowBody_ParsesCleanly()
+    {
+        const string source = "package P\nstruct C {\n  var d int32\n}\nfunc operator implicit (c C) int32 -> c.d\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+    }
+
+    [Fact]
+    public void FunctionFatArrowBody_ReportsDiagnostic()
+    {
+        // Issue #1278: the C# fat arrow `=>` is not a G# member body form.
+        const string source = "package P\nfunc Square(x int32) int32 => x * x\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Contains(tree.Diagnostics, d => d.Id == "GS0005");
+    }
+
+    [Fact]
+    public void LambdaArrow_StillParsesInExpressionPosition()
+    {
+        // Issue #1278: the member-declaration arrow must not break arrow lambdas
+        // in expression position.
+        const string source = "package P\nfunc Main() {\n  var add = (x int32) -> x + 1\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Syntax/PropertyParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/PropertyParserTests.cs
@@ -258,13 +258,48 @@ public class PropertyParserTests
     }
 
     [Fact]
-    public void ArrowGetter_ReportsDiagnostic()
+    public void ArrowGetter_ParsesCleanly()
     {
-        // Issue #1273: the G# lambda arrow `->` is also not a valid accessor
-        // body form; only a block `{ }` or `;` is allowed.
+        // Issue #1278 / ADR-0131: the G# lambda arrow `->` is now a valid
+        // accessor expression-body form: `get -> e` desugars to `{ return e }`.
         const string source = "package P\nclass Foo {\n  prop X int32 { get -> 5 }\n}\n";
         var tree = SyntaxTree.Parse(source);
-        Assert.Contains(tree.Diagnostics, d => d.Id == "GS0005");
+        Assert.Empty(tree.Diagnostics);
+    }
+
+    [Fact]
+    public void ArrowGetterAndSetter_ParseCleanly()
+    {
+        // Issue #1278 / ADR-0131: `get -> e` and `set -> e` are expression-bodied
+        // accessors; a setter body may use the implicit `value` parameter.
+        const string source = "package P\nclass Foo {\n  var n int32\n  prop X int32 { get -> this.n set -> this.n = value }\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+    }
+
+    [Fact]
+    public void PropertyLevelArrow_ParsesCleanly()
+    {
+        // Issue #1278 / ADR-0131: `prop Name T -> expr` is an expression-bodied
+        // read-only property that desugars to a single get-only accessor.
+        const string source = "package P\nclass Foo {\n  var n int32\n  prop Doubled int32 -> this.n * 2\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+        var structDecl = tree.Root.Members.OfType<StructDeclarationSyntax>().Single();
+        var propDecl = structDecl.Properties.Single();
+        var accessor = Assert.Single(propDecl.Accessors);
+        Assert.True(accessor.IsGetter);
+        Assert.NotNull(accessor.Body);
+    }
+
+    [Fact]
+    public void IndexerLevelArrow_ParsesCleanly()
+    {
+        // Issue #1278 / ADR-0131: `prop this[i T] U -> expr` is an
+        // expression-bodied read-only indexer.
+        const string source = "package P\nclass Repo {\n  var data []int32\n  prop this[i int32] int32 -> this.data[i]\n}\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
     }
 
     [Fact]

--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/GMember.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/GMember.cs
@@ -77,11 +77,13 @@ public sealed class PropertyAccessor : GNode
     /// <param name="kind">The accessor kind.</param>
     /// <param name="body">The optional accessor body.</param>
     /// <param name="setterParameterName">The setter value parameter name (e.g. <c>v</c>).</param>
-    public PropertyAccessor(AccessorKind kind, BlockStatement body = null, string setterParameterName = null)
+    /// <param name="expressionBody">The optional single-statement arrow body (issue #1278 / ADR-0131); when set the accessor renders as <c>get -&gt; expr</c> / <c>set -&gt; expr</c>.</param>
+    public PropertyAccessor(AccessorKind kind, BlockStatement body = null, string setterParameterName = null, GStatement expressionBody = null)
     {
         Kind = kind;
         Body = body;
         SetterParameterName = setterParameterName;
+        ExpressionBody = expressionBody;
     }
 
     /// <summary>Gets the accessor kind.</summary>
@@ -92,6 +94,13 @@ public sealed class PropertyAccessor : GNode
 
     /// <summary>Gets the setter value parameter name.</summary>
     public string SetterParameterName { get; }
+
+    /// <summary>
+    /// Gets the optional single-statement arrow body (issue #1278 / ADR-0131).
+    /// When non-null the accessor renders as an expression-bodied accessor
+    /// <c>get -&gt; expr</c> / <c>set -&gt; expr</c> rather than a block body.
+    /// </summary>
+    public GStatement ExpressionBody { get; }
 }
 
 /// <summary>
@@ -111,6 +120,7 @@ public sealed class PropertyDeclaration : GMember
     /// <param name="isOverride">Whether the property is an <c>override</c>.</param>
     /// <param name="attributes">The property attributes.</param>
     /// <param name="indexerParameters">The index parameters for an indexer member (ADR-0118); empty for an ordinary property.</param>
+    /// <param name="expressionBody">The optional single-statement arrow body for an expression-bodied read-only property/indexer (issue #1278 / ADR-0131); when set the member renders as <c>prop Name T -&gt; expr</c>.</param>
     public PropertyDeclaration(
         string name,
         GTypeReference type,
@@ -119,7 +129,8 @@ public sealed class PropertyDeclaration : GMember
         bool isOpen = false,
         bool isOverride = false,
         IReadOnlyList<AttributeUse> attributes = null,
-        IReadOnlyList<Parameter> indexerParameters = null)
+        IReadOnlyList<Parameter> indexerParameters = null,
+        GStatement expressionBody = null)
     {
         Name = name;
         Type = type;
@@ -129,6 +140,7 @@ public sealed class PropertyDeclaration : GMember
         IsOverride = isOverride;
         Attributes = attributes ?? new List<AttributeUse>();
         IndexerParameters = indexerParameters ?? new List<Parameter>();
+        ExpressionBody = expressionBody;
     }
 
     /// <summary>Gets the property name.</summary>
@@ -157,6 +169,13 @@ public sealed class PropertyDeclaration : GMember
 
     /// <summary>Gets a value indicating whether this property is an indexer member (<c>prop this[...]</c>).</summary>
     public bool IsIndexer => IndexerParameters.Count > 0;
+
+    /// <summary>
+    /// Gets the optional single-statement arrow body (issue #1278 / ADR-0131).
+    /// When non-null the property/indexer renders as an expression-bodied
+    /// read-only member <c>prop Name T -&gt; expr</c> rather than an accessor list.
+    /// </summary>
+    public GStatement ExpressionBody { get; }
 }
 
 /// <summary>
@@ -182,6 +201,7 @@ public sealed class MethodDeclaration : GMember
     /// <param name="isOverride">Whether the method is an <c>override</c>.</param>
     /// <param name="isAsync">Whether the method is asynchronous.</param>
     /// <param name="attributes">The method attributes.</param>
+    /// <param name="expressionBody">The optional single-statement arrow body for an expression-bodied method/function (issue #1278 / ADR-0131); when set the member renders as <c>func F(...) T -&gt; expr</c>.</param>
     public MethodDeclaration(
         string name,
         IReadOnlyList<Parameter> parameters = null,
@@ -193,7 +213,8 @@ public sealed class MethodDeclaration : GMember
         bool isOpen = false,
         bool isOverride = false,
         bool isAsync = false,
-        IReadOnlyList<AttributeUse> attributes = null)
+        IReadOnlyList<AttributeUse> attributes = null,
+        GStatement expressionBody = null)
     {
         Name = name;
         Parameters = parameters ?? new List<Parameter>();
@@ -206,6 +227,7 @@ public sealed class MethodDeclaration : GMember
         IsOverride = isOverride;
         IsAsync = isAsync;
         Attributes = attributes ?? new List<AttributeUse>();
+        ExpressionBody = expressionBody;
     }
 
     /// <summary>Gets the method name.</summary>
@@ -240,6 +262,13 @@ public sealed class MethodDeclaration : GMember
 
     /// <summary>Gets the method attributes.</summary>
     public IReadOnlyList<AttributeUse> Attributes { get; }
+
+    /// <summary>
+    /// Gets the optional single-statement arrow body (issue #1278 / ADR-0131).
+    /// When non-null the method/function renders as an expression-bodied member
+    /// <c>func F(...) T -&gt; expr</c> rather than a block body.
+    /// </summary>
+    public GStatement ExpressionBody { get; }
 }
 
 /// <summary>

--- a/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
@@ -1206,6 +1206,13 @@ public static class GSharpPrinter
             sb.Append($"prop {property.Name} {RenderType(property.Type)}");
         }
 
+        if (property.ExpressionBody != null)
+        {
+            // Issue #1278 / ADR-0131: expression-bodied read-only property/indexer.
+            sb.Append($" -> {RenderArrowInline(property.ExpressionBody, indent)}");
+            return sb.ToString();
+        }
+
         if (property.Accessors.Count == 0)
         {
             return sb.ToString();
@@ -1241,6 +1248,12 @@ public static class GSharpPrinter
                     ? "set"
                     : $"set({accessor.SetterParameterName})";
                 break;
+        }
+
+        if (accessor.ExpressionBody != null)
+        {
+            // Issue #1278 / ADR-0131: expression-bodied accessor `get -> e` / `set -> e`.
+            return $"{pad}{head} -> {RenderArrowInline(accessor.ExpressionBody, indent)}";
         }
 
         if (accessor.Body == null)
@@ -1290,6 +1303,13 @@ public static class GSharpPrinter
             sb.Append(RenderType(method.ReturnType));
         }
 
+        if (method.ExpressionBody != null)
+        {
+            // Issue #1278 / ADR-0131: expression-bodied method/function.
+            sb.Append($" -> {RenderArrowInline(method.ExpressionBody, indent)}");
+            return sb.ToString();
+        }
+
         if (method.Body == null)
         {
             sb.Append(';');
@@ -1299,6 +1319,26 @@ public static class GSharpPrinter
         sb.Append(' ');
         sb.Append(RenderBlock(method.Body, indent));
         return sb.ToString();
+    }
+
+    // Issue #1278 / ADR-0131: render the inline content of an expression-bodied
+    // member's single statement as the right-hand side of the `->` arrow. A
+    // value-returning member's body is a `return expr` whose `return` keyword is
+    // dropped; a void member's body is an expression or assignment statement
+    // rendered as-is.
+    private static string RenderArrowInline(GStatement statement, int indent)
+    {
+        switch (statement)
+        {
+            case ReturnStatement ret:
+                return ret.Expression == null ? string.Empty : RenderExpression(ret.Expression, indent);
+            case ExpressionStatement expr:
+                return RenderExpression(expr.Expression, indent);
+            case AssignmentStatement assignment:
+                return $"{RenderExpression(assignment.Target, indent)} {assignment.Operator} {RenderExpression(assignment.Value, indent)}";
+            default:
+                return RenderStatement(statement, 0).TrimStart();
+        }
     }
 
     private static string RenderConstructor(ConstructorDeclaration constructor, int indent)

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1273ExpressionBodiedAccessorTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1273ExpressionBodiedAccessorTranslationTests.cs
@@ -12,12 +12,13 @@ using Xunit;
 namespace Cs2Gs.Tests;
 
 /// <summary>
-/// Issue #1273: G# has no fat-arrow <c>=&gt;</c> expression-bodied accessor (that
-/// is C# syntax) and no lambda-arrow <c>-&gt;</c> accessor either — a G# property
-/// accessor body is a block <c>{ }</c> or <c>;</c> only. cs2gs must therefore
-/// translate a C# expression-bodied accessor (<c>public int P =&gt; 7;</c> or an
-/// explicit <c>get =&gt; e</c> / <c>set =&gt; e</c>) into a G# <b>block body</b>
-/// (<c>get { return e }</c>), never emitting <c>=&gt;</c> in the G# output.
+/// Issue #1273 / #1278 (ADR-0131): G# now has a first-class expression-bodied
+/// member form using the lambda arrow <c>-&gt;</c> (never the C# fat arrow
+/// <c>=&gt;</c>). cs2gs therefore translates a C# expression-bodied member
+/// (<c>public int Expr =&gt; 7;</c> or an explicit <c>get =&gt; e</c> /
+/// <c>set =&gt; e</c>) into the idiomatic G# arrow form
+/// (<c>prop Expr int32 -&gt; 7</c>, <c>get -&gt; e</c>, <c>set -&gt; e</c>),
+/// never emitting a fat arrow <c>=&gt;</c> in the output.
 /// </summary>
 public class Issue1273ExpressionBodiedAccessorTranslationTests
 {
@@ -40,13 +41,15 @@ namespace Corpus.Issue1273
 ";
 
     [Fact]
-    public void ExpressionBodiedAccessors_RenderAsBlockBodies()
+    public void ExpressionBodiedProperty_RendersAsPropertyLevelArrow()
     {
         string rendered = Render();
 
-        // The expression-bodied getters become block bodies with a return.
-        Assert.Contains("get {", rendered, StringComparison.Ordinal);
-        Assert.Contains("return", rendered, StringComparison.Ordinal);
+        // The expression-bodied read-only property becomes `prop Expr int32 -> 7`.
+        Assert.Contains("prop Expr int32 -> 7", rendered, StringComparison.Ordinal);
+
+        // It should NOT fall back to a get-block body for this simple case.
+        Assert.DoesNotContain("get { return 7", rendered, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -54,18 +57,27 @@ namespace Corpus.Issue1273
     {
         string rendered = Render();
 
-        // G# accessors never use the C# fat arrow.
+        // G# never uses the C# fat arrow; the arrow form is `->`.
         Assert.DoesNotContain("=>", rendered, StringComparison.Ordinal);
     }
 
     [Fact]
-    public void ExpressionBodiedSetter_RendersAsBlockBody()
+    public void ExpressionBodiedGetter_RendersAsArrowAccessor()
     {
         string rendered = Render();
 
-        // The expression-bodied setter becomes a block body, not `set => e`.
-        Assert.Contains("set {", rendered, StringComparison.Ordinal);
-        Assert.DoesNotContain("set =>", rendered, StringComparison.Ordinal);
+        // `get => this.n` becomes `get -> this.n`, not a block body.
+        Assert.Contains("get -> this.n", rendered, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ExpressionBodiedSetter_RendersAsArrowAccessor()
+    {
+        string rendered = Render();
+
+        // `set => this.n = value` becomes `set -> this.n = value`, not `set { }`.
+        Assert.Contains("set -> this.n = value", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("set { this.n", rendered, StringComparison.Ordinal);
     }
 
     private static string Render()

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1278ExpressionBodiedMemberTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1278ExpressionBodiedMemberTranslationTests.cs
@@ -1,0 +1,142 @@
+// <copyright file="Issue1278ExpressionBodiedMemberTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #1278 (ADR-0131): a C# expression-bodied member (fat arrow
+/// <c>=&gt;</c>) translates to the idiomatic G# arrow form (<c>-&gt;</c>) across
+/// the full set of member kinds that route through the same parser path:
+/// methods/free functions, read-only properties, get/set accessors, indexers,
+/// operators, and user-defined conversion operators. The C# fat arrow
+/// <c>=&gt;</c> is never emitted.
+/// </summary>
+public class Issue1278ExpressionBodiedMemberTranslationTests
+{
+    [Fact]
+    public void ExpressionBodiedMethod_RendersAsArrow()
+    {
+        string g = Render(@"
+namespace N
+{
+    public class C
+    {
+        public int Square(int x) => x * x;
+    }
+}");
+
+        Assert.Contains("func Square(x int32) int32 -> x * x", g, StringComparison.Ordinal);
+        Assert.DoesNotContain("=>", g, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ExpressionBodiedVoidMethod_RendersAsArrow()
+    {
+        string g = Render(@"
+namespace N
+{
+    using System;
+    public class C
+    {
+        public void Shout(string s) => Console.WriteLine(s);
+    }
+}");
+
+        Assert.Contains("func Shout(s string) -> Console.WriteLine(s)", g, StringComparison.Ordinal);
+        Assert.DoesNotContain("=>", g, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ExpressionBodiedReadOnlyProperty_RendersAsArrow()
+    {
+        string g = Render(@"
+namespace N
+{
+    public class C
+    {
+        public string Tag => ""x"";
+    }
+}");
+
+        Assert.Contains("prop Tag string -> \"x\"", g, StringComparison.Ordinal);
+        Assert.DoesNotContain("=>", g, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ExpressionBodiedOperator_RendersAsArrow()
+    {
+        string g = Render(@"
+namespace N
+{
+    public struct V
+    {
+        public int X;
+        public static V operator +(V a, V b) => new V { X = a.X + b.X };
+    }
+}");
+
+        // The receiver-clause operator form carries the arrow body.
+        Assert.Contains("operator +", g, StringComparison.Ordinal);
+        Assert.Contains("->", g, StringComparison.Ordinal);
+        Assert.DoesNotContain("=>", g, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ExpressionBodiedConversionOperator_RendersAsArrow()
+    {
+        string g = Render(@"
+namespace N
+{
+    public struct Celsius
+    {
+        public int Degrees;
+        public static implicit operator int(Celsius c) => c.Degrees;
+    }
+}");
+
+        Assert.Contains("func operator implicit", g, StringComparison.Ordinal);
+        Assert.Contains("-> c.Degrees", g, StringComparison.Ordinal);
+        Assert.DoesNotContain("=>", g, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ExpressionBodiedIndexer_RendersAsArrow()
+    {
+        string g = Render(@"
+namespace N
+{
+    public class C
+    {
+        private int[] data;
+        public int this[int i] => this.data[i];
+    }
+}");
+
+        Assert.Contains("prop this[i int32] int32 -> this.data[i]", g, StringComparison.Ordinal);
+        Assert.DoesNotContain("=>", g, StringComparison.Ordinal);
+    }
+
+    private static string Render(string csharp)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", csharp) });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        return GSharpPrinter.Print(unit);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/L1DeclarationTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/L1DeclarationTranslationTests.cs
@@ -196,8 +196,10 @@ namespace Corpus.L1
             tuple.ElementTypes.Select(e => Assert.IsType<NamedTypeReference>(e).Name));
     }
 
-    /// <summary>B.11: an expression-bodied property (<c>int LineCount =&gt; ...</c>)
-    /// maps to a get-only property of width-bearing type <c>int32</c>.</summary>
+    /// <summary>B.11 / ADR-0131: an expression-bodied property
+    /// (<c>int LineCount =&gt; ...</c>) maps to a get-only computed property of
+    /// width-bearing type <c>int32</c>, rendered with the G# property-level arrow
+    /// (<c>prop LineCount int32 -&gt; expr</c>) via <see cref="PropertyDeclaration.ExpressionBody"/>.</summary>
     [Fact]
     public void L1Document_MapsExpressionBodiedPropertyToGetOnly()
     {
@@ -207,9 +209,9 @@ namespace Corpus.L1
             .Single(p => p.Name == "LineCount");
 
         Assert.Equal("int32", Assert.IsType<NamedTypeReference>(lineCount.Type).Name);
-        PropertyAccessor accessor = Assert.Single(lineCount.Accessors);
-        Assert.Equal(AccessorKind.Get, accessor.Kind);
-        Assert.NotNull(accessor.Body);
+        Assert.Empty(lineCount.Accessors);
+        Assert.NotNull(lineCount.ExpressionBody);
+        Assert.IsType<ReturnStatement>(lineCount.ExpressionBody);
     }
 
     /// <summary>B.5/B.12: <c>int Subtotal()</c> maps to an in-body method (no

--- a/tools/cs2gs/Cs2Gs.Tests/L3TranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/L3TranslationTests.cs
@@ -151,7 +151,7 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("async func DoubleAsync(n int32) int32 {", printed);
+        Assert.Contains("async func DoubleAsync(n int32) int32 -> await Task.FromResult(n * 2)", printed);
         Assert.Contains("await Task.FromResult(n * 2)", printed);
         Assert.DoesNotContain("Task[int32] {", printed);
     }
@@ -241,7 +241,7 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("func (value string) WordLen() int32 {", printed);
+        Assert.Contains("func (value string) WordLen() int32 -> value.Length", printed);
         Assert.DoesNotContain("class StringExtras", printed);
         Assert.DoesNotContain("shared {", printed);
     }

--- a/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
@@ -510,8 +510,8 @@ namespace Demo
         Assert.Contains("func GetEnumerator() IEnumerator[T]", printed);
         Assert.DoesNotContain("func GetEnumerator() sequence[T]", printed);
 
-        // The non-generic bridge is retained.
-        Assert.Contains("func GetEnumerator() IEnumerator {", printed);
+        // The non-generic bridge is retained (expression-bodied → arrow form).
+        Assert.Contains("func GetEnumerator() IEnumerator -> GetEnumerator()", printed);
 
         // The IEnumerable<T> generator still lowers to sequence[T].
         Assert.Contains("func All() sequence[T]", printed);

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -1664,6 +1664,15 @@ public sealed class CSharpToGSharpTranslator
             // issue #1007 (`func F[T](...) R;`); the printer emits the
             // type-parameter list via the same path as a class method or free
             // func, so the `[T]` clause is retained on interface methods.
+            // Issue #1278 / ADR-0131: a C# expression-bodied method (`=> expr`)
+            // renders as the idiomatic G# arrow form `func F(...) T -> expr`
+            // when the translated body folds to a single inline statement.
+            GStatement arrowBody = node.ExpressionBody != null ? TryFoldArrowBody(body) : null;
+            if (arrowBody != null)
+            {
+                body = null;
+            }
+
             var method = new MethodDeclaration(
                 SanitizeIdentifier(node.Identifier.Text),
                 parameters: parameters,
@@ -1675,7 +1684,8 @@ public sealed class CSharpToGSharpTranslator
                 isOpen: isOpen,
                 isOverride: isOverride,
                 isAsync: symbol != null && symbol.IsAsync,
-                attributes: this.MapAttributes(node.AttributeLists));
+                attributes: this.MapAttributes(node.AttributeLists),
+                expressionBody: arrowBody);
 
             return (method, isStatic);
         }
@@ -1719,6 +1729,12 @@ public sealed class CSharpToGSharpTranslator
                 ? this.TranslateBody(node, $"operator '{operatorToken}'")
                 : null;
 
+            GStatement arrowBody = node.ExpressionBody != null ? TryFoldArrowBody(body) : null;
+            if (arrowBody != null)
+            {
+                body = null;
+            }
+
             var method = new MethodDeclaration(
                 $"operator {operatorToken}",
                 parameters: parameters,
@@ -1730,7 +1746,8 @@ public sealed class CSharpToGSharpTranslator
                 isOpen: false,
                 isOverride: false,
                 isAsync: false,
-                attributes: this.MapAttributes(node.AttributeLists));
+                attributes: this.MapAttributes(node.AttributeLists),
+                expressionBody: arrowBody);
 
             // Operators carry the receiver-clause form and are lifted to a top-level
             // sibling; returning IsStatic=false routes them through the existing
@@ -1760,12 +1777,19 @@ public sealed class CSharpToGSharpTranslator
                 ? this.TranslateBody(node, $"conversion operator '{kindKeyword}'")
                 : null;
 
+            GStatement arrowBody = node.ExpressionBody != null ? TryFoldArrowBody(body) : null;
+            if (arrowBody != null)
+            {
+                body = null;
+            }
+
             var method = new MethodDeclaration(
                 $"operator {kindKeyword}",
                 parameters: parameters,
                 returnType: returnType,
                 body: body,
-                attributes: this.MapAttributes(node.AttributeLists));
+                attributes: this.MapAttributes(node.AttributeLists),
+                expressionBody: arrowBody);
 
             // The conversion operator has no receiver clause, so it stays an
             // in-body member of the owning type (returning IsStatic=false routes it
@@ -1863,6 +1887,16 @@ public sealed class CSharpToGSharpTranslator
 
             List<PropertyAccessor> accessors = this.MapAccessors(node);
 
+            // Issue #1278 / ADR-0131: a C# expression-bodied read-only property
+            // (`string Name => expr;`) renders as the idiomatic G# property-level
+            // arrow `prop Name T -> expr` when its get body folds to a single
+            // inline statement.
+            GStatement arrowBody = TryFoldComputedPropertyArrow(node.ExpressionBody, accessors);
+            if (arrowBody != null)
+            {
+                accessors = new List<PropertyAccessor>();
+            }
+
             bool isOverride = symbol != null && symbol.IsOverride && !OverridesExternalBaseProperty(symbol);
 
             // Interface members are implicitly abstract; canonical G# interface
@@ -1879,7 +1913,8 @@ public sealed class CSharpToGSharpTranslator
                 visibility: MapVisibility(symbol, this.context, node),
                 isOpen: isOpen,
                 isOverride: isOverride,
-                attributes: this.MapAttributes(node.AttributeLists));
+                attributes: this.MapAttributes(node.AttributeLists),
+                expressionBody: arrowBody);
 
             return (property, isStatic);
         }
@@ -1887,6 +1922,26 @@ public sealed class CSharpToGSharpTranslator
         private List<PropertyAccessor> MapAccessors(PropertyDeclarationSyntax node)
         {
             return this.MapAccessors(node, $"property '{node.Identifier.Text}'");
+        }
+
+        // Issue #1278 / ADR-0131: fold a C# expression-bodied property/indexer
+        // into a property-level G# arrow `prop Name T -> expr`. Returns the
+        // foldable single statement when the C# member used `=> expr` and its
+        // translated get accessor is a single inline statement; otherwise null
+        // (the caller keeps the get-only block accessor list).
+        private static GStatement TryFoldComputedPropertyArrow(
+            ArrowExpressionClauseSyntax csExpressionBody,
+            List<PropertyAccessor> accessors)
+        {
+            if (csExpressionBody == null
+                || accessors.Count != 1
+                || accessors[0].Kind != AccessorKind.Get
+                || accessors[0].Body == null)
+            {
+                return null;
+            }
+
+            return TryFoldArrowBody(accessors[0].Body);
         }
 
         private (GMember Member, bool IsStatic) TranslateIndexer(IndexerDeclarationSyntax node)
@@ -1906,6 +1961,15 @@ public sealed class CSharpToGSharpTranslator
 
             List<PropertyAccessor> accessors = this.MapAccessors(node, "indexer 'this[]'");
 
+            // Issue #1278 / ADR-0131: a C# expression-bodied indexer
+            // (`public T this[int i] => expr;`) renders as the idiomatic G#
+            // indexer-level arrow `prop this[i T] U -> expr`.
+            GStatement arrowBody = TryFoldComputedPropertyArrow(node.ExpressionBody, accessors);
+            if (arrowBody != null)
+            {
+                accessors = new List<PropertyAccessor>();
+            }
+
             bool isOverride = symbol != null && symbol.IsOverride && !OverridesExternalBaseProperty(symbol);
             bool inInterface = symbol?.ContainingType?.TypeKind == TypeKind.Interface;
             bool isOpen = symbol != null && !inInterface && !symbol.IsSealed &&
@@ -1920,7 +1984,8 @@ public sealed class CSharpToGSharpTranslator
                 isOpen: isOpen,
                 isOverride: isOverride,
                 attributes: this.MapAttributes(node.AttributeLists),
-                indexerParameters: indexParameters);
+                indexerParameters: indexParameters,
+                expressionBody: arrowBody);
 
             return (property, isStatic);
         }
@@ -2011,7 +2076,18 @@ public sealed class CSharpToGSharpTranslator
                         accessor,
                         $"{displayName} {kind.ToString().ToLowerInvariant()}ter")
                     : null;
-                accessors.Add(new PropertyAccessor(kind, body));
+
+                // Issue #1278 / ADR-0131: a C# expression-bodied accessor
+                // (`get => e` / `set => e`) renders as the idiomatic G# arrow
+                // accessor `get -> e` / `set -> e` when its body folds to a
+                // single inline statement.
+                GStatement arrowBody = accessor.ExpressionBody != null ? TryFoldArrowBody(body) : null;
+                if (arrowBody != null)
+                {
+                    body = null;
+                }
+
+                accessors.Add(new PropertyAccessor(kind, body, expressionBody: arrowBody));
             }
 
             return accessors;
@@ -2557,6 +2633,31 @@ public sealed class CSharpToGSharpTranslator
             }
         }
 
+        // Issue #1278 / ADR-0131: a C# expression-bodied member (`=> expr`)
+        // translates to the idiomatic G# arrow form (`-> expr`) when the
+        // translated body folds to a single, inline-renderable statement. A
+        // value-returning body is `{ return expr }`; a void body is a single
+        // expression or assignment statement. Bodies that needed extra
+        // statements (parameter shadows, hoisted temporaries, a bare `throw`
+        // expression, or an `unsafe { }` wrap) do not fold and keep their block
+        // body so the emitted G# stays correct.
+        private static GStatement TryFoldArrowBody(BlockStatement block)
+        {
+            if (block == null || block.IsUnsafe || block.Statements.Count != 1)
+            {
+                return null;
+            }
+
+            GStatement only = block.Statements[0];
+            return only switch
+            {
+                ReturnStatement r when r.Expression != null => r,
+                ExpressionStatement => only,
+                AssignmentStatement => only,
+                _ => null,
+            };
+        }
+
         // G# function parameters are read-only (Kotlin-style); a C# method that
         // reassigns a value parameter must shadow it with a mutable local at the top
         // of the body (`var p = p`) so the later writes are legal. Parameters that
@@ -2678,6 +2779,10 @@ public sealed class CSharpToGSharpTranslator
                 case PropertyDeclarationSyntax property when property.ExpressionBody != null:
                     // An expression-bodied property is a get-only computed property.
                     return this.WrapExpressionBody(property.ExpressionBody.Expression, isVoid: false);
+
+                case IndexerDeclarationSyntax indexer when indexer.ExpressionBody != null:
+                    // An expression-bodied indexer is a get-only computed indexer.
+                    return this.WrapExpressionBody(indexer.ExpressionBody.Expression, isVoid: false);
 
                 case DestructorDeclarationSyntax destructor:
                     if (destructor.Body != null)

--- a/website/docs/ref/spec.md
+++ b/website/docs/ref/spec.md
@@ -415,7 +415,7 @@ Functions use `func`. Receiver clauses declare extension functions on types this
 ```ebnf
 FunctionDecl      = "func" ReceiverClause? ( identifier | OperatorName | ConversionOperatorName ) TypeParamList? "(" Parameters? ")" RefReturnClause? FunctionBody .
 AsyncFunctionDecl = "async" FunctionDecl .
-FunctionBody      = Block | ";" .
+FunctionBody      = Block | "->" Expression | ";" .  (* "->" Expression = expression-bodied member, ADR-0131 / issue #1278 *)
 ReceiverClause    = "(" Parameter ")" .
 OperatorName      = "operator" OperatorToken .
 ConversionOperatorName = "operator" ( "implicit" | "explicit" ) .
@@ -432,6 +432,18 @@ A function declared `func f(...) ref T` returns a managed pointer and pairs with
 A function declared `func f(name ...T)` is **variadic**: the source-level element type is `T`, the parameter is seen inside the body as a slice `[]T`, and the call site may supply either *N* trailing positional arguments (packed into a freshly allocated `[]T`) or exactly one trailing `[]T` value (forwarded unwrapped — array identity is preserved). At most one variadic parameter is allowed per signature (`GS0364`) and it must be the last parameter (`GS0145`). Variadic declarations are accepted on top-level `func`, class instance / static methods, interface methods (including default-body methods), constructors, lambdas (function-literal and arrow form), named delegate declarations (ADR-0102), and primary-constructor parameter lists on `class` / `struct` / `data class` / `data struct` / `inline struct` (ADR-0103). On a primary-constructor parameter list the trailing variadic promotes to a `[]T` auto-field with the same name, exactly as the explicit `init(…)` lowering would. The emitter stamps `[System.ParamArrayAttribute]` on the last parameter so the method is consumable by C# / F# / VB callers using their native variadic syntax. The C# `params` keyword is not recognised in G# source; encountering it reports `GS0363` pointing at the canonical `...T` form. See [ADR-0101](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0101-variadic-params.md), [ADR-0102](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0102-variadic-params-additional-sites.md), and [ADR-0103](https://github.com/DavidObando/gsharp/blob/main/docs/adr/0103-primary-ctor-variadic.md).
 
 A `;` in place of the `Block` body marks the declaration as "no managed body". Per ADR-0086, the body-less form is reserved for functions annotated with `@DllImport("libname", ...)` — see [Native interop (P/Invoke)](#native-interop-pinvoke). An unannotated `;` body is rejected with `GS0325`.
+
+An `-> Expression` in place of the `Block` body declares an **expression-bodied
+member** (ADR-0131, issue #1278), using the G# arrow `->` (never the C# fat
+arrow `=>`, which remains a `GS0005` syntax error in every member position).
+`func f(...) T -> expr` desugars to `{ return expr }` when the function has a
+return type, and to `{ expr }` (an expression statement) when it is void —
+mirroring C#'s expression-bodied void methods. Because operators and
+user-defined conversion operators route through the same function-declaration
+path, they accept the arrow form too (`func (a V) operator + (b V) V -> …`,
+`func operator implicit (c T) U -> …`). The arrow body lives in a member
+position that is syntactically distinct from expression position, so it does not
+collide with arrow lambdas (`(x int32) -> x + 1`).
 
 #### Overload resolution and generic constraints
 
@@ -474,22 +486,26 @@ ConstructorDecl  = "init" "(" Parameters? ")" ( ":" identifier "(" Arguments? ")
 SharedBlock      = "shared" "{" SharedMember* "}" .
 SharedMember     = Accessibility? ( MethodDecl | PropertyDecl | EventDecl | FieldDecl ) .
 FieldDecl        = Accessibility? ( "var" | "let" ) identifier TypeClause ( "=" Expression )? .
-PropertyDecl     = "prop" ( identifier | IndexerHeader ) TypeClause PropertyBody? .
+PropertyDecl     = "prop" ( identifier | IndexerHeader ) TypeClause ( PropertyBody | "->" Expression )? .  (* "->" Expression = read-only computed property/indexer, ADR-0131 *)
 IndexerHeader    = "this" "[" Parameters "]" .  (* ADR-0118: user indexer member, emitted as the CLR default `Item` property *)
-PropertyAccessor = ( "get" | ( "set" | "init" ) ( "(" identifier ")" )? ) ( Block | ";" )? .
+PropertyAccessor = ( "get" | ( "set" | "init" ) ( "(" identifier ")" )? ) ( Block | "->" Expression | ";" )? .  (* "->" Expression = expression-bodied accessor, ADR-0131 *)
 EventDecl        = "event" identifier TypeClause EventBody? .
 EventAccessor    = ( "add" | "remove" | "raise" ) ( Block | ";" )? .
 InterfaceBody    = "{" ( InterfaceMethodDecl | PropertyDecl | EventDecl )* "}" .
 InterfaceMethodDecl = "func" identifier "(" Parameters? ")" TypeClause? FunctionBody .  (* FunctionBody ";" = no-body (abstract) marker; issue #881 *)
 ```
 
-A property or event accessor body is a block `{ … }` or `;` (a bare/auto
-accessor) **only**. Unlike C#, G# has **no** fat-arrow `=>` expression-bodied
-accessor, and the G# lambda arrow `->` is likewise **not** a valid accessor-body
-form — a computed accessor must use an explicit block body (e.g.
-`get { return e }`). A `get => e`, `get -> e`, or `add => e` is a syntax error
-(GS0005). This mirrors G# having no expression-body arrow form for members in
-general (issue #1273).
+A property or event accessor body is a block `{ … }`, an `-> Expression`
+expression body, or `;` (a bare/auto accessor). The expression-body form
+(ADR-0131, issue #1278) uses the G# arrow `->`: `prop Name T -> expr` is a
+get-only computed property (and `prop this[i T] U -> expr` a get-only computed
+indexer), while `get -> expr`, `set -> expr`, and `init -> expr` are
+expression-bodied accessors — `get -> e` desugars to `{ return e }` and
+`set -> e` / `init -> e` to `{ e }` (the setter may use the implicit `value`
+parameter, or a named one via `set(name)`). The C# fat arrow `=>` is **not** a
+G# token: `get => e` or `add => e` remains a syntax error (GS0005). This narrows
+the issue #1273 rule, which previously rejected every non-block accessor body;
+event accessors (`add`/`remove`/`raise`) still take a block `{ … }` or `;` only.
 
 #### Protected accessibility (issue #950)
 
@@ -1342,8 +1358,8 @@ Async             ::= 'async'
 Annotation        ::= '@' (AnnotationTarget ':')? identifier ('.' identifier)* ('(' Arguments? ')')?
 AnnotationTarget  ::= 'field' | 'param' | 'return' | 'type' | 'method' | 'property' | 'event' | 'module' | 'assembly' | 'genericparam'
 
-FunctionDecl      ::= 'func' ReceiverClause? (identifier | OperatorName | ConversionOperatorName) TypeParamList? '(' Parameters? ')' 'ref'? TypeClause? (Block | ';')
-                      (* ';' is the no-body marker: P/Invoke (ADR-0086) and abstract members (issue #881) *)
+FunctionDecl      ::= 'func' ReceiverClause? (identifier | OperatorName | ConversionOperatorName) TypeParamList? '(' Parameters? ')' 'ref'? TypeClause? (Block | '->' Expression | ';')
+                      (* '->' Expression = expression-bodied member (ADR-0131); ';' is the no-body marker: P/Invoke (ADR-0086) and abstract members (issue #881) *)
 ReceiverClause    ::= '(' Parameter ')'
 OperatorName      ::= 'operator' OperatorToken
 ConversionOperatorName ::= 'operator' ('implicit' | 'explicit')
@@ -1381,10 +1397,10 @@ SharedBlock       ::= 'shared' '{' SharedMember* '}'
 SharedMember      ::= Annotation* Accessibility? (Async? MethodDecl | PropertyDecl | EventDecl | FieldDecl)
 MethodDecl        ::= FunctionDecl
 FieldDecl         ::= Accessibility? ('var' | 'let') identifier TypeClause ('=' Expression)?
-PropertyDecl      ::= 'prop' (identifier | IndexerHeader) TypeClause PropertyBody?
+PropertyDecl      ::= 'prop' (identifier | IndexerHeader) TypeClause (PropertyBody | '->' Expression)?   (* '->' Expression = read-only computed property/indexer, ADR-0131 *)
 IndexerHeader     ::= 'this' '[' Parameters ']'   (* ADR-0118: user indexer member; emitted as CLR default 'Item' property *)
 PropertyBody      ::= '{' PropertyAccessor* '}'
-PropertyAccessor  ::= ('get' | 'set' ('(' identifier ')')?) (Block | ';')?
+PropertyAccessor  ::= ('get' | 'set' ('(' identifier ')')?) (Block | '->' Expression | ';')?   (* '->' Expression = expression-bodied accessor, ADR-0131 *)
 EventDecl         ::= 'event' identifier TypeClause EventBody?
 EventBody         ::= '{' EventAccessor* '}'
 EventAccessor     ::= ('add' | 'remove' | 'raise') (Block | ';')?


### PR DESCRIPTION
Fixes #1278. Related to #1277, #1273, #1271, #1270.

Implements C#-style expression-bodied members in G#, using the existing G# arrow token `->` (`RightArrowToken`) — **not** the C# fat arrow `=>`, which remains a `GS0005` syntax error in every member position.

## Member kinds implemented
- Free functions and methods: `func Square(x int32) int32 -> x * x`
- Void methods (no return type): `func Log(s String) -> Console.WriteLine(s)` → `{ expr }`
- Read-only properties: `prop Name String -> "..."`
- `get` / `set` / `init` accessors: `get -> field`, `set -> field = value`
- Indexers (+ their accessors): `prop this[i int32] T -> ...`
- Operators: `func (a V) operator + (b V) V -> ...`
- User-defined conversion operators: `func operator implicit (c T) U -> ...`

## Consciously excluded (see ADR-0131 for reasons)
- **Constructors** (`init(...)`) — always void, frequently multi-statement; G#'s constructor grammar is single-form (brace block) and an arrow adds no expressive gain.
- **Finalizers** (`deinit { }`) — rare, always a cleanup block, discouraged in idiomatic G#.
- **Local functions** — the arrow *lambda* form (`let f = (x int32) -> x + 1`) already covers one-expression local callables.

Each excluded kind already has a natural brace or lambda spelling; adding an arrow form would create redundant syntax. No work was deferred.

## Per-layer summary
- **Parser** (`src/Core/CodeAnalysis/Syntax/Parser.cs`): `ParseFunctionDeclaration`, `ParsePropertyDeclaration`, `ParseIndexerDeclaration`, and `ParsePropertyAccessors` accept a `->` expression body. `ParseArrowExpressionBody`/`SynthesizeArrowGetAccessorList` desugar it **at parse time** into synthesized block bodies (`return expr` for value-yielding members; `expr`-statement for void/`set`/`init`), reusing all existing binding/lowering/emit. No new `SyntaxKind` or `BoundNodeKind` — the coverage matrix and exhaustiveness allowlists are unchanged.
- **Binder/emit**: unchanged — desugaring reuses the existing block-body and return-statement paths.
- **cs2gs** (`tools/cs2gs/...`): `MethodDeclaration`/`PropertyDeclaration`/`PropertyAccessor` gain an optional `ExpressionBody`; `GSharpPrinter` renders `-> ...`; the translator folds single-statement C# `=>` bodies into the arrow form, keeping block bodies where folding is unsafe (throw expressions, parameter shadows, hoisted temporaries, `unsafe` wraps). Fixed a pre-existing missing `IndexerDeclarationSyntax` case in the body seam.
- **ADR**: new `docs/adr/0131-expression-bodied-members.md` enumerating the full C# member set, the implemented `->` forms, the exclusions with reasons, and the parser-synthesized-block approach.
- **Docs**: `website/docs/ref/spec.md` grammar (`FunctionBody`, `PropertyDecl`, `PropertyAccessor`) and the accessor-body prose updated; the #1273 "block body or `;` only" note narrowed to admit the `->` form while keeping `=>` rejected.
- **Tests**: new parser, binder, and emit tests (gsc) plus cs2gs translation tests; the #1273 accessor-translation tests updated to assert the idiomatic `->` output. Negative coverage that `=>` is still `GS0005` is retained.

## Validation
- `dotnet build GSharp.sln --configuration Release`: succeeds, 0 warnings / 0 errors.
- Core.Tests (`~Issue1278`, `~PropertyParser`): 46 passed.
- cs2gs (`~Issue1278`, `~Issue1273`): 10 passed; full cs2gs suite 296 passed.
- Compiler.Tests (`~Issue1278ArrowExpressionMemberEmit`): 7 passed.
