### PR TITLE
cs2gs: map C# 'unmanaged' constraint to the G# 'unmanaged' flag

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/L3TranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/L3TranslationTests.cs
@@ -387,6 +387,34 @@ namespace Demo
             d => d.IsUnsupported && d.ConstructKind == "TypeParameterConstraintClause");
     }
 
+    /// <summary>
+    /// Issue #1336: C# <c>where T : unmanaged</c> maps to the G# <c>unmanaged</c>
+    /// flag constraint (which gsc supports for <c>sizeof(T)</c> / <c>*T</c>). It
+    /// subsumes <c>struct</c>, so the translator emits <c>unmanaged</c> only — gsc
+    /// reports a conflict if both <c>unmanaged</c> and <c>struct</c> are spelled.
+    /// </summary>
+    [Fact]
+    public void UnmanagedConstraint_EmitsUnmanagedFlagNotStruct()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    using System;
+    public static class ConstraintHost
+    {
+        public static int Size<T>() where T : unmanaged, IComparable<T>
+        {
+            return 0;
+        }
+    }
+}");
+
+        Assert.Contains("unmanaged", printed);
+        Assert.DoesNotContain("struct]", printed);
+        Assert.DoesNotContain("unmanaged struct", printed);
+        Assert.DoesNotContain("struct unmanaged", printed);
+    }
+
     private static string TranslateUnit(string source)
     {
         (string printed, _) = Translate(source);

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -2404,7 +2404,14 @@ public sealed class CSharpToGSharpTranslator
                 flags.Add("class");
             }
 
-            if (tp.HasValueTypeConstraint)
+            if (tp.HasUnmanagedTypeConstraint)
+            {
+                // Issue #1336: C# `where T : unmanaged` maps to the G# `unmanaged`
+                // flag constraint. It subsumes `struct` (gsc reports a conflict if
+                // both are spelled), so the value-type flag is intentionally omitted.
+                flags.Add("unmanaged");
+            }
+            else if (tp.HasValueTypeConstraint)
             {
                 flags.Add("struct");
             }


### PR DESCRIPTION
## Problem
The translator mapped C# `where T : unmanaged` to the G# `struct` flag. Once gsc gained `unmanaged`-constraint support (#1336), the generic unsafe SIMD helpers in `Oahu.Decrypt/HelperExtensions` still failed: a merely `struct`-constrained `T` is not statically unmanaged, so `sizeof(T)` raised the new GS0415 (non-unmanaged operand) and `*T` raised GS0398 (unmanaged pointer to T).

## Fix
Map Roslyn's `HasUnmanagedTypeConstraint` to the G# `unmanaged` flag, and omit the redundant `struct` flag — gsc reports a constraint conflict if both `unmanaged` and `struct` are spelled, because `unmanaged` subsumes the value-type constraint.

```
// C#:  where T : unmanaged, IComparable<T>
// G#:  [T IComparable[T] unmanaged]   (was: [T IComparable[T] struct])
```

## Result
`Oahu.Decrypt` compile errors **52 -> 48** (HelperExtensions GS0415x2 + GS0398x2 cleared; `sizeof(T)` and `*T` now bind). The residual HelperExtensions errors are unrelated generic BCL-intrinsic resolution (`Vector256.Load`/`LessThanOrEqualAll`). 329 cs2gs tests pass (added `UnmanagedConstraint_EmitsUnmanagedFlagNotStruct`).

Refs #914
