### PR TITLE
Fix GS9998 for catch/pattern locals declared inside lambda bodies (#1437)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -1450,6 +1450,31 @@ internal sealed class LambdaBinder
             return base.RewritePattern(node);
         }
 
+        protected override BoundExpression RewriteNullConditionalAccessExpression(BoundNullConditionalAccessExpression node)
+        {
+            // Issue #1437 (generalization): the `?.` / `?(…)` operators introduce a
+            // synthetic `Capture` local (`$ncap_N`) that the receiver value is
+            // spilled into, and `WhenNotNull` references that `Capture` as its
+            // receiver. Value-typed results also introduce a `$nres_N` ResultSlot.
+            // Both are body-local declarations — not BoundVariableDeclarations — so,
+            // exactly like a catch/arm/loop variable, without recording them here
+            // RecordReference would see the `Capture` read inside `WhenNotNull` as a
+            // capture of an enclosing-scope variable, box it, and desynchronize it
+            // from the slot the emit planner allocates (crashing with GS9998
+            // "Variable '$ncap_N' has no local slot").
+            if (node.Capture != null)
+            {
+                this.declared.Add(node.Capture);
+            }
+
+            if (node.ResultSlot != null)
+            {
+                this.declared.Add(node.ResultSlot);
+            }
+
+            return base.RewriteNullConditionalAccessExpression(node);
+        }
+
         protected override BoundExpression RewriteAssignmentExpression(BoundAssignmentExpression node)
         {
             // Issue #523: an assignment LHS is a USE of the variable that

--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -1353,6 +1353,103 @@ internal sealed class LambdaBinder
             return base.RewriteVariableDeclaration(node);
         }
 
+        // Issue #1437: a `let`/`var` is not the only construct that introduces a
+        // local inside a lambda body. Catch clauses, `select` arms, range/ellipsis
+        // loop variables, `fixed` pin/pointer locals and type-pattern bindings all
+        // declare variables that are *local* to the body being walked. They must be
+        // recorded in `declared` exactly like a BoundVariableDeclaration; otherwise
+        // RecordReference misclassifies a later read of one of them as a capture of
+        // an enclosing-scope variable. That false capture then flows into
+        // BoundFunctionLiteralExpression.CapturedVariables and the CaptureBoxingRewriter
+        // hoists the *catch/arm/loop* variable into a heap box — desynchronizing the
+        // variable's declaration site (still the original symbol, which the emit
+        // local-slot planner allocates a slot for) from its in-body reads (rewritten
+        // to `box.Value` against a fresh, slot-less box local), crashing emit with
+        // GS9998 "has no local slot or parameter index in the current method."
+        // Recording these declarations keeps any genuine capture by a *nested* lambda
+        // correct: there the variable is declared in this body's scope, so the nested
+        // literal's capture is satisfied here and is not propagated outward.
+        protected override BoundStatement RewriteTryStatement(BoundTryStatement node)
+        {
+            foreach (var clause in node.CatchClauses)
+            {
+                if (clause.Variable != null)
+                {
+                    this.declared.Add(clause.Variable);
+                }
+            }
+
+            return base.RewriteTryStatement(node);
+        }
+
+        protected override BoundStatement RewriteSelectStatement(BoundSelectStatement node)
+        {
+            foreach (var arm in node.Cases)
+            {
+                if (arm.Variable != null)
+                {
+                    this.declared.Add(arm.Variable);
+                }
+            }
+
+            return base.RewriteSelectStatement(node);
+        }
+
+        protected override BoundStatement RewriteForRangeStatement(BoundForRangeStatement node)
+        {
+            if (node.KeyVariable != null)
+            {
+                this.declared.Add(node.KeyVariable);
+            }
+
+            if (node.ValueVariable != null)
+            {
+                this.declared.Add(node.ValueVariable);
+            }
+
+            return base.RewriteForRangeStatement(node);
+        }
+
+        protected override BoundStatement RewriteForEllipsisStatement(BoundForEllipsisStatement node)
+        {
+            if (node.Variable != null)
+            {
+                this.declared.Add(node.Variable);
+            }
+
+            return base.RewriteForEllipsisStatement(node);
+        }
+
+        protected override BoundStatement RewriteFixedStatement(BoundFixedStatement node)
+        {
+            if (node.PinnedVariable != null)
+            {
+                this.declared.Add(node.PinnedVariable);
+            }
+
+            if (node.PointerVariable != null)
+            {
+                this.declared.Add(node.PointerVariable);
+            }
+
+            if (node.SourceVariable != null)
+            {
+                this.declared.Add(node.SourceVariable);
+            }
+
+            return base.RewriteFixedStatement(node);
+        }
+
+        protected override BoundPattern RewritePattern(BoundPattern node)
+        {
+            if (node is BoundTypePattern typePattern && typePattern.Variable != null)
+            {
+                this.declared.Add(typePattern.Variable);
+            }
+
+            return base.RewritePattern(node);
+        }
+
         protected override BoundExpression RewriteAssignmentExpression(BoundAssignmentExpression node)
         {
             // Issue #523: an assignment LHS is a USE of the variable that

--- a/test/Compiler.Tests/Emit/Issue1437CatchInLambdaEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1437CatchInLambdaEmitTests.cs
@@ -1,0 +1,251 @@
+// <copyright file="Issue1437CatchInLambdaEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1437 — a body-introduced local (a <c>catch</c> clause variable, a
+/// <c>switch</c> type-pattern binding, etc.) declared inside a <c>func</c>
+/// literal / lambda body crashed emit with
+/// <c>GS9998: InvalidOperationException: Variable '...' has no local slot or
+/// parameter index in the current method.</c>.
+/// <para>
+/// Root cause: the binder's captured-variable analysis
+/// (<c>CapturedVariableCollector</c>) only recorded <c>BoundVariableDeclaration</c>
+/// targets as locals declared *within* the lambda. Catch / select-arm / range /
+/// pattern variables were therefore misclassified as captures of an enclosing
+/// scope. That false capture flowed into the lambda's
+/// <c>CapturedVariables</c> set, and <c>CaptureBoxingRewriter</c> hoisted the
+/// variable into a heap box — desynchronizing its declaration site (the
+/// original symbol, for which the emit local-slot planner allocates a slot)
+/// from its in-body reads (rewritten to <c>box.Value</c> against a fresh,
+/// slot-less box local).
+/// </para>
+/// <para>
+/// The fix records every body-introduced local from all such constructs as
+/// declared, so it is symmetric with how top-level method bodies plan their
+/// slots. These tests cover the generalization end-to-end (compile + run):
+/// a catch variable used in a lambda, <c>throw ex</c> rethrow in a lambda
+/// catch, a lambda that both captures an outer variable and has a try/catch,
+/// a try/catch nested inside a <c>let</c>/<c>if</c> block in a lambda, and a
+/// switch type-pattern variable in a lambda. Every package/user name is unique
+/// so the process-wide <c>FunctionTypeSymbol</c> cache cannot alias across
+/// in-process tests.
+/// </para>
+/// </summary>
+public class Issue1437CatchInLambdaEmitTests
+{
+    [Fact]
+    public void EndToEnd_CatchVariableUsedInLambda_Runs()
+    {
+        var source = """
+            package Probe1437a
+            import System
+
+            func Main() {
+                let f = func () {
+                    try {
+                        throw Exception("boom1437a")
+                    } catch (ex Exception) {
+                        Console.WriteLine("caught: " + ex.Message)
+                    }
+                }
+                f()
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("caught: boom1437a\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_RethrowInLambdaCatch_Runs()
+    {
+        var source = """
+            package Probe1437b
+            import System
+
+            func Main() {
+                let f = func () {
+                    try {
+                        try {
+                            throw Exception("inner1437b")
+                        } catch (ex Exception) {
+                            throw ex
+                        }
+                    } catch (e Exception) {
+                        Console.WriteLine("outer caught: " + e.Message)
+                    }
+                }
+                f()
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("outer caught: inner1437b\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_LambdaCapturesOuterVariableAndHasCatch_Runs()
+    {
+        var source = """
+            package Probe1437c
+            import System
+
+            func Main() {
+                let prefix = "P1437c:"
+                let f = func () {
+                    try {
+                        throw Exception("z")
+                    } catch (ex Exception) {
+                        Console.WriteLine(prefix + ex.Message)
+                    }
+                }
+                f()
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("P1437c:z\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_TryCatchNestedInsideLetBlockInLambda_Runs()
+    {
+        var source = """
+            package Probe1437d
+            import System
+
+            func Main() {
+                let f = func () {
+                    let outer = "O1437d:"
+                    if true {
+                        let inner = "I"
+                        try {
+                            throw Exception("q")
+                        } catch (ex Exception) {
+                            Console.WriteLine(outer + inner + ex.Message)
+                        }
+                    }
+                }
+                f()
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("O1437d:Iq\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_TypePatternVariableInLambda_Runs()
+    {
+        var source = """
+            package Probe1437e
+            import System
+
+            func Main() {
+                let classify = func (o object) string {
+                    return switch o {
+                        case s is string: "str:" + s
+                        case n is int32: "int"
+                        default: "other"
+                    }
+                }
+                Console.WriteLine(classify("hi1437e"))
+                Console.WriteLine(classify(5))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("str:hi1437e\nint\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1437_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue1437CatchInLambdaEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1437CatchInLambdaEmitTests.cs
@@ -167,6 +167,39 @@ public class Issue1437CatchInLambdaEmitTests
         Assert.Equal("str:hi1437e\nint\n", output);
     }
 
+    [Fact]
+    public void EndToEnd_NullConditionalInvokeCaptureLocalInLambda_Runs()
+    {
+        // The `?(…)` operator introduces a synthetic `$ncap_N` capture local
+        // referenced inside `WhenNotNull`. When the whole null-conditional sits
+        // in a lambda body, that capture local must be treated as a body-local
+        // declaration (not misclassified as a capture of an enclosing scope),
+        // otherwise emit crashes with GS9998 "Variable '$ncap_N' has no local
+        // slot". Here the nullable delegate is a captured parameter.
+        var source = """
+            package Probe1437f
+            import System
+
+            func Build1437f(cb ((int32) -> void)?) () -> void {
+                return () -> {
+                    cb?(5)
+                }
+            }
+
+            func Main() {
+                var total = 0
+                let run = Build1437f((n int32) -> { total = total + n })
+                run()
+                let noop = Build1437f(nil)
+                noop()
+                Console.WriteLine(total)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("5\n", output);
+    }
+
     private static string CompileAndRun(string source)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_1437_exe_").FullName;


### PR DESCRIPTION
## Summary

A body-introduced local — a `catch`-clause variable, a `switch` type-pattern binding, a `select` arm, a range loop variable, etc. — declared **inside a `func` literal / lambda body** crashed emit with:

```
GS9998: InvalidOperationException: Variable 'ex' has no local slot or parameter index in the current method.
```

The same construct at top level (not in a lambda) compiled fine.

## Root cause

The binder's captured-variable analysis (`CapturedVariableCollector` in `LambdaBinder`) recorded only `BoundVariableDeclaration` targets as locals declared *within* the lambda (`declared` set). Catch / select-arm / range / pattern variables are **not** `BoundVariableDeclaration` nodes, so a later read of one (e.g. `throw ex`) was misclassified by `RecordReference` as a **capture of an enclosing scope**.

That false capture flowed into `BoundFunctionLiteralExpression.CapturedVariables`, and `CaptureBoxingRewriter` then hoisted the variable into a heap box. This desynchronized the variable's **declaration site** (still the original symbol, for which the emit local-slot planner allocates a slot) from its **in-body reads** (rewritten to `box.Value` against a fresh, slot-less box local). The read then had no slot → GS9998.

Verified concretely by instrumenting plan-time vs emit-time symbol identity: the catch clause kept its original `VariableSymbol` (slot allocated), while the body read pointed at a different, boxed symbol with no slot.

## Fix (generalized — not catch-specific)

Record **every body-introduced local** as `declared`, symmetric with how top-level method bodies plan their slots. New `CapturedVariableCollector` overrides cover:

- `try`/`catch` clause variables
- `select` arm variables
- `for`-range key/value variables
- `for`-ellipsis variables
- `fixed` pinned / pointer / source locals
- `switch` / `is` type-pattern variables

Genuine captures by a **nested** lambda remain correct: the variable is declared in this body's scope, so the nested literal's capture is satisfied here and is not propagated outward.

## Tests

Adds `test/Compiler.Tests/Emit/Issue1437CatchInLambdaEmitTests.cs` — end-to-end (compile + run, asserting printed output):

- catch variable used inside a lambda (`ex.Message`)
- `throw ex` rethrow inside a lambda catch
- a lambda that **both** captures an outer variable **and** has a try/catch
- a try/catch nested inside a `let`/`if` block in a lambda
- a `switch` type-pattern variable in a lambda (generalization)

Each uses unique package/user names to avoid the process-wide `FunctionTypeSymbol` cache aliasing across in-process tests. All five were confirmed to fail on the pre-fix build (catch cases: `Variable 'ex' ...`; pattern case: `Variable 's' ...`).

## Verification

- `dotnet build GSharp.sln -c Release -graph` → 0 warnings, 0 errors
- New tests: 5/5 pass
- `dotnet test test/Core.Tests` → 4788 passed, 1 skipped (no IL baseline regression)
- Closure/Lambda/Try slice → 149/149 pass
- Capture/Box/Switch/Pattern/Select/Range/Fixed slice → 178/178 pass

Fixes #1437

Refs #914

---
**Update:** also recorded the null-conditional `?.`/`?(…)` synthetic capture locals (`$ncap_N`/`$nres_N`) as body-local declarations — they were the same class of body-introduced local missed by the first pass (a `delegate?(args)` invocation inside a lambda hit GS9998 `Variable $ncap_N has no local slot`). Added a regression test for it.
