### PR TITLE
cs2gs: render null-checked properties as T? and assert non-null value reads (#1354)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue1354PropertyNullableTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1354PropertyNullableTranslationTests.cs
@@ -1,0 +1,167 @@
+// <copyright file="Issue1354PropertyNullableTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Translator-fidelity tests for issue #1354 (the cs2gs part): G# follows
+/// Kotlin-style nullability, so a `nil` comparison is only legal on a nullable
+/// type. The issue-#1072 null-spillover promotion (`T` rendered `T?` when
+/// null-checked) is extended to PROPERTIES, and the flow-proven non-null
+/// assertion (`!!`) is extended from receiver positions to VALUE positions
+/// (a `return` expression and the arms of a conditional), because G# does not
+/// smart-cast a property/field chain. The negative tests pin the precision
+/// guards so a property that is never null-checked keeps its non-nullable type
+/// and a non-null value is never spuriously asserted.
+/// </summary>
+public class Issue1354PropertyNullableTranslationTests
+{
+    [Fact]
+    public void NullCheckedSettableProperty_RendersNullableType()
+    {
+        // A settable auto-property compared against `null` (here via the
+        // `is null` pattern) is genuinely nullable and must render `T?`.
+        string printed = TranslateUnit(@"
+#nullable enable
+namespace Demo
+{
+    public class Flags { public int Size => 1; }
+    public class C
+    {
+        public Flags Bits { get; set; } = new Flags();
+        public int Size() => Bits is null ? 0 : Bits.Size;
+    }
+}");
+
+        Assert.Contains("prop Bits Flags?", printed);
+    }
+
+    [Fact]
+    public void NullCheckedProperty_ReceiverUse_EmitsNonNullAssertion()
+    {
+        // Once the property is promoted to `T?`, a flow-proven non-null member
+        // access on it (after the `is null` guard) needs the `!!` assertion,
+        // exactly like the existing field/local receiver pass.
+        string printed = TranslateUnit(@"
+#nullable enable
+namespace Demo
+{
+    public class Flags { public int Size => 1; }
+    public class C
+    {
+        public Flags Bits { get; set; } = new Flags();
+        public int Size()
+        {
+            if (Bits is null) return 0;
+            return Bits.Size;
+        }
+    }
+}");
+
+        Assert.Contains("prop Bits Flags?", printed);
+        Assert.Contains("Bits!!.Size", printed);
+    }
+
+    [Fact]
+    public void NullCheckedComputedProperty_ConditionalArm_EmitsNonNullAssertion()
+    {
+        // A computed get-only property that is `null`-checked promotes to `T?`;
+        // the non-null conditional ARM that reads it (a VALUE position, not a
+        // receiver) gets the `!!` assertion so the conditional unifies to the
+        // non-null result type.
+        string printed = TranslateUnit(@"
+#nullable enable
+using System.Threading.Tasks;
+namespace Demo
+{
+    public class C
+    {
+        private Task? backing;
+        protected virtual Task Work => backing ?? Task.CompletedTask;
+        public Task Run() => Work is null ? Task.CompletedTask : Work;
+    }
+}");
+
+        Assert.Contains("prop Work Task?", printed);
+        Assert.Contains("else { Work!! }", printed);
+    }
+
+    [Fact]
+    public void NullCheckedComputedProperty_ReturnValue_EmitsNonNullAssertion()
+    {
+        // A bare `return Work` of a promoted `T?` property, where the method
+        // returns the non-null `T`, gets the `!!` assertion in value position.
+        string printed = TranslateUnit(@"
+#nullable enable
+using System.Threading.Tasks;
+namespace Demo
+{
+    public class C
+    {
+        private Task? backing;
+        protected virtual Task Work => backing ?? Task.CompletedTask;
+        public Task Pick(bool b)
+        {
+            if (Work is null) return Task.CompletedTask;
+            return Work;
+        }
+    }
+}");
+
+        Assert.Contains("prop Work Task?", printed);
+        Assert.Contains("return Work!!", printed);
+    }
+
+    [Fact]
+    public void PropertyNeverNullChecked_StaysNonNullable()
+    {
+        // Precision guard: a property that is never null-checked nor
+        // null-assigned keeps its declared non-nullable type, and a plain read
+        // of it is never spuriously asserted.
+        string printed = TranslateUnit(@"
+#nullable enable
+namespace Demo
+{
+    public class Flags { public int Size => 1; }
+    public class C
+    {
+        public Flags Bits { get; set; } = new Flags();
+        public int Size() => Bits.Size;
+    }
+}");
+
+        Assert.Contains("prop Bits Flags", printed);
+        Assert.DoesNotContain("prop Bits Flags?", printed);
+        Assert.DoesNotContain("Bits!!", printed);
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -1973,6 +1973,15 @@ public sealed class CSharpToGSharpTranslator
                 ? this.typeMapper.Map(symbol.Type, this.context, node.GetLocation())
                 : new NamedTypeReference(CSharpTypeMapper.UnsupportedPlaceholderType);
 
+            // Issue #1354 / #1072: a non-nullable reference property that is
+            // null-checked or null-assigned anywhere in the declaring type is
+            // really nullable; render it `T?` so the `== nil`/`is null` guard
+            // type-checks (gsc rejects `== nil` on a non-null operand, GS0129).
+            if (symbol != null)
+            {
+                type = this.PromoteIfUsedAsNullable(type, symbol);
+            }
+
             List<PropertyAccessor> accessors = this.MapAccessors(node);
 
             // Issue #1278 / ADR-0131: a C# expression-bodied read-only property
@@ -3165,7 +3174,9 @@ public sealed class CSharpToGSharpTranslator
                     return new[]
                     {
                         (GStatement)new ReturnStatement(
-                            ret.Expression == null ? null : this.TranslateExpression(ret.Expression)),
+                            ret.Expression == null
+                                ? null
+                                : this.TranslateValueWithNullForgiveness(ret.Expression)),
                     };
 
                 case IfStatementSyntax ifStatement:
@@ -3616,8 +3627,8 @@ public sealed class CSharpToGSharpTranslator
             ConditionalExpressionSyntax conditional)
         {
             GExpression condition = this.TranslateExpression(conditional.Condition);
-            GExpression whenTrue = this.TranslateExpression(conditional.WhenTrue);
-            GExpression whenFalse = this.TranslateExpression(conditional.WhenFalse);
+            GExpression whenTrue = this.TranslateValueWithNullForgiveness(conditional.WhenTrue);
+            GExpression whenFalse = this.TranslateValueWithNullForgiveness(conditional.WhenFalse);
 
             ITypeSymbol resultType = this.context.GetTypeInfo(conditional).Type;
             ITypeSymbol trueType = this.context.GetTypeInfo(conditional.WhenTrue).Type;
@@ -4927,6 +4938,7 @@ public sealed class CSharpToGSharpTranslator
             ITypeSymbol declared = symbol switch
             {
                 IFieldSymbol f => f.Type,
+                IPropertySymbol pr => pr.Type,
                 ILocalSymbol l => l.Type,
                 IParameterSymbol p => p.Type,
                 _ => null,
@@ -4954,6 +4966,10 @@ public sealed class CSharpToGSharpTranslator
 
                 case IFieldSymbol field:
                     return field.ContainingType?
+                        .DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax();
+
+                case IPropertySymbol property:
+                    return property.ContainingType?
                         .DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax();
 
                 case ILocalSymbol local:
@@ -6038,6 +6054,27 @@ public sealed class CSharpToGSharpTranslator
             GExpression translated = this.TranslateExpression(recv);
 
             if (this.ReceiverNeedsNullForgiveness(recv))
+            {
+                return new NonNullAssertionExpression(translated);
+            }
+
+            return translated;
+        }
+
+        // Issue #1354: a value-position read (a `return` expression or a
+        // conditional-expression arm) of a declared-`T?`/promoted-to-`T?` symbol
+        // that Roslyn's flow analysis has narrowed to non-null needs a `!!`
+        // assertion to satisfy a non-null target. G# does not smart-cast
+        // property/field chains, so unlike the receiver pass this also covers
+        // bare reads consumed as values (`return Continuation` /
+        // `cond ? a : Continuation`). The shared <see cref="ReceiverNeedsNullForgiveness"/>
+        // predicate already excludes null-comparison operands (flow there is not
+        // NotNull), `?.` receivers, `this`/`base`, and literals.
+        private GExpression TranslateValueWithNullForgiveness(ExpressionSyntax value)
+        {
+            GExpression translated = this.TranslateExpression(value);
+
+            if (this.ReceiverNeedsNullForgiveness(value))
             {
                 return new NonNullAssertionExpression(translated);
             }


### PR DESCRIPTION
## Summary

Completes the **cs2gs** part of #1354. The gsc parts (revert #1349, import unannotated reference types as `T?`, emit complete nullability metadata) already merged via #1374; this PR closes the issue by teaching the translator to faithfully render null-checked **properties** as `T?` and to assert flow-proven non-null reads consumed as **values**.

G# follows Kotlin-style nullability: a `nil` comparison is only legal on a nullable type, and smart-casts narrow only local variables — never a property/field-access chain. So:

1. **Property null-spillover promotion.** The issue-#1072 rule (a `T` that is `== null`/`is null`-checked or null-assigned in its declaring type is really `T?`) is extended from field/local/parameter to **`IPropertySymbol`** (`IsPromotedToNullableReference` + `GetNullabilityScope`), and `TranslateProperty` now runs `PromoteIfUsedAsNullable`.
2. **Value-position non-null assertion.** The existing `!!` pass only covered *receiver* positions (`recv!!.Member`). A promoted/declared-`T?` symbol that Roslyn flow-proves non-null but is consumed as a **value** (a `return` expression or a conditional arm) now also gets `!!` via `TranslateValueWithNullForgiveness`. The shared `ReceiverNeedsNullForgiveness` predicate already excludes null-comparison operands, `?.` receivers, `this`/`base`, and literals, so the `== nil` guard itself is never asserted.

## Effect on the Oahu.Decrypt migration

`Decrypt 48 → 45` — both `GS0129` cleared, plus `GS0155` 5 → 4, **no regressions**:

- `ExtendedHeader.ExtendedFlags` (settable auto-property, `is null`-checked) → `prop ExtendedFlags Flags?`; every member/index read gets `!!`.
- `Mp4Operation.Continuation` (computed get-only property, `is null`-checked) → `prop Continuation Task?`; the conditional else-arm and bare returns get `!!` (`else { Continuation!! }`, `return Work!!`).

## Tests

`334 cs2gs tests (+5)` — `Issue1354PropertyNullableTranslationTests` covers settable + computed property promotion, receiver `!!`, conditional-arm `!!`, return-value `!!`, and a never-null-checked precision negative.

Fixes #1354
Refs #914
