### PR TITLE
Fix #1344: preserve user element type for Channel[E].Reader.ReadAllAsync()

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -4053,9 +4053,21 @@ internal sealed partial class ExpressionBinder
             // a bare-parameter property cannot be a constructed generic over a
             // user element (the #1305 ChannelWriter[Entry] concern), so it does
             // not regress those call sites.
+            //
+            // Issue #1344: a `Channel[Entry].Reader` (`ChannelReader[Entry]`)
+            // and `.Writer` (`ChannelWriter[Entry]`) are also constructed
+            // generics over a same-compilation user element. They are not
+            // enumerable collections, but the reader exposes
+            // `ReadAllAsync()` -> `IAsyncEnumerable[Entry]`; if the property
+            // erases to `ChannelReader[object]`, the async stream erases to
+            // `IAsyncEnumerable[object]` and the `await for` loop variable
+            // collapses to `object`. Surface the symbolic `[Entry]` so the
+            // element type survives; member/method lookup still resolves
+            // against the erased CLR shape (proven by #1088).
             return TypeSymbol.ContainsTypeParameter(mapped)
                 || TypeSymbol.IsSameCompilationUserTypeTopLevel(mapped)
                 || IsUserElementEnumerableCollection(mapped)
+                || IsUserElementChannelReaderWriter(mapped)
                 || openPropType.IsGenericParameter
                 ? mapped
                 : null;
@@ -4088,6 +4100,25 @@ internal sealed partial class ExpressionBinder
         => mapped is ImportedTypeSymbol { ClrType: { } clr }
             && TypeSymbol.ContainsSameCompilationUserType(mapped)
             && MemberLookup.TryGetClrEnumerableElementType(clr, out _);
+
+    /// <summary>
+    /// Issue #1344: returns <see langword="true"/> when <paramref name="mapped"/>
+    /// is a constructed <c>System.Threading.Channels.ChannelReader&lt;T&gt;</c>
+    /// or <c>ChannelWriter&lt;T&gt;</c> over a same-compilation user element.
+    /// Such a reader/writer is not an enumerable collection, but the reader
+    /// exposes <c>ReadAllAsync()</c> -> <c>IAsyncEnumerable[T]</c>; surfacing the
+    /// symbolic argument keeps the user element type instead of erasing to
+    /// <c>object</c>, so an <c>await for</c> over <c>reader.ReadAllAsync()</c>
+    /// binds member access on the loop element. Member/method lookup still
+    /// resolves against the erased closed shape (proven by #1088).
+    /// </summary>
+    /// <param name="mapped">The symbolic projection produced by <see cref="MemberLookup.MapOpenClrTypeToSymbolic(Type, ImportedTypeSymbol)"/>.</param>
+    /// <returns><see langword="true"/> when the mapped type is a user-element channel reader/writer.</returns>
+    private static bool IsUserElementChannelReaderWriter(TypeSymbol mapped)
+        => mapped is ImportedTypeSymbol { OpenDefinition: { } def }
+            && (def.FullName == "System.Threading.Channels.ChannelReader`1"
+                || def.FullName == "System.Threading.Channels.ChannelWriter`1")
+            && TypeSymbol.ContainsSameCompilationUserType(mapped);
 
     private static bool IsReadOnlyRefReturn(PropertyInfo indexer, MethodInfo getter)
     {

--- a/test/Compiler.Tests/Emit/Issue1344ChannelReaderUserElementEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1344ChannelReaderUserElementEmitTests.cs
@@ -1,0 +1,152 @@
+// <copyright file="Issue1344ChannelReaderUserElementEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1344: iterating a <c>Channel[UserType].Reader.ReadAllAsync()</c>
+/// async sequence erased the user element type to <c>System.Object</c>, so
+/// member access on the <c>await for</c> loop variable failed
+/// <c>GS0158: Cannot find member</c>. The <c>.Reader</c> property surfaced an
+/// erased <c>ChannelReader[object]</c>, whose <c>ReadAllAsync()</c> yields
+/// <c>IAsyncEnumerable[object]</c>. The fix keeps the symbolic
+/// <c>ChannelReader[UserType]</c> projection (sibling of #1320/#1328), so the
+/// stream is <c>IAsyncEnumerable[UserType]</c> and member access binds. These
+/// tests compile, IL-verify, and run the issue repro end-to-end.
+/// </summary>
+public class Issue1344ChannelReaderUserElementEmitTests
+{
+    // G# erases same-compilation user types used as CLR generic arguments to
+    // System.Object on the closed type; surfacing the symbolic ChannelReader[E]
+    // projection makes ilverify see ChannelReader`1<object> on the signature
+    // but ChannelReader`1<E> on the stack (a verifier-only StackUnexpected the
+    // CLR accepts — the tests run the program to prove correctness), mirroring
+    // #1088.
+    private static readonly string[] ErasureIlVerifyIgnored =
+    {
+        "StackUnexpected",
+    };
+
+    [Fact]
+    public void ChannelReaderReadAllAsync_UserElement_BindsAndRuns()
+    {
+        var source = """
+            package P
+            import System
+            import System.Threading.Channels
+            import System.Threading.Tasks
+
+            class Issue1344Entry { var NumEntries int32 = 0 }
+
+            public var total = 0
+            async func Consume(ch Channel[Issue1344Entry]) {
+                await for messages in ch.Reader.ReadAllAsync() {
+                    total = total + messages.NumEntries
+                }
+            }
+
+            let ch = Channel.CreateUnbounded[Issue1344Entry]()
+            var a = Issue1344Entry()
+            a.NumEntries = 42
+            var wrote = ch.Writer.TryWrite(a)
+            var b = Issue1344Entry()
+            b.NumEntries = 7
+            var wrote2 = ch.Writer.TryWrite(b)
+            ch.Writer.Complete()
+            Consume(ch).Wait()
+            Console.WriteLine(total)
+            """;
+
+        Assert.Equal("49\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1344_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+            string Ref(string name) => "/r:" + Path.Combine(runtimeDir, name);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    Ref("System.Private.CoreLib.dll"),
+                    Ref("System.Runtime.dll"),
+                    Ref("System.Console.dll"),
+                    Ref("System.Collections.dll"),
+                    Ref("System.Threading.dll"),
+                    Ref("System.Threading.Channels.dll"),
+                    Ref("System.Threading.Tasks.dll"),
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+            IlVerifier.Verify(outPath, null, ErasureIlVerifyIgnored);
+
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1344ChannelReaderUserElementTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1344ChannelReaderUserElementTests.cs
@@ -1,0 +1,131 @@
+// <copyright file="Issue1344ChannelReaderUserElementTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1344: iterating <c>Channel[UserType].Reader.ReadAllAsync()</c> with
+/// <c>await for</c> erased the user element type to <c>object</c>, so member
+/// access on the loop variable failed <c>GS0158</c>. The <c>.Reader</c>
+/// property surfaced an erased <c>ChannelReader[object]</c> whose
+/// <c>ReadAllAsync()</c> yields <c>IAsyncEnumerable[object]</c>. The fix keeps
+/// the symbolic <c>ChannelReader[UserType]</c> projection (sibling of
+/// #1320/#1328). These binder tests mirror the issue repro; the user-element
+/// case binds clean and the primitive-element control keeps working.
+/// </summary>
+public class Issue1344ChannelReaderUserElementTests
+{
+    [Fact]
+    public void ReadAllAsync_UserElement_AwaitFor_MemberAccess_Binds()
+    {
+        // BUG: GS0158 — `messages` erased to object so `.NumEntries` not found.
+        const string source = @"
+package p
+import System.Threading.Channels
+import System.Threading.Tasks
+class BufferEntry { prop NumEntries int32 { get; init; } }
+class Reader {
+    async func Consume(ch Channel[BufferEntry]) {
+        await for messages in ch.Reader.ReadAllAsync() {
+            let n = messages.NumEntries
+        }
+    }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void ReadAllAsync_PrimitiveElement_Control_Binds()
+    {
+        // Control: primitive element type was never affected.
+        const string source = @"
+package p
+import System.Threading.Channels
+import System.Threading.Tasks
+class Reader {
+    async func Consume(ch Channel[int32]) {
+        await for n in ch.Reader.ReadAllAsync() {
+            let m = n + 1
+        }
+    }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    private static ReferenceResolver MetadataLoadContextResolver()
+    {
+        var paths = new[]
+        {
+            typeof(object).Assembly.Location,
+            typeof(System.Console).Assembly.Location,
+            typeof(System.Threading.Channels.Channel).Assembly.Location,
+            typeof(System.Threading.Tasks.Task).Assembly.Location,
+            typeof(System.Collections.Generic.List<>).Assembly.Location,
+        }
+        .Where(p => !string.IsNullOrEmpty(p))
+        .Distinct(StringComparer.OrdinalIgnoreCase)
+        .ToArray();
+
+        return ReferenceResolver.WithReferences(paths);
+    }
+
+    private static ImmutableArrayOfDiagnostic GetDiagnostics(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var globalScope = Binder.BindGlobalScope(
+            previous: null,
+            ImmutableArray.Create(tree),
+            MetadataLoadContextResolver());
+        var program = Binder.BindProgram(globalScope, MetadataLoadContextResolver());
+        var all = tree.Diagnostics
+            .Concat(globalScope.Diagnostics)
+            .Concat(program.Diagnostics)
+            .Where(d => d.IsError)
+            .ToImmutableArray();
+        return new ImmutableArrayOfDiagnostic(all);
+    }
+
+    /// <summary>
+    /// Thin wrapper so the test cases can call <c>Assert.Empty</c> against a
+    /// <see cref="ImmutableArray{T}"/> without exposing the GSharp diagnostic
+    /// surface to xUnit's enumerable inference.
+    /// </summary>
+    private readonly struct ImmutableArrayOfDiagnostic : IReadOnlyCollection<Diagnostic>
+    {
+        private readonly ImmutableArray<Diagnostic> diagnostics;
+
+        public ImmutableArrayOfDiagnostic(ImmutableArray<Diagnostic> diagnostics)
+        {
+            this.diagnostics = diagnostics;
+        }
+
+        public int Count => this.diagnostics.Length;
+
+        public IEnumerator<Diagnostic> GetEnumerator()
+        {
+            foreach (var diagnostic in this.diagnostics)
+            {
+                yield return diagnostic;
+            }
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}


### PR DESCRIPTION
## Issue
Fixes #1344. Sibling of #1320 / #1328.

Iterating a `Channel[UserType].Reader.ReadAllAsync()` async sequence erased the user element type to `System.Object`, so member access on the `await for` loop variable failed `GS0158: Cannot find member`. Primitive element types were unaffected.

Repro (failed on `main`):
```gsharp
package p
import System.Threading.Channels
import System.Threading.Tasks
class BufferEntry { prop NumEntries int32 { get; init; } }
class Reader {
    async func Consume(ch Channel[BufferEntry]) {
        await for messages in ch.Reader.ReadAllAsync() {
            let n = messages.NumEntries   // GS0158
        }
    }
}
```

## Root cause
`ch.Reader` is a `ChannelReader[BufferEntry]` property — a constructed BCL generic over a same-compilation user element. `ResolveInstancePropertyTypeFromReceiver` only surfaced the symbolic argument for a top-level user type or an enumerable-collection wrapper; a `ChannelReader[E]` is neither, so it fell back to the type-erased closed shape `ChannelReader[object]`. `ReadAllAsync()` then yields `IAsyncEnumerable[object]`, and the `await for` loop variable binds as `object`.

## Fix
- **`ExpressionBinder.Access.cs`** — broaden the property gate with `IsUserElementChannelReaderWriter`: a constructed `ChannelReader[E]` / `ChannelWriter[E]` over a same-compilation user element surfaces its symbolic argument. The reader's `ReadAllAsync()` return type then projects to `IAsyncEnumerable[E]` (the proven path) and member access binds. Member/method lookup still resolves against the erased CLR shape (proven by #1088).

## Verification
- `dotnet build GSharp.sln -c Release -graph` — 0 warnings / 0 errors.
- Standalone gsc on the issue repro: compiles, IL-verifies, runs to 42/49.
- New binder tests `Issue1344ChannelReaderUserElementTests` (2, user + primitive control) — green.
- New emit/run test `Issue1344ChannelReaderUserElementEmitTests` (1, end-to-end) — green.
- Full Core.Tests (4768) green; related emit regression set (#1088/#1305/#1320/#1328/#1002/#652/#937/#1376/#1338, 30) green.
