### PR TITLE
cs2gs: translate C# await foreach to G# await for

### DIFF
--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/GStatement.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/GStatement.cs
@@ -313,6 +313,13 @@ public sealed class ForInStatement : GStatement
 
     /// <summary>Gets the loop body.</summary>
     public BlockStatement Body { get; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this is an asynchronous iteration
+    /// (<c>await for x in seq</c>, the translation of C# <c>await foreach</c>).
+    /// Async iteration is only valid for the single-variable form.
+    /// </summary>
+    public bool IsAwait { get; set; }
 }
 
 /// <summary>

--- a/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
@@ -748,7 +748,8 @@ public static class GSharpPrinter
                 var loopVars = string.IsNullOrEmpty(forIn.ValueName)
                     ? forIn.VariableName
                     : $"{forIn.VariableName}, {forIn.ValueName}";
-                return $"{pad}for {loopVars} in {RenderExpression(forIn.Iterable, indent)} {RenderBlock(forIn.Body, indent)}";
+                var forKeyword = forIn.IsAwait ? "await for" : "for";
+                return $"{pad}{forKeyword} {loopVars} in {RenderExpression(forIn.Iterable, indent)} {RenderBlock(forIn.Body, indent)}";
 
             case DeferStatement defer:
                 return $"{pad}defer {RenderBlock(defer.Body, indent)}";

--- a/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
@@ -357,6 +357,60 @@ namespace Demo
     }
 
     /// <summary>
+    /// A C# <c>await foreach</c> over an <c>IAsyncEnumerable&lt;T&gt;</c> lowers to
+    /// G#'s asynchronous-iteration form <c>await for x in seq</c> (spec
+    /// AwaitForRangeStmt). A plain <c>for x in seq</c> over an async sequence is
+    /// rejected by gsc (GS0116 "not indexable").
+    /// </summary>
+    [Fact]
+    public void AwaitForeach_LowersToAwaitForLoop()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public async System.Threading.Tasks.Task F(System.Collections.Generic.IAsyncEnumerable<int> src)
+        {
+            await foreach (var x in src)
+            {
+                System.Console.WriteLine(x);
+            }
+        }
+    }
+}");
+
+        Assert.Contains("await for x in src", printed);
+        Assert.DoesNotMatch(@"(?<!await )for x in src", printed);
+    }
+
+    /// <summary>
+    /// A non-async <c>foreach</c> still lowers to a plain <c>for x in seq</c>
+    /// (no spurious <c>await</c>).
+    /// </summary>
+    [Fact]
+    public void Foreach_NonAsync_LowersToPlainForLoop()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public void F(System.Collections.Generic.IEnumerable<int> src)
+        {
+            foreach (var x in src)
+            {
+                System.Console.WriteLine(x);
+            }
+        }
+    }
+}");
+
+        Assert.Contains("for x in src", printed);
+        Assert.DoesNotContain("await for", printed);
+    }
+
+    /// <summary>
     /// A control character inside a string literal (here NUL from C# <c>\0</c>)
     /// is re-escaped as a <c>\uXXXX</c> escape so the emitted G# string stays
     /// terminated and round-trips (ADR-0115 §B).

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -3183,12 +3183,20 @@ public sealed class CSharpToGSharpTranslator
                     // narrow only locals, so `for x in field` over a `T?` field is
                     // rejected (GS0116 "not indexable") without an explicit
                     // `field!!`.
+                    //
+                    // A C# `await foreach` carries a non-empty `await` keyword; it
+                    // lowers to G#'s async-iteration form `await for x in seq`
+                    // (spec AwaitForRangeStmt). Without it, iterating an
+                    // `IAsyncEnumerable<T>` with a plain `for` is rejected (GS0116).
                     return new[]
                     {
                         (GStatement)new ForInStatement(
                             SanitizeIdentifier(forEach.Identifier.Text),
                             this.TranslateReceiverWithNullForgiveness(forEach.Expression),
-                            this.TranslateStatementAsBlock(forEach.Statement)),
+                            this.TranslateStatementAsBlock(forEach.Statement))
+                        {
+                            IsAwait = !forEach.AwaitKeyword.IsKind(SyntaxKind.None),
+                        },
                     };
 
                 case ForEachVariableStatementSyntax forEachVariable:
@@ -7151,7 +7159,10 @@ public sealed class CSharpToGSharpTranslator
                 return new ForInStatement(
                     pair,
                     this.TranslateReceiverWithNullForgiveness(node.Expression),
-                    new BlockStatement(statements));
+                    new BlockStatement(statements))
+                {
+                    IsAwait = !node.AwaitKeyword.IsKind(SyntaxKind.None),
+                };
             }
 
             this.context.ReportUnsupported(


### PR DESCRIPTION
## Summary
A C# `await foreach (var x in src)` over an `IAsyncEnumerable<T>` was emitted by cs2gs as a plain `for x in src`. gsc rejects that with **GS0116** ("not indexable") because G#'s synchronous `for x in seq` does not iterate asynchronous sequences. G# has a dedicated asynchronous-iteration form — `await for x in seq` (spec `AwaitForRangeStmt`) — which is the correct lowering.

## Change
- Add an `IsAwait` flag to the `ForInStatement` G-AST node.
- `GSharpPrinter` renders `await for` when the flag is set (plain `for` otherwise).
- The translator sets the flag from `ForEachStatementSyntax.AwaitKeyword` and the deconstruction `ForEachVariableStatementSyntax.AwaitKeyword`.

## Impact
Surfaces in `Oahu.Decrypt` `FrameFilterBase.Encoder`, which uses `await foreach` over a `Channel` reader. The non-async `foreach` path is unchanged.

## Tests
Two new translator tests; full cs2gs suite 325 pass.

Refs #914
