### PR TITLE
Fix #1422: chained Select GS0159 when projection element is a generic interface

### DIFF
--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -700,29 +700,29 @@ internal sealed class MemberLookup
             // parameter and reported GS0159. Erase using an `object` resolved
             // in the same context as `openDef`.
             var openParams = openDef.GetGenericArguments();
-            var erasedArgs = new Type[openParams.Length];
             var contextObject = ResolveErasedObjectInContext(openDef);
-            for (int i = 0; i < openParams.Length; i++)
-            {
-                erasedArgs[i] = contextObject;
-            }
 
-            Type erasedClosed;
-            try
-            {
-                erasedClosed = openDef.MakeGenericType(erasedArgs);
-            }
-            catch
-            {
-                // Fallback: if the type-erased construction violates a
-                // declared constraint (e.g. a `where T : struct` parameter
-                // that rejects `object`), fall back to the original open
-                // shape — downstream emit still encodes correctly via the
-                // OpenDefinition + TypeArguments.
-                erasedClosed = openClr;
-            }
+            // Issue #1422: preserve the *nested* generic structure of each
+            // symbolic argument when erasing. A chained projection such as
+            // `xs.Select(e -> e.GetEnumerator())` yields an element type that is
+            // itself a constructed generic interface (`IEnumerator[T]`). Flatly
+            // erasing every top-level argument to `object` would collapse the
+            // result's ClrType to `IEnumerable<object>`, so the next chained
+            // extension (`.Select((e IEnumerator[T]) -> …)`) would infer
+            // `TSource = object` and reject the typed selector with GS0159.
+            // Recurse through each symbolic argument's own open definition so
+            // the erased closed shape becomes `IEnumerable<IEnumerator<object>>`
+            // — matching the (identically erased) selector parameter type — and
+            // generic inference recovers the right `TSource`. Leaf type
+            // parameters and concrete arguments still erase to `object`, which
+            // mirrors how the selector's parameter type is erased, keeping the
+            // two shapes structurally aligned.
+            var symbolicArgs = symbolic.ToImmutable();
+            Type erasedClosed =
+                TryBuildErasedClosedGeneric(openDef, openParams, symbolicArgs, contextObject)
+                ?? openClr;
 
-            return ImportedTypeSymbol.GetConstructed(erasedClosed, openDef, symbolic.MoveToImmutable());
+            return ImportedTypeSymbol.GetConstructed(erasedClosed, openDef, symbolicArgs);
         }
 
         return TypeSymbol.FromClrType(openClr);
@@ -2012,6 +2012,104 @@ internal sealed class MemberLookup
         }
 
         return hostObject;
+    }
+
+    /// <summary>
+    /// Issue #1422: builds the type-erased closed shape for a constructed
+    /// generic whose symbolic arguments may themselves be constructed generics
+    /// (e.g. <c>IEnumerable&lt;IEnumerator&lt;T&gt;&gt;</c>). Each top-level
+    /// argument's <em>nested</em> generic structure is preserved by recursing
+    /// through its open definition, while leaf type parameters and concrete
+    /// leaves collapse to the context's <c>object</c> placeholder — matching the
+    /// erasure applied to selector/lambda parameter types, so generic inference
+    /// recovers the right element type for a chained extension call. Falls back
+    /// to a flat all-<c>object</c> erasure, then to <see langword="null"/>, when
+    /// the richer construction is rejected (e.g. cross-context or constraint
+    /// violations).
+    /// </summary>
+    /// <param name="openDef">The open generic type definition being closed.</param>
+    /// <param name="openParams">The open definition's generic parameters.</param>
+    /// <param name="symbolicArgs">The symbolic type arguments, aligned with <paramref name="openParams"/>.</param>
+    /// <param name="contextObject">The <c>object</c> placeholder resolved in <paramref name="openDef"/>'s context.</param>
+    /// <returns>The erased closed CLR type, or <see langword="null"/> when no valid closure could be formed.</returns>
+    private static Type TryBuildErasedClosedGeneric(Type openDef, Type[] openParams, ImmutableArray<TypeSymbol> symbolicArgs, Type contextObject)
+    {
+        var richArgs = new Type[openParams.Length];
+        var anyRich = false;
+        for (var i = 0; i < openParams.Length; i++)
+        {
+            var projected = i < symbolicArgs.Length
+                ? ProjectSymbolicArgToErasedClr(symbolicArgs[i], contextObject)
+                : null;
+            if (projected != null && !projected.IsSameAs(contextObject))
+            {
+                anyRich = true;
+            }
+
+            richArgs[i] = projected ?? contextObject;
+        }
+
+        if (anyRich)
+        {
+            try
+            {
+                return openDef.MakeGenericType(richArgs);
+            }
+            catch
+            {
+                // Fall through to the flat erasure below.
+            }
+        }
+
+        var flatArgs = new Type[openParams.Length];
+        for (var i = 0; i < openParams.Length; i++)
+        {
+            flatArgs[i] = contextObject;
+        }
+
+        try
+        {
+            return openDef.MakeGenericType(flatArgs);
+        }
+        catch
+        {
+            // Constraint or cross-context failure — caller falls back to the
+            // open shape; downstream emit still encodes correctly via the
+            // OpenDefinition + TypeArguments.
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Issue #1422: projects a single symbolic type argument onto an erased CLR
+    /// type in <paramref name="contextObject"/>'s load context. Nested
+    /// constructed generics (carrying an <see cref="ImportedTypeSymbol.OpenDefinition"/>)
+    /// are rebuilt recursively so their generic shape survives; leaf type
+    /// parameters and other leaves collapse to <paramref name="contextObject"/>.
+    /// Returns <see langword="null"/> when no useful erasure could be formed.
+    /// </summary>
+    /// <param name="symbolicArg">The symbolic type argument.</param>
+    /// <param name="contextObject">The <c>object</c> placeholder for the target context.</param>
+    /// <returns>The erased CLR type, or <see langword="null"/>.</returns>
+    private static Type ProjectSymbolicArgToErasedClr(TypeSymbol symbolicArg, Type contextObject)
+    {
+        switch (symbolicArg)
+        {
+            case null:
+            case TypeParameterSymbol:
+                return contextObject;
+            case ImportedTypeSymbol imp when imp.OpenDefinition != null && !imp.TypeArguments.IsDefaultOrEmpty:
+                return TryBuildErasedClosedGeneric(
+                    imp.OpenDefinition,
+                    imp.OpenDefinition.GetGenericArguments(),
+                    imp.TypeArguments,
+                    contextObject);
+            default:
+                // Concrete leaf (e.g. a fully-closed imported type): erase to the
+                // context placeholder so the shape stays in a single load context
+                // and mirrors how the same leaf is erased on the selector side.
+                return contextObject;
+        }
     }
 
     private static bool ReturnTypeMatchesSubstituted(TypeSymbol candidateReturn, Type openReturn, ImmutableArray<TypeSymbol> symbolicArgs)

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1422ChainedSelectGenericInterfaceElementTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1422ChainedSelectGenericInterfaceElementTests.cs
@@ -1,0 +1,167 @@
+// <copyright file="Issue1422ChainedSelectGenericInterfaceElementTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1422 (refs #914): a chained <c>.Select(...).Select(...)</c> failed on
+/// the SECOND <c>Select</c> with <c>GS0159 (Cannot find function Select)</c> when
+/// the first projection's element type was itself a <em>constructed generic
+/// interface over an in-scope type parameter</em> (e.g. <c>IEnumerator[T]</c>),
+/// even though each <c>Select</c> bound cleanly in isolation.
+/// <para>
+/// Root cause: when the first <c>Select</c>'s result type
+/// (<c>IEnumerable[IEnumerator[T]]</c>) was projected to its type-erased closed
+/// CLR shape, every top-level generic argument was flatly erased to
+/// <c>System.Object</c> — collapsing the receiver to <c>IEnumerable&lt;object&gt;</c>
+/// and discarding the nested <c>IEnumerator&lt;…&gt;</c> structure. The second
+/// <c>Select</c>'s generic inference then bound <c>TSource = object</c>, which
+/// no longer matched the explicitly-typed <c>(e IEnumerator[T])</c> selector, so
+/// the candidate was dropped (GS0159). The fix erases each argument while
+/// preserving its <em>nested</em> generic shape
+/// (<c>IEnumerable&lt;IEnumerator&lt;object&gt;&gt;</c>), mirroring how the
+/// selector's parameter type is erased, so inference recovers the right
+/// <c>TSource</c>.
+/// </para>
+/// </summary>
+public class Issue1422ChainedSelectGenericInterfaceElementTests
+{
+    [Fact]
+    public void ChainedSelect_FirstProjectionGenericInterfaceElement_Binds()
+    {
+        // BUG: GS0159 on the SECOND Select — the first projection's element type
+        // `IEnumerator[T]` collapsed to object on the chained receiver.
+        const string source = @"
+package p
+import System
+import System.Collections.Generic
+import System.Linq
+func C[T](xs []IEnumerable[T]) []int32 ->
+    xs.Select((e IEnumerable[T]) -> e.GetEnumerator())
+      .Select((e IEnumerator[T]) -> 1)
+      .ToArray()
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void ChainedSelect_ThreeDeep_GenericInterfaceElement_Binds()
+    {
+        // A three-deep chain keeps the nested `IEnumerator[T]` element identity
+        // across every link.
+        const string source = @"
+package p
+import System
+import System.Collections.Generic
+import System.Linq
+func C[T](xs []IEnumerable[T]) []int32 ->
+    xs.Select((e IEnumerable[T]) -> e.GetEnumerator())
+      .Select((e IEnumerator[T]) -> e)
+      .Select((e IEnumerator[T]) -> 1)
+      .ToArray()
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void ChainedSelect_ThenOrderBy_GenericInterfaceElement_Binds()
+    {
+        // A chain terminating in a different generic LINQ operator (OrderBy)
+        // also recovers the nested element type.
+        const string source = @"
+package p
+import System
+import System.Collections.Generic
+import System.Linq
+func C[T](xs []IEnumerable[T]) []IEnumerator[T] ->
+    xs.Select((e IEnumerable[T]) -> e.GetEnumerator())
+      .OrderBy((e IEnumerator[T]) -> 1)
+      .ToArray()
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void Controls_ConcreteElement_And_SingleSelect_Bind()
+    {
+        // Control 1: a fully-concrete element type (no in-scope type parameter)
+        // was never affected and still binds.
+        const string concreteElement = @"
+package p
+import System
+import System.Collections.Generic
+import System.Linq
+func C(xs []IEnumerable[int32]) []int32 ->
+    xs.Select((e IEnumerable[int32]) -> e.GetEnumerator())
+      .Select((e IEnumerator[int32]) -> 1)
+      .ToArray()
+";
+
+        // Control 2: each Select binds in isolation (the issue's premise).
+        const string singleSelect = @"
+package p
+import System
+import System.Collections.Generic
+import System.Linq
+func C[T](xs []IEnumerable[T]) []int32 ->
+    xs.Select((e IEnumerable[T]) -> e.Count()).ToArray()
+";
+        Assert.Empty(GetDiagnostics(concreteElement));
+        Assert.Empty(GetDiagnostics(singleSelect));
+    }
+
+    private static ImmutableArrayOfDiagnostic GetDiagnostics(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var parseDiagnostics = tree.Diagnostics;
+        var bindDiagnostics = compilation.GlobalScope.Diagnostics;
+        var programDiagnostics = compilation.BoundProgram.Diagnostics;
+        var all = parseDiagnostics
+            .Concat(bindDiagnostics)
+            .Concat(programDiagnostics)
+            .Where(d => d.IsError)
+            .ToImmutableArray();
+        return new ImmutableArrayOfDiagnostic(all);
+    }
+
+    /// <summary>
+    /// Thin wrapper so the test cases can call <c>Assert.Empty</c> against a
+    /// <see cref="ImmutableArray{T}"/> without exposing the GSharp diagnostic
+    /// surface to xUnit's enumerable inference.
+    /// </summary>
+    private readonly struct ImmutableArrayOfDiagnostic : IReadOnlyCollection<Diagnostic>
+    {
+        private readonly ImmutableArray<Diagnostic> diagnostics;
+
+        public ImmutableArrayOfDiagnostic(ImmutableArray<Diagnostic> diagnostics)
+        {
+            this.diagnostics = diagnostics;
+        }
+
+        public int Count => this.diagnostics.Length;
+
+        public IEnumerator<Diagnostic> GetEnumerator()
+        {
+            foreach (var diagnostic in this.diagnostics)
+            {
+                yield return diagnostic;
+            }
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
A chained `.Select(...).Select(...)` failed on the **second** `Select` with `GS0159: Cannot find function Select` whenever the first projection's element type was itself a constructed generic interface over an in-scope type parameter (e.g. `IEnumerator[T]`) — even though each `Select` bound cleanly in isolation.

```gsharp
func C[T](xs []IEnumerable[T]) []int32 ->
    xs.Select((e IEnumerable[T]) -> e.GetEnumerator())
      .Select((e IEnumerator[T]) -> 1)   // GS0159 here
      .ToArray()
```

## Root cause
When the first `Select`'s result type (`IEnumerable[IEnumerator[T]]`) was projected to its type-erased closed CLR shape in `MemberLookup.MapOpenClrTypeToSymbolic`, every top-level generic argument was **flatly** erased to `System.Object`, collapsing the chained receiver to `IEnumerable<object>` and discarding the nested `IEnumerator<…>` structure. The second `Select`'s generic inference then bound `TSource = object`, which no longer matched the explicitly-typed `(e IEnumerator[T])` selector, so the candidate was dropped.

## Fix
Erase each generic argument while **preserving its nested generic shape** (`IEnumerable<IEnumerator<object>>`), recursing through each symbolic argument's own open definition. Leaf type parameters and concrete leaves still collapse to the context `object` placeholder, mirroring how the selector's parameter type is erased, so inference recovers the correct `TSource`. The construction stays within a single load context and falls back to the prior flat erasure (then the open shape) when a richer closure is rejected, preserving behaviour under both `ReferenceResolver.Default` and `MetadataLoadContext`.

## Validation
- Repro, a 3-deep chain, and a chain ending in `OrderBy` all bind clean.
- New binder regression tests: `Issue1422ChainedSelectGenericInterfaceElementTests` (4 tests, incl. concrete-element / single-Select controls).
- Full `Core.Tests` suite green: **4779 passed, 1 skipped** (IL baseline unchanged).

Fixes #1422
Refs #914
