### PR TITLE
Use target-typed new expressions

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BinderContext.cs
+++ b/src/Core/CodeAnalysis/Binding/BinderContext.cs
@@ -130,7 +130,7 @@ internal sealed class BinderContext
     /// <summary>
     /// Gets the diagnostics bag for the binder this context backs.
     /// </summary>
-    public DiagnosticBag Diagnostics { get; } = new DiagnosticBag();
+    public DiagnosticBag Diagnostics { get; } = new();
 
     /// <summary>
     /// Gets the reference resolver associated with the binder's scope chain.

--- a/src/Core/CodeAnalysis/Binding/ControlFlowGraph.cs
+++ b/src/Core/CodeAnalysis/Binding/ControlFlowGraph.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ControlFlowGraph.cs" company="GSharp">
+// <copyright file="ControlFlowGraph.cs" company="GSharp">
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
@@ -164,17 +164,17 @@ public sealed class ControlFlowGraph
         /// <summary>
         /// Gets the list of statements in this block.
         /// </summary>
-        public List<BoundStatement> Statements { get; } = new List<BoundStatement>();
+        public List<BoundStatement> Statements { get; } = new();
 
         /// <summary>
         /// Gets the list of incoming branches to this block.
         /// </summary>
-        public List<BasicBlockBranch> Incoming { get; } = new List<BasicBlockBranch>();
+        public List<BasicBlockBranch> Incoming { get; } = new();
 
         /// <summary>
         /// Gets the list of outgoing branches from this block.
         /// </summary>
-        public List<BasicBlockBranch> Outgoing { get; } = new List<BasicBlockBranch>();
+        public List<BasicBlockBranch> Outgoing { get; } = new();
 
         /// <inheritdoc/>
         public override string ToString()
@@ -254,8 +254,8 @@ public sealed class ControlFlowGraph
     /// </summary>
     public sealed class BasicBlockBuilder
     {
-        private readonly List<BoundStatement> statements = new List<BoundStatement>();
-        private readonly List<BasicBlock> blocks = new List<BasicBlock>();
+        private readonly List<BoundStatement> statements = new();
+        private readonly List<BasicBlock> blocks = new();
 
         /// <summary>
         /// Builds a basic block from the provided bound block statement and adds
@@ -332,11 +332,11 @@ public sealed class ControlFlowGraph
     /// </summary>
     public sealed class GraphBuilder
     {
-        private readonly Dictionary<BoundStatement, BasicBlock> blockFromStatement = new Dictionary<BoundStatement, BasicBlock>();
-        private readonly Dictionary<BoundLabel, BasicBlock> blockFromLabel = new Dictionary<BoundLabel, BasicBlock>();
-        private readonly List<BasicBlockBranch> branches = new List<BasicBlockBranch>();
-        private readonly BasicBlock start = new BasicBlock(isStart: true);
-        private readonly BasicBlock end = new BasicBlock(isStart: false);
+        private readonly Dictionary<BoundStatement, BasicBlock> blockFromStatement = new();
+        private readonly Dictionary<BoundLabel, BasicBlock> blockFromLabel = new();
+        private readonly List<BasicBlockBranch> branches = new();
+        private readonly BasicBlock start = new(isStart: true);
+        private readonly BasicBlock end = new(isStart: false);
 
         /// <summary>
         /// Builds a control flow graph from the provided list of basic blocks.

--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Conversion.cs" company="GSharp">
+// <copyright file="Conversion.cs" company="GSharp">
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
@@ -16,25 +16,25 @@ public sealed class Conversion
     /// <summary>
     /// States that there's no conversion between the given types.
     /// </summary>
-    public static readonly Conversion None = new Conversion(exists: false, isIdentity: false, isImplicit: false);
+    public static readonly Conversion None = new(exists: false, isIdentity: false, isImplicit: false);
 
     /// <summary>
     /// States that there's an identity conversion between the given types.
     /// </summary>
-    public static readonly Conversion Identity = new Conversion(exists: true, isIdentity: true, isImplicit: true);
+    public static readonly Conversion Identity = new(exists: true, isIdentity: true, isImplicit: true);
 
     /// <summary>
     /// States that there's an implicit conversion between the given types.
     /// </summary>
-    public static readonly Conversion Implicit = new Conversion(exists: true, isIdentity: false, isImplicit: true);
+    public static readonly Conversion Implicit = new(exists: true, isIdentity: false, isImplicit: true);
 
     /// <summary>
     /// States that there's an explicit conversion between the given types.
     /// </summary>
-    public static readonly Conversion Explicit = new Conversion(exists: true, isIdentity: false, isImplicit: false);
+    public static readonly Conversion Explicit = new(exists: true, isIdentity: false, isImplicit: false);
 
     // ADR-0044 implicit numeric widening lattice, keyed by source CLR full
-    // name → set of target CLR full names. Mirrors C# §6.1.2 plus the
+    // name ? set of target CLR full names. Mirrors C# §6.1.2 plus the
     // ADR-0044 inclusion of `decimal` as a widening target for every
     // integral source. Native-width integers (nint/nuint) follow C#'s
     // rules: nint widens to int64/single/double/decimal; nuint widens to
@@ -223,7 +223,7 @@ public sealed class Conversion
 
         // Issue #1256: element-wise tuple conversion. A tuple `(T1, …, Tn)`
         // converts implicitly to `(U1, …, Un)` when both are tuple types of
-        // the SAME arity and EACH element `Ti → Ui` has an implicit conversion
+        // the SAME arity and EACH element `Ti ? Ui` has an implicit conversion
         // (identity, reference/interface upcast, nullable-reference upcast,
         // numeric widening, boxing, …). Mirrors C# §10.2.13 implicit tuple
         // conversions — the element conversions are classified recursively via
@@ -236,7 +236,7 @@ public sealed class Conversion
         // `ValueTuple<…>` from per-element converted accesses, because two
         // distinct `ValueTuple<…>` instantiations are not IL-reinterpretable.
         // When any element lacks an implicit conversion (e.g. a downcast
-        // `Base → Derived`, or `int32 → string`) or the arities differ, this
+        // `Base ? Derived`, or `int32 ? string`) or the arities differ, this
         // branch declines and the conversion falls through to `None`, so such
         // tuples remain errors exactly as C# requires.
         if (from is TupleTypeSymbol fromTuple && to is TupleTypeSymbol toTuple
@@ -280,8 +280,8 @@ public sealed class Conversion
             return Conversion.Identity;
         }
 
-        // Phase 3.C.1 / ADR-0001: T → T? is an implicit widening; T? → T?
-        // when underlyings match is identity. T? → T requires the bang
+        // Phase 3.C.1 / ADR-0001: T ? T? is an implicit widening; T? ? T?
+        // when underlyings match is identity. T? ? T requires the bang
         // operator (Phase 3.C.3) and is not implicit here.
         if (to is NullableTypeSymbol toNullable)
         {
@@ -297,10 +297,10 @@ public sealed class Conversion
                     return Conversion.Identity;
                 }
 
-                // Issue #1236: lifted numeric widening — `T1? → T2?` is an
-                // implicit conversion whenever the underlying `T1 → T2` is an
-                // implicit (lossless) numeric widening (e.g. `uint8? → int32?`,
-                // `int32? → int64?`). This mirrors C# §10.2.6 lifted conversions
+                // Issue #1236: lifted numeric widening — `T1? ? T2?` is an
+                // implicit conversion whenever the underlying `T1 ? T2` is an
+                // implicit (lossless) numeric widening (e.g. `uint8? ? int32?`,
+                // `int32? ? int64?`). This mirrors C# §10.2.6 lifted conversions
                 // and lets nullable numeric operands participate in the same
                 // widening lattice as their non-nullable forms, so a lifted
                 // binary operator can bind at a common underlying type. The
@@ -318,10 +318,10 @@ public sealed class Conversion
                     }
                 }
 
-                // Issue #1255: lifted nullable reference upcast — `T? → U?` is an
-                // implicit conversion whenever the underlying `T → U` is an
+                // Issue #1255: lifted nullable reference upcast — `T? ? U?` is an
+                // implicit conversion whenever the underlying `T ? U` is an
                 // implicit reference/interface upcast (T derives from or
-                // implements U). This mirrors the non-null #1121 rule (`T → U?`)
+                // implements U). This mirrors the non-null #1121 rule (`T ? U?`)
                 // for the nullable-source case so the two stay consistent. For
                 // reference-type underlyings a nullable wrapper shares the CLR
                 // representation of the bare reference (null stays null, a
@@ -329,7 +329,7 @@ public sealed class Conversion
                 // preserving no-op conversion — never boxing or wrapping. The
                 // value-type underlying case is handled by the lifted numeric
                 // rule above and intentionally excluded here. Note this never
-                // makes `T? → U` (non-nullable target, handled below) implicit,
+                // makes `T? ? U` (non-nullable target, handled below) implicit,
                 // so the narrowing null-dropping conversion still errors.
                 if (IsReferenceLikeTarget(fromNullable.UnderlyingType)
                     && IsReferenceLikeTarget(toNullable.UnderlyingType))
@@ -356,9 +356,9 @@ public sealed class Conversion
             // conversion — a non-null reference is always a valid U?. For a
             // reference-type underlying U the nullable wrap is a representation
             // no-op, so we defer to the full implicit-conversion classification
-            // of `T → U` (identity, reference/upcast, interface implementation,
+            // of `T ? U` (identity, reference/upcast, interface implementation,
             // boxing-to-object). Restricted to reference-like underlying targets
-            // so numeric nullable lifting (e.g. int32 → int64?) is unaffected.
+            // so numeric nullable lifting (e.g. int32 ? int64?) is unaffected.
             if (IsReferenceLikeTarget(toNullable.UnderlyingType))
             {
                 var underlyingConversion = Classify(from, toNullable.UnderlyingType);
@@ -416,7 +416,7 @@ public sealed class Conversion
         // `Invoke` signature is assignment-compatible. This lifts the
         // materialization that previously only happened in argument position
         // into a general rule, so assignment, return, and cast positions all
-        // accept func → delegate conversions (Action/Func/Predicate and named
+        // accept func ? delegate conversions (Action/Func/Predicate and named
         // delegate types alike).
         if (from is FunctionTypeSymbol fnSource && to?.ClrType != null
             && IsFunctionToDelegateConvertible(fnSource, to.ClrType))
@@ -425,7 +425,7 @@ public sealed class Conversion
         }
 
         // ADR-0059 / issue #255: same rule for user-declared named delegate
-        // types. They have no ClrType during binding, so the func→delegate
+        // types. They have no ClrType during binding, so the func?delegate
         // path above does not fire — classify the conversion structurally
         // against the delegate's parameter/return signature instead.
         if (from is FunctionTypeSymbol fnSource2 && to is DelegateTypeSymbol toDelegate
@@ -468,8 +468,8 @@ public sealed class Conversion
 
         // Issue #421 P2-5: user-defined and imported enums convert to/from
         // their underlying numeric primitive, and one enum converts to
-        // another. Mirrors C# §10.2.4: every enum⇄numeric direction is an
-        // explicit conversion (even enum→its own underlying), since enum
+        // another. Mirrors C# §10.2.4: every enum?numeric direction is an
+        // explicit conversion (even enum?its own underlying), since enum
         // identity is intentionally distinct from the integral identity.
         if (TryClassifyEnumConversion(from, to, out var enumConversion))
         {
@@ -478,8 +478,8 @@ public sealed class Conversion
 
         // ADR-0044 numeric lattice. Both operands must be CLR primitives in
         // the numeric set; the widening map decides implicit vs. explicit.
-        // Decimal narrowings (decimal → int etc.) and signed/unsigned
-        // mismatches at the same width (int ↔ uint) are explicit per C#.
+        // Decimal narrowings (decimal ? int etc.) and signed/unsigned
+        // mismatches at the same width (int ? uint) are explicit per C#.
         var fromClr = from?.ClrType?.FullName;
         var toClr = to?.ClrType?.FullName;
         if (fromClr != null && toClr != null
@@ -581,7 +581,7 @@ public sealed class Conversion
         // type has a null `ClrType` during binding — `MakeGenericType` could
         // not close the type because the argument lives in the assembly being
         // emitted — so `IsValueTypeLikeFrom`/`IsInterfaceLikeType` cannot fire
-        // and the value-type → interface box above is skipped. The target
+        // and the value-type ? interface box above is skipped. The target
         // generic interface (`IEnumerator[T]`) is likewise unclosed. Match the
         // target interface's open definition against the generic interfaces the
         // struct's open definition implements, substituting the struct's
@@ -697,12 +697,12 @@ public sealed class Conversion
 
         // Issue #528: a G# slice `[]T` is backed by a CLR `T[]` at runtime
         // (`SliceTypeSymbol.ClrType` is built via `MakeArrayType()` on the
-        // element's `ClrType`). The reverse direction (`T[] → []T`) is
+        // element's `ClrType`). The reverse direction (`T[] ? []T`) is
         // already classified above; this branch documents and enforces the
-        // forward direction (`[]T → T[]`) explicitly so it survives any
+        // forward direction (`[]T ? T[]`) explicitly so it survives any
         // future refactor of the generic #521 reference upcast below.
         // Element-type identity is required (matched by CLR full name to
-        // bridge live ↔ MetadataLoadContext types), preserving slice
+        // bridge live ? MetadataLoadContext types), preserving slice
         // invariance: `[]string` does NOT convert to `object[]` even though
         // the CLR allows array reference covariance, because G# slices are
         // invariant in their element type. The IL is a no-op since the
@@ -938,7 +938,7 @@ public sealed class Conversion
     /// a substitution map mapping each class's declaration type parameters onto
     /// the concrete type arguments seen at the most-derived level, composing the
     /// map down every hop, so the base reference is fully substituted before the
-    /// comparison. Handles multi-level chains (concrete leaf → generic mid →
+    /// comparison. Handles multi-level chains (concrete leaf ? generic mid ?
     /// generic base), type-parameter renaming, and partial type-parameter flow
     /// (only some of the derived's parameters reaching the base). A wrong type
     /// argument or an unrelated definition still fails (GS0155).
@@ -1037,7 +1037,7 @@ public sealed class Conversion
     /// recovering same-compilation user types whose <see cref="TypeSymbol.ClrType"/>
     /// has erased to <c>object</c> (or is <see langword="null"/>). Same-compilation
     /// symbols are reference-equal; distinct user types differ by reference / name
-    /// so genuine negative conversions (e.g. <c>Channel[A]</c> → <c>Channel[B]</c>)
+    /// so genuine negative conversions (e.g. <c>Channel[A]</c> ? <c>Channel[B]</c>)
     /// still report GS0155.
     /// </summary>
     private static bool AreTypeArgumentsEquivalent(TypeSymbol a, TypeSymbol b)
@@ -1278,7 +1278,7 @@ public sealed class Conversion
             }
 
             // Parameter types are contravariant in C#; G# v1 mirrors the
-            // existing CLR-typed func→delegate rule, which is name-based
+            // existing CLR-typed func?delegate rule, which is name-based
             // assignability — i.e., identity or an implicit conversion.
             var conv = Classify(fromType, toType);
             if (!conv.Exists || !conv.IsImplicit)
@@ -1303,7 +1303,7 @@ public sealed class Conversion
         return retConv.Exists && retConv.IsImplicit;
     }
 
-    // Issue #421 P2-5: enum⇄numeric and enum⇄enum conversions. Both
+    // Issue #421 P2-5: enum?numeric and enum?enum conversions. Both
     // directions are explicit per C# §10.3.3 / §10.3.4 — the binder must
     // permit them so the cast syntax (`int32(myEnum)`) reaches the emitter,
     // which then routes them through the underlying numeric primitive.
@@ -1318,7 +1318,7 @@ public sealed class Conversion
             return false;
         }
 
-        // enum → enum (any pair, including the same enum). Identity already
+        // enum ? enum (any pair, including the same enum). Identity already
         // returned above, so this only fires for distinct enum types.
         if (fromIsEnum && toIsEnum)
         {
@@ -1326,14 +1326,14 @@ public sealed class Conversion
             return true;
         }
 
-        // enum → numeric primitive.
+        // enum ? numeric primitive.
         if (fromIsEnum && to?.ClrType?.FullName is string toName && NumericClrFullNames.Contains(toName))
         {
             conversion = Conversion.Explicit;
             return true;
         }
 
-        // numeric primitive → enum.
+        // numeric primitive ? enum.
         if (toIsEnum && from?.ClrType?.FullName is string fromName && NumericClrFullNames.Contains(fromName))
         {
             conversion = Conversion.Explicit;
@@ -1347,7 +1347,7 @@ public sealed class Conversion
     /// <summary>
     /// Issue #1150: determines whether the CLR type <paramref name="fromClr"/>
     /// implicitly, losslessly widens to the CLR type <paramref name="toClr"/>
-    /// per the standard numeric-widening lattice (e.g. <c>uint16</c> →
+    /// per the standard numeric-widening lattice (e.g. <c>uint16</c> ?
     /// <c>int64</c>). Compared by <see cref="Type.FullName"/> so it is safe
     /// across reflection contexts. Narrowing and signed/unsigned same-width
     /// mismatches return <see langword="false"/>.
@@ -1363,7 +1363,7 @@ public sealed class Conversion
     /// <summary>
     /// Issue #1150: determines whether <paramref name="fromReturn"/> implicitly,
     /// losslessly widens to <paramref name="toReturn"/> per the numeric-widening
-    /// lattice. Used for the function-type → function-type return-type
+    /// lattice. Used for the function-type ? function-type return-type
     /// relaxation. Both types must be non-void numeric CLR primitives.
     /// </summary>
     private static bool ReturnTypeWidens(TypeSymbol fromReturn, TypeSymbol toReturn)
@@ -1477,7 +1477,7 @@ public sealed class Conversion
 
     private static bool IsValueTypeAssignableToInterface(TypeSymbol from, TypeSymbol to)
     {
-        // User-declared struct → user-declared interface: walk the struct's
+        // User-declared struct ? user-declared interface: walk the struct's
         // declared interface list.
         if (from is StructSymbol fromStruct && to is InterfaceSymbol toInterface)
         {
@@ -1492,7 +1492,7 @@ public sealed class Conversion
             return false;
         }
 
-        // Issue #976: a user-declared value-type struct → imported CLR
+        // Issue #976: a user-declared value-type struct ? imported CLR
         // interface declared in its `: …` clause. The struct symbol has no
         // ClrType during binding, so the general CLR-assignability path below
         // cannot fire — match structurally against `ImplementedClrInterfaces`,
@@ -1682,7 +1682,7 @@ public sealed class Conversion
     }
 
     /// <summary>
-    /// Issue #1302: symbolic struct → generic-interface implementation check for
+    /// Issue #1302: symbolic struct ? generic-interface implementation check for
     /// a constructed BCL value struct (e.g. <c>List[T].Enumerator</c>) whose
     /// element <c>T</c> is a same-compilation user type, so its
     /// <see cref="TypeSymbol.ClrType"/> (and the target interface's) is

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -94,14 +94,14 @@ internal sealed class DeclarationBinder
     // Method bodies already see fully-populated constructors because they are
     // bound in a later phase; deferring base-initializer argument binding to a
     // post-pass gives it the same guarantee, regardless of source-file order.
-    private readonly List<Action> pendingBaseInitializerBindings = new List<Action>();
+    private readonly List<Action> pendingBaseInitializerBindings = new();
 
     // Issue #1194: field-initializer binding is deferred until after all
     // top-level functions are declared in Binder.BindGlobalScope, so a field
     // initializer can resolve an unqualified call to a free function or a
     // sibling static method/const. Each entry re-establishes the captured
     // scope and the enclosing type's static-member scope before binding.
-    private readonly List<Action> pendingFieldInitializerBindings = new List<Action>();
+    private readonly List<Action> pendingFieldInitializerBindings = new();
 
     // Issue #1069: nested struct/class and interface type-name shells declared in
     // phase 1 (DeclareNestedTypeShells) so a sibling member signature can
@@ -110,9 +110,9 @@ internal sealed class DeclarationBinder
     // type alias. Nested enums are fully bound during the shell phase (their
     // members reference no user types) and so are not tracked here.
     private readonly Dictionary<StructDeclarationSyntax, StructSymbol> nestedStructShells
-        = new Dictionary<StructDeclarationSyntax, StructSymbol>();
+        = new();
     private readonly Dictionary<InterfaceDeclarationSyntax, InterfaceSymbol> nestedInterfaceShells
-        = new Dictionary<InterfaceDeclarationSyntax, InterfaceSymbol>();
+        = new();
 
     public DeclarationBinder(
         BinderContext binderCtx,

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
@@ -500,7 +500,7 @@ internal sealed partial class ExpressionBinder
         // StructSymbol object).
         if (structSymbol.IsGenericDefinition)
         {
-            Dictionary<TypeParameterSymbol, TypeSymbol> substitution = new Dictionary<TypeParameterSymbol, TypeSymbol>();
+            Dictionary<TypeParameterSymbol, TypeSymbol> substitution = new();
             var tps = structSymbol.TypeParameters;
 
             if (syntax.TypeArgumentList != null)

--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -1210,7 +1210,7 @@ internal sealed class LambdaBinder
     // outer lambda's candidate set.
     private sealed class ReturnTypeCollector : BoundTreeWalker
     {
-        public List<TypeSymbol> ReturnTypes { get; } = new List<TypeSymbol>();
+        public List<TypeSymbol> ReturnTypes { get; } = new();
 
         protected override void VisitReturnStatement(BoundReturnStatement node)
         {

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.cs
@@ -2550,7 +2550,7 @@ internal sealed class StatementBinder
     /// </summary>
     private sealed class YieldFinder : BoundTreeWalker
     {
-        private readonly List<TextLocation> locations = new List<TextLocation>();
+        private readonly List<TextLocation> locations = new();
 
         public static bool ContainsYieldInOwnTryBlock(BoundStatement tryBlock)
         {

--- a/src/Core/CodeAnalysis/BuiltinFunctions.cs
+++ b/src/Core/CodeAnalysis/BuiltinFunctions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="BuiltinFunctions.cs" company="GSharp">
+// <copyright file="BuiltinFunctions.cs" company="GSharp">
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
@@ -18,7 +18,7 @@ public static class BuiltinFunctions
     /// <summary>
     /// Prints to the console.
     /// </summary>
-    public static readonly FunctionSymbol Print = new FunctionSymbol(
+    public static readonly FunctionSymbol Print = new(
         name: "print",
         parameters: ImmutableArray.Create(new ParameterSymbol("text", TypeSymbol.String)),
         type: TypeSymbol.Void);
@@ -26,7 +26,7 @@ public static class BuiltinFunctions
     /// <summary>
     /// Reads from the console.
     /// </summary>
-    public static readonly FunctionSymbol Input = new FunctionSymbol(
+    public static readonly FunctionSymbol Input = new(
         name: "input",
         parameters: ImmutableArray<ParameterSymbol>.Empty,
         type: TypeSymbol.String);
@@ -34,7 +34,7 @@ public static class BuiltinFunctions
     /// <summary>
     /// Produces a random number.
     /// </summary>
-    public static readonly FunctionSymbol Rnd = new FunctionSymbol(
+    public static readonly FunctionSymbol Rnd = new(
         name: "rnd",
         parameters: ImmutableArray.Create(new ParameterSymbol("max", TypeSymbol.Int32)),
         type: TypeSymbol.Int32);

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="DiagnosticBag.cs" company="GSharp">
+// <copyright file="DiagnosticBag.cs" company="GSharp">
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
@@ -16,7 +16,7 @@ namespace GSharp.Core.CodeAnalysis;
 /// </summary>
 public sealed class DiagnosticBag : IEnumerable<Diagnostic>
 {
-    private readonly List<Diagnostic> diagnostics = new List<Diagnostic>();
+    private readonly List<Diagnostic> diagnostics = new();
 
     /// <summary>
     /// Gets the number of diagnostics currently held in the bag. Used together
@@ -2372,7 +2372,7 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
 
     /// <summary>
     /// Issue #343: reports a positional call argument written after a named call
-    /// argument. Named arguments must come last; positional → named ordering is
+    /// argument. Named arguments must come last; positional ? named ordering is
     /// fixed by the parser to support unambiguous matching against the parameter
     /// list.
     /// </summary>
@@ -3696,7 +3696,7 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
         Report(
             location,
             "GS0358",
-            $"'@MarshalAs(UnmanagedType.{unmanagedType})' is not valid on parameter '{parameterName}' of type '{parameterType}'. See ADR-0096 §3 for the parameter-type ↔ UnmanagedType compatibility table.");
+            $"'@MarshalAs(UnmanagedType.{unmanagedType})' is not valid on parameter '{parameterName}' of type '{parameterType}'. See ADR-0096 §3 for the parameter-type ? UnmanagedType compatibility table.");
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Emit/ClosureEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ClosureEmitter.cs
@@ -154,7 +154,7 @@ internal sealed class ClosureEmitter
     /// <c>enclosingClosure</c>) and by <c>BodyEmitter</c> itself (for the
     /// <c>EmitFunctionLiteral</c> path).
     /// </summary>
-    public Dictionary<BoundFunctionLiteralExpression, ClosureInfo> ClosureInfos { get; } = new Dictionary<BoundFunctionLiteralExpression, ClosureInfo>();
+    public Dictionary<BoundFunctionLiteralExpression, ClosureInfo> ClosureInfos { get; } = new();
 
     /// <summary>
     /// Gets per-<c>go</c>-site closure metadata. The display class wraps the
@@ -162,7 +162,7 @@ internal sealed class ClosureEmitter
     /// <c>InvokeAsync</c> for async <c>go</c>) that <c>Task.Run</c> can
     /// bind to.
     /// </summary>
-    public Dictionary<BoundGoStatement, ClosureInfo> GoClosureInfos { get; } = new Dictionary<BoundGoStatement, ClosureInfo>();
+    public Dictionary<BoundGoStatement, ClosureInfo> GoClosureInfos { get; } = new();
 
     /// <summary>
     /// Gets the reverse map from a closure-invoke <see cref="FunctionSymbol"/> to
@@ -171,7 +171,7 @@ internal sealed class ClosureEmitter
     /// captures (issue #503 follow-up) route through the enclosing
     /// display class.
     /// </summary>
-    public Dictionary<FunctionSymbol, ClosureInfo> ClosureInvokeToInfo { get; } = new Dictionary<FunctionSymbol, ClosureInfo>();
+    public Dictionary<FunctionSymbol, ClosureInfo> ClosureInvokeToInfo { get; } = new();
 
     /// <summary>
     /// Gets every synthesized aggregate class emitted on behalf of a closure,
@@ -181,7 +181,7 @@ internal sealed class ClosureEmitter
     /// PR-E-10) also append to this list directly, which is why the
     /// collection is exposed as a mutable <see cref="List{T}"/>.
     /// </summary>
-    public List<StructSymbol> SynthesizedClosureClasses { get; } = new List<StructSymbol>();
+    public List<StructSymbol> SynthesizedClosureClasses { get; } = new();
 
     // Phase 4 emit parity (E2): for each lambda that captures outer variables,
     // synthesize a sealed closure class on the entry-point package with:
@@ -451,7 +451,7 @@ internal sealed class ClosureEmitter
     /// </summary>
     public sealed class ConstructedTypeCollector : BoundTreeRewriter
     {
-        public HashSet<StructSymbol> Constructed { get; } = new HashSet<StructSymbol>();
+        public HashSet<StructSymbol> Constructed { get; } = new();
 
         protected override BoundExpression RewriteExpression(BoundExpression node)
         {

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
@@ -96,14 +96,14 @@ internal sealed partial class MethodBodyEmitter
     // bound labels defined lexically within that region (including nested
     // protected sub-regions). Used to translate goto/conditional-goto whose
     // target lies outside the innermost region into the CLR-required `leave`.
-    private readonly Stack<HashSet<BoundLabel>> protectedRegionStack = new Stack<HashSet<BoundLabel>>();
+    private readonly Stack<HashSet<BoundLabel>> protectedRegionStack = new();
 
     // Phase 4 (ADR-0027 §7.7a) Portable PDB sequence-point capture. Always
     // allocated (cheap) so EmitStatement can append without a null check;
     // the outer harvests this list via SequencePoints after EmitBlock and
     // hands it to PortablePdbEmitter only when PDB emit is enabled. Empty
     // for synthesized methods that go through other emit paths.
-    private readonly List<SequencePoint> sequencePoints = new List<SequencePoint>();
+    private readonly List<SequencePoint> sequencePoints = new();
     private int lastSequencePointIlOffset = -1;
 
     public MethodBodyEmitter(

--- a/src/Core/CodeAnalysis/Emit/PortablePdbEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/PortablePdbEmitter.cs
@@ -37,14 +37,14 @@ namespace GSharp.Core.CodeAnalysis.Emit;
 internal sealed class PortablePdbEmitter
 {
     // ECMA-335 / Portable PDB hash algorithm GUIDs (spec § "Document").
-    private static readonly Guid HashAlgorithmSha256 = new Guid("8829D00F-11B8-4213-878B-770E8597AC16");
+    private static readonly Guid HashAlgorithmSha256 = new("8829D00F-11B8-4213-878B-770E8597AC16");
 
     // Portable PDB CustomDebugInformation kind GUIDs
     // (spec § "CustomDebugInformation").
-    private static readonly Guid EmbeddedSourceKind = new Guid("0E8A571B-6926-466E-B4AD-8AB04611F5FE");
-    private static readonly Guid SourceLinkKind = new Guid("CC110556-A091-4D38-9FEC-25AB9A351A6A");
-    private static readonly Guid CompilationOptionsKind = new Guid("B5FEEC05-8CD0-4A83-96DA-466284BB4BD8");
-    private static readonly Guid CompilationMetadataReferencesKind = new Guid("7E4D4708-096E-4C5C-AEDA-CB10BA6A740D");
+    private static readonly Guid EmbeddedSourceKind = new("0E8A571B-6926-466E-B4AD-8AB04611F5FE");
+    private static readonly Guid SourceLinkKind = new("CC110556-A091-4D38-9FEC-25AB9A351A6A");
+    private static readonly Guid CompilationOptionsKind = new("B5FEEC05-8CD0-4A83-96DA-466284BB4BD8");
+    private static readonly Guid CompilationMetadataReferencesKind = new("7E4D4708-096E-4C5C-AEDA-CB10BA6A740D");
 
     /// <summary>
     /// Stable GSharp language GUID. Once a tool keys off this value (debugger,
@@ -52,11 +52,11 @@ internal sealed class PortablePdbEmitter
     /// <c>docs/debug-info.md</c>. Generated specifically for this language and
     /// not shared with any other compiler.
     /// </summary>
-    public static readonly Guid GSharpLanguageGuid = new Guid("4F4D7B6A-0E33-4C2E-A3D7-2E5F8B7F9C00");
+    public static readonly Guid GSharpLanguageGuid = new("4F4D7B6A-0E33-4C2E-A3D7-2E5F8B7F9C00");
 
-    private readonly MetadataBuilder pdbMetadata = new MetadataBuilder();
-    private readonly Dictionary<SyntaxTree, DocumentHandle> documentsByTree = new Dictionary<SyntaxTree, DocumentHandle>();
-    private readonly Dictionary<int, RecordedMethod> recordedMethods = new Dictionary<int, RecordedMethod>();
+    private readonly MetadataBuilder pdbMetadata = new();
+    private readonly Dictionary<SyntaxTree, DocumentHandle> documentsByTree = new();
+    private readonly Dictionary<int, RecordedMethod> recordedMethods = new();
     private readonly DebugInformationOptions options;
     private IReadOnlyDictionary<SyntaxTree, ImmutableArray<ImportSymbol>> importsPerTree;
     private ImmutableArray<ReferenceInfo> referenceInfos;

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -111,7 +111,7 @@ internal sealed class ReflectionMetadataEmitter
     // Each lambda's synthetic FunctionSymbol is registered alongside user
     // functions in functionsByPackage so it gets a MethodDef row, and its
     // body is emitted via the same EmitFunction path.
-    private readonly Dictionary<FunctionSymbol, BoundBlockStatement> lambdaBodies = new Dictionary<FunctionSymbol, BoundBlockStatement>();
+    private readonly Dictionary<FunctionSymbol, BoundBlockStatement> lambdaBodies = new();
 
     // PR-E-9: closure-environment metadata and synthesized display classes
     // moved onto ClosureEmitter. Where this file used to declare:
@@ -312,7 +312,7 @@ internal sealed class ReflectionMetadataEmitter
     // creates each generic state-machine. Used to auto-push the remap inside
     // GetUserStructFieldRef when the containing type is a generic SM class
     // (so its field-signature MemberRef matches the FieldDef blob exactly).
-    internal readonly Dictionary<StructSymbol, Dictionary<TypeParameterSymbol, int>> iteratorStateMachineRemapsByClass = new Dictionary<StructSymbol, Dictionary<TypeParameterSymbol, int>>();
+    internal readonly Dictionary<StructSymbol, Dictionary<TypeParameterSymbol, int>> iteratorStateMachineRemapsByClass = new();
 
     /// <summary>
     /// Issue #810: push the SM remap for <paramref name="smClass"/> so that
@@ -9451,13 +9451,13 @@ internal sealed class ReflectionMetadataEmitter
     // is cached by its parameter/return symbol identities (see
     // FunctionTypeSymbol.Get) so reference-equality is sufficient.
     private readonly Dictionary<FunctionTypeSymbol, EntityHandle> functionDelegateTypeSpecCache =
-        new Dictionary<FunctionTypeSymbol, EntityHandle>(ReferenceEqualityComparer.Instance);
+        new(ReferenceEqualityComparer.Instance);
 
     private readonly Dictionary<FunctionTypeSymbol, EntityHandle> functionDelegateCtorRefCache =
-        new Dictionary<FunctionTypeSymbol, EntityHandle>(ReferenceEqualityComparer.Instance);
+        new(ReferenceEqualityComparer.Instance);
 
     private readonly Dictionary<FunctionTypeSymbol, EntityHandle> functionDelegateInvokeRefCache =
-        new Dictionary<FunctionTypeSymbol, EntityHandle>(ReferenceEqualityComparer.Instance);
+        new(ReferenceEqualityComparer.Instance);
 
     /// <summary>
     /// ADR-0087 §3 R6: encodes a <see cref="FunctionTypeSymbol"/> whose
@@ -9700,7 +9700,7 @@ internal sealed class ReflectionMetadataEmitter
     /// </summary>
     private sealed class FunctionEmitOrderComparer : IComparer<FunctionSymbol>
     {
-        public static readonly FunctionEmitOrderComparer Instance = new FunctionEmitOrderComparer();
+        public static readonly FunctionEmitOrderComparer Instance = new();
 
         private FunctionEmitOrderComparer()
         {

--- a/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
+++ b/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
@@ -653,7 +653,7 @@ internal sealed class SlotPlanner
 
     private sealed class BlockExpressionLocalCollector : BoundTreeWalker
     {
-        public List<VariableSymbol> Variables { get; } = new List<VariableSymbol>();
+        public List<VariableSymbol> Variables { get; } = new();
 
         protected override void VisitBlockExpression(BoundBlockExpression node)
         {

--- a/src/Core/CodeAnalysis/Emit/StateMachineEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/StateMachineEmitter.cs
@@ -176,7 +176,7 @@ internal sealed class StateMachineEmitter
     /// <c>EmitFunction</c> swaps in this body for the user-authored iterator
     /// function so the kickoff returns a freshly-constructed SM struct.
     /// </summary>
-    public Dictionary<FunctionSymbol, BoundBlockStatement> IteratorKickoffBodies { get; } = new Dictionary<FunctionSymbol, BoundBlockStatement>();
+    public Dictionary<FunctionSymbol, BoundBlockStatement> IteratorKickoffBodies { get; } = new();
 
     /// <summary>
     /// Gets per-iterator-SM metadata. Populated by
@@ -185,7 +185,7 @@ internal sealed class StateMachineEmitter
     /// <c>IEnumerator&lt;T&gt;</c> / <c>IDisposable</c> interface
     /// implementations.
     /// </summary>
-    public Dictionary<StructSymbol, IteratorStateMachineInfo> IteratorStateMachineInfos { get; } = new Dictionary<StructSymbol, IteratorStateMachineInfo>();
+    public Dictionary<StructSymbol, IteratorStateMachineInfo> IteratorStateMachineInfos { get; } = new();
 
     /// <summary>
     /// Gets per-async-iterator-SM plan. Populated by
@@ -195,7 +195,7 @@ internal sealed class StateMachineEmitter
     /// <c>IValueTaskSource&lt;bool&gt;</c> / <c>IAsyncStateMachine</c> interface
     /// implementations.
     /// </summary>
-    public Dictionary<StructSymbol, AsyncIteratorPlan> AsyncIteratorInfos { get; } = new Dictionary<StructSymbol, AsyncIteratorPlan>();
+    public Dictionary<StructSymbol, AsyncIteratorPlan> AsyncIteratorInfos { get; } = new();
 
     /// <summary>
     /// Gets per-async-iterator-SM emit-time context (builder field + builder
@@ -203,7 +203,7 @@ internal sealed class StateMachineEmitter
     /// <c>BodyEmitter</c> via the root emitter when threading the async
     /// iterator MoveNext path through the await pipeline.
     /// </summary>
-    public Dictionary<StructSymbol, AsyncIteratorEmitContext> AsyncIteratorEmitContexts { get; } = new Dictionary<StructSymbol, AsyncIteratorEmitContext>();
+    public Dictionary<StructSymbol, AsyncIteratorEmitContext> AsyncIteratorEmitContexts { get; } = new();
 
     /// <summary>
     /// Gets the map from a capture-bearing async lambda's SM struct to the
@@ -211,7 +211,7 @@ internal sealed class StateMachineEmitter
     /// nesting convention). SM structs NOT in this map nest inside the
     /// per-package <c>&lt;Program&gt;</c> class.
     /// </summary>
-    public Dictionary<StructSymbol, StructSymbol> AsyncSmEnclosingClosures { get; } = new Dictionary<StructSymbol, StructSymbol>();
+    public Dictionary<StructSymbol, StructSymbol> AsyncSmEnclosingClosures { get; } = new();
 
     /// <summary>
     /// Gets or sets the async state-machine plans produced by
@@ -563,7 +563,7 @@ internal sealed class StateMachineEmitter
                 ImmutableArray.Create<BoundStatement>(
                 new BoundReturnStatement(null, this.CreateIteratorStateMachineLiteral(kickoffSmType, stateField, parameterFields, plan.Function.Parameters, p => new BoundVariableExpression(null, p),
                     thisProxyField, plan.Function.ThisParameter != null ? new BoundVariableExpression(null, plan.Function.ThisParameter) : null)))));
-            this.IteratorStateMachineInfos[smClass] = new IteratorStateMachineInfo(plan, smClass, outerMethodTPs, classTPs);
+            this.IteratorStateMachineInfos[smClass] = new(plan, smClass, outerMethodTPs, classTPs);
             this.closures.SynthesizedClosureClasses.Add(smClass);
         }
     }
@@ -885,7 +885,7 @@ internal sealed class StateMachineEmitter
             // Resolve builder info for async iterator emit context.
             var returnClrType = plan.Function.Type?.ClrType;
             var aiBuilderInfo = AsyncMethodBuilderInfo.Resolve(returnClrType, this.emitCtx.References);
-            this.AsyncIteratorEmitContexts[smClass] = new AsyncIteratorEmitContext(smClass, builderField, aiBuilderInfo);
+            this.AsyncIteratorEmitContexts[smClass] = new(smClass, builderField, aiBuilderInfo);
         }
     }
 

--- a/src/Core/CodeAnalysis/Emit/TypeIdentityComparer.cs
+++ b/src/Core/CodeAnalysis/Emit/TypeIdentityComparer.cs
@@ -27,7 +27,7 @@ namespace GSharp.Core.CodeAnalysis.Emit;
 /// </summary>
 internal sealed class TypeIdentityComparer : IEqualityComparer<Type>
 {
-    public static readonly TypeIdentityComparer Instance = new TypeIdentityComparer();
+    public static readonly TypeIdentityComparer Instance = new();
 
     private TypeIdentityComparer()
     {

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Evaluator.cs" company="GSharp">
+// <copyright file="Evaluator.cs" company="GSharp">
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
@@ -22,18 +22,18 @@ public sealed class Evaluator
 {
     private readonly BoundProgram program;
     private readonly Dictionary<VariableSymbol, object> globals;
-    private readonly Stack<Dictionary<VariableSymbol, object>> locals = new Stack<Dictionary<VariableSymbol, object>>();
-    private readonly object goLock = new object();
-    private readonly Stack<ScopeFrame> scopeFrames = new Stack<ScopeFrame>();
-    private readonly Stack<System.Collections.IList> iteratorSinks = new Stack<System.Collections.IList>();
-    private readonly Dictionary<Symbols.FunctionSymbol, bool> iteratorFunctionCache = new Dictionary<Symbols.FunctionSymbol, bool>();
-    private readonly Dictionary<(Symbols.StructSymbol, Symbols.FieldSymbol), object> staticFields = new Dictionary<(Symbols.StructSymbol, Symbols.FieldSymbol), object>();
+    private readonly Stack<Dictionary<VariableSymbol, object>> locals = new();
+    private readonly object goLock = new();
+    private readonly Stack<ScopeFrame> scopeFrames = new();
+    private readonly Stack<System.Collections.IList> iteratorSinks = new();
+    private readonly Dictionary<Symbols.FunctionSymbol, bool> iteratorFunctionCache = new();
+    private readonly Dictionary<(Symbols.StructSymbol, Symbols.FieldSymbol), object> staticFields = new();
 
     // ADR-0089 / issue #1030: interface static-field storage. Keyed by the
     // owning interface symbol so each closed construction of a generic interface
     // (`IBox[int32]` vs `IBox[string]`) owns independent storage, matching CLR
     // static-field semantics. The non-generic case keys by the single interface.
-    private readonly Dictionary<(Symbols.InterfaceSymbol, Symbols.FieldSymbol), object> interfaceStaticFields = new Dictionary<(Symbols.InterfaceSymbol, Symbols.FieldSymbol), object>();
+    private readonly Dictionary<(Symbols.InterfaceSymbol, Symbols.FieldSymbol), object> interfaceStaticFields = new();
     private Random random;
 
     private object lastValue;
@@ -2280,7 +2280,7 @@ public sealed class Evaluator
             if (leftValue != null)
             {
                 // Issue #1239: when the best common type widened the left's
-                // underlying numeric type (e.g. `int32? ?? int64` → `int64`),
+                // underlying numeric type (e.g. `int32? ?? int64` ? `int64`),
                 // convert the non-null left value to the result type. Reference
                 // results are representation-preserving and need no conversion.
                 var leftUnderlying = b.Left.Type is NullableTypeSymbol ln ? ln.UnderlyingType : b.Left.Type;
@@ -2593,7 +2593,7 @@ public sealed class Evaluator
     private static object NarrowToResultType(object value, TypeSymbol resultType)
     {
         // C# arithmetic on sub-int types promotes to int. To preserve the
-        // operator's declared result type (e.g. byte + byte → byte) we
+        // operator's declared result type (e.g. byte + byte ? byte) we
         // narrow back here. Other widths already match their CLR type.
         if (resultType == TypeSymbol.Int8)
         {
@@ -2633,7 +2633,7 @@ public sealed class Evaluator
 
     /// <summary>
     /// Issue #615: converts a boxed CLR enum value to its underlying primitive
-    /// (e.g. DayOfWeek.Monday → int 1) so that the pattern-matching arms in
+    /// (e.g. DayOfWeek.Monday ? int 1) so that the pattern-matching arms in
     /// NumericAdd/Sub/Compare/OnesComplement etc. can match the value. Non-enum
     /// values pass through unchanged.
     /// </summary>
@@ -3124,14 +3124,14 @@ public sealed class Evaluator
         // produces `ldnull` for reference types (e.g. `string`), zero for
         // primitive value types, and `initobj` for arbitrary value types.
         // The interpreter mirrors this:
-        //   - reference types and nullable types → nil
-        //   - value types → zero / zeroed struct
+        //   - reference types and nullable types ? nil
+        //   - value types ? zero / zeroed struct
         // Prior to ADR-0100 the interpreter returned `""` for
         // `default(string)` (the Go-style zero), which diverged from the
         // compiled behaviour. Both shapes now produce `nil`.
 
         // Issue #504: a NullableTypeSymbol's default is `nil`, not the
-        // underlying type's zero. The binder lowers `nil → Nullable<T>`
+        // underlying type's zero. The binder lowers `nil ? Nullable<T>`
         // (value-type) to a BoundDefaultExpression so the emitter can
         // materialise `default(Nullable<T>)` via ldloca/initobj/ldloc; the
         // interpreter must mirror that by producing the absent-value sentinel
@@ -3187,8 +3187,8 @@ public sealed class Evaluator
 
     private object EvaluateMakeChannelExpression(BoundMakeChannelExpression node)
     {
-        // Phase 5.4 / ADR-0022: `make(chan T)` → Channel.CreateUnbounded<T>();
-        // `make(chan T, capacity)` → Channel.CreateBounded<T>(new BoundedChannelOptions(capacity)).
+        // Phase 5.4 / ADR-0022: `make(chan T)` ? Channel.CreateUnbounded<T>();
+        // `make(chan T, capacity)` ? Channel.CreateBounded<T>(new BoundedChannelOptions(capacity)).
         var elementClr = node.ChannelType.ElementType.ClrType ?? typeof(object);
         if (node.Capacity == null)
         {
@@ -3729,7 +3729,7 @@ public sealed class Evaluator
         {
             // Phase 3.C.1: nullability is a bind-time annotation; the runtime
             // representation is identical to the underlying type. Issue #1236:
-            // a lifted numeric widening (`T1? → T2?`, e.g. `uint8? → int32?`)
+            // a lifted numeric widening (`T1? ? T2?`, e.g. `uint8? ? int32?`)
             // must still convert a present underlying value to the target
             // underlying type so a lifted binary operator sees a homogeneous
             // pair; a null source stays null (the lifted operator preserves it).
@@ -3748,8 +3748,8 @@ public sealed class Evaluator
             || (node.Type is StructSymbol upcastTarget && upcastTarget.IsClass)
             || (node.Type?.ClrType != null && !node.Type.ClrType.IsValueType))
         {
-            // Reference upcast (class → implemented interface, derived class
-            // → base class, or any → object). Also covers issue #521: a CLR
+            // Reference upcast (class ? implemented interface, derived class
+            // ? base class, or any ? object). Also covers issue #521: a CLR
             // class or interface widening. The interpreter stores instances
             // as boxed objects, so the upcast is a no-op at runtime — only
             // the bind-time static type changes.
@@ -3785,7 +3785,7 @@ public sealed class Evaluator
         // Convert.ChangeType is checked and throws OverflowException instead.
         if (value is decimal dv)
         {
-            // decimal → primitive is checked at the BCL level even for
+            // decimal ? primitive is checked at the BCL level even for
             // unchecked casts; route through (long) first when applicable.
             if (to.IsSameAs(typeof(float)))
             {
@@ -4443,8 +4443,8 @@ public sealed class Evaluator
 
     private sealed class ScopeFrame
     {
-        public List<Task> Tasks { get; } = new List<Task>();
+        public List<Task> Tasks { get; } = new();
 
-        public System.Threading.CancellationTokenSource Cts { get; } = new System.Threading.CancellationTokenSource();
+        public System.Threading.CancellationTokenSource Cts { get; } = new();
     }
 }

--- a/src/Core/CodeAnalysis/Lowering/Async/AsyncCaptureWalker.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AsyncCaptureWalker.cs
@@ -118,8 +118,8 @@ public static class AsyncCaptureWalker
 
     private sealed class ReferenceCollector : BoundTreeRewriter
     {
-        private readonly HashSet<LocalVariableSymbol> seen = new HashSet<LocalVariableSymbol>();
-        private readonly List<LocalVariableSymbol> orderedLocals = new List<LocalVariableSymbol>();
+        private readonly HashSet<LocalVariableSymbol> seen = new();
+        private readonly List<LocalVariableSymbol> orderedLocals = new();
 
         public IReadOnlyList<LocalVariableSymbol> Locals => orderedLocals;
 

--- a/src/Core/CodeAnalysis/Lowering/Async/AsyncStateMachineFieldMap.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AsyncStateMachineFieldMap.cs
@@ -21,8 +21,8 @@ namespace GSharp.Core.CodeAnalysis.Lowering.Async;
 /// </remarks>
 public sealed class AsyncStateMachineFieldMap
 {
-    private readonly Dictionary<ParameterSymbol, FieldSymbol> parameterFields = new Dictionary<ParameterSymbol, FieldSymbol>();
-    private readonly Dictionary<VariableSymbol, FieldSymbol> localFields = new Dictionary<VariableSymbol, FieldSymbol>();
+    private readonly Dictionary<ParameterSymbol, FieldSymbol> parameterFields = new();
+    private readonly Dictionary<VariableSymbol, FieldSymbol> localFields = new();
 
     private AsyncStateMachineFieldMap(SynthesizedStateMachineType stateMachine, StructSymbol structType)
     {

--- a/src/Core/CodeAnalysis/Lowering/Async/AsyncStateMachineRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AsyncStateMachineRewriter.cs
@@ -168,7 +168,7 @@ public static class AsyncStateMachineRewriter
 
     private sealed class AwaitStateCollector : BoundTreeWalker
     {
-        private readonly ResumableStateAllocator allocator = new ResumableStateAllocator();
+        private readonly ResumableStateAllocator allocator = new();
         private readonly ImmutableDictionary<BoundAwaitExpression, int>.Builder states =
             ImmutableDictionary.CreateBuilder<BoundAwaitExpression, int>();
 

--- a/src/Core/CodeAnalysis/Lowering/Async/AsyncStateMachineTypeBuilder.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AsyncStateMachineTypeBuilder.cs
@@ -256,7 +256,7 @@ public static class AsyncStateMachineTypeBuilder
 
     private sealed class AwaiterTypeCollector : BoundTreeWalker
     {
-        public List<(Type ClrType, TypeSymbol TypeSymbol)> AwaiterTypes { get; } = new List<(Type ClrType, TypeSymbol TypeSymbol)>();
+        public List<(Type ClrType, TypeSymbol TypeSymbol)> AwaiterTypes { get; } = new();
 
         public void Walk(BoundStatement body)
         {

--- a/src/Core/CodeAnalysis/Lowering/Async/MoveNextBodyRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/MoveNextBodyRewriter.cs
@@ -80,7 +80,7 @@ public static class MoveNextBodyRewriter
         private readonly Dictionary<BoundAwaitExpression, AwaitResumePoint> awaitResumeMap;
         private readonly LocalVariableSymbol cachedStateLocal;
         private readonly LocalVariableSymbol retValLocal;
-        private readonly List<LocalVariableSymbol> allLocals = new List<LocalVariableSymbol>();
+        private readonly List<LocalVariableSymbol> allLocals = new();
 
         public RewriteContext(AsyncStateMachinePlan plan)
         {

--- a/src/Core/CodeAnalysis/Lowering/Async/SynthesizedStateMachineType.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/SynthesizedStateMachineType.cs
@@ -35,8 +35,8 @@ namespace GSharp.Core.CodeAnalysis.Lowering.Async;
 /// </remarks>
 public sealed class SynthesizedStateMachineType : TypeSymbol
 {
-    private readonly List<FieldSymbol> fields = new List<FieldSymbol>();
-    private readonly Dictionary<Type, FieldSymbol> awaiterPoolFields = new Dictionary<Type, FieldSymbol>();
+    private readonly List<FieldSymbol> fields = new();
+    private readonly Dictionary<Type, FieldSymbol> awaiterPoolFields = new();
     private StructSymbol materializedStruct;
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Lowering/Async/TryDispatchPlanner.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/TryDispatchPlanner.cs
@@ -60,10 +60,10 @@ internal static class TryDispatchPlanner
     private sealed class WalkVisitor : BoundTreeWalker
     {
         private readonly IReadOnlyDictionary<BoundAwaitExpression, AwaitResumePoint> awaitResumeMap;
-        private readonly Stack<BoundTryStatement> tryStack = new Stack<BoundTryStatement>();
-        private readonly Dictionary<BoundTryStatement, BoundLabel> entryLabels = new Dictionary<BoundTryStatement, BoundLabel>();
-        private readonly Dictionary<int, BoundLabel> outerDispatch = new Dictionary<int, BoundLabel>();
-        private readonly Dictionary<BoundTryStatement, List<TryDispatchEntry>> internalDispatch = new Dictionary<BoundTryStatement, List<TryDispatchEntry>>();
+        private readonly Stack<BoundTryStatement> tryStack = new();
+        private readonly Dictionary<BoundTryStatement, BoundLabel> entryLabels = new();
+        private readonly Dictionary<int, BoundLabel> outerDispatch = new();
+        private readonly Dictionary<BoundTryStatement, List<TryDispatchEntry>> internalDispatch = new();
         private int entryOrdinal;
 
         public WalkVisitor(IReadOnlyDictionary<BoundAwaitExpression, AwaitResumePoint> awaitResumeMap)

--- a/src/Core/CodeAnalysis/Lowering/Iterators/AsyncIteratorMoveNextBodyBuilder.cs
+++ b/src/Core/CodeAnalysis/Lowering/Iterators/AsyncIteratorMoveNextBodyBuilder.cs
@@ -68,8 +68,8 @@ public static class AsyncIteratorMoveNextBodyBuilder
         private readonly Dictionary<int, BoundLabel> awaitResumeLabels = new();
         private readonly Dictionary<int, BoundLabel> awaitResumeAfterLabels = new();
 
-        private readonly BoundLabel exitLabel = new BoundLabel("<>ai_exit");
-        private readonly BoundLabel endOfBodyLabel = new BoundLabel("<>ai_end");
+        private readonly BoundLabel exitLabel = new("<>ai_exit");
+        private readonly BoundLabel endOfBodyLabel = new("<>ai_end");
 
         public BuildContext(
             AsyncIteratorPlan plan,

--- a/src/Core/CodeAnalysis/Lowering/Iterators/AsyncIteratorRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/Iterators/AsyncIteratorRewriter.cs
@@ -225,7 +225,7 @@ public static class AsyncIteratorRewriter
     /// </summary>
     public sealed class YieldStateCollector : BoundTreeWalker
     {
-        private readonly ResumableStateAllocator allocator = new ResumableStateAllocator();
+        private readonly ResumableStateAllocator allocator = new();
         private readonly ImmutableDictionary<BoundYieldStatement, int>.Builder states =
             ImmutableDictionary.CreateBuilder<BoundYieldStatement, int>();
 
@@ -242,7 +242,7 @@ public static class AsyncIteratorRewriter
     /// </summary>
     public sealed class AwaitStateCollector : BoundTreeWalker
     {
-        private readonly ResumableStateAllocator allocator = new ResumableStateAllocator();
+        private readonly ResumableStateAllocator allocator = new();
         private readonly ImmutableDictionary<BoundAwaitExpression, int>.Builder states =
             ImmutableDictionary.CreateBuilder<BoundAwaitExpression, int>();
 
@@ -257,7 +257,7 @@ public static class AsyncIteratorRewriter
 
     private sealed class LocalCollector : BoundTreeWalker
     {
-        public List<VariableSymbol> Locals { get; } = new List<VariableSymbol>();
+        public List<VariableSymbol> Locals { get; } = new();
 
         protected override void VisitVariableDeclaration(BoundVariableDeclaration node)
         {
@@ -282,7 +282,7 @@ public static class AsyncIteratorRewriter
 
     private sealed class AwaiterTypeCollector : BoundTreeWalker
     {
-        public List<Type> AwaiterTypes { get; } = new List<Type>();
+        public List<Type> AwaiterTypes { get; } = new();
 
         protected override void VisitAwaitExpression(BoundAwaitExpression node)
         {

--- a/src/Core/CodeAnalysis/Lowering/Iterators/IteratorMoveNextBodyBuilder.cs
+++ b/src/Core/CodeAnalysis/Lowering/Iterators/IteratorMoveNextBodyBuilder.cs
@@ -504,7 +504,7 @@ public static class IteratorMoveNextBodyBuilder
         // before jumping to endLabel, mirroring the CLR's normal stack
         // unwinding on `leave`. Yields do NOT consume this stack — the
         // finally is run lazily by Dispose on premature termination.
-        private readonly Stack<BoundStatement> pendingFinallies = new Stack<BoundStatement>();
+        private readonly Stack<BoundStatement> pendingFinallies = new();
 
         public FieldAccessYieldRewriter(
             StructSymbol smClass,

--- a/src/Core/CodeAnalysis/Lowering/Iterators/IteratorRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/Iterators/IteratorRewriter.cs
@@ -197,7 +197,7 @@ public static class IteratorRewriter
 
     private sealed class LocalCollector : BoundTreeWalker
     {
-        public List<VariableSymbol> Locals { get; } = new List<VariableSymbol>();
+        public List<VariableSymbol> Locals { get; } = new();
 
         protected override void VisitVariableDeclaration(BoundVariableDeclaration node)
         {

--- a/src/Core/CodeAnalysis/Lowering/Iterators/IteratorTryDispatchPlanner.cs
+++ b/src/Core/CodeAnalysis/Lowering/Iterators/IteratorTryDispatchPlanner.cs
@@ -51,13 +51,13 @@ internal static class IteratorTryDispatchPlanner
     private sealed class Walker : BoundTreeWalker
     {
         private readonly IReadOnlyDictionary<BoundYieldStatement, int> yieldStates;
-        private readonly Stack<BoundTryStatement> tryStack = new Stack<BoundTryStatement>();
-        private readonly Dictionary<BoundTryStatement, BoundLabel> entryLabels = new Dictionary<BoundTryStatement, BoundLabel>();
-        private readonly Dictionary<int, BoundLabel> outerDispatch = new Dictionary<int, BoundLabel>();
-        private readonly Dictionary<BoundTryStatement, List<IteratorTryDispatchEntry>> internalDispatch = new Dictionary<BoundTryStatement, List<IteratorTryDispatchEntry>>();
-        private readonly Dictionary<BoundTryStatement, List<int>> tryYieldStates = new Dictionary<BoundTryStatement, List<int>>();
-        private readonly List<BoundTryStatement> finallyTrysInnermostFirst = new List<BoundTryStatement>();
-        private readonly Dictionary<int, BoundLabel> resumeLabels = new Dictionary<int, BoundLabel>();
+        private readonly Stack<BoundTryStatement> tryStack = new();
+        private readonly Dictionary<BoundTryStatement, BoundLabel> entryLabels = new();
+        private readonly Dictionary<int, BoundLabel> outerDispatch = new();
+        private readonly Dictionary<BoundTryStatement, List<IteratorTryDispatchEntry>> internalDispatch = new();
+        private readonly Dictionary<BoundTryStatement, List<int>> tryYieldStates = new();
+        private readonly List<BoundTryStatement> finallyTrysInnermostFirst = new();
+        private readonly Dictionary<int, BoundLabel> resumeLabels = new();
         private int entryOrdinal;
 
         public Walker(IReadOnlyDictionary<BoundYieldStatement, int> yieldStates)

--- a/src/Core/CodeAnalysis/Symbols/FunctionPointerTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/FunctionPointerTypeSymbol.cs
@@ -24,7 +24,7 @@ namespace GSharp.Core.CodeAnalysis.Symbols;
 /// </remarks>
 public sealed class FunctionPointerTypeSymbol : TypeSymbol
 {
-    private static readonly ConcurrentDictionary<string, FunctionPointerTypeSymbol> Cache = new ConcurrentDictionary<string, FunctionPointerTypeSymbol>();
+    private static readonly ConcurrentDictionary<string, FunctionPointerTypeSymbol> Cache = new();
 
     private FunctionPointerTypeSymbol(string name, bool isManaged, CallingConvention callingConvention, ImmutableArray<TypeSymbol> parameterTypes, TypeSymbol returnType)
         : base(name, typeof(System.IntPtr))

--- a/src/Core/CodeAnalysis/Symbols/FunctionTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/FunctionTypeSymbol.cs
@@ -15,9 +15,9 @@ namespace GSharp.Core.CodeAnalysis.Symbols;
 /// </summary>
 public sealed class FunctionTypeSymbol : TypeSymbol
 {
-    private static readonly ConcurrentDictionary<string, FunctionTypeSymbol> Cache = new ConcurrentDictionary<string, FunctionTypeSymbol>();
+    private static readonly ConcurrentDictionary<string, FunctionTypeSymbol> Cache = new();
 
-    private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<TypeParameterSymbol, object> TypeParameterIds = new System.Runtime.CompilerServices.ConditionalWeakTable<TypeParameterSymbol, object>();
+    private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<TypeParameterSymbol, object> TypeParameterIds = new();
 
     private static long typeParameterIdSeed;
 

--- a/src/Core/CodeAnalysis/Symbols/TypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/TypeSymbol.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TypeSymbol.cs" company="GSharp">
+// <copyright file="TypeSymbol.cs" company="GSharp">
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
@@ -14,100 +14,100 @@ public class TypeSymbol : Symbol
     /// <summary>
     /// The type error symbol.
     /// </summary>
-    public static readonly TypeSymbol Error = new TypeSymbol("?");
+    public static readonly TypeSymbol Error = new("?");
 
     /// <summary>
     /// The `bool` symbol.
     /// </summary>
-    public static readonly TypeSymbol Bool = new TypeSymbol("bool", typeof(bool));
+    public static readonly TypeSymbol Bool = new("bool", typeof(bool));
 
     /// <summary>
     /// The `uint8` symbol (8-bit unsigned integer, <c>System.Byte</c>). Renamed from `byte` by ADR-0049.
     /// </summary>
-    public static readonly TypeSymbol UInt8 = new TypeSymbol("uint8", typeof(byte));
+    public static readonly TypeSymbol UInt8 = new("uint8", typeof(byte));
 
     /// <summary>
     /// The `int8` symbol (8-bit signed integer, <c>System.SByte</c>). Renamed from `sbyte` by ADR-0049.
     /// </summary>
-    public static readonly TypeSymbol Int8 = new TypeSymbol("int8", typeof(sbyte));
+    public static readonly TypeSymbol Int8 = new("int8", typeof(sbyte));
 
     /// <summary>
     /// The `int16` symbol (16-bit signed integer, <c>System.Int16</c>). Renamed from `short` by ADR-0049.
     /// </summary>
-    public static readonly TypeSymbol Int16 = new TypeSymbol("int16", typeof(short));
+    public static readonly TypeSymbol Int16 = new("int16", typeof(short));
 
     /// <summary>
     /// The `uint16` symbol (16-bit unsigned integer, <c>System.UInt16</c>). Renamed from `ushort` by ADR-0049.
     /// </summary>
-    public static readonly TypeSymbol UInt16 = new TypeSymbol("uint16", typeof(ushort));
+    public static readonly TypeSymbol UInt16 = new("uint16", typeof(ushort));
 
     /// <summary>
     /// The `int32` symbol (32-bit signed integer, <c>System.Int32</c>). Renamed from `int` by ADR-0049.
     /// </summary>
-    public static readonly TypeSymbol Int32 = new TypeSymbol("int32", typeof(int));
+    public static readonly TypeSymbol Int32 = new("int32", typeof(int));
 
     /// <summary>
     /// The `uint32` symbol (32-bit unsigned integer, <c>System.UInt32</c>). Renamed from `uint` by ADR-0049.
     /// </summary>
-    public static readonly TypeSymbol UInt32 = new TypeSymbol("uint32", typeof(uint));
+    public static readonly TypeSymbol UInt32 = new("uint32", typeof(uint));
 
     /// <summary>
     /// The `int64` symbol (64-bit signed integer, <c>System.Int64</c>). Renamed from `long` by ADR-0049.
     /// </summary>
-    public static readonly TypeSymbol Int64 = new TypeSymbol("int64", typeof(long));
+    public static readonly TypeSymbol Int64 = new("int64", typeof(long));
 
     /// <summary>
     /// The `uint64` symbol (64-bit unsigned integer, <c>System.UInt64</c>). Renamed from `ulong` by ADR-0049.
     /// </summary>
-    public static readonly TypeSymbol UInt64 = new TypeSymbol("uint64", typeof(ulong));
+    public static readonly TypeSymbol UInt64 = new("uint64", typeof(ulong));
 
     /// <summary>
     /// The `nint` symbol (native-width signed integer, <c>System.IntPtr</c>). Added by ADR-0044.
     /// </summary>
-    public static readonly TypeSymbol NInt = new TypeSymbol("nint", typeof(nint));
+    public static readonly TypeSymbol NInt = new("nint", typeof(nint));
 
     /// <summary>
     /// The `nuint` symbol (native-width unsigned integer, <c>System.UIntPtr</c>). Added by ADR-0044.
     /// </summary>
-    public static readonly TypeSymbol NUInt = new TypeSymbol("nuint", typeof(nuint));
+    public static readonly TypeSymbol NUInt = new("nuint", typeof(nuint));
 
     /// <summary>
     /// The `float32` symbol (IEEE 754 binary32, <c>System.Single</c>). Added by ADR-0044.
     /// </summary>
-    public static readonly TypeSymbol Float32 = new TypeSymbol("float32", typeof(float));
+    public static readonly TypeSymbol Float32 = new("float32", typeof(float));
 
     /// <summary>
     /// The `float64` symbol (IEEE 754 binary64, <c>System.Double</c>). Added by ADR-0044.
     /// </summary>
-    public static readonly TypeSymbol Float64 = new TypeSymbol("float64", typeof(double));
+    public static readonly TypeSymbol Float64 = new("float64", typeof(double));
 
     /// <summary>
     /// The `decimal` symbol (128-bit base-10, <c>System.Decimal</c>). Added by ADR-0044.
     /// </summary>
-    public static readonly TypeSymbol Decimal = new TypeSymbol("decimal", typeof(decimal));
+    public static readonly TypeSymbol Decimal = new("decimal", typeof(decimal));
 
     /// <summary>
     /// The `char` symbol (UTF-16 code unit, <c>System.Char</c>). Added by ADR-0044.
     /// </summary>
-    public static readonly TypeSymbol Char = new TypeSymbol("char", typeof(char));
+    public static readonly TypeSymbol Char = new("char", typeof(char));
 
     /// <summary>
     /// The `string` symbol.
     /// </summary>
-    public static readonly TypeSymbol String = new TypeSymbol("string", typeof(string));
+    public static readonly TypeSymbol String = new("string", typeof(string));
 
     /// <summary>
     /// The `object` symbol (universal upper bound, <c>System.Object</c>). Added by ADR-0044 / ADR-0045.
     /// </summary>
-    public static readonly TypeSymbol Object = new TypeSymbol("object", typeof(object));
+    public static readonly TypeSymbol Object = new("object", typeof(object));
 
     /// <summary>
     /// The void type symbol.
     /// </summary>
-    public static readonly TypeSymbol Void = new TypeSymbol("void", typeof(void));
+    public static readonly TypeSymbol Void = new("void", typeof(void));
 
     /// <summary>The static type of the <c>nil</c> literal (Phase 3.C.2 / ADR-0001). Implicitly convertible to any <see cref="NullableTypeSymbol"/>; not assignable to a non-nullable type.</summary>
-    public static readonly TypeSymbol Null = new TypeSymbol("nil");
+    public static readonly TypeSymbol Null = new("nil");
 
     /// <summary>
     /// Issue #1018: the bottom ("never") type of a <c>throw</c> expression. A
@@ -117,7 +117,7 @@ public class TypeSymbol : Symbol
     /// conversion source, and the conditional/null-coalesce common-type logic
     /// resolves to the sibling operand's type.
     /// </summary>
-    public static readonly TypeSymbol Never = new TypeSymbol("never");
+    public static readonly TypeSymbol Never = new("never");
 
     private protected TypeSymbol(string name)
         : base(name)

--- a/src/Core/CodeAnalysis/Syntax/InterfaceDeclarationSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/InterfaceDeclarationSyntax.cs
@@ -205,7 +205,7 @@ public sealed class InterfaceDeclarationSyntax : MemberSyntax
     /// Empty when the interface declares no base interfaces. Each clause must
     /// resolve to an interface; the binder rejects class/struct bases.
     /// </summary>
-    public SeparatedSyntaxList<TypeClauseSyntax> BaseTypeClauses { get; set; } = new SeparatedSyntaxList<TypeClauseSyntax>(ImmutableArray<SyntaxNode>.Empty);
+    public SeparatedSyntaxList<TypeClauseSyntax> BaseTypeClauses { get; set; } = new(ImmutableArray<SyntaxNode>.Empty);
 
     /// <summary>Gets a value indicating whether this interface declares one or more base interfaces (issue #1006).</summary>
     public bool HasBaseInterfaces => BaseColonToken != null;

--- a/src/Core/CodeAnalysis/Syntax/Lexer.cs
+++ b/src/Core/CodeAnalysis/Syntax/Lexer.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Lexer.cs" company="GSharp">
+// <copyright file="Lexer.cs" company="GSharp">
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
@@ -37,7 +37,7 @@ public sealed class Lexer
     /// <summary>
     /// Gets the lexer diagnostics.
     /// </summary>
-    public DiagnosticBag Diagnostics { get; } = new DiagnosticBag();
+    public DiagnosticBag Diagnostics { get; } = new();
 
     private char Current => Peek(0);
 
@@ -1224,7 +1224,7 @@ public sealed class Lexer
         }
 
         // Disallow leading underscore in a decimal literal (which is impossible
-        // here because the dispatcher only routes digits → ReadNumber, but kept
+        // here because the dispatcher only routes digits ? ReadNumber, but kept
         // explicit for clarity). Underscore IS allowed immediately after a
         // base prefix per Go's spec (e.g., `0x_FF`).
         bool sawIntDigit = false;
@@ -1493,7 +1493,7 @@ public sealed class Lexer
             return (uint)parsed;
         }
 
-        // No suffix → C# §6.4.5.3 integer-literal type inference. The literal
+        // No suffix ? C# §6.4.5.3 integer-literal type inference. The literal
         // takes the type of the first of int32, uint32, int64, uint64 in which
         // its value can be represented. A bare literal that fits int32 stays
         // int32; larger in-range values widen to the smallest fitting type and
@@ -1512,7 +1512,7 @@ public sealed class Lexer
             return (int)(uint)parsed;
         }
 
-        // §6.4.5.3 widening lattice: uint32 → int64 → uint64. `parsed` is a
+        // §6.4.5.3 widening lattice: uint32 ? int64 ? uint64. `parsed` is a
         // ulong, so a value that overflowed uint64 already threw above and was
         // reported; anything reaching here is representable as uint64.
         if (parsed <= uint.MaxValue)

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -23,7 +23,7 @@ public class Parser
     // enums, which expand into a sealed base + one class per case), the
     // expander stages the additional siblings here. `ParseMembers` drains the
     // queue after each `ParseMember` call so they appear in declaration order.
-    private readonly Queue<MemberSyntax> pendingSyntheticMembers = new Queue<MemberSyntax>();
+    private readonly Queue<MemberSyntax> pendingSyntheticMembers = new();
 
     private int position;
 
@@ -103,7 +103,7 @@ public class Parser
     /// <summary>
     /// Gets tiagnostic bag associated to this parser.
     /// </summary>
-    public DiagnosticBag Diagnostics { get; } = new DiagnosticBag();
+    public DiagnosticBag Diagnostics { get; } = new();
 
     /// <summary>
     /// Gets the documentation comment tokens collected during lexing (ADR-0057 §7).
@@ -469,7 +469,7 @@ public class Parser
         // intervening tokens (we use it to disambiguate "annotation with no
         // args" from "annotation followed by something that opens a `(`").
         SyntaxToken openParen = null;
-        SeparatedSyntaxList<ExpressionSyntax> arguments = new SeparatedSyntaxList<ExpressionSyntax>(ImmutableArray<SyntaxNode>.Empty);
+        SeparatedSyntaxList<ExpressionSyntax> arguments = new(ImmutableArray<SyntaxNode>.Empty);
         SyntaxToken closeParen = null;
         if (Current.Kind == SyntaxKind.OpenParenthesisToken)
         {
@@ -1538,7 +1538,7 @@ public class Parser
         // primary constructor parameter list.
         SyntaxToken primaryCtorOpenParen = null;
         SyntaxToken primaryCtorCloseParen = null;
-        SeparatedSyntaxList<ParameterSyntax> primaryCtorParameters = new SeparatedSyntaxList<ParameterSyntax>(ImmutableArray<SyntaxNode>.Empty);
+        SeparatedSyntaxList<ParameterSyntax> primaryCtorParameters = new(ImmutableArray<SyntaxNode>.Empty);
         if (Current.Kind == SyntaxKind.OpenParenthesisToken)
         {
             primaryCtorOpenParen = MatchToken(SyntaxKind.OpenParenthesisToken);
@@ -1556,7 +1556,7 @@ public class Parser
         SyntaxToken baseColon = null;
         SyntaxToken baseTypeIdentifier = null;
         SyntaxToken baseCtorOpenParen = null;
-        SeparatedSyntaxList<ExpressionSyntax> baseCtorArguments = new SeparatedSyntaxList<ExpressionSyntax>(ImmutableArray<SyntaxNode>.Empty);
+        SeparatedSyntaxList<ExpressionSyntax> baseCtorArguments = new(ImmutableArray<SyntaxNode>.Empty);
         SyntaxToken baseCtorCloseParen = null;
         var additionalBaseIdentifiers = ImmutableArray.CreateBuilder<SyntaxToken>();
         var baseTypeClauseNodesAndSeparators = ImmutableArray.CreateBuilder<SyntaxNode>();
@@ -2114,7 +2114,7 @@ public class Parser
         SyntaxToken baseColon = null;
         SyntaxToken baseKeyword = null;
         SyntaxToken baseOpenParen = null;
-        SeparatedSyntaxList<ExpressionSyntax> baseArguments = new SeparatedSyntaxList<ExpressionSyntax>(ImmutableArray<SyntaxNode>.Empty);
+        SeparatedSyntaxList<ExpressionSyntax> baseArguments = new(ImmutableArray<SyntaxNode>.Empty);
         SyntaxToken baseCloseParen = null;
         if (Current.Kind == SyntaxKind.ColonToken)
         {

--- a/src/Interpreter/GSharpRepl.cs
+++ b/src/Interpreter/GSharpRepl.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="GSharpRepl.cs" company="GSharp">
+// <copyright file="GSharpRepl.cs" company="GSharp">
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
@@ -17,13 +17,13 @@ namespace GSharp.Interpreter;
 /// </summary>
 public class GSharpRepl : Repl
 {
-    private readonly Dictionary<VariableSymbol, object> variables = new Dictionary<VariableSymbol, object>();
+    private readonly Dictionary<VariableSymbol, object> variables = new();
 
     private Compilation previous;
     private bool showTree;
     private bool showProgram;
 
-    private List<int> linesWithOpenMultilineComments = new List<int>();
+    private List<int> linesWithOpenMultilineComments = new();
 
     /// <inheritdoc/>
     public override void EvaluateSubmission(string text)

--- a/src/Interpreter/Repl.cs
+++ b/src/Interpreter/Repl.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Repl.cs" company="GSharp">
+// <copyright file="Repl.cs" company="GSharp">
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
@@ -14,7 +14,7 @@ namespace GSharp.Interpreter;
 /// </summary>
 public abstract class Repl
 {
-    private readonly List<string> submissionHistory = new List<string>();
+    private readonly List<string> submissionHistory = new();
     private int submissionHistoryIndex;
 
     private bool done;

--- a/src/LanguageServer/CrossAssemblyDefinitionResolver.cs
+++ b/src/LanguageServer/CrossAssemblyDefinitionResolver.cs
@@ -320,7 +320,7 @@ internal static class CrossAssemblyDefinitionResolver
             location = new Location
             {
                 Uri = DocumentUri.FromFileSystemPath(sourceFile),
-                Range = new Range(new Position(line, character), new Position(line, character + simpleName.Length)),
+                Range = new(new Position(line, character), new Position(line, character + simpleName.Length)),
             };
             return true;
         }
@@ -401,7 +401,7 @@ internal static class CrossAssemblyDefinitionResolver
             location = new Location
             {
                 Uri = DocumentUri.FromFileSystemPath(sourceFile),
-                Range = new Range(new Position(line, character), new Position(line, character + memberName.Length)),
+                Range = new(new Position(line, character), new Position(line, character + memberName.Length)),
             };
             return true;
         }
@@ -802,7 +802,7 @@ internal static class CrossAssemblyDefinitionResolver
         return new Location
         {
             Uri = DocumentUri.FromFileSystemPath(source.FilePath),
-            Range = new Range(new Position(startLine, startCol), new Position(endLine, endCol)),
+            Range = new(new Position(startLine, startCol), new Position(endLine, endCol)),
         };
     }
 

--- a/src/LanguageServer/DocumentSyncHandler.cs
+++ b/src/LanguageServer/DocumentSyncHandler.cs
@@ -129,7 +129,7 @@ public static class DocumentSyncHandler
         {
             Code = new DiagnosticCode(code),
             Message = message,
-            Range = new Range(ToPosition(start, sourceText), ToPosition(end, sourceText)),
+            Range = new(ToPosition(start, sourceText), ToPosition(end, sourceText)),
             Severity = severity,
             Source = Constants.LanguageIdentifier,
         };

--- a/src/LanguageServer/InlayHintComputer.cs
+++ b/src/LanguageServer/InlayHintComputer.cs
@@ -75,7 +75,7 @@ public static class InlayHintComputer
 
             hints.Add(new InlayHint
             {
-                Position = new Position(line, character),
+                Position = new(line, character),
                 Label = new StringOrInlayHintLabelParts($"{param.Name}:"),
                 Kind = InlayHintKind.Parameter,
                 PaddingRight = true,

--- a/src/LanguageServer/Program.cs
+++ b/src/LanguageServer/Program.cs
@@ -166,7 +166,7 @@ public class Program
         private readonly Stream inner;
         private readonly string logFile;
         private readonly string prefix;
-        private readonly object lockObj = new object();
+        private readonly object lockObj = new();
 
         public LoggingStream(Stream inner, string logFile, string prefix)
         {

--- a/src/LanguageServer/Protocol/Models.cs
+++ b/src/LanguageServer/Protocol/Models.cs
@@ -297,7 +297,7 @@ public sealed class CompletionList
     public bool IsIncomplete { get; set; }
 
     [JsonPropertyName("items")]
-    public List<CompletionItem> Items { get; set; } = new List<CompletionItem>();
+    public List<CompletionItem> Items { get; set; } = new();
 }
 
 public enum SymbolKind

--- a/src/LanguageServer/SelectionRangeComputer.cs
+++ b/src/LanguageServer/SelectionRangeComputer.cs
@@ -40,7 +40,7 @@ public static class SelectionRangeComputer
             var lastChar = text.Lines[lastLine].Length;
             current = new SelectionRange
             {
-                Range = new Range(
+                Range = new(
                     new Position(0, 0),
                     new Position(lastLine, lastChar)),
             };

--- a/src/LanguageServer/SemanticLookup.cs
+++ b/src/LanguageServer/SemanticLookup.cs
@@ -1293,7 +1293,7 @@ public static class SemanticLookup
         private readonly Dictionary<(string FileName, int SpanStart, int SpanEnd), Symbol> declarationsBySpan;
         private readonly Dictionary<string, Symbol> globals;
         private readonly Dictionary<SyntaxNode, Dictionary<string, Symbol>> localDeclarations;
-        private readonly object referencesLock = new object();
+        private readonly object referencesLock = new();
         private Dictionary<Symbol, List<SyntaxToken>> referencesIndex;
 
         // Cached tree-walk results. Resolve's fallback path used to call

--- a/src/LanguageServer/Server/LspServer.cs
+++ b/src/LanguageServer/Server/LspServer.cs
@@ -33,9 +33,9 @@ public sealed class LspServer
 {
     private readonly DocumentContentService documentContentService;
     private readonly WorkspaceState workspaceState;
-    private readonly SemaphoreSlim gate = new SemaphoreSlim(1, 1);
-    private readonly TaskCompletionSource<int> exitSource = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-    private readonly object refreshLock = new object();
+    private readonly SemaphoreSlim gate = new(1, 1);
+    private readonly TaskCompletionSource<int> exitSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly object refreshLock = new();
 
     private JsonRpc rpc;
     private bool shutdownRequested;
@@ -977,7 +977,7 @@ public sealed class LspServer
         // Debounce: coalesce bursts of changes into a single workspace/diagnostic/refresh request.
         lock (this.refreshLock)
         {
-            this.refreshTimer ??= new Timer(_ => this.SendDiagnosticRefresh(), null, Timeout.Infinite, Timeout.Infinite);
+            this.refreshTimer ??= new(_ => this.SendDiagnosticRefresh(), null, Timeout.Infinite, Timeout.Infinite);
             this.refreshTimer.Change(500, Timeout.Infinite);
         }
     }
@@ -1038,7 +1038,7 @@ public sealed class LspServer
         {
             new TextEdit
             {
-                Range = new Range(new Position(0, 0), new Position(lastLine, lastChar)),
+                Range = new(new Position(0, 0), new Position(lastLine, lastChar)),
                 NewText = formatted,
             },
         };

--- a/test/Core.Tests/CodeAnalysis/Binding/DeferStatementTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/DeferStatementTests.cs
@@ -162,7 +162,7 @@ DeferFixture.Snapshot()
 /// <summary>Side-effect helpers exposed to GSharp defer tests.</summary>
 public static class DeferFixture
 {
-    private static readonly List<string> Events = new List<string>();
+    private static readonly List<string> Events = new();
 
     /// <summary>Clears the recorded event log.</summary>
     public static void Reset() => Events.Clear();

--- a/test/Core.Tests/CodeAnalysis/Emit/PortablePdbEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/PortablePdbEmitTests.cs
@@ -763,13 +763,13 @@ internal static class PortablePdbEmitterTestHelpers
     // Mirror of PortablePdbEmitter.GSharpLanguageGuid for cross-assembly assertion.
     // Kept in sync via the unit test in PortablePdbEmitTests — if the
     // emitter ever reissues the GUID this constant must move with it.
-    public static readonly Guid GSharpLanguageGuid = new Guid("4F4D7B6A-0E33-4C2E-A3D7-2E5F8B7F9C00");
+    public static readonly Guid GSharpLanguageGuid = new("4F4D7B6A-0E33-4C2E-A3D7-2E5F8B7F9C00");
 
     // Mirror of PortablePdbEmitter's CustomDebugInformation kind GUIDs;
     // used by Phase 6 acceptance tests to look up specific CDI rows.
-    public static readonly Guid EmbeddedSourceKind = new Guid("0E8A571B-6926-466E-B4AD-8AB04611F5FE");
-    public static readonly Guid SourceLinkKind = new Guid("CC110556-A091-4D38-9FEC-25AB9A351A6A");
-    public static readonly Guid CompilationOptionsKind = new Guid("B5FEEC05-8CD0-4A83-96DA-466284BB4BD8");
+    public static readonly Guid EmbeddedSourceKind = new("0E8A571B-6926-466E-B4AD-8AB04611F5FE");
+    public static readonly Guid SourceLinkKind = new("CC110556-A091-4D38-9FEC-25AB9A351A6A");
+    public static readonly Guid CompilationOptionsKind = new("B5FEEC05-8CD0-4A83-96DA-466284BB4BD8");
 }
 
 public class PortablePdbPhase6Tests
@@ -1424,7 +1424,7 @@ func main() {
 /// </summary>
 public class PortablePdbPhase219Tests
 {
-    public static readonly Guid CompilationMetadataReferencesKind = new Guid("7E4D4708-096E-4C5C-AEDA-CB10BA6A740D");
+    public static readonly Guid CompilationMetadataReferencesKind = new("7E4D4708-096E-4C5C-AEDA-CB10BA6A740D");
 
     private const string SimpleProgram = @"package main
 

--- a/test/Core.Tests/CodeAnalysis/Lowering/Async/AsyncStateMachineRewriterTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Async/AsyncStateMachineRewriterTests.cs
@@ -14,7 +14,7 @@ namespace GSharp.Core.Tests.CodeAnalysis.Lowering.Async;
 
 public class AsyncStateMachineRewriterTests
 {
-    private static readonly PackageSymbol Package = new PackageSymbol("main", declaration: null);
+    private static readonly PackageSymbol Package = new("main", declaration: null);
     private static readonly ReferenceResolver Resolver = ReferenceResolver.Default();
 
     [Fact]

--- a/test/Core.Tests/CodeAnalysis/Lowering/Async/KickoffBodyBuilderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Async/KickoffBodyBuilderTests.cs
@@ -12,7 +12,7 @@ namespace GSharp.Core.Tests.CodeAnalysis.Lowering.Async;
 
 public class KickoffBodyBuilderTests
 {
-    private static readonly PackageSymbol Package = new PackageSymbol("main", declaration: null);
+    private static readonly PackageSymbol Package = new("main", declaration: null);
     private static readonly ReferenceResolver Resolver = ReferenceResolver.Default();
 
     [Fact]

--- a/test/Core.Tests/CodeAnalysis/Lowering/Async/MoveNextBodyRewriterTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Async/MoveNextBodyRewriterTests.cs
@@ -20,7 +20,7 @@ namespace GSharp.Core.Tests.CodeAnalysis.Lowering.Async;
 /// </summary>
 public class MoveNextBodyRewriterTests
 {
-    private static readonly PackageSymbol Package = new PackageSymbol("main", declaration: null);
+    private static readonly PackageSymbol Package = new("main", declaration: null);
     private static readonly ReferenceResolver Resolver = ReferenceResolver.Default();
 
     [Fact]

--- a/test/Core.Tests/CodeAnalysis/Lowering/Iterators/AsyncIteratorRewriterTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Iterators/AsyncIteratorRewriterTests.cs
@@ -23,7 +23,7 @@ namespace GSharp.Core.Tests.CodeAnalysis.Lowering.Iterators;
 /// </summary>
 public class AsyncIteratorRewriterTests
 {
-    private static readonly PackageSymbol Package = new PackageSymbol("main", declaration: null);
+    private static readonly PackageSymbol Package = new("main", declaration: null);
 
     [Fact]
     public void Rewrite_YieldOnly_CreatesAsyncIteratorPlan()

--- a/test/Core.Tests/CodeAnalysis/Lowering/Iterators/IteratorRewriterTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Iterators/IteratorRewriterTests.cs
@@ -20,7 +20,7 @@ namespace GSharp.Core.Tests.CodeAnalysis.Lowering.Iterators;
 /// </summary>
 public class IteratorRewriterTests
 {
-    private static readonly PackageSymbol Package = new PackageSymbol("main", declaration: null);
+    private static readonly PackageSymbol Package = new("main", declaration: null);
 
     [Fact]
     public void Rewrite_SingleYield_CreatesIteratorPlan()

--- a/test/Extensions.Tests/AggressiveInliningTests.cs
+++ b/test/Extensions.Tests/AggressiveInliningTests.cs
@@ -44,7 +44,7 @@ public class AggressiveInliningTests
     private static readonly System.Type OptionalHost = ResolveHost("Gsharp.Extensions.Optional");
     private static readonly System.Type SequencesHost = ResolveHost("Gsharp.Extensions.Sequences");
 
-    private static readonly (System.Type Type, string Method)[] InlinedMethods = new (System.Type, string)[]
+    private static readonly (System.Type Type, string Method)[] InlinedMethods = new(System.Type, string)[]
     {
         // OptionalExtensions — both class-receiver and struct-receiver
         // overloads carry [AggressiveInlining] per ADR-0084. The test iterates
@@ -71,7 +71,7 @@ public class AggressiveInliningTests
         (typeof(Sequences), nameof(Sequences.Empty)),
     };
 
-    private static readonly (System.Type Type, string Method)[] NotInlinedMethods = new (System.Type, string)[]
+    private static readonly (System.Type Type, string Method)[] NotInlinedMethods = new(System.Type, string)[]
     {
         // OrThrow intentionally preserves its stack frame on both the class
         // and struct overloads.

--- a/test/LanguageServer.Tests/Issue816HandlerExceptionTests.cs
+++ b/test/LanguageServer.Tests/Issue816HandlerExceptionTests.cs
@@ -137,10 +137,10 @@ type ScreenImpl class : ITabScreen {
             _ = await server.CodeLensAsync(new CodeLensParams { TextDocument = id });
             _ = await server.SemanticTokensFullAsync(new SemanticTokensParams { TextDocument = id });
             _ = await server.SemanticTokensRangeAsync(new SemanticTokensRangeParams { TextDocument = id });
-            _ = await server.HoverAsync(new HoverParams { TextDocument = id, Position = new Position(0, 0) });
+            _ = await server.HoverAsync(new HoverParams { TextDocument = id, Position = new(0, 0) });
             _ = await server.DocumentSymbolAsync(new DocumentSymbolParams { TextDocument = id });
             _ = await server.FoldingRangeAsync(new FoldingRangeParams { TextDocument = id });
-            _ = await server.CompletionAsync(new CompletionParams { TextDocument = id, Position = new Position(0, 0) });
+            _ = await server.CompletionAsync(new CompletionParams { TextDocument = id, Position = new(0, 0) });
         }
         finally
         {
@@ -166,7 +166,7 @@ type ScreenImpl class : ITabScreen {
         var id = new TextDocumentIdentifier { Uri = uri };
 
         // Each of these handler types would historically tear down with NRE.
-        Assert.Null(await server.HoverAsync(new HoverParams { TextDocument = id, Position = new Position(0, 0) }));
+        Assert.Null(await server.HoverAsync(new HoverParams { TextDocument = id, Position = new(0, 0) }));
         Assert.Empty(await server.InlayHintAsync(new InlayHintParams { TextDocument = id }) ?? Array.Empty<InlayHint>());
         Assert.Empty(await server.CodeLensAsync(new CodeLensParams { TextDocument = id }) ?? Array.Empty<CodeLens>());
 

--- a/test/LanguageServer.Tests/LspServerConcurrencyTests.cs
+++ b/test/LanguageServer.Tests/LspServerConcurrencyTests.cs
@@ -46,7 +46,7 @@ func Add(a int32, b int32) int32 {
         // client cancelled via $/cancelRequest) must abort instead of computing to
         // completion and tying up a thread.
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
-            () => server.HoverAsync(new HoverParams { TextDocument = id, Position = new Position(2, 9) }, cancelled));
+            () => server.HoverAsync(new HoverParams { TextDocument = id, Position = new(2, 9) }, cancelled));
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
             () => server.SemanticTokensFullAsync(new SemanticTokensParams { TextDocument = id }, cancelled));
@@ -75,7 +75,7 @@ func Add(a int32, b int32) int32 {
             await server.DocumentSymbolAsync(new DocumentSymbolParams { TextDocument = id });
             await server.FoldingRangeAsync(new FoldingRangeParams { TextDocument = id });
             await server.SemanticTokensFullAsync(new SemanticTokensParams { TextDocument = id });
-            await server.HoverAsync(new HoverParams { TextDocument = id, Position = new Position(2, 9) });
+            await server.HoverAsync(new HoverParams { TextDocument = id, Position = new(2, 9) });
         }));
 
         await Task.WhenAll(reads);

--- a/test/LanguageServer.Tests/LspServerMemberFeatureTests.cs
+++ b/test/LanguageServer.Tests/LspServerMemberFeatureTests.cs
@@ -71,7 +71,7 @@ public class LspServerMemberFeatureTests
             var completion = await server.CompletionAsync(new CompletionParams
             {
                 TextDocument = id,
-                Position = new Position(dotPos.Line, dotPos.Character + "Width.".Length),
+                Position = new(dotPos.Line, dotPos.Character + "Width.".Length),
             });
             Assert.NotNull(completion);
             Assert.NotEmpty(completion.Items);

--- a/tools/cs2gs/Cs2Gs.Pipeline/BaselineTestsOracle.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/BaselineTestsOracle.cs
@@ -58,7 +58,7 @@ public sealed class BaselineTestsOracle
     /// <summary>Gets or sets the per-test name/outcome records.</summary>
     [JsonPropertyName("tests")]
     [JsonPropertyOrder(7)]
-    public List<TestCaseOutcome> Tests { get; set; } = new List<TestCaseOutcome>();
+    public List<TestCaseOutcome> Tests { get; set; } = new();
 
     /// <summary>
     /// Loads and parses a <c>baseline.tests.json</c> oracle from disk.

--- a/tools/cs2gs/Cs2Gs.Pipeline/Fingerprint.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/Fingerprint.cs
@@ -24,21 +24,21 @@ namespace Cs2Gs.Pipeline;
 public static class Fingerprint
 {
     // Identifiers: a letter/underscore start then word chars. Collapsed to `id`.
-    private static readonly Regex IdentifierPattern = new Regex(
+    private static readonly Regex IdentifierPattern = new(
         @"[A-Za-z_][A-Za-z0-9_]*",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     // String/char/interpolated literals (single- and double-quoted, with simple
     // escape tolerance) and numeric literals. Collapsed to `lit`.
-    private static readonly Regex StringLiteralPattern = new Regex(
+    private static readonly Regex StringLiteralPattern = new(
         "\"(?:\\\\.|[^\"\\\\])*\"|'(?:\\\\.|[^'\\\\])*'",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
-    private static readonly Regex NumberLiteralPattern = new Regex(
+    private static readonly Regex NumberLiteralPattern = new(
         @"\b\d[\d_]*(?:\.\d[\d_]*)?(?:[eE][+-]?\d+)?\b",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
-    private static readonly Regex WhitespacePattern = new Regex(
+    private static readonly Regex WhitespacePattern = new(
         @"\s+",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 

--- a/tools/cs2gs/Cs2Gs.Pipeline/GscInvoker.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/GscInvoker.cs
@@ -22,7 +22,7 @@ public sealed class GscInvoker
 {
     // Matches a gsc diagnostic line: `<file>(l,c,el,ec): <severity> GSxxxx: <message>`
     // as emitted by TextWriterExtensions.WriteDiagnostics in src/Core/IO.
-    private static readonly Regex DiagnosticPattern = new Regex(
+    private static readonly Regex DiagnosticPattern = new(
         @"^(?<file>.*)\((?<line>\d+),(?<col>\d+),(?<eline>\d+),(?<ecol>\d+)\):\s+" +
         @"(?<sev>error|warning|info)\s+(?<id>GS\d+):\s+(?<msg>.*)$",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);

--- a/tools/cs2gs/Cs2Gs.Pipeline/IMigrationStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/IMigrationStage.cs
@@ -76,7 +76,7 @@ public sealed class StageExecutionContext
     public TriageBuilder Triage { get; }
 
     /// <summary>Gets the G# files emitted by the Translate stage for downstream stages.</summary>
-    public List<EmittedGsFile> EmittedFiles { get; } = new List<EmittedGsFile>();
+    public List<EmittedGsFile> EmittedFiles { get; } = new();
 
     /// <summary>
     /// Gets or sets the absolute path of the assembly emitted by the Compile

--- a/tools/cs2gs/Cs2Gs.Pipeline/IlVerifyRunner.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/IlVerifyRunner.cs
@@ -38,7 +38,7 @@ public sealed class IlVerifyRunner
     // the `<assembly> : <Type>::<Method>(<sig>)` skeleton up to the `[offset …]`
     // marker (lazy so the `]` inside array types like `string[]` is not mistaken
     // for the location's closing bracket); `message` is the rest.
-    private static readonly Regex ErrorPattern = new Regex(
+    private static readonly Regex ErrorPattern = new(
         @"^\[IL\]:\s*Error\s*\[(?<code>[^\]]+)\]:\s*" +
         @"(?:\[(?<location>.*?)\]\s*\[offset[^\]]*\]\s*)?(?<message>.*)$",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);

--- a/tools/cs2gs/Cs2Gs.Pipeline/RunResult.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/RunResult.cs
@@ -43,7 +43,7 @@ public sealed class RunResult
     /// <summary>Gets or sets the per-app results.</summary>
     [JsonPropertyName("apps")]
     [JsonPropertyOrder(5)]
-    public List<AppResult> Apps { get; set; } = new List<AppResult>();
+    public List<AppResult> Apps { get; set; } = new();
 }
 
 /// <summary>
@@ -70,17 +70,17 @@ public sealed class AppResult
     /// <summary>Gets or sets the per-stage results, in execution order.</summary>
     [JsonPropertyName("stages")]
     [JsonPropertyOrder(3)]
-    public List<StageResult> Stages { get; set; } = new List<StageResult>();
+    public List<StageResult> Stages { get; set; } = new();
 
     /// <summary>Gets or sets the run-relative paths of the triage artifacts produced for this app.</summary>
     [JsonPropertyName("artifacts")]
     [JsonPropertyOrder(4)]
-    public List<string> Artifacts { get; set; } = new List<string>();
+    public List<string> Artifacts { get; set; } = new();
 
     /// <summary>Gets or sets the distinct fingerprints captured for this app.</summary>
     [JsonPropertyName("fingerprints")]
     [JsonPropertyOrder(5)]
-    public List<string> Fingerprints { get; set; } = new List<string>();
+    public List<string> Fingerprints { get; set; } = new();
 }
 
 /// <summary>

--- a/tools/cs2gs/Cs2Gs.Pipeline/TriageArtifact.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TriageArtifact.cs
@@ -79,7 +79,7 @@ public sealed class TriageArtifact
     /// <summary>Gets or sets the prior <c>{runId, gscVersion, result}</c> records for this fingerprint.</summary>
     [JsonPropertyName("retryHistory")]
     [JsonPropertyOrder(12)]
-    public List<TriageRetryEntry> RetryHistory { get; set; } = new List<TriageRetryEntry>();
+    public List<TriageRetryEntry> RetryHistory { get; set; } = new();
 }
 
 /// <summary>
@@ -180,7 +180,7 @@ public sealed class TriageSuggestedIssue
     /// <summary>Gets or sets the issue labels (always includes <c>Oats</c>).</summary>
     [JsonPropertyName("labels")]
     [JsonPropertyOrder(2)]
-    public List<string> Labels { get; set; } = new List<string>();
+    public List<string> Labels { get; set; } = new();
 }
 
 /// <summary>

--- a/tools/cs2gs/Cs2Gs.Report/ReportModel.cs
+++ b/tools/cs2gs/Cs2Gs.Report/ReportModel.cs
@@ -56,17 +56,17 @@ public sealed class ReportModel
     /// <summary>Gets or sets the stage names in execution order (Translate→Compile→IlVerify→TestParity).</summary>
     [JsonPropertyName("stageOrder")]
     [JsonPropertyOrder(6)]
-    public List<string> StageOrder { get; set; } = new List<string>();
+    public List<string> StageOrder { get; set; } = new();
 
     /// <summary>Gets or sets the per-app results, sorted by app id, each with its stages in execution order.</summary>
     [JsonPropertyName("apps")]
     [JsonPropertyOrder(7)]
-    public List<AppReport> Apps { get; set; } = new List<AppReport>();
+    public List<AppReport> Apps { get; set; } = new();
 
     /// <summary>Gets or sets the discovered gaps, grouped by fingerprint and sorted by fingerprint.</summary>
     [JsonPropertyName("gaps")]
     [JsonPropertyOrder(8)]
-    public List<GapReport> Gaps { get; set; } = new List<GapReport>();
+    public List<GapReport> Gaps { get; set; } = new();
 
     /// <summary>
     /// Builds a <see cref="ReportModel"/> from a run directory by reading its
@@ -294,17 +294,17 @@ public sealed class AppReport
     /// <summary>Gets or sets the per-stage statuses, in execution order.</summary>
     [JsonPropertyName("stages")]
     [JsonPropertyOrder(3)]
-    public List<StageReport> Stages { get; set; } = new List<StageReport>();
+    public List<StageReport> Stages { get; set; } = new();
 
     /// <summary>Gets or sets the run-relative triage artifact paths for this app.</summary>
     [JsonPropertyName("artifacts")]
     [JsonPropertyOrder(4)]
-    public List<string> Artifacts { get; set; } = new List<string>();
+    public List<string> Artifacts { get; set; } = new();
 
     /// <summary>Gets or sets the distinct fingerprints captured for this app.</summary>
     [JsonPropertyName("fingerprints")]
     [JsonPropertyOrder(5)]
-    public List<string> Fingerprints { get; set; } = new List<string>();
+    public List<string> Fingerprints { get; set; } = new();
 }
 
 /// <summary>
@@ -368,12 +368,12 @@ public sealed class GapReport
     /// <summary>Gets or sets the per-app occurrences (appId + source location), sorted by app id.</summary>
     [JsonPropertyName("occurrences")]
     [JsonPropertyOrder(6)]
-    public List<GapOccurrence> Occurrences { get; set; } = new List<GapOccurrence>();
+    public List<GapOccurrence> Occurrences { get; set; } = new();
 
     /// <summary>Gets or sets the merged, deduped retry history for this fingerprint.</summary>
     [JsonPropertyName("retryHistory")]
     [JsonPropertyOrder(7)]
-    public List<TriageRetryEntry> RetryHistory { get; set; } = new List<TriageRetryEntry>();
+    public List<TriageRetryEntry> RetryHistory { get; set; } = new();
 }
 
 /// <summary>

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1072NullCheckedAsNullableTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1072NullCheckedAsNullableTranslationTests.cs
@@ -105,7 +105,7 @@ namespace Demo
 {
     public class C
     {
-        private object box = new object();
+        private object box = new();
         public bool HasBox() => box != null;
     }
 }");

--- a/tools/cs2gs/Cs2Gs.Tests/LocalExplicitTypePreservationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/LocalExplicitTypePreservationTests.cs
@@ -102,7 +102,7 @@ namespace Demo
     {
         public void F()
         {
-            IBox b = new Box();
+            IBox b = new();
             b = null!;
             System.Console.WriteLine(b);
         }

--- a/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
@@ -490,7 +490,7 @@ namespace Demo
 
     public class Repo<T> : IEnumerable<T>
     {
-        private readonly List<T> items = new List<T>();
+        private readonly List<T> items = new();
 
         public IEnumerator<T> GetEnumerator()
         {

--- a/tools/cs2gs/Cs2Gs.Tests/OahuFoundationTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuFoundationTranslationTests.cs
@@ -202,7 +202,7 @@ namespace Demo
 {
     public class LockX
     {
-        private readonly object gate = new object();
+        private readonly object gate = new();
         public int Run(int n)
         {
             int Twice(int v) => v * 2;

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -316,7 +316,7 @@ public sealed class CSharpToGSharpTranslator
         // The set of hard G# keywords (Cs2Gs.Compiler SyntaxFacts.GetKeywordKind).
         // A C# identifier that collides with one of these cannot be emitted bare; it
         // is suffixed with `_` consistently at every declaration and reference site.
-        private static readonly HashSet<string> GSharpReservedWords = new HashSet<string>(System.StringComparer.Ordinal)
+        private static readonly HashSet<string> GSharpReservedWords = new(System.StringComparer.Ordinal)
         {
             "as", "async", "await", "break", "case", "catch", "chan", "class", "const",
             "continue", "default", "defer", "do", "else", "enum", "false", "fallthrough",
@@ -360,7 +360,7 @@ public sealed class CSharpToGSharpTranslator
         // top-level receiver-clause `func`s emitted as siblings of the type
         // (issue #938, ADR-0115 §B.5). Collected here per aggregate and drained
         // by the document translator.
-        private readonly List<GMember> pendingTopLevelDeclarations = new List<GMember>();
+        private readonly List<GMember> pendingTopLevelDeclarations = new();
 
         // While translating a switch-expression arm whose C# pattern bound a
         // variable through a property subpattern (`Circle { Radius: var r }`), the
@@ -369,7 +369,7 @@ public sealed class CSharpToGSharpTranslator
         // from the bound local symbol to its replacement expression is consulted
         // by reference-translation (ADR-0115 §B switch lowering).
         private readonly Dictionary<ISymbol, GExpression> patternBindings =
-            new Dictionary<ISymbol, GExpression>(SymbolEqualityComparer.Default);
+            new(SymbolEqualityComparer.Default);
 
         // C# post-increment/decrement (`i++`, `i--`) sub-expressions that the
         // surrounding statement seam has hoisted into trailing `i++` statements
@@ -377,14 +377,14 @@ public sealed class CSharpToGSharpTranslator
         // While a node is in this set, `TranslateExpression` renders it as a bare
         // read of its operand (the pre-increment value).
         private readonly HashSet<SyntaxNode> suppressedPostfix =
-            new HashSet<SyntaxNode>();
+            new();
 
         // Static-field initializers lifted out of a `static` constructor body
         // (`static T() { Field = value; }`). G# has no static constructor, so a
         // simple static ctor is folded into the corresponding `shared { }` field
         // initializers and the ctor itself is dropped (ADR-0115 §B.11).
         private readonly Dictionary<ISymbol, GExpression> staticFieldInitializers =
-            new Dictionary<ISymbol, GExpression>(SymbolEqualityComparer.Default);
+            new(SymbolEqualityComparer.Default);
 
         // The syntax node whose body is currently being translated. It bounds the
         // data-flow scan that decides whether a local is mutable (var) or
@@ -7097,7 +7097,7 @@ public sealed class CSharpToGSharpTranslator
             // `foreach ((a, b) in xs)` / `foreach (var (a, b) in xs)` map to the
             // G# two-name iteration `for a, b in xs` (ForInStatement key/value form;
             // ADR-0115 §B). Tuple element names are collected from the designation.
-            List<string> names = new List<string>();
+            List<string> names = new();
             CollectForEachVariableNames(node.Variable, names);
 
             if (names.Count == 2)
@@ -7383,7 +7383,7 @@ public sealed class CSharpToGSharpTranslator
         /// </summary>
         private sealed class ConstructorLift
         {
-            public static readonly ConstructorLift None = new ConstructorLift();
+            public static readonly ConstructorLift None = new();
 
             public ConstructorDeclarationSyntax Constructor { get; init; }
 
@@ -7391,9 +7391,9 @@ public sealed class CSharpToGSharpTranslator
 
             public IReadOnlyList<Parameter> PrimaryParameters { get; init; } = new List<Parameter>();
 
-            public HashSet<string> FieldsAsPrimaryParameters { get; init; } = new HashSet<string>();
+            public HashSet<string> FieldsAsPrimaryParameters { get; init; } = new();
 
-            public HashSet<string> PropertiesAsPrimaryParameters { get; init; } = new HashSet<string>();
+            public HashSet<string> PropertiesAsPrimaryParameters { get; init; } = new();
 
             public Dictionary<string, GExpression> FieldInitializers { get; init; } =
                 new Dictionary<string, GExpression>();

--- a/tools/cs2gs/Cs2Gs.Translator/Loading/CSharpProjectLoader.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/Loading/CSharpProjectLoader.cs
@@ -37,7 +37,7 @@ namespace Cs2Gs.Translator.Loading;
 /// </summary>
 public static class CSharpProjectLoader
 {
-    private static readonly object MSBuildRegistrationLock = new object();
+    private static readonly object MSBuildRegistrationLock = new();
     private static bool msbuildRegistered;
 
     /// <summary>

--- a/tools/cs2gs/Cs2Gs.Translator/TranslationContext.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/TranslationContext.cs
@@ -20,7 +20,7 @@ namespace Cs2Gs.Translator;
 /// </summary>
 public sealed class TranslationContext
 {
-    private readonly List<TranslationDiagnostic> diagnostics = new List<TranslationDiagnostic>();
+    private readonly List<TranslationDiagnostic> diagnostics = new();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TranslationContext"/> class.


### PR DESCRIPTION
Closes #1370

Applies target-typed new expressions across applicable Core, interpreter, language server, test, and cs2gs declarations where the target type is already clear. Leaves explicit constructor types where inference would be invalid or less clear.