### PR TITLE
Publish gsi REPL and cs2gs as .NET tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,15 @@ function pointers, struct marshalling — is documented in the
 | MSBuild SDK + templates | [`docs/sdk-usage.md`](docs/sdk-usage.md) |
 | Compiler architecture | [`docs/emit-pipeline.md`](docs/emit-pipeline.md) |
 
+## .NET tools
+
+The REPL and the C#→G# migrator ship as global .NET tools (requires a .NET 10 runtime):
+
+```sh
+dotnet tool install --global Gsharp.Repl    # `gsi` — interactive REPL / file runner
+dotnet tool install --global Gsharp.Cs2Gs   # `cs2gs` — C# to G# migration tool
+```
+
 ## Repository layout
 
 ```

--- a/src/Repl/Repl.csproj
+++ b/src/Repl/Repl.csproj
@@ -10,6 +10,29 @@
     <NoWarn>$(NoWarn);CS1591;SA0001;SA1600;SA1601;SA1602;SA1611;SA1615;SA1623;SA1629;SA1633;SA1652;SA1201;SA1202;SA1204;SA1309;SA1502;SA1513;SA1515;SA1516;SA1101;SA1208;SA1413;SA1649</NoWarn>
   </PropertyGroup>
 
+  <!-- Ship the interactive REPL as a .NET tool: `dotnet tool install Gsharp.Repl`
+       exposes the `gsi` command (issue #1404). -->
+  <PropertyGroup>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>gsi</ToolCommandName>
+    <PackageId>Gsharp.Repl</PackageId>
+    <IsPackable>true</IsPackable>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Title>GSharp interactive REPL</Title>
+    <Description>Interactive REPL (`gsi`) for the GSharp language. Requires a .NET 10 runtime.</Description>
+    <PackageTags>gsharp;repl;gsi;interactive;cli</PackageTags>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/DavidObando/gsharp</PackageProjectUrl>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageIcon>icon.png</PackageIcon>
+    <NoPackageAnalysis>true</NoPackageAnalysis>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)..\..\assets\PACKAGE_README.md" Pack="true" PackagePath="README.md" Visible="false" />
+    <None Include="$(MSBuildThisFileDirectory)..\..\assets\gsharp-icon.png" Pack="true" PackagePath="icon.png" Visible="false" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Spectre.Console" Version="0.55.2" />
   </ItemGroup>

--- a/tools/cs2gs/Cs2Gs.Cli/Cs2Gs.Cli.csproj
+++ b/tools/cs2gs/Cs2Gs.Cli/Cs2Gs.Cli.csproj
@@ -5,7 +5,33 @@
     <TargetFramework>$(NetCoreAppTargetFramework)</TargetFramework>
     <RootNamespace>Cs2Gs.Cli</RootNamespace>
     <AssemblyName>cs2gs</AssemblyName>
+    <!-- The cs2gs Directory.Build.props marks the whole tree IsTestProject=true
+         (skips docs/StyleCop), which also defaults IsPackable=false. Re-enable
+         packing below without re-enabling StyleCop. -->
   </PropertyGroup>
+
+  <!-- Ship the C#->G# translator as a .NET tool: `dotnet tool install Gsharp.Cs2Gs`
+       exposes the `cs2gs` command. -->
+  <PropertyGroup>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>cs2gs</ToolCommandName>
+    <PackageId>Gsharp.Cs2Gs</PackageId>
+    <IsPackable>true</IsPackable>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Title>GSharp cs2gs C# to G# translator</Title>
+    <Description>Command-line tool (`cs2gs`) that translates C# source to GSharp. Requires a .NET 10 runtime.</Description>
+    <PackageTags>gsharp;cs2gs;migration;csharp;translator;cli</PackageTags>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/DavidObando/gsharp</PackageProjectUrl>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageIcon>icon.png</PackageIcon>
+    <NoPackageAnalysis>true</NoPackageAnalysis>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)..\..\..\assets\PACKAGE_README.md" Pack="true" PackagePath="README.md" Visible="false" />
+    <None Include="$(MSBuildThisFileDirectory)..\..\..\assets\gsharp-icon.png" Pack="true" PackagePath="icon.png" Visible="false" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Cs2Gs.Pipeline\Cs2Gs.Pipeline.csproj" />

--- a/tools/cs2gs/README.md
+++ b/tools/cs2gs/README.md
@@ -45,6 +45,16 @@ This builds the compiler (`gsc`) and all `cs2gs` projects. Produced assemblies:
 IL verification (stage 3) uses the repo's local `ilverify` tool — restore it
 once with `dotnet tool restore` at the repo root.
 
+## Install as a .NET tool
+
+`cs2gs` ships as the `Gsharp.Cs2Gs` package (exposes the `cs2gs` command). A
+.NET 10 runtime is required.
+
+```sh
+dotnet tool install --global Gsharp.Cs2Gs
+cs2gs migrate --help
+```
+
 ## Run
 
 ### `migrate` — translate + verify the corpus


### PR DESCRIPTION
## What
Ship the G# interactive REPL and the C#→G# migrator as installable global/local **.NET tools**.

- `src/Repl` → package **Gsharp.Repl**, command **`gsi`** (closure: Core + LanguageServer + Spectre.Console).
- `tools/cs2gs/Cs2Gs.Cli` → package **Gsharp.Cs2Gs**, command **`cs2gs`**.

## How
Added `PackAsTool` + `ToolCommandName` + `GeneratePackageOnBuild` to both CLIs, mirroring existing `Gsharp.NET.Sdk`/`Templates` metadata (MIT license, shared icon/README). The cs2gs CLI sets `IsPackable=true` to override the cs2gs tree's `IsTestProject=true` default without re-enabling StyleCop. Both nupkgs land in `out/bin/Release/nupkgs`, which the existing `v*`-tag CI publish job already uploads and pushes to NuGet — no workflow change required.

Install (requires a .NET 10 runtime):

    dotnet tool install --global Gsharp.Repl    # gsi
    dotnet tool install --global Gsharp.Cs2Gs   # cs2gs

## Verification
- `dotnet build GSharp.sln -c Release -graph` → 0 warnings / 0 errors; both nupkgs emitted.
- Verified both are DotnetTool packages with full dependency closure; installed via `--tool-path` and smoke-tested: `cs2gs --help` and `gsi smoke.gs` (6*7 → 42).
- READMEs document install + runtime requirement.
