### PR TITLE
Reduce Core internals coupling for LanguageServer

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -1701,7 +1701,7 @@ public sealed class Binder
     /// <param name="additionalLocals">In-scope locals/parameters to declare before binding, or <c>null</c>.</param>
     /// <param name="expression">The receiver expression to infer a type for.</param>
     /// <returns>The inferred non-error, non-void type, or <c>null</c> when inference fails.</returns>
-    internal static TypeSymbol TryInferExpressionType(
+    public static TypeSymbol TryInferExpressionType(
         BoundGlobalScope globalScope,
         ReferenceResolver references,
         FunctionSymbol containingFunction,

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -199,72 +199,13 @@ internal sealed class MemberLookup
 
     /// <summary>
     /// Issue #1181: collects the transitive closure of imported/BCL base
-    /// interfaces declared on <paramref name="interfaceSymbol"/> or on any of
-    /// its user base interfaces. A user interface
-    /// <c>interface IBox : System.IDisposable</c> records <c>IDisposable</c> in
-    /// <see cref="InterfaceSymbol.BaseClrInterfaces"/>; this walk surfaces that
-    /// CLR interface plus every interface IT extends (e.g.
-    /// <c>IEnumerable&lt;T&gt;</c> → <c>IEnumerable</c>) so the binder and the
-    /// language server can project the inherited CLR members onto an
-    /// <c>IBox</c>-typed receiver. The result is deduplicated structurally via
-    /// <see cref="ClrTypeUtilities.AreSame"/> (FullName-based, robust across
-    /// metadata-load contexts).
+    /// interfaces declared on <paramref name="interfaceSymbol"/>. Delegates
+    /// to <see cref="ClrTypeUtilities.GetTransitiveClrBaseInterfaces"/>.
     /// </summary>
     /// <param name="interfaceSymbol">The user interface whose imported base interfaces to collect.</param>
     /// <returns>The transitive CLR base interface <see cref="Type"/>s, each appearing once.</returns>
     public static IReadOnlyList<Type> GetTransitiveClrBaseInterfaces(InterfaceSymbol interfaceSymbol)
-    {
-        if (interfaceSymbol == null)
-        {
-            return Array.Empty<Type>();
-        }
-
-        var result = new List<Type>();
-
-        void AddClr(Type clr)
-        {
-            if (clr == null || !clr.IsInterface)
-            {
-                return;
-            }
-
-            foreach (var existing in result)
-            {
-                if (ClrTypeUtilities.AreSame(existing, clr))
-                {
-                    return;
-                }
-            }
-
-            result.Add(clr);
-
-            foreach (var transitive in ClrTypeUtilities.SafeGetInterfaces(clr))
-            {
-                AddClr(transitive);
-            }
-        }
-
-        // A user base interface may itself extend a CLR interface, so walk the
-        // whole user interface hierarchy (this-first) and harvest each level's
-        // imported base interfaces.
-        foreach (var iface in interfaceSymbol.SelfAndAllBaseInterfaces())
-        {
-            if (iface.BaseClrInterfaces.IsDefaultOrEmpty)
-            {
-                continue;
-            }
-
-            foreach (var clrBase in iface.BaseClrInterfaces)
-            {
-                if (clrBase?.ClrType is Type clrType)
-                {
-                    AddClr(clrType);
-                }
-            }
-        }
-
-        return result;
-    }
+        => ClrTypeUtilities.GetTransitiveClrBaseInterfaces(interfaceSymbol);
 
     /// <summary>
     /// Issue #1181: returns whether <paramref name="candidate"/> already has a

--- a/src/Core/CodeAnalysis/Documentation/DocumentationValidator.cs
+++ b/src/Core/CodeAnalysis/Documentation/DocumentationValidator.cs
@@ -11,7 +11,11 @@ using GSharp.Core.CodeAnalysis.Syntax;
 
 namespace GSharp.Core.CodeAnalysis.Documentation;
 
-internal static class DocumentationValidator
+/// <summary>
+/// Validates documentation comments across a compilation or syntax tree,
+/// emitting diagnostics for missing, floating, or unknown doc tags.
+/// </summary>
+public static class DocumentationValidator
 {
     private static readonly HashSet<string> KnownTags = new(StringComparer.Ordinal)
     {

--- a/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
+++ b/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
@@ -17,7 +17,7 @@ namespace GSharp.Core.CodeAnalysis.Symbols;
 /// <see cref="Type.IsAssignableFrom"/> only work within a single context, so
 /// cross-context comparisons must fall back to name-based matching.
 /// </summary>
-internal static class ClrTypeUtilities
+public static class ClrTypeUtilities
 {
     /// <summary>
     /// Returns whether two <see cref="Type"/>s refer to the same logical CLR
@@ -576,11 +576,74 @@ internal static class ClrTypeUtilities
     }
 
     /// <summary>
-    /// Issue #529: tolerantly retrieves the transitive interface set
-    /// for a type, guarding against metadata-load failures.
+    /// Issue #1181: collects the transitive closure of imported/BCL base
+    /// interfaces declared on <paramref name="interfaceSymbol"/> or on any of
+    /// its user base interfaces. A user interface
+    /// <c>interface IBox : System.IDisposable</c> records <c>IDisposable</c> in
+    /// <see cref="InterfaceSymbol.BaseClrInterfaces"/>; this walk surfaces that
+    /// CLR interface plus every interface IT extends (e.g.
+    /// <c>IEnumerable&lt;T&gt;</c> → <c>IEnumerable</c>) so the binder and the
+    /// language server can project the inherited CLR members onto an
+    /// <c>IBox</c>-typed receiver. The result is deduplicated structurally via
+    /// <see cref="ClrTypeUtilities.AreSame"/> (FullName-based, robust across
+    /// metadata-load contexts).
     /// </summary>
-    /// <param name="type">The type whose interfaces to retrieve.</param>
-    /// <returns>The transitive interface set, or empty on failure.</returns>
+    /// <param name="interfaceSymbol">The user interface whose imported base interfaces to collect.</param>
+    /// <returns>The transitive CLR base interface <see cref="Type"/>s, each appearing once.</returns>
+    public static IReadOnlyList<Type> GetTransitiveClrBaseInterfaces(InterfaceSymbol interfaceSymbol)
+    {
+        if (interfaceSymbol == null)
+        {
+            return Array.Empty<Type>();
+        }
+
+        var result = new List<Type>();
+
+        void AddClr(Type clr)
+        {
+            if (clr == null || !clr.IsInterface)
+            {
+                return;
+            }
+
+            foreach (var existing in result)
+            {
+                if (AreSame(existing, clr))
+                {
+                    return;
+                }
+            }
+
+            result.Add(clr);
+
+            foreach (var transitive in SafeGetInterfaces(clr))
+            {
+                AddClr(transitive);
+            }
+        }
+
+        // A user base interface may itself extend a CLR interface, so walk the
+        // whole user interface hierarchy (this-first) and harvest each level's
+        // imported base interfaces.
+        foreach (var iface in interfaceSymbol.SelfAndAllBaseInterfaces())
+        {
+            if (iface.BaseClrInterfaces.IsDefaultOrEmpty)
+            {
+                continue;
+            }
+
+            foreach (var clrBase in iface.BaseClrInterfaces)
+            {
+                if (clrBase?.ClrType is Type clrType)
+                {
+                    AddClr(clrType);
+                }
+            }
+        }
+
+        return result;
+    }
+
     internal static Type[] SafeGetInterfaces(Type type)
     {
         if (type is null)

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -14,7 +14,6 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="GSharp.Core.Tests" />
-    <InternalsVisibleTo Include="GSharp.LanguageServer" />
   </ItemGroup>
 
 </Project>

--- a/src/LanguageServer/HoverComputer.cs
+++ b/src/LanguageServer/HoverComputer.cs
@@ -2122,7 +2122,7 @@ public static class CompletionComputer
         // also surfaces that interface's (and its transitive CLR bases')
         // members on an interface-typed receiver — keep the completion surface
         // consistent with the binder's member resolution.
-        foreach (var clrBaseIface in MemberLookup.GetTransitiveClrBaseInterfaces(interfaceType))
+        foreach (var clrBaseIface in ClrTypeUtilities.GetTransitiveClrBaseInterfaces(interfaceType))
         {
             AddClrMembers(items, seen, clrBaseIface, staticMembers: false);
         }

--- a/test/LanguageServer.Tests/ProjectStateTests.cs
+++ b/test/LanguageServer.Tests/ProjectStateTests.cs
@@ -109,9 +109,12 @@ public class ProjectStateTests
     [Fact]
     public void ProjectDirectory_DerivedFromProjectFilePath()
     {
-        var project = new ProjectState("/test/myapp/myapp.gsproj");
+        var projectFilePath = "/test/myapp/myapp.gsproj";
 
-        Assert.Equal("/test/myapp", project.ProjectDirectory);
+        var project = new ProjectState(projectFilePath);
+        var expected = Path.GetDirectoryName(Path.GetFullPath(projectFilePath));
+
+        Assert.Equal(expected, project.ProjectDirectory);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #1367

Removes the Core InternalsVisibleTo grant for LanguageServer by promoting the required semantic helpers to explicit public APIs, preserving the shared TypeMemberModel lookup path, and keeping LanguageServer tests portable on Windows.