### PR TITLE
Add property-based tests for overload resolution

### DIFF
--- a/test/Core.Tests/CodeAnalysis/Binding/OverloadResolutionGenerators.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/OverloadResolutionGenerators.cs
@@ -1,0 +1,255 @@
+// <copyright file="OverloadResolutionGenerators.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reflection;
+using FsCheck;
+using FsCheck.Fluent;
+using GSharp.Core.CodeAnalysis.Binding;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Custom FsCheck generators for the overload-resolution property tests.
+/// </summary>
+public static class OverloadResolutionGenerators
+{
+    private static readonly ImmutableArray<Type> ArgumentTypes =
+    [
+        typeof(bool),
+        typeof(byte),
+        typeof(char),
+        typeof(decimal),
+        typeof(double),
+        typeof(float),
+        typeof(int),
+        typeof(long),
+        typeof(object),
+        typeof(sbyte),
+        typeof(short),
+        typeof(string),
+        typeof(uint),
+        typeof(ulong),
+        typeof(ushort),
+    ];
+
+    internal static readonly ImmutableArray<MethodInfo> Methods = typeof(OverloadResolutionPropertyFixture)
+        .GetMethods(BindingFlags.Public | BindingFlags.Static)
+        .Where(m => m.DeclaringType == typeof(OverloadResolutionPropertyFixture))
+        .ToImmutableArray();
+
+    private static readonly Gen<Type> TypeGen = Gen.Elements(ArgumentTypes.ToArray());
+
+    /// <summary>
+    /// Gets generated candidate arrays.
+    /// </summary>
+    /// <returns>The arbitrary candidate generator.</returns>
+    public static Arbitrary<MethodInfo[]> Candidates()
+    {
+        var gen =
+            from candidateCount in Gen.Choose(0, Math.Min(8, Methods.Length))
+            from indexes in Gen.ArrayOf(Gen.Choose(0, Methods.Length - 1), candidateCount)
+            select indexes.Distinct().Select(i => Methods[i]).ToArray();
+
+        return Arb.From(gen);
+    }
+
+    /// <summary>
+    /// Gets generated argument-type arrays.
+    /// </summary>
+    /// <returns>The arbitrary argument-type generator.</returns>
+    public static Arbitrary<Type[]> ArgTypes()
+    {
+        var gen =
+            from argumentCount in Gen.Choose(0, 3)
+            from argumentTypes in Gen.ArrayOf(TypeGen, argumentCount)
+            select argumentTypes;
+        return Arb.From(gen);
+    }
+
+    /// <summary>
+    /// Gets generated argument types.
+    /// </summary>
+    /// <returns>The arbitrary type generator.</returns>
+    public static Arbitrary<Type> Types()
+    {
+        return Arb.From(TypeGen);
+    }
+
+    internal static ImmutableArray<MethodInfo> FindOneParameterMethods()
+        => Methods.Where(m => m.GetParameters().Length == 1).ToImmutableArray();
+
+    internal static ImmutableArray<MethodInfo> FindNumericOneParameterMethods()
+        => FindOneParameterMethods()
+            .Where(m => IsNumericOrChar(m.GetParameters()[0].ParameterType))
+            .ToImmutableArray();
+
+    internal static int CompareExpected(
+        OverloadResolution.ImplicitConversionKind firstClassification,
+        Type firstTarget,
+        OverloadResolution.ImplicitConversionKind secondClassification,
+        Type secondTarget,
+        Type source)
+    {
+        if (firstClassification != secondClassification)
+        {
+            return ((int)firstClassification).CompareTo((int)secondClassification);
+        }
+
+        if (firstClassification == OverloadResolution.ImplicitConversionKind.NumericWidening)
+        {
+            return OverloadResolution.CompareNumericTargets(firstTarget, secondTarget, source);
+        }
+
+        return 0;
+    }
+
+    internal static bool IsNumericOrChar(Type type)
+        => type == typeof(byte)
+            || type == typeof(char)
+            || type == typeof(decimal)
+            || type == typeof(double)
+            || type == typeof(float)
+            || type == typeof(int)
+            || type == typeof(long)
+            || type == typeof(sbyte)
+            || type == typeof(short)
+            || type == typeof(uint)
+            || type == typeof(ulong)
+            || type == typeof(ushort);
+
+    internal static MethodInfo FindExactOneParameterMethod(Type argumentType)
+        => FindOneParameterMethods().Single(m => m.GetParameters()[0].ParameterType == argumentType);
+}
+
+/// <summary>
+/// Fixture methods used by property-based overload-resolution tests.
+/// </summary>
+public static class OverloadResolutionPropertyFixture
+{
+    /// <summary>Accepts a Boolean value.</summary>
+    /// <param name="value">The value.</param>
+    public static void Bool(bool value) => _ = value;
+
+    /// <summary>Accepts a byte value.</summary>
+    /// <param name="value">The value.</param>
+    public static void Byte(byte value) => _ = value;
+
+    /// <summary>Accepts a char value.</summary>
+    /// <param name="value">The value.</param>
+    public static void Char(char value) => _ = value;
+
+    /// <summary>Accepts a decimal value.</summary>
+    /// <param name="value">The value.</param>
+    public static void Decimal(decimal value) => _ = value;
+
+    /// <summary>Accepts a double value.</summary>
+    /// <param name="value">The value.</param>
+    public static void Double(double value) => _ = value;
+
+    /// <summary>Accepts a float value.</summary>
+    /// <param name="value">The value.</param>
+    public static void Float(float value) => _ = value;
+
+    /// <summary>Accepts an int value.</summary>
+    /// <param name="value">The value.</param>
+    public static void Int(int value) => _ = value;
+
+    /// <summary>Accepts a long value.</summary>
+    /// <param name="value">The value.</param>
+    public static void Long(long value) => _ = value;
+
+    /// <summary>Accepts an object value.</summary>
+    /// <param name="value">The value.</param>
+    public static void Object(object value) => _ = value;
+
+    /// <summary>Accepts an sbyte value.</summary>
+    /// <param name="value">The value.</param>
+    public static void SByte(sbyte value) => _ = value;
+
+    /// <summary>Accepts a short value.</summary>
+    /// <param name="value">The value.</param>
+    public static void Short(short value) => _ = value;
+
+    /// <summary>Accepts a string value.</summary>
+    /// <param name="value">The value.</param>
+    public static void String(string value) => _ = value;
+
+    /// <summary>Accepts a uint value.</summary>
+    /// <param name="value">The value.</param>
+    public static void UInt(uint value) => _ = value;
+
+    /// <summary>Accepts a ulong value.</summary>
+    /// <param name="value">The value.</param>
+    public static void ULong(ulong value) => _ = value;
+
+    /// <summary>Accepts a ushort value.</summary>
+    /// <param name="value">The value.</param>
+    public static void UShort(ushort value) => _ = value;
+
+    /// <summary>Accepts two int values.</summary>
+    /// <param name="first">The first value.</param>
+    /// <param name="second">The second value.</param>
+    public static void PairIntInt(int first, int second)
+    {
+        _ = first;
+        _ = second;
+    }
+
+    /// <summary>Accepts two long values.</summary>
+    /// <param name="first">The first value.</param>
+    /// <param name="second">The second value.</param>
+    public static void PairLongLong(long first, long second)
+    {
+        _ = first;
+        _ = second;
+    }
+
+    /// <summary>Accepts an int and a long.</summary>
+    /// <param name="first">The first value.</param>
+    /// <param name="second">The second value.</param>
+    public static void PairIntLong(int first, long second)
+    {
+        _ = first;
+        _ = second;
+    }
+
+    /// <summary>Accepts a long and an int.</summary>
+    /// <param name="first">The first value.</param>
+    /// <param name="second">The second value.</param>
+    public static void PairLongInt(long first, int second)
+    {
+        _ = first;
+        _ = second;
+    }
+
+    /// <summary>Accepts three int values.</summary>
+    /// <param name="first">The first value.</param>
+    /// <param name="second">The second value.</param>
+    /// <param name="third">The third value.</param>
+    public static void TripleInt(int first, int second, int third)
+    {
+        _ = first;
+        _ = second;
+        _ = third;
+    }
+}
+
+internal sealed class MethodIdentityComparer : IEqualityComparer<MethodInfo>
+{
+    public static readonly MethodIdentityComparer Instance = new();
+
+    private MethodIdentityComparer()
+    {
+    }
+
+    public bool Equals(MethodInfo x, MethodInfo y)
+        => x is null ? y is null : y is not null && x.MetadataToken == y.MetadataToken && x.Module == y.Module;
+
+    public int GetHashCode(MethodInfo obj)
+        => HashCode.Combine(obj.Module, obj.MetadataToken);
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/OverloadResolutionPropertyTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/OverloadResolutionPropertyTests.cs
@@ -1,0 +1,158 @@
+// <copyright file="OverloadResolutionPropertyTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Linq;
+using System.Reflection;
+using FsCheck.Xunit;
+using GSharp.Core.CodeAnalysis.Binding;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Property-based tests for <see cref="OverloadResolution"/>.
+/// </summary>
+public class OverloadResolutionPropertyTests
+{
+    /// <summary>
+    /// Resolving the same candidate set and arguments repeatedly is deterministic.
+    /// </summary>
+    /// <param name="scenario">The generated overload-resolution input.</param>
+    /// <returns><see langword="true"/> when both attempts produce the same result.</returns>
+    [Property(MaxTest = 300, Arbitrary = [typeof(OverloadResolutionGenerators)])]
+    public bool Resolution_is_deterministic(MethodInfo[] candidates, Type[] argTypes)
+    {
+        var first = OverloadResolution.Resolve(candidates, argTypes);
+        var second = OverloadResolution.Resolve(candidates, argTypes);
+
+        return first.Outcome == second.Outcome
+            && MethodIdentityComparer.Instance.Equals(first.Best, second.Best)
+            && first.Ambiguous.SequenceEqual(second.Ambiguous, MethodIdentityComparer.Instance);
+    }
+
+    /// <summary>
+    /// Resolution results maintain their public shape invariants.
+    /// </summary>
+    /// <param name="scenario">The generated overload-resolution input.</param>
+    /// <returns><see langword="true"/> when the outcome and payload agree.</returns>
+    [Property(MaxTest = 300, Arbitrary = [typeof(OverloadResolutionGenerators)])]
+    public bool Outcome_payloads_match_outcome(MethodInfo[] candidates, Type[] argTypes)
+    {
+        var result = OverloadResolution.Resolve(candidates, argTypes);
+
+        return result.Outcome switch
+        {
+            OverloadResolution.ResolutionOutcome.NoneApplicable =>
+                result.Best is null && result.Ambiguous.IsEmpty,
+            OverloadResolution.ResolutionOutcome.Resolved =>
+                result.Best is not null && result.Ambiguous.IsEmpty,
+            OverloadResolution.ResolutionOutcome.Ambiguous =>
+                result.Best is null && result.Ambiguous.Length >= 2,
+            _ => false,
+        };
+    }
+
+    /// <summary>
+    /// Every reported best or ambiguous method came from the original candidate set.
+    /// </summary>
+    /// <param name="scenario">The generated overload-resolution input.</param>
+    /// <returns><see langword="true"/> when all returned methods were supplied as candidates.</returns>
+    [Property(MaxTest = 300, Arbitrary = [typeof(OverloadResolutionGenerators)])]
+    public bool Resolution_only_returns_input_candidates(MethodInfo[] candidates, Type[] argTypes)
+    {
+        var result = OverloadResolution.Resolve(candidates, argTypes);
+
+        return result.Outcome switch
+        {
+            OverloadResolution.ResolutionOutcome.Resolved =>
+                Contains(candidates, result.Best),
+            OverloadResolution.ResolutionOutcome.Ambiguous =>
+                result.Ambiguous.All(m => Contains(candidates, m)),
+            _ => true,
+        };
+    }
+
+    /// <summary>
+    /// An applicable identity conversion wins over widening, boxing, and reference conversions.
+    /// </summary>
+    /// <param name="scenario">The generated exact-match scenario.</param>
+    /// <returns><see langword="true"/> when the exact candidate resolves.</returns>
+    [Property(MaxTest = 200, Arbitrary = [typeof(OverloadResolutionGenerators)])]
+    public bool Exact_match_is_preferred(Type argumentType, MethodInfo[] distractors)
+    {
+        var exact = OverloadResolutionGenerators.FindExactOneParameterMethod(argumentType);
+        var candidates = new[] { exact }
+            .Concat(distractors.Where(m => !MethodIdentityComparer.Instance.Equals(m, exact)))
+            .Distinct(MethodIdentityComparer.Instance)
+            .ToArray();
+        var result = OverloadResolution.Resolve(candidates, [argumentType]);
+
+        return result.Outcome == OverloadResolution.ResolutionOutcome.Resolved
+            && MethodIdentityComparer.Instance.Equals(exact, result.Best);
+    }
+
+    /// <summary>
+    /// Numeric better-conversion ordering is antisymmetric and drives overload choice.
+    /// </summary>
+    /// <param name="scenario">The generated numeric-betterness scenario.</param>
+    /// <returns><see langword="true"/> when the expected numeric target resolves.</returns>
+    [Property(MaxTest = 300, Arbitrary = [typeof(OverloadResolutionGenerators)])]
+    public bool Numeric_betterness_is_antisymmetric_and_selects_expected_candidate(
+        Type source,
+        int firstIndex,
+        int secondIndex)
+    {
+        if (!OverloadResolutionGenerators.IsNumericOrChar(source))
+        {
+            return true;
+        }
+
+        var methods = OverloadResolutionGenerators.FindNumericOneParameterMethods();
+        var first = methods[PositiveModulo(firstIndex, methods.Length)];
+        var second = methods[PositiveModulo(secondIndex, methods.Length)];
+        if (MethodIdentityComparer.Instance.Equals(first, second))
+        {
+            return true;
+        }
+
+        var firstTarget = first.GetParameters()[0].ParameterType;
+        var secondTarget = second.GetParameters()[0].ParameterType;
+        var firstClassification = OverloadResolution.ClassifyImplicit(firstTarget, source);
+        var secondClassification = OverloadResolution.ClassifyImplicit(secondTarget, source);
+        if (firstClassification == OverloadResolution.ImplicitConversionKind.None
+            || secondClassification == OverloadResolution.ImplicitConversionKind.None)
+        {
+            return true;
+        }
+
+        var comparison = OverloadResolutionGenerators.CompareExpected(
+            firstClassification,
+            firstTarget,
+            secondClassification,
+            secondTarget,
+            source);
+        if (comparison == 0)
+        {
+            return true;
+        }
+
+        var expected = comparison < 0 ? first : second;
+        var forward = OverloadResolution.CompareNumericTargets(firstTarget, secondTarget, source);
+        var reverse = OverloadResolution.CompareNumericTargets(secondTarget, firstTarget, source);
+        if (forward != -reverse)
+        {
+            return false;
+        }
+
+        var result = OverloadResolution.Resolve(new[] { first, second }, [source]);
+        return result.Outcome == OverloadResolution.ResolutionOutcome.Resolved
+            && MethodIdentityComparer.Instance.Equals(expected, result.Best);
+    }
+
+    private static int PositiveModulo(int value, int modulus)
+        => (int)(((long)value - int.MinValue) % modulus);
+
+    private static bool Contains(MethodInfo[] candidates, MethodInfo method)
+        => candidates.Any(candidate => MethodIdentityComparer.Instance.Equals(candidate, method));
+}

--- a/test/Core.Tests/Core.Tests.csproj
+++ b/test/Core.Tests/Core.Tests.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FsCheck.Xunit" Version="3.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="@(GsharpCore)" />
   </ItemGroup>
 


### PR DESCRIPTION
Closes #1373

Adds FsCheck coverage for overload-resolution determinism, outcome payload invariants, returned-candidate provenance, exact-match preference, and numeric better-conversion selection.