### PR TITLE
Fix #1305: chained LINQ over user-element collections (receiver-inferred result interning)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -747,11 +747,23 @@ internal sealed class MemberLookup
             // ImportedTypeSymbol.GetConstructed callers (#313 / #671): ClrType
             // remains a real closed `Type` that reflection can probe for
             // members, while TypeArguments carries the symbolic projection.
+            //
+            // Issue #1305: when this projection runs over a method-level
+            // return type (e.g. `Where<TSource>(…) → IEnumerable<TSource>`)
+            // whose `openDef` was loaded by the references' MetadataLoadContext,
+            // a live `typeof(object)` cannot close it ("type was not loaded by
+            // the MetadataLoadContext"). The construction then fell into the
+            // catch below and surfaced the *open* `IEnumerable<TSource>` as the
+            // result's ClrType, so the next chained extension lookup
+            // (`e.Where(…).Where(…)`) matched against an unbound method type
+            // parameter and reported GS0159. Erase using an `object` resolved
+            // in the same context as `openDef`.
             var openParams = openDef.GetGenericArguments();
             var erasedArgs = new Type[openParams.Length];
+            var contextObject = ResolveErasedObjectInContext(openDef);
             for (int i = 0; i < openParams.Length; i++)
             {
-                erasedArgs[i] = typeof(object);
+                erasedArgs[i] = contextObject;
             }
 
             Type erasedClosed;
@@ -2001,6 +2013,41 @@ internal sealed class MemberLookup
     /// <returns>The parameters visible to a non-extension caller.</returns>
     private static ImmutableArray<ParameterSymbol> GetCallableParameters(FunctionSymbol method)
         => method.ExplicitReceiverParameter == null ? method.Parameters : method.Parameters.RemoveAt(0);
+
+    /// <summary>
+    /// Issue #1305 / #821: resolves the <c>System.Object</c> used to erase the
+    /// type arguments when closing <paramref name="openDef"/> via
+    /// <see cref="Type.MakeGenericType"/>. When <paramref name="openDef"/> was
+    /// loaded by the references' <c>MetadataLoadContext</c> (reference-pack
+    /// assemblies), passing a live <c>typeof(object)</c> raises an
+    /// <see cref="ArgumentException"/> ("type was not loaded by the
+    /// MetadataLoadContext that loaded the generic type or method"). A generic
+    /// parameter's effective base type is <c>System.Object</c> in that same
+    /// context, so reuse it. Falls back to the host <c>typeof(object)</c> when
+    /// <paramref name="openDef"/> lives in the host runtime or no
+    /// <c>System.Object</c> base can be recovered.
+    /// </summary>
+    /// <param name="openDef">The open generic type definition being closed.</param>
+    /// <returns>An <c>object</c> <see cref="Type"/> loaded in the same context as <paramref name="openDef"/>.</returns>
+    private static Type ResolveErasedObjectInContext(Type openDef)
+    {
+        var hostObject = typeof(object);
+        if (openDef == null || openDef.Assembly == hostObject.Assembly)
+        {
+            return hostObject;
+        }
+
+        foreach (var p in openDef.GetGenericArguments())
+        {
+            var baseType = p.BaseType;
+            if (baseType != null && baseType.FullName == "System.Object")
+            {
+                return baseType;
+            }
+        }
+
+        return hostObject;
+    }
 
     private static bool ReturnTypeMatchesSubstituted(TypeSymbol candidateReturn, Type openReturn, ImmutableArray<TypeSymbol> symbolicArgs)
     {

--- a/test/Compiler.Tests/Emit/Issue1305ChainedLinqEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1305ChainedLinqEmitTests.cs
@@ -1,0 +1,194 @@
+// <copyright file="Issue1305ChainedLinqEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1305: chaining an extension/LINQ method whose generic type parameter
+/// is inferred from the receiver element type (e.g. <c>Where</c>'s
+/// <c>TSource</c>) over a same-compilation user element produced a constructed
+/// result whose backing <c>ClrType</c> surfaced the open method type parameter
+/// rather than the type-erased closed shape, so the next chained call failed to
+/// bind (GS0159). These tests pin the fix end-to-end: each builds a
+/// user-element collection, chains <c>Where(...).Select(...)</c> (the second
+/// call's <c>TSource</c>/receiver is the first call's result), and sums the
+/// projected values at runtime — proving the chained calls both bind AND emit
+/// correctly. A primitive-element control guards the unchanged path.
+/// </summary>
+public class Issue1305ChainedLinqEmitTests
+{
+    // Each struct-element test uses a distinct struct name (ChWs, ChCw). These
+    // emit tests share one process and compile with no explicit /reference, so
+    // the (host-keyed) FunctionTypeSymbol cache for `Func<TStruct, …>` selector
+    // delegates is not torn down between compilations; a shared struct name
+    // would alias a prior compilation's struct symbol into the next emit.
+    private static readonly string[] InitOnlyStructLiteral = { "InitOnly" };
+
+    [Fact]
+    public void StructElement_WhereThenSelect_SumsKept()
+    {
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+            import System.Linq
+
+            struct ChWs { prop V int32 { get; init; } }
+
+            func SumKept(e IEnumerable[ChWs]) int32 {
+                var total = 0
+                var filtered = e.Where((c ChWs)->c.V>1).Select((c ChWs)->c.V)
+                var en = filtered.GetEnumerator()
+                while en.MoveNext() {
+                    total = total + en.Current
+                }
+                return total
+            }
+
+            var l = List[ChWs]()
+            l.Add(ChWs{V: 1})
+            l.Add(ChWs{V: 5})
+            l.Add(ChWs{V: 9})
+            Console.WriteLine(SumKept(l))
+            """;
+
+        // Keeps V>1 → 5 + 9 = 14.
+        Assert.Equal("14\n", CompileAndRun(source, InitOnlyStructLiteral));
+    }
+
+    [Fact]
+    public void StructElement_ChainedWhere_CountsKept()
+    {
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+            import System.Linq
+
+            struct ChCw { prop V int32 { get; init; } }
+
+            func CountKept(e IEnumerable[ChCw]) int32 {
+                var kept = e.Where((c ChCw)->c.V>0).Where((c ChCw)->c.V>3)
+                var n = 0
+                var en = kept.GetEnumerator()
+                while en.MoveNext() {
+                    n = n + 1
+                }
+                return n
+            }
+
+            var l = List[ChCw]()
+            l.Add(ChCw{V: 1})
+            l.Add(ChCw{V: 5})
+            l.Add(ChCw{V: 9})
+            Console.WriteLine(CountKept(l))
+            """;
+
+        // V>0 keeps all three; V>3 keeps 5 and 9 → 2.
+        Assert.Equal("2\n", CompileAndRun(source, InitOnlyStructLiteral));
+    }
+
+    [Fact]
+    public void PrimitiveElement_WhereThenSelect_StillRuns()
+    {
+        // Regression control: primitive element throughout was never affected.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+            import System.Linq
+
+            func SumKept(e IEnumerable[int32]) int32 {
+                var total = 0
+                var filtered = e.Where((x int32)->x>1).Select((x int32)->x*2)
+                var en = filtered.GetEnumerator()
+                while en.MoveNext() {
+                    total = total + en.Current
+                }
+                return total
+            }
+
+            var l = List[int32]()
+            l.Add(1)
+            l.Add(5)
+            l.Add(9)
+            Console.WriteLine(SumKept(l))
+            """;
+
+        // Keeps 5,9 then doubles → 10 + 18 = 28.
+        Assert.Equal("28\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source, string[] ignoredIlErrorCodes = null)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1305_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath, ignoredErrorCodes: ignoredIlErrorCodes);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1305ChainedLinqTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1305ChainedLinqTests.cs
@@ -1,0 +1,218 @@
+// <copyright file="Issue1305ChainedLinqTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1305: chaining an extension/LINQ method whose generic type parameter
+/// is inferred from the <em>receiver</em> element type (e.g. <c>Where</c>'s
+/// <c>TSource</c>, <c>OfType</c>/<c>Cast</c>'s result) over a same-compilation
+/// user element produced a constructed result type whose backing
+/// <c>ClrType</c> surfaced the <em>open</em> method type parameter
+/// (<c>IEnumerable&lt;TSource&gt;</c>) instead of the type-erased
+/// <c>IEnumerable&lt;object&gt;</c>. The root cause: the type-erased closed
+/// shape was built with a live <c>typeof(object)</c>, which cannot close an
+/// open definition loaded by the references' <c>MetadataLoadContext</c>; the
+/// failed <c>MakeGenericType</c> fell back to the open return type. The next
+/// extension lookup then matched against an unbound method type parameter and
+/// reported GS0159 ("Cannot find function ...") on the SECOND call. These
+/// binder-level tests assert the chained forms now bind with no diagnostics,
+/// while the controls (primitive element, single call, lambda-inferred result)
+/// keep working.
+/// </summary>
+public class Issue1305ChainedLinqTests
+{
+    [Fact]
+    public void ChainedWhere_OverStructElement_NoDiagnostics()
+    {
+        // Repro (1): the SECOND .Where previously failed with GS0159.
+        const string source = @"
+package p
+import System.Collections.Generic
+import System.Linq
+struct Ch { prop V bool { get; init; } }
+func A(e IEnumerable[Ch]) IEnumerable[Ch] { return e.Where((c Ch)->c.V).Where((c Ch)->c.V) }
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void WhereThenSelect_OverStructElement_NoDiagnostics()
+    {
+        // Repro (2): Select after a receiver-inferred Where failed with GS0159.
+        const string source = @"
+package p
+import System.Collections.Generic
+import System.Linq
+struct Ch { prop V bool { get; init; } }
+func B(e IEnumerable[Ch]) IEnumerable[bool] { return e.Where((c Ch)->c.V).Select((c Ch)->c.V) }
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void OfTypeThenWhere_OverStructElement_NoDiagnostics()
+    {
+        // Repro (3): OfType[Ch]() result as a receiver failed the next Where.
+        const string source = @"
+package p
+import System.Collections.Generic
+import System.Linq
+struct Ch { prop V bool { get; init; } }
+func C(e IEnumerable[object]) IEnumerable[Ch] { return e.OfType[Ch]().Where((c Ch)->c.V) }
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void CastThenWhere_OverStructElement_NoDiagnostics()
+    {
+        // Repro (4): Cast[Ch]() result as a receiver failed the next Where.
+        const string source = @"
+package p
+import System.Collections.Generic
+import System.Linq
+struct Ch { prop V bool { get; init; } }
+func D(e IEnumerable[object]) IEnumerable[Ch] { return e.Cast[Ch]().Where((c Ch)->c.V) }
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void ChainedWhere_OverClassElement_NoDiagnostics()
+    {
+        const string source = @"
+package p
+import System.Collections.Generic
+import System.Linq
+class Seg { public var X int32 = 0 }
+func A(e IEnumerable[Seg]) IEnumerable[Seg] { return e.Where((s Seg)->s.X>0).Where((s Seg)->s.X>0) }
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void TripleChainedWhere_OverStructElement_NoDiagnostics()
+    {
+        // Chaining beyond two calls must also resolve.
+        const string source = @"
+package p
+import System.Collections.Generic
+import System.Linq
+struct Ch { prop V bool { get; init; } }
+func E(e IEnumerable[Ch]) IEnumerable[Ch] { return e.Where((c Ch)->c.V).Where((c Ch)->c.V).Where((c Ch)->c.V) }
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void OrderByThenWhere_OverStructElement_NoDiagnostics()
+    {
+        const string source = @"
+package p
+import System.Collections.Generic
+import System.Linq
+struct Ch { prop V int32 { get; init; } }
+func O(e IEnumerable[Ch]) IEnumerable[Ch] { return e.OrderBy((c Ch)->c.V).Where((c Ch)->c.V>0) }
+func O2(e IEnumerable[Ch]) IEnumerable[Ch] { return e.OrderByDescending((c Ch)->c.V).Where((c Ch)->c.V>0) }
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void SingleWhere_OverStructElement_StillBinds()
+    {
+        // Control S: the single (first) call always bound; keep it green.
+        const string source = @"
+package p
+import System.Collections.Generic
+import System.Linq
+struct Ch { prop V bool { get; init; } }
+func S(e IEnumerable[Ch]) IEnumerable[Ch] { return e.Where((c Ch)->c.V) }
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void LambdaInferredSelectThenWhere_StillBinds()
+    {
+        // Control T: when TResult is inferred from the lambda (not the
+        // receiver), the constructed result already interned correctly.
+        const string source = @"
+package p
+import System.Collections.Generic
+import System.Linq
+struct Ch { prop V bool { get; init; } }
+func T(e IEnumerable[int32]) IEnumerable[Ch] { return e.Select((x int32)->Ch{V:true}).Where((c Ch)->c.V) }
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void ChainedWhere_OverPrimitiveElement_StillBinds()
+    {
+        // Control U: primitive element throughout was never affected.
+        const string source = @"
+package p
+import System.Collections.Generic
+import System.Linq
+func U(e IEnumerable[int32]) IEnumerable[int32] { return e.Where((x int32)->x>0).Where((x int32)->x>0) }
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    private static ImmutableArrayOfDiagnostic GetDiagnostics(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var parseDiagnostics = tree.Diagnostics;
+        var bindDiagnostics = compilation.GlobalScope.Diagnostics;
+        var programDiagnostics = compilation.BoundProgram.Diagnostics;
+        var all = parseDiagnostics
+            .Concat(bindDiagnostics)
+            .Concat(programDiagnostics)
+            .Where(d => d.IsError)
+            .ToImmutableArray();
+        return new ImmutableArrayOfDiagnostic(all);
+    }
+
+    /// <summary>
+    /// Thin wrapper so the test cases can call <c>Assert.Empty</c> against a
+    /// <see cref="ImmutableArray{T}"/> without exposing the GSharp diagnostic
+    /// surface to xUnit's enumerable inference.
+    /// </summary>
+    private readonly struct ImmutableArrayOfDiagnostic : IReadOnlyCollection<Diagnostic>
+    {
+        private readonly ImmutableArray<Diagnostic> diagnostics;
+
+        public ImmutableArrayOfDiagnostic(ImmutableArray<Diagnostic> diagnostics)
+        {
+            this.diagnostics = diagnostics;
+        }
+
+        public int Count => this.diagnostics.Length;
+
+        public IEnumerator<Diagnostic> GetEnumerator()
+        {
+            foreach (var diagnostic in this.diagnostics)
+            {
+                yield return diagnostic;
+            }
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1305
Refs #914