### PR TITLE
Fix #1341: order-independent member lookup on constructed-generic user types

### DIFF
--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -20,6 +20,37 @@ public sealed class StructSymbol : TypeSymbol
 {
     private static readonly ConcurrentDictionary<(StructSymbol Def, string ArgsKey), StructSymbol> ConstructedCache = new();
 
+    // Issue #1341: backing stores for the generically-erased member tables whose
+    // reads are forwarded to Definition on a constructed instance. On a
+    // definition (or non-generic type) these hold the canonical member set; on a
+    // constructed instance they are unused (the forwarding getter reads
+    // Definition's store) so a late-bound definition body is always observed.
+    private ImmutableArray<FunctionSymbol> methods = ImmutableArray<FunctionSymbol>.Empty;
+    private ImmutableArray<FunctionSymbol> staticMethods = ImmutableArray<FunctionSymbol>.Empty;
+    private ImmutableArray<FieldSymbol> staticFields = ImmutableArray<FieldSymbol>.Empty;
+    private ImmutableArray<FieldSymbol> constFields = ImmutableArray<FieldSymbol>.Empty;
+    private ImmutableArray<FieldSymbol> fieldsStore = ImmutableArray<FieldSymbol>.Empty;
+    private ImmutableArray<PropertySymbol> propertiesStore = ImmutableArray<PropertySymbol>.Empty;
+    private ImmutableArray<PropertySymbol> staticPropertiesStore = ImmutableArray<PropertySymbol>.Empty;
+
+    // Issue #1341: memoized substitution of the definition's instance-member
+    // tables (whose member types may mention the type parameters) for a
+    // constructed instance. These are recomputed when the definition's source
+    // array changes reference — which happens exactly once, when the
+    // definition's body is bound — so a construction materialized before the
+    // definition's body still observes the substituted members afterward,
+    // making member lookup independent of source-file binding order.
+    private Dictionary<TypeParameterSymbol, TypeSymbol> substitutionMap;
+    private ImmutableArray<FieldSymbol> substitutedFields;
+    private ImmutableArray<FieldSymbol> substitutedFieldsSource;
+    private bool substitutedFieldsComputed;
+    private ImmutableArray<PropertySymbol> substitutedProperties;
+    private ImmutableArray<PropertySymbol> substitutedPropertiesSource;
+    private bool substitutedPropertiesComputed;
+    private ImmutableArray<PropertySymbol> substitutedStaticProperties;
+    private ImmutableArray<PropertySymbol> substitutedStaticPropertiesSource;
+    private bool substitutedStaticPropertiesComputed;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="StructSymbol"/> class.
     /// </summary>
@@ -153,7 +184,12 @@ public sealed class StructSymbol : TypeSymbol
     }
 
     /// <summary>Gets the field declarations in source order.</summary>
-    public ImmutableArray<FieldSymbol> Fields { get; private set; }
+    /// <remarks>Issue #1341: on a constructed instance, fields are substituted lazily from <see cref="Definition"/> so a late-bound definition body is observed (order-independent member lookup).</remarks>
+    public ImmutableArray<FieldSymbol> Fields
+    {
+        get => Definition != null && !ReferenceEquals(Definition, this) ? GetSubstitutedFields() : fieldsStore;
+        private set => fieldsStore = value;
+    }
 
     /// <summary>Gets the struct CLR accessibility.</summary>
     public Accessibility Accessibility { get; }
@@ -237,16 +273,41 @@ public sealed class StructSymbol : TypeSymbol
     public ImmutableArray<TypeSymbol> ImplementedClrInterfaces { get; private set; } = ImmutableArray<TypeSymbol>.Empty;
 
     /// <summary>Gets the methods declared inside the class body (Phase 3.B.3 sub-step 2b). Populated by the binder after the symbol is constructed; defaults to empty.</summary>
-    public ImmutableArray<FunctionSymbol> Methods { get; private set; } = ImmutableArray<FunctionSymbol>.Empty;
+    /// <remarks>
+    /// Issue #1341: methods are erased generically (ADR-0004) and carried on a
+    /// constructed instance without per-construction substitution, so a
+    /// constructed instance always reflects its <see cref="Definition"/>'s
+    /// current method set by forwarding the read. This keeps member lookup on a
+    /// constructed generic user type independent of the order in which source
+    /// files are bound: even when the construction is materialized (and cached)
+    /// before the definition's body — and therefore its methods — has been
+    /// bound, reads observe the methods once they are populated rather than an
+    /// empty snapshot captured at construction time.
+    /// </remarks>
+    public ImmutableArray<FunctionSymbol> Methods
+    {
+        get => Definition != null && !ReferenceEquals(Definition, this) ? Definition.Methods : methods;
+        private set => methods = value;
+    }
 
     /// <summary>Gets the properties declared on this type (ADR-0051). Populated by the binder after the symbol is constructed; defaults to empty.</summary>
-    public ImmutableArray<PropertySymbol> Properties { get; private set; } = ImmutableArray<PropertySymbol>.Empty;
+    /// <remarks>Issue #1341: on a constructed instance, properties are substituted lazily from <see cref="Definition"/> so a late-bound definition body is observed (order-independent member lookup).</remarks>
+    public ImmutableArray<PropertySymbol> Properties
+    {
+        get => Definition != null && !ReferenceEquals(Definition, this) ? GetSubstitutedProperties() : propertiesStore;
+        private set => propertiesStore = value;
+    }
 
     /// <summary>Gets the events declared on this type (ADR-0052). Populated by the binder after the symbol is constructed; defaults to empty.</summary>
     public ImmutableArray<EventSymbol> Events { get; private set; } = ImmutableArray<EventSymbol>.Empty;
 
     /// <summary>Gets the static fields declared inside a <c>shared</c> block (ADR-0053). Populated by the binder; defaults to empty.</summary>
-    public ImmutableArray<FieldSymbol> StaticFields { get; private set; } = ImmutableArray<FieldSymbol>.Empty;
+    /// <remarks>Issue #1341: forwarded from <see cref="Definition"/> on a constructed instance (static members are shared by identity per issue #1209) so reads are order-independent.</remarks>
+    public ImmutableArray<FieldSymbol> StaticFields
+    {
+        get => Definition != null && !ReferenceEquals(Definition, this) ? Definition.StaticFields : staticFields;
+        private set => staticFields = value;
+    }
 
     /// <summary>
     /// Gets the compile-time constant fields declared with <c>const</c>
@@ -256,13 +317,27 @@ public sealed class StructSymbol : TypeSymbol
     /// emitter never produces a runtime static field or a <c>.cctor</c>
     /// assignment for them. Populated by the binder; defaults to empty.
     /// </summary>
-    public ImmutableArray<FieldSymbol> ConstFields { get; private set; } = ImmutableArray<FieldSymbol>.Empty;
+    public ImmutableArray<FieldSymbol> ConstFields
+    {
+        get => Definition != null && !ReferenceEquals(Definition, this) ? Definition.ConstFields : constFields;
+        private set => constFields = value;
+    }
 
     /// <summary>Gets the static methods declared inside a <c>shared</c> block (ADR-0053). Populated by the binder; defaults to empty.</summary>
-    public ImmutableArray<FunctionSymbol> StaticMethods { get; private set; } = ImmutableArray<FunctionSymbol>.Empty;
+    /// <remarks>Issue #1341: forwarded from <see cref="Definition"/> on a constructed instance (static members are shared by identity per issue #1209) so reads are order-independent.</remarks>
+    public ImmutableArray<FunctionSymbol> StaticMethods
+    {
+        get => Definition != null && !ReferenceEquals(Definition, this) ? Definition.StaticMethods : staticMethods;
+        private set => staticMethods = value;
+    }
 
     /// <summary>Gets the static properties declared inside a <c>shared</c> block (ADR-0053). Populated by the binder; defaults to empty.</summary>
-    public ImmutableArray<PropertySymbol> StaticProperties { get; private set; } = ImmutableArray<PropertySymbol>.Empty;
+    /// <remarks>Issue #1341: on a constructed instance, static properties are substituted lazily from <see cref="Definition"/> so a late-bound definition body is observed (order-independent member lookup).</remarks>
+    public ImmutableArray<PropertySymbol> StaticProperties
+    {
+        get => Definition != null && !ReferenceEquals(Definition, this) ? GetSubstitutedStaticProperties() : staticPropertiesStore;
+        private set => staticPropertiesStore = value;
+    }
 
     /// <summary>Gets the static events declared inside a <c>shared</c> block (ADR-0053). Populated by the binder; defaults to empty.</summary>
     public ImmutableArray<EventSymbol> StaticEvents { get; private set; } = ImmutableArray<EventSymbol>.Empty;
@@ -1231,8 +1306,14 @@ public sealed class StructSymbol : TypeSymbol
             constructed.SetImplementedClrInterfaces(substitutedClrIfaces.MoveToImmutable());
         }
 
-        constructed.SetMethods(definition.Methods);
-
+        // Issue #1341: Methods and the static-member tables below are
+        // generically erased (ADR-0004) and shared with the definition by
+        // identity (no per-construction substitution). They are NOT snapshotted
+        // here: the constructed instance forwards their reads to Definition so
+        // member lookup observes the definition's members even when this
+        // construction is materialized (and cached) before the definition's
+        // body has been bound — making lookup independent of source-file order.
+        //
         // Issue #1209: a constructed generic class/struct must surface the open
         // definition's static members so a qualified static reference on the
         // construction (`Box[int32].Default`, `Box[int32].Make()`) resolves the
@@ -1242,28 +1323,126 @@ public sealed class StructSymbol : TypeSymbol
         // identity (no per-construction substitution at emit). The constructed
         // symbol is still carried as the owner of the bound access so member
         // resolution and diagnostics see the closed type.
-        constructed.SetStaticMethods(definition.StaticMethods);
-        constructed.SetStaticFields(definition.StaticFields);
-        constructed.SetConstFields(definition.ConstFields);
 
-        // Issue #989: a generic auto-property (or computed property) whose type
-        // mentions the class type parameter must resolve on a constructed
-        // instance with `T` substituted — exactly like instance fields above.
-        // Carry the property tables across with substituted property/indexer
-        // types so `TryGetProperty` finds them and the bound access reports the
-        // substituted type. Accessor FunctionSymbols and backing fields are
-        // shared with the open definition (only the definition is emitted; the
-        // external accessor call is parented at the constructed TypeSpec by the
-        // emitter, and inside-the-type access lowers against the definition).
-        constructed.SetProperties(SubstituteProperties(definition.Properties, subst));
-        constructed.SetStaticProperties(SubstituteProperties(definition.StaticProperties, subst));
-
+        // Issue #989 / #1341: a generic auto-property (or computed property)
+        // whose type mentions the class type parameter must resolve on a
+        // constructed instance with `T` substituted — exactly like instance
+        // fields. The property tables are NOT snapshotted here: the constructed
+        // instance substitutes them lazily from the definition (see
+        // GetSubstitutedProperties) so a property bound after this construction
+        // is materialized is still observed. Accessor FunctionSymbols and
+        // backing fields are shared with the open definition (only the
+        // definition is emitted; the external accessor call is parented at the
+        // constructed TypeSpec by the emitter, and inside-the-type access lowers
+        // against the definition).
         if (definition.ImportedBaseType != null)
         {
             constructed.SetImportedBaseType(definition.ImportedBaseType);
         }
 
         return constructed;
+    }
+
+    // Issue #1341: builds (once) the type-parameter -> type-argument map used to
+    // substitute the definition's instance-member types for this constructed
+    // instance. Generic definitions are immutable in their type parameters and
+    // a construction's type arguments are fixed, so the map is cached.
+    private Dictionary<TypeParameterSymbol, TypeSymbol> GetSubstitutionMap()
+    {
+        if (substitutionMap != null)
+        {
+            return substitutionMap;
+        }
+
+        var def = Definition;
+        var map = new Dictionary<TypeParameterSymbol, TypeSymbol>(
+            def.TypeParameters.IsDefaultOrEmpty ? 0 : def.TypeParameters.Length);
+        if (!def.TypeParameters.IsDefaultOrEmpty && !TypeArguments.IsDefaultOrEmpty)
+        {
+            var count = System.Math.Min(def.TypeParameters.Length, TypeArguments.Length);
+            for (var i = 0; i < count; i++)
+            {
+                map[def.TypeParameters[i]] = TypeArguments[i];
+            }
+        }
+
+        substitutionMap = map;
+        return map;
+    }
+
+    // Issue #1341: lazily substitutes the definition's instance fields for this
+    // constructed instance, memoized against the definition's current field
+    // array. The array is replaced (by reference) exactly when the definition's
+    // body is bound, so reading after that point recomputes the substitution —
+    // making member lookup independent of the order the definition is bound.
+    private ImmutableArray<FieldSymbol> GetSubstitutedFields()
+    {
+        var source = Definition.Fields;
+        if (substitutedFieldsComputed && substitutedFieldsSource.Equals(source))
+        {
+            return substitutedFields;
+        }
+
+        var subst = GetSubstitutionMap();
+        ImmutableArray<FieldSymbol> result;
+        if (source.IsDefaultOrEmpty || subst.Count == 0)
+        {
+            result = source;
+        }
+        else
+        {
+            var builder = ImmutableArray.CreateBuilder<FieldSymbol>(source.Length);
+            foreach (var f in source)
+            {
+                var newType = SubstituteTypeForConstruction(f.Type, subst);
+                builder.Add(ReferenceEquals(newType, f.Type)
+                    ? f
+                    : new FieldSymbol(f.Name, newType, f.Accessibility));
+            }
+
+            result = builder.MoveToImmutable();
+        }
+
+        substitutedFields = result;
+        substitutedFieldsSource = source;
+        substitutedFieldsComputed = true;
+        return result;
+    }
+
+    // Issue #1341: lazily substitutes the definition's instance properties for
+    // this constructed instance, memoized against the definition's current
+    // property array (see GetSubstitutedFields for the ordering rationale).
+    private ImmutableArray<PropertySymbol> GetSubstitutedProperties()
+    {
+        var source = Definition.Properties;
+        if (substitutedPropertiesComputed && substitutedPropertiesSource.Equals(source))
+        {
+            return substitutedProperties;
+        }
+
+        var result = SubstituteProperties(source, GetSubstitutionMap());
+        substitutedProperties = result;
+        substitutedPropertiesSource = source;
+        substitutedPropertiesComputed = true;
+        return result;
+    }
+
+    // Issue #1341: lazily substitutes the definition's static properties for this
+    // constructed instance, memoized against the definition's current static
+    // property array (see GetSubstitutedFields for the ordering rationale).
+    private ImmutableArray<PropertySymbol> GetSubstitutedStaticProperties()
+    {
+        var source = Definition.StaticProperties;
+        if (substitutedStaticPropertiesComputed && substitutedStaticPropertiesSource.Equals(source))
+        {
+            return substitutedStaticProperties;
+        }
+
+        var result = SubstituteProperties(source, GetSubstitutionMap());
+        substitutedStaticProperties = result;
+        substitutedStaticPropertiesSource = source;
+        substitutedStaticPropertiesComputed = true;
+        return result;
     }
 
     private static ImmutableArray<PropertySymbol> SubstituteProperties(

--- a/test/Compiler.Tests/Emit/Issue1341GenericMemberOrderTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1341GenericMemberOrderTests.cs
@@ -1,0 +1,215 @@
+// <copyright file="Issue1341GenericMemberOrderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1341: member lookup on a constructed-generic <em>user</em> type
+/// <c>G[X]</c> must not depend on the order in which source files are presented
+/// to the compiler. The using-file may legitimately precede the file that
+/// declares the generic type <c>G</c> (the cs2gs pipeline topologically sorts by
+/// base-class edges only), so a constructed instance can be materialized — and
+/// cached — before the generic definition's body, and therefore its members,
+/// has been bound. The constructed instance must still surface the definition's
+/// methods, instance fields, and properties once they are bound.
+/// </summary>
+public class Issue1341GenericMemberOrderTests
+{
+    private const string BaseFile = """
+        package q
+        open class FrameFilterBase[TInput]() {
+            var Value int32 = 0
+            prop Count int32 { get { return Value } }
+            open func SetCancellationToken(t int32) {}
+            func Get() int32 { return Value }
+        }
+        """;
+
+    private const string UserFile = """
+        package r
+        import q
+        class User {
+            func F(filter FrameFilterBase[int32]) int32 {
+                filter.SetCancellationToken(0)
+                return filter.Value + filter.Count + filter.Get()
+            }
+        }
+        """;
+
+    [Fact]
+    public void MethodLookup_UserBeforeBase_Compiles()
+    {
+        // The regression: with the using-file first, the constructed
+        // FrameFilterBase[int32] is materialized while binding User.F's
+        // signature, before FrameFilterBase's body (and methods) are bound.
+        var (exit, output) = CompileLibrary(
+            ("u.gs", UserFile),
+            ("b.gs", BaseFile));
+
+        Assert.True(exit == 0, $"user-before-base compile failed ({exit}):\n{output}");
+    }
+
+    [Fact]
+    public void MethodLookup_BaseBeforeUser_Compiles()
+    {
+        // The historically-working order, kept as a control.
+        var (exit, output) = CompileLibrary(
+            ("b.gs", BaseFile),
+            ("u.gs", UserFile));
+
+        Assert.True(exit == 0, $"base-before-user compile failed ({exit}):\n{output}");
+    }
+
+    [Fact]
+    public void MemberLookup_UserBeforeBase_EmitsAndRuns()
+    {
+        // End-to-end: compile an executable in user-before-base order, verify
+        // the IL, and run it. Confirms the constructed instance's method,
+        // instance field, and property all bind and emit correctly regardless
+        // of file order.
+        var main = """
+            package r
+            import q
+            import System
+
+            func Run() int32 {
+                var f = FrameFilterBase[int32]{ Value: 7 }
+                f.SetCancellationToken(0)
+                return f.Value + f.Count + f.Get()
+            }
+
+            Console.WriteLine(Run())
+            """;
+
+        // 7 (Value) + 7 (Count) + 7 (Get) == 21.
+        Assert.Equal("21\n", CompileAndRunExe(("m.gs", main), ("b.gs", BaseFile)));
+    }
+
+    private static (int Exit, string Output) CompileLibrary(params (string Name, string Content)[] files)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1341_lib_").FullName;
+        try
+        {
+            var outPath = Path.Combine(tempDir, "out.dll");
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:library",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+            };
+
+            foreach (var (name, content) in files)
+            {
+                var path = Path.Combine(tempDir, name);
+                File.WriteAllText(path, content);
+                args.Add(path);
+            }
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int exit;
+            try
+            {
+                exit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            return (exit, compileOut.ToString() + compileErr.ToString());
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static string CompileAndRunExe(params (string Name, string Content)[] files)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1341_emit_").FullName;
+        try
+        {
+            var outPath = Path.Combine(tempDir, "test.dll");
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+            };
+
+            foreach (var (name, content) in files)
+            {
+                var path = Path.Combine(tempDir, name);
+                File.WriteAllText(path, content);
+                args.Add(path);
+            }
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Member lookup on a constructed-generic **user** type `G[X]` failed with `GS0159: Cannot find function <member>` (and `GS0158` for fields/properties) when the file declaring the generic type `G` was passed to `gsc` **after** the file that uses it. The failure was order-dependent — base-first order worked, user-first order failed. Non-generic user bases worked in either order; the type argument (primitive vs user) was irrelevant.

This is a real robustness bug: the cs2gs migration pipeline topologically sorts emitted files by base-class edges only, so a using-file can legitimately precede the generic type's declaration file.

### Minimal repro (user-before-base order failed)

```
// b.gs
package q
open class FrameFilterBase[TInput]() {
    open func SetCancellationToken(t int32) {}
}

// u.gs
package r
import q
class User {
    func F(filter FrameFilterBase[int32]) {
        filter.SetCancellationToken(0)
    }
}
```

`gsc ... u.gs b.gs` -> `GS0159`; `gsc ... b.gs u.gs` -> OK.

## Root cause

`StructSymbol.CreateConstructed` snapshotted the generic definition's member tables (methods, static members, instance fields, properties) at construction time and cached the constructed instance in `ConstructedCache`. When a construction was materialized while binding a using-file's signature — **before** the generic definition's body (and therefore its members) had been bound — the cached constructed instance permanently held an empty/incomplete member set. Later member lookups against that cached instance found nothing.

## Fix

A constructed instance no longer snapshots its member tables; it forwards reads to its `Definition`:

- **Methods** and **static members** (`StaticMethods`/`StaticFields`/`ConstFields`) — generically erased (ADR-0004) and shared with the definition by identity (issue #1209) — forward directly to the definition.
- **Instance `Fields`, `Properties`, and `StaticProperties`** (whose member types may mention the type parameters) are substituted lazily and memoized against the definition's current member-array reference, so the substitution is recomputed once the definition's body is bound.

Member lookup is now independent of the order source files are presented to the compiler. Both repro orders compile, and the fix also covers the same root for instance fields and properties (which exhibited the equivalent `GS0158` ordering failure).

## Tests

Added `test/Compiler.Tests/Emit/Issue1341GenericMemberOrderTests.cs`:
- `MethodLookup_UserBeforeBase_Compiles` (regression) and `MethodLookup_BaseBeforeUser_Compiles` (control).
- `MemberLookup_UserBeforeBase_EmitsAndRuns` — compiles an executable in user-before-base order, runs `IlVerifier.Verify`, and executes it, exercising a method, instance field, and property on the constructed generic.

## Verification

- `dotnet build GSharp.sln -c Release -graph` -> 0 warnings/errors.
- Both repro orders now compile.
- New tests pass (3/3).
- Full `Core.Tests` suite: 4692 passed.
- Filtered `Compiler.Tests` slices around generics, member lookup, properties, fields, structs, inheritance, static members and emit: 958 passed.

Fixes #1341
Refs #914
