### PR TITLE
cs2gs: null-forgive tuple-literal elements (Oahu.Decrypt nullability)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
@@ -648,6 +648,35 @@ namespace Demo
         Assert.DoesNotContain(" as int32", printed);
     }
 
+    /// <summary>
+    /// A tuple literal element is a value position: a declared-nullable
+    /// (<c>T?</c>) operand flow-proven non-null by a preceding guard must be
+    /// emitted with the G# non-null assertion (<c>x!!</c>), because G# does not
+    /// smart-cast across the tuple boundary and would otherwise reject the
+    /// nullable element against the non-null tuple slot (issue #914).
+    /// </summary>
+    [Fact]
+    public void TupleLiteralElement_GuardedNullable_RendersNonNullAssertion()
+    {
+        string printed = TranslateUnit(@"
+#nullable enable
+namespace Demo
+{
+    public class Inner { }
+
+    public class C
+    {
+        public (Inner, int) M(Inner? a)
+        {
+            if (a is null) throw new System.InvalidOperationException();
+            return (a, 1);
+        }
+    }
+}");
+
+        Assert.Contains("return (a!!,", printed);
+    }
+
     private static string TranslateUnit(string source)
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -5102,7 +5102,7 @@ public sealed class CSharpToGSharpTranslator
 
                 case TupleExpressionSyntax tuple:
                     return new TupleLiteralExpression(
-                        tuple.Arguments.Select(a => this.TranslateExpression(a.Expression)).ToList());
+                        tuple.Arguments.Select(a => this.TranslateValueWithNullForgiveness(a.Expression)).ToList());
 
                 case ElementAccessExpressionSyntax elementAccess:
                     if (elementAccess.ArgumentList.Arguments.Count == 1 &&


### PR DESCRIPTION
## What
Tuple literal elements are value positions. A declared-nullable (`T?`) operand that Roslyn flow-proves non-null must emit the G# non-null assertion (`x!!`) so the nullable value binds against the non-null tuple slot — G# does not smart-cast across the tuple boundary (would otherwise be GS0154/GS0155). Route tuple elements through `TranslateValueWithNullForgiveness`.

## Impact
- **Oahu.Decrypt cs2gs compile errors: 24 → 22** (tuple-position GS errors cleared).
- Oahu.Foundation: still translates green (0 errors) — no regression.
- Added regression test `TupleLiteralElement_GuardedNullable_RendersNonNullAssertion`; full cs2gs suite 336/336 pass.

## Remaining Decrypt errors are gsc COMPILER gaps (file separately, label bug,Oahu)
Verified with minimal standalone gsc repros:
- **GS0159 LINQ stdlib missing**: `Select`, `OrderBy`, `Order`, `Compare`, `ThrowIfNull`. Repro: `class T { func F(xs []int32) []int32 { return xs.OrderBy((x int32)->x).ToArray() } }` → GS0159 Cannot find function OrderBy.
- GS0263/GS0158 conditional []T? vs []T common-type + `!!`-array `.Length`; GS0155 Span<T> conversions; GS0102 while-condition `is Pattern var` + `out var` re-evaluation.

Refs #914