### PR TITLE
Fixes #1298: nullable user-defined enums in equality and emit

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundBinaryOperator.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundBinaryOperator.cs
@@ -118,6 +118,37 @@ public sealed class BoundBinaryOperator
             return new BoundBinaryOperator(syntaxKind, enumKind, leftType, rightType, enumResultType);
         }
 
+        // Issue #1298: lifted equality / inequality over a nullable user-defined
+        // enum (`E? == E`, `E? != E`, `E? == E?`, …). A user-declared
+        // EnumSymbol has no static CLR type, so the generic value-type lifted
+        // arms further below (gated on `UnderlyingType.ClrType.IsValueType`)
+        // skip it, and BCL nullable enums never reach here because their
+        // underlying carries a real ClrType. Bind the comparison directly to
+        // `bool` whenever both operands denote the SAME user enum and at least
+        // one side is its nullable form; the emitter lowers it via
+        // `box Nullable<E>` + `Object.Equals` (C# `Nullable<T>` lifted
+        // equality semantics). Operands are left unlifted so each side boxes
+        // with its own type token. Non-nullable `E == E` is already handled by
+        // the EnumOperatorTable arm above; `E? == nil` by the IsNullCompare arm
+        // below.
+        if (syntaxKind == SyntaxKind.EqualsEqualsToken || syntaxKind == SyntaxKind.BangEqualsToken)
+        {
+            var leftEnum = leftType is NullableTypeSymbol leftNullableEnum
+                ? leftNullableEnum.UnderlyingType as EnumSymbol
+                : leftType as EnumSymbol;
+            var rightEnum = rightType is NullableTypeSymbol rightNullableEnum
+                ? rightNullableEnum.UnderlyingType as EnumSymbol
+                : rightType as EnumSymbol;
+            var eitherNullable = leftType is NullableTypeSymbol || rightType is NullableTypeSymbol;
+            if (leftEnum != null && rightEnum != null && leftEnum == rightEnum && eitherNullable)
+            {
+                var enumCmpKind = syntaxKind == SyntaxKind.EqualsEqualsToken
+                    ? BoundBinaryOperatorKind.Equals
+                    : BoundBinaryOperatorKind.NotEquals;
+                return new BoundBinaryOperator(syntaxKind, enumCmpKind, leftType, rightType, TypeSymbol.Bool);
+            }
+        }
+
         // Phase 3.B.2 / ADR-0029 + ADR-0033: structural == / != on data and inline struct values.
         //
         // Issue #614 audit: intentionally a single arm — only 2 operators (== / !=)

--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -517,7 +517,8 @@ internal sealed class ConversionClassifier
         if (expression.Type == TypeSymbol.Null
             && type is NullableTypeSymbol nilTargetNullable
             && (nilTargetNullable.UnderlyingType?.ClrType is { IsValueType: true }
-                || nilTargetNullable.UnderlyingType is TypeParameterSymbol))
+                || nilTargetNullable.UnderlyingType is TypeParameterSymbol
+                || nilTargetNullable.UnderlyingType is EnumSymbol))
         {
             return new BoundDefaultExpression(null, type);
         }

--- a/src/Core/CodeAnalysis/Emit/MetadataTokenCache.cs
+++ b/src/Core/CodeAnalysis/Emit/MetadataTokenCache.cs
@@ -148,6 +148,16 @@ internal sealed class MetadataTokenCache
         = new Dictionary<TypeParameterSymbol, MemberReferenceHandle>();
 
     /// <summary>
+    /// Gets the cache mapping a user-defined <see cref="EnumSymbol"/> to the
+    /// <see cref="MemberReferenceHandle"/> for
+    /// <c>System.Nullable`1&lt;E&gt;::.ctor(!0)</c> (issue #1298). The parent
+    /// TypeSpec closes <c>Nullable&lt;&gt;</c> over the enum's emitted TypeDef,
+    /// so one MemberRef per enum serves every <c>E -&gt; E?</c> lift site.
+    /// </summary>
+    public Dictionary<EnumSymbol, MemberReferenceHandle> NullableUserEnumCtorMemberRefs { get; }
+        = new Dictionary<EnumSymbol, MemberReferenceHandle>();
+
+    /// <summary>
     /// Gets the cache mapping a <see cref="FieldInfo"/> to its
     /// <see cref="MemberReferenceHandle"/>.
     /// </summary>

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
@@ -141,6 +141,21 @@ internal sealed partial class MethodBodyEmitter
                 + "ldloca/initobj/ldloc. Reaching EmitConversion indicates a missing lowering path.");
         }
 
+        // Issue #1298: value-type `E → E?` lift where E is a user-declared
+        // enum. The enum has no runtime CLR type, so the BCL-backed ctor path
+        // below (which closes `Nullable<>` over a real `Type`) cannot fire;
+        // instead emit `newobj Nullable<E>::.ctor(!0)` against a TypeSpec
+        // parent that closes `Nullable<>` over the enum's emitted TypeDef.
+        // Mirrors the open-type-parameter branch in the value-type lift below.
+        if (to is NullableTypeSymbol toUserEnumNullableLift
+            && toUserEnumNullableLift.UnderlyingType is EnumSymbol
+            && from == toUserEnumNullableLift.UnderlyingType)
+        {
+            this.il.OpCode(ILOpCode.Newobj);
+            this.il.Token(this.outer.GetNullableCtorMemberRefForUserEnum(toUserEnumNullableLift));
+            return;
+        }
+
         // Issue #504: value-type `T → Nullable<T>` is a true CLR widening;
         // emit `newobj Nullable<T>::.ctor(T)`. This must run before the
         // reference-compatibility shortcut below, which would otherwise

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
@@ -327,6 +327,23 @@ internal sealed partial class MethodBodyEmitter
             return;
         }
 
+        // Issue #1298: lifted equality / inequality over a nullable
+        // user-defined enum (`E? == E?`, `E? == E`, `E? == nil`, …). A
+        // user EnumSymbol has no static CLR type, so the value-type
+        // Nullable<T> machinery above (gated on `ClrType`) never owns these
+        // nodes. `box Nullable<E>` yields a managed-null reference when the
+        // wrapper has no value and a boxed `E` otherwise (ECMA-335 III.4.1),
+        // so dispatching through static `Object.Equals(object, object)`
+        // reproduces C# `Nullable<T>` lifted equality: nil == nil → true,
+        // nil == value → false, value == value → underlying compare. The
+        // `nil`-literal arm boxes the single nullable operand and compares to
+        // `ldnull`.
+        if ((b.Op.Kind == BoundBinaryOperatorKind.Equals || b.Op.Kind == BoundBinaryOperatorKind.NotEquals)
+            && this.TryEmitNullableUserEnumEquality(b))
+        {
+            return;
+        }
+
         // String concatenation / equality go through BCL helpers.
         if (b.Left.Type == TypeSymbol.String && b.Right.Type == TypeSymbol.String)
         {
@@ -577,6 +594,75 @@ internal sealed partial class MethodBodyEmitter
 
         EmitNarrowingTruncationIfNeeded(b.Op.Kind, b.Type);
     }
+
+    // Issue #1298: returns true when this binary node is a nullable
+    // user-defined enum equality / inequality and emits the lifted
+    // comparison via `box` + `Object.Equals` (or `box` + `ldnull; ceq`
+    // for the `nil`-literal form). Returns false (emitting nothing) when
+    // the node is not such a comparison, so the caller can fall through.
+    private bool TryEmitNullableUserEnumEquality(BoundBinaryExpression b)
+    {
+        var left = b.Left;
+        var right = b.Right;
+        bool leftIsNullableEnum = IsNullableUserEnum(left.Type);
+        bool rightIsNullableEnum = IsNullableUserEnum(right.Type);
+
+        // `E? == nil` / `nil == E?` (and `!=`): box the nullable operand
+        // and compare the resulting reference against null.
+        if (leftIsNullableEnum && right.Type == TypeSymbol.Null)
+        {
+            this.EmitBoxedEnumOperand(left);
+            this.il.OpCode(ILOpCode.Ldnull);
+            this.il.OpCode(ILOpCode.Ceq);
+            this.EmitEqualityNegationIfNeeded(b.Op.Kind);
+            return true;
+        }
+
+        if (rightIsNullableEnum && left.Type == TypeSymbol.Null)
+        {
+            this.EmitBoxedEnumOperand(right);
+            this.il.OpCode(ILOpCode.Ldnull);
+            this.il.OpCode(ILOpCode.Ceq);
+            this.EmitEqualityNegationIfNeeded(b.Op.Kind);
+            return true;
+        }
+
+        // `E? == E?`, `E? == E`, `E == E?`: at least one operand is a
+        // nullable user enum and the other is the same user enum (nullable
+        // or not). Box both operands with their own type token and dispatch
+        // through static Object.Equals.
+        bool leftIsEnum = leftIsNullableEnum || left.Type is EnumSymbol;
+        bool rightIsEnum = rightIsNullableEnum || right.Type is EnumSymbol;
+        if ((leftIsNullableEnum || rightIsNullableEnum) && leftIsEnum && rightIsEnum)
+        {
+            this.EmitBoxedEnumOperand(left);
+            this.EmitBoxedEnumOperand(right);
+            this.il.Call(this.outer.wellKnown.GetObjectStaticEqualsReference());
+            this.EmitEqualityNegationIfNeeded(b.Op.Kind);
+            return true;
+        }
+
+        return false;
+    }
+
+    private void EmitBoxedEnumOperand(BoundExpression operand)
+    {
+        this.EmitExpression(operand);
+        this.il.OpCode(ILOpCode.Box);
+        this.il.Token(this.outer.GetElementTypeToken(operand.Type));
+    }
+
+    private void EmitEqualityNegationIfNeeded(BoundBinaryOperatorKind kind)
+    {
+        if (kind == BoundBinaryOperatorKind.NotEquals)
+        {
+            this.il.LoadConstantI4(0);
+            this.il.OpCode(ILOpCode.Ceq);
+        }
+    }
+
+    private static bool IsNullableUserEnum(TypeSymbol type)
+        => type is NullableTypeSymbol nullable && nullable.UnderlyingType is EnumSymbol;
 
     /// <summary>
     /// Issue #831: matches `T? == nil` / `T? != nil` (and the symmetric

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -5618,6 +5618,18 @@ internal sealed class ReflectionMetadataEmitter
             return this.GetElementTypeToken(nullableTpInner);
         }
 
+        // Issue #1298: `E?` over a user-declared enum tokenises as a TypeSpec
+        // naming the generic instantiation `System.Nullable<E>`. This is the
+        // token consumed by `box Nullable<E>` in the lifted enum-equality emit
+        // (and by `initobj` when zero-initialising such a slot).
+        if (element is NullableTypeSymbol nullableEnumElement
+            && nullableEnumElement.UnderlyingType is EnumSymbol)
+        {
+            var sigBlob = new BlobBuilder();
+            this.EncodeTypeSymbol(new BlobEncoder(sigBlob).TypeSpecificationSignature(), nullableEnumElement);
+            return this.emitCtx.Metadata.AddTypeSpecification(this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
+        }
+
         if (element == TypeSymbol.Int32)
         {
             return this.GetTypeReference(this.emitCtx.CoreInt32Type);
@@ -8163,6 +8175,52 @@ internal sealed class ReflectionMetadataEmitter
     }
 
     /// <summary>
+    /// Issue #1298: gets a MemberRef for <c>System.Nullable`1&lt;E&gt;::.ctor(!0)</c>
+    /// where <c>E</c> is a user-declared enum emitted in this assembly. The
+    /// enum has no runtime CLR type, so the BCL-backed
+    /// <see cref="WellKnownReferences"/> ctor path cannot construct it; instead
+    /// the parent TypeSpec closes <c>Nullable&lt;&gt;</c> over the enum's TypeDef
+    /// and the ctor signature refers to that argument as <c>!0</c>. Mirrors
+    /// <see cref="GetNullableCtorMemberRefForOpenTypeParameter"/>.
+    /// </summary>
+    /// <param name="nullableOfEnum">A <c>Nullable&lt;E&gt;</c> over a user enum.</param>
+    /// <returns>The constructor MemberRef.</returns>
+    internal MemberReferenceHandle GetNullableCtorMemberRefForUserEnum(NullableTypeSymbol nullableOfEnum)
+    {
+        if (nullableOfEnum?.UnderlyingType is not EnumSymbol enumSym)
+        {
+            throw new InvalidOperationException(
+                "GetNullableCtorMemberRefForUserEnum requires Nullable<EnumSymbol>.");
+        }
+
+        if (this.cache.NullableUserEnumCtorMemberRefs.TryGetValue(enumSym, out var cached))
+        {
+            return cached;
+        }
+
+        var parentBlob = new BlobBuilder();
+        this.EncodeTypeSymbol(new BlobEncoder(parentBlob).TypeSpecificationSignature(), nullableOfEnum);
+        var parent = this.emitCtx.Metadata.AddTypeSpecification(this.emitCtx.Metadata.GetOrAddBlob(parentBlob));
+
+        var sigBlob = new BlobBuilder();
+        new BlobEncoder(sigBlob).MethodSignature(isInstanceMethod: true)
+            .Parameters(
+                parameterCount: 1,
+                returnType: r => r.Void(),
+                parameters: ps =>
+                {
+                    ps.AddParameter().Type().GenericTypeParameter(0);
+                });
+
+        var handle = this.emitCtx.Metadata.AddMemberReference(
+            parent: parent,
+            name: this.emitCtx.Metadata.GetOrAddString(".ctor"),
+            signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
+        this.cache.NullableUserEnumCtorMemberRefs[enumSym] = handle;
+        return handle;
+    }
+
+    /// <summary>
     /// Phase 4 emit parity: get a MemberRef for a CLR field on a possibly
     /// generic declaring type (e.g. <c>KeyValuePair&lt;K, V&gt;.Key</c>).
     /// </summary>
@@ -8542,8 +8600,23 @@ internal sealed class ReflectionMetadataEmitter
 
             if (inner is EnumSymbol nestedEnum)
             {
-                throw new NotSupportedException(
-                    $"Nullable user-defined enum '{nestedEnum.Name}?' is not yet supported by the emitter.");
+                // Issue #1298: `E?` over a user-declared enum lowers to
+                // `System.Nullable<E>` — a generic instantiation whose single
+                // argument is the enum's own emitted TypeDef. Mirrors the
+                // struct-constrained type-parameter branch above.
+                if (!this.cache.EnumTypeDefs.ContainsKey(nestedEnum))
+                {
+                    throw new InvalidOperationException(
+                        $"Enum '{nestedEnum.Name}' has no emitted TypeDef.");
+                }
+
+                var nullableOpenForEnum = typeof(System.Nullable<>);
+                var giNullableEnum = encoder.GenericInstantiation(
+                    this.GetTypeReference(nullableOpenForEnum),
+                    genericArgumentCount: 1,
+                    isValueType: true);
+                this.EncodeTypeSymbol(giNullableEnum.AddArgument(), nestedEnum);
+                return;
             }
 
             EncodeTypeSymbol(encoder, inner);
@@ -8996,6 +9069,17 @@ internal sealed class ReflectionMetadataEmitter
         if (type is NullableTypeSymbol nullableTp
             && nullableTp.UnderlyingType is TypeParameterSymbol tp
             && tp.HasValueTypeConstraint)
+        {
+            return true;
+        }
+
+        // Issue #1298: `E?` over a user-declared enum lowers to the CLR struct
+        // `System.Nullable<E>`. The enum has no ClrType on the symbol, so the
+        // ClrType-based branch below misses it; recognise the symbolic form so
+        // default-init (`ldloca; initobj; ldloc`) and boxing decisions treat it
+        // as a value type.
+        if (type is NullableTypeSymbol nullableEnum
+            && nullableEnum.UnderlyingType is EnumSymbol)
         {
             return true;
         }

--- a/test/Compiler.Tests/Emit/Issue1298NullableUserEnumEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1298NullableUserEnumEmitTests.cs
@@ -1,0 +1,248 @@
+// <copyright file="Issue1298NullableUserEnumEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1298: nullable user-defined enums (<c>E?</c>) support lifted equality
+/// and inequality with C#/<c>Nullable&lt;T&gt;</c> semantics, both in the binder
+/// (no GS0129 "operator not defined") and the emitter (no GS9998 ICE encoding
+/// <c>Nullable&lt;E&gt;</c>). Two <c>nil</c>s are equal, a <c>nil</c> and a value
+/// are unequal, and two values compare by the enum's underlying integral value.
+///
+/// Each test compiles via <c>gsc</c>, IL-verifies the produced PE, then executes
+/// it under <c>dotnet exec</c> and asserts on captured stdout.
+/// </summary>
+public class Issue1298NullableUserEnumEmitTests
+{
+    [Fact]
+    public void NullableEnumEqualsEnum_PresentMatch_IsTrue()
+    {
+        var source = """
+            package P
+
+            import System
+
+            enum E { A, B }
+
+            func Eq(x E?) bool { return x == E.A }
+
+            let a E? = E.A
+            let b E? = E.B
+            let n E? = nil
+            Console.WriteLine(Eq(a))
+            Console.WriteLine(Eq(b))
+            Console.WriteLine(Eq(n))
+            """;
+
+        // present A == A -> True; present B == A -> False; nil == A -> False.
+        Assert.Equal("True\nFalse\nFalse\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void NullableEnumNotEqualsEnum_LiftsOverNil()
+    {
+        var source = """
+            package P
+
+            import System
+
+            enum E { A, B }
+
+            func Ne(x E?) bool { return x != E.A }
+
+            let a E? = E.A
+            let b E? = E.B
+            let n E? = nil
+            Console.WriteLine(Ne(a))
+            Console.WriteLine(Ne(b))
+            Console.WriteLine(Ne(n))
+            """;
+
+        // A != A -> False; B != A -> True; nil != A -> True (nil unequal to value).
+        Assert.Equal("False\nTrue\nTrue\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void NullableEnumEqualsNil_DistinguishesPresentFromAbsent()
+    {
+        var source = """
+            package P
+
+            import System
+
+            enum E { A, B }
+
+            func IsNil(x E?) bool { return x == nil }
+            func NotNil(x E?) bool { return x != nil }
+
+            let a E? = E.A
+            let n E? = nil
+            Console.WriteLine(IsNil(a))
+            Console.WriteLine(IsNil(n))
+            Console.WriteLine(NotNil(a))
+            Console.WriteLine(NotNil(n))
+            """;
+
+        // a==nil -> False; n==nil -> True; a!=nil -> True; n!=nil -> False.
+        Assert.Equal("False\nTrue\nTrue\nFalse\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void NilEqualsNullableEnum_SymmetricOperand()
+    {
+        var source = """
+            package P
+
+            import System
+
+            enum E { A, B }
+
+            func IsNil(x E?) bool { return nil == x }
+
+            let a E? = E.A
+            let n E? = nil
+            Console.WriteLine(IsNil(a))
+            Console.WriteLine(IsNil(n))
+            """;
+
+        Assert.Equal("False\nTrue\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void NullableEnumEqualsNullableEnum_LiftedSemantics()
+    {
+        var source = """
+            package P
+
+            import System
+
+            enum E { A, B }
+
+            func Eq(x E?, y E?) bool { return x == y }
+            func Ne(x E?, y E?) bool { return x != y }
+
+            let a E? = E.A
+            let b E? = E.B
+            let n E? = nil
+            Console.WriteLine(Eq(n, n))
+            Console.WriteLine(Eq(a, n))
+            Console.WriteLine(Eq(a, a))
+            Console.WriteLine(Eq(a, b))
+            Console.WriteLine(Ne(a, b))
+            Console.WriteLine(Ne(n, n))
+            """;
+
+        // nil==nil -> True; a==nil -> False; a==a -> True; a==b -> False;
+        // a!=b -> True; nil!=nil -> False.
+        Assert.Equal("True\nFalse\nTrue\nFalse\nTrue\nFalse\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var (exitCode, stdout, stderr) = CompileAndRunRaw(source);
+        Assert.True(
+            exitCode == 0,
+            $"exited {exitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout;
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) CompileAndRunRaw(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1298_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+            };
+
+            foreach (var bcl in BclReferences.Value)
+            {
+                args.Add("/r:" + bcl);
+            }
+
+            args.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            return (proc.ExitCode, stdout.Replace("\r\n", "\n"), stderr.Replace("\r\n", "\n"));
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static readonly Lazy<IReadOnlyList<string>> BclReferences = new(() =>
+    {
+        var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location);
+        if (string.IsNullOrEmpty(runtimeDir) || !Directory.Exists(runtimeDir))
+        {
+            return Array.Empty<string>();
+        }
+
+        return Directory.EnumerateFiles(runtimeDir, "*.dll", SearchOption.TopDirectoryOnly)
+            .Where(p =>
+            {
+                var name = Path.GetFileName(p);
+                return name.StartsWith("System.", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "mscorlib.dll", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "netstandard.dll", StringComparison.OrdinalIgnoreCase);
+            })
+            .ToList();
+    });
+}


### PR DESCRIPTION
## Summary
Nullable **user-defined** enums (`E?`) were not fully supported. Two coupled defects, both specific to user-declared `EnumSymbol` types (primitive nullables and BCL nullable enums like `System.DayOfWeek?` already worked):

### Defect 1 — lifted comparison undefined (GS0129, binder)
```gsharp
enum E { A, B }
func F(x E?) bool { return x != E.A }   // GS0129: '!=' not defined for 'E?' and 'E'
```
Same for `==`, `E? == E?`, `E? != E?`.

### Defect 2 — `E? == nil` crashes the emitter (GS9998 ICE)
```gsharp
func F(x E?) bool { return x == nil }   // GS9998: Nullable user-defined enum 'E?' is not yet supported by the emitter
```

## Root cause
- **Binder:** the generic value-type lifted / mixed-mode equality arms are gated on `UnderlyingType.ClrType.IsValueType`. A user enum has **no static CLR type** during compilation, so those arms skipped it and the operator stayed unbound → GS0129. (BCL enums carry a real `ClrType`, hence they worked.)
- **Emitter:** the metadata type encoder had an explicit `throw` for `Nullable<UserEnum>`; `Nullable<E>` was never encoded as a generic instantiation over the enum's emitted TypeDef, so any `E?` signature/box token aborted with GS9998.

The two are coupled — binding the operators without emit support would have turned Defect 1 cases into Defect-2 ICEs — so both sides are fixed together.

## What changed
**Binder**
- `BoundBinaryOperator.Bind`: bind `E? == E?`, `E? == E`, `E == E?` (and `!=`) directly to `bool` when both operands denote the same user enum and at least one side is nullable. `E? == nil` already bound via the IsNullCompare arm; non-nullable `E == nil` still reports GS0129 (existing by-design behaviour, preserved).
- `ConversionClassifier`: lower `nil -> E?` to a `BoundDefaultExpression` (matching the value-type-nullable path) so emit materialises `default(Nullable<E>)` via `initobj`.

**Emitter**
- `ReflectionMetadataEmitter.EncodeTypeSymbol` / `GetElementTypeToken`: encode `Nullable<E>` as a generic instantiation `System.Nullable` over the enum's TypeDef (signature blob + TypeSpec for `box`/`initobj` tokens), replacing the GS9998 throw.
- `IsValueTypeSymbol`: recognise `E?` as a value type (so default-init and boxing pick the struct path).
- `GetNullableCtorMemberRefForUserEnum`: MemberRef for `Nullable<E>::.ctor(!0)` parented at the TypeSpec, used by the `E -> E?` lift (mirrors the existing open-type-parameter path).
- `MethodBodyEmitter.Operators`: lower nullable-user-enum equality/inequality via `box Nullable<E>` + static `Object.Equals(object, object)` (or `box` + `ldnull; ceq` for the `nil` form). `box Nullable<T>` yields a managed-null reference when empty (ECMA-335 III.4.1), so this reproduces C# `Nullable<T>` lifted semantics: `nil == nil` → true, `nil == value` → false, `value == value` → underlying compare.

No new `BoundNodeKind` / `SyntaxKind` / `ConversionKind` were introduced, so the coverage matrix is unchanged.

## Test evidence
New `test/Compiler.Tests/Emit/Issue1298NullableUserEnumEmitTests.cs` (5 facts) **compiles, IL-verifies (`IlVerifier.Verify`), and executes** the produced assemblies under `dotnet exec`, asserting runtime semantics:
- `E? == E` / `E? != E` true & false, lifted over `nil`
- `E? == nil` / `E? != nil` (present vs absent), and symmetric `nil == E?`
- `E? == E?` / `E? != E?` (nil/nil, nil/value, value/value)

Results:
- `Issue1298` emit tests: **5/5 passed** (IL-verified + executed).
- Regression slices: `~Nullable` **180/180**, `~Enum` **138/138**.
- `Core.Tests`: **4554 passed, 1 skipped**.
- Full solution: `dotnet build GSharp.sln -c Release -graph` → **0 warnings / 0 errors**.
- Original repros now compile; non-nullable `E == nil` still correctly reports GS0129.
