### PR TITLE
Fix #1279: accept all integer types as array/slice element index

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -2903,19 +2903,29 @@ internal sealed partial class ExpressionBinder
         var element = GetIndexElementType(target.Type);
         if (element != null)
         {
-            var index = ConvertIndex(TypeSymbol.Int32);
+            // Issue #1279: array/slice element access accepts any integer-typed
+            // index (matching C#). `boundIndex` is non-null for every non-
+            // default/interpolated index; those two carry no natural type and
+            // keep the historical int32 conversion driven by the target type.
+            var index = boundIndex != null
+                ? ConvertArrayElementIndex(indexSyntax.Location, boundIndex)
+                : ConvertIndex(TypeSymbol.Int32);
             return new BoundIndexExpression(null, target, index, element);
         }
 
         // Issue #1129: `string` is the primitive `TypeSymbol.String` (not an
         // `ImportedTypeSymbol`), so it matches none of the indexer-resolution
         // branches below. Model `s[i]` against .NET's `String` indexer
-        // (`char this[int]` / `get_Chars(int)`), yielding a `char`. The index is
-        // converted to int32 exactly like array indexing. Emit already lowers a
-        // `BoundIndexExpression` whose target is `string` to `get_Chars` (#537).
+        // (`char this[int]` / `get_Chars(int)`), yielding a `char`. Issue #1279:
+        // any integer-typed index is accepted; because `get_Chars` takes an
+        // int32, the wider integer types convert (narrow) to int32. Emit already
+        // lowers a `BoundIndexExpression` whose target is `string` to `get_Chars`
+        // (#537).
         if (target.Type == TypeSymbol.String)
         {
-            var index = ConvertIndex(TypeSymbol.Int32);
+            var index = boundIndex != null
+                ? ConvertStringCharIndex(indexSyntax.Location, boundIndex)
+                : ConvertIndex(TypeSymbol.Int32);
             return new BoundIndexExpression(null, target, index, TypeSymbol.Char);
         }
 
@@ -3215,7 +3225,7 @@ internal sealed partial class ExpressionBinder
         var element = GetIndexElementType(variable.Type);
         if (element != null)
         {
-            var index = conversions.BindConversion(indexSyntax, TypeSymbol.Int32);
+            var index = BindArrayElementIndex(indexSyntax);
             var value = BindValue(element);
             return new BoundIndexAssignmentExpression(null, variable, index, value, element);
         }
@@ -4196,6 +4206,56 @@ internal sealed partial class ExpressionBinder
         lengthMember = lengthProp;
         sliceMethod = slice;
         return true;
+    }
+
+    // Issue #1279: array/slice element access accepts any integer-typed index
+    // (matching C#). Integer types that implicitly widen to int32
+    // (int8/uint8/int16/uint16/char/int32) convert to int32; the wider integer
+    // types (uint32/int64/uint64/nint/nuint) convert to native int (nint),
+    // which CIL ldelem/stelem/ldelema accept as the index operand. Non-integer
+    // indices fall through to the int32 conversion, which reports GS0156.
+    private static bool IsWideIntegerIndexType(TypeSymbol type) =>
+        type == TypeSymbol.UInt32 || type == TypeSymbol.Int64 || type == TypeSymbol.UInt64
+        || type == TypeSymbol.NInt || type == TypeSymbol.NUInt;
+
+    private BoundExpression ConvertArrayElementIndex(TextLocation location, BoundExpression boundIndex)
+    {
+        if (IsWideIntegerIndexType(boundIndex.Type))
+        {
+            return conversions.BindConversion(location, boundIndex, TypeSymbol.NInt, allowExplicit: true);
+        }
+
+        return conversions.BindConversion(location, boundIndex, TypeSymbol.Int32);
+    }
+
+    // Issue #1279: `string` char-indexing (`s[i]`) lowers to the CLR
+    // `get_Chars(int32)` accessor, so any integer index converts to int32 (an
+    // explicit narrowing for the wider integer types). Non-integer indices
+    // report GS0156 via the implicit int32 conversion.
+    private BoundExpression ConvertStringCharIndex(TextLocation location, BoundExpression boundIndex)
+    {
+        return conversions.BindConversion(
+            location, boundIndex, TypeSymbol.Int32, allowExplicit: IsWideIntegerIndexType(boundIndex.Type));
+    }
+
+    // Issue #1279: bind an array/slice element index from syntax. A
+    // default/interpolated index carries no natural type, so it keeps the
+    // historical target-typed int32 conversion; every other index is bound and
+    // then converted via the integer-aware element-index rule above.
+    private BoundExpression BindArrayElementIndex(ExpressionSyntax indexSyntax)
+    {
+        if (indexSyntax is DefaultExpressionSyntax || indexSyntax is InterpolatedStringExpressionSyntax)
+        {
+            return conversions.BindConversion(indexSyntax, TypeSymbol.Int32);
+        }
+
+        var boundIndex = BindExpression(indexSyntax);
+        if (boundIndex is BoundErrorExpression)
+        {
+            return boundIndex;
+        }
+
+        return ConvertArrayElementIndex(indexSyntax.Location, boundIndex);
     }
 
     private static TypeSymbol GetIndexElementType(TypeSymbol type)

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1279ArrayIndexTypesBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1279ArrayIndexTypesBinderTests.cs
@@ -1,0 +1,138 @@
+// <copyright file="Issue1279ArrayIndexTypesBinderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1279: array/slice element access accepts ANY C#-supported integer
+/// type as the index (matching C#'s element-access rule). Narrower types that
+/// implicitly widen to int32 already worked; this verifies the wider integer
+/// types (uint32/int64/uint64/nint/nuint) are now accepted too, while a
+/// non-integer index still reports GS0156.
+/// </summary>
+public class Issue1279ArrayIndexTypesBinderTests
+{
+    [Theory]
+    [InlineData("int8")]
+    [InlineData("uint8")]
+    [InlineData("int16")]
+    [InlineData("uint16")]
+    [InlineData("char")]
+    [InlineData("int32")]
+    [InlineData("uint32")]
+    [InlineData("int64")]
+    [InlineData("uint64")]
+    [InlineData("nint")]
+    [InlineData("nuint")]
+    public void ArrayElementRead_AcceptsAnyIntegerIndexType(string indexType)
+    {
+        var source = $@"
+package main
+func F(arr []int32, i {indexType}) int32 {{ return arr[i] }}
+";
+        Assert.Empty(Errors(source));
+    }
+
+    [Theory]
+    [InlineData("int8")]
+    [InlineData("uint8")]
+    [InlineData("int16")]
+    [InlineData("uint16")]
+    [InlineData("char")]
+    [InlineData("int32")]
+    [InlineData("uint32")]
+    [InlineData("int64")]
+    [InlineData("uint64")]
+    [InlineData("nint")]
+    [InlineData("nuint")]
+    public void ArrayElementWrite_AcceptsAnyIntegerIndexType(string indexType)
+    {
+        var source = $@"
+package main
+func G(arr []int32, i {indexType}, v int32) {{ arr[i] = v }}
+";
+        Assert.Empty(Errors(source));
+    }
+
+    [Theory]
+    [InlineData("int8")]
+    [InlineData("uint8")]
+    [InlineData("int16")]
+    [InlineData("uint16")]
+    [InlineData("char")]
+    [InlineData("int32")]
+    [InlineData("uint32")]
+    [InlineData("int64")]
+    [InlineData("uint64")]
+    [InlineData("nint")]
+    [InlineData("nuint")]
+    public void SliceElementRead_AcceptsAnyIntegerIndexType(string indexType)
+    {
+        // A `[N]T` fixed-size slice exercises the same element-index path.
+        var source = $@"
+package main
+func F(arr [4]int32, i {indexType}) int32 {{ return arr[i] }}
+";
+        Assert.Empty(Errors(source));
+    }
+
+    [Theory]
+    [InlineData("int32")]
+    [InlineData("int64")]
+    [InlineData("uint64")]
+    [InlineData("nint")]
+    public void StringCharIndex_AcceptsAnyIntegerIndexType(string indexType)
+    {
+        var source = $@"
+package main
+func F(s string, i {indexType}) char {{ return s[i] }}
+";
+        Assert.Empty(Errors(source));
+    }
+
+    [Theory]
+    [InlineData("float32")]
+    [InlineData("float64")]
+    public void ArrayElementAccess_NonIntegerIndex_StillReportsGS0156(string indexType)
+    {
+        var source = $@"
+package main
+func F(arr []int32, i {indexType}) int32 {{ return arr[i] }}
+";
+        Assert.Contains(Errors(source), d => d.Id == "GS0156");
+    }
+
+    [Theory]
+    [InlineData("bool")]
+    [InlineData("string")]
+    public void ArrayElementAccess_NonNumericIndex_StillRejected(string indexType)
+    {
+        // bool/string have no conversion to a CIL index type at all, so the
+        // element index is still rejected (a non-integer index is never valid).
+        var source = $@"
+package main
+func F(arr []int32, i {indexType}) int32 {{ return arr[i] }}
+";
+        Assert.NotEmpty(Errors(source));
+    }
+
+    private static IReadOnlyList<Diagnostic> Errors(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        using var peStream = new MemoryStream();
+        return compilation.Emit(peStream).Diagnostics
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .ToList();
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue1279ArrayIndexTypesEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue1279ArrayIndexTypesEmitTests.cs
@@ -1,0 +1,132 @@
+// <copyright file="Issue1279ArrayIndexTypesEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #1279: array/slice element access accepts any integer-typed index.
+/// The narrower types convert to int32 and the wider integer types
+/// (uint32/int64/uint64/nint/nuint) convert to native int — both valid CIL
+/// ldelem/stelem index operands. These tests verify the correct element is
+/// read and written at runtime for every supported index type.
+/// </summary>
+public class Issue1279ArrayIndexTypesEmitTests
+{
+    [Theory]
+    [InlineData("int8")]
+    [InlineData("uint8")]
+    [InlineData("int16")]
+    [InlineData("uint16")]
+    [InlineData("char")]
+    [InlineData("int32")]
+    [InlineData("uint32")]
+    [InlineData("int64")]
+    [InlineData("uint64")]
+    [InlineData("nint")]
+    [InlineData("nuint")]
+    public void ArrayRead_WithIntegerIndex_ReadsCorrectElement(string indexType)
+    {
+        // a[2] == 30, indexed via a value of `indexType`.
+        var source = $@"package main
+import System
+var a = []int32{{10, 20, 30, 40}}
+var i = {indexType}(2)
+Console.WriteLine(a[i])
+";
+        var lines = CompileAndRun(source, "Issue1279-Read-" + indexType);
+        Assert.Equal("30", lines[0]);
+    }
+
+    [Theory]
+    [InlineData("int8")]
+    [InlineData("uint8")]
+    [InlineData("int16")]
+    [InlineData("uint16")]
+    [InlineData("char")]
+    [InlineData("int32")]
+    [InlineData("uint32")]
+    [InlineData("int64")]
+    [InlineData("uint64")]
+    [InlineData("nint")]
+    [InlineData("nuint")]
+    public void ArrayWrite_WithIntegerIndex_WritesCorrectElement(string indexType)
+    {
+        // a[3] = 99 via a `indexType` index, then read it back.
+        var source = $@"package main
+import System
+var a = []int32{{0, 0, 0, 0}}
+var i = {indexType}(3)
+a[i] = 99
+Console.WriteLine(a[3])
+";
+        var lines = CompileAndRun(source, "Issue1279-Write-" + indexType);
+        Assert.Equal("99", lines[0]);
+    }
+
+    [Fact]
+    public void ArrayCompoundAssignment_WithWideIndex_Works()
+    {
+        var source = @"package main
+import System
+var a = []int32{1, 2, 3, 4}
+var i = int64(1)
+a[i] += 40
+Console.WriteLine(a[1])
+";
+        var lines = CompileAndRun(source, "Issue1279-Compound");
+        Assert.Equal("42", lines[0]);
+    }
+
+    private static string[] CompileAndRun(string source, string contextName)
+    {
+        using var peStream = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Emit(peStream);
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(contextName, isCollectible: true);
+        try
+        {
+            var asm = loadContext.LoadFromStream(peStream);
+            var programType = asm.GetTypes().FirstOrDefault(t => t.Name == "<Program>");
+            Assert.NotNull(programType);
+            var entry = programType!.GetMethod(
+                "<Main>$",
+                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(entry);
+
+            var stdout = Console.Out;
+            var captured = new StringWriter();
+            Console.SetOut(captured);
+            try
+            {
+                entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { System.Array.Empty<string>() });
+            }
+            finally
+            {
+                Console.SetOut(stdout);
+            }
+
+            return captured.ToString().Replace("\r\n", "\n").TrimEnd('\n').Split('\n');
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue914IndexCoercionTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue914IndexCoercionTranslationTests.cs
@@ -13,22 +13,25 @@ using Xunit;
 namespace Cs2Gs.Tests;
 
 /// <summary>
-/// Translation tests for the array/indexer element-access index coercion defect
-/// discovered migrating <c>Oahu.Decrypt</c> (issue #914). G# array and indexer
-/// element access require an <c>int32</c> index; C# accepts any integral index
-/// and only widens the narrow kinds (<c>byte</c>, <c>sbyte</c>, <c>short</c>,
-/// <c>ushort</c>, <c>char</c>) to <c>int</c>. The wider/unsigned kinds
-/// (<c>uint</c>, <c>long</c>, <c>ulong</c>, <c>nint</c>, <c>nuint</c>) do not
-/// implicitly convert, so they must be coerced via the conversion-call form
-/// (<c>int32(i)</c>) (otherwise gsc reports GS0156).
+/// Translation tests for the array/indexer element-access index handling.
+/// Issue #1279: gsc now accepts ANY C#-supported integer type as an ARRAY/slice
+/// element index (it converts the wider/unsigned kinds — <c>uint</c>,
+/// <c>long</c>, <c>ulong</c>, <c>nint</c>, <c>nuint</c> — to native int), so an
+/// array index is emitted WITHOUT an <c>int32(...)</c> wrapper. A CLR/user
+/// indexer whose single parameter is <c>int32</c> (<c>List&lt;T&gt;</c>,
+/// <c>Span&lt;T&gt;</c>, <c>IReadOnlyList&lt;T&gt;</c>) still binds its argument
+/// to <c>int32</c> via normal conversion rules in gsc, so a wide index against
+/// such an indexer is still coerced via the conversion-call form
+/// (<c>int32(i)</c>). Originally tracked the #914 (<c>Oahu.Decrypt</c>) array
+/// coercion defect.
 /// </summary>
 public class Issue914IndexCoercionTranslationTests
 {
     /// <summary>
-    /// A <c>uint</c> array index is coerced to <c>int32</c>.
+    /// A <c>uint</c> array index is emitted uncoerced (gsc accepts it).
     /// </summary>
     [Fact]
-    public void ArrayIndex_UintIndex_CoercesToInt32()
+    public void ArrayIndex_UintIndex_NoCoercion()
     {
         string printed = TranslateUnit(@"
 namespace Demo
@@ -39,14 +42,15 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("arr[int32(i)]", printed);
+        Assert.Contains("arr[i]", printed);
+        Assert.DoesNotContain("int32(", printed);
     }
 
     /// <summary>
-    /// A <c>long</c> array index is coerced to <c>int32</c>.
+    /// A <c>long</c> array index is emitted uncoerced (gsc accepts it).
     /// </summary>
     [Fact]
-    public void ArrayIndex_LongIndex_CoercesToInt32()
+    public void ArrayIndex_LongIndex_NoCoercion()
     {
         string printed = TranslateUnit(@"
 namespace Demo
@@ -57,15 +61,16 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("arr[int32(i)]", printed);
+        Assert.Contains("arr[i]", printed);
+        Assert.DoesNotContain("int32(", printed);
     }
 
     /// <summary>
-    /// A computed <c>uint</c> index expression (<c>chunk - 1u</c>) is coerced to
-    /// <c>int32</c> as a whole.
+    /// A computed <c>uint</c> array-index expression (<c>chunk - 1u</c>) is
+    /// emitted uncoerced (gsc accepts the whole wide index).
     /// </summary>
     [Fact]
-    public void ArrayIndex_UintExpression_CoercesToInt32()
+    public void ArrayIndex_UintExpression_NoCoercion()
     {
         string printed = TranslateUnit(@"
 namespace Demo
@@ -76,8 +81,27 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("int32(", printed);
         Assert.Contains("chunk", printed);
+        Assert.DoesNotContain("int32(", printed);
+    }
+
+    /// <summary>
+    /// A <c>nint</c> array index is emitted uncoerced (gsc accepts it).
+    /// </summary>
+    [Fact]
+    public void ArrayIndex_NintIndex_NoCoercion()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public int Get(int[] arr, nint i) => arr[i];
+    }
+}");
+
+        Assert.Contains("arr[i]", printed);
+        Assert.DoesNotContain("int32(", printed);
     }
 
     /// <summary>

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -3363,21 +3363,27 @@ public sealed class CSharpToGSharpTranslator
             return length;
         }
 
-        // G# array/indexer element access requires an `int32` index. C# accepts any
-        // integral index and implicitly widens the narrow ones (`byte`, `sbyte`,
-        // `short`, `ushort`, `char`) to `int`, but the wider/unsigned kinds
-        // (`uint`, `long`, `ulong`, `nint`, `nuint`) do NOT implicitly convert to
-        // `int32`, so gsc rejects them with GS0156. When the indexed target's index
-        // type is `int32` (an array, or an indexer whose single parameter is
-        // `int32` — e.g. `List<T>`/`Span<T>`/`IReadOnlyList<T>`) and the C# index
-        // expression has a non-`int32` integral type that does not widen, wrap the
-        // index in the conversion-call form `int32(<index>)`. Dictionary/other
-        // indexers whose key type is not `int32`, `System.Index`/`System.Range`
-        // indices, and indices already `int`/narrower are left untouched.
+        // G# array/indexer element access. Issue #1279: gsc now accepts ANY
+        // C#-supported integer type as an array/slice element index (it converts
+        // the wider/unsigned kinds — `uint`, `long`, `ulong`, `nint`, `nuint` —
+        // to native int), so an ARRAY index needs no `int32(...)` coercion and is
+        // emitted idiomatically. A user/CLR indexer (`List<T>`, `Span<T>`,
+        // `IReadOnlyList<T>`, ...) whose single parameter is `int32` still binds
+        // its argument to `int32` via normal conversion rules in gsc, so a wide
+        // index against such an indexer is still wrapped in `int32(<index>)`.
+        // Dictionary/other indexers keyed by a non-`int32` type, `System.Index`/
+        // `System.Range` indices, and indices already `int`/narrower are left
+        // untouched.
         private GExpression CoerceIndexToInt32(
             ElementAccessExpressionSyntax elementAccess, GExpression index)
         {
             if (elementAccess.ArgumentList.Arguments.Count != 1)
+            {
+                return index;
+            }
+
+            // Issue #1279: arrays accept any integer index in gsc — no coercion.
+            if (this.context.GetTypeInfo(elementAccess.Expression).Type is IArrayTypeSymbol)
             {
                 return index;
             }

--- a/website/docs/ref/spec.md
+++ b/website/docs/ref/spec.md
@@ -181,7 +181,7 @@ let ys = [3]int32{1, 2, 3}
 let grid = [][]int32{ []int32{1, 2}, []int32{3, 4, 5} }
 ```
 
-A runtime/zero-initialised array allocation is written `[n]T` (issue #1272), where `n` is an arbitrary length expression and there are no element initialisers. It allocates a fresh, zero-initialised slice `[]T` of length `n` (the idiomatic native form replacing the BCL call `System.GC.AllocateArray[T](n)`). The empty-initializer spelling `[n]T{}` is equivalent. The length is converted to `int32` (the same typing as array indices and the underlying CIL `newarr`):
+A runtime/zero-initialised array allocation is written `[n]T` (issue #1272), where `n` is an arbitrary length expression and there are no element initialisers. It allocates a fresh, zero-initialised slice `[]T` of length `n` (the idiomatic native form replacing the BCL call `System.GC.AllocateArray[T](n)`). The empty-initializer spelling `[n]T{}` is equivalent. The length is converted to `int32` (the typing the underlying CIL `newarr` requires):
 
 ```gsharp
 func zeros(n int32) []int32 {
@@ -192,6 +192,8 @@ let buffer = [8]int32     // length-8, all elements 0
 ```
 
 Slices are backed by CLR arrays. `len` and `cap` observe array length, and `append` allocates and copies into a new array in the current implementation. The `len`, `cap`, `append`, `delete`, and `make` built-ins are Go-style and require `import Gsharp.Extensions.Go` (ADR-0083); see [Go-style built-ins (`import Gsharp.Extensions.Go`)](#go-style-built-ins-import-gsharpextensionsgo) for the gate and the .NET-idiomatic alternatives (`.Length`, `.Count`, `.Remove(k)`, `List[T].Add`).
+
+Array and slice element access (`a[i]`, read or write) accepts **any** integer-typed index, matching C#'s element-access rule (issue #1279): `int8`, `uint8`, `int16`, `uint16`, `char`, `int32`, `uint32`, `int64`, `uint64`, `nint`, and `nuint`. The narrower kinds that implicitly widen to `int32` are converted to `int32`; the wider kinds (`uint32`, `int64`, `uint64`, `nint`, `nuint`) are converted to the native index type `nint`, which the underlying CIL `ldelem`/`stelem`/`ldelema` accept as the index operand. A non-integer index (`float32`/`float64`/`bool`/`string`/`decimal`/a user type) is rejected (`GS0156`). `string` char-indexing (`s[i]`) likewise accepts any integer index, converting to the `int32` the `get_Chars` accessor takes.
 
 ### Maps
 


### PR DESCRIPTION
Fixes #1279.

## Summary
G# now accepts **any** C#-supported integer type as an array, slice, or string element index, matching C#'s element-access rule. Previously `gsc` rejected `uint32`, `int64`, `uint64`, `nint`, and `nuint` indices with **GS0156**, even though all of these (and the narrower `int8`/`uint8`/`int16`/`uint16`/`char`/`int32`) compile in C#.

The issue body claimed `a[long]` errors in C#; empirically it does not — `long`/`uint`/`ulong`/`nint`/`nuint` all compile. This change implements the **real** C# behavior (accept them all).

## Index types now accepted (array/slice element access)
`int8`, `uint8`, `int16`, `uint16`, `char`, `int32`, `uint32`, `int64`, `uint64`, `nint`, `nuint`.

**Still rejected (GS0156 / no-conversion):** non-integer indices — `float32`, `float64`, `bool`, `string`, `decimal`, user types.

## Changes by layer

### Binder (`ExpressionBinder.Access.cs`)
- New helpers `ConvertArrayElementIndex`, `ConvertStringCharIndex`, `BindArrayElementIndex`, `IsWideIntegerIndexType`.
- Narrower integer indices that implicitly widen to `int32` convert to **int32** (unchanged); the wider integers (`uint32`/`int64`/`uint64`/`nint`/`nuint`) convert to **native int (nint)**, which CIL `ldelem`/`stelem`/`ldelema` accept as the index operand.
- Applied to the array/slice **read** path, the **write** path (`BoundIndexAssignmentExpression`), and `string` char-indexing (which narrows wide indices to the `int32` `get_Chars` takes). Compound (`arr[i] += v`) and address-of (`&arr[i]`) route through these paths.
- User-defined indexers, `^n` from-end, and `System.Range` endpoints are intentionally **unchanged** (C# `Index`/`Range` are int32).

### Emit
- No emitter change needed: `ldelem`/`stelem`/`ldelema` accept an int32 **or** native-int index, and the existing conversion machinery emits `conv.i` for the nint conversions. Verified read/write/compound at runtime.

### cs2gs (`CSharpToGSharpTranslator.cs`)
- Array/slice indices are emitted **without** the `int32(...)` wrapper now that `gsc` accepts wide indices natively (idiomatic G#). The coercion is scoped so it no longer applies to arrays; CLR int32-parameter indexers are unaffected.

### Docs (`website/docs/ref/spec.md`)
- Documented that array/slice element access accepts any integer-typed index, converted to the native index type.

### Tests
- `Issue1279ArrayIndexTypesBinderTests` — every integer index type accepted for array read/write, `[N]T` slice read, and string indexing; non-integer indices rejected (GS0156 for float, error for bool/string).
- `Issue1279ArrayIndexTypesEmitTests` — emit/run proving the correct element is read and written for every integer index type, plus a wide-index compound assignment.
- Updated `Issue914IndexCoercionTranslationTests` to assert the new uncoerced array-index output.

## Validation
- `dotnet build GSharp.sln -c Release` — succeeds.
- Full `test/Core.Tests` — 4552 passed, 1 skipped.
- `test/Compiler.Tests` (`~Index|~Array|~Elem`) — 248 passed.
- cs2gs full suite — 300 passed.
- Coverage matrix golden — green (no new node kinds).