### PR TITLE
Fix #1319: honor optional parameter defaults at instance-method and constructor call sites

### DIFF
--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -4476,6 +4476,25 @@ internal sealed class OverloadResolver
             && method.Parameters[method.Parameters.Length - 1].IsVariadic;
         var fixedCallableParamCount = isVariadic ? callableParameterCount - 1 : callableParameterCount;
 
+        // ADR-0063 / issue #1319: count the leading non-optional callable
+        // parameters. An instance / constructor call may omit any trailing
+        // parameter that declares a default value; the omitted slots are
+        // synthesized from each parameter's captured default constant below,
+        // mirroring the top-level and static (`shared`) call paths. The
+        // receiver parameter (when present) is excluded via `parameterOffset`.
+        var requiredCallableParamCount = callableParameterCount;
+        for (var i = callableParameterCount - 1; i >= 0; i--)
+        {
+            if (method.Parameters[i + parameterOffset].HasExplicitDefaultValue)
+            {
+                requiredCallableParamCount = i;
+            }
+            else
+            {
+                break;
+            }
+        }
+
         // Issue #343: variadic functions and named arguments do not compose.
         if (isVariadic && !argumentNames.IsDefault)
         {
@@ -4491,15 +4510,16 @@ internal sealed class OverloadResolver
                 return new BoundErrorExpression(null);
             }
         }
-        else if (arguments.Length != callableParameterCount)
+        else if (arguments.Length < requiredCallableParamCount || arguments.Length > callableParameterCount)
         {
             Diagnostics.ReportWrongArgumentCount(ce.Location, method.Name, callableParameterCount, arguments.Length);
             return new BoundErrorExpression(null);
         }
 
         // Issue #343: reorder named arguments into the method's parameter
-        // order. User-defined methods have no default parameter values, so
-        // every parameter slot must be filled.
+        // order. ADR-0063 / issue #1319: positional calls may omit trailing
+        // optional parameters; the omitted slots are padded from each
+        // parameter's captured default value after the reorder below.
         ExpressionSyntax[] permutedSyntax;
         ImmutableArray<BoundExpression> permutedArguments;
         if (!argumentNames.IsDefault)
@@ -4525,6 +4545,24 @@ internal sealed class OverloadResolver
             }
 
             permutedArguments = arguments;
+        }
+
+        // ADR-0063 / issue #1319: pad any omitted trailing optional parameters
+        // with their captured default values so the per-position conversion loop
+        // binds the full callable parameter list (matching the top-level and
+        // static call paths). Variadic methods never reach here with a short
+        // slice (their trailing slot is packed below), so the optional pad is
+        // gated on the non-variadic shape.
+        if (argumentNames.IsDefault && !isVariadic && permutedArguments.Length < callableParameterCount)
+        {
+            var padded = ImmutableArray.CreateBuilder<BoundExpression>(callableParameterCount);
+            padded.AddRange(permutedArguments);
+            for (var i = permutedArguments.Length; i < callableParameterCount; i++)
+            {
+                padded.Add(CreateOptionalUserDefaultArgument(method.Parameters[i + parameterOffset]));
+            }
+
+            permutedArguments = padded.MoveToImmutable();
         }
 
         // Phase 4.3b / ADR-0020: if the receiver is a constructed generic

--- a/test/Compiler.Tests/Emit/Issue1319OptionalDefaultCallSiteEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1319OptionalDefaultCallSiteEmitTests.cs
@@ -1,0 +1,178 @@
+// <copyright file="Issue1319OptionalDefaultCallSiteEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1319 — end-to-end emit + IL-verify + execute coverage proving that an
+/// omitted trailing optional argument on a user-defined <em>instance</em> method
+/// or constructor is materialized from the captured default value in the
+/// generated IL (so the value is actually passed at runtime). Before the fix the
+/// binder rejected such call sites with GS0144; the emit side never received a
+/// synthesized default argument.
+/// </summary>
+public class Issue1319OptionalDefaultCallSiteEmitTests
+{
+    [Fact]
+    public void InstanceMethod_OmittedOptional_PassesDefaultAtRuntime()
+    {
+        var source = """
+            package Probe
+
+            class C {
+                func F(x int32 = 7) int32 { return x }
+            }
+
+            public var result = C().F()
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal(7, GetField<int>(assembly, "result"));
+    }
+
+    [Fact]
+    public void InstanceMethod_SuppliedOptional_OverridesDefaultAtRuntime()
+    {
+        var source = """
+            package Probe
+
+            class C {
+                func F(x int32 = 7) int32 { return x }
+            }
+
+            public var result = C().F(5)
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal(5, GetField<int>(assembly, "result"));
+    }
+
+    [Fact]
+    public void InstanceMethod_MultipleTrailingOptionals_OmitTwo_PassesDefaults()
+    {
+        var source = """
+            package Probe
+
+            class C {
+                func F(a int32, b int32 = 1, c int32 = 2) int32 { return a + b + c }
+            }
+
+            public var result = C().F(10)
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal(13, GetField<int>(assembly, "result"));
+    }
+
+    [Fact]
+    public void InstanceMethod_MultipleTrailingOptionals_OmitOne_PassesDefault()
+    {
+        var source = """
+            package Probe
+
+            class C {
+                func F(a int32, b int32 = 1, c int32 = 2) int32 { return a + b + c }
+            }
+
+            public var result = C().F(10, 20)
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal(32, GetField<int>(assembly, "result"));
+    }
+
+    [Fact]
+    public void Constructor_OmittedOptional_PassesDefaultAtRuntime()
+    {
+        var source = """
+            package Probe
+
+            class C {
+                var X int32
+                init(x int32 = 100) { X = x }
+            }
+
+            public var result = C().X
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal(100, GetField<int>(assembly, "result"));
+    }
+
+    [Fact]
+    public void InstanceMethod_StringDefault_OmittedOptional_PassesDefaultAtRuntime()
+    {
+        var source = """
+            package Probe
+
+            class C {
+                func Tag(s string = "hello") string { return s }
+            }
+
+            public var result = C().Tag()
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal("hello", GetField<string>(assembly, "result"));
+    }
+
+    private static Assembly CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1319_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+        IlVerifier.Verify(outPath);
+
+        var bytes = File.ReadAllBytes(outPath);
+        var assembly = Assembly.Load(bytes);
+
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+        entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+
+        return assembly;
+    }
+
+    private static T GetField<T>(Assembly assembly, string name)
+    {
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var resultField = program.GetField(name, BindingFlags.Public | BindingFlags.Static);
+        return (T)resultField!.GetValue(null)!;
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1319OptionalDefaultCallSiteTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1319OptionalDefaultCallSiteTests.cs
@@ -1,0 +1,224 @@
+// <copyright file="Issue1319OptionalDefaultCallSiteTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1319 (ADR-0063 follow-up): a call to a user-defined <em>instance</em>
+/// method or constructor must honor declared parameter defaults when trailing
+/// optional arguments are omitted at the call site. Before the fix, only
+/// top-level functions, static (<c>shared</c>) methods, and constructors
+/// consumed the captured defaults; instance-method calls (both implicit-<c>this</c>
+/// and explicit-receiver) wrongly reported GS0144 ("requires N arguments").
+/// </summary>
+public class Issue1319OptionalDefaultCallSiteTests
+{
+    [Fact]
+    public void InstanceMethod_TrailingOptionalOmitted_ViaReceiver_UsesDefault()
+    {
+        var source = @"
+class C {
+    func F(x int32 = 7) int32 { return x }
+}
+
+var c = C()
+c.F()
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(7, result.Value);
+    }
+
+    [Fact]
+    public void InstanceMethod_TrailingOptionalSupplied_ViaReceiver_UsesArgument()
+    {
+        var source = @"
+class C {
+    func F(x int32 = 7) int32 { return x }
+}
+
+var c = C()
+c.F(5)
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(5, result.Value);
+    }
+
+    [Fact]
+    public void InstanceMethod_ImplicitThis_TrailingOptionalOmitted_UsesDefault()
+    {
+        var source = @"
+class C {
+    func F(x int32 = 9) int32 { return x }
+    func G() int32 { return F() }
+}
+
+var c = C()
+c.G()
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(9, result.Value);
+    }
+
+    [Fact]
+    public void InstanceMethod_MultipleTrailingOptionals_OmitOne_UsesDefault()
+    {
+        var source = @"
+class C {
+    func F(a int32, b int32 = 1, c int32 = 2) int32 { return a + b + c }
+}
+
+var c = C()
+c.F(10, 20)
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(32, result.Value);
+    }
+
+    [Fact]
+    public void InstanceMethod_MultipleTrailingOptionals_OmitAll_UsesDefaults()
+    {
+        var source = @"
+class C {
+    func F(a int32, b int32 = 1, c int32 = 2) int32 { return a + b + c }
+}
+
+var c = C()
+c.F(10)
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(13, result.Value);
+    }
+
+    [Fact]
+    public void InstanceMethod_MultipleTrailingOptionals_AllSupplied_UsesArguments()
+    {
+        var source = @"
+class C {
+    func F(a int32, b int32 = 1, c int32 = 2) int32 { return a + b + c }
+}
+
+var c = C()
+c.F(10, 20, 30)
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(60, result.Value);
+    }
+
+    [Fact]
+    public void Constructor_TrailingOptionalOmitted_UsesDefault()
+    {
+        var source = @"
+class C {
+    var X int32
+    init(x int32 = 100) { X = x }
+}
+
+var c = C()
+c.X
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(100, result.Value);
+    }
+
+    [Fact]
+    public void InstanceMethod_TooFewRequiredArguments_StillDiagnosesGS0144()
+    {
+        // The required (non-optional) leading parameter `a` is still mandatory.
+        var source = @"
+class C {
+    func F(a int32, b int32 = 1) int32 { return a + b }
+}
+
+var c = C()
+c.F()
+";
+        var result = Evaluate(source);
+        AssertHasDiagnosticId(result.Diagnostics, "GS0144");
+    }
+
+    [Fact]
+    public void InstanceMethod_TooManyArguments_StillDiagnosesGS0144()
+    {
+        var source = @"
+class C {
+    func F(a int32, b int32 = 1) int32 { return a + b }
+}
+
+var c = C()
+c.F(1, 2, 3)
+";
+        var result = Evaluate(source);
+        AssertHasDiagnosticId(result.Diagnostics, "GS0144");
+    }
+
+    [Fact]
+    public void InstanceMethod_OverloadResolution_ExactArityNotPenalized()
+    {
+        // An exact-arity overload must win over a defaulted-slot candidate so
+        // existing passing code is not made ambiguous by the new behavior.
+        var source = @"
+class C {
+    func F(a int32) int32 { return a }
+    func F(a int32, b int32 = 100) int32 { return a + b }
+}
+
+var c = C()
+c.F(5)
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(5, result.Value);
+    }
+
+    [Fact]
+    public void InstanceMethod_StringDefault_TrailingOptionalOmitted_UsesDefault()
+    {
+        var source = @"
+class C {
+    func Tag(s string = ""hello"") string { return s }
+}
+
+var c = C()
+c.Tag()
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("hello", result.Value);
+    }
+
+    private static void AssertHasDiagnosticId(IEnumerable<Diagnostic> diagnostics, string id)
+    {
+        foreach (var diagnostic in diagnostics)
+        {
+            if (diagnostic.Id == id)
+            {
+                return;
+            }
+        }
+
+        Assert.Fail($"Expected diagnostic '{id}' was not reported.");
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
## Summary
gsc parsed optional parameter declarations (`func F(x int32 = 0)`) but did **not** honor the default at *instance-method* (and constructor) call sites. Calling such a method while omitting a trailing optional argument failed with `GS0144` ("requires N arguments but was given M"), even though supplying the argument compiled fine. Top-level `func`s and static (`shared`) methods already worked; only the instance/ctor path was broken.

## Root cause
Unqualified (`F()`) and explicit-receiver (`c.F()`) instance calls both route through `OverloadResolver.BindUserInstanceCall`. That method computed only the full callable parameter count and rejected any call whose argument count was not an exact match (`arguments.Length != callableParameterCount`), then padded nothing — its comment even asserted "user-defined methods have no default parameter values." The default expression was already captured on `ParameterSymbol` (`HasExplicitDefaultValue` / `ExplicitDefaultValue`, issue #1182), but the instance/ctor call path never consumed it.

## The fix (binder + emit)
In `BindUserInstanceCall`:
1. **Binding** — compute the count of leading non-optional callable parameters (`requiredCallableParamCount`) and relax the arity check to accept any count between required and the full callable count (matching the top-level / static paths). Too-few-required and too-many still report `GS0144`.
2. **Emit** — pad the omitted trailing slots with `CreateOptionalUserDefaultArgument(...)` (a `BoundLiteralExpression` for a captured constant, or `BoundDefaultExpression` for `nil` / `default(T)`) **before** the per-position conversion loop. The synthesized default arguments flow into the bound call and are emitted as normal arguments, so the default value is actually passed in the generated IL at runtime.

This covers implicit-`this` calls, explicit-receiver calls, constructors, and multiple trailing optionals. Overload resolution already accounted for defaults in applicability (`SelectBestInstanceOverload`), so exact-arity matches are not penalized.

## Verification
- **Binder/semantic** — `Issue1319OptionalDefaultCallSiteTests` (11 cases): receiver & implicit-`this` omission, multiple trailing optionals (omit one / omit all / all supplied), constructor default, string default, overload-resolution sanity (exact-arity wins), and regression guards that `GS0144` still fires for too-few-required and too-many arguments. **11/11 pass.**
- **Emit/runtime** — `Issue1319OptionalDefaultCallSiteEmitTests` (6 cases): compile → `IlVerifier.Verify` → execute. Proves the default is passed at runtime, e.g. `C().F()` returns the default `7` while `C().F(5)` returns `5`; multi-optional `C().F(10)` → `13`; constructor `C().X` default → `100`; string default → `"hello"`. **6/6 pass.**
- `dotnet build GSharp.sln -c Release -graph` → **0 warnings / 0 errors**.
- Regression sweeps: full `Core.Tests` **4648 passed** (1 pre-existing skip); narrowed `Compiler.Tests` Emit sweeps (Optional/Overload/Adr0063/Adr0065/Issue1182/Adr0112 → **87 passed**; Method/Constructor/Variadic/Issue1319 → **265 passed**).

## Not addressed (intentional)
- Named / out-of-order argument syntax with omitted middle defaults on *instance* methods is unchanged — G# uses positional args and the issue scope is trailing omission. The positional padding is gated on `argumentNames.IsDefault`, preserving existing named-argument behavior.

Fixes #1319
Refs #914
