### PR TITLE
Fix #1325: user-defined struct satisfies 'where T : struct' constraint (MemoryMarshal.Cast/AsBytes)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -2420,7 +2420,20 @@ internal sealed partial class ExpressionBinder
                 var staticArguments = OverloadResolver.BuildOrderedCallArguments(staticConvertedArgs, staticDownstreamMapping, staticParameters);
                 var refKinds = ComputeArgumentRefKinds(staticParameters);
                 overloads.ValidateRefArguments(staticArguments, refKinds, methodName, ce.Location);
-                BoundExpression staticCall = new BoundImportedCallExpression(null, staticFn, staticArguments, refKinds, typeArgSymbols);
+
+                // Issue #1325: when the type arguments were inferred (no explicit
+                // `[...]` list), recover the symbolic method type-argument vector
+                // from the argument symbols so a same-compilation user value type
+                // (erased to `object` in the closed CLR method) is emitted as its
+                // real TypeDef token in the MethodSpec — e.g.
+                // `MemoryMarshal.AsBytes<E>` rather than the constraint-violating
+                // `AsBytes<object>`. Mirrors the instance/inherited call paths.
+                var staticSymbolicArgs = MemberLookup.BuildSymbolicArgTypeVector(
+                    receiverType: null,
+                    ImmutableArray.CreateRange(arguments.Select(a => a?.Type)));
+                var staticSymbolicTypeArgs = MemberLookup.BuildSymbolicMethodTypeArgs(staticFn.Method, typeArgSymbols, staticSymbolicArgs);
+                var staticTypeArgSymbolsForCall = !staticSymbolicTypeArgs.IsDefault ? staticSymbolicTypeArgs : typeArgSymbols;
+                BoundExpression staticCall = new BoundImportedCallExpression(null, staticFn, staticArguments, refKinds, staticTypeArgSymbolsForCall);
                 return WrapWithHandlerPrelude(staticCall, staticHandlerPrelude, ce);
             }
 

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
@@ -241,7 +241,7 @@ internal sealed partial class ExpressionBinder
 
     /// <summary>
     /// ADR-0055 Tier 4 (#369): builds the per-argument flags consumed by
-    /// <see cref="OverloadResolution.Resolve{T}(System.Collections.Generic.IEnumerable{T}, System.Collections.Generic.IReadOnlyList{System.Type}, System.Collections.Generic.IReadOnlyList{System.Type}, System.Func{System.Type, System.Type}, System.Collections.Generic.IReadOnlyList{bool}, System.Collections.Generic.IReadOnlyList{string})"/>,
+    /// <see cref="OverloadResolution.Resolve{T}(System.Collections.Generic.IEnumerable{T}, System.Collections.Generic.IReadOnlyList{System.Type}, System.Collections.Generic.IReadOnlyList{System.Type}, System.Func{System.Type, System.Type}, System.Collections.Generic.IReadOnlyList{bool}, System.Collections.Generic.IReadOnlyList{string}, System.Func{System.Reflection.MethodInfo, System.Collections.Immutable.ImmutableArray{GSharp.Core.CodeAnalysis.Symbols.TypeSymbol}})"/>,
     /// marking each positional argument whose syntax is an interpolated-string
     /// literal. These arguments may convert to an
     /// <c>IFormattable</c>/<c>FormattableString</c> parameter in addition to

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
@@ -571,7 +571,15 @@ internal static class OverloadResolution
     /// the bound arguments into parameter order before emit.
     /// </param>
     /// <returns>The resolution result.</returns>
-    public static Result<T> Resolve<T>(IEnumerable<T> candidates, IReadOnlyList<Type> argTypes, IReadOnlyList<Type> explicitTypeArgs = null, Func<Type, Type> projectTypeArgument = null, IReadOnlyList<bool> interpolatedStringArgs = null, IReadOnlyList<string> argumentNames = null)
+    /// <param name="recoverTypeArgSymbols">
+    /// Issue #1325: optional callback that, given the closed candidate method,
+    /// returns its recovered symbolic type-argument vector (open-arity order).
+    /// Used so the generic value-type/struct constraint check can see through
+    /// the <c>object</c> erasure of same-compilation user value types. When
+    /// <see langword="null"/>, the constraint check relies solely on the CLR
+    /// type arguments (prior behaviour).
+    /// </param>
+    public static Result<T> Resolve<T>(IEnumerable<T> candidates, IReadOnlyList<Type> argTypes, IReadOnlyList<Type> explicitTypeArgs = null, Func<Type, Type> projectTypeArgument = null, IReadOnlyList<bool> interpolatedStringArgs = null, IReadOnlyList<string> argumentNames = null, Func<MethodInfo, ImmutableArray<TypeSymbol>> recoverTypeArgSymbols = null)
         where T : MethodBase
     {
         var applicable = new List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[] Mapping, bool IsExpanded)>();
@@ -595,7 +603,7 @@ internal static class OverloadResolution
             // rest.
             try
             {
-                EvaluateCandidate(rawCandidate, argTypes, explicitTypeArgs, projectTypeArgument, applicable, interpolatedStringArgs, argumentNames);
+                EvaluateCandidate(rawCandidate, argTypes, explicitTypeArgs, projectTypeArgument, applicable, interpolatedStringArgs, argumentNames, recoverTypeArgSymbols);
             }
             catch (Exception ex) when (IsMetadataLoadFailure(ex))
             {
@@ -614,7 +622,7 @@ internal static class OverloadResolution
             {
                 try
                 {
-                    EvaluateExpandedParamsCandidate(rawCandidate, argTypes, explicitTypeArgs, projectTypeArgument, applicable, argumentNames);
+                    EvaluateExpandedParamsCandidate(rawCandidate, argTypes, explicitTypeArgs, projectTypeArgument, applicable, argumentNames, recoverTypeArgSymbols);
                 }
                 catch (Exception ex) when (IsMetadataLoadFailure(ex))
                 {
@@ -1622,11 +1630,11 @@ internal static class OverloadResolution
     /// <summary>
     /// Evaluates a single candidate for applicability against the supplied
     /// argument types, appending it to <paramref name="applicable"/> when it
-    /// applies. Factored out of <see cref="Resolve{T}(IEnumerable{T}, IReadOnlyList{Type}, IReadOnlyList{Type}, Func{Type, Type}, IReadOnlyList{bool}, IReadOnlyList{string})"/>
+    /// applies. Factored out of <see cref="Resolve{T}(IEnumerable{T}, IReadOnlyList{Type}, IReadOnlyList{Type}, Func{Type, Type}, IReadOnlyList{bool}, IReadOnlyList{string}, Func{MethodInfo, ImmutableArray{TypeSymbol}})"/>
     /// so the per-candidate work can be guarded against reflection load
     /// failures (issue #321) without disturbing the surrounding control flow.
     /// </summary>
-    private static void EvaluateCandidate<T>(T rawCandidate, IReadOnlyList<Type> argTypes, IReadOnlyList<Type> explicitTypeArgs, Func<Type, Type> projectTypeArgument, List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[] Mapping, bool IsExpanded)> applicable, IReadOnlyList<bool> interpolatedStringArgs = null, IReadOnlyList<string> argumentNames = null)
+    private static void EvaluateCandidate<T>(T rawCandidate, IReadOnlyList<Type> argTypes, IReadOnlyList<Type> explicitTypeArgs, Func<Type, Type> projectTypeArgument, List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[] Mapping, bool IsExpanded)> applicable, IReadOnlyList<bool> interpolatedStringArgs = null, IReadOnlyList<string> argumentNames = null, Func<MethodInfo, ImmutableArray<TypeSymbol>> recoverTypeArgSymbols = null)
         where T : MethodBase
     {
         {
@@ -1638,6 +1646,19 @@ internal static class OverloadResolution
             // violations drop the candidate silently (matches C# §7.5.2 "if
             // type inference fails, the method is not applicable").
             T candidate = rawCandidate;
+
+            // Issue #1325: when a candidate must be closed over a
+            // same-compilation user value type — erased to a `System.Object`
+            // placeholder — live-reflection `MakeGenericMethod` rejects the
+            // `object` argument against a `where T : struct` parameter (unlike
+            // the MetadataLoadContext overload, which never validates). The
+            // fallback below closes the method over a value-type placeholder so
+            // a valid closed `MethodInfo` is obtained, and rewrites the closed
+            // parameter types back to the `object`-erased shape so applicability
+            // still matches the `object`-erased argument types. Emit uses the
+            // recovered symbolic type arguments, so the placeholder never leaks
+            // into the produced IL.
+            Func<Type, Type> paramTypeRewrite = null;
             if (explicitTypeArgs != null)
             {
                 // Issue #311: explicit type-argument path. Only open generic
@@ -1648,20 +1669,30 @@ internal static class OverloadResolution
                     && gmi.GetGenericArguments().Length == explicitTypeArgs.Count)
                 {
                     MethodInfo closed;
+                    var explicitTypeArgsArray = explicitTypeArgs.ToArray();
                     try
                     {
-                        closed = gmi.MakeGenericMethod(explicitTypeArgs.ToArray());
+                        closed = gmi.MakeGenericMethod(explicitTypeArgsArray);
                     }
                     catch (ArgumentException)
                     {
-                        // Generic constraints not satisfied — drop this candidate.
-                        return;
+                        // Issue #1325: live reflection rejects the `object`
+                        // erasure of a user value type against a `struct`
+                        // constraint. Retry over a value-type placeholder when
+                        // the recovered symbols satisfy the real constraints.
+                        if (!TryCloseOverUserValueTypePlaceholders(gmi, explicitTypeArgsArray, recoverTypeArgSymbols?.Invoke(gmi) ?? default, out closed))
+                        {
+                            // Generic constraints not satisfied — drop this candidate.
+                            return;
+                        }
+
+                        paramTypeRewrite = static t => SubstituteClrType(t, typeof(UserValueTypeConstraintPlaceholder), typeof(object));
                     }
 
                     // Issue #750 / ADR-0088: same constraint check as the
                     // inference path. Required because MetadataLoadContext's
                     // MakeGenericMethod does not validate constraints.
-                    if (!SatisfiesGenericConstraints(gmi, explicitTypeArgs.ToArray()))
+                    if (!SatisfiesGenericConstraints(gmi, explicitTypeArgsArray, recoverTypeArgSymbols?.Invoke(closed) ?? default))
                     {
                         return;
                     }
@@ -1718,8 +1749,17 @@ internal static class OverloadResolution
                 }
                 catch (ArgumentException)
                 {
-                    // Generic constraints not satisfied — drop this candidate.
-                    return;
+                    // Issue #1325: live reflection rejects the `object` erasure
+                    // of a user value type against a `struct` constraint. Retry
+                    // over a value-type placeholder when the recovered symbols
+                    // satisfy the real constraints.
+                    if (!TryCloseOverUserValueTypePlaceholders(mi, typeArgs, recoverTypeArgSymbols?.Invoke(mi) ?? default, out closed))
+                    {
+                        // Generic constraints not satisfied — drop this candidate.
+                        return;
+                    }
+
+                    paramTypeRewrite = static t => SubstituteClrType(t, typeof(UserValueTypeConstraintPlaceholder), typeof(object));
                 }
 
                 // Issue #750 / ADR-0088: explicitly validate generic-parameter
@@ -1730,7 +1770,7 @@ internal static class OverloadResolution
                 // bound with T = Nullable<int> survives applicability and the
                 // resolver picks the wrong overload, emitting IL that fails
                 // verification at runtime.
-                if (!SatisfiesGenericConstraints(mi, typeArgs))
+                if (!SatisfiesGenericConstraints(mi, typeArgs, recoverTypeArgSymbols?.Invoke(closed) ?? default))
                 {
                     return;
                 }
@@ -1770,7 +1810,9 @@ internal static class OverloadResolution
             for (var i = 0; i < argTypes.Count; i++)
             {
                 var paramIndex = mapping != null ? mapping[i] : i;
-                paramTypes[i] = parameters[paramIndex].ParameterType;
+                paramTypes[i] = paramTypeRewrite != null
+                    ? paramTypeRewrite(parameters[paramIndex].ParameterType)
+                    : parameters[paramIndex].ParameterType;
                 var conv = ClassifyImplicit(paramTypes[i], argTypes[i]);
                 if (conv == ImplicitConversionKind.None)
                 {
@@ -1830,7 +1872,7 @@ internal static class OverloadResolution
     /// applicability check in <see cref="EvaluateCandidate"/> but rewrites the
     /// trailing parameter type to the element type for ranking purposes.
     /// </summary>
-    private static void EvaluateExpandedParamsCandidate<T>(T rawCandidate, IReadOnlyList<Type> argTypes, IReadOnlyList<Type> explicitTypeArgs, Func<Type, Type> projectTypeArgument, List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[] Mapping, bool IsExpanded)> applicable, IReadOnlyList<string> argumentNames = null)
+    private static void EvaluateExpandedParamsCandidate<T>(T rawCandidate, IReadOnlyList<Type> argTypes, IReadOnlyList<Type> explicitTypeArgs, Func<Type, Type> projectTypeArgument, List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[] Mapping, bool IsExpanded)> applicable, IReadOnlyList<string> argumentNames = null, Func<MethodInfo, ImmutableArray<TypeSymbol>> recoverTypeArgSymbols = null)
         where T : MethodBase
     {
         T candidate = rawCandidate;
@@ -1855,7 +1897,7 @@ internal static class OverloadResolution
                     return;
                 }
 
-                if (!SatisfiesGenericConstraints(gmi, explicitTypeArgs.ToArray()))
+                if (!SatisfiesGenericConstraints(gmi, explicitTypeArgs.ToArray(), recoverTypeArgSymbols?.Invoke(closed) ?? default))
                 {
                     return;
                 }
@@ -1892,7 +1934,7 @@ internal static class OverloadResolution
                 return;
             }
 
-            if (!SatisfiesGenericConstraints(mi, typeArgs))
+            if (!SatisfiesGenericConstraints(mi, typeArgs, recoverTypeArgSymbols?.Invoke(closed) ?? default))
             {
                 return;
             }
@@ -2757,8 +2799,14 @@ internal static class OverloadResolution
     /// </summary>
     /// <param name="openMethod">The open generic method definition.</param>
     /// <param name="typeArgs">The candidate type arguments in declaration order.</param>
+    /// <param name="typeArgSymbols">
+    /// Issue #1325: the recovered symbolic type-argument vector (open-arity
+    /// order), or <see langword="default"/>. Lets the value-type/struct
+    /// constraint checks see through the <c>object</c> erasure of
+    /// same-compilation user value types.
+    /// </param>
     /// <returns><see langword="true"/> when every constraint is satisfied.</returns>
-    private static bool SatisfiesGenericConstraints(MethodInfo openMethod, Type[] typeArgs)
+    private static bool SatisfiesGenericConstraints(MethodInfo openMethod, Type[] typeArgs, ImmutableArray<TypeSymbol> typeArgSymbols = default)
     {
         if (openMethod is null || typeArgs is null)
         {
@@ -2801,11 +2849,23 @@ internal static class OverloadResolution
 
             var special = attrs & GenericParameterAttributes.SpecialConstraintMask;
 
+            // Issue #1325: a same-compilation user value type (a non-class
+            // `StructSymbol` or an `EnumSymbol`) is erased to a `System.Object`
+            // placeholder in the CLR `typeArgs` vector because its symbol carries
+            // no reference-context CLR type during binding. The recovered
+            // symbolic vector lets the value-type/reference-type constraint
+            // checks see through that erasure so a `where T : struct` candidate
+            // (e.g. MemoryMarshal.Cast/AsBytes) is not wrongly filtered out and a
+            // `where T : class` candidate is not wrongly admitted.
+            var argIsUserValueType = !typeArgSymbols.IsDefaultOrEmpty
+                && i < typeArgSymbols.Length
+                && IsUserValueTypeSymbol(typeArgSymbols[i]);
+
             if ((special & GenericParameterAttributes.ReferenceTypeConstraint) != 0)
             {
                 // `where T : class` — arg must be a reference type (not a
                 // value type, not Nullable<T>).
-                if (arg.IsValueType)
+                if (arg.IsValueType || argIsUserValueType)
                 {
                     return false;
                 }
@@ -2814,7 +2874,10 @@ internal static class OverloadResolution
             if ((special & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0)
             {
                 // `where T : struct` — arg must be a non-nullable value type.
-                if (!arg.IsValueType || NullableLifting.IsValueTypeNullableClr(arg))
+                // A user struct/enum (erased to `object`) satisfies this even
+                // though `arg.IsValueType` is false for the placeholder.
+                if (!argIsUserValueType
+                    && (!arg.IsValueType || NullableLifting.IsValueTypeNullableClr(arg)))
                 {
                     return false;
                 }
@@ -2826,7 +2889,7 @@ internal static class OverloadResolution
                 // `where T : new()` — arg must have a public parameterless
                 // constructor. Value types always satisfy this implicitly;
                 // reference types require an actual ctor.
-                if (!arg.IsValueType)
+                if (!arg.IsValueType && !argIsUserValueType)
                 {
                     try
                     {
@@ -2869,6 +2932,19 @@ internal static class OverloadResolution
                     continue;
                 }
 
+                // Issue #1325: a `where T : struct` parameter carries an implicit
+                // `System.ValueType` base constraint in metadata (and an enum a
+                // `System.Enum` one). A same-compilation user value type is erased
+                // to a `System.Object` placeholder, which is not name-assignable
+                // to `ValueType`/`Enum`, so without this guard the candidate is
+                // wrongly rejected here even though the struct check above passed.
+                if (argIsUserValueType
+                    && (string.Equals(constraint.FullName, "System.ValueType", StringComparison.Ordinal)
+                        || string.Equals(constraint.FullName, "System.Enum", StringComparison.Ordinal)))
+                {
+                    continue;
+                }
+
                 try
                 {
                     if (!ClrTypeUtilities.IsAssignableByName(constraint, arg))
@@ -2884,6 +2960,127 @@ internal static class OverloadResolution
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// Issue #1325: recognizes a type-argument symbol that is a same-compilation
+    /// user value type — a non-class <see cref="StructSymbol"/> or an
+    /// <see cref="EnumSymbol"/>. These are erased to a <c>System.Object</c>
+    /// placeholder in the CLR type-argument vector, so the value-type/struct
+    /// generic constraint checks need the symbol to classify them correctly. A
+    /// user class (<c>StructSymbol { IsClass: true }</c>) and a nullable value
+    /// type are deliberately excluded.
+    /// </summary>
+    /// <param name="symbol">The recovered type-argument symbol.</param>
+    /// <returns><see langword="true"/> when the symbol is a user struct or enum.</returns>
+    private static bool IsUserValueTypeSymbol(TypeSymbol symbol)
+        => symbol is StructSymbol { IsClass: false } or EnumSymbol;
+
+    /// <summary>
+    /// Issue #1325: attempts to close <paramref name="openDef"/> over a value-type
+    /// placeholder for every type-argument slot whose CLR type was erased to a
+    /// non-value-type placeholder but whose recovered symbol is a user value
+    /// type (a non-class <see cref="StructSymbol"/> or an <see cref="EnumSymbol"/>).
+    /// Succeeds only when at least one such slot exists, the recovered symbols
+    /// satisfy the method's generic constraints, and the placeholder closure is
+    /// accepted by <see cref="MethodInfo.MakeGenericMethod(Type[])"/>.
+    /// </summary>
+    /// <param name="openDef">The open generic method definition.</param>
+    /// <param name="typeArgs">The CLR type arguments (with user value types erased).</param>
+    /// <param name="recoveredSymbols">The recovered symbolic type-argument vector, or default.</param>
+    /// <param name="closed">On success, the method closed over the placeholder.</param>
+    /// <returns><see langword="true"/> when a placeholder closure was produced.</returns>
+    private static bool TryCloseOverUserValueTypePlaceholders(
+        MethodInfo openDef,
+        Type[] typeArgs,
+        ImmutableArray<TypeSymbol> recoveredSymbols,
+        out MethodInfo closed)
+    {
+        closed = null;
+        if (openDef is null || typeArgs is null || recoveredSymbols.IsDefaultOrEmpty)
+        {
+            return false;
+        }
+
+        var substituted = (Type[])typeArgs.Clone();
+        var anyUserValueType = false;
+        for (var i = 0; i < substituted.Length && i < recoveredSymbols.Length; i++)
+        {
+            if (substituted[i] != null
+                && !substituted[i].IsValueType
+                && IsUserValueTypeSymbol(recoveredSymbols[i]))
+            {
+                substituted[i] = typeof(UserValueTypeConstraintPlaceholder);
+                anyUserValueType = true;
+            }
+        }
+
+        if (!anyUserValueType || !SatisfiesGenericConstraints(openDef, typeArgs, recoveredSymbols))
+        {
+            return false;
+        }
+
+        try
+        {
+            closed = openDef.MakeGenericMethod(substituted);
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Issue #1325: structurally rewrites every occurrence of
+    /// <paramref name="from"/> within <paramref name="type"/> to
+    /// <paramref name="to"/>, recursing through by-ref, array and constructed
+    /// generic types. Used to map a placeholder-closed parameter type
+    /// (e.g. <c>Span&lt;Placeholder&gt;</c>) back to the <c>object</c>-erased
+    /// shape (<c>Span&lt;object&gt;</c>) for applicability.
+    /// </summary>
+    /// <param name="type">The type to rewrite.</param>
+    /// <param name="from">The type to replace.</param>
+    /// <param name="to">The replacement type.</param>
+    /// <returns>The rewritten type, or the original when no occurrence is found.</returns>
+    private static Type SubstituteClrType(Type type, Type from, Type to)
+    {
+        if (type is null || type == from)
+        {
+            return type == from ? to : type;
+        }
+
+        if (type.IsByRef)
+        {
+            return SubstituteClrType(type.GetElementType(), from, to).MakeByRefType();
+        }
+
+        if (type.IsArray)
+        {
+            var element = SubstituteClrType(type.GetElementType(), from, to);
+            var rank = type.GetArrayRank();
+            return rank == 1 ? element.MakeArrayType() : element.MakeArrayType(rank);
+        }
+
+        if (type.IsGenericType && !type.IsGenericTypeDefinition)
+        {
+            var args = type.GetGenericArguments();
+            var changed = false;
+            for (var i = 0; i < args.Length; i++)
+            {
+                var rewritten = SubstituteClrType(args[i], from, to);
+                if (!ReferenceEquals(rewritten, args[i]))
+                {
+                    args[i] = rewritten;
+                    changed = true;
+                }
+            }
+
+            return changed ? type.GetGenericTypeDefinition().MakeGenericType(args) : type;
+        }
+
+        return type;
     }
 
     /// <summary>
@@ -3337,6 +3534,23 @@ internal static class OverloadResolution
         internal static Result<T> Single(T best, ImmutableArray<int> parameterMapping, bool isExpanded) => new(ResolutionOutcome.Resolved, best, ImmutableArray<T>.Empty, parameterMapping, isExpanded);
 
         internal static Result<T> AmbiguousResult(ImmutableArray<T> tied) => new(ResolutionOutcome.Ambiguous, default, tied, default, false);
+    }
+
+    /// <summary>
+    /// Issue #1325: a value-type stand-in used to close a generic method over a
+    /// same-compilation user value type under live reflection. The user value
+    /// type has no reference-context CLR type during binding (it is erased to
+    /// <c>System.Object</c>), and the live-reflection
+    /// <see cref="MethodInfo.MakeGenericMethod(Type[])"/> rejects <c>object</c>
+    /// against a <c>where T : struct</c> parameter. Closing over this
+    /// placeholder yields a valid <see cref="MethodInfo"/>; the placeholder is
+    /// then rewritten back to <c>object</c> in the candidate's parameter types
+    /// (see <see cref="SubstituteClrType"/>) so applicability still matches the
+    /// <c>object</c>-erased argument types, and emit uses the recovered symbolic
+    /// type arguments rather than this placeholder.
+    /// </summary>
+    private struct UserValueTypeConstraintPlaceholder
+    {
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
@@ -222,7 +222,14 @@ public sealed class ImportedClassSymbol : Symbol
         OverloadResolution.Result<MethodInfo> result;
         try
         {
-            result = OverloadResolution.Resolve(nameMatches, argTypes, explicitTypeArgs, projectTypeArgument, ComputeInterpolatedStringArgFlags(callExpression, arguments.Length), argumentNames);
+            // Issue #1325: recover the symbolic type-argument vector per candidate
+            // so the generic-constraint check can see through the `object`
+            // erasure of same-compilation user value types (a user struct must
+            // satisfy `where T : struct`, e.g. MemoryMarshal.Cast/AsBytes).
+            var symbolicArgVector = MemberLookup.BuildSymbolicArgTypeVector(
+                receiverType: null,
+                ImmutableArray.CreateRange(arguments.Select(a => a?.Type)));
+            result = OverloadResolution.Resolve(nameMatches, argTypes, explicitTypeArgs, projectTypeArgument, ComputeInterpolatedStringArgFlags(callExpression, arguments.Length), argumentNames, closed => MemberLookup.BuildSymbolicMethodTypeArgs(closed, typeArgSymbols, symbolicArgVector));
         }
         finally
         {

--- a/test/Compiler.Tests/Emit/Issue1325StructConstraintEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1325StructConstraintEmitTests.cs
@@ -1,0 +1,139 @@
+// <copyright file="Issue1325StructConstraintEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1325: end-to-end emit + execution test proving that a generic method
+/// with a <c>where T : struct</c> constraint resolves, binds, and emits
+/// verifiable IL when the type argument is a SAME-COMPILATION user-defined
+/// struct — exercised through
+/// <see cref="System.Runtime.InteropServices.MemoryMarshal"/>'s
+/// <c>AsBytes&lt;T&gt;</c> (inferred type argument) and
+/// <c>Cast&lt;TFrom, TTo&gt;</c> (explicit type arguments).
+/// <para>
+/// Before the fix the user struct was erased to a <c>System.Object</c>
+/// placeholder, failing the value-type/struct constraint check, and the call
+/// was rejected with <c>GS0159</c>. The emitted MethodSpec must carry the real
+/// user-struct TypeDef token (not <c>object</c>) so the reinterpretation
+/// computes the correct element size at runtime. This test compiles via
+/// <c>gsc</c>, ilverifies (no tolerated codes — the IL must be fully
+/// verifiable), and executes to assert the reinterpreted bytes/uint32 values.
+/// </para>
+/// </summary>
+public class Issue1325StructConstraintEmitTests
+{
+    [Fact]
+    public void UserStructSpan_MemoryMarshalAsBytesAndCast_CompilesVerifiesAndRuns()
+    {
+        const string source = """
+            package Probe
+            import System
+            import System.Runtime.InteropServices
+
+            struct E { var a int32 }
+
+            func run() {
+                var arr []E = []E{E{a: int32(0x01020304)}, E{a: int32(0x05060708)}}
+                var sp Span[E] = arr.AsSpan()
+                var bytes = MemoryMarshal.AsBytes(sp)
+                Console.WriteLine(bytes.Length)
+                var u = MemoryMarshal.Cast[E, uint32](sp)
+                Console.WriteLine(u.Length)
+                Console.WriteLine(u[0])
+                Console.WriteLine(u[1])
+            }
+
+            run()
+            """;
+
+        // The reinterpretation is fully verifiable; no tolerated codes.
+        var output = CompileAndRun(source, Array.Empty<string>());
+
+        // 2 E (4 bytes each) -> 8 bytes; cast to uint32 -> 2 elements whose
+        // little-endian values are the original int32 fields.
+        Assert.Equal("8\n2\n16909060\n84281096\n", output);
+    }
+
+    private static string CompileAndRun(string source, string[] ilVerifyIgnored)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1325_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath, null, ilVerifyIgnored);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+                // ignored
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1325StructConstraintTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1325StructConstraintTests.cs
@@ -1,0 +1,136 @@
+// <copyright file="Issue1325StructConstraintTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1325: a generic method with a <c>where T : struct</c>
+/// (non-nullable value type) constraint — such as
+/// <see cref="System.Runtime.InteropServices.MemoryMarshal"/>'s
+/// <c>Cast&lt;TFrom, TTo&gt;</c> and <c>AsBytes&lt;T&gt;</c> — must resolve
+/// when the supplied type argument is a SAME-COMPILATION user-defined struct.
+/// <para>
+/// Such a user struct carries no reference-context CLR type during binding and
+/// is erased to a <c>System.Object</c> placeholder in the constraint check's
+/// CLR type-argument vector, so the naive <c>arg.IsValueType</c> test reported
+/// <see langword="false"/> and the candidate was wrongly filtered out, failing
+/// the whole call with <c>GS0159</c>. The fix threads the recovered symbolic
+/// type-argument vector into the constraint check so a user struct/enum is
+/// recognized as a non-nullable value type — while a user CLASS and a
+/// nullable value type are still correctly rejected.
+/// </para>
+/// </summary>
+public class Issue1325StructConstraintTests
+{
+    [Fact]
+    public void UserStruct_SatisfiesStructConstraint_MemoryMarshalCast_NoDiagnostics()
+    {
+        const string source = @"
+package p
+import System.Runtime.InteropServices
+
+struct E { var a int32 }
+
+class C {
+    func DoCast(s Span[E]) Span[uint32] { return MemoryMarshal.Cast[E, uint32](s) }
+}
+";
+        var diagnostics = Bind(source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0159");
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void UserStruct_SatisfiesStructConstraint_MemoryMarshalAsBytes_NoDiagnostics()
+    {
+        // AsBytes infers T = E from the Span[E] argument (no explicit `[...]`).
+        const string source = @"
+package p
+import System.Runtime.InteropServices
+
+struct E { var a int32 }
+
+class C {
+    func DoBytes(s Span[E]) Span[uint8] { return MemoryMarshal.AsBytes(s) }
+}
+";
+        var diagnostics = Bind(source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0159");
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void PrimitiveValueType_StillSatisfiesStructConstraint_NoDiagnostics()
+    {
+        // Control: the primitive value-type path must keep resolving unchanged.
+        const string source = @"
+package p
+import System.Runtime.InteropServices
+
+class C {
+    func DoCast(s Span[uint8]) Span[uint32] { return MemoryMarshal.Cast[uint8, uint32](s) }
+    func DoBytes(s Span[int32]) Span[uint8] { return MemoryMarshal.AsBytes(s) }
+}
+";
+        var diagnostics = Bind(source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0159");
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void UserClass_DoesNotSatisfyStructConstraint_ReportsGS0159()
+    {
+        // A user CLASS is a reference type and must NOT satisfy `where T : struct`,
+        // so the MemoryMarshal.Cast candidate is correctly filtered out (GS0159).
+        const string source = @"
+package p
+import System.Runtime.InteropServices
+
+class K { var a int32 }
+
+class C {
+    func DoCast(s Span[K]) Span[uint32] { return MemoryMarshal.Cast[K, uint32](s) }
+}
+";
+        var diagnostics = Bind(source);
+        Assert.Contains(diagnostics, d => d.Id == "GS0159");
+    }
+
+    [Fact]
+    public void NullableValueType_DoesNotSatisfyStructConstraint_ReportsGS0159()
+    {
+        // A nullable value type (Nullable<int32>) is a value type but IS nullable,
+        // so `where T : struct` (non-nullable value type) must still reject it.
+        const string source = @"
+package p
+import System.Runtime.InteropServices
+
+class C {
+    func DoCast(s Span[int32?]) Span[uint32] { return MemoryMarshal.Cast[int32?, uint32](s) }
+}
+";
+        var diagnostics = Bind(source);
+        Assert.Contains(diagnostics, d => d.Id == "GS0159");
+    }
+
+    private static IReadOnlyList<Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var program = Binder.BindProgram(compilation.GlobalScope, compilation.References);
+        return tree.Diagnostics
+            .Concat(compilation.GlobalScope.Diagnostics)
+            .Concat(program.Diagnostics)
+            .ToList();
+    }
+}


### PR DESCRIPTION
## Summary

A generic method with a `where T : struct` constraint — e.g. `MemoryMarshal.Cast<TFrom, TTo>` and `MemoryMarshal.AsBytes<T>` — failed to resolve with **`GS0159: Cannot find function`** when the supplied type argument was a **same-compilation user-defined struct**, while the same call with a **primitive** value-type argument resolved fine.

```gsharp
package p
import System.Runtime.InteropServices
struct E { var a int32 }
class C {
    func DoCast(s Span[E]) Span[uint32] { return MemoryMarshal.Cast[E, uint32](s) } // GS0159 before
    func DoBytes(s Span[E]) Span[uint8] { return MemoryMarshal.AsBytes(s) }          // GS0159 before
}
```

## Root cause

A same-compilation user struct has no reference-context CLR type during binding and is **erased to a `System.Object` placeholder** in the constraint check's CLR type-argument vector. In `OverloadResolution.SatisfiesGenericConstraints`:

1. The `where T : struct` (`NotNullableValueTypeConstraint`) check saw `arg.IsValueType == false` for the `object` placeholder and filtered the candidate out.
2. A `where T : struct` parameter also carries an **implicit `System.ValueType` base constraint** in metadata (an enum carries `System.Enum`); `object` is not name-assignable to `ValueType`/`Enum`, so the candidate was rejected even after (1) was addressed.
3. Under the **live-reflection resolver** (`ReferenceResolver.Default()`, used by `new Compilation(tree)` in unit tests), `MakeGenericMethod([object,…])` itself **throws `ArgumentException`** for the struct constraint and drops the candidate *before* the explicit constraint check runs. The `MetadataLoadContext` resolver (explicit `/reference`, used by production `gsc`) never validates, so it reached the check.

## Fix

- **Recover the symbolic type-argument vector** (via `MemberLookup.BuildSymbolicMethodTypeArgs`, works for both explicit `Cast[E,uint32]` and inferred `AsBytes(s)`) and thread it into `SatisfiesGenericConstraints`. A user `StructSymbol`/`EnumSymbol` is now recognized as a non-nullable value type: it **satisfies** `struct`/`new()`, is **rejected** for `class`, and the implicit `ValueType`/`Enum` base-constraint is skipped for it.
- **Live-reflection path:** when `MakeGenericMethod` throws for a user value type that satisfies the recovered constraints, close the method over an internal **value-type placeholder** and rewrite the closed parameter types back to the `object`-erased shape so applicability still matches the `object`-erased argument types. The placeholder never leaks into IL.
- **Emit:** the inferred static-call MethodSpec now uses the recovered symbolic type args, so `MemoryMarshal.AsBytes<E>` (not the constraint-violating `AsBytes<object>`) is emitted.

## Controls preserved (no regression)

| Case | Before | After |
|------|--------|-------|
| user struct `Cast[E,uint32]` / `AsBytes` | GS0159 | ✅ binds & emits |
| primitive `Cast[uint8,uint32]` / `AsBytes` | ✅ | ✅ |
| user **class** arg to `struct`-constrained method | GS0159 | ✅ still GS0159 (rejected) |
| **nullable** value type `int32?` arg | GS0159 | ✅ still GS0159 (rejected) |

All four cases verified under **both** the host (no `/reference`) and MetadataLoadContext (explicit `/reference`) resolvers.

## Verification

- `dotnet build GSharp.sln -c Release -graph` → **0 warnings / 0 errors**.
- Standalone `gsc`: failing repro now compiles; controls still compile; user-class and nullable still rejected.
- **End-to-end execution + ilverify** (`test/Compiler.Tests/Emit/Issue1325StructConstraintEmitTests.cs`): a `Span` of user structs round-trips through `MemoryMarshal.AsBytes`/`Cast`, IL is **fully verifiable**, and runtime output is correct (`8`, `2`, `16909060`, `84281096`).
- New binder tests (`test/Core.Tests/CodeAnalysis/Binding/Issue1325StructConstraintTests.cs`): user struct satisfies; user class does not; nullable does not; primitive still does.
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release` → **4677 passed, 1 skipped, 0 failed**.

## Files changed

- `src/Core/CodeAnalysis/Binding/OverloadResolution.cs` — constraint check + live-reflection placeholder fallback.
- `src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs` — wires the symbol-recovery delegate into `Resolve`.
- `src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs` — emit inferred static call with recovered symbolic type args.
- `src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs` — XML-doc cref update for the changed `Resolve` signature.
- `test/Core.Tests/CodeAnalysis/Binding/Issue1325StructConstraintTests.cs` — new binder tests.
- `test/Compiler.Tests/Emit/Issue1325StructConstraintEmitTests.cs` — new end-to-end emit/execution test.

Fixes #1325
Refs #914
