### PR TITLE
Fix #1334: preserve user element type for Dictionary.Values/.Keys LINQ receivers

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -387,7 +387,7 @@ internal sealed class ConversionClassifier
             && widenTargetFnType.ReturnType != TypeSymbol.Error
             && widenTargetFnType.Arity == widenCandidateFnType.Arity
             && !ReferenceEquals(widenCandidateFnType.ReturnType, widenTargetFnType.ReturnType)
-            && IsNumericReturnWidening(widenCandidateFnType.ReturnType, widenTargetFnType.ReturnType))
+            && IsNumericReturnWideningCore(widenCandidateFnType.ReturnType, widenTargetFnType.ReturnType))
         {
             var widened = createErasedFunctionLiteralAdapter(widenCandidateLiteral, widenTargetFnType);
             if (!ReferenceEquals(widened, widenCandidateLiteral))
@@ -1338,6 +1338,15 @@ internal sealed class ConversionClassifier
         return new BoundAwaitExpression(null, clrCall, TypeSymbol.Void);
     }
 
+    // Issue #1334: shared accessor so the generic-LINQ delegate-argument rebind
+    // path (ExpressionBinder.Calls) can apply the same NUMERIC-only return
+    // widening gate used by BindConversion, rather than an over-broad implicit
+    // conversion check that erased same-compilation user-type projections.
+    internal static bool IsNumericReturnWidening(TypeSymbol source, TypeSymbol target)
+    {
+        return IsNumericReturnWideningCore(source, target);
+    }
+
     // ----- Private helpers (kept here because they are only used by methods in this class) -----
 
     /// <summary>
@@ -1460,7 +1469,7 @@ internal sealed class ConversionClassifier
     // per the standard widening lattice. Both types must be numeric CLR
     // primitives and the conversion classified implicit (i.e. directional
     // widening — narrowing and signed/unsigned same-width pairs are excluded).
-    private static bool IsNumericReturnWidening(TypeSymbol source, TypeSymbol target)
+    private static bool IsNumericReturnWideningCore(TypeSymbol source, TypeSymbol target)
     {
         var sourceClr = source?.ClrType?.FullName;
         var targetClr = target?.ClrType?.FullName;

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -3872,6 +3872,18 @@ internal sealed partial class ExpressionBinder
     // target (the common LINQ case: Where/Single/Select with bool/string
     // selectors) are left completely untouched, preserving their natural
     // concrete delegate signature.
+    //
+    // Issue #1334: the widening gate is deliberately restricted to NUMERIC
+    // (value-type primitive) return widening — matching the equivalent guard on
+    // the BindConversion path. A non-numeric implicit widening (a reference
+    // covariance, or a same-compilation user-type return widening to the
+    // type-erased `object` of a generic LINQ projection such as
+    // `Select<TSource, TResult>` where `TResult` is recovered symbolically) must
+    // NOT be erased here: doing so materialised the lambda as `Func<object,
+    // object>` while the call site re-closed `Select<Entry, Filter>`, producing
+    // an ilverify StackUnexpected mismatch. Reference covariance is handled by
+    // the CLR delegate's natural variance at emit, so leaving such literals at
+    // their concrete delegate signature is both correct and verifiable.
     private ImmutableArray<BoundExpression> RebindNumericReturnWideningDelegateArguments(
         ImmutableArray<BoundExpression> arguments,
         ParameterInfo[] parameters,
@@ -3893,7 +3905,7 @@ internal sealed partial class ExpressionBinder
                 && targetFunctionType.ReturnType != TypeSymbol.Error
                 && targetFunctionType.Arity == literalFnType.Arity
                 && !ReferenceEquals(literalFnType.ReturnType, targetFunctionType.ReturnType)
-                && Conversion.Classify(literalFnType.ReturnType, targetFunctionType.ReturnType).IsImplicit)
+                && ConversionClassifier.IsNumericReturnWidening(literalFnType.ReturnType, targetFunctionType.ReturnType))
             {
                 rebound = lambdas.CreateErasedFunctionLiteralAdapter(literal, targetFunctionType);
             }

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -2314,6 +2314,39 @@ internal sealed class MemberLookup
                 return;
             }
 
+            // Issue #1334: open formal is a delegate shape (Func<…, TResult> /
+            // Action<…>) and actual is a G# arrow/lambda (FunctionTypeSymbol).
+            // Unify each delegate parameter with the lambda's parameter type and
+            // — for Func — the trailing return slot with the lambda's return
+            // type. This recovers a method type parameter that only appears in
+            // the projection result (e.g. the `TResult` of
+            // `Select<TSource, TResult>(this IEnumerable<TSource>,
+            // Func<TSource, TResult>)`) when that result is a same-compilation
+            // user type whose CLR backing is still erased to `object` during
+            // binding. Without this, `dict.Values.Select((e Entry) -> e.Member)`
+            // surfaces `IEnumerable<object>` and the loop variable loses the
+            // user element identity (GS0159). The receiver still supplies
+            // `TSource` via Pattern C.
+            if (actual is FunctionTypeSymbol fn)
+            {
+                var fnVoid = FunctionTypeSymbol.IsVoidReturn(fn.ReturnType);
+                var expectedArgs = fnVoid ? fn.ParameterTypes.Length : fn.ParameterTypes.Length + 1;
+                if (openArgs.Length == expectedArgs)
+                {
+                    for (int j = 0; j < fn.ParameterTypes.Length; j++)
+                    {
+                        UnifyForMethodTypeArgs(openArgs[j], fn.ParameterTypes[j], openMethod, result);
+                    }
+
+                    if (!fnVoid)
+                    {
+                        UnifyForMethodTypeArgs(openArgs[openArgs.Length - 1], fn.ReturnType, openMethod, result);
+                    }
+                }
+
+                return;
+            }
+
             // Pattern B: open formal is IEnumerable<T> / IEnumerable<...> and
             // actual is a slice/array/sequence — the element type lifts as the
             // single substitution.

--- a/test/Compiler.Tests/Emit/Issue1334DictionaryLinqReceiverErasureEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1334DictionaryLinqReceiverErasureEmitTests.cs
@@ -1,0 +1,231 @@
+// <copyright file="Issue1334DictionaryLinqReceiverErasureEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1334 (follow-up to #1328): a <c>Dictionary[K, V].Values</c> /
+/// <c>.Keys</c> collection over a same-compilation user element, when used as the
+/// RECEIVER of a LINQ operator (<c>.Select</c>, <c>.Where</c>), erased the
+/// projected result element to <c>System.Object</c>, so a member access on the
+/// loop variable failed <c>GS0159</c>. The fix recovers the symbolic
+/// <c>TResult</c> from the explicitly-annotated projection lambda while the
+/// receiver supplies <c>TSource</c>. These end-to-end tests pin the fix at
+/// runtime: each builds a <c>Dictionary[uint32, E]</c>, runs the value collection
+/// through a LINQ operator that projects to / preserves a user element, accesses
+/// the user member, executes, and asserts the result. A primitive-projection
+/// control guards the closed-CLR path that always worked.
+/// </summary>
+public class Issue1334DictionaryLinqReceiverErasureEmitTests
+{
+    [Fact]
+    public void ValuesSelect_ProjectsUserType_ForIn_YieldsUserMember()
+    {
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+            import System.Linq
+
+            data class FilterSel(Tag uint32) { func Go() uint32 -> Tag }
+            data class EntrySel(FirstFilter FilterSel) {}
+
+            func ViaSelect(d Dictionary[uint32, EntrySel]) uint32 {
+                var sum uint32 = 0
+                for f in d.Values.Select((e EntrySel) -> e.FirstFilter) { sum = sum + f.Go() }
+                return sum
+            }
+
+            let d = Dictionary[uint32, EntrySel]()
+            let k1 uint32 = 1
+            let k2 uint32 = 2
+            d.Add(k1, EntrySel(FilterSel(10)))
+            d.Add(k2, EntrySel(FilterSel(20)))
+            Console.WriteLine(ViaSelect(d))
+            """;
+
+        Assert.Equal("30\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void ValuesWhere_ForIn_YieldsUserMember()
+    {
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+            import System.Linq
+
+            data class FilterWhr(Tag uint32) { func Go() uint32 -> Tag }
+            data class EntryWhr(FirstFilter FilterWhr) {}
+
+            func ViaWhere(d Dictionary[uint32, EntryWhr]) uint32 {
+                var sum uint32 = 0
+                for e in d.Values.Where((x EntryWhr) -> true) { sum = sum + e.FirstFilter.Go() }
+                return sum
+            }
+
+            let d = Dictionary[uint32, EntryWhr]()
+            let k1 uint32 = 1
+            let k2 uint32 = 2
+            d.Add(k1, EntryWhr(FilterWhr(10)))
+            d.Add(k2, EntryWhr(FilterWhr(20)))
+            Console.WriteLine(ViaWhere(d))
+            """;
+
+        Assert.Equal("30\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void ValuesWhereThenSelect_Chained_ForIn_YieldsUserMember()
+    {
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+            import System.Linq
+
+            data class FilterChn(Tag uint32) { func Go() uint32 -> Tag }
+            data class EntryChn(FirstFilter FilterChn) {}
+
+            func Chained(d Dictionary[uint32, EntryChn]) uint32 {
+                var sum uint32 = 0
+                for f in d.Values.Where((x EntryChn) -> true).Select((e EntryChn) -> e.FirstFilter) { sum = sum + f.Go() }
+                return sum
+            }
+
+            let d = Dictionary[uint32, EntryChn]()
+            let k1 uint32 = 1
+            let k2 uint32 = 2
+            d.Add(k1, EntryChn(FilterChn(10)))
+            d.Add(k2, EntryChn(FilterChn(20)))
+            Console.WriteLine(Chained(d))
+            """;
+
+        Assert.Equal("30\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void ValuesSelect_ThenLinqTerminal_YieldsUserMember()
+    {
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+            import System.Linq
+
+            data class FilterTrm(Tag uint32) { func Go() uint32 -> Tag }
+            data class EntryTrm(FirstFilter FilterTrm) {}
+
+            func SelectFirst(d Dictionary[uint32, EntryTrm]) uint32 -> d.Values.Select((e EntryTrm) -> e.FirstFilter).First().Go()
+
+            let d = Dictionary[uint32, EntryTrm]()
+            let k1 uint32 = 1
+            d.Add(k1, EntryTrm(FilterTrm(42)))
+            Console.WriteLine(SelectFirst(d))
+            """;
+
+        Assert.Equal("42\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void PrimitiveProjection_Control_StillWorks()
+    {
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+            import System.Linq
+
+            data class EPrim(Value uint32) {}
+
+            func SelectPrimitive(d Dictionary[uint32, EPrim]) uint32 {
+                var sum uint32 = 0
+                for v in d.Values.Select((e EPrim) -> e.Value) { sum = sum + v }
+                return sum
+            }
+
+            let d = Dictionary[uint32, EPrim]()
+            let k1 uint32 = 1
+            let k2 uint32 = 2
+            d.Add(k1, EPrim(5))
+            d.Add(k2, EPrim(9))
+            Console.WriteLine(SelectPrimitive(d))
+            """;
+
+        Assert.Equal("14\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source, string[] ignoredIlErrorCodes = null)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1334_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath, ignoredErrorCodes: ignoredIlErrorCodes);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1334DictionaryLinqReceiverErasureTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1334DictionaryLinqReceiverErasureTests.cs
@@ -1,0 +1,257 @@
+// <copyright file="Issue1334DictionaryLinqReceiverErasureTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1334 (follow-up to #1328): when a <c>Dictionary[K, V].Values</c> /
+/// <c>.Keys</c> collection over a same-compilation user element <c>V</c> / <c>K</c>
+/// is used as the RECEIVER of a LINQ operator (<c>.Select</c>, <c>.Where</c>,
+/// <c>.OrderBy</c>, …), the projected/result element type erased to
+/// <c>System.Object</c>. A subsequent member access on the loop / chain variable
+/// then failed <c>GS0159</c> (cannot find function) or <c>GS0158</c> even though
+/// the source element type is the symbolic user type and the lambda is
+/// explicitly annotated.
+/// <para>
+/// Root cause: the LINQ overload's generic inference reflected over the receiver's
+/// type-erased CLR <c>IEnumerable&lt;object&gt;</c> shape and inferred
+/// <c>TSource = object</c>, which poisoned the projection result <c>TResult</c> to
+/// <c>object</c>. The fix unifies the arrow/lambda argument
+/// (<c>FunctionTypeSymbol</c>) against the open delegate formal
+/// (<c>Func&lt;TSource, TResult&gt;</c>) during symbolic method-type-argument
+/// inference, so <c>TResult</c> recovers the same-compilation user type from the
+/// lambda's symbolic return while the receiver supplies <c>TSource</c>.
+/// </para>
+/// <para>
+/// These binder-level tests mirror the issue's repro matrix; every formerly-broken
+/// LINQ-receiver form now binds clean. Controls (projection to a primitive, a
+/// <c>List[E]</c> receiver, and the direct non-LINQ enumeration) keep working.
+/// </para>
+/// </summary>
+public class Issue1334DictionaryLinqReceiverErasureTests
+{
+    [Fact]
+    public void ValuesSelect_ProjectsUserType_ForIn_UserMember_Binds()
+    {
+        // BUG: GS0159 — `.Select` projection result erased to object so the
+        // loop variable lost the user `Filter` identity and `.Go()` was not found.
+        const string source = @"
+package p
+import System.Collections.Generic
+import System.Linq
+class Filter { func Go() {} }
+class Entry { prop FirstFilter Filter -> Filter() }
+class C {
+    func ViaSelect(d Dictionary[uint32, Entry]) {
+        for f in d.Values.Select((e Entry) -> e.FirstFilter) { f.Go() }
+    }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void ValuesWhere_ForIn_UserMember_Binds()
+    {
+        // BUG: GS0159/GS0158 — `.Where` result element erased to object.
+        const string source = @"
+package p
+import System.Collections.Generic
+import System.Linq
+class Filter { func Go() {} }
+class Entry { prop FirstFilter Filter -> Filter() }
+class C {
+    func ViaWhere(d Dictionary[uint32, Entry]) {
+        for e in d.Values.Where((x Entry) -> true) { e.FirstFilter.Go() }
+    }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void ValuesWhereThenSelect_Chained_ForIn_UserMember_Binds()
+    {
+        // BUG: GS0159 — the chained `.Where(...).Select(...)` projection result
+        // erased to object across both operators.
+        const string source = @"
+package p
+import System.Collections.Generic
+import System.Linq
+class Filter { func Go() {} }
+class Entry { prop FirstFilter Filter -> Filter() }
+class C {
+    func Chained(d Dictionary[uint32, Entry]) {
+        for f in d.Values.Where((x Entry) -> true).Select((e Entry) -> e.FirstFilter) { f.Go() }
+    }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void ValuesSelect_ThenLinqTerminal_UserMember_Binds()
+    {
+        // BUG: GS0159 — `.Select(...).First()` terminal returned object.
+        const string source = @"
+package p
+import System.Collections.Generic
+import System.Linq
+class Filter { func Go() {} }
+class Entry { prop FirstFilter Filter -> Filter() }
+class C {
+    func SelectFirst(d Dictionary[uint32, Entry]) {
+        d.Values.Select((e Entry) -> e.FirstFilter).First().Go()
+    }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void ValuesSelect_OrderBy_ForIn_UserMember_Binds()
+    {
+        // BUG: GS0159 — `.OrderBy` on a user-projected sequence erased the
+        // ordered element to object.
+        const string source = @"
+package p
+import System.Collections.Generic
+import System.Linq
+class Filter { prop Tag uint32 -> 0 func Go() {} }
+class Entry { prop FirstFilter Filter -> Filter() }
+class C {
+    func ViaOrderBy(d Dictionary[uint32, Entry]) {
+        for f in d.Values.Select((e Entry) -> e.FirstFilter).OrderBy((g Filter) -> g.Tag) { f.Go() }
+    }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void KeysSelect_ProjectsUserType_ForIn_UserMember_Binds()
+    {
+        // BUG: GS0159 — `.Keys` receiver erased the user key element through
+        // the `.Select` projection.
+        const string source = @"
+package p
+import System.Collections.Generic
+import System.Linq
+class Filter { func Go() {} }
+class Entry { prop FirstFilter Filter -> Filter() }
+class C {
+    func ViaKeys(d Dictionary[Entry, uint32]) {
+        for f in d.Keys.Select((e Entry) -> e.FirstFilter) { f.Go() }
+    }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void ListSelect_ProjectsUserType_ForIn_UserMember_Binds()
+    {
+        // Sibling: a plain List[Entry] LINQ receiver projecting to a user type
+        // shares the same recovery path.
+        const string source = @"
+package p
+import System.Collections.Generic
+import System.Linq
+class Filter { func Go() {} }
+class Entry { prop FirstFilter Filter -> Filter() }
+class C {
+    func ViaList(items List[Entry]) {
+        for f in items.Select((e Entry) -> e.FirstFilter) { f.Go() }
+    }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void Controls_PrimitiveProjection_And_DirectEnumeration_Bind()
+    {
+        // Control 1: projecting to a primitive still binds (closed-CLR path).
+        const string primitiveProjection = @"
+package p
+import System.Collections.Generic
+import System.Linq
+data class E(Value uint32) {}
+class C {
+    func SelectPrimitive(d Dictionary[uint32, E]) uint32 -> d.Values.Select((e E) -> e.Value).First()
+}
+";
+
+        // Control 2: direct (non-LINQ) enumeration of the user values keeps
+        // working (#1328).
+        const string directEnumeration = @"
+package p
+import System.Collections.Generic
+import System.Linq
+data class E(Value uint32) {}
+class C {
+    func Direct(d Dictionary[uint32, E]) uint32 {
+        for x in d.Values { return x.Value }
+        return 0
+    }
+}
+";
+        Assert.Empty(GetDiagnostics(primitiveProjection));
+        Assert.Empty(GetDiagnostics(directEnumeration));
+    }
+
+    private static ImmutableArrayOfDiagnostic GetDiagnostics(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var parseDiagnostics = tree.Diagnostics;
+        var bindDiagnostics = compilation.GlobalScope.Diagnostics;
+        var programDiagnostics = compilation.BoundProgram.Diagnostics;
+        var all = parseDiagnostics
+            .Concat(bindDiagnostics)
+            .Concat(programDiagnostics)
+            .Where(d => d.IsError)
+            .ToImmutableArray();
+        return new ImmutableArrayOfDiagnostic(all);
+    }
+
+    /// <summary>
+    /// Thin wrapper so the test cases can call <c>Assert.Empty</c> against a
+    /// <see cref="ImmutableArray{T}"/> without exposing the GSharp diagnostic
+    /// surface to xUnit's enumerable inference.
+    /// </summary>
+    private readonly struct ImmutableArrayOfDiagnostic : IReadOnlyCollection<Diagnostic>
+    {
+        private readonly ImmutableArray<Diagnostic> diagnostics;
+
+        public ImmutableArrayOfDiagnostic(ImmutableArray<Diagnostic> diagnostics)
+        {
+            this.diagnostics = diagnostics;
+        }
+
+        public int Count => this.diagnostics.Length;
+
+        public IEnumerator<Diagnostic> GetEnumerator()
+        {
+            foreach (var diagnostic in this.diagnostics)
+            {
+                yield return diagnostic;
+            }
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Direct follow-up to #1328. When a `Dictionary[K, V].Values` / `.Keys` collection over a **same-compilation user element type** is used as the **receiver of a LINQ operator** (`.Select`, `.Where`, `.OrderBy`, chained), the projected/result element type erased to `System.Object`. A subsequent member access on the loop/chain variable then failed `GS0159` (cannot find function), even though the source element type is the symbolic user type and the projection lambda is explicitly annotated.

```gsharp
for e in Entries.Values { e.FirstFilter.Go() }                          // already OK (#1328)
for f in Entries.Values.Select((e Entry) -> e.FirstFilter) { f.Go() }   // BUG: GS0159
```

## Root cause (two erasure points)

1. **Binding** — `MemberLookup.UnifyForMethodTypeArgs` did not unify a G# arrow lambda (`FunctionTypeSymbol`) against an open delegate formal (`Func<TSource, TResult>` / `Action<…>`). The LINQ overload's generic inference reflected only over the receiver's type-erased CLR `IEnumerable<object>` shape, inferring `TSource = object`, which poisoned the projection result `TResult` to `object`. The new unification case recovers `TResult` (and `TSource`) from the explicitly annotated lambda's parameter/return slots.

2. **Emit** — `RebindNumericReturnWideningDelegateArguments` used an over-broad `Conversion.Classify(...).IsImplicit` guard that also fired for a user-type return widening to the erased `object`, materialising the lambda as `Func<object, object>` while the re-closed `Select<Entry, Filter>` expected the symbolic delegate (ilverify `StackUnexpected`). The guard is now restricted to **numeric** (value-type primitive) return widening, reusing the gate already applied on the `BindConversion` path (`ConversionClassifier.IsNumericReturnWidening`). Reference covariance is handled by the CLR delegate's natural variance at emit.

## Files changed

- `src/Core/CodeAnalysis/Binding/MemberLookup.cs` — new `FunctionTypeSymbol` → delegate-formal unification case in `UnifyForMethodTypeArgs`.
- `src/Core/CodeAnalysis/Binding/ConversionClassifier.cs` — exposed `IsNumericReturnWidening` (internal) so the rebind path can share the tight numeric gate.
- `src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs` — tightened `RebindNumericReturnWideningDelegateArguments` guard to numeric-only.
- `test/Core.Tests/CodeAnalysis/Binding/Issue1334DictionaryLinqReceiverErasureTests.cs` — 8 binder/diagnostic tests.
- `test/Compiler.Tests/Emit/Issue1334DictionaryLinqReceiverErasureEmitTests.cs` — 5 emit/execution tests.

## Verification

- `dotnet build GSharp.sln -c Release -graph` → **0 errors**.
- Standalone repro (`ViaSelect`/`ViaWhere` over `Dictionary[uint32, Entry]`) compiles cleanly and runs correctly (**30/30**).
- Full `dotnet test test/Core.Tests` → **4692 passed, 1 skipped, 0 failed**.
- New emit tests (`~Issue1334`) → **5/5 pass**, ilverify clean.
- Regression subsets: `~Issue1328|~Issue1320|~Issue1304|~Issue1305` emit → **16/16**; `~Issue1150|~Linq|~Adr0112` → **34/34**.

Fixes #1334
Refs #914
