### PR TITLE
Fix #1320: resolve GetEnumerator on sequence[UserType] and user-element arrays

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -1142,6 +1142,75 @@ internal sealed partial class ExpressionBinder
     }
 
     /// <summary>
+    /// Issue #1320: a <c>sequence[T]</c> / <c>asyncsequence[T]</c> (iterator
+    /// return types, aliases for <c>IEnumerable&lt;T&gt;</c> /
+    /// <c>IAsyncEnumerable&lt;T&gt;</c>) or a user-element array receiver over a
+    /// same-compilation user element type has a <see langword="null"/>
+    /// <see cref="TypeSymbol.ClrType"/> during binding (the element type is not
+    /// yet emitted). That null ClrType caused instance-method lookup
+    /// (e.g. <c>GetEnumerator</c>) to dead-end with GS0159, even though the same
+    /// call resolves on an explicitly-typed <c>IEnumerable[T]</c> parameter
+    /// (whose ClrType type-erases to <c>IEnumerable&lt;object&gt;</c>) and on a
+    /// primitive-element <c>sequence[int32]</c> / array. Normalize such a
+    /// receiver to the equivalent type-erased shape so the shared CLR
+    /// member-lookup + symbolic return-type recovery path resolves it uniformly:
+    /// <list type="bullet">
+    /// <item><c>sequence[T]</c> → a constructed <see cref="ImportedTypeSymbol"/>
+    /// over <c>IEnumerable&lt;&gt;</c> with the symbolic <c>[T]</c> argument
+    /// (so the generic <c>GetEnumerator() → IEnumerator[T]</c> overload and its
+    /// element-typed return are recovered, exactly as for an
+    /// <c>IEnumerable[T]</c> parameter).</item>
+    /// <item><c>asyncsequence[T]</c> → the <c>IAsyncEnumerable&lt;&gt;</c>
+    /// counterpart.</item>
+    /// <item>user-element array / slice → a plain
+    /// <see cref="ImportedTypeSymbol"/> over the erased array CLR type
+    /// (e.g. <c>object[]</c>), reaching parity with a primitive-element array
+    /// (which finds the non-generic <c>GetEnumerator()</c>).</item>
+    /// </list>
+    /// The bound call keeps the original receiver expression; the emitter
+    /// already normalizes sequence/array receivers
+    /// (<c>TryNormalizeToSymbolicContainer</c>), so emission is unaffected.
+    /// Returns <see langword="false"/> when no normalization applies.
+    /// </summary>
+    /// <param name="receiverType">The receiver's static type symbol.</param>
+    /// <param name="normalized">The normalized receiver type, on success.</param>
+    /// <returns><see langword="true"/> when a normalized receiver type was produced.</returns>
+    private static bool TryNormalizeSymbolicEnumerableReceiver(TypeSymbol receiverType, out TypeSymbol normalized)
+    {
+        normalized = null;
+        if (receiverType == null || receiverType.ClrType != null)
+        {
+            return false;
+        }
+
+        switch (receiverType)
+        {
+            case SequenceTypeSymbol seq:
+                normalized = ImportedTypeSymbol.GetConstructed(
+                    typeof(System.Collections.Generic.IEnumerable<object>),
+                    typeof(System.Collections.Generic.IEnumerable<>),
+                    ImmutableArray.Create(seq.ElementType));
+                return true;
+            case AsyncSequenceTypeSymbol aseq:
+                normalized = ImportedTypeSymbol.GetConstructed(
+                    typeof(System.Collections.Generic.IAsyncEnumerable<object>),
+                    typeof(System.Collections.Generic.IAsyncEnumerable<>),
+                    ImmutableArray.Create(aseq.ElementType));
+                return true;
+            case ArrayTypeSymbol or SliceTypeSymbol:
+                if (MemberLookup.TryProjectErasedClrType(receiverType, out var erasedArray))
+                {
+                    normalized = ImportedTypeSymbol.Get(erasedArray);
+                    return true;
+                }
+
+                return false;
+            default:
+                return false;
+        }
+    }
+
+    /// <summary>
     /// Issue #794: when an instance call is dispatched against a receiver whose
     /// <see cref="ImportedTypeSymbol"/> carries symbolic type arguments
     /// (e.g. <c>List[T]</c>, <c>Dictionary[K, V]</c>) — including the
@@ -2385,7 +2454,20 @@ internal sealed partial class ExpressionBinder
             return new BoundErrorExpression(null);
         }
 
-        if (receiver == null || receiver.Type?.ClrType == null)
+        // Issue #1320: normalize a sequence[T]/asyncsequence[T] or user-element
+        // array receiver (whose ClrType is null during binding) to its erased
+        // CLR shape so the shared CLR-instance member-lookup path below resolves
+        // its enumerable surface (GetEnumerator, ...) uniformly with an
+        // explicitly-typed IEnumerable[T] parameter and a primitive-element
+        // receiver. The bound call keeps the original receiver expression.
+        var effectiveReceiverType = receiver?.Type;
+        if (receiver?.Type != null
+            && TryNormalizeSymbolicEnumerableReceiver(receiver.Type, out var normalizedReceiverType))
+        {
+            effectiveReceiverType = normalizedReceiverType;
+        }
+
+        if (receiver == null || effectiveReceiverType?.ClrType == null)
         {
             // ADR-0059 / issue #255: a value of a user-declared named delegate
             // type supports member-style invocation `del.Invoke(args)` (same as
@@ -2660,7 +2742,7 @@ internal sealed partial class ExpressionBinder
             && nullableRecv.UnderlyingType?.ClrType is { IsValueType: true } nullableInnerVt
             && this.memberLookup.TryGetNullableConstructedType(nullableInnerVt, out var nullableConstructed)
             ? nullableConstructed
-            : receiver.Type.ClrType;
+            : effectiveReceiverType.ClrType;
 
         // Issue #529: use interface-aware method enumeration so that
         // methods declared on a base interface (e.g.
@@ -2729,12 +2811,12 @@ internal sealed partial class ExpressionBinder
                             // against the resolved by-ref parameter so the new
                             // local is declared with the inferred pointee type.
                             arguments = RebindInlineOutVarArguments(ce, arguments, resolution.Best, resolution.ParameterMapping, receiver?.Type);
-                            var instSymbolicArgs = MemberLookup.BuildSymbolicArgTypeVector(receiver?.Type, ImmutableArray.CreateRange(arguments.Select(a => a?.Type)));
+                            var instSymbolicArgs = MemberLookup.BuildSymbolicArgTypeVector(effectiveReceiverType, ImmutableArray.CreateRange(arguments.Select(a => a?.Type)));
                             var instSymbolicTypeArgs = MemberLookup.BuildSymbolicMethodTypeArgs(resolution.Best, typeArgSymbols, instSymbolicArgs);
                             var instTypeArgSymbolsForCall = !instSymbolicTypeArgs.IsDefault ? instSymbolicTypeArgs : typeArgSymbols;
                             var returnType = ResolveImportedGenericReturnType(resolution.Best, typeArgSymbols)
-                                ?? MemberLookup.ResolveCallReturnTypeFromSymbolicTypeArgs(resolution.Best, instSymbolicTypeArgs, receiver?.Type)
-                                ?? ResolveInstanceReturnTypeFromReceiver(receiver?.Type, resolution.Best)
+                                ?? MemberLookup.ResolveCallReturnTypeFromSymbolicTypeArgs(resolution.Best, instSymbolicTypeArgs, effectiveReceiverType)
+                                ?? ResolveInstanceReturnTypeFromReceiver(effectiveReceiverType, resolution.Best)
                                 ?? MapClrMemberType(resolution.Best.ReturnType);
                             var instParameters = resolution.Best.GetParameters();
                             var instMapping = resolution.ParameterMapping;

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -1035,6 +1035,30 @@ internal sealed class MemberLookup
                 }
 
                 return false;
+            case SequenceTypeSymbol seq:
+                // Issue #1320: `sequence[T]` (an iterator return, alias for
+                // `IEnumerable<T>`) over a same-compilation user element type has
+                // a null ClrType during binding. Erase the element so the
+                // constructed enumerable still passes the ClrType gate; the
+                // symbolic-argument recovery downstream re-derives the real
+                // element type for the member's return projection.
+                if (TryProjectErasedClrType(seq.ElementType, out var seqElement))
+                {
+                    erased = typeof(System.Collections.Generic.IEnumerable<>).MakeGenericType(seqElement);
+                    return true;
+                }
+
+                return false;
+            case AsyncSequenceTypeSymbol aseq:
+                // Issue #1320: the async-iterator counterpart, alias for
+                // `IAsyncEnumerable<T>`.
+                if (TryProjectErasedClrType(aseq.ElementType, out var aseqElement))
+                {
+                    erased = typeof(System.Collections.Generic.IAsyncEnumerable<>).MakeGenericType(aseqElement);
+                    return true;
+                }
+
+                return false;
             case NullableTypeSymbol nullable when nullable.UnderlyingType != null:
                 return TryProjectErasedClrType(nullable.UnderlyingType, out erased);
             case FunctionTypeSymbol fn:

--- a/test/Compiler.Tests/Emit/Issue1320UserElementGetEnumeratorEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1320UserElementGetEnumeratorEmitTests.cs
@@ -1,0 +1,188 @@
+// <copyright file="Issue1320UserElementGetEnumeratorEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1320: <c>GetEnumerator()</c> on a <c>sequence[UserType]</c> (an
+/// iterator return type, alias for <c>IEnumerable&lt;UserType&gt;</c>) failed to
+/// bind with GS0159, while it resolved for a primitive element and for an
+/// explicitly-typed <c>IEnumerable[UserType]</c>. These end-to-end tests pin the
+/// fix at runtime: each drives the bridged <c>SeqUser().GetEnumerator()</c> via
+/// <c>MoveNext()</c> / <c>Current</c> and asserts the user values it yields,
+/// proving the generic <c>IEnumerator[UserType]</c> overload both binds AND emits
+/// a runtime-correct enumerator. A <c>sequence[int32]</c> control guards the
+/// primitive path.
+/// </summary>
+public class Issue1320UserElementGetEnumeratorEmitTests
+{
+    [Fact]
+    public void StructSequence_GetEnumerator_YieldsUserValues()
+    {
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            struct E { var X int32 }
+
+            func SeqUser() sequence[E] {
+                yield E{X: 10}
+                yield E{X: 20}
+                yield E{X: 30}
+            }
+
+            func Sum() int32 {
+                var e = SeqUser().GetEnumerator()
+                var sum = 0
+                while e.MoveNext() {
+                    sum = sum + e.Current.X
+                }
+                return sum
+            }
+
+            Console.WriteLine(Sum())
+            """;
+
+        Assert.Equal("60\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void ClassSequence_GetEnumerator_YieldsUserValues()
+    {
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            class Seg { public var X int32 = 0 }
+
+            func MakeSeg(v int32) Seg {
+                var s = Seg()
+                s.X = v
+                return s
+            }
+
+            func SeqUser() sequence[Seg] {
+                yield MakeSeg(1)
+                yield MakeSeg(2)
+            }
+
+            func Count() int32 {
+                var e = SeqUser().GetEnumerator()
+                var n = 0
+                while e.MoveNext() {
+                    n = n + e.Current.X
+                }
+                return n
+            }
+
+            Console.WriteLine(Count())
+            """;
+
+        Assert.Equal("3\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void PrimitiveSequence_GetEnumerator_StillWorks()
+    {
+        // Regression control: the primitive (sequence[int32]) path is unchanged.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            func SeqPrim() sequence[int32] {
+                yield 1
+                yield 2
+                yield 3
+            }
+
+            func Sum() int32 {
+                var e = SeqPrim().GetEnumerator()
+                var sum = 0
+                while e.MoveNext() {
+                    sum = sum + e.Current
+                }
+                return sum
+            }
+
+            Console.WriteLine(Sum())
+            """;
+
+        Assert.Equal("6\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source, string[] ignoredIlErrorCodes = null)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1320_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath, ignoredErrorCodes: ignoredIlErrorCodes);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1320UserElementGetEnumeratorTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1320UserElementGetEnumeratorTests.cs
@@ -1,0 +1,212 @@
+// <copyright file="Issue1320UserElementGetEnumeratorTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1320: <c>GetEnumerator()</c> (and the <c>IEnumerable&lt;T&gt;</c>
+/// member surface generally) could not be resolved on a <c>sequence[UserType]</c>
+/// (an iterator return type, alias for <c>IEnumerable&lt;UserType&gt;</c>) or on
+/// a user-element array <c>[]UserType</c>, while the identical call resolved on a
+/// primitive element type and on an explicitly-typed <c>IEnumerable[UserType]</c>
+/// / <c>List[UserType]</c>. The root cause: those receivers have a
+/// <see langword="null"/> <c>ClrType</c> during binding (the element type is not
+/// yet emitted), so the CLR member-lookup path dead-ended with GS0159. These
+/// binder-level tests mirror the issue's repro matrix: the formerly broken
+/// <c>sequence[UserType]</c> case now resolves to the generic
+/// <c>IEnumerator[UserType]</c> overload, the user-element array now finds the
+/// member at parity with a primitive array, and every control keeps working.
+/// </summary>
+public class Issue1320UserElementGetEnumeratorTests
+{
+    [Fact]
+    public void SequenceUserElement_GetEnumerator_ResolvesGenericOverload()
+    {
+        // BUG line (Oahu blocker): SeqUser().GetEnumerator() must resolve to
+        // IEnumerator[E] so the IEnumerator[E] return type binds.
+        const string source = @"
+package p
+import System.Collections.Generic
+struct E { var X int32 }
+class C {
+    func SeqUser() sequence[E] { yield E{X:1} }
+    func UseSeq() IEnumerator[E] -> SeqUser().GetEnumerator()
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void SequenceClassElement_GetEnumerator_ResolvesGenericOverload()
+    {
+        const string source = @"
+package p
+import System.Collections.Generic
+class Seg { public var X int32 = 0 }
+class C {
+    func SeqSeg() sequence[Seg] { yield Seg() }
+    func UseSeq() IEnumerator[Seg] -> SeqSeg().GetEnumerator()
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void SequencePrimitiveElement_GetEnumerator_StillResolves()
+    {
+        // Control: the primitive sequence path is unchanged.
+        const string source = @"
+package p
+import System.Collections.Generic
+class C {
+    func SeqPrim() sequence[int32] { yield 1 }
+    func UsePrim() IEnumerator[int32] -> SeqPrim().GetEnumerator()
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void IEnumerableUserElement_GetEnumerator_StillResolves()
+    {
+        // Control: the explicitly-typed IEnumerable[E] parameter path is unchanged.
+        const string source = @"
+package p
+import System.Collections.Generic
+struct E { var X int32 }
+class C {
+    func FromIface(xs IEnumerable[E]) IEnumerator[E] -> xs.GetEnumerator()
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void ListUserElement_GetEnumerator_StillResolves()
+    {
+        // Control: the explicitly-typed List[E] parameter path is unchanged.
+        const string source = @"
+package p
+import System.Collections.Generic
+struct E { var X int32 }
+class C {
+    func FromList(xs List[E]) IEnumerator[E] -> xs.GetEnumerator()
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void UserElementArray_GetEnumerator_FindsMemberAtPrimitiveParity()
+    {
+        // The user-element array now FINDS GetEnumerator (resolving the
+        // non-generic IEnumerator overload), exactly like a primitive array —
+        // previously GS0159 ("Cannot find function GetEnumerator"). Both the
+        // user-element and primitive arrays must produce identical diagnostics.
+        const string userSource = @"
+package p
+import System.Collections
+struct E { var X int32 }
+class C {
+    func FromArr(xs []E) IEnumerator -> xs.GetEnumerator()
+}
+";
+        const string primitiveSource = @"
+package p
+import System.Collections
+class C {
+    func FromArr(xs []int32) IEnumerator -> xs.GetEnumerator()
+}
+";
+        Assert.Empty(GetDiagnostics(userSource));
+        Assert.Empty(GetDiagnostics(primitiveSource));
+    }
+
+    [Fact]
+    public void UserElementArray_GetEnumerator_NoLongerReportsCannotFindFunction()
+    {
+        // Even when forced to the generic IEnumerator[E] return (which, at
+        // parity with a primitive array, the non-generic GetEnumerator cannot
+        // satisfy → GS0155), the member is now FOUND: the diagnostic is a
+        // conversion error, never GS0159 ("Cannot find function").
+        const string userSource = @"
+package p
+import System.Collections.Generic
+struct E { var X int32 }
+class C {
+    func FromArr(xs []E) IEnumerator[E] -> xs.GetEnumerator()
+}
+";
+        const string primitiveSource = @"
+package p
+import System.Collections.Generic
+class C {
+    func FromArr(xs []int32) IEnumerator[int32] -> xs.GetEnumerator()
+}
+";
+        var userDiags = GetDiagnostics(userSource);
+        var primitiveDiags = GetDiagnostics(primitiveSource);
+
+        // Parity: the user-element array now behaves exactly like the primitive
+        // array (both GS0155), where it previously reported GS0159.
+        Assert.DoesNotContain(userDiags, d => d.Id == "GS0159");
+        Assert.Equal(
+            primitiveDiags.Select(d => d.Id).OrderBy(id => id),
+            userDiags.Select(d => d.Id).OrderBy(id => id));
+    }
+
+    private static ImmutableArrayOfDiagnostic GetDiagnostics(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var parseDiagnostics = tree.Diagnostics;
+        var bindDiagnostics = compilation.GlobalScope.Diagnostics;
+        var programDiagnostics = compilation.BoundProgram.Diagnostics;
+        var all = parseDiagnostics
+            .Concat(bindDiagnostics)
+            .Concat(programDiagnostics)
+            .Where(d => d.IsError)
+            .ToImmutableArray();
+        return new ImmutableArrayOfDiagnostic(all);
+    }
+
+    /// <summary>
+    /// Thin wrapper so the test cases can call <c>Assert.Empty</c> against a
+    /// <see cref="ImmutableArray{T}"/> without exposing the GSharp diagnostic
+    /// surface to xUnit's enumerable inference.
+    /// </summary>
+    private readonly struct ImmutableArrayOfDiagnostic : IReadOnlyCollection<Diagnostic>
+    {
+        private readonly ImmutableArray<Diagnostic> diagnostics;
+
+        public ImmutableArrayOfDiagnostic(ImmutableArray<Diagnostic> diagnostics)
+        {
+            this.diagnostics = diagnostics;
+        }
+
+        public int Count => this.diagnostics.Length;
+
+        public IEnumerator<Diagnostic> GetEnumerator()
+        {
+            foreach (var diagnostic in this.diagnostics)
+            {
+                yield return diagnostic;
+            }
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}


### PR DESCRIPTION
## Root cause

`GetEnumerator()` (and the `IEnumerable<T>` member surface generally) could not be resolved on a **`sequence[UserType]`** (a G# iterator return type, alias for `IEnumerable<UserType>`) or on a **user-element array `[]UserType`**, while the identical call resolved on a primitive element type and on an explicitly-typed `IEnumerable[UserType]` / `List[UserType]` (the GS0159 "Cannot find function GetEnumerator." Oahu blocker).

`sequence[T]`/`asyncsequence[T]` and user-element arrays build their CLR type from the element's `ClrType`, which is `null` during binding for a same-compilation user element (the type is not yet emitted). The instance-call binder short-circuits into the user-shape-only path when `receiver.Type.ClrType` is null, so the shared CLR member-lookup + symbolic return-type recovery path — the path an `IEnumerable[T]` parameter (type-erased to `IEnumerable<object>`) flows through — was never reached, dead-ending with GS0159. This is residue the prior receiver-interning / user-element substitution fixes (#1162, #1103, #1304, #1305, #1301, #1302) did not cover for the iterator (`sequence`) and array enumerable surfaces.

## Fix

Normalize such a receiver to its erased CLR shape for member lookup and return-type recovery. The bound call keeps the **original** receiver expression; the emitter already normalizes sequence/array receivers via `TryNormalizeToSymbolicContainer`, so emission is unaffected.

- `sequence[T]` → a constructed `ImportedTypeSymbol` over `IEnumerable<>` carrying the symbolic `[T]` argument, so the generic `GetEnumerator() → IEnumerator[T]` overload **and its element-typed return** are recovered, exactly as for an `IEnumerable[T]` parameter.
- `asyncsequence[T]` → the `IAsyncEnumerable<>` counterpart.
- user-element array / slice → the erased array CLR type (e.g. `object[]`), reaching **parity** with a primitive-element array (which finds the non-generic `GetEnumerator()`).

Also extended `MemberLookup.TryProjectErasedClrType` to erase `sequence`/`asyncsequence` element types so the constructed enumerable passes the ClrType gate.

Files changed:
- `src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs` — `TryNormalizeSymbolicEnumerableReceiver` + wiring of an `effectiveReceiverType` through the instance-call lookup/return-type path.
- `src/Core/CodeAnalysis/Binding/MemberLookup.cs` — sequence/asyncsequence erasure in `TryProjectErasedClrType`.

## Verification

- Repro matrix: `SeqUser().GetEnumerator()` now resolves to `IEnumerator[E]` and `func UseSeq() IEnumerator[E] -> SeqUser().GetEnumerator()` compiles. The user-element array now **finds** `GetEnumerator` (resolving the non-generic `IEnumerator` overload, identical diagnostics to a primitive array) where it previously reported GS0159. Primitive `sequence[int32]`, `IEnumerable[E]`, and `List[E]` controls still compile.
- **Runtime (emit + execute):** iterating a `sequence[UserType]` through the bridged `GetEnumerator()` (`MoveNext()`/`Current`) yields the correct user values — struct element sum `60` (10+20+30), class element sum `3`, primitive control sum `6`. IL verification passes.
- New tests:
  - `Issue1320UserElementGetEnumeratorTests` (Core.Tests, binder/semantic) — 7 tests.
  - `Issue1320UserElementGetEnumeratorEmitTests` (Compiler.Tests, runtime) — 3 tests.
- `dotnet build GSharp.sln -c Release -graph` clean (0 warnings / 0 errors).
- Regression sweep: Core.Tests full **4644 passed** (1 skipped). Compiler.Tests Emit narrowed filters: iterator/sequence/enumerator/linq/forin/#1302/#1304/#1305 **136 passed**; array/slice/member/generic/getenumerator **504 passed**.

## Deliberately not addressed

The repro line `func FromArr(xs []E) IEnumerator[E] -> xs.GetEnumerator()` still reports **GS0155** (conversion), *not* GS0159 — exactly as the primitive `[]int32` equivalent does, because arrays expose only the non-generic `GetEnumerator()` as a public method (`IEnumerable<T>.GetEnumerator` is an explicit interface implementation). The issue explicitly states reaching parity with the primitive-array behavior (finding the member) is sufficient for the array case; surfacing the generic array enumerable overload would be a separate, broader change.
