### PR TITLE
Target-type bare default switch-expression arms (Fixes #1443)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.SwitchExpr.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.SwitchExpr.cs
@@ -125,6 +125,26 @@ internal sealed partial class ExpressionBinder
         foreach (var arm in boundArmBuilders)
         {
             var result = arm.Result;
+
+            // Issue #1443: a bare `default` arm result (`case 0: default`) is
+            // an untyped placeholder `BoundDefaultExpression(Error)` until a
+            // target type is known — its concrete type is supplied by the
+            // switch's result type, exactly like `default` in a return/arrow
+            // body. Re-bind it against `resultType` (which already honors any
+            // outer target type and the other arms) so it materialises as
+            // `default(resultType)`. Without this it would fall into the
+            // conversion-failure branch below and be silently replaced by a
+            // BoundErrorExpression that crashes emission (GS9998).
+            if (result is BoundDefaultExpression bareDefault
+                && bareDefault.Type == TypeSymbol.Error
+                && resultType != TypeSymbol.Error
+                && resultType != TypeSymbol.Void)
+            {
+                result = BindExpression(arm.Syntax.Result, resultType);
+                arms.Add(new BoundSwitchExpressionArm(null, arm.Pattern, arm.Guard, result));
+                continue;
+            }
+
             var conversion = Conversion.Classify(result.Type, resultType);
             if (!conversion.Exists || conversion.IsExplicit)
             {

--- a/test/Compiler.Tests/Emit/Issue1443DefaultSwitchArmEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1443DefaultSwitchArmEmitTests.cs
@@ -1,0 +1,160 @@
+// <copyright file="Issue1443DefaultSwitchArmEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1443 — a bare <c>default</c> used as a switch-expression arm result
+/// (<c>case 0: default</c>) stayed an untyped <c>BoundDefaultExpression(Error)</c>
+/// placeholder because arm results were bound without a target type. It then fell
+/// into the conversion-failure branch and was silently replaced by a
+/// <c>BoundErrorExpression</c>, crashing emission with GS9998. The fix re-binds the
+/// bare-<c>default</c> arm against the switch's result type so it materialises as
+/// <c>default(resultType)</c>, exactly like <c>default</c> in a return/arrow body.
+/// </summary>
+public class Issue1443DefaultSwitchArmEmitTests
+{
+    [Fact]
+    public void EndToEnd_DefaultArmReturnsNullableUserClass_Runs()
+    {
+        var source = """
+            package Probe1443a
+            import System
+
+            open class Thing1443a {
+                prop Name string -> "thing"
+            }
+
+            func Pick(kind int32) Thing1443a? {
+                return switch kind {
+                    case 0: default
+                    case 1: Thing1443a()
+                    default: throw InvalidOperationException("bad")
+                }
+            }
+
+            func Main() {
+                Console.WriteLine(Pick(0) == nil)
+                Console.WriteLine(Pick(1) != nil)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\nTrue\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_DefaultArmReturnsValueTypeZero_Runs()
+    {
+        var source = """
+            package Probe1443b
+            import System
+
+            func Score(kind int32) int32 {
+                return switch kind {
+                    case 1: 10
+                    case 2: 20
+                    default: default
+                }
+            }
+
+            func Main() {
+                Console.WriteLine(Score(1))
+                Console.WriteLine(Score(2))
+                Console.WriteLine(Score(99))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("10\n20\n0\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1443_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

A bare `default` used as a switch-expression arm result (`case 0: default`)
stayed an untyped `BoundDefaultExpression(Error)` placeholder because arm
results are bound without a target type. It then fell into the conversion-failure
branch in `BindSwitchExpression` and was silently replaced by a
`BoundErrorExpression`, which crashed emission with GS9998 (the crash also
masked every other per-file binding diagnostic in a multi-file compile).

The fix re-binds a bare-`default` arm against the switch's already-computed
result type (which honors any outer target type and the other arms), so it
materialises as `default(resultType)` — exactly like `default` in a return or
arrow-body position, both of which already worked.

## Tests

`test/Compiler.Tests/Emit/Issue1443DefaultSwitchArmEmitTests.cs` — two
end-to-end (compile + IL-verify + run) tests:
- `default` arm returning a value type (`int32`) produces `0`.
- `default` arm returning a nullable reference type (`Thing?`) produces `nil`.

Core.Tests: 4788 pass.

Fixes #1443

Refs #914
