### PR TITLE
cs2gs: emit explicit zero default for optional value-type/null parameters

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue1182OptionalDefaultParameterTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1182OptionalDefaultParameterTranslationTests.cs
@@ -1,0 +1,125 @@
+// <copyright file="Issue1182OptionalDefaultParameterTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #1182 / #914: an optional parameter whose default is the zero value
+/// (<c>= default</c>, <c>= default(T)</c>, or <c>= null</c>) was previously
+/// silently dropped, turning the optional parameter into a required one and
+/// producing GS0144 ("requires N arguments") at call sites. cs2gs now emits the
+/// explicit zero default: <c>default(T)</c> for a non-nullable value type (bare
+/// <c>default</c> is rejected by gsc with GS0265), and <c>nil</c> for a reference
+/// or nullable value type. The default is preserved on ordinary <c>func</c>
+/// parameters and on a parameter that is lifted into a primary constructor.
+/// </summary>
+public class Issue1182OptionalDefaultParameterTranslationTests
+{
+    private const string Source = @"
+using System;
+
+namespace Corpus.Issue1182
+{
+    public class ChapterInfo
+    {
+        public ChapterInfo(TimeSpan offsetFromBeginning = default)
+        {
+            this.Offset = offsetFromBeginning;
+        }
+
+        public TimeSpan Offset { get; }
+    }
+
+    public class Defaults
+    {
+        public void ValueTypeDefault(TimeSpan span = default(TimeSpan)) { }
+
+        public void ReferenceDefault(string name = null) { }
+
+        public void NullableValueDefault(int? count = null) { }
+
+        public void IntLiteralDefault(int n = 3) { }
+    }
+}
+";
+
+    [Fact]
+    public void ValueTypeDefault_OnFunc_RendersAsTypedDefault()
+    {
+        string rendered = Render();
+
+        // `TimeSpan span = default(TimeSpan)` survives as a typed default
+        // (gsc rejects a bare `= default`).
+        Assert.Contains("span TimeSpan = default(TimeSpan)", rendered, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ValueTypeDefault_LiftedIntoPrimaryConstructor_RendersAsTypedDefault()
+    {
+        string rendered = Render();
+
+        // The explicit constructor `ChapterInfo(TimeSpan offsetFromBeginning = default)`
+        // is lifted into a primary constructor; the optional default must survive the
+        // lift so callers can write `ChapterInfo()`.
+        Assert.Contains("class ChapterInfo(Offset TimeSpan = default(TimeSpan))", rendered, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ReferenceAndNullableDefaults_RenderAsNil()
+    {
+        string rendered = Render();
+
+        // A reference-type `= null` and a nullable value-type `= null` both become `= nil`.
+        Assert.Contains("name string = nil", rendered, StringComparison.Ordinal);
+        Assert.Contains("count int32? = nil", rendered, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void LiteralDefault_StillRendersAsLiteral()
+    {
+        string rendered = Render();
+
+        Assert.Contains("n int32 = 3", rendered, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TranslatedOutput_ContainsNoBareDefault()
+    {
+        string rendered = Render();
+
+        // A bare `= default` (GS0265) must never appear; it is always typed or `nil`.
+        Assert.DoesNotContain("= default\n", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("= default)", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("= default ", rendered, StringComparison.Ordinal);
+    }
+
+    private static string Render()
+    {
+        (CompilationUnit unit, _) = Translate();
+        return GSharpPrinter.Print(unit);
+    }
+
+    private static (CompilationUnit Unit, TranslationContext Context) Translate()
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("ChapterInfo.cs", Source) });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        return (unit, context);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -1234,7 +1234,8 @@ public sealed class CSharpToGSharpTranslator
             {
                 (string Name, ITypeSymbol Type, bool IsProperty) target = paramToTarget[param];
                 GTypeReference type = this.typeMapper.Map(target.Type, this.context, param.Locations.FirstOrDefault());
-                primaryParameters.Add(new Parameter(target.Name, type));
+                GExpression liftedDefault = this.BuildOptionalParameterDefault(param, type);
+                primaryParameters.Add(new Parameter(target.Name, type, defaultValue: liftedDefault));
                 if (target.IsProperty)
                 {
                     propertiesAsParams.Add(target.Name);
@@ -2534,21 +2535,52 @@ public sealed class CSharpToGSharpTranslator
                 type = this.PromoteIfUsedAsNullable(type, symbol);
             }
 
-            GExpression defaultValue = null;
-            if (symbol.HasExplicitDefaultValue)
-            {
-                defaultValue = MapConstantDefault(symbol);
-                if (defaultValue == null && symbol.ExplicitDefaultValue != null)
-                {
-                    this.context.Report(new TranslationDiagnostic(
-                        nameof(SyntaxKind.EqualsValueClause),
-                        $"parameter '{symbol.Name}' has a default value that is not a simple literal; the default is omitted for now (deferred to step 7).",
-                        symbol.Locations.FirstOrDefault(),
-                        TranslationSeverity.Info));
-                }
-            }
+            GExpression defaultValue = this.BuildOptionalParameterDefault(symbol, type);
 
             return new Parameter(SanitizeIdentifier(symbol.Name), type, variadic, refKind, defaultValue);
+        }
+
+        /// <summary>
+        /// Computes the G# default-value expression for an optional C# parameter,
+        /// or <c>null</c> when the parameter is required or its default cannot be
+        /// represented as a simple literal. An optional parameter whose default is
+        /// the zero value (<c>= default</c>, <c>= default(T)</c>, or <c>= null</c>)
+        /// must never be dropped — doing so makes the parameter required and triggers
+        /// GS0144 at call sites. A non-nullable value type emits <c>default(T)</c>
+        /// (gsc rejects a bare <c>default</c> with GS0265); a reference or nullable
+        /// value type emits <c>nil</c>.
+        /// </summary>
+        private GExpression BuildOptionalParameterDefault(IParameterSymbol symbol, GTypeReference type)
+        {
+            if (!symbol.HasExplicitDefaultValue)
+            {
+                return null;
+            }
+
+            GExpression defaultValue = MapConstantDefault(symbol);
+            if (defaultValue != null)
+            {
+                return defaultValue;
+            }
+
+            if (symbol.ExplicitDefaultValue == null)
+            {
+                bool nullableValueType =
+                    symbol.Type.OriginalDefinition?.SpecialType == SpecialType.System_Nullable_T;
+                bool nonNullableValueType = symbol.Type.IsValueType
+                    && !nullableValueType
+                    && symbol.Type.NullableAnnotation != NullableAnnotation.Annotated;
+                return nonNullableValueType
+                    ? new DefaultValueExpression(type)
+                    : new IdentifierExpression("nil");
+            }
+
+            this.context.Report(new TranslationDiagnostic(
+                nameof(SyntaxKind.EqualsValueClause),
+                $"parameter '{symbol.Name}' has a default value that is not a simple literal; the default is omitted for now (deferred to step 7).",
+                symbol.Locations.FirstOrDefault(),
+                TranslationSeverity.Info));
+            return null;
         }
 
         private GTypeReference MapReturnType(IMethodSymbol symbol, MethodDeclarationSyntax node)


### PR DESCRIPTION
## Problem
An optional C# parameter whose default is the zero value (`= default`, `= default(T)`, or `= null`) was **silently dropped** by cs2gs, turning the optional parameter into a required one and producing GS0144 ("requires N arguments") at call sites. Oahu's `ChapterInfo(TimeSpan offsetFromBeginning = default)` hit this — callers writing `ChapterInfo()` failed to compile.

Root cause: Roslyn reports `ExplicitDefaultValue == null` for all three forms, so `MapConstantDefault` returned `null` and the default was discarded.

## Fix
Emit the explicit zero default:
- `default(T)` for a non-nullable value type (gsc rejects a bare `= default` with GS0265).
- `nil` for a reference type or a nullable value type.

Shared via a new `BuildOptionalParameterDefault` helper, applied both to ordinary `func` parameters and to a parameter that is **lifted into a primary constructor** (which previously also dropped the default).

## Verification
- New `Issue1182OptionalDefaultParameterTranslationTests` (5 tests).
- Full cs2gs suite: 320 passed.
- Oahu.Decrypt re-baseline: 106 → 102 (ChapterInfo GS0144 cleared, no regressions).

Refs #914
