### PR TITLE
cs2gs: lower foreach tuple deconstruction to single-element loop + inner deconstruction

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
@@ -299,11 +299,13 @@ namespace Demo
     }
 
     /// <summary>
-    /// A <c>foreach</c> over a tuple deconstruction maps to the G# two-name
-    /// iteration <c>for a, b in xs</c> (ADR-0115 §B).
+    /// A <c>foreach</c> over a tuple deconstruction iterates a single element and
+    /// deconstructs it inside the body (<c>for __deconN in xs { let (a, b) =
+    /// __deconN; … }</c>). The G# two-name <c>for k, v in xs</c> form is
+    /// index/element iteration, NOT tuple deconstruction (ADR-0115 §B).
     /// </summary>
     [Fact]
-    public void ForEachVariable_TupleDeconstruction_MappedToTwoNameForIn()
+    public void ForEachVariable_TupleDeconstruction_DeconstructsElementInBody()
     {
         string printed = TranslateUnit(@"
 namespace Demo
@@ -323,7 +325,9 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("for a, b in xs", printed);
+        Assert.Matches(@"for __decon\d+ in xs", printed);
+        Assert.Matches(@"let \(a, b\) = __decon\d+", printed);
+        Assert.DoesNotContain("for a, b in xs", printed);
     }
 
     /// <summary>

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -7094,24 +7094,38 @@ public sealed class CSharpToGSharpTranslator
 
         private GStatement TranslateForEachVariable(ForEachVariableStatementSyntax node)
         {
-            // `foreach ((a, b) in xs)` / `foreach (var (a, b) in xs)` map to the
-            // G# two-name iteration `for a, b in xs` (ForInStatement key/value form;
-            // ADR-0115 §B). Tuple element names are collected from the designation.
+            // `foreach (var (a, b) in xs)` is a C# TUPLE DECONSTRUCTION over a
+            // sequence whose element is a tuple. G#'s two-name `for k, v in xs`
+            // form is NOT tuple deconstruction — it is index/element iteration
+            // (the key is the int32 index), so emitting `for a, b in xs` would
+            // bind `a` to the loop index. Instead iterate a single element and
+            // deconstruct it inside the body: `for __deconN in xs { let (a, b) =
+            // __deconN; <body> }` (ADR-0115 §B).
             List<string> names = new List<string>();
             CollectForEachVariableNames(node.Variable, names);
 
-            if (names.Count == 2)
+            if (names.Count >= 2)
             {
+                string pair = $"__decon{this.deconCounter++}";
+                BlockStatement body = this.TranslateStatementAsBlock(node.Statement);
+                var statements = new List<GStatement>(body.Statements.Count + 1)
+                {
+                    new TupleDeconstructionStatement(
+                        BindingKind.Let,
+                        names,
+                        new IdentifierExpression(pair)),
+                };
+                statements.AddRange(body.Statements);
+
                 return new ForInStatement(
-                    names[0],
-                    names[1],
+                    pair,
                     this.TranslateReceiverWithNullForgiveness(node.Expression),
-                    this.TranslateStatementAsBlock(node.Statement));
+                    new BlockStatement(statements));
             }
 
             this.context.ReportUnsupported(
                 node,
-                "foreach tuple deconstruction with arity != 2 has no canonical G# form yet (ADR-0115 §B).");
+                "foreach tuple deconstruction with arity < 2 has no canonical G# form yet (ADR-0115 §B).");
             return new RawStatement("// unsupported: foreach variable deconstruction");
         }
 


### PR DESCRIPTION
C# `foreach (var (a, b) in xs)` was translated to the G# two-name `for a, b in xs` form. But that G# form is **index/element** iteration — the first name binds to the `int32` index, not a tuple element. So the deconstructed names mis-bound (in Oahu, `track` became `int32`), producing GS0155.

This lowers a foreach tuple deconstruction to a single-element loop that deconstructs inside the body:

```
for __deconN in xs {
    let (a, b) = __deconN
    <body>
}
```

It also generalizes to arity > 2 (previously only arity == 2 was handled). Clears the Oahu.Decrypt `Mp4File` `for track, filter in filters` mis-binding (Decrypt 84 → 80).

322 cs2gs tests pass; verified the emitted form compiles in gsc over a G# tuple element type.

Refs #914