### PR TITLE
Fix #1358 imported pointer parameter methods

### DIFF
--- a/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
@@ -357,6 +357,12 @@ internal static class OverloadResolution
             return ImplicitConversionKind.Identity;
         }
 
+        if (target.IsPointer && source.IsPointer
+            && string.Equals(target.GetElementType()?.FullName, "System.Void", StringComparison.Ordinal))
+        {
+            return ImplicitConversionKind.Reference;
+        }
+
         if (IsNumericWidening(source, target))
         {
             return ImplicitConversionKind.NumericWidening;
@@ -1151,6 +1157,17 @@ internal static class OverloadResolution
             if (type.IsByRef)
             {
                 return TryCloseInferredType(type.GetElementType(), bounds, out closed);
+            }
+
+            if (type.IsPointer)
+            {
+                if (!TryCloseInferredType(type.GetElementType(), bounds, out var elem))
+                {
+                    return false;
+                }
+
+                closed = elem.MakePointerType();
+                return true;
             }
 
             if (type.IsArray)
@@ -3083,6 +3100,11 @@ internal static class OverloadResolution
             return SubstituteClrType(type.GetElementType(), from, to).MakeByRefType();
         }
 
+        if (type.IsPointer)
+        {
+            return SubstituteClrType(type.GetElementType(), from, to).MakePointerType();
+        }
+
         if (type.IsArray)
         {
             var element = SubstituteClrType(type.GetElementType(), from, to);
@@ -3381,6 +3403,16 @@ internal static class OverloadResolution
                 parameterType.GetElementType(),
                 argumentType.IsByRef ? argumentType.GetElementType() : argumentType,
                 bounds);
+        }
+
+        if (parameterType.IsPointer)
+        {
+            if (argumentType.IsPointer)
+            {
+                return UnifyForInference(parameterType.GetElementType(), argumentType.GetElementType(), bounds);
+            }
+
+            return true;
         }
 
         if (parameterType.IsArray)

--- a/src/Core/CodeAnalysis/Symbols/TypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/TypeSymbol.cs
@@ -161,6 +161,11 @@ public class TypeSymbol : Symbol
             return NullableTypeSymbol.Get(FromClrType(inner));
         }
 
+        if (clrType.IsPointer)
+        {
+            return PointerTypeSymbol.Get(FromClrType(clrType.GetElementType()));
+        }
+
         // Compare by FullName so types loaded from a MetadataLoadContext (carrying the
         // target framework's identity) still map onto the built-in primitive symbols.
         var fullName = clrType.FullName;

--- a/test/Compiler.Tests/Emit/Issue1358ImportedPointerParameterEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1358ImportedPointerParameterEmitTests.cs
@@ -1,0 +1,98 @@
+// <copyright file="Issue1358ImportedPointerParameterEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1358: imported BCL methods whose parameters are <c>T*</c> or
+/// <c>void*</c> must compile through emit after binding selects them.
+/// </summary>
+public class Issue1358ImportedPointerParameterEmitTests
+{
+    [Fact]
+    public void Vector256Load_GenericPointerParameter_Compiles()
+    {
+        const string source = """
+            package P
+            import System.Runtime.Intrinsics
+
+            class C {
+                unsafe func G(p *uint8) {
+                    let v = Vector256.Load(p)
+                }
+            }
+            """;
+
+        Compile(source);
+    }
+
+    [Fact]
+    public void UnsafeRead_VoidPointerParameter_Compiles()
+    {
+        const string source = """
+            package P
+            import System.Runtime.CompilerServices
+
+            class C {
+                unsafe func G(p *uint8) {
+                    let v = Unsafe.Read[uint8](p)
+                }
+            }
+            """;
+
+        Compile(source);
+    }
+
+    private static void Compile(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1358_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + outPath,
+                "/target:library",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int exitCode;
+            try
+            {
+                exitCode = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(exitCode == 0, $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1358ImportedPointerParameterBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1358ImportedPointerParameterBindingTests.cs
@@ -1,0 +1,92 @@
+// <copyright file="Issue1358ImportedPointerParameterBindingTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1358: imported static methods with unmanaged-pointer parameters must
+/// remain in the candidate set and participate in overload resolution.
+/// </summary>
+public class Issue1358ImportedPointerParameterBindingTests
+{
+    [Fact]
+    public void ImportedGenericStaticMethod_WithTypedPointerParameter_Binds()
+    {
+        const string source = """
+            package P
+            import System.Runtime.Intrinsics
+
+            class C {
+                unsafe func G(p *uint8) {
+                    let v = Vector256.Load(p)
+                }
+            }
+            """;
+
+        Assert.Empty(GetErrorDiagnostics(source));
+    }
+
+    [Fact]
+    public void ImportedGenericStaticMethod_WithVoidPointerParameter_Binds()
+    {
+        const string source = """
+            package P
+            import System.Runtime.CompilerServices
+
+            class C {
+                unsafe func G(p *uint8) {
+                    let v = Unsafe.Read[uint8](p)
+                }
+            }
+            """;
+
+        Assert.Empty(GetErrorDiagnostics(source));
+    }
+
+    private static DiagnosticCollection GetErrorDiagnostics(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var all = tree.Diagnostics
+            .Concat(compilation.GlobalScope.Diagnostics)
+            .Concat(compilation.BoundProgram.Diagnostics)
+            .Where(d => d.IsError)
+            .ToImmutableArray();
+        return new DiagnosticCollection(all);
+    }
+
+    private readonly struct DiagnosticCollection : IReadOnlyCollection<Diagnostic>
+    {
+        private readonly ImmutableArray<Diagnostic> diagnostics;
+
+        public DiagnosticCollection(ImmutableArray<Diagnostic> diagnostics)
+        {
+            this.diagnostics = diagnostics;
+        }
+
+        public int Count => this.diagnostics.Length;
+
+        public IEnumerator<Diagnostic> GetEnumerator()
+        {
+            foreach (var diagnostic in this.diagnostics)
+            {
+                yield return diagnostic;
+            }
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- include imported pointer-parameter methods in overload resolution for generic inference
- support typed-pointer to void* imported calls
- add binder and emit regressions for Vector256.Load and Unsafe.Read

## Verification
- dotnet build GSharp.sln -c Release -graph
- dotnet test test/Core.Tests/Core.Tests.csproj -c Release --no-build --filter Issue1358 -- xUnit.MaxParallelThreads=2
- dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Release --no-build --filter Issue1358 -- xUnit.MaxParallelThreads=2
- gsc repros for Vector256.Load and Unsafe.Read compile
- Oahu.Decrypt migration: HelperExtensions GS0159 count 0 (other pre-existing app errors remain)

Fixes #1358
Refs #914