### PR TITLE
Introduce structured logging across compiler hosts

### DIFF
--- a/src/Compiler/Program.cs
+++ b/src/Compiler/Program.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Text;
 using GSharp.Core.CodeAnalysis;
 using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Diagnostics;
 using GSharp.Core.CodeAnalysis.Emit;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
@@ -91,15 +92,18 @@ public class Program
             var references = parsed.References.Count > 0
                 ? ReferenceResolver.WithReferences(parsed.References)
                 : null;
+            ILogger logger = parsed.LogPath is not null ? new FileLogger(parsed.LogPath) : NullLogger.Instance;
 
             try
             {
+                logger.LogInfo($"Starting compiler. Sources: {parsed.SourceFiles.Count}; Output: {parsed.OutputPath ?? "<none>"}");
                 ReportMissingTransitiveReferences(references, parsed);
 
                 var compilation = new Compilation(references, syntaxTrees.ToArray())
                 {
                     ImplicitSystemImport = parsed.ImplicitSystemImport,
                     IsLibrary = parsed.Target == OutputTarget.Library,
+                    Logger = logger,
                     DebugInformation =
                     {
                         Format = parsed.DebugFormat,
@@ -120,6 +124,7 @@ public class Program
             }
             finally
             {
+                (logger as IDisposable)?.Dispose();
                 references?.Dispose();
             }
         }
@@ -504,9 +509,14 @@ public class Program
             if (IsSwitch(raw))
             {
                 var body = raw.Substring(1);
-                var colon = body.IndexOf(':');
-                var name = colon < 0 ? body : body.Substring(0, colon);
-                var value = colon < 0 ? string.Empty : body.Substring(colon + 1);
+                if (body.StartsWith("-", StringComparison.Ordinal))
+                {
+                    body = body.Substring(1);
+                }
+
+                var separator = IndexOfSwitchValueSeparator(body);
+                var name = separator < 0 ? body : body.Substring(0, separator);
+                var value = separator < 0 ? string.Empty : body.Substring(separator + 1);
 
                 switch (name.ToLowerInvariant())
                 {
@@ -677,6 +687,12 @@ public class Program
                         result.EmbedAllSources = false;
                         break;
 
+                    case "log":
+                        result.LogPath = string.IsNullOrWhiteSpace(value)
+                            ? DiagnosticLogPaths.GetDefaultFilePath("gsharp-compiler-debug.log")
+                            : value.Trim();
+                        break;
+
                     case "?":
                     case "help":
                         result.ShowHelp = true;
@@ -796,6 +812,23 @@ public class Program
         };
     }
 
+    private static int IndexOfSwitchValueSeparator(string value)
+    {
+        var colon = value.IndexOf(':');
+        var equals = value.IndexOf('=');
+        if (colon < 0)
+        {
+            return equals;
+        }
+
+        if (equals < 0)
+        {
+            return colon;
+        }
+
+        return Math.Min(colon, equals);
+    }
+
     private static bool IsSwitch(string arg)
     {
         if (arg.Length == 0)
@@ -891,6 +924,9 @@ public class Program
 
         /// <summary>Gets or sets the informational version string stamped on the output assembly (from /version:).</summary>
         public string Version { get; set; }
+
+        /// <summary>Gets or sets the log file path (from /log:&lt;file&gt;). When non-null, a <see cref="FileLogger"/> is created and attached to the compilation.</summary>
+        public string LogPath { get; set; }
     }
 
     private sealed class CommandLineException : Exception

--- a/src/Core/CodeAnalysis/Compilation/Compilation.cs
+++ b/src/Core/CodeAnalysis/Compilation/Compilation.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Diagnostics;
 using GSharp.Core.CodeAnalysis.Documentation;
 using GSharp.Core.CodeAnalysis.Emit;
 using GSharp.Core.CodeAnalysis.Lowering.Iterators;
@@ -58,6 +59,7 @@ public class Compilation
         IsLibrary = previous?.IsLibrary ?? false;
         PreprocessorSymbols = previous?.PreprocessorSymbols ?? ImmutableHashSet<string>.Empty;
         WarnOnMissingDocumentation = previous?.WarnOnMissingDocumentation ?? false;
+        Logger = previous?.Logger ?? NullLogger.Instance;
         debugInformation = CloneDebugInformation(previous?.DebugInformation);
     }
 
@@ -133,10 +135,17 @@ public class Compilation
 
     /// <summary>
     /// Gets or sets a value indicating whether public source symbols missing
-    /// documentation comments should produce GS0228 warnings during emit.
+    /// documentation comments should produce GS0228 diagnostics during emit.
     /// Defaults to <see langword="false"/>.
     /// </summary>
     public bool WarnOnMissingDocumentation { get; set; }
+
+    /// <summary>
+    /// Gets or sets the optional <see cref="ILogger"/> instance used for
+    /// host-level diagnostic logging. Defaults to <see cref="NullLogger"/>
+    /// so there is zero overhead when the host does not configure one.
+    /// </summary>
+    public ILogger Logger { get; set; } = NullLogger.Instance;
 
     /// <summary>
     /// Gets or sets the optional per-project bound-body cache (ADR-0105

--- a/src/Core/CodeAnalysis/Diagnostic/DiagnosticLogPaths.cs
+++ b/src/Core/CodeAnalysis/Diagnostic/DiagnosticLogPaths.cs
@@ -1,0 +1,21 @@
+// <copyright file="DiagnosticLogPaths.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Core.CodeAnalysis.Diagnostics;
+
+/// <summary>
+/// Resolves default log file locations for host applications.
+/// </summary>
+public static class DiagnosticLogPaths
+{
+    /// <summary>
+    /// Gets a default file path for opt-in host logging.
+    /// </summary>
+    /// <param name="fileName">The log file name.</param>
+    /// <returns>An absolute path beneath the platform temporary directory.</returns>
+    public static string GetDefaultFilePath(string fileName)
+    {
+        return Path.Combine(Path.GetTempPath(), fileName);
+    }
+}

--- a/src/Core/CodeAnalysis/Diagnostic/FileLogger.cs
+++ b/src/Core/CodeAnalysis/Diagnostic/FileLogger.cs
@@ -1,0 +1,98 @@
+// <copyright file="FileLogger.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+#nullable enable
+
+using System.Text.Json;
+
+namespace GSharp.Core.CodeAnalysis.Diagnostics;
+
+/// <summary>
+/// A simple logger that writes structured log entries to a text file.
+/// Each entry is prefixed with a timestamp and severity level.
+/// </summary>
+public sealed class FileLogger : ILogger, IDisposable
+{
+    private readonly string filePath;
+    private readonly object lockObj = new();
+    private StreamWriter? writer;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FileLogger"/> class.
+    /// </summary>
+    /// <param name="filePath">The path to the log file.</param>
+    public FileLogger(string filePath)
+    {
+        this.filePath = filePath;
+
+        var dir = Path.GetDirectoryName(filePath);
+        if (!string.IsNullOrEmpty(dir))
+        {
+            Directory.CreateDirectory(dir);
+        }
+
+        writer = new StreamWriter(filePath, append: true) { AutoFlush = true };
+    }
+
+    /// <inheritdoc/>
+    public void Log(LogLevel level, string message, Exception? exception = null)
+    {
+        lock (lockObj)
+        {
+            if (writer == null)
+            {
+                return;
+            }
+
+            var entry = new
+            {
+                Timestamp = DateTimeOffset.UtcNow,
+                Level = ToLevelName(level),
+                Message = message,
+                ExceptionType = exception?.GetType().FullName,
+                Exception = exception?.ToString(),
+            };
+
+            writer.WriteLine(JsonSerializer.Serialize(entry));
+        }
+    }
+
+    /// <inheritdoc/>
+    public bool IsEnabled(LogLevel level) => true;
+
+    /// <inheritdoc/>
+    public void LogDebug(string message, Exception? exception = null) => Log(LogLevel.Debug, message, exception);
+
+    /// <inheritdoc/>
+    public void LogInfo(string message, Exception? exception = null) => Log(LogLevel.Info, message, exception);
+
+    /// <inheritdoc/>
+    public void LogWarning(string message, Exception? exception = null) => Log(LogLevel.Warning, message, exception);
+
+    /// <inheritdoc/>
+    public void LogError(string message, Exception? exception = null) => Log(LogLevel.Error, message, exception);
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        lock (lockObj)
+        {
+            if (writer != null)
+            {
+                writer.Dispose();
+                writer = null;
+            }
+        }
+    }
+
+    private static string ToLevelName(LogLevel level)
+        => level switch
+        {
+            LogLevel.Debug => "Debug",
+            LogLevel.Info => "Info",
+            LogLevel.Warning => "Warning",
+            LogLevel.Error => "Error",
+            _ => level.ToString(),
+        };
+}

--- a/src/Core/CodeAnalysis/Diagnostic/ILogger.cs
+++ b/src/Core/CodeAnalysis/Diagnostic/ILogger.cs
@@ -1,0 +1,113 @@
+// <copyright file="ILogger.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+#nullable enable
+
+namespace GSharp.Core.CodeAnalysis.Diagnostics;
+
+/// <summary>
+/// Defines logging severity levels.
+/// </summary>
+public enum LogLevel
+{
+    /// <summary>Verbose diagnostic information.</summary>
+    Debug,
+
+    /// <summary>Informational messages.</summary>
+    Info,
+
+    /// <summary>Potentially harmful situations.</summary>
+    Warning,
+
+    /// <summary>Error events.</summary>
+    Error,
+}
+
+/// <summary>
+/// A lightweight logging abstraction for host applications.
+/// </summary>
+public interface ILogger
+{
+    /// <summary>
+    /// Writes a log entry.
+    /// </summary>
+    /// <param name="level">The severity level of the log entry.</param>
+    /// <param name="message">The log message.</param>
+    /// <param name="exception">Optional exception to include.</param>
+    void Log(LogLevel level, string message, Exception? exception = null);
+
+    /// <summary>
+    /// Writes a debug log entry.
+    /// </summary>
+    /// <param name="message">The log message.</param>
+    /// <param name="exception">Optional exception to include.</param>
+    void LogDebug(string message, Exception? exception = null);
+
+    /// <summary>
+    /// Writes an informational log entry.
+    /// </summary>
+    /// <param name="message">The log message.</param>
+    /// <param name="exception">Optional exception to include.</param>
+    void LogInfo(string message, Exception? exception = null);
+
+    /// <summary>
+    /// Writes a warning log entry.
+    /// </summary>
+    /// <param name="message">The log message.</param>
+    /// <param name="exception">Optional exception to include.</param>
+    void LogWarning(string message, Exception? exception = null);
+
+    /// <summary>
+    /// Writes an error log entry.
+    /// </summary>
+    /// <param name="message">The log message.</param>
+    /// <param name="exception">Optional exception to include.</param>
+    void LogError(string message, Exception? exception = null);
+
+    /// <summary>
+    /// Checks if the given log level is enabled.
+    /// </summary>
+    /// <param name="level">The severity level to check.</param>
+    /// <returns><see langword="true"/> if this level is enabled; otherwise, <see langword="false"/>.</returns>
+    bool IsEnabled(LogLevel level);
+}
+
+/// <summary>
+/// A no-op logger that discards all log entries. Use <see cref="Instance"/> to access the singleton.
+/// </summary>
+public sealed class NullLogger : ILogger
+{
+    /// <summary>
+    /// Gets the singleton instance of <see cref="NullLogger"/>.
+    /// </summary>
+    public static readonly NullLogger Instance = new();
+
+    /// <inheritdoc/>
+    public void Log(LogLevel level, string message, Exception? exception = null)
+    {
+    }
+
+    /// <inheritdoc/>
+    public void LogDebug(string message, Exception? exception = null)
+    {
+    }
+
+    /// <inheritdoc/>
+    public void LogInfo(string message, Exception? exception = null)
+    {
+    }
+
+    /// <inheritdoc/>
+    public void LogWarning(string message, Exception? exception = null)
+    {
+    }
+
+    /// <inheritdoc/>
+    public void LogError(string message, Exception? exception = null)
+    {
+    }
+
+    /// <inheritdoc/>
+    public bool IsEnabled(LogLevel level) => false;
+}

--- a/src/Interpreter/GSharpRepl.cs
+++ b/src/Interpreter/GSharpRepl.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Diagnostics;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.IO;
@@ -25,15 +26,30 @@ public class GSharpRepl : Repl
 
     private List<int> linesWithOpenMultilineComments = new List<int>();
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GSharpRepl"/> class.
+    /// </summary>
+    /// <param name="logger">Optional host logger.</param>
+    public GSharpRepl(ILogger logger = null)
+    {
+        Logger = logger ?? NullLogger.Instance;
+    }
+
+    /// <summary>
+    /// Gets the host logger for this REPL.
+    /// </summary>
+    public ILogger Logger { get; }
+
     /// <inheritdoc/>
     public override void EvaluateSubmission(string text)
     {
         linesWithOpenMultilineComments.Clear();
+        Logger.LogDebug("Evaluating REPL submission");
 
         var syntaxTree = SyntaxTree.Parse(text);
 
         var compilation = previous == null
-                            ? new Compilation(syntaxTree)
+                            ? new Compilation(syntaxTree) { Logger = Logger }
                             : previous.ContinueWith(syntaxTree);
 
         if (showTree)
@@ -54,6 +70,7 @@ public class GSharpRepl : Repl
         // the compilation as successful unless an error severity is present.
         if (result.Diagnostics.Any())
         {
+            Logger.LogInfo($"Submission produced {result.Diagnostics.Length} diagnostic(s)");
             Console.Out.WriteDiagnostics(result.Diagnostics);
         }
 
@@ -68,6 +85,10 @@ public class GSharpRepl : Repl
             }
 
             previous = compilation;
+        }
+        else
+        {
+            Logger.LogWarning("Submission completed with errors");
         }
     }
 

--- a/src/Interpreter/Program.cs
+++ b/src/Interpreter/Program.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Globalization;
 using System.IO;
+using GSharp.Core.CodeAnalysis.Diagnostics;
 
 namespace GSharp.Interpreter;
 
@@ -20,35 +21,81 @@ public class Program
     /// <returns>Exit code.</returns>
     public static int Main(string[] args)
     {
-        var repl = new GSharpRepl();
-        if (args?.Length > 0)
+        var logPath = GetLogPath(args);
+        ILogger logger = logPath is not null ? new FileLogger(logPath) : NullLogger.Instance;
+        try
         {
-            var arg0 = args[0];
-            if (arg0.Length > 0 &&
-                arg0.EndsWith(".gs", ignoreCase: true, culture: CultureInfo.InvariantCulture) &&
-                File.Exists(arg0))
+            var filteredArgs = FilterLogArg(args);
+            var repl = new GSharpRepl(logger);
+            if (filteredArgs.Length > 0)
             {
-                var success = EvaluateFile(repl, arg0);
-                if (!success)
+                var arg0 = filteredArgs[0];
+                if (arg0.Length > 0 &&
+                    arg0.EndsWith(".gs", ignoreCase: true, culture: CultureInfo.InvariantCulture) &&
+                    File.Exists(arg0))
                 {
+                    logger.LogInfo($"Evaluating file: {arg0}");
+                    var success = EvaluateFile(repl, arg0, logger);
+                    if (!success)
+                    {
+                        return 1;
+                    }
+                }
+                else
+                {
+                    logger.LogWarning($"Unable to find specified file {arg0}");
+                    Console.WriteLine($"Unable to find specified file {arg0}");
                     return 1;
                 }
             }
             else
             {
-                Console.WriteLine($"Unable to find specified file {arg0}");
-                return 1;
+                logger.LogInfo("Starting REPL session");
+                repl.Run();
             }
-        }
-        else
-        {
-            repl.Run();
-        }
 
-        return 0;
+            return 0;
+        }
+        finally
+        {
+            (logger as IDisposable)?.Dispose();
+        }
     }
 
-    private static bool EvaluateFile(GSharpRepl repl, string filePath)
+    private static string GetLogPath(string[] args)
+    {
+        var logArg = Array.Find(args, a =>
+            string.Equals(a, "--log", StringComparison.OrdinalIgnoreCase) ||
+            a.StartsWith("--log=", StringComparison.OrdinalIgnoreCase) ||
+            a.StartsWith("--log:", StringComparison.OrdinalIgnoreCase));
+
+        if (logArg == null)
+        {
+            return null;
+        }
+
+        var separatorIndex = logArg.IndexOfAny(new[] { '=', ':' });
+        if (separatorIndex >= 0)
+        {
+            var path = logArg.Substring(separatorIndex + 1).Trim();
+            if (!string.IsNullOrEmpty(path))
+            {
+                return path;
+            }
+        }
+
+        return DiagnosticLogPaths.GetDefaultFilePath("gsharp-interpreter-debug.log");
+    }
+
+    private static string[] FilterLogArg(string[] args)
+    {
+        return Array.FindAll(args, a =>
+            !string.Equals(a, "--log", StringComparison.OrdinalIgnoreCase) &&
+            !a.StartsWith("--log=", StringComparison.OrdinalIgnoreCase) &&
+            !a.StartsWith("--log:", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static bool EvaluateFile(GSharpRepl repl, string filePath, ILogger logger)
     {
         string text;
         using (var reader = new StreamReader(filePath))
@@ -69,6 +116,7 @@ public class Program
         }
         else
         {
+            logger.LogWarning($"Invalid input: empty file {filePath}");
             Console.WriteLine("Invalid input: empty file.");
         }
 

--- a/src/LanguageServer/Program.cs
+++ b/src/LanguageServer/Program.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using GSharp.Core.CodeAnalysis.Diagnostics;
 using GSharp.LanguageServer.Protocol;
 using GSharp.LanguageServer.Server;
 using StreamJsonRpc;
@@ -25,20 +26,17 @@ public class Program
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     public static async Task Main(string[] args)
     {
+        ILogger logger = NullLogger.Instance;
         var logFile = GetLogPath(args);
-        var logEnabled = logFile != null;
-
-        if (logEnabled)
+        if (logFile != null)
         {
-            File.AppendAllText(logFile, $"\n\n--- SERVER START ---\nArgs: {string.Join(" ", args)}\n");
+            logger = new FileLogger(logFile);
+            logger.LogInfo($"Server start. Args: {string.Join(" ", args)}");
         }
 
         AppDomain.CurrentDomain.UnhandledException += (s, e) =>
         {
-            if (logEnabled)
-            {
-                File.AppendAllText(logFile, $"UNHANDLED EXCEPTION: {e.ExceptionObject}\n");
-            }
+            logger.LogError("Unhandled exception", e.ExceptionObject as Exception);
         };
 
         var pipeName = GetPipeName(args);
@@ -59,23 +57,19 @@ public class Program
             receiving = Console.OpenStandardInput();
         }
 
-        if (logEnabled)
+        if (logger.IsEnabled(LogLevel.Debug))
         {
-            sending = new LoggingStream(sending, logFile, "OUT");
-            receiving = new LoggingStream(receiving, logFile, "IN");
+            sending = new LoggingStream(sending, logger, "OUT");
+            receiving = new LoggingStream(receiving, logger, "IN");
         }
 
         try
         {
-            await RunAsync(sending, receiving);
+            await RunAsync(sending, receiving, logger);
         }
         catch (Exception ex)
         {
-            if (logEnabled)
-            {
-                File.AppendAllText(logFile, $"FATAL ERROR: {ex}\n");
-            }
-
+            logger.LogError("Fatal error", ex);
             throw;
         }
         finally
@@ -84,14 +78,16 @@ public class Program
             {
                 await stream.DisposeAsync();
             }
+
+            (logger as IDisposable)?.Dispose();
         }
     }
 
-    private static async Task RunAsync(Stream sending, Stream receiving)
+    private static async Task RunAsync(Stream sending, Stream receiving, ILogger logger)
     {
         var documentContentService = new DocumentContentService();
         var workspaceState = new WorkspaceState();
-        var target = new LspServer(documentContentService, workspaceState);
+        var target = new LspServer(documentContentService, workspaceState, logger);
 
         var formatter = new SystemTextJsonFormatter { JsonSerializerOptions = LspJson.Options };
         var handler = new HeaderDelimitedMessageHandler(sending, receiving, formatter);
@@ -156,22 +152,19 @@ public class Program
             }
         }
 
-        return System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows)
-            ? Path.Combine(Path.GetTempPath(), "gsharp-lsp-debug.log")
-            : "/tmp/gsharp-lsp-debug.log";
+        return DiagnosticLogPaths.GetDefaultFilePath("gsharp-lsp-debug.log");
     }
 
     private sealed class LoggingStream : Stream
     {
         private readonly Stream inner;
-        private readonly string logFile;
+        private readonly ILogger logger;
         private readonly string prefix;
-        private readonly object lockObj = new object();
 
-        public LoggingStream(Stream inner, string logFile, string prefix)
+        public LoggingStream(Stream inner, ILogger logger, string prefix)
         {
             this.inner = inner;
-            this.logFile = logFile;
+            this.logger = logger;
             this.prefix = prefix;
         }
 
@@ -237,10 +230,7 @@ public class Program
             }
 
             var text = System.Text.Encoding.UTF8.GetString(buffer, offset, count);
-            lock (this.lockObj)
-            {
-                File.AppendAllText(this.logFile, $"[{this.prefix}] {text}\n");
-            }
+            this.logger.LogDebug($"[{this.prefix}] {text}");
         }
     }
 }

--- a/src/LanguageServer/Server/LspServer.cs
+++ b/src/LanguageServer/Server/LspServer.cs
@@ -11,6 +11,7 @@ using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using GSharp.Core.CodeAnalysis.Diagnostics;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.LanguageServer.Protocol;
@@ -33,6 +34,7 @@ public sealed class LspServer
 {
     private readonly DocumentContentService documentContentService;
     private readonly WorkspaceState workspaceState;
+    private readonly ILogger logger;
     private readonly SemaphoreSlim gate = new SemaphoreSlim(1, 1);
     private readonly TaskCompletionSource<int> exitSource = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly object refreshLock = new object();
@@ -43,10 +45,11 @@ public sealed class LspServer
     private bool clientSupportsDiagnosticRefresh;
     private Timer refreshTimer;
 
-    public LspServer(DocumentContentService documentContentService, WorkspaceState workspaceState)
+    public LspServer(DocumentContentService documentContentService, WorkspaceState workspaceState, ILogger logger = null)
     {
         this.documentContentService = documentContentService;
         this.workspaceState = workspaceState;
+        this.logger = logger ?? NullLogger.Instance;
     }
 
     /// <summary>Gets a task that completes when the client sends the <c>exit</c> notification.</summary>
@@ -567,7 +570,7 @@ public sealed class LspServer
                 // a per-request "Object reference not set to an instance of an object"
                 // popup for every diagnostic / inlayHint / codeLens / semanticTokens pull
                 // until the user restarted the editor. Swallow the exception, log it to
-                // stderr for diagnosis, and return a safe default (null for reference
+                // structured logging for diagnosis, and return a safe default (null for reference
                 // types — LSP clients treat that as "no result" rather than an error).
                 LogHandlerException(caller, ex);
                 return default;
@@ -864,16 +867,15 @@ public sealed class LspServer
     private static SemanticTokens EmptySemanticTokens()
         => new SemanticTokens { Data = System.Collections.Immutable.ImmutableArray<int>.Empty };
 
-    private static void LogHandlerException(string handler, Exception ex)
+    private void LogHandlerException(string handler, Exception ex)
     {
         try
         {
-            Console.Error.WriteLine($"[gsharp-lsp] {handler ?? "handler"} failed: {ex.GetType().FullName}: {ex.Message}");
-            Console.Error.WriteLine(ex.StackTrace);
+            this.logger.LogError($"{handler ?? "handler"} failed: {ex.GetType().FullName}: {ex.Message}", ex);
         }
         catch
         {
-            // Logging is best-effort; never let a stderr write tear down the server.
+            // Logging is best-effort; never let a logger failure tear down the server.
         }
     }
 


### PR DESCRIPTION
Closes #1362

Adds a lightweight Core logging abstraction with JSON file logging, wires opt-in log files into gsc, the REPL, and the language server, and routes language-server handler failures through the shared logger.