### PR TITLE
Fix #1307: apply constant-narrowing literal adaptation in base-constructor initializers

### DIFF
--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -6734,7 +6734,8 @@ internal sealed class DeclarationBinder
             var argument = boundArguments[i];
             var parameter = baseParams[i];
             if (argument.Type != parameter.Type
-                && !Conversion.Classify(argument.Type, parameter.Type).IsImplicit)
+                && !Conversion.Classify(argument.Type, parameter.Type).IsImplicit
+                && !ExpressionBinder.IsImplicitConstantNarrowingArgument(argument, parameter.Type))
             {
                 if (argument.Type != TypeSymbol.Error)
                 {
@@ -6805,6 +6806,15 @@ internal sealed class DeclarationBinder
                 // Error-typed arguments don't disqualify a candidate: a prior
                 // diagnostic already explains the bad argument.
                 if (argType == TypeSymbol.Error)
+                {
+                    continue;
+                }
+
+                // Issue #1307: a constant integer argument that fits a narrower /
+                // cross-sign integer parameter is implicitly convertible there
+                // (C# §10.2.11, issue #1281), so it must not disqualify the
+                // candidate even though the lattice conversion is not implicit.
+                if (ExpressionBinder.IsImplicitConstantNarrowingArgument(boundArguments[i], paramType))
                 {
                     continue;
                 }

--- a/test/Compiler.Tests/Emit/Issue1307BaseInitNarrowingEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1307BaseInitNarrowingEmitTests.cs
@@ -1,0 +1,179 @@
+// <copyright file="Issue1307BaseInitNarrowingEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1307: end-to-end CLR emit + ilverify coverage proving that a
+/// base-constructor initializer (<c>: base(&lt;literal&gt;)</c>) applies the
+/// implicit constant-narrowing / integer-literal adaptation (C# §10.2.11,
+/// issues #1281/#1306). A literal <c>5</c> chained into a <c>uint8</c> base
+/// constructor must bind, emit a correctly-typed <c>uint8</c> constant, and
+/// produce the right runtime value — matching direct construction <c>B(5)</c>.
+/// </summary>
+public class Issue1307BaseInitNarrowingEmitTests
+{
+    [Fact]
+    public void EndToEnd_BaseInitLiteralAdaptsToUint8Ctor_ProducesCorrectValue()
+    {
+        var source = """
+            package p
+            open class B {
+                var T uint8
+                init(t uint8) { T = t }
+            }
+            class D : B {
+                init() : base(5) {}
+            }
+            func Main() {
+                var d = D()
+                System.Console.WriteLine(d.T)
+            }
+            """;
+        var output = CompileAndRun(source);
+        Assert.Equal("5\n", output);
+    }
+
+    [Fact]
+    public void Library_BaseInitLiteralAdaptsToUint8Ctor_PassesIlVerify()
+    {
+        var source = """
+            package p
+            open class B {
+                init(t uint8) {}
+            }
+            class D : B {
+                init() : base(5) {}
+            }
+            """;
+        var dllPath = CompileLibrary(source);
+        TryCleanup(dllPath);
+    }
+
+    private static string CompileLibrary(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1307_lib_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        var args = new[]
+        {
+            "/out:" + outPath,
+            "/target:library",
+            "/targetframework:net10.0",
+            srcPath,
+        };
+
+        RunCompiler(args);
+        IlVerifier.Verify(outPath);
+        return outPath;
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1307_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            RunCompiler(args);
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static void RunCompiler(string[] args)
+    {
+        using var stdoutWriter = new StringWriter();
+        using var stderrWriter = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(stdoutWriter);
+        Console.SetError(stderrWriter);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+    }
+
+    private static void TryCleanup(string dllPath)
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(dllPath);
+            if (dir != null && Directory.Exists(dir))
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+        catch
+        {
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1307BaseInitNarrowingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1307BaseInitNarrowingTests.cs
@@ -1,0 +1,110 @@
+// <copyright file="Issue1307BaseInitNarrowingTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1307 — a base-constructor initializer (<c>: base(&lt;literal&gt;)</c>)
+/// must apply the same implicit constant-narrowing / integer-literal adaptation
+/// (C# §10.2.11, issues #1281/#1306) that ordinary calls and direct
+/// constructions already apply. The base-init argument-binding path previously
+/// bypassed that pass, so <c>: base(5)</c> against a <c>uint8</c> constructor
+/// failed overload resolution with GS0214 even though literal <c>5</c> adapts
+/// to <c>uint8</c> everywhere else.
+/// </summary>
+public class Issue1307BaseInitNarrowingTests
+{
+    [Fact]
+    public void BaseInitLiteralAdaptsToNarrowerExplicitCtor_BindsWithoutDiagnostics()
+    {
+        var source = @"
+package p
+open class B {
+    init(t uint8) {}
+}
+class D : B {
+    init() : base(5) {}
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void BaseInitLiteralAdaptsToNarrowerPrimaryCtor_BindsWithoutDiagnostics()
+    {
+        var source = @"
+package p
+open class B(t uint8) {}
+class D : B {
+    init() : base(5) {}
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void BaseInitWithNoNarrowingNeeded_StillBindsWithoutDiagnostics()
+    {
+        var source = @"
+package p
+open class C {
+    init(t int32) {}
+}
+class E : C {
+    init() : base(5) {}
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void BaseInitWithExplicitCast_StillBindsWithoutDiagnostics()
+    {
+        var source = @"
+package p
+open class B {
+    init(t uint8) {}
+}
+class D2 : B {
+    init() : base(uint8(5)) {}
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void BaseInitOutOfRangeLiteral_StillReportsDiagnostic()
+    {
+        var source = @"
+package p
+open class B {
+    init(t uint8) {}
+}
+class D : B {
+    init() : base(300) {}
+}
+";
+        var result = Evaluate(source);
+        Assert.NotEmpty(result.Diagnostics);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
Fixes #1307
Refs #914

## Root cause
A base-constructor initializer `: base(<literal>)` did not apply the implicit constant-expression narrowing / integer-literal adaptation (C# §10.2.11) introduced for ordinary calls/constructions in #1281/#1306. The G# base-init argument binding (`DeclarationBinder.ResolveGSharpExplicitBaseConstructor`, and the primary-ctor fast path in `ResolveGSharpBaseConstructor`) tested candidate applicability only with the ADR-0044 widening lattice (`Conversion.Classify(...).IsImplicit`) and never consulted the literal-adaptation pass. So `: base(5)` against a `uint8` ctor failed overload resolution with **GS0214**, even though literal `5` adapts to `uint8` in direct construction `B(5)`, method calls, and declaration targets.

## Fix
Route both base-init applicability checks through the existing shared helper `ExpressionBinder.IsImplicitConstantNarrowingArgument` — the same gate used by `OverloadResolver` for ordinary calls/constructions. The final argument conversion already flows through `conversions.BindConversion`, which re-materialises the literal at the parameter type. No parallel logic is forked.

Non-constant narrowing and out-of-range constants still require an explicit `T(x)` cast (GS0214 preserved). The CLR-base path is intentionally unchanged, consistent with the scope of #1281 (CLR overload resolution untouched).

## `: this(...)` finding (step 3)
The constructor-delegation form `: this(<literal>)` surfaces a *different* diagnostic, **GS0213** ("A base-constructor argument list requires an explicit base class"). This is a separate, pre-existing concern unrelated to narrowing: the grammar/parser only models a `base` initializer (`ConstructorDeclarationSyntax` exposes only `BaseKeyword`/`BaseArguments`), so `this`-delegation is not a supported construct at all. It is not reachable from — nor fixed by — the narrowing change, and fixing it would be scope creep. Left as-is.

## Tests
- **Core.Tests** (`Issue1307BaseInitNarrowingTests`, 5 tests): `: base(5)` → `uint8` explicit ctor binds; `: base(5)` → `uint8` primary ctor binds; int32 no-narrowing control; explicit-cast `uint8(5)` control; out-of-range `300` still errors.
- **Compiler.Tests/Emit** (`Issue1307BaseInitNarrowingEmitTests`, 2 tests): end-to-end exe run proving the runtime value is `5`, plus a library ilverify pass.

All new tests pass; full Core.Tests green (4602 passed, 0 failed). Minimal repro and the four controls re-verified against the freshly built `gsc`.
