### PR TITLE
cs2gs: preserve type args on constructed-generic static-call receivers (Type<T>.Member → Type[T].Member)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/GenericStaticReceiverTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/GenericStaticReceiverTranslationTests.cs
@@ -1,0 +1,87 @@
+// <copyright file="GenericStaticReceiverTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// #914: a static member accessed through a constructed generic type
+/// (<c>Mp4Operation&lt;ChapterInfo?&gt;.FromCompleted(...)</c>) must keep its
+/// type arguments. cs2gs previously rendered the receiver of such an access as a
+/// bare identifier (dropping <c>&lt;T&gt;</c>), so the call bound to the
+/// non-generic type's overload and failed GS0144. The receiver is now rendered as
+/// the constructed generic type <c>T[args]</c>.
+/// </summary>
+public class GenericStaticReceiverTranslationTests
+{
+    private const string Source = @"
+namespace Corpus.Issue1322
+{
+    public class Box
+    {
+        public static Box FromOne(int a) => new Box();
+    }
+
+    public class Box<T>
+    {
+        public static Box<T> FromTwo(int a, T value) => new Box<T>();
+    }
+
+    public class Use
+    {
+        public Box<int> A() => Box<int>.FromTwo(1, 7);
+
+        public Box B() => Box.FromOne(1);
+    }
+}
+";
+
+    [Fact]
+    public void StaticCallOnConstructedGenericType_KeepsTypeArguments()
+    {
+        string rendered = Render();
+
+        // The receiver keeps its type argument: `Box[int32].FromTwo(1, 7)`.
+        Assert.Contains("Box[int32].FromTwo(1, 7)", rendered, StringComparison.Ordinal);
+
+        // It must NOT collapse to the non-generic `Box.FromTwo`.
+        Assert.DoesNotContain("Box.FromTwo", rendered, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void StaticCallOnNonGenericType_Unchanged()
+    {
+        string rendered = Render();
+
+        Assert.Contains("Box.FromOne(1)", rendered, StringComparison.Ordinal);
+    }
+
+    private static string Render()
+    {
+        (CompilationUnit unit, _) = Translate();
+        return GSharpPrinter.Print(unit);
+    }
+
+    private static (CompilationUnit Unit, TranslationContext Context) Translate()
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Box.cs", Source) });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        return (unit, context);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -4951,6 +4951,22 @@ public sealed class CSharpToGSharpTranslator
                     return this.TranslateIdentifierName(identifier);
 
                 case GenericNameSyntax generic:
+                    // A generic name used as an expression is most often a generic
+                    // *method* group (`Method<T>(...)`), whose bracket type arguments
+                    // are applied by the enclosing invocation — there the bare
+                    // identifier is correct. But it can also be a constructed generic
+                    // *type* used as the receiver of a static member access
+                    // (`Mp4Operation<ChapterInfo?>.FromCompleted(...)`); dropping the
+                    // type arguments there picks the wrong (non-generic) overload
+                    // (GS0144). Render the type with its arguments as `T[args]` so the
+                    // static member resolves on the constructed generic type.
+                    if (this.context.GetSymbolInfo(generic).Symbol is INamedTypeSymbol genericType)
+                    {
+                        GTypeReference typeRef = this.typeMapper.Map(
+                            genericType, this.context, generic.GetLocation());
+                        return new TypeExpression(typeRef);
+                    }
+
                     return new IdentifierExpression(generic.Identifier.Text);
 
                 case ThisExpressionSyntax:


### PR DESCRIPTION
## Summary

cs2gs rendered a bare `GenericNameSyntax` in expression position (a static-member-access receiver on a **constructed generic type**, e.g. `Mp4Operation<ChapterInfo?>.FromCompleted(this, null)`) as a bare identifier, **dropping the type arguments**. The emitted G# became `Mp4Operation.FromCompleted(...)`, which bound the wrong non-generic overload and failed with `GS0144` at the call site.

This renders such a receiver as a `TypeExpression` so the type arguments are preserved: `Mp4Operation[ChapterInfo?].FromCompleted(...)`. Generic **method groups** (`M<T>(...)`, where the enclosing invocation applies the type args) continue to render as bare identifiers — the fix is gated on the generic name binding to an `INamedTypeSymbol`.

## Detail

- `TranslateExpression`'s `GenericNameSyntax` case previously returned `new IdentifierExpression(generic.Identifier.Text)`, erasing `<…>`.
- Now: when `GetSymbolInfo(generic).Symbol is INamedTypeSymbol`, render `new TypeExpression(typeMapper.Map(genericType, …))` → `Name[args]`; otherwise keep the bare identifier (method-group case).
- Depends on gsc #1323 (now merged) so the emitted `Type[T?].Member` form round-trip-parses for nullable/array/nested-generic type args.

## Oahu impact (#914)

`Oahu.Decrypt` `Mp4File.cs:161` `Mp4Operation<ChapterInfo?>.FromCompleted(this, null)` now translates to `Mp4Operation[ChapterInfo?].FromCompleted(this, nil)` and the `GS0144` clears. Decrypt baseline 94 → 92.

## Tests

`GenericStaticReceiverTranslationTests` (2): static call on a constructed generic type keeps `[T]`; non-generic call is unchanged.

## Verification

- `dotnet build GSharp.sln -c Release -graph`: 0/0.
- Full cs2gs suite: **322 passed**.
- Decrypt re-baseline: Mp4File `FromCompleted` `GS0144` cleared.

Refs #914
