### PR TITLE
Support generic unsafe SIMD over unmanaged T: sizeof(T) and *T (#1336)

### DIFF
--- a/docs/adr/0135-unmanaged-constraint-and-sizeof.md
+++ b/docs/adr/0135-unmanaged-constraint-and-sizeof.md
@@ -1,0 +1,179 @@
+# ADR-0135: `unmanaged` type-parameter constraint and `sizeof(T)` expression
+
+- **Status**: Accepted
+- **Date**: 2026-07-04
+- **Phase**: Binder + emit hardening (unsafe generics)
+- **Closes**: Issue #1336 (G# language gap — generic unsafe SIMD over an `unmanaged`-constrained type parameter `T` is unsupported: `sizeof(T)` reported GS0130/GS0125 and `*T` reported GS0398)
+- **Related**: ADR-0097 (`class`/`struct`/`init()` flag-style type-parameter constraints — `unmanaged` is a new member of that flag family); ADR-0122 (unsafe-context unmanaged pointers — source of GS0398, now widened to admit pointers to an `unmanaged`-constrained type parameter); ADR-0020 (generic bracket constraint slot); ADR-0088 (constraint-aware overload resolution); issue #914 (Oahu migration — the real-world driver)
+
+## Context
+
+The Oahu corpus (`Oahu.Decrypt/Mpeg4/Util/HelperExtensions.cs`) contains
+`unsafe` generic SIMD helpers shaped like:
+
+```csharp
+private static unsafe bool AllLessThanOrEqual_256<T>(Span<T> ints, T value, out int checkedcount)
+    where T : unmanaged, IComparable<T>
+{
+    int vecSize = 256 / 8 / sizeof(T);   // sizeof over a generic type parameter
+    ...
+    fixed (T* p = ints) { ... }          // pointer to a generic type parameter
+}
+```
+
+Two G# language gaps blocked porting this code:
+
+1. **`sizeof(T)` over a generic type parameter** had no user-facing surface
+   syntax at all. `sizeof` existed only as an *internal* bound node
+   (`BoundSizeOfExpression`) used to lower pointer arithmetic; a source-level
+   `sizeof(T)` parsed as a call to an undefined function `sizeof`, producing
+   `GS0130` ("Function 'sizeof' doesn't exist") and `GS0125` ("Variable 'T'
+   doesn't exist").
+2. **`*T` (a pointer to a type parameter)** was rejected by the ADR-0122
+   pointer-pointee blittability gate with `GS0398` ("Unmanaged pointer to 'T'
+   is not supported"), because a bare type parameter is not statically known to
+   be blittable.
+
+Both are legal on the CLR **specifically because of the `unmanaged`
+constraint**: the CIL `sizeof` opcode accepts a generic type token, and the
+runtime permits a pointer to an `unmanaged`-constrained type parameter. But G#
+had no spelling for the `unmanaged` constraint, so neither capability could be
+unlocked. This ADR adds the constraint and the `sizeof(T)` expression, and
+widens the pointer gate.
+
+## Decision
+
+### 1. `unmanaged` constraint spelling
+
+The `[…]` flag-constraint slot introduced by ADR-0097 is widened with a fourth
+flag keyword, `unmanaged`:
+
+```
+constraint-spec  ::= 'any' | 'comparable' | InterfaceName generic-args?
+                   | 'class' | 'struct' | 'init' '(' ')' | 'unmanaged'
+```
+
+```
+func sizeOf[T unmanaged](sample T) int32 { return sizeof(T) }
+unsafe func first[T unmanaged](p *T) T { return *p }
+func cmp[T IComparable[T] unmanaged](a T, b T) int32 { return a.CompareTo(b) }
+```
+
+`unmanaged` is a **contextual** keyword — only a constraint inside a generic
+type-parameter list. It may be combined with a single legacy interface bound
+that precedes it (interface-first ordering, e.g. `[T IComparable[T] unmanaged]`,
+matching ADR-0097's "legacy slot precedes flags slot" rule).
+
+**Conflicts.** `unmanaged` implies `struct` (a non-nullable value type), so the
+binder rejects the redundant/contradictory combinations `unmanaged struct`,
+`unmanaged class`, and `unmanaged init()` with **GS0361** (the same
+mutually-exclusive-constraint diagnostic introduced by ADR-0097), recovering by
+keeping `unmanaged`.
+
+### 2. Constraint satisfaction (`Binder.SatisfiesConstraint`)
+
+`unmanaged` is checked via `Binder.IsUnmanagedTypeForConstraint(arg)`:
+
+- A **type parameter** satisfies it when it itself carries `HasUnmanagedConstraint`.
+- Any other type is classified by `BlittableDetector.IsUnmanaged(type)`.
+
+"Unmanaged" is **broader than "blittable"**: `bool`, `char`, and `decimal` are
+unmanaged (legal `sizeof` / `where T : unmanaged`) but are *not* blittable for
+marshalling. `IsUnmanaged` therefore accepts those primitives, enums (G# and
+CLR), pointers, and value structs whose fields are all (recursively) unmanaged,
+while rejecting reference types. A failing substitution reports `GS0152` with
+`DescribeConstraint` printing `"unmanaged"`.
+
+### 3. `sizeof(T)` expression
+
+A new `SizeOfExpressionSyntax` (`SyntaxKind.SizeOfExpression`) mirrors
+`typeof(T)`: `sizeof` `(` *type-clause* `)`. It is recognized contextually so
+existing code that uses `sizeof` as an identifier is unaffected. The binder
+(`ExpressionBinder.BindSizeOfExpression`) validates the operand with
+`Binder.IsUnmanagedTypeForConstraint`; a non-unmanaged operand (e.g.
+`sizeof(string)`, or `sizeof(T)` where `T` is unconstrained) reports the new
+**GS0415**. A valid operand produces the existing `BoundSizeOfExpression`, whose
+emit (`EmitSizeOf` → CIL `sizeof <token>` via `GetElementTypeToken`) already
+accepts a generic type token, so `sizeof(T)` lowers to a single verifiable
+`sizeof !!T` instruction. `sizeof(int32)` / `sizeof(SomeStruct)` continue to
+work.
+
+### 4. `*T` pointer over an `unmanaged`-constrained type parameter
+
+The ADR-0122 pointer-pointee gate in `Binder` is widened to admit a pointee that
+is a `TypeParameterSymbol { HasUnmanagedConstraint: true }`, alongside the
+existing blittable-primitive / blittable-value-struct / pointer pointees. A bare
+(unconstrained) type parameter is still rejected with `GS0398`. As with all raw
+pointer code (ADR-0122), pointer *dereference* is unverifiable by design;
+`ilverify` reports the same inherent `UnmanagedPointer` / `StackByRef` codes for
+generic `*T` as for concrete `*int32`.
+
+### 5. CLR mapping (emit)
+
+The `unmanaged` constraint emits exactly what C# emits — verified byte-for-byte
+against `csc` output:
+
+- On the `GenericParam` row:
+  `GenericParameterAttributes.NotNullableValueTypeConstraint | DefaultConstructorConstraint`
+  (the same bits `struct` emits, per ECMA-335 II.10.1.7).
+- **Plus** a `GenericParamConstraint` row whose `Constraint` is a `TypeSpec`
+  encoding `System.ValueType` decorated with a **required custom modifier**
+  (`modreq`) of `System.Runtime.InteropServices.UnmanagedType`. The signature
+  blob is:
+
+  ```
+  ELEMENT_TYPE_CMOD_REQD <UnmanagedType>  ELEMENT_TYPE_CLASS <System.ValueType>
+  ```
+
+  `System.ValueType` is itself an abstract **class**, so it is encoded with
+  `ELEMENT_TYPE_CLASS` (0x12) — **not** `ELEMENT_TYPE_VALUETYPE` (0x11).
+  Encoding it as a value type makes the CLR loader reject every closed
+  instantiation at runtime with a "value type mismatch" `TypeLoadException`,
+  even though such an assembly still passes `ilverify`. This subtlety is the
+  single most error-prone part of the feature and is covered by an executing
+  emit test (not merely a verification test).
+
+`TypeDefEmitter.FlushPendingGenericParameters` emits the extra constraint row
+when `PendingGenericParameter.HasUnmanagedConstraint` is set;
+`ReflectionMetadataEmitter.BuildUnmanagedConstraintTypeSpec` builds the modreq
+blob (written manually with `BlobBuilder`, because the `SignatureTypeEncoder`
+from `TypeSpecificationSignature()` does not expose `CustomModifiers()`).
+
+A combined `[T IComparable[T] unmanaged]` emits **both** `GenericParamConstraint`
+rows (the `IComparable<T>` generic-instance TypeSpec and the modreq-ValueType
+TypeSpec).
+
+## Diagnostics
+
+| ID | When |
+| --- | --- |
+| GS0415 | The operand of `sizeof(T)` is not an unmanaged type. |
+| GS0152 | A type argument does not satisfy an `unmanaged` constraint (reuses the existing constraint-satisfaction code; `DescribeConstraint` prints `"unmanaged"`). |
+| GS0398 | A pointer pointee is a type parameter that is **not** `unmanaged`-constrained (unchanged ADR-0122 diagnostic; now narrowed so the `unmanaged` case is allowed). |
+
+## Consequences
+
+- The Oahu `unsafe` generic SIMD helpers (issue #914) compile and emit
+  verifiable IL (the `sizeof(T)` portion is fully verifiable; the `*T` portion
+  is unverifiable-by-design exactly like concrete pointers).
+- `unmanaged` joins `class` / `struct` / `init()` as a first-class flag
+  constraint; the metadata is byte-compatible with C#, so a G#-authored
+  `where T : unmanaged` generic is consumable from C# and vice versa.
+- `sizeof` becomes a contextual keyword in expression position. Existing
+  identifiers named `sizeof` outside `sizeof(...)` are unaffected.
+
+### Tests
+
+- `test/Core.Tests/CodeAnalysis/Binding/Issue1336GenericUnmanagedConstraintTests.cs`
+  — binder coverage: `sizeof(T)` over `[T unmanaged]` binds; `sizeof(T)` over
+  `[T any]` and `sizeof(string)` report GS0415; `sizeof(int32)` binds; `*T` over
+  `[T unmanaged]` binds while `*T` over `[T any]` reports GS0398; `unmanaged`
+  satisfaction (int32 ok, string → GS0152); combined `[T IComparable[T]
+  unmanaged]`.
+- `test/Compiler.Tests/Emit/Issue1336GenericUnmanagedSizeOfEmitTests.cs`
+  — executing emit coverage: `sizeof(T)` yields the correct per-instantiation
+  size (1/4/8) and the `256/8/sizeof(T)` lane count (32/16/8) under `ilverify`
+  with no ignored codes; `*T` pointer write-through runs correctly under the
+  inherent-unsafety ignored-code set. These tests **execute** the produced
+  assembly, which is what catches the `ELEMENT_TYPE_CLASS` vs
+  `ELEMENT_TYPE_VALUETYPE` distinction that `ilverify` alone misses.

--- a/docs/coverage-matrix.md
+++ b/docs/coverage-matrix.md
@@ -214,6 +214,7 @@ ShiftLeftEqualsToken
 ShiftLeftToken
 ShiftRightEqualsToken
 ShiftRightToken
+SizeOfExpression
 SlashEqualsToken
 SlashToken
 StackAllocExpression

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -825,6 +825,20 @@ GS0414 fires — but only at the use site, mirroring C# `using static`
 ambiguity. Qualify the call or identifier with the owning type
 (`EnumUtil.GetValues()`) to disambiguate. See ADR-0134.
 
+## `sizeof` operand diagnostic (GS0415)
+
+| ID | Severity | Description |
+|----|----------|-------------|
+| GS0415 | Error | The operand of `sizeof(T)` must be an unmanaged type — a blittable primitive, an enum, a value struct whose fields are all unmanaged, a pointer, or a generic type parameter constrained `unmanaged`. |
+
+GS0415 supports the user-facing `sizeof(T)` expression (issue #1336, ADR-0135).
+`sizeof` yields the size in bytes of an unmanaged type and lowers to the CIL
+`sizeof` opcode, which accepts a generic type token. A reference type
+(`sizeof(string)`), or a generic type parameter that is *not* constrained
+`unmanaged` (`func F[T any]() int32 { return sizeof(T) }`), has no statically
+known unmanaged size and is rejected with GS0415. Constrain the type parameter
+`unmanaged` (`[T unmanaged]`) to make `sizeof(T)` legal.
+
 ## Internal compiler error diagnostics (GS9998–GS9999)
 
 | ID | Severity | Description |

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -2299,14 +2299,19 @@ public sealed class Binder
                 if (pointeeType != TypeSymbol.Void
                     && !TypeSymbol.IsLegalPointeeType(pointeeType)
                     && pointeeType is not PointerTypeSymbol
-                    && !BlittableDetector.IsBlittableValueStructPointee(pointeeType))
+                    && !BlittableDetector.IsBlittableValueStructPointee(pointeeType)
+                    && pointeeType is not TypeParameterSymbol { HasUnmanagedConstraint: true })
                 {
                     // ADR-0122 §4 / issue #1034: a pointer to a blittable user
                     // struct (`*Point`) is legal — accepted by the
-                    // BlittableDetector check above. A pointer to a non-blittable
-                    // struct (one that contains a managed reference / string /
-                    // class field) or to any managed reference type is still
-                    // rejected here with GS0398, matching C#'s unmanaged-type rule.
+                    // BlittableDetector check above. Issue #1336: a pointer to a
+                    // generic type parameter constrained `unmanaged` (`*T`) is
+                    // likewise legal — the `unmanaged` constraint guarantees the
+                    // pointee is a GC-free value type, exactly as in C#. A
+                    // pointer to a non-blittable struct (one that contains a
+                    // managed reference / string / class field) or to any
+                    // managed reference type is still rejected here with GS0398,
+                    // matching C#'s unmanaged-type rule.
                     Diagnostics.ReportUnmanagedPointerIllegalPointee(syntax.PointerPointeeType.Location, pointeeType.Name);
                     return PointerTypeSymbol.Get(pointeeType);
                 }
@@ -3768,6 +3773,14 @@ public sealed class Binder
             return false;
         }
 
+        // Issue #1336: enforce the `unmanaged` constraint — the type argument
+        // must be an unmanaged type (a non-nullable value type whose fields are
+        // recursively unmanaged).
+        if (tp.HasUnmanagedConstraint && !IsUnmanagedTypeForConstraint(typeArgument))
+        {
+            return false;
+        }
+
         if (tp.HasDefaultConstructorConstraint && !HasDefaultConstructorForConstraint(typeArgument))
         {
             return false;
@@ -3916,6 +3929,33 @@ public sealed class Binder
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Issue #1336: returns <see langword="true"/> when <paramref name="type"/>
+    /// satisfies a <c>where T : unmanaged</c> constraint — it is an unmanaged
+    /// (blittable, GC-free) type. Blittable primitives, enums, pointers and
+    /// non-nullable value structs whose fields are recursively unmanaged
+    /// qualify, as does another type parameter constrained <c>unmanaged</c>.
+    /// Managed reference types, nullable value types, and structs containing a
+    /// managed field do not. Mirrors C#'s unmanaged-type rule (ECMA-335 /
+    /// ADR-0093 blittability).
+    /// </summary>
+    /// <param name="type">The candidate type argument.</param>
+    /// <returns><see langword="true"/> when the type is unmanaged.</returns>
+    internal static bool IsUnmanagedTypeForConstraint(TypeSymbol type)
+    {
+        if (type is null || type is NullableTypeSymbol)
+        {
+            return false;
+        }
+
+        if (type is TypeParameterSymbol tp)
+        {
+            return tp.HasUnmanagedConstraint;
+        }
+
+        return new BlittableDetector().IsUnmanaged(type);
     }
 
     /// <summary>
@@ -4258,9 +4298,14 @@ public sealed class Binder
             flags.Add("class");
         }
 
-        if (tp.HasValueTypeConstraint)
+        if (tp.HasValueTypeConstraint && !tp.HasUnmanagedConstraint)
         {
             flags.Add("struct");
+        }
+
+        if (tp.HasUnmanagedConstraint)
+        {
+            flags.Add("unmanaged");
         }
 
         if (tp.HasDefaultConstructorConstraint && !tp.HasValueTypeConstraint)

--- a/src/Core/CodeAnalysis/Binding/BlittableDetector.cs
+++ b/src/Core/CodeAnalysis/Binding/BlittableDetector.cs
@@ -35,6 +35,7 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 internal sealed class BlittableDetector
 {
     private readonly Dictionary<TypeSymbol, bool> cache = new(ReferenceEqualityComparer.Instance);
+    private readonly Dictionary<TypeSymbol, bool> unmanagedCache = new(ReferenceEqualityComparer.Instance);
 
     /// <summary>
     /// Returns <c>true</c> when <paramref name="type"/> is blittable per
@@ -44,7 +45,25 @@ internal sealed class BlittableDetector
     /// <returns><c>true</c> when blittable.</returns>
     public bool IsBlittable(TypeSymbol type)
     {
-        return type != null && IsBlittableImpl(type, new HashSet<StructSymbol>(ReferenceEqualityComparer.Instance));
+        return type != null && IsBlittableImpl(type, new HashSet<StructSymbol>(ReferenceEqualityComparer.Instance), unmanaged: false);
+    }
+
+    /// <summary>
+    /// Issue #1336. Returns <c>true</c> when <paramref name="type"/> is an
+    /// <em>unmanaged</em> type — bit-for-bit representable with no GC-tracked
+    /// references. This is a strict superset of <see cref="IsBlittable"/>:
+    /// <c>bool</c>, <c>char</c> and <c>decimal</c> are unmanaged (they satisfy
+    /// C#'s <c>where T : unmanaged</c> and are valid <c>sizeof</c> operands)
+    /// even though they are not blittable for P/Invoke marshalling. Enums,
+    /// pointers, and value structs whose fields are recursively unmanaged also
+    /// qualify; managed reference types and structs containing a managed field
+    /// do not.
+    /// </summary>
+    /// <param name="type">The bound type symbol to classify.</param>
+    /// <returns><c>true</c> when unmanaged.</returns>
+    public bool IsUnmanaged(TypeSymbol type)
+    {
+        return type != null && IsBlittableImpl(type, new HashSet<StructSymbol>(ReferenceEqualityComparer.Instance), unmanaged: true);
     }
 
     /// <summary>
@@ -75,7 +94,7 @@ internal sealed class BlittableDetector
         return new BlittableDetector().IsBlittable(type);
     }
 
-    private bool IsBlittableImpl(TypeSymbol type, HashSet<StructSymbol> visiting)
+    private bool IsBlittableImpl(TypeSymbol type, HashSet<StructSymbol> visiting, bool unmanaged)
     {
         if (type == null || type == TypeSymbol.Error)
         {
@@ -83,19 +102,29 @@ internal sealed class BlittableDetector
             return true;
         }
 
-        if (cache.TryGetValue(type, out var cached))
+        var modeCache = unmanaged ? unmanagedCache : cache;
+        if (modeCache.TryGetValue(type, out var cached))
         {
             return cached;
         }
 
-        var result = ClassifyImpl(type, visiting);
-        cache[type] = result;
+        var result = ClassifyImpl(type, visiting, unmanaged);
+        modeCache[type] = result;
         return result;
     }
 
-    private bool ClassifyImpl(TypeSymbol type, HashSet<StructSymbol> visiting)
+    private bool ClassifyImpl(TypeSymbol type, HashSet<StructSymbol> visiting, bool unmanaged)
     {
         if (IsBlittablePrimitive(type))
+        {
+            return true;
+        }
+
+        // Issue #1336: `bool`, `char` and `decimal` are unmanaged (no GC
+        // references) even though they are not blittable for P/Invoke
+        // marshalling. In unmanaged mode they are accepted here; in blittable
+        // mode they fall through to the known-non-blittable rejection below.
+        if (unmanaged && IsUnmanagedOnlyPrimitive(type))
         {
             return true;
         }
@@ -117,9 +146,22 @@ internal sealed class BlittableDetector
             return byRef.PointeeType != null;
         }
 
+        // Issue #1336: a raw unmanaged pointer (`*T`) and an enum are unmanaged
+        // (and blittable — a pointer is an address-sized integer, an enum is
+        // its integral underlying type).
+        if (type is PointerTypeSymbol)
+        {
+            return true;
+        }
+
+        if (type is EnumSymbol)
+        {
+            return true;
+        }
+
         if (type is StructSymbol structSym)
         {
-            return IsBlittableStruct(structSym, visiting);
+            return IsBlittableStruct(structSym, visiting, unmanaged);
         }
 
         // Imported CLR types: defer to the runtime's classification by
@@ -128,6 +170,11 @@ internal sealed class BlittableDetector
         var clr = type.ClrType;
         if (clr != null && clr.IsValueType)
         {
+            if (clr.IsEnum)
+            {
+                return true;
+            }
+
             try
             {
                 System.Runtime.InteropServices.Marshal.SizeOf(clr);
@@ -142,6 +189,13 @@ internal sealed class BlittableDetector
         return false;
     }
 
+    private static bool IsUnmanagedOnlyPrimitive(TypeSymbol type)
+    {
+        return type == TypeSymbol.Bool
+            || type == TypeSymbol.Char
+            || type == TypeSymbol.Decimal;
+    }
+
     private static bool IsKnownNonBlittablePrimitive(TypeSymbol type)
     {
         return type == TypeSymbol.Bool
@@ -152,13 +206,19 @@ internal sealed class BlittableDetector
             || type == TypeSymbol.Null;
     }
 
-    private bool IsBlittableStruct(StructSymbol structSym, HashSet<StructSymbol> visiting)
+    private bool IsBlittableStruct(StructSymbol structSym, HashSet<StructSymbol> visiting, bool unmanaged)
     {
         // ADR-0093 §4: a class is blittable only when it carries an
         // explicit @StructLayout annotation and every field is blittable.
         // The default class layout is Auto, which is not P/Invoke-portable.
         if (structSym.IsClass)
         {
+            // Issue #1336: a class is a managed reference type — never unmanaged.
+            if (unmanaged)
+            {
+                return false;
+            }
+
             var layout = structSym.LayoutMetadata;
             if (layout == null)
             {
@@ -184,7 +244,7 @@ internal sealed class BlittableDetector
         {
             foreach (var field in structSym.Fields)
             {
-                if (!IsBlittableImpl(field.Type, visiting))
+                if (!IsBlittableImpl(field.Type, visiting, unmanaged))
                 {
                     return false;
                 }

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -5828,6 +5828,26 @@ internal sealed class DeclarationBinder
                 var hasRefType = p.HasClassConstraint;
                 var hasValueType = p.HasStructConstraint;
                 var hasDefaultCtor = p.HasInitConstraint;
+                var hasUnmanaged = p.HasUnmanagedConstraint;
+
+                // Issue #1336: the `unmanaged` constraint subsumes `struct` —
+                // an unmanaged type is necessarily a non-nullable value type —
+                // so it implies the value-type (and therefore default-ctor)
+                // CLR flag bits. Spelling both `unmanaged` and `struct` is
+                // redundant; flag the explicit `struct`.
+                if (hasUnmanaged && hasValueType)
+                {
+                    Diagnostics.ReportTypeParameterConstraintConflict(p.StructConstraintKeyword.Location, name, "unmanaged", "struct");
+                    hasValueType = false;
+                }
+
+                // `unmanaged` is a value-type constraint and cannot be combined
+                // with the reference-type (`class`) constraint.
+                if (hasUnmanaged && hasRefType)
+                {
+                    Diagnostics.ReportTypeParameterConstraintConflict(p.ClassConstraintKeyword.Location, name, "class", "unmanaged");
+                    hasUnmanaged = false;
+                }
 
                 if (hasRefType && hasValueType)
                 {
@@ -5844,9 +5864,22 @@ internal sealed class DeclarationBinder
                     hasDefaultCtor = false;
                 }
 
+                // Issue #1336: `unmanaged` likewise implies the default-ctor
+                // flag (it is a value-type constraint); flag a redundant
+                // explicit `init()`.
+                if (hasUnmanaged && hasDefaultCtor)
+                {
+                    Diagnostics.ReportTypeParameterConstraintConflict(p.InitConstraintKeyword.Location, name, "unmanaged", "init()");
+                    hasDefaultCtor = false;
+                }
+
+                // Issue #1336: project `unmanaged` onto the value-type CLR flag
+                // bits. The dedicated modreq(UnmanagedType) GenericParamConstraint
+                // is emitted by TypeDefEmitter from HasUnmanagedConstraint.
                 symbol.HasReferenceTypeConstraint = hasRefType;
-                symbol.HasValueTypeConstraint = hasValueType;
+                symbol.HasValueTypeConstraint = hasValueType || hasUnmanaged;
                 symbol.HasDefaultConstructorConstraint = hasDefaultCtor;
+                symbol.HasUnmanagedConstraint = hasUnmanaged;
             }
         }
         finally

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
@@ -60,6 +60,30 @@ internal sealed partial class ExpressionBinder
         return new BoundTypeOfExpression(null, typeSymbol, systemType);
     }
 
+    internal BoundExpression BindSizeOfExpression(SizeOfExpressionSyntax syntax)
+    {
+        // Issue #1336: `sizeof(T)` returns the unmanaged byte size of T as an
+        // int32, emitted via the CIL `sizeof <T>` opcode (which accepts a
+        // generic type token). The operand must be an unmanaged type — a
+        // blittable primitive, an enum, a pointer, a blittable value struct, or
+        // a generic type parameter constrained `unmanaged`. This mirrors C#'s
+        // `sizeof` over unmanaged types and shares the emit path the
+        // unmanaged-pointer arithmetic lowering already uses (ADR-0122 §4).
+        var typeSymbol = bindTypeClause(syntax.TypeClause);
+        if (typeSymbol == null || typeSymbol == TypeSymbol.Error)
+        {
+            return new BoundErrorExpression(null);
+        }
+
+        if (!Binder.IsUnmanagedTypeForConstraint(typeSymbol))
+        {
+            Diagnostics.ReportSizeOfRequiresUnmanagedType(syntax.TypeClause.Location, typeSymbol.Name);
+            return new BoundErrorExpression(null);
+        }
+
+        return new BoundSizeOfExpression(null, typeSymbol);
+    }
+
     internal BoundExpression BindDefaultExpression(DefaultExpressionSyntax syntax)
     {
         // ADR-0100 / issue #795: `default(T)` and bare `default`.

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -298,6 +298,8 @@ internal sealed partial class ExpressionBinder
                 return BindMakeChannelExpression((MakeChannelExpressionSyntax)syntax);
             case SyntaxKind.TypeOfExpression:
                 return BindTypeOfExpression((TypeOfExpressionSyntax)syntax);
+            case SyntaxKind.SizeOfExpression:
+                return BindSizeOfExpression((SizeOfExpressionSyntax)syntax);
             case SyntaxKind.NameOfExpression:
                 return BindNameOfExpression((NameOfExpressionSyntax)syntax);
             case SyntaxKind.DefaultExpression:

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -4277,6 +4277,25 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
     }
 
     /// <summary>
+    /// Issue #1336: GS0415 — a <c>sizeof(T)</c> expression names a type that is
+    /// not an unmanaged type. <c>sizeof</c> measures the unmanaged byte size of
+    /// its operand, so the operand must be a blittable primitive, an enum, a
+    /// pointer, a blittable value struct, or a generic type parameter
+    /// constrained <c>unmanaged</c>; managed reference types and non-blittable
+    /// structs are rejected (mirrors C#'s <c>sizeof</c> over unmanaged types).
+    /// </summary>
+    /// <param name="location">The text location of the measured type clause.</param>
+    /// <param name="typeName">The illegal measured type name.</param>
+    public void ReportSizeOfRequiresUnmanagedType(TextLocation location, string typeName)
+    {
+        Report(
+            location,
+            "GS0415",
+            $"'sizeof' operand '{typeName}' must be an unmanaged type — a blittable primitive, an enum, a pointer, a blittable value struct, or a type parameter constrained 'unmanaged' (issue #1336).",
+            DiagnosticSeverity.Error);
+    }
+
+    /// <summary>
     /// Issue #987: GS0386 — an attempt to construct (instantiate) an abstract
     /// class. A class is abstract when it declares (or inherits without
     /// overriding) an abstract method — a no-body <c>open func F() R;</c>. Like

--- a/src/Core/CodeAnalysis/Emit/PendingGenericParameter.cs
+++ b/src/Core/CodeAnalysis/Emit/PendingGenericParameter.cs
@@ -25,9 +25,17 @@ namespace GSharp.Core.CodeAnalysis.Emit;
 /// constraint. (G# static-virtual sealed-interface constraints, ADR-0089, are
 /// not emitted here.)
 /// </param>
+/// <param name="HasUnmanagedConstraint">
+/// Issue #1336: <see langword="true"/> when the type parameter carries an
+/// <c>unmanaged</c> constraint, requiring an additional
+/// <c>GenericParamConstraint</c> row to <c>System.ValueType</c> decorated with
+/// a required custom modifier of
+/// <c>System.Runtime.InteropServices.UnmanagedType</c>.
+/// </param>
 internal readonly record struct PendingGenericParameter(
     EntityHandle Owner,
     GenericParameterAttributes Attributes,
     string Name,
     ushort Index,
-    GSharp.Core.CodeAnalysis.Symbols.TypeSymbol InterfaceConstraintType);
+    GSharp.Core.CodeAnalysis.Symbols.TypeSymbol InterfaceConstraintType,
+    bool HasUnmanagedConstraint = false);

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -113,6 +113,11 @@ internal sealed class ReflectionMetadataEmitter
     // body is emitted via the same EmitFunction path.
     private readonly Dictionary<FunctionSymbol, BoundBlockStatement> lambdaBodies = new Dictionary<FunctionSymbol, BoundBlockStatement>();
 
+    // Issue #1336: cached TypeSpec for the `unmanaged` constraint's
+    // modreq-decorated System.ValueType GenericParamConstraint. Built lazily and
+    // shared across every `where T : unmanaged` type parameter in the module.
+    private EntityHandle unmanagedConstraintTypeSpec;
+
     // PR-E-9: closure-environment metadata and synthesized display classes
     // moved onto ClosureEmitter. Where this file used to declare:
     //   closureInfos                  -> closures.ClosureInfos
@@ -2761,7 +2766,7 @@ internal sealed class ReflectionMetadataEmitter
         // MethodDefs are emitted in interleaved visit orders, the rows
         // were buffered into emitCtx.PendingGenericParameters and are
         // flushed in sorted order here, just before PE serialisation.
-        TypeDefEmitter.FlushPendingGenericParameters(this.emitCtx, this.GetElementTypeToken);
+        TypeDefEmitter.FlushPendingGenericParameters(this.emitCtx, this.GetElementTypeToken, this.BuildUnmanagedConstraintTypeSpec);
         var peHeaderBuilder = new PEHeaderBuilder(
             imageCharacteristics: entryHandle.IsNil
                 ? Characteristics.Dll | Characteristics.ExecutableImage
@@ -5800,6 +5805,43 @@ internal sealed class ReflectionMetadataEmitter
         }
 
         return fallback;
+    }
+
+    /// <summary>
+    /// Issue #1336: builds the <c>TypeSpec</c> used as the <c>Constraint</c> of
+    /// the <c>GenericParamConstraint</c> row that encodes a <c>where T :
+    /// unmanaged</c> constraint. The signature is
+    /// <c>System.ValueType modreq(System.Runtime.InteropServices.UnmanagedType)</c>
+    /// — the exact metadata shape C# emits — written as a raw type signature
+    /// blob: <c>ELEMENT_TYPE_CMOD_REQD &lt;UnmanagedType&gt;
+    /// ELEMENT_TYPE_CLASS &lt;System.ValueType&gt;</c>.
+    /// </summary>
+    /// <returns>The TypeSpec handle for the modreq-decorated ValueType constraint.</returns>
+    private EntityHandle BuildUnmanagedConstraintTypeSpec()
+    {
+        if (!this.unmanagedConstraintTypeSpec.IsNil)
+        {
+            return this.unmanagedConstraintTypeSpec;
+        }
+
+        var unmanagedTypeRef = this.GetTypeReference(
+            this.ResolveCoreType("System.Runtime.InteropServices.UnmanagedType", typeof(System.Runtime.InteropServices.UnmanagedType)));
+        var valueTypeRef = this.GetTypeReference(this.emitCtx.CoreValueType);
+
+        var blob = new BlobBuilder();
+        blob.WriteByte((byte)SignatureTypeCode.RequiredModifier);
+        blob.WriteCompressedInteger(CodedIndex.TypeDefOrRefOrSpec(unmanagedTypeRef));
+
+        // System.ValueType is itself a reference type (an abstract class), so it
+        // must be encoded as ELEMENT_TYPE_CLASS (0x12) — NOT ELEMENT_TYPE_VALUETYPE
+        // (0x11). This matches exactly what the C# compiler emits; encoding it as
+        // VALUETYPE makes the CLR loader reject the type with a "value type
+        // mismatch" TypeLoadException at runtime.
+        blob.WriteByte((byte)SignatureTypeKind.Class);
+        blob.WriteCompressedInteger(CodedIndex.TypeDefOrRefOrSpec(valueTypeRef));
+
+        this.unmanagedConstraintTypeSpec = this.emitCtx.Metadata.AddTypeSpecification(this.emitCtx.Metadata.GetOrAddBlob(blob));
+        return this.unmanagedConstraintTypeSpec;
     }
 
     internal EntityHandle GetTypeOfToken(TypeSymbol type)

--- a/src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs
@@ -1801,7 +1801,8 @@ internal sealed class TypeDefEmitter
                 Attributes: attrs,
                 Name: tp.Name,
                 Index: (ushort)i,
-                InterfaceConstraintType: tp.ConstraintReferenceType));
+                InterfaceConstraintType: tp.ConstraintReferenceType,
+                HasUnmanagedConstraint: tp.HasUnmanagedConstraint));
         }
     }
 
@@ -1816,9 +1817,15 @@ internal sealed class TypeDefEmitter
     /// <c>TypeDefOrRefOrSpec</c> handle for the matching <c>GenericParamConstraint</c>
     /// row. Supplied by the emitter (its <c>GetElementTypeToken</c>).
     /// </param>
+    /// <param name="resolveUnmanagedConstraintHandle">
+    /// Issue #1336: builds the <c>TypeSpec</c> handle for the <c>unmanaged</c>
+    /// constraint's modreq-decorated <c>System.ValueType</c>
+    /// <c>GenericParamConstraint</c>. Supplied by the emitter.
+    /// </param>
     internal static void FlushPendingGenericParameters(
         EmitContext emitCtx,
-        Func<TypeSymbol, EntityHandle> resolveConstraintHandle)
+        Func<TypeSymbol, EntityHandle> resolveConstraintHandle,
+        Func<EntityHandle> resolveUnmanagedConstraintHandle)
     {
         var pending = emitCtx.PendingGenericParameters;
         if (pending.Count == 0)
@@ -1859,6 +1866,23 @@ internal sealed class TypeDefEmitter
                 metadata.AddGenericParameterConstraint(
                     gpHandle,
                     resolveConstraintHandle(row.InterfaceConstraintType));
+            }
+
+            // Issue #1336: emit the `unmanaged` constraint as a
+            // GenericParamConstraint to `System.ValueType` carrying a required
+            // custom modifier (`modreq`) of
+            // `System.Runtime.InteropServices.UnmanagedType` — the exact
+            // metadata shape C# emits for `where T : unmanaged`. This is what
+            // makes a pointer to the type parameter (`*T`) and `sizeof(T)` over
+            // it verifiable. A parameter may carry BOTH an interface constraint
+            // and the unmanaged constraint (e.g. `[T IComparable[T] unmanaged]`),
+            // producing two constraint rows for the same owner; both share the
+            // same gpHandle so the table stays sorted by Owner.
+            if (row.HasUnmanagedConstraint)
+            {
+                metadata.AddGenericParameterConstraint(
+                    gpHandle,
+                    resolveUnmanagedConstraintHandle());
             }
         }
 

--- a/src/Core/CodeAnalysis/Symbols/TypeParameterSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/TypeParameterSymbol.cs
@@ -120,6 +120,23 @@ public sealed class TypeParameterSymbol : TypeSymbol
     public bool HasDefaultConstructorConstraint { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether this type parameter carries an
+    /// <c>unmanaged</c> constraint (issue #1336). Type arguments must be an
+    /// unmanaged type — a non-nullable value type whose fields are recursively
+    /// unmanaged (blittable primitives, enums, pointers, or other unmanaged
+    /// structs). The <c>unmanaged</c> constraint implies the value-type
+    /// (<c>struct</c>) and default-constructor flags at the CLR level, and the
+    /// emitter additionally projects a <c>GenericParamConstraint</c> to
+    /// <c>System.ValueType</c> carrying a required custom modifier
+    /// (<c>modreq</c>) of
+    /// <c>System.Runtime.InteropServices.UnmanagedType</c> — the exact metadata
+    /// shape C# emits for <c>where T : unmanaged</c>. That modreq is what makes
+    /// a pointer to the type parameter (<c>*T</c>) and <c>sizeof(T)</c> over it
+    /// verifiable.
+    /// </summary>
+    public bool HasUnmanagedConstraint { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether this type parameter is declared
     /// on a generic method (as opposed to a generic type). When
     /// <see langword="true"/> the emitter encodes it as

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -3419,6 +3419,7 @@ public class Parser
         SyntaxToken initKw = null;
         SyntaxToken initOpenParen = null;
         SyntaxToken initCloseParen = null;
+        SyntaxToken unmanagedKw = null;
         while (true)
         {
             if (Current.Kind == SyntaxKind.ClassKeyword)
@@ -3437,6 +3438,19 @@ public class Parser
                 if (structKw == null)
                 {
                     structKw = NextToken();
+                }
+                else
+                {
+                    break;
+                }
+            }
+            else if (Current.Kind == SyntaxKind.IdentifierToken
+                     && Current.Text == "unmanaged")
+            {
+                // Issue #1336: contextual `unmanaged` constraint keyword.
+                if (unmanagedKw == null)
+                {
+                    unmanagedKw = NextToken();
                 }
                 else
                 {
@@ -3477,7 +3491,8 @@ public class Parser
             structKw,
             initKw,
             initOpenParen,
-            initCloseParen);
+            initCloseParen,
+            unmanagedKw);
     }
 
     /// <summary>
@@ -3492,6 +3507,12 @@ public class Parser
     private bool IsAdditionalConstraintStart(SyntaxToken token)
     {
         if (token.Kind == SyntaxKind.ClassKeyword || token.Kind == SyntaxKind.StructKeyword)
+        {
+            return true;
+        }
+
+        // Issue #1336: contextual `unmanaged` constraint keyword.
+        if (token.Kind == SyntaxKind.IdentifierToken && token.Text == "unmanaged")
         {
             return true;
         }
@@ -7807,6 +7828,13 @@ public class Parser
             current = ParseTypeOfExpression();
         }
         else if (Current.Kind == SyntaxKind.IdentifierToken
+            && Current.Text == "sizeof"
+            && Peek(1).Kind == SyntaxKind.OpenParenthesisToken)
+        {
+            // Issue #1336: contextual `sizeof(T)` — argument is a type clause.
+            current = ParseSizeOfExpression();
+        }
+        else if (Current.Kind == SyntaxKind.IdentifierToken
             && Current.Text == "nameof"
             && Peek(1).Kind == SyntaxKind.OpenParenthesisToken)
         {
@@ -8670,6 +8698,16 @@ public class Parser
         var typeClause = ParseTypeClause();
         var closeParen = MatchToken(SyntaxKind.CloseParenthesisToken);
         return new TypeOfExpressionSyntax(syntaxTree, typeOfIdentifier, openParen, typeClause, closeParen);
+    }
+
+    private ExpressionSyntax ParseSizeOfExpression()
+    {
+        // Issue #1336: `sizeof(T)` — the argument is a type clause, not an expression.
+        var sizeOfIdentifier = MatchToken(SyntaxKind.IdentifierToken);
+        var openParen = MatchToken(SyntaxKind.OpenParenthesisToken);
+        var typeClause = ParseTypeClause();
+        var closeParen = MatchToken(SyntaxKind.CloseParenthesisToken);
+        return new SizeOfExpressionSyntax(syntaxTree, sizeOfIdentifier, openParen, typeClause, closeParen);
     }
 
     private DefaultExpressionSyntax ParseDefaultExpression()

--- a/src/Core/CodeAnalysis/Syntax/SizeOfExpressionSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/SizeOfExpressionSyntax.cs
@@ -1,0 +1,53 @@
+// <copyright file="SizeOfExpressionSyntax.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Core.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Represents the built-in <c>sizeof(T)</c> operator (issue #1336).
+/// <c>sizeof</c> is recognized as a contextual identifier when followed by
+/// <c>(</c> and a type clause. The result is the unmanaged byte size of the
+/// referenced type as an <c>int32</c>. The measured type must be an unmanaged
+/// type — a blittable primitive, a blittable value struct, a pointer, or a
+/// generic type parameter constrained <c>unmanaged</c>. Emits the CIL
+/// <c>sizeof &lt;T&gt;</c> opcode (which accepts a generic type token), matching
+/// C# <c>sizeof(T)</c> over a <c>where T : unmanaged</c> parameter.
+/// </summary>
+public sealed class SizeOfExpressionSyntax : ExpressionSyntax
+{
+    /// <summary>Initializes a new instance of the <see cref="SizeOfExpressionSyntax"/> class.</summary>
+    /// <param name="syntaxTree">The parent syntax tree.</param>
+    /// <param name="sizeOfIdentifier">The <c>sizeof</c> identifier token.</param>
+    /// <param name="openParenthesis">The <c>(</c> token.</param>
+    /// <param name="typeClause">The type-clause argument.</param>
+    /// <param name="closeParenthesis">The <c>)</c> token.</param>
+    public SizeOfExpressionSyntax(
+        SyntaxTree syntaxTree,
+        SyntaxToken sizeOfIdentifier,
+        SyntaxToken openParenthesis,
+        TypeClauseSyntax typeClause,
+        SyntaxToken closeParenthesis)
+        : base(syntaxTree)
+    {
+        SizeOfIdentifier = sizeOfIdentifier;
+        OpenParenthesis = openParenthesis;
+        TypeClause = typeClause;
+        CloseParenthesis = closeParenthesis;
+    }
+
+    /// <inheritdoc/>
+    public override SyntaxKind Kind => SyntaxKind.SizeOfExpression;
+
+    /// <summary>Gets the <c>sizeof</c> identifier token.</summary>
+    public SyntaxToken SizeOfIdentifier { get; }
+
+    /// <summary>Gets the opening <c>(</c> token.</summary>
+    public SyntaxToken OpenParenthesis { get; }
+
+    /// <summary>Gets the type-clause argument.</summary>
+    public TypeClauseSyntax TypeClause { get; }
+
+    /// <summary>Gets the closing <c>)</c> token.</summary>
+    public SyntaxToken CloseParenthesis { get; }
+}

--- a/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
@@ -258,6 +258,9 @@ public enum SyntaxKind
     TypeOfExpression,
     NameOfExpression,
 
+    // Issue #1336: sizeof(T) contextual operator over an unmanaged type
+    SizeOfExpression,
+
     // Issue #141 / ADR-0047: attribute (annotation) syntax
     Annotation,
     AnnotationTarget,

--- a/src/Core/CodeAnalysis/Syntax/TypeParameterSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/TypeParameterSyntax.cs
@@ -80,6 +80,51 @@ public sealed class TypeParameterSyntax : SyntaxNode
         SyntaxToken initConstraintKeyword,
         SyntaxToken initConstraintOpenParenToken,
         SyntaxToken initConstraintCloseParenToken)
+        : this(
+            syntaxTree,
+            varianceModifier,
+            identifier,
+            constraint,
+            constraintTypeArgumentOpenBracketToken,
+            constraintTypeArguments,
+            constraintTypeArgumentCloseBracketToken,
+            classConstraintKeyword,
+            structConstraintKeyword,
+            initConstraintKeyword,
+            initConstraintOpenParenToken,
+            initConstraintCloseParenToken,
+            unmanagedConstraintKeyword: null)
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="TypeParameterSyntax"/> class with an optional <c>unmanaged</c> constraint (issue #1336).</summary>
+    /// <param name="syntaxTree">The parent syntax tree.</param>
+    /// <param name="varianceModifier">Optional variance contextual keyword.</param>
+    /// <param name="identifier">The type-parameter identifier token.</param>
+    /// <param name="constraint">Optional legacy constraint identifier (<c>any</c>, <c>comparable</c>, or a sealed-interface name).</param>
+    /// <param name="constraintTypeArgumentOpenBracketToken">Optional opening <c>[</c> of the constraint's type-argument list.</param>
+    /// <param name="constraintTypeArguments">Optional comma-separated list of type-argument clauses for the constraint.</param>
+    /// <param name="constraintTypeArgumentCloseBracketToken">Optional closing <c>]</c> of the constraint's type-argument list.</param>
+    /// <param name="classConstraintKeyword">Optional <c>class</c> keyword token (ADR-0097).</param>
+    /// <param name="structConstraintKeyword">Optional <c>struct</c> keyword token (ADR-0097).</param>
+    /// <param name="initConstraintKeyword">Optional <c>init</c> contextual keyword token (ADR-0097 / issue #997); when set, the parens MUST also be set.</param>
+    /// <param name="initConstraintOpenParenToken">Optional <c>(</c> token of the <c>init()</c> constraint (issue #997).</param>
+    /// <param name="initConstraintCloseParenToken">Optional <c>)</c> token of the <c>init()</c> constraint (issue #997).</param>
+    /// <param name="unmanagedConstraintKeyword">Optional <c>unmanaged</c> contextual keyword token (issue #1336).</param>
+    public TypeParameterSyntax(
+        SyntaxTree syntaxTree,
+        SyntaxToken varianceModifier,
+        SyntaxToken identifier,
+        SyntaxToken constraint,
+        SyntaxToken constraintTypeArgumentOpenBracketToken,
+        SeparatedSyntaxList<TypeClauseSyntax> constraintTypeArguments,
+        SyntaxToken constraintTypeArgumentCloseBracketToken,
+        SyntaxToken classConstraintKeyword,
+        SyntaxToken structConstraintKeyword,
+        SyntaxToken initConstraintKeyword,
+        SyntaxToken initConstraintOpenParenToken,
+        SyntaxToken initConstraintCloseParenToken,
+        SyntaxToken unmanagedConstraintKeyword)
         : base(syntaxTree)
     {
         VarianceModifier = varianceModifier;
@@ -93,6 +138,7 @@ public sealed class TypeParameterSyntax : SyntaxNode
         InitConstraintKeyword = initConstraintKeyword;
         InitConstraintOpenParenToken = initConstraintOpenParenToken;
         InitConstraintCloseParenToken = initConstraintCloseParenToken;
+        UnmanagedConstraintKeyword = unmanagedConstraintKeyword;
     }
 
     /// <inheritdoc/>
@@ -131,6 +177,9 @@ public sealed class TypeParameterSyntax : SyntaxNode
     /// <summary>Gets the optional closing <c>)</c> of the <c>init()</c> constraint (issue #997).</summary>
     public SyntaxToken InitConstraintCloseParenToken { get; }
 
+    /// <summary>Gets the optional <c>unmanaged</c> contextual keyword token introducing an unmanaged-type constraint (issue #1336).</summary>
+    public SyntaxToken UnmanagedConstraintKeyword { get; }
+
     /// <summary>Gets a value indicating whether this type parameter carries a generic-instance constraint (ADR-0089).</summary>
     public bool HasConstraintTypeArguments => ConstraintTypeArgumentOpenBracketToken != null;
 
@@ -142,4 +191,7 @@ public sealed class TypeParameterSyntax : SyntaxNode
 
     /// <summary>Gets a value indicating whether this type parameter carries an <c>init()</c> constraint (ADR-0097 / issue #997).</summary>
     public bool HasInitConstraint => InitConstraintKeyword != null;
+
+    /// <summary>Gets a value indicating whether this type parameter carries an <c>unmanaged</c> constraint (issue #1336).</summary>
+    public bool HasUnmanagedConstraint => UnmanagedConstraintKeyword != null;
 }

--- a/test/Compiler.Tests/Emit/Issue1336GenericUnmanagedSizeOfEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1336GenericUnmanagedSizeOfEmitTests.cs
@@ -1,0 +1,197 @@
+// <copyright file="Issue1336GenericUnmanagedSizeOfEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1336 / Refs #914: end-to-end emit + execution tests for unsafe
+/// generic SIMD-style code over an <c>unmanaged</c>-constrained type parameter
+/// <c>T</c>. Covers two capabilities the real Oahu corpus needs:
+/// <list type="number">
+/// <item><c>sizeof(T)</c> over a generic <c>T : unmanaged</c> — lowered to the
+/// CIL <c>sizeof</c> opcode over a generic type token. This is fully
+/// verifiable IL.</item>
+/// <item><c>*T</c> (a pointer to the type parameter) over <c>T : unmanaged</c>.
+/// Like all raw-pointer code this is unverifiable by design, so the inherent
+/// pointer error codes are tolerated while still gating other regressions.</item>
+/// </list>
+/// </summary>
+public class Issue1336GenericUnmanagedSizeOfEmitTests
+{
+    private static readonly string[] UnsafeIlVerifyIgnored =
+    {
+        "UnmanagedPointer",
+        "StackUnexpected",
+        "StackByRef",
+        "ExpectedPtr",
+        "StackUnexpectedArrayType",
+    };
+
+    [Fact]
+    public void SizeOfGenericUnmanaged_CompilesVerifiesAndRuns()
+    {
+        var source = """
+            package Probe
+            import System
+
+            func sizeOf[T unmanaged](sample T) int32 {
+                return sizeof(T)
+            }
+
+            func run() {
+                var a uint8 = 0
+                var b int32 = 0
+                var c int64 = 0
+                Console.WriteLine(sizeOf(a))
+                Console.WriteLine(sizeOf(b))
+                Console.WriteLine(sizeOf(c))
+            }
+
+            run()
+            """;
+
+        // sizeof over a generic type token is fully verifiable IL: no ignored
+        // codes — any verification error fails the test. The type argument is
+        // inferred from the typed local, so each instantiation emits a distinct
+        // generic `sizeof !!T`.
+        var output = CompileAndRun(source, Array.Empty<string>());
+        Assert.Equal("1\n4\n8\n", output);
+    }
+
+    [Fact]
+    public void SizeOfGenericUnmanaged_VecLaneCount_CompilesAndRuns()
+    {
+        // Mirrors the Oahu driver: 256 / 8 / sizeof(T) lane count.
+        var source = """
+            package Probe
+            import System
+
+            func laneCount[T unmanaged](sample T) int32 {
+                return 256 / 8 / sizeof(T)
+            }
+
+            func run() {
+                var a uint8 = 0
+                var b int16 = 0
+                var c int32 = 0
+                Console.WriteLine(laneCount(a))
+                Console.WriteLine(laneCount(b))
+                Console.WriteLine(laneCount(c))
+            }
+
+            run()
+            """;
+
+        var output = CompileAndRun(source, Array.Empty<string>());
+        Assert.Equal("32\n16\n8\n", output);
+    }
+
+    [Fact]
+    public void PointerToGenericUnmanaged_CompilesVerifiesAndRuns()
+    {
+        var source = """
+            package Probe
+            import System
+
+            unsafe func writeFirst[T unmanaged](arr []T, value T) {
+                var p = &arr[0]
+                *p = value
+            }
+
+            unsafe func run() {
+                var arr = []int32{0, 0, 0}
+                writeFirst[int32](arr, 42)
+                Console.WriteLine(arr[0])
+            }
+
+            run()
+            """;
+
+        // Raw pointer code is unverifiable by design; tolerate the inherent
+        // pointer codes while still gating other verification regressions.
+        var output = CompileAndRun(source, UnsafeIlVerifyIgnored);
+        Assert.Equal("42\n", output);
+    }
+
+    private static string CompileAndRun(string source, string[] ignoredIlVerifyCodes)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1336_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath, null, ignoredIlVerifyCodes);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+                // ignored
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1336GenericUnmanagedConstraintTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1336GenericUnmanagedConstraintTests.cs
@@ -1,0 +1,208 @@
+// <copyright file="Issue1336GenericUnmanagedConstraintTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1336: unsafe generic SIMD code over an <c>unmanaged</c>-constrained
+/// type parameter <c>T</c> must bind. Two capabilities are required:
+/// <list type="number">
+/// <item><c>sizeof(T)</c> where <c>T</c> is a generic type parameter
+/// constrained <c>unmanaged</c> (previously GS0130/GS0125).</item>
+/// <item><c>*T</c> (a pointer to a type parameter) where <c>T : unmanaged</c>
+/// (previously GS0398).</item>
+/// </list>
+/// The <c>unmanaged</c> constraint is what makes both legal; a plain
+/// (unconstrained) type parameter must still be rejected.
+/// </summary>
+public class Issue1336GenericUnmanagedConstraintTests
+{
+    [Fact]
+    public void SizeOfTypeParameter_WithUnmanagedConstraint_NoDiagnostics()
+    {
+        const string source = @"
+package p
+class C {
+    func Size[T unmanaged]() int32 {
+        return sizeof(T)
+    }
+}
+";
+        var diagnostics = Bind(source);
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void SizeOfTypeParameter_WithoutUnmanagedConstraint_ReportsGS0415()
+    {
+        const string source = @"
+package p
+class C {
+    func Size[T any]() int32 {
+        return sizeof(T)
+    }
+}
+";
+        var diagnostics = Bind(source);
+        Assert.Contains(diagnostics, d => d.Id == "GS0415");
+    }
+
+    [Fact]
+    public void SizeOfReferenceType_ReportsGS0415()
+    {
+        const string source = @"
+package p
+class C {
+    func Size() int32 {
+        return sizeof(string)
+    }
+}
+";
+        var diagnostics = Bind(source);
+        Assert.Contains(diagnostics, d => d.Id == "GS0415");
+    }
+
+    [Fact]
+    public void SizeOfPrimitive_NoDiagnostics()
+    {
+        const string source = @"
+package p
+class C {
+    func Size() int32 {
+        return sizeof(int32)
+    }
+}
+";
+        var diagnostics = Bind(source);
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void PointerToTypeParameter_WithUnmanagedConstraint_NoGS0398()
+    {
+        const string source = @"
+package p
+class C {
+    unsafe func First[T unmanaged](p *T) T {
+        return *p
+    }
+}
+";
+        var diagnostics = Bind(source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0398");
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void PointerToTypeParameter_WithoutUnmanagedConstraint_ReportsGS0398()
+    {
+        const string source = @"
+package p
+class C {
+    unsafe func First[T any](p *T) T {
+        return *p
+    }
+}
+";
+        var diagnostics = Bind(source);
+        Assert.Contains(diagnostics, d => d.Id == "GS0398");
+    }
+
+    [Fact]
+    public void UnmanagedConstraint_SatisfiedByPrimitive_NoDiagnostics()
+    {
+        const string source = @"
+package p
+class C {
+    func Id[T unmanaged](x T) T { return x }
+    func Use() int32 { return Id[int32](5) }
+}
+";
+        var diagnostics = Bind(source);
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void UnmanagedConstraint_NotSatisfiedByReferenceType_ReportsGS0152()
+    {
+        const string source = @"
+package p
+class C {
+    func Id[T unmanaged](x T) T { return x }
+    func Use() string { return Id[string](""a"") }
+}
+";
+        var diagnostics = Bind(source);
+        Assert.Contains(diagnostics, d => d.Id == "GS0152");
+    }
+
+    [Fact]
+    public void CombinedInterfaceAndUnmanagedConstraint_PrimitiveOk_ReferenceRejected()
+    {
+        const string source = @"
+package p
+import System
+class C {
+    func Cmp[T IComparable[T] unmanaged](a T, b T) int32 {
+        return a.CompareTo(b) + sizeof(T)
+    }
+    func Ok() int32 { return Cmp[int32](1, 2) }
+}
+";
+        var diagnostics = Bind(source);
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void CombinedInterfaceAndUnmanagedConstraint_ReferenceType_Rejected()
+    {
+        const string source = @"
+package p
+import System
+class C {
+    func Cmp[T IComparable[T] unmanaged](a T, b T) int32 {
+        return a.CompareTo(b) + sizeof(T)
+    }
+    func Bad() int32 { return Cmp[string](""a"", ""b"") }
+}
+";
+        var diagnostics = Bind(source);
+        Assert.Contains(diagnostics, d => d.Id == "GS0152");
+    }
+
+    [Fact]
+    public void UnmanagedCombinedWithStruct_ReportsGS0361()
+    {
+        // `unmanaged` already implies `struct`; spelling both is a
+        // mutually-exclusive/redundant constraint conflict (ADR-0097 GS0361).
+        const string source = @"
+package p
+class C {
+    func F[T unmanaged struct](x T) T { return x }
+}
+";
+        var diagnostics = Bind(source);
+        Assert.Contains(diagnostics, d => d.Id == "GS0361");
+    }
+
+    private static IReadOnlyList<Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var program = Binder.BindProgram(compilation.GlobalScope, compilation.References);
+        return tree.Diagnostics
+            .Concat(compilation.GlobalScope.Diagnostics)
+            .Concat(program.Diagnostics)
+            .ToList();
+    }
+}

--- a/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
+++ b/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
@@ -214,6 +214,7 @@ ShiftLeftEqualsToken
 ShiftLeftToken
 ShiftRightEqualsToken
 ShiftRightToken
+SizeOfExpression
 SlashEqualsToken
 SlashToken
 StackAllocExpression


### PR DESCRIPTION
## Summary

G# could not compile unsafe generic code over an `unmanaged`-constrained type parameter `T` — the pattern at the heart of the Oahu SIMD helpers (`Oahu.Decrypt/Mpeg4/Util/HelperExtensions.cs`):

```
private static unsafe bool AllLessThanOrEqual_256<T>(Span<T> ints, T value, out int n)
    where T : unmanaged, IComparable<T>
{
    int vecSize = 256 / 8 / sizeof(T);   // sizeof over a type parameter
    fixed (T* p = ints) { ... }          // pointer to a type parameter
}
```

## Root cause

Two gaps, both unlockable only by the `unmanaged` constraint, which G# had no spelling for:

1. **`sizeof(T)`** had no surface syntax — it existed only as an internal bound node used to lower pointer arithmetic. Source `sizeof(T)` parsed as a call to an undefined `sizeof` function → **GS0130** + **GS0125**.
2. **`*T`** (pointer to a type parameter) was rejected by the ADR-0122 pointer-pointee blittability gate → **GS0398**, because a bare type parameter is not statically known to be blittable.

## Fix (parse → bind → emit)

- **`unmanaged` constraint** — new flag type-parameter constraint joining `class`/`struct`/`init()` (ADR-0097). Implies the value-type CLR flags and emits the **C#-faithful** `GenericParamConstraint` TypeSpec `CMOD_REQD(UnmanagedType) CLASS(System.ValueType)`. Verified byte-for-byte against `csc`.
  - **Critical subtlety:** `System.ValueType` is itself an abstract *class*, so it must be encoded `ELEMENT_TYPE_CLASS` (0x12), **not** `VALUETYPE` (0x11). The value-type encoding passes `ilverify` but throws a `"value type mismatch"` `TypeLoadException` at runtime — caught only because the emit tests *execute* the assembly.
- **`sizeof(T)` expression** — new `SizeOfExpressionSyntax` / `SyntaxKind.SizeOfExpression`, contextual so existing `sizeof` identifiers are unaffected. Reuses the existing `BoundSizeOfExpression` emit (CIL `sizeof <token>`, which accepts a generic type token). Non-unmanaged operand → new **GS0415**.
- **`*T` pointer** — widened the ADR-0122 gate to admit a pointee that is an `unmanaged`-constrained type parameter; a bare unconstrained `T` still → GS0398.
- **`BlittableDetector.IsUnmanaged`** — new mode distinct from blittability (accepts `bool`/`char`/`decimal`/enums/pointers, rejects reference types).

## Test evidence

- **Binder** (`Issue1336GenericUnmanagedConstraintTests`, 11 tests, all green): `sizeof(T)` over `[T unmanaged]` binds; `sizeof(T)` over `[T any]` and `sizeof(string)` → GS0415; `sizeof(int32)` binds; `*T` over `[T unmanaged]` binds while `*T` over `[T any]` → GS0398; `unmanaged` satisfaction (int32 ok, string → GS0152); combined `[T IComparable[T] unmanaged]`; `unmanaged struct` conflict → GS0361.
- **Emit / IL-verify (executing)** (`Issue1336GenericUnmanagedSizeOfEmitTests`, 3 tests, all green): `sizeof(T)` yields correct per-instantiation sizes (1/4/8) and the `256/8/sizeof(T)` lane count (32/16/8) under `ilverify` with **no ignored codes**; `*T` write-through runs correctly under the inherent-unsafety ignored-code set (same as Issue1014).
- Full **Core.Tests** green (4712, incl. coverage-matrix golden); existing pointer (`Issue1014`) and struct-constraint (`Issue1325`) emit tests green; full `dotnet build GSharp.sln -c Release -graph` → **0 warnings / 0 errors**.

## Docs

ADR-0135; diagnostics.md GS0415; coverage-matrix updated for the new `SizeOfExpression` syntax kind.

## Deferred

Nothing. Note: an unrelated pre-existing limitation (explicit type arguments on a generic call are routed through argument inference, so `f[int64](0)` infers `int32` from the literal) is out of scope for #1336 — the tests use inference from typed locals, matching the real Oahu `Span<T>` call sites.

Fixes #1336
Refs #914