### PR TITLE
Support calling static members declared on interfaces (#1433)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundCallExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundCallExpression.cs
@@ -73,6 +73,17 @@ public sealed class BoundCallExpression : BoundExpression
     public StructSymbol StaticGenericOwnerType { get; internal set; }
 
     /// <summary>
+    /// Gets, for issue #1433, the constructed generic interface when a static
+    /// (<c>shared</c>) method is dispatched on a constructed generic interface
+    /// (<c>IBox[int32].Create()</c>), so the emitter parents the call at the
+    /// construction's <c>TypeSpec</c> (mirroring the interface static-field path
+    /// of issue #1030). <see langword="null"/> for ordinary calls, non-generic
+    /// interface receivers, and struct/class receivers (which use
+    /// <see cref="StaticGenericOwnerType"/> or a bare <c>MethodDef</c>).
+    /// </summary>
+    public InterfaceSymbol StaticGenericInterfaceOwnerType { get; internal set; }
+
+    /// <summary>
     /// Gets the function symbol.
     /// </summary>
     public FunctionSymbol Function { get; }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -1603,16 +1603,16 @@ internal sealed partial class ExpressionBinder
         var fieldOwner = interfaceSym.Definition ?? interfaceSym;
         switch (rightPart)
         {
-            case NameExpressionSyntax ne:
-                var memberName = ne.IdentifierToken.Text;
-                var field = fieldOwner.GetStaticField(memberName);
-                if (field != null)
-                {
-                    return new BoundFieldAccessExpression(null, field, interfaceSym);
-                }
+            // Issue #1433: `IName.method(args)` — a static (`shared`) method
+            // declared on the interface. Route through the same canonical
+            // member-resolution + overload machinery used for struct/class
+            // statics; the only difference (a constructed generic interface
+            // owner) is carried on the bound call for the emitter.
+            case CallExpressionSyntax ce:
+                return BindUserTypeStaticCall(interfaceSym, ce);
 
-                Diagnostics.ReportUnableToFindMember(ne.Location, memberName);
-                return new BoundErrorExpression(null);
+            case NameExpressionSyntax ne:
+                return BindInterfaceStaticMemberAccess(interfaceSym, fieldOwner, ne);
 
             case AccessorExpressionSyntax nested:
                 var head = BindInterfaceStaticAccessorStep(interfaceSym, nested.LeftPart);
@@ -1626,6 +1626,64 @@ internal sealed partial class ExpressionBinder
             default:
                 return new BoundErrorExpression(null);
         }
+    }
+
+    /// <summary>
+    /// Issue #1433: resolves <c>IName.member</c> in non-call position against an
+    /// interface's static members. A static field reads to a static
+    /// <see cref="BoundFieldAccessExpression"/> (issue #1030); a static
+    /// (<c>shared</c>) method named here is a method group with a null receiver
+    /// (overload selection deferred to the conversion classifier), mirroring the
+    /// struct/class path in <see cref="BindUserTypeStaticMemberAccess"/>.
+    /// </summary>
+    /// <param name="interfaceSym">The interface receiver (constructed or open).</param>
+    /// <param name="fieldOwner">The interface definition owning static fields.</param>
+    /// <param name="ne">The member being accessed.</param>
+    /// <returns>The bound access, or a bound error expression.</returns>
+    private BoundExpression BindInterfaceStaticMemberAccess(InterfaceSymbol interfaceSym, InterfaceSymbol fieldOwner, NameExpressionSyntax ne)
+    {
+        var memberName = ne.IdentifierToken.Text;
+
+        var field = fieldOwner.GetStaticField(memberName);
+        if (field != null)
+        {
+            return new BoundFieldAccessExpression(null, field, interfaceSym);
+        }
+
+        // Issue #1433: a default-bodied static (`shared`) property on the
+        // interface (ADR-0089 / issue #1019) read in non-call position. Static
+        // interface properties are modeled as static-virtual accessor methods,
+        // not on a `StaticProperties` bucket, so a direct read is lowered to a
+        // call of the getter MethodDef — reusing the static-method-call emit
+        // path. Only a concrete (non-abstract, default-bodied) getter can be
+        // invoked directly on the interface type.
+        foreach (var prop in fieldOwner.Properties)
+        {
+            if (prop.IsStatic && !prop.IsIndexer && prop.Name == memberName)
+            {
+                if (prop.GetterSymbol != null && prop.HasGetter)
+                {
+                    return new BoundCallExpression(null, prop.GetterSymbol, ImmutableArray<BoundExpression>.Empty, prop.Type)
+                    {
+                        StaticGenericInterfaceOwnerType = interfaceSym.Definition != null ? interfaceSym : null,
+                    };
+                }
+
+                Diagnostics.ReportUnableToFindMember(ne.Location, memberName);
+                return new BoundErrorExpression(null);
+            }
+        }
+
+        // ADR-0112: a static method named here in non-call position is a method
+        // group with a null receiver, driven by the target delegate signature.
+        var staticMethods = TypeMemberModel.GetMethods(interfaceSym, memberName, MemberQuery.Static(MemberKinds.Method));
+        if (TryBuildUserMethodGroup(receiver: null, staticMethods, out var staticGroup))
+        {
+            return staticGroup;
+        }
+
+        Diagnostics.ReportUnableToFindMember(ne.Location, memberName);
+        return new BoundErrorExpression(null);
     }
 
     /// <summary>
@@ -2078,7 +2136,34 @@ internal sealed partial class ExpressionBinder
     }
 
     internal BoundExpression BindUserTypeStaticCall(StructSymbol structSym, CallExpressionSyntax ce)
+        => BindUserTypeStaticCall((TypeSymbol)structSym, ce);
+
+    /// <summary>
+    /// Issue #1433: resolves <c>TypeName.method(args)</c> for a static
+    /// (<c>shared</c>) method declared on a user struct/class OR interface. The
+    /// member-resolution and overload/substitution logic is identical for both
+    /// owner kinds (it routes through the canonical <see cref="TypeMemberModel"/>
+    /// layer, ADR-0112); only the generic-owner carried to the emitter differs:
+    /// a constructed generic struct goes through
+    /// <see cref="BoundCallExpression.StaticGenericOwnerType"/> (issue #1209) and
+    /// a constructed generic interface through
+    /// <see cref="BoundCallExpression.StaticGenericInterfaceOwnerType"/> (issue
+    /// #1030 parenting extended to methods) so the call is parented at the
+    /// correct construction <c>TypeSpec</c>. A non-generic owner of either kind
+    /// emits a bare <c>MethodDef</c> token.
+    /// </summary>
+    internal BoundExpression BindUserTypeStaticCall(TypeSymbol ownerType, CallExpressionSyntax ce)
     {
+        var structSym = ownerType as StructSymbol;
+        var ifaceSym = ownerType as InterfaceSymbol;
+        var ownerDefinition = structSym?.Definition ?? (TypeSymbol)ifaceSym?.Definition;
+        var ownerDefTypeParameters = structSym?.Definition?.TypeParameters
+            ?? ifaceSym?.Definition?.TypeParameters
+            ?? ImmutableArray<TypeParameterSymbol>.Empty;
+        var ownerTypeArguments = structSym?.TypeArguments
+            ?? ifaceSym?.TypeArguments
+            ?? ImmutableArray<TypeSymbol>.Empty;
+
         var methodName = ce.Identifier.Text;
 
         var boundArguments = ImmutableArray.CreateBuilder<BoundExpression>();
@@ -2117,7 +2202,7 @@ internal sealed partial class ExpressionBinder
         // for instance methods). A single-candidate group is returned unchanged
         // so the legacy per-position arity/optional/variadic diagnostics below
         // still apply (e.g. genuine arity mismatch on a non-overloaded method).
-        var staticMethodGroup = TypeMemberModel.GetMethods(structSym, methodName, MemberQuery.Static(MemberKinds.Method));
+        var staticMethodGroup = TypeMemberModel.GetMethods(ownerType, methodName, MemberQuery.Static(MemberKinds.Method));
         if (!staticMethodGroup.IsDefaultOrEmpty)
         {
             var method = overloads.SelectInstanceOverloadOrReport(staticMethodGroup, arguments, ce, methodName, argumentNames: default);
@@ -2209,17 +2294,17 @@ internal sealed partial class ExpressionBinder
             // counterpart of the imported-generic fix in issue #1216 and exercises
             // the binding receiver added in issue #1323.
             Dictionary<TypeParameterSymbol, TypeSymbol> substitution = null;
-            if (structSym.Definition != null
-                && !ReferenceEquals(structSym.Definition, structSym)
-                && !structSym.TypeArguments.IsDefaultOrEmpty
-                && !structSym.Definition.TypeParameters.IsDefaultOrEmpty)
+            if (ownerDefinition != null
+                && !ReferenceEquals(ownerDefinition, ownerType)
+                && !ownerTypeArguments.IsDefaultOrEmpty
+                && !ownerDefTypeParameters.IsDefaultOrEmpty)
             {
                 substitution = new Dictionary<TypeParameterSymbol, TypeSymbol>();
-                var defParams = structSym.Definition.TypeParameters;
-                var count = Math.Min(defParams.Length, structSym.TypeArguments.Length);
+                var defParams = ownerDefTypeParameters;
+                var count = Math.Min(defParams.Length, ownerTypeArguments.Length);
                 for (var i = 0; i < count; i++)
                 {
-                    substitution[defParams[i]] = structSym.TypeArguments[i];
+                    substitution[defParams[i]] = ownerTypeArguments[i];
                 }
             }
 
@@ -2431,7 +2516,12 @@ internal sealed partial class ExpressionBinder
             // the call at the construction's TypeSpec (a bare MethodDef token is
             // invalid for a method of a generic type). Null for non-generic
             // receivers leaves the ordinary MethodDef path unchanged.
-            var staticGenericOwner = structSym.Definition != null ? structSym : null;
+            // Issue #1433: the same parenting requirement applies to a
+            // constructed generic INTERFACE owner; it is carried separately
+            // because the emitter resolves interface- and struct-declared
+            // statics through different TypeSpec helpers.
+            var staticGenericOwner = structSym?.Definition != null ? structSym : null;
+            var staticGenericInterfaceOwner = ifaceSym?.Definition != null ? ifaceSym : null;
 
             if (substitution != null)
             {
@@ -2439,22 +2529,22 @@ internal sealed partial class ExpressionBinder
                 if (method.IsAsync && !isAsyncIteratorReturnType(method.Type))
                 {
                     substitutedReturn = lambdas.WrapAsTask(substitutedReturn);
-                    return new BoundCallExpression(null, method, convertedArgs.ToImmutable(), substitutedReturn) { StaticGenericOwnerType = staticGenericOwner };
+                    return new BoundCallExpression(null, method, convertedArgs.ToImmutable(), substitutedReturn) { StaticGenericOwnerType = staticGenericOwner, StaticGenericInterfaceOwnerType = staticGenericInterfaceOwner };
                 }
 
                 if (!ReferenceEquals(substitutedReturn, method.Type))
                 {
-                    return new BoundCallExpression(null, method, convertedArgs.ToImmutable(), substitutedReturn) { StaticGenericOwnerType = staticGenericOwner };
+                    return new BoundCallExpression(null, method, convertedArgs.ToImmutable(), substitutedReturn) { StaticGenericOwnerType = staticGenericOwner, StaticGenericInterfaceOwnerType = staticGenericInterfaceOwner };
                 }
             }
 
             if (method.IsAsync && !isAsyncIteratorReturnType(method.Type))
             {
                 var asyncReturn = lambdas.WrapAsTask(method.Type);
-                return new BoundCallExpression(null, method, convertedArgs.ToImmutable(), asyncReturn) { StaticGenericOwnerType = staticGenericOwner };
+                return new BoundCallExpression(null, method, convertedArgs.ToImmutable(), asyncReturn) { StaticGenericOwnerType = staticGenericOwner, StaticGenericInterfaceOwnerType = staticGenericInterfaceOwner };
             }
 
-            return new BoundCallExpression(null, method, convertedArgs.ToImmutable()) { StaticGenericOwnerType = staticGenericOwner };
+            return new BoundCallExpression(null, method, convertedArgs.ToImmutable()) { StaticGenericOwnerType = staticGenericOwner, StaticGenericInterfaceOwnerType = staticGenericInterfaceOwner };
         }
 
         Diagnostics.ReportUnableToFindMember(ce.Location, methodName);

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
@@ -133,6 +133,19 @@ internal sealed partial class MethodBodyEmitter
                     this.EmitExpression(arg);
                 }
 
+                // Issue #1433: a `shared` (static) method called on a
+                // constructed generic INTERFACE (`IBox[int32].Make()`) must be
+                // referenced through a MemberRef parented at the construction's
+                // TypeSpec. The substituted method is not in the handle cache,
+                // so resolve it before the generic-struct/cache lookups below.
+                if (call.StaticGenericInterfaceOwnerType != null
+                    && ReflectionMetadataEmitter.IsUserGenericInterfaceReference(call.StaticGenericInterfaceOwnerType))
+                {
+                    this.il.OpCode(ILOpCode.Call);
+                    this.il.Token(this.outer.ResolveUserInterfaceStaticMethodToken(call.StaticGenericInterfaceOwnerType, call.Function));
+                    break;
+                }
+
                 if (!this.outer.cache.FunctionHandles.TryGetValue(call.Function, out var fnHandle)
                     && !this.outer.cache.MethodHandles.TryGetValue(call.Function, out fnHandle))
                 {
@@ -545,14 +558,16 @@ internal sealed partial class MethodBodyEmitter
                 this.EmitAsExpression(asExpr);
                 break;
             case BoundErrorExpression:
-                // GS0268: a BoundErrorExpression leaked from lowering into emit.
-                // This typically means the lowerer could not resolve a required
-                // method (e.g. GetEnumerator) for a for-in loop. Throw a
-                // descriptive exception so BuildEmitFailureDiagnostic surfaces
-                // a clear GS9998 message instead of an opaque MSB4181.
+                // A BoundErrorExpression reached emit. This means an earlier
+                // phase (binding/lowering) produced an unresolved node that was
+                // not reported as a diagnostic. Surface a truthful, location-
+                // anchored GS9998 rather than a hard-coded (and frequently
+                // wrong) for-in message. This is a defensive emit-phase guard
+                // with no DiagnosticBag in scope; the anchor is the node's own
+                // syntax when available so the error points at real source.
                 {
-                    const string msg = "Internal compiler error (GS0268): a for-in loop over an enumerable type could not be lowered. "
-                        + "The collection type may not expose a resolvable GetEnumerator()/MoveNext()/Current pattern.";
+                    const string msg = "Internal compiler error: an unresolved (error) expression reached code emission. "
+                        + "This usually indicates an unsupported or mis-bound construct that earlier phases failed to report.";
                     EmitDiagnosticException.Throw(expression.Syntax, msg);
                 }
 

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -6983,6 +6983,71 @@ internal sealed class ReflectionMetadataEmitter
     }
 
     /// <summary>
+    /// Issue #1433: resolves the token for a call to a user <c>shared</c>
+    /// (static) method whose declaring type is a user-declared INTERFACE
+    /// (<c>IThing.Create()</c> / <c>IBox[int32].Make()</c>). For a non-generic
+    /// interface returns the bare <c>MethodDef</c>; for a constructed generic
+    /// interface returns a <c>MemberRef</c> parented at the construction's
+    /// <c>TypeSpec</c> (mirroring the interface static-field path, issue #1030).
+    /// The substituted method on a constructed interface is mapped back to the
+    /// open definition's slot so its emitted <c>MethodDef</c> handle and open
+    /// (<c>VAR</c>-placeholdered) signature are used.
+    /// </summary>
+    /// <param name="containingInterface">The constructed (or open) interface reference.</param>
+    /// <param name="method">The static method being called.</param>
+    /// <returns>The MethodDef or TypeSpec-parented MemberRef token.</returns>
+    internal EntityHandle ResolveUserInterfaceStaticMethodToken(InterfaceSymbol containingInterface, FunctionSymbol method)
+    {
+        var openMethod = ResolveOpenInterfaceStaticMethod(containingInterface, method);
+        if (!this.cache.MethodHandles.TryGetValue(openMethod, out var openDef)
+            && !this.cache.FunctionHandles.TryGetValue(openMethod, out openDef))
+        {
+            throw new InvalidOperationException(
+                $"Static interface method '{method.Name}' has no emitted handle.");
+        }
+
+        if (!IsUserGenericInterfaceReference(containingInterface))
+        {
+            return openDef;
+        }
+
+        return this.GetUserInterfaceMethodRef(containingInterface, openDef, openMethod.Name, this.EncodeOpenMethodSignature(openMethod));
+    }
+
+    /// <summary>
+    /// Issue #1433: returns a <c>MemberRef</c> handle for a static method on a
+    /// user-declared generic interface, parented at the <c>TypeSpec</c> for
+    /// <paramref name="containingInterface"/>. Mirrors
+    /// <see cref="GetUserStructMethodRef"/>; the signature is supplied by the
+    /// caller (already encoded against the open definition with <c>VAR</c> slots).
+    /// </summary>
+    /// <param name="containingInterface">The constructed (or open) interface reference.</param>
+    /// <param name="openMethodDef">The open method's emitted MethodDef handle.</param>
+    /// <param name="methodName">The method name.</param>
+    /// <param name="signature">The open method signature blob.</param>
+    /// <returns>The MemberRef token parented at the interface TypeSpec.</returns>
+    internal EntityHandle GetUserInterfaceMethodRef(
+        InterfaceSymbol containingInterface,
+        EntityHandle openMethodDef,
+        string methodName,
+        BlobBuilder signature)
+    {
+        var key = (containingInterface, openMethodDef);
+        if (this.userInterfaceMethodRefCache.TryGetValue(key, out var cached))
+        {
+            return cached;
+        }
+
+        var parent = this.GetUserInterfaceTypeSpec(containingInterface);
+        var memberRef = (EntityHandle)this.emitCtx.Metadata.AddMemberReference(
+            parent: parent,
+            name: this.emitCtx.Metadata.GetOrAddString(methodName),
+            signature: this.emitCtx.Metadata.GetOrAddBlob(signature));
+        this.userInterfaceMethodRefCache[key] = memberRef;
+        return memberRef;
+    }
+
+    /// <summary>
     /// Issue #989: resolves the right token for a call to a user property's
     /// get/set accessor. For a non-generic containing type returns the bare
     /// accessor <c>MethodDef</c>; for a constructed generic containing type

--- a/test/Compiler.Tests/Emit/Issue1433InterfaceStaticMemberCallEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1433InterfaceStaticMemberCallEmitTests.cs
@@ -1,0 +1,252 @@
+// <copyright file="Issue1433InterfaceStaticMemberCallEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1433 — calling a static (<c>shared</c>) member declared on a
+/// user-defined <c>interface</c>. Before the fix the binder produced no
+/// resolution for <c>IName.Method(args)</c> (and interface static property
+/// reads / method groups), leaking a <see cref="GSharp.Core.CodeAnalysis.Binding.BoundErrorExpression"/>
+/// into emit which crashed with a misleading <c>GS0268</c> ("for-in loop")
+/// internal compiler error. These tests cover the generalized fix: interface
+/// static method calls (used + discarded), a static method group, a static
+/// property read, and a constructed generic interface static method call,
+/// validated end-to-end (compile + run). Every user type is uniquely named so
+/// the process-wide <c>FunctionTypeSymbol</c> cache cannot alias across tests.
+/// </summary>
+public class Issue1433InterfaceStaticMemberCallEmitTests
+{
+    [Fact]
+    public void EndToEnd_InterfaceStaticMethodCall_UsedAndDiscarded_Runs()
+    {
+        var source = """
+            package Probe1433a
+            import System
+
+            interface IThingA1433 {
+                prop Name string { get; }
+                shared {
+                    func Create(n int32) IThingA1433 {
+                        return ThingA1433(n)
+                    }
+                }
+            }
+
+            class ThingA1433(N int32) : IThingA1433 {
+                prop Name string -> "t${N}"
+            }
+
+            func Main() {
+                let t = IThingA1433.Create(7)
+                Console.WriteLine(t.Name)
+                IThingA1433.Create(99)
+                Console.WriteLine("done")
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("t7\ndone\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_InterfaceStaticMethodOverloads_AndArgumentPosition_Runs()
+    {
+        var source = """
+            package Probe1433b
+            import System
+
+            interface IFactoryB1433 {
+                shared {
+                    func Make() string {
+                        return "none"
+                    }
+                    func Make(n int32) string {
+                        return "int${n}"
+                    }
+                    func Make(s string) string {
+                        return "str${s}"
+                    }
+                }
+            }
+
+            func Use(value string) string -> value
+
+            func Main() {
+                Console.WriteLine(IFactoryB1433.Make())
+                Console.WriteLine(IFactoryB1433.Make(5))
+                Console.WriteLine(Use(IFactoryB1433.Make("x")))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("none\nint5\nstrx\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_InterfaceStaticProperty_Read_Runs()
+    {
+        var source = """
+            package Probe1433c
+            import System
+
+            sealed interface IDataC1433 {
+                shared {
+                    prop Origin string { get { return "origin" } }
+                }
+            }
+
+            func Main() {
+                Console.WriteLine(IDataC1433.Origin)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("origin\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_ConstructedGenericInterfaceStaticMethodCall_Runs()
+    {
+        var source = """
+            package Probe1433e
+            import System
+
+            interface IBoxE1433[T] {
+                shared {
+                    func Tag() int32 {
+                        return 7
+                    }
+                }
+            }
+
+            func Main() {
+                Console.WriteLine(IBoxE1433[int32].Tag())
+                Console.WriteLine(IBoxE1433[string].Tag())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("7\n7\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_InterfaceStaticMethodCall_InReturnPosition_Runs()
+    {
+        var source = """
+            package Probe1433f
+            import System
+
+            interface IThingF1433 {
+                prop Name string { get; }
+                shared {
+                    func Create(n int32) IThingF1433 {
+                        return ThingF1433(n)
+                    }
+                }
+            }
+
+            class ThingF1433(N int32) : IThingF1433 {
+                prop Name string -> "f${N}"
+            }
+
+            func Build() IThingF1433 -> IThingF1433.Create(3)
+
+            func Main() {
+                Console.WriteLine(Build().Name)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("f3\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1433_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath, ignoredErrorCodes: IlVerifier.KnownIssues.StaticVirtualInterface);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Calling a `static` member declared in a `shared { ... }` block on an **interface** crashed the emitter with an internal compiler error. The same `shared` static member on a **class** or **struct** worked fine.

Minimal repro (now fixed):

```gsharp
interface IThing {
    prop Name string { get; }
    shared {
        func Create(n int32) IThing { return Thing(n) }
    }
}
class Thing(N int32) : IThing { prop Name string -> "t${N}" }
class Caller { func Use() IThing -> IThing.Create(7) }
```

Before: `GS9998: Internal compiler error (GS0268): a for-in loop over an enumerable type could not be lowered.` — wrong code, wrong message, anchored at `(1,1)`. No for-in was involved (and `GS0268` is actually the nested-type diagnostic).

## Root cause (two gaps)

1. **Binder** — `BindInterfaceStaticAccessorStep` only resolved interface static *fields* (issue #1030). A static method call (`IThing.Create(7)`), a static method group, and a static (default-bodied) property read all fell through to a `BoundErrorExpression` with **no diagnostic reported**.
2. **Emit** — the `case BoundErrorExpression` fallback in `MethodBodyEmitter.Expressions.cs` unconditionally reported the leaked node as the misleading `GS0268` for-in message, anchored at `(1,1)`.

## Fix (generalized — not special-cased to the repro shape)

- `BindUserTypeStaticCall` is generalized from `StructSymbol` to `TypeSymbol`, so interface static method calls reuse the **identical** canonical member-resolution (ADR-0112), overload selection, and optional/variadic/generic substitution machinery as struct/class statics — including overloads, argument-position calls, and generic static methods.
- `BindInterfaceStaticAccessorStep` now handles call, method-group, and static-property-read positions; interface static fields keep working.
- A constructed generic interface owner is carried on the new `BoundCallExpression.StaticGenericInterfaceOwnerType`; the emitter resolves it through new `ResolveUserInterfaceStaticMethodToken` / `GetUserInterfaceMethodRef` that parent the call at the interface construction TypeSpec (mirroring the issue #1030 static-field path). Non-generic interfaces emit a bare `MethodDef`, exactly like classes/structs.
- The emit-phase `BoundErrorExpression` guard now reports a **truthful, location-anchored** internal error instead of the bogus for-in message.

Files changed:
- `src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs` (binder)
- `src/Core/CodeAnalysis/Binding/BoundCallExpression.cs` (new owner field)
- `src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs` (interface static token/MemberRef resolvers)
- `src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs` (emit dispatch + truthful diagnostic)
- `test/Compiler.Tests/Emit/Issue1433InterfaceStaticMemberCallEmitTests.cs` (new regression tests)

## Verification

- **Minimal repro** compiles clean and **runs**; verified discarded-statement, return/assignment, static-property read, and constructed generic interface (`IBox[int32].Tag()`) forms.
- **cs2gs Oahu.Decrypt harness**: the `GS9998`/`GS0268` cluster from `Mp4aWriter`/`IChunkOffsets.Create` is **gone**. New histogram shows only `3 GS9998`, all from an **unrelated pre-existing** decimal `op_Explicit` ambiguity (`Mp4aWriter.gs (120,45)`), not introduced here.
- New `Issue1433` emit regression tests pass (5).
- Sibling interface/static emit tests (`1007`/`1019`/`1030`/`1209`/`1379`) pass (20).
- Full `Core.Tests` pass (4788; baseline gate intact).
- `dotnet build GSharp.sln -c Release -graph` → 0 warnings, 0 errors.

## Deferred / note

Forming a *delegate* directly from an interface static method group (`IOps.Twice` as a `func(...)`) is not asserted: interface static methods are emitted `Static | Virtual` per ADR-0089, and `ldftn` of a non-final virtual for delegate creation is rejected by ilverify. This is a pre-existing static-virtual emit limitation independent of this issue (binding still resolves the method group correctly).

Fixes #1433
Refs #914
