### PR TITLE
[cs2gs] Hoist side-effecting is-pattern loop conditions

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue914WhileConditionHoistTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue914WhileConditionHoistTranslationTests.cs
@@ -1,0 +1,208 @@
+// <copyright file="Issue914WhileConditionHoistTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Regression tests for the <c>Oahu.Decrypt</c> migration fix tracked under
+/// issue #914: a <c>while</c>/<c>do-while</c> whose condition carries a
+/// side-effecting <c>is</c>-pattern clause (a call declaring <c>out var</c>
+/// matched against an <c>and</c>/<c>not</c> pattern combinator). G# has no
+/// <c>and</c>/<c>not</c> combinators, so the naive lowering re-emitted the
+/// scrutinee per sub-test — re-running the call and re-declaring the
+/// <c>out var</c> (→ GS0102). The fix hoists the scrutinee to a single local at
+/// the top of the loop body and converts the trailing pattern tests into
+/// <c>break</c> guards, keeping the leading side-effect-free clauses as the real
+/// loop condition. Each snippet must round-trip-parse through the real G# parser.
+/// </summary>
+public class Issue914WhileConditionHoistTranslationTests
+{
+    /// <summary>
+    /// The motivating <c>Frame.LoadChildren</c> shape:
+    /// <c>while (a &amp;&amp; b &amp;&amp; M(out var n) is Frame child and not EmptyFrame)</c>.
+    /// The leading pure clauses stay in the loop condition; the scrutinee is
+    /// evaluated once into <c>let child = …</c>; the <c>not EmptyFrame</c> test
+    /// becomes an <c>if child is EmptyFrame { break }</c> guard; and the
+    /// <c>out var</c> declaration appears exactly once.
+    /// </summary>
+    [Fact]
+    public void WhileWithOutVarAndPatternCombinator_HoistsScrutineeOnce()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public abstract class Frame { }
+
+    public sealed class EmptyFrame : Frame { }
+
+    public sealed class RealFrame : Frame { }
+
+    public static class TagFactory
+    {
+        public static Frame CreateTag(out int lengthRead)
+        {
+            lengthRead = 1;
+            return new RealFrame();
+        }
+    }
+
+    public sealed class Loader
+    {
+        public System.Collections.Generic.List<Frame> Children { get; } = new();
+
+        public void LoadChildren(int endPosition)
+        {
+            int position = 0;
+            int origPosition = position;
+
+            while (position < endPosition
+                && origPosition == position
+                && TagFactory.CreateTag(out var lengthRead) is Frame child and not EmptyFrame)
+            {
+                origPosition += lengthRead;
+                Children.Add(child);
+            }
+        }
+    }
+}");
+
+        // Leading side-effect-free clauses remain the real loop condition.
+        Assert.Contains("while position < endPosition && origPosition == position {", printed);
+
+        // The scrutinee is evaluated once into the hoist local reusing the binder name.
+        Assert.Contains("let child = TagFactory.CreateTag(out var lengthRead)", printed);
+
+        // The `not EmptyFrame` arm becomes a break guard.
+        Assert.Contains("if child is EmptyFrame {", printed);
+        Assert.Contains("break", printed);
+
+        // The `out var` declaration and the call must each appear exactly once.
+        Assert.Equal(1, CountOccurrences(printed, "out var lengthRead"));
+        Assert.Equal(1, CountOccurrences(printed, "TagFactory.CreateTag"));
+
+        // The body still reads the hoisted binder and out-var.
+        Assert.Contains("Children.Add(child)", printed);
+    }
+
+    /// <summary>
+    /// A plain <c>while</c> with no pattern binding or side-effecting duplicated
+    /// scrutinee must be left as a plain <c>while cond { }</c> — the hoist
+    /// transform must not regress ordinary loops.
+    /// </summary>
+    [Fact]
+    public void SimpleWhile_IsNotHoisted()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public sealed class C
+    {
+        public int Sum(int n)
+        {
+            int i = 0;
+            int total = 0;
+            while (i < n)
+            {
+                total += i;
+                i++;
+            }
+
+            return total;
+        }
+    }
+}");
+
+        Assert.Contains("while i < n {", printed);
+        Assert.DoesNotContain("break", printed);
+    }
+
+    /// <summary>
+    /// A <c>while</c> whose only condition is a side-effecting pattern clause
+    /// (no leading pure clauses) hoists the scrutinee with a <c>true</c> loop
+    /// condition.
+    /// </summary>
+    [Fact]
+    public void WhilePatternOnly_HoistsWithTrueCondition()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public abstract class Node { }
+
+    public sealed class Stop : Node { }
+
+    public sealed class Step : Node { }
+
+    public static class Source
+    {
+        public static Node Next(out int read)
+        {
+            read = 1;
+            return new Step();
+        }
+    }
+
+    public sealed class C
+    {
+        public int Drain()
+        {
+            int consumed = 0;
+            while (Source.Next(out var read) is Node node and not Stop)
+            {
+                consumed += read;
+            }
+
+            return consumed;
+        }
+    }
+}");
+
+        Assert.Contains("while true {", printed);
+        Assert.Contains("let node = Source.Next(out var read)", printed);
+        Assert.Contains("if node is Stop {", printed);
+        Assert.Equal(1, CountOccurrences(printed, "out var read"));
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        int count = 0;
+        for (int index = haystack.IndexOf(needle, StringComparison.Ordinal);
+            index >= 0;
+            index = haystack.IndexOf(needle, index + needle.Length, StringComparison.Ordinal))
+        {
+            count++;
+        }
+
+        return count;
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -405,6 +405,10 @@ public sealed class CSharpToGSharpTranslator
         // tuple-deconstruction assignments (`(a, b) = (x, y)`); ADR-0115 §B.
         private int deconCounter;
 
+        // Monotonic counter for synthesizing the hoist local when a loop condition
+        // carries a binder-less side-effecting `is`-pattern clause (issue #914).
+        private int loopHoistCounter;
+
         // When translating the body of a lifted owned-value-aggregate receiver
         // method (issue #938), the implicit `this.` of a bare instance-member
         // reference must be made explicit through the receiver name (`self.`),
@@ -3146,6 +3150,15 @@ public sealed class CSharpToGSharpTranslator
                     return new[] { (GStatement)new ContinueStatement() };
 
                 case DoStatementSyntax doStatement:
+                    if (this.TryTranslateLoopWithConditionHoist(
+                            doStatement.Condition,
+                            doStatement.Statement,
+                            isDoWhile: true,
+                            out IReadOnlyList<GStatement> doHoisted))
+                    {
+                        return doHoisted;
+                    }
+
                     return new[]
                     {
                         (GStatement)new DoWhileStatement(
@@ -3193,6 +3206,15 @@ public sealed class CSharpToGSharpTranslator
                     return this.TranslateIfStatements(ifStatement).ToArray();
 
                 case WhileStatementSyntax whileStatement:
+                    if (this.TryTranslateLoopWithConditionHoist(
+                            whileStatement.Condition,
+                            whileStatement.Statement,
+                            isDoWhile: false,
+                            out IReadOnlyList<GStatement> whileHoisted))
+                    {
+                        return whileHoisted;
+                    }
+
                     return new[]
                     {
                         (GStatement)new WhileStatement(
@@ -4304,6 +4326,291 @@ public sealed class CSharpToGSharpTranslator
                 _ => false,
             };
         }
+
+        /// <summary>
+        /// Lowers a <c>while</c>/<c>do-while</c> whose condition carries an
+        /// <c>is</c>-pattern clause that would otherwise duplicate a side-effecting
+        /// scrutinee or leak a binder the G# loop body cannot see (issue #914).
+        /// <para>
+        /// C# allows a loop condition such as
+        /// <c>M(out var n) is Frame child and not EmptyFrame</c>, binding
+        /// <c>child</c>/<c>n</c> for the loop body. G# has no <c>and</c>/<c>not</c>
+        /// pattern combinators (only <c>&amp;&amp;</c>/<c>!</c>), so the combinator
+        /// lowering re-emits the scrutinee per sub-test — re-running the call and
+        /// re-declaring <c>out var n</c> (→ GS0102). Pattern/out-var bindings in a
+        /// <c>while</c> condition are also invisible in the body (GS0125), and G#
+        /// narrows locals in <c>if</c> bodies but not <c>while</c> bodies.
+        /// </para>
+        /// <para>
+        /// The condition is split on its top-level <c>&amp;&amp;</c> clauses. The
+        /// leading side-effect-free clauses stay the real loop condition; from the
+        /// first clause that binds or duplicates a side-effecting scrutinee onward,
+        /// each clause is hoisted to the top of the loop body — the scrutinee
+        /// evaluated once into a local, the remaining must-hold tests converted to
+        /// <c>if !test { break }</c> guards:
+        /// <code>
+        /// while a &amp;&amp; b &amp;&amp; M(out var n) is Frame child and not EmptyFrame { … }
+        /// // becomes
+        /// while a &amp;&amp; b {
+        ///     let child = M(out var n)
+        ///     if child is EmptyFrame { break }
+        ///     …
+        /// }
+        /// </code>
+        /// Returns <see langword="false"/> (keep the plain <c>while cond { }</c>
+        /// form) when no clause needs hoisting, so simple loops are unaffected.
+        /// </para>
+        /// </summary>
+        private bool TryTranslateLoopWithConditionHoist(
+            ExpressionSyntax condition,
+            StatementSyntax bodyStatement,
+            bool isDoWhile,
+            out IReadOnlyList<GStatement> result)
+        {
+            result = null;
+
+            var clauses = new List<ExpressionSyntax>();
+            FlattenAndClauses(condition, clauses);
+
+            int firstHoist = -1;
+            for (int i = 0; i < clauses.Count; i++)
+            {
+                if (this.ClauseRequiresConditionHoist(clauses[i]))
+                {
+                    firstHoist = i;
+                    break;
+                }
+            }
+
+            if (firstHoist < 0)
+            {
+                return false;
+            }
+
+            // The leading side-effect-free clauses remain the real loop condition.
+            GExpression loopCondition = null;
+            for (int i = 0; i < firstHoist; i++)
+            {
+                GExpression clause = this.TranslateExpression(clauses[i]);
+                loopCondition = loopCondition == null
+                    ? clause
+                    : new BinaryExpression(loopCondition, "&&", clause);
+            }
+
+            loopCondition ??= LiteralExpression.Bool(true);
+
+            // The remaining clauses hoist to the top of the loop body as a single
+            // scrutinee evaluation plus `if !test { break }` guards.
+            var hoisted = new List<GStatement>();
+            for (int i = firstHoist; i < clauses.Count; i++)
+            {
+                this.HoistLoopConditionClause(clauses[i], hoisted);
+            }
+
+            BlockStatement originalBody = this.TranslateStatementAsBlock(bodyStatement);
+            var bodyStatements = new List<GStatement>(hoisted);
+            bodyStatements.AddRange(originalBody.Statements);
+            var body = new BlockStatement(bodyStatements);
+
+            result = isDoWhile
+                ? new GStatement[] { new DoWhileStatement(body, GuardBlockCondition(loopCondition)) }
+                : new GStatement[] { new WhileStatement(GuardBlockCondition(loopCondition), body) };
+            return true;
+        }
+
+        // Flattens the left-to-right top-level `&&` operands of a condition into
+        // `clauses`. Parentheses are transparent for the split.
+        private static void FlattenAndClauses(ExpressionSyntax expression, List<ExpressionSyntax> clauses)
+        {
+            ExpressionSyntax expr = expression;
+            while (expr is ParenthesizedExpressionSyntax paren)
+            {
+                expr = paren.Expression;
+            }
+
+            if (expr is BinaryExpressionSyntax binary && binary.IsKind(SyntaxKind.LogicalAndExpression))
+            {
+                FlattenAndClauses(binary.Left, clauses);
+                FlattenAndClauses(binary.Right, clauses);
+            }
+            else
+            {
+                clauses.Add(expr);
+            }
+        }
+
+        // A loop-condition clause needs hoisting when it is an `is`-pattern whose
+        // lowering would duplicate a side-effecting scrutinee (an `and`/`or`
+        // combinator re-emits the receiver), declare an `out var` more than once
+        // (GS0102), or bind a pattern variable the G# loop body cannot see (GS0125).
+        private bool ClauseRequiresConditionHoist(ExpressionSyntax clause)
+        {
+            return clause is IsPatternExpressionSyntax isPattern &&
+                (PatternIntroducesBinding(isPattern.Pattern) ||
+                 PatternDuplicatesScrutinee(isPattern.Pattern) ||
+                 ExpressionDeclaresOutVar(isPattern.Expression));
+        }
+
+        private static bool PatternIntroducesBinding(PatternSyntax pattern) =>
+            pattern.DescendantNodesAndSelf().OfType<SingleVariableDesignationSyntax>().Any();
+
+        private static bool PatternDuplicatesScrutinee(PatternSyntax pattern) =>
+            pattern.DescendantNodesAndSelf().OfType<BinaryPatternSyntax>().Any();
+
+        private static bool ExpressionDeclaresOutVar(ExpressionSyntax expression) =>
+            expression.DescendantNodesAndSelf().OfType<DeclarationExpressionSyntax>().Any();
+
+        // Emits the hoisted statements for a single loop-condition clause: a pure
+        // clause becomes a negated `break` guard; an `is`-pattern clause evaluates
+        // its scrutinee once into a local and turns the pattern's must-hold tests
+        // into `break` guards (issue #914).
+        private void HoistLoopConditionClause(ExpressionSyntax clause, List<GStatement> into)
+        {
+            if (clause is not IsPatternExpressionSyntax isPattern)
+            {
+                into.Add(BreakIf(Negate(this.TranslateExpression(clause))));
+                return;
+            }
+
+            GExpression receiver = this.TranslateExpression(isPattern.Expression);
+            ITypeSymbol scrutineeType = this.context.GetTypeInfo(isPattern.Expression).Type;
+
+            // The hoist local reuses a top-level binder's name when present (so body
+            // references to that binder print as the hoist local); otherwise a fresh
+            // synthetic name is used.
+            ILocalSymbol mainBinder = this.FindMainPatternBinder(isPattern.Pattern);
+            string hoistName = mainBinder != null
+                ? SanitizeIdentifier(mainBinder.Name)
+                : $"__scrutinee{this.loopHoistCounter++}";
+
+            BindingKind binding = mainBinder != null && this.IsLocalReassigned(mainBinder)
+                ? BindingKind.Var
+                : BindingKind.Let;
+
+            into.Add(new LocalDeclarationStatement(binding, hoistName, type: null, initializer: receiver));
+
+            var idExpr = new IdentifierExpression(hoistName);
+
+            // Any secondary binder prints as the hoist local inside the body.
+            foreach (ILocalSymbol binder in this.EnumeratePatternBinders(isPattern.Pattern))
+            {
+                if (!SymbolEqualityComparer.Default.Equals(binder, mainBinder))
+                {
+                    this.patternBindings[binder] = idExpr;
+                }
+            }
+
+            this.EmitMustHoldGuards(idExpr, scrutineeType, isPattern.Pattern, mainBinder, into);
+        }
+
+        // Converts a must-hold pattern over the already-hoisted `idExpr` into a list
+        // of `if !test { break }` guards. An `and` combinator splits into one guard
+        // per side; a `not P` breaks when `P` matches; the main binder whose static
+        // type already satisfies its type test is a bind-only (no guard).
+        private void EmitMustHoldGuards(
+            GExpression idExpr,
+            ITypeSymbol scrutineeType,
+            PatternSyntax pattern,
+            ILocalSymbol mainBinder,
+            List<GStatement> into)
+        {
+            switch (pattern)
+            {
+                case ParenthesizedPatternSyntax parenthesized:
+                    this.EmitMustHoldGuards(idExpr, scrutineeType, parenthesized.Pattern, mainBinder, into);
+                    return;
+
+                case BinaryPatternSyntax andPattern when andPattern.OperatorToken.IsKind(SyntaxKind.AndKeyword):
+                    this.EmitMustHoldGuards(idExpr, scrutineeType, andPattern.Left, mainBinder, into);
+                    this.EmitMustHoldGuards(idExpr, scrutineeType, andPattern.Right, mainBinder, into);
+                    return;
+
+                case UnaryPatternSyntax notPattern when notPattern.IsKind(SyntaxKind.NotPattern):
+                    // `not P` must hold → break when `P` matches.
+                    into.Add(BreakIf(this.TranslatePatternTest(idExpr, notPattern.Pattern, scrutineeType)));
+                    return;
+
+                case DeclarationPatternSyntax declaration
+                    when this.IsBindOnlyMainBinder(declaration, scrutineeType, mainBinder):
+                    // The main binder whose static type already satisfies the test is
+                    // a non-null bind (e.g. a method returning a non-null `Frame`); no
+                    // guard is needed and the binder prints as the hoist local.
+                    return;
+
+                case DeclarationPatternSyntax declaration:
+                    // A secondary type-binder: emit the type test as a break guard;
+                    // references to the binder print as the hoist local (registered by
+                    // HoistLoopConditionClause).
+                    into.Add(BreakIf(Negate(new BinaryExpression(
+                        idExpr, "is", new TypeExpression(this.MapTypeSyntax(declaration.Type))))));
+                    return;
+
+                default:
+                    into.Add(BreakIf(Negate(this.TranslatePatternTest(idExpr, pattern, scrutineeType))));
+                    return;
+            }
+        }
+
+        // True when `declaration` binds the hoist local and the scrutinee's static
+        // type already (non-nullably) satisfies the declared type — so the type test
+        // is statically true and the pattern is a pure binding.
+        private bool IsBindOnlyMainBinder(
+            DeclarationPatternSyntax declaration, ITypeSymbol scrutineeType, ILocalSymbol mainBinder)
+        {
+            if (mainBinder == null ||
+                declaration.Designation is not SingleVariableDesignationSyntax single ||
+                this.context.GetDeclaredSymbol(single) is not ILocalSymbol symbol ||
+                !SymbolEqualityComparer.Default.Equals(symbol, mainBinder))
+            {
+                return false;
+            }
+
+            ITypeSymbol target = this.context.GetTypeInfo(declaration.Type).Type;
+            return IsAssignableNonNull(scrutineeType, target);
+        }
+
+        // True when `scrutineeType` is a non-nullable reference convertible to
+        // `target` by identity or base/interface — i.e. `scrutinee is target` is
+        // statically guaranteed.
+        private static bool IsAssignableNonNull(ITypeSymbol scrutineeType, ITypeSymbol target)
+        {
+            if (scrutineeType == null || target == null ||
+                scrutineeType.NullableAnnotation == NullableAnnotation.Annotated)
+            {
+                return false;
+            }
+
+            for (ITypeSymbol t = scrutineeType; t != null; t = t.BaseType)
+            {
+                if (SymbolEqualityComparer.Default.Equals(t, target))
+                {
+                    return true;
+                }
+            }
+
+            return scrutineeType.AllInterfaces.Any(i => SymbolEqualityComparer.Default.Equals(i, target));
+        }
+
+        private ILocalSymbol FindMainPatternBinder(PatternSyntax pattern) =>
+            this.EnumeratePatternBinders(pattern).FirstOrDefault();
+
+        private IEnumerable<ILocalSymbol> EnumeratePatternBinders(PatternSyntax pattern)
+        {
+            foreach (SyntaxNode node in pattern.DescendantNodesAndSelf())
+            {
+                if (node is SingleVariableDesignationSyntax single &&
+                    this.context.GetDeclaredSymbol(single) is ILocalSymbol symbol)
+                {
+                    yield return symbol;
+                }
+            }
+        }
+
+        private static GStatement BreakIf(GExpression condition) =>
+            new IfStatement(condition, new BlockStatement(new GStatement[] { new BreakStatement() }));
+
+        private static GExpression Negate(GExpression expression) =>
+            new UnaryExpression("!", new ParenthesizedExpression(expression));
 
         /// <summary>
         /// Translates an <c>if</c> statement into one or more G# statements. A C#


### PR DESCRIPTION
## Problem

The cs2gs translation of `Oahu.Decrypt` failed to compile with **GS0102** (`'lengthRead' is already declared`) in `Frame.gs`. The C# source (`Frame.LoadChildren`):

```csharp
while (file.Position < endPosition
    && origPosition == file.Position
    && TagFactory.CreateTag(file, this, out var lengthRead) is Frame child and not EmptyFrame)
{
    origPosition += lengthRead;
    Children.Add(child);
}
```

G# has no `and`/`not` pattern combinators (only `&&`/`!`), so the combinator was lowered by **re-emitting the scrutinee for each pattern sub-test**, duplicating the side-effecting `CreateTag(..., out var lengthRead)` call three times. That re-declared `out var lengthRead` (→ GS0102) and re-ran the call (a real correctness bug).

Compounding constraints, empirically verified in gsc: pattern/`out var` bindings in a `while` condition are invisible in the loop body (GS0125), and G# narrows locals in `if` bodies but not `while` bodies.

## Fix (translator-only, `tools/cs2gs`)

`TryTranslateLoopWithConditionHoist` splits a `while`/`do-while` condition on its top-level `&&` clauses:

- Leading **side-effect-free** clauses stay the real loop condition.
- From the first clause that binds or duplicates a side-effecting scrutinee onward, each clause is hoisted to the top of the loop body — the scrutinee evaluated **once** into a local, the remaining must-hold pattern tests converted into `if !test { break }` guards.

Emitted `Frame.gs` is now faithful and calls `CreateTag` exactly once:

```
while file.Position < endPosition && origPosition == file.Position {
    let child = TagFactory.CreateTag(file, this, out var lengthRead)
    if child is EmptyFrame { break }
    origPosition += int64(lengthRead)
    Children.Add(child)
}
```

Simple loops (no binding / side-effecting duplicated scrutinee) keep the plain `while cond { }` form and are unaffected.

## Validation

- **Decrypt**: GS0102 (3×) eliminated; `Frame.gs` calls `CreateTag` once. The next error to surface is a **pre-existing, latent** GS9998 in `ChunkReader.gs` (an `InterleaveBy` generic-inference issue, unrelated to loops) — `ChunkReader.gs` is byte-identical between branches; it was masked because gsc bails after the binding-phase GS0102 in `Frame.gs`. Out of scope for #914.
- **cs2gs tests**: 343/343 pass, including the new `Issue914WhileConditionHoistTranslationTests` (3 cases: combinator+out-var hoist, simple-while non-regression, pattern-only-with-`true`-condition).
- **Built-in corpus (L1–L5)**: identical to `origin/main` — no new failures (the CompileGap-Library and L5-Console ilverify failures are pre-existing).
- **Oahu.Foundation**: identical pre-existing failure (same fingerprint `9dd020ef25f2`, an unrelated `@`-token round-trip issue) — no regression.

Refs #914