### PR TITLE
Fix #1399 nullable function type spelling ((T)->R)?

### DIFF
--- a/docs/adr/0137-nullable-function-type-spelling.md
+++ b/docs/adr/0137-nullable-function-type-spelling.md
@@ -1,0 +1,50 @@
+# ADR-0137: Nullable function type spelling
+
+- **Status**: Accepted
+- **Date**: 2026-06-28
+- **Phase**: Phase 9 — language surface completeness
+- **Related**: ADR-0001 (nullable types `T?`), ADR-0075 (arrow function type clause), issues [#1399](https://github.com/DavidObando/gsharp/issues/1399), [#914](https://github.com/DavidObando/gsharp/issues/914)
+
+## Context
+
+G# uses `T?` for nullable types. Function types already use arrow spelling:
+`(T) -> R`. That makes `(T) -> R?` naturally read as a function whose return
+value is nullable.
+
+Issue #1399 exposed an ambiguity for nullable function values. A previous fix made
+`(T) -> void?` a void-only special case for a nullable delegate, but that conflicts
+with the general rule that `?` after `R` belongs to the return type. It also does
+not scale to non-void returns such as `(T) -> int32?`.
+
+## Decision
+
+Use parentheses to put `?` on the function type itself:
+
+- `(T) -> R?` means a non-null function returning `R?`.
+- `((T) -> R)?` means a nullable function returning `R`.
+- `((T) -> R?)?` means a nullable function returning `R?`.
+
+The same rule applies to async function type clauses: `async ((T) -> R)?` is a
+nullable async function type, while `async (T) -> R?` has a nullable result.
+
+## Options considered
+
+1. **Keep `(T) -> R?` as nullable function type.** Rejected because it is
+   ambiguous with nullable return types and makes `(T) -> int32?` impossible to
+   read consistently.
+2. **Use `((T) -> R)?`.** Chosen because it follows the existing nullable-type
+   rule: parenthesize the type expression that `?` should apply to.
+3. **Make function/delegate values nullable by default.** Rejected. Delegates stay
+   non-null by default for safety and consistency with G#'s non-null reference
+   model tracked by #914; nullable function slots must be explicit.
+
+## Consequences
+
+The parser accepts a parenthesized arrow function type followed by an optional
+`?`. Binder and emit no longer need a nullable-void special case: nullable
+function slots are represented as `NullableTypeSymbol(FunctionTypeSymbol(...))`,
+and nullable returns remain on `FunctionTypeSymbol.ReturnType`.
+
+Existing code that used `(T) -> void?` intending a nullable delegate must migrate
+to `((T) -> void)?`. Code that meant a nullable return keeps the direct spelling
+`(T) -> R?`.

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -2178,7 +2178,8 @@ public sealed class Binder
             }
 
             var variadicFlags = anyVariadic ? variadicFlagsBuilder.MoveToImmutable() : default;
-            return FunctionTypeSymbol.Get(paramTypes.MoveToImmutable(), variadicFlags, ret ?? TypeSymbol.Void);
+            var functionType = FunctionTypeSymbol.Get(paramTypes.MoveToImmutable(), variadicFlags, ret ?? TypeSymbol.Void);
+            return functionType;
         }
 
         if (syntax.IsTuple)

--- a/src/Core/CodeAnalysis/Symbols/FunctionTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/FunctionTypeSymbol.cs
@@ -175,24 +175,19 @@ public sealed class FunctionTypeSymbol : TypeSymbol
     /// Issue #1049: returns whether a function-type return slot denotes "no
     /// value" for the purpose of selecting <c>System.Action&lt;...&gt;</c> over
     /// <c>System.Func&lt;..., R&gt;</c>. A slot is void when it is
-    /// <see langword="null"/>, <see cref="TypeSymbol.Void"/>, or a
-    /// <see cref="NullableTypeSymbol"/> wrapping <see cref="TypeSymbol.Void"/>.
+    /// <see langword="null"/> or <see cref="TypeSymbol.Void"/>.
     /// </summary>
     /// <remarks>
-    /// A function type cannot be parenthesised in G# (<c>(() -> void)?</c> is a
-    /// parse error), so <c>(Args) -> void?</c> is the only spelling of a
-    /// nullable delegate and binds with a nullable-<c>void</c> return. Its
-    /// underlying return is still <c>void</c>, so it must map to
-    /// <c>System.Action&lt;...&gt;</c>; treating it as a non-void return built
-    /// the illegal <c>System.Func&lt;..., System.Void&gt;</c> instantiation and
-    /// crashed with GS9998.
+    /// Issue #1399 / ADR-0137: <c>(Args) -&gt; void?</c> is a function returning
+    /// nullable <c>void</c> (not a nullable function type). A nullable function
+    /// type is spelled <c>((Args) -&gt; void)?</c>, so this helper must not unwrap
+    /// nullable return slots.
     /// </remarks>
     /// <param name="returnType">The function-type return slot.</param>
-    /// <returns><see langword="true"/> when the (unwrapped) return type is void.</returns>
+    /// <returns><see langword="true"/> when the return type is void.</returns>
     internal static bool IsVoidReturn(TypeSymbol returnType)
     {
-        var underlying = returnType is NullableTypeSymbol nullable ? nullable.UnderlyingType : returnType;
-        return underlying == null || underlying == TypeSymbol.Void;
+        return returnType == null || returnType == TypeSymbol.Void;
     }
 
     private static void AppendIdentityKey(System.Text.StringBuilder builder, TypeSymbol type)

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -3749,6 +3749,11 @@ public class Parser
                 return ParseArrowFunctionTypeClause(asyncModifier: null);
             }
 
+            if (LooksLikeParenthesizedArrowFunctionTypeClauseStart())
+            {
+                return ParseParenthesizedArrowFunctionTypeClause(asyncModifier: null);
+            }
+
             return ParseTupleTypeClause();
         }
 
@@ -4091,6 +4096,11 @@ public class Parser
             return ParseArrowFunctionTypeClause(asyncModifier);
         }
 
+        if (Current.Kind == SyntaxKind.OpenParenthesisToken && LooksLikeParenthesizedArrowFunctionTypeClauseStart())
+        {
+            return ParseParenthesizedArrowFunctionTypeClause(asyncModifier);
+        }
+
         if (Current.Kind != SyntaxKind.SequenceKeyword)
         {
             Diagnostics.ReportAsyncModifierInTypeClauseRequiresSequenceOrFunc(asyncModifier.Location, Current.Kind);
@@ -4270,6 +4280,42 @@ public class Parser
             question);
     }
 
+    private TypeClauseSyntax ParseParenthesizedArrowFunctionTypeClause(SyntaxToken asyncModifier)
+    {
+        // Issue #1399 / ADR-0137: a nullable function type is spelled by
+        // parenthesizing the whole arrow function type, then applying `?`:
+        // `((T) -> R)?`. Without these outer parens, `(T) -> R?` keeps the
+        // nullable marker on the return type.
+        _ = MatchToken(SyntaxKind.OpenParenthesisToken);
+        var inner = ParseArrowFunctionTypeClause(asyncModifier);
+        _ = MatchToken(SyntaxKind.CloseParenthesisToken);
+        var question = Current.Kind == SyntaxKind.QuestionToken ? MatchToken(SyntaxKind.QuestionToken) : null;
+
+        if (inner.AsyncModifier != null)
+        {
+            return TypeClauseSyntax.CreateAsyncArrowFunction(
+                syntaxTree,
+                inner.AsyncModifier,
+                inner.OpenParenToken,
+                inner.FunctionParameterTypes,
+                inner.FunctionParameterEllipsisTokens,
+                inner.CloseParenToken,
+                inner.ArrowToken,
+                inner.ReturnTypeClause,
+                question);
+        }
+
+        return TypeClauseSyntax.CreateArrowFunction(
+            syntaxTree,
+            inner.OpenParenToken,
+            inner.FunctionParameterTypes,
+            inner.FunctionParameterEllipsisTokens,
+            inner.CloseParenToken,
+            inner.ArrowToken,
+            inner.ReturnTypeClause,
+            question);
+    }
+
     /// <summary>
     /// ADR-0095 / issue #761: parses the raw function-pointer type clause
     /// <c>unmanaged[CC] (T1, T2, ...) -&gt; R</c>. The leading
@@ -4384,7 +4430,19 @@ public class Parser
     // shape of the parenthesised list to decide which grammar to apply.
     private bool LooksLikeArrowFunctionTypeClauseStart()
     {
-        if (Current.Kind != SyntaxKind.OpenParenthesisToken)
+        return LooksLikeArrowFunctionTypeClauseStart(0);
+    }
+
+    private bool LooksLikeParenthesizedArrowFunctionTypeClauseStart()
+    {
+        return Current.Kind == SyntaxKind.OpenParenthesisToken
+            && Peek(1).Kind == SyntaxKind.OpenParenthesisToken
+            && LooksLikeArrowFunctionTypeClauseStart(1);
+    }
+
+    private bool LooksLikeArrowFunctionTypeClauseStart(int startOffset)
+    {
+        if (Peek(startOffset).Kind != SyntaxKind.OpenParenthesisToken)
         {
             return false;
         }
@@ -4392,7 +4450,7 @@ public class Parser
         var parenDepth = 1;
         var bracketDepth = 0;
         var braceDepth = 0;
-        var offset = 1;
+        var offset = startOffset + 1;
         const int maxScan = 4096;
         while (offset < maxScan)
         {

--- a/test/Compiler.Tests/Emit/Issue1049NullableVoidDelegateEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1049NullableVoidDelegateEmitTests.cs
@@ -13,11 +13,11 @@ namespace GSharp.Compiler.Tests.Emit;
 
 /// <summary>
 /// Issue #1049: emitting a nullable function (delegate) type whose return type
-/// is <c>void</c> — e.g. <c>(Args) -> void?</c> — crashed the compiler with
+/// is <c>void</c> — e.g. <c>((Args) -> void)?</c> — crashed the compiler with
 /// <c>GS9998: ArgumentException: The type 'System.Void' may not be used as a
-/// type argument</c>. A function type cannot be parenthesised in G#
-/// (<c>(() -> void)?</c> is a parse error), so <c>(Args) -> void?</c> is the
-/// only way to spell a nullable delegate; its underlying return is still
+/// type argument</c>. Issue #1399 / ADR-0137 makes nullable function types use
+/// parenthesized spelling, so <c>(Args) -> void?</c> remains a nullable return
+/// and <c>((Args) -> void)?</c> is the nullable delegate. Its underlying return is still
 /// <c>void</c>, so it must map to <c>System.Action&lt;...&gt;</c> rather than
 /// the illegal <c>System.Func&lt;..., System.Void&gt;</c>.
 /// </summary>
@@ -29,7 +29,7 @@ public class Issue1049NullableVoidDelegateEmitTests
         var asm = LoadCompiled("""
             package p
             class C {
-                var f () -> void?
+                var f (() -> void)?
             }
             """);
 
@@ -43,7 +43,7 @@ public class Issue1049NullableVoidDelegateEmitTests
         var asm = LoadCompiled("""
             package p
             class C {
-                var g (int32) -> void?
+                var g ((int32) -> void)?
             }
             """);
 

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue715ArrowFunctionTypeClauseBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue715ArrowFunctionTypeClauseBinderTests.cs
@@ -169,6 +169,58 @@ greet()
         Assert.Equal(1, result.Value);
     }
 
+    [Fact]
+    public void ParenthesizedNullableArrowFunctionType_AcceptsMethodGroupAndNil()
+    {
+        var result = Evaluate(@"
+func cb(a int32) { }
+let h ((int32) -> void)? = cb
+let n ((int32) -> void)? = nil
+let ah async ((int32) -> void)? = async func(a int32) { }
+let an async ((int32) -> void)? = nil
+1
+");
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal(1, result.Value);
+    }
+
+    [Fact]
+    public void NonNullableArrowFunctionType_RejectsNil()
+    {
+        var result = Evaluate(@"
+func cb(a int32) { }
+let h (int32) -> void = cb
+let n (int32) -> void = nil
+1
+");
+        Assert.Contains(result.Diagnostics, d => d.IsError && d.Id == "GS0155");
+    }
+
+    [Fact]
+    public void NullableReturnArrowFunctionType_NonVoidAndAsyncForms_StillWork()
+    {
+        var result = Evaluate(@"
+func maybe(a int32) int32? { return a + 1 }
+let h (int32) -> int32? = maybe
+let v int32? = h(41)
+let ah async (int32) -> int32? = async func(a int32) int32? { return a + 1 }
+v!!
+");
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void ParenthesizedNullableArrowFunctionType_NonVoid_AcceptsNil()
+    {
+        var result = Evaluate(@"
+let n ((int32) -> int32)? = nil
+1
+");
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal(1, result.Value);
+    }
+
     private static EvaluationResult Evaluate(string source)
     {
         var syntaxTree = SyntaxTree.Parse(SourceText.From(source));

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue715ArrowFunctionTypeClauseEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue715ArrowFunctionTypeClauseEmitTests.cs
@@ -280,6 +280,89 @@ func runEach(cb func(int32) int32) {
         Assert.Single(warnings);
     }
 
+    [Fact]
+    public void ParenthesizedNullableArrowFunctionType_OnProperty_AcceptsMethodGroupAndNil()
+    {
+        const string Source = @"package Issue1399NullableFunctionProperty
+
+class Args { }
+
+class C {
+    prop H ((Args) -> void)?
+
+    func cb(a Args) { }
+
+    func F() { H = cb }
+
+    func G() { H = nil }
+}
+";
+        var (asm, ctx) = CompileToAssembly(Source, nameof(ParenthesizedNullableArrowFunctionType_OnProperty_AcceptsMethodGroupAndNil));
+        try
+        {
+            var c = asm.GetTypes().Single(t => t.Name == "C");
+            var h = c.GetProperty("H", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(h);
+            Assert.Equal(typeof(System.Action<>).Name, h!.PropertyType.GetGenericTypeDefinition().Name);
+        }
+        finally
+        {
+            ctx.Unload();
+        }
+    }
+
+    [Fact]
+    public void NullableReturnArrowFunctionType_OnProperty_EmitsFuncDelegate()
+    {
+        const string Source = @"package Issue1399NullableReturnFunctionProperty
+
+class C {
+    prop H (int32) -> int32?
+
+    func maybe(a int32) int32? { return a + 1 }
+
+    func F() { H = maybe }
+}
+";
+        var (asm, ctx) = CompileToAssembly(Source, nameof(NullableReturnArrowFunctionType_OnProperty_EmitsFuncDelegate));
+        try
+        {
+            var c = asm.GetTypes().Single(t => t.Name == "C");
+            var h = c.GetProperty("H", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(h);
+            Assert.Equal(typeof(System.Func<,>).Name, h!.PropertyType.GetGenericTypeDefinition().Name);
+        }
+        finally
+        {
+            ctx.Unload();
+        }
+    }
+
+    [Fact]
+    public void ParenthesizedNullableArrowFunctionType_NonVoid_OnProperty_AcceptsNil()
+    {
+        const string Source = @"package Issue1399NullableNonVoidFunctionProperty
+
+class C {
+    prop H ((int32) -> int32)?
+
+    func G() { H = nil }
+}
+";
+        var (asm, ctx) = CompileToAssembly(Source, nameof(ParenthesizedNullableArrowFunctionType_NonVoid_OnProperty_AcceptsNil));
+        try
+        {
+            var c = asm.GetTypes().Single(t => t.Name == "C");
+            var h = c.GetProperty("H", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(h);
+            Assert.Equal(typeof(System.Func<,>).Name, h!.PropertyType.GetGenericTypeDefinition().Name);
+        }
+        finally
+        {
+            ctx.Unload();
+        }
+    }
+
     private static MethodInfo GetProgramMethod(Assembly asm, string name)
     {
         var programType = asm.GetTypes().FirstOrDefault(t => t.Name == "<Program>");

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue715ArrowFunctionTypeClauseParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue715ArrowFunctionTypeClauseParserTests.cs
@@ -121,6 +121,53 @@ public class Issue715ArrowFunctionTypeClauseParserTests
     }
 
     [Fact]
+    public void Parses_ParenthesizedArrowFunctionType_AsNullableFunctionType()
+    {
+        const string source = """
+            package P
+            var cb ((int32) -> void)? = nil
+            """;
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var clause = FindAll<TypeClauseSyntax>(tree).First(t => t.IsArrowFunction);
+        Assert.True(clause.IsNullable);
+        Assert.Single(clause.FunctionParameterTypes);
+        Assert.Equal("void", clause.ReturnTypeClause.Identifier.Text);
+    }
+
+    [Fact]
+    public void Parses_ParenthesizedAsyncArrowFunctionType_AsNullableFunctionType()
+    {
+        const string source = """
+            package P
+            var cb async ((int32) -> int32)? = nil
+            """;
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var clause = FindAll<TypeClauseSyntax>(tree).First(t => t.IsArrowFunction);
+        Assert.True(clause.IsNullable);
+        Assert.NotNull(clause.AsyncModifier);
+        Assert.Equal("int32", clause.ReturnTypeClause.Identifier.Text);
+    }
+
+    [Fact]
+    public void Parses_NullableReturnArrowFunctionType_WithoutNullableFunctionType()
+    {
+        const string source = """
+            package P
+            var cb (int32) -> int32? = nil
+            """;
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var clause = FindAll<TypeClauseSyntax>(tree).First(t => t.IsArrowFunction);
+        Assert.False(clause.IsNullable);
+        Assert.True(clause.ReturnTypeClause.IsNullable);
+    }
+
+    [Fact]
     public void Parses_ArrowFunctionType_InParameterPosition()
     {
         const string source = """

--- a/website/docs/ref/spec.md
+++ b/website/docs/ref/spec.md
@@ -311,7 +311,7 @@ Console.WriteLine(len(nums))     // 4
 
 ### Function types
 
-Function types are written `(T1, T2) -> R` (ADR-0075) — fully-parenthesized parameter type list, a single `->` arrow, then a return type clause. A void-returning function uses `void` as the return type: `(T1, T2) -> void`. Multi-return shapes use a tuple return type: `() -> (T1, T2)`. Async function type clauses are written `async (T) -> R`; they represent functions returning `Task<R>` or `Task` for no result. G# function values can convert to compatible CLR delegate types. The legacy `func(T1, T2) R` and `async func(T) R` type-clause spellings continue to parse for one release; each occurrence emits a `GS0303` deprecation warning.
+Function types are written `(T1, T2) -> R` (ADR-0075) — fully-parenthesized parameter type list, a single `->` arrow, then a return type clause. A void-returning function uses `void` as the return type: `(T1, T2) -> void`. Multi-return shapes use a tuple return type: `() -> (T1, T2)`. A nullable return is written on the return type, so `(T) -> R?` is a non-null function returning `R?`. A nullable function type must parenthesize the whole function type before `?`: `((T) -> R)?`; both can combine as `((T) -> R?)?` (ADR-0137). Async function type clauses are written `async (T) -> R`; nullable async function types use the same outer parentheses, `async ((T) -> R)?`. G# function values can convert to compatible CLR delegate types. The legacy `func(T1, T2) R` and `async func(T) R` type-clause spellings continue to parse for one release; each occurrence emits a `GS0303` deprecation warning.
 
 ### Structs, classes, data classes/structs, and inline value classes
 
@@ -1443,8 +1443,10 @@ InterfaceSharedMember ::= 'private'? 'func' identifier TypeParamList? '(' Parame
 TypeClause        ::= identifier ('.' identifier)* TypeArgList? '?'?
                     | '[' Number? ']' identifier ('.' identifier)* '?'?
                     | '(' TypeClause (',' TypeClause)+ ')' '?'?                          (* tuple type *)
-                    | '(' FnTypeParamList? ')' '->' TypeClause '?'?                       (* arrow function type, ADR-0075 *)
-                    | 'async' '(' FnTypeParamList? ')' '->' TypeClause '?'?
+                    | '(' FnTypeParamList? ')' '->' TypeClause                            (* arrow function type, ADR-0075; `?` in TypeClause is return nullability *)
+                    | '(' '(' FnTypeParamList? ')' '->' TypeClause ')' '?'?               (* parenthesized arrow function type, ADR-0137 *)
+                    | 'async' '(' FnTypeParamList? ')' '->' TypeClause
+                    | 'async' '(' '(' FnTypeParamList? ')' '->' TypeClause ')' '?'?       (* parenthesized async arrow function type, ADR-0137 *)
                     | 'map' '[' TypeClause ',' TypeClause ']' '?'?                        (* canonical, ADR-0104 *)
                     | 'map' '[' TypeClause ']' TypeClause '?'?                            (* legacy; GS0366 *)
                     | 'chan' TypeClause '?'?


### PR DESCRIPTION
## Summary
- Parse parenthesized arrow function types so `((T) -> R)?` denotes a nullable function type
- Revert nullable-void function-type special casing so `(T) -> R?` remains nullable-return
- Document ADR-0137 and update the spec grammar/prose
- Add parser, binder, Core emit, and Compiler emit coverage for the new spelling

## Validation
- `dotnet build GSharp.sln -c Release -graph --no-restore`
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release --no-build`
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Release --no-build --filter Issue1049NullableVoidDelegateEmitTests -- xUnit.MaxParallelThreads=2`
- `dotnet out/bin/Release/Compiler/gsc.dll build/repro-1399.gs /target:library /out:build/repro-1399.dll`

Fixes #1399
Refs #914