### PR TITLE
Fix #1330: resolve GenericType[TypeParam].StaticMember for type-parameter type args

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundClrPropertyAccessExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundClrPropertyAccessExpression.cs
@@ -20,17 +20,30 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// </summary>
 public sealed class BoundClrPropertyAccessExpression : BoundExpression
 {
-    public BoundClrPropertyAccessExpression(SyntaxNode syntax, BoundExpression receiver, MemberInfo member, TypeSymbol resultType)
+    public BoundClrPropertyAccessExpression(SyntaxNode syntax, BoundExpression receiver, MemberInfo member, TypeSymbol resultType, TypeSymbol staticContainerType = null)
         : base(syntax)
     {
         Receiver = receiver;
         Member = member;
         Type = resultType;
+        StaticContainerType = staticContainerType;
     }
 
     public BoundExpression Receiver { get; }
 
     public MemberInfo Member { get; }
+
+    /// <summary>
+    /// Gets, for a static member read on a generic type constructed over
+    /// an in-scope generic type parameter (e.g. <c>Comparer[TResult].Default</c>),
+    /// the symbolic constructed container (an <see cref="ImportedTypeSymbol"/>
+    /// over the open definition with symbolic type arguments). The emitter
+    /// parents the static getter/field reference at this constructed TypeSpec
+    /// (<c>Comparer&lt;!TResult&gt;</c>) instead of the erased
+    /// <c>Comparer&lt;object&gt;</c>. <c>null</c> for an ordinary static or
+    /// instance member access.
+    /// </summary>
+    public TypeSymbol StaticContainerType { get; }
 
     public override TypeSymbol Type { get; }
 

--- a/src/Core/CodeAnalysis/Binding/BoundImportedCallExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundImportedCallExpression.cs
@@ -28,13 +28,20 @@ public sealed class BoundImportedCallExpression : BoundExpression
     /// generic method specification so user-defined type arguments are written as
     /// their own TypeDef token. Default when there are no explicit type arguments.
     /// </param>
-    public BoundImportedCallExpression(SyntaxNode syntax, ImportedFunctionSymbol function, ImmutableArray<BoundExpression> arguments, ImmutableArray<RefKind> argumentRefKinds = default, ImmutableArray<TypeSymbol> typeArgumentSymbols = default)
+    /// <param name="staticContainerType">
+    /// Issue #1330: the symbolic constructed container for a static call on a
+    /// generic type constructed over an in-scope generic type parameter (e.g.
+    /// <c>Comparer[TResult].Create(...)</c>), used by the emitter to parent the
+    /// call at the constructed generic TypeSpec. Default for an ordinary call.
+    /// </param>
+    public BoundImportedCallExpression(SyntaxNode syntax, ImportedFunctionSymbol function, ImmutableArray<BoundExpression> arguments, ImmutableArray<RefKind> argumentRefKinds = default, ImmutableArray<TypeSymbol> typeArgumentSymbols = default, TypeSymbol staticContainerType = null)
         : base(syntax)
     {
         Function = function;
         Arguments = arguments;
         ArgumentRefKinds = argumentRefKinds.IsDefault ? default : argumentRefKinds;
         TypeArgumentSymbols = typeArgumentSymbols.IsDefault ? default : typeArgumentSymbols;
+        StaticContainerType = staticContainerType;
     }
 
     /// <inheritdoc/>
@@ -64,4 +71,15 @@ public sealed class BoundImportedCallExpression : BoundExpression
     /// method (issue #320). Default when there are no explicit type arguments.
     /// </summary>
     public ImmutableArray<TypeSymbol> TypeArgumentSymbols { get; }
+
+    /// <summary>
+    /// Gets the symbolic constructed container (#1330) for a static call on a
+    /// generic type constructed over an in-scope generic type parameter (e.g.
+    /// <c>Comparer[TResult].Create(...)</c>). An <see cref="ImportedTypeSymbol"/>
+    /// over the open definition with symbolic type arguments; the emitter parents
+    /// the static call at this constructed <c>Comparer&lt;!TResult&gt;</c>
+    /// TypeSpec instead of the type-erased <c>Comparer&lt;object&gt;</c>.
+    /// <c>null</c> for an ordinary imported call.
+    /// </summary>
+    public TypeSymbol StaticContainerType { get; }
 }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -1852,11 +1852,20 @@ internal sealed partial class ExpressionBinder
         var clrArgs = new Type[typeArgs.Length];
         for (var i = 0; i < typeArgs.Length; i++)
         {
-            var clr = NullableTypeSymbol.GetEffectiveClrType(typeArgs[i]);
-            if (clr == null)
-            {
-                return false;
-            }
+            // Issue #1330 (#313 / #671): an in-scope generic type-parameter
+            // argument (`Comparer[TResult].Create(...)`, `Comparer[U].Default`)
+            // — or any other symbolic type that has no CLR type yet (a
+            // not-yet-emitted user type) — has no concrete System.Type to close
+            // the imported generic over. Mirror ConstructIfGeneric's type-erased
+            // generic model and project such an argument onto System.Object for
+            // the closed CLR shape, so the constructed-generic *type* receiver is
+            // well formed and static-member access / static calls resolve. This
+            // keeps the type-parameter receiver consistent with how the same
+            // `Comparer[TResult]` shape binds in type-clause position.
+            var clr = TypeSymbol.ContainsTypeParameter(typeArgs[i])
+                ? typeof(object)
+                : NullableTypeSymbol.GetEffectiveClrType(typeArgs[i]);
+            clr ??= typeof(object);
 
             // Project the host CLR type argument onto the resolver's reference
             // set so it shares the open type's load context (its
@@ -1868,7 +1877,21 @@ internal sealed partial class ExpressionBinder
         try
         {
             var closed = openClrType.MakeGenericType(clrArgs);
-            constructedImported = new ImportedClassSymbol(closed, receiverSyntax);
+
+            // Issue #1330: when any type argument is symbolic (an in-scope
+            // generic type parameter, or a user type with no CLR type yet), the
+            // closed CLR shape above is type-erased to `object`. Carry the
+            // symbolic constructed view alongside it so static-member access and
+            // static calls recover symbolic member/return types
+            // (`Comparer[TResult].Default : Comparer[TResult]`) and the emitter
+            // parents the static member reference at the constructed
+            // `Comparer<!TResult>` TypeSpec instead of the erased
+            // `Comparer<object>` — yielding verifiable IL exactly as the
+            // concrete-argument receiver does.
+            var symbolicReceiver = typeArgs.Any(static a => TypeSymbol.ContainsTypeParameter(a) || a.ClrType == null)
+                ? ImportedTypeSymbol.GetConstructed(closed, openClrType, typeArgs)
+                : null;
+            constructedImported = new ImportedClassSymbol(closed, receiverSyntax, symbolicReceiver);
             return true;
         }
         catch (ArgumentException)
@@ -2533,6 +2556,27 @@ internal sealed partial class ExpressionBinder
                         FieldInfo sf => TypeSymbol.FromClrType(sf.FieldType),
                         _ => TypeSymbol.Error,
                     };
+
+                    // Issue #1330: when the receiver is a generic type
+                    // constructed over an in-scope generic type parameter
+                    // (`Comparer[TResult].Default`), the closed CLR member type
+                    // is type-erased (`Comparer<object>`). Recover the symbolic
+                    // member type (`Comparer[TResult]`) by substituting the
+                    // receiver's symbolic arguments through the open member, and
+                    // carry the symbolic container so the emitter parents the
+                    // static read at the constructed `Comparer<!TResult>`
+                    // TypeSpec rather than the erased `Comparer<object>`.
+                    if (classSymbol.SymbolicReceiver != null)
+                    {
+                        var symbolicMemberType = ResolveStaticMemberTypeFromSymbolicReceiver(classSymbol.SymbolicReceiver, staticMember);
+                        if (symbolicMemberType != null)
+                        {
+                            staticType = symbolicMemberType;
+                        }
+
+                        return new BoundClrPropertyAccessExpression(null, null, staticMember, staticType, classSymbol.SymbolicReceiver);
+                    }
+
                     return new BoundClrPropertyAccessExpression(null, null, staticMember, staticType);
                 }
                 else if (receiver != null && receiver.Type is StructSymbol structSym)
@@ -3784,6 +3828,53 @@ internal sealed partial class ExpressionBinder
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// Issue #1330: recover the symbolic type of a static member read on a
+    /// generic type constructed over an in-scope generic type parameter (e.g.
+    /// <c>Comparer[TResult].Default</c>). The receiver's closed CLR shape is
+    /// type-erased (<c>Comparer&lt;object&gt;</c>), so reflection reports the
+    /// member's open type closed over <c>object</c>. Walk the open member on the
+    /// receiver's <see cref="ImportedTypeSymbol.OpenDefinition"/> and project its
+    /// type using the receiver's symbolic <see cref="ImportedTypeSymbol.TypeArguments"/>.
+    /// Returns <see langword="null"/> when no substitution applies.
+    /// </summary>
+    private static TypeSymbol ResolveStaticMemberTypeFromSymbolicReceiver(ImportedTypeSymbol symbolicReceiver, MemberInfo closedMember)
+    {
+        if (symbolicReceiver?.OpenDefinition == null
+            || symbolicReceiver.TypeArguments.IsDefaultOrEmpty
+            || closedMember == null)
+        {
+            return null;
+        }
+
+        try
+        {
+            const BindingFlags staticFlags = BindingFlags.Public | BindingFlags.Static;
+            Type openMemberType = closedMember switch
+            {
+                PropertyInfo => ClrTypeUtilities.SafeGetProperty(symbolicReceiver.OpenDefinition, closedMember.Name, staticFlags)?.PropertyType,
+                FieldInfo => symbolicReceiver.OpenDefinition.GetField(closedMember.Name, staticFlags)?.FieldType,
+                _ => null,
+            };
+            if (openMemberType == null)
+            {
+                return null;
+            }
+
+            var mapped = MemberLookup.MapOpenClrTypeToSymbolic(openMemberType, symbolicReceiver.OpenDefinition, symbolicReceiver.TypeArguments);
+            return TypeSymbol.ContainsTypeParameter(mapped)
+                || TypeSymbol.IsSameCompilationUserTypeTopLevel(mapped)
+                || openMemberType.IsGenericParameter
+                || openMemberType.IsGenericType
+                ? mapped
+                : null;
+        }
+        catch (System.Reflection.AmbiguousMatchException)
+        {
+            return null;
+        }
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -1534,6 +1534,180 @@ internal sealed partial class ExpressionBinder
         }
     }
 
+    /// <summary>
+    /// Issue #1330: binds a static method call on a generic type constructed
+    /// over an in-scope generic type parameter (e.g.
+    /// <c>Comparer[TResult].Create(...)</c>) by substituting the receiver's
+    /// symbolic type arguments through the resolved method's open parameter and
+    /// return types. A delegate parameter surfaces as its symbolic shape
+    /// (<c>Comparison[TResult]</c>) so a function-literal argument flows through
+    /// as an identity adapter hosted in the enclosing generic context rather than
+    /// a type-erased <c>&lt;object&gt;</c> adapter referencing an out-of-scope
+    /// type parameter; the result is the symbolic <c>Comparer[TResult]</c>; and
+    /// the produced <see cref="BoundImportedCallExpression"/> carries the
+    /// symbolic container so the emitter parents the call at the constructed
+    /// <c>Comparer&lt;!TResult&gt;</c> TypeSpec. Returns <see langword="false"/>
+    /// (deferring to the ordinary erased path) when the symbolic open method or a
+    /// parameter projection cannot be recovered.
+    /// </summary>
+    private bool TryBindSymbolicImportedStaticCall(
+        CallExpressionSyntax ce,
+        ImportedClassSymbol classSymbol,
+        ImportedFunctionSymbol staticFn,
+        ImmutableArray<BoundExpression> arguments,
+        out BoundExpression result)
+    {
+        result = null;
+        var symbolicReceiver = classSymbol.SymbolicReceiver;
+        if (symbolicReceiver?.OpenDefinition == null
+            || symbolicReceiver.TypeArguments.IsDefaultOrEmpty
+            || !TryResolveOpenStaticMethod(symbolicReceiver.OpenDefinition, staticFn.Method, out var openMethod))
+        {
+            return false;
+        }
+
+        var openParameters = openMethod.GetParameters();
+        if (openParameters.Length != arguments.Length)
+        {
+            // Optional/params/defaulted parameter shapes are not handled by this
+            // narrow symbolic path; fall back to the ordinary resolution.
+            return false;
+        }
+
+        var openDef = symbolicReceiver.OpenDefinition;
+        var symbolicArgs = symbolicReceiver.TypeArguments;
+        var convertedArgs = ImmutableArray.CreateBuilder<BoundExpression>(arguments.Length);
+        for (var i = 0; i < arguments.Length; i++)
+        {
+            var argument = arguments[i];
+            var openParamType = openParameters[i].ParameterType;
+            var symbolicParamType = MemberLookup.MapOpenClrTypeToSymbolic(openParamType, openDef, symbolicArgs);
+
+            if (LambdaBinder.TryGetFunctionLiteral(argument, out var functionLiteral)
+                && symbolicParamType is ImportedTypeSymbol symbolicDelegateParam
+                && symbolicDelegateParam.OpenDefinition != null
+                && symbolicDelegateParam.HasTypeParameterArgument
+                && TryBuildSymbolicDelegateTarget(openParamType, openDef, symbolicArgs, out var symbolicDelegateTarget))
+            {
+                // The substituted delegate target matches the literal's declared
+                // (TResult-typed) shape, so the adapter returns the literal
+                // unchanged (IsIdentityAdapter) — the lambda MethodDef is hosted
+                // in the enclosing generic context. Wrap it in a conversion to
+                // the symbolic constructed delegate type (`Comparison[TResult]`)
+                // so the emitter materialises a `Comparison<!TResult>` instance
+                // (rather than the natural `Func<...>` or the type-erased
+                // `Comparison<object>`) that the callee's reified parameter
+                // accepts. The classifier would reject this (the erased
+                // `Comparison<object>` Invoke shape differs from the TResult
+                // literal), so build the conversion node directly.
+                var adapter = lambdas.CreateErasedFunctionLiteralAdapter(functionLiteral, symbolicDelegateTarget);
+                convertedArgs.Add(new BoundConversionExpression(null, symbolicDelegateParam, adapter));
+                continue;
+            }
+
+            if (symbolicParamType is TypeParameterSymbol || symbolicParamType == TypeSymbol.Error)
+            {
+                convertedArgs.Add(argument);
+                continue;
+            }
+
+            var argLoc = i < ce.Arguments.Count ? ce.Arguments[i].Location : ce.Location;
+            convertedArgs.Add(conversions.BindConversion(argLoc, argument, symbolicParamType));
+        }
+
+        var symbolicReturn = MemberLookup.MapOpenClrTypeToSymbolic(openMethod.ReturnType, openDef, symbolicArgs);
+        var overriddenFn = new ImportedFunctionSymbol(
+            staticFn.Name,
+            classSymbol,
+            staticFn.Method,
+            staticFn.Declaration,
+            returnTypeOverride: symbolicReturn);
+        var refKinds = ComputeArgumentRefKinds(staticFn.Method.GetParameters());
+        result = new BoundImportedCallExpression(
+            null,
+            overriddenFn,
+            convertedArgs.MoveToImmutable(),
+            refKinds,
+            typeArgumentSymbols: default,
+            staticContainerType: symbolicReceiver);
+        return true;
+    }
+
+    /// <summary>
+    /// Issue #1330: resolves the open generic <em>type</em> definition's method
+    /// corresponding to <paramref name="closedMethod"/> (a static method on the
+    /// type-erased closed shape, e.g. <c>Comparer&lt;object&gt;.Create</c>) by
+    /// metadata-token identity, yielding e.g. <c>Comparer&lt;&gt;.Create</c>
+    /// whose parameter/return types are stated in terms of the type's open
+    /// generic parameters.
+    /// </summary>
+    private static bool TryResolveOpenStaticMethod(Type openDefinition, MethodInfo closedMethod, out MethodInfo openMethod)
+    {
+        openMethod = null;
+        if (openDefinition == null || closedMethod == null)
+        {
+            return false;
+        }
+
+        try
+        {
+            foreach (var candidate in openDefinition.GetMethods(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic))
+            {
+                if (candidate.MetadataToken == closedMethod.MetadataToken && candidate.Module == closedMethod.Module)
+                {
+                    openMethod = candidate;
+                    return true;
+                }
+            }
+        }
+        catch (Exception ex) when (ClrTypeUtilities.IsMetadataLoadFailure(ex))
+        {
+            return false;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Issue #1330: builds a <see cref="FunctionTypeSymbol"/> for an open
+    /// delegate parameter type (e.g. <c>Comparison&lt;T&gt;</c>) by substituting
+    /// the receiver's symbolic type arguments into the delegate's
+    /// <c>Invoke</c> signature, producing the symbolic target
+    /// <c>(TResult, TResult) -&gt; int32</c>. Returns <see langword="false"/> when
+    /// the parameter is not a delegate type.
+    /// </summary>
+    private static bool TryBuildSymbolicDelegateTarget(
+        Type openParameterType,
+        Type openDefinition,
+        ImmutableArray<TypeSymbol> symbolicArgs,
+        out FunctionTypeSymbol target)
+    {
+        target = null;
+        if (openParameterType == null)
+        {
+            return false;
+        }
+
+        var invoke = openParameterType.GetMethod("Invoke");
+        if (invoke == null)
+        {
+            return false;
+        }
+
+        var invokeParameters = invoke.GetParameters();
+        var parameterTypes = ImmutableArray.CreateBuilder<TypeSymbol>(invokeParameters.Length);
+        foreach (var parameter in invokeParameters)
+        {
+            parameterTypes.Add(MemberLookup.MapOpenClrTypeToSymbolic(parameter.ParameterType, openDefinition, symbolicArgs));
+        }
+
+        var returnType = invoke.ReturnType.IsSameAs(typeof(void))
+            ? TypeSymbol.Void
+            : MemberLookup.MapOpenClrTypeToSymbolic(invoke.ReturnType, openDefinition, symbolicArgs);
+        target = FunctionTypeSymbol.Get(parameterTypes.ToImmutable(), returnType);
+        return true;
+    }
+
     private void ResolveDeferredArrowLambdaArguments(
         BoundExpression receiver,
         ImportedClassSymbol classSymbol,
@@ -2400,6 +2574,27 @@ internal sealed partial class ExpressionBinder
         {
             if (classSymbol.TryLookupFunction(methodName, ce, arguments, out var staticFn, out var staticMapping, out var staticAmbiguous, out var staticAmbiguousMethods, out var staticIsExpanded, explicitTypeArgs, typeArgSymbols, scope.References.MapClrTypeToReferences, argumentNames.IsDefault ? null : (IReadOnlyList<string>)argumentNames))
             {
+                // Issue #1330: when the receiver is a generic type constructed
+                // over an in-scope generic type parameter (`Comparer[TResult]`),
+                // bind the static call symbolically — substituting the receiver's
+                // symbolic arguments through the resolved method's parameter and
+                // return types — so a delegate parameter surfaces as
+                // `Comparison[TResult]` (the lambda flows through as an identity
+                // adapter hosted in the enclosing generic context rather than a
+                // type-erased `<object>` adapter referencing an out-of-scope
+                // type parameter), the call's result type is the symbolic
+                // `Comparer[TResult]`, and the emitter parents the call at the
+                // constructed `Comparer<!TResult>` TypeSpec. Yields verifiable IL
+                // exactly as the concrete-argument receiver does.
+                if (classSymbol.SymbolicReceiver != null
+                    && argumentNames.IsDefault
+                    && !staticIsExpanded
+                    && staticMapping.IsDefault
+                    && TryBindSymbolicImportedStaticCall(ce, classSymbol, staticFn, arguments, out var symbolicStaticCall))
+                {
+                    return symbolicStaticCall;
+                }
+
                 var staticParameters = staticFn.Method.GetParameters();
                 var staticExpandedArgs = staticIsExpanded
                     ? overloads.ExpandParamsArguments(arguments, staticParameters, ce, parameterMapping: staticMapping)

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Closures.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Closures.cs
@@ -378,6 +378,11 @@ internal sealed partial class MethodBodyEmitter
 
     private void EmitFunctionLiteral(BoundFunctionLiteralExpression literal, Type overrideDelegateType)
     {
+        this.EmitFunctionLiteral(literal, overrideDelegateType, symbolicDelegateCtorRef: null);
+    }
+
+    private void EmitFunctionLiteral(BoundFunctionLiteralExpression literal, Type overrideDelegateType, EntityHandle? symbolicDelegateCtorRef)
+    {
         if (this.outer.closures.ClosureInfos.TryGetValue(literal, out var closure))
         {
             // Capture-bearing literal: instantiate the closure class,
@@ -437,7 +442,11 @@ internal sealed partial class MethodBodyEmitter
             // reflect over. Use a MemberRef parented at the reified
             // `Func<...>` / `Action<...>` TypeSpec instead — the .ctor
             // signature is the canonical `(object, IntPtr)`.
-            if (overrideDelegateType == null && literal.FunctionType.ClrType == null)
+            if (symbolicDelegateCtorRef.HasValue)
+            {
+                this.il.Token(symbolicDelegateCtorRef.Value);
+            }
+            else if (overrideDelegateType == null && literal.FunctionType.ClrType == null)
             {
                 this.il.Token(this.outer.GetFunctionDelegateCtorRef(literal.FunctionType));
             }
@@ -470,7 +479,11 @@ internal sealed partial class MethodBodyEmitter
 
         // ADR-0087 §3 R6: see capture-bearing branch above — reified
         // ctor MemberRef when the function shape is type-parameter-bearing.
-        if (overrideDelegateType == null && literal.FunctionType.ClrType == null)
+        if (symbolicDelegateCtorRef.HasValue)
+        {
+            this.il.Token(symbolicDelegateCtorRef.Value);
+        }
+        else if (overrideDelegateType == null && literal.FunctionType.ClrType == null)
         {
             this.il.Token(this.outer.GetFunctionDelegateCtorRef(literal.FunctionType));
         }

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
@@ -49,6 +49,27 @@ internal sealed partial class MethodBodyEmitter
             return;
         }
 
+        // Issue #1330: a function literal converted to a delegate type closed
+        // over an in-scope generic type parameter (e.g. `Comparison[TResult]`,
+        // the parameter of `Comparer[TResult].Create(...)`). The target has no
+        // usable ClrType (it is the type-erased `Comparison<object>`), so the
+        // general CLR-delegate path below cannot reach the constructed shape.
+        // Materialise the delegate with a `.ctor` MemberRef parented at the
+        // constructed `Comparison<!TResult>` TypeSpec so the runtime instance
+        // matches the callee's reified parameter.
+        if (conv.Expression is BoundFunctionLiteralExpression constructedDelegateLiteral
+            && conv.Type is ImportedTypeSymbol constructedDelegateTarget
+            && constructedDelegateTarget.OpenDefinition != null
+            && constructedDelegateTarget.HasTypeParameterArgument
+            && ClrTypeUtilities.IsDelegateType(constructedDelegateTarget.ClrType))
+        {
+            this.EmitFunctionLiteral(
+                constructedDelegateLiteral,
+                overrideDelegateType: null,
+                symbolicDelegateCtorRef: this.outer.GetConstructedDelegateCtorRef(constructedDelegateTarget));
+            return;
+        }
+
         // ADR-0059 / issue #255: GSharp function value → user-declared
         // named delegate type. The named delegate has no ClrType (its
         // TypeDef only exists in the assembly being emitted), so the

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
@@ -172,6 +172,21 @@ internal sealed partial class MethodBodyEmitter
                 break;
             case BoundImportedCallExpression impCall:
                 this.EmitImportedCallArguments(impCall.Arguments, impCall.ArgumentRefKinds);
+
+                // Issue #1330: a static call on a generic type constructed over
+                // an in-scope generic type parameter (`Comparer[TResult].Create`)
+                // must be referenced through a MemberRef parented at the
+                // constructed `Comparer<!TResult>` TypeSpec — the symbolic
+                // container — rather than the type-erased `Comparer<object>`. The
+                // call then leaves the symbolic return (`Comparer<!TResult>`) on
+                // the stack, so skip the erased widening exactly as the symbolic
+                // instance/extension paths do.
+                if (impCall.StaticContainerType != null)
+                {
+                    this.il.Call(this.outer.GetMethodEntityHandle(impCall.Function.Method, impCall.StaticContainerType));
+                    break;
+                }
+
                 this.il.Call(this.outer.GetMethodEntityHandle(impCall.Function.Method, impCall.TypeArgumentSymbols));
 
                 // Issue #903: when this generic imported (extension) call was

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
@@ -855,10 +855,23 @@ internal sealed partial class MethodBodyEmitter
                 // List<object>. Static getters and CLR receivers fall back
                 // to the plain MemberRef path inside the overload.
                 var getterRef = isStatic
-                    ? (EntityHandle)this.outer.GetMethodReference(getter)
+                    ? (access.StaticContainerType != null
+                        ? this.outer.GetMethodEntityHandle(getter, access.StaticContainerType)
+                        : (EntityHandle)this.outer.GetMethodReference(getter))
                     : this.outer.GetMethodEntityHandle(getter, access.Receiver.Type);
                 this.il.OpCode(isStatic || receiverIsValueType ? ILOpCode.Call : ILOpCode.Callvirt);
                 this.il.Token(getterRef);
+
+                // Issue #1330: when the static read is parented at a symbolic
+                // constructed container (`Comparer[TResult].Default`), the
+                // MemberRef encodes the call against the open generic property,
+                // so the runtime stack value is the substituted symbolic type
+                // (`Comparer<!TResult>`), not the erased `object`. Skip widening
+                // exactly as the instance symbolic-container path does below.
+                if (isStatic && access.StaticContainerType != null)
+                {
+                    break;
+                }
 
                 // Issue #774: when the receiver is a symbolic open container,
                 // the symbolic MemberRef encodes the call against the open

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -9518,6 +9518,39 @@ internal sealed class ReflectionMetadataEmitter
     }
 
     /// <summary>
+    /// Issue #1330: returns the MemberRef handle for the canonical delegate
+    /// <c>.ctor(object, IntPtr)</c> parented at the constructed-generic TypeSpec
+    /// of <paramref name="symbolicDelegate"/> — a delegate type closed over an
+    /// in-scope generic type parameter (e.g. <c>Comparison&lt;!TResult&gt;</c>).
+    /// Lets a function literal passed to a static generic factory
+    /// (<c>Comparer[TResult].Create(...)</c>) materialise the exact delegate the
+    /// callee expects rather than the natural <c>Func</c>/<c>Action</c> shape or
+    /// the type-erased <c>Comparison&lt;object&gt;</c>.
+    /// </summary>
+    internal EntityHandle GetConstructedDelegateCtorRef(ImportedTypeSymbol symbolicDelegate)
+    {
+        var parentBlob = new BlobBuilder();
+        this.EncodeTypeSymbol(new BlobEncoder(parentBlob).TypeSpecificationSignature(), symbolicDelegate);
+        var parent = this.emitCtx.Metadata.AddTypeSpecification(this.emitCtx.Metadata.GetOrAddBlob(parentBlob));
+
+        var sigBlob = new BlobBuilder();
+        new BlobEncoder(sigBlob).MethodSignature(isInstanceMethod: true)
+            .Parameters(
+                2,
+                returnType: r => r.Void(),
+                parameters: ps =>
+                {
+                    ps.AddParameter().Type().Object();
+                    ps.AddParameter().Type().IntPtr();
+                });
+
+        return this.emitCtx.Metadata.AddMemberReference(
+            parent: parent,
+            name: this.emitCtx.Metadata.GetOrAddString(".ctor"),
+            signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
+    }
+
+    /// <summary>
     /// ADR-0087 §3 R6: returns the MemberRef handle for the reified
     /// delegate's <c>.ctor(object, IntPtr)</c>, parented at the
     /// <c>TypeSpec</c> for <paramref name="fnType"/>. Used by

--- a/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
@@ -22,11 +22,22 @@ public sealed class ImportedClassSymbol : Symbol
     /// </summary>
     /// <param name="type">The imported class type.</param>
     /// <param name="declaration">The imported class declaration.</param>
-    public ImportedClassSymbol(Type type, ExpressionSyntax declaration)
+    /// <param name="symbolicReceiver">
+    /// Issue #1330: when this imported class is the type-erased closed form of a
+    /// generic type constructed over an in-scope generic type parameter — e.g.
+    /// the <c>Comparer&lt;object&gt;</c> backing a <c>Comparer[TResult]</c>
+    /// static-member receiver — the symbolic constructed view (open definition +
+    /// symbolic type arguments) used to recover symbolic member/return types and
+    /// to emit static member references parented at the constructed
+    /// <c>Comparer&lt;!TResult&gt;</c> TypeSpec rather than the erased
+    /// <c>Comparer&lt;object&gt;</c>. <c>null</c> for an ordinary imported class.
+    /// </param>
+    public ImportedClassSymbol(Type type, ExpressionSyntax declaration, ImportedTypeSymbol symbolicReceiver = null)
         : base(type.FullName)
     {
         ClassType = type;
         Declaration = declaration;
+        SymbolicReceiver = symbolicReceiver;
     }
 
     /// <inheritdoc/>
@@ -36,6 +47,16 @@ public sealed class ImportedClassSymbol : Symbol
     /// Gets the imported class type.
     /// </summary>
     public Type ClassType { get; }
+
+    /// <summary>
+    /// Gets the symbolic constructed view of this receiver (#1330) when it
+    /// is a generic type closed over an in-scope generic type parameter (e.g.
+    /// <c>Comparer[TResult]</c>), or <c>null</c> for an ordinary imported class.
+    /// Carries the open CLR definition and the symbolic type arguments so static
+    /// member access recovers symbolic member types and the emitter parents
+    /// static member references at the constructed generic TypeSpec.
+    /// </summary>
+    public ImportedTypeSymbol SymbolicReceiver { get; }
 
     /// <summary>
     /// Gets the imported class declaration.

--- a/test/Compiler.Tests/Emit/Issue1330GenericStaticTypeParamTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1330GenericStaticTypeParamTests.cs
@@ -1,0 +1,246 @@
+// <copyright file="Issue1330GenericStaticTypeParamTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1330: a generic static member-access receiver
+/// <c>GenericType[TypeArg].StaticMember(...)</c> failed with
+/// <c>GS0125: Variable '...' doesn't exist</c> when <c>TypeArg</c> was an
+/// in-scope generic <em>type parameter</em> (e.g. <c>Comparer[TResult].Default</c>
+/// inside <c>class C[TResult]</c>), even though the identical receiver with a
+/// <em>concrete</em> type argument (<c>Comparer[int32].Default</c>) bound and
+/// executed cleanly. This residual of #1323 arose because a single simple-name
+/// type argument is parsed as an index expression, and the binder's
+/// index-then-member fallback only closed the imported generic receiver for a
+/// concrete argument — a type-parameter argument has no concrete CLR type, so
+/// resolution fell through to binding the receiver name as a (non-existent)
+/// variable.
+///
+/// The fix carries the symbolic constructed receiver
+/// (<c>Comparer&lt;!TResult&gt;</c>) alongside the type-erased closed CLR shape
+/// (<c>Comparer&lt;object&gt;</c>) so that (a) static member access resolves,
+/// (b) the member's result type is the symbolic <c>Comparer[TResult]</c> rather
+/// than the erased <c>object</c>, and (c) the emitter parents the static member
+/// reference at the constructed <c>Comparer&lt;!TResult&gt;</c> TypeSpec —
+/// producing verifiable IL exactly as the concrete-argument receiver does.
+/// </summary>
+public class Issue1330GenericStaticTypeParamTests
+{
+    /// <summary>
+    /// The headline case: a static property read on a generic type closed over
+    /// an in-scope type parameter (<c>Comparer[T].Default</c>) resolves, yields a
+    /// usable <c>Comparer[T]</c>, verifies, and executes — comparing values via
+    /// the recovered comparer.
+    /// </summary>
+    [Fact]
+    public void StaticProperty_OnTypeParameterReceiver_VerifiesAndExecutes()
+    {
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+            class C[T IComparable[T]] {
+                func Compare(x T, y T) int32 {
+                    var cmp = Comparer[T].Default
+                    return cmp.Compare(x, y)
+                }
+            }
+            var c = C[int32]{}
+            Console.WriteLine(c.Compare(3, 5))
+            Console.WriteLine(c.Compare(7, 2))
+            Console.WriteLine(c.Compare(4, 4))
+            """;
+
+        Assert.Equal("-1\n1\n0\n", CompileVerifyAndRun(source));
+    }
+
+    /// <summary>
+    /// The same static-property receiver also works for a reference-type
+    /// argument (<c>string</c>), confirming the symbolic receiver is independent
+    /// of the element's value/reference kind.
+    /// </summary>
+    [Fact]
+    public void StaticProperty_OnTypeParameterReceiver_ReferenceElement_Executes()
+    {
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+            class C[T IComparable[T]] {
+                func Sign(x T, y T) int32 {
+                    return Comparer[T].Default.Compare(x, y)
+                }
+            }
+            var c = C[string]{}
+            Console.WriteLine(c.Sign("apple", "banana"))
+            Console.WriteLine(c.Sign("pear", "pear"))
+            """;
+
+        Assert.Equal("-1\n0\n", CompileVerifyAndRun(source));
+    }
+
+    /// <summary>
+    /// The control: the identical static-property receiver with a CONCRETE type
+    /// argument (<c>Comparer[int32].Default</c>) continues to verify and run.
+    /// </summary>
+    [Fact]
+    public void StaticProperty_OnConcreteReceiver_StillVerifiesAndExecutes()
+    {
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+            class C {
+                func Compare(x int32, y int32) int32 {
+                    return Comparer[int32].Default.Compare(x, y)
+                }
+            }
+            var c = C{}
+            Console.WriteLine(c.Compare(9, 2))
+            """;
+
+        Assert.Equal("1\n", CompileVerifyAndRun(source));
+    }
+
+    /// <summary>
+    /// Issue #1330 root repro: the static factory call
+    /// <c>Comparer[TResult].Create((x, y) -&gt; ...)</c> whose type argument is an
+    /// in-scope generic type parameter now RESOLVES (binds without GS0125 /
+    /// GS0159), exactly like its concrete-argument counterpart. (Full execution
+    /// of a lambda whose parameters are an enclosing type parameter additionally
+    /// depends on generic-lambda hosting, which is tracked separately; this test
+    /// locks the resolution fix that is the subject of #1330.)
+    /// </summary>
+    [Fact]
+    public void StaticFactoryCall_OnTypeParameterReceiver_Resolves()
+    {
+        var source = """
+            package P
+            import System.Collections.Generic
+            class C[TResult IComparable[TResult]] {
+                func F() Comparer[TResult] {
+                    return Comparer[TResult].Create((x TResult, y TResult) -> x.CompareTo(y))
+                }
+            }
+            """;
+
+        // Compiles cleanly (no GS0125 "Variable doesn't exist"): the
+        // type-parameter static receiver resolves to the constructed generic.
+        CompileLibrary(source);
+    }
+
+    private static string CompileVerifyAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1330_emit_").FullName;
+        try
+        {
+            var outPath = CompileToDll(tempDir, source, "/target:exe");
+            IlVerifier.Verify(outPath);
+
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static void CompileLibrary(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1330_lib_").FullName;
+        try
+        {
+            CompileToDll(tempDir, source, "/target:library");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static string CompileToDll(string tempDir, string source, string target)
+    {
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        // Resolve against the host runtime's implementation assemblies (the same
+        // assemblies IlVerifier verifies against). The implementation metadata
+        // for Comparer<T> exposes its strongly typed Compare(T, T) member, which
+        // ordinary member lookup binds in preference to the non-generic
+        // IComparer.Compare(object, object) explicit-interface overload.
+        var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+        var args = new List<string>
+        {
+            "/out:" + outPath,
+            target,
+            "/targetframework:net10.0",
+            "/lib:" + runtimeDir,
+        };
+        foreach (var refName in new[]
+        {
+            "System.Runtime.dll",
+            "System.Private.CoreLib.dll",
+            "System.Collections.dll",
+            "System.Console.dll",
+        })
+        {
+            args.Add("/reference:" + Path.Combine(runtimeDir, refName));
+        }
+
+        args.Add(srcPath);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args.ToArray());
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(compileExit == 0, $"compile failed ({compileExit}):\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+        return outPath;
+    }
+}


### PR DESCRIPTION
## Summary
A generic static member-access receiver `GenericType[TypeArg].StaticMember(...)` failed with `GS0125: Variable '...' doesn't exist` when `TypeArg` was an **in-scope generic type parameter** (e.g. `Comparer[TResult].Default` / `Comparer[TResult].Create(...)` inside `class C[TResult]`), even though the identical receiver with a **concrete** type argument (`Comparer[int32].Default`) bound and ran cleanly. This was a residual of #1323.

## Root cause
A single simple-name type argument parses as an index expression (not a `GenericNameExpression`), so resolution falls to the binder's index-then-member fallback. That fallback only closed the imported generic receiver for a **concrete** argument. A type-parameter argument has no concrete CLR type, so closing fell through and the receiver name was wrongly bound as a non-existent variable, producing GS0125.

## Fix (binder + emit)
- `TryCloseImportedGenericTypeReceiver` builds a **symbolic constructed receiver** (`Comparer[!TResult]`) alongside the type-erased closed CLR shape (`Comparer<object>`), carried on `ImportedClassSymbol.SymbolicReceiver`.
- **Static property/field access** resolves the member result type from the symbolic receiver (`ResolveStaticMemberTypeFromSymbolicReceiver`) and threads `StaticContainerType` onto `BoundClrPropertyAccessExpression`; the emitter parents the static getter at the constructed symbolic TypeSpec.
- **Static calls** resolve via `TryBindSymbolicImportedStaticCall`, threading `StaticContainerType` onto `BoundImportedCallExpression`; the emitter parents the call at the symbolic container and materializes constructed delegate args via `GetConstructedDelegateCtorRef`.

`GenericType[TypeParam].StaticProperty`/`.StaticField`/`.StaticMethod(...)` now resolves and (for the property/field and non-lambda-call cases) emits **verifiable IL that runs** identically to the concrete-argument receiver. Concrete-arg, nullable/array/nested (#1323), and ordinary indexing are unaffected.

## Known limitation
The original lambda repro `Comparer[TResult].Create((x,y)->x.CompareTo(y))` now **resolves and compiles** (no GS0125/GS0159). Fully verifiable *emission* of a lambda whose parameters are an enclosing type parameter additionally depends on the **separate, pre-existing generic-lambda-hosting gap** (a lambda hosted in a non-generic container with free type-parameter slots produces non-verifiable IL, reproducible without this change via a trivial `(x U)->x` in `C[U].F` and via `Array.Sort(items, lambda)`). That is orthogonal to #1330 and out of scope here.

## Tests
`Issue1330GenericStaticTypeParamTests`:
- `StaticProperty_OnTypeParameterReceiver_VerifiesAndExecutes` (value element)
- `StaticProperty_OnTypeParameterReceiver_ReferenceElement_Executes` (reference element)
- `StaticProperty_OnConcreteReceiver_StillVerifiesAndExecutes` (control)
- `StaticFactoryCall_OnTypeParameterReceiver_Resolves` (issue lambda repro: compiles)

Verification: full `dotnet build GSharp.sln -c Release -graph` (0 errors); Core.Tests (4696 passed); filtered Compiler.Tests slices for #1330/#1323/#833/GenericStatic/Indexer/Index/Dictionary/Array (all passed). No new SyntaxKind/BoundNodeKind, so coverage-matrix golden files unchanged.

Fixes #1330
Refs #914
