### PR TITLE
Emit string(charArray) via String(char[]) constructor

### DIFF
--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
@@ -447,6 +447,26 @@ internal sealed partial class MethodBodyEmitter
             return;
         }
 
+        // Issue #1441: `string(charArray)` — the G# rendering of C#
+        // `new string(char[])`. The binder accepts a `[]char -> string`
+        // conversion, but there is no primitive IL cast for it; materialise it
+        // through the `System.String(char[])` constructor. Resolving the ctor
+        // from `to.ClrType` (rather than `typeof(string)`) keeps it in the
+        // active reference context (live host vs MetadataLoadContext).
+        if (to?.ClrType != null && to.ClrType.IsSameAs(typeof(string))
+            && from?.ClrType is { IsArray: true } fromArray
+            && fromArray.GetElementType() is System.Type fromElement
+            && fromElement.IsSameAs(typeof(char)))
+        {
+            var stringCtor = to.ClrType.GetConstructor(new[] { fromArray });
+            if (stringCtor != null)
+            {
+                this.il.OpCode(ILOpCode.Newobj);
+                this.il.Token(this.outer.GetCtorReference(stringCtor));
+                return;
+            }
+        }
+
         throw new NotSupportedException(
             $"Conversion from '{from.Name}' to '{to.Name}' is not yet supported by the emitter.");
     }

--- a/test/Compiler.Tests/Emit/Issue1441StringFromCharArrayEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1441StringFromCharArrayEmitTests.cs
@@ -1,0 +1,153 @@
+// <copyright file="Issue1441StringFromCharArrayEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1441 — `string(charArray)` (the G# rendering of C#
+/// <c>new string(char[])</c>) bound as a <c>[]char -&gt; string</c> conversion
+/// but had no emit path, crashing with GS9998
+/// "Conversion from '[]char' to 'string' is not yet supported by the emitter".
+/// The fix materialises it via the <c>System.String(char[])</c> constructor.
+/// </summary>
+public class Issue1441StringFromCharArrayEmitTests
+{
+    [Fact]
+    public void EndToEnd_StringFromMutatedCharArray_Runs()
+    {
+        var source = """
+            package Probe1441a
+            import System
+
+            func Conv(n int32) string {
+                let nameBts = [n]char
+                var i = 0
+                while i < n {
+                    nameBts[i] = 'x'
+                    i = i + 1
+                }
+                return string(nameBts)
+            }
+
+            func Main() {
+                Console.WriteLine(Conv(3))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("xxx\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_StringFromCharArrayParameter_Runs()
+    {
+        var source = """
+            package Probe1441b
+            import System
+
+            func ToText(chars []char) string {
+                return string(chars)
+            }
+
+            func Main() {
+                let buf = [3]char
+                buf[0] = 'h'
+                buf[1] = 'i'
+                buf[2] = '!'
+                Console.WriteLine(ToText(buf))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("hi!\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1441_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
## Problem
`string(charArray)` — the G# rendering of C# `new string(char[])` — binds as a `[]char -> string` conversion, but the emitter has no IL path for it and crashes:

```
GS9998: NotSupportedException: Conversion from '[]char' to 'string' is not yet supported by the emitter.
```

## Minimal repro
```gsharp
func Conv(n int32) string {
    let nameBts = [n]char
    var i = 0
    while i < n { nameBts[i] = 'x'; i = i + 1 }
    return string(nameBts)
}
```

## Fix
In `MethodBodyEmitter.EmitConversion` (`MethodBodyEmitter.Conversions.cs`), before the fallback `NotSupportedException`, recognise a `char[] -> string` conversion and emit `newobj instance void System.String::.ctor(char[])`. The ctor is resolved from `to.ClrType` so it stays in the active reference context (live host vs MetadataLoadContext). Generalises to every `new string(charArray)`.

## Verification
- New `Issue1441StringFromCharArrayEmitTests` (mutated local char array + char-array parameter) — both pass and IL-verify.
- Minimal repro now compiles and runs.
- Core.Tests: 4788 pass.

## Oahu impact
Unblocks `Oahu.Decrypt` translate stage (`AlternativeInfo`, `MdhdBox`, `StreamExtensions` all use `new string(char[])`).

Fixes #1441

Refs #914