### PR TITLE
Bind LINQ extensions on user types implementing generic collection interfaces (#1423)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -3832,6 +3832,22 @@ internal sealed partial class ExpressionBinder
             }
         }
 
+        // Issue #1423: a user class that implements a generic collection
+        // interface (e.g. `class EntryList : IReadOnlyCollection[Entry]`, which
+        // extends `IEnumerable[Entry]`) erases to `System.Object` via
+        // TryProjectErasedClrType (it has no imported base class), so an
+        // extension method whose `this` self-parameter is `IEnumerable<TSource>`
+        // (LINQ Where/Select/OrderBy/…) cannot match the receiver and TSource
+        // cannot be inferred. Project the receiver to the most-derived
+        // implemented CLR interface instead so overload resolution sees the
+        // collection element type; the bound receiver expression is unchanged.
+        if (receiver.Type is StructSymbol { IsClass: true } userReceiverClass
+            && (receiverClrType == null || receiverClrType.IsSameAs(typeof(object)))
+            && TryProjectUserClassReceiverInterface(userReceiverClass, out var receiverIface))
+        {
+            receiverClrType = receiverIface;
+        }
+
         // Build the argument-type vector as the extension method sees it: the
         // receiver becomes the first ("this") parameter, followed by the user
         // arguments. Every argument must carry a concrete CLR type so overload
@@ -4012,6 +4028,94 @@ internal sealed partial class ExpressionBinder
         overloads.ValidateRefArguments(bound, refKinds, methodName, ce.Location);
         result = new BoundImportedCallExpression(null, function, bound, refKinds, extensionTypeArgSymbolsForCall);
         return true;
+    }
+
+    /// <summary>
+    /// Issue #1423: projects a user-declared class to the implemented CLR
+    /// interface best suited to drive extension-method receiver matching and
+    /// generic inference. Prefers an implemented interface that is, or extends,
+    /// <c>IEnumerable&lt;T&gt;</c> (so LINQ-style extensions whose <c>this</c>
+    /// self-parameter is <c>IEnumerable&lt;TSource&gt;</c> bind and infer
+    /// <c>TSource</c>), choosing the most-derived such interface so any
+    /// methods declared on the richer interface remain reachable. Falls back to
+    /// the first implemented CLR interface so non-collection extensions can
+    /// still match an interface receiver.
+    /// </summary>
+    /// <param name="userClass">The user-declared class receiver.</param>
+    /// <param name="clrInterface">The projected CLR interface type, on success.</param>
+    /// <returns><see langword="true"/> when an implemented CLR interface was found.</returns>
+    private static bool TryProjectUserClassReceiverInterface(StructSymbol userClass, out Type clrInterface)
+    {
+        clrInterface = null;
+        if (userClass.ImplementedClrInterfaces.IsDefaultOrEmpty)
+        {
+            return false;
+        }
+
+        Type firstInterface = null;
+        Type bestEnumerable = null;
+        foreach (var implemented in userClass.ImplementedClrInterfaces)
+        {
+            var clr = implemented?.ClrType;
+            if (clr == null || !clr.IsInterface)
+            {
+                continue;
+            }
+
+            firstInterface ??= clr;
+
+            // A generic collection interface (IReadOnlyCollection<T>,
+            // ICollection<T>, IList<T>, IEnumerable<T>, …) exposes
+            // IEnumerable<T> through its base interfaces, letting overload
+            // resolution recover the element type. Prefer the most-derived
+            // such interface (the one whose interface set is largest).
+            if (ImplementsGenericEnumerable(clr)
+                && (bestEnumerable == null
+                    || SafeInterfaceCount(clr) > SafeInterfaceCount(bestEnumerable)))
+            {
+                bestEnumerable = clr;
+            }
+        }
+
+        clrInterface = bestEnumerable ?? firstInterface;
+        return clrInterface != null;
+    }
+
+    private static bool ImplementsGenericEnumerable(Type clr)
+    {
+        if (clr.IsGenericType && clr.GetGenericTypeDefinition().FullName == "System.Collections.Generic.IEnumerable`1")
+        {
+            return true;
+        }
+
+        try
+        {
+            foreach (var iface in clr.GetInterfaces())
+            {
+                if (iface.IsGenericType && iface.GetGenericTypeDefinition().FullName == "System.Collections.Generic.IEnumerable`1")
+                {
+                    return true;
+                }
+            }
+        }
+        catch (Exception)
+        {
+            // Cross-context (MLC) types may throw on GetInterfaces(); ignore.
+        }
+
+        return false;
+    }
+
+    private static int SafeInterfaceCount(Type clr)
+    {
+        try
+        {
+            return clr.GetInterfaces().Length;
+        }
+        catch (Exception)
+        {
+            return 0;
+        }
     }
 
     private ImmutableArray<BoundExpression> RebindFunctionLiteralDelegateArguments(

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1423UserCollectionInterfaceExtensionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1423UserCollectionInterfaceExtensionTests.cs
@@ -1,0 +1,169 @@
+// <copyright file="Issue1423UserCollectionInterfaceExtensionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1423: LINQ extension methods (<c>OrderBy</c>, <c>Where</c>,
+/// <c>Select</c>, …) resolve on a concrete <c>List[T]</c> but failed
+/// <c>GS0159</c> on a user-defined class that implements a generic collection
+/// interface such as <c>IReadOnlyCollection[T]</c> (which extends
+/// <c>IEnumerable[T]</c>). They should bind via the inherited base interface
+/// <c>IEnumerable[TSource]</c>.
+/// <para>
+/// Root cause: a user class with no imported base class erased to
+/// <c>System.Object</c> for the extension-call receiver slot, so the
+/// <c>this IEnumerable&lt;TSource&gt;</c> self-parameter could not match and
+/// <c>TSource</c> could not be inferred. The fix projects the receiver to the
+/// most-derived implemented CLR collection interface so overload resolution
+/// recovers the element type.
+/// </para>
+/// </summary>
+public class Issue1423UserCollectionInterfaceExtensionTests
+{
+    [Fact]
+    public void OrderBy_OnUserReadOnlyCollection_Binds()
+    {
+        // BUG: GS0159 — `.OrderBy` self-param `IEnumerable<TSource>` unmatched
+        // because EntryList erased to System.Object.
+        const string source = @"
+package p
+import System.Collections
+import System.Collections.Generic
+import System.Linq
+class Entry { prop Off int64 }
+class EntryList : IReadOnlyCollection[Entry] {
+    prop Count int32 -> 0
+    func GetEnumerator() IEnumerator[Entry] -> List[Entry]().GetEnumerator()
+    private func GetEnumerator() IEnumerator -> GetEnumerator()
+}
+class C {
+    func F(e EntryList) {
+        let c = e.OrderBy((s Entry) -> s.Off).ToList()
+    }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void Where_Select_Count_OnUserReadOnlyCollection_Bind()
+    {
+        const string source = @"
+package p
+import System.Collections
+import System.Collections.Generic
+import System.Linq
+class Entry { prop Off int64 }
+class EntryList : IReadOnlyCollection[Entry] {
+    prop Count int32 -> 0
+    func GetEnumerator() IEnumerator[Entry] -> List[Entry]().GetEnumerator()
+    private func GetEnumerator() IEnumerator -> GetEnumerator()
+}
+class C {
+    func F(e EntryList) {
+        let a = e.Where((s Entry) -> s.Off > 0).ToList()
+        let b = e.Select((s Entry) -> s.Off).ToList()
+        let n = e.Count((s Entry) -> s.Off > 0)
+    }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void Select_OnUserDirectEnumerable_Binds()
+    {
+        // A class implementing IEnumerable[T] directly must keep working.
+        const string source = @"
+package p
+import System.Collections
+import System.Collections.Generic
+import System.Linq
+class Entry { prop Off int64 }
+class DirectList : IEnumerable[Entry] {
+    func GetEnumerator() IEnumerator[Entry] -> List[Entry]().GetEnumerator()
+    private func GetEnumerator() IEnumerator -> GetEnumerator()
+}
+class C {
+    func G(d DirectList) {
+        let a = d.Select((s Entry) -> s.Off).ToList()
+        let b = d.Where((s Entry) -> s.Off > 0).ToList()
+    }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void OrderBy_OnConcreteList_StillBinds()
+    {
+        // Control: the concrete List[T] receiver path was never broken.
+        const string source = @"
+package p
+import System.Collections.Generic
+import System.Linq
+class C {
+    func F(xs List[int32]) {
+        let c = xs.OrderBy((s int32) -> s).ToList()
+    }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    private static ImmutableArrayOfDiagnostic GetDiagnostics(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var parseDiagnostics = tree.Diagnostics;
+        var bindDiagnostics = compilation.GlobalScope.Diagnostics;
+        var programDiagnostics = compilation.BoundProgram.Diagnostics;
+        var all = parseDiagnostics
+            .Concat(bindDiagnostics)
+            .Concat(programDiagnostics)
+            .Where(d => d.IsError)
+            .ToImmutableArray();
+        return new ImmutableArrayOfDiagnostic(all);
+    }
+
+    /// <summary>
+    /// Thin wrapper so the test cases can call <c>Assert.Empty</c> against a
+    /// <see cref="ImmutableArray{T}"/> without exposing the GSharp diagnostic
+    /// surface to xUnit's enumerable inference.
+    /// </summary>
+    private readonly struct ImmutableArrayOfDiagnostic : IReadOnlyCollection<Diagnostic>
+    {
+        private readonly ImmutableArray<Diagnostic> diagnostics;
+
+        public ImmutableArrayOfDiagnostic(ImmutableArray<Diagnostic> diagnostics)
+        {
+            this.diagnostics = diagnostics;
+        }
+
+        public int Count => this.diagnostics.Length;
+
+        public IEnumerator<Diagnostic> GetEnumerator()
+        {
+            foreach (var diagnostic in this.diagnostics)
+            {
+                yield return diagnostic;
+            }
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Fixes #1423. LINQ extension methods (`OrderBy`, `Where`, `Select`, `Count`, …) resolved on a concrete `List[T]` but failed `GS0159: Cannot find function` on a user-defined class implementing a generic collection interface such as `IReadOnlyCollection[T]` (which extends `IEnumerable[T]`).

## Root cause
A user class with no imported base class erases to `System.Object` for the extension-call receiver slot (`TryProjectErasedClrType`). The `this IEnumerable<TSource>` self-parameter of the LINQ operator then could not match the receiver, and `TSource` could not be inferred — so every candidate was rejected.

## Fix
In `TryBindImportedExtensionCall` (`ExpressionBinder.Calls.cs`), when the receiver is a user class that would otherwise erase to `object`, project it to its most-derived implemented CLR interface — preferring one that is or extends `IEnumerable<T>` — so overload resolution recovers the element type and binds via the inherited base interface. The bound receiver expression is unchanged; only the CLR type used for resolution/inference is adjusted. Uses `FullName`-based / `IsSameAs` checks so it holds under both `ReferenceResolver.Default` and `MetadataLoadContext`.

## Tests
New binder regression tests in `Issue1423UserCollectionInterfaceExtensionTests.cs` cover `OrderBy`/`Where`/`Select`/`Count` on an `IReadOnlyCollection[T]` implementer, a direct `IEnumerable[T]` implementer, and a `List[T]` control. Full `Core.Tests` suite passes (4783 passed, 1 skipped).

Refs #914