### PR TITLE
Fix GS0159 for default arg to imported generic method with explicit type arg

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -592,7 +592,25 @@ internal sealed class ConversionClassifier
             if (paramIndex < parameters.Length)
             {
                 var parameterType = parameters[paramIndex].ParameterType;
-                if (!parameterType.IsByRef && argument.Type != TypeSymbol.Error)
+
+                // Issue #1391: an untyped `default` literal (bound as a
+                // BoundDefaultExpression with the Error sentinel type) survives
+                // overload resolution against an imported method via the
+                // DefaultLiteralArgumentType wildcard. Materialize it here at the
+                // resolved (substituted) parameter type so the emitter lowers it
+                // to the correct typed default — `default(int32)` = 0 for
+                // `Task.FromResult[int32](default)` — instead of leaking an
+                // Error-typed default that produces invalid IL.
+                if (!parameterType.IsByRef && argument is BoundDefaultExpression { Type: var defType } && defType == TypeSymbol.Error)
+                {
+                    var defSubstituted = TrySubstituteParameterTypeFromReceiver(method, paramIndex, receiverType);
+                    var defTargetType = defSubstituted ?? TypeSymbol.FromClrType(parameterType);
+                    if (defTargetType != null && defTargetType != TypeSymbol.Error)
+                    {
+                        rebound = new BoundDefaultExpression(argument.Syntax, defTargetType);
+                    }
+                }
+                else if (!parameterType.IsByRef && argument.Type != TypeSymbol.Error)
                 {
                     // ADR-0087 §3 R5 / issue #765: when the call dispatches
                     // through a constructed CLR generic whose type arguments

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
@@ -230,6 +230,22 @@ internal static class OverloadResolution
 #pragma warning restore SA1201
 
     /// <summary>
+    /// Issue #1391: sentinel argument type representing the untyped <c>default</c>
+    /// literal whose concrete type is supplied by the chosen parameter. The bare
+    /// <c>default</c> is implicitly convertible to <em>any</em> type (its value is
+    /// the zero/null of whatever parameter type it lands on), so during overload
+    /// resolution against an imported (CLR) method it must classify as applicable
+    /// to every (non-by-ref) parameter — mirroring the user-defined generic method
+    /// path, which already accepts <c>default</c>. Using a dedicated marker keeps
+    /// the literal neutral during betterness ranking (always an identity
+    /// conversion) while the concrete-typed default is materialized by
+    /// <c>BindClrParameterConversions</c> against the resolved parameter type.
+    /// </summary>
+#pragma warning disable SA1201 // Elements should appear in the correct order
+    public static readonly Type DefaultLiteralArgumentType = typeof(DefaultLiteralArgumentMarker);
+#pragma warning restore SA1201
+
+    /// <summary>
     /// Issue #658: per-call supplementary interface check for user-defined G#
     /// classes whose CLR type does not exist at bind time. When set (non-null),
     /// <see cref="ClassifyImplicit"/> invokes this callback as a final
@@ -286,6 +302,17 @@ internal static class OverloadResolution
         if (ReferenceEquals(source, InlineOutVarArgumentType))
         {
             return target.IsByRef ? ImplicitConversionKind.Identity : ImplicitConversionKind.None;
+        }
+
+        // Issue #1391: the untyped `default` literal is implicitly convertible to
+        // any (non-by-ref) parameter type — its value is the zero/null of whatever
+        // type it lands on. Classify it as an identity conversion so an imported
+        // generic method invoked with an explicit type argument (e.g.
+        // `Task.FromResult[int32](default)`) stays applicable; the concrete-typed
+        // default is materialized against the resolved parameter after selection.
+        if (ReferenceEquals(source, DefaultLiteralArgumentType))
+        {
+            return target.IsByRef ? ImplicitConversionKind.None : ImplicitConversionKind.Identity;
         }
 
         // Issue #533: a null source represents the `nil` literal in G#.
@@ -3559,6 +3586,15 @@ internal static class OverloadResolution
     /// arguments during overload resolution. Never instantiated.
     /// </summary>
     private sealed class InlineOutVarArgumentMarker
+    {
+    }
+
+    /// <summary>
+    /// Issue #1391: private marker type whose <see cref="Type"/> identity is used
+    /// as the <see cref="DefaultLiteralArgumentType"/> sentinel for an untyped
+    /// <c>default</c> literal argument during overload resolution. Never instantiated.
+    /// </summary>
+    private sealed class DefaultLiteralArgumentMarker
     {
     }
 }

--- a/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
@@ -187,6 +187,19 @@ public sealed class ImportedClassSymbol : Symbol
         var hasUserClassArg = false;
         for (var i = 0; i < arguments.Length; i++)
         {
+            // Issue #1391: the untyped `default` literal (bound as a
+            // BoundDefaultExpression whose type is the Error sentinel until a
+            // target type is known) is convertible to any parameter type. Pass
+            // the dedicated overload-resolution sentinel so it stays applicable
+            // against an imported generic method closed over an explicit type
+            // argument; the concrete-typed default is materialized downstream by
+            // BindClrParameterConversions against the resolved parameter type.
+            if (arguments[i] is BoundDefaultExpression { Type: var defType } && defType == TypeSymbol.Error)
+            {
+                argTypes[i] = OverloadResolution.DefaultLiteralArgumentType;
+                continue;
+            }
+
             // Issue #530: use effective CLR type so nullable value types
             // (e.g. int32?) are matched as Nullable<T> in overload resolution.
             // Issue #533: allow null (nil literal) through; overload resolution

--- a/test/Compiler.Tests/Emit/Issue1391DefaultArgImportedGenericEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1391DefaultArgImportedGenericEmitTests.cs
@@ -1,0 +1,142 @@
+// <copyright file="Issue1391DefaultArgImportedGenericEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1391: passing the untyped <c>default</c> literal to an IMPORTED (CLR)
+/// generic method invoked with an explicit type argument — e.g.
+/// <c>Task.FromResult[int32](default)</c> — must compile AND lower the argument
+/// to the proper default value of the SUBSTITUTED parameter type
+/// (<c>default(int32)</c> = 0, <c>default(string)</c> = null,
+/// <c>default(bool)</c> = false). Before the fix the call failed overload
+/// resolution (GS0159); these tests round-trip gsc → PE → ilverify → dotnet exec
+/// to prove a valid, correctly-typed default is emitted.
+/// </summary>
+public class Issue1391DefaultArgImportedGenericEmitTests
+{
+    [Fact]
+    public void ImportedGenericDefault_PrimitiveTypeArg_ProducesZero()
+    {
+        var source = """
+            package P
+            import System
+            import System.Threading.Tasks
+
+            func R() Task[int32] { return Task.FromResult[int32](default) }
+
+            var t = R()
+            Console.WriteLine(t.Result)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("0\n", output);
+    }
+
+    [Fact]
+    public void ImportedGenericDefault_ReferenceTypeArg_ProducesNull()
+    {
+        var source = """
+            package P
+            import System
+            import System.Threading.Tasks
+
+            func R() Task[string] { return Task.FromResult[string](default) }
+
+            var t = R()
+            Console.WriteLine(t.Result == nil)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\n", output);
+    }
+
+    [Fact]
+    public void ImportedGenericDefault_BoolTypeArg_ProducesFalse()
+    {
+        var source = """
+            package P
+            import System
+            import System.Threading.Tasks
+
+            func R() Task[bool] { return Task.FromResult[bool](default) }
+
+            var t = R()
+            Console.WriteLine(t.Result)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("False\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1391_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi);
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1391DefaultArgImportedGenericTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1391DefaultArgImportedGenericTests.cs
@@ -1,0 +1,126 @@
+// <copyright file="Issue1391DefaultArgImportedGenericTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Regression tests for issue #1391: passing the untyped <c>default</c> literal
+/// as an argument to an IMPORTED (CLR) generic method invoked with an explicit
+/// type argument — e.g. <c>Task.FromResult[int32](default)</c> — must bind. The
+/// bare <c>default</c> is bound with the <see cref="TypeSymbol.Error"/> sentinel
+/// type until a target is known, and the imported overload-resolution path
+/// previously discarded the candidate (no effective CLR type for the argument),
+/// reporting GS0159 "Cannot find function". The user-defined generic method path
+/// already accepted <c>default</c>, so the defect was specific to applicability
+/// of imported generic methods against an untyped <c>default</c> argument.
+/// </summary>
+public class Issue1391DefaultArgImportedGenericTests
+{
+    private static ReferenceResolver MetadataLoadContextResolver()
+    {
+        var paths = new[]
+        {
+            typeof(object).Assembly.Location,
+            typeof(System.Array).Assembly.Location,
+            typeof(System.Threading.Tasks.Task).Assembly.Location,
+            typeof(System.Console).Assembly.Location,
+        }
+        .Where(p => !string.IsNullOrEmpty(p))
+        .Distinct(StringComparer.OrdinalIgnoreCase)
+        .ToArray();
+
+        return ReferenceResolver.WithReferences(paths);
+    }
+
+    private static ImmutableArray<Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var globalScope = Binder.BindGlobalScope(
+            previous: null,
+            ImmutableArray.Create(tree),
+            MetadataLoadContextResolver());
+        var program = Binder.BindProgram(globalScope, MetadataLoadContextResolver());
+        return globalScope.Diagnostics.AddRange(program.Diagnostics);
+    }
+
+    [Fact]
+    public void TaskFromResult_With_PrimitiveTypeArg_And_DefaultArg_Binds()
+    {
+        var source = """
+            package p
+            import System.Threading.Tasks
+
+            class C { func A() Task[int32] -> Task.FromResult[int32](default) }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void TaskFromResult_With_TypeParameterTypeArg_And_DefaultArg_Binds()
+    {
+        // The real-world shape: an in-scope generic type parameter as the
+        // explicit type argument, with a bare `default` argument.
+        var source = """
+            package p
+            import System.Threading.Tasks
+
+            class Box[T] { func Make() Task[T?] -> Task.FromResult[T](default) }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void TaskFromResult_With_ReferenceTypeArg_And_DefaultArg_Binds()
+    {
+        var source = """
+            package p
+            import System.Threading.Tasks
+
+            class C { func A() Task[string] -> Task.FromResult[string](default) }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void TaskFromResult_With_PrimitiveTypeArg_And_ConcreteArg_StillBinds()
+    {
+        // Regression guard: a concrete value argument must continue to bind.
+        var source = """
+            package p
+            import System.Threading.Tasks
+
+            class C { func A() Task[int32] -> Task.FromResult[int32](0) }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void UserGenericMethod_With_DefaultArg_StillBinds()
+    {
+        // Control: the user-defined generic method path that already accepted
+        // `default` must remain unaffected.
+        var source = """
+            package p
+
+            class Box { shared { func Wrap[T](v T) T -> v } }
+            class C { func A() int32 -> Box.Wrap[int32](default) }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+}


### PR DESCRIPTION
Passing the untyped `default` literal to an imported (CLR) generic method
invoked with an explicit type argument — e.g. `Task.FromResult[int32](default)`
— failed overload resolution with GS0159 ("Cannot find function"). The bare
`default` is bound with the `TypeSymbol.Error` sentinel until a target type is
known; the imported overload-resolution path could not derive an effective CLR
type for it and discarded every candidate. User-defined generic methods already
accepted `default`, so the defect was specific to applicability of imported
generic methods against an untyped `default` argument.

## Root cause / fix
- `ImportedClassSymbol.TryLookupFunction` returned false when an argument had no
  effective CLR type and was not the nil literal. A bare `default` hit that path
  and dropped the candidate. Now a `BoundDefaultExpression` with the Error type
  is mapped to a new `OverloadResolution.DefaultLiteralArgumentType` sentinel.
- `OverloadResolution.ClassifyImplicit` classifies that sentinel as an identity
  conversion to any non-by-ref parameter, mirroring `default`'s universal
  convertibility (and the existing inline-out-var sentinel pattern), so the
  candidate stays applicable and neutral during betterness ranking.
- `ConversionClassifier.BindClrParameterConversions` previously skipped
  Error-typed arguments, leaking an untyped default into emit (InvalidProgram).
  It now materializes a bare `default` at the resolved (substituted) parameter
  type so the emitter lowers it to the correct typed default — `default(int32)`
  = 0, `default(string)` = null, `default(bool)` = false.

## Verification
- `dotnet build GSharp.sln -c Release -graph`: 0 Warning(s), 0 Error(s).
- Minimal repro `Task.FromResult[int32](default)` and all controls (concrete
  arg, user generic method `Box.Wrap[int32](default)`, `default` as normal
  arg/initializer, and the `Box[T].Make() -> Task.FromResult[T](default)`
  generic-type variant) compile cleanly.
- Execution confirms the substituted default value at runtime: int32→0,
  string→null, bool→false.
- Tests: Core.Tests Issue1391 5/5, Issue1216 4/4, Default 166/166, Overload
  130/130, Conversion 144/144, Imported 69/69, OutVar 20/20. Compiler.Tests
  Issue1391 emit 3/3, Issue1216 3/3, Default 56/56, Generic 241/241.

## Tests added
- `test/Core.Tests/CodeAnalysis/Binding/Issue1391DefaultArgImportedGenericTests.cs`
- `test/Compiler.Tests/Emit/Issue1391DefaultArgImportedGenericEmitTests.cs`

Nothing deferred.

Fixes #1391
Refs #914
