### PR TITLE
Fix #1401 TypeBuilder generic member refs

### DIFF
--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -22,6 +22,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Reflection.Emit;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
@@ -7332,10 +7333,22 @@ internal sealed class ReflectionMetadataEmitter
         foreach (var candidate in open.GetMethods(
             BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic))
         {
-            if (candidate.MetadataToken == method.MetadataToken && candidate.Module == method.Module)
+            if (SameMetadataDefinition(candidate, method))
             {
                 return candidate;
             }
+        }
+
+        var parameters = method.GetParameters();
+        var fallback = open.GetMethods(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
+            .FirstOrDefault(candidate =>
+                candidate.Name == method.Name
+                && candidate.IsStatic == method.IsStatic
+                && candidate.IsGenericMethod == method.IsGenericMethod
+                && candidate.GetParameters().Length == parameters.Length);
+        if (fallback != null)
+        {
+            return fallback;
         }
 
         return method;
@@ -7353,17 +7366,117 @@ internal sealed class ReflectionMetadataEmitter
         foreach (var candidate in open.GetConstructors(
             BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
         {
-            if (candidate.MetadataToken == ctor.MetadataToken && candidate.Module == ctor.Module)
+            if (SameMetadataDefinition(candidate, ctor))
             {
                 return candidate;
             }
         }
 
+        var parameters = ctor.GetParameters();
+        var fallback = open.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+            .FirstOrDefault(candidate => candidate.GetParameters().Length == parameters.Length);
+        if (fallback != null)
+        {
+            return fallback;
+        }
+
         return ctor;
+    }
+
+    private static bool SameMetadataDefinition(MemberInfo candidate, MemberInfo member)
+    {
+        try
+        {
+            return candidate.MetadataToken == member.MetadataToken && candidate.Module == member.Module;
+        }
+        catch (NotSupportedException)
+        {
+            return false;
+        }
+        catch (InvalidOperationException)
+        {
+            return false;
+        }
+    }
+
+    private static bool ContainsTypeBuilderGenericArgument(Type type)
+    {
+        if (type == null)
+        {
+            return false;
+        }
+
+        if (type is TypeBuilder)
+        {
+            return true;
+        }
+
+        if (type.HasElementType)
+        {
+            return ContainsTypeBuilderGenericArgument(type.GetElementType());
+        }
+
+        if (!type.IsGenericType)
+        {
+            return false;
+        }
+
+        try
+        {
+            return type.GetGenericArguments().Any(ContainsTypeBuilderGenericArgument);
+        }
+        catch (NotSupportedException)
+        {
+            return false;
+        }
+    }
+
+    private static MethodInfo ResolveTypeBuilderConstructedGenericMethod(MethodInfo method)
+    {
+        var declaring = method?.DeclaringType;
+        if (!ContainsTypeBuilderGenericArgument(declaring))
+        {
+            return method;
+        }
+
+        var openMethod = GetOpenMethod(method);
+        return openMethod != null && openMethod.DeclaringType?.IsGenericTypeDefinition == true
+            ? TypeBuilder.GetMethod(declaring, openMethod)
+            : method;
+    }
+
+    private static ConstructorInfo ResolveTypeBuilderConstructedGenericCtor(ConstructorInfo ctor)
+    {
+        var declaring = ctor?.DeclaringType;
+        if (!ContainsTypeBuilderGenericArgument(declaring))
+        {
+            return ctor;
+        }
+
+        var openCtor = GetOpenCtor(ctor);
+        return openCtor != null && openCtor.DeclaringType?.IsGenericTypeDefinition == true
+            ? TypeBuilder.GetConstructor(declaring, openCtor)
+            : ctor;
+    }
+
+    private static FieldInfo ResolveTypeBuilderConstructedGenericField(FieldInfo field)
+    {
+        var declaring = field?.DeclaringType;
+        if (!ContainsTypeBuilderGenericArgument(declaring) || declaring == null || !declaring.IsConstructedGenericType)
+        {
+            return field;
+        }
+
+        var openType = declaring.GetGenericTypeDefinition();
+        var openField = openType.GetField(
+            field.Name,
+            BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+        return openField != null ? TypeBuilder.GetField(declaring, openField) : field;
     }
 
     internal MemberReferenceHandle GetMethodReference(MethodInfo method)
     {
+        method = ResolveTypeBuilderConstructedGenericMethod(method);
         if (this.cache.MethodRefs.TryGetValue(method, out var existing))
         {
             return existing;
@@ -7794,7 +7907,7 @@ internal sealed class ReflectionMetadataEmitter
 
         foreach (var candidate in openDefinition.GetMethods(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic))
         {
-            if (candidate.MetadataToken == method.MetadataToken && candidate.Module == method.Module)
+            if (SameMetadataDefinition(candidate, method))
             {
                 return candidate;
             }
@@ -7823,7 +7936,7 @@ internal sealed class ReflectionMetadataEmitter
 
         foreach (var candidate in openDefinition.GetProperties(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic))
         {
-            if (candidate.MetadataToken == property.MetadataToken && candidate.Module == property.Module)
+            if (SameMetadataDefinition(candidate, property))
             {
                 return candidate;
             }
@@ -8020,6 +8133,7 @@ internal sealed class ReflectionMetadataEmitter
     /// <returns>A MemberRef handle for the constructor on the correctly-typed parent.</returns>
     internal MemberReferenceHandle GetCtorReference(ConstructorInfo ctor, TypeSymbol containingTypeSymbol)
     {
+        ctor = ResolveTypeBuilderConstructedGenericCtor(ctor);
         // Issue #671: when the containing type carries symbolic user-type
         // arguments, the cache key needs to discriminate per symbol set
         // (multiple distinct user-type closures share a single type-erased
@@ -8153,7 +8267,7 @@ internal sealed class ReflectionMetadataEmitter
 
         foreach (var candidate in openDefinition.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
         {
-            if (candidate.MetadataToken == ctor.MetadataToken && candidate.Module == ctor.Module)
+            if (SameMetadataDefinition(candidate, ctor))
             {
                 return candidate;
             }
@@ -8267,6 +8381,7 @@ internal sealed class ReflectionMetadataEmitter
     /// </summary>
     internal MemberReferenceHandle GetFieldReference(FieldInfo field)
     {
+        field = ResolveTypeBuilderConstructedGenericField(field);
         if (this.cache.FieldRefs.TryGetValue(field, out var existing))
         {
             return existing;

--- a/test/Compiler.Tests/Emit/Issue1100GenericMemberOnUserTypeArgEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1100GenericMemberOnUserTypeArgEmitTests.cs
@@ -125,6 +125,45 @@ public class Issue1100GenericMemberOnUserTypeArgEmitTests
         Assert.Equal("7\n2\n", CompileAndRun(source));
     }
 
+    [Fact]
+    public void Issue1401_QueueAndListOfUserStructAndClass_EmitAndRun()
+    {
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            data struct StructEntry(Id int32)
+
+            class ClassEntry {
+                var Id int32
+                init(id int32) {
+                    Id = id
+                }
+            }
+
+            class C {
+                let structs Queue[StructEntry] = Queue[StructEntry]()
+                let classes List[ClassEntry] = List[ClassEntry]()
+
+                func run() int32 {
+                    structs.Enqueue(StructEntry{Id: 5})
+                    structs.Enqueue(StructEntry{Id: 6})
+                    classes.Add(ClassEntry(7))
+                    classes.Add(ClassEntry(8))
+
+                    let a = structs.Dequeue()
+                    let b = structs.Dequeue()
+                    return a.Id + b.Id + classes[0].Id + classes[1].Id + structs.Count + classes.Count
+                }
+            }
+
+            Console.WriteLine(C().run())
+            """;
+
+        Assert.Equal("28\n", CompileAndRun(source));
+    }
+
     private static string CompileAndRun(string source)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_issue1100_emit_").FullName;


### PR DESCRIPTION
Fixes #1401.
Refs #914.

## Summary
- Resolve methods/constructors/fields on TypeBuilder-backed generic instantiations through TypeBuilder helper APIs before emitting MemberRefs.
- Add executed Queue/List user struct+class emit coverage.

## Validation
- dotnet build GSharp.sln -c Release -graph
- dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Release --no-build --filter "FullyQualifiedName~Issue1100GenericMemberOnUserTypeArgEmitTests" -- xUnit.MaxParallelThreads=2
- Oahu migrate repro rerun; no GS9998/TypeBuilder member-resolution diagnostics found (current corpus still has unrelated compile errors).
