### PR TITLE
Fix #1212: []T? = array of nullable elements; []?T = nullable array

### DIFF
--- a/docs/adr/0132-nullable-array-element-spelling.md
+++ b/docs/adr/0132-nullable-array-element-spelling.md
@@ -85,6 +85,14 @@ element-nullable array `[]int32?` is backed by `Nullable<int32>[]` (and reads
 and writes round-trip a nil element), while a reference-type `[]object?` is
 backed by `object[]` (the wrapper is a binder-level annotation).
 
+`NullableTypeSymbol` renders its G# display name so that a nullable array binds
+the `?` to the array, not the element: a `Nullable(Slice(T))` displays as
+`[]?T` and a `Nullable(Array(N, T))` as `[N]?T` (all other underlying types keep
+the trailing-`?` form `T?`). Without this, both `Slice(Nullable(int32))` and
+`Nullable(Slice(int32))` rendered as `[]int32?`, making diagnostics such as
+GS0116 ambiguous and self-contradictory (it would report the nullable array as
+`[]int32?`, the spelling that now means the indexable element-nullable array).
+
 ### 4. `cs2gs` translation
 
 The G# printer renders an array reference's own nullability as `[]?T` (the `?`

--- a/docs/adr/0132-nullable-array-element-spelling.md
+++ b/docs/adr/0132-nullable-array-element-spelling.md
@@ -1,0 +1,113 @@
+# ADR-0132: `[]T?` array of nullable elements vs `[]?T` nullable array
+
+- **Status**: Accepted
+- **Date**: 2026-06-27
+- **Phase**: Phase 9 — language surface completeness
+- **Related**: ADR-0001 (nullable types `T?`), ADR-0016 (slice `[]T`), ADR-0073 (`a?[i]` null-conditional indexing), issues [#710](https://github.com/DavidObando/gsharp/issues/710), [#1046](https://github.com/DavidObando/gsharp/issues/1046) (nested element type clauses), [#1212](https://github.com/DavidObando/gsharp/issues/1212)
+
+## Context
+
+G# had **no** syntax for an "array of nullable elements" (the C# `T?[]`). A
+trailing `?` on an array/slice type clause was parsed and bound as a **nullable
+array** — the whole array reference possibly nil — i.e. `[]T?` meant `([]T)?`.
+
+That single spelling created two problems:
+
+1. There was no way to express a *non-nil* array whose **elements** are nullable
+   (`Nullable<int32>[]`, or an `object[]` that legitimately stores nils). The
+   `cs2gs` translator could not faithfully render C# `T?[]`.
+2. Indexing a `[]T?` value was rejected with **GS0116 "Type '[]T?' is not
+   indexable"** because the bound type was a `NullableTypeSymbol` wrapping a
+   slice; the array had to be null-forgiven (`!!`) or accessed through the
+   null-conditional `?[` before an element could be read.
+
+Both the array-level and the element-level nullability are useful, and a single
+trailing `?` cannot encode both. We need two distinct spellings.
+
+## Decision
+
+The position of the `?` in an array/slice type clause now selects *what* is
+nullable. This is a **breaking** redefinition of the existing `[]T?` spelling.
+
+### 1. The two (and a half) spellings
+
+| Spelling | Meaning | Bound type | Indexable? |
+| --- | --- | --- | --- |
+| `[]T?`   | array of nullable **elements** | `Slice(Nullable(T))` | yes — `a[i]` yields `T?` |
+| `[]?T`   | nullable **array** | `Nullable(Slice(T))` | no — needs `!!` / `?[` first |
+| `[]?T?`  | nullable array of nullable elements | `Nullable(Slice(Nullable(T)))` | no — `!!` then `a[i]` yields `T?` |
+
+The same rule applies to fixed-length arrays: `[N]T?` is a fixed array of
+nullable elements (`Array(Nullable(T), N)`), `[N]?T` is a nullable fixed array
+(`Nullable(Array(T, N))`), and `[N]?T?` is both. Jagged element-nullable arrays
+follow naturally: in `[][]T?` the trailing `?` binds to the innermost element,
+and `[]*T?` is a slice of nullable pointers.
+
+The mnemonic: a `?` **after `]`** marks the array; a `?` **after the element**
+marks the element.
+
+### 2. Syntax
+
+`TypeClauseSyntax` gains one token field, `ArrayQuestionToken` (exposed as
+`IsArrayNullable`), capturing a `?` placed immediately after `]`. The existing
+`QuestionToken` (`IsNullable`) keeps representing the trailing `?`, but for an
+array clause it now binds to the **element** rather than the whole array. The
+parser captures the after-`]` marker before the element-vs-nested-element
+branch, so `[]?T`, `[]?*T`, `[N]?T`, and the element-nullable `[]T?` / `[][]T?`
+all parse. Element-nullable array **literals** (`[]T?{…}`, `[N]T?{…}`) route the
+element through a nullable-suffixed type clause, reusing the issue #1046 nested
+element-clause path.
+
+A nullable array whose element is itself a *slice* (`[]?[]T`) is **not**
+spellable, because `?[` lexes as the single null-conditional-index token
+(`QuestionOpenBracketToken`, ADR-0073). This corner case is intentionally left
+out of scope; `[]?*T` and `[]?Map[K,V]` and the identifier forms cover the
+nested-element need.
+
+No new `SyntaxKind` or `BoundNodeKind` is introduced.
+
+### 3. Binding
+
+`ApplyArraySuffix` wraps the element in `NullableTypeSymbol` when the trailing
+`?` (`IsNullable`) is present (`[]T?` → `Slice(Nullable(T))`). `BindTypeClause`
+no longer wraps the *whole* array for that trailing `?`; instead it wraps the
+array in `NullableTypeSymbol` only when the after-`]` marker
+(`IsArrayNullable`) is present (`[]?T` → `Nullable(Slice(T))`). Because `[]T?`
+now binds to a `SliceTypeSymbol` (not a `NullableTypeSymbol`), the existing
+slice element-access path indexes it directly and yields `T?`; the nullable
+array `[]?T` remains a `NullableTypeSymbol` and stays non-indexable (GS0116)
+until null-forgiven, preserving the prior nullable-array semantics under the new
+spelling.
+
+`SliceTypeSymbol` and `ArrayTypeSymbol` now compute their backing CLR array type
+from `NullableLifting.GetEffectiveClrType(element)`, so a value-type
+element-nullable array `[]int32?` is backed by `Nullable<int32>[]` (and reads
+and writes round-trip a nil element), while a reference-type `[]object?` is
+backed by `object[]` (the wrapper is a binder-level annotation).
+
+### 4. `cs2gs` translation
+
+The G# printer renders an array reference's own nullability as `[]?T` (the `?`
+right after `]`) and an element's nullability as `[]T?` (the element rendering
+carries its own trailing `?`). The translator already captures C# array-level
+nullability (`T[]?` → `ArrayTypeReference { IsNullable = true }`) and element
+nullability (`T?[]` → an `ArrayTypeReference` whose element is nullable), so only
+the print position changed. Net effect: C# `T?[]` → `[]T?`, C# `T[]?` → `[]?T`,
+C# `T?[]?` → `[]?T?`.
+
+## Consequences
+
+- `func F(a []object?) object? { return a[0] }` and
+  `func G(a []int32?) int32? { return a[0] }` now compile and index directly,
+  yielding `T?`. Writing a nil and a value into `[]int32?` / `[]object?` and
+  reading them back round-trips at runtime.
+- `func N(a []?int32) int32 { return a!![0] }` compiles; a bare index on a
+  nullable array (`[]?int32`) is still rejected with GS0116, and `a?[i]`
+  short-circuits on a nil array as before.
+- **Breaking change.** Existing G# that wrote `[]T?` for a *nullable array* must
+  migrate to `[]?T`. In-repo usages were migrated: `samples/NullConditionalIndexing.gs`
+  and the issue #710/#751/#1154/#1238/#1240 binder/emit/interpreter tests
+  (`[]int32?`/`[]uint8?` → `[]?int32`/`[]?uint8`), and the issue #1072 `cs2gs`
+  assertions (`[]uint8?` → `[]?uint8`).
+- No new `SyntaxKind`/`BoundNodeKind` was added; the coverage matrix and
+  exhaustiveness allowlists are unaffected.

--- a/samples/NullConditionalIndexing.gs
+++ b/samples/NullConditionalIndexing.gs
@@ -12,12 +12,12 @@ import System.Collections.Generic
 
 var calls int32 = 0
 
-func bump() []int32? {
+func bump() []?int32 {
     calls = calls + 1
     return []int32{7, 8, 9}
 }
 
-func nilBump() []int32? {
+func nilBump() []?int32 {
     calls = calls + 1
     return nil
 }
@@ -25,11 +25,11 @@ func nilBump() []int32? {
 func main() {
     // 1. Slice receiver. The first read indexes a live slice; the second
     // reads through a nil slice and short-circuits to nil.
-    var live []int32? = []int32{10, 20, 30}
+    var live []?int32 = []int32{10, 20, 30}
     var first = live?[1]
     Console.WriteLine(first)
 
-    var missing []int32? = nil
+    var missing []?int32 = nil
     var firstMissing = missing?[0]
     if firstMissing == nil {
         Console.WriteLine("nil-slice")

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -2542,6 +2542,18 @@ public sealed class Binder
             return element;
         }
 
+        // Issue #1212: a trailing `?` on an array/slice clause (`[]T?`,
+        // `[N]T?`) binds to the *element* type, yielding an array whose
+        // elements are nullable (`Slice(Nullable(T))` / `Array(Nullable(T))`).
+        // This is orthogonal to a *nullable array reference* (`[]?T`), spelled
+        // with a `?` right after `]` and handled by the outer NullableTypeSymbol
+        // wrap in BindTypeClause. Element-nullable arrays stay indexable (the
+        // array itself is non-nil), reading/writing `T?`.
+        if (syntax.IsNullable)
+        {
+            element = NullableTypeSymbol.Get(element);
+        }
+
         if (syntax.IsSlice)
         {
             return SliceTypeSymbol.Get(element);
@@ -2559,7 +2571,21 @@ public sealed class Binder
     private TypeSymbol BindTypeClause(TypeClauseSyntax syntax)
     {
         var bound = BindNonNullableTypeClause(syntax);
-        if (bound == null || !syntax.IsNullable)
+        if (bound == null)
+        {
+            return bound;
+        }
+
+        // Issue #1212: for an array/slice clause the trailing `?` is consumed
+        // by ApplyArraySuffix and applied to the element type (`[]T?`), so it
+        // must not also wrap the whole array. The *array* is made nullable only
+        // by an explicit `?` right after `]` (`[]?T` → `ArrayQuestionToken`).
+        if (syntax.IsArray)
+        {
+            return syntax.IsArrayNullable ? NullableTypeSymbol.Get(bound) : bound;
+        }
+
+        if (!syntax.IsNullable)
         {
             return bound;
         }

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -702,7 +702,7 @@ internal sealed class OverloadResolver
         // wholly-inapplicable overload (e.g. F(string) for a []uint8 argument)
         // can tie — and thus be reported ambiguous (GS0266) — with the unique
         // genuinely-applicable overload that merely needs an implicit
-        // nullable/reference widening (e.g. []uint8 -> []uint8?). Drop such
+        // nullable/reference widening (e.g. []uint8 -> []?uint8). Drop such
         // non-convertible candidates here, conservatively (see skips below), so
         // the unique applicable overload is selected without a spurious GS0266.
         if (applicable.Count > 1 && !HasNamedArguments(argumentNames))

--- a/src/Core/CodeAnalysis/Symbols/ArrayTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ArrayTypeSymbol.cs
@@ -21,7 +21,7 @@ public sealed class ArrayTypeSymbol : TypeSymbol
     private static readonly ConcurrentDictionary<(TypeSymbol Element, int Length), ArrayTypeSymbol> Cache = new();
 
     private ArrayTypeSymbol(TypeSymbol elementType, int length)
-        : base($"[{length}]{elementType.Name}", elementType.ClrType?.MakeArrayType())
+        : base($"[{length}]{elementType.Name}", NullableLifting.GetEffectiveClrType(elementType)?.MakeArrayType())
     {
         ElementType = elementType;
         Length = length;

--- a/src/Core/CodeAnalysis/Symbols/NullableTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/NullableTypeSymbol.cs
@@ -21,7 +21,7 @@ public sealed class NullableTypeSymbol : TypeSymbol
     private static readonly ConcurrentDictionary<TypeSymbol, NullableTypeSymbol> Cache = new();
 
     private NullableTypeSymbol(TypeSymbol underlyingType)
-        : base(underlyingType.Name + "?", underlyingType.ClrType)
+        : base(ComputeDisplayName(underlyingType), underlyingType.ClrType)
     {
         UnderlyingType = underlyingType;
     }
@@ -55,4 +55,22 @@ public sealed class NullableTypeSymbol : TypeSymbol
     /// <returns>The CLR <see cref="Type"/> to use for overload resolution, or <see langword="null"/> if <paramref name="typeSymbol"/> is <see langword="null"/>.</returns>
     public static Type GetEffectiveClrType(TypeSymbol typeSymbol)
         => NullableLifting.GetEffectiveClrType(typeSymbol);
+
+    /// <summary>
+    /// Issue #1212: a nullable array/slice must render with the <c>?</c> bound to
+    /// the array itself (<c>[]?T</c> / <c>[N]?T</c>) so its display name is distinct
+    /// from an array of nullable elements (<c>[]T?</c> = <c>Slice(Nullable(T))</c>).
+    /// For all other underlying types the nullable marker trails the name (<c>T?</c>).
+    /// </summary>
+    /// <param name="underlyingType">The non-nullable underlying type.</param>
+    /// <returns>The G# display name for the nullable wrapper.</returns>
+    private static string ComputeDisplayName(TypeSymbol underlyingType)
+    {
+        return underlyingType switch
+        {
+            SliceTypeSymbol slice => $"[]?{slice.ElementType.Name}",
+            ArrayTypeSymbol array => $"[{array.Length}]?{array.ElementType.Name}",
+            _ => underlyingType.Name + "?",
+        };
+    }
 }

--- a/src/Core/CodeAnalysis/Symbols/SliceTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/SliceTypeSymbol.cs
@@ -25,7 +25,7 @@ public sealed class SliceTypeSymbol : TypeSymbol
     private static readonly ConcurrentDictionary<TypeSymbol, SliceTypeSymbol> Cache = new();
 
     private SliceTypeSymbol(TypeSymbol elementType)
-        : base($"[]{elementType.Name}", elementType.ClrType?.MakeArrayType())
+        : base($"[]{elementType.Name}", NullableLifting.GetEffectiveClrType(elementType)?.MakeArrayType())
     {
         ElementType = elementType;
     }

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -3800,6 +3800,12 @@ public class Parser
 
             var closeBracket = MatchToken(SyntaxKind.CloseSquareBracketToken);
 
+            // Issue #1212: a `?` placed immediately after the `]` (before the
+            // element type) marks the *whole array reference* nullable —
+            // `[]?T` / `[N]?T` is `([]T)?`. This is distinct from a trailing
+            // `?` after the element (`[]T?`), which binds to the element type.
+            var arrayNullableQuestion = Current.Kind == SyntaxKind.QuestionToken ? MatchToken(SyntaxKind.QuestionToken) : null;
+
             // Issue #1046: a jagged/nested array element — the element type is
             // itself a non-identifier type clause (`[][]T`, `[]*T`, `[]map[K,V]`,
             // `[]chan T`, `[]func(...) R`, `[](T1, T2)`, …). When the token after
@@ -3818,7 +3824,8 @@ public class Parser
                     length,
                     closeBracket,
                     nestedElement,
-                    nestedQuestion);
+                    nestedQuestion,
+                    arrayNullableQuestion);
             }
 
             var elementIdentifier = MatchToken(SyntaxKind.IdentifierToken);
@@ -3866,7 +3873,8 @@ public class Parser
                 arrayTypeArgOpen,
                 arrayTypeArgs,
                 arrayTypeArgClose,
-                arrayQuestion);
+                arrayQuestion,
+                arrayNullableQuestion);
         }
 
         var identifier = MatchToken(SyntaxKind.IdentifierToken);
@@ -7543,6 +7551,42 @@ public class Parser
         }
 
         var elementType = MatchToken(SyntaxKind.IdentifierToken);
+
+        // Issue #1212: an element-nullable array literal `[]T?{ … }` /
+        // `[N]T?{ … }`. The `?` binds to the element identifier, so route the
+        // element through a nullable-suffixed type clause (the nested-element
+        // path) instead of the bare-identifier fast path, yielding a
+        // `Slice(Nullable(T))` / `Array(Nullable(T), N)`.
+        if (Current.Kind == SyntaxKind.QuestionToken)
+        {
+            var questionToken = MatchToken(SyntaxKind.QuestionToken);
+            var elementClause = new TypeClauseSyntax(syntaxTree, openBracketToken: null, lengthToken: null, closeBracketToken: null, elementType, questionToken);
+            var (nElemOpenBrace, nElemElements, nElemCloseBrace, nElemHasElements) = ParseOptionalArrayInitializer();
+
+            if (!nElemHasElements && (lengthExpression != null || lengthToken != null))
+            {
+                return new ArrayCreationExpressionSyntax(
+                    syntaxTree,
+                    openBracket,
+                    lengthExpression ?? new LiteralExpressionSyntax(syntaxTree, lengthToken),
+                    closeBracket,
+                    elementClause,
+                    nElemOpenBrace,
+                    nElemElements,
+                    nElemCloseBrace);
+            }
+
+            return new ArrayCreationExpressionSyntax(
+                syntaxTree,
+                openBracket,
+                lengthExpression == null ? lengthToken : ToLengthLiteralToken(lengthExpression),
+                closeBracket,
+                elementClause,
+                nElemOpenBrace ?? MatchToken(SyntaxKind.OpenBraceToken),
+                nElemElements ?? new SeparatedSyntaxList<ExpressionSyntax>(ImmutableArray<SyntaxNode>.Empty),
+                nElemCloseBrace ?? MatchToken(SyntaxKind.CloseBraceToken));
+        }
+
         var (openBrace, elements, closeBrace, hasElements) = ParseOptionalArrayInitializer();
 
         // Issue #1272: `[n]T` (no initializer) or `[n]T{}` (empty initializer)

--- a/src/Core/CodeAnalysis/Syntax/TypeClauseSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/TypeClauseSyntax.cs
@@ -104,6 +104,7 @@ public sealed class TypeClauseSyntax : SyntaxNode
     /// <param name="typeArguments">The type-argument list, or the default value.</param>
     /// <param name="typeArgumentCloseBracketToken">The closing bracket of the type-argument list, or <c>null</c>.</param>
     /// <param name="questionToken">The optional trailing <c>?</c> marking the type nullable.</param>
+    /// <param name="arrayQuestionToken">The optional <c>?</c> placed immediately after <c>]</c>, marking the whole array nullable (<c>[]?T</c>, issue #1212).</param>
     public TypeClauseSyntax(
         SyntaxTree syntaxTree,
         SyntaxToken openBracketToken,
@@ -115,7 +116,8 @@ public sealed class TypeClauseSyntax : SyntaxNode
         SyntaxToken typeArgumentOpenBracketToken,
         SeparatedSyntaxList<TypeClauseSyntax> typeArguments,
         SyntaxToken typeArgumentCloseBracketToken,
-        SyntaxToken questionToken)
+        SyntaxToken questionToken,
+        SyntaxToken arrayQuestionToken = null)
         : base(syntaxTree)
     {
         OpenBracketToken = openBracketToken;
@@ -128,6 +130,7 @@ public sealed class TypeClauseSyntax : SyntaxNode
         TypeArguments = typeArguments;
         TypeArgumentCloseBracketToken = typeArgumentCloseBracketToken;
         QuestionToken = questionToken;
+        ArrayQuestionToken = arrayQuestionToken;
     }
 
     /// <summary>Initializes a new instance of the <see cref="TypeClauseSyntax"/> class for a tuple type <c>(T1, T2, ...)</c> (Phase 4.5).</summary>
@@ -241,7 +244,8 @@ public sealed class TypeClauseSyntax : SyntaxNode
         SyntaxToken closeBracketToken,
         TypeClauseSyntax arrayElementType,
         SyntaxToken questionToken,
-        bool isNestedArray)
+        bool isNestedArray,
+        SyntaxToken arrayQuestionToken = null)
         : base(syntaxTree)
     {
         OpenBracketToken = openBracketToken;
@@ -249,6 +253,7 @@ public sealed class TypeClauseSyntax : SyntaxNode
         CloseBracketToken = closeBracketToken;
         ArrayElementType = arrayElementType;
         QuestionToken = questionToken;
+        ArrayQuestionToken = arrayQuestionToken;
         QualifierDotTokens = ImmutableArray<SyntaxToken>.Empty;
         QualifierIdentifierTokens = ImmutableArray<SyntaxToken>.Empty;
     }
@@ -483,6 +488,12 @@ public sealed class TypeClauseSyntax : SyntaxNode
     /// <summary>Gets a value indicating whether this clause denotes a nullable type <c>T?</c> (Phase 3.C.1).</summary>
     public bool IsNullable => QuestionToken != null;
 
+    /// <summary>Gets the optional <c>?</c> token placed immediately after the array <c>]</c> (before the element type), marking the whole array reference nullable (<c>[]?T</c> / <c>[N]?T</c>, issue #1212).</summary>
+    public SyntaxToken ArrayQuestionToken { get; }
+
+    /// <summary>Gets a value indicating whether this array/slice clause is itself a nullable array reference (<c>[]?T</c>), spelled with a <c>?</c> right after <c>]</c> (issue #1212).</summary>
+    public bool IsArrayNullable => ArrayQuestionToken != null;
+
     /// <summary>Gets the opening <c>(</c> token for tuple types, or <c>null</c>.</summary>
     public SyntaxToken OpenParenToken { get; }
 
@@ -659,6 +670,7 @@ public sealed class TypeClauseSyntax : SyntaxNode
     /// <param name="closeBracketToken">The closing <c>]</c> token of the array/slice prefix.</param>
     /// <param name="elementType">The nested element type clause.</param>
     /// <param name="questionToken">The optional trailing <c>?</c> nullability marker.</param>
+    /// <param name="arrayQuestionToken">The optional <c>?</c> placed immediately after <c>]</c>, marking the whole array nullable (<c>[]?T</c>, issue #1212).</param>
     /// <returns>An array/slice type clause carrying a nested element type clause.</returns>
     public static TypeClauseSyntax CreateArray(
         SyntaxTree syntaxTree,
@@ -666,9 +678,10 @@ public sealed class TypeClauseSyntax : SyntaxNode
         SyntaxToken lengthToken,
         SyntaxToken closeBracketToken,
         TypeClauseSyntax elementType,
-        SyntaxToken questionToken)
+        SyntaxToken questionToken,
+        SyntaxToken arrayQuestionToken = null)
     {
-        return new TypeClauseSyntax(syntaxTree, openBracketToken, lengthToken, closeBracketToken, elementType, questionToken, isNestedArray: true);
+        return new TypeClauseSyntax(syntaxTree, openBracketToken, lengthToken, closeBracketToken, elementType, questionToken, isNestedArray: true, arrayQuestionToken);
     }
 
     /// <summary>Creates a sequence type clause <c>sequence[T]</c> (ADR-0040).</summary>

--- a/test/Compiler.Tests/Emit/Issue1154NullableWideningOverloadEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1154NullableWideningOverloadEmitTests.cs
@@ -16,7 +16,7 @@ namespace GSharp.Compiler.Tests.Emit;
 /// overload that needs an implicit nullable-widening conversion (T → T?) when
 /// a second, wholly non-applicable overload (e.g. <c>F(string)</c>) also
 /// exists — without a spurious GS0266 ambiguity. This test proves the selected
-/// <c>F([]uint8?)</c> overload actually runs: a non-null array argument flows
+/// <c>F([]?uint8)</c> overload actually runs: a non-null array argument flows
 /// into the nullable-array overload body and produces its distinctive output.
 /// </summary>
 public class Issue1154NullableWideningOverloadEmitTests
@@ -32,7 +32,7 @@ public class Issue1154NullableWideningOverloadEmitTests
             class C {
                 shared { func Make() []uint8 { var r = []uint8{uint8(10), uint8(20), uint8(30)} return r } }
                 func F(a string) string { return "string-overload" }
-                func F(a []uint8?) string {
+                func F(a []?uint8) string {
                     if a == nil { return "null" }
                     return "bytes-overload:" + a.Length.ToString()
                 }

--- a/test/Compiler.Tests/Emit/Issue1212NullableElementArrayIndexEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1212NullableElementArrayIndexEmitTests.cs
@@ -1,0 +1,184 @@
+// <copyright file="Issue1212NullableElementArrayIndexEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1212 — emit/execution coverage for indexing an array/slice whose
+/// element type is nullable (<c>[]T?</c>). Each test compiles via in-process
+/// <c>gsc</c>, IL-verifies the emitted PE, and runs it under <c>dotnet exec</c>,
+/// asserting captured stdout. Both a nullable *value*-element array
+/// (<c>[]int32?</c>, backed by <c>Nullable&lt;int32&gt;[]</c>) and a nullable
+/// *reference*-element array (<c>[]object?</c>, backed by <c>object[]</c>) are
+/// written (including a nil and a value) and read back, proving the emitted
+/// <c>ldelem</c>/<c>stelem</c> round-trip the nullable element correctly. A
+/// nullable array reference (<c>[]?int32</c>) is also exercised through the
+/// null-forgiving <c>!!</c> path.
+/// </summary>
+public class Issue1212NullableElementArrayIndexEmitTests
+{
+    [Fact]
+    public void NullableValueElementSlice_WriteReadRoundTrips()
+    {
+        var source = """
+            package Test
+            import System
+
+            func main() {
+                var a []int32? = []int32?{nil, 7, nil}
+                a[0] = 42
+                if a[0] == nil { Console.WriteLine("nil") } else { Console.WriteLine(a[0]!!) }
+                if a[1] == nil { Console.WriteLine("nil") } else { Console.WriteLine(a[1]!!) }
+                if a[2] == nil { Console.WriteLine("nil") } else { Console.WriteLine(a[2]!!) }
+            }
+
+            main()
+            """;
+
+        Assert.Equal("42\n7\nnil\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void NullableReferenceElementSlice_WriteReadRoundTrips()
+    {
+        var source = """
+            package Test
+            import System
+
+            func main() {
+                var a []object? = []object?{nil, "hi"}
+                a[0] = "set"
+                if a[0] == nil { Console.WriteLine("nil") } else { Console.WriteLine(a[0]!!) }
+                if a[1] == nil { Console.WriteLine("nil") } else { Console.WriteLine(a[1]!!) }
+            }
+
+            main()
+            """;
+
+        Assert.Equal("set\nhi\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void NullableValueElementSlice_WriteNil_ReadsBackNil()
+    {
+        var source = """
+            package Test
+            import System
+
+            func main() {
+                var a []int32? = []int32?{1, 2, 3}
+                a[1] = nil
+                Console.WriteLine(a.Length)
+                if a[1] == nil {
+                    Console.WriteLine("cleared")
+                } else {
+                    Console.WriteLine("kept")
+                }
+                Console.WriteLine(a[2]!!)
+            }
+
+            main()
+            """;
+
+        Assert.Equal("3\ncleared\n3\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void NullableArrayReference_IndexableAfterNullForgiving()
+    {
+        // `[]?int32` is a nullable array reference: it can hold nil and must be
+        // null-forgiven (`!!`) before indexing.
+        var source = """
+            package Test
+            import System
+
+            func main() {
+                var a []?int32 = nil
+                if a == nil { Console.WriteLine("nil-array") }
+                a = []int32{10, 20, 30}
+                Console.WriteLine(a!![1])
+            }
+
+            main()
+            """;
+
+        Assert.Equal("nil-array\n20\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1212_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed (exit {compileExit}):\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"sample exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue710NullConditionalIndexingEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue710NullConditionalIndexingEmitTests.cs
@@ -27,7 +27,7 @@ public class Issue710NullConditionalIndexingEmitTests
             import System
 
             func main() {
-                var a []int32? = nil
+                var a []?int32 = nil
                 var x = a?[0]
                 if x == nil {
                     Console.WriteLine("nil")
@@ -50,7 +50,7 @@ public class Issue710NullConditionalIndexingEmitTests
             import System
 
             func main() {
-                var a []int32? = []int32{10, 20, 30}
+                var a []?int32 = []int32{10, 20, 30}
                 var x = a?[1]
                 Console.WriteLine(x)
             }
@@ -149,12 +149,12 @@ public class Issue710NullConditionalIndexingEmitTests
             var receiverCalls int32 = 0
             var indexCalls int32 = 0
 
-            func getSlice() []int32? {
+            func getSlice() []?int32 {
                 receiverCalls = receiverCalls + 1
                 return []int32{7, 8, 9}
             }
 
-            func getNilSlice() []int32? {
+            func getNilSlice() []?int32 {
                 receiverCalls = receiverCalls + 1
                 return nil
             }
@@ -197,7 +197,7 @@ public class Issue710NullConditionalIndexingEmitTests
             import System
 
             class Holder {
-                var Data []int32?
+                var Data []?int32
             }
 
             func main() {

--- a/test/Compiler.Tests/Emit/Issue751RichReceiverEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue751RichReceiverEmitTests.cs
@@ -68,7 +68,7 @@ public class Issue751RichReceiverEmitTests
             package P
             import System
 
-            func (self []int32?) FirstOrZero() int32 {
+            func (self []?int32) FirstOrZero() int32 {
                 if self == nil {
                     return 0
                 }
@@ -78,8 +78,8 @@ public class Issue751RichReceiverEmitTests
                 return self[0]
             }
 
-            var present []int32? = []int32{10, 20}
-            var absent []int32? = nil
+            var present []?int32 = []int32{10, 20}
+            var absent []?int32 = nil
             Console.WriteLine(present.FirstOrZero())
             Console.WriteLine(absent.FirstOrZero())
             """;

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1154NullableWideningOverloadTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1154NullableWideningOverloadTests.cs
@@ -31,14 +31,14 @@ public class Issue1154NullableWideningOverloadTests
     [Fact]
     public void Repro_NullableWidening_UniqueApplicable_BindsWithoutGS0266()
     {
-        // REPRO: F(string), F([]uint8?); arg is non-nullable []uint8.
-        // Only F([]uint8?) is applicable ([]uint8 -> []uint8? implicit widening).
+        // REPRO: F(string), F([]?uint8); arg is non-nullable []uint8.
+        // Only F([]?uint8) is applicable ([]uint8 -> []?uint8 implicit widening).
         const string source = @"
 package p
 class C {
     shared { func Make() []uint8 { var r []uint8 return r } }
     func F(a string) { F(C.Make()) }
-    func F(a []uint8?) { var n = 1 }
+    func F(a []?uint8) { var n = 1 }
 }
 ";
         var compilation = Compile(source);
@@ -78,12 +78,12 @@ class C {
     [Fact]
     public void VariantB_NullableWideningOnly_StillBinds()
     {
-        // F([]uint8?) only; arg []uint8 -> nullable widening applicable.
+        // F([]?uint8) only; arg []uint8 -> nullable widening applicable.
         const string source = @"
 package p
 class C {
     shared { func Make() []uint8 { var r []uint8 return r } }
-    func F(a []uint8?) { F(C.Make()) }
+    func F(a []?uint8) { F(C.Make()) }
 }
 ";
         var compilation = Compile(source);
@@ -100,13 +100,13 @@ class C {
     [Fact]
     public void VariantC_ExactNullableMatch_StillBinds()
     {
-        // F(string), F([]uint8?); arg is []uint8? -> exact match to T?.
+        // F(string), F([]?uint8); arg is []?uint8 -> exact match to T?.
         const string source = @"
 package p
 class C {
-    shared { func Make() []uint8? { var r []uint8? return r } }
+    shared { func Make() []?uint8 { var r []?uint8 return r } }
     func F(a string) { F(C.Make()) }
-    func F(a []uint8?) { var n = 1 }
+    func F(a []?uint8) { var n = 1 }
 }
 ";
         var compilation = Compile(source);

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1212NullableElementArrayIndexTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1212NullableElementArrayIndexTests.cs
@@ -1,0 +1,141 @@
+// <copyright file="Issue1212NullableElementArrayIndexTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1212: the two array nullability spellings.
+/// <list type="bullet">
+/// <item><c>[]T?</c> is a (non-nil) array whose ELEMENTS are nullable. It is
+/// indexable as ordinary element access yielding <c>T?</c> (read) and accepting
+/// <c>T?</c> (write).</item>
+/// <item><c>[]?T</c> is a nullable ARRAY reference (the whole array may be nil).
+/// Indexing it directly is rejected with GS0116; a null-forgiving <c>!!</c>
+/// (or the null-conditional <c>?[</c>) is required first.</item>
+/// <item><c>[]?T?</c> is a nullable array of nullable elements.</item>
+/// </list>
+/// </summary>
+public class Issue1212NullableElementArrayIndexTests
+{
+    [Fact]
+    public void NullableReferenceElementSlice_IsIndexable_ForRead()
+    {
+        var diagnostics = Bind("""
+            package p
+            func F(a []object?) object? { return a[0] }
+            """);
+        Assert.Empty(diagnostics.Where(d => d.IsError));
+    }
+
+    [Fact]
+    public void NullableValueElementSlice_IsIndexable_ForRead()
+    {
+        var diagnostics = Bind("""
+            package p
+            func G(a []int32?) int32? { return a[0] }
+            """);
+        Assert.Empty(diagnostics.Where(d => d.IsError));
+    }
+
+    [Fact]
+    public void NonNullableElementSlice_StillIndexable()
+    {
+        var diagnostics = Bind("""
+            package p
+            func H(a []object) object { return a[0] }
+            """);
+        Assert.Empty(diagnostics.Where(d => d.IsError));
+    }
+
+    [Fact]
+    public void NullableElementSlice_IndexResult_IsNullableElementType()
+    {
+        // `a[0]` on `[]int32?` yields `int32?`; assigning it to a non-nullable
+        // `int32` return must be rejected, proving the read result is nullable.
+        var diagnostics = Bind("""
+            package p
+            func F(a []int32?) int32 { return a[0] }
+            """);
+        Assert.Contains(diagnostics, d => d.IsError);
+    }
+
+    [Fact]
+    public void NullableElementSlice_IndexedWrite_AcceptsNullableElement()
+    {
+        var diagnostics = Bind("""
+            package p
+            func W(a []object?, x object?) { a[0] = x }
+            func V(a []int32?, x int32?) { a[0] = x }
+            """);
+        Assert.Empty(diagnostics.Where(d => d.IsError));
+    }
+
+    [Fact]
+    public void NullableElementFixedArray_IsIndexable()
+    {
+        var diagnostics = Bind("""
+            package p
+            func F(a [3]int32?) int32? { return a[0] }
+            """);
+        Assert.Empty(diagnostics.Where(d => d.IsError));
+    }
+
+    [Fact]
+    public void WholeNullableArray_RequiresNullCheck_BeforeIndexing()
+    {
+        // `[]?int32` is a nullable array *reference*; indexing it directly is
+        // rejected with GS0116 (the array may be nil).
+        var diagnostics = Bind("""
+            package p
+            func F(a []?int32) int32 { return a[0] }
+            """);
+        Assert.Contains(diagnostics, d => d.Id == "GS0116");
+    }
+
+    [Fact]
+    public void WholeNullableArray_IsIndexable_AfterNullForgiving()
+    {
+        var diagnostics = Bind("""
+            package p
+            func F(a []?int32) int32 { return a!![0] }
+            """);
+        Assert.Empty(diagnostics.Where(d => d.IsError));
+    }
+
+    [Fact]
+    public void NullableArrayOfNullableElements_IndexAfterForgiving_YieldsNullableElement()
+    {
+        var diagnostics = Bind("""
+            package p
+            func F(a []?int32?) int32? { return a!![0] }
+            """);
+        Assert.Empty(diagnostics.Where(d => d.IsError));
+    }
+
+    private static ImmutableArray<Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        if (tree.Diagnostics.Any(d => d.IsError))
+        {
+            return tree.Diagnostics;
+        }
+
+        var globalScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+        if (globalScope.Diagnostics.Any(d => d.IsError))
+        {
+            return globalScope.Diagnostics;
+        }
+
+        var program = Binder.BindProgram(globalScope);
+        return program.Diagnostics.ToImmutableArray();
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1212NullableElementArrayIndexTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1212NullableElementArrayIndexTests.cs
@@ -121,6 +121,33 @@ public class Issue1212NullableElementArrayIndexTests
         Assert.Empty(diagnostics.Where(d => d.IsError));
     }
 
+    [Fact]
+    public void NullableArray_DisplayName_BindsQuestionToArray_NotElement()
+    {
+        // Issue #1212: the GS0116 message must render the whole-array nullable
+        // spelling `[]?int32`, NOT `[]int32?` (which now means nullable elements).
+        var diagnostics = Bind("""
+            package p
+            func N(a []?int32) int32 { return a[0] }
+            """);
+        var gs0116 = Assert.Single(diagnostics, d => d.Id == "GS0116");
+        Assert.Contains("[]?int32", gs0116.Message);
+        Assert.DoesNotContain("[]int32?", gs0116.Message);
+    }
+
+    [Fact]
+    public void NullableElementSlice_DisplayName_BindsQuestionToElement()
+    {
+        // The element-nullable spelling renders `[]int32?` (no conversion to string).
+        var diagnostics = Bind("""
+            package p
+            func F(a []int32?) string { return a }
+            """);
+        var gs0156 = Assert.Single(diagnostics, d => d.Id == "GS0156");
+        Assert.Contains("[]int32?", gs0156.Message);
+        Assert.DoesNotContain("[]?int32", gs0156.Message);
+    }
+
     private static ImmutableArray<Diagnostic> Bind(string source)
     {
         var tree = SyntaxTree.Parse(SourceText.From(source));

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1238ConditionalArgumentTargetTypingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1238ConditionalArgumentTargetTypingTests.cs
@@ -53,7 +53,7 @@ class C {
 import System.Text
 
 class C {
-    func Sink(name string, data []uint8?) { }
+    func Sink(name string, data []?uint8) { }
     func Call(data string?) {
         Sink(""x"", if data == nil { nil } else { Encoding.UTF8.GetBytes(data!!) })
     }
@@ -135,14 +135,14 @@ class C {
 import System.Text
 
 class C {
-    func R(data string?) []uint8? {
+    func R(data string?) []?uint8 {
         return if data == nil { nil } else { Encoding.UTF8.GetBytes(data!!) }
     }
-    func L(data string?) []uint8? {
-        let r []uint8? = if data == nil { nil } else { Encoding.UTF8.GetBytes(data!!) }
+    func L(data string?) []?uint8 {
+        let r []?uint8 = if data == nil { nil } else { Encoding.UTF8.GetBytes(data!!) }
         return r
     }
-    func Sink(data []uint8?) { }
+    func Sink(data []?uint8) { }
     func PlainNil() { Sink(nil) }
 }
 ";

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1240ParameterShadowsFieldTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1240ParameterShadowsFieldTests.cs
@@ -31,18 +31,18 @@ public class Issue1240ParameterShadowsFieldTests
     public void Constructor_NullableParam_ShadowsNonNullableField_NoDiagnostics()
     {
         // Faithful repro from the issue: the field is non-nullable []uint8 while
-        // the parameter is nullable []uint8?. Bare `iv` must bind to the
+        // the parameter is nullable []?uint8. Bare `iv` must bind to the
         // PARAMETER, so `iv == nil` typechecks; binding to the field would emit
         // GS0129 ('==' not defined for '[]uint8' and 'nil').
         var source = @"
 package p
 class C {
     private let iv []uint8
-    init(iv []uint8?) {
+    init(iv []?uint8) {
         if iv == nil { throw System.ArgumentException(""x"") }
         this.iv = iv!!
     }
-    func M(iv []uint8?) bool {
+    func M(iv []?uint8) bool {
         return iv == nil
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue710NullConditionalIndexingBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue710NullConditionalIndexingBindingTests.cs
@@ -28,7 +28,7 @@ public class Issue710NullConditionalIndexingBindingTests
         var diagnostics = Bind("""
             package P
             func F() {
-                var a []int32? = nil
+                var a []?int32 = nil
                 var x = a?[0]
             }
             """);
@@ -52,12 +52,12 @@ public class Issue710NullConditionalIndexingBindingTests
     [Fact]
     public void Result_Is_Nullable_Form_Of_Element_Type()
     {
-        // `a?[0]` where a is `[]int32?` (slice of int32, nullable slice)
+        // `a?[0]` where a is `[]?int32` (slice of int32, nullable slice)
         // should give `int32?` for the read result.
         var program = BindProgramFor("""
             package P
             func F() int32? {
-                var a []int32? = nil
+                var a []?int32 = nil
                 return a?[0]
             }
             """);
@@ -72,7 +72,7 @@ public class Issue710NullConditionalIndexingBindingTests
         var diagnostics = Bind("""
             package P
             class Holder {
-                var Data []int32?
+                var Data []?int32
             }
             func F() {
                 var h Holder? = Holder{Data: []int32{1, 2, 3}}
@@ -115,7 +115,7 @@ public class Issue710NullConditionalIndexingBindingTests
         var diagnostics = Bind("""
             package P
             func F() {
-                var a []int32? = nil
+                var a []?int32 = nil
                 a?[0] = 1
             }
             """);
@@ -128,7 +128,7 @@ public class Issue710NullConditionalIndexingBindingTests
         var diagnostics = Bind("""
             package P
             func F() {
-                var a []int32? = nil
+                var a []?int32 = nil
                 a?[0] += 1
             }
             """);
@@ -143,7 +143,7 @@ public class Issue710NullConditionalIndexingBindingTests
         var diagnostics = Bind("""
             package P
             func F() {
-                var a []int32? = nil
+                var a []?int32 = nil
                 a?[0] ??= 1
             }
             """);

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue751RichReceiverBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue751RichReceiverBinderTests.cs
@@ -82,7 +82,7 @@ p.Tag() + ""|"" + q.Tag()
     public void NullableArray_Receiver_Dispatches_Via_DotSyntax()
     {
         var source = @"
-func (self []int32?) FirstOrZero() int32 {
+func (self []?int32) FirstOrZero() int32 {
     if self == nil {
         return 0
     }
@@ -92,8 +92,8 @@ func (self []int32?) FirstOrZero() int32 {
     return self[0]
 }
 
-var present []int32? = []int32{10, 20}
-var absent []int32? = nil
+var present []?int32 = []int32{10, 20}
+var absent []?int32 = nil
 present.FirstOrZero() + absent.FirstOrZero()
 ";
         var result = Evaluate(source);

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue1212NullableArrayElementParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue1212NullableArrayElementParserTests.cs
@@ -1,0 +1,136 @@
+// <copyright file="Issue1212NullableArrayElementParserTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Issue #1212: where the nullable <c>?</c> binds in an array/slice type clause.
+/// <list type="bullet">
+/// <item><c>[]T?</c> — the trailing <c>?</c> binds to the ELEMENT
+/// (<see cref="TypeClauseSyntax.IsNullable"/> on the array clause; the array
+/// itself is non-nullable).</item>
+/// <item><c>[]?T</c> — a <c>?</c> right after <c>]</c> marks the whole array
+/// nullable (<see cref="TypeClauseSyntax.IsArrayNullable"/>).</item>
+/// <item><c>[]?T?</c> — both markers are present.</item>
+/// </list>
+/// Covers slices, fixed-length arrays, and jagged arrays.
+/// </summary>
+public class Issue1212NullableArrayElementParserTests
+{
+    private static TypeClauseSyntax LocalVarType(string typeText)
+    {
+        var source = $@"
+package P
+func Use() {{
+    var x {typeText} = default({typeText})
+}}
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+        var fn = tree.Root.Members.OfType<FunctionDeclarationSyntax>().Single();
+        var varDecl = fn.Body.Statements.OfType<VariableDeclarationSyntax>().Single();
+        Assert.NotNull(varDecl.TypeClause);
+        return varDecl.TypeClause;
+    }
+
+    [Fact]
+    public void ElementNullableSlice_BindsQuestionToElement()
+    {
+        var type = LocalVarType("[]int32?");
+
+        Assert.True(type.IsSlice);
+        Assert.True(type.IsNullable);          // trailing `?` -> element nullable
+        Assert.False(type.IsArrayNullable);    // array itself is non-nullable
+        Assert.Equal("int32", type.Identifier.Text);
+    }
+
+    [Fact]
+    public void NullableArraySlice_BindsQuestionToArray()
+    {
+        var type = LocalVarType("[]?int32");
+
+        Assert.True(type.IsSlice);
+        Assert.False(type.IsNullable);         // element is non-nullable
+        Assert.True(type.IsArrayNullable);     // `?` after `]` -> array nullable
+        Assert.Equal("int32", type.Identifier.Text);
+    }
+
+    [Fact]
+    public void NullableArrayOfNullableElements_HasBothMarkers()
+    {
+        var type = LocalVarType("[]?int32?");
+
+        Assert.True(type.IsSlice);
+        Assert.True(type.IsNullable);          // trailing `?` -> element nullable
+        Assert.True(type.IsArrayNullable);     // leading `?` -> array nullable
+        Assert.Equal("int32", type.Identifier.Text);
+    }
+
+    [Fact]
+    public void ElementNullableFixedArray_BindsQuestionToElement()
+    {
+        var type = LocalVarType("[3]int32?");
+
+        Assert.True(type.IsArray);
+        Assert.False(type.IsSlice);
+        Assert.True(type.IsNullable);
+        Assert.False(type.IsArrayNullable);
+        Assert.Equal("3", type.LengthToken.Text);
+        Assert.Equal("int32", type.Identifier.Text);
+    }
+
+    [Fact]
+    public void NullableFixedArray_BindsQuestionToArray()
+    {
+        var type = LocalVarType("[3]?int32");
+
+        Assert.True(type.IsArray);
+        Assert.False(type.IsSlice);
+        Assert.False(type.IsNullable);
+        Assert.True(type.IsArrayNullable);
+        Assert.Equal("3", type.LengthToken.Text);
+        Assert.Equal("int32", type.Identifier.Text);
+    }
+
+    [Fact]
+    public void JaggedSliceOfNullableElements_BindsInnerElementNullable()
+    {
+        // `[][]int32?` — the trailing `?` binds to the innermost element.
+        var type = LocalVarType("[][]int32?");
+
+        Assert.True(type.IsSlice);
+        Assert.False(type.IsNullable);
+        Assert.False(type.IsArrayNullable);
+        Assert.True(type.HasNestedArrayElement);
+
+        var inner = type.ArrayElementType;
+        Assert.True(inner.IsSlice);
+        Assert.True(inner.IsNullable);         // inner `[]int32?` element nullable
+        Assert.False(inner.IsArrayNullable);
+        Assert.Equal("int32", inner.Identifier.Text);
+    }
+
+    [Fact]
+    public void NullableArrayOfNestedElement_BindsOuterArrayNullable()
+    {
+        // `[]?*int32` — the outer slice reference is nullable; the element is a
+        // nested (pointer) type clause. (A nested *slice* element `[]?[]T` is
+        // not spellable because `?[` lexes as the null-conditional index token.)
+        var type = LocalVarType("[]?*int32");
+
+        Assert.True(type.IsSlice);
+        Assert.True(type.IsArrayNullable);
+        Assert.False(type.IsNullable);
+        Assert.True(type.HasNestedArrayElement);
+
+        var inner = type.ArrayElementType;
+        Assert.True(inner.IsPointer);
+        Assert.False(inner.IsArrayNullable);
+        Assert.False(inner.IsNullable);
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue751ReceiverClauseParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue751ReceiverClauseParserTests.cs
@@ -12,7 +12,8 @@ namespace GSharp.Core.Tests.CodeAnalysis.Syntax;
 /// Parser-level coverage for issue #751 / ADR-0084 §L2: the receiver
 /// clause `func (recv RecvType) Name(...)` must accept the full type
 /// grammar — nullable spellings (`T?`), generic applications
-/// (`sequence[T]`, `map[K,V]`), array+nullable combinations (`[]T?`),
+/// (`sequence[T]`, `map[K,V]`), array+nullable combinations (`[]T?` for
+/// nullable elements and `[]?T` for a nullable array, issue #1212),
 /// tuple types (`(int32, T)`), and arbitrary nesting (`sequence[T]?`).
 /// Prior to the fix, <c>LooksLikeReceiverClause</c> only matched a
 /// bare identifier or `[N]T` / `[]T` and silently demoted the rest to
@@ -25,6 +26,7 @@ public class Issue751ReceiverClauseParserTests
     [InlineData("func (self sequence[T]) M[T]() { }", "M")]
     [InlineData("func (self sequence[T]?) M[T]() { }", "M")]
     [InlineData("func (self []T?) M[T]() { }", "M")]
+    [InlineData("func (self []?T) M[T]() { }", "M")]
     [InlineData("func (self map[K,V]) M[K, V]() { }", "M")]
     [InlineData("func (self []T) M[T]() { }", "M")]
     [InlineData("func (self [3]int32) M() { }", "M")]

--- a/test/Interpreter.Tests/Issue710NullConditionalIndexingInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue710NullConditionalIndexingInterpreterTests.cs
@@ -22,7 +22,7 @@ public class Issue710NullConditionalIndexingInterpreterTests
     public void Slice_NullReceiver_YieldsNil()
     {
         var source = """
-            var a []int32? = nil
+            var a []?int32 = nil
             var x = a?[0]
             if x == nil {
                 Console.WriteLine("nil")
@@ -39,7 +39,7 @@ public class Issue710NullConditionalIndexingInterpreterTests
     public void Slice_NonNullReceiver_YieldsLiftedValue()
     {
         var source = """
-            var a []int32? = []int32{10, 20, 30}
+            var a []?int32 = []int32{10, 20, 30}
             var x = a?[1]
             Console.WriteLine(x)
             """;
@@ -107,12 +107,12 @@ public class Issue710NullConditionalIndexingInterpreterTests
             var receiverCalls int32 = 0
             var indexCalls int32 = 0
 
-            func getSlice() []int32? {
+            func getSlice() []?int32 {
                 receiverCalls = receiverCalls + 1
                 return []int32{7, 8, 9}
             }
 
-            func getNilSlice() []int32? {
+            func getNilSlice() []?int32 {
                 receiverCalls = receiverCalls + 1
                 return nil
             }
@@ -153,7 +153,7 @@ public class Issue710NullConditionalIndexingInterpreterTests
     {
         var source = """
             class Holder {
-                var Data []int32?
+                var Data []?int32
             }
 
             func main() {

--- a/test/Interpreter.Tests/Issue751RichReceiverInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue751RichReceiverInterpreterTests.cs
@@ -53,7 +53,7 @@ public class Issue751RichReceiverInterpreterTests
     public void NullableArray_Receiver_Dispatches()
     {
         var source = """
-            func (self []int32?) FirstOrZero() int32 {
+            func (self []?int32) FirstOrZero() int32 {
                 if self == nil {
                     return 0
                 }
@@ -63,8 +63,8 @@ public class Issue751RichReceiverInterpreterTests
                 return self[0]
             }
 
-            var present []int32? = []int32{10, 20}
-            var absent []int32? = nil
+            var present []?int32 = []int32{10, 20}
+            var absent []?int32 = nil
             Console.WriteLine(present.FirstOrZero())
             Console.WriteLine(absent.FirstOrZero())
             """;

--- a/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
@@ -106,6 +106,15 @@ public static class GSharpPrinter
 
     private static string RenderType(GTypeReference type)
     {
+        // Issue #1212: an array's own nullability is spelled `[]?T` (the `?`
+        // sits right after `]`), distinct from an array of nullable elements
+        // `[]T?` (where the element rendering carries its own trailing `?`).
+        if (type is ArrayTypeReference array)
+        {
+            var arrayMarker = array.IsNullable ? "?" : string.Empty;
+            return $"[]{arrayMarker}{RenderType(array.ElementType)}";
+        }
+
         var rendered = RenderTypeCore(type);
         return type != null && type.IsNullable ? rendered + "?" : rendered;
     }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1072NullCheckedAsNullableTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1072NullCheckedAsNullableTranslationTests.cs
@@ -58,7 +58,7 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("key []uint8?", printed);
+        Assert.Contains("key []?uint8", printed);
     }
 
     [Fact]
@@ -78,7 +78,7 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("iv []uint8?", printed);
+        Assert.Contains("iv []?uint8", printed);
     }
 
     [Fact]

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1212NullableArrayElementTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1212NullableArrayElementTranslationTests.cs
@@ -1,0 +1,108 @@
+// <copyright file="Issue1212NullableArrayElementTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #1212 — cs2gs must distinguish the two array nullability spellings:
+/// a C# array of nullable ELEMENTS (<c>T?[]</c>) renders as <c>[]T?</c> (a
+/// non-nullable slice whose element type is <c>T?</c>), while a C# nullable
+/// ARRAY reference (<c>T[]?</c>) renders as <c>[]?T</c> (the whole slice may be
+/// nil). Both must round-trip through gsc.
+/// </summary>
+public class Issue1212NullableArrayElementTranslationTests
+{
+    [Fact]
+    public void NullableReferenceElementArray_RendersElementNullable()
+    {
+        string printed = TranslateUnit(@"
+#nullable enable
+namespace Demo
+{
+    public class C
+    {
+        public void F(object?[] items) { }
+    }
+}");
+
+        Assert.Contains("F(items []object?)", printed);
+    }
+
+    [Fact]
+    public void NullableValueElementArray_RendersElementNullable()
+    {
+        string printed = TranslateUnit(@"
+#nullable enable
+namespace Demo
+{
+    public class C
+    {
+        public void F(int?[] items) { }
+    }
+}");
+
+        Assert.Contains("F(items []int32?)", printed);
+    }
+
+    [Fact]
+    public void NullableReferenceArray_RendersArrayNullable()
+    {
+        string printed = TranslateUnit(@"
+#nullable enable
+namespace Demo
+{
+    public class C
+    {
+        public void F(object[]? items) { }
+    }
+}");
+
+        Assert.Contains("F(items []?object)", printed);
+    }
+
+    [Fact]
+    public void NullableArrayOfNullableElements_RendersBothMarkers()
+    {
+        string printed = TranslateUnit(@"
+#nullable enable
+namespace Demo
+{
+    public class C
+    {
+        public void F(object?[]? items) { }
+    }
+}");
+
+        Assert.Contains("F(items []?object?)", printed);
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/website/docs/ref/spec.md
+++ b/website/docs/ref/spec.md
@@ -193,6 +193,29 @@ let buffer = [8]int32     // length-8, all elements 0
 
 Slices are backed by CLR arrays. `len` and `cap` observe array length, and `append` allocates and copies into a new array in the current implementation. The `len`, `cap`, `append`, `delete`, and `make` built-ins are Go-style and require `import Gsharp.Extensions.Go` (ADR-0083); see [Go-style built-ins (`import Gsharp.Extensions.Go`)](#go-style-built-ins-import-gsharpextensionsgo) for the gate and the .NET-idiomatic alternatives (`.Length`, `.Count`, `.Remove(k)`, `List[T].Add`).
 
+#### Nullable arrays vs arrays of nullable elements (issue #1212)
+
+The position of a nullable `?` in an array/slice type clause selects **what** is nullable — the array reference itself, or each element. A `?` **after the element** marks the element; a `?` **right after `]`** marks the whole array:
+
+| Spelling | Meaning | Indexable? |
+| --- | --- | --- |
+| `[]T?`   | a (non-nil) array of **nullable elements** | yes — `a[i]` yields `T?` |
+| `[]?T`   | a **nullable array** reference (the whole array may be nil) | no — null-forgive (`!!`) or use `a?[i]` first |
+| `[]?T?`  | a nullable array of nullable elements | no — `!!` first, then `a[i]` yields `T?` |
+
+The same rule applies to fixed arrays: `[N]T?` is a fixed array of nullable elements, `[N]?T` is a nullable fixed array, and `[N]?T?` is both. In a jagged type the trailing `?` binds to the innermost element, so `[][]T?` is a slice of slices of `T?`, and `[]*T?` is a slice of nullable pointers. An element-nullable value array (`[]int32?`) is backed by `Nullable<int32>[]` and round-trips nil elements; a nullable array (`[]?T`) is a nullable reference to a slice and stays non-indexable until null-forgiven (`GS0116` otherwise), preserving the prior nullable-array semantics under the new spelling. A nullable array whose element is itself a slice (`[]?[]T`) is not spellable, because `?[` lexes as the null-conditional index token.
+
+```gsharp
+var elems []int32? = []int32?{nil, 7}   // array of nullable elements
+elems[0] = 42                            // a[i] : int32? (read/write nil)
+
+var maybe []?int32 = nil                 // nullable array reference
+if maybe == nil { /* … */ }
+var first = maybe?[0]                     // null-conditional index, first : int32?
+```
+
+Slices are backed by CLR arrays. `len` and `cap` observe array length, and `append` allocates and copies into a new array in the current implementation.
+
 Array and slice element access (`a[i]`, read or write) accepts **any** integer-typed index, matching C#'s element-access rule (issue #1279): `int8`, `uint8`, `int16`, `uint16`, `char`, `int32`, `uint32`, `int64`, `uint64`, `nint`, and `nuint`. The narrower kinds that implicitly widen to `int32` are converted to `int32`; the wider kinds (`uint32`, `int64`, `uint64`, `nint`, `nuint`) are converted to the native index type `nint`, which the underlying CIL `ldelem`/`stelem`/`ldelema` accept as the index operand. A non-integer index (`float32`/`float64`/`bool`/`string`/`decimal`/a user type) is rejected (`GS0156`). `string` char-indexing (`s[i]`) likewise accepts any integer index, converting to the `int32` the `get_Chars` accessor takes.
 
 ### Maps
@@ -356,8 +379,8 @@ The implementation emits **reified CLR generic metadata** for user-declared and 
 
 ```ebnf
 TypeClause = identifier TypeArgList? "?"?
-           | "[" number? "]" identifier TypeArgList? "?"?
-           | "[" number? "]" TypeClause "?"?
+           | "[" number? "]" "?"? identifier TypeArgList? "?"?
+           | "[" number? "]" "?"? TypeClause "?"?
            | "(" TypeClause { "," TypeClause } ")" "?"?
            | "(" TypeClauseList? ")" "->" TypeClause "?"?
            | "async" "(" TypeClauseList? ")" "->" TypeClause "?"?


### PR DESCRIPTION
Fixes #1212.

G# had no syntax for an "array of nullable elements" (C# `T?[]`). A trailing `?` on an array clause meant a **nullable array** (`[]T?` = `([]T)?`), so indexing `a[0]` on `[]object?`/`[]int32?` failed with **GS0116** unless the array was null-forgiven first. This PR makes the breaking, coordinated redefinition of where `?` binds in an array/slice type clause, implementing **both** spellings together.

## Design (the three spellings)

| Spelling | Meaning | Bound type | Indexable? |
| --- | --- | --- | --- |
| `[]T?`   | array of nullable **elements** | `Slice(Nullable(T))` | yes — `a[i]` yields `T?` |
| `[]?T`   | nullable **array** | `Nullable(Slice(T))` | no — needs `!!` / `?[` first |
| `[]?T?`  | nullable array of nullable elements | `Nullable(Slice(Nullable(T)))` | no — `!!`, then `a[i]` yields `T?` |

Same for fixed arrays (`[N]T?`, `[N]?T`, `[N]?T?`) and jagged element-nullable forms (`[][]T?`, `[]*T?`). Mnemonic: a `?` **after `]`** marks the array; a `?` **after the element** marks the element.

cs2gs mapping: C# `T?[]` → `[]T?`, C# `T[]?` → `[]?T`, C# `T?[]?` → `[]?T?`.

## Per-layer summary

- **Syntax** (`TypeClauseSyntax`): new `ArrayQuestionToken` / `IsArrayNullable` for the `?` placed right after `]`. No new `SyntaxKind`/`BoundNodeKind`.
- **Parser**: captures the after-`]` array-nullable marker before the element-vs-nested-element branch; element-nullable array literals (`[]T?{…}`) route the element through a nullable-suffixed type clause.
- **Binder**: `ApplyArraySuffix` wraps the element in `NullableTypeSymbol` for a trailing `?`; `BindTypeClause` wraps the whole array in `NullableTypeSymbol` only for the after-`]` marker. `SliceTypeSymbol`/`ArrayTypeSymbol` back their CLR array type with `NullableLifting.GetEffectiveClrType(element)`, so `[]int32?` is `Nullable<int32>[]` and round-trips nil elements.
- **Indexing**: `[]T?` now binds to a slice, so the existing element-access path indexes it and yields `T?`; `[]?T` stays a `NullableTypeSymbol` and remains GS0116 until null-forgiven (the `?[` path is unchanged).
- **cs2gs**: the G# printer renders array-level nullability as `[]?T` and element-level as `[]T?` (the translator already captured both pieces of data).
- **ADR/docs**: new `docs/adr/0132-nullable-array-element-spelling.md`; `website/docs/ref/spec.md` updated (type-syntax EBNF + a nullable-arrays section).

## Breaking-change migration

Existing G# that wrote `[]T?` for a *nullable array* was migrated to `[]?T`: `samples/NullConditionalIndexing.gs`, and the issue #710/#751/#1154/#1238/#1240 binder/emit/interpreter tests (`[]int32?`/`[]uint8?` → `[]?int32`/`[]?uint8`), plus the issue #1072 cs2gs assertions (`[]uint8?` → `[]?uint8`). `[3]int32?` and `func (self []T?)` parser tests are now correct element-nullable cases.

## Examples (verified)

- `func F(a []object?) object? { return a[0] }` and `func G(a []int32?) int32? { return a[0] }` compile and index directly.
- `func N(a []?int32) int32 { return a!![0] }` compiles; a bare index on `[]?int32` is still GS0116.
- Runtime round-trip: writing a nil and a value into `[]int32?`/`[]object?` and reading them back works.

## Tests

- gsc parser tests: `[]T?`, `[]?T`, `[]?T?`, `[N]T?`, `[N]?T`, jagged `[][]T?`, nested `[]?*T`.
- gsc binder + emit tests: indexing `[]object?`/`[]int32?` yields `T?` and runs; `[]?T` is non-indexable bare (GS0116) and indexable after `!!`.
- cs2gs translation tests for `object?[]`, `int?[]`, `object[]?`, `object?[]?`, all round-tripping through gsc.
- Full Core.Tests (4568 passed), targeted Compiler emit (Array/Nullable/Index/Slice/Issue1212, 419 + 16 passed), Interpreter (#710/#751), and full cs2gs (306 passed) are green. No new `SyntaxKind`/`BoundNodeKind`, so the coverage matrix and refactoring baseline are unaffected.
