### PR TITLE
Make generic static receiver resolution arity-aware on name collision (#1395)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -1715,7 +1715,13 @@ internal sealed partial class ExpressionBinder
         // binding the bracket contents as type arguments, so that we never emit
         // spurious type diagnostics for a non-generic-type target.
         var arity = FlattenCommaList(index.Index).Count();
-        var userGenericDef = scope.TryLookupTypeAlias(name, out var alias)
+
+        // Issue #1395: when a non-generic (arity-0) type and a generic type
+        // share the same simple name (arity overloading, e.g. `Box` and
+        // `Box[T]`), the arity-unaware lookup prefers the arity-0 type and the
+        // generic receiver fails to resolve. Disambiguate using the bracketed
+        // type-argument count so `Box[int32]` selects the arity-1 `Box[T]`.
+        var userGenericDef = scope.TryLookupTypeAlias(name, preferredArity: arity, out var alias)
             && ((alias is StructSymbol sDef && sDef.IsGenericDefinition && sDef.TypeParameters.Length == arity)
                 || (alias is InterfaceSymbol iDef && iDef.IsGenericDefinition && iDef.TypeParameters.Length == arity));
         Type openClrType = null;
@@ -1790,7 +1796,12 @@ internal sealed partial class ExpressionBinder
 
         var argClauses = generic.TypeArgumentList.Arguments;
         var arity = argClauses.Count;
-        var userGenericDef = scope.TryLookupTypeAlias(name, out var alias)
+
+        // Issue #1395: same arity-collision disambiguation as the
+        // index-expression overload — select the same-name type whose generic
+        // arity matches the supplied type-argument count so `Box[int32]`
+        // resolves to `Box[T]` rather than the non-generic `Box`.
+        var userGenericDef = scope.TryLookupTypeAlias(name, preferredArity: arity, out var alias)
             && ((alias is StructSymbol sDef && sDef.IsGenericDefinition && sDef.TypeParameters.Length == arity)
                 || (alias is InterfaceSymbol iDef && iDef.IsGenericDefinition && iDef.TypeParameters.Length == arity));
         Type openClrType = null;

--- a/test/Compiler.Tests/Emit/Issue1395ArityCollisionStaticReceiverEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1395ArityCollisionStaticReceiverEmitTests.cs
@@ -1,0 +1,154 @@
+// <copyright file="Issue1395ArityCollisionStaticReceiverEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1395: when a non-generic (arity-0) type and a generic type share the
+/// same simple name (arity overloading, e.g. <c>Box</c> and <c>Box[T]</c>), a
+/// generic static member-access receiver <c>Box[int32].Make(...)</c> must
+/// resolve the receiver to the arity-1 generic type — selected by the supplied
+/// type-argument count — while a plain <c>Box.Make()</c> still resolves to the
+/// non-generic type. These end-to-end tests round-trip gsc → PE → dotnet exec
+/// (with IL verification) proving both same-name static call sites emit the
+/// correct, distinct constructions.
+/// </summary>
+public class Issue1395ArityCollisionStaticReceiverEmitTests
+{
+    [Fact]
+    public void ArityCollision_GenericAndNonGenericStaticCalls_Execute()
+    {
+        // `Box` (arity-0) and `Box[T]` (arity-1) share a simple name. The
+        // generic receiver `Box[int32].Make(7)` must bind to `Box[T]` and the
+        // non-generic `Box.Make()` to `Box`, each carrying its own value.
+        var source = """
+            package P
+            import System
+
+            class Box {
+                var tag int32
+                init() { tag = -1 }
+                shared { func Make() Box -> Box() }
+            }
+
+            class Box[T] {
+                var value T
+                init(v T) { value = v }
+                shared { func Make(v T) Box[T] -> Box[T](v) }
+            }
+
+            func Run() int32 {
+                let generic = Box[int32].Make(7)
+                let nonGeneric = Box.Make()
+                return generic.value + nonGeneric.tag
+            }
+
+            Console.WriteLine(Run())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("6\n", output);
+    }
+
+    [Fact]
+    public void ArityCollision_NullableTypeArg_Executes()
+    {
+        // The generic type argument is nullable (`Box[int32?]`); the receiver
+        // must still resolve to the arity-1 generic construction.
+        var source = """
+            package P
+            import System
+
+            class Box {
+                shared { func Tag() int32 -> 100 }
+            }
+
+            class Box[T] {
+                var value T
+                init(v T) { value = v }
+                shared { func Make(v T) Box[T] -> Box[T](v) }
+            }
+
+            func Run() int32 {
+                let g = Box[int32?].Make(41)
+                return (g.value ?? 0) + Box.Tag()
+            }
+
+            Console.WriteLine(Run())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("141\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1395_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi);
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1395ArityCollisionStaticReceiverTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1395ArityCollisionStaticReceiverTests.cs
@@ -1,0 +1,103 @@
+// <copyright file="Issue1395ArityCollisionStaticReceiverTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1395: when a non-generic (arity-0) type and a generic type share the
+/// same simple name (arity overloading, e.g. <c>Box</c> and <c>Box[T]</c>,
+/// mirroring BCL <c>Task</c>/<c>Task&lt;T&gt;</c>), a generic static
+/// member-access receiver <c>Name[TypeArg].StaticMember(...)</c> must resolve
+/// the receiver to the arity-N generic type — selected by the supplied
+/// type-argument count — rather than the arity-0 type. Before the fix the
+/// arity-unaware type lookup preferred the non-generic type, so the generic
+/// type's static member could not be found (GS0125 / GS0159). This is the
+/// arity-collision counterpart to #1323 (generic static receiver binding) and
+/// #1379 (return-type substitution), both of which assumed a single same-name
+/// type.
+/// </summary>
+public class Issue1395ArityCollisionStaticReceiverTests
+{
+    [Fact]
+    public void ReproB_MinimalArityCollision_BindsWithoutDiagnostics()
+    {
+        const string source = @"
+package p
+class Box { shared { func Make() Box -> Box() } }
+class Box[T] { let v T?  shared { func Make(v T) Box[T] -> Box[T]() } }
+class C { func F() Box[int32] { return Box[int32].Make(5) } }
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void ReproA_ArityCollisionWithInheritance_BindsWithoutDiagnostics()
+    {
+        const string source = @"
+package p
+import System.Threading
+import System.Threading.Tasks
+
+class Mp4File {}
+class ChapterInfo {}
+
+open class Op {
+    protected init(mp4File Mp4File?) {}
+    shared { func FromCompleted(mp4File Mp4File?) Op -> Op(mp4File) }
+}
+
+open class Op[TOutput] : Op {
+    init(mp4File Mp4File, result TOutput) : base(mp4File) {}
+    shared { func FromCompleted(mp4File Mp4File, result TOutput) Op[TOutput] -> Op[TOutput](mp4File, result) }
+}
+
+class Caller {
+    func Get() Op[ChapterInfo?] {
+        return Op[ChapterInfo?].FromCompleted(Mp4File(), nil)
+    }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void NullableTypeArg_ArityCollision_BindsWithoutDiagnostics()
+    {
+        const string source = @"
+package p
+class Box { shared { func Make() Box -> Box() } }
+class Box[T] { let v T?  shared { func Make(v T) Box[T] -> Box[T]() } }
+class C { func F() Box[int32?] { return Box[int32?].Make(5) } }
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void NonGenericSameNameStaticCall_StillBindsWithoutDiagnostics()
+    {
+        const string source = @"
+package p
+class Box { shared { func Make() Box -> Box() } }
+class Box[T] { let v T?  shared { func Make(v T) Box[T] -> Box[T]() } }
+class C { func F() Box { return Box.Make() } }
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    private static IReadOnlyList<Diagnostic> GetDiagnostics(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree) { IsLibrary = true };
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return result.Diagnostics;
+    }
+}


### PR DESCRIPTION
## Problem

When a non-generic (arity-0) type and a generic type share the same simple name (arity overloading — e.g. `Box` and `Box[T]`, exactly like BCL `Task`/`Task<T>`), a **generic static member-access** `Name[TypeArg].StaticMember(...)` resolved its receiver to the **non-generic** (arity-0) type instead of the arity-1 generic type. The generic type's static member was then not found:

```
arity2.gs(4,..): error GS0125: Variable 'Box' doesn't exist.
arity2.gs(4,..): error GS0159: Cannot find function Make.
```

(The receiver `Box[int32]` was bound to the non-generic `Box`, so `[int32]` was mis-bound as indexing a value named `Box`, then `.Make` was not found. The inheritance variant produced GS0124 / GS0159.)

## Root cause

Both `TryResolveConstructedGenericTypeReceiver` overloads in `src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs` (the `IndexExpressionSyntax` form for `Box[int32]` and the `GenericNameExpressionSyntax` form for `Box[int32?]` etc.) looked the receiver name up via the **arity-unaware** `scope.TryLookupTypeAlias(name, out alias)`, which prefers the arity-0 type. On a name collision the arity-0 `Box` was returned, failed the `IsGenericDefinition`/arity check, and the receiver fell through to value/variable binding.

## Fix

Pass the supplied bracketed type-argument count as `preferredArity` to the existing `TryLookupTypeAlias(name, preferredArity, out alias)` overload (issue #1051 already provided arity-aware lookup with arity-0 fallback). This selects the same-name type whose generic arity matches the type-argument list (`Box[int32]` → `Box[T]`), while a plain `Box.Make()` still resolves to the non-generic `Box`. Surgical two-line change, one per overload.

This is the arity-collision counterpart to #1323 (generic static receiver binding) and #1379 (return-type substitution), both of which assumed a single same-name type.

## Verification

- `dotnet build GSharp.sln -c Release -graph` → **0 Warning, 0 Error**.
- Repro B (minimal `Box`/`Box[T]`), Repro A (Oahu `Op`/`Op[TOutput]` with inheritance + nullable type arg `Op[ChapterInfo?]`), and the no-collision control all compile with **no diagnostics**.
- Non-generic same-name static call (`Box.Make()`) still resolves alongside `Box[int32].Make(5)`.
- Core.Tests: `Issue1395` 4/4 pass; `Issue1323`/`Issue1379` 15/15 pass; `~Static` 223/223 pass.
- Compiler.Tests Emit (capped at 2 threads): `Issue1395` 2/2 pass; `Issue1323`/`Issue1379` 8/8 pass.

## Tests added

- `test/Core.Tests/CodeAnalysis/Binding/Issue1395ArityCollisionStaticReceiverTests.cs` — Repro A, Repro B, nullable-type-arg variant, and a non-generic same-name static control.
- `test/Compiler.Tests/Emit/Issue1395ArityCollisionStaticReceiverEmitTests.cs` — compiles a `/target:exe` program that calls both the generic `Box[int32].Make(...)` and the non-generic `Box.Make()` and asserts via `IlVerifier.Verify` + execution they produce the right instances/values.

Nothing deferred.

Fixes #1395
Refs #914
