### PR TITLE
cs2gs: hoist non-smart-castable is-pattern scrutinee into a local

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue914TranslatorFidelityTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue914TranslatorFidelityTests.cs
@@ -51,7 +51,31 @@ namespace Demo
     }
 
     [Fact]
-    public void PositivePattern_UsedOnlyInsideThen_KeepsSmartCastNoHoist()
+    public void PositivePattern_LocalScrutinee_UsedOnlyInsideThen_KeepsSmartCastNoHoist()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class E { public int X; }
+    public class Box { public E? Esds => null; }
+    public class C
+    {
+        public void F(Box b)
+        {
+            var local = b.Esds;
+            if (local is E esds) { System.Console.WriteLine(esds.X); }
+        }
+    }
+}");
+
+        // A bare local scrutinee smart-casts in gsc, so no hoist: the existing
+        // smart-cast `is` test is kept and `esds` rewrites to the local.
+        Assert.Contains("local is E", printed);
+        Assert.DoesNotContain("as E", printed);
+    }
+
+    [Fact]
+    public void PositivePattern_PropertyScrutinee_UsedOnlyInsideThen_HoistsLocal()
     {
         string printed = TranslateUnit(@"
 namespace Demo
@@ -67,9 +91,37 @@ namespace Demo
     }
 }");
 
-        // No hoist: the existing smart-cast `is` test is kept.
-        Assert.Contains("b.Esds is E", printed);
-        Assert.DoesNotContain("as E", printed);
+        // A property-access scrutinee cannot be smart-cast by gsc, so even when the
+        // binder is used only inside the then-block it must hoist into a local
+        // (rewriting `esds` to `b.Esds` would yield `b.Esds.X` → GS0158).
+        Assert.Contains("let esds E? = b.Esds as E", printed);
+        Assert.Contains("if esds != nil", printed);
+    }
+
+    [Fact]
+    public void PositivePattern_MethodCallScrutinee_UsedOnlyInsideThen_HoistsLocalOnce()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class E { public int X; }
+    public class Box { public T? GetChild<T>() where T : class => null; }
+    public class C
+    {
+        public void F(Box b)
+        {
+            if (b.GetChild<E>() is E child) { System.Console.WriteLine(child.X + child.X); }
+        }
+    }
+}");
+
+        // A method-call scrutinee must be evaluated once into a hoisted local; the
+        // side-effecting call must not be re-emitted at each use of the binder.
+        Assert.Contains("let child E? = b.GetChild[E]() as E", printed);
+        Assert.Contains("if child != nil", printed);
+        // The method call is emitted exactly once (in the hoist), not per binder use.
+        string[] occurrences = printed.Split("GetChild[E]()");
+        Assert.Equal(2, occurrences.Length);
     }
 
     [Fact]

--- a/tools/cs2gs/Cs2Gs.Tests/Issue914TranslatorFidelityTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue914TranslatorFidelityTests.cs
@@ -125,6 +125,30 @@ namespace Demo
     }
 
     [Fact]
+    public void PositivePattern_JaggedArrayTarget_PropertyScrutinee_FallsBackToSmartCast()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class Chunk { public byte[][] ExtraData => null; }
+    public class C
+    {
+        public int F(Chunk chunk)
+        {
+            if (chunk.ExtraData is byte[][] ivs) { return ivs.Length; }
+            return 0;
+        }
+    }
+}");
+
+        // A nullable jagged-array local annotation (`[]?[]uint8`) does not yet
+        // round-trip-parse in gsc, so an array target that does not escape keeps the
+        // smart-cast `is` test instead of hoisting a malformed nullable local.
+        Assert.Contains("chunk.ExtraData is [][]uint8", printed);
+        Assert.DoesNotContain("[]?[]", printed);
+    }
+
+    [Fact]
     public void PositivePattern_UsedAfterIf_NeverReassigned_HoistsAsLet()
     {
         string printed = TranslateUnit(@"

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -4269,11 +4269,23 @@ public sealed class CSharpToGSharpTranslator
                 return false;
             }
 
-            // Only hoist when the pattern variable escapes the then-block. If it is
-            // used solely inside the guarded block the existing smart cast (rewriting
-            // `t` to the receiver) is correct and avoids an unnecessary local.
-            if (this.context.GetDeclaredSymbol(single) is not ILocalSymbol patternSymbol ||
-                !this.IsSymbolReferencedOutside(patternSymbol, ifStatement.Statement))
+            // Hoist when EITHER the pattern variable escapes the then-block, OR the
+            // scrutinee is a non-trivial expression that gsc cannot smart-cast. gsc
+            // narrows only a bare local/parameter (ADR-0069); a method-call result,
+            // member-access chain or field reference re-emitted at each use of `t`
+            // would not smart-cast (→ GS0158) and, for a side-effecting scrutinee
+            // such as `M(out var x)`, would be re-evaluated (→ GS0102). When the
+            // scrutinee IS a smart-castable local and `t` is used solely inside the
+            // guarded block, the existing smart cast (rewriting `t` to the receiver)
+            // is correct and avoids an unnecessary local.
+            if (this.context.GetDeclaredSymbol(single) is not ILocalSymbol patternSymbol)
+            {
+                return false;
+            }
+
+            bool escapesThenBlock =
+                this.IsSymbolReferencedOutside(patternSymbol, ifStatement.Statement);
+            if (!escapesThenBlock && this.IsSmartCastableScrutinee(isPattern.Expression))
             {
                 return false;
             }
@@ -4311,6 +4323,25 @@ public sealed class CSharpToGSharpTranslator
 
             result = new GStatement[] { hoist, new IfStatement(guard, then, elseBranch) };
             return true;
+        }
+
+        /// <summary>
+        /// A scrutinee is smart-castable by gsc only when it is a bare local or
+        /// parameter reference; gsc narrows locals, not method-call results,
+        /// member-access chains, or field references (ADR-0069). When the scrutinee
+        /// is not smart-castable, an <c>x is T t</c> whose binder is used in the
+        /// guarded block must hoist the scrutinee into a local (so the local
+        /// smart-casts) rather than re-emit the expression at each use of <c>t</c>.
+        /// </summary>
+        private bool IsSmartCastableScrutinee(ExpressionSyntax expression)
+        {
+            if (expression is not IdentifierNameSyntax)
+            {
+                return false;
+            }
+
+            ISymbol symbol = this.context.GetSymbolInfo(expression).Symbol;
+            return symbol is ILocalSymbol or IParameterSymbol;
         }
 
         // Extracts the target type and single-variable designation from a positive

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -4283,16 +4283,24 @@ public sealed class CSharpToGSharpTranslator
                 return false;
             }
 
+            GTypeReference targetType = this.MapTypeSyntax(typeSyntax);
             bool escapesThenBlock =
                 this.IsSymbolReferencedOutside(patternSymbol, ifStatement.Statement);
-            if (!escapesThenBlock && this.IsSmartCastableScrutinee(isPattern.Expression))
+
+            // The broadened "non-smart-castable scrutinee" hoist requires a
+            // well-formed nullable local annotation. Only a NamedTypeReference target
+            // nullable-annotates cleanly (`T?`); a nullable jagged/array target
+            // (`[]?[]T`) does not yet round-trip-parse in gsc, so for array/pointer/
+            // tuple targets that do not escape, keep the existing smart cast.
+            if (!escapesThenBlock &&
+                (this.IsSmartCastableScrutinee(isPattern.Expression) ||
+                 targetType is not NamedTypeReference))
             {
                 return false;
             }
 
             string localName = SanitizeIdentifier(single.Identifier.Text);
             GExpression receiver = this.TranslateExpression(isPattern.Expression);
-            GTypeReference targetType = this.MapTypeSyntax(typeSyntax);
 
             // `var t T? = receiver as T` when the leaked variable is reassigned
             // anywhere in the body (C# allows it); otherwise an immutable `let`.


### PR DESCRIPTION
## Problem
When an `if (expr is T t)` pattern variable is used only inside the then-block, the translator rewrote each use of `t` to the **scrutinee expression**. gsc smart-casts only a bare local/parameter (ADR-0069), so a property-access, member chain, or **method-call** scrutinee re-emitted at each use of `t`:
- fails to smart-cast -> `GS0158`, and
- for a side-effecting `M(out var x)` scrutinee, is re-evaluated -> `GS0102`.

This drove the dominant `Oahu.Decrypt` cascade (e.g. `MoovBox`: `if (AudioTrack.GetChild<TrefBox>() is TrefBox tref) { tref.References...; tref.AddReference(...) }`).

## Fix
Extend `TryBuildPositiveGuardHoist` to also hoist the scrutinee into a nullable local plus a positive nil-guard when the scrutinee is **not** a smart-castable local/parameter -- not only when the binder escapes the then-block. A bare local scrutinee still keeps the existing no-hoist smart cast.

`MoovBox` now emits a single-evaluation hoist:
```
let tref TrefBox? = AudioTrack.GetChild[TrefBox]() as TrefBox
if tref != nil { ... tref.References ... tref.AddReference("chap", references) }
```

## Array caveat (#1351)
A nullable jagged-array local annotation (`[]?[]T`) does not yet round-trip-parse in gsc (filed #1351), so the broadened hoist is restricted to `NamedTypeReference` targets; array/pointer/tuple targets that do not escape keep the existing smart-cast `is` test.

## Result
`Oahu.Decrypt` compile errors **63 -> 55** (GS0158 21->17, GS0159 19->17). 330 cs2gs tests pass; translate stays green.

Refs #914
