### PR TITLE
Fix #1335: protected/private member access from a lambda uses the enclosing type's access context

### DIFF
--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -287,6 +287,7 @@ internal sealed class LambdaBinder
         var outerFunction = getCurrentFunction();
         Scope = new BoundScope(outerScope);
         setCurrentFunction(synthetic);
+        synthetic.LexicalEnclosingType = ResolveLexicalEnclosingType(outerFunction);
         foreach (var ps in synthetic.Parameters)
         {
             // Issue #1262: discard parameters (`_`) are non-referenceable —
@@ -496,6 +497,7 @@ internal sealed class LambdaBinder
         var outerFunction = getCurrentFunction();
         Scope = new BoundScope(outerScope);
         setCurrentFunction(placeholder);
+        placeholder.LexicalEnclosingType = ResolveLexicalEnclosingType(outerFunction);
         foreach (var ps in placeholder.Parameters)
         {
             // Issue #1262: discard parameters (`_`) are non-referenceable —
@@ -554,6 +556,7 @@ internal sealed class LambdaBinder
 
         var synthetic = new FunctionSymbol(syntheticName, placeholder.Parameters, returnType);
         synthetic.IsAsync = isAsync;
+        synthetic.LexicalEnclosingType = placeholder.LexicalEnclosingType;
 
         // ADR-0076 / issue #716: rewrite the bound body so every return
         // statement's expression is converted to the inferred return type.
@@ -756,6 +759,11 @@ internal sealed class LambdaBinder
 
         return element;
     }
+
+    private static TypeSymbol ResolveLexicalEnclosingType(FunctionSymbol outerFunction)
+        => outerFunction?.ReceiverType
+            ?? outerFunction?.StaticOwnerType
+            ?? outerFunction?.LexicalEnclosingType;
 
     // Issue #893: rewrite a value-returning function-literal block body so a bare
     // trailing expression statement becomes the implicit `return` value. This is

--- a/src/Core/CodeAnalysis/Emit/ClosureEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ClosureEmitter.cs
@@ -219,6 +219,24 @@ internal sealed class ClosureEmitter
                 invokeName: "Invoke");
 
             this.ClosureInfos[literal] = info;
+
+            // Issue #1335: a closure declared inside a member of a user type must
+            // be able to reach that type's `protected`/`private` members (matching
+            // C#, which nests display classes inside the containing type). Emitting
+            // the closure as a CLR type nested in the enclosing user type grants it
+            // the CLR nested-type access to the encloser's family/private members
+            // (and the encloser's inherited protected members). Without nesting the
+            // synthesized Invoke method triggers MethodAccessException/
+            // FieldAccessException at runtime. Generic enclosing types are skipped:
+            // a nested type would have to re-declare the encloser's type parameters,
+            // which the closure synthesis does not model, and the public-member case
+            // those closures already handle does not need nesting.
+            if (literal.Function?.LexicalEnclosingType is StructSymbol enclosing
+                && enclosing.TypeParameters.IsDefaultOrEmpty
+                && info.ClassSym.ContainingType == null)
+            {
+                info.ClassSym.SetContainingType(enclosing);
+            }
         }
     }
 

--- a/src/Core/CodeAnalysis/Symbols/AccessibilityChecker.cs
+++ b/src/Core/CodeAnalysis/Symbols/AccessibilityChecker.cs
@@ -42,7 +42,8 @@ internal static class AccessibilityChecker
         }
 
         var enclosingType = (currentFunction?.ReceiverType as StructSymbol)
-            ?? (currentFunction?.StaticOwnerType as StructSymbol);
+            ?? (currentFunction?.StaticOwnerType as StructSymbol)
+            ?? (currentFunction?.LexicalEnclosingType as StructSymbol);
 
         for (var t = enclosingType; t != null; t = t.BaseClass)
         {

--- a/src/Core/CodeAnalysis/Symbols/FunctionSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/FunctionSymbol.cs
@@ -249,6 +249,18 @@ public sealed class FunctionSymbol : Symbol
     /// <summary>Gets or sets the type that owns this static method (ADR-0053 for struct/class owners; ADR-0089 for interface owners). <c>null</c> for non-static or top-level functions.</summary>
     public TypeSymbol StaticOwnerType { get; set; }
 
+    /// <summary>
+    /// Gets or sets the nearest enclosing user-defined type whose member body
+    /// lexically contains this function (issue #1335). This is set on synthetic
+    /// lambda / function-literal symbols so that <c>protected</c>/<c>private</c>
+    /// accessibility checks performed while binding a closure body resolve the
+    /// same access context as the enclosing member — a closure nested in a
+    /// member of type <c>C</c> has the same access to <c>C</c>'s members as the
+    /// member itself. <c>null</c> for ordinary methods and top-level functions
+    /// (which carry their context via <see cref="ReceiverType"/>/<see cref="StaticOwnerType"/>).
+    /// </summary>
+    public TypeSymbol LexicalEnclosingType { get; set; }
+
     /// <summary>Gets or sets a value indicating whether this function should be emitted with <c>MethodAttributes.SpecialName</c> (e.g., event accessor methods).</summary>
     public bool IsSpecialName { get; set; }
 

--- a/test/Compiler.Tests/Emit/Issue1335LambdaProtectedAccessTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1335LambdaProtectedAccessTests.cs
@@ -1,0 +1,280 @@
+// <copyright file="Issue1335LambdaProtectedAccessTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1335 — a <c>protected</c>/<c>private</c> member of the enclosing class
+/// referenced from inside a lambda / function-literal declared in the same class
+/// must have the same access as the enclosing member (matching C#). Previously
+/// the bind-time accessibility check lost the enclosing-type context inside a
+/// closure body and wrongly reported <c>GS0379</c>. These tests pin the fix:
+/// protected, private, field, property, and inherited-protected access all
+/// compile and run from a closure (including nested closures), while genuine
+/// inaccessibility (a protected member of an unrelated class) still reports
+/// <c>GS0379</c>.
+/// </summary>
+public class Issue1335LambdaProtectedAccessTests
+{
+    [Fact]
+    public void Lambda_CallsProtectedAndPrivateMember_Runs()
+    {
+        CompileVerifyAndRun(
+            """
+            package Maui.Issue1335.Tests
+
+            import System
+
+            open class C {
+                protected func Prot() int32 {
+                    return 13
+                }
+                private func Priv() int32 {
+                    return 11
+                }
+                func F() int32 {
+                    let g = func () int32 { return Prot() + Priv() }
+                    return g()
+                }
+            }
+
+            func Main() {
+                let c = C{}
+                Console.WriteLine(c.F())
+            }
+            """,
+            "24\n");
+    }
+
+    [Fact]
+    public void Lambda_ReadsProtectedPropertyAndPrivateField_Runs()
+    {
+        CompileVerifyAndRun(
+            """
+            package Maui.Issue1335.Tests
+
+            import System
+
+            open class C {
+                private var f int32
+                protected prop P int32 { get { return 9 } }
+                func F() int32 {
+                    f = 5
+                    let g = func () int32 { return f + P }
+                    return g()
+                }
+            }
+
+            func Main() {
+                let c = C{}
+                Console.WriteLine(c.F())
+            }
+            """,
+            "14\n");
+    }
+
+    [Fact]
+    public void Lambda_CallsInheritedProtectedMember_Runs()
+    {
+        CompileVerifyAndRun(
+            """
+            package Maui.Issue1335.Tests
+
+            import System
+
+            open class Base {
+                protected func BaseHelper() int32 {
+                    return 7
+                }
+            }
+
+            open class Derived : Base {
+                func F() int32 {
+                    let g = func () int32 { return BaseHelper() }
+                    return g()
+                }
+            }
+
+            func Main() {
+                let d = Derived{}
+                Console.WriteLine(d.F())
+            }
+            """,
+            "7\n");
+    }
+
+    [Fact]
+    public void NestedLambda_CallsProtectedAndPrivateMember_Runs()
+    {
+        CompileVerifyAndRun(
+            """
+            package Maui.Issue1335.Tests
+
+            import System
+
+            open class C {
+                protected func Prot() int32 {
+                    return 13
+                }
+                private func Priv() int32 {
+                    return 11
+                }
+                func F() int32 {
+                    let outer = func () int32 {
+                        let inner = func () int32 { return Prot() + Priv() }
+                        return inner()
+                    }
+                    return outer()
+                }
+            }
+
+            func Main() {
+                let c = C{}
+                Console.WriteLine(c.F())
+            }
+            """,
+            "24\n");
+    }
+
+    [Fact]
+    public void Lambda_AccessesUnrelatedClassProtectedMember_FailsToCompile()
+    {
+        var (exit, output) = TryCompile(
+            """
+            package Maui.Issue1335.Tests
+
+            import System
+
+            open class Other {
+                protected func Secret() int32 {
+                    return 1
+                }
+            }
+
+            class C {
+                func F() int32 {
+                    let o = Other{}
+                    let g = func () int32 { return o.Secret() }
+                    return g()
+                }
+            }
+
+            func Main() {
+                let c = C{}
+                Console.WriteLine(c.F())
+            }
+            """);
+        Assert.NotEqual(0, exit);
+        Assert.Contains("GS0379", output);
+    }
+
+    private static void CompileVerifyAndRun(string source, string expected)
+    {
+        var dll = CompileToDll(source);
+        try
+        {
+            IlVerifier.Verify(dll);
+
+            var runtimeConfigPath = Path.ChangeExtension(dll, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + dll + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            Assert.Equal(expected, stdout.Replace("\r\n", "\n"));
+        }
+        finally
+        {
+            TryDeleteDir(Path.GetDirectoryName(dll));
+        }
+    }
+
+    private static string CompileToDll(string source)
+    {
+        var (exit, output, outPath) = RunCompiler(source);
+        Assert.True(exit == 0, $"compile failed ({exit}): {output}");
+        return outPath;
+    }
+
+    private static (int Exit, string Output) TryCompile(string source)
+    {
+        var (exit, output, outDir) = RunCompiler(source);
+        TryDeleteDir(Path.GetDirectoryName(outDir));
+        return (exit, output);
+    }
+
+    private static (int Exit, string Output, string OutPath) RunCompiler(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1335_emit_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        var args = new[]
+        {
+            "/out:" + outPath,
+            "/target:exe",
+            "/targetframework:net10.0",
+            "/nowarn:GS9100",
+            srcPath,
+        };
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        return (compileExit, compileOut.ToString() + compileErr.ToString(), outPath);
+    }
+
+    private static void TryDeleteDir(string dir)
+    {
+        try
+        {
+            if (dir != null)
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+        catch
+        {
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1335LambdaProtectedAccessBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1335LambdaProtectedAccessBinderTests.cs
@@ -1,0 +1,147 @@
+// <copyright file="Issue1335LambdaProtectedAccessBinderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1335: a <c>protected</c>/<c>private</c> member of the enclosing class
+/// referenced from inside a lambda / function-literal declared in the same class
+/// must have the same access as the enclosing member (matching C#). Previously
+/// the bind-time accessibility check lost the enclosing-type context inside the
+/// closure body — it keyed off the lambda's synthetic function (which carries no
+/// receiver) — and wrongly reported <c>GS0379</c>. These binder tests pin the
+/// fix for both lambda forms (<c>func (…) { … }</c> and <c>(…) -&gt; …</c>),
+/// nested lambdas, and inherited <c>protected</c> members, while confirming that
+/// genuine inaccessibility (an unrelated class's <c>protected</c> member) still
+/// reports <c>GS0379</c>.
+/// </summary>
+public class Issue1335LambdaProtectedAccessBinderTests
+{
+    [Fact]
+    public void ProtectedAndPrivateCall_InFuncLiteralLambda_NoGS0379()
+    {
+        var source = @"
+open class C {
+    protected func Prot() int32 { return 1 }
+    private func Priv() int32 { return 2 }
+    func F() int32 {
+        let g = func () int32 { return Prot() + Priv() }
+        return g()
+    }
+}
+";
+        AssertNoGS0379(Evaluate(source));
+    }
+
+    [Fact]
+    public void ProtectedAndPrivateCall_InArrowLambda_NoGS0379()
+    {
+        var source = @"
+open class C {
+    protected func Prot() int32 { return 1 }
+    private func Priv() int32 { return 2 }
+    func F() int32 {
+        let g = (d int32) -> Prot() + Priv() + d
+        return g(1)
+    }
+}
+";
+        AssertNoGS0379(Evaluate(source));
+    }
+
+    [Fact]
+    public void PrivateFieldAndProtectedProperty_InLambda_NoGS0379()
+    {
+        var source = @"
+open class C {
+    private var f int32 = 5
+    protected prop P int32 { get { return 9 } }
+    func F() int32 {
+        let g = func () int32 { return f + P }
+        return g()
+    }
+}
+";
+        AssertNoGS0379(Evaluate(source));
+    }
+
+    [Fact]
+    public void InheritedProtectedMember_InLambda_NoGS0379()
+    {
+        var source = @"
+open class Base {
+    protected func BaseHelper() int32 { return 7 }
+}
+open class Derived : Base {
+    func F() int32 {
+        let g = func () int32 { return BaseHelper() }
+        return g()
+    }
+}
+";
+        AssertNoGS0379(Evaluate(source));
+    }
+
+    [Fact]
+    public void NestedLambda_ProtectedAndPrivate_NoGS0379()
+    {
+        var source = @"
+open class C {
+    protected func Prot() int32 { return 1 }
+    private func Priv() int32 { return 2 }
+    func F() int32 {
+        let outer = func () int32 {
+            let inner = func () int32 { return Prot() + Priv() }
+            return inner()
+        }
+        return outer()
+    }
+}
+";
+        AssertNoGS0379(Evaluate(source));
+    }
+
+    [Fact]
+    public void UnrelatedClassProtectedMember_InLambda_StillReportsGS0379()
+    {
+        // Genuine inaccessibility must still be reported: a `protected` member of
+        // an unrelated class accessed from a lambda is not made accessible by the
+        // enclosing-type fallback.
+        var source = @"
+open class Other {
+    protected func Secret() int32 { return 1 }
+}
+class C {
+    func F() int32 {
+        let o = Other{}
+        let g = func () int32 { return o.Secret() }
+        return g()
+    }
+}
+";
+        var diagnostics = Evaluate(source).Diagnostics;
+        Assert.Contains(diagnostics, d => d.Id == "GS0379");
+    }
+
+    private static void AssertNoGS0379(EvaluationResult result)
+    {
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0379");
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
## Summary
A `protected` (or `private`) member of the enclosing class was reported `GS0379` ('… is inaccessible due to its protection level') when referenced from inside a **lambda / function-literal** declared in the same class, even though the same member is reachable directly from the method body. This makes a closure nested in a member of `C` have the same access to `C`'s `protected`/`private` members as the enclosing member (matching C#).

## Root cause
The bind-time accessibility check (`AccessibilityChecker.IsAccessible`) derives the *current type* access context from the binder's current function via `ReceiverType` / `StaticOwnerType`. Inside a lambda body the current function is the synthetic `<lambdaN>` closure symbol, which carries neither, so `this`'s own protected/private members were treated as external and rejected.

There was also a latent emit problem: closure display classes were emitted as top-level types, so even once binding allowed the access, the synthesized `Invoke` method hit `MethodAccessException` / `FieldAccessException` at runtime when calling the encloser's `family`/`private` members.

## Fix
- Add `FunctionSymbol.LexicalEnclosingType` recording the nearest enclosing user type for synthetic lambda / function-literal symbols. `LambdaBinder` propagates it from the outer function (`ReceiverType ?? StaticOwnerType ?? LexicalEnclosingType`, so nested lambdas inherit it) for both the function-literal and arrow-lambda binding paths.
- `AccessibilityChecker` falls back to `LexicalEnclosingType` so a closure resolves the same access context — and base-class walk — as its enclosing member.
- Emit: nest the closure display class inside the enclosing (non-generic) user type via `SetContainingType`, granting it CLR nested-type access to the encloser's `family`/`private` members (and inherited `protected`).

Genuine inaccessibility (e.g. a `protected` member of an unrelated class accessed from a lambda) still reports `GS0379`.

## Tests
- `Issue1335LambdaProtectedAccessTests` (Emit): compile + run a class where a lambda/nested lambda calls a `protected` method, a `private` method, reads a `private` field and a `protected` property, and calls an inherited `protected` member; plus a negative test asserting `GS0379` still fires for an unrelated class's `protected` member.
- `Issue1335LambdaProtectedAccessBinderTests` (binder): both lambda forms (`func (…) { … }` and `(…) -> …`), private field/protected property, inherited protected, nested lambdas, and the negative `GS0379` guard.

Verification: full `Core.Tests` (4702 passing) and filtered `Compiler.Tests` slices around closures/lambdas/accessibility/async/iterator/reflection/metadata all green.

Fixes #1335
Refs #914