### PR TITLE
Fixes #1301, #1302: substitute user-defined element type T in from-end index and Enumerator->interface conversion

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -576,6 +576,28 @@ public sealed class Conversion
             return Conversion.Implicit;
         }
 
+        // Issue #1302: a constructed BCL value struct (e.g.
+        // `List[T].Enumerator`) whose element `T` is a same-compilation user
+        // type has a null `ClrType` during binding — `MakeGenericType` could
+        // not close the type because the argument lives in the assembly being
+        // emitted — so `IsValueTypeLikeFrom`/`IsInterfaceLikeType` cannot fire
+        // and the value-type → interface box above is skipped. The target
+        // generic interface (`IEnumerator[T]`) is likewise unclosed. Match the
+        // target interface's open definition against the generic interfaces the
+        // struct's open definition implements, substituting the struct's
+        // symbolic type arguments by generic-parameter position and comparing
+        // each element via `AreTypeArgumentsEquivalent`, so
+        // `List[Ch].Enumerator -> IEnumerator[Ch]` boxes implicitly while a
+        // genuine element mismatch still reports GS0155.
+        if (from is ImportedTypeSymbol fromCtorStruct
+            && fromCtorStruct.OpenDefinition is { IsValueType: true }
+            && to is ImportedTypeSymbol toCtorIface
+            && toCtorIface.OpenDefinition is { IsInterface: true }
+            && ConstructedValueTypeImplementsInterfaceSymbolically(fromCtorStruct, toCtorIface))
+        {
+            return Conversion.Implicit;
+        }
+
         // Reference upcast: a class implicitly converts to any interface in
         // its (transitive) implements-list or to any of its (transitive)
         // base classes. The interpreter stores instances as objects of the
@@ -1657,5 +1679,82 @@ public sealed class Conversion
         }
 
         return AreTypeArgumentsEquivalent(imported.TypeArguments[0], slice.ElementType);
+    }
+
+    /// <summary>
+    /// Issue #1302: symbolic struct → generic-interface implementation check for
+    /// a constructed BCL value struct (e.g. <c>List[T].Enumerator</c>) whose
+    /// element <c>T</c> is a same-compilation user type, so its
+    /// <see cref="TypeSymbol.ClrType"/> (and the target interface's) is
+    /// <see langword="null"/> during binding. Walk the generic interfaces the
+    /// struct's OPEN definition implements, match the target interface's open
+    /// definition by full name, then substitute each interface argument through
+    /// the struct's symbolic <see cref="ImportedTypeSymbol.TypeArguments"/> by
+    /// generic-parameter position and compare to the target's arguments via
+    /// <see cref="AreTypeArgumentsEquivalent"/>. A genuine element mismatch
+    /// returns <see langword="false"/> (GS0155).
+    /// </summary>
+    private static bool ConstructedValueTypeImplementsInterfaceSymbolically(
+        ImportedTypeSymbol from,
+        ImportedTypeSymbol toInterface)
+    {
+        var fromOpen = from.OpenDefinition;
+        var toOpen = toInterface.OpenDefinition;
+        if (fromOpen is null || toOpen?.FullName is null || toInterface.TypeArguments.IsDefaultOrEmpty)
+        {
+            return false;
+        }
+
+        foreach (var iface in fromOpen.GetInterfaces())
+        {
+            if (!iface.IsGenericType)
+            {
+                continue;
+            }
+
+            if (!string.Equals(
+                    iface.GetGenericTypeDefinition().FullName,
+                    toOpen.FullName,
+                    StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var ifaceArgs = iface.GetGenericArguments();
+            if (ifaceArgs.Length != toInterface.TypeArguments.Length)
+            {
+                continue;
+            }
+
+            var allMatch = true;
+            for (var i = 0; i < ifaceArgs.Length; i++)
+            {
+                var ifaceArg = ifaceArgs[i];
+                TypeSymbol substituted;
+                if (ifaceArg.IsGenericParameter
+                    && ifaceArg.GenericParameterPosition >= 0
+                    && ifaceArg.GenericParameterPosition < from.TypeArguments.Length)
+                {
+                    substituted = from.TypeArguments[ifaceArg.GenericParameterPosition];
+                }
+                else
+                {
+                    substituted = TypeSymbol.FromClrType(ifaceArg);
+                }
+
+                if (!AreTypeArgumentsEquivalent(substituted, toInterface.TypeArguments[i]))
+                {
+                    allMatch = false;
+                    break;
+                }
+            }
+
+            if (allMatch)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -3455,6 +3455,33 @@ internal sealed partial class ExpressionBinder
         return TypeSymbol.FromClrType(propertyType);
     }
 
+    // Issue #1301: resolve the element type of a closed indexer against the
+    // receiver's symbolic type arguments, mirroring the normal `this[int]`
+    // index path. Routing the from-end (`a[^n]`) / `System.Index` indexer
+    // paths through here keeps a user-defined element type `T` (whose
+    // `ClrType` is null during binding) typed as `T` instead of erasing to
+    // `object`.
+    private static TypeSymbol ResolveIndexerElementType(TypeSymbol targetType, PropertyInfo indexer)
+    {
+        if (targetType is NullabilityAnnotatedTypeSymbol annot && annot.ClrType is System.Type)
+        {
+            return annot.GetTypeArgumentSymbolForClrType(indexer.PropertyType);
+        }
+
+        if (targetType is ImportedTypeSymbol imported)
+        {
+            return MapErasedIndexerElementType(imported, indexer);
+        }
+
+        var propertyType = indexer.PropertyType;
+        if (propertyType.IsByRef)
+        {
+            return ByRefTypeSymbol.Get(TypeSymbol.FromClrType(propertyType.GetElementType()!));
+        }
+
+        return TypeSymbol.FromClrType(propertyType);
+    }
+
     private static TypeSymbol MapClrMemberType(System.Type clrType)
     {
         if (clrType != null && clrType.IsByRef)
@@ -3648,7 +3675,7 @@ internal sealed partial class ExpressionBinder
                     indexCtor,
                     ImmutableArray.Create<BoundExpression>(offset, new BoundLiteralExpression(null, true)),
                     indexSym);
-                var resultType = TypeSymbol.FromClrType(indexIndexer.PropertyType);
+                var resultType = ResolveIndexerElementType(target.Type, indexIndexer);
                 return new BoundClrIndexExpression(fromEnd, target, indexIndexer, ImmutableArray.Create<BoundExpression>(indexValue), resultType);
             }
 
@@ -3658,7 +3685,7 @@ internal sealed partial class ExpressionBinder
                 var srcLocal = DeclareRangeTemp("src", target.Type, target, statements);
                 var lengthExpr = new BoundClrPropertyAccessExpression(null, new BoundVariableExpression(null, srcLocal), lengthMember, TypeSymbol.Int32);
                 var idx = MakeFromEndOffset(fromEnd, lengthExpr);
-                var resultType = TypeSymbol.FromClrType(intIndexer.PropertyType);
+                var resultType = ResolveIndexerElementType(target.Type, intIndexer);
                 var read = new BoundClrIndexExpression(
                     null,
                     new BoundVariableExpression(null, srcLocal),

--- a/test/Compiler.Tests/Emit/Issue1301FromEndIndexUserElementEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1301FromEndIndexUserElementEmitTests.cs
@@ -1,0 +1,211 @@
+// <copyright file="Issue1301FromEndIndexUserElementEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1301: a from-end index <c>list[^n]</c> (a <c>System.Index</c> /
+/// counted <c>this[int]</c> read) over a generic collection whose element type
+/// <c>T</c> is a same-compilation user type erased the result element to
+/// <c>object</c> (GS0155 / GS0158), even though the normal <c>this[int]</c>
+/// path substituted <c>T</c> correctly. These tests pin the fix end-to-end by
+/// running the emitted IL and asserting the runtime value read from the
+/// user-element member — proving both that the element type is recovered AND
+/// that the IL emits correctly. A <c>List[int32]</c> control guards the
+/// primitive path against regressions.
+/// </summary>
+public class Issue1301FromEndIndexUserElementEmitTests
+{
+    // A value struct with an `init`-only auto-property is constructed via a
+    // struct literal whose property setters emit `stfld` to the backing
+    // readonly field outside the .ctor, which `dotnet-ilverify` flags as
+    // `InitOnly`. This is a pre-existing G# value-struct-literal emit
+    // characteristic, orthogonal to the issue #1301 binding fix; the runtime
+    // assertions below prove correct execution, so these cases verify with
+    // `InitOnly` treated as non-fatal.
+    private static readonly string[] InitOnlyStructLiteral = { "InitOnly" };
+
+    [Fact]
+    public void StructElementList_FromEndIndex_ReadsMember()
+    {
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            struct Chapter { prop EndOffset int32 { get; init; } }
+
+            var l = List[Chapter]()
+            l.Add(Chapter{EndOffset: 10})
+            l.Add(Chapter{EndOffset: 20})
+            l.Add(Chapter{EndOffset: 30})
+            Console.WriteLine(l[^1].EndOffset)
+            Console.WriteLine(l[^2].EndOffset)
+            Console.WriteLine(l[^3].EndOffset)
+            """;
+
+        Assert.Equal("30\n20\n10\n", CompileAndRun(source, InitOnlyStructLiteral));
+    }
+
+    [Fact]
+    public void StructElementList_FromEndIndex_WholeElementType()
+    {
+        // The from-end read returns `Chapter` (not `object`), so it can be
+        // assigned to a `Chapter`-typed local and have its member read.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            struct Chapter { prop EndOffset int32 { get; init; } }
+
+            var l = List[Chapter]()
+            l.Add(Chapter{EndOffset: 7})
+            l.Add(Chapter{EndOffset: 9})
+            var last = l[^1]
+            Console.WriteLine(last.EndOffset)
+            """;
+
+        Assert.Equal("9\n", CompileAndRun(source, InitOnlyStructLiteral));
+    }
+
+    [Fact]
+    public void DataStructElementList_FromEndIndex_ReadsMember()
+    {
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            data struct Point { var X int32
+                                var Y int32 }
+
+            var l = List[Point]()
+            l.Add(Point{X: 1, Y: 2})
+            l.Add(Point{X: 3, Y: 4})
+            l.Add(Point{X: 5, Y: 6})
+            Console.WriteLine(l[^1].Y)
+            Console.WriteLine(l[^2].X)
+            """;
+
+        Assert.Equal("6\n3\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void ClassElementList_FromEndIndex_ReadsMember()
+    {
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            class Seg { public var X int32 = 0 }
+
+            var a = Seg()
+            a.X = 11
+            var b = Seg()
+            b.X = 22
+            var l = List[Seg]()
+            l.Add(a)
+            l.Add(b)
+            Console.WriteLine(l[^1].X)
+            Console.WriteLine(l[^2].X)
+            """;
+
+        Assert.Equal("22\n11\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void PrimitiveElementList_FromEndIndex_StillWorks()
+    {
+        // Regression control: the primitive (List[int32]) path is unchanged.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            var l = List[int32]()
+            l.Add(10)
+            l.Add(20)
+            l.Add(30)
+            Console.WriteLine(l[^1])
+            Console.WriteLine(l[^2])
+            Console.WriteLine(l[^3])
+            """;
+
+        Assert.Equal("30\n20\n10\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source, string[] ignoredIlErrorCodes = null)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1301_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath, ignoredErrorCodes: ignoredIlErrorCodes);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue1302EnumeratorInterfaceUserElementEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1302EnumeratorInterfaceUserElementEmitTests.cs
@@ -1,0 +1,207 @@
+// <copyright file="Issue1302EnumeratorInterfaceUserElementEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1302: converting a constructed BCL value struct
+/// (<c>List[T].Enumerator</c>) to its generic interface
+/// (<c>IEnumerator[T]</c>) failed with GS0155 when the element type <c>T</c>
+/// was a same-compilation user type, because the implemented-interface set was
+/// compared against the target by erased CLR identity (a user element symbol
+/// has a null <c>ClrType</c> during binding) instead of structurally over the
+/// substituted element type. These tests pin the fix end-to-end: each returns
+/// <c>list.GetEnumerator()</c> as an <c>IEnumerator[UserStruct]</c>, then drives
+/// the converted enumerator at runtime and asserts the number of elements it
+/// yields — proving the boxing conversion both binds AND emits a runtime-correct
+/// enumerator. A <c>List[int32]</c> control guards the primitive path.
+/// </summary>
+public class Issue1302EnumeratorInterfaceUserElementEmitTests
+{
+    private static readonly string[] InitOnlyStructLiteral = { "InitOnly" };
+
+    [Fact]
+    public void StructElementList_EnumeratorToInterface_Iterates()
+    {
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            struct Ch { prop V int32 { get; init; } }
+
+            func F(l List[Ch]) IEnumerator[Ch] { return l.GetEnumerator() }
+
+            var l = List[Ch]()
+            l.Add(Ch{V: 5})
+            l.Add(Ch{V: 7})
+            l.Add(Ch{V: 9})
+            var e = F(l)
+            var n = 0
+            while e.MoveNext() {
+                n = n + 1
+            }
+            Console.WriteLine(n)
+            """;
+
+        Assert.Equal("3\n", CompileAndRun(source, InitOnlyStructLiteral));
+    }
+
+    [Fact]
+    public void ClassElementList_EnumeratorToInterface_Iterates()
+    {
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            class Seg { public var X int32 = 0 }
+
+            func F(l List[Seg]) IEnumerator[Seg] { return l.GetEnumerator() }
+
+            var a = Seg()
+            var b = Seg()
+            var l = List[Seg]()
+            l.Add(a)
+            l.Add(b)
+            var e = F(l)
+            var n = 0
+            while e.MoveNext() {
+                n = n + 1
+            }
+            Console.WriteLine(n)
+            """;
+
+        Assert.Equal("2\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void DataStructElementList_EnumeratorToInterface_Iterates()
+    {
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            data struct Point { var X int32
+                                var Y int32 }
+
+            func F(l List[Point]) IEnumerator[Point] { return l.GetEnumerator() }
+
+            var l = List[Point]()
+            l.Add(Point{X: 1, Y: 2})
+            l.Add(Point{X: 3, Y: 4})
+            l.Add(Point{X: 5, Y: 6})
+            l.Add(Point{X: 7, Y: 8})
+            var e = F(l)
+            var n = 0
+            while e.MoveNext() {
+                n = n + 1
+            }
+            Console.WriteLine(n)
+            """;
+
+        Assert.Equal("4\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void PrimitiveElementList_EnumeratorToInterface_StillWorks()
+    {
+        // Regression control: the primitive (List[int32]) path is unchanged.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            func F(l List[int32]) IEnumerator[int32] { return l.GetEnumerator() }
+
+            var l = List[int32]()
+            l.Add(1)
+            l.Add(2)
+            l.Add(3)
+            var e = F(l)
+            var sum = 0
+            while e.MoveNext() {
+                sum = sum + e.Current
+            }
+            Console.WriteLine(sum)
+            """;
+
+        Assert.Equal("6\n", CompileAndRun(source));
+    }
+
+    // The struct case prints the iteration count over a three-element list,
+    // proving the converted IEnumerator[Ch] yields every element at runtime.
+    private static string CompileAndRun(string source, string[] ignoredIlErrorCodes = null)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1302_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath, ignoredErrorCodes: ignoredIlErrorCodes);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/MigrationPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/MigrationPipelineTests.cs
@@ -199,16 +199,19 @@ public class MigrationPipelineTests
     }
 
     /// <summary>
-    /// Pointing the pipeline at <c>corpus/L3-Library</c> translates cleanly but
-    /// reaches the compile stage and captures a <c>compile-error</c> triage
-    /// artifact for residual compiler gaps (generic <c>IEnumerable</c>
-    /// implementation / <c>GetEnumerator</c> overload resolution). The artifact
+    /// Pointing the pipeline at <c>corpus/CompileGap-Library</c> translates
+    /// cleanly but reaches the compile stage and captures a
+    /// <c>compile-error</c> triage artifact. That fixture exists solely to
+    /// exercise this machinery: its body translates to valid G# yet references
+    /// an undefined helper, so <c>gsc</c> rejects it with a stable diagnostic
+    /// regardless of which real compiler gaps are open or closed (the earlier
+    /// anchor, <c>corpus/L3-Library</c>, now compiles green). The artifact
     /// carries a non-empty diagnostic id and a stable <c>sha256:</c>
     /// fingerprint. Gated on compiler presence (the pipeline resolves
     /// <c>gsc</c> up front).
     /// </summary>
     [Fact]
-    public async Task L3_CompileStageFailure_WritesTriageArtifact()
+    public async Task CompileStageFailure_WritesTriageArtifact()
     {
         string compiler = FindCompiler();
         if (compiler is null)
@@ -217,11 +220,11 @@ public class MigrationPipelineTests
         }
 
         string corpus = ResolveCorpusDir();
-        string outRoot = NewOutputRoot("l3-capture");
+        string outRoot = NewOutputRoot("compilegap-capture");
         var options = new PipelineOptions { GscPath = compiler, OutputRoot = outRoot };
         var pipeline = new MigrationPipeline(options);
 
-        CorpusApp l3 = CorpusDiscovery.FindById(corpus, "corpus/L3-Library");
+        CorpusApp l3 = CorpusDiscovery.FindById(corpus, "corpus/CompileGap-Library");
         RunResult result = await pipeline.RunAsync(new[] { l3 });
         AppResult app = Assert.Single(result.Apps);
 
@@ -242,7 +245,9 @@ public class MigrationPipelineTests
     /// <summary>
     /// Re-running against the same <c>--gsc</c> carries the prior run forward in
     /// each fingerprint's <c>retryHistory</c> (the §C retry mechanism). Anchored
-    /// on <c>corpus/L3-Library</c>, which still fails at the compile stage.
+    /// on <c>corpus/CompileGap-Library</c>, whose synthetic body always fails at
+    /// the compile stage (an undefined-helper reference), so the machinery is
+    /// exercised independent of the corpus's evolving compile health.
     /// Gated on compiler presence.
     /// </summary>
     [Fact]
@@ -258,7 +263,7 @@ public class MigrationPipelineTests
         string outRoot = NewOutputRoot("retry");
         var options = new PipelineOptions { GscPath = compiler, OutputRoot = outRoot };
 
-        CorpusApp l3 = CorpusDiscovery.FindById(corpus, "corpus/L3-Library");
+        CorpusApp l3 = CorpusDiscovery.FindById(corpus, "corpus/CompileGap-Library");
 
         RunResult first = await new MigrationPipeline(options).RunAsync(new[] { l3 });
         RunResult second = await new MigrationPipeline(options).RunAsync(new[] { l3 });

--- a/tools/cs2gs/corpus/CompileGap-Library/CompileGap-Library.csproj
+++ b/tools/cs2gs/corpus/CompileGap-Library/CompileGap-Library.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>Corpus.CompileGap</RootNamespace>
+    <AssemblyName>CompileGap-Library</AssemblyName>
+  </PropertyGroup>
+
+</Project>

--- a/tools/cs2gs/corpus/CompileGap-Library/Residual.cs
+++ b/tools/cs2gs/corpus/CompileGap-Library/Residual.cs
@@ -1,0 +1,20 @@
+namespace Corpus.CompileGap;
+
+/// <summary>
+/// A deliberately permanent compile gap. The body translates cleanly to G#
+/// (so the translate stage passes) but references an undefined helper, so
+/// <c>gsc</c> rejects it with a stable diagnostic regardless of which real
+/// compiler gaps are open or closed. This fixture exists solely to exercise
+/// the pipeline's triage-artifact + retry-history machinery (ADR-0115 §C),
+/// decoupling those tests from the corpus's evolving compile health.
+/// </summary>
+public static class Residual
+{
+    /// <summary>Returns a probe value via an intentionally undefined helper.</summary>
+    /// <param name="value">An arbitrary input.</param>
+    /// <returns>Never compiles; the call target does not exist.</returns>
+    public static int Probe(int value)
+    {
+        return UndefinedTriageHelper(value);
+    }
+}


### PR DESCRIPTION
## Summary

Two bugs in the **same family**: a constructed BCL/generic type over a same-compilation **user-defined element type `T`** loses correct type/interface resolution that works fine for primitive/BCL element types. The shared root is that a user element symbol's `ClrType` is `null` during binding (its CLR type is still being emitted), so code paths that resolve against the closed/CLR shape fall back to the type-erased `object` form. Each repro is fixed and verified independently.

## Bug #1301 — `list[^n]` on `List[UserType]` erased the element to `object`

```gsharp
struct Chapter { prop EndOffset int32 { get; init; } }
func F(l List[Chapter]) Chapter { return l[^1] }          // was GS0155: object -> Chapter
func G(l List[Chapter]) int32  { return l[^1].EndOffset } // was GS0158: no member EndOffset
```

**Root cause:** the normal `this[int]` index path routes the result element type through `MapErasedIndexerElementType`, which substitutes the receiver's symbolic type arguments back through the open indexer (typing `list[i]` on `List[T]` as `T`). The from-end (`^n` / `System.Index`) path instead used a raw `TypeSymbol.FromClrType(indexer.PropertyType)`, which erased the open generic parameter to `object`.

**Fix:** added `ResolveIndexerElementType` (delegating to the existing substitution helpers for `ImportedTypeSymbol` and `NullabilityAnnotatedTypeSymbol` receivers) and routed both from-end indexer branches (`System.Index` indexer and counted `this[int]`) through it.

## Bug #1302 — `List[UserType].Enumerator → IEnumerator[UserType]` failed (GS0155)

```gsharp
struct Ch { prop V int32 { get; init; } }
func F(l List[Ch]) IEnumerator[Ch] { return l.GetEnumerator() } // was GS0155
```

**Root cause:** the value-type → interface box path is gated on `IsValueTypeLikeFrom`/`IsInterfaceLikeType`, both of which require a non-null CLR backing. A constructed BCL struct/interface over a user element has a `null`/erased CLR shape, so the box was skipped and the conversion was rejected.

**Fix:** added a symbolic branch (`ConstructedValueTypeImplementsInterfaceSymbolically`) that matches the target interface's open definition against the generic interfaces the struct's open definition implements, substituting the struct's symbolic type arguments by generic-parameter position and comparing each element via the existing invariance-preserving `AreTypeArgumentsEquivalent`. A genuine element mismatch (`IEnumerator[Other]`) still reports GS0155.

This mirrors the precedent fixes for #1162 (user-element array → `IEnumerable[T]`) and #1088 (constructed-generic identity by symbolic type arguments).

## Files changed

- `src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs` — `ResolveIndexerElementType` helper; both from-end indexer branches routed through it.
- `src/Core/CodeAnalysis/Binding/Conversion.cs` — symbolic constructed-value-struct → generic-interface branch + `ConstructedValueTypeImplementsInterfaceSymbolically` helper.

## Tests added

End-to-end emit+run tests (compile via `Program.Main` `/target:exe`, `IlVerifier.Verify`, then exec the dll and assert runtime output):

- `Issue1301FromEndIndexUserElementEmitTests` — from-end index over struct / `data struct` / class element `List`s reads the user member with the correct value (e.g. `l[^1].EndOffset == 30`); `List[int32]` control.
- `Issue1302EnumeratorInterfaceUserElementEmitTests` — returns `GetEnumerator()` as `IEnumerator[T]` over struct / `data struct` / class elements and drives the converted enumerator at runtime; `List[int32]` control.

## Test evidence

- New tests: `Failed: 0, Passed: 9` (`~Issue1301|~Issue1302`).
- Regression slices: `~Index` (121 passed), `~Enumerator` (9 passed), `~Conversion|~Slice|~Issue1162|~Issue1088` (118 passed).
- Full `Core.Tests`: `Passed: 4574, Skipped: 1`.
- IlVerifier: clean for every emitted assembly (value-struct-literal cases ignore the pre-existing `InitOnly` characteristic, as in #1162).
- Full solution build (`dotnet build GSharp.sln -c Release -graph`): 0 warnings / 0 errors.

## Out of scope (noted)

Reading a per-element member via `e.Current.V` on `IEnumerator[Ch]` (or even directly on `List[Ch].Enumerator`) erases `.Current` to `object` — this reproduces with **zero conversions** and is a distinct member-access/unbox erasure concern, not part of the #1302 conversion bug. The #1302 tests therefore drive the converted enumerator and assert the element count, proving the conversion yields a runtime-correct `IEnumerator[T]`.
