### PR TITLE
Fix #1410 nullable delegate property invocation

### DIFF
--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -3031,6 +3031,11 @@ internal sealed class OverloadResolver
             return new BoundIndirectCallExpression(null, BuildImplicitFieldLoad(implicitField), fnType, args);
         }
 
+        if (TryBuildImplicitMemberLoad(variable, syntax.Identifier.Location, out var memberLoad))
+        {
+            return new BoundIndirectCallExpression(null, memberLoad, fnType, args);
+        }
+
         return new BoundIndirectCallExpression(null, new BoundVariableExpression(null, variable), fnType, args);
     }
 
@@ -3047,6 +3052,197 @@ internal sealed class OverloadResolver
             new BoundVariableExpression(null, implicitField.Receiver),
             implicitField.StructType,
             implicitField.Field);
+
+    private bool TryBindNullableDelegateInvocation(
+        VariableSymbol variable,
+        CallExpressionSyntax syntax,
+        ImmutableArray<BoundExpression> boundArguments,
+        ImmutableArray<string> argumentNames,
+        out BoundExpression result)
+    {
+        result = null;
+        if (syntax.NullableQuestionToken == null
+            || variable.Type is not NullableTypeSymbol nullable
+            || !MemberLookup.TryGetDelegateFunctionTypeFromSymbol(nullable.UnderlyingType, out var functionType))
+        {
+            return false;
+        }
+
+        if (!argumentNames.IsDefault)
+        {
+            Diagnostics.ReportNamedArgumentParameterNotFound(syntax.Identifier.Location, variable.Name, FirstNamedArgumentName(argumentNames));
+            result = new BoundErrorExpression(null);
+            return true;
+        }
+
+        if (!TryBindFunctionTypeArguments(variable.Name, functionType, syntax, boundArguments, out var convertedArgs))
+        {
+            result = new BoundErrorExpression(null);
+            return true;
+        }
+
+        var delegateLoad = TryBuildImplicitMemberLoad(variable, syntax.Identifier.Location, out var implicitLoad)
+            ? implicitLoad
+            : new BoundVariableExpression(null, variable);
+        if (delegateLoad is BoundErrorExpression)
+        {
+            result = delegateLoad;
+            return true;
+        }
+
+        var captureName = "$ncap_" + (++binderCtx.NullConditionalCaptureCounter)
+            .ToString(System.Globalization.CultureInfo.InvariantCulture);
+        var capture = new LocalVariableSymbol(captureName, isReadOnly: true, type: nullable.UnderlyingType);
+        var captureRef = new BoundVariableExpression(null, capture);
+        var whenNotNull = new BoundIndirectCallExpression(null, captureRef, functionType, convertedArgs);
+
+        if (ReferenceEquals(functionType.ReturnType, TypeSymbol.Void))
+        {
+            result = new BoundNullConditionalAccessExpression(
+                syntax,
+                delegateLoad,
+                capture,
+                whenNotNull,
+                TypeSymbol.Void,
+                resultSlot: null);
+            return true;
+        }
+
+        var resultType = functionType.ReturnType is NullableTypeSymbol
+            ? functionType.ReturnType
+            : (TypeSymbol)NullableTypeSymbol.Get(functionType.ReturnType);
+        LocalVariableSymbol resultSlot = null;
+        if (resultType is NullableTypeSymbol nullableResult
+            && nullableResult.UnderlyingType?.ClrType is { IsValueType: true })
+        {
+            var resultSlotName = "$nres_" + binderCtx.NullConditionalCaptureCounter
+                .ToString(System.Globalization.CultureInfo.InvariantCulture);
+            resultSlot = new LocalVariableSymbol(resultSlotName, isReadOnly: false, type: resultType);
+        }
+
+        result = new BoundNullConditionalAccessExpression(
+            syntax,
+            delegateLoad,
+            capture,
+            whenNotNull,
+            resultType,
+            resultSlot);
+        return true;
+    }
+
+    private bool TryBindFunctionTypeArguments(
+        string calleeName,
+        FunctionTypeSymbol functionType,
+        CallExpressionSyntax syntax,
+        ImmutableArray<BoundExpression> boundArguments,
+        out ImmutableArray<BoundExpression> convertedArgs)
+    {
+        convertedArgs = default;
+        var isVariadic = functionType.HasVariadic;
+        var fixedCount = isVariadic ? functionType.Arity - 1 : functionType.Arity;
+
+        if (isVariadic)
+        {
+            if (syntax.Arguments.Count < fixedCount)
+            {
+                Diagnostics.ReportTooFewArgumentsForVariadic(syntax.Identifier.Location, calleeName, fixedCount, syntax.Arguments.Count);
+                return false;
+            }
+        }
+        else if (syntax.Arguments.Count != functionType.Arity)
+        {
+            Diagnostics.ReportWrongArgumentCount(syntax.Identifier.Location, calleeName, functionType.Arity, syntax.Arguments.Count);
+            return false;
+        }
+
+        var permutedArgs = boundArguments;
+        if (isVariadic)
+        {
+            var sliceType = (SliceTypeSymbol)functionType.ParameterTypes[functionType.Arity - 1];
+            var trailing = syntax.Arguments.Count - fixedCount;
+            var passThrough = trailing == 1 && boundArguments[fixedCount].Type == sliceType;
+            if (!passThrough)
+            {
+                var packed = ImmutableArray.CreateBuilder<BoundExpression>(trailing);
+                for (var i = fixedCount; i < syntax.Arguments.Count; i++)
+                {
+                    packed.Add(boundArguments[i]);
+                }
+
+                var rebuilt = ImmutableArray.CreateBuilder<BoundExpression>(fixedCount + 1);
+                for (var i = 0; i < fixedCount; i++)
+                {
+                    rebuilt.Add(boundArguments[i]);
+                }
+
+                rebuilt.Add(new BoundArrayCreationExpression(syntax, sliceType, packed.MoveToImmutable()));
+                permutedArgs = rebuilt.ToImmutable();
+            }
+        }
+
+        var convertedBuilder = ImmutableArray.CreateBuilder<BoundExpression>(permutedArgs.Length);
+        for (var i = 0; i < permutedArgs.Length; i++)
+        {
+            var argLoc = i < syntax.Arguments.Count ? syntax.Arguments[i].Location : syntax.Identifier.Location;
+            var argument = permutedArgs[i];
+            var argSyntax = i < syntax.Arguments.Count ? UnwrapNamedArgumentValue(syntax.Arguments[i]) : null;
+            if (argSyntax != null
+                && bindLambdaWithTarget != null
+                && IsUntypedArrowLambda(argSyntax)
+                && functionType.ParameterTypes[i] is FunctionTypeSymbol lambdaTarget)
+            {
+                argument = bindLambdaWithTarget((LambdaExpressionSyntax)argSyntax, lambdaTarget);
+            }
+
+            convertedBuilder.Add(conversions.BindConversion(argLoc, argument, functionType.ParameterTypes[i]));
+        }
+
+        convertedArgs = convertedBuilder.MoveToImmutable();
+        return true;
+    }
+
+    private bool TryBuildImplicitMemberLoad(VariableSymbol variable, TextLocation location, out BoundExpression load)
+    {
+        load = null;
+        switch (variable)
+        {
+            case ImplicitStaticFieldVariableSymbol staticField:
+                load = staticField.InterfaceType != null
+                    ? new BoundFieldAccessExpression(null, staticField.Field, staticField.InterfaceType)
+                    : new BoundFieldAccessExpression(null, receiver: null, staticField.StructType, staticField.Field);
+                return true;
+            case ImplicitPropertyVariableSymbol prop:
+                if (!prop.Property.HasGetter)
+                {
+                    Diagnostics.ReportCannotAssign(location, prop.Property.Name);
+                    load = new BoundErrorExpression(null);
+                    return true;
+                }
+
+                load = new BoundPropertyAccessExpression(
+                    null,
+                    new BoundVariableExpression(null, prop.Receiver),
+                    prop.StructType,
+                    prop.Property);
+                return true;
+            case ImplicitStaticPropertyVariableSymbol staticProp:
+                if (!staticProp.Property.HasGetter)
+                {
+                    Diagnostics.ReportCannotAssign(location, staticProp.Property.Name);
+                    load = new BoundErrorExpression(null);
+                    return true;
+                }
+
+                load = new BoundPropertyAccessExpression(
+                    null,
+                    receiver: null,
+                    staticProp.StructType,
+                    staticProp.Property);
+                return true;
+            default:
+                return false;
+        }
+    }
 
     public BoundExpression BindCallExpression(CallExpressionSyntax syntax)
     {
@@ -3439,6 +3635,12 @@ internal sealed class OverloadResolver
                 new BoundVariableExpression(null, fpVar),
                 fpConvertedArgs.MoveToImmutable(),
                 fpSym);
+        }
+
+        if (symbol is VariableSymbol nullableDelegateVar
+            && TryBindNullableDelegateInvocation(nullableDelegateVar, syntax, boundArguments.ToImmutable(), argumentNames, out var nullableDelegateCall))
+        {
+            return nullableDelegateCall;
         }
 
         // Phase 4.7: invoking a function-typed variable goes through the

--- a/test/Compiler.Tests/Emit/Issue1410NullableDelegatePropertyEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1410NullableDelegatePropertyEmitTests.cs
@@ -1,0 +1,153 @@
+// <copyright file="Issue1410NullableDelegatePropertyEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1410: null-conditional invocation of a nullable function-typed
+/// property must load the property getter result before invoking the delegate.
+/// </summary>
+public class Issue1410NullableDelegatePropertyEmitTests
+{
+    [Fact]
+    public void NullableVoidDelegateProperty_NullConditionalInvoke_LoadsGetterAndExecutesWhenPresent()
+    {
+        var source = """
+            package P
+            import System
+
+            class C {
+                prop H ((int32)->void)? { get; set }
+
+                func Set() {
+                    H = (x int32) -> Console.WriteLine(x + 1)
+                }
+
+                func Raise(x int32) {
+                    H?(x)
+                }
+            }
+
+            let c = C()
+            c.Raise(100)
+            c.Set()
+            c.Raise(41)
+            """;
+
+        Assert.Equal("42\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void NullableValueReturningDelegateProperty_NullConditionalInvoke_ReturnsNullableValue()
+    {
+        var source = """
+            package P
+            import System
+
+            class C {
+                prop H ((int32)->int32)? { get; set }
+
+                func Set() {
+                    H = (x int32) -> x * 2
+                }
+
+                func Run(x int32) int32? {
+                    return H?(x)
+                }
+            }
+
+            let empty = C()
+            Console.WriteLine(empty.Run(21) == nil)
+
+            let c = C()
+            c.Set()
+            Console.WriteLine(c.Run(21))
+            """;
+
+        Assert.Equal("True\n42\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Path.Combine(AppContext.BaseDirectory, "Issue1410_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new System.Collections.Generic.List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Route nullable delegate call syntax through property/implicit member loads before invoking the delegate
- Add emit tests for nullable function-typed properties with void and value returns

## Validation
- dotnet build GSharp.sln -c Release -graph
- dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Release --no-build --filter Issue1410 -- xUnit.MaxParallelThreads=2
- Oahu.Decrypt corpus recheck: GS0131=0, GS0144=0 (corpus still has pre-existing compile failures)

Fixes #1410
Refs #914