### PR TITLE
Fix #1311: constant-narrowing literal adaptation in imported/BCL method overload resolution

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -756,6 +756,7 @@ internal sealed partial class ExpressionBinder
                     IsUserClassAssignableToInterface(boundArguments, argTypes, source, target);
             }
 
+            OverloadResolution.ConstantNarrowingArgumentCheck = MakeConstantNarrowingArgumentCheck(boundArguments);
             try
             {
                 var resolution = OverloadResolution.Resolve(ctors, argTypes, interpolatedStringArgs: ComputeInterpolatedStringArgFlags(syntax.Arguments, boundArguments.Count), argumentNames: argumentNames.IsDefault ? null : (IReadOnlyList<string>)argumentNames);
@@ -779,6 +780,8 @@ internal sealed partial class ExpressionBinder
                 {
                     OverloadResolution.SupplementaryInterfaceCheck = null;
                 }
+
+                OverloadResolution.ConstantNarrowingArgumentCheck = null;
             }
         }
 
@@ -2716,6 +2719,7 @@ internal sealed partial class ExpressionBinder
 
                 try
                 {
+                    OverloadResolution.ConstantNarrowingArgumentCheck = MakeConstantNarrowingArgumentCheck(arguments);
                     var resolution = OverloadResolution.Resolve(candidates, argTypes, explicitTypeArgs, scope.References.MapClrTypeToReferences, ComputeInterpolatedStringArgFlags(ce.Arguments, arguments.Length), argumentNames.IsDefault ? null : (IReadOnlyList<string>)argumentNames);
                     switch (resolution.Outcome)
                     {
@@ -2760,6 +2764,8 @@ internal sealed partial class ExpressionBinder
                     {
                         OverloadResolution.SupplementaryInterfaceCheck = null;
                     }
+
+                    OverloadResolution.ConstantNarrowingArgumentCheck = null;
                 }
             }
         }
@@ -3365,6 +3371,7 @@ internal sealed partial class ExpressionBinder
         OverloadResolution.Result<MethodInfo> resolution;
         try
         {
+            OverloadResolution.ConstantNarrowingArgumentCheck = MakeConstantNarrowingArgumentCheck(arguments);
             resolution = OverloadResolution.Resolve(candidates, argTypes, explicitTypeArgs, scope.References.MapClrTypeToReferences, argumentNames: argumentNames.IsDefault ? null : (IReadOnlyList<string>)argumentNames);
         }
         finally
@@ -3373,6 +3380,8 @@ internal sealed partial class ExpressionBinder
             {
                 OverloadResolution.SupplementaryInterfaceCheck = null;
             }
+
+            OverloadResolution.ConstantNarrowingArgumentCheck = null;
         }
 
         switch (resolution.Outcome)
@@ -3601,6 +3610,10 @@ internal sealed partial class ExpressionBinder
         OverloadResolution.Result<MethodInfo> resolution;
         try
         {
+            // Issue #1311: imported extension calls dispatch as
+            // `Class.Method(this receiver, args…)`, so argTypes slot 0 is the
+            // receiver and user argument `i` lives at slot `i + 1`.
+            OverloadResolution.ConstantNarrowingArgumentCheck = MakeConstantNarrowingArgumentCheck(arguments, argumentOffset: 1);
             resolution = OverloadResolution.Resolve(candidates, argTypes, explicitTypeArgs, scope.References.MapClrTypeToReferences, argumentNames: extensionArgumentNames);
         }
         finally
@@ -3609,6 +3622,8 @@ internal sealed partial class ExpressionBinder
             {
                 OverloadResolution.SupplementaryInterfaceCheck = null;
             }
+
+            OverloadResolution.ConstantNarrowingArgumentCheck = null;
         }
 
         switch (resolution.Outcome)

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
@@ -1740,4 +1740,41 @@ internal sealed partial class ExpressionBinder
             && TryGetConstantIntegerValue(argument, out var value)
             && TryAdaptIntegerLiteral(value, parameterType, out _);
     }
+
+    // Issue #1311: builds the per-call constant-narrowing applicability hook for
+    // imported/BCL overload resolution (OverloadResolution.Resolve). The hook
+    // receives the source-argument index (into argTypes) and the candidate's CLR
+    // parameter type; it returns true when the corresponding bound argument is a
+    // constant integer expression whose value fits that (possibly narrower /
+    // cross-sign) integer parameter — i.e. the same §10.2.11 rule applied on the
+    // user-method path. `argumentOffset` accounts for a synthesised leading
+    // receiver slot (imported extension calls pass [receiver, args…], offset 1).
+    internal static Func<int, System.Type, bool> MakeConstantNarrowingArgumentCheck(
+        IReadOnlyList<BoundExpression> boundArguments,
+        int argumentOffset = 0)
+    {
+        if (boundArguments == null)
+        {
+            return null;
+        }
+
+        return (index, clrParameterType) =>
+        {
+            var argIndex = index - argumentOffset;
+            if (argIndex < 0 || argIndex >= boundArguments.Count || clrParameterType == null)
+            {
+                return false;
+            }
+
+            // A constant literal can never bind by-ref; peel defensively so a
+            // by-ref parameter maps to its element type rather than a managed
+            // pointer (which TypeSymbol.FromClrType cannot represent).
+            if (clrParameterType.IsByRef)
+            {
+                clrParameterType = clrParameterType.GetElementType();
+            }
+
+            return IsImplicitConstantNarrowingArgument(boundArguments[argIndex], TypeSymbol.FromClrType(clrParameterType));
+        };
+    }
 }

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
@@ -172,6 +172,22 @@ internal static class OverloadResolution
         /// the target.
         /// </summary>
         DelegateReturnNumericWidening = 12,
+
+        /// <summary>
+        /// Issue #1311: a constant integer argument (an integer literal, or a
+        /// unary +/- over one) whose value lies within the parameter's
+        /// (possibly narrower or cross-sign) integer type range converts
+        /// implicitly with no cast — C# §10.2.11 implicit constant expression
+        /// conversion. This mirrors the user-method overload path
+        /// (<c>OverloadResolver.IsApplicableUserCallable</c> via
+        /// <c>ExpressionBinder.IsImplicitConstantNarrowingArgument</c>) for
+        /// imported/BCL candidates so e.g. <c>stream.WriteByte(0)</c> binds to
+        /// <c>Stream.WriteByte(byte)</c>. The binder's
+        /// <c>BindClrParameterConversions</c> pass then re-materialises the
+        /// correctly-typed (narrower) literal before emit. Ranked last (worst)
+        /// so an exact identity or widening match always wins when applicable.
+        /// </summary>
+        ConstantNarrowing = 13,
     }
 
     /// <summary>
@@ -226,6 +242,25 @@ internal static class OverloadResolution
 #pragma warning disable SA1401 // Field should be private
 #pragma warning disable SA1201 // Elements should appear in the correct order
     internal static Func<Type, Type, bool> SupplementaryInterfaceCheck;
+#pragma warning restore SA1201
+#pragma warning restore SA1401
+
+    /// <summary>
+    /// Issue #1311: per-call constant-narrowing applicability hook for imported/
+    /// BCL candidates. When set (non-null), <see cref="EvaluateCandidate{T}"/>
+    /// invokes it for an argument whose natural type has no implicit conversion
+    /// to the parameter type. The callback receives the source argument index
+    /// and the CLR parameter type and returns <see langword="true"/> when the
+    /// argument is a constant integer expression whose value fits that
+    /// (possibly narrower / cross-sign) integer parameter — i.e. C# §10.2.11
+    /// implicit constant expression conversion. The binder sets this from the
+    /// bound arguments before calling <see cref="Resolve{T}"/> and clears it
+    /// immediately after. Modelled on <see cref="SupplementaryInterfaceCheck"/>.
+    /// </summary>
+    [ThreadStatic]
+#pragma warning disable SA1401 // Field should be private
+#pragma warning disable SA1201 // Elements should appear in the correct order
+    internal static Func<int, Type, bool> ConstantNarrowingArgumentCheck;
 #pragma warning restore SA1201
 #pragma warning restore SA1401
 
@@ -1752,6 +1787,18 @@ internal static class OverloadResolution
                         && IsFormattableStringTarget(paramTypes[i]))
                     {
                         conv = ImplicitConversionKind.InterpolatedStringToFormattable;
+                    }
+                    else if (ConstantNarrowingArgumentCheck != null
+                        && ConstantNarrowingArgumentCheck(i, paramTypes[i]))
+                    {
+                        // Issue #1311: a constant integer argument that fits a
+                        // narrower / cross-sign integer parameter is implicitly
+                        // convertible there (C# §10.2.11), so it must not
+                        // disqualify the imported/BCL candidate. Mirrors the
+                        // user-method path (OverloadResolver). The binder's
+                        // BindClrParameterConversions pass re-materialises the
+                        // correctly-typed literal before emit.
+                        conv = ImplicitConversionKind.ConstantNarrowing;
                     }
                     else
                     {

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
@@ -2656,6 +2656,18 @@ internal static class OverloadResolution
             return CompareNumericTargets(paramA, paramB, source);
         }
 
+        // Issue #1311 follow-up: when the SAME constant literal adapts to two
+        // candidates via constant-narrowing (e.g. `UIntPtr(16)` matching both
+        // `.ctor(UInt32)` and `.ctor(UInt64)`), apply the same "better
+        // conversion target" rule so the narrowest applicable integral target
+        // wins (UInt32 over UInt64) instead of producing a spurious GS0160.
+        // A genuinely non-orderable pair (CompareNumericTargets returns 0)
+        // still surfaces as ambiguous.
+        if (ka == ImplicitConversionKind.ConstantNarrowing)
+        {
+            return CompareNumericTargets(paramA, paramB, source);
+        }
+
         // Issue #1150: when two candidates both convert a delegate argument by
         // numeric return-type widening, prefer the one whose delegate return is
         // the "better conversion target" for the source's return type — so a

--- a/test/Compiler.Tests/Emit/Issue1311ImportedMethodNarrowingEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1311ImportedMethodNarrowingEmitTests.cs
@@ -1,0 +1,181 @@
+// <copyright file="Issue1311ImportedMethodNarrowingEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1311: end-to-end CLR emit + ilverify coverage proving that calling an
+/// imported/BCL method whose parameter is a narrower integer type
+/// (<c>System.IO.Stream.WriteByte(byte)</c>) with a bare in-range <c>int</c>
+/// literal binds, emits a correctly-typed <c>uint8</c> constant, and produces
+/// the right runtime bytes (C# §10.2.11, issues #1281/#1306/#1307). The literal
+/// must round-trip through <c>MemoryStream</c> with the exact written values.
+/// </summary>
+public class Issue1311ImportedMethodNarrowingEmitTests
+{
+    [Fact]
+    public void EndToEnd_ImportedWriteByteLiteralAdapts_ProducesCorrectBytes()
+    {
+        var source = """
+            package p
+            import System
+            import System.IO
+            func Main() {
+                var ms = MemoryStream()
+                ms.WriteByte(65)
+                ms.WriteByte(0)
+                ms.WriteByte(255)
+                var bytes = ms.ToArray()
+                Console.WriteLine(int32(bytes.Length))
+                Console.WriteLine(int32(bytes[0]))
+                Console.WriteLine(int32(bytes[1]))
+                Console.WriteLine(int32(bytes[2]))
+            }
+            """;
+        var output = CompileAndRun(source);
+        Assert.Equal("3\n65\n0\n255\n", output);
+    }
+
+    [Fact]
+    public void Library_ImportedWriteByteLiteralAdapts_PassesIlVerify()
+    {
+        var source = """
+            package p
+            import System.IO
+            class C {
+                func W(file Stream) {
+                    file.WriteByte(0)
+                }
+            }
+            """;
+        var dllPath = CompileLibrary(source);
+        TryCleanup(dllPath);
+    }
+
+    private static string CompileLibrary(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1311_lib_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        var args = new[]
+        {
+            "/out:" + outPath,
+            "/target:library",
+            "/targetframework:net10.0",
+            srcPath,
+        };
+
+        RunCompiler(args);
+        IlVerifier.Verify(outPath);
+        return outPath;
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1311_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            RunCompiler(args);
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static void RunCompiler(string[] args)
+    {
+        using var stdoutWriter = new StringWriter();
+        using var stderrWriter = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(stdoutWriter);
+        Console.SetError(stderrWriter);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+    }
+
+    private static void TryCleanup(string dllPath)
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(dllPath);
+            if (dir != null && Directory.Exists(dir))
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+        catch
+        {
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1311ImportedMethodNarrowingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1311ImportedMethodNarrowingTests.cs
@@ -1,0 +1,124 @@
+// <copyright file="Issue1311ImportedMethodNarrowingTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1311 — calling an imported/BCL method whose parameter is a narrower
+/// integer type (e.g. <c>System.IO.Stream.WriteByte(byte)</c>) with a bare
+/// in-range <c>int</c> literal must apply the same implicit constant-narrowing /
+/// integer-literal adaptation (C# §10.2.11, issues #1281/#1306/#1307) already
+/// applied to user-defined methods and base-constructor initializers. Imported
+/// overload resolution previously tested only the lattice conversion and
+/// rejected the literal with GS0159 ("Cannot find function").
+/// </summary>
+public class Issue1311ImportedMethodNarrowingTests
+{
+    [Fact]
+    public void ImportedInstanceMethodLiteralAdaptsToNarrowerParam_BindsWithoutDiagnostics()
+    {
+        var source = @"
+package p
+import System.IO
+class C {
+    func W(file Stream) {
+        file.WriteByte(0)
+    }
+}
+";
+        Assert.Empty(EmitDiagnostics(source));
+    }
+
+    [Fact]
+    public void ImportedInstanceMethodLiteralAdaptsOnDerivedReceiver_BindsWithoutDiagnostics()
+    {
+        var source = @"
+package p
+import System.IO
+class C {
+    func W() {
+        let ms MemoryStream = MemoryStream()
+        ms.WriteByte(0)
+    }
+}
+";
+        Assert.Empty(EmitDiagnostics(source));
+    }
+
+    [Fact]
+    public void ImportedInstanceMethodWithExplicitCast_StillBindsWithoutDiagnostics()
+    {
+        var source = @"
+package p
+import System.IO
+class C {
+    func W(file Stream) {
+        file.WriteByte(uint8(0))
+    }
+}
+";
+        Assert.Empty(EmitDiagnostics(source));
+    }
+
+    [Fact]
+    public void ImportedInstanceMethodInRangeLiteralAdapts_BindsWithoutDiagnostics()
+    {
+        var source = @"
+package p
+import System.IO
+class C {
+    func W(file Stream) {
+        file.WriteByte(255)
+    }
+}
+";
+        Assert.Empty(EmitDiagnostics(source));
+    }
+
+    [Fact]
+    public void ImportedInstanceMethodOutOfRangeLiteral_StillReportsDiagnostic()
+    {
+        var source = @"
+package p
+import System.IO
+class C {
+    func W(file Stream) {
+        file.WriteByte(300)
+    }
+}
+";
+        Assert.NotEmpty(EmitDiagnostics(source));
+    }
+
+    [Fact]
+    public void UserMethodLiteralAdaptation_RemainsUnaffected()
+    {
+        var source = @"
+package p
+class C {
+    func U(b uint8) {}
+    func W() {
+        U(0)
+    }
+}
+";
+        Assert.Empty(EmitDiagnostics(source));
+    }
+
+    private static IReadOnlyList<Diagnostic> EmitDiagnostics(string source)
+    {
+        var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(source)));
+        using var peStream = new MemoryStream();
+        return compilation.Emit(peStream).Diagnostics.ToList();
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1311ImportedMethodNarrowingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1311ImportedMethodNarrowingTests.cs
@@ -115,6 +115,26 @@ class C {
         Assert.Empty(EmitDiagnostics(source));
     }
 
+    [Fact]
+    public void ImportedConstructorWithNarrowAndWideOverloads_BindsToNarrowestWithoutAmbiguity()
+    {
+        // System.UIntPtr exposes both .ctor(UInt32) and .ctor(UInt64). A bare
+        // in-range int literal adapts to BOTH via constant-narrowing; the
+        // better-conversion-target tie-break must pick the narrower UInt32
+        // overload rather than reporting GS0160 ambiguity.
+        var source = @"
+package p
+class C {
+    func F() {
+        let p = UIntPtr(16)
+    }
+}
+";
+        var diagnostics = EmitDiagnostics(source);
+        Assert.DoesNotContain(diagnostics, d => d.Message.Contains("ambiguous"));
+        Assert.Empty(diagnostics);
+    }
+
     private static IReadOnlyList<Diagnostic> EmitDiagnostics(string source)
     {
         var compilation = new Compilation(SyntaxTree.Parse(SourceText.From(source)));


### PR DESCRIPTION
Fixes #1311
Refs #914