### PR TITLE
Use collection expressions for initializers

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ControlFlowGraph.cs
+++ b/src/Core/CodeAnalysis/Binding/ControlFlowGraph.cs
@@ -164,17 +164,17 @@ public sealed class ControlFlowGraph
         /// <summary>
         /// Gets the list of statements in this block.
         /// </summary>
-        public List<BoundStatement> Statements { get; } = new List<BoundStatement>();
+        public List<BoundStatement> Statements { get; } = [];
 
         /// <summary>
         /// Gets the list of incoming branches to this block.
         /// </summary>
-        public List<BasicBlockBranch> Incoming { get; } = new List<BasicBlockBranch>();
+        public List<BasicBlockBranch> Incoming { get; } = [];
 
         /// <summary>
         /// Gets the list of outgoing branches from this block.
         /// </summary>
-        public List<BasicBlockBranch> Outgoing { get; } = new List<BasicBlockBranch>();
+        public List<BasicBlockBranch> Outgoing { get; } = [];
 
         /// <inheritdoc/>
         public override string ToString()
@@ -254,8 +254,8 @@ public sealed class ControlFlowGraph
     /// </summary>
     public sealed class BasicBlockBuilder
     {
-        private readonly List<BoundStatement> statements = new List<BoundStatement>();
-        private readonly List<BasicBlock> blocks = new List<BasicBlock>();
+        private readonly List<BoundStatement> statements = [];
+        private readonly List<BasicBlock> blocks = [];
 
         /// <summary>
         /// Builds a basic block from the provided bound block statement and adds
@@ -332,9 +332,9 @@ public sealed class ControlFlowGraph
     /// </summary>
     public sealed class GraphBuilder
     {
-        private readonly Dictionary<BoundStatement, BasicBlock> blockFromStatement = new Dictionary<BoundStatement, BasicBlock>();
-        private readonly Dictionary<BoundLabel, BasicBlock> blockFromLabel = new Dictionary<BoundLabel, BasicBlock>();
-        private readonly List<BasicBlockBranch> branches = new List<BasicBlockBranch>();
+        private readonly Dictionary<BoundStatement, BasicBlock> blockFromStatement = [];
+        private readonly Dictionary<BoundLabel, BasicBlock> blockFromLabel = [];
+        private readonly List<BasicBlockBranch> branches = [];
         private readonly BasicBlock start = new BasicBlock(isStart: true);
         private readonly BasicBlock end = new BasicBlock(isStart: false);
 

--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -1210,7 +1210,7 @@ internal sealed class LambdaBinder
     // outer lambda's candidate set.
     private sealed class ReturnTypeCollector : BoundTreeWalker
     {
-        public List<TypeSymbol> ReturnTypes { get; } = new List<TypeSymbol>();
+        public List<TypeSymbol> ReturnTypes { get; } = [];
 
         protected override void VisitReturnStatement(BoundReturnStatement node)
         {
@@ -1335,7 +1335,7 @@ internal sealed class LambdaBinder
         {
             this.parameters = parameters;
             this.seen = seen;
-            this.declared = new HashSet<VariableSymbol>();
+            this.declared = [];
             this.captured = captured;
         }
 

--- a/src/Core/CodeAnalysis/Emit/ClosureEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ClosureEmitter.cs
@@ -154,7 +154,7 @@ internal sealed class ClosureEmitter
     /// <c>enclosingClosure</c>) and by <c>BodyEmitter</c> itself (for the
     /// <c>EmitFunctionLiteral</c> path).
     /// </summary>
-    public Dictionary<BoundFunctionLiteralExpression, ClosureInfo> ClosureInfos { get; } = new Dictionary<BoundFunctionLiteralExpression, ClosureInfo>();
+    public Dictionary<BoundFunctionLiteralExpression, ClosureInfo> ClosureInfos { get; } = [];
 
     /// <summary>
     /// Gets per-<c>go</c>-site closure metadata. The display class wraps the
@@ -162,7 +162,7 @@ internal sealed class ClosureEmitter
     /// <c>InvokeAsync</c> for async <c>go</c>) that <c>Task.Run</c> can
     /// bind to.
     /// </summary>
-    public Dictionary<BoundGoStatement, ClosureInfo> GoClosureInfos { get; } = new Dictionary<BoundGoStatement, ClosureInfo>();
+    public Dictionary<BoundGoStatement, ClosureInfo> GoClosureInfos { get; } = [];
 
     /// <summary>
     /// Gets the reverse map from a closure-invoke <see cref="FunctionSymbol"/> to
@@ -171,7 +171,7 @@ internal sealed class ClosureEmitter
     /// captures (issue #503 follow-up) route through the enclosing
     /// display class.
     /// </summary>
-    public Dictionary<FunctionSymbol, ClosureInfo> ClosureInvokeToInfo { get; } = new Dictionary<FunctionSymbol, ClosureInfo>();
+    public Dictionary<FunctionSymbol, ClosureInfo> ClosureInvokeToInfo { get; } = [];
 
     /// <summary>
     /// Gets every synthesized aggregate class emitted on behalf of a closure,
@@ -181,7 +181,7 @@ internal sealed class ClosureEmitter
     /// PR-E-10) also append to this list directly, which is why the
     /// collection is exposed as a mutable <see cref="List{T}"/>.
     /// </summary>
-    public List<StructSymbol> SynthesizedClosureClasses { get; } = new List<StructSymbol>();
+    public List<StructSymbol> SynthesizedClosureClasses { get; } = [];
 
     // Phase 4 emit parity (E2): for each lambda that captures outer variables,
     // synthesize a sealed closure class on the entry-point package with:
@@ -451,7 +451,7 @@ internal sealed class ClosureEmitter
     /// </summary>
     public sealed class ConstructedTypeCollector : BoundTreeRewriter
     {
-        public HashSet<StructSymbol> Constructed { get; } = new HashSet<StructSymbol>();
+        public HashSet<StructSymbol> Constructed { get; } = [];
 
         protected override BoundExpression RewriteExpression(BoundExpression node)
         {

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -111,7 +111,7 @@ internal sealed class ReflectionMetadataEmitter
     // Each lambda's synthetic FunctionSymbol is registered alongside user
     // functions in functionsByPackage so it gets a MethodDef row, and its
     // body is emitted via the same EmitFunction path.
-    private readonly Dictionary<FunctionSymbol, BoundBlockStatement> lambdaBodies = new Dictionary<FunctionSymbol, BoundBlockStatement>();
+    private readonly Dictionary<FunctionSymbol, BoundBlockStatement> lambdaBodies = [];
 
     // PR-E-9: closure-environment metadata and synthesized display classes
     // moved onto ClosureEmitter. Where this file used to declare:
@@ -828,7 +828,7 @@ internal sealed class ReflectionMetadataEmitter
 
             if (!nestedChildrenByParent.TryGetValue(parent, out var list))
             {
-                list = new List<TypeSymbol>();
+                list = [];
                 nestedChildrenByParent[parent] = list;
             }
 
@@ -1791,7 +1791,7 @@ internal sealed class ReflectionMetadataEmitter
         var functionsByPackage = new Dictionary<PackageSymbol, List<FunctionSymbol>>();
         foreach (var pkg in packages)
         {
-            functionsByPackage[pkg] = new List<FunctionSymbol>();
+            functionsByPackage[pkg] = [];
         }
 
         foreach (var kvp in this.emitCtx.Program.Functions)
@@ -1827,7 +1827,7 @@ internal sealed class ReflectionMetadataEmitter
             var owningPackage = kvp.Key.Package ?? this.emitCtx.Program.EntryPointPackage ?? packages[0];
             if (!functionsByPackage.TryGetValue(owningPackage, out var bucket))
             {
-                bucket = new List<FunctionSymbol>();
+                bucket = [];
                 functionsByPackage[owningPackage] = bucket;
                 packages = packages.Add(owningPackage);
             }
@@ -1862,7 +1862,7 @@ internal sealed class ReflectionMetadataEmitter
         {
             if (!functionsByPackage.TryGetValue(lambdaHostPackage, out var hostBucket))
             {
-                hostBucket = new List<FunctionSymbol>();
+                hostBucket = [];
                 functionsByPackage[lambdaHostPackage] = hostBucket;
                 packages = packages.Add(lambdaHostPackage);
             }
@@ -5875,7 +5875,7 @@ internal sealed class ReflectionMetadataEmitter
             {
                 Version = typeof(object).Assembly.GetName().Version ?? new Version(0, 0, 0, 0),
             };
-            sysRuntimeName.SetPublicKeyToken(new byte[] { 0xb0, 0x3f, 0x5f, 0x7f, 0x11, 0xd5, 0x0a, 0x3a });
+            sysRuntimeName.SetPublicKeyToken([0xb0, 0x3f, 0x5f, 0x7f, 0x11, 0xd5, 0x0a, 0x3a]);
         }
 
         var publicKeyToken = sysRuntimeName.GetPublicKeyToken();

--- a/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
+++ b/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
@@ -653,7 +653,7 @@ internal sealed class SlotPlanner
 
     private sealed class BlockExpressionLocalCollector : BoundTreeWalker
     {
-        public List<VariableSymbol> Variables { get; } = new List<VariableSymbol>();
+        public List<VariableSymbol> Variables { get; } = [];
 
         protected override void VisitBlockExpression(BoundBlockExpression node)
         {

--- a/src/Core/CodeAnalysis/Emit/StateMachineEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/StateMachineEmitter.cs
@@ -176,7 +176,7 @@ internal sealed class StateMachineEmitter
     /// <c>EmitFunction</c> swaps in this body for the user-authored iterator
     /// function so the kickoff returns a freshly-constructed SM struct.
     /// </summary>
-    public Dictionary<FunctionSymbol, BoundBlockStatement> IteratorKickoffBodies { get; } = new Dictionary<FunctionSymbol, BoundBlockStatement>();
+    public Dictionary<FunctionSymbol, BoundBlockStatement> IteratorKickoffBodies { get; } = [];
 
     /// <summary>
     /// Gets per-iterator-SM metadata. Populated by
@@ -185,7 +185,7 @@ internal sealed class StateMachineEmitter
     /// <c>IEnumerator&lt;T&gt;</c> / <c>IDisposable</c> interface
     /// implementations.
     /// </summary>
-    public Dictionary<StructSymbol, IteratorStateMachineInfo> IteratorStateMachineInfos { get; } = new Dictionary<StructSymbol, IteratorStateMachineInfo>();
+    public Dictionary<StructSymbol, IteratorStateMachineInfo> IteratorStateMachineInfos { get; } = [];
 
     /// <summary>
     /// Gets per-async-iterator-SM plan. Populated by
@@ -195,7 +195,7 @@ internal sealed class StateMachineEmitter
     /// <c>IValueTaskSource&lt;bool&gt;</c> / <c>IAsyncStateMachine</c> interface
     /// implementations.
     /// </summary>
-    public Dictionary<StructSymbol, AsyncIteratorPlan> AsyncIteratorInfos { get; } = new Dictionary<StructSymbol, AsyncIteratorPlan>();
+    public Dictionary<StructSymbol, AsyncIteratorPlan> AsyncIteratorInfos { get; } = [];
 
     /// <summary>
     /// Gets per-async-iterator-SM emit-time context (builder field + builder
@@ -203,7 +203,7 @@ internal sealed class StateMachineEmitter
     /// <c>BodyEmitter</c> via the root emitter when threading the async
     /// iterator MoveNext path through the await pipeline.
     /// </summary>
-    public Dictionary<StructSymbol, AsyncIteratorEmitContext> AsyncIteratorEmitContexts { get; } = new Dictionary<StructSymbol, AsyncIteratorEmitContext>();
+    public Dictionary<StructSymbol, AsyncIteratorEmitContext> AsyncIteratorEmitContexts { get; } = [];
 
     /// <summary>
     /// Gets the map from a capture-bearing async lambda's SM struct to the
@@ -211,7 +211,7 @@ internal sealed class StateMachineEmitter
     /// nesting convention). SM structs NOT in this map nest inside the
     /// per-package <c>&lt;Program&gt;</c> class.
     /// </summary>
-    public Dictionary<StructSymbol, StructSymbol> AsyncSmEnclosingClosures { get; } = new Dictionary<StructSymbol, StructSymbol>();
+    public Dictionary<StructSymbol, StructSymbol> AsyncSmEnclosingClosures { get; } = [];
 
     /// <summary>
     /// Gets or sets the async state-machine plans produced by

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -26,14 +26,14 @@ public sealed class Evaluator
     private readonly object goLock = new object();
     private readonly Stack<ScopeFrame> scopeFrames = new Stack<ScopeFrame>();
     private readonly Stack<System.Collections.IList> iteratorSinks = new Stack<System.Collections.IList>();
-    private readonly Dictionary<Symbols.FunctionSymbol, bool> iteratorFunctionCache = new Dictionary<Symbols.FunctionSymbol, bool>();
-    private readonly Dictionary<(Symbols.StructSymbol, Symbols.FieldSymbol), object> staticFields = new Dictionary<(Symbols.StructSymbol, Symbols.FieldSymbol), object>();
+    private readonly Dictionary<Symbols.FunctionSymbol, bool> iteratorFunctionCache = [];
+    private readonly Dictionary<(Symbols.StructSymbol, Symbols.FieldSymbol), object> staticFields = [];
 
     // ADR-0089 / issue #1030: interface static-field storage. Keyed by the
     // owning interface symbol so each closed construction of a generic interface
     // (`IBox[int32]` vs `IBox[string]`) owns independent storage, matching CLR
     // static-field semantics. The non-generic case keys by the single interface.
-    private readonly Dictionary<(Symbols.InterfaceSymbol, Symbols.FieldSymbol), object> interfaceStaticFields = new Dictionary<(Symbols.InterfaceSymbol, Symbols.FieldSymbol), object>();
+    private readonly Dictionary<(Symbols.InterfaceSymbol, Symbols.FieldSymbol), object> interfaceStaticFields = [];
     private Random random;
 
     private object lastValue;
@@ -424,7 +424,7 @@ public sealed class Evaluator
         var getEnumerator = asyncEnumerableInterface.GetMethod(
             "GetAsyncEnumerator",
             new[] { typeof(System.Threading.CancellationToken) });
-        var enumerator = getEnumerator.Invoke(stream, new object[] { cancellationToken });
+        var enumerator = getEnumerator.Invoke(stream, [cancellationToken]);
         if (enumerator == null)
         {
             throw new EvaluatorException("'await for' GetAsyncEnumerator returned null.", node);
@@ -824,7 +824,7 @@ public sealed class Evaluator
                     continue;
                 }
 
-                var literalResult = appendLiteral.Invoke(handler, new object[] { part.Literal });
+                var literalResult = appendLiteral.Invoke(handler, [part.Literal]);
                 if (literalResult is bool lb)
                 {
                     shouldAppend = lb;
@@ -2699,7 +2699,7 @@ public sealed class Evaluator
                     locals[parameter] = EvaluateExpression(addrOf.Operand);
                     if (parameter.RefKind == RefKind.Ref || parameter.RefKind == RefKind.Out)
                     {
-                        userRefSlots ??= new List<(ParameterSymbol, BoundExpression)>();
+                        userRefSlots ??= [];
                         userRefSlots.Add((parameter, addrOf.Operand));
                     }
                 }
@@ -3205,7 +3205,7 @@ public sealed class Evaluator
                 && m.IsGenericMethodDefinition
                 && m.GetParameters().Length == 1
                 && m.GetParameters()[0].ParameterType.IsSameAs(typeof(BoundedChannelOptions)));
-        return bounded.MakeGenericMethod(elementClr).Invoke(null, new object[] { options });
+        return bounded.MakeGenericMethod(elementClr).Invoke(null, [options]);
     }
 
     private void EvaluateChannelSendStatement(BoundChannelSendStatement node)
@@ -3243,7 +3243,7 @@ public sealed class Evaluator
         var reader = channel.GetType().GetProperty("Reader").GetValue(channel);
         var elementType = reader.GetType().GenericTypeArguments[0];
         var readAsync = reader.GetType().GetMethod("ReadAsync", new[] { typeof(System.Threading.CancellationToken) });
-        var valueTask = readAsync.Invoke(reader, new object[] { System.Threading.CancellationToken.None });
+        var valueTask = readAsync.Invoke(reader, [System.Threading.CancellationToken.None]);
         var asTask = valueTask.GetType().GetMethod("AsTask").Invoke(valueTask, null);
         try
         {
@@ -3266,7 +3266,7 @@ public sealed class Evaluator
         }
 
         var writer = channel.GetType().GetProperty("Writer").GetValue(channel);
-        writer.GetType().GetMethod("Complete", new[] { typeof(Exception) }).Invoke(writer, new object[] { null });
+        writer.GetType().GetMethod("Complete", new[] { typeof(Exception) }).Invoke(writer, [null]);
         return null;
     }
 
@@ -3405,13 +3405,13 @@ public sealed class Evaluator
         {
             var writer = channel.GetType().GetProperty("Writer").GetValue(channel);
             var waitToWrite = writer.GetType().GetMethod("WaitToWriteAsync", new[] { typeof(System.Threading.CancellationToken) });
-            var vt = waitToWrite.Invoke(writer, new object[] { System.Threading.CancellationToken.None });
+            var vt = waitToWrite.Invoke(writer, [System.Threading.CancellationToken.None]);
             return (Task)vt.GetType().GetMethod("AsTask").Invoke(vt, null);
         }
 
         var reader = channel.GetType().GetProperty("Reader").GetValue(channel);
         var waitToRead = reader.GetType().GetMethod("WaitToReadAsync", new[] { typeof(System.Threading.CancellationToken) });
-        var vt2 = waitToRead.Invoke(reader, new object[] { System.Threading.CancellationToken.None });
+        var vt2 = waitToRead.Invoke(reader, [System.Threading.CancellationToken.None]);
         return (Task)vt2.GetType().GetMethod("AsTask").Invoke(vt2, null);
     }
 
@@ -4052,7 +4052,7 @@ public sealed class Evaluator
                 args[i] = EvaluateExpression(addrOf.Operand);
                 if (rk == RefKind.Ref || rk == RefKind.Out)
                 {
-                    refSlots ??= new List<(int, BoundExpression)>();
+                    refSlots ??= [];
                     refSlots.Add((i, addrOf.Operand));
                 }
             }
@@ -4443,7 +4443,7 @@ public sealed class Evaluator
 
     private sealed class ScopeFrame
     {
-        public List<Task> Tasks { get; } = new List<Task>();
+        public List<Task> Tasks { get; } = [];
 
         public System.Threading.CancellationTokenSource Cts { get; } = new System.Threading.CancellationTokenSource();
     }

--- a/src/Core/CodeAnalysis/Lowering/Async/AsyncStateMachineTypeBuilder.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AsyncStateMachineTypeBuilder.cs
@@ -256,7 +256,7 @@ public static class AsyncStateMachineTypeBuilder
 
     private sealed class AwaiterTypeCollector : BoundTreeWalker
     {
-        public List<(Type ClrType, TypeSymbol TypeSymbol)> AwaiterTypes { get; } = new List<(Type ClrType, TypeSymbol TypeSymbol)>();
+        public List<(Type ClrType, TypeSymbol TypeSymbol)> AwaiterTypes { get; } = [];
 
         public void Walk(BoundStatement body)
         {

--- a/src/Core/CodeAnalysis/Lowering/Iterators/AsyncIteratorRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/Iterators/AsyncIteratorRewriter.cs
@@ -257,7 +257,7 @@ public static class AsyncIteratorRewriter
 
     private sealed class LocalCollector : BoundTreeWalker
     {
-        public List<VariableSymbol> Locals { get; } = new List<VariableSymbol>();
+        public List<VariableSymbol> Locals { get; } = [];
 
         protected override void VisitVariableDeclaration(BoundVariableDeclaration node)
         {
@@ -282,7 +282,7 @@ public static class AsyncIteratorRewriter
 
     private sealed class AwaiterTypeCollector : BoundTreeWalker
     {
-        public List<Type> AwaiterTypes { get; } = new List<Type>();
+        public List<Type> AwaiterTypes { get; } = [];
 
         protected override void VisitAwaitExpression(BoundAwaitExpression node)
         {

--- a/src/Core/CodeAnalysis/Lowering/Iterators/IteratorRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/Iterators/IteratorRewriter.cs
@@ -197,7 +197,7 @@ public static class IteratorRewriter
 
     private sealed class LocalCollector : BoundTreeWalker
     {
-        public List<VariableSymbol> Locals { get; } = new List<VariableSymbol>();
+        public List<VariableSymbol> Locals { get; } = [];
 
         protected override void VisitVariableDeclaration(BoundVariableDeclaration node)
         {

--- a/src/LanguageServer/CodeLensComputer.cs
+++ b/src/LanguageServer/CodeLensComputer.cs
@@ -161,7 +161,7 @@ public static class CodeLensComputer
             {
                 Title = title,
                 Name = "gsharp.showReferences",
-                Arguments = new object[] { uri, range.Start },
+                Arguments = [uri, range.Start],
             },
         };
     }

--- a/src/LanguageServer/Protocol/Models.cs
+++ b/src/LanguageServer/Protocol/Models.cs
@@ -291,13 +291,13 @@ public sealed class CompletionList
     {
     }
 
-    public CompletionList(IEnumerable<CompletionItem> items) => this.Items = items?.ToList() ?? new List<CompletionItem>();
+    public CompletionList(IEnumerable<CompletionItem> items) => this.Items = items?.ToList() ?? [];
 
     [JsonPropertyName("isIncomplete")]
     public bool IsIncomplete { get; set; }
 
     [JsonPropertyName("items")]
-    public List<CompletionItem> Items { get; set; } = new List<CompletionItem>();
+    public List<CompletionItem> Items { get; set; } = [];
 }
 
 public enum SymbolKind
@@ -488,10 +488,10 @@ public sealed class CommandOrCodeActionContainer : IEnumerable<CommandOrCodeActi
 {
     private readonly List<CommandOrCodeAction> items;
 
-    public CommandOrCodeActionContainer() => this.items = new List<CommandOrCodeAction>();
+    public CommandOrCodeActionContainer() => this.items = [];
 
     public CommandOrCodeActionContainer(IEnumerable<CommandOrCodeAction> items)
-        => this.items = items?.ToList() ?? new List<CommandOrCodeAction>();
+        => this.items = items?.ToList() ?? [];
 
     public IEnumerator<CommandOrCodeAction> GetEnumerator() => this.items.GetEnumerator();
 

--- a/test/Compiler.Tests/Emit/Issue538ForInEnumerableEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue538ForInEnumerableEmitTests.cs
@@ -267,7 +267,7 @@ public class Issue538ForInEnumerableEmitTests
                         => new[] { 1, 2, 3, 4, 5 };
 
                     public static ICollection<string> GetCollection()
-                        => new List<string> { "x", "y" };
+                        => ["x", "y"];
 
                     public static IReadOnlyList<string> GetEmptyReadOnlyList()
                         => Array.Empty<string>();

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue666LinqExtensionOnClrRefTypeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue666LinqExtensionOnClrRefTypeTests.cs
@@ -192,7 +192,7 @@ var q = Enumerable.Where[Issue666ItemCls](xs, func(i Issue666ItemCls) bool { ret
         // plus all BCL assemblies through a MetadataLoadContext, reproducing
         // the cross-context configuration that triggers issue #666.
         var fixturePath = typeof(Fixtures.Issue666ItemCls).Assembly.Location;
-        var paths = new List<string> { fixturePath };
+        List<string> paths = [fixturePath];
 
         // Include BCL assemblies so System.Linq.Enumerable is discoverable.
         var tpa = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;

--- a/test/LanguageServer.Tests/FoldingComputerTests.cs
+++ b/test/LanguageServer.Tests/FoldingComputerTests.cs
@@ -45,7 +45,7 @@ public class FoldingComputerTests
     public void ComputeFoldings_NoFunctions_ReturnsEmpty()
     {
         var tree = SyntaxTree.Parse("package P\n");
-        var content = new DocumentContent(tree, new List<int> { 9 });
+        var content = new DocumentContent(tree, [9]);
         Assert.Empty(FoldingComputer.ComputeFoldings(content));
     }
 }

--- a/test/LanguageServer.Tests/LspServerMemberFeatureTests.cs
+++ b/test/LanguageServer.Tests/LspServerMemberFeatureTests.cs
@@ -87,6 +87,6 @@ public class LspServerMemberFeatureTests
         => server.DidChangeAsync(new DidChangeTextDocumentParams
         {
             TextDocument = new VersionedTextDocumentIdentifier { Uri = uri, Version = version },
-            ContentChanges = new List<TextDocumentContentChangeEvent> { new TextDocumentContentChangeEvent { Text = text } },
+            ContentChanges = [new TextDocumentContentChangeEvent { Text = text }],
         });
 }


### PR DESCRIPTION
Closes #1371

Updates targeted Core, compiler, and language server code to use C# 12 collection expressions where target types support them, while leaving dictionary key/value initializers unchanged.