### PR TITLE
Fixes #1294: terminate arrow body before a following generic receiver method

### DIFF
--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -8719,8 +8719,12 @@ public class Parser
                 depth--;
                 if (depth == 0)
                 {
+                    // After the receiver clause a method declaration continues
+                    // with its name followed by either a value-parameter list
+                    // `Name(` or a type-parameter list `Name[` (generic method).
                     return Peek(i + 1).Kind == SyntaxKind.IdentifierToken
-                        && Peek(i + 2).Kind == SyntaxKind.OpenParenthesisToken;
+                        && (Peek(i + 2).Kind == SyntaxKind.OpenParenthesisToken
+                            || Peek(i + 2).Kind == SyntaxKind.OpenSquareBracketToken);
                 }
             }
         }

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue1278ArrowExpressionMemberParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue1278ArrowExpressionMemberParserTests.cs
@@ -123,4 +123,28 @@ public class Issue1278ArrowExpressionMemberParserTests
         Assert.Equal(3, funcs.Length);
         Assert.All(funcs, f => Assert.NotNull(f.Body));
     }
+
+    [Fact]
+    public void ArrowCallBody_FollowedByGenericReceiverFunc_ParsesCleanly()
+    {
+        // Issue #1294 follow-up: when the declaration following an arrow call
+        // body is a *generic* receiver method, its name is followed by a
+        // type-parameter list (`Name[...]`) rather than a value-parameter list
+        // (`Name(...)`). The trailing-lambda guard must recognise both shapes,
+        // otherwise the following `func (recv) Name[...]` is gobbled as a
+        // trailing lambda and reports GS0005. This is the exact Oahu.Decrypt
+        // InterleavedIterator shape (an arrow receiver method directly before a
+        // generic extension method with a constrained type parameter).
+        const string source =
+            "package P\n" +
+            "struct B { }\n" +
+            "func Q(b B) int32 { return 1 }\n" +
+            "func (b B) M() int32 -> Q(b)\n" +
+            "func (s B) N[T IComparable[T]](x T) int32 { return 2 }\n";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+        var funcs = tree.Root.Members.OfType<FunctionDeclarationSyntax>().ToArray();
+        Assert.Equal(3, funcs.Length);
+        Assert.All(funcs, f => Assert.NotNull(f.Body));
+    }
 }


### PR DESCRIPTION
## Problem
Follow-up to #1296. That PR fixed the trailing-lambda heuristic so an expression-bodied arrow member (`-> Q(b)`) terminates before a following receiver method declaration. But the guard `LooksLikeReceiverMethodDeclaration` only recognised the **non-generic** shape (receiver close-paren → `Identifier (`).

A **generic** receiver method begins its parameters with a type-parameter list, so after the receiver clause the tokens are `Identifier [` (e.g. `func (s B) N[T IComparable[T]](x T)`). The guard returned false, the trailing-lambda heuristic fired, and it gobbled the following declaration → `GS0005: Unexpected token <IdentifierToken>, expected <CloseSquareBracketToken>`.

This is the exact Oahu.Decrypt `InterleavedIterator[T].gs` shape — an arrow receiver method (`func (track TrakBox) ChunkEntries() ... -> ChunkEntryList(track)`) directly before a generic extension method (`func (source IEnumerable[TSource]) InterleaveBy[TSource, TResult, TKey IComparable[TKey]](...)`) — and it was still blocking the Decrypt translate stage entirely.

## Repro
```gsharp
package p
struct B { }
func Q(b B) int32 { return 1 }
func (b B) M() int32 -> Q(b)
func (s B) N[T IComparable[T]](x T) int32 { return 2 }
```
Before: `GS0005`. After: parses cleanly.

## Fix
`LooksLikeReceiverMethodDeclaration` (Parser.cs) now treats an identifier followed by **either** a value-parameter list `(` **or** a type-parameter list `[` as a method declaration, so the trailing-lambda heuristic correctly bails in both cases.

## Tests
- Added `ArrowCallBody_FollowedByGenericReceiverFunc_ParsesCleanly` to `Issue1278ArrowExpressionMemberParserTests`.
- Issue1278 parser tests: 10/10 pass.
- Full `GSharp.sln` Release build: 0 warnings / 0 errors.
- Full Core.Tests: 4555 passed, 1 skipped, 0 failed.