### PR TITLE
cs2gs: lower a type reference in a combinator pattern to a type test, not equality

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
@@ -331,6 +331,32 @@ namespace Demo
     }
 
     /// <summary>
+    /// A type reference that Roslyn parses as a constant pattern after a pattern
+    /// combinator (<c>is Frame f and not EmptyFrame</c>) lowers to a type test
+    /// <c>!(x is EmptyFrame)</c>, not an equality <c>x != EmptyFrame</c> (which
+    /// would treat the type name as a value → GS0125).
+    /// </summary>
+    [Fact]
+    public void IsPattern_TypeReferenceAfterCombinator_LowersToTypeTest()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class Frame { }
+    public sealed class EmptyFrame : Frame { }
+    public static class C
+    {
+        public static bool IsRealFrame(object o) => o is Frame f and not EmptyFrame;
+    }
+}");
+
+        Assert.Contains("is Frame", printed);
+        Assert.Contains("is EmptyFrame", printed);
+        Assert.DoesNotContain("!= EmptyFrame", printed);
+        Assert.DoesNotContain("== EmptyFrame", printed);
+    }
+
+    /// <summary>
     /// A control character inside a string literal (here NUL from C# <c>\0</c>)
     /// is re-escaped as a <c>\uXXXX</c> escape so the emitted G# string stays
     /// terminated and round-trips (ADR-0115 §B).

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -5201,6 +5201,15 @@ public sealed class CSharpToGSharpTranslator
             }
         }
 
+        // A constant pattern whose expression is actually a bare/qualified TYPE
+        // reference (Roslyn parses `is T`/`not T` after a pattern combinator as a
+        // ConstantPattern over an identifier, since it cannot tell at parse time
+        // that the identifier names a type). Such a pattern is a type test, not an
+        // equality, so it must lower to `x is T` rather than `x == T`.
+        private bool IsTypeReferencePattern(ExpressionSyntax expression) =>
+            expression is TypeSyntax
+            && this.context.GetSymbolInfo(expression).Symbol is ITypeSymbol;
+
         private GExpression TranslateIsPattern(IsPatternExpressionSyntax isPattern)
         {
             GExpression receiver = this.TranslateExpression(isPattern.Expression);
@@ -5217,6 +5226,17 @@ public sealed class CSharpToGSharpTranslator
                     when constant.Expression.IsKind(SyntaxKind.NullLiteralExpression):
                     // `x is null` → `x == nil`.
                     return new BinaryExpression(receiver, "==", LiteralExpression.Null());
+
+                case ConstantPatternSyntax constant
+                    when this.IsTypeReferencePattern(constant.Expression):
+                    // Roslyn parses `x is T` where `T` is a bare type name after a
+                    // combinator (e.g. `is Frame child and not EmptyFrame`) as a
+                    // ConstantPattern over an identifier — but the identifier binds
+                    // to a TYPE, so it is a type test, not an equality. `x is T`.
+                    return new BinaryExpression(
+                        receiver,
+                        "is",
+                        new TypeExpression(this.MapTypeSyntax((TypeSyntax)constant.Expression)));
 
                 case ConstantPatternSyntax constant:
                     // `x is 0` / `x is "moov"` / `x is true`. G# `is` only tests a
@@ -5302,6 +5322,17 @@ public sealed class CSharpToGSharpTranslator
                     when constant.Expression.IsKind(SyntaxKind.NullLiteralExpression):
                     // `x is not null` → `x != nil`.
                     return new BinaryExpression(receiver, "!=", LiteralExpression.Null());
+
+                case ConstantPatternSyntax constant
+                    when this.IsTypeReferencePattern(constant.Expression):
+                    // `x is not T` where Roslyn parsed `T` as a ConstantPattern
+                    // identifier that binds to a TYPE → `!(x is T)`.
+                    return new UnaryExpression(
+                        "!",
+                        new ParenthesizedExpression(new BinaryExpression(
+                            receiver,
+                            "is",
+                            new TypeExpression(this.MapTypeSyntax((TypeSyntax)constant.Expression)))));
 
                 case ConstantPatternSyntax constant:
                     // `x is not 6` → `x != 6` (with numeric retyping to the receiver).


### PR DESCRIPTION
Roslyn parses a bare type name appearing after a pattern combinator — e.g. `o is Frame f and not EmptyFrame` — as a **ConstantPattern** over an *identifier expression*, because it cannot tell at parse time that the identifier names a type. The translator therefore lowered `not EmptyFrame` to `!= EmptyFrame` (and a positive `EmptyFrame` to `== EmptyFrame`), treating the type name as a value → `GS0125: Variable 'EmptyFrame' doesn't exist`.

This detects when a constant pattern's expression actually binds to a **type** (`IsTypeReferencePattern`: the expression is a `TypeSyntax` and `GetSymbolInfo(...).Symbol is ITypeSymbol`) and lowers it to the type test `x is T` / `!(x is T)` in both the positive and negated branches.

Clears the `Oahu.Decrypt` `Frame.gs` `is Frame child and not EmptyFrame` GS0125.

323 cs2gs tests pass (new test `IsPattern_TypeReferenceAfterCombinator_LowersToTypeTest`).

Refs #914
