### PR TITLE
Fix base auto-property read mis-bound as write (GS0127) (#1347)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundBaseClassCallExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundBaseClassCallExpression.cs
@@ -26,16 +26,20 @@ public sealed class BoundBaseClassCallExpression : BoundExpression
     /// <param name="syntax">The originating syntax.</param>
     /// <param name="receiver">The implicit <c>this</c> receiver of the enclosing instance member.</param>
     /// <param name="baseClass">The base class whose member is invoked (the declaring type of <paramref name="method"/>).</param>
-    /// <param name="method">The base-class method whose implementation is invoked non-virtually.</param>
+    /// <param name="method">The base-class method whose implementation is invoked non-virtually, or <see langword="null"/> for a base auto-property accessor (issue #1347), in which case <paramref name="property"/> identifies the accessor and <paramref name="returnTypeOverride"/> must be supplied.</param>
     /// <param name="arguments">The bound argument expressions in declared order.</param>
-    /// <param name="returnTypeOverride">Optional substituted return type for a constructed generic base; <see langword="null"/> uses <see cref="FunctionSymbol.Type"/>.</param>
+    /// <param name="returnTypeOverride">Optional substituted return type for a constructed generic base; <see langword="null"/> uses <see cref="FunctionSymbol.Type"/>. Required when <paramref name="method"/> is <see langword="null"/>.</param>
+    /// <param name="property">Issue #1347: the base auto-property whose synthesized accessor is invoked non-virtually, or <see langword="null"/> for an ordinary method/computed-accessor call.</param>
+    /// <param name="isSetterAccessor">Issue #1347: when <paramref name="property"/> is set, whether the setter accessor (rather than the getter) is invoked.</param>
     public BoundBaseClassCallExpression(
         SyntaxNode syntax,
         BoundExpression receiver,
         StructSymbol baseClass,
         FunctionSymbol method,
         ImmutableArray<BoundExpression> arguments,
-        TypeSymbol returnTypeOverride = null)
+        TypeSymbol returnTypeOverride = null,
+        PropertySymbol property = null,
+        bool isSetterAccessor = false)
         : base(syntax)
     {
         Receiver = receiver;
@@ -43,22 +47,37 @@ public sealed class BoundBaseClassCallExpression : BoundExpression
         Method = method;
         Arguments = arguments;
         this.returnTypeOverride = returnTypeOverride;
+        Property = property;
+        IsSetterAccessor = isSetterAccessor;
     }
 
     /// <inheritdoc/>
     public override BoundNodeKind Kind => BoundNodeKind.BaseClassCallExpression;
 
     /// <inheritdoc/>
-    public override TypeSymbol Type => returnTypeOverride ?? Method.Type;
+    public override TypeSymbol Type => returnTypeOverride ?? Method?.Type;
 
     /// <summary>Gets the implicit <c>this</c> receiver — a <see cref="BoundVariableExpression"/> reading the enclosing method's first parameter.</summary>
     public BoundExpression Receiver { get; }
 
-    /// <summary>Gets the base class whose member is invoked (the declaring type of <see cref="Method"/>).</summary>
+    /// <summary>Gets the base class whose member is invoked (the declaring type of <see cref="Method"/> or <see cref="Property"/>).</summary>
     public StructSymbol BaseClass { get; }
 
-    /// <summary>Gets the base-class method whose implementation is invoked non-virtually.</summary>
+    /// <summary>Gets the base-class method whose implementation is invoked non-virtually, or <see langword="null"/> for a base auto-property accessor (issue #1347).</summary>
     public FunctionSymbol Method { get; }
+
+    /// <summary>
+    /// Gets the base auto-property whose synthesized accessor is invoked
+    /// non-virtually, or <see langword="null"/> for an ordinary method or
+    /// computed-accessor call (issue #1347). Auto-properties have no accessor
+    /// <see cref="FunctionSymbol"/>, so the accessor is resolved through the
+    /// property's emitted get_/set_ MethodDef (or, in the interpreter, its
+    /// synthesized backing field).
+    /// </summary>
+    public PropertySymbol Property { get; }
+
+    /// <summary>Gets a value indicating whether <see cref="Property"/>'s setter accessor (rather than its getter) is invoked (issue #1347).</summary>
+    public bool IsSetterAccessor { get; }
 
     /// <summary>Gets the bound argument expressions in declared order.</summary>
     public ImmutableArray<BoundExpression> Arguments { get; }

--- a/src/Core/CodeAnalysis/Binding/BoundNodePrinter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundNodePrinter.cs
@@ -1554,7 +1554,7 @@ public static class BoundNodePrinter
         writer.WriteIdentifier(node.BaseClass.Name);
         writer.WritePunctuation(SyntaxKind.CloseSquareBracketToken);
         writer.WritePunctuation(SyntaxKind.DotToken);
-        writer.WriteIdentifier(node.Method.Name);
+        writer.WriteIdentifier(node.Method?.Name ?? ((node.IsSetterAccessor ? "set_" : "get_") + node.Property?.Name));
         writer.WritePunctuation(SyntaxKind.OpenParenthesisToken);
         for (var i = 0; i < node.Arguments.Length; i++)
         {

--- a/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -1900,7 +1900,9 @@ public abstract class BoundTreeRewriter
             node.BaseClass,
             node.Method,
             builder?.ToImmutable() ?? node.Arguments,
-            node.Type);
+            node.Type,
+            node.Property,
+            node.IsSetterAccessor);
     }
 
     /// <summary>Rewrites a field read.</summary>

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -4828,7 +4828,7 @@ internal sealed partial class ExpressionBinder
             return new BoundErrorExpression(null);
         }
 
-        if (!prop.HasGetter || prop.GetterSymbol == null)
+        if (!prop.HasGetter)
         {
             Diagnostics.ReportCannotAssign(member.IdentifierToken.Location, memberName);
             return new BoundErrorExpression(null);
@@ -4841,6 +4841,25 @@ internal sealed partial class ExpressionBinder
         }
 
         var receiver = new BoundVariableExpression(null, function.ThisParameter);
+
+        // Issue #1347: an auto-property has no getter FunctionSymbol — its
+        // getter is a compiler-synthesized backing-field read. Route the base
+        // access through the property so the emitter resolves the synthesized
+        // `get_Prop` MethodDef and the interpreter reads the backing field,
+        // rather than mis-binding the read as a write (GS0127).
+        if (prop.GetterSymbol == null)
+        {
+            return new BoundBaseClassCallExpression(
+                member,
+                receiver,
+                declaringType,
+                method: null,
+                ImmutableArray<BoundExpression>.Empty,
+                prop.Type,
+                property: prop,
+                isSetterAccessor: false);
+        }
+
         return new BoundBaseClassCallExpression(
             member,
             receiver,
@@ -4896,7 +4915,7 @@ internal sealed partial class ExpressionBinder
             return new BoundErrorExpression(null);
         }
 
-        if (!prop.HasSetter || prop.SetterSymbol == null)
+        if (!prop.HasSetter)
         {
             Diagnostics.ReportCannotAssign(equalsLocation, memberName);
             return new BoundErrorExpression(null);
@@ -4910,6 +4929,25 @@ internal sealed partial class ExpressionBinder
 
         var converted = conversions.BindConversion(valueLocation, value, prop.Type);
         var receiver = new BoundVariableExpression(null, function.ThisParameter);
+
+        // Issue #1347: an auto-property has no setter FunctionSymbol — its
+        // setter is a compiler-synthesized backing-field write. Route the base
+        // assignment through the property so the emitter resolves the
+        // synthesized `set_Prop` MethodDef and the interpreter writes the
+        // backing field.
+        if (prop.SetterSymbol == null)
+        {
+            return new BoundBaseClassCallExpression(
+                value.Syntax,
+                receiver,
+                declaringType,
+                method: null,
+                ImmutableArray.Create(converted),
+                TypeSymbol.Void,
+                property: prop,
+                isSetterAccessor: true);
+        }
+
         return new BoundBaseClassCallExpression(
             value.Syntax,
             receiver,

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Calls.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Calls.cs
@@ -746,7 +746,9 @@ internal sealed partial class MethodBodyEmitter
             }
         }
 
-        var methodToken = this.outer.ResolveUserInstanceMethodToken(baseClass, call.Method);
+        var methodToken = call.Method != null
+            ? this.outer.ResolveUserInstanceMethodToken(baseClass, call.Method)
+            : this.outer.ResolveUserPropertyAccessorToken(baseClass, call.Property, call.IsSetterAccessor);
 
         // Issue #986: non-virtual `call`, NOT `callvirt`. callvirt would
         // re-dispatch through the v-table and re-enter the derived override.

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -3557,6 +3557,33 @@ public sealed class Evaluator
     private object EvaluateBaseClassCallExpression(BoundBaseClassCallExpression node)
     {
         var receiverValue = EvaluateExpression(node.Receiver);
+
+        // Issue #1347: a base auto-property access has no accessor
+        // FunctionSymbol — read/write its synthesized backing field directly on
+        // the receiver, mirroring the ordinary auto-property fallback paths.
+        if (node.Method == null && node.Property != null)
+        {
+            var backingField = node.Property.BackingField;
+            if (node.IsSetterAccessor)
+            {
+                var value = EvaluateExpression(node.Arguments[0]);
+                if (receiverValue is StructValue target && backingField != null)
+                {
+                    target.Fields[backingField.Name] = value;
+                }
+
+                return value;
+            }
+
+            if (receiverValue is StructValue sv && backingField != null
+                && sv.Fields.TryGetValue(backingField.Name, out var fieldValue))
+            {
+                return fieldValue;
+            }
+
+            return DefaultValue(node.Property.Type);
+        }
+
         var method = node.Method;
 
         var frame = new Dictionary<VariableSymbol, object>

--- a/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
@@ -980,7 +980,7 @@ public static class SpillSequenceSpiller
                 return Trivial(call);
             }
 
-            var value = new BoundBaseClassCallExpression(null, receiver, call.BaseClass, call.Method, args.ToImmutable(), call.Type);
+            var value = new BoundBaseClassCallExpression(null, receiver, call.BaseClass, call.Method, args.ToImmutable(), call.Type, call.Property, call.IsSetterAccessor);
             return new BoundSpillSequenceExpression(
                 null,
                 locals.ToImmutable(),

--- a/test/Compiler.Tests/Emit/Issue1347BaseAutoPropertyReadEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1347BaseAutoPropertyReadEmitTests.cs
@@ -1,0 +1,352 @@
+// <copyright file="Issue1347BaseAutoPropertyReadEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1347: end-to-end CLR emit + ilverify coverage for reading and writing
+/// a base-class <em>auto-property</em> through <c>base.Prop</c>. An
+/// auto-property has no accessor <see cref="GSharp.Core.CodeAnalysis.Symbols.FunctionSymbol"/>
+/// — its getter/setter are compiler-synthesized over a backing field — and the
+/// original #1104 support mis-bound such a read as a write (GS0127). These tests
+/// validate that the read/write now lower to the non-virtual
+/// <c>call instance R BaseClass::get_Prop()</c> / <c>... set_Prop(value)</c>
+/// shape (NOT <c>callvirt</c>, which would re-enter the derived override and
+/// stack-overflow), produce the correct runtime values, and pass ilverify.
+/// </summary>
+public class Issue1347BaseAutoPropertyReadEmitTests
+{
+    [Fact]
+    public void EndToEnd_BaseDotAutoProperty_Read_RunsSynthesizedGetter()
+    {
+        var source = """
+            package Probe
+            import System
+
+            open class Base {
+                prop Stored int64 { get; init; }
+            }
+
+            open class Deriv : Base {
+                func ReadBase() int64 {
+                    return base.Stored
+                }
+            }
+
+            func Main() {
+                var d = Deriv{Stored: 17L}
+                Console.WriteLine(d.ReadBase())
+            }
+            """;
+        var output = CompileAndRun(source);
+        Assert.Equal("17\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_BaseDotAutoProperty_ExpressionBodiedReExposure_Reads()
+    {
+        // The Oahu.Decrypt DashFile shape: a derived expression-bodied member
+        // re-exposing the base auto-property (`prop Mirror T -> base.Stored`).
+        var source = """
+            package Probe
+            import System
+
+            open class Base {
+                prop Stored int64 { get; init; }
+            }
+
+            open class Deriv : Base {
+                prop Mirror int64 -> base.Stored
+            }
+
+            func Main() {
+                var d = Deriv{Stored: 23L}
+                Console.WriteLine(d.Mirror)
+            }
+            """;
+        var output = CompileAndRun(source);
+        Assert.Equal("23\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_BaseDotAutoProperty_Write_RunsSynthesizedSetter()
+    {
+        var source = """
+            package Probe
+            import System
+
+            open class Base {
+                prop Stored int64 { get; set; }
+            }
+
+            open class Deriv : Base {
+                func SetBase(v int64) {
+                    base.Stored = v
+                }
+                func ReadBase() int64 {
+                    return base.Stored
+                }
+            }
+
+            func Main() {
+                var d = Deriv{Stored: 100L}
+                Console.WriteLine(d.ReadBase())
+                d.SetBase(42L)
+                Console.WriteLine(d.ReadBase())
+            }
+            """;
+        var output = CompileAndRun(source);
+        Assert.Equal("100\n42\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_BaseDotAutoProperty_ReachesGrandparentGetter()
+    {
+        var source = """
+            package Probe
+            import System
+
+            open class A {
+                prop Tag int64 { get; init; }
+            }
+
+            open class B : A {
+            }
+
+            open class C : B {
+                func Read() int64 {
+                    return base.Tag
+                }
+            }
+
+            func Main() {
+                var c = C{Tag: 5L}
+                Console.WriteLine(c.Read())
+            }
+            """;
+        var output = CompileAndRun(source);
+        Assert.Equal("5\n", output);
+    }
+
+    [Fact]
+    public void Library_BaseDotAutoProperty_PassesIlVerify_AndUsesCallNotCallvirt()
+    {
+        var source = """
+            package Probe
+
+            open class Base {
+                prop Stored int64 { get; init; }
+            }
+
+            open class Deriv : Base {
+                prop Mirror int64 -> base.Stored
+            }
+            """;
+
+        var dllPath = CompileLibrary(source);
+        try
+        {
+            using var stream = File.OpenRead(dllPath);
+            using var peReader = new PEReader(stream);
+            var reader = peReader.GetMetadataReader();
+
+            // Find Deriv::get_Mirror — the expression-bodied getter that
+            // contains the base auto-property read.
+            MethodDefinitionHandle? mirrorGetter = null;
+            foreach (var typeHandle in reader.TypeDefinitions)
+            {
+                var td = reader.GetTypeDefinition(typeHandle);
+                if (!reader.StringComparer.Equals(td.Name, "Deriv"))
+                {
+                    continue;
+                }
+
+                foreach (var mh in td.GetMethods())
+                {
+                    var md = reader.GetMethodDefinition(mh);
+                    if (reader.StringComparer.Equals(md.Name, "get_Mirror"))
+                    {
+                        mirrorGetter = mh;
+                    }
+                }
+            }
+
+            Assert.True(mirrorGetter.HasValue, "expected to find Deriv::get_Mirror");
+
+            var method = reader.GetMethodDefinition(mirrorGetter.Value);
+            Assert.True(method.RelativeVirtualAddress != 0, "Deriv::get_Mirror must carry a body");
+            var body = peReader.GetMethodBody(method.RelativeVirtualAddress);
+            var ilBytes = body.GetILBytes();
+            Assert.NotNull(ilBytes);
+
+            // ECMA-335 opcodes: `call` = 0x28; `callvirt` = 0x6F. The base
+            // auto-property read MUST be a non-virtual `call` to the
+            // synthesized base get_Stored.
+            bool sawCall = false;
+            bool sawCallvirt = false;
+            for (int i = 0; i < ilBytes.Length; i++)
+            {
+                if (ilBytes[i] == 0x28)
+                {
+                    sawCall = true;
+                }
+                else if (ilBytes[i] == 0x6F)
+                {
+                    sawCallvirt = true;
+                }
+            }
+
+            Assert.True(sawCall, "Deriv::get_Mirror must contain a `call` opcode (non-virtual base auto-property read)");
+            Assert.False(sawCallvirt, "Deriv::get_Mirror must NOT use `callvirt` for base.Stored");
+        }
+        finally
+        {
+            TryCleanup(dllPath);
+        }
+    }
+
+    private static string CompileLibrary(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_bap_lib_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        var args = new[]
+        {
+            "/out:" + outPath,
+            "/target:library",
+            "/targetframework:net10.0",
+            srcPath,
+        };
+
+        using var stdoutWriter = new StringWriter();
+        using var stderrWriter = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(stdoutWriter);
+        Console.SetError(stderrWriter);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+        IlVerifier.Verify(outPath);
+        return outPath;
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_bap_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static void TryCleanup(string dllPath)
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(dllPath);
+            if (dir != null && Directory.Exists(dir))
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+        catch
+        {
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1347BaseAutoPropertyReadBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1347BaseAutoPropertyReadBinderTests.cs
@@ -1,0 +1,153 @@
+// <copyright file="Issue1347BaseAutoPropertyReadBinderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1347: binder/interpreter tests for reading and writing a base-class
+/// <em>auto-property</em> through <c>base.Prop</c>. Auto-properties have no
+/// accessor <see cref="FunctionSymbol"/> (their getter/setter are
+/// compiler-synthesized over a backing field), and the original #1104 support
+/// mis-bound such a read as a write — emitting GS0127. These tests verify the
+/// read binds as a value (no GS0127), the write binds as an assignment, and
+/// both run with the expected backing-field semantics, including for
+/// getter-only (<c>{ get; }</c>), expression-bodied re-exposure, and
+/// grandparent auto-properties.
+/// </summary>
+public class Issue1347BaseAutoPropertyReadBinderTests
+{
+    [Fact]
+    public void BaseDotAutoProperty_InitOnly_Read_BindsWithoutGS0127()
+    {
+        var source = @"
+open class BaseFile {
+    prop Tag int { get; init; }
+}
+
+open class DashFile : BaseFile {
+    func Read() int {
+        return base.Tag
+    }
+}
+
+let d = DashFile{Tag: 42}
+d.Read()
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0127");
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void BaseDotAutoProperty_ExpressionBodiedReExposure_BindsWithoutGS0127()
+    {
+        // The Oahu.Decrypt DashFile shape: an expression-bodied derived member
+        // re-exposing the base auto-property (`prop Mirror T -> base.Tag`).
+        var source = @"
+open class BaseFile {
+    prop Tag int { get; init; }
+}
+
+open class DashFile : BaseFile {
+    prop Mirror int -> base.Tag
+}
+
+let d = DashFile{Tag: 7}
+d.Mirror
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0127");
+        Assert.Equal(7, result.Value);
+    }
+
+    [Fact]
+    public void BaseDotAutoProperty_GetSet_ReadAndWrite_RoundTrips()
+    {
+        var source = @"
+open class BaseFile {
+    prop Tag int { get; set; }
+}
+
+open class DashFile : BaseFile {
+    func Read() int {
+        return base.Tag
+    }
+    func Write(v int) {
+        base.Tag = v
+    }
+}
+
+let d = DashFile{Tag: 1}
+d.Write(99)
+d.Read()
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0127");
+        Assert.Equal(99, result.Value);
+    }
+
+    [Fact]
+    public void BaseDotAutoProperty_ReachesGrandparentAutoProperty()
+    {
+        var source = @"
+open class A {
+    prop Tag int { get; init; }
+}
+
+open class B : A {
+}
+
+open class C : B {
+    func Read() int {
+        return base.Tag
+    }
+}
+
+let c = C{Tag: 5}
+c.Read()
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0127");
+        Assert.Equal(5, result.Value);
+    }
+
+    [Fact]
+    public void BaseDotAutoProperty_GetOnly_Write_DiagnosticGS0127()
+    {
+        // A getter-only auto-property has no setter, so writing it via base
+        // remains a GS0127 (the access really is read-only here).
+        var source = @"
+open class BaseFile {
+    prop Tag int { get; }
+}
+
+open class DashFile : BaseFile {
+    func Set(v int) {
+        base.Tag = v
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0127");
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
## Root cause
Reading a base-class **auto-property** through `base.Prop` was mis-bound as an *assignment*, producing `GS0127: Variable 'X' is read-only and cannot be assigned to.` even for a pure read.

The `base.Prop` support from #1104 assumed every readable property exposes an accessor `FunctionSymbol`. Auto-properties have none — their getter/setter are compiler-synthesized over a backing field (`<Prop>k__BackingField`). So `BindBaseClassPropertyRead` hit its `prop.GetterSymbol == null` guard and fell through to the cannot-assign branch, emitting GS0127 at the `base.Prop` read. The expression-bodied/computed base getter worked only because computed properties *do* carry a `GetterSymbol`.

## Fix
- `base.Prop` for an auto-property now lowers to a `BoundBaseClassCallExpression` carrying the source `PropertySymbol` (with `Method == null`) instead of requiring an accessor `FunctionSymbol`.
- **Emit**: `EmitBaseClassCall` resolves the synthesized `get_Prop`/`set_Prop` MethodDef through the existing `ResolveUserPropertyAccessorToken` (which also handles constructed generic bases) and emits a non-virtual `call` — never `callvirt`, which would re-enter the derived override and stack-overflow.
- **Interpreter**: `EvaluateBaseClassCallExpression` reads/writes the property backing field directly on the receiver.
- The symmetric write path (`base.Prop = value` for `{ get; set; }` / `{ get; init; }` auto-properties) is fixed the same way. A getter-only (`{ get; }`) auto-property write still correctly reports GS0127.
- Updated `BoundTreeRewriter`, `SpillSequenceSpiller`, and `BoundNodePrinter` to carry/print the new `Property`/`IsSetterAccessor` fields.

No new `SyntaxKind`/`BoundNodeKind` was introduced (the existing `BoundBaseClassCallExpression` was extended), so the coverage matrix is unchanged.

## Test evidence
- New binder tests `test/Core.Tests/.../Issue1347BaseAutoPropertyReadBinderTests.cs` (5 tests): get/init read, expression-bodied re-exposure (`prop Mirror T -> base.Tag`), get/set read+write round-trip, grandparent auto-property, and getter-only write still GS0127. **5/5 pass.**
- New emit/IL-verify tests `test/Compiler.Tests/Emit/Issue1347BaseAutoPropertyReadEmitTests.cs` (5 tests): end-to-end run for read, re-exposure, write, grandparent; plus an ilverify + `call`-not-`callvirt` opcode assertion. **5/5 pass.**
- Existing `Issue1104` / `Issue1260BaseBcl` / `Issue986Base` emit tests: **17/17 pass** (no regression).
- Full `Core.Tests`: **4718 pass, 1 skipped.**
- Property/auto-property emit subset: **137/137 pass.**
- `dotnet build GSharp.sln -c Release -graph`: **0 warnings / 0 errors.**

Fixes #1347
Refs #914
