### PR TITLE
Fix await of void receiver-clause async func (GS0124)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -607,7 +607,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundCallExpression(null, node.Function, builder.MoveToImmutable());
+        return new BoundCallExpression(null, node.Function, builder.MoveToImmutable(), node.ReturnType, node.IsConditionalElided);
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -4446,7 +4446,22 @@ internal sealed class OverloadResolver
         if (substitution != null)
         {
             var returnType = substituteType(extension.Type, substitution);
+            if (extension.IsAsync && !isAsyncIteratorReturnType(extension.Type))
+            {
+                returnType = wrapAsTask(returnType);
+            }
+
             return new BoundCallExpression(null, extension, convertedArgs.MoveToImmutable(), returnType);
+        }
+
+        // Issue #1376: an async receiver-clause (extension) function's call-site
+        // return type is Task / Task[T], not the underlying void / T. Wrap here
+        // so awaiting the call sees a value-bearing Task, mirroring the async
+        // free-function and user-instance-call paths.
+        if (extension.IsAsync && !isAsyncIteratorReturnType(extension.Type))
+        {
+            var asyncReturn = wrapAsTask(extension.Type);
+            return new BoundCallExpression(null, extension, convertedArgs.MoveToImmutable(), asyncReturn);
         }
 
         return new BoundCallExpression(null, extension, convertedArgs.MoveToImmutable());

--- a/test/Compiler.Tests/Emit/Issue1376AwaitVoidReceiverAsyncEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1376AwaitVoidReceiverAsyncEmitTests.cs
@@ -1,0 +1,153 @@
+// <copyright file="Issue1376AwaitVoidReceiverAsyncEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1376: awaiting a call to a top-level receiver-clause (extension)
+/// <c>async func</c> that declares no return type (a void-result <c>Task</c>)
+/// must bind and emit. Before the fix the awaited call expression was typed as
+/// <c>void</c> instead of <c>Task</c>, so the surrounding <c>await</c> rejected
+/// it with GS0124 ("Expression must have a value"). The root cause was twofold:
+/// the extension-call binder did not widen the async return type to <c>Task</c>,
+/// and <c>BoundTreeRewriter.RewriteCallExpression</c> dropped the call-site
+/// return-type override when it rebuilt the call after rewriting an argument
+/// (e.g. a hoisted parameter becoming a state-machine field), reverting the type
+/// back to the symbol's raw <c>void</c>. These tests compile programs that await
+/// a void receiver-clause async func, verify the emitted IL, and assert runtime
+/// output to prove the awaits actually execute in order.
+/// </summary>
+public class Issue1376AwaitVoidReceiverAsyncEmitTests
+{
+    [Fact]
+    public void AwaitVoidReceiverClauseAsyncFunc_FromPlainAsync_EmitsAndRuns()
+    {
+        var source = """
+            package P
+            import System
+            import System.Threading.Tasks
+
+            async func (s string) PrintAsync() {
+                await Task.Delay(1)
+                Console.WriteLine(s)
+            }
+
+            async func RunAsync() {
+                await "hello".PrintAsync()
+                await "world".PrintAsync()
+            }
+
+            RunAsync().GetAwaiter().GetResult()
+            """;
+
+        Assert.Equal("hello\nworld\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void AwaitVoidReceiverClauseAsyncFunc_FromAnotherReceiverClauseAsync_EmitsAndRuns()
+    {
+        // The awaiting function is itself a void receiver-clause async func, and
+        // it awaits another void receiver-clause async func whose call carries a
+        // hoisted argument (the receiver). This exercises the RewriteCallExpression
+        // return-type-preservation path on both ends.
+        var source = """
+            package P
+            import System
+            import System.Threading.Tasks
+
+            async func (s string) StepAsync(label string) {
+                await Task.Delay(1)
+                Console.WriteLine(label + ":" + s)
+            }
+
+            async func (s string) RunAsync() {
+                await s.StepAsync("a")
+                await s.StepAsync("b")
+            }
+
+            "x".RunAsync().GetAwaiter().GetResult()
+            """;
+
+        Assert.Equal("a:x\nb:x\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1376_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new System.Collections.Generic.List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+
+            // (a) Static verification: the emitted IL must be valid.
+            IlVerifier.Verify(outPath);
+
+            // (b) Dynamic verification: the emitted code must execute.
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Awaiting a call to a top-level **receiver-clause (extension) `async func` with no declared return type** (a void-result `Task`) failed to bind with **GS0124: Expression must have a value**. The awaited call expression was typed as `void` instead of `Task`, so the surrounding `await` rejected it. The same shape works for a class instance async method and for a plain top-level async func — only the receiver-clause/extension form with no return type was broken.

### Repro (now compiles cleanly)
```gsharp
package p
import System.IO
import System.Threading.Tasks

async func (s Stream) SeekAsync(off int64) {
    await Task.Delay(1)
}

async func (s Stream) ReadAsync2(off int64) {
    await s.SeekAsync(off)   // was: GS0124
}
```

## Root cause

Two defects combined:

1. **`OverloadResolver.BindExtensionFunctionCall`** (`src/Core/CodeAnalysis/Binding/OverloadResolver.cs`) did not widen an async extension func's call-site return type from `void`/`T` to `Task`/`Task[T]`. The async free-function path (`BindFunctionCall`) and the user-instance-call path (`BindUserInstanceCall`) already perform this `wrapAsTask` widening (issue #502); the extension-call path was the lone omission, so the awaited call was typed `void` → GS0124.

2. **`BoundTreeRewriter.RewriteCallExpression`** (`src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs:610`) dropped the call-site return-type override (and the `IsConditionalElided` flag) when it rebuilt a `BoundCallExpression` after rewriting an argument. Since `BoundCallExpression.Type` falls back to `Function.Type`, the wrapped `Task` reverted to the symbol's raw `void` during async lowering — specifically when a hoisted parameter argument (the extension receiver) is rewritten into a state-machine field. This produced an invalid `void` local at emit time (`InvalidOperationException: Use ReturnTypeEncoder.Void() for void returns`). Plain async calls with **no arguments** were unaffected because the rewriter returned the node unchanged, which is why the plain-func and class-method controls always worked.

## Fix

- Widen the async extension func's call-site return type via `wrapAsTask`, mirroring the free-function and user-instance-call paths.
- Preserve `ReturnType`/`IsConditionalElided` when `RewriteCallExpression` rebuilds a call. This is strictly more correct — the override was previously lost for any rebuilt call carrying a substituted/wrapped return type.

Both changes are surgical (one line + one widening block).

## Verification

- **Build:** `dotnet build GSharp.sln -c Release -graph` → **0 warnings, 0 errors**.
- **Core.Tests:** `dotnet test test/Core.Tests/Core.Tests.csproj -c Release --no-build` → **4731 passed, 1 skipped, 0 failed**.
- **New regression tests:** `Issue1376AwaitVoidReceiverAsyncEmitTests` (2 tests) — compile + `IlVerifier.Verify` + run, asserting ordered runtime output. Both pass.
- **Targeted Emit suites:** async/await (99), extension/receiver/generic (339) → all pass.
- **Repro + controls:** the issue repro now emits cleanly; the class-method and plain top-level async controls still compile and run.

### Out of scope (noted in #1376)
Giving the receiver func an explicit `Task` return type instead surfaces a separate **GS0100: Not all code paths return a value**. That is a distinct control-flow-analysis defect with a different root cause and is intentionally not addressed here.

Fixes #1376
Refs #914
