### PR TITLE
Fix #1401 follow-up: route remaining generic TypeBuilder member paths

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -1171,7 +1171,7 @@ public sealed class Conversion
 
         try
         {
-            var invoke = delegateType.GetMethod("Invoke");
+            var invoke = delegateType.GetMethodSafe("Invoke");
             if (invoke == null)
             {
                 return false;
@@ -1210,7 +1210,7 @@ public sealed class Conversion
             return false;
         }
 
-        var openInvoke = definition.GetMethod("Invoke");
+        var openInvoke = definition.GetMethodSafe("Invoke");
         if (openInvoke == null)
         {
             return false;

--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -816,7 +816,7 @@ internal sealed class ConversionClassifier
             return new BoundErrorExpression(null);
         }
 
-        var invoke = delegateClr.GetMethod("Invoke");
+        var invoke = delegateClr.GetMethodSafe("Invoke");
         if (invoke == null)
         {
             Diagnostics.ReportCannotConvertMethodGroup(diagnosticLocation, group.MethodName, targetType);

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -1688,7 +1688,7 @@ internal sealed partial class ExpressionBinder
             return false;
         }
 
-        var invoke = openParameterType.GetMethod("Invoke");
+        var invoke = openParameterType.GetMethodSafe("Invoke");
         if (invoke == null)
         {
             return false;
@@ -2168,7 +2168,7 @@ internal sealed partial class ExpressionBinder
                 try
                 {
                     var delegateType = openParameters[paramIndex].ParameterType;
-                    invoke = delegateType?.GetMethod("Invoke");
+                    invoke = delegateType?.GetMethodSafe("Invoke");
                     invokeParameters = invoke?.GetParameters();
                 }
                 catch (Exception ex) when (ClrTypeUtilities.IsMetadataLoadFailure(ex))
@@ -3472,7 +3472,7 @@ internal sealed partial class ExpressionBinder
         // No applicable Invoke overload — most likely an argument-count or
         // type mismatch. Report against the member name (not "Invoke") so the
         // diagnostic points to what the user wrote.
-        var invoke = memberClrType.GetMethod("Invoke");
+        var invoke = memberClrType.GetMethodSafe("Invoke");
         var expectedArity = invoke?.GetParameters().Length ?? 0;
         if (arguments.Length != expectedArity)
         {

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -771,7 +771,7 @@ internal sealed partial class ExpressionBinder
             return false;
         }
 
-        var invoke = delegateType.GetMethod("Invoke");
+        var invoke = delegateType.GetMethodSafe("Invoke");
         if (invoke == null)
         {
             return false;

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -1113,7 +1113,7 @@ internal sealed class MemberLookup
             return false;
         }
 
-        var invoke = delegateType.GetMethod("Invoke");
+        var invoke = delegateType.GetMethodSafe("Invoke");
         if (invoke == null)
         {
             return false;

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
@@ -1077,7 +1077,7 @@ internal static class OverloadResolution
                     return false;
                 }
 
-                invoke = delegateType.GetMethod("Invoke");
+                invoke = delegateType.GetMethodSafe("Invoke");
                 if (invoke is null)
                 {
                     return false;
@@ -1224,8 +1224,8 @@ internal static class OverloadResolution
         MethodInfo sourceInvoke;
         try
         {
-            targetInvoke = target.GetMethod("Invoke");
-            sourceInvoke = source.GetMethod("Invoke");
+            targetInvoke = target.GetMethodSafe("Invoke");
+            sourceInvoke = source.GetMethodSafe("Invoke");
         }
         catch (Exception)
         {
@@ -1488,7 +1488,7 @@ internal static class OverloadResolution
 
         try
         {
-            var invoke = delegateType.GetMethod("Invoke");
+            var invoke = delegateType.GetMethodSafe("Invoke");
             if (invoke != null)
             {
                 var ps = invoke.GetParameters();
@@ -1554,7 +1554,7 @@ internal static class OverloadResolution
         try
         {
             var definition = delegateType.GetGenericTypeDefinition();
-            var defInvoke = definition.GetMethod("Invoke");
+            var defInvoke = definition.GetMethodSafe("Invoke");
             if (defInvoke == null)
             {
                 return false;

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -3601,7 +3601,7 @@ internal sealed class OverloadResolver
                 return invokeCall;
             }
 
-            var invoke = delegateClrType.GetMethod("Invoke");
+            var invoke = delegateClrType.GetMethodSafe("Invoke");
             var expectedArity = invoke?.GetParameters().Length ?? 0;
             if (syntax.Arguments.Count != expectedArity)
             {

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
@@ -844,7 +844,7 @@ internal sealed partial class MethodBodyEmitter
         switch (access.Member)
         {
             case PropertyInfo property:
-                var getter = property.GetGetMethod(nonPublic: false)
+                var getter = ReflectionMetadataEmitter.GetTypeBuilderSafePropertyAccessor(property, wantSetter: false)
                     ?? throw new InvalidOperationException(
                         $"Property '{property.DeclaringType?.FullName}.{property.Name}' has no public getter.");
                 // Issue #671: when the receiver is a symbolic constructed
@@ -931,7 +931,7 @@ internal sealed partial class MethodBodyEmitter
         switch (assn.Member)
         {
             case PropertyInfo property:
-                var setter = property.GetSetMethod(nonPublic: false)
+                var setter = ReflectionMetadataEmitter.GetTypeBuilderSafePropertyAccessor(property, wantSetter: true)
                     ?? throw new InvalidOperationException(
                         $"Property '{property.DeclaringType?.FullName}.{property.Name}' has no public setter.");
                 this.il.OpCode(isStatic || receiverIsValueType ? ILOpCode.Call : ILOpCode.Callvirt);
@@ -1016,7 +1016,7 @@ internal sealed partial class MethodBodyEmitter
             this.EmitExpression(arg);
         }
 
-        var getter = idx.Indexer.GetGetMethod(nonPublic: false)
+        var getter = ReflectionMetadataEmitter.GetTypeBuilderSafePropertyAccessor(idx.Indexer, wantSetter: false)
             ?? throw new InvalidOperationException(
                 $"Indexer on '{idx.Indexer.DeclaringType?.FullName}' has no public getter.");
         var receiverIsValueType = ReflectionMetadataEmitter.IsValueTypeSymbol(idx.Target.Type);
@@ -1047,7 +1047,7 @@ internal sealed partial class MethodBodyEmitter
 
     private void EmitClrIndexAssignment(BoundClrIndexAssignmentExpression ixa)
     {
-        var setter = ixa.Indexer.GetSetMethod(nonPublic: false);
+        var setter = ReflectionMetadataEmitter.GetTypeBuilderSafePropertyAccessor(ixa.Indexer, wantSetter: true);
 
         // ADR-0056 §2: span element write. `Span[T]` has no setter; its
         // indexer getter returns `ref T`. Obtain the managed pointer via
@@ -1057,7 +1057,7 @@ internal sealed partial class MethodBodyEmitter
         // get_Item that would re-evaluate the index arguments.
         if (setter == null)
         {
-            var refGetter = ixa.Indexer.GetGetMethod(nonPublic: false)
+            var refGetter = ReflectionMetadataEmitter.GetTypeBuilderSafePropertyAccessor(ixa.Indexer, wantSetter: false)
                 ?? throw new InvalidOperationException(
                     $"Indexer on '{ixa.Indexer.DeclaringType?.FullName}' has no public setter or getter.");
             BoundExpression receiver = ixa.TargetExpression ?? new BoundVariableExpression(null, ixa.Target);

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -7434,7 +7434,7 @@ internal sealed class ReflectionMetadataEmitter
     private static MethodInfo ResolveTypeBuilderConstructedGenericMethod(MethodInfo method)
     {
         var declaring = method?.DeclaringType;
-        if (!ContainsTypeBuilderGenericArgument(declaring))
+        if (declaring == null || !declaring.IsConstructedGenericType || !ContainsTypeBuilderGenericArgument(declaring))
         {
             return method;
         }
@@ -7448,7 +7448,7 @@ internal sealed class ReflectionMetadataEmitter
     private static ConstructorInfo ResolveTypeBuilderConstructedGenericCtor(ConstructorInfo ctor)
     {
         var declaring = ctor?.DeclaringType;
-        if (!ContainsTypeBuilderGenericArgument(declaring))
+        if (declaring == null || !declaring.IsConstructedGenericType || !ContainsTypeBuilderGenericArgument(declaring))
         {
             return ctor;
         }
@@ -7472,6 +7472,25 @@ internal sealed class ReflectionMetadataEmitter
             field.Name,
             BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
         return openField != null ? TypeBuilder.GetField(declaring, openField) : field;
+    }
+
+    internal static MethodInfo GetTypeBuilderSafePropertyAccessor(PropertyInfo property, bool wantSetter, bool nonPublic = false)
+    {
+        var declaring = property?.DeclaringType;
+        if (!ContainsTypeBuilderGenericArgument(declaring) || declaring == null || !declaring.IsConstructedGenericType)
+        {
+            return wantSetter
+                ? property?.GetSetMethod(nonPublic)
+                : property?.GetGetMethod(nonPublic);
+        }
+
+        var openProperty = ResolvePropertyOnOpenDefinition(declaring.GetGenericTypeDefinition(), property);
+        var openAccessor = wantSetter
+            ? openProperty?.GetSetMethod(nonPublic)
+            : openProperty?.GetGetMethod(nonPublic);
+        return openAccessor != null
+            ? TypeBuilder.GetMethod(declaring, openAccessor)
+            : null;
     }
 
     internal MemberReferenceHandle GetMethodReference(MethodInfo method)

--- a/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
+++ b/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using System.Reflection.Emit;
 
 namespace GSharp.Core.CodeAnalysis.Symbols;
 
@@ -19,6 +20,37 @@ namespace GSharp.Core.CodeAnalysis.Symbols;
 /// </summary>
 public static class ClrTypeUtilities
 {
+    /// <summary>
+    /// Resolves a named method without asking a constructed
+    /// <see cref="TypeBuilder"/> generic instantiation to resolve members
+    /// directly.
+    /// </summary>
+    /// <param name="type">The type that declares or inherits the method.</param>
+    /// <param name="name">The method name to resolve.</param>
+    /// <returns>The resolved method, or <see langword="null"/> when no matching method exists.</returns>
+    public static MethodInfo GetMethodSafe(this Type type, string name)
+    {
+        if (type is null || name is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            return type.GetMethod(name);
+        }
+        catch (NotSupportedException)
+        {
+            if (!IsConstructedGenericWithTypeBuilderArgument(type))
+            {
+                return null;
+            }
+
+            var openMethod = type.GetGenericTypeDefinition().GetMethod(name);
+            return openMethod != null ? TypeBuilder.GetMethod(type, openMethod) : null;
+        }
+    }
+
     /// <summary>
     /// Returns whether two <see cref="Type"/>s refer to the same logical CLR
     /// type, regardless of which reflection context produced them. Two types
@@ -659,6 +691,53 @@ public static class ClrTypeUtilities
         {
             return Array.Empty<Type>();
         }
+    }
+
+    private static bool IsConstructedGenericWithTypeBuilderArgument(Type type)
+    {
+        return type != null
+            && type.IsConstructedGenericType
+            && ContainsTypeBuilderGenericArgument(type);
+    }
+
+    private static bool ContainsTypeBuilderGenericArgument(Type type)
+    {
+        if (type == null)
+        {
+            return false;
+        }
+
+        if (type is TypeBuilder)
+        {
+            return true;
+        }
+
+        if (type.HasElementType)
+        {
+            return ContainsTypeBuilderGenericArgument(type.GetElementType());
+        }
+
+        if (!type.IsGenericType)
+        {
+            return false;
+        }
+
+        try
+        {
+            foreach (var arg in type.GetGenericArguments())
+            {
+                if (ContainsTypeBuilderGenericArgument(arg))
+                {
+                    return true;
+                }
+            }
+        }
+        catch (NotSupportedException)
+        {
+            return false;
+        }
+
+        return false;
     }
 
     private static bool InterfaceMatchesByName(Type candidate, Type target)

--- a/test/Compiler.Tests/Emit/Issue1100GenericMemberOnUserTypeArgEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1100GenericMemberOnUserTypeArgEmitTests.cs
@@ -164,6 +164,35 @@ public class Issue1100GenericMemberOnUserTypeArgEmitTests
         Assert.Equal("28\n", CompileAndRun(source));
     }
 
+    [Fact]
+    public void DelegateVariableClosedOverUserClass_Invoke_EmitsAndRuns()
+    {
+        var source = """
+            package P
+            import System
+
+            class Entry {
+                var Value int32
+                init(value int32) {
+                    Value = value
+                }
+            }
+
+            class C {
+                func run() int32 {
+                    var seen = 0
+                    let f (Entry) -> void = (e Entry) -> seen = e.Value
+                    f(Entry(42))
+                    return seen
+                }
+            }
+
+            Console.WriteLine(C().run())
+            """;
+
+        Assert.Equal("42\n", CompileAndRun(source));
+    }
+
     private static string CompileAndRun(string source)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_issue1100_emit_").FullName;


### PR DESCRIPTION
Refs #914\n\n## Summary\n- route TypeBuilder generic delegate Invoke lookups through TypeBuilder.GetMethod\n- avoid direct property/indexer accessor resolution on TypeBuilder generic instantiations\n- add an emit regression for invoking a delegate closed over a same-compilation user class\n\n## Verification\n- dotnet build GSharp.sln -c Release -graph\n- dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Release --filter FullyQualifiedName~Issue1100GenericMemberOnUserTypeArgEmitTests -- xUnit.MaxParallelThreads=2\n- Oahu.Decrypt migrate: GS9998 count 0 (remaining corpus compile errors are non-GS9998 diagnostics)