### PR TITLE
Fix #1328: preserve user element type when enumerating Dictionary[K,V] (.Values/.Keys/KeyValuePair)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -3820,12 +3820,39 @@ internal sealed partial class ExpressionBinder
             // The override is restricted to a TOP-LEVEL user type (after
             // unwrapping nullable/slice/array). A member typed as a constructed
             // generic over a user element (e.g. a `ChannelWriter[Entry]`
-            // property) is intentionally left to the closed reflection
-            // fallback, because method/extension lookup on such a non-interned
-            // constructed generic is not yet supported (#1305); surfacing it
-            // here would regress those call sites.
+            // property) is generally left to the closed reflection fallback,
+            // because method/extension lookup on such a non-interned constructed
+            // generic is not yet supported (#1305); surfacing it would regress
+            // those call sites.
+            //
+            // Issue #1328: an exception is a constructed generic that is itself
+            // an enumerable COLLECTION over a same-compilation user element —
+            // e.g. `Dictionary[K, V].Values` -> `ValueCollection[K, V]` (and
+            // `.Keys` -> `KeyCollection[K, V]`). Such a wrapper's erased
+            // `ClrType` (`ValueCollection<K, object>`) still implements
+            // `IEnumerable<V>`, so member/extension lookup (`.Single()`,
+            // `.ToList()`, the `for … in` enumerable surface) resolves against
+            // it exactly as for an `IEnumerable[V]`/`List[V]` receiver, while
+            // the symbolic `[K, V]` arguments let the element-type recovery
+            // surface the user `V` instead of erasing to `object`. This matches
+            // the #903/#1305 machinery already proven for `IEnumerable[User]`.
+            //
+            // Issue #1328 also: when the OPEN property type is itself a bare
+            // generic parameter (e.g. `KeyValuePair[K, V].Key` -> `K`,
+            // `.Value` -> `V`), the receiver's closed `ClrType` may have erased
+            // *every* type argument to `object` because a SIBLING argument is a
+            // same-compilation user type (a constructed generic over a user
+            // element erases the whole closed shape — so `KeyValuePair[uint32,
+            // E]` closes to `KeyValuePair<object, object>`, erasing the
+            // perfectly concrete `uint32` too). The symbolic projection is then
+            // authoritative for the member, so prefer it. This is safe because
+            // a bare-parameter property cannot be a constructed generic over a
+            // user element (the #1305 ChannelWriter[Entry] concern), so it does
+            // not regress those call sites.
             return TypeSymbol.ContainsTypeParameter(mapped)
                 || TypeSymbol.IsSameCompilationUserTypeTopLevel(mapped)
+                || IsUserElementEnumerableCollection(mapped)
+                || openPropType.IsGenericParameter
                 ? mapped
                 : null;
         }
@@ -3834,6 +3861,29 @@ internal sealed partial class ExpressionBinder
             return null;
         }
     }
+
+    /// <summary>
+    /// Issue #1328: returns <see langword="true"/> when <paramref name="mapped"/>
+    /// is a constructed imported generic that (a) carries a same-compilation
+    /// user type among its symbolic arguments and (b) whose type-erased
+    /// <see cref="TypeSymbol.ClrType"/> still implements
+    /// <c>IEnumerable&lt;T&gt;</c> — i.e. an enumerable collection wrapper such
+    /// as <c>Dictionary[K, V].Values</c> (<c>ValueCollection[K, V]</c>) or
+    /// <c>.Keys</c> (<c>KeyCollection[K, V]</c>). Surfacing the symbolic form
+    /// of such a wrapper preserves the user element type through the
+    /// <c>for … in</c> enumerable surface and LINQ terminals
+    /// (<c>.Single()</c>/<c>.ToList()</c>), while member/extension lookup still
+    /// resolves against the erased CLR shape (which implements the same
+    /// <c>IEnumerable&lt;object&gt;</c>). Unlike a general constructed generic
+    /// (e.g. <c>ChannelWriter[Entry]</c>, #1305), the enumerable surface is the
+    /// proven #903/#1304 path, so this is safe to surface.
+    /// </summary>
+    /// <param name="mapped">The symbolic projection produced by <see cref="MemberLookup.MapOpenClrTypeToSymbolic(Type, ImportedTypeSymbol)"/>.</param>
+    /// <returns><see langword="true"/> when the mapped type is a user-element enumerable collection wrapper.</returns>
+    private static bool IsUserElementEnumerableCollection(TypeSymbol mapped)
+        => mapped is ImportedTypeSymbol { ClrType: { } clr }
+            && TypeSymbol.ContainsSameCompilationUserType(mapped)
+            && MemberLookup.TryGetClrEnumerableElementType(clr, out _);
 
     private static bool IsReadOnlyRefReturn(PropertyInfo indexer, MethodInfo getter)
     {

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.cs
@@ -3448,7 +3448,18 @@ internal sealed class StatementBinder
         else
         {
             // `for v := range coll` — single var binds the value/element.
-            valueVariable = bindLocalVariable(syntax.FirstIdentifier, isReadOnly: false, type: valueType);
+            //
+            // Issue #1328: a SINGLE-identifier iteration over a dictionary
+            // binds the whole `KeyValuePair[K, V]` element (the static type of
+            // `Current`), matching `foreach (var kv in dict)` and single-var
+            // iteration over an `IEnumerable[KeyValuePair[K, V]]`. The two-var
+            // form `for k, v in dict` continues to destructure into K and V.
+            // The symbolic `[K, V]` arguments are preserved so `kv.Key`/`kv.Value`
+            // expose the user element types rather than erasing to `object`.
+            var singleVarType = iterationKind == ForRangeKind.Dictionary
+                ? BuildKeyValuePairType(keyType, valueType)
+                : valueType;
+            valueVariable = bindLocalVariable(syntax.FirstIdentifier, isReadOnly: false, type: singleVarType);
         }
 
         var body = BindLoopBody(syntax.Body, labelName, out var breakLabel, out var continueLabel);
@@ -3496,6 +3507,27 @@ internal sealed class StatementBinder
     /// <returns>The mapped <see cref="TypeSymbol"/>.</returns>
     private static TypeSymbol MapOpenClrTypeToSymbolic(Type openClr, ImportedTypeSymbol openImp)
         => MemberLookup.MapOpenClrTypeToSymbolic(openClr, openImp);
+
+    /// <summary>
+    /// Issue #1328: builds the symbolic <c>KeyValuePair[K, V]</c> element type
+    /// for a single-identifier dictionary iteration. The closed
+    /// <c>ImportedTypeSymbol.ClrType</c> is the type-erased
+    /// <c>KeyValuePair&lt;object, object&gt;</c> (mirroring the #313/#671
+    /// convention) while the symbolic <c>[K, V]</c> arguments are preserved so
+    /// member access on the loop variable (<c>kv.Key</c>/<c>kv.Value</c>)
+    /// recovers the user element types instead of erasing to <c>object</c>.
+    /// This matches the element type the lowerer synthesises for the same loop
+    /// (<see cref="System.Collections.Generic.IEnumerable{T}"/> of
+    /// <c>KeyValuePair[K, V]</c>).
+    /// </summary>
+    /// <param name="keyType">The symbolic key type <c>K</c>.</param>
+    /// <param name="valueType">The symbolic value type <c>V</c>.</param>
+    /// <returns>The constructed <c>KeyValuePair[K, V]</c> symbol.</returns>
+    private static TypeSymbol BuildKeyValuePairType(TypeSymbol keyType, TypeSymbol valueType)
+        => ImportedTypeSymbol.GetConstructed(
+            typeof(System.Collections.Generic.KeyValuePair<object, object>),
+            typeof(System.Collections.Generic.KeyValuePair<,>),
+            ImmutableArray.Create(keyType, valueType));
 
     private BoundStatement BindForConditionStatement(ForConditionStatementSyntax syntax)
     {

--- a/src/Core/CodeAnalysis/Lowering/Lowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/Lowerer.cs
@@ -793,42 +793,51 @@ public sealed class Lowerer : BoundTreeRewriter
 
         if (isDictionary)
         {
-            // Issue #774: when `currentAccess.Type` is a symbolic open
-            // KeyValuePair[K, V] (because the receiver was an open
-            // `Dictionary[K, V]`), the closed CLR `Key`/`Value` properties
-            // both report `object`. Honour the symbolic arguments so the
-            // synthesised key/value declarations carry the user's `K`/`V`.
-            var kvpType = currentAccess.Type;
-            var kvpClr = kvpType.ClrType;
-            var keyProp = kvpClr.GetProperty("Key");
-            var valueProp = kvpClr.GetProperty("Value");
-
-            TypeSymbol keyAccessType = TypeSymbol.FromClrType(keyProp.PropertyType);
-            TypeSymbol valueAccessType = TypeSymbol.FromClrType(valueProp.PropertyType);
-            if (kvpType is ImportedTypeSymbol kvpImp
-                && kvpImp.HasSubstitutableTypeArgument
-                && kvpImp.TypeArguments.Length == 2)
+            // Issue #1328: a single-identifier dictionary iteration
+            // (`for kv in dict`) binds the whole `KeyValuePair[K, V]` element —
+            // there is no key variable, so assign `Current` (the pair) directly
+            // to the loop variable. The two-var form (`for k, v in dict`)
+            // continues to destructure into `Current.Key` / `Current.Value`.
+            if (node.KeyVariable == null)
             {
-                keyAccessType = kvpImp.TypeArguments[0];
-                valueAccessType = kvpImp.TypeArguments[1];
+                statements.Add(new BoundVariableDeclaration(node.Syntax, node.ValueVariable, currentAccess));
             }
-
-            var kvpSymbol = new LocalVariableSymbol("$kvp", isReadOnly: true, type: kvpType);
-            statements.Add(new BoundVariableDeclaration(node.Syntax, kvpSymbol, currentAccess));
-            var kvpExpr = new BoundVariableExpression(node.Syntax, kvpSymbol);
-
-            if (node.KeyVariable != null)
+            else
             {
+                // Issue #774: when `currentAccess.Type` is a symbolic open
+                // KeyValuePair[K, V] (because the receiver was an open
+                // `Dictionary[K, V]`), the closed CLR `Key`/`Value` properties
+                // both report `object`. Honour the symbolic arguments so the
+                // synthesised key/value declarations carry the user's `K`/`V`.
+                var kvpType = currentAccess.Type;
+                var kvpClr = kvpType.ClrType;
+                var keyProp = kvpClr.GetProperty("Key");
+                var valueProp = kvpClr.GetProperty("Value");
+
+                TypeSymbol keyAccessType = TypeSymbol.FromClrType(keyProp.PropertyType);
+                TypeSymbol valueAccessType = TypeSymbol.FromClrType(valueProp.PropertyType);
+                if (kvpType is ImportedTypeSymbol kvpImp
+                    && kvpImp.HasSubstitutableTypeArgument
+                    && kvpImp.TypeArguments.Length == 2)
+                {
+                    keyAccessType = kvpImp.TypeArguments[0];
+                    valueAccessType = kvpImp.TypeArguments[1];
+                }
+
+                var kvpSymbol = new LocalVariableSymbol("$kvp", isReadOnly: true, type: kvpType);
+                statements.Add(new BoundVariableDeclaration(node.Syntax, kvpSymbol, currentAccess));
+                var kvpExpr = new BoundVariableExpression(node.Syntax, kvpSymbol);
+
                 statements.Add(new BoundVariableDeclaration(
                     node.Syntax,
                     node.KeyVariable,
                     new BoundClrPropertyAccessExpression(node.Syntax, kvpExpr, keyProp, keyAccessType)));
-            }
 
-            statements.Add(new BoundVariableDeclaration(
-                node.Syntax,
-                node.ValueVariable,
-                new BoundClrPropertyAccessExpression(node.Syntax, kvpExpr, valueProp, valueAccessType)));
+                statements.Add(new BoundVariableDeclaration(
+                    node.Syntax,
+                    node.ValueVariable,
+                    new BoundClrPropertyAccessExpression(node.Syntax, kvpExpr, valueProp, valueAccessType)));
+            }
         }
         else
         {

--- a/test/Compiler.Tests/Emit/Issue1328DictionaryUserElementErasureEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1328DictionaryUserElementErasureEmitTests.cs
@@ -1,0 +1,243 @@
+// <copyright file="Issue1328DictionaryUserElementErasureEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1328: enumerating a <c>Dictionary[K, V]</c> whose VALUE type
+/// <c>V</c> is a same-compilation user type erased the element to
+/// <c>System.Object</c> whenever the element type had to be INFERRED (foreach /
+/// LINQ), so member access failed with GS0158 and assignment with GS0155. This
+/// is the <c>Dictionary</c>/<c>ValueCollection</c> sibling of #1320. These
+/// end-to-end tests pin the fix at runtime: each builds a
+/// <c>Dictionary[uint32, E]</c>, enumerates it through the four formerly-broken
+/// inference forms (<c>for x in d.Values</c>, <c>for kv in d</c>,
+/// <c>d.Values.Single()</c>, <c>d.Values.ToList()[i]</c>), accesses the user
+/// member, executes, and asserts the values. A primitive-value control guards
+/// the path that always worked.
+/// </summary>
+public class Issue1328DictionaryUserElementErasureEmitTests
+{
+    [Fact]
+    public void ViaValues_ForIn_YieldsUserValues()
+    {
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+            import System.Linq
+
+            data class E(Value uint32) {}
+
+            func ViaValues(d Dictionary[uint32, E]) uint32 {
+                var sum uint32 = 0
+                for x in d.Values { sum = sum + x.Value }
+                return sum
+            }
+
+            let d = Dictionary[uint32, E]()
+            let k1 uint32 = 1
+            let k2 uint32 = 2
+            d.Add(k1, E(10))
+            d.Add(k2, E(20))
+            Console.WriteLine(ViaValues(d))
+            """;
+
+        Assert.Equal("30\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void ViaPair_ForIn_KeyValuePair_YieldsUserMembers()
+    {
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+            import System.Linq
+
+            data class E(Value uint32) {}
+
+            func ViaPair(d Dictionary[uint32, E]) uint32 {
+                var sum uint32 = 0
+                for kv in d { sum = sum + kv.Key + kv.Value.Value }
+                return sum
+            }
+
+            let d = Dictionary[uint32, E]()
+            let k1 uint32 = 1
+            d.Add(k1, E(10))
+            Console.WriteLine(ViaPair(d))
+            """;
+
+        // key 1 + value 10 = 11
+        Assert.Equal("11\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void TwoVar_ForIn_Destructures_YieldsUserValue()
+    {
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            data class E(Value uint32) {}
+
+            func TwoVar(d Dictionary[uint32, E]) uint32 {
+                var sum uint32 = 0
+                for k, v in d { sum = sum + k + v.Value }
+                return sum
+            }
+
+            let d = Dictionary[uint32, E]()
+            let k1 uint32 = 1
+            d.Add(k1, E(10))
+            Console.WriteLine(TwoVar(d))
+            """;
+
+        Assert.Equal("11\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void ViaSingle_LinqTerminal_YieldsUserValue()
+    {
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+            import System.Linq
+
+            data class E(Value uint32) {}
+
+            func ViaSingle(d Dictionary[uint32, E]) uint32 -> d.Values.Single().Value
+
+            let d = Dictionary[uint32, E]()
+            let k1 uint32 = 1
+            d.Add(k1, E(42))
+            Console.WriteLine(ViaSingle(d))
+            """;
+
+        Assert.Equal("42\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void ViaToList_Indexer_YieldsUserValue()
+    {
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+            import System.Linq
+
+            data class E(Value uint32) {}
+
+            func ViaToList(d Dictionary[uint32, E]) uint32 -> d.Values.ToList()[0].Value
+
+            let d = Dictionary[uint32, E]()
+            let k1 uint32 = 1
+            d.Add(k1, E(7))
+            Console.WriteLine(ViaToList(d))
+            """;
+
+        Assert.Equal("7\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void PrimitiveValues_ForIn_Control_StillWorks()
+    {
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+            import System.Linq
+
+            func PrimValues(d Dictionary[uint32, int32]) int32 {
+                var sum int32 = 0
+                for x in d.Values { sum = sum + x }
+                return sum
+            }
+
+            let d = Dictionary[uint32, int32]()
+            let k1 uint32 = 1
+            let k2 uint32 = 2
+            d.Add(k1, 5)
+            d.Add(k2, 9)
+            Console.WriteLine(PrimValues(d))
+            """;
+
+        Assert.Equal("14\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source, string[] ignoredIlErrorCodes = null)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1328_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath, ignoredErrorCodes: ignoredIlErrorCodes);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1328DictionaryUserElementErasureTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1328DictionaryUserElementErasureTests.cs
@@ -1,0 +1,231 @@
+// <copyright file="Issue1328DictionaryUserElementErasureTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1328: enumerating a <c>Dictionary[K, V]</c> whose VALUE type
+/// <c>V</c> is a same-compilation user type erased the element to
+/// <c>System.Object</c> whenever the element type had to be INFERRED
+/// (foreach / LINQ). Member access on the inferred element then failed
+/// <c>GS0158</c> (cannot find member) and assignment failed <c>GS0155</c>
+/// (cannot convert <c>object</c> to <c>V</c>). This is the
+/// <c>Dictionary</c>/<c>ValueCollection</c> sibling of #1320 (which fixed the
+/// same erasure for <c>sequence[T]</c> / <c>[]T</c>). The fix recovers the
+/// symbolic <c>V</c> from the constructed-generic collection type
+/// (<c>ValueCollection[K, V]</c>, <c>KeyCollection[K, V]</c>,
+/// <c>KeyValuePair[K, V]</c>) instead of reflecting over the erased CLR
+/// interface. These binder-level tests mirror the issue's repro matrix; every
+/// formerly-broken inference form now binds clean, and the controls (explicit
+/// element annotation, primitive value type, <c>List[E]</c>) keep working.
+/// </summary>
+public class Issue1328DictionaryUserElementErasureTests
+{
+    [Fact]
+    public void ViaValues_ForIn_UserMember_Binds()
+    {
+        // BUG: GS0158 — `x` erased to object so `.Value` was not found.
+        const string source = @"
+package p
+import System.Collections.Generic
+import System.Linq
+data class E(Value uint32) {}
+class C {
+    func ViaValues(d Dictionary[uint32, E]) uint32 {
+        for x in d.Values { return x.Value }
+        return 0
+    }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void ViaPair_ForIn_KeyValuePair_UserMember_Binds()
+    {
+        // BUG: GS0158 — single-var dict iteration must yield KeyValuePair[K, V]
+        // whose `.Value` carries the user `V` and `.Key` the symbolic `K`.
+        const string source = @"
+package p
+import System.Collections.Generic
+import System.Linq
+data class E(Value uint32) {}
+class C {
+    func ViaPair(d Dictionary[uint32, E]) uint32 {
+        for kv in d { return kv.Key + kv.Value.Value }
+        return 0
+    }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void ViaSingle_LinqTerminal_UserMember_Binds()
+    {
+        // BUG: GS0158 — `.Single()` return type erased to object.
+        const string source = @"
+package p
+import System.Collections.Generic
+import System.Linq
+data class E(Value uint32) {}
+class C {
+    func ViaSingle(d Dictionary[uint32, E]) uint32 {
+        let s = d.Values.Single()
+        return s.Value
+    }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void ViaToList_Indexer_Assignment_Binds()
+    {
+        // BUG: GS0155 — `.ToList()[0]` typed as object could not convert to E.
+        const string source = @"
+package p
+import System.Collections.Generic
+import System.Linq
+data class E(Value uint32) {}
+class C {
+    func ViaToList(d Dictionary[uint32, E]) E {
+        return d.Values.ToList()[0]
+    }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void TwoVar_ForIn_Destructures_To_UserValue_And_Key()
+    {
+        // The two-var form keeps destructuring into K and V; V must carry the
+        // user type so `.Value` resolves.
+        const string source = @"
+package p
+import System.Collections.Generic
+data class E(Value uint32) {}
+class C {
+    func TwoVar(d Dictionary[uint32, E]) uint32 {
+        for k, v in d { return k + v.Value }
+        return 0
+    }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void Keys_ForIn_UserKey_Member_Binds()
+    {
+        // `.Keys` (KeyCollection) over a user KEY type must surface the user
+        // element so `.Value` resolves.
+        const string source = @"
+package p
+import System.Collections.Generic
+data class E(Value uint32) {}
+class C {
+    func ViaKeys(d Dictionary[E, uint32]) uint32 {
+        for k in d.Keys { return k.Value }
+        return 0
+    }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void Controls_StillBind()
+    {
+        // Primitive value type, List[E], and explicit lambda-param annotation
+        // were never broken; capture them as regression guards.
+        const string primitiveValues = @"
+package p
+import System.Collections.Generic
+import System.Linq
+class C {
+    func PrimValues(d Dictionary[uint32, int32]) int32 {
+        for x in d.Values { return x }
+        return 0
+    }
+}
+";
+        const string listSingle = @"
+package p
+import System.Collections.Generic
+import System.Linq
+data class E(Value uint32) {}
+class C {
+    func ListSingle(l List[E]) uint32 -> l.Single().Value
+}
+";
+        const string selectExplicit = @"
+package p
+import System.Collections.Generic
+import System.Linq
+data class E(Value uint32) {}
+class C {
+    func SelectExplicit(d Dictionary[uint32, E]) uint32 -> d.Values.Select((e E) -> e.Value).First()
+}
+";
+        Assert.Empty(GetDiagnostics(primitiveValues));
+        Assert.Empty(GetDiagnostics(listSingle));
+        Assert.Empty(GetDiagnostics(selectExplicit));
+    }
+
+    private static ImmutableArrayOfDiagnostic GetDiagnostics(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var parseDiagnostics = tree.Diagnostics;
+        var bindDiagnostics = compilation.GlobalScope.Diagnostics;
+        var programDiagnostics = compilation.BoundProgram.Diagnostics;
+        var all = parseDiagnostics
+            .Concat(bindDiagnostics)
+            .Concat(programDiagnostics)
+            .Where(d => d.IsError)
+            .ToImmutableArray();
+        return new ImmutableArrayOfDiagnostic(all);
+    }
+
+    /// <summary>
+    /// Thin wrapper so the test cases can call <c>Assert.Empty</c> against a
+    /// <see cref="ImmutableArray{T}"/> without exposing the GSharp diagnostic
+    /// surface to xUnit's enumerable inference.
+    /// </summary>
+    private readonly struct ImmutableArrayOfDiagnostic : IReadOnlyCollection<Diagnostic>
+    {
+        private readonly ImmutableArray<Diagnostic> diagnostics;
+
+        public ImmutableArrayOfDiagnostic(ImmutableArray<Diagnostic> diagnostics)
+        {
+            this.diagnostics = diagnostics;
+        }
+
+        public int Count => this.diagnostics.Length;
+
+        public IEnumerator<Diagnostic> GetEnumerator()
+        {
+            foreach (var diagnostic in this.diagnostics)
+            {
+                yield return diagnostic;
+            }
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}


### PR DESCRIPTION
## Issue
Fixes #1328. Refs #914.

Enumerating a `Dictionary[K, V]` whose **value type `V` is a same-compilation user type** erased the element type to `System.Object` whenever the element type had to be **inferred** (foreach / LINQ). Member access on the inferred element then failed `GS0158: Cannot find member`, and assignment failed `GS0155: Cannot convert type 'object' to 'V'`. This is the `Dictionary`/`ValueCollection` sibling of #1320 (which fixed the same erasure for `sequence[T]` and `[]T`).

Repro (all four failed before this change):
```gsharp
package p
import System.Collections.Generic
import System.Linq
data class E(Value uint32) {}

class C {
    func ViaValues(d Dictionary[uint32, E]) uint32 {
        for x in d.Values { return x.Value }     // GS0158
    }
    func ViaPair(d Dictionary[uint32, E]) uint32 {
        for kv in d { return kv.Value.Value }    // GS0158 (KeyValuePair[K,V])
    }
    func ViaSingle(d Dictionary[uint32, E]) uint32 {
        return d.Values.Single().Value           // GS0158
    }
    func ViaToList(d Dictionary[uint32, E]) E {
        return d.Values.ToList()[0]              // GS0155
    }
}
```

## Root cause
Same underlying problem as #1320 / #1325: a same-compilation user type has no real reference-context CLR type during binding and is erased to `System.Object` in CLR-reflection-based paths. The foreach / LINQ element-type **inference** reflected over the erased CLR `IEnumerable<V>` interface of `Dictionary<K,V>.ValueCollection` (or `KeyValuePair<K,V>` for direct iteration) and recovered `V`'s CLR type as `object`, losing the user type. When the element type was supplied explicitly (annotated lambda param `(e E)`), the symbolic `V` was used — which is why that path always worked and masked the bug.

## Fix
Recover the **symbolic** element type from the constructed-generic collection type instead of the erased CLR interface.

- **`ExpressionBinder.Access.cs`** — `ResolveInstancePropertyTypeFromReceiver`: broaden the gate so a constructed-generic enumerable collection over a user element (`Dictionary[K,V].Values` → `ValueCollection[K,V]`, `.Keys` → `KeyCollection[K,V]`) and a bare-generic-parameter property (`KeyValuePair[K,V].Key`/`.Value`) surface their symbolic `[K, V]` arguments instead of erasing to `object`. New helper `IsUserElementEnumerableCollection` recognizes the collection wrappers; the `openPropType.IsGenericParameter` condition handles `KeyValuePair` members (whose closed CLR shape erases *every* argument to `object` when a sibling argument is a user type).
- **`StatementBinder.cs`** — single-identifier dictionary iteration (`for kv in d`) now binds the whole `KeyValuePair[K, V]` element (the static type of `Current`, matching `IEnumerable[KeyValuePair[K,V]]` iteration and ADR-0031), with the symbolic `[K, V]` arguments preserved so `kv.Key`/`kv.Value` carry the user types. New helper `BuildKeyValuePairType`. The two-var form (`for k, v in d`) still destructures into K and V.
- **`Lowerer.cs`** — `LowerCollectionRange` dictionary branch: single-var iteration assigns `Current` (the pair) directly to the loop variable; two-var continues to destructure into `Current.Key` / `Current.Value`.

## Controls preserved (no regression)
- `IEnumerable[E].Single().Member` / `List[E].Single().Member` resolve fine.
- `Dictionary[uint32, int32].Values` (primitive value type) loop works.
- `d.Values.Select((e E) -> e.Member)` (explicit annotation) works.
- Two-var `for k, v in d` destructuring works.

## Verification
- `dotnet build GSharp.sln -c Release -graph` — **0 warnings / 0 errors**.
- Standalone gsc: all four failing forms now compile, IL-verify clean, and execute with correct values (ViaValues=30, ViaPair=11, ViaSingle/ViaToList over user members); controls unaffected.
- New binder tests `Issue1328DictionaryUserElementErasureTests` (7) — all green.
- New end-to-end emit/execution tests `Issue1328DictionaryUserElementErasureEmitTests` (6) — ilverify-clean and runtime-asserted.
- Full `Core.Tests` (4684 passed), full `Interpreter.Tests` (332 passed), emit regression subset (85 passed, incl. #774/#1320/#1304/#1305/#939/#1088) — all green.
