### PR TITLE
Fix #1323: parse generic static member-access receiver Type[T].Member for nullable/array/nested-generic type args

### DIFF
--- a/docs/coverage-matrix.md
+++ b/docs/coverage-matrix.md
@@ -103,6 +103,7 @@ FromEndIndexExpression
 FuncKeyword
 FunctionDeclaration
 FunctionLiteralExpression
+GenericNameExpression
 GlobalStatement
 GoKeyword
 GoStatement

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -483,8 +483,26 @@ internal sealed partial class ExpressionBinder
         return false;
     }
 
+    /// <summary>
+    /// Issue #1323: binds a <see cref="GenericNameExpressionSyntax"/> that
+    /// appears in value position rather than as a member-access receiver. A
+    /// constructed generic type reference is not itself a value, so this reports
+    /// a diagnostic. (In practice the parser only emits this node immediately
+    /// before a `.` member access, which <see cref="BindAccessorExpression"/>
+    /// handles via the accessor leftPart switch.)
+    /// </summary>
+    private BoundExpression BindGenericNameExpression(GenericNameExpressionSyntax syntax)
+    {
+        Diagnostics.ReportExpressionMustHaveValue(syntax.Location);
+        return new BoundErrorExpression(null);
+    }
+
     private BoundExpression BindAccessorExpression(AccessorExpressionSyntax syntax)
     {
+        // Issue #1323: a GenericNameExpression only arises from the parser as the
+        // receiver of a member access; the accessor leftPart switch below resolves
+        // it to a constructed generic type. See BindGenericNameExpression for the
+        // standalone (non-receiver) diagnostic path.
         // Phase 3.C.3b / ADR-0001: null-conditional access `lhs?.rhs`.
         // Evaluate the receiver once, capture it into a synthetic local,
         // then bind the rest of the access against the capture so the
@@ -787,6 +805,33 @@ internal sealed partial class ExpressionBinder
             else
             {
                 classSymbol = constructedImported;
+            }
+        }
+        else if (leftPart is GenericNameExpressionSyntax genericTypeName
+            && TryResolveConstructedGenericTypeReceiver(
+                genericTypeName,
+                out var genericConstructedStruct,
+                out var genericConstructedInterface,
+                out var genericConstructedImported))
+        {
+            // Issue #1323: a constructed generic *type* reference used as a
+            // member-access receiver where the type argument is unambiguously a
+            // type (`Box[int32?].Make(5)`, `Box[[]int32].Make(5)`,
+            // `Box[List[int32]].Make(5)`, `Pair[int, string].Default`). The
+            // parser emits a GenericNameExpression here (the bracket contents
+            // cannot be reshaped from an index expression), so bind the closed
+            // construction directly as the static-access receiver.
+            if (genericConstructedInterface != null)
+            {
+                userInterfaceSymbol = genericConstructedInterface;
+            }
+            else if (genericConstructedStruct != null)
+            {
+                userStructSymbol = genericConstructedStruct;
+            }
+            else
+            {
+                classSymbol = genericConstructedImported;
             }
         }
         else if (leftPart is AccessorExpressionSyntax qualifiedNestedType
@@ -1678,6 +1723,104 @@ internal sealed partial class ExpressionBinder
         // ArrayPool<byte>) and surface it as an imported class so the existing
         // static-member / static-call binding path resolves members against the
         // closed construction.
+        return TryCloseImportedGenericTypeReceiver(openClrType, typeArgs, index, out constructedImported);
+    }
+
+    /// <summary>
+    /// Issue #1323: resolves a constructed generic type receiver from a
+    /// <see cref="GenericNameExpressionSyntax"/> (<c>Box[int32?]</c>,
+    /// <c>Pair[int, string]</c>, <c>List[List[int32]]</c>). Unlike the
+    /// index-expression form, the type arguments are real
+    /// <see cref="TypeClauseSyntax"/> nodes, so nullable/array/nested-generic
+    /// arguments bind directly without needing to be reshaped from an
+    /// expression. Mirrors the gating of the index-expression overload: the name
+    /// must NOT be a value and must name a generic type definition (user
+    /// class/struct/interface or imported CLR generic) of matching arity.
+    /// </summary>
+    /// <param name="generic">The constructed-generic type reference.</param>
+    /// <param name="constructedStruct">The constructed generic class/struct on success.</param>
+    /// <param name="constructedInterface">The constructed generic interface on success.</param>
+    /// <param name="constructedImported">The constructed imported CLR generic type on success.</param>
+    /// <returns>Whether a constructed generic type receiver was resolved.</returns>
+    private bool TryResolveConstructedGenericTypeReceiver(
+        GenericNameExpressionSyntax generic,
+        out StructSymbol constructedStruct,
+        out InterfaceSymbol constructedInterface,
+        out ImportedClassSymbol constructedImported)
+    {
+        constructedStruct = null;
+        constructedInterface = null;
+        constructedImported = null;
+
+        var name = generic.Identifier.Text;
+
+        // A value-named receiver is genuine element access, never a type.
+        if (scope.TryLookupSymbol(name) is VariableSymbol)
+        {
+            return false;
+        }
+
+        var argClauses = generic.TypeArgumentList.Arguments;
+        var arity = argClauses.Count;
+        var userGenericDef = scope.TryLookupTypeAlias(name, out var alias)
+            && ((alias is StructSymbol sDef && sDef.IsGenericDefinition && sDef.TypeParameters.Length == arity)
+                || (alias is InterfaceSymbol iDef && iDef.IsGenericDefinition && iDef.TypeParameters.Length == arity));
+        Type openClrType = null;
+        var clrGenericDef = !userGenericDef
+            && scope.TryLookupImportedGenericClass(name, arity, out openClrType);
+
+        if (!userGenericDef && !clrGenericDef)
+        {
+            return false;
+        }
+
+        var typeArgsBuilder = ImmutableArray.CreateBuilder<TypeSymbol>(arity);
+        foreach (var clause in argClauses)
+        {
+            var bound = bindTypeClause(clause);
+            if (bound == null)
+            {
+                return false;
+            }
+
+            typeArgsBuilder.Add(bound);
+        }
+
+        var typeArgs = typeArgsBuilder.ToImmutable();
+
+        if (userGenericDef)
+        {
+            switch (alias)
+            {
+                case StructSymbol structDef:
+                    constructedStruct = StructSymbol.Construct(structDef, typeArgs);
+                    return true;
+                case InterfaceSymbol ifaceDef:
+                    constructedInterface = InterfaceSymbol.Construct(ifaceDef, typeArgs);
+                    return true;
+            }
+        }
+
+        return TryCloseImportedGenericTypeReceiver(openClrType, typeArgs, generic, out constructedImported);
+    }
+
+    /// <summary>
+    /// Closes an open imported CLR generic definition over the CLR types of the
+    /// bound type arguments (e.g. <c>ArrayPool`1</c> + <c>byte</c> -&gt;
+    /// <c>ArrayPool&lt;byte&gt;</c>) and surfaces it as an
+    /// <see cref="ImportedClassSymbol"/> so the existing static-member /
+    /// static-call binding path resolves members against the closed
+    /// construction. Shared by the index-expression and generic-name receiver
+    /// resolvers (Issue #1209 / Issue #1323).
+    /// </summary>
+    private bool TryCloseImportedGenericTypeReceiver(
+        Type openClrType,
+        ImmutableArray<TypeSymbol> typeArgs,
+        ExpressionSyntax receiverSyntax,
+        out ImportedClassSymbol constructedImported)
+    {
+        constructedImported = null;
+
         var clrArgs = new Type[typeArgs.Length];
         for (var i = 0; i < typeArgs.Length; i++)
         {
@@ -1697,7 +1840,7 @@ internal sealed partial class ExpressionBinder
         try
         {
             var closed = openClrType.MakeGenericType(clrArgs);
-            constructedImported = new ImportedClassSymbol(closed, index);
+            constructedImported = new ImportedClassSymbol(closed, receiverSyntax);
             return true;
         }
         catch (ArgumentException)

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -254,6 +254,8 @@ internal sealed partial class ExpressionBinder
                 return BindBinaryExpression((BinaryExpressionSyntax)syntax);
             case SyntaxKind.CallExpression:
                 return overloads.BindCallExpression((CallExpressionSyntax)syntax);
+            case SyntaxKind.GenericNameExpression:
+                return BindGenericNameExpression((GenericNameExpressionSyntax)syntax);
             case SyntaxKind.ObjectCreationExpression:
                 return BindObjectCreationExpression((ObjectCreationExpressionSyntax)syntax);
             case SyntaxKind.CollectionInitializerExpression:

--- a/src/Core/CodeAnalysis/Syntax/GenericNameExpressionSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/GenericNameExpressionSyntax.cs
@@ -1,0 +1,45 @@
+// <copyright file="GenericNameExpressionSyntax.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Core.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Issue #1323: a constructed-generic *type* reference used in expression
+/// position, e.g. the <c>Box[int32?]</c> receiver in
+/// <c>Box[int32?].Make(5)</c>. The parser emits this node (rather than an
+/// <see cref="IndexExpressionSyntax"/>) when a bracketed type-argument list is
+/// unambiguously a type — it carries one or more <see cref="TypeClauseSyntax"/>
+/// arguments that need not be expressible as ordinary index expressions (a
+/// nullable <c>T?</c>, an array/slice <c>[]T</c>, or a nested generic
+/// <c>List[T]</c>) — and is followed by a member access (<c>.Member</c>). The
+/// binder resolves it to the closed construction so static-member access binds
+/// against the constructed type.
+/// </summary>
+public sealed class GenericNameExpressionSyntax : ExpressionSyntax
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GenericNameExpressionSyntax"/> class.
+    /// </summary>
+    /// <param name="syntaxTree">The parent syntax tree.</param>
+    /// <param name="identifier">The generic type name.</param>
+    /// <param name="typeArgumentList">The bracketed type-argument list.</param>
+    public GenericNameExpressionSyntax(
+        SyntaxTree syntaxTree,
+        SyntaxToken identifier,
+        TypeArgumentListSyntax typeArgumentList)
+        : base(syntaxTree)
+    {
+        Identifier = identifier;
+        TypeArgumentList = typeArgumentList;
+    }
+
+    /// <inheritdoc/>
+    public override SyntaxKind Kind => SyntaxKind.GenericNameExpression;
+
+    /// <summary>Gets the generic type name.</summary>
+    public SyntaxToken Identifier { get; }
+
+    /// <summary>Gets the bracketed type-argument list.</summary>
+    public TypeArgumentListSyntax TypeArgumentList { get; }
+}

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -7888,14 +7888,16 @@ public class Parser
         }
 
         var typeArgumentCount = 0;
+        var sawComplexTypeArgument = false;
         while (true)
         {
-            if (!TryScanTypeClause(ref pos))
+            if (!TryScanTypeClause(ref pos, out var argumentIsComplex))
             {
                 return false;
             }
 
             typeArgumentCount++;
+            sawComplexTypeArgument |= argumentIsComplex;
 
             if (Peek(pos).Kind == SyntaxKind.CommaToken)
             {
@@ -7939,17 +7941,31 @@ public class Parser
             return true;
         }
 
-        // Issue #942: only a multi-type-argument list (which cannot be an
-        // indexer) commits to a generic call site on a trailing `.`. A single
-        // bracketed argument followed by `.` is an indexer-then-member access.
-        return nextKind == SyntaxKind.DotToken && typeArgumentCount > 1;
+        // Issue #942 / Issue #1323: a multi-type-argument list (which cannot be
+        // an indexer) always commits to a generic call site on a trailing `.`.
+        // A single bracketed argument followed by `.` is normally treated as an
+        // indexer-then-member access (`dict[key].Prop`, `Box[int32].Make` — the
+        // latter resolves later in the binder). But a single argument whose
+        // shape is unambiguously a TYPE — it carries a nullable suffix (`T?`),
+        // an array/slice prefix (`[]T`), or its own nested type-argument list
+        // (`List[T]`) — cannot be a legal index expression, so it must be a
+        // generic call site (`Box[int32?].Make`, `Box[[]int32].Make`,
+        // `Box[List[int32]].Make`).
+        return nextKind == SyntaxKind.DotToken
+            && (typeArgumentCount > 1 || sawComplexTypeArgument);
     }
 
-    private bool TryScanTypeClause(ref int pos)
+    private bool TryScanTypeClause(ref int pos) => TryScanTypeClause(ref pos, out _);
+
+    private bool TryScanTypeClause(ref int pos, out bool isComplex)
     {
+        isComplex = false;
+
         // Optional leading bracketed segment: '[' ']' or '[' Number ']' for slice/array shapes.
         if (Peek(pos).Kind == SyntaxKind.OpenSquareBracketToken)
         {
+            // An array/slice prefix is unambiguously a type shape (Issue #1323).
+            isComplex = true;
             pos++;
             if (Peek(pos).Kind == SyntaxKind.NumberToken)
             {
@@ -7976,6 +7992,8 @@ public class Parser
         // tuple-type clause `(T1, T2, ...)`. Both start with '('.
         if (Peek(pos).Kind == SyntaxKind.OpenParenthesisToken)
         {
+            // A function/tuple type clause is unambiguously a type shape.
+            isComplex = true;
             pos++;
             if (Peek(pos).Kind != SyntaxKind.CloseParenthesisToken)
             {
@@ -8025,6 +8043,8 @@ public class Parser
         // Phase 4.7: legacy `func(T) R` function-type clause.
         if (Peek(pos).Kind == SyntaxKind.FuncKeyword)
         {
+            // A legacy function-type clause is unambiguously a type shape.
+            isComplex = true;
             pos++;
             if (Peek(pos).Kind != SyntaxKind.OpenParenthesisToken)
             {
@@ -8084,10 +8104,14 @@ public class Parser
         pos++;
 
         // Nested type-argument list, e.g. `List[int]`.
-        if (!TryScanOptionalTypeArgumentList(ref pos))
+        if (!TryScanOptionalTypeArgumentList(ref pos, out var headHadTypeArgumentList))
         {
             return false;
         }
+
+        // A nested type-argument list makes this unambiguously a type shape
+        // (`List[int32]`) rather than a plain index expression (Issue #1323).
+        isComplex |= headHadTypeArgumentList;
 
         // Issue #1174: a dotted tail names a (possibly nested, possibly
         // generic) type — `Container.Nested`, `A.B.C`, or `Outer.Generic[T]`.
@@ -8102,15 +8126,19 @@ public class Parser
             && Peek(pos + 1).Kind == SyntaxKind.IdentifierToken)
         {
             pos += 2;
-            if (!TryScanOptionalTypeArgumentList(ref pos))
+            if (!TryScanOptionalTypeArgumentList(ref pos, out var segmentHadTypeArgumentList))
             {
                 return false;
             }
+
+            isComplex |= segmentHadTypeArgumentList;
         }
 
         // Optional trailing `?` for nullables.
         if (Peek(pos).Kind == SyntaxKind.QuestionToken)
         {
+            // A nullable suffix is unambiguously a type shape (Issue #1323).
+            isComplex = true;
             pos++;
         }
 
@@ -8120,19 +8148,24 @@ public class Parser
     /// <summary>
     /// Issue #1174: scans an optional bracketed type-argument list
     /// (<c>[T1, T2, ...]</c>) starting at <paramref name="pos"/>. A missing list
-    /// is a success (no-op). Used by <see cref="TryScanTypeClause"/> for both the
+    /// is a success (no-op). Used by <see cref="TryScanTypeClause(ref int)"/> for both the
     /// head identifier and each dotted-tail segment so a nested generic type such
     /// as <c>Outer.Generic[T]</c> scans as one type clause.
     /// </summary>
     /// <param name="pos">The scan position, advanced past the list when present.</param>
     /// <returns><see langword="true"/> when there is no list or it scans cleanly.</returns>
     private bool TryScanOptionalTypeArgumentList(ref int pos)
+        => TryScanOptionalTypeArgumentList(ref pos, out _);
+
+    private bool TryScanOptionalTypeArgumentList(ref int pos, out bool present)
     {
         if (Peek(pos).Kind != SyntaxKind.OpenSquareBracketToken)
         {
+            present = false;
             return true;
         }
 
+        present = true;
         pos++;
         while (true)
         {
@@ -8185,6 +8218,18 @@ public class Parser
             var literal = new StructLiteralExpressionSyntax(syntaxTree, identifier, openBrace, initializers, closeBrace);
             literal.TypeArgumentList = typeArguments;
             return literal;
+        }
+
+        // Issue #1323: a `[…]` type-argument list followed by `.` is a member
+        // access on the constructed generic *type* (`Box[int32?].Make(5)`,
+        // `Pair[int, string].Default`). The committed-to-generic decision was
+        // already made by LooksLikeGenericCallSite (multi-arg, or a single
+        // unambiguously type-shaped argument). Emit a generic-name expression so
+        // ParsePostfixChain attaches the `.Member(...)` accessor and the binder
+        // resolves the closed construction as the static-access receiver.
+        if (Current.Kind == SyntaxKind.DotToken)
+        {
+            return new GenericNameExpressionSyntax(syntaxTree, identifier, typeArguments);
         }
 
         var openParen = MatchToken(SyntaxKind.OpenParenthesisToken);

--- a/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
@@ -158,6 +158,7 @@ public enum SyntaxKind
     InterpolatedStringExpression,
     NameExpression,
     CallExpression,
+    GenericNameExpression,
     AccessorExpression,
     ArrayCreationExpression,
     StackAllocExpression,

--- a/test/Compiler.Tests/Emit/Issue1323GenericStaticReceiverEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1323GenericStaticReceiverEmitTests.cs
@@ -1,0 +1,150 @@
+// <copyright file="Issue1323GenericStaticReceiverEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1323: a generic static member-access receiver
+/// <c>Type[TypeArg].StaticMember(...)</c> previously only parsed when
+/// <c>TypeArg</c> was a SIMPLE name. When the single type argument was nullable
+/// (<c>T?</c>), an array/slice (<c>[]T</c>), or a nested generic
+/// (<c>List[T]</c>) the parser failed with GS0005 because the #942 trailing-`.`
+/// rule treated <c>Name[singleArg].Member</c> as an indexer-then-member access,
+/// and those argument shapes are not legal index expressions.
+///
+/// The fix commits to a generic call site on a trailing <c>.</c> when the
+/// single type argument is unambiguously type-shaped, and emits a
+/// <c>GenericNameExpression</c> receiver the binder resolves to the closed
+/// construction. These end-to-end tests lock the parse → bind → emit → execute
+/// chain for the constructed-generic static-call receiver.
+/// </summary>
+public class Issue1323GenericStaticReceiverEmitTests
+{
+    [Fact]
+    public void NullableTypeArg_StaticCall_Executes()
+    {
+        // `Box[int32?].Make(41)` — nullable single type argument.
+        var source = """
+            package P
+            struct Box[T] { shared { func Make(x int32) int32 { return x + 1 } } }
+            public var result = Box[int32?].Make(41)
+            """;
+
+        Assert.Equal(42, RunAndGetIntResult(source));
+    }
+
+    [Fact]
+    public void ArrayTypeArg_StaticCall_Executes()
+    {
+        // `Box[[]int32].Make(9)` — array/slice single type argument.
+        var source = """
+            package P
+            struct Box[T] { shared { func Make(x int32) int32 { return x + 1 } } }
+            public var result = Box[[]int32].Make(9)
+            """;
+
+        Assert.Equal(10, RunAndGetIntResult(source));
+    }
+
+    [Fact]
+    public void NestedGenericTypeArg_StaticCall_Executes()
+    {
+        // `Box[List[int32]].Make(100)` — nested-generic single type argument.
+        var source = """
+            package P
+            import System.Collections.Generic
+            struct Box[T] { shared { func Make(x int32) int32 { return x + 1 } } }
+            public var result = Box[List[int32]].Make(100)
+            """;
+
+        Assert.Equal(101, RunAndGetIntResult(source));
+    }
+
+    [Fact]
+    public void SimpleTypeArg_StaticCall_StillExecutes()
+    {
+        // Control: a simple single type argument `Box[int32].Make(7)` keeps
+        // working (this resolves through the index-then-member binder path).
+        var source = """
+            package P
+            struct Box[T] { shared { func Make(x int32) int32 { return x + 1 } } }
+            public var result = Box[int32].Make(7)
+            """;
+
+        Assert.Equal(8, RunAndGetIntResult(source));
+    }
+
+    [Fact]
+    public void MultiTypeArg_StaticCall_Executes()
+    {
+        // Control: a multi-type-argument list followed by `.` commits to a
+        // generic call site (`Pair[int32, string].Make(21)`).
+        var source = """
+            package P
+            struct Pair[T, U] { shared { func Make(x int32) int32 { return x * 2 } } }
+            public var result = Pair[int32, string].Make(21)
+            """;
+
+        Assert.Equal(42, RunAndGetIntResult(source));
+    }
+
+    private static int RunAndGetIntResult(string source)
+    {
+        var assembly = CompileToAssembly(source);
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var entry = program.GetMethod(
+            "<Main>$",
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+        var resultField = program.GetField(
+            "result",
+            BindingFlags.Public | BindingFlags.Static);
+
+        entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { System.Array.Empty<string>() });
+        return (int)resultField!.GetValue(null)!;
+    }
+
+    private static Assembly CompileToAssembly(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1323_emit_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+        var bytes = File.ReadAllBytes(outPath);
+        return Assembly.Load(bytes);
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1323GenericStaticReceiverBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1323GenericStaticReceiverBinderTests.cs
@@ -1,0 +1,89 @@
+// <copyright file="Issue1323GenericStaticReceiverBinderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1323: binding a generic static member-access receiver
+/// <c>Type[TypeArg].StaticMember(...)</c> where the single type argument is
+/// nullable (<c>T?</c>), an array/slice (<c>[]T</c>), or a nested generic
+/// (<c>List[T]</c>). The parser emits a <c>GenericNameExpression</c> receiver
+/// for these (and for the multi-argument shape); the binder must resolve it to
+/// the closed construction and bind the static call without diagnostics.
+/// </summary>
+public class Issue1323GenericStaticReceiverBinderTests
+{
+    [Fact]
+    public void NullableTypeArg_StaticCall_BindsWithoutDiagnostics()
+    {
+        const string source = @"
+package p
+struct Box[T] { shared { func Make(x int32) int32 { return x } } }
+class C { func F() int32 { return Box[int32?].Make(5) } }
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void ArrayTypeArg_StaticCall_BindsWithoutDiagnostics()
+    {
+        const string source = @"
+package p
+struct Box[T] { shared { func Make(x int32) int32 { return x } } }
+class C { func F() int32 { return Box[[]int32].Make(5) } }
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void NestedGenericTypeArg_StaticCall_BindsWithoutDiagnostics()
+    {
+        const string source = @"
+package p
+import System.Collections.Generic
+struct Box[T] { shared { func Make(x int32) int32 { return x } } }
+class C { func F() int32 { return Box[List[int32]].Make(5) } }
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void MultiTypeArg_StaticCall_BindsWithoutDiagnostics()
+    {
+        const string source = @"
+package p
+struct Pair[T, U] { shared { func Make(x int32) int32 { return x } } }
+class C { func F() int32 { return Pair[int32, string].Make(5) } }
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void SimpleTypeArg_StaticCall_StillBindsWithoutDiagnostics()
+    {
+        const string source = @"
+package p
+struct Box[T] { shared { func Make(x int32) int32 { return x } } }
+class C { func F() int32 { return Box[int32].Make(5) } }
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    private static IReadOnlyList<Diagnostic> GetDiagnostics(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree) { IsLibrary = true };
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return result.Diagnostics;
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue1323GenericStaticReceiverParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue1323GenericStaticReceiverParserTests.cs
@@ -1,0 +1,142 @@
+// <copyright file="Issue1323GenericStaticReceiverParserTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Issue #1323: a generic static member-access receiver
+/// <c>Type[TypeArg].StaticMember(...)</c> must parse even when the single type
+/// argument is unambiguously type-shaped — nullable (<c>T?</c>), array/slice
+/// (<c>[]T</c>), or a nested generic (<c>List[T]</c>). The #942 trailing-`.`
+/// rule formerly treated a single bracketed argument followed by <c>.</c> as an
+/// indexer-then-member access, which only worked for a simple-name argument and
+/// surfaced GS0005 for the type-shaped forms. The fix commits to a generic call
+/// site for these (emitting a <see cref="GenericNameExpressionSyntax"/>
+/// receiver) while a single SIMPLE-name bracketed argument still parses as an
+/// indexer-then-member access so genuine indexers are not regressed.
+/// </summary>
+public class Issue1323GenericStaticReceiverParserTests
+{
+    [Fact]
+    public void NullableTypeArg_StaticCall_ParsesWithoutDiagnostics()
+    {
+        const string source = @"
+package p
+struct Box[T] { shared { func Make(x int32) int32 { return x } } }
+class C { func F() int32 { return Box[int32?].Make(5) } }
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+        Assert.IsType<GenericNameExpressionSyntax>(GetReturnedAccessorReceiver(tree));
+    }
+
+    [Fact]
+    public void ArrayTypeArg_StaticCall_ParsesWithoutDiagnostics()
+    {
+        const string source = @"
+package p
+struct Box[T] { shared { func Make(x int32) int32 { return x } } }
+class C { func F() int32 { return Box[[]int32].Make(5) } }
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+        Assert.IsType<GenericNameExpressionSyntax>(GetReturnedAccessorReceiver(tree));
+    }
+
+    [Fact]
+    public void NestedGenericTypeArg_StaticCall_ParsesWithoutDiagnostics()
+    {
+        const string source = @"
+package p
+import System.Collections.Generic
+struct Box[T] { shared { func Make(x int32) int32 { return x } } }
+class C { func F() int32 { return Box[List[int32]].Make(5) } }
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var receiver = Assert.IsType<GenericNameExpressionSyntax>(GetReturnedAccessorReceiver(tree));
+        Assert.Equal("Box", receiver.Identifier.Text);
+        Assert.Single(receiver.TypeArgumentList.Arguments);
+    }
+
+    [Fact]
+    public void MultiTypeArg_StaticCall_ParsesAsGenericName()
+    {
+        // A multi-type-argument list followed by `.` commits to a generic call
+        // site (an indexer can never hold a comma-separated list).
+        const string source = @"
+package p
+struct Pair[T, U] { shared { func Make(x int32) int32 { return x } } }
+class C { func F() int32 { return Pair[int32, string].Make(5) } }
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var receiver = Assert.IsType<GenericNameExpressionSyntax>(GetReturnedAccessorReceiver(tree));
+        Assert.Equal(2, receiver.TypeArgumentList.Arguments.Count);
+    }
+
+    [Fact]
+    public void SimpleTypeArg_StaticCall_StillParsesAsIndexerThenMember()
+    {
+        // Regression guard: a single SIMPLE-name bracketed argument followed by
+        // `.` keeps the indexer-then-member parse path so genuine indexers
+        // (`dict[key].Prop`) are not absorbed into a generic call site.
+        const string source = @"
+package p
+struct Box[T] { shared { func Make(x int32) int32 { return x } } }
+class C { func F() int32 { return Box[int32].Make(5) } }
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+        Assert.IsType<IndexExpressionSyntax>(GetReturnedAccessorReceiver(tree));
+    }
+
+    [Fact]
+    public void Indexer_Then_Member_On_SingleIdentifierIndex_StillParsesAsIndexer()
+    {
+        // `dict[key].Prop`-style indexer-then-member access must remain an
+        // IndexExpression receiver, not a generic name.
+        const string source = @"
+package p
+import System.Collections.Generic
+class C { func F(d Dictionary[string, int32], key string) int32 { return d[key].ToString().Length } }
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var all = Descendants(tree.Root).ToList();
+        Assert.Contains(all, n => n is IndexExpressionSyntax);
+        Assert.DoesNotContain(all, n => n is GenericNameExpressionSyntax);
+    }
+
+    private static ExpressionSyntax GetReturnedAccessorReceiver(SyntaxTree tree)
+    {
+        // The constructed-generic receiver lives in `class C`'s `func F`, which
+        // is declared after the generic struct (whose own `return x` body would
+        // otherwise be selected first by a pre-order walk).
+        var returnStmt = Descendants(tree.Root)
+            .OfType<ReturnStatementSyntax>()
+            .Last();
+        var accessor = Assert.IsType<AccessorExpressionSyntax>(returnStmt.Expression);
+        return accessor.LeftPart;
+    }
+
+    private static System.Collections.Generic.IEnumerable<SyntaxNode> Descendants(SyntaxNode node)
+    {
+        foreach (var child in node.GetChildren())
+        {
+            yield return child;
+            foreach (var d in Descendants(child))
+            {
+                yield return d;
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
+++ b/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
@@ -103,6 +103,7 @@ FromEndIndexExpression
 FuncKeyword
 FunctionDeclaration
 FunctionLiteralExpression
+GenericNameExpression
 GlobalStatement
 GoKeyword
 GoStatement


### PR DESCRIPTION
## Summary

Fixes #1323. A generic static member-access receiver `Type[TypeArg].StaticMember(...)` only parsed when `TypeArg` was a **simple name**. When the single type argument was nullable (`T?`), an array/slice (`[]T`), or a nested generic (`List[T]`), the parser failed with `GS0005`.

```gsharp
package p
struct Box[T] { shared { func Make(x int32) int32 { return x } } }
class C { func F() int32 { return Box[int32?].Make(5) } } // was GS0005
```

## Root cause

The Issue #942 trailing-`.` follow-set rule in `LooksLikeGenericCallSite` only committed a **multi**-type-argument list to a generic call site on a trailing `.`:

```csharp
return nextKind == SyntaxKind.DotToken && typeArgumentCount > 1;
```

So `Name[singleArg].Member` was always parsed as an **indexer-then-member** access. That works for a simple-name argument (the binder later resolves the constructed-generic static access via the `IndexExpression` path, Issue #1209), but a nullable/array/nested-generic argument is **not a legal index expression**, so the index-argument parser failed with `GS0005`.

A side effect of the old rule: the direct multi-arg member access `Type[T, U].Member` *also* never actually parsed — it committed to a generic call site but `ParseGenericCallExpression` required `(`/`{` and errored on `.`. This is now fixed too.

## Fix

- `TryScanTypeClause` / `TryScanOptionalTypeArgumentList` now report whether a scanned type clause is **complex** — it carries a `?` (nullable), an array/slice prefix (`[]T`), a nested type-argument list (`List[T]`), or a function/tuple-type shape. The final disambiguation becomes:

  ```csharp
  return nextKind == SyntaxKind.DotToken
      && (typeArgumentCount > 1 || sawComplexTypeArgument);
  ```

- `ParseGenericCallExpression` emits a new `GenericNameExpressionSyntax` receiver when a `.` follows the type-argument list, so `ParsePostfixChain` attaches the `.Member(...)` accessor.

- The binder resolves a `GenericNameExpression` accessor receiver to the closed construction (user struct/interface or imported CLR generic) via a new `TryResolveConstructedGenericTypeReceiver` overload that binds the real `TypeClauseSyntax` arguments directly (no expression reshaping needed), sharing the imported-close helper with the existing `IndexExpression` path.

## Controls preserved (no regression)

- A single **simple-name** bracketed argument followed by `.` (`dict[key].Prop`, `Box[int32].Make`) still parses as an indexer-then-member access and binds via the existing path.
- Genuine indexers (`xs[i]`, `xs[i].ToString()`, `d[key].ToString().Length`) are unaffected.

## Verification

- `dotnet build GSharp.sln -c Release -graph` → **0 warnings / 0 errors**.
- Standalone `gsc` compiles all four forms (`Box[int32?]`, `Box[[]int32]`, `Box[List[int32]]`, `Box[int32]`) plus `Pair[int32, string].Make(5)` and indexer controls; an executed exe prints the expected `42 / 10 / 101 / 8 / 42`.
- New tests:
  - Parser: `Issue1323GenericStaticReceiverParserTests` (nullable/array/nested/multi parse to a `GenericNameExpression`; simple-name still an `IndexExpression`; `dict[key].Member` stays an indexer).
  - Binder: `Issue1323GenericStaticReceiverBinderTests` (all forms bind without diagnostics).
  - Emit: `Issue1323GenericStaticReceiverEmitTests` (parse → bind → emit → execute, asserting runtime results).
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release` → **4665 passed**.
- Related emit regression suites (Issue942/693/1209/1030/1088) → **34 passed**.

Refs #914
