### PR TITLE
Use nint for CLR native int references

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
@@ -421,7 +421,7 @@ internal sealed partial class ExpressionBinder
 
         // nint/nuint and pointer-to-pointer are pointer-sized; the supported
         // execution targets are 64-bit.
-        return System.IntPtr.Size;
+        return nint.Size;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Statements.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Statements.cs
@@ -392,7 +392,7 @@ internal sealed partial class MethodBodyEmitter
 
         if (isAsync)
         {
-            var funcTaskCtor = typeof(Func<System.Threading.Tasks.Task>).GetConstructor(new[] { typeof(object), typeof(IntPtr) });
+            var funcTaskCtor = typeof(Func<System.Threading.Tasks.Task>).GetConstructor(new[] { typeof(object), typeof(nint) });
             this.il.OpCode(ILOpCode.Ldftn);
             this.il.Token(invokeHandle);
             this.il.OpCode(ILOpCode.Newobj);
@@ -400,7 +400,7 @@ internal sealed partial class MethodBodyEmitter
         }
         else
         {
-            var actionCtor = typeof(Action).GetConstructor(new[] { typeof(object), typeof(IntPtr) });
+            var actionCtor = typeof(Action).GetConstructor(new[] { typeof(object), typeof(nint) });
             this.il.OpCode(ILOpCode.Ldftn);
             this.il.Token(invokeHandle);
             this.il.OpCode(ILOpCode.Newobj);

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -506,7 +506,7 @@ internal sealed class ReflectionMetadataEmitter
         // ADR-0059 / issue #255: cache the base type and `IntPtr` parameter
         // type for user-declared named delegate emission.
         this.emitCtx.CoreMulticastDelegateType = this.ResolveCoreType("System.MulticastDelegate", typeof(System.MulticastDelegate));
-        this.emitCtx.CoreIntPtrType = this.ResolveCoreType("System.IntPtr", typeof(System.IntPtr));
+        this.emitCtx.CoreIntPtrType = this.ResolveCoreType("System.IntPtr", typeof(nint));
 
         // PR-E-3: WellKnownReferences depends on EmitContext.Core* and on the
         // dedup-cached GetTypeReference / GetMethodReference resolvers that
@@ -5401,7 +5401,7 @@ internal sealed class ReflectionMetadataEmitter
                 : "StringToCoTaskMemUTF8";
             var convertMethod = marshalType.GetMethod(convertName, new[] { typeof(string) })
                 ?? throw new InvalidOperationException($"Cannot resolve Marshal.{convertName}(string).");
-            var freeMethod = marshalType.GetMethod("FreeCoTaskMem", new[] { typeof(IntPtr) })
+            var freeMethod = marshalType.GetMethod("FreeCoTaskMem", new[] { typeof(nint) })
                 ?? throw new InvalidOperationException("Cannot resolve Marshal.FreeCoTaskMem(IntPtr).");
             convertRef = this.GetMethodReference(convertMethod);
             freeRef = this.GetMethodReference(freeMethod);

--- a/src/Core/CodeAnalysis/Symbols/FunctionPointerTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/FunctionPointerTypeSymbol.cs
@@ -27,7 +27,7 @@ public sealed class FunctionPointerTypeSymbol : TypeSymbol
     private static readonly ConcurrentDictionary<string, FunctionPointerTypeSymbol> Cache = new ConcurrentDictionary<string, FunctionPointerTypeSymbol>();
 
     private FunctionPointerTypeSymbol(string name, bool isManaged, CallingConvention callingConvention, ImmutableArray<TypeSymbol> parameterTypes, TypeSymbol returnType)
-        : base(name, typeof(System.IntPtr))
+        : base(name, typeof(nint))
     {
         IsManaged = isManaged;
         CallingConvention = callingConvention;

--- a/test/Compiler.Tests/Emit/NamedDelegateEmitTests.cs
+++ b/test/Compiler.Tests/Emit/NamedDelegateEmitTests.cs
@@ -58,7 +58,7 @@ public class NamedDelegateEmitTests
         var parms = ctor.GetParameters();
         Assert.Equal(2, parms.Length);
         Assert.Equal(typeof(object), parms[0].ParameterType);
-        Assert.Equal(typeof(IntPtr), parms[1].ParameterType);
+        Assert.Equal(typeof(nint), parms[1].ParameterType);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #1372

Summary:
- Replaces C# source-level IntPtr native integer references with nint aliases where metadata remains System.IntPtr.
- Preserves G# semantic strings and emitted IntPtr/UIntPtr metadata encoding.