### PR TITLE
Fix #1407 BCL generic method inference

### DIFF
--- a/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
@@ -3375,6 +3375,14 @@ internal static class OverloadResolution
             return true;
         }
 
+        if (parameterType.IsByRef)
+        {
+            return UnifyForInference(
+                parameterType.GetElementType(),
+                argumentType.IsByRef ? argumentType.GetElementType() : argumentType,
+                bounds);
+        }
+
         if (parameterType.IsArray)
         {
             if (argumentType.IsArray)
@@ -3387,9 +3395,24 @@ internal static class OverloadResolution
             return true;
         }
 
-        if (parameterType.IsByRef)
+        if (IsStructurallyInferrableDelegate(parameterType, argumentType))
         {
-            return UnifyForInference(parameterType.GetElementType(), argumentType, bounds);
+            if (!TryGetDelegateSignature(parameterType, out var parameterDelegateParameters, out var parameterDelegateReturn)
+                || !TryGetDelegateSignature(argumentType, out var argumentDelegateParameters, out var argumentDelegateReturn)
+                || parameterDelegateParameters.Length != argumentDelegateParameters.Length)
+            {
+                return true;
+            }
+
+            for (var i = 0; i < parameterDelegateParameters.Length; i++)
+            {
+                if (!UnifyForInference(parameterDelegateParameters[i], argumentDelegateParameters[i], bounds))
+                {
+                    return false;
+                }
+            }
+
+            return UnifyForInference(parameterDelegateReturn, argumentDelegateReturn, bounds);
         }
 
         if (parameterType.IsGenericType && !parameterType.IsGenericTypeDefinition)
@@ -3416,6 +3439,33 @@ internal static class OverloadResolution
             // If no matching closed generic is found we don't fail inference
             // here — the applicability pass will reject the candidate.
             return true;
+        }
+
+        return true;
+    }
+
+    private static bool IsStructurallyInferrableDelegate(Type parameterType, Type argumentType)
+    {
+        if (parameterType == null || argumentType == null)
+        {
+            return false;
+        }
+
+        if (!parameterType.ContainsGenericParameters
+            || !ClrTypeUtilities.IsDelegateType(parameterType)
+            || !ClrTypeUtilities.IsDelegateType(argumentType))
+        {
+            return false;
+        }
+
+        if (parameterType.IsGenericType
+            && argumentType.IsGenericType
+            && MatchesOpenDefinition(
+                argumentType.GetGenericTypeDefinition(),
+                parameterType.GetGenericTypeDefinition(),
+                parameterType.GetGenericTypeDefinition().FullName))
+        {
+            return false;
         }
 
         return true;

--- a/test/Compiler.Tests/Emit/Issue1407BclGenericMethodInferenceEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1407BclGenericMethodInferenceEmitTests.cs
@@ -1,0 +1,125 @@
+// <copyright file="Issue1407BclGenericMethodInferenceEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1407: BCL generic method inference must handle a by-ref array
+/// parameter (<c>Array.Resize&lt;T&gt;(ref T[], int)</c>) and method type inference
+/// from an arrow literal to a named delegate parameter
+/// (<c>List&lt;T&gt;.ConvertAll&lt;U&gt;(Converter&lt;T,U&gt;)</c>).
+/// </summary>
+public class Issue1407BclGenericMethodInferenceEmitTests
+{
+    [Fact]
+    public void ArrayResize_InfersElementTypeFromRefSlice_CompilesAndRuns()
+    {
+        var source = """
+            package p
+            import System
+
+            var b = []uint8{0}
+            Array.Resize(&b, 5)
+            if b.Length != 5 { Environment.Exit(11) }
+            if b[0] != 0 { Environment.Exit(12) }
+            b[4] = 7
+            if b[4] != 7 { Environment.Exit(13) }
+            """;
+
+        CompileVerifyAndRun(source);
+    }
+
+    [Fact]
+    public void ListConvertAll_InfersResultTypeFromArrowToConverter_CompilesAndRuns()
+    {
+        var source = """
+            package p
+            import System
+            import System.Collections.Generic
+            import System.Linq
+
+            let xs = []int32{1,2}.ToList()
+            let y = xs.ConvertAll((x int32)->x)
+            if y.Count != 2 { Environment.Exit(21) }
+            if y[0] != 1 { Environment.Exit(22) }
+            if y[1] != 2 { Environment.Exit(23) }
+            """;
+
+        CompileVerifyAndRun(source);
+    }
+
+    private static void CompileVerifyAndRun(string source)
+    {
+        var workDir = Path.Combine(AppContext.BaseDirectory, "issue1407_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(workDir);
+        try
+        {
+            var srcPath = Path.Combine(workDir, "test.gs");
+            var outPath = Path.Combine(workDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            File.WriteAllText(Path.ChangeExtension(outPath, "runtimeconfig.json"), """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            Assert.True(proc.ExitCode == 0, $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(workDir, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1407.

Refs #914.

## Summary
- Infer generic method type arguments through by-ref array parameters.
- Infer named delegate generic method arguments structurally from function-literal delegate signatures.
- Add emit tests for Array.Resize and List.ConvertAll.

## Verification
- dotnet build GSharp.sln -c Release -graph --nologo
- dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Release --filter Issue1407 -- xUnit.MaxParallelThreads=2
- Control emit filters for Issue891/Issue1305/Issue1049/Issue1213
- Manual gsc library and executable repros