### PR TITLE
Fix #1208: support SafeHandle/SafeFileHandle in P/Invoke marshalling

### DIFF
--- a/docs/adr/0086-pinvoke-native-interop.md
+++ b/docs/adr/0086-pinvoke-native-interop.md
@@ -64,6 +64,7 @@ A P/Invoke parameter or return type is **valid in v1** if and only if it falls i
 | `string`                         | `System.String`     | Marshalled per `CharSet` (default: `CharSet.Ansi`, matching CLR default). |
 | `*T` (where `T` is a primitive)  | `T*` (unmanaged pointer) | Raw pointer; not GC-tracked.            |
 | `[]T` for primitive `T`          | `T[]` (managed array) | Marshalled as an LPArray; pinned and a base pointer passed. |
+| `SafeHandle` (and derived)       | `System.Runtime.InteropServices.SafeHandle` (or subclass, e.g. `Microsoft.Win32.SafeHandles.SafeFileHandle`) | The CLR marshaller special-cases `SafeHandle`: as a parameter it adds a ref to the handle for the duration of the call; as a return value it constructs the managed wrapper and takes ownership of the native handle. Not blittable and not a pointer — accepted as a managed reference type. |
 | `void` (return only)             | `System.Void`       |                                            |
 
 **Not yet supported in v1** (diagnose with GS0323; tracked in follow-up issues):
@@ -72,8 +73,29 @@ A P/Invoke parameter or return type is **valid in v1** if and only if it falls i
 - Delegates as function pointers (`[MarshalAs(UnmanagedType.FunctionPtr)]`).
 - Out / ref parameters with primitive types (filed as follow-up #728).
 - Custom marshallers (`[MarshalAs(CustomMarshaler = ...)]`).
-- `StringBuilder` and `SafeHandle` derived types.
+- `StringBuilder`.
 - `@LibraryImport` source-generator pattern (filed as follow-up #729).
+
+#### 2.1 `SafeHandle` marshalling (issue #1208)
+
+`System.Runtime.InteropServices.SafeHandle` and any type that derives from it
+(e.g. `Microsoft.Win32.SafeHandles.SafeFileHandle`,
+`Microsoft.Win32.SafeHandles.SafeWaitHandle`) are accepted as a P/Invoke
+**parameter** and as a **return value**. `SafeHandle` is the standard,
+idiomatic way to write safe Win32 interop in .NET: the CLR marshaller performs
+the handle ref-count / lifetime bookkeeping automatically, so the canonical
+`CreateFile` → `SafeFileHandle` / `ReadFile(SafeHandle, …)` shape compiles and
+emits a `PinvokeImpl` method whose signature references the real handle type via
+a `TypeRef`. The binder detects "is or derives from `SafeHandle`" by walking the
+CLR base-type chain on the type's `ClrType` and comparing the full name
+`System.Runtime.InteropServices.SafeHandle` — only `SafeHandle` and its
+subclasses are accepted; arbitrary reference types are **not** broadened in (a
+`StringBuilder` parameter or an arbitrary class return is still rejected with
+GS0323). `SafeHandle` is neither blittable nor a pointer, so it bypasses the
+struct / pointer blittability checks (it is a managed reference type the
+marshaller special-cases). The emitter needs no marshalling-specific gate: the
+general method-signature type encoder emits the handle type's `TypeRef`
+directly, and the runtime marshaller does the rest.
 
 ### 3. Attribute knobs
 

--- a/src/Core/CodeAnalysis/Binding/PInvokeBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/PInvokeBinder.cs
@@ -171,6 +171,17 @@ internal static class PInvokeBinder
                 continue;
             }
 
+            // ADR-0086 §2 / issue #1208: SafeHandle (and derived types such as
+            // SafeFileHandle, SafeWaitHandle) marshal as managed handle
+            // wrappers — the CLR marshaller performs the handle ref-count /
+            // lifetime bookkeeping automatically. Accept them as a by-value
+            // parameter; this guard takes precedence over the struct / class
+            // and generic unsupported-type rejections below.
+            if (IsSafeHandleType(parameter.Type))
+            {
+                continue;
+            }
+
             // ADR-0093 §3 / §4: struct values and (layout-annotated) class
             // references are validated separately so the binder can issue
             // the tailored GS0349 "not blittable" message rather than the
@@ -205,7 +216,15 @@ internal static class PInvokeBinder
             // ownership / lifetime contract. The caller should declare the
             // return as `unmanaged[CC] (...) -> R` or `nint` and use
             // `Marshal.GetDelegateForFunctionPointer` manually.
-            if (function.Type is DelegateTypeSymbol returnDelegate)
+            if (IsSafeHandleType(function.Type))
+            {
+                // ADR-0086 §2 / issue #1208: SafeHandle return — the CLR
+                // marshaller constructs the managed wrapper and assumes
+                // ownership of the native handle. This guard precedes the
+                // class-return / unsupported-type rejections so an imported
+                // BCL handle type (e.g. SafeFileHandle) is never misclassified.
+            }
+            else if (function.Type is DelegateTypeSymbol returnDelegate)
             {
                 diagnostics.ReportPInvokeDelegateReturnNotSupported(returnLocation, returnDelegate.Name);
             }
@@ -274,6 +293,11 @@ internal static class PInvokeBinder
         }
 
         if (type == TypeSymbol.String)
+        {
+            return true;
+        }
+
+        if (IsSafeHandleType(type))
         {
             return true;
         }
@@ -432,6 +456,46 @@ internal static class PInvokeBinder
         }
 
         structSymbol = null;
+        return false;
+    }
+
+    /// <summary>
+    /// ADR-0086 §2 / issue #1208: returns <c>true</c> when
+    /// <paramref name="type"/> is
+    /// <c>System.Runtime.InteropServices.SafeHandle</c> or any type deriving
+    /// from it (e.g. <c>Microsoft.Win32.SafeHandles.SafeFileHandle</c>,
+    /// <c>Microsoft.Win32.SafeHandles.SafeWaitHandle</c>). <c>SafeHandle</c> is
+    /// a managed reference type that the CLR marshaller special-cases for
+    /// P/Invoke: it performs the handle ref-count / lifetime management
+    /// automatically and accepts the type as both a parameter and a return
+    /// value. <c>SafeHandle</c> is neither blittable nor a pointer, so it must
+    /// bypass the struct / pointer marshalling checks. Detection walks the CLR
+    /// base-type chain on the symbol's <see cref="TypeSymbol.ClrType"/> and
+    /// compares the full name, so it works for imported BCL handle types loaded
+    /// through a <c>MetadataLoadContext</c>. A <see cref="NullableTypeSymbol"/>
+    /// wrapper is unwrapped first so <c>SafeFileHandle?</c> is still recognised.
+    /// Only <c>SafeHandle</c> and its subclasses are accepted — arbitrary
+    /// reference types are not broadened in.
+    /// </summary>
+    /// <param name="type">The bound parameter or return type.</param>
+    /// <returns><c>true</c> when the type is or derives from <c>SafeHandle</c>.</returns>
+    internal static bool IsSafeHandleType(TypeSymbol type)
+    {
+        if (type == null)
+        {
+            return false;
+        }
+
+        var unwrapped = type is NullableTypeSymbol nullable ? nullable.UnderlyingType : type;
+        var clrType = unwrapped?.ClrType;
+        for (var current = clrType; current != null; current = current.BaseType)
+        {
+            if (current.FullName == "System.Runtime.InteropServices.SafeHandle")
+            {
+                return true;
+            }
+        }
+
         return false;
     }
 

--- a/test/Compiler.Tests/Emit/Issue1208SafeHandlePInvokeEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1208SafeHandlePInvokeEmitTests.cs
@@ -1,0 +1,182 @@
+// <copyright file="Issue1208SafeHandlePInvokeEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Emit coverage for ADR-0086 §2 / issue #1208: a P/Invoke whose parameter or
+/// return type is <c>System.Runtime.InteropServices.SafeHandle</c> (or a derived
+/// type such as <c>Microsoft.Win32.SafeHandles.SafeFileHandle</c>) lowers to a
+/// <c>PinvokeImpl</c> MethodDef whose signature references the real handle type
+/// via a TypeRef, so the CLR marshaller performs the handle ref-count /
+/// lifetime bookkeeping. kernel32 is not callable off-Windows, so these tests
+/// only assert on the emitted metadata, not on runtime invocation.
+/// </summary>
+public class Issue1208SafeHandlePInvokeEmitTests
+{
+    [Fact]
+    public void SafeHandle_Param_And_SafeFileHandle_Return_ReferenceRealTypesInSignature()
+    {
+        const string source = """
+            package P
+            import System.Runtime.InteropServices
+            import Microsoft.Win32.SafeHandles
+
+            unsafe class C {
+                shared {
+                    @DllImport("kernel32", SetLastError: true, CharSet: 3)
+                    func CreateFile(name string, a uint32, b uint32, c uint32, d uint32, e uint32, f int32) SafeFileHandle;
+
+                    @DllImport("kernel32", SetLastError: true)
+                    func ReadFile(handle SafeHandle, pBuffer *void, n int32, pRead *int32, ov int32) bool;
+                }
+            }
+            """;
+
+        var tempDir = Directory.CreateTempSubdirectory("gs_pinvoke_safehandle_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+            CompileOrThrow(srcPath, outPath, target: "library");
+
+            using var pe = new PEReader(File.OpenRead(outPath));
+            var md = pe.GetMetadataReader();
+            var provider = new NameSignatureProvider(md);
+
+            var sawCreateFile = false;
+            var sawReadFile = false;
+            foreach (var h in md.MethodDefinitions)
+            {
+                var m = md.GetMethodDefinition(h);
+                var name = md.GetString(m.Name);
+                if (name == "CreateFile")
+                {
+                    sawCreateFile = true;
+                    Assert.True(
+                        (m.Attributes & System.Reflection.MethodAttributes.PinvokeImpl) == System.Reflection.MethodAttributes.PinvokeImpl,
+                        "CreateFile should carry PinvokeImpl");
+                    var sig = m.DecodeSignature(provider, genericContext: null);
+                    Assert.Equal("Microsoft.Win32.SafeHandles.SafeFileHandle", sig.ReturnType);
+                }
+                else if (name == "ReadFile")
+                {
+                    sawReadFile = true;
+                    Assert.True(
+                        (m.Attributes & System.Reflection.MethodAttributes.PinvokeImpl) == System.Reflection.MethodAttributes.PinvokeImpl,
+                        "ReadFile should carry PinvokeImpl");
+                    var sig = m.DecodeSignature(provider, genericContext: null);
+                    Assert.Equal("System.Runtime.InteropServices.SafeHandle", sig.ParameterTypes[0]);
+                }
+            }
+
+            Assert.True(sawCreateFile, "expected an emitted P/Invoke method named CreateFile");
+            Assert.True(sawReadFile, "expected an emitted P/Invoke method named ReadFile");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    private static void CompileOrThrow(string srcPath, string outPath, string target)
+    {
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:" + target,
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+    }
+
+    /// <summary>
+    /// Minimal <see cref="ISignatureTypeProvider{TType, TGenericContext}"/> that
+    /// renders each referenced type as its full CLR name so the test can assert
+    /// the emitted P/Invoke signature points at the real SafeHandle types.
+    /// </summary>
+    private sealed class NameSignatureProvider : ISignatureTypeProvider<string, object>
+    {
+        private readonly MetadataReader reader;
+
+        public NameSignatureProvider(MetadataReader reader)
+        {
+            this.reader = reader;
+        }
+
+        public string GetArrayType(string elementType, ArrayShape shape) => elementType + "[]";
+
+        public string GetByReferenceType(string elementType) => "ref " + elementType;
+
+        public string GetFunctionPointerType(MethodSignature<string> signature) => "fnptr";
+
+        public string GetGenericInstantiation(string genericType, ImmutableArray<string> typeArguments) => genericType + "<...>";
+
+        public string GetGenericMethodParameter(object genericContext, int index) => "!!" + index;
+
+        public string GetGenericTypeParameter(object genericContext, int index) => "!" + index;
+
+        public string GetModifiedType(string modifier, string unmodifiedType, bool isRequired) => unmodifiedType;
+
+        public string GetPinnedType(string elementType) => elementType;
+
+        public string GetPointerType(string elementType) => elementType + "*";
+
+        public string GetPrimitiveType(PrimitiveTypeCode typeCode) => typeCode.ToString();
+
+        public string GetSZArrayType(string elementType) => elementType + "[]";
+
+        public string GetTypeFromDefinition(MetadataReader metadataReader, TypeDefinitionHandle handle, byte rawTypeKind)
+        {
+            var def = metadataReader.GetTypeDefinition(handle);
+            var ns = metadataReader.GetString(def.Namespace);
+            var name = metadataReader.GetString(def.Name);
+            return string.IsNullOrEmpty(ns) ? name : ns + "." + name;
+        }
+
+        public string GetTypeFromReference(MetadataReader metadataReader, TypeReferenceHandle handle, byte rawTypeKind)
+        {
+            var typeRef = metadataReader.GetTypeReference(handle);
+            var ns = metadataReader.GetString(typeRef.Namespace);
+            var name = metadataReader.GetString(typeRef.Name);
+            return string.IsNullOrEmpty(ns) ? name : ns + "." + name;
+        }
+
+        public string GetTypeFromSpecification(MetadataReader metadataReader, object genericContext, TypeSpecificationHandle handle, byte rawTypeKind) => "spec";
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1208SafeHandlePInvokeBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1208SafeHandlePInvokeBinderTests.cs
@@ -1,0 +1,144 @@
+// <copyright file="Issue1208SafeHandlePInvokeBinderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1208 / ADR-0086 §2: <c>System.Runtime.InteropServices.SafeHandle</c>
+/// and any type deriving from it (e.g.
+/// <c>Microsoft.Win32.SafeHandles.SafeFileHandle</c>,
+/// <c>Microsoft.Win32.SafeHandles.SafeWaitHandle</c>) marshal as P/Invoke
+/// parameters and return values — the CLR marshaller performs the handle
+/// ref-count / lifetime bookkeeping automatically. The binder must therefore
+/// accept them and not report <c>GS0323</c> (unsupported marshalling type).
+/// Arbitrary reference types remain unsupported.
+/// </summary>
+public class Issue1208SafeHandlePInvokeBinderTests
+{
+    [Fact]
+    public void SafeFileHandleReturn_And_SafeHandleParam_NoGS0323()
+    {
+        // The canonical Win32 interop shape from the issue: CreateFile returns a
+        // SafeFileHandle and ReadFile takes a SafeHandle by value.
+        const string source = @"
+package P
+import System.Runtime.InteropServices
+import Microsoft.Win32.SafeHandles
+
+unsafe class C {
+    shared {
+        @DllImport(""kernel32"", SetLastError: true, CharSet: 3)
+        func CreateFile(name string, a uint32, b uint32, c uint32, d uint32, e uint32, f int32) SafeFileHandle;
+
+        @DllImport(""kernel32"", SetLastError: true)
+        func ReadFile(handle SafeHandle, pBuffer *void, n int32, pRead *int32, ov int32) bool;
+    }
+}
+";
+        var diagnostics = GetDiagnostics(source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0323");
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+    }
+
+    [Fact]
+    public void SafeHandleParameter_NoGS0323()
+    {
+        const string source = @"
+package P
+import System.Runtime.InteropServices
+
+@DllImport(""kernel32"", SetLastError: true)
+func CloseHandle(handle SafeHandle) bool;
+";
+        var diagnostics = GetDiagnostics(source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0323");
+    }
+
+    [Fact]
+    public void SafeFileHandleReturn_NoGS0323_NotClassReturn()
+    {
+        // A SafeHandle-derived return must bypass BOTH the generic GS0323 and
+        // the class-return rejection (GS reported by ReportPInvokeClassReturnNotSupported).
+        const string source = @"
+package P
+import System.Runtime.InteropServices
+import Microsoft.Win32.SafeHandles
+
+@DllImport(""kernel32"", SetLastError: true, CharSet: 3)
+func CreateFile(name string, a uint32, b uint32, c uint32, d uint32, e uint32, f int32) SafeFileHandle;
+";
+        var diagnostics = GetDiagnostics(source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0323");
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+    }
+
+    [Fact]
+    public void SafeWaitHandle_DerivedType_NoGS0323()
+    {
+        // SafeWaitHandle derives from SafeHandle through the same base chain.
+        const string source = @"
+package P
+import System.Runtime.InteropServices
+import Microsoft.Win32.SafeHandles
+
+unsafe class C {
+    shared {
+        @DllImport(""kernel32"", SetLastError: true)
+        func WaitForSingleObject(handle SafeWaitHandle, ms uint32) uint32;
+    }
+}
+";
+        var diagnostics = GetDiagnostics(source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0323");
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+    }
+
+    [Fact]
+    public void ArbitraryReferenceTypeParameter_StillReportsGS0323()
+    {
+        // Negative control: SafeHandle support must NOT broaden to arbitrary
+        // reference types. A StringBuilder parameter is still rejected.
+        const string source = @"
+package P
+import System.Text
+import System.Runtime.InteropServices
+
+@DllImport(""kernel32"")
+func Foo(sb StringBuilder) bool;
+";
+        var diagnostics = GetDiagnostics(source);
+        Assert.Contains(diagnostics, d => d.Id == "GS0323");
+    }
+
+    [Fact]
+    public void ArbitraryReferenceTypeReturn_StillRejected()
+    {
+        // Negative control: a non-SafeHandle reference return remains rejected.
+        const string source = @"
+package P
+import System.Text
+import System.Runtime.InteropServices
+
+@DllImport(""kernel32"")
+func Foo() StringBuilder;
+";
+        var diagnostics = GetDiagnostics(source);
+        Assert.Contains(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+    }
+
+    private static IEnumerable<Diagnostic> GetDiagnostics(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new GSharp.Core.CodeAnalysis.Compilation.Compilation(tree);
+        using var peStream = new System.IO.MemoryStream();
+        return compilation.Emit(peStream).Diagnostics.ToArray();
+    }
+}


### PR DESCRIPTION
Fixes #1208.

## Summary
P/Invoke (`@DllImport` / `@LibraryImport`) signatures that use `System.Runtime.InteropServices.SafeHandle` — or a derived type such as `Microsoft.Win32.SafeHandles.SafeFileHandle` / `SafeWaitHandle` — as a parameter or return type were rejected with `GS0323` ("not supported for P/Invoke marshalling in v1"). `SafeHandle` is the standard, idiomatic way to write safe Win32 interop in .NET: the CLR marshaller performs the handle ref-count / lifetime bookkeeping automatically. This PR expands the ADR-0086 §2 v1 supported-marshalling set to include `SafeHandle` and its derived types, as a parameter and as a return value.

### Repro that previously failed (GS0323 x2), now compiles to a DLL
```gsharp
package p
import System.Runtime.InteropServices
import Microsoft.Win32.SafeHandles
unsafe class C {
    shared {
        @DllImport("kernel32", SetLastError: true, CharSet: 3)
        func CreateFile(name string, a uint32, b uint32, c uint32, d uint32, e uint32, f int32) SafeFileHandle;

        @DllImport("kernel32", SetLastError: true)
        func ReadFile(handle SafeHandle, pBuffer *void, n int32, pRead *int32, ov int32) bool;
    }
}
```
The emitted `PinvokeImpl` signature references the real types — `CreateFile` returns `Microsoft.Win32.SafeHandles.SafeFileHandle` and `ReadFile` takes `System.Runtime.InteropServices.SafeHandle` — so the CLR marshaller handles the ref-counting.

## Changes
- **Binder** (`src/Core/CodeAnalysis/Binding/PInvokeBinder.cs`): new `IsSafeHandleType(TypeSymbol)` helper detects "is or derives from `System.Runtime.InteropServices.SafeHandle`" by walking the CLR base-type chain on the symbol's `ClrType` and comparing the full name (works for imported BCL types loaded through a `MetadataLoadContext`; unwraps a nullable wrapper). The guard is applied with **precedence over** the struct / class-return and generic unsupported-type rejections in **both** the parameter path and the return path, and is also folded into `IsSupportedMarshallingType`. `SafeHandle` is neither blittable nor a pointer, so it bypasses the struct / pointer blittability checks. Only `SafeHandle` and its subclasses are accepted — arbitrary reference types are **not** broadened in.
- **Emit**: no change required. The general method-signature type encoder already emits the handle type's `TypeRef` directly; there is no marshalling-specific gate in the emitter. Verified the emitted `PinvokeImpl` signature references the real handle types.
- **Docs** (`docs/adr/0086-pinvoke-native-interop.md`): §2 marshalling table gains a `SafeHandle` row, `SafeHandle` is removed from the "not yet supported" list (`StringBuilder` remains), and a new §2.1 documents the support and rationale. `docs/diagnostics.md` GS0323 already points to ADR-0086 §2 generically, so no change there.
- **Tests**:
  - `test/Core.Tests/.../Issue1208SafeHandlePInvokeBinderTests.cs` — asserts no `GS0323` for a `SafeHandle` parameter + `SafeFileHandle` return, a `SafeHandle`-only parameter, a `SafeFileHandle`-only return (also not misclassified as a class-return), and a derived `SafeWaitHandle`; plus negative controls proving an arbitrary reference type (`StringBuilder`) parameter / return is still rejected.
  - `test/Compiler.Tests/Emit/Issue1208SafeHandlePInvokeEmitTests.cs` — compiles the repro to a library and decodes the `PinvokeImpl` method signatures, asserting the return references `Microsoft.Win32.SafeHandles.SafeFileHandle` and the parameter references `System.Runtime.InteropServices.SafeHandle`.

## Validation
- `dotnet build GSharp.sln -c Release` — succeeds, 0 warnings / 0 errors.
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release --filter "FullyQualifiedName~Issue1208SafeHandle"` — 6/6 passed.
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release --filter "FullyQualifiedName~PInvoke|FullyQualifiedName~DllImport|FullyQualifiedName~LibraryImport|FullyQualifiedName~Marshal|FullyQualifiedName~StructMarshalling"` — 136/136 passed.
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Release --no-build --filter "FullyQualifiedName~PInvoke|FullyQualifiedName~DllImport|FullyQualifiedName~LibraryImport|FullyQualifiedName~Marshal" -- xUnit.MaxParallelThreads=2` — 51/51 passed.
- Standalone `gsc` harness compiled the repro: "Wrote x.dll".