### PR TITLE
Fix order-dependent if-expression nullability (#1428)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
@@ -916,12 +916,45 @@ internal sealed partial class ExpressionBinder
         var pairwise = ComputeConditionalCommonType(left, right);
         if (pairwise != null)
         {
-            return pairwise;
+            return UnionArmNullability(pairwise, left, right);
         }
 
         // (c) Best-common-type (least-upper-bound) fallback: unify sibling
         // subtypes to their shared base/interface.
-        return ComputeBestCommonType(new[] { left, right });
+        return UnionArmNullability(ComputeBestCommonType(new[] { left, right }), left, right);
+    }
+
+    /// <summary>
+    /// Issue #1428: the least-upper-bound of two conditional/if-expression arms
+    /// must UNION the nullable annotation of both arms, independent of arm order.
+    /// The pairwise/best-common routines can return a non-nullable type when one
+    /// arm is non-nullable and the other is reference-convertible to it (e.g.
+    /// arm0 <c>T</c>, arm1 <c>T?</c> for a reference/interface <c>T</c>, where
+    /// both arms are mutually implicitly convertible), dropping the nullable
+    /// annotation that the second arm contributed. This lifts the chosen result
+    /// to its nullable form whenever EITHER arm is nullable, mirroring C# where
+    /// <c>cond ? e : null</c> (and the reversed form) both yield <c>T?</c>.
+    /// </summary>
+    /// <param name="result">The chosen common type (may be <see langword="null"/>).</param>
+    /// <param name="left">The true-arm type.</param>
+    /// <param name="right">The false-arm type.</param>
+    /// <returns>The result lifted to nullable when either arm is nullable; otherwise <paramref name="result"/>.</returns>
+    private static TypeSymbol UnionArmNullability(TypeSymbol result, TypeSymbol left, TypeSymbol right)
+    {
+        if (result == null
+            || result == TypeSymbol.Error
+            || result == TypeSymbol.Never
+            || result is NullableTypeSymbol)
+        {
+            return result;
+        }
+
+        if (left is NullableTypeSymbol || right is NullableTypeSymbol)
+        {
+            return NullableTypeSymbol.Get(result);
+        }
+
+        return result;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -2298,7 +2298,7 @@ internal sealed class MemberLookup
                 var pos = openClr.GenericParameterPosition;
                 if ((uint)pos < (uint)result.Length && result[pos] == null)
                 {
-                    result[pos] = StripNullability(actual);
+                    result[pos] = NormalizeRecoveredNullability(actual);
                 }
             }
 
@@ -2415,9 +2415,21 @@ internal sealed class MemberLookup
         }
     }
 
-    private static TypeSymbol StripNullability(TypeSymbol t)
+    /// <summary>
+    /// Issue #1428: normalizes a symbolic type argument recovered while unifying
+    /// a method type parameter (e.g. the <c>TResult</c> of <c>Select</c>) against
+    /// the actual argument shape. A <em>reference</em>-typed nullable (e.g.
+    /// <c>IEnumerator[T]?</c>) keeps its nullable annotation so the projected
+    /// result element (<c>IEnumerable[IEnumerator[T]?]</c> → <c>IEnumerator[T]?[]</c>)
+    /// remains nullable — its CLR backing is identical to the underlying type, so
+    /// emit and overload resolution are unaffected by carrying the annotation.
+    /// A <em>value</em>-typed nullable (<c>int?</c> = <c>Nullable&lt;int&gt;</c>) is
+    /// still stripped to its underlying type, preserving the pre-existing CLR
+    /// encoding expectations for value-type projections.
+    /// </summary>
+    private static TypeSymbol NormalizeRecoveredNullability(TypeSymbol t)
     {
-        if (t is NullableTypeSymbol nn && nn.UnderlyingType != null)
+        if (t is NullableTypeSymbol nn && nn.UnderlyingType?.ClrType is { IsValueType: true })
         {
             return nn.UnderlyingType;
         }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1428ConditionalNullableOrderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1428ConditionalNullableOrderTests.cs
@@ -1,0 +1,126 @@
+// <copyright file="Issue1428ConditionalNullableOrderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1428: the best-common-type of a value-producing <c>if</c>/conditional
+/// expression must UNION the nullable annotation of BOTH arms regardless of arm
+/// order. When a non-nullable reference arm <c>T</c> appears first and a
+/// nullable arm <c>T?</c> second (both mutually reference-convertible), the
+/// merged type must still be <c>T?</c> — mirroring C# where <c>cond ? e : null</c>
+/// (and the reversed form) both yield <c>T?</c>.
+/// </summary>
+public class Issue1428ConditionalNullableOrderTests
+{
+    [Fact]
+    public void IfExpression_NonNullThenNullableElse_UnifiesToNullable()
+    {
+        var scope = BindGlobalScope(@"
+let s string? = ""hi""
+let x = if true { ""lit"" } else { s }
+");
+
+        Assert.Empty(scope.Diagnostics);
+        var x = scope.Variables.Single(v => v.Name == "x").Type;
+        var nullable = Assert.IsType<NullableTypeSymbol>(x);
+        Assert.Equal(TypeSymbol.String, nullable.UnderlyingType);
+    }
+
+    [Fact]
+    public void IfExpression_NullableThenNonNullElse_UnifiesToNullable()
+    {
+        // The reversed arm order already worked before the fix; it must keep
+        // yielding the same nullable result so both orders agree.
+        var scope = BindGlobalScope(@"
+let s string? = ""hi""
+let x = if true { s } else { ""lit"" }
+");
+
+        Assert.Empty(scope.Diagnostics);
+        var x = scope.Variables.Single(v => v.Name == "x").Type;
+        var nullable = Assert.IsType<NullableTypeSymbol>(x);
+        Assert.Equal(TypeSymbol.String, nullable.UnderlyingType);
+    }
+
+    [Fact]
+    public void IfExpression_NonNullBothArms_StaysNonNull()
+    {
+        // Regression guard: two non-nullable reference arms must NOT be lifted.
+        var scope = BindGlobalScope(@"
+let a string = ""a""
+let b string = ""b""
+let x = if true { a } else { b }
+");
+
+        Assert.Empty(scope.Diagnostics);
+        var x = scope.Variables.Single(v => v.Name == "x").Type;
+        Assert.IsNotType<NullableTypeSymbol>(x);
+        Assert.Equal(TypeSymbol.String, x);
+    }
+
+    [Fact]
+    public void IfExpression_GenericInterfaceArm_NonNullFirst_AssignNilSucceeds()
+    {
+        // The issue repro: arm0 is the non-null `IEnumerator[T]` and arm1 is the
+        // nullable `IEnumerator[T]?`. The unified type must be nullable so a
+        // later `x = nil` assignment is legal.
+        var diagnostics = Bind(@"
+import System.Collections.Generic
+func F[T](e IEnumerator[T]) {
+    var x = if true { e } else { default(IEnumerator[T]?) }
+    x = nil
+}
+");
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void IfExpression_GenericInterfaceArm_NullableFirst_AssignNilSucceeds()
+    {
+        var diagnostics = Bind(@"
+import System.Collections.Generic
+func F[T](e IEnumerator[T]) {
+    var x = if true { default(IEnumerator[T]?) } else { e }
+    x = nil
+}
+");
+
+        Assert.Empty(diagnostics);
+    }
+
+    private static ImmutableArray<Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        if (tree.Diagnostics.Any())
+        {
+            return tree.Diagnostics;
+        }
+
+        var globalScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+        if (globalScope.Diagnostics.Any())
+        {
+            return globalScope.Diagnostics;
+        }
+
+        var program = Binder.BindProgram(globalScope);
+        return program.Diagnostics.ToImmutableArray();
+    }
+
+    private static BoundGlobalScope BindGlobalScope(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        return Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+    }
+}


### PR DESCRIPTION
## Summary
The value-producing `if`/conditional expression best-common-type was **order-dependent** and dropped nullability when the non-nullable arm appeared first:

```gsharp
func F[T](e IEnumerator[T]) {
    var x = if true { e } else { default(IEnumerator[T]?) }
    x = nil   // GS0155 before fix
}
```

Reversing the arms compiled cleanly, so the merged type was wrongly `T` (non-null) when arm0 was `T` and arm1 was `T?`. It must be `T?` — the least-upper-bound must UNION the nullable annotation of both arms regardless of order, mirroring C# `cond ? e : null` ⇒ `T?`.

## Root cause
When both arms are mutually implicitly convertible (as `T` and `T?` are for a reference/interface `T`), `ComputeConditionalCommonType` falls through to `return left`, discarding the nullable annotation contributed by the second arm.

A second, related blocker affected the LINQ projection case: when recovering the symbolic `TResult` of `Select` by unifying against the lambda's return type, `UnifyForMethodTypeArgs` unconditionally stripped nullability, so the projected array element lost its `?`.

## Fix
- **`ExpressionBinder.Operators`**: post-process the pairwise/best-common result via `UnionArmNullability`, lifting the chosen type to its nullable form whenever **either** arm is nullable (idempotent for already-nullable / `Error` / `Never`).
- **`MemberLookup`**: preserve a **reference-typed** nullable annotation when recovering a symbolic method type argument (`NormalizeRecoveredNullability`) so a nullable LINQ projection element flows through to a nullable array element (`IEnumerator[T]?[]`). Value-type nullables are still stripped to keep their CLR encoding unchanged.

## Verification
- Both issue repros (direct `if`-expression and the `.Select(...).ToArray()` LINQ case) compile clean.
- Reversed arm order and the value+`nil` arm cases still unify to nullable.
- A non-null/non-null pair correctly **stays** non-null (assigning `nil` still errors).
- New regression tests `Issue1428ConditionalNullableOrderTests` (5 tests) pass.
- Full `Core.Tests` suite green (4783 passed); related conditional/Select/nullable suites (405 tests) green.

Fixes #1428
Refs #914
