### PR TITLE
Substitute receiver type args into generic user-type static call signatures (#1379)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -2187,13 +2187,37 @@ internal sealed partial class ExpressionBinder
                 return new BoundErrorExpression(null);
             }
 
+            // Issue #1379: a `shared` (static) method on a generic user type may
+            // reference the type's own type parameter(s) in its return type
+            // and/or parameter types (`func Make(v T) Box[T]`). When the receiver
+            // is a closed construction (`Box[int32]`), seed the substitution map
+            // with the struct's type parameters -> the construction's type
+            // arguments so the call's return (and parameter) types are surfaced
+            // closed (`Box[int32]`), not the raw/open form (which fails the
+            // conversion to the closed type, GS0155). This is the user-defined
+            // counterpart of the imported-generic fix in issue #1216 and exercises
+            // the binding receiver added in issue #1323.
+            Dictionary<TypeParameterSymbol, TypeSymbol> substitution = null;
+            if (structSym.Definition != null
+                && !ReferenceEquals(structSym.Definition, structSym)
+                && !structSym.TypeArguments.IsDefaultOrEmpty
+                && !structSym.Definition.TypeParameters.IsDefaultOrEmpty)
+            {
+                substitution = new Dictionary<TypeParameterSymbol, TypeSymbol>();
+                var defParams = structSym.Definition.TypeParameters;
+                var count = Math.Min(defParams.Length, structSym.TypeArguments.Length);
+                for (var i = 0; i < count; i++)
+                {
+                    substitution[defParams[i]] = structSym.TypeArguments[i];
+                }
+            }
+
             // Issue #312 / ADR-0020: resolve a generic static method's own type
             // arguments from an explicit `[T1, T2]` list at the call site or by
             // left-to-right inference from argument types.
-            Dictionary<TypeParameterSymbol, TypeSymbol> substitution = null;
             if (method.IsGeneric)
             {
-                substitution = new Dictionary<TypeParameterSymbol, TypeSymbol>();
+                substitution ??= new Dictionary<TypeParameterSymbol, TypeSymbol>();
                 if (ce.TypeArgumentList != null)
                 {
                     var explicitArgs = ce.TypeArgumentList.Arguments;
@@ -2356,7 +2380,13 @@ internal sealed partial class ExpressionBinder
                     continue;
                 }
 
-                if (paramType is TypeParameterSymbol)
+                // Issue #1379: a parameter typed by the GENERIC STRUCT's own type
+                // parameter (`func Make(v T)` on `Box[T]`) is substituted to the
+                // closed receiver type argument (`int32`) so the argument is
+                // converted to the concrete type. A parameter typed by an
+                // unsubstituted (method) type parameter still passes through.
+                if (paramType is TypeParameterSymbol typeParamParam
+                    && (substitution == null || !substitution.ContainsKey(typeParamParam)))
                 {
                     convertedArgs.Add(permutedArgs[i]);
                     continue;

--- a/test/Compiler.Tests/Emit/Issue1379GenericStaticReturnEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1379GenericStaticReturnEmitTests.cs
@@ -1,0 +1,164 @@
+// <copyright file="Issue1379GenericStaticReturnEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1379: a <c>shared</c> (static) method on a user-defined generic type
+/// whose return type references the type's own type parameter
+/// (<c>func Make() Box[T]</c>) must have the receiver's type argument
+/// substituted at the call site, so <c>Box[int32].Make()</c> is typed
+/// <c>Box[int32]</c> rather than the raw/open <c>Box</c> (which fails the
+/// conversion to the closed construction, GS0155). These end-to-end tests lock
+/// the parse -> bind -> emit -> verify -> execute chain for the substituted
+/// static return (and parameter) types.
+/// </summary>
+public class Issue1379GenericStaticReturnEmitTests
+{
+    [Fact]
+    public void StaticReturnReferencingT_VerifiesAndExecutes()
+    {
+        // `Box[int32].Make(5)` returns `Box[int32]`; read its T-typed field.
+        var source = """
+            package P
+            import System
+            struct Box[T] {
+                var V T
+                shared { func Make(v T) Box[T] -> Box[T]{ V: v } }
+            }
+            var b = Box[int32].Make(5)
+            Console.WriteLine(b.V)
+            """;
+
+        Assert.Equal("5\n", CompileVerifyAndRun(source));
+    }
+
+    [Fact]
+    public void StaticReturnReferencingT_StringTypeArg_VerifiesAndExecutes()
+    {
+        // The substituted return type is independent of the element's
+        // value/reference kind (`Box[string]`).
+        var source = """
+            package P
+            import System
+            struct Box[T] {
+                var V T
+                shared { func Make(v T) Box[T] -> Box[T]{ V: v } }
+            }
+            var b = Box[string].Make("hi")
+            Console.WriteLine(b.V)
+            """;
+
+        Assert.Equal("hi\n", CompileVerifyAndRun(source));
+    }
+
+    [Fact]
+    public void StaticReturnNotReferencingT_StillVerifiesAndExecutes()
+    {
+        // Control: a static method whose return type does NOT reference T keeps
+        // emitting and executing unchanged.
+        var source = """
+            package P
+            import System
+            struct Box[T] { shared { func Make() int32 -> 41 } }
+            Console.WriteLine(Box[int32].Make() + 1)
+            """;
+
+        Assert.Equal("42\n", CompileVerifyAndRun(source));
+    }
+
+    private static string CompileVerifyAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1379_emit_").FullName;
+        try
+        {
+            var outPath = CompileToDll(tempDir, source, "/target:exe");
+            IlVerifier.Verify(outPath);
+
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static string CompileToDll(string tempDir, string source, string target)
+    {
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+        var args = new List<string>
+        {
+            "/out:" + outPath,
+            target,
+            "/targetframework:net10.0",
+            "/lib:" + runtimeDir,
+        };
+        foreach (var refName in new[]
+        {
+            "System.Runtime.dll",
+            "System.Private.CoreLib.dll",
+            "System.Console.dll",
+        })
+        {
+            args.Add("/reference:" + Path.Combine(runtimeDir, refName));
+        }
+
+        args.Add(srcPath);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args.ToArray());
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(compileExit == 0, $"compile failed ({compileExit}):\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+        return outPath;
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1379GenericStaticReturnSubstitutionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1379GenericStaticReturnSubstitutionTests.cs
@@ -1,0 +1,82 @@
+// <copyright file="Issue1379GenericStaticReturnSubstitutionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1379: a <c>shared</c> (static) method on a user-defined generic type
+/// whose return type (and/or parameter types) reference the type's own type
+/// parameter must have the receiver's type argument substituted at the call
+/// site. <c>Box[int32].Make()</c> returning <c>Box[T]</c> must be typed
+/// <c>Box[int32]</c> — not the raw/open <c>Box</c>, which fails the conversion
+/// to the closed construction (GS0155). This is the user-defined counterpart of
+/// the imported-generic fix in issue #1216 and exercises the binding receiver
+/// added in issue #1323 (whose tests only used a non-generic static return type,
+/// so the return-type substitution path was never covered).
+/// </summary>
+public class Issue1379GenericStaticReturnSubstitutionTests
+{
+    [Fact]
+    public void StaticReturnReferencingT_BindsToClosedConstruction()
+    {
+        const string source = @"
+package p
+struct Box[T] { shared { func Make() Box[T] -> Box[T]{} } }
+class C { func F() Box[int32] { return Box[int32].Make() } }
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void StaticReturnAndParamReferencingT_BindsWithoutDiagnostics()
+    {
+        const string source = @"
+package p
+struct Box[T] { var V T shared { func Make(v T) Box[T] -> Box[T]{ V: v } } }
+class C { func F() Box[int32] { return Box[int32].Make(5) } }
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void StaticReturnReferencingT_WithNullableTypeArg_BindsWithoutDiagnostics()
+    {
+        const string source = @"
+package p
+struct Info { var X int32 }
+struct Box[T] { var V T shared { func Make(v T) Box[T] -> Box[T]{ V: v } } }
+class C { func F(i Info?) Box[Info?] { return Box[Info?].Make(i) } }
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void StaticReturnNotReferencingT_StillBindsWithoutDiagnostics()
+    {
+        // Control: a static method whose return type does NOT reference T keeps
+        // working unchanged.
+        const string source = @"
+package p
+struct Box[T] { shared { func Make() int32 -> 5 } }
+class C { func F() int32 { return Box[int32].Make() } }
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    private static IReadOnlyList<Diagnostic> GetDiagnostics(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree) { IsLibrary = true };
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return result.Diagnostics;
+    }
+}


### PR DESCRIPTION
## Summary

A `shared` (static) method on a **user-defined generic type** whose **return type references the type parameter** did not get the receiver's type argument substituted at the call site. The call resolved to the **raw/open** generic type, so converting the result to the closed construction failed:

```
genret.gs(11,16,11,33): error GS0155: Cannot convert type 'Box' to 'Box'.
```

```
struct Box[T] { shared { func Make() Box[T] -> Box[T]{} } }
class C { func F() Box[int32] { return Box[int32].Make() } }
```

## Root cause

`BindUserTypeStaticCall` (`src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs`) only built a type-argument substitution map for the static method's **own** generic type parameters (issue #312 / ADR-0020). It never seeded a substitution from the **generic struct's** type parameters, so a static method whose signature embeds the struct's `T` (e.g. return type `Box[T]`, parameter type `T`) surfaced the open form. The receiver-binding plumbing for `Type[TypeArg].StaticMember(...)` existed (issue #1323), but those tests only used a non-generic static return type, so the return-type substitution path was never exercised. This is the user-defined counterpart of the imported/BCL generic-static fix in issue #1216.

## Fix

In `BindUserTypeStaticCall`:

1. Seed the substitution map from the closed receiver construction (`structSym.Definition.TypeParameters` -> `structSym.TypeArguments`) before the method's own generic substitution is layered on (`??=`). The existing return-type and parameter-type `SubstituteType` calls then surface the closed forms (`Box[int32]`).
2. Stop short-circuiting argument conversion for a parameter typed by a type parameter that is present in the substitution map, so `func Make(v T)` converts its argument to the concrete receiver type argument (`int32`).

## Tests

- `test/Core.Tests/CodeAnalysis/Binding/Issue1379GenericStaticReturnSubstitutionTests.cs` — binder tests: return-only `Box[T]`, return+parameter, nullable type argument `Box[Info?]`, and a control where the return type does not reference `T`.
- `test/Compiler.Tests/Emit/Issue1379GenericStaticReturnEmitTests.cs` — emit/execution tests (compile `/target:exe`, `IlVerifier.Verify`, run): value-type arg, string (reference-type) arg, and control case.

## Verification

- `dotnet build GSharp.sln -c Release -graph`: **0 Warning(s), 0 Error(s)**.
- Minimal repro (`Box[int32].Make()`) now compiles clean (`Success.`, exit 0). Parameter-substitution (`Box[int32].Make(5)`) and nullable (`Box[Info?].Make(i)`) cases compile clean; control case unaffected.
- Core.Tests `Issue1379|Issue1323|Issue1216`: **19 passed**.
- Compiler.Tests Emit `Issue1379`: **3 passed**; `Issue1323|Issue1330|Issue1216`: **12 passed**.
- Broader Core.Tests `StaticCall|StaticMember|GenericStatic|Shared`: **165 passed**.

Nothing deferred.

Fixes #1379
Refs #914
