### PR TITLE
cs2gs: render nullable function type as ((T)->R)? (ADR-0137)

### DIFF
--- a/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
@@ -116,7 +116,15 @@ public static class GSharpPrinter
         }
 
         var rendered = RenderTypeCore(type);
-        return type != null && type.IsNullable ? rendered + "?" : rendered;
+        if (type == null || !type.IsNullable)
+        {
+            return rendered;
+        }
+
+        // A nullable function type must be parenthesized: `((T) -> R)?` (ADR-0137 /
+        // issue #1399). A bare `(T) -> R?` binds `?` to the return type, not the
+        // function type. Every other type spells nullable with a trailing `?`.
+        return type is ArrowTypeReference ? $"({rendered})?" : rendered + "?";
     }
 
     private static string RenderTypeCore(GTypeReference type)

--- a/tools/cs2gs/Cs2Gs.Tests/GoldenTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/GoldenTests.cs
@@ -525,8 +525,34 @@ public class GoldenTests
         AssertGolden(expected, unit);
     }
 
-    /// <summary>§For loops: the C-style three-clause <c>for init; cond; incr { }</c>
-    /// loop with a <c>var</c> init and an increment incrementor.</summary>
+    /// <summary>ADR-0137 / #1399: a nullable function type renders parenthesized
+    /// as <c>((T) -> R)?</c>, not <c>(T) -> R?</c> (which would bind the <c>?</c>
+    /// to the return type). A nullable return still renders <c>(T) -> R?</c>.</summary>
+    [Fact]
+    public void BNullable_FunctionTypeParenthesized()
+    {
+        var unit = new CompilationUnit("Demo", members: Nodes(
+            new FieldDeclaration(
+                BindingKind.Var,
+                "onClick",
+                new ArrowTypeReference(
+                    List<GTypeReference>(Type("int32")),
+                    List<GTypeReference>()) { IsNullable = true }),
+            new FieldDeclaration(
+                BindingKind.Var,
+                "nullableReturn",
+                new ArrowTypeReference(
+                    List<GTypeReference>(Type("int32")),
+                    List<GTypeReference>(new NamedTypeReference("int32") { IsNullable = true })))));
+
+        var expected = Lines(
+            "package Demo",
+            string.Empty,
+            "var onClick ((int32) -> void)?",
+            "var nullableReturn (int32) -> int32?");
+
+        AssertGolden(expected, unit);
+    }
     [Fact]
     public void BFor_CStyleThreeClause()
     {


### PR DESCRIPTION
Per ADR-0137 / #1399, a nullable function type is spelled `((T)->R)?` (Kotlin-style), not `(T)->R?` (which binds `?` to the return type). Updates the cs2gs printer accordingly and adds a golden test. Mirrors C# nullable delegate fields (`Action<T>?`/`Func<...>?`).

Refs #914