### PR TITLE
Use records for simple bound data holders

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundAttributeArgument.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundAttributeArgument.cs
@@ -13,7 +13,7 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// Per ADR-0047 §3 / ECMA-335 II.23.3 only compile-time constants of the
 /// recognised attribute-argument value space are permitted.
 /// </summary>
-public sealed class BoundAttributeArgument
+public sealed record BoundAttributeArgument
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="BoundAttributeArgument"/> class.

--- a/src/Core/CodeAnalysis/Binding/BoundBinaryOperator.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundBinaryOperator.cs
@@ -10,7 +10,7 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// <summary>
 /// Bound binary operator.
 /// </summary>
-public sealed class BoundBinaryOperator
+public sealed record BoundBinaryOperator
 {
     private static readonly TypeSymbol[] SignedIntegralTypes =
     {

--- a/src/Core/CodeAnalysis/Binding/BoundBodyCacheKey.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundBodyCacheKey.cs
@@ -2,8 +2,6 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
-using System;
-
 namespace GSharp.Core.CodeAnalysis.Binding;
 
 /// <summary>
@@ -15,52 +13,16 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// identical across re-parses of byte-identical text and differs whenever the
 /// body changes.
 /// </summary>
-public readonly struct BoundBodyCacheKey : IEquatable<BoundBodyCacheKey>
+public readonly record struct BoundBodyCacheKey(string StableMemberId, string BodyHash)
 {
-    /// <summary>
-    /// Initializes a new instance of the <see cref="BoundBodyCacheKey"/> struct.
-    /// </summary>
-    /// <param name="stableMemberId">The position-independent member identity.</param>
-    /// <param name="bodyHash">The content hash of the member body's source text.</param>
-    public BoundBodyCacheKey(string stableMemberId, string bodyHash)
-    {
-        StableMemberId = stableMemberId ?? string.Empty;
-        BodyHash = bodyHash ?? string.Empty;
-    }
-
     /// <summary>
     /// Gets the position-independent member identity (source file path, owning
     /// package, containing-type path and name + parameter-type signature).
     /// </summary>
-    public string StableMemberId { get; }
+    public string StableMemberId { get; } = StableMemberId ?? string.Empty;
 
     /// <summary>Gets the content hash of the member body's source text.</summary>
-    public string BodyHash { get; }
-
-    /// <summary>Determines whether two keys are equal.</summary>
-    /// <param name="left">The left key.</param>
-    /// <param name="right">The right key.</param>
-    /// <returns><see langword="true"/> when the keys are equal.</returns>
-    public static bool operator ==(BoundBodyCacheKey left, BoundBodyCacheKey right) => left.Equals(right);
-
-    /// <summary>Determines whether two keys are not equal.</summary>
-    /// <param name="left">The left key.</param>
-    /// <param name="right">The right key.</param>
-    /// <returns><see langword="true"/> when the keys are not equal.</returns>
-    public static bool operator !=(BoundBodyCacheKey left, BoundBodyCacheKey right) => !left.Equals(right);
-
-    /// <inheritdoc/>
-    public bool Equals(BoundBodyCacheKey other) =>
-        string.Equals(StableMemberId, other.StableMemberId, StringComparison.Ordinal)
-        && string.Equals(BodyHash, other.BodyHash, StringComparison.Ordinal);
-
-    /// <inheritdoc/>
-    public override bool Equals(object obj) => obj is BoundBodyCacheKey other && Equals(other);
-
-    /// <inheritdoc/>
-    public override int GetHashCode() => HashCode.Combine(
-        StringComparer.Ordinal.GetHashCode(StableMemberId ?? string.Empty),
-        StringComparer.Ordinal.GetHashCode(BodyHash ?? string.Empty));
+    public string BodyHash { get; } = BodyHash ?? string.Empty;
 
     /// <inheritdoc/>
     public override string ToString() => $"{StableMemberId}#{BodyHash}";

--- a/src/Core/CodeAnalysis/Binding/BoundCatchClause.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundCatchClause.cs
@@ -9,7 +9,7 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// <summary>
 /// Bound catch clause attached to a <see cref="BoundTryStatement"/>.
 /// </summary>
-public sealed class BoundCatchClause
+public sealed record BoundCatchClause
 {
     /// <summary>Initializes a new instance of the <see cref="BoundCatchClause"/> class.</summary>
     /// <param name="exceptionType">The exception type filter; <c>null</c> matches the base exception type.</param>

--- a/src/Core/CodeAnalysis/Binding/BoundFieldInitializer.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundFieldInitializer.cs
@@ -16,7 +16,7 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// <see cref="PropertySymbol"/> (a <c>prop</c> auto-property with a
 /// <c>set</c>/<c>init</c> accessor).
 /// </summary>
-public sealed class BoundFieldInitializer
+public sealed record BoundFieldInitializer
 {
     public BoundFieldInitializer(FieldSymbol field, BoundExpression value)
     {

--- a/src/Core/CodeAnalysis/Binding/BoundMapLiteralExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundMapLiteralExpression.cs
@@ -44,7 +44,7 @@ public sealed class BoundMapLiteralExpression : BoundExpression
 /// <summary>
 /// A single bound <c>key: value</c> entry in a <see cref="BoundMapLiteralExpression"/>.
 /// </summary>
-public sealed class BoundMapEntry
+public sealed record BoundMapEntry
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="BoundMapEntry"/> class.

--- a/src/Core/CodeAnalysis/Binding/BoundSelectCase.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundSelectCase.cs
@@ -10,7 +10,7 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// <summary>
 /// A single bound arm of a <c>select</c> statement (Phase 5.6 / ADR-0022).
 /// </summary>
-public sealed class BoundSelectCase
+public sealed record BoundSelectCase
 {
     /// <summary>Initializes a new instance of the <see cref="BoundSelectCase"/> class.</summary>
     /// <param name="caseKind">Which arm shape this is.</param>

--- a/src/Core/CodeAnalysis/Binding/BoundUnaryOperator.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundUnaryOperator.cs
@@ -10,7 +10,7 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// <summary>
 /// Bound unary operator.
 /// </summary>
-public sealed class BoundUnaryOperator
+public sealed record BoundUnaryOperator
 {
     private static BoundUnaryOperator[] supportedOperators = BuildSupportedOperators();
 

--- a/src/Core/CodeAnalysis/Symbols/MarshalAsMetadata.cs
+++ b/src/Core/CodeAnalysis/Symbols/MarshalAsMetadata.cs
@@ -26,7 +26,7 @@ namespace GSharp.Core.CodeAnalysis.Symbols;
 /// it as a <c>CustomAttribute</c> row (see
 /// <see cref="Binding.KnownAttributes.IsPseudoCustomAttribute"/>).
 /// </remarks>
-public sealed class MarshalAsMetadata
+public sealed record MarshalAsMetadata
 {
     /// <summary>Initializes a new instance of the <see cref="MarshalAsMetadata"/> class.</summary>
     /// <param name="unmanagedType">The primary <see cref="UnmanagedType"/> override.</param>

--- a/src/Core/CodeAnalysis/Symbols/PInvokeMetadata.cs
+++ b/src/Core/CodeAnalysis/Symbols/PInvokeMetadata.cs
@@ -17,7 +17,7 @@ namespace GSharp.Core.CodeAnalysis.Symbols;
 /// marshalling stub that calls a hidden blittable P/Invoke inner method
 /// (LibraryImport).
 /// </summary>
-public sealed class PInvokeMetadata
+public sealed record PInvokeMetadata
 {
     /// <summary>Initializes a new instance of the <see cref="PInvokeMetadata"/> class.</summary>
     /// <param name="libraryName">The unmanaged library name (required positional argument).</param>

--- a/src/Core/CodeAnalysis/Symbols/StructLayoutMetadata.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructLayoutMetadata.cs
@@ -30,7 +30,7 @@ namespace GSharp.Core.CodeAnalysis.Symbols;
 /// <c>struct</c> and <see cref="LayoutKind.Auto"/> for <c>class</c>.
 /// </para>
 /// </remarks>
-public sealed class StructLayoutMetadata
+public sealed record StructLayoutMetadata
 {
     /// <summary>Initializes a new instance of the <see cref="StructLayoutMetadata"/> class.</summary>
     /// <param name="layout">The validated layout kind (Sequential or Explicit).</param>


### PR DESCRIPTION
Closes #1368

Converts simple bound-node helper and metadata carrier data classes to records, and simplifies the bound body cache key to a readonly record struct while preserving its normalization and display behavior.