### PR TITLE
Fix #1329: nameof accepts a constructed/generic type argument

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
@@ -137,6 +137,15 @@ internal sealed partial class ExpressionBinder
                 name = call.Identifier.Text;
                 return !string.IsNullOrEmpty(name);
 
+            case GenericNameExpressionSyntax generic:
+                // Issue #1329: a constructed-generic *type* reference such as
+                // `IAppleData[TData]`, `List[int32]` or `Dictionary[string, int32]`
+                // is parsed (issue #1323) as a GenericNameExpression. `nameof` of
+                // a generic type yields the unqualified type name with the type
+                // arguments dropped (matches C# `nameof(List<int>)` -> "List").
+                name = generic.Identifier.Text;
+                return !string.IsNullOrEmpty(name);
+
             case ParenthesizedExpressionSyntax p:
                 return TryExtractNameOfName(p.Expression, out name);
 

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -8701,9 +8701,74 @@ public class Parser
         // emits a diagnostic otherwise.
         var nameOfIdentifier = MatchToken(SyntaxKind.IdentifierToken);
         var openParen = MatchToken(SyntaxKind.OpenParenthesisToken);
-        var argument = ParseExpression();
+        var argument = ParseNameOfArgument();
         var closeParen = MatchToken(SyntaxKind.CloseParenthesisToken);
         return new NameOfExpressionSyntax(syntaxTree, nameOfIdentifier, openParen, argument, closeParen);
+    }
+
+    // Issue #1329: parse the argument of `nameof(...)`, recognising a
+    // constructed-generic *type* reference (`IAppleData[TData]`, `List[int32]`,
+    // `Dictionary[string, int32]`) as a GenericNameExpression. Such an argument
+    // is closed by the nameof `)` rather than by one of the ADR-0020 generic
+    // follow-set markers (`(`, `{`, `.`), so the ordinary postfix parser would
+    // otherwise treat the bracketed type-argument list as an indexer (and a
+    // multi-argument list would not parse at all). When the leading
+    // `Identifier[…]` scans as a type-argument list closed immediately by `)`,
+    // emit a GenericNameExpression so the binder folds it to the unqualified
+    // type name (matching C# `nameof(List<int>)` -> "List").
+    private ExpressionSyntax ParseNameOfArgument()
+    {
+        if (Current.Kind == SyntaxKind.IdentifierToken
+            && Peek(1).Kind == SyntaxKind.OpenSquareBracketToken
+            && NameOfGenericArgumentScansToCloseParen(1))
+        {
+            var identifier = MatchToken(SyntaxKind.IdentifierToken);
+            var typeArguments = ParseTypeArgumentList();
+            return new GenericNameExpressionSyntax(syntaxTree, identifier, typeArguments);
+        }
+
+        return ParseExpression();
+    }
+
+    // Issue #1329: bounded-lookahead test for a generic-type nameof argument.
+    // Like <see cref="LooksLikeGenericCallSite"/>, but the accepted follow-set
+    // marker after the matching `]` is the nameof closing `)` (any arity).
+    private bool NameOfGenericArgumentScansToCloseParen(int bracketOffset)
+    {
+        if (Peek(bracketOffset).Kind != SyntaxKind.OpenSquareBracketToken)
+        {
+            return false;
+        }
+
+        var pos = bracketOffset + 1;
+        if (Peek(pos).Kind == SyntaxKind.CloseSquareBracketToken)
+        {
+            return false;
+        }
+
+        while (true)
+        {
+            if (!TryScanTypeClause(ref pos))
+            {
+                return false;
+            }
+
+            if (Peek(pos).Kind == SyntaxKind.CommaToken)
+            {
+                pos++;
+                continue;
+            }
+
+            if (Peek(pos).Kind == SyntaxKind.CloseSquareBracketToken)
+            {
+                pos++;
+                break;
+            }
+
+            return false;
+        }
+
+        return Peek(pos).Kind == SyntaxKind.CloseParenthesisToken;
     }
 
     // Phase 4.9: Kotlin-style trailing-lambda call syntax. When a call's

--- a/test/Compiler.Tests/Emit/Issue1329NameofGenericTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1329NameofGenericTests.cs
@@ -1,0 +1,180 @@
+// <copyright file="Issue1329NameofGenericTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1329: <c>nameof(...)</c> accepts a constructed/generic type argument
+/// and folds to the unqualified type name as a compile-time constant string,
+/// with the type arguments dropped — matching C# (<c>nameof(List&lt;int&gt;)</c>
+/// → <c>"List"</c>). These tests compile and run emitted programs and assert the
+/// printed bare type names, covering:
+/// <list type="bullet">
+/// <item><description>a generic over a concrete type (<c>List[int32]</c>).</description></item>
+/// <item><description>a generic over a type parameter (<c>IAppleData[TData]</c>).</description></item>
+/// <item><description>a multi-argument generic (<c>Dictionary[string, int32]</c>).</description></item>
+/// <item><description>a nested generic argument (<c>List[List[int32]]</c>).</description></item>
+/// <item><description>regression: the bare-name and member-access forms still work.</description></item>
+/// </list>
+/// </summary>
+public class Issue1329NameofGenericTests
+{
+    [Fact]
+    public void GenericOverConcreteType_YieldsBareName()
+    {
+        var source = """
+            package P
+            import System
+
+            class List[T] {}
+
+            Console.WriteLine(nameof(List[int32]))
+            """;
+
+        Assert.Equal("List\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void GenericOverTypeParameter_YieldsBareName()
+    {
+        var source = """
+            package P
+            import System
+
+            interface IAppleData[TData] {}
+
+            class C {
+                func F[TData](x TData) string -> nameof(IAppleData[TData])
+            }
+
+            Console.WriteLine(C().F(5))
+            """;
+
+        Assert.Equal("IAppleData\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void MultiArgGeneric_YieldsBareName()
+    {
+        var source = """
+            package P
+            import System
+
+            class Dictionary[K, V] {}
+
+            Console.WriteLine(nameof(Dictionary[string, int32]))
+            """;
+
+        Assert.Equal("Dictionary\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void NestedGeneric_YieldsOuterBareName()
+    {
+        var source = """
+            package P
+            import System
+
+            class List[T] {}
+
+            Console.WriteLine(nameof(List[List[int32]]))
+            """;
+
+        Assert.Equal("List\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void BareNameAndMemberAccess_StillWork()
+    {
+        // Regression: the existing accepted forms (plain identifier and member
+        // access) keep their behaviour alongside the new generic form.
+        var source = """
+            package P
+            import System
+
+            class List[T] {}
+
+            Console.WriteLine(nameof(List))
+            Console.WriteLine(nameof(Console.WriteLine))
+            """;
+
+        Assert.Equal("List\nWriteLine\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1329_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi);
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/TypeOfNameOfTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/TypeOfNameOfTests.cs
@@ -122,6 +122,51 @@ var n = nameof(Console.WriteLine(""hi""))
         Assert.Contains(diagnostics, d => d.Id == "GS0190");
     }
 
+    [Fact]
+    public void NameOf_Generic_Type_Returns_Unqualified_Name()
+    {
+        // Issue #1329: nameof of a constructed-generic type yields the bare
+        // type name with the type arguments dropped (C# nameof(List<int>) -> "List").
+        var (eval, vars) = EvaluateWithVariables(@"
+var n = nameof(List[int32])
+");
+        Assert.Empty(eval.Diagnostics);
+        Assert.Equal("List", vars["n"]);
+    }
+
+    [Fact]
+    public void NameOf_MultiArg_Generic_Type_Returns_Unqualified_Name()
+    {
+        // Issue #1329: a multi-type-argument generic is accepted and folds to
+        // the bare type name (C# nameof(Dictionary<string, int>) -> "Dictionary").
+        var (eval, vars) = EvaluateWithVariables(@"
+var n = nameof(Dictionary[string, int32])
+");
+        Assert.Empty(eval.Diagnostics);
+        Assert.Equal("Dictionary", vars["n"]);
+    }
+
+    [Fact]
+    public void NameOf_Nested_Generic_Type_Returns_Unqualified_Name()
+    {
+        // Issue #1329: a nested generic type argument is accepted and folds to
+        // the outer type's bare name (C# nameof(List<List<int>>) -> "List").
+        var (eval, vars) = EvaluateWithVariables(@"
+var n = nameof(List[List[int32]])
+");
+        Assert.Empty(eval.Diagnostics);
+        Assert.Equal("List", vars["n"]);
+    }
+
+    [Fact]
+    public void NameOf_Generic_Type_Result_Type_Is_String()
+    {
+        var tree = SyntaxTree.Parse(SourceText.From("var n = nameof(List[int32])\n"));
+        var compilation = new Compilation(tree);
+        var variable = FindVariable(compilation, "n");
+        Assert.Same(TypeSymbol.String, variable.Type);
+    }
+
     private static VariableSymbol FindVariable(Compilation compilation, string name)
     {
         foreach (var symbol in compilation.GlobalScope.Variables)


### PR DESCRIPTION
## Summary
`nameof(...)` rejected a constructed/generic type argument with `GS0190` ("The argument to 'nameof' must be a name reference"). In C#, `nameof` of a generic type is legal and evaluates to the **unqualified type name** as a compile-time constant string, with the type arguments dropped (`nameof(List<int>)` → `"List"`). G# now matches this.

## Root cause
A constructed-generic type used as the `nameof` argument is closed by the `nameof` `)` rather than one of the ADR-0020 generic follow-set markers (`(`, `{`, `.`). The general-expression parser therefore treated the bracketed type-argument list as an indexer (`IndexExpressionSyntax`), and a multi-argument list (`Dictionary[string, int32]`) did not parse at all — so the binder rejected the argument with `GS0190`.

## Fix
- **Parser** (`Parser.cs`): parse the `nameof` argument specially via `ParseNameOfArgument`. When the leading `Identifier[...]` scans as a type-argument list closed immediately by `)`, emit a `GenericNameExpression` (the node introduced for issue #1323) rather than an indexer. Handles any arity, including nested generics.
- **Binder** (`ExpressionBinder.Literals.cs`): `TryExtractNameOfName` now accepts `GenericNameExpressionSyntax`, folding it to the unqualified type name (the identifier text, type arguments dropped).

The existing accepted forms (plain identifier, member access, simple type) are unchanged, and genuinely invalid arguments (literals like `nameof(123)`, arbitrary calls like `nameof(Console.WriteLine("hi"))`) still report `GS0190`.

## Tests
- `TypeOfNameOfTests` (binder/evaluator): generic-over-concrete, multi-arg, nested generic, and result-type-is-string.
- `Issue1329NameofGenericTests` (end-to-end emit/execution): concrete (`List[int32]`), type-parameter (`IAppleData[TData]`), multi-arg (`Dictionary[string, int32]`), nested (`List[List[int32]]`), plus bare-name and member-access regressions.

All Core.Tests (4696) pass; filtered Compiler.Tests nameof/#1323/#693 slices pass.

Fixes #1329
Refs #914
