### PR TITLE
Fix interface method group to delegate conversion (#1397)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -2778,6 +2778,20 @@ internal sealed partial class ExpressionBinder
                         return new BoundPropertyAccessExpression(null, receiver, null, ifaceProp);
                     }
 
+                    // Issue #1397: an instance method declared on the static
+                    // interface type (or any user base interface) named in
+                    // method-group position is captured against the bound
+                    // receiver, mirroring the class-receiver path above. The
+                    // emitter dispatches via `ldvirtftn` so the delegate invokes
+                    // the concrete implementation through interface dispatch.
+                    // TypeMemberModel.GetMethods walks SelfAndAllBaseInterfaces
+                    // so an inherited base-interface method binds too.
+                    var ifaceInstanceMethods = TypeMemberModel.GetMethods(ifaceSym, ne.IdentifierToken.Text, MemberQuery.Instance(MemberKinds.Method));
+                    if (TryBuildUserMethodGroup(receiver, ifaceInstanceMethods, out var ifaceUserGroup))
+                    {
+                        return ifaceUserGroup;
+                    }
+
                     // Issue #1181: a user interface that extends an imported/BCL
                     // interface (e.g. `interface IBox : ICollection`) inherits
                     // that interface's properties/fields/methods. Mirror the

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Closures.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Closures.cs
@@ -545,8 +545,11 @@ internal sealed partial class MethodBodyEmitter
             // For an `open` (virtual) instance method, honor virtual
             // dispatch via `ldvirtftn` so an override on a derived
             // receiver is invoked. Non-virtual / sealed methods use
-            // `ldftn` directly.
-            if (methodGroup.Function.IsOpen || methodGroup.Function.IsOverride)
+            // `ldftn` directly. Issue #1397: an interface-typed receiver
+            // must also dispatch via `ldvirtftn` so the delegate invokes
+            // the concrete implementation through interface dispatch.
+            if (methodGroup.Function.IsOpen || methodGroup.Function.IsOverride
+                || methodGroup.Receiver.Type is InterfaceSymbol)
             {
                 this.il.OpCode(ILOpCode.Dup);
                 this.il.OpCode(ILOpCode.Ldvirtftn);

--- a/test/Compiler.Tests/Emit/Issue1397InterfaceMethodGroupEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1397InterfaceMethodGroupEmitTests.cs
@@ -1,0 +1,137 @@
+// <copyright file="Issue1397InterfaceMethodGroupEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1397: a method accessed as a method group on an interface-typed
+/// receiver must lower to a delegate over an interface dispatch so invoking it
+/// reaches the concrete implementation. Emit must be verifiable and the
+/// delegate must invoke through the interface (ldvirtftn), including for a
+/// method inherited from a base interface.
+/// </summary>
+public class Issue1397InterfaceMethodGroupEmitTests
+{
+    [Fact]
+    public void InterfaceMethodGroup_ToDelegate_DispatchesAndRuns()
+    {
+        var source = """
+            package P
+            import System
+
+            interface IReader { func Run(x int32) int32; }
+            class Reader : IReader { func Run(x int32) int32 -> x * 10 }
+
+            func Use(r IReader) int32 {
+                let d (int32) -> int32 = r.Run
+                return d(5)
+            }
+
+            Console.WriteLine(Use(Reader()))
+            """;
+
+        Assert.Equal("50\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void InheritedInterfaceMethodGroup_ToDelegate_DispatchesAndRuns()
+    {
+        var source = """
+            package P
+            import System
+
+            interface IBase { func Run(x int32) int32; }
+            interface IReader : IBase {}
+            class Reader : IReader { func Run(x int32) int32 -> x + 1 }
+
+            func Use(r IReader) int32 {
+                let d (int32) -> int32 = r.Run
+                return d(41)
+            }
+
+            Console.WriteLine(Use(Reader()))
+            """;
+
+        Assert.Equal("42\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1397_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new System.Collections.Generic.List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+
+            // (a) Static verification: the emitted IL must be valid.
+            IlVerifier.Verify(outPath);
+
+            // (b) Dynamic verification: the emitted code must execute.
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1397InterfaceMethodGroupTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1397InterfaceMethodGroupTests.cs
@@ -1,0 +1,82 @@
+// <copyright file="Issue1397InterfaceMethodGroupTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1397: accessing an instance method as a method group (for delegate
+/// conversion, without calling it) on a receiver whose static type is an
+/// interface must bind — just as it does for a class receiver. Member lookup
+/// for an interface CALL already worked; only the method-group path was broken
+/// because it never consulted the interface's member set (including inherited
+/// base-interface members).
+/// </summary>
+public class Issue1397InterfaceMethodGroupTests
+{
+    [Fact]
+    public void InterfaceMethodGroup_ToDelegateLocal_BindsClean()
+    {
+        const string source = """
+            package p
+            interface IReader { func Run(x int32) int32; }
+            class Reader : IReader { func Run(x int32) int32 -> x }
+            class C { func F(reader IReader) { let d (int32) -> int32 = reader.Run } }
+            """;
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void InterfaceMethodGroup_AsDelegateArgument_BindsClean()
+    {
+        const string source = """
+            package p
+            import System.Threading
+            import System.Threading.Tasks
+            interface IReader { func RunAsync(cts CancellationTokenSource) Task; }
+            class Op { init(start async (CancellationTokenSource) -> void) {} }
+            class C { func F(reader IReader) { let op = Op(reader.RunAsync) } }
+            """;
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void InheritedInterfaceMethodGroup_ToDelegateLocal_BindsClean()
+    {
+        const string source = """
+            package p
+            interface IBase { func Run(x int32) int32; }
+            interface IReader : IBase {}
+            class Reader : IReader { func Run(x int32) int32 -> x }
+            class C { func F(reader IReader) { let d (int32) -> int32 = reader.Run } }
+            """;
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void ClassReceiverMethodGroup_StillBindsClean()
+    {
+        const string source = """
+            package p
+            interface IReader { func Run(x int32) int32; }
+            class Reader : IReader { func Run(x int32) int32 -> x }
+            class C { func F(reader Reader) { let d (int32) -> int32 = reader.Run } }
+            """;
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    private static IReadOnlyList<Diagnostic> GetDiagnostics(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.GlobalScope.Diagnostics.ToList();
+    }
+}


### PR DESCRIPTION
Accessing an instance method as a method group (for delegate conversion, without calling it) on a receiver whose static type is an interface failed with `GS0158: Cannot find member`, while the same access on a class receiver and a normal interface call worked.

## Root cause
The interface-receiver branch of member-access binding (`ExpressionBinder.Access.cs`) resolved properties and CLR base-interface method groups, but never consulted the user interface's own/inherited method set — so an interface method group was never built.

## Fix
- Binder: in the `InterfaceSymbol` receiver branch, resolve instance methods via `TypeMemberModel.GetMethods` (walks `SelfAndAllBaseInterfaces`) and build a user method group, mirroring the class-receiver path.
- Emit: `EmitMethodGroup` now dispatches via `ldvirtftn` when the receiver type is an interface, so the delegate reaches the concrete implementation through interface dispatch (and IL is verifiable).

## Verification
- Build: 0 Warning, 0 Error.
- Core.Tests Issue1397: 4/4; MethodGroup 23/23; Interface 251/251.
- Compiler.Tests Issue1397: 2/2; MethodGroup 15/15; Delegate 41/41.
- Repros (minimal, inherited interface, delegate-arg) compile clean; runtime delegate invoked through the interface returns expected values.

Fixes #1397
Refs #914
