### PR TITLE
Fixes #1294: terminate arrow expression body before a following receiver-form func declaration

### DIFF
--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -8641,6 +8641,25 @@ public class Parser
             return arguments;
         }
 
+        // Issue #1294: the `func (` lookahead above also matches a RECEIVER-form
+        // method declaration `func (recv Type) Name(...)`, whose leading
+        // `(recv Type)` is a receiver clause rather than a function-literal
+        // parameter list. This collides with expression-bodied members from
+        // issue #1278: an arrow body that ends in a call (`-> Q(b)`) followed by
+        // a receiver-form declaration on the next line would otherwise gobble
+        // that declaration's `func (recv Type)` as a trailing lambda. A function
+        // LITERAL never has a method name after its parameter list (its `)` is
+        // followed by `{` or a return-type clause, then `{`); a receiver-form
+        // declaration is uniquely `func (recv Type) Identifier (` — an
+        // identifier (the method name) immediately followed by its own `(`. When
+        // we see that shape, the following `func` is a declaration: leave it for
+        // the declaration parser and do not attach it as a trailing lambda.
+        var funcOffset = isAsyncLiteral ? 1 : 0;
+        if (LooksLikeReceiverMethodDeclaration(funcOffset))
+        {
+            return arguments;
+        }
+
         var lambda = ParseFunctionLiteralExpression();
         var existing = arguments.GetWithSeparators();
         var builder = ImmutableArray.CreateBuilder<SyntaxNode>(existing.Length + 2);
@@ -8658,6 +8677,53 @@ public class Parser
 
         builder.Add(lambda);
         return new SeparatedSyntaxList<ExpressionSyntax>(builder.ToImmutable());
+    }
+
+    // Issue #1294: disambiguate a function LITERAL `func (params) ...` from a
+    // RECEIVER-form method DECLARATION `func (recv Type) Name(...)` that happens
+    // to follow a call's closing `)` (e.g. an expression-bodied member from
+    // issue #1278 whose arrow body ends in a call). Both begin `func (`, so the
+    // single-token lookahead used by the trailing-lambda heuristic cannot tell
+    // them apart. This scans the balanced parens immediately after the `func`
+    // keyword (whose offset relative to <see cref="Current"/> is
+    // <paramref name="funcOffset"/>) and reports whether the token after the
+    // matching `)` is an identifier followed by its own `(` — the method-name +
+    // parameter-list shape unique to a receiver-form declaration. A function
+    // literal's parameter `)` is instead followed by `{` (a body) or a
+    // return-type clause that opens with a type token, never an
+    // `Identifier (` pair, so this never misclassifies a genuine trailing
+    // lambda.
+    private bool LooksLikeReceiverMethodDeclaration(int funcOffset)
+    {
+        var openParenOffset = funcOffset + 1;
+        if (Peek(openParenOffset).Kind != SyntaxKind.OpenParenthesisToken)
+        {
+            return false;
+        }
+
+        var depth = 0;
+        for (var i = openParenOffset; ; i++)
+        {
+            var kind = Peek(i).Kind;
+            if (kind == SyntaxKind.EndOfFileToken)
+            {
+                return false;
+            }
+
+            if (kind == SyntaxKind.OpenParenthesisToken)
+            {
+                depth++;
+            }
+            else if (kind == SyntaxKind.CloseParenthesisToken)
+            {
+                depth--;
+                if (depth == 0)
+                {
+                    return Peek(i + 1).Kind == SyntaxKind.IdentifierToken
+                        && Peek(i + 2).Kind == SyntaxKind.OpenParenthesisToken;
+                }
+            }
+        }
     }
 
     private SeparatedSyntaxList<ExpressionSyntax> ParseArguments()

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue1278ArrowExpressionMemberParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue1278ArrowExpressionMemberParserTests.cs
@@ -79,4 +79,48 @@ public class Issue1278ArrowExpressionMemberParserTests
         var tree = SyntaxTree.Parse(source);
         Assert.Empty(tree.Diagnostics);
     }
+
+    [Fact]
+    public void ArrowCallBody_FollowedByReceiverFunc_ParsesCleanly()
+    {
+        // Issue #1294 regression: an expression-bodied arrow member whose body
+        // is a call (`-> Q(b)`, ending in `)`) immediately followed by a
+        // declaration that begins with a receiver clause (`func (b B) N()...`)
+        // must terminate the arrow body before the next `func`. Previously the
+        // trailing-lambda heuristic misread the following `func (b B)` receiver
+        // clause as a `func(...)` literal attaching to the call, gobbling the
+        // declaration and reporting GS0005.
+        const string source =
+            "package P\n" +
+            "struct B { }\n" +
+            "func Q(b B) int32 { return 1 }\n" +
+            "func (b B) M() int32 -> Q(b)\n" +
+            "func (b B) N() int32 { return 2 }\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+        var funcs = tree.Root.Members.OfType<FunctionDeclarationSyntax>().ToArray();
+        Assert.Equal(3, funcs.Length);
+        Assert.All(funcs, f => Assert.NotNull(f.Body));
+    }
+
+    [Fact]
+    public void ArrowGenericCallBody_FollowedByReceiverGenericFunc_ParsesCleanly()
+    {
+        // Issue #1294: the real-world Oahu.Decrypt shape — an arrow body that is
+        // a call returning a generic type, on a receiver method, followed by
+        // another receiver method with a generic return type. The arrow body
+        // must still terminate before the next `func (recv Type)`.
+        const string source =
+            "package P\n" +
+            "struct ChunkEntry { }\n" +
+            "struct TrakBox { }\n" +
+            "func ChunkEntryList(t TrakBox) List[ChunkEntry] { return nil }\n" +
+            "func (track TrakBox) ChunkEntries() List[ChunkEntry] -> ChunkEntryList(track)\n" +
+            "func (track TrakBox) Other() List[ChunkEntry] -> ChunkEntryList(track)\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+        var funcs = tree.Root.Members.OfType<FunctionDeclarationSyntax>().ToArray();
+        Assert.Equal(3, funcs.Length);
+        Assert.All(funcs, f => Assert.NotNull(f.Body));
+    }
 }


### PR DESCRIPTION
Fixes #1294.

## The regression
PR #1292 (#1278) introduced expression-bodied members via the `->` arrow. An arrow member whose body is a **call** (ends in `)`) immediately followed by **another declaration that begins with a receiver clause** failed to parse with GS0005.

### Repro
```gsharp
package p
struct B { }
func Q(b B) int32 { return 1 }
func (b B) M() int32 -> Q(b)
func (b B) N() int32 { return 2 }
```
Before this fix:
```
error GS0005: Unexpected token <OpenParenthesisToken>, expected <OpenBraceToken>.
```
reported on the second function's line.

Boundaries (all now parse): literal arrow body (`-> 1`), arrow call body followed by a non-receiver free func, and a braced (non-arrow) body all already worked — only **arrow call body + following receiver-form func** failed.

## Root cause
The arrow body parses a full expression via `ParseExpression`. For a call body, after consuming the call's closing `)`, the parser runs `MaybeAppendTrailingLambda`, the Kotlin-style trailing-lambda heuristic. It attaches a following `func (...) {...}` **literal** as the call's last argument, detected with a single-token lookahead (`func` then `(`).

A receiver-form method **declaration** on the next line — `func (b B) N() int32 { ... }` — begins with the same `func (` tokens. The heuristic mis-read the declaration's `(b B)` receiver clause as a function-literal parameter list, swallowed the entire next declaration, and reported GS0005.

Boundary #2 (following **free** func `func N()`) was unaffected because there `func` is followed by an identifier, not `(`.

## What changed
`src/Core/CodeAnalysis/Syntax/Parser.cs`: in `MaybeAppendTrailingLambda`, after recognizing `func (`, a new `LooksLikeReceiverMethodDeclaration` helper scans the balanced parens and bails out when the shape is a receiver-form declaration — `func (recv Type) Identifier (` (a method name immediately followed by its own parameter list). A function literal's parameter `)` is never followed by an `Identifier (` pair (it is followed by `{` or a return-type clause), so genuine trailing lambdas are unaffected. This also covers the real-world Oahu.Decrypt shape with generic return types.

## Test evidence
- New regression tests in `Issue1278ArrowExpressionMemberParserTests` (simple repro + real-world generic receiver shape): pass.
- `TrailingLambdaTests`: 8/8 pass (no trailing-lambda regression).
- Full `Core.Tests`: 4490 passed, 1 skipped, 0 failed.
- `dotnet build GSharp.sln -c Release -graph`: 0 warnings / 0 errors.
