### PR TITLE
Infer type parameters from native function-type parameter/return shapes (#1431)

### DIFF
--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
@@ -440,6 +440,27 @@ internal sealed partial class MethodBodyEmitter
             return true;
         }
 
+        // Issue #1431: two reference types that resolve to the SAME closed CLR
+        // type token are identical at the IL level even when their symbols use
+        // different representations of the same type argument (e.g. a lambda
+        // body bound against a native `(T) -> IEnumerable[R]` parameter yields
+        // `IEnumerable<System.Int64>` projected through the
+        // MetadataLoadContext, while the substituted target return is the
+        // GS-side `IEnumerable[int64]` whose `ClrType` still carries the erased
+        // `IEnumerable<object>` shape but whose `TypeArguments` correctly hold
+        // `int64`). Both denote the identical metadata instantiation, so
+        // assigning one into the other is a no-op reference conversion. Without
+        // this, native-function-type lambda returns that mention a closed
+        // generic threw NotSupportedException from EmitConversion (the
+        // CLR-delegate `Func[...]` form already matched via reference
+        // equality). The comparison reconstructs each side's effective closed
+        // shape from its symbol `TypeArguments` (preferred) or `ClrType`
+        // generic arguments so an erased `ClrType` does not defeat the match.
+        if (SameClosedReferenceShape(a, b))
+        {
+            return true;
+        }
+
         // ADR-0045: any reference type widens to `object` at the IL
         // level as a no-op; the slot already holds the reference.
         if (b?.ClrType.IsSameAs(typeof(object)) == true && a?.ClrType != null && !a.ClrType.IsValueType)
@@ -671,6 +692,82 @@ internal sealed partial class MethodBodyEmitter
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Issue #1431: returns <see langword="true"/> when <paramref name="a"/>
+    /// and <paramref name="b"/> denote the same closed constructed generic
+    /// reference type, comparing by the open definition's full name and each
+    /// effective type argument (taken from the symbol's <c>TypeArguments</c>
+    /// when present, otherwise from the <c>ClrType</c>'s generic arguments).
+    /// This recognises the no-op identity conversion between two symbols for
+    /// the same instantiation that differ only in representation — notably a
+    /// substituted target whose <c>ClrType</c> was left in the type-erased
+    /// open form while its <c>TypeArguments</c> carry the real arguments.
+    /// </summary>
+    private static bool SameClosedReferenceShape(TypeSymbol a, TypeSymbol b)
+    {
+        if (!TryGetClosedReferenceShape(a, out var aDef, out var aArgs)
+            || !TryGetClosedReferenceShape(b, out var bDef, out var bArgs))
+        {
+            return false;
+        }
+
+        if (!aDef.IsSameAs(bDef) || aArgs.Length != bArgs.Length)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < aArgs.Length; i++)
+        {
+            if (aArgs[i] == null || bArgs[i] == null || !aArgs[i].IsSameAs(bArgs[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool TryGetClosedReferenceShape(TypeSymbol type, out Type definition, out Type[] args)
+    {
+        definition = null;
+        args = null;
+
+        var clr = type?.ClrType;
+        if (clr == null || !clr.IsGenericType || clr.IsValueType)
+        {
+            return false;
+        }
+
+        definition = clr.GetGenericTypeDefinition();
+
+        // Prefer the symbol's own type arguments — they survive the type
+        // erasure that can leave `ClrType` in the open `IEnumerable<object>`
+        // shape — and fall back to the CLR generic arguments when the symbol
+        // elided them.
+        if (type is ImportedTypeSymbol imported
+            && !imported.TypeArguments.IsDefaultOrEmpty
+            && imported.TypeArguments.Length == clr.GetGenericArguments().Length)
+        {
+            var symbolicArgs = new Type[imported.TypeArguments.Length];
+            for (var i = 0; i < symbolicArgs.Length; i++)
+            {
+                var argClr = imported.TypeArguments[i]?.ClrType;
+                if (argClr == null)
+                {
+                    return false;
+                }
+
+                symbolicArgs[i] = argClr;
+            }
+
+            args = symbolicArgs;
+            return true;
+        }
+
+        args = clr.GetGenericArguments();
+        return true;
     }
 
     private static bool IsSystemDelegateHostType(Type type)

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -6174,6 +6174,20 @@ internal sealed class ReflectionMetadataEmitter
             return fromReturn;
         }
 
+        // Issue #1431 (secondary): reaching here means no parameter, return,
+        // or function-type shape mentioned `tp` after the structural unifier
+        // (now including the `FunctionTypeSymbol` parameter/return branch) was
+        // exhausted. For a well-formed program the binder has already either
+        // inferred or rejected the call's type arguments during binding
+        // (GS0151 covers the user-facing "cannot infer … supply it explicitly"
+        // case), so any failure that propagates this far is a genuine internal
+        // invariant violation, not user error. This emit-phase code has no
+        // DiagnosticBag in scope and surfacing a clean diagnostic here would
+        // require threading binder diagnostics through the metadata emitter —
+        // a large architectural change for an otherwise unreachable path. The
+        // throw therefore remains a defensive ICE guard (surfaced as GS9998)
+        // rather than a regression risk; the primary fix above ensures it no
+        // longer fires for the inferable native-function-type cases.
         throw new InvalidOperationException(
             $"Cannot infer type argument for '{tp.Name}'; "
             + "the type parameter does not appear in any parameter or return shape.");
@@ -6425,6 +6439,34 @@ internal sealed class ReflectionMetadataEmitter
             }
         }
 
+        // Issue #1431: unify native G# function types `(T1, ...) -> R` so a
+        // type parameter that appears ONLY in a function-type parameter or
+        // return slot can be recovered when building the MethodSpec. The CLR
+        // delegate form (`Func[...]` / `Action[...]`) already flows through
+        // the generic-arguments fallback below because it is an
+        // `ImportedTypeSymbol`; a `FunctionTypeSymbol` has no GS-side type
+        // arguments (its slots live only on `ParameterTypes`/`ReturnType`)
+        // so it must be unified structurally here. Both sides may arrive as a
+        // native `FunctionTypeSymbol` OR as a `Func`/`Action`-shaped CLR
+        // delegate after binder substitution, so the shape is normalised to a
+        // flat slot list (parameter types followed by the return type unless
+        // void) and unified slot-by-slot. This bridges the cross-shape case
+        // where a native formal faces a `Func[...]`-shaped actual (or vice
+        // versa).
+        if ((formal is FunctionTypeSymbol || actual is FunctionTypeSymbol)
+            && TryGetFunctionShapeSlots(formal, out var formalFnSlots)
+            && TryGetFunctionShapeSlots(actual, out var actualFnSlots)
+            && formalFnSlots.Length == actualFnSlots.Length)
+        {
+            for (int i = 0; i < formalFnSlots.Length; i++)
+            {
+                if (TryUnify(formalFnSlots[i], actualFnSlots[i], tp, out inferred))
+                {
+                    return true;
+                }
+            }
+        }
+
         var formalArgs = GetGenericTypeArguments(formal);
         var actualArgs = GetGenericTypeArguments(actual);
         if (!formalArgs.IsDefaultOrEmpty && !actualArgs.IsDefaultOrEmpty
@@ -6441,6 +6483,62 @@ internal sealed class ReflectionMetadataEmitter
 
         inferred = null;
         return false;
+    }
+
+    private static bool TryGetFunctionShapeSlots(TypeSymbol type, out ImmutableArray<TypeSymbol> slots)
+    {
+        // Issue #1431: normalise a function shape into a flat slot list of
+        // [parameter types..., return type?] so a native `FunctionTypeSymbol`
+        // and a `Func`/`Action`-shaped CLR delegate unify uniformly. A void
+        // return contributes no trailing slot, mirroring how
+        // `FunctionTypeSymbol.BuildClrType` selects `Action<...>` (no return
+        // slot) over `Func<..., R>` (return slot appended).
+        if (type is FunctionTypeSymbol fn)
+        {
+            var b = ImmutableArray.CreateBuilder<TypeSymbol>(fn.ParameterTypes.Length + 1);
+            b.AddRange(fn.ParameterTypes);
+            if (!FunctionTypeSymbol.IsVoidReturn(fn.ReturnType))
+            {
+                b.Add(fn.ReturnType);
+            }
+
+            slots = b.ToImmutable();
+            return true;
+        }
+
+        // A delegate that arrived in CLR form (`Func[...]` / `Action[...]`).
+        // Its CLR generic arguments are already laid out as
+        // [parameter types..., return type] for `Func` and
+        // [parameter types...] for `Action`, matching the native slot order.
+        var clr = type?.ClrType;
+        if (clr != null && clr.IsGenericType && IsFuncOrActionDefinition(clr.GetGenericTypeDefinition()))
+        {
+            slots = GetGenericTypeArguments(type);
+            return !slots.IsDefaultOrEmpty;
+        }
+
+        slots = default;
+        return false;
+    }
+
+    private static bool IsFuncOrActionDefinition(Type openDef)
+    {
+        if (openDef == null)
+        {
+            return false;
+        }
+
+        // Name-based check (rather than `typeof` identity) so it holds across
+        // a `MetadataLoadContext` projection of `System.Func`/`System.Action`.
+        var name = openDef.Name;
+        var ns = openDef.Namespace;
+        if (ns != "System")
+        {
+            return false;
+        }
+
+        return name.StartsWith("Func`", StringComparison.Ordinal)
+            || name.StartsWith("Action`", StringComparison.Ordinal);
     }
 
     private static ImmutableArray<TypeSymbol> GetGenericTypeArguments(TypeSymbol type)

--- a/test/Compiler.Tests/Emit/Issue1431NativeFunctionTypeInferenceEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1431NativeFunctionTypeInferenceEmitTests.cs
@@ -1,0 +1,192 @@
+// <copyright file="Issue1431NativeFunctionTypeInferenceEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1431: emit-time generic type inference must descend into a native
+/// G# function type <c>(T1, ...) -&gt; R</c> at both the parameter and return
+/// positions when building a generic-method <c>MethodSpec</c>. Before the fix,
+/// a type parameter that appeared ONLY in the return slot of a native
+/// function-type parameter (e.g. <c>keySelector (TResult) -&gt; TKey</c>)
+/// threw an internal compiler error (GS9998 / InvalidOperationException)
+/// because the structural unifier had no <c>FunctionTypeSymbol</c> branch.
+/// The equivalent declaration using a CLR <c>Func[...]</c> delegate already
+/// inferred fine.
+/// </summary>
+/// <remarks>
+/// These tests also pin the latent emitter conversion gap the inference ICE
+/// previously masked: a lambda bound against a native
+/// <c>(T) -&gt; IEnumerable[R]</c> parameter yields an
+/// <c>IEnumerable&lt;System.Int64&gt;</c> body whose closed CLR shape differs
+/// in representation (but not identity) from the type-erased substituted
+/// target return, which is a no-op reference conversion at the IL level.
+/// </remarks>
+public class Issue1431NativeFunctionTypeInferenceEmitTests
+{
+    [Fact]
+    public void NativeFunctionType_TypeParamOnlyInReturnPosition_InfersAndRuns()
+    {
+        // `TKey` appears ONLY in the return position of the native function
+        // type `(TResult) -> TKey` and nowhere else in a parameter or the
+        // method return — the exact shape that threw GS9998 before the fix.
+        var source = """
+            package Probe1431A
+            import System.Collections.Generic
+
+            func Project1431[TSource, TResult, TKey](
+                    source IEnumerable[TSource],
+                    selector (TSource) -> TResult,
+                    keySelector (TResult) -> TKey) TResult {
+                for s in source {
+                    return selector(s)
+                }
+
+                return default(TResult?)!!
+            }
+
+            public var result = Project1431([]int32{5, 6, 7}, (s int32) -> s * 10, (t int32) -> t)
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal(50, GetIntField(assembly, "result"));
+    }
+
+    [Fact]
+    public void NativeFunctionType_ReturningEnumerable_InfersAndRuns()
+    {
+        // `TResult` appears only inside the function-type return shape
+        // `(TSource) -> IEnumerable[TResult]`. The unifier must recurse
+        // through the FunctionTypeSymbol's return slot and then through the
+        // `IEnumerable[...]` generic arguments. The lambda body
+        // (`IEnumerable[int64]`) flowing into the substituted target return
+        // also exercises the no-op identity reference conversion the
+        // inference ICE previously masked.
+        var source = """
+            package Probe1431B
+            import System.Collections.Generic
+
+            func Pair1431(v int64) IEnumerable[int64] {
+                yield v
+                yield v * 10
+            }
+
+            func FlatFirst1431[TSource, TResult](
+                    source IEnumerable[TSource],
+                    selector (TSource) -> IEnumerable[TResult]) IEnumerable[TResult] {
+                for s in source {
+                    return selector(s)
+                }
+
+                return default(IEnumerable[TResult]?)!!
+            }
+
+            public var total = 0
+            for v in FlatFirst1431([]int32{1, 2, 3}, (s int32) -> Pair1431(int64(s))) {
+                total = total + int32(v)
+            }
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal(11, GetIntField(assembly, "total"));
+    }
+
+    [Fact]
+    public void NativeFunctionType_ExtensionMethodIssueShape_CompilesCleanLibrary()
+    {
+        // The literal issue repro: an extension method whose constrained
+        // type parameter `TKey` only appears in the return slot of a native
+        // function-type parameter. Compiles to a library with no GS9998 ICE.
+        var source = """
+            package Probe1431C
+            import System
+            import System.Collections.Generic
+
+            func (source IEnumerable[TSource]) IB1431[TSource, TResult, TKey IComparable[TKey]](
+                    selector (TSource) -> IEnumerable[TResult],
+                    keySelector (TResult) -> TKey) IEnumerable[TResult] -> default(IEnumerable[TResult]?)!!
+
+            func F1431(xs IEnumerable[int32]) {
+                let r = xs.IB1431((s int32) -> default(IEnumerable[int64]?)!!, (t int64) -> t)
+            }
+            """;
+
+        // Compiling to a library is sufficient — the ICE fired during emit
+        // while building the MethodSpec for the `IB1431` call, so a clean
+        // exit proves the fix.
+        var assembly = CompileLibrary(source);
+        Assert.NotNull(assembly);
+    }
+
+    private static Assembly CompileAndRun(string source)
+    {
+        var outPath = CompileToFile(source, target: "exe");
+
+        var bytes = File.ReadAllBytes(outPath);
+        var assembly = Assembly.Load(bytes);
+
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+        entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+
+        return assembly;
+    }
+
+    private static Assembly CompileLibrary(string source)
+    {
+        var outPath = CompileToFile(source, target: "library");
+        return Assembly.LoadFile(outPath);
+    }
+
+    private static string CompileToFile(string source, string target)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1431_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:" + target,
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+        IlVerifier.Verify(outPath);
+        return outPath;
+    }
+
+    private static int GetIntField(Assembly assembly, string name)
+    {
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var field = program.GetField(name, BindingFlags.Public | BindingFlags.Static);
+        return (int)field!.GetValue(null)!;
+    }
+}


### PR DESCRIPTION
## Problem

A generic method/function whose type parameter appears ONLY in the parameter or return slot of a **native** G# function-type parameter `(T) -> K` threw an internal compiler error (GS9998) during emit-time generic type inference:

```
GS9998: InvalidOperationException: Cannot infer type argument for 'TKey';
the type parameter does not appear in any parameter or return shape.
```

The equivalent declaration using the CLR delegate `Func[T, K]` inferred fine.

## Root cause

The structural unifier `TryUnify` in `ReflectionMetadataEmitter` handles slices, arrays, sequences, async sequences, nullable, tuples, imported CLR generic interfaces, and a generic-type-arguments fallback — but it had **no branch for `FunctionTypeSymbol`** (the native `(T) -> R` type). `Func[...]`/`Action[...]` are `ImportedTypeSymbol`s caught by the generic-args fallback, but a native `FunctionTypeSymbol` carries its slots only on `ParameterTypes`/`ReturnType`, so the type parameter was never collected and inference fell through to the throw.

## Fix

1. **Primary** — added a `FunctionTypeSymbol` unification branch to `TryUnify`. It normalises a function shape (native `FunctionTypeSymbol` or a `Func`/`Action`-shaped CLR delegate) into a flat slot list of parameter types followed by the return type (omitted for `void`) and unifies slot-by-slot, recursing through **both** parameter and return positions. This bridges the cross-shape case where a native formal faces a `Func[...]`-shaped actual (or vice versa).

2. **Emitter conversion gap** (previously masked by the ICE) — a lambda bound against a native `(T) -> IEnumerable[R]` parameter yields an `IEnumerable<System.Int64>` body whose closed CLR shape differs in representation but not identity from the type-erased substituted target return (`ClrType` left as `IEnumerable<object>` while `TypeArguments` correctly hold `int64`). `IsReferenceCompatible` now recognises this no-op identity reference conversion via a new `SameClosedReferenceShape` helper that reconstructs each side's effective closed shape from `TypeArguments` so an erased `ClrType` does not defeat the match.

3. **Secondary** — documented why the residual emit-phase inference failure stays a defensive ICE guard: this path has no `DiagnosticBag` in scope, the binder already surfaces the user-facing `GS0151` "cannot infer … supply it explicitly" diagnostic during binding, and threading binder diagnostics through the metadata emitter for an otherwise-unreachable path would be a large architectural change. The primary fix ensures it no longer fires for inferable cases.

## Verification

- `dotnet build GSharp.sln -c Release -graph` → **0 Warning(s), 0 Error(s)**.
- The issue repro (native `(T) -> K`) now compiles clean; the `Func[...]` control still compiles clean.
- New `Issue1431` emit tests pass: return-position inference (runs, asserts `50`), function-type-returning-`IEnumerable` (runs, asserts `11`), and the literal extension-method issue shape (clean library compile).
- Sibling `Issue810`/`813`/`814`/`821` emit tests pass.
- Full `Core.Tests` suite passes (4788 passed), including the byte-identical `RefactoringBaselineTests` gate — no baseline regeneration needed (the change only fires on paths that previously threw).

Fixes #1431
Refs #914
