### PR TITLE
Use file-scoped test helper types

### DIFF
--- a/test/Core.Tests/CodeAnalysis/Symbols/ClrTypeUtilitiesTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/ClrTypeUtilitiesTests.cs
@@ -195,7 +195,7 @@ public class ClrTypeUtilitiesTests
 /// </summary>
 #pragma warning disable CS0067 // event is never used; only its signature is reflected over.
 #pragma warning disable CS0649 // field is never assigned; only its signature is reflected over.
-internal sealed class Fixture338
+file sealed class Fixture338
 {
     public Fixture338()
     {

--- a/test/Core.Tests/CodeAnalysis/Symbols/SymbolDisplayAsyncClrMethodTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/SymbolDisplayAsyncClrMethodTests.cs
@@ -72,7 +72,7 @@ public class SymbolDisplayAsyncClrMethodTests
 }
 
 #pragma warning disable CS1998 // async method without await: intentional — the test only inspects metadata, not runtime behavior.
-internal static class AsyncClrMethodSamples
+file static class AsyncClrMethodSamples
 {
     public static async Task<int> AsyncResult(string name) => name.Length;
 


### PR DESCRIPTION
Closes #1369

Converted two Core.Tests helper fixtures that are referenced only within their defining source files to C# file-scoped types. Verified candidate usages across the solution and left cross-file or corpus sample types unchanged.