### PR TITLE
Fix #1351: parse nullable jagged array []?[]T

### DIFF
--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -16,7 +16,6 @@ namespace GSharp.Core.CodeAnalysis.Syntax;
 public class Parser
 {
     private readonly SyntaxTree syntaxTree;
-    private readonly ImmutableArray<SyntaxToken> tokens;
 
     // ADR-0078 / issue #725: when a single source-level declaration desugars
     // into multiple synthesized top-level members (notably discriminated-union
@@ -24,6 +23,8 @@ public class Parser
     // expander stages the additional siblings here. `ParseMembers` drains the
     // queue after each `ParseMember` call so they appear in declaration order.
     private readonly Queue<MemberSyntax> pendingSyntheticMembers = new Queue<MemberSyntax>();
+
+    private ImmutableArray<SyntaxToken> tokens;
 
     private int position;
 
@@ -3825,6 +3826,17 @@ public class Parser
             }
 
             var closeBracket = MatchToken(SyntaxKind.CloseSquareBracketToken);
+
+            // Issue #1351: a nullable array whose element type is itself an
+            // array spells the element with a leading `[`. The lexer greedily
+            // fuses the nullability `?` and that `[` into a single
+            // `?[` (`QuestionOpenBracketToken`). Split it back into `?` + `[`
+            // so the nullable marker is consumed below and the recursive
+            // element parse sees the nested array's open bracket.
+            if (Current.Kind == SyntaxKind.QuestionOpenBracketToken)
+            {
+                SplitQuestionOpenBracketToken();
+            }
 
             // Issue #1212: a `?` placed immediately after the `]` (before the
             // element type) marks the *whole array reference* nullable —
@@ -9890,6 +9902,23 @@ public class Parser
         var current = Current;
         position++;
         return current;
+    }
+
+    /// <summary>
+    /// Issue #1351: replaces the current fused <c>?[</c>
+    /// (<see cref="SyntaxKind.QuestionOpenBracketToken"/>) with two distinct
+    /// tokens — a <c>?</c> (<see cref="SyntaxKind.QuestionToken"/>) followed by
+    /// a <c>[</c> (<see cref="SyntaxKind.OpenSquareBracketToken"/>) — at the
+    /// current parse position. The lexer fuses these for null-conditional
+    /// indexing (<c>a?[i]</c>); in a nullable-array type clause whose element is
+    /// itself an array (<c>[]?[]T</c>) they must be parsed separately.
+    /// </summary>
+    private void SplitQuestionOpenBracketToken()
+    {
+        var fused = tokens[position];
+        var question = new SyntaxToken(syntaxTree, SyntaxKind.QuestionToken, fused.Position, "?", null);
+        var open = new SyntaxToken(syntaxTree, SyntaxKind.OpenSquareBracketToken, fused.Position + 1, "[", null);
+        tokens = tokens.SetItem(position, question).Insert(position + 1, open);
     }
 
     /// <summary>

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue1212NullableArrayElementParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue1212NullableArrayElementParserTests.cs
@@ -119,8 +119,7 @@ func Use() {{
     public void NullableArrayOfNestedElement_BindsOuterArrayNullable()
     {
         // `[]?*int32` — the outer slice reference is nullable; the element is a
-        // nested (pointer) type clause. (A nested *slice* element `[]?[]T` is
-        // not spellable because `?[` lexes as the null-conditional index token.)
+        // nested (pointer) type clause.
         var type = LocalVarType("[]?*int32");
 
         Assert.True(type.IsSlice);
@@ -132,5 +131,26 @@ func Use() {{
         Assert.True(inner.IsPointer);
         Assert.False(inner.IsArrayNullable);
         Assert.False(inner.IsNullable);
+    }
+
+    [Fact]
+    public void NullableArrayOfArrayElement_BindsOuterArrayNullable()
+    {
+        // Issue #1351: `[]?[]int32` — the outer slice is nullable and its element
+        // is itself a slice. The `?[` is lexed as a single null-conditional index
+        // token; the parser splits it back into `?` (array-nullable) + `[` (nested
+        // element array) so the faithful nullable-jagged-array form parses.
+        var type = LocalVarType("[]?[]int32");
+
+        Assert.True(type.IsSlice);
+        Assert.True(type.IsArrayNullable);
+        Assert.False(type.IsNullable);
+        Assert.True(type.HasNestedArrayElement);
+
+        var inner = type.ArrayElementType;
+        Assert.True(inner.IsSlice);
+        Assert.False(inner.IsArrayNullable);
+        Assert.False(inner.IsNullable);
+        Assert.Equal("int32", inner.Identifier.Text);
     }
 }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue914TranslatorFidelityTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue914TranslatorFidelityTests.cs
@@ -125,7 +125,7 @@ namespace Demo
     }
 
     [Fact]
-    public void PositivePattern_JaggedArrayTarget_PropertyScrutinee_FallsBackToSmartCast()
+    public void PositivePattern_JaggedArrayTarget_PropertyScrutinee_HoistsNullableJaggedArray()
     {
         string printed = TranslateUnit(@"
 namespace Demo
@@ -141,11 +141,12 @@ namespace Demo
     }
 }");
 
-        // A nullable jagged-array local annotation (`[]?[]uint8`) does not yet
-        // round-trip-parse in gsc, so an array target that does not escape keeps the
-        // smart-cast `is` test instead of hoisting a malformed nullable local.
-        Assert.Contains("chunk.ExtraData is [][]uint8", printed);
-        Assert.DoesNotContain("[]?[]", printed);
+        // Issue #1351: a nullable jagged-array local annotation (`[]?[]uint8`) now
+        // round-trip-parses in gsc, so an array target with a non-smart-castable
+        // (property-chain) scrutinee hoists the faithful nullable local + `!= nil`
+        // guard instead of falling back to the smart-cast `is` test.
+        Assert.Contains("let ivs []?[]uint8 = chunk.ExtraData as [][]uint8", printed);
+        Assert.Contains("if ivs != nil", printed);
     }
 
     [Fact]

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -4306,13 +4306,14 @@ public sealed class CSharpToGSharpTranslator
                 this.IsSymbolReferencedOutside(patternSymbol, ifStatement.Statement);
 
             // The broadened "non-smart-castable scrutinee" hoist requires a
-            // well-formed nullable local annotation. Only a NamedTypeReference target
-            // nullable-annotates cleanly (`T?`); a nullable jagged/array target
-            // (`[]?[]T`) does not yet round-trip-parse in gsc, so for array/pointer/
-            // tuple targets that do not escape, keep the existing smart cast.
+            // well-formed nullable local annotation. NamedTypeReference (`T?`) and
+            // ArrayTypeReference (`[]?T`, incl. nullable jagged arrays `[]?[]T`,
+            // issue #1351) both nullable-annotate and round-trip-parse in gsc; a
+            // pointer/tuple target's nullable form does not yet, so for those keep
+            // the existing smart cast when the binder does not escape.
             if (!escapesThenBlock &&
                 (this.IsSmartCastableScrutinee(isPattern.Expression) ||
-                 targetType is not NamedTypeReference))
+                 targetType is not (NamedTypeReference or ArrayTypeReference)))
             {
                 return false;
             }


### PR DESCRIPTION
## Summary
Fixes #1351 — gsc rejected a nullable array whose element type is itself an array (`[]?[]T`) with GS0005, while `[]?int32` parsed fine.

**Root**: the lexer greedily fuses `?[` into one `QuestionOpenBracketToken` (for null-conditional indexing `a?[i]`). In `[]?[]uint8` the array-nullable `?` and the element array's `[` lex as one token, so the `?`-after-`]` check never fired and the element parse expected an identifier.

## Fix
- **Parser**: in the array type-clause path, split the fused `?[` back into `?` + `[` so the array-nullable marker is consumed and the element type recurses (including nested arrays).
- **cs2gs**: broaden the `is`-pattern hoist from `NamedTypeReference`-only to also `ArrayTypeReference`. Jagged-array `is` patterns with a non-smart-castable scrutinee now emit the faithful `let ivs []?[]uint8 = chunk.ExtraData as [][]uint8` + `if ivs != nil`, replacing the smart-cast fallback.

## Tests
- New parser test `NullableArrayOfArrayElement_BindsOuterArrayNullable`; corrected stale "not spellable" comment.
- `Issue914TranslatorFidelity` jagged-array test flipped from fallback to faithful hoist.
- Core syntax (778) and cs2gs (335) suites pass; repro and translated hoist compile end-to-end.

Refs #1212, #914
