### PR TITLE
Fix func conversion return-type covariance from type parameter T to T? (#1356)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -1374,7 +1374,30 @@ public sealed class Conversion
             return false;
         }
 
-        return WidensNumerically(fromReturn.ClrType, toReturn.ClrType);
+        if (WidensNumerically(fromReturn.ClrType, toReturn.ClrType))
+        {
+            return true;
+        }
+
+        // Issue #1356: a function returning a bare type `T` widens to a function
+        // returning `T?` (the nullable form of the same type). This mirrors the
+        // scalar `T → T?` implicit conversion and is the return-covariance
+        // analogue that, until now, only `WidensNumerically` handled for
+        // concrete numeric returns. It is essential for a return type that is a
+        // bare type parameter `T` widening to `T?`: such a type parameter carries
+        // no CLR backing during binding, so the numeric path never fires, yet
+        // widening a non-null value to its nullable form is always safe.
+        //
+        // The reverse direction (`T? → T`, a null-dropping narrowing) is
+        // intentionally NOT recognized here — it requires the bang operator — so
+        // an unsafe `(T) -> T?` to `(T) -> T` conversion stays rejected.
+        if (toReturn is NullableTypeSymbol toNullable
+            && toNullable.UnderlyingType == fromReturn)
+        {
+            return true;
+        }
+
+        return false;
     }
 
     private static bool IsEnumLikeType(TypeSymbol type)

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
@@ -97,6 +97,25 @@ internal sealed partial class MethodBodyEmitter
             return;
         }
 
+        // Issue #1356: a function-typed value `(P...) -> R` flowing into a
+        // `(P...) -> R?` slot where the two differ only by a nullable annotation
+        // on the return type of the same underlying type (`T -> T?`). The
+        // nullable annotation is a binder-level concept only — a
+        // NullableTypeSymbol erases to its UnderlyingType.ClrType — so both
+        // function types materialise to the identical CLR delegate. The
+        // conversion is therefore a representation-preserving no-op: emit the
+        // source value unchanged. This is the only path that reaches here for a
+        // return type built over a bare type parameter `T`, whose ClrType is
+        // null during binding so the concrete CLR-delegate path above cannot
+        // fire.
+        if (conv.Expression.Type is FunctionTypeSymbol fnNoOpFrom
+            && conv.Type is FunctionTypeSymbol fnNoOpTo
+            && IsReturnNullableWideningFunctionConversion(fnNoOpFrom, fnNoOpTo))
+        {
+            this.EmitExpression(conv.Expression);
+            return;
+        }
+
         this.EmitExpression(conv.Expression);
         var from = conv.Expression.Type;
         var to = conv.Type;
@@ -430,6 +449,34 @@ internal sealed partial class MethodBodyEmitter
 
         throw new NotSupportedException(
             $"Conversion from '{from.Name}' to '{to.Name}' is not yet supported by the emitter.");
+    }
+
+    // Issue #1356: returns true when two function types differ only by a
+    // return-type nullable widening (`(P...) -> T` to `(P...) -> T?`, same
+    // underlying type), with identical parameter shapes. Such a conversion is a
+    // representation-preserving no-op because a nullable annotation erases to its
+    // underlying CLR type, so both function types materialise to the same
+    // delegate. The reverse direction (`T? -> T`) is not recognised — the binder
+    // already rejects it — so this never widens a narrowing.
+    private static bool IsReturnNullableWideningFunctionConversion(
+        FunctionTypeSymbol from,
+        FunctionTypeSymbol to)
+    {
+        if (from.Arity != to.Arity)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < from.Arity; i++)
+        {
+            if (from.ParameterTypes[i] != to.ParameterTypes[i])
+            {
+                return false;
+            }
+        }
+
+        return to.ReturnType is NullableTypeSymbol toNullableReturn
+            && toNullableReturn.UnderlyingType == from.ReturnType;
     }
 
     // Issue #1236: emit a lifted numeric widening between two distinct value-type

--- a/test/Compiler.Tests/Emit/Issue1356FuncReturnCovarianceEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1356FuncReturnCovarianceEmitTests.cs
@@ -1,0 +1,296 @@
+// <copyright file="Issue1356FuncReturnCovarianceEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1356: a function-typed value whose return type is a bare type
+/// parameter <c>T</c> implicitly converts to a function whose return type is the
+/// nullable form <c>T?</c> of the same type parameter. Widening a non-null value
+/// to its nullable form is always safe, so a <c>(T) -> T</c> flows into a
+/// <c>(T) -> T?</c> slot. The reverse (<c>(T) -> T?</c> to <c>(T) -> T</c>) is a
+/// null-dropping narrowing and stays rejected.
+/// </summary>
+public class Issue1356FuncReturnCovarianceEmitTests
+{
+    [Fact]
+    public void Library_FuncReturnTypeParameterWidensToNullable_Compiles()
+    {
+        // The minimal repro from issue #1356: a `(T) -> T` lambda is stored in a
+        // `(T) -> T?` field. Before the fix this errored with GS0155.
+        var source = """
+            package p
+
+            class Box[T] {
+                let f (T) -> T?
+                init(g (T) -> T) {
+                    this.f = g
+                }
+            }
+            """;
+
+        var dllPath = CompileLibrary(source);
+        TryCleanup(dllPath);
+    }
+
+    [Fact]
+    public void Library_ConcreteReferenceReturnWidensToNullable_StillCompiles()
+    {
+        // Control: concrete reference return widening must keep working.
+        var source = """
+            package p
+
+            class Box {
+                let f (int32) -> string?
+                init(g (int32) -> string) {
+                    this.f = g
+                }
+            }
+            """;
+
+        var dllPath = CompileLibrary(source);
+        TryCleanup(dllPath);
+    }
+
+    [Fact]
+    public void Library_ReferenceCovariantReturn_StillCompiles()
+    {
+        // Control: reference covariance on the return type must keep working.
+        var source = """
+            package p
+
+            class Box {
+                let f () -> object
+                init(g () -> string) {
+                    this.f = g
+                }
+            }
+            """;
+
+        var dllPath = CompileLibrary(source);
+        TryCleanup(dllPath);
+    }
+
+    [Fact]
+    public void Library_NullableReturnDoesNotNarrowToNonNullable_IsRejected()
+    {
+        // Negative control: the unsafe reverse direction (`(T) -> T?` into a
+        // `(T) -> T` slot) drops the nullable annotation and must be rejected.
+        var source = """
+            package p
+
+            class Box[T] {
+                let f (T) -> T
+                init(g (T) -> T?) {
+                    this.f = g
+                }
+            }
+            """;
+
+        var (exit, stdout, stderr) = TryCompileLibrary(source);
+        Assert.True(exit != 0, $"expected compile failure but succeeded.\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        Assert.Contains("GS0155", stdout + stderr);
+    }
+
+    [Fact]
+    public void EndToEnd_BoxOfString_StoresAndInvokesNullableReturningField()
+    {
+        // A `Box[string]` built from a `(string) -> string` lambda stores the
+        // lambda in its `(string) -> string?` field and invoking it returns a
+        // `string?` carrying the computed value at runtime. A reference-type
+        // reification exercises the conversion soundly: `string?` shares the CLR
+        // representation of `string`, so the widened function is the same
+        // delegate and the runtime value flows through unchanged.
+        var source = """
+            package p
+
+            class Box[T] {
+                let f (T) -> T?
+                init(g (T) -> T) {
+                    this.f = g
+                }
+
+                func apply(x T) T? {
+                    return this.f(x)
+                }
+            }
+
+            func Main() {
+                let b = Box[string](func (x string) string { return x + "!" })
+                System.Console.WriteLine(b.apply("hi"))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("hi!\n", output);
+    }
+
+    private static string CompileLibrary(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1356_lib_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        var args = new[]
+        {
+            "/out:" + outPath,
+            "/target:library",
+            "/targetframework:net10.0",
+            srcPath,
+        };
+
+        RunCompiler(args);
+        IlVerifier.Verify(outPath);
+        return outPath;
+    }
+
+    private static (int Exit, string Stdout, string Stderr) TryCompileLibrary(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1356_neg_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + outPath,
+                "/target:library",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            return (compileExit, stdoutWriter.ToString(), stderrWriter.ToString());
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1356_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            RunCompiler(args);
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static void RunCompiler(string[] args)
+    {
+        using var stdoutWriter = new StringWriter();
+        using var stderrWriter = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(stdoutWriter);
+        Console.SetError(stderrWriter);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+    }
+
+    private static void TryCleanup(string dllPath)
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(dllPath);
+            if (dir != null && Directory.Exists(dir))
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+        catch
+        {
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1356FuncReturnNullableWideningConversionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1356FuncReturnNullableWideningConversionTests.cs
@@ -1,0 +1,66 @@
+// <copyright file="Issue1356FuncReturnNullableWideningConversionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1356: a function type whose return type is a bare type parameter
+/// <c>T</c> implicitly converts to a function returning the nullable form
+/// <c>T?</c> of the same type parameter (return-type covariance via the
+/// always-safe <c>T → T?</c> widening). The reverse, null-dropping direction
+/// (<c>T? → T</c>) must stay rejected. These tests pin
+/// <see cref="Conversion.Classify"/> so the rule survives future refactors.
+/// </summary>
+public class Issue1356FuncReturnNullableWideningConversionTests
+{
+    private static TypeParameterSymbol NewTypeParameter() =>
+        new("T", 0, TypeParameterConstraint.Any, TypeParameterVariance.None);
+
+    [Fact]
+    public void FuncReturningTypeParameter_WidensToFuncReturningNullable()
+    {
+        var t = NewTypeParameter();
+        var parameters = ImmutableArray.Create<TypeSymbol>(t);
+        var from = FunctionTypeSymbol.Get(parameters, t);
+        var to = FunctionTypeSymbol.Get(parameters, NullableTypeSymbol.Get(t));
+
+        var conversion = Conversion.Classify(from, to);
+
+        Assert.True(conversion.Exists);
+        Assert.True(conversion.IsImplicit);
+        Assert.False(conversion.IsIdentity);
+    }
+
+    [Fact]
+    public void FuncReturningNullable_DoesNotNarrowToFuncReturningTypeParameter()
+    {
+        var t = NewTypeParameter();
+        var parameters = ImmutableArray.Create<TypeSymbol>(t);
+        var from = FunctionTypeSymbol.Get(parameters, NullableTypeSymbol.Get(t));
+        var to = FunctionTypeSymbol.Get(parameters, t);
+
+        var conversion = Conversion.Classify(from, to);
+
+        Assert.False(conversion.Exists);
+    }
+
+    [Fact]
+    public void FuncReturningConcreteReference_WidensToFuncReturningNullable()
+    {
+        // Control: the concrete reference-return widening keeps working.
+        var parameters = ImmutableArray.Create<TypeSymbol>(TypeSymbol.Int32);
+        var from = FunctionTypeSymbol.Get(parameters, TypeSymbol.String);
+        var to = FunctionTypeSymbol.Get(parameters, NullableTypeSymbol.Get(TypeSymbol.String));
+
+        var conversion = Conversion.Classify(from, to);
+
+        Assert.True(conversion.Exists);
+        Assert.True(conversion.IsImplicit);
+    }
+}


### PR DESCRIPTION
## Summary
gsc rejected function-type (delegate/func) conversions that require **return-type covariance from a bare type parameter `T` to its nullable form `T?`**. A `(T) -> T` was not considered convertible to `(T) -> T?`, even though widening a non-null value to its nullable form is always safe.

### Minimal repro (failed with GS0155 before this fix, compiles now)
```
package p

class Box[T] {
    let f (T) -> T?
    init(g (T) -> T) {
        this.f = g
    }
}
```

## Root cause
Return-type covariance for function types is gated by `Conversion.ReturnTypeWidens` in `src/Core/CodeAnalysis/Binding/Conversion.cs`. It only recognized lossless numeric widening (`WidensNumerically`). Concrete reference returns succeed via the identity / CLR-delegate paths, but a return type that is a **bare type parameter `T`** carries no CLR backing during binding, so neither the numeric nor the delegate path fires — the conversion fell through and produced GS0155. The scalar `T -> T?` widening is already implicit elsewhere in the classifier; the function-type return-covariance gate simply did not honor it.

## Fix
- **Binder** (`Conversion.ReturnTypeWidens`): also recognize `T -> T?` — when the target return type is the `NullableTypeSymbol` form of the same underlying source return type — mirroring the scalar implicit conversion. The unsafe reverse direction (`T? -> T`, null-dropping narrowing) stays rejected, so `(T) -> T?` is still **not** convertible to `(T) -> T`.
- **Emitter** (`MethodBodyEmitter.Conversions`): a function-type conversion that differs only by a return-type nullable annotation of the same underlying type is a representation-preserving no-op — a `NullableTypeSymbol` erases to its `UnderlyingType.ClrType`, so both function types materialize to the identical CLR delegate. This is the path reached for an open-generic `(T) -> T?` whose `ClrType` is null during binding. Concrete numeric/reference widenings keep flowing through the existing CLR-delegate adapter path.

## Tests added
- **Core.Tests** (`Issue1356FuncReturnNullableWideningConversionTests`): classifier-level coverage that `(T) -> T` widens implicitly to `(T) -> T?`, that `(T) -> T?` does **not** narrow to `(T) -> T`, and that concrete reference-return widening still classifies as implicit.
- **Compiler.Tests Emit** (`Issue1356FuncReturnCovarianceEmitTests`): the exact repro compiles + ilverifies; both working controls (`(int32) -> string` to `(int32) -> string?`, `() -> string` to `() -> object`) still compile; the negative reverse direction is rejected with GS0155; and an end-to-end `Box[string]` built from a `(string) -> string` lambda stores and invokes the `(string) -> string?` field, returning the value at runtime.

## Verification
- `dotnet build GSharp.sln -c Release -graph` → 0 warnings / 0 errors.
- Full `Core.Tests` → 4721 passed, 1 skipped.
- `Compiler.Tests` Emit (Conversion/Delegate/Func/Nullable filters, incl. the new class) → 356 passed.
- Minimal repro now **compiles**; both pre-existing controls still **pass**.

## Out of scope / note
Generic **value-type** nullable representation (e.g. `Box[int32]` reified, or scalar `T -> T?` over a value type) is a separate, pre-existing limitation: on `origin/main` a generic `wrap[T](x T) T? { return x }` reified to `int32` already produces wrong output, independent of this conversion gap. This PR fixes the reported function-conversion rejection and keeps the sound reference-type / open-generic paths correct; it intentionally does not attempt to fix the broader generic value-type nullable substrate.

Fixes #1356
Refs #914
