### PR TITLE
Fix #1420: Span[T] generic-extension binding across int32 alias vs System.Int32 identity

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using GSharp.Core.CodeAnalysis.Symbols;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
@@ -276,6 +277,28 @@ public sealed class Conversion
             && toGeneric.OpenDefinition != null
             && (fromGeneric.HasSubstitutableTypeArgument || toGeneric.HasSubstitutableTypeArgument)
             && AreConstructedGenericsIdentical(fromGeneric, toGeneric))
+        {
+            return Conversion.Identity;
+        }
+
+        // Issue #1420: identity between a CLR-backed closed constructed generic
+        // (e.g. `Span<System.Int32>` recovered from a BCL signature such as
+        // `CollectionsMarshal.AsSpan`, whose symbolic `TypeArguments` are empty
+        // because the closed shape is fully described by its `ClrType`) and a
+        // SYMBOLICALLY constructed generic produced by substituting an
+        // extension's open receiver (e.g. `Span[T]` with `{T: int32}` →
+        // `Span[int32]`). Substitution cannot rebuild the real closed CLR type
+        // via `MakeGenericType` because the primitive alias `int32` carries the
+        // RUNTIME `System.Int32` while the open `Span<>` came from a
+        // MetadataLoadContext (mixing the two throws), so the substituted form
+        // stays symbolic with an erased `ClrType`. Comparing the two structurally
+        // — normalizing the CLR-backed side's generic arguments through
+        // `TypeSymbol.FromClrType` so a BCL `System.Int32` and the alias `int32`
+        // collapse to the SAME `TypeSymbol` — lets the generic-extension receiver
+        // bind instead of failing GS0155.
+        if (from is ImportedTypeSymbol fromImported
+            && to is ImportedTypeSymbol toImported
+            && AreConstructedGenericShapesIdentical(fromImported, toImported))
         {
             return Conversion.Identity;
         }
@@ -886,6 +909,90 @@ public sealed class Conversion
 
         return source?.ClrType != null && target?.ClrType != null
             && ClrTypeUtilities.IsAssignableByName(target.ClrType, source.ClrType);
+    }
+
+    /// <summary>
+    /// Issue #1420: determines whether two <see cref="ImportedTypeSymbol"/>
+    /// instances denote the same closed constructed generic when ONE side
+    /// carries symbolic <see cref="ImportedTypeSymbol.TypeArguments"/> (produced
+    /// by substituting an extension's open generic receiver) while the OTHER is a
+    /// plain CLR-backed closed generic whose arguments are described only by its
+    /// <see cref="TypeSymbol.ClrType"/>. The CLR-backed side's generic arguments
+    /// are normalized through <see cref="TypeSymbol.FromClrType"/> so a BCL
+    /// primitive (e.g. <c>System.Int32</c>) and the corresponding G# alias (e.g.
+    /// <c>int32</c>) resolve to the SAME <see cref="TypeSymbol"/>. Requires at
+    /// least one side to be symbolic so genuinely CLR-backed comparisons keep
+    /// flowing through the existing (variance-aware) rules.
+    /// </summary>
+    private static bool AreConstructedGenericShapesIdentical(ImportedTypeSymbol from, ImportedTypeSymbol to)
+    {
+        var fromSymbolic = !from.TypeArguments.IsDefaultOrEmpty;
+        var toSymbolic = !to.TypeArguments.IsDefaultOrEmpty;
+
+        // Scope to the asymmetric case: the symmetric symbolic/symbolic and the
+        // symmetric CLR/CLR paths are already handled above and elsewhere.
+        if (fromSymbolic == toSymbolic)
+        {
+            return false;
+        }
+
+        if (!TryGetConstructedGenericShape(from, out var fromOpen, out var fromArgs)
+            || !TryGetConstructedGenericShape(to, out var toOpen, out var toArgs))
+        {
+            return false;
+        }
+
+        if (!ClrTypeUtilities.IsSameAs(fromOpen, toOpen) || fromArgs.Length != toArgs.Length)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < fromArgs.Length; i++)
+        {
+            if (!AreTypeArgumentsEquivalent(fromArgs[i], toArgs[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Issue #1420: extracts the open generic CLR definition and the symbolic
+    /// type arguments of a constructed generic <see cref="ImportedTypeSymbol"/>,
+    /// whether the arguments are carried symbolically (#313 construction) or only
+    /// by the closed <see cref="TypeSymbol.ClrType"/>. CLR-backed arguments are
+    /// projected through <see cref="TypeSymbol.FromClrType"/> so primitive
+    /// aliases and their BCL counterparts unify.
+    /// </summary>
+    private static bool TryGetConstructedGenericShape(ImportedTypeSymbol symbol, out Type openDefinition, out ImmutableArray<TypeSymbol> typeArguments)
+    {
+        if (symbol.OpenDefinition != null && !symbol.TypeArguments.IsDefaultOrEmpty)
+        {
+            openDefinition = symbol.OpenDefinition;
+            typeArguments = symbol.TypeArguments;
+            return true;
+        }
+
+        var clr = symbol.ClrType;
+        if (clr != null && clr.IsGenericType && !clr.IsGenericTypeDefinition)
+        {
+            var clrArgs = clr.GetGenericArguments();
+            var builder = ImmutableArray.CreateBuilder<TypeSymbol>(clrArgs.Length);
+            foreach (var arg in clrArgs)
+            {
+                builder.Add(TypeSymbol.FromClrType(arg));
+            }
+
+            openDefinition = clr.GetGenericTypeDefinition();
+            typeArguments = builder.MoveToImmutable();
+            return true;
+        }
+
+        openDefinition = null;
+        typeArguments = ImmutableArray<TypeSymbol>.Empty;
+        return false;
     }
 
     /// <summary>

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1420SpanExtensionIdentityTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1420SpanExtensionIdentityTests.cs
@@ -1,0 +1,104 @@
+// <copyright file="Issue1420SpanExtensionIdentityTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Regression tests for issue #1420: a generic extension declared on a
+/// <c>ref struct</c> receiver (<c>func (ints Span[T]) AllLE[...](...)</c>) must
+/// bind against a <c>Span&lt;int&gt;</c> produced by a BCL signature
+/// (<c>CollectionsMarshal.AsSpan(List[int32])</c>).
+/// <para>
+/// The BCL signature surfaces the element type as the metadata
+/// <c>System.Int32</c> while the substituted extension receiver carries the G#
+/// primitive alias <c>int32</c>. Substitution cannot rebuild the real closed
+/// CLR <c>Span&lt;int&gt;</c> (the alias holds the runtime <c>System.Int32</c>
+/// whereas <c>Span&lt;&gt;</c> came from a MetadataLoadContext, and mixing the
+/// two throws), so the substituted receiver stays symbolic. Conversion identity
+/// must normalize the two element representations onto the SAME
+/// <see cref="TypeSymbol"/> so the receiver binds instead of failing GS0155.
+/// </para>
+/// </summary>
+public class Issue1420SpanExtensionIdentityTests
+{
+    private static ReferenceResolver MetadataLoadContextResolver()
+    {
+        var paths = new[]
+        {
+            typeof(object).Assembly.Location,
+            typeof(System.Collections.Generic.List<>).Assembly.Location,
+            typeof(System.Runtime.InteropServices.CollectionsMarshal).Assembly.Location,
+            typeof(System.IComparable<>).Assembly.Location,
+        }
+        .Where(p => !string.IsNullOrEmpty(p))
+        .Distinct(StringComparer.OrdinalIgnoreCase)
+        .ToArray();
+
+        return ReferenceResolver.WithReferences(paths);
+    }
+
+    private static ImmutableArray<Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var globalScope = Binder.BindGlobalScope(
+            previous: null,
+            ImmutableArray.Create(tree),
+            MetadataLoadContextResolver());
+        var program = Binder.BindProgram(globalScope, MetadataLoadContextResolver());
+        return globalScope.Diagnostics.AddRange(program.Diagnostics);
+    }
+
+    [Fact]
+    public void SpanGenericExtension_BindsAgainstAsSpanResult()
+    {
+        var source = """
+            package App
+            import System
+            import System.Collections.Generic
+            import System.Runtime.InteropServices
+
+            func (ints Span[T]) AllLE[T IComparable[T] unmanaged](value T) bool -> true
+
+            func F(list List[int32]) {
+                let sp = CollectionsMarshal.AsSpan(list)
+                let b = sp.AllLE(int32(5))
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void SpanWrongElement_StillReportsConversionError()
+    {
+        // The BCL Span<long> from AsSpan(List[int64]) must NOT unify with the
+        // explicit Span[int32] parameter — the identity normalization is by
+        // element type, not blanket acceptance of any Span instantiation.
+        var source = """
+            package App
+            import System
+            import System.Collections.Generic
+            import System.Runtime.InteropServices
+
+            func G(s Span[int32]) int32 -> 0
+
+            func F(list List[int64]) {
+                let sp = CollectionsMarshal.AsSpan(list)
+                let r = G(sp)
+            }
+            """;
+
+        Assert.NotEmpty(Bind(source));
+    }
+}


### PR DESCRIPTION
## Problem
A generic extension declared on a `ref struct` receiver fails to bind against a `Span<int>` recovered from a BCL signature:

```gsharp
func (ints Span[T]) AllLE[T IComparable[T] unmanaged](value T) bool -> true

func F(list List[int32]) {
    let sp = CollectionsMarshal.AsSpan(list)
    let b = sp.AllLE(int32(5))   // GS0155
}
```

=> `GS0155: Cannot convert type 'System.Span\`1[System.Int32]' to 'System.Span\`1[int32]'`.

## Root cause
Substituting the open receiver `Span[T]` with `{T: int32}` can't rebuild the real closed CLR `Span<int>` because the `int32` alias holds the runtime `System.Int32` while the open `Span<>` came from a MetadataLoadContext (mixing the two in `MakeGenericType` throws). So the substituted receiver stays a **symbolic** constructed generic (`Span[int32]`, erased `ClrType`), while the `AsSpan` result is a plain **CLR-backed** `Span<System.Int32>` with empty symbolic `TypeArguments`. The existing constructed-generic identity rule required **both** sides to carry symbolic args, so the asymmetric pairing fell through to GS0155.

## Fix
In `Conversion.Classify`, handle the asymmetric case: extract an effective `(open-definition, type-arguments)` shape from each `ImportedTypeSymbol`, projecting the CLR-backed side's generic arguments through `TypeSymbol.FromClrType` so a BCL `System.Int32` and the alias `int32` collapse to the **same** `TypeSymbol`, then compare structurally. Mismatched element types (e.g. `Span<long>` vs `Span[int32]`) still report GS0155.

## Tests
- New `Issue1420SpanExtensionIdentityTests` (MetadataLoadContext path): positive bind + negative wrong-element guard.
- Full `Core.Tests`: 4770 passed, 1 skipped. RefactoringBaseline byte-identical gate unaffected.

Fixes #1420
Refs #914