### PR TITLE
Fix interface-typed argument binding to object? overloads (#1421)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -718,6 +718,50 @@ public sealed class Conversion
             }
         }
 
+        // Issue #1421: a user-declared interface value is a CLR reference type
+        // whose implicit root base is System.Object, so it converts implicitly
+        // to `object`/`object?` as a plain reference upcast (no IL op, no box —
+        // an interface reference already IS an object reference). It also
+        // upcasts to any of its (transitive) base interfaces, whether
+        // user-declared (`BaseInterfaces`) or imported CLR (`BaseClrInterfaces`,
+        // including interfaces those transitively inherit). An InterfaceSymbol
+        // carries no ClrType during binding (its TypeDef only exists in the
+        // assembly being emitted), so the general object-widening rule and the
+        // #521 reference-upcast arm — both of which require `from.ClrType != null`
+        // — cannot fire. Without this, passing an interface-typed value to a
+        // `ThrowIfNull(object?, …)`-style overload failed to bind (GS0159). The
+        // `object?` target is routed here by the #1121 nullable-wrapping rule.
+        if (from is InterfaceSymbol fromInterface)
+        {
+            if (to == TypeSymbol.Object || to?.ClrType?.IsSameAs(typeof(object)) == true)
+            {
+                return Conversion.Implicit;
+            }
+
+            if (to is InterfaceSymbol toBaseInterface)
+            {
+                foreach (var baseInterface in fromInterface.SelfAndAllBaseInterfaces())
+                {
+                    if (baseInterface == toBaseInterface)
+                    {
+                        return Conversion.Implicit;
+                    }
+                }
+            }
+
+            if (to?.ClrType is { IsInterface: true } toClrInterface)
+            {
+                foreach (var baseClrInterface in fromInterface.BaseClrInterfaces)
+                {
+                    var clr = baseClrInterface?.ClrType;
+                    if (clr != null && (clr.IsSameAs(toClrInterface) || toClrInterface.IsAssignableFrom(clr)))
+                    {
+                        return Conversion.Implicit;
+                    }
+                }
+            }
+        }
+
         // Issue #528: a G# slice `[]T` is backed by a CLR `T[]` at runtime
         // (`SliceTypeSymbol.ClrType` is built via `MakeArrayType()` on the
         // element's `ClrType`). The reverse direction (`T[] → []T`) is

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
@@ -460,6 +460,47 @@ internal sealed partial class MethodBodyEmitter
             return true;
         }
 
+        // Issue #1421: a user-declared interface value is a CLR reference type,
+        // so widening it to `object` — or up to any of its (transitive) base
+        // interfaces, user-declared (`BaseInterfaces`) or imported CLR
+        // (`BaseClrInterfaces`) — is a no-op reference conversion at the IL
+        // level (the slot already holds the reference). The InterfaceSymbol
+        // carries no ClrType during emit (its TypeDef only exists in the
+        // assembly being emitted), so the CLR-backed `object`-widening and #521
+        // rules cannot fire. Without this, passing an interface-typed value to a
+        // `ThrowIfNull(object?)`-style parameter — or assigning it to `object` —
+        // threw NotSupportedException from EmitConversion.
+        if (a is InterfaceSymbol srcInterface)
+        {
+            if (b?.ClrType.IsSameAs(typeof(object)) == true || b == TypeSymbol.Object)
+            {
+                return true;
+            }
+
+            if (b is InterfaceSymbol targetBaseInterface)
+            {
+                foreach (var baseInterface in srcInterface.SelfAndAllBaseInterfaces())
+                {
+                    if (baseInterface == targetBaseInterface)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            if (b?.ClrType is { IsInterface: true } targetClrInterface)
+            {
+                foreach (var baseClrInterface in srcInterface.BaseClrInterfaces)
+                {
+                    var clr = baseClrInterface?.ClrType;
+                    if (clr != null && (clr.IsSameAs(targetClrInterface) || targetClrInterface.IsAssignableFrom(clr)))
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+
         if (a is StructSymbol aClass && b is StructSymbol bClass && aClass.IsClass && bClass.IsClass)
         {
             // Issue #1248: a constructed generic class's base-type reference is

--- a/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
@@ -214,6 +214,19 @@ public sealed class ImportedClassSymbol : Symbol
                     t = ss.ImportedBaseType?.ClrType ?? typeof(object);
                     hasUserClassArg = true;
                 }
+                else if (arguments[i].Type is InterfaceSymbol || arguments[i].Type is DelegateTypeSymbol)
+                {
+                    // Issue #1421 / ADR-0087 §3 R5: a user-defined G# interface or
+                    // named delegate argument carries no ClrType during binding
+                    // (its TypeDef only exists in the assembly being emitted), so
+                    // GetEffectiveClrType returned null above. It rides through the
+                    // same `object` boundary as a user struct — an interface value
+                    // is reference-convertible to `object` — so overload resolution
+                    // can pick an `object`(?) parameter (e.g.
+                    // `ArgumentNullException.ThrowIfNull(object?)`). Mirrors
+                    // ExpressionBinder.GetEffectiveArgumentClrTypeForOverloadResolution.
+                    t = typeof(object);
+                }
                 else if (arguments[i].Type is EnumSymbol)
                 {
                     // Issue #661: user-defined G# enum — backed by int32 at CLR level.

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1421InterfaceToObjectConversionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1421InterfaceToObjectConversionTests.cs
@@ -1,0 +1,187 @@
+// <copyright file="Issue1421InterfaceToObjectConversionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1421: a value of a user-declared <c>interface</c> type is
+/// reference-convertible to <c>object</c> (an interface reference already IS an
+/// object reference), so it must bind against an <c>object?</c> parameter such
+/// as <c>ArgumentNullException.ThrowIfNull(object?)</c> — it previously failed
+/// to resolve with GS0159 even though class- and slice-typed arguments worked.
+/// The same implicit reference conversion also covers interface → base-interface
+/// upcasts. These tests pin the binder (under both the live-reflection default
+/// resolver and a MetadataLoadContext resolver) and the emitter.
+/// </summary>
+public class Issue1421InterfaceToObjectConversionTests
+{
+    [Fact]
+    public void ThrowIfNull_OnUserInterfaceValue_BindsWithNoDiagnostics()
+    {
+        const string source = """
+            package t
+            import System
+            interface IBox { prop Type string }
+            func G(parent IBox) {
+                ArgumentNullException.ThrowIfNull(parent)
+            }
+            """;
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void ThrowIfNull_OnUserInterfaceValue_BindsUnderMetadataLoadContext()
+    {
+        const string source = """
+            package t
+            import System
+            interface IBox { prop Type string }
+            func G(parent IBox) {
+                ArgumentNullException.ThrowIfNull(parent)
+            }
+            """;
+        Assert.Empty(BindWithReferences(source));
+    }
+
+    [Fact]
+    public void InterfaceValue_AssignedToObject_BindsWithNoDiagnostics()
+    {
+        const string source = """
+            package t
+            interface IBox { prop Type string }
+            func G(parent IBox) {
+                var o object = parent
+            }
+            """;
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void DerivedInterfaceValue_PassedToBaseInterfaceParameter_BindsWithNoDiagnostics()
+    {
+        const string source = """
+            package t
+            interface IAnimal { prop Name string }
+            interface IDog : IAnimal { prop Breed string }
+            func TakesAnimal(a IAnimal) {}
+            func G(d IDog) {
+                TakesAnimal(d)
+            }
+            """;
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void InterfaceValue_FlowsThroughObjectAndBaseInterface_AtRuntime()
+    {
+        const string source = """
+            package t
+            import System
+            interface IAnimal { prop Name string }
+            interface IDog : IAnimal { prop Breed string }
+            class Dog : IDog {
+                prop Name string
+                prop Breed string
+            }
+            func Describe(a IAnimal) string {
+                return a.Name
+            }
+            func Main() {
+                var d IDog = Dog{ Name: "Rex", Breed: "Lab" }
+                ArgumentNullException.ThrowIfNull(d)
+                var o object = d
+                Console.WriteLine(o.ToString())
+                Console.WriteLine(Describe(d))
+            }
+            """;
+
+        var output = CompileLoadInvokeCaptureStdout(source, "Issue1421-InterfaceToObject");
+        Assert.Contains("Rex", output);
+    }
+
+    private static IReadOnlyList<Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.GlobalScope.Diagnostics.ToList();
+    }
+
+    private static ImmutableArray<Diagnostic> BindWithReferences(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var globalScope = GSharp.Core.CodeAnalysis.Binding.Binder.BindGlobalScope(
+            previous: null,
+            ImmutableArray.Create(tree),
+            MetadataLoadContextResolver());
+        var program = GSharp.Core.CodeAnalysis.Binding.Binder.BindProgram(globalScope, MetadataLoadContextResolver());
+        return globalScope.Diagnostics.AddRange(program.Diagnostics);
+    }
+
+    private static ReferenceResolver MetadataLoadContextResolver()
+    {
+        var paths = new[]
+        {
+            typeof(object).Assembly.Location,
+            typeof(System.Console).Assembly.Location,
+            typeof(System.ArgumentNullException).Assembly.Location,
+        }
+        .Where(p => !string.IsNullOrEmpty(p))
+        .Distinct(StringComparer.OrdinalIgnoreCase)
+        .ToArray();
+
+        return ReferenceResolver.WithReferences(paths);
+    }
+
+    private static string CompileLoadInvokeCaptureStdout(string source, string contextName)
+    {
+        using var peStream = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Emit(peStream);
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(contextName, isCollectible: true);
+        try
+        {
+            var asm = loadContext.LoadFromStream(peStream);
+            var entry = asm.EntryPoint;
+            Assert.NotNull(entry);
+
+            var stdout = Console.Out;
+            var captured = new StringWriter();
+            Console.SetOut(captured);
+            try
+            {
+                entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { System.Array.Empty<string>() });
+            }
+            finally
+            {
+                Console.SetOut(stdout);
+            }
+
+            return captured.ToString();
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
`ArgumentNullException.ThrowIfNull(parent)` failed with **GS0159: Cannot find function ThrowIfNull** when `parent` was a value of a user-declared `interface` type, even though class- and slice-typed arguments resolved fine. An interface reference is reference-convertible to `object?`, so the `ThrowIfNull(object?, string?)` overload should bind.

```gsharp
import System
interface IBox { prop Type string }
func G(parent IBox) {
    ArgumentNullException.ThrowIfNull(parent)   // was GS0159
}
```

## Root cause
A user-declared `InterfaceSymbol` carries no `ClrType` during binding (its TypeDef only exists in the assembly being emitted), so three layers never recognised the interface → object reference conversion:

1. **`ImportedClassSymbol.TryLookupFunction`** — computes the argument's effective CLR type for static-call overload resolution. It handled user class / enum / open type parameter but had **no `InterfaceSymbol` case**, so it bailed with no candidate (GS0159).
2. **`Conversion.Classify`** — no arm for an interface source, so interface → object / interface → base-interface classified as `None`.
3. **`MethodBodyEmitter.IsReferenceCompatible`** — did not treat an interface widening to object / base interface as a no-op reference conversion, throwing `NotSupportedException` at emit.

## Fix
- Add `InterfaceSymbol`/`DelegateTypeSymbol` → `object` ride-through in `TryLookupFunction` (mirrors `GetEffectiveArgumentClrTypeForOverloadResolution`).
- Add an interface-source arm to `Conversion.Classify`: interface → `object`/`object?` and interface → (transitive) base interface (user-declared `BaseInterfaces` and imported CLR `BaseClrInterfaces`).
- Add the matching no-op emit arm to `IsReferenceCompatible`.

This generally enables interface → object and interface → base-interface implicit reference conversions, not just for `ThrowIfNull`. Holds under both the live-reflection default resolver and the MetadataLoadContext resolver.

## Tests
New `Issue1421InterfaceToObjectConversionTests` (5 tests): ThrowIfNull binding under both resolvers, interface→object assignment, derived→base interface parameter passing, and an end-to-end emit+execute test. Verified no `RefactoringBaselineTests` byte-gate changes (additive conversion acceptance only).

Fixes #1421
Refs #914
