### PR TITLE
Route array-element and member writes through bare auto-properties (Fixes #1446, #1448)

### DIFF
--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/APICFrame.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/APICFrame.gs
@@ -1,0 +1,48 @@
+package Oahu.Decrypt.Mpeg4.ID3
+
+import System.IO
+import System.Text
+
+class APICFrame : Frame {
+    init(file Stream, header Header, parent Frame) : base(header, parent) {
+        let startPos = file.Position
+        let textEncoding = file.ReadByte()
+        ImageFormat = Frame.ReadNullTerminatedString(file, false)
+        Description = Frame.ReadNullTerminatedString(file, textEncoding == 1)
+        Type = uint8(file.ReadByte())
+        Image = [int32((startPos + int64(header.Size) - file.Position))]uint8
+        file.ReadExactly(Image)
+    }
+
+    override prop Size int32 {
+        get {
+            let fixedSize = 1 + ImageFormat.Length + 1 + 1 + Image.Length
+            if Frame.IsUnicode(Description) {
+                return Frame.UnicodeLength(Description) + 2 + fixedSize
+            } else {
+                return Description.Length + 1 + fixedSize
+            }
+        }
+    }
+
+    prop ImageFormat string
+    prop Description string
+    prop Type uint8
+    prop Image []uint8
+
+    override func Render(file Stream) {
+        let txtFormat = if Frame.IsUnicode(Description) { 1 } else { 0 }
+        file.WriteByte(uint8(txtFormat))
+        file.Write(Encoding.ASCII.GetBytes(ImageFormat))
+        file.WriteByte(0)
+        file.WriteByte(Type)
+        if txtFormat == 0 {
+            file.Write(Encoding.ASCII.GetBytes(Description))
+            file.WriteByte(0)
+        } else {
+            file.Write(Frame.UnicodeBytes(Description))
+            file.Write(stackalloc [2]uint8)
+        }
+        file.Write(Image)
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/AacValidateFilter.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/AacValidateFilter.gs
@@ -1,0 +1,20 @@
+package Oahu.Decrypt.FrameFilters.Audio
+
+import System
+
+internal open class AacValidateFilter : FrameTransformBase[FrameEntry, FrameEntry] {
+    protected open override prop InputBufferSize int32 -> 1000
+
+    open override func PerformFiltering(input FrameEntry) FrameEntry {
+        return if AacValidateFilter.ValidateFrame(input.FrameData.Span) { input } else { throw Exception("Aac error!")
+            default(FrameEntry) }
+    }
+
+    shared {
+        private func ValidateFrame(frame ReadOnlySpan[uint8]) bool -> (AacValidateFilter.AV_RB16(frame) & uint16(0xfff0)) != 0xfff0
+
+        private func AV_RB16(frame ReadOnlySpan[uint8]) uint16 {
+            return uint16((frame[0] << 8 | int32(frame[1])))
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/AavdFilter.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/AavdFilter.gs
@@ -1,0 +1,40 @@
+package Oahu.Decrypt.FrameFilters.Audio
+
+import System
+import System.Security.Cryptography
+
+internal open class AavdFilter : AacValidateFilter {
+    private let aes Aes
+    private let iv []uint8
+
+    init(key []?uint8, iv []?uint8) {
+        if key == nil || key!!.Length != AavdFilter.AesBlockSize {
+            throw ArgumentException("${nameof(key)} must be ${AavdFilter.AesBlockSize} bytes long.")
+        }
+        if iv == nil || iv!!.Length != AavdFilter.AesBlockSize {
+            throw ArgumentException("${nameof(iv)} must be ${AavdFilter.AesBlockSize} bytes long.")
+        }
+        this.aes = Aes.Create()
+        this.aes.Key = key
+        this.iv = iv
+    }
+
+    open override func PerformFiltering(input FrameEntry) FrameEntry {
+        if input.FrameData.Length >= 0x10 {
+            let encBlocks = input.FrameData.Slice(0, input.FrameData.Length & 0x7ffffff0).Span
+            aes.DecryptCbc(encBlocks, iv, encBlocks, PaddingMode.None)
+        }
+        return base.PerformFiltering(input)
+    }
+
+    protected open override func Dispose(disposing bool) {
+        if disposing && !Disposed {
+            aes.Dispose()
+        }
+        base.Dispose(disposing)
+    }
+
+    shared {
+        private const AesBlockSize int32 = 16
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/AaxFile.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/AaxFile.gs
@@ -1,0 +1,116 @@
+package Oahu.Decrypt
+
+import System
+import System.Collections.Generic
+import System.IO
+import System.Linq
+import Oahu.Decrypt.FrameFilters
+import Oahu.Decrypt.FrameFilters.Audio
+import Oahu.Decrypt.Mpeg4.Boxes
+import Oahu.Decrypt.Mpeg4.Util
+
+class AaxFile : Mp4File {
+    init(file Stream, fileSize int64, additionalFixups bool = true) : base(file, fileSize) {
+        if FileType != FileType.Aax && FileType != FileType.Aaxc {
+            throw ArgumentException("This instance of ${nameof(Mp4File)} is not an Aax or Aaxc file.")
+        }
+        let esds EsdsBox? = AudioSampleEntry.Esds as EsdsBox
+        if esds != nil {
+            esds.ES_Descriptor.DecoderConfig.AudioSpecificConfig.DependsOnCoreCoder = false
+        }
+        AudioSampleEntry.Header.ChangeAtomName("mp4a")
+        if additionalFixups {
+            let children = AudioSampleEntry.Children
+            for var i = children.Count - 1; i >= 0; i-- {
+                if children[i] is FreeBox {
+                    children.RemoveAt(i)
+                }
+            }
+            Ftyp = FtypBox.Create("isom", 0x200)
+            Ftyp.CompatibleBrands.Add("iso2")
+            Ftyp.CompatibleBrands.Add("mp41")
+            Ftyp.CompatibleBrands.Add("M4A ")
+            Ftyp.CompatibleBrands.Add("M4B ")
+        }
+    }
+
+    convenience init(file Stream) {
+        init(file, file.Length)
+    }
+
+    convenience init(fileName string, access FileAccess = 1, share FileShare = 1) {
+        init(File.Open(fileName, FileMode.Open, access, share))
+    }
+
+    prop Key []?uint8
+    prop IV []?uint8
+
+    override func GetAudioFrameFilter() FrameTransformBase[FrameEntry, FrameEntry] {
+        return if Key != nil && IV != nil { AavdFilter(Key!!, IV!!) } else { throw InvalidOperationException("This instance of ${nameof(AaxFile)} does not have a decryption key set.")
+            default(AavdFilter) }
+    }
+
+    func SetDecryptionKey(activationBytes string) {
+        if String.IsNullOrWhiteSpace(activationBytes) || activationBytes.Length != 8 {
+            throw ArgumentException("${nameof(activationBytes)} must be 4 bytes long.")
+        }
+        let actBytes = ByteUtil.BytesFromHexString(activationBytes)
+        SetDecryptionKey(actBytes)
+    }
+
+    func SetDecryptionKey(activationBytes []?uint8) {
+        if activationBytes == nil || activationBytes!!.Length != 4 {
+            throw ArgumentException("${nameof(activationBytes)} must be 4 bytes long.")
+        }
+        if FileType != FileType.Aax {
+            throw ArgumentException("This instance of ${nameof(AaxFile)} is not an ${FileType.Aax} file.")
+        }
+        let adrm = AudioSampleEntry.GetChild[AdrmBox]() ?? throw InvalidOperationException("This instance of ${nameof(AaxFile)} does not contain an adrm box.")
+        let intermediate_key = Crypto.Sha1((AaxFile.AudibleFixedKey, 0, AaxFile.AudibleFixedKey.Length), (activationBytes!!, 0, activationBytes!!.Length))
+        let intermediate_iv = Crypto.Sha1((AaxFile.AudibleFixedKey, 0, AaxFile.AudibleFixedKey.Length), (intermediate_key, 0, intermediate_key.Length), (activationBytes!!, 0, activationBytes!!.Length))
+        let calculatedChecksum = Crypto.Sha1((intermediate_key, 0, 16), (intermediate_iv, 0, 16))
+        if !ByteUtil.BytesEqual(calculatedChecksum, adrm.Checksum) {
+            throw Exception("Calculated checksum doesn't match AAX file checksum.")
+        }
+        let drmBlob = ByteUtil.CloneBytes(adrm.DrmBlob)
+        Crypto.DecryptInPlace(ByteUtil.CloneBytes(intermediate_key, 0, 16), ByteUtil.CloneBytes(intermediate_iv, 0, 16), drmBlob)
+        if !ByteUtil.BytesEqual(drmBlob, 0, activationBytes!!, 0, 4, true) {
+            throw Exception("Supplied key doesn't match calculated key.")
+        }
+        let file_key = ByteUtil.CloneBytes(drmBlob, 8, 16)
+        let file_iv = Crypto.Sha1((drmBlob, 26, 16), (file_key, 0, 16), (AaxFile.AudibleFixedKey, 0, 16))
+        AudioSampleEntry.Children.Remove(adrm)
+        let aabd IBox? = AudioSampleEntry.Children.FirstOrDefault((b IBox) -> b.Header.Type == "aabd") as IBox
+        if aabd != nil {
+            AudioSampleEntry.Children.Remove(aabd)
+        }
+        SetDecryptionKey(file_key, ByteUtil.CloneBytes(file_iv, 0, 16))
+    }
+
+    func SetDecryptionKey(audible_key string, audible_iv string) {
+        if String.IsNullOrWhiteSpace(audible_key) || audible_key.Length != 32 {
+            throw ArgumentException("${nameof(audible_key)} must be 16 bytes long.")
+        }
+        if String.IsNullOrWhiteSpace(audible_iv) || audible_iv.Length != 32 {
+            throw ArgumentException("${nameof(audible_iv)} must be 16 bytes long.")
+        }
+        let key = ByteUtil.BytesFromHexString(audible_key)
+        let iv = ByteUtil.BytesFromHexString(audible_iv)
+        SetDecryptionKey(key, iv)
+    }
+
+    func SetDecryptionKey(key []?uint8, iv []?uint8) {
+        if key == nil || key!!.Length != 16 {
+            throw ArgumentException("${nameof(key)} must be 16 bytes long.")
+        }
+        if iv == nil || iv!!.Length != 16 {
+            throw ArgumentException("${nameof(iv)} must be 16 bytes long.")
+        }
+        Key = key
+        IV = iv
+    }
+
+    shared {
+        private let AudibleFixedKey []uint8 = []uint8{uint8(0x77), uint8(0x21), uint8(0x4d), uint8(0x4b), uint8(0x19), uint8(0x6a), uint8(0x87), uint8(0xcd), uint8(0x52), uint8(0x00), uint8(0x45), uint8(0xfd), uint8(0x20), uint8(0xa5), uint8(0x1d), uint8(0x67)}
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Ac4BitrateDsi.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Ac4BitrateDsi.gs
@@ -1,0 +1,15 @@
+package Oahu.Decrypt.Mpeg4.Boxes.AC4SpecificBox
+
+import Oahu.Decrypt.Mpeg4.Util
+
+class Ac4BitrateDsi {
+    var BitRateMode BitRateMode
+    var BitRate uint32
+    var BitRatePrecision uint32
+
+    init(reader BitReader) {
+        BitRateMode = BitRateMode(reader.Read(2))
+        BitRate = reader.Read(32)
+        BitRatePrecision = reader.Read(32)
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Ac4DsiV1.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Ac4DsiV1.gs
@@ -1,0 +1,61 @@
+package Oahu.Decrypt.Mpeg4.Boxes.AC4SpecificBox
+
+import System
+import Oahu.Decrypt.Mpeg4.Util
+
+class Ac4DsiV1 {
+    var Ac4DsiVersion uint8
+    var BitstreamVersion uint8
+    var FsIndex uint8
+    var FrameRateIndex uint8
+    var NPresentations uint16
+    var BProgramId bool?
+    var ShortProgramId uint16?
+    var BUuid bool?
+    var ProgramUuid Guid?
+    var Ac4BitrateDsi Ac4BitrateDsi
+    var Presentations []object?
+
+    init(reader BitReader) {
+        Ac4DsiVersion = uint8(reader.Read(3))
+        BitstreamVersion = uint8(reader.Read(7))
+        FsIndex = uint8(reader.Read(1))
+        FrameRateIndex = uint8(reader.Read(4))
+        NPresentations = uint16(reader.Read(9))
+        if BitstreamVersion > uint8(1) {
+            BProgramId = reader.ReadBool()
+            if BProgramId.Value {
+                ShortProgramId = uint16(reader.Read(16))
+                BUuid = reader.ReadBool()
+                if BUuid.Value {
+                    ProgramUuid = Guid(reader.Read(32), uint16(reader.Read(16)), uint16(reader.Read(16)), uint8(reader.Read(8)), uint8(reader.Read(8)), uint8(reader.Read(8)), uint8(reader.Read(8)), uint8(reader.Read(8)), uint8(reader.Read(8)), uint8(reader.Read(8)), uint8(reader.Read(8)))
+                }
+            }
+        }
+        Ac4BitrateDsi = Ac4BitrateDsi(reader)
+        reader.ByteAlign()
+        Presentations = [int32(NPresentations)]object
+        for var i = 0; i < int32(NPresentations); i++ {
+            var presentationBytes uint32
+            let presentationVersion = reader.Read(8)
+            var presBytes = reader.Read(8)
+            if presBytes == uint32(255) {
+                let addPresBytes = reader.Read(16)
+                presBytes += addPresBytes
+            }
+            if presentationVersion == uint32(0) {
+                throw NotSupportedException("ac4_presentation_v0_dsi not yet supported")
+            } else {
+                if presentationVersion == uint32(1) || presentationVersion == uint32(2) {
+                    let start = reader.Position
+                    Presentations[i] = Ac4PresentationV1Dsi(presentationVersion, presBytes, reader)
+                    presentationBytes = uint32((reader.Position - start)) / uint32(8)
+                } else {
+                    presentationBytes = uint32(0)
+                }
+            }
+            let skipBytes = presBytes - presentationBytes
+            reader.Position += 8 * int32(skipBytes)
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Ac4Extensions.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Ac4Extensions.gs
@@ -1,0 +1,51 @@
+package Oahu.Decrypt.Mpeg4.Boxes.AC4SpecificBox
+
+import System.Linq
+
+class Ac4Extensions {
+    shared {
+        private let NumChannelsPerGroup []uint8 = []uint8{uint8(2), uint8(1), uint8(2), uint8(2), uint8(2), uint8(2), uint8(1), uint8(2), uint8(2), uint8(1), uint8(1), uint8(1), uint8(1), uint8(2), uint8(1), uint8(1), uint8(2), uint8(2), uint8(2)}
+
+        func ChannelCount(channels ChannelGroups) int32 {
+            var channelCount = 0
+            for var g = 0; g <= 18; g++ {
+                let group = ChannelGroups((1 << g))
+                if channels.HasFlag(group) {
+                    channelCount += int32(Ac4Extensions.NumChannelsPerGroup[g])
+                }
+            }
+            return channelCount
+        }
+    }
+}
+
+func (ac4DsiV1 Ac4DsiV1?) SampleRate() int32? -> if ac4DsiV1 == nil { nil } else { if ac4DsiV1!!.FsIndex == uint8(0) { 44100 } else { 48000 } }
+
+func (ac4DsiV1 Ac4DsiV1?) AverageBitrate() uint32? {
+    if ac4DsiV1 == nil {
+        return nil
+    }
+    if ac4DsiV1!!.Ac4BitrateDsi.BitRate != uint32(0) {
+        return ac4DsiV1!!.Ac4BitrateDsi.BitRate
+    }
+    for presentation in ac4DsiV1!!.Presentations.OfType[Ac4PresentationV1Dsi]().Where((p Ac4PresentationV1Dsi) -> p.BPresentationBitrateInfo) {
+        if presentation!!.Ac4BitrateDsi is Ac4BitrateDsi && (presentation!!.Ac4BitrateDsi as Ac4BitrateDsi)!!.BitRate != uint32(0) {
+            return (presentation!!.Ac4BitrateDsi as Ac4BitrateDsi)!!.BitRate
+        }
+    }
+    return nil
+}
+
+func (ac4DsiV1 Ac4DsiV1?) Channels() ChannelGroups? {
+    if ac4DsiV1 == nil {
+        return nil
+    }
+    for presentation in ac4DsiV1!!.Presentations.OfType[Ac4PresentationV1Dsi]().OrderByDescending((p Ac4PresentationV1Dsi) -> p.PresentationVersion) {
+        if presentation!!.BPresentationChannelCoded == true {
+            return presentation!!.PresentationChannelMaskV1
+        } else if presentation!!.Substream?.BChannelCoded == true {
+            return presentation!!.Substream!!.Substreams[0].DsiSubstreamChannelMask
+        }
+    }
+    return nil
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Ac4PresentationV1Dsi.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Ac4PresentationV1Dsi.gs
@@ -1,0 +1,121 @@
+package Oahu.Decrypt.Mpeg4.Boxes.AC4SpecificBox
+
+import System
+import Oahu.Decrypt.Mpeg4.Util
+
+class Ac4PresentationV1Dsi {
+    var PresentationVersion uint32
+    var PresentationConfigV1 uint8
+    var BAddEmdfSubstreams bool
+    var Mdcompat uint8?
+    var BPresentationId bool?
+    var PresentationId uint8?
+    var DsiFrameRateMultiplyInfo uint8?
+    var DsiFrameRateFractionInfo uint8?
+    var PresentationEmdfVersion uint8?
+    var PresentationKeyId uint16?
+    var BPresentationChannelCoded bool?
+    var DsiPresentationChMode uint8?
+    var PresB4BackChannelsPresent uint8?
+    var PresTopChannelPairs uint8?
+    var PresentationChannelMaskV1 ChannelGroups?
+    var BPresentationCoreDiffers bool?
+    var BPresentationCoreChannelCoded bool?
+    var DsiPresentationChannelModeCore uint8?
+    var BPresentationFilter bool?
+    var BEnablePresentation bool?
+    var NFilterBytes uint8?
+    var FilterData []?uint8
+    var Substream Ac4SubstreamGroupDsi?
+    var BPreVirtualized bool?
+    var NAddEmdfSubstreams uint8?
+    var SubstreamsEmdfs []?(uint8, uint16)
+    var BPresentationBitrateInfo bool
+    var Ac4BitrateDsi Ac4BitrateDsi?
+    var BAlternative bool
+    var AlternativeInfo AlternativeInfo?
+    var DeIndicator uint8?
+    var BExtendedPresentationId bool?
+    var ExtendedPresentationId uint16?
+    var DolbyAtmosIndicator bool?
+
+    init(presentationVersion uint32, presBytes uint32, reader BitReader) {
+        PresentationVersion = presentationVersion
+        let start = reader.Position
+        PresentationConfigV1 = uint8(reader.Read(5))
+        if PresentationConfigV1 == uint8(6) {
+            BAddEmdfSubstreams = true
+        } else {
+            Mdcompat = uint8(reader.Read(3))
+            BPresentationId = reader.ReadBool()
+            if BPresentationId.Value {
+                PresentationId = uint8(reader.Read(5))
+            }
+            DsiFrameRateMultiplyInfo = uint8(reader.Read(2))
+            DsiFrameRateFractionInfo = uint8(reader.Read(2))
+            PresentationEmdfVersion = uint8(reader.Read(5))
+            PresentationKeyId = uint16(reader.Read(10))
+            BPresentationChannelCoded = reader.ReadBool()
+            if BPresentationChannelCoded.Value {
+                DsiPresentationChMode = uint8(reader.Read(5))
+                if DsiPresentationChMode == (11 as uint8?) || DsiPresentationChMode == (12 as uint8?) || DsiPresentationChMode == (13 as uint8?) || DsiPresentationChMode == (14 as uint8?) {
+                    PresB4BackChannelsPresent = uint8(reader.Read(1))
+                    PresTopChannelPairs = uint8(reader.Read(2))
+                }
+                PresentationChannelMaskV1 = ChannelGroups(reader.Read(24))
+            }
+            BPresentationCoreDiffers = reader.ReadBool()
+            if BPresentationCoreDiffers.Value {
+                BPresentationCoreChannelCoded = reader.ReadBool()
+                if BPresentationCoreChannelCoded.Value {
+                    DsiPresentationChannelModeCore = uint8(reader.Read(2))
+                }
+            }
+            BPresentationFilter = reader.ReadBool()
+            if BPresentationFilter.Value {
+                BEnablePresentation = reader.ReadBool()
+                NFilterBytes = uint8(reader.Read(8))
+                FilterData = [int32(NFilterBytes.Value)]uint8
+                for var i = 0; i < int32(NFilterBytes.Value); i++ {
+                    FilterData!![i] = uint8(reader.Read(8))
+                }
+            }
+            if PresentationConfigV1 == uint8(0x1f) {
+                Substream = Ac4SubstreamGroupDsi(reader)
+            } else {
+                throw NotSupportedException()
+            }
+            BPreVirtualized = reader.ReadBool()
+            BAddEmdfSubstreams = reader.ReadBool()
+        }
+        if BAddEmdfSubstreams {
+            NAddEmdfSubstreams = uint8(reader.Read(7))
+            SubstreamsEmdfs = [int32(NAddEmdfSubstreams.Value)](uint8, uint16)
+            for var j = 0; j < (NAddEmdfSubstreams as int32?); j++ {
+                SubstreamsEmdfs!![j] = (uint8(reader.Read(5)), uint16(reader.Read(10)))
+            }
+        }
+        BPresentationBitrateInfo = reader.ReadBool()
+        if BPresentationBitrateInfo {
+            Ac4BitrateDsi = Ac4BitrateDsi(reader)
+        }
+        BAlternative = reader.ReadBool()
+        if BAlternative {
+            reader.ByteAlign()
+            AlternativeInfo = AlternativeInfo(reader)
+        }
+        reader.ByteAlign()
+        let read = reader.Position - start
+        if int64(read) <= int64((presBytes - uint32(1)) * uint32(8)) {
+            DeIndicator = uint8(reader.Read(1))
+            DolbyAtmosIndicator = reader.ReadBool()
+            reader.Read(4)
+            BExtendedPresentationId = reader.ReadBool()
+            if BExtendedPresentationId.Value {
+                ExtendedPresentationId = uint16(reader.Read(9))
+            } else {
+                reader.Read(1)
+            }
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Ac4Substream.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Ac4Substream.gs
@@ -1,0 +1,41 @@
+package Oahu.Decrypt.Mpeg4.Boxes.AC4SpecificBox
+
+import Oahu.Decrypt.Mpeg4.Util
+
+class Ac4Substream {
+    var DsiSfMultiplier uint8
+    var BSubstreamBitrateIndicator bool
+    var SubstreamBitrateIndicator uint8?
+    var DsiSubstreamChannelMask ChannelGroups?
+    var BAjoc bool?
+    var BStaticDmx bool?
+    var NDmxObjectsMinus1 uint8?
+    var NUmxObjectsMinus1 uint8?
+    var BSubstreamContainsBedObjects bool?
+    var BSubstreamContainsDynamicObjects bool?
+    var BSubstreamContainsIsfObjects bool?
+
+    init(info Ac4SubstreamGroupDsi, reader BitReader) {
+        DsiSfMultiplier = uint8(reader.Read(2))
+        BSubstreamBitrateIndicator = reader.ReadBool()
+        if BSubstreamBitrateIndicator {
+            SubstreamBitrateIndicator = uint8(reader.Read(5))
+        }
+        if info.BChannelCoded {
+            DsiSubstreamChannelMask = ChannelGroups(reader.Read(24))
+        } else {
+            BAjoc = reader.ReadBool()
+            if BAjoc.Value {
+                BStaticDmx = reader.ReadBool()
+                if BStaticDmx.Value {
+                    NDmxObjectsMinus1 = uint8(reader.Read(4))
+                }
+                NUmxObjectsMinus1 = uint8(reader.Read(6))
+            }
+            BSubstreamContainsBedObjects = reader.ReadBool()
+            BSubstreamContainsDynamicObjects = reader.ReadBool()
+            BSubstreamContainsIsfObjects = reader.ReadBool()
+            reader.Read(1)
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Ac4SubstreamGroupDsi.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Ac4SubstreamGroupDsi.gs
@@ -1,0 +1,39 @@
+package Oahu.Decrypt.Mpeg4.Boxes.AC4SpecificBox
+
+import Oahu.Decrypt.Mpeg4.Util
+
+class Ac4SubstreamGroupDsi {
+    var BSubstreamsPresent bool
+    var BHsfExt bool
+    var BChannelCoded bool
+    var NSubstreams uint8
+    var Substreams []Ac4Substream
+    var BContentType bool
+    var ContentClassifier uint8?
+    var BLanguageIndicator bool?
+    var NLanguageTagBytes int32?
+    var LanguageTagBytes []?uint8
+
+    init(reader BitReader) {
+        BSubstreamsPresent = reader.ReadBool()
+        BHsfExt = reader.ReadBool()
+        BChannelCoded = reader.ReadBool()
+        NSubstreams = uint8(reader.Read(8))
+        Substreams = [int32(NSubstreams)]Ac4Substream
+        for var i = 0; i < int32(NSubstreams); i++ {
+            Substreams[i] = Ac4Substream(this, reader)
+        }
+        BContentType = reader.ReadBool()
+        if BContentType {
+            ContentClassifier = uint8(reader.Read(3))
+            BLanguageIndicator = reader.ReadBool()
+            if BLanguageIndicator.Value {
+                NLanguageTagBytes = uint8(reader.Read(6))
+                LanguageTagBytes = [NLanguageTagBytes.Value]uint8
+                for var i = 0; i < LanguageTagBytes!!.Length; i++ {
+                    LanguageTagBytes!![i] = uint8(reader.Read(8))
+                }
+            }
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/AdrmBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/AdrmBox.gs
@@ -1,0 +1,39 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class AdrmBox : Box {
+    private let beginBlob []uint8
+    private let middleBlob []uint8
+    private let endBlob []uint8
+
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        beginBlob = file.ReadBlock(8)
+        DrmBlob = file.ReadBlock(56)
+        middleBlob = file.ReadBlock(4)
+        Checksum = file.ReadBlock(20)
+        let len = RemainingBoxLength(file)
+        endBlob = file.ReadBlock(int32(len))
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(beginBlob.Length) + int64(DrmBlob.Length) + int64(middleBlob.Length) + int64(Checksum.Length) + int64(endBlob.Length)
+
+    prop DrmBlob []uint8 {
+        get;
+        init;
+    }
+
+    prop Checksum []uint8 {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        file.Write(beginBlob)
+        file.Write(DrmBlob)
+        file.Write(middleBlob)
+        file.Write(Checksum)
+        file.Write(endBlob)
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/AesCtr.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/AesCtr.gs
@@ -1,0 +1,88 @@
+package Oahu.Decrypt.Mpeg4.Util
+
+import System
+import System.Security.Cryptography
+
+unsafe class AesCtr : IDisposable {
+    private let encryptor ICryptoTransform
+    private let aes Aes
+    private let encryptedCounter []uint8 = [AesCtr.AesBlockSize]uint8
+    private var isDisposed bool
+
+    init(key []uint8) {
+        ArgumentNullException.ThrowIfNull(key, nameof(key))
+        if key.Length != AesCtr.AesBlockSize {
+            throw ArgumentException("${nameof(key)} must be exactly ${AesCtr.AesBlockSize} bytes long.")
+        }
+        aes = Aes.Create()
+        this.aes.Padding = PaddingMode.None
+        this.aes.Mode = CipherMode.ECB
+        encryptor = aes.CreateEncryptor(key, nil)
+    }
+
+    func Decrypt(iv []uint8, source ReadOnlySpan[uint8], destination Span[uint8]) {
+        ArgumentNullException.ThrowIfNull(iv, nameof(iv))
+        ArgumentOutOfRangeException.ThrowIfNotEqual(iv.Length, AesCtr.AesBlockSize, nameof(iv))
+        if destination.Length < source.Length {
+            throw ArithmeticException("Destination array is not long enough. (Parameter '${nameof(destination)}')")
+        }
+        const aesNumDwords = AesCtr.AesBlockSize / 4
+        fixed pD *uint8 = destination {
+            fixed pS *uint8 = source {
+                fixed pEc *uint8 = encryptedCounter {
+                    var pD32 = *uint32(pD)
+                    var pS32 = *uint32(pS)
+                    let pEc32 = *uint32(pEc)
+                    var dataPos = 0
+                    var count = source.Length
+                    while count >= AesCtr.AesBlockSize {
+                        encryptor.TransformBlock(iv, 0, AesCtr.AesBlockSize, encryptedCounter, 0)
+                        AesCtr.IncrementBE(iv)
+                        for var i = 0; i < aesNumDwords; i++ {
+                            *pD32 = pEc32[i] ^ *pS32
+                            pD32++
+                            pS32++
+                        }
+                        dataPos += AesCtr.AesBlockSize
+                        count -= AesCtr.AesBlockSize
+                    }
+                    if count > 0 {
+                        encryptor.TransformBlock(iv, 0, AesCtr.AesBlockSize, encryptedCounter, 0)
+                        {
+                            var i = 0
+                            while i < count {
+                                pD[dataPos] = uint8((pEc[i] ^ pS[dataPos]))
+                                i++
+                                dataPos++
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    func Dispose() {
+        Dispose(true)
+        GC.SuppressFinalize(this)
+    }
+
+    private func Dispose(disposing bool) {
+        if disposing & !isDisposed {
+            encryptor.Dispose()
+            aes.Dispose()
+            isDisposed = true
+        }
+    }
+
+    shared {
+        const AesBlockSize int32 = 16
+
+        private func IncrementBE(data []uint8) {
+            var i = data.Length - 1
+            do {
+                data[i]++
+            } while data[i] == uint8(0) && i-- > 0
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/AlternativeInfo.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/AlternativeInfo.gs
@@ -1,0 +1,24 @@
+package Oahu.Decrypt.Mpeg4.Boxes.AC4SpecificBox
+
+import Oahu.Decrypt.Mpeg4.Util
+
+class AlternativeInfo {
+    var NameLen uint16
+    var PresentationName string
+    var NTargets uint8
+    var TargetIds [](uint8, uint8)
+
+    init(reader BitReader) {
+        NameLen = uint16(reader.Read(16))
+        let nameBts = [int32(NameLen)]char
+        for var i = 0; i < int32(NameLen); i++ {
+            nameBts[i] = char(reader.Read(8))
+        }
+        PresentationName = string(nameBts)
+        NTargets = uint8(reader.Read(5))
+        TargetIds = [int32(NTargets)](uint8, uint8)
+        for var i = 0; i < int32(NameLen); i++ {
+            TargetIds[i] = (uint8(reader.Read(3)), uint8(reader.Read(8)))
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/AppleDataBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/AppleDataBox.gs
@@ -1,0 +1,63 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.Diagnostics
+import System.IO
+import System.Text
+import Oahu.Decrypt.Mpeg4.Util
+
+@DebuggerDisplay("{DebuggerDisplay,nq}")
+open class AppleDataBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        DataType = AppleDataType(file.ReadUInt32BE())
+        Flags = file.ReadUInt32BE()
+        let length = RemainingBoxLength(file)
+        Data = file.ReadBlock(int32(length))
+    }
+
+    private init(header BoxHeader, parent IBox, data []uint8, type_ AppleDataType) : base(header, parent) {
+        DataType = type_
+        Flags = uint32(0)
+        Data = data
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(8) + int64(Data.Length)
+
+    prop DataType AppleDataType {
+        get;
+        init;
+    }
+
+    prop Flags uint32 {
+        get;
+        init;
+    }
+
+    prop Data []uint8
+
+    @DebuggerHidden
+    private prop DebuggerDisplay string -> if DataType is AppleDataType { "[UTF-8]: '${Encoding.UTF8.GetString(Data)}'" } else { if DataType is AppleDataType { "[UTF-16]: '${Encoding.Unicode.GetString(Data)}'" } else { "[$DataType]: ${Data.Length} bytes" } }
+
+    func ReadAsString() string {
+        return switch DataType {
+            case AppleDataType.Utf_8: Encoding.UTF8.GetString(Data)
+            case AppleDataType.Utf_16: Encoding.Unicode.GetString(Data)
+            default: throw InvalidDataException("Cannot read AppleDataBox of type $DataType as string.")
+        }
+    }
+
+    protected open override func Render(file Stream) {
+        file.WriteUInt32BE(uint32(DataType))
+        file.WriteUInt32BE(Flags)
+        file.Write(Data)
+    }
+
+    shared {
+        func Create(parent IBox, data []uint8, type_ AppleDataType) AppleDataBox {
+            let size = data.Length + 8
+            let header = BoxHeader(uint32(size), "data")
+            let dataBox = AppleDataBox(header, parent, data, type_)
+            parent.Children.Add(dataBox)
+            return dataBox
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/AppleDataType.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/AppleDataType.gs
@@ -1,0 +1,3 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+enum AppleDataType { ContainsData, Utf_8, Utf_16, Utf_8_Sort, Utf_16_Sort, JPEG, PNG, BE_Signed_Integer, BE_Unsigned_Integer, BE_Float_32, BE_Float_64, BMP, Signed_Byte, BE_Signed_Integer_16, BE_Signed_Integer_32, BE_Signed_Integer_64, Unigned_Byte, BE_Unsigned_Integer_16, BE_Unsigned_Integer_32, BE_Unsigned_Integer_64 }

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/AppleListBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/AppleListBox.gs
@@ -1,0 +1,143 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.Collections.Generic
+import System.IO
+import System.Linq
+import System.Text
+
+open class AppleListBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        let endPos = Header.FilePosition + Header.TotalBoxSize
+        while file.Position < endPos {
+            let tagBoxHeader = BoxHeader(file)
+            let appleTag = if tagBoxHeader.Type == "----" { FreeformTagBox(file, tagBoxHeader, this) } else { AppleTagBox(file, tagBoxHeader, this) }
+            if appleTag.Header.TotalBoxSize == int64(0) {
+                break
+            }
+            Children.Add(appleTag)
+        }
+    }
+
+    private init(parent IBox) : base(BoxHeader(8, "ilst"), parent) {
+    }
+
+    prop TagNames IEnumerable[string] -> Tags.Select((t AppleTagBox) -> t.Header.Type)
+    prop FreeformTagNames IEnumerable[string] -> FreeformTags.Select((t FreeformTagBox) -> t.TagName)
+    prop Tags IEnumerable[AppleTagBox] -> GetChildren[AppleTagBox]()
+    prop FreeformTags IEnumerable[FreeformTagBox] -> GetChildren[FreeformTagBox]()
+
+    func AddTag(name string, data string) {
+        AppleTagBox.Create(this, name, Encoding.UTF8.GetBytes(data), AppleDataType.Utf_8)
+    }
+
+    func AddTag(name string, data []uint8, type_ AppleDataType) {
+        AppleTagBox.Create(this, name, data, type_)
+    }
+
+    func RemoveTag(name string) bool -> GetTagBox(name) != nil && RemoveTag(GetTagBox(name)!!!!)
+    func RemoveFreeformTag(domain string, name string) bool -> GetFreeformTagBox(domain, name) != nil && RemoveTag(GetFreeformTagBox(domain, name)!!!!)
+
+    func RemoveTag(tag AppleTagBox) bool {
+        if Children.Remove(tag) {
+            tag.Dispose()
+            return true
+        } else if tag is FreeformTagBox {
+            if tag.Mean?.ReverseDnsDomain != nil && tag.Name?.Name != nil && GetFreeformTagBox(tag.Mean?.ReverseDnsDomain!!!!, tag.Name?.Name!!!!) != nil && Children.Remove(GetFreeformTagBox(tag.Mean?.ReverseDnsDomain!!!!, tag.Name?.Name!!!!)!!!!) {
+                GetFreeformTagBox(tag.Mean?.ReverseDnsDomain!!!!, tag.Name?.Name!!!!)!!!!.Dispose()
+                return true
+            }
+        } else if GetTagBox(tag.Header.Type) != nil && Children.Remove(GetTagBox(tag.Header.Type)!!!!) {
+            GetTagBox(tag.Header.Type)!!!!.Dispose()
+            return true
+        }
+        return false
+    }
+
+    func EditOrAddTag(name string, data string?) {
+        EditOrAddTag(name, if data == nil { default([]?uint8) } else { Encoding.UTF8.GetBytes(data!!) }, AppleDataType.Utf_8)
+    }
+
+    func EditOrAddTag(name string, data []?uint8) {
+        EditOrAddTag(name, data, AppleDataType.ContainsData)
+    }
+
+    func EditOrAddTag[TData IAppleData[TData]](name string, data TData?) {
+        var bytes []?uint8
+        if data != nil {
+            bytes = [TData.SizeInBytes]uint8
+            data.Write(bytes!!)
+        } else {
+            bytes = nil
+        }
+        EditOrAddTag(name, bytes, AppleDataType.ContainsData)
+    }
+
+    func EditOrAddTag(name string, data []?uint8, type_ AppleDataType) {
+        if GetTagBox(name) != nil {
+            EditExistingTag(GetTagBox(name)!!!!, data, type_)
+        } else if data != nil {
+            AddTag(name, data!!, type_)
+        }
+    }
+
+    func AddFreeformTag(domain string, name string, data string) {
+        FreeformTagBox.Create(this, domain, name, Encoding.UTF8.GetBytes(data), AppleDataType.Utf_8)
+    }
+
+    func AddFreeformTag(domain string, name string, data []uint8, type_ AppleDataType) {
+        FreeformTagBox.Create(this, domain, name, data, type_)
+    }
+
+    func EditOrAddFreeformTag(domain string, name string, data string?) {
+        EditOrAddFreeformTag(domain, name, if data == nil { default([]?uint8) } else { Encoding.UTF8.GetBytes(data!!) }, AppleDataType.Utf_8)
+    }
+
+    func EditOrAddFreeformTag(domain string, name string, data []?uint8) {
+        EditOrAddFreeformTag(domain, name, data, AppleDataType.ContainsData)
+    }
+
+    func EditOrAddFreeformTag(domain string, name string, data []?uint8, type_ AppleDataType) {
+        if GetFreeformTagBox(domain, name) != nil {
+            EditExistingTag(GetFreeformTagBox(domain, name)!!!!, data, type_)
+        } else if data != nil {
+            AddFreeformTag(domain, name, data!!, type_)
+        }
+    }
+
+    func GetTagString(name string) string? -> AppleListBox.GetTagString(GetTagBox(name))
+    func GetFreeformTagString(domain string, name string) string? -> AppleListBox.GetTagString(GetFreeformTagBox(domain, name))
+
+    func GetTagData[TData IAppleData[TData]](name string) TData? -> if GetTagBox(name)?.Data == nil { default } else { if GetTagBox(name)?.Data!!.DataType != AppleDataType.ContainsData { throw InvalidDataException("Apple data type ${GetTagBox(name)?.Data!!.DataType} is not compatible with ${nameof(IAppleData[TData])}")
+        default(TData) } else { if GetTagBox(name)?.Data!!.Data.Length != TData.SizeInBytes { throw InvalidDataException("Tag data size (${GetTagBox(name)?.Data!!.Data.Length}) differs from ${nameof(IAppleData[TData])} size (${TData.SizeInBytes})")
+        default(TData) } else { TData.Create(GetTagBox(name)?.Data!!.Data) } } }
+
+    func GetTagBox(name string) AppleTagBox? -> Tags.FirstOrDefault((t AppleTagBox) -> t.Header.Type == name)
+    func GetFreeformTagBox(domain string, name string) AppleTagBox? -> Tags.OfType[FreeformTagBox]().FirstOrDefault((t FreeformTagBox) -> t.Mean?.ReverseDnsDomain == domain && t.Name?.Name == name)
+
+    protected open override func Render(file Stream) {
+    }
+
+    private func EditExistingTag(tagBox AppleTagBox, data []?uint8, type_ AppleDataType) {
+        if data == nil {
+            RemoveTag(tagBox)
+        } else {
+            let dataBox = tagBox.GetChildOrThrow[AppleDataBox]()
+            dataBox.Data = if dataBox.DataType == type_ { data!! } else { throw InvalidDataException("Existing tag data type ${dataBox.DataType} differs from new edited type $type_")
+                default([]uint8) }
+        }
+    }
+
+    shared {
+        func CreateEmpty(parent IBox) AppleListBox {
+            let ilist = AppleListBox(parent)
+            parent.Children.Add(ilist!!)
+            return ilist!!
+        }
+
+        private func GetTagString(tagBox AppleTagBox?) string? -> if tagBox?.Data == nil { default(string?) } else { (switch tagBox?.Data!!.DataType {
+            case AppleDataType.Utf_8: Encoding.UTF8.GetString(tagBox?.Data!!.Data)
+            case AppleDataType.Utf_16: Encoding.Unicode.GetString(tagBox?.Data!!.Data)
+            default: throw InvalidDataException("Apple data type ${tagBox?.Data!!.DataType} is not a string type")
+        }) }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/AppleTagBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/AppleTagBox.gs
@@ -1,0 +1,40 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.Diagnostics
+import System.IO
+import System.Text
+
+@DebuggerDisplay("{DebuggerDisplay,nq}")
+open class AppleTagBox : Box {
+    init(file Stream, header BoxHeader, parent IBox) : base(header, parent) {
+        LoadChildren(file)
+    }
+
+    protected init(header BoxHeader, parent IBox?) : base(header, parent) {
+    }
+
+    @DebuggerHidden
+    open prop TagName string -> Header.Type
+
+    prop Data AppleDataBox -> GetChildOrThrow[AppleDataBox]()
+    private prop DebuggerDisplay string -> "[AppleTag]: $TagName"
+
+    protected open override func Render(file Stream) {
+        return
+    }
+
+    shared {
+        func Create(parent AppleListBox, name string, data []uint8, dataType AppleDataType) AppleTagBox {
+            if Encoding.ASCII.GetByteCount(name) != 4 {
+                throw ArgumentOutOfRangeException(nameof(name), "${nameof(name)} must be exactly 4 bytes long")
+            }
+            let size = data.Length + 2 + 8
+            let header = BoxHeader(uint32(size), name)
+            let tagBox = AppleTagBox(header, parent)
+            AppleDataBox.Create(tagBox, data, dataType)
+            parent.Children.Add(tagBox)
+            return tagBox
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/AudioCodingMode.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/AudioCodingMode.gs
@@ -1,0 +1,3 @@
+package Oahu.Decrypt.Mpeg4.Boxes.EC3SpecificBox
+
+enum AudioCodingMode { Ch1_Ch2, C, L_R, L_C_R, L_R_S, L_C_R_S, L_R_Ls_Rs, L_C_R_Ls_Rs }

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/AudioSampleEntry.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/AudioSampleEntry.gs
@@ -1,0 +1,50 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class AudioSampleEntry : SampleEntry {
+    private let reserved []uint8
+    private let reserved2 []uint8
+    private let sampleRateLoworder uint16
+
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        reserved = file.ReadBlock(8)
+        ChannelCount = file.ReadUInt16BE()
+        SampleSize = file.ReadUInt16BE()
+        PreDefined = file.ReadInt16BE()
+        reserved2 = file.ReadBlock(2)
+        SampleRate = file.ReadUInt16BE()
+        sampleRateLoworder = file.ReadUInt16BE()
+        LoadChildren(file)
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(20)
+    prop ChannelCount uint16
+
+    prop SampleSize uint16 {
+        get;
+        init;
+    }
+
+    prop PreDefined int16 {
+        get;
+        init;
+    }
+
+    prop SampleRate uint16
+    prop Esds EsdsBox? -> GetChild[EsdsBox]()
+    prop Dec3 Dec3Box? -> GetChild[Dec3Box]()
+    prop Dac4 Dac4Box? -> GetChild[Dac4Box]()
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.Write(reserved)
+        file.WriteUInt16BE(ChannelCount)
+        file.WriteUInt16BE(SampleSize)
+        file.WriteInt16BE(PreDefined)
+        file.Write(reserved2)
+        file.WriteUInt16BE(SampleRate)
+        file.WriteUInt16BE(sampleRateLoworder)
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/AudioSpecificConfig.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/AudioSpecificConfig.gs
@@ -1,0 +1,115 @@
+package Oahu.Decrypt.Mpeg4.Descriptors
+
+import System
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+interface IASC {
+    prop AudioObjectType int32
+    prop SamplingFrequency int32
+    prop ChannelConfiguration int32
+    prop FrameLengthFlag bool
+    prop DependsOnCoreCoder bool
+}
+
+class AudioSpecificConfig : BaseDescriptor, IASC {
+    private var ascBlobLength int32 = 0
+    private var bitReader BitReader
+
+    init(file Stream, header DescriptorHeader) : base(file, header) {
+        let ascBlob = file.ReadBlock(Header.TotalBoxSize - Header.HeaderSize)
+        bitReader = AudioSpecificConfig.LoadAscBlob(this, ascBlob!!)
+        ascBlobLength = ascBlob!!.Length
+    }
+
+    private init() : base(5) {
+        bitReader = AudioSpecificConfig.LoadAscBlob(this, []uint8{uint8(0x13), uint8(0x90)})
+        ascBlobLength = 2
+    }
+
+    prop AudioObjectType int32
+    prop SamplingFrequency int32
+    prop ChannelConfiguration int32
+    prop FrameLengthFlag bool
+    prop DependsOnCoreCoder bool
+    override prop InternalSize int32 -> base.InternalSize + ascBlobLength
+
+    prop AscBlob []uint8 {
+        get -> GetAscBlob()
+        set {
+            bitReader = AudioSpecificConfig.LoadAscBlob(this, value)
+            ascBlobLength = value.Length
+        }
+    }
+
+    override func Render(file Stream) {
+        file.Write(AscBlob)
+    }
+
+    private func GetAscBlob() []uint8 {
+        ArgumentOutOfRangeException.ThrowIfLessThan(AudioObjectType, 0, nameof(AudioObjectType))
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(AudioObjectType, 32 + 63, nameof(AudioObjectType))
+        let sampleIndex = Array.IndexOf(AudioSpecificConfig.AscSampleRates, SamplingFrequency)
+        if sampleIndex < 0 {
+            throw ArgumentException("Unsupported SamplingFrequency of $SamplingFrequency. Supported values are [${String.Join(", ", SamplingFrequency)}]", nameof(SamplingFrequency))
+        }
+        ArgumentOutOfRangeException.ThrowIfLessThan(ChannelConfiguration, 1, nameof(ChannelConfiguration))
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(ChannelConfiguration, 7, nameof(ChannelConfiguration))
+        let writer = BitWriter()
+        if AudioObjectType < int32(AudioSpecificConfig.AotEscape) {
+            writer!!.Write(uint32(AudioObjectType), 5)
+        } else {
+            writer!!.Write(AudioSpecificConfig.AotEscape, 5)
+            writer!!.Write(uint32(AudioObjectType) - uint32(32), 6)
+        }
+        writer!!.Write(uint32(sampleIndex), 4)
+        writer!!.Write(uint32(ChannelConfiguration), 4)
+        writer!!.Write(if FrameLengthFlag { 1u } else { uint32(0) }, 1)
+        writer!!.Write(if DependsOnCoreCoder { 1u } else { uint32(0) }, 1)
+        let startPos = bitReader.Position
+        bitReader.CopyTo(writer!!)
+        this.bitReader.Position = startPos
+        return writer!!.ToByteArray()
+    }
+
+    private class InternalAudioSpecificConfig : IASC {
+        prop AudioObjectType int32
+        prop SamplingFrequency int32
+        prop ChannelConfiguration int32
+        prop FrameLengthFlag bool
+        prop DependsOnCoreCoder bool
+    }
+
+    shared {
+        let AscSampleRates []int32 = []int32{96000, 88200, 64000, 48000, 44100, 32000, 24000, 22050, 16000, 12000, 11025, 8000, 7350}
+        let MinSampleRate int32 = AudioSpecificConfig.AscSampleRates[^1]
+        let MaxSampleRate int32 = AudioSpecificConfig.AscSampleRates[0]
+        private const AotEscape uint8 = uint8(31)
+        private let SupportedObjectTypes []uint8 = []uint8{uint8(1), uint8(2), uint8(3), uint8(4), uint8(6), uint8(7), uint8(17), uint8(19), uint8(20), uint8(21), uint8(22), uint8(23), uint8(42)}
+        func CreateEmpty() AudioSpecificConfig -> AudioSpecificConfig()
+
+        func Parse(ascBlob []uint8) IASC {
+            let internalAsc = InternalAudioSpecificConfig()
+            AudioSpecificConfig.LoadAscBlob(internalAsc!!, ascBlob)
+            return internalAsc!!
+        }
+
+        private func LoadAscBlob(asc IASC, ascBlob []uint8) BitReader {
+            let bitReader = BitReader(ascBlob)
+            asc.AudioObjectType = int32(bitReader!!.Read(5))
+            if asc.AudioObjectType == int32(AudioSpecificConfig.AotEscape) {
+                asc.AudioObjectType = int32(bitReader!!.Read(6)) + 32
+            }
+            if Array.IndexOf(AudioSpecificConfig.SupportedObjectTypes, uint8(asc.AudioObjectType)) < 0 {
+                throw NotSupportedException("${nameof(AudioObjectType)} of ${asc.AudioObjectType} is unsupported")
+            }
+            let samplingFrequencyIndex = bitReader!!.Read(4)
+            asc.SamplingFrequency = if samplingFrequencyIndex <= uint32(12) { AudioSpecificConfig.AscSampleRates[samplingFrequencyIndex] } else { throw NotSupportedException("Sampling frequency index of $samplingFrequencyIndex is not supported.")
+                default(int32) }
+            asc.ChannelConfiguration = int32(bitReader!!.Read(4))
+            asc.FrameLengthFlag = bitReader!!.Read(1) != uint32(0)
+            asc.DependsOnCoreCoder = bitReader!!.Read(1) != uint32(0)
+            return bitReader!!
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/BaseDescriptor.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/BaseDescriptor.gs
@@ -1,0 +1,66 @@
+package Oahu.Decrypt.Mpeg4.Descriptors
+
+import System
+import System.Collections.Generic
+import System.IO
+import System.Linq
+
+open class BaseDescriptor {
+    init(file Stream, header DescriptorHeader) {
+        Children = List[BaseDescriptor]()
+        Header = header
+    }
+
+    protected init(tagId uint8) {
+        Children = List[BaseDescriptor]()
+        Header = DescriptorHeader(tagId)
+    }
+
+    prop Header DescriptorHeader {
+        get;
+        init;
+    }
+
+    prop Children List[BaseDescriptor] {
+        get;
+        init;
+    }
+
+    prop RenderSize uint32 -> uint32(1) + uint32(Header.GetEncodedSizeLength(InternalSize)) + uint32(InternalSize)
+    open prop InternalSize int32 -> int32(Children.Sum((c BaseDescriptor) -> c.RenderSize))
+    open func Render(file Stream);
+
+    func GetChild[T BaseDescriptor]() T? {
+        let children = GetChildren[T]()
+        return switch children.Count() {
+            case 0: nil
+            case 1: children.First()
+            default: throw InvalidOperationException("${GetType().Name} has ${children.Count()} children of type ${typeof(T)}. Call ${nameof(GetChildren)} instead.")
+        }
+    }
+
+    func GetChildOrThrow[T BaseDescriptor]() T -> GetChild[T]() ?? throw InvalidDataException("Descriptor does not contain a child of type ${typeof(T)}")
+
+    func GetChildren[T BaseDescriptor]() IEnumerable[T] {
+        return Children.OfType[T]()
+    }
+
+    func Save(file Stream) {
+        file.WriteByte(Header.TagID)
+        ExpandableClass.EncodeSize(file, InternalSize, Header.GetEncodedSizeLength(InternalSize))
+        Render(file)
+        for child in Children {
+            child.Save(file)
+        }
+    }
+
+    protected func LoadChildren(file Stream) {
+        while file.Position < Header.FilePosition + int64(Header.TotalBoxSize) {
+            let child = DescriptorFactory.CreateDescriptor(file)
+            if child.InternalSize == 0 {
+                break
+            }
+            Children.Add(child)
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/BitRateMode.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/BitRateMode.gs
@@ -1,0 +1,3 @@
+package Oahu.Decrypt.Mpeg4.Boxes.AC4SpecificBox
+
+enum BitRateMode { NotSpecified, Constant, Average, Variable }

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/BitReader.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/BitReader.gs
@@ -1,0 +1,93 @@
+package Oahu.Decrypt.Mpeg4.Util
+
+import System
+import System.Linq
+
+class BitReader(bytes []uint8) {
+    private var byteIndex int32 = 0
+    private var bitIndex int32 = 0
+
+    prop Position int32 {
+        get -> byteIndex * 8 + bitIndex
+        set {
+            ArgumentOutOfRangeException.ThrowIfLessThan(value, 0, nameof(Position))
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(value, bytes.Length * 8, nameof(Position))
+            byteIndex = value / 8
+            bitIndex = value % 8
+        }
+    }
+
+    prop Length int32 -> bytes.Length * 8
+    func ReadBool() bool -> Read(1) != uint32(0)
+
+    func ByteAlign() {
+        let bitPad = Position % 8
+        if bitPad != 0 {
+            Position += 8 - bitPad
+        }
+    }
+
+    func Read(numBits int32) uint32 {
+        var numBits = numBits
+        ArgumentOutOfRangeException.ThrowIfLessThan(numBits, 0, nameof(numBits))
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(numBits, 4 * 8, nameof(numBits))
+        var value uint32 = uint32(0)
+        while numBits > 0 {
+            if byteIndex >= bytes.Length {
+                throw InvalidOperationException("Not enough data to read the requested number of bits.")
+            }
+            let bitsToRead = Math.Min(numBits, 8 - bitIndex)
+            let mask = (1u << bitsToRead) - uint32(1)
+            value <<= bitsToRead
+            value |= (uint32(bytes[byteIndex]) >> (8 - bitIndex - bitsToRead)) & mask
+            numBits -= bitsToRead
+            bitIndex += bitsToRead
+            if bitIndex == 8 {
+                byteIndex++
+                bitIndex = 0
+            }
+        }
+        return value
+    }
+
+    func CopyTo(writer BitWriter) {
+        if bitIndex != 0 {
+            let toRead = 8 - bitIndex
+            let value = Read(toRead)
+            writer.Write(value, toRead)
+        }
+        while byteIndex < bytes.Length {
+            writer.Write(bytes[byteIndex], 8)
+            byteIndex++
+        }
+    }
+}
+
+class BitWriter {
+    private var byteIndex int32 = 0
+    private var bitIndex int32 = 0
+    private var bytes []uint8 = []uint8{}
+    prop Position int32 -> byteIndex * 8 + bitIndex
+    func ToByteArray() []uint8 -> bytes.ToArray()
+
+    func Write(value uint32, numBits int32) {
+        var value = value
+        var numBits = numBits
+        ArgumentOutOfRangeException.ThrowIfLessThan(numBits, 0, nameof(numBits))
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(numBits, 4 * 8, nameof(numBits))
+        while numBits > 0 {
+            if bitIndex == 0 {
+                Array.Resize(&bytes, byteIndex + 1)
+            }
+            let bitsToWrite = Math.Min(numBits, 8 - bitIndex)
+            value &= if numBits == 32 { UInt32.MaxValue } else { (1u << numBits) - uint32(1) }
+            bytes[byteIndex] |= uint8(((value >> (numBits - bitsToWrite)) << (8 - bitIndex - bitsToWrite)))
+            numBits -= bitsToWrite
+            bitIndex += bitsToWrite
+            if bitIndex == 8 {
+                byteIndex++
+                bitIndex = 0
+            }
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Box.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Box.gs
@@ -1,0 +1,104 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.Collections.Generic
+import System.IO
+import System.Linq
+import System.Threading
+import Oahu.Decrypt.Mpeg4.Util
+
+open class Box : IBox {
+    private var disposed int32 = 0
+
+    init(header BoxHeader, parent IBox?) {
+        Children = List[IBox]()
+        Header = header
+        Parent = parent
+    }
+
+    deinit {
+        Dispose(false)
+    }
+
+    prop Parent IBox? {
+        get;
+        init;
+    }
+
+    prop Header BoxHeader {
+        get;
+        init;
+    }
+
+    prop Children List[IBox] {
+        get;
+        init;
+    }
+
+    open prop RenderSize int64 -> int64(8) + Children.Sum((b IBox) -> b.RenderSize)
+    protected prop Disposed bool -> disposed != 0
+
+    func GetChild[T IBox]() T? {
+        let children = GetChildren[T]()
+        return switch children.Count() {
+            case 0: default
+            case 1: children.First()
+            default: throw InvalidOperationException("${GetType().Name} has ${children.Count()} children of type ${typeof(T)}. Call ${nameof(GetChildren)} instead.")
+        }
+    }
+
+    func GetChildOrThrow[T IBox]() T -> GetChild[T]() ?? throw InvalidDataException("${Header.Type} does not contain a child of type ${typeof(T)}")
+
+    func GetChildren[T IBox]() IEnumerable[T] {
+        return Children.OfType[T]()
+    }
+
+    func GetFreeBoxes() List[FreeBox] {
+        let freeBoxes = GetChildren[FreeBox]().ToList()
+        for child in Children {
+            freeBoxes.AddRange(child!!.GetFreeBoxes())
+        }
+        return freeBoxes
+    }
+
+    func Save(file Stream) {
+        ObjectDisposedException.ThrowIf(Disposed, this)
+        this.Header.FilePosition = file.Position
+        file.WriteHeader(Header, RenderSize)
+        Render(file)
+        for child in Children {
+            child!!.Save(file)
+        }
+    }
+
+    func Dispose() {
+        Dispose(true)
+        GC.SuppressFinalize(this)
+    }
+
+    protected func RemainingBoxLength(file Stream) int64 -> Header.FilePosition + Header.TotalBoxSize - file.Position
+    protected open func Render(file Stream);
+
+    protected func LoadChildren(file Stream) {
+        let endPos = Header.FilePosition + Header.TotalBoxSize
+        while file.Position < endPos {
+            let child = BoxFactory.CreateBox(file, this)
+            if child.Header.TotalBoxSize == int64(0) {
+                break
+            }
+            Children.Add(child)
+            if child.Header.FilePosition + child.Header.TotalBoxSize != file.Position {
+                break
+            }
+        }
+    }
+
+    protected open func Dispose(disposing bool) {
+        if disposing && Interlocked.CompareExchange(&disposed, 1, 0) == 0 {
+            for child in Children {
+                child?.Dispose()
+            }
+            Children.Clear()
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/BoxFactory.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/BoxFactory.gs
@@ -1,0 +1,72 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.Diagnostics
+import System.IO
+
+class BoxFactory {
+    shared {
+        func CreateBox[T Box](file Stream, parent IBox?) T {
+            let box = BoxFactory.CreateBox(file, parent)
+            return box as T ?? throw InvalidDataException("The ${box!!.Header.Type} box is not of type ${typeof(T)}")
+        }
+
+        func CreateBox(file Stream, parent IBox?) IBox -> BoxFactory.CreateBox(BoxHeader(file), file, parent)
+
+        func CreateBox(header BoxHeader, file Stream, parent IBox?) IBox {
+            let box IBox = switch header.Type {
+                case "free" or "skip": FreeBox(file, header, parent)
+                case "ftyp": FtypBox(file, header)
+                case "mdat": MdatBox(header)
+                case "moov": MoovBox(file, header)
+                case "moof": MoofBox(file, header)
+                case "mvhd": MvhdBox(file, header, parent)
+                case "trak": TrakBox(file, header, parent)
+                case "tkhd": TkhdBox(file, header, parent)
+                case "mdia": MdiaBox(file, header, parent)
+                case "minf": MinfBox(file, header, parent)
+                case "mdhd": MdhdBox(file, header, parent)
+                case "hdlr": HdlrBox(file, header, parent)
+                case "stbl": StblBox(file, header, parent)
+                case "stsd": StsdBox(file, header, parent)
+                case "esds": EsdsBox(file, header, parent)
+                case "btrt": BtrtBox(file, header, parent)
+                case "adrm": AdrmBox(file, header, parent)
+                case "stts": SttsBox(file, header, parent)
+                case "stsc": StscBox(file, header, parent)
+                case "stsz": StszBox(file, header, parent)
+                case "stz2": Stz2Box(file, header, parent)
+                case "stco": StcoBox(file, header, parent)
+                case "co64": Co64Box(file, header, parent)
+                case "udta": UdtaBox(file, header, parent)
+                case "meta": MetaBox(file, header, parent)
+                case "ilst": AppleListBox(file, header, parent)
+                case "data": AppleDataBox(file, header, parent)
+                case "mean": MeanBox(file, header, parent)
+                case "name": NameBox(file, header, parent)
+                case "pssh": PsshBox(file, header, parent)
+                case "sidx": SidxBox(file, header, parent)
+                case "mfhd": MfhdBox(file, header, parent)
+                case "tfhd": TfhdBox(file, header, parent)
+                case "traf": TrafBox(file, header, parent)
+                case "tfdt": TfdtBox(file, header, parent)
+                case "trun": TrunBox(file, header, parent)
+                case "saiz": SaizBox(file, header, parent)
+                case "saio": SaioBox(file, header, parent)
+                case "schm": SchmBox(file, header, parent)
+                case "frma": FrmaBox(file, header, parent)
+                case "tenc": TencBox(file, header, parent)
+                case "schi": SchiBox(file, header, parent)
+                case "sinf": SinfBox(file, header, parent)
+                case "senc": SencBox(file, header, parent)
+                case "mvex": MvexBox(file, header, parent)
+                case "mehd": MehdBox(file, header, parent)
+                case "dec3": Dec3Box(file, header, parent)
+                case "tref": TrefBox(file, header, parent)
+                case "dac4": Dac4Box(file, header, parent)
+                default: UnknownBox(file, header, parent)
+            }
+            Debug.Assert(box.RenderSize == header.TotalBoxSize || box is MdatBox)
+            return box
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/BoxHeader.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/BoxHeader.gs
@@ -1,0 +1,56 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.IO
+import System.Text
+import Oahu.Decrypt.Mpeg4.Util
+
+class BoxHeader {
+    init(file Stream) {
+        FilePosition = file.Position
+        TotalBoxSize = file.ReadUInt32BE()
+        Type = file.ReadType()
+        HeaderSize = uint32(8)
+        if TotalBoxSize == int64(1) {
+            Version = 1
+            TotalBoxSize = file.ReadInt64BE()
+            HeaderSize += uint32(uint32(8))
+        }
+    }
+
+    init(boxSize int64, boxType string) {
+        if boxSize < int64(8) {
+            throw ArgumentException("${nameof(boxSize)} must be at least 8 bytes.")
+        }
+        if String.IsNullOrEmpty(boxType) || Encoding.ASCII.GetByteCount(boxType) != 4 {
+            throw ArgumentException("${nameof(boxType)} must be a 4-byte long ASCII string.")
+        }
+        FilePosition = 0
+        Version = if boxSize > int64(UInt32.MaxValue) { 1 } else { 0 }
+        TotalBoxSize = boxSize
+        Type = boxType
+        HeaderSize = if boxSize > int64(UInt32.MaxValue) { 16u } else { 8u }
+    }
+
+    prop FilePosition int64
+
+    prop TotalBoxSize int64 {
+        get;
+        init;
+    }
+
+    prop Type string
+    prop HeaderSize uint32
+    prop Version int32
+
+    func ChangeAtomName(newAtomName string) {
+        if String.IsNullOrEmpty(newAtomName) || Encoding.UTF8.GetByteCount(newAtomName) != 4 {
+            throw ArgumentException("${nameof(newAtomName)} must be exactly 4 UTF-8 bytes long")
+        }
+        Type = newAtomName
+    }
+
+    func ToString() string {
+        return Type
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/BtrtBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/BtrtBox.gs
@@ -1,0 +1,43 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class BtrtBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        BufferSizeDB = file.ReadUInt32BE()
+        MaxBitrate = file.ReadUInt32BE()
+        AvgBitrate = file.ReadUInt32BE()
+    }
+
+    private init(bufferSizeDB uint32, maxBitrate uint32, avgBitrate uint32, header BoxHeader, parent IBox) : base(header, parent) {
+        BufferSizeDB = bufferSizeDB
+        MaxBitrate = maxBitrate
+        AvgBitrate = avgBitrate
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(12)
+
+    prop BufferSizeDB uint32 {
+        get;
+        init;
+    }
+
+    prop MaxBitrate uint32
+    prop AvgBitrate uint32
+
+    protected open override func Render(file Stream) {
+        file.WriteUInt32BE(BufferSizeDB)
+        file.WriteUInt32BE(MaxBitrate)
+        file.WriteUInt32BE(AvgBitrate)
+    }
+
+    shared {
+        func Create(bufferSizeDB uint32, maxBitrate uint32, avgBitrate uint32, parent Box) BtrtBox {
+            let header = BoxHeader(20, "btrt")
+            let btrt = BtrtBox(bufferSizeDB, maxBitrate, avgBitrate, header, parent)
+            parent.Children.Add(btrt)
+            return btrt
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/ByteUtil.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/ByteUtil.gs
@@ -1,0 +1,44 @@
+package Oahu.Decrypt.Mpeg4.Util
+
+import System
+
+class ByteUtil {
+    shared {
+        func BytesFromHexString(hexString string) []uint8 {
+            let byteCount = hexString.Length / 2
+            let bytes = [byteCount]uint8
+            for var i = 0; i < byteCount; i++ {
+                bytes[i] = Byte.Parse(hexString.Substring(2 * i, 2), System.Globalization.NumberStyles.HexNumber)
+            }
+            return bytes
+        }
+
+        func CloneBytes(src []uint8) []uint8 {
+            return ByteUtil.CloneBytes(src, 0, src.Length)
+        }
+
+        func CloneBytes(src []uint8, srcOffset int32, count int32) []uint8 {
+            let dst = [count]uint8
+            Buffer.BlockCopy(src, srcOffset, dst, 0, count)
+            return dst
+        }
+
+        func BytesEqual(array1 []uint8, array2 []uint8, reverseDirection bool = false) bool {
+            return ByteUtil.BytesEqual(array1, 0, array2, 0, array1.Length, reverseDirection)
+        }
+
+        func BytesEqual(array1 []uint8, startIndex1 int32, array2 []uint8, startIndex2 int32, count int32, reverseDirection bool = false) bool {
+            if array1.Length < startIndex1 + count || array2.Length < startIndex2 + count {
+                return false
+            }
+            let indexDiff = startIndex2 - startIndex1
+            for var i = startIndex1; i < startIndex1 + count; i++ {
+                let array2Index = if reverseDirection { startIndex2 + count - 1 - (i - startIndex1) } else { i + indexDiff }
+                if (array1[i] != array2[array2Index]) {
+                    return false
+                }
+            }
+            return true
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/CHAPFrame.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/CHAPFrame.gs
@@ -1,0 +1,50 @@
+package Oahu.Decrypt.Mpeg4.ID3
+
+import System
+import System.IO
+import System.Linq
+import System.Text
+
+enum ChapterFlags { TopLevel, Ordered }
+
+class CHAPFrame : Frame {
+    init(parent Frame, startTime TimeSpan, endTime TimeSpan, chNum int32, title string, subtitle string? = nil, subtitle2 string? = nil) : base(FrameHeader("CHAP", 0, parent.Version), parent) {
+        ChapterID = title
+        StartTime = startTime
+        EndTime = endTime
+        ByteStart = UInt32.MaxValue
+        ByteEnd = UInt32.MaxValue
+        if subtitle != nil {
+            TEXTFrame.Create(this, "TIT2", subtitle!!)
+        }
+        if subtitle2 != nil {
+            TEXTFrame.Create(this, "TIT3", subtitle2!!)
+        }
+    }
+
+    init(file Stream, header Header, parent Frame) : base(header, parent) {
+        let endPosition = file.Position + int64(Header.Size)
+        ChapterID = Frame.ReadNullTerminatedString(file, false)
+        StartTime = TimeSpan.FromMilliseconds(Header.ReadUInt32BE(file))
+        EndTime = TimeSpan.FromMilliseconds(Header.ReadUInt32BE(file))
+        ByteStart = Header.ReadUInt32BE(file)
+        ByteEnd = Header.ReadUInt32BE(file)
+        LoadChildren(file, endPosition)
+    }
+
+    override prop Size int32 -> Encoding.ASCII.GetByteCount(ChapterID) + 1 + 4 * 4 + Children.Sum((c Frame) -> c.Size + 10)
+    prop ChapterID string
+    prop StartTime TimeSpan
+    prop EndTime TimeSpan
+    prop ByteStart uint32
+    prop ByteEnd uint32
+
+    override func Render(file Stream) {
+        file.Write(Encoding.ASCII.GetBytes(ChapterID))
+        file.WriteByte(0)
+        Header.WriteUInt32BE(file, uint32(Math.Round(StartTime.TotalMilliseconds)))
+        Header.WriteUInt32BE(file, uint32(Math.Round(EndTime.TotalMilliseconds)))
+        Header.WriteUInt32BE(file, ByteStart)
+        Header.WriteUInt32BE(file, ByteEnd)
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/CTOCFrame.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/CTOCFrame.gs
@@ -1,0 +1,56 @@
+package Oahu.Decrypt.Mpeg4.ID3
+
+import System.Collections.Generic
+import System.IO
+import System.Linq
+import System.Text
+
+class CTOCFrame : Frame {
+    init(parent Frame, chapterFlags ChapterFlags, elementId string = "TOC1") : base(FrameHeader("CTOC", 0, parent.Version), parent) {
+        ChildElementIDs = List[string]()
+        ChapterFlags = chapterFlags
+        ElementID = elementId
+    }
+
+    init(file Stream, header Header, parent Frame) : base(header, parent) {
+        ChildElementIDs = List[string]()
+        let endPosition = file.Position + int64(Header.Size)
+        ElementID = Frame.ReadNullTerminatedString(file, false)
+        ChapterFlags = ChapterFlags(file.ReadByte())
+        let elemIdCount = file.ReadByte()
+        for var i = 0; i < elemIdCount; i++ {
+            ChildElementIDs.Add(Frame.ReadNullTerminatedString(file, false))
+        }
+        LoadChildren(file, endPosition)
+    }
+
+    override prop Size int32 -> Encoding.ASCII.GetByteCount(ElementID) + 3 + ChildElementIDs.Sum((c string) -> Encoding.ASCII.GetByteCount(c) + 1) + Children.Sum((c Frame) -> c.Size + c.Header.HeaderSize)
+
+    prop ElementID string {
+        get;
+        init;
+    }
+
+    prop ChapterFlags ChapterFlags {
+        get;
+        init;
+    }
+
+    prop ChildElementIDs List[string] {
+        get;
+        init;
+    }
+
+    func Add(chapter CHAPFrame) -> ChildElementIDs.Add(chapter.ChapterID)
+
+    override func Render(file Stream) {
+        file.Write(Encoding.ASCII.GetBytes(ElementID))
+        file.WriteByte(0)
+        file.WriteByte(uint8(ChapterFlags))
+        file.WriteByte(uint8(ChildElementIDs.Count))
+        for ch in ChildElementIDs {
+            file.Write(Encoding.ASCII.GetBytes(ch!!))
+            file.WriteByte(0)
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/ChannelGroups.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/ChannelGroups.gs
@@ -1,0 +1,8 @@
+package Oahu.Decrypt.Mpeg4.Boxes.AC4SpecificBox
+
+import System
+import System.Collections.Generic
+import System.Text
+import System.Threading.Tasks
+
+enum ChannelGroups { Left_Right, Center, LeftSurround_RightSurround, LeftBack_RightBack, TopFrontLeft_TopFrontRight, TopBackLeft_TopBackRight, LFE, TopLeft_TopRight, TopSideLeft_TopSideRight, TopFrontCentre, Tfc, TopCenter, LFE2, BottomFrontLeft_BottomFrontRight, BottomFrontCentre, BackCenter, LeftScreen_RightScreen, LeftWide_RightWide, VerticalHeightLeft_VerticalHeightRight, NOT_CHANNEL_CODED }

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/ChannelLocation.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/ChannelLocation.gs
@@ -1,0 +1,3 @@
+package Oahu.Decrypt.Mpeg4.Boxes.EC3SpecificBox
+
+enum ChannelLocation { Lc_Rc_Pair, Lrs_Rrs_Pair, Cs, Ts, Lsd_Rsd_Pair, Lw_Rw_Pair, Lvh_Rvh_Pair, Cvh, LFE2 }

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Chapter.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Chapter.gs
@@ -1,0 +1,53 @@
+package Oahu.Decrypt.Mpeg4
+
+import System
+import System.IO
+import System.Text
+import Oahu.Decrypt.Mpeg4.Util
+
+open class Chapter {
+    init(title string, start TimeSpan, duration TimeSpan) {
+        ArgumentNullException.ThrowIfNull(title, nameof(title))
+        Title = title
+        StartOffset = start
+        Duration = duration
+        EndOffset = StartOffset + Duration
+    }
+
+    prop Title string {
+        get;
+        init;
+    }
+
+    prop StartOffset TimeSpan {
+        get;
+        init;
+    }
+
+    prop Duration TimeSpan {
+        get;
+        init;
+    }
+
+    prop EndOffset TimeSpan {
+        get;
+        init;
+    }
+
+    prop RenderSize int32 -> 2 + Encoding.UTF8.GetByteCount(Title) + Chapter.Encd.Length
+
+    func WriteChapter(output Stream) {
+        let title = Encoding.UTF8.GetBytes(Title)
+        output.WriteInt16BE(int16(title.Length))
+        output.Write(title)
+        output.Write(Chapter.Encd)
+    }
+
+    func ToString() string {
+        return "$Title {{$StartOffset - $EndOffset}}"
+    }
+
+    shared {
+        private let Encd []uint8 = []uint8{uint8(0), uint8(0), uint8(0), uint8(0xc), uint8('e'), uint8('n'), uint8('c'), uint8('d'), uint8(0), uint8(0), uint8(1), uint8(0)}
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/ChapterFilter.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/ChapterFilter.gs
@@ -1,0 +1,17 @@
+package Oahu.Decrypt.FrameFilters.Text
+
+import System
+import System.Threading.Tasks
+
+open class ChapterFilter : FrameFinalBase[FrameEntry] {
+    event ChapterRead (object?, FrameEntry) -> void
+    protected open override prop InputBufferSize int32 -> 1
+
+    open override func AddInputAsync(input FrameEntry) Task {
+        ChapterRead?(this, input)
+        return Task.CompletedTask
+    }
+
+    protected open override func FlushAsync() Task -> Task.CompletedTask
+    protected open override func PerformFilteringAsync(input FrameEntry) Task -> Task.CompletedTask
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/ChapterInfo.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/ChapterInfo.gs
@@ -1,0 +1,39 @@
+package Oahu.Decrypt.Mpeg4
+
+import System
+import System.Collections
+import System.Collections.Generic
+import System.Linq
+
+open class ChapterInfo : IEnumerable[Chapter] {
+    private let chapterList List[Chapter] = List[Chapter]()
+
+    init(offsetFromBeginning TimeSpan = default(TimeSpan)) {
+        StartOffset = offsetFromBeginning
+    }
+
+    prop StartOffset TimeSpan {
+        get;
+        init;
+    }
+
+    prop EndOffset TimeSpan -> if Count == 0 { StartOffset } else { chapterList.Max((c Chapter) -> c.EndOffset) }
+    prop Chapters IReadOnlyList[Chapter] -> chapterList
+    prop Count int32 -> chapterList.Count
+    prop RenderSize int32 -> chapterList.Sum((c Chapter) -> c.RenderSize)
+
+    func AddChapter(title string, duration TimeSpan) {
+        let startTime = if Count == 0 { StartOffset } else { chapterList[^1].EndOffset }
+        chapterList.Add(Chapter(title, startTime, duration))
+    }
+
+    func Add(title string, duration TimeSpan) -> AddChapter(title, duration)
+
+    func GetEnumerator() IEnumerator[Chapter] {
+        return chapterList.GetEnumerator()
+    }
+
+    private func GetEnumerator() IEnumerator {
+        return GetEnumerator()
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/ChapterQueue.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/ChapterQueue.gs
@@ -1,0 +1,105 @@
+package Oahu.Decrypt
+
+import System
+import System.Collections.Generic
+import System.Diagnostics.CodeAnalysis
+import System.IO
+import System.Text
+import Oahu.Decrypt.FrameFilters
+import Oahu.Decrypt.Mpeg4
+
+class ChapterEntry {
+    init(title string) {
+        ArgumentNullException.ThrowIfNull(title, nameof(title))
+        Title = title
+    }
+
+    prop FrameData Memory[uint8] {
+        get;
+        init;
+    }
+
+    prop SamplesInFrame uint32 {
+        get;
+        init;
+    }
+
+    prop Title string {
+        get;
+        init;
+    }
+}
+
+class ChapterQueue {
+    private let sampleScaleFactor float64
+    private let outputSampleRate SampleRate
+    private let lockObj object = System.Object()
+    private let chapterEntries Queue[ChapterEntry] = Queue[ChapterEntry]()
+    private var subtractNext int32 = 0
+
+    init(inputRate SampleRate, outputRate SampleRate) {
+        outputSampleRate = outputRate
+        sampleScaleFactor = float64(outputRate) / float64(inputRate)
+    }
+
+    func TryGetNextChapter(out chapterEntry ChapterEntry?) bool {
+        {
+            Monitor.Enter(lockObj)
+            try {
+                if chapterEntries.Count > 0 {
+                    chapterEntry = chapterEntries.Dequeue()
+                    return true
+                }
+            } finally {
+                Monitor.Exit(lockObj)
+            }
+        }
+        chapterEntry = nil
+        return false
+    }
+
+    func AddRange(chapters IEnumerable[Chapter]) {
+        for ch in chapters {
+            Add(ch!!)
+        }
+    }
+
+    func Add(chapter Chapter) {
+        let frameData = [chapter.RenderSize]uint8
+        using let ms = MemoryStream(frameData)
+        chapter.WriteChapter(ms!!)
+        let sampleDelta = uint32((chapter.Duration.TotalSeconds * float64(int32(outputSampleRate))))
+        {
+            Monitor.Enter(lockObj)
+            try {
+                chapterEntries.Enqueue(ChapterEntry(chapter.Title))
+            } finally {
+                Monitor.Exit(lockObj)
+            }
+        }
+    }
+
+    func Add(entry FrameEntry) {
+        let frameData ReadOnlySpan[uint8] = entry.FrameData.Span
+        var title = String.Empty
+        if frameData.Length >= 2 {
+            var size = (frameData[0] << 8) | int32(frameData[1])
+            if size > frameData.Length - 2 {
+                size = frameData.Length - 2
+            }
+            if size > 0 {
+                title = Encoding.UTF8.GetString(frameData.Slice(2, size))
+            }
+        }
+        let sif = int32(entry.SamplesInFrame)
+        {
+            Monitor.Enter(lockObj)
+            try {
+                chapterEntries.Enqueue(ChapterEntry(title))
+            } finally {
+                Monitor.Exit(lockObj)
+            }
+        }
+        subtractNext = if sif < 0 { sif } else { 0 }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/ChunkEntry.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/ChunkEntry.gs
@@ -1,0 +1,43 @@
+package Oahu.Decrypt.Mpeg4.Chunks
+
+class ChunkEntry {
+    prop TrackId uint32 {
+        get;
+        init;
+    }
+
+    prop ChunkIndex uint32 {
+        get;
+        init;
+    }
+
+    prop ChunkOffset int64 {
+        get;
+        init;
+    }
+
+    prop FirstSample int64 {
+        get;
+        init;
+    }
+
+    prop ChunkSize int32 {
+        get;
+        init;
+    }
+
+    prop FrameSizes []int32 {
+        get;
+        init;
+    }
+
+    prop FrameDurations []uint32 {
+        get;
+        init;
+    }
+
+    prop ExtraData object? {
+        get;
+        init;
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/ChunkEntryList.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/ChunkEntryList.gs
@@ -1,0 +1,47 @@
+package Oahu.Decrypt.Mpeg4.Chunks
+
+import System
+import System.Collections
+import System.Collections.Generic
+import System.Linq
+import Oahu.Decrypt.Mpeg4.Boxes
+
+class ChunkEntryList : IReadOnlyCollection[ChunkEntry] {
+    private let chunkOffsets ChunkOffsetList
+    private let stsz IStszBox
+    private let stts SttsBox
+    private let chunkFrameTable []ChunkFrames
+    private let trackId uint32
+
+    init(track TrakBox) {
+        trackId = track.Tkhd.TrackID
+        stsz = track.Mdia.Minf.Stbl.Stsz ?? throw ArgumentNullException(nameof(track))
+        let coBox = track.Mdia.Minf.Stbl.COBox
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(coBox!!.EntryCount, uint32(Int32.MaxValue), "COBox.EntryCount")
+        chunkOffsets = coBox!!.ChunkOffsets
+        Count = int32(coBox!!.EntryCount)
+        stts = track.Mdia.Minf.Stbl.Stts
+        chunkFrameTable = track.Mdia.Minf.Stbl.Stsc.CalculateChunkFrameTable(coBox!!.EntryCount)
+    }
+
+    prop Count int32 {
+        get;
+        init;
+    }
+
+    func GetEnumerator() IEnumerator[ChunkEntry] -> EnumerateChunks().GetEnumerator()
+    private func GetEnumerator() IEnumerator -> GetEnumerator()
+
+    private func EnumerateChunks() sequence[ChunkEntry] {
+        var startSample int64 = 0
+        for var chunkIndex = 0; chunkIndex < Count; chunkIndex++ {
+            let chunkOffset = chunkOffsets.GetOffsetAtIndex(chunkIndex)
+            let chunkFrames = chunkFrameTable[chunkIndex]
+            let (frameSizes, totalChunkSize) = stsz.GetFrameSizes(chunkFrames.FirstFrameIndex, chunkFrames.NumberOfFrames)
+            let frameDurations = stts.EnumerateFrameDeltas(chunkFrames.FirstFrameIndex).Take(frameSizes.Length).ToArray()
+            let entry = ChunkEntry{TrackId: trackId, FrameSizes: frameSizes, ChunkIndex: uint32(chunkIndex), ChunkSize: totalChunkSize, ChunkOffset: chunkOffset, FirstSample: startSample, FrameDurations: frameDurations}
+            startSample += entry!!.FrameDurations.Sum((d uint32) -> d)
+            yield entry
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/ChunkOffsetList.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/ChunkOffsetList.gs
@@ -1,0 +1,272 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.Buffers.Binary
+import System.Collections
+import System.Collections.Generic
+import System.IO
+import System.Linq
+import System.Runtime.InteropServices
+import Oahu.Decrypt.Mpeg4.Util
+
+class ChunkOffsetList : ICollection[int64] {
+    private let chunkOffsets32 List[uint32]
+    private var chunkOffsets64 List[int64]?
+
+    init() {
+        chunkOffsets32 = List[uint32]()
+    }
+
+    private init(capacity int32) {
+        chunkOffsets32 = List[uint32](capacity)
+    }
+
+    prop Count int32 -> chunkOffsets32.Count + (chunkOffsets64?.Count ?? 0)
+    prop IsReadOnly bool -> false
+
+    func Clear() {
+        chunkOffsets32.Clear()
+        chunkOffsets64?.Clear()
+        chunkOffsets64 = nil
+    }
+
+    func Sort() {
+        if chunkOffsets64 != nil {
+            chunkOffsets64!!.Sort()
+            let index = ChunkOffsetList.FindLast32bit(CollectionsMarshal.AsSpan(chunkOffsets64!!))
+            if index >= 0 {
+                let countToMove = index + 1
+                let toMove = [countToMove]uint32
+                for var i = 0; i < countToMove; i++ {
+                    toMove[i] = uint32(chunkOffsets64!![i])
+                }
+                chunkOffsets32.AddRange(toMove)
+                chunkOffsets64!!.RemoveRange(0, countToMove)
+                if chunkOffsets64!!.Count == 0 {
+                    chunkOffsets64 = nil
+                }
+            }
+        }
+        chunkOffsets32.Sort()
+    }
+
+    func GetOffsetAtIndex(index int32) int64 {
+        var index = index
+        if index < chunkOffsets32.Count {
+            return chunkOffsets32[index]
+        } else if chunkOffsets64 != nil {
+            index -= chunkOffsets32.Count
+            if index < chunkOffsets64!!.Count {
+                return chunkOffsets64!![index]
+            }
+        }
+        throw IndexOutOfRangeException("Index $index is out of range for chunk offsets.")
+    }
+
+    func SetOffsetAtIndex(index int32, value int64) {
+        var index = index
+        if index < chunkOffsets32.Count {
+            if value > int64(UInt32.MaxValue) {
+                let toMove = chunkOffsets32.Count - index
+                let longs = [toMove]int64
+                longs[0] = value
+                for var i = 1; i < toMove; i++ {
+                    longs[i] = chunkOffsets32[index + i]
+                }
+                CollectionsMarshal.SetCount(chunkOffsets32, index)
+                chunkOffsets64 ??= List[int64](longs.Length)
+                chunkOffsets64!!.InsertRange(0, longs)
+            } else {
+                chunkOffsets32[index] = uint32(value)
+            }
+            return
+        } else if chunkOffsets64 != nil {
+            index -= chunkOffsets32.Count
+            if index < chunkOffsets64!!.Count {
+                chunkOffsets64!![index] = value
+                return
+            }
+        }
+        throw IndexOutOfRangeException("Index $index is out of range for chunk offsets.")
+    }
+
+    func Write32(file Stream) {
+        if chunkOffsets64 != nil && chunkOffsets64!!.Count > 0 {
+            throw InvalidOperationException("Cannot write 32-bit chunk offsets when 64-bit offsets are present.")
+        }
+        let span = CollectionsMarshal.AsSpan(chunkOffsets32)
+        if BitConverter.IsLittleEndian {
+            BinaryPrimitives.ReverseEndianness(span, span)
+        }
+        file.Write(MemoryMarshal.AsBytes(span))
+        if BitConverter.IsLittleEndian {
+            BinaryPrimitives.ReverseEndianness(span, span)
+        }
+    }
+
+    func Write64(file Stream) {
+        for offset32 in chunkOffsets32 {
+            file.WriteInt64BE(offset32)
+        }
+        let span64 = CollectionsMarshal.AsSpan(chunkOffsets64)
+        if BitConverter.IsLittleEndian {
+            BinaryPrimitives.ReverseEndianness(span64, span64)
+        }
+        file.Write(MemoryMarshal.AsBytes(span64))
+        if BitConverter.IsLittleEndian {
+            BinaryPrimitives.ReverseEndianness(span64, span64)
+        }
+    }
+
+    func IndexOf(item int64) int32 {
+        if item <= int64(UInt32.MaxValue) {
+            let index32 = chunkOffsets32.IndexOf(uint32(item))
+            if index32 >= 0 {
+                return index32
+            }
+        } else if chunkOffsets64 != nil {
+            let index64 = chunkOffsets64!!.IndexOf(item)
+            if index64 >= 0 {
+                return chunkOffsets32.Count + index64
+            }
+        }
+        return -1
+    }
+
+    func RemoveAt(index int32) {
+        var index = index
+        if index < chunkOffsets32.Count {
+            chunkOffsets32.RemoveAt(index)
+            return
+        } else if chunkOffsets64 != nil {
+            index -= chunkOffsets32.Count
+            if index < chunkOffsets64!!.Count {
+                chunkOffsets64!!.RemoveAt(index)
+                return
+            }
+        }
+        throw IndexOutOfRangeException()
+    }
+
+    func Add(offset int64) {
+        if offset > int64(UInt32.MaxValue) {
+            chunkOffsets64 ??= List[int64]()
+            chunkOffsets64!!.Add(offset)
+        } else {
+            chunkOffsets32.Add(uint32(offset))
+        }
+    }
+
+    func Contains(item int64) bool -> IndexOf(item) >= 0
+
+    func Remove(item int64) bool {
+        let index = IndexOf(item)
+        if index >= 0 {
+            RemoveAt(index)
+            return true
+        }
+        return false
+    }
+
+    func GetEnumerator() IEnumerator[int64] -> chunkOffsets32.ConvertAll((i uint32) -> int64(i)).Concat(chunkOffsets64 ?? List[int64]()).GetEnumerator()
+
+    func CopyTo(array []int64, arrayIndex int32) {
+        var arrayIndex = arrayIndex
+        {
+            var i = 0
+            while i < chunkOffsets32.Count {
+                array[arrayIndex] = chunkOffsets32[i]
+                i++
+                arrayIndex++
+            }
+        }
+        if chunkOffsets64 != nil {
+            {
+                var i = 0
+                while i < chunkOffsets64!!.Count {
+                    array[arrayIndex] = chunkOffsets64!![i]
+                    i++
+                    arrayIndex++
+                }
+            }
+        }
+    }
+
+    private func GetEnumerator() IEnumerator -> GetEnumerator()
+
+    shared {
+        func Read32(file Stream, entryCount uint32) ChunkOffsetList {
+            let list = ChunkOffsetList(int32(entryCount))
+            CollectionsMarshal.SetCount(list.chunkOffsets32, int32(entryCount))
+            let span = CollectionsMarshal.AsSpan(list.chunkOffsets32)
+            file.ReadExactly(MemoryMarshal.AsBytes(span))
+            if BitConverter.IsLittleEndian {
+                BinaryPrimitives.ReverseEndianness(span, span)
+            }
+            var lastChunkOffset int64 = 0
+            for var i = 0; i < list.chunkOffsets32.Count; i++ {
+                var chunkOffset int64 = list.chunkOffsets32[i]
+                if chunkOffset < lastChunkOffset && lastChunkOffset - chunkOffset > int64(UInt32.MaxValue / uint32(2)) {
+                    if list.chunkOffsets64 == nil {
+                        let count = list.chunkOffsets32.Count - i
+                        list.chunkOffsets64 = List[int64](count)
+                    }
+                    chunkOffset += 1L << 32
+                    list.chunkOffsets32.RemoveAt(i)
+                    i--
+                    list.chunkOffsets64!!.Add(chunkOffset)
+                }
+                lastChunkOffset = chunkOffset
+            }
+            list.chunkOffsets32.Sort()
+            list.chunkOffsets64?.Sort()
+            return list
+        }
+
+        func Read64(file Stream, entryCount uint32) ChunkOffsetList {
+            unsafe {
+                let pLongs = Marshal.AllocHGlobal(8 * IntPtr(entryCount))
+                try {
+                    let longsSpan = Span[int64](pLongs.ToPointer(), int32(entryCount))
+                    file.ReadExactly(MemoryMarshal.AsBytes(longsSpan))
+                    if BitConverter.IsLittleEndian {
+                        BinaryPrimitives.ReverseEndianness(longsSpan, longsSpan)
+                    }
+                    longsSpan.Sort()
+                    let count32Bit = ChunkOffsetList.FindLast32bit(longsSpan) + 1
+                    let list = ChunkOffsetList(count32Bit)
+                    CollectionsMarshal.SetCount(list.chunkOffsets32, count32Bit)
+                    let span = CollectionsMarshal.AsSpan(list.chunkOffsets32)
+                    for var i = 0; i < count32Bit; i++ {
+                        span[i] = uint32(longsSpan[i])
+                    }
+                    let remainder = longsSpan.Slice(count32Bit)
+                    list.chunkOffsets64 = List[int64](remainder.Length)
+                    CollectionsMarshal.SetCount(list.chunkOffsets64!!, remainder.Length)
+                    let span64 = CollectionsMarshal.AsSpan(list.chunkOffsets64!!)
+                    remainder.CopyTo(span64)
+                    return list
+                } finally {
+                    Marshal.FreeHGlobal(pLongs)
+                }
+            }
+        }
+
+        private func FindLast32bit(longsSpan ReadOnlySpan[int64]) int32 {
+            var l = 0
+            var r = longsSpan.Length - 1
+            while l <= r {
+                let mid = l + (r - l) / 2
+                let midValue = longsSpan[mid]
+                if midValue > int64(UInt32.MaxValue) {
+                    r = mid - 1
+                } else if midValue == int64(UInt32.MaxValue) || mid >= r || longsSpan[mid + 1] >= int64(UInt32.MaxValue) {
+                    return mid
+                } else {
+                    l = mid + 1
+                }
+            }
+            return -1
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/ChunkReader.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/ChunkReader.gs
@@ -1,0 +1,148 @@
+package Oahu.Decrypt.Chunks
+
+import System
+import System.Collections.Generic
+import System.IO
+import System.Linq
+import System.Threading
+import System.Threading.Tasks
+import Oahu.Decrypt.FrameFilters
+import Oahu.Decrypt.Mpeg4.Boxes
+import Oahu.Decrypt.Mpeg4.Chunks
+import Oahu.Decrypt.Mpeg4.Util
+
+interface IChunkReader {
+    prop OnProgressUpdateDelegate ((ConversionProgressEventArgs) -> void)?
+    func RunAsync(cancellationSource CancellationTokenSource) Task;
+    func AddTrack(track TrakBox, filter FrameFilterBase[FrameEntry]);
+}
+
+internal open class ChunkReader : IChunkReader {
+    private var beginProcess DateTime
+    private var nextUpdate DateTime
+
+    init(inputStream Stream, startTime TimeSpan, endTime TimeSpan) {
+        TrackEntries = Dictionary[uint32, TrackEntry]()
+        InputStream = inputStream
+        if startTime >= endTime {
+            throw ArgumentException("Start time must be less than end time.", nameof(startTime))
+        }
+        StartTime = startTime
+        EndTime = endTime
+    }
+
+    prop OnProgressUpdateDelegate ((ConversionProgressEventArgs) -> void)?
+
+    protected prop TrackEntries Dictionary[uint32, TrackEntry] {
+        get;
+        init;
+    }
+
+    protected prop InputStream Stream {
+        get;
+        init;
+    }
+
+    protected prop StartTime TimeSpan {
+        get;
+        init;
+    }
+
+    protected prop EndTime TimeSpan {
+        get;
+        init;
+    }
+
+    open func AddTrack(track TrakBox, filter FrameFilterBase[FrameEntry]) {
+        let trackEntry = TrackEntry(track.Tkhd.TrackID, track.Mdia.Mdhd.Timescale, filter, track)
+        TrackEntries.Add(track.Tkhd.TrackID, trackEntry!!)
+    }
+
+    async func RunAsync(cancellationSource CancellationTokenSource) {
+        for filter in TrackEntries.Values.Select((e TrackEntry) -> e.FirstFilter) {
+            filter!!.SetCancellationToken(cancellationSource.Token)
+        }
+        OnInitialProgress()
+        let token = cancellationSource.Token
+        try {
+            for c in EnumerateChunks() {
+                let chunkData Memory[uint8] = [c!!.ChunkSize]uint8
+                await InputStream.ReadNextChunkAsync(c!!.ChunkOffset, chunkData, token)
+                await DispatchChunk(c!!, chunkData, token)
+            }
+        } catch (ex OperationCanceledException) {
+        } catch (ex Exception) {
+            cancellationSource.Cancel()
+            throw ex
+        } finally {
+            OnFinalProgress()
+            await Task.WhenAll(TrackEntries.Values.Select((e TrackEntry) -> e.FirstFilter.CompleteAsync()))
+        }
+    }
+
+    protected open func EnumerateChunks() IEnumerable[ChunkEntry] {
+        let ChunkHasFrameInRange = func (value ChunkEntry) bool {
+            let timeScale = GetTrackEntryFromId(value.TrackId).Timescale
+            let minimumSample = StartTime.TotalSeconds * float64(timeScale)
+            let maximumSample = EndTime.TotalSeconds * float64(timeScale)
+            return float64(value.FirstSample) <= maximumSample && float64((value.FirstSample + value.FrameDurations.Sum((d uint32) -> d))) >= minimumSample
+        }
+        return TrackEntries.Values.Select((e TrackEntry) -> e.TrakBox).InterleaveBy((t TrakBox) -> t.ChunkEntries(), (t ChunkEntry) -> t.ChunkOffset).Where(ChunkHasFrameInRange)
+    }
+
+    protected func GetTrackEntryFromId(trackId uint32) TrackEntry -> if TrackEntries.TryGetValue(trackId, out var trackEntry) { trackEntry!! } else { throw ArgumentOutOfRangeException(nameof(trackId), "Track ID $trackId is not present in this ${nameof(ChunkReader)} instance.")
+        default(TrackEntry) }
+
+    protected open func CreateFrameEntry(chunk ChunkEntry, frameInChunk int32, frameDelta uint32, frameData Memory[uint8]) FrameEntry -> FrameEntry{Chunk: chunk, SamplesInFrame: frameDelta, FrameData: frameData}
+
+    private async func DispatchChunk(chunk ChunkEntry, chunkData Memory[uint8], token CancellationToken) {
+        var sampleIndex = chunk.FirstSample
+        let trackEntry = GetTrackEntryFromId(chunk.TrackId)
+        let startSample = int64((StartTime.TotalSeconds * float64(trackEntry!!.Timescale)))
+        let endSample = int64((EndTime.TotalSeconds * float64(trackEntry!!.Timescale)))
+        var frameDelta uint32
+        {
+            var start = 0
+            var f = 0
+            while f < chunk.FrameSizes.Length {
+                frameDelta = chunk.FrameDurations[f]
+                if startSample >= sampleIndex + int64(frameDelta) {
+                    continue
+                }
+                if endSample < sampleIndex {
+                    break
+                }
+                OnProgressReport(sampleIndex, trackEntry!!.Timescale)
+                let frameData = chunkData.Slice(start, chunk.FrameSizes[f])
+                let frameEntry = CreateFrameEntry(chunk, f, frameDelta, frameData)
+                token.ThrowIfCancellationRequested()
+                await trackEntry!!.FirstFilter.AddInputAsync(frameEntry!!)
+                start += chunk.FrameSizes[f]
+                f++
+                sampleIndex += int64(frameDelta)
+            }
+        }
+    }
+
+    private func OnInitialProgress() {
+        beginProcess = DateTime.UtcNow
+        nextUpdate = beginProcess
+        OnProgressUpdateDelegate?(ConversionProgressEventArgs(StartTime, EndTime, StartTime, 0.0))
+    }
+
+    private func OnFinalProgress() {
+        OnProgressUpdateDelegate?(ConversionProgressEventArgs(StartTime, EndTime, EndTime, (EndTime - StartTime) / (DateTime.UtcNow - beginProcess)))
+    }
+
+    private func OnProgressReport(sampleNumber int64, timeScale uint32) {
+        if DateTime.UtcNow > nextUpdate {
+            let trackPosition = TimeSpan.FromSeconds(float64(sampleNumber) / float64(timeScale))
+            let speed = (trackPosition - StartTime) / (DateTime.UtcNow - beginProcess)
+            OnProgressUpdateDelegate?(ConversionProgressEventArgs(StartTime, EndTime, trackPosition, speed))
+            nextUpdate = DateTime.UtcNow.AddMilliseconds(100.0)
+        }
+    }
+
+    protected open data class TrackEntry(TrackId uint32, Timescale uint32, FirstFilter FrameFilterBase[FrameEntry], TrakBox TrakBox) {
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Co64Box.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Co64Box.gs
@@ -1,0 +1,51 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+internal open class Co64Box : FullBox, IChunkOffsets {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        let entryCount = file.ReadUInt32BE()
+        if entryCount > uint32(Int32.MaxValue) {
+            throw NotSupportedException("Oahu.Decrypt.Mpeg4 does not support MPEG-4 files with more than ${Int32.MaxValue} chunk offsets")
+        }
+        ChunkOffsets = ChunkOffsetList.Read64(file, entryCount)
+    }
+
+    private init(chunkOffsets ChunkOffsetList, versionFlags []uint8, header BoxHeader, parent IBox) : base(versionFlags, header, parent) {
+        ChunkOffsets = chunkOffsets
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(4) + int64(ChunkOffsets.Count * 8)
+    prop EntryCount uint32 -> uint32(ChunkOffsets.Count)
+
+    prop ChunkOffsets ChunkOffsetList {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.WriteUInt32BE(EntryCount)
+        ChunkOffsets.Write64(file)
+    }
+
+    protected open override func Dispose(disposing bool) {
+        if disposing && !Disposed {
+            ChunkOffsets.Clear()
+        }
+        base.Dispose(disposing)
+    }
+
+    shared {
+        internal func CreateBlank(parent IBox, chunkOffsets ChunkOffsetList) Co64Box {
+            let size = 4 + 12
+            let header = BoxHeader(uint32(size), "co64")
+            chunkOffsets.Sort()
+            let co64Box = Co64Box(chunkOffsets, []uint8{uint8(0), uint8(0), uint8(0), uint8(0)}, header, parent)
+            parent.Children.Add(co64Box)
+            return co64Box
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/ConversionProgressEventArgs.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/ConversionProgressEventArgs.gs
@@ -1,0 +1,38 @@
+package Oahu.Decrypt
+
+import System
+
+class ConversionProgressEventArgs : EventArgs {
+    internal init(startTime TimeSpan, endTime TimeSpan, processPosition TimeSpan, processSpeed float64) {
+        StartTime = startTime
+        EndTime = endTime
+        ProcessPosition = processPosition
+        ProcessSpeed = processSpeed
+        FractionCompleted = (processPosition - startTime) / (endTime - startTime)
+    }
+
+    prop ProcessPosition TimeSpan {
+        get;
+        init;
+    }
+
+    prop StartTime TimeSpan {
+        get;
+        init;
+    }
+
+    prop EndTime TimeSpan {
+        get;
+        init;
+    }
+
+    prop ProcessSpeed float64 {
+        get;
+        init;
+    }
+
+    prop FractionCompleted float64 {
+        get;
+        init;
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Crypto.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Crypto.gs
@@ -1,0 +1,25 @@
+package Oahu.Decrypt.Mpeg4.Util
+
+import System.Security.Cryptography
+
+class Crypto {
+    shared {
+        func DecryptInPlace(key []uint8, iv []uint8, encryptedBlocks []uint8) {
+            using let aes = Aes.Create()
+            aes.Mode = CipherMode.CBC
+            aes.Padding = PaddingMode.None
+            using let cbcDecryptor = aes.CreateDecryptor(key, iv)
+            cbcDecryptor.TransformBlock(encryptedBlocks, 0, encryptedBlocks.Length & 0x7ffffff0, encryptedBlocks, 0)
+        }
+
+        func Sha1(blocks ...([]uint8, int32, int32)) []uint8 {
+            using let sha = SHA1.Create()
+            var i = 0
+            for ; i < blocks.Length - 1; i++ {
+                sha.TransformBlock(blocks[i].Item1, blocks[i].Item2, blocks[i].Item3, nil, 0)
+            }
+            sha.TransformFinalBlock(blocks[i].Item1, blocks[i].Item2, blocks[i].Item3)
+            return sha.Hash!!
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Dac4Box.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Dac4Box.gs
@@ -1,0 +1,44 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Boxes.AC4SpecificBox
+import Oahu.Decrypt.Mpeg4.Util
+
+open class Dac4Box : Box {
+    var Ac4DsiV1 Ac4DsiV1?
+    private let ac4Data []uint8
+
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        ac4Data = file.ReadBlock(int32((header.TotalBoxSize - int64(header.HeaderSize))))
+        try {
+            let reader = BitReader(ac4Data)
+            Ac4DsiV1 = Ac4DsiV1(reader!!)
+        } catch (ex Exception) {
+            return
+        }
+        SampleRate = Ac4DsiV1.SampleRate()
+        AverageBitrate = Ac4DsiV1.AverageBitrate()
+        NumberOfChannels = (if Ac4DsiV1.Channels() != nil { Ac4Extensions.ChannelCount(Ac4DsiV1.Channels()!!) } else { nil })
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(ac4Data.Length)
+
+    prop AverageBitrate uint32? {
+        get;
+        init;
+    }
+
+    prop SampleRate int32? {
+        get;
+        init;
+    }
+
+    prop NumberOfChannels int32? {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        file.Write(ac4Data)
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/DashChunkEntryies.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/DashChunkEntryies.gs
@@ -1,0 +1,90 @@
+package Oahu.Decrypt.Mpeg4.Chunks
+
+import System
+import System.Collections
+import System.Collections.Generic
+import System.IO
+import System.Linq
+import Oahu.Decrypt.Mpeg4.Boxes
+import Oahu.Decrypt.Mpeg4.Util
+
+class DashChunkEntryies(InputStream Stream, TrackId uint32, Sidx SidxBox, FirstMoof MoofBox, FirstMdat MdatBox, MinimumSample int64, MaximumSample int64) : IEnumerable[ChunkEntry] {
+    func GetEnumerator() IEnumerator[ChunkEntry] -> EnumerateChunks().GetEnumerator()
+    private func GetEnumerator() IEnumerator -> GetEnumerator()
+
+    private func EnumerateChunks() sequence[ChunkEntry] {
+        SkipToFirstMoof(out var moofBox, out var mdatBox, out var startSample)
+        let totalDataSize = Sidx.Segments.Sum((s Segment) -> int64(s.ReferenceSize))
+        let endOfFile = FirstMoof.Header.FilePosition + totalDataSize
+        while InputStream.Position < endOfFile {
+            if startSample > MaximumSample {
+                break
+            }
+            let trackChunk = ValidateMdatSize(moofBox!!, mdatBox!!, startSample)
+            startSample += trackChunk!!.FrameDurations.Sum((d uint32) -> d)
+            if startSample > MinimumSample {
+                yield trackChunk
+            } else {
+                let endOfMdat = InputStream.Position + mdatBox!!.Header.TotalBoxSize - int64(mdatBox!!.Header.HeaderSize)
+                InputStream.SeekToOffset(endOfMdat)
+            }
+            if InputStream.Position < endOfFile {
+                moofBox = BoxFactory.CreateBox[MoofBox](InputStream, nil)
+                mdatBox = BoxFactory.CreateBox[MdatBox](InputStream, nil)
+            }
+        }
+    }
+
+    private func ValidateMdatSize(moofBox MoofBox, mdatBox MdatBox, startSample int64) ChunkEntry {
+        let trun TrunBox? = moofBox.Traf.Trun as TrunBox
+        if trun == nil {
+            throw InvalidDataException("The ${nameof(TrafBox)} doesn't contain a ${nameof(TrunBox)}")
+        }
+        let frameSizes = if trun.SampleSizePresent { trun.Samples.Select((s SampleInfo) -> s.SampleSize).OfType[int32]().ToArray() } else { if moofBox.Traf.Tfhd.DefaultSampleSize is uint32 { Enumerable.Repeat(int32(moofBox.Traf.Tfhd.DefaultSampleSize!!), trun.Samples.Length).ToArray() } else { throw InvalidOperationException("Trun sample infos don't contain sample sizes and no default sample size is set.")
+            default([]int32) } }
+        let mdatSize = mdatBox.Header.TotalBoxSize - int64(mdatBox.Header.HeaderSize)
+        if int64(frameSizes!!.Sum()) != mdatSize {
+            throw InvalidDataException("Mdat box size doesn't match sample sizes in track fragment")
+        }
+        if mdatSize > int64(Int32.MaxValue) {
+            throw InvalidDataException("Mdat is larger than Int32.MaxValue")
+        }
+        let frameDurations = if trun.SampleDurationPresent { trun.Samples.Select((s SampleInfo) -> s.SampleDuration).OfType[uint32]().ToArray() } else { if moofBox.Traf.Tfhd.DefaultSampleDuration is uint32 { Enumerable.Repeat(moofBox.Traf.Tfhd.DefaultSampleDuration!!, trun.Samples.Length).ToArray() } else { throw InvalidOperationException("Trun sample infos don't contain sample durations and no default sample duration is set.")
+            default([]uint32) } }
+        if frameDurations!!.Length != frameSizes!!.Length {
+            throw InvalidDataException("The number of frame sizes (${frameSizes!!.Length}) does not match the number of durations (${frameDurations!!.Length}) in fragment ${moofBox.Mfhd.SequenceNumber}")
+        }
+        var extraData object? = nil
+        if moofBox.Traf.Senc != nil {
+            extraData = if frameSizes!!.Length == moofBox.Traf.Senc!!!!.IVs.Length { moofBox.Traf.Senc!!!!.IVs } else { throw InvalidDataException("The number of IVs (${moofBox.Traf.Senc!!!!.IVs.Length}) does not match the number of samples (${frameSizes!!.Length}) in fragment ${moofBox.Mfhd.SequenceNumber}")
+                default([][]uint8) }
+        }
+        return ChunkEntry{TrackId: TrackId, ChunkIndex: uint32(moofBox.Mfhd.SequenceNumber), ChunkOffset: InputStream.Position, ChunkSize: int32(mdatSize), FirstSample: startSample, FrameSizes: frameSizes, FrameDurations: frameDurations, ExtraData: extraData}
+    }
+
+    private func SkipToFirstMoof(out firstMoof MoofBox, out firstMdat MdatBox, out firstSample int64) {
+        let startPosition = FirstMoof.Header.FilePosition
+        var dataOffset int64 = 0
+        firstSample = 0
+        if Sidx.Segments.Any((s Segment) -> s.ReferenceType || !s.StartsWithSAP || s.SapType != 1 || s.SapDeltaTime != 0) {
+            throw InvalidOperationException("AAXClean doesn't know how to inrepret segment index boxes other than " + "${nameof(SidxBox.Segment.SapType)} = 1, " + "${nameof(SidxBox.Segment.SapDeltaTime)} = 0, " + "${nameof(SidxBox.Segment.StartsWithSAP)} = 1, " + "${nameof(SidxBox.Segment.ReferenceType)} = 0")
+        }
+        for segment in Sidx.Segments {
+            if MinimumSample < firstSample + int64(segment!!.SubsegmentDuration) {
+                break
+            }
+            dataOffset += int64(segment!!.ReferenceSize)
+            firstSample += int64(segment!!.SubsegmentDuration)
+        }
+        if dataOffset == int64(0) {
+            var __decon0 = FirstMoof
+            var __decon1 = FirstMdat
+            firstMoof = __decon0
+            firstMdat = __decon1
+        } else {
+            InputStream.SeekToOffset(startPosition + dataOffset)
+            firstMoof = BoxFactory.CreateBox[MoofBox](InputStream, nil)
+            firstMdat = BoxFactory.CreateBox[MdatBox](InputStream, nil)
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/DashChunkReader.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/DashChunkReader.gs
@@ -1,0 +1,46 @@
+package Oahu.Decrypt.Chunks
+
+import System
+import System.Collections.Generic
+import System.IO
+import System.Linq
+import Oahu.Decrypt.FrameFilters
+import Oahu.Decrypt.Mpeg4.Boxes
+import Oahu.Decrypt.Mpeg4.Chunks
+
+internal open class DashChunkReader : ChunkReader {
+    init(dash DashFile, inputStream Stream, startTime TimeSpan, endTime TimeSpan) : base(inputStream, startTime, endTime) {
+        ArgumentNullException.ThrowIfNull(dash, nameof(dash))
+        ArgumentNullException.ThrowIfNull(inputStream, nameof(inputStream))
+        Dash = dash
+    }
+
+    private prop Dash DashFile {
+        get;
+        init;
+    }
+
+    open override func AddTrack(track TrakBox, filter FrameFilterBase[FrameEntry]) {
+        if TrackEntries.Count > 0 {
+            throw InvalidOperationException("The ${nameof(DashChunkReader)} currently only supports a single track.")
+        }
+        base.AddTrack(track, filter)
+    }
+
+    protected open override func CreateFrameEntry(chunk ChunkEntry, frameInChunk int32, frameDelta uint32, frameData Memory[uint8]) FrameEntry {
+        let entry = base.CreateFrameEntry(chunk, frameInChunk, frameDelta, frameData)
+        let ivs []?[]uint8 = chunk.ExtraData as [][]uint8
+        if ivs != nil {
+            entry!!.ExtraData = if ivs.Length > frameInChunk { ivs[frameInChunk] } else { throw InvalidDataException("There are only ${ivs.Length} in the chunk, but caller requesting frame at index $frameInChunk.")
+                default([]uint8) }
+        }
+        return entry!!
+    }
+
+    protected open override func EnumerateChunks() IEnumerable[ChunkEntry] {
+        let singleTrack = TrackEntries.Values.Single()
+        let minimumSample = int64((StartTime.TotalSeconds * float64(singleTrack!!.Timescale)))
+        let maximumSample = int64((EndTime.TotalSeconds * float64(singleTrack!!.Timescale)))
+        return DashChunkEntryies(InputStream, singleTrack!!.TrackId, Dash.Sidx, Dash.FirstMoof, Dash.FirstMdat, minimumSample, maximumSample)
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/DashFile.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/DashFile.gs
@@ -1,0 +1,115 @@
+package Oahu.Decrypt
+
+import System
+import System.Buffers
+import System.IO
+import System.Linq
+import Oahu.Decrypt.Chunks
+import Oahu.Decrypt.FrameFilters
+import Oahu.Decrypt.FrameFilters.Audio
+import Oahu.Decrypt.Mpeg4.Boxes
+import Oahu.Decrypt.Mpeg4.Util
+
+open class DashFile : Mp4File {
+    convenience init(fileName string, access FileAccess = 1, share FileShare = 1) {
+        init(File.Open(fileName, FileMode.Open, access, share))
+    }
+
+    convenience init(file Stream) {
+        init(file, file.Length)
+    }
+
+    init(file Stream, fileLength int64) : base(file, fileLength) {
+        if FileType != FileType.Dash {
+            throw ArgumentException("This instance of ${nameof(Mp4File)} is not a Dash file.")
+        }
+        FirstMoof = TopLevelBoxes.OfType[MoofBox]().Single()
+        let audioSampleEntry = Moov.AudioTrack.Mdia.Minf.Stbl.Stsd.AudioSampleEntry ?? throw InvalidDataException("The audio track doesn't contain an ${nameof(AudioSampleEntry)}")
+        if audioSampleEntry.GetChild[SinfBox]() != nil {
+            if audioSampleEntry.GetChild[SinfBox]()!!!!.SchemeType?.Type != SchmBox.SchemeType.Cenc {
+                throw NotSupportedException("Only ${nameof(SchmBox.SchemeType.Cenc)} dash files are currently supported.")
+            }
+            Tenc = audioSampleEntry.GetChild[SinfBox]()!!!!.SchemeInformation?.TrackEncryption
+            audioSampleEntry!!.Children.Remove(audioSampleEntry.GetChild[SinfBox]()!!!!)
+            audioSampleEntry!!.Header.ChangeAtomName(audioSampleEntry.GetChild[SinfBox]()!!!!.OriginalFormat.DataFormat)
+        }
+        for pssh in Moov.GetChildren[PsshBox]().ToArray() {
+            Moov.Children.Remove(pssh!!)
+        }
+        if AudioSampleEntry.Dec3 != nil || AudioSampleEntry.Dac4 != nil {
+            Ftyp = FtypBox.Create("mp42", 0)
+            Ftyp.CompatibleBrands.Add("dby1")
+            Ftyp.CompatibleBrands.Add("iso8")
+            Ftyp.CompatibleBrands.Add("isom")
+            Ftyp.CompatibleBrands.Add("mp41")
+            Ftyp.CompatibleBrands.Add("M4A ")
+            Ftyp.CompatibleBrands.Add("M4B ")
+        } else {
+            Ftyp = FtypBox.Create("isom", 0x200)
+            Ftyp.CompatibleBrands.Add("iso2")
+            Ftyp.CompatibleBrands.Add("mp41")
+            Ftyp.CompatibleBrands.Add("M4A ")
+            Ftyp.CompatibleBrands.Add("M4B ")
+        }
+    }
+
+    prop FirstMoof MoofBox {
+        get;
+        init;
+    }
+
+    prop FirstMdat MdatBox -> Mdat
+    prop Sidx SidxBox -> TopLevelBoxes.OfType[SidxBox]().Single()
+    open override prop Duration TimeSpan -> TimeSpan.FromSeconds(float64(Moov.GetChildOrThrow[MvexBox]().GetChildOrThrow[MehdBox]().FragmentDuration) / float64(TimeScale))
+
+    prop Tenc TencBox? {
+        get;
+        init;
+    }
+
+    prop Key []?uint8
+    private prop Mdat MdatBox -> base.Mdat
+
+    func SetDecryptionKey(keyId string, decryptionKey string) {
+        if String.IsNullOrWhiteSpace(keyId) || keyId.Length != AesCtr.AesBlockSize * 2 {
+            throw ArgumentException("${nameof(keyId)} must be ${AesCtr.AesBlockSize} bytes long.")
+        }
+        if String.IsNullOrWhiteSpace(decryptionKey) || decryptionKey.Length != AesCtr.AesBlockSize * 2 {
+            throw ArgumentException("${nameof(decryptionKey)} must be ${AesCtr.AesBlockSize} bytes long.")
+        }
+        let keyIdBts = Convert.FromHexString(keyId)
+        let decryptionKeyBts = Convert.FromHexString(decryptionKey)
+        SetDecryptionKey(keyIdBts, decryptionKeyBts)
+    }
+
+    open override func GetAudioFrameFilter() FrameTransformBase[FrameEntry, FrameEntry] {
+        return if Key == nil && Tenc != nil { throw InvalidOperationException("This instance of ${nameof(DashFile)} does not have a decryption key set.")
+            default(DashFilter) } else { DashFilter(Key) }
+    }
+
+    func SetDecryptionKey(keyId []?uint8, decryptionKey []?uint8) {
+        if Tenc == nil {
+            throw InvalidOperationException("This instance of ${nameof(DashFile)} does not contain a ${nameof(TencBox)}.")
+        }
+        if keyId == nil || keyId!!.Length != AesCtr.AesBlockSize {
+            throw ArgumentException("${nameof(keyId)} must be ${AesCtr.AesBlockSize} bytes long.")
+        }
+        if decryptionKey == nil || decryptionKey!!.Length != AesCtr.AesBlockSize {
+            throw ArgumentException("${nameof(decryptionKey)} must be ${AesCtr.AesBlockSize} bytes long.")
+        }
+        let keyUUID = Guid(keyId!!, true)
+        if keyUUID != Tenc!!.DefaultKID {
+            throw InvalidOperationException("Supplied keyId does not match dash default keyId: ${Convert.ToHexString(Tenc!!.DefaultKID.ToByteArray(true))}")
+        }
+        Key = decryptionKey
+    }
+
+    protected open override func CalculateBitrate() uint32 {
+        let totalSize = Sidx.Segments.Sum((s Segment) -> int64(s.ReferenceSize)) * int64(8)
+        let totalDuration = Sidx.Segments.Sum((s Segment) -> int64(s.SubsegmentDuration))
+        let bitRate = totalSize * int64(Sidx.Timescale) / totalDuration
+        return uint32(bitRate)
+    }
+
+    protected open override func CreateChunkReader(inputStream Stream, startTime TimeSpan, endTime TimeSpan) IChunkReader -> DashChunkReader(this, inputStream, startTime, endTime)
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/DashFilter.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/DashFilter.gs
@@ -1,0 +1,41 @@
+package Oahu.Decrypt.FrameFilters.Audio
+
+import Oahu.Decrypt.Mpeg4.Util
+
+internal open class DashFilter : AacValidateFilter {
+    init(key []?uint8) {
+        Key = key
+        AesCtr = if key == nil { default(AesCtr?) } else { AesCtr(key!!) }
+    }
+
+    prop Key []?uint8 {
+        get;
+        init;
+    }
+
+    protected open override prop InputBufferSize int32 -> 1000
+
+    private prop AesCtr AesCtr? {
+        get;
+        init;
+    }
+
+    open override func PerformFiltering(input FrameEntry) FrameEntry {
+        let iv []?uint8 = input.ExtraData as []uint8
+        if iv != nil {
+            if AesCtr == nil {
+                throw NullReferenceException("AesCtr is null but the frame entry has an IV.")
+            }
+            let frameData = input.FrameData.Span
+            AesCtr!!.Decrypt(iv, frameData, frameData)
+        }
+        return base.PerformFiltering(input)
+    }
+
+    protected open override func Dispose(disposing bool) {
+        if disposing && !Disposed {
+            AesCtr?.Dispose()
+        }
+        base.Dispose(disposing)
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Dec3Box.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Dec3Box.gs
@@ -1,0 +1,73 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.Diagnostics
+import System.IO
+import System.Linq
+import Oahu.Decrypt.Mpeg4.Boxes.EC3SpecificBox
+import Oahu.Decrypt.Mpeg4.Util
+
+open class Dec3Box : Box {
+    private let ec3Data []uint8
+
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        ec3Data = file.ReadBlock(int32((header.TotalBoxSize - int64(header.HeaderSize))))
+        let reader = BitReader(ec3Data)
+        AverageBitrate = reader!!.Read(13) * uint32(1024)
+        let num_ind_sub = reader!!.Read(3)
+        Debug.Assert(num_ind_sub == uint32(0))
+        IndependentSubstream = [int32(num_ind_sub + uint32(1))]Ec3IndependentSubstream
+        for var i = 0; int64(i) <= int64(num_ind_sub); i++ {
+            IndependentSubstream[i] = Ec3IndependentSubstream(reader!!)
+        }
+        let indSample = IndependentSubstream.First()
+        Debug.Assert(indSample!!.NumDepSub == uint8(0))
+        SampleRate = indSample!!.GetSampleRate()
+        NumberOfChannels = indSample!!.ChannelCount()
+        if reader!!.Length - reader!!.Position < 8 {
+            return
+        }
+        reader!!.Position += 7
+        FlagEc3ExtensionTypeA = reader!!.ReadBool()
+        if FlagEc3ExtensionTypeA.Value {
+            ComplexityIndexTypeA = uint8(reader!!.Read(8))
+        }
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(ec3Data.Length)
+
+    prop AverageBitrate uint32 {
+        get;
+        init;
+    }
+
+    prop SampleRate int32 {
+        get;
+        init;
+    }
+
+    prop NumberOfChannels int32 {
+        get;
+        init;
+    }
+
+    prop IndependentSubstream []Ec3IndependentSubstream {
+        get;
+        init;
+    }
+
+    prop IsAtmos bool -> FlagEc3ExtensionTypeA.HasValue
+
+    prop FlagEc3ExtensionTypeA bool? {
+        get;
+        init;
+    }
+
+    prop ComplexityIndexTypeA uint8? {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        file.Write(ec3Data)
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/DecoderConfigDescriptor.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/DecoderConfigDescriptor.gs
@@ -1,0 +1,47 @@
+package Oahu.Decrypt.Mpeg4.Descriptors
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+class DecoderConfigDescriptor : BaseDescriptor {
+    private let blob []uint8
+
+    init(file Stream, header DescriptorHeader) : base(file, header) {
+        ObjectTypeIndication = uint8(file.ReadByte())
+        blob = file.ReadBlock(4)
+        MaxBitrate = file.ReadUInt32BE()
+        AverageBitrate = file.ReadUInt32BE()
+        LoadChildren(file)
+    }
+
+    private init(objectTypeIndication uint8, blob []uint8) : base(4) {
+        ObjectTypeIndication = objectTypeIndication
+        this.blob = blob
+    }
+
+    prop ObjectTypeIndication uint8 {
+        get;
+        init;
+    }
+
+    prop MaxBitrate uint32
+    prop AverageBitrate uint32
+    prop AudioSpecificConfig AudioSpecificConfig -> GetChildOrThrow[AudioSpecificConfig]()
+    override prop InternalSize int32 -> base.InternalSize + 13
+
+    override func Render(file Stream) {
+        file.WriteByte(ObjectTypeIndication)
+        file.Write(blob)
+        file.WriteUInt32BE(MaxBitrate)
+        file.WriteUInt32BE(AverageBitrate)
+    }
+
+    shared {
+        func CreateAudio() DecoderConfigDescriptor {
+            let descriptor = DecoderConfigDescriptor(0x40, []uint8{uint8(0x15), uint8(0x00), uint8(0x00), uint8(0x00)})
+            let asc = AudioSpecificConfig.CreateEmpty()
+            descriptor!!.Children.Add(asc!!)
+            return descriptor!!
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/DescriptorFactory.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/DescriptorFactory.gs
@@ -1,0 +1,18 @@
+package Oahu.Decrypt.Mpeg4.Descriptors
+
+import System.IO
+
+class DescriptorFactory {
+    shared {
+        func CreateDescriptor(file Stream) BaseDescriptor {
+            let header = DescriptorHeader(file)
+            return switch header!!.TagID {
+                case 3: ES_Descriptor(file, header!!)
+                case 4: DecoderConfigDescriptor(file, header!!)
+                case 5: AudioSpecificConfig(file, header!!)
+                case 6: SLConfigDescriptor(file, header!!)
+                default: UnknownDescriptor(file, header!!)
+            }
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/DescriptorHeader.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/DescriptorHeader.gs
@@ -1,0 +1,35 @@
+package Oahu.Decrypt.Mpeg4.Descriptors
+
+import System.IO
+
+class DescriptorHeader {
+    init(file Stream) {
+        FilePosition = file.Position
+        TagID = uint8(file.ReadByte())
+        let start = file.Position
+        let originalInternalSize = ExpandableClass.DecodeSize(file)
+        let originalSizeOfSize = int32((file.Position - start))
+        HeaderSize = originalSizeOfSize + 1
+        TotalBoxSize = HeaderSize + originalInternalSize
+    }
+
+    init(tagId uint8) {
+        TagID = tagId
+        HeaderSize = 1
+    }
+
+    prop FilePosition int64
+
+    prop TotalBoxSize int32 {
+        get;
+        init;
+    }
+
+    prop TagID uint8
+    prop HeaderSize int32
+
+    func GetEncodedSizeLength(internalSize int32) int32 {
+        let minimumEncodeSize = HeaderSize - 1
+        return ExpandableClass.GetSizeByteCount(internalSize, minimumEncodeSize)
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/ES_Descriptor.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/ES_Descriptor.gs
@@ -1,0 +1,85 @@
+package Oahu.Decrypt.Mpeg4.Descriptors
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+class ES_Descriptor : BaseDescriptor {
+    private let esFlags uint8
+    private let dependsOnEsId uint16
+    private let urlLength uint8
+    private let urlString []?uint8
+    private let ocrEsId uint16
+
+    init(file Stream, header DescriptorHeader) : base(file, header) {
+        EsId = file.ReadUInt16BE()
+        esFlags = uint8(file.ReadByte())
+        if StreamDependenceFlag == 1 {
+            dependsOnEsId = file.ReadUInt16BE()
+        }
+        if UrlFlag == 1 {
+            urlLength = uint8(file.ReadByte())
+            urlString = file.ReadBlock(urlLength)
+        }
+        if OcrStreamFlag == 1 {
+            ocrEsId = file.ReadUInt16BE()
+        }
+        LoadChildren(file)
+    }
+
+    private init() : base(0x3) {
+        EsId = uint16(0)
+        esFlags = uint8(0)
+    }
+
+    prop EsId uint16 {
+        get;
+        init;
+    }
+
+    prop StreamPriority int32 -> esFlags & uint8(31)
+    prop DecoderConfig DecoderConfigDescriptor -> GetChildOrThrow[DecoderConfigDescriptor]()
+    override prop InternalSize int32 -> base.InternalSize + GetLength()
+    private prop StreamDependenceFlag int32 -> esFlags >> 7
+    private prop UrlFlag int32 -> (esFlags >> 6) & 1
+    private prop OcrStreamFlag int32 -> (esFlags >> 5) & 1
+
+    override func Render(file Stream) {
+        file.WriteUInt16BE(EsId)
+        file.WriteByte(esFlags)
+        if StreamDependenceFlag == 1 {
+            file.WriteUInt16BE(dependsOnEsId)
+        }
+        if UrlFlag == 1 {
+            file.WriteByte(urlLength)
+            file.Write(urlString)
+        }
+        if OcrStreamFlag == 1 {
+            file.WriteUInt16BE(ocrEsId)
+        }
+    }
+
+    private func GetLength() int32 {
+        var length = 3
+        if StreamDependenceFlag == 1 {
+            length += 2
+        }
+        if UrlFlag == 1 {
+            length += uint8(1) + urlLength
+        }
+        if OcrStreamFlag == 1 {
+            length += 2
+        }
+        return length
+    }
+
+    shared {
+        func CreateAudio() ES_Descriptor {
+            let descriptor = ES_Descriptor()
+            let decoder = DecoderConfigDescriptor.CreateAudio()
+            let slConfig = SLConfigDescriptor.CreateMp4()
+            descriptor!!.Children.Add(decoder!!)
+            descriptor!!.Children.Add(slConfig!!)
+            return descriptor!!
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Ec3Extensions.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Ec3Extensions.gs
@@ -1,0 +1,14 @@
+package Oahu.Decrypt.Mpeg4.Boxes.EC3SpecificBox
+
+import System.IO
+
+class Ec3Extensions {
+    shared {
+        private let FfAc3ChannelsTab []uint8 = []uint8{uint8(2), uint8(1), uint8(2), uint8(3), uint8(3), uint8(4), uint8(4), uint8(5)}
+    }
+}
+
+func (indSub Ec3IndependentSubstream) GetSampleRate() int32 -> if indSub.Fscod == uint8(0) { 48000 } else { if indSub.Fscod == uint8(1) { 44100 } else { if indSub.Fscod == uint8(2) { 32000 } else { throw InvalidDataException("${nameof(indSub.Fscod)} value of ${indSub.Fscod} is not valid")
+    default(int32) } } }
+
+func (indSub Ec3IndependentSubstream) ChannelCount() int32 -> int32(Ec3Extensions.FfAc3ChannelsTab[uint8(indSub.Acmod)]) + (if indSub.Lfeon { 1 } else { 0 })

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Ec3IndependentSubstream.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Ec3IndependentSubstream.gs
@@ -1,0 +1,35 @@
+package Oahu.Decrypt.Mpeg4.Boxes.EC3SpecificBox
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+class Ec3IndependentSubstream {
+    var Fscod uint8
+    var Bsid uint8
+    var Asvc bool
+    var Bsmod uint8
+    var Acmod AudioCodingMode
+    var Lfeon bool
+    var NumDepSub uint8
+    var ChanLoc ChannelLocation
+
+    init(reader BitReader) {
+        Fscod = uint8(reader.Read(2))
+        Bsid = uint8(reader.Read(5))
+        if Bsid != uint8(16) {
+            throw InvalidDataException("Invalid bsid value: $Bsid. Expected 16 for E-AC-3.")
+        }
+        reader.Position += 1
+        Asvc = reader.ReadBool()
+        Bsmod = uint8(reader.Read(3))
+        Acmod = AudioCodingMode(reader.Read(3))
+        Lfeon = reader.Read(1) > uint32(0)
+        reader.Position += 3
+        let numDepSub = reader.Read(4)
+        if numDepSub > uint32(0) {
+            ChanLoc = ChannelLocation(reader.Read(9))
+        } else {
+            reader.Position++
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/EmptyFrame.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/EmptyFrame.gs
@@ -1,0 +1,20 @@
+package Oahu.Decrypt.Mpeg4.ID3
+
+import System.IO
+
+internal class EmptyFrame : Frame {
+    convenience init(parent Frame) {
+        init(FrameHeader(EmptyFrame.GetEmptyFrameId(parent.Version), 0, parent.Version), parent)
+    }
+
+    init(header Header, parent Frame) : base(header, parent) {
+    }
+
+    override func Render(file Stream) {
+    }
+
+    shared {
+        func GetEmptyFrameSize(version int32) int32 -> if version == 0x200 { 6 } else { 10 }
+        private func GetEmptyFrameId(version int32) string -> if version == 0x200 { "\u0000\u0000\u0000" } else { "\u0000\u0000\u0000\u0000" }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/EsdsBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/EsdsBox.gs
@@ -1,0 +1,35 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Descriptors
+
+open class EsdsBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        let descroptor = DescriptorFactory.CreateDescriptor(file)
+        ES_Descriptor = descroptor as ES_Descriptor ?? throw InvalidDataException("${descroptor!!.GetType()} is not an ${nameof(ES_Descriptor)}")
+    }
+
+    private init(es_Descriptor ES_Descriptor, parent IBox) : base([]uint8{uint8(0), uint8(0), uint8(0), uint8(0)}, BoxHeader(8, "esds"), parent) {
+        ES_Descriptor = es_Descriptor
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(ES_Descriptor.RenderSize)
+
+    prop ES_Descriptor ES_Descriptor {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        ES_Descriptor.Save(file)
+    }
+
+    shared {
+        func CreateEmpty(parent IBox) EsdsBox {
+            let esds = EsdsBox(ES_Descriptor.CreateAudio(), parent)
+            parent.Children.Add(esds!!)
+            return esds!!
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/ExpandableClass.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/ExpandableClass.gs
@@ -1,0 +1,39 @@
+package Oahu.Decrypt.Mpeg4.Descriptors
+
+import System
+import System.IO
+
+class ExpandableClass {
+    shared {
+        func EncodeSize(file Stream, sizeOfInstance int32, minimumBytes int32) {
+            const IntegerBytes = 4
+            const MaxSize = (1 << (7 * IntegerBytes)) - 1
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(sizeOfInstance, MaxSize, nameof(sizeOfInstance))
+            let size = ExpandableClass.GetSizeByteCount(sizeOfInstance, minimumBytes)
+            for var i = size - 1; i > 0; i-- {
+                let b = 0x80 | ((sizeOfInstance >> (7 * i)) & 0x7f)
+                file.WriteByte(uint8(b))
+            }
+            file.WriteByte(uint8((sizeOfInstance & 0x7f)))
+        }
+
+        func GetSizeByteCount(sizeOfInstance int32, minimumBytes int32) int32 {
+            var sizeOfInstance = sizeOfInstance
+            var r = 0
+            while (1) != 0 {
+                r++
+            }
+            return Math.Max(minimumBytes, r / 7 + 1)
+        }
+
+        func DecodeSize(file Stream) int32 {
+            var b int32
+            var sizeOfInstance = 0
+            do {
+                b = file.ReadByte()
+                sizeOfInstance = (sizeOfInstance << 7) | (b & 0x7f)
+            } while (b & 0x80) != 0
+            return sizeOfInstance
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/ExtendedHeader.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/ExtendedHeader.gs
@@ -1,0 +1,116 @@
+package Oahu.Decrypt.Mpeg4.ID3
+
+import System.IO
+
+class Id3ExtendedHeader : Frame {
+    private init(header Header, parent Frame) : base(header, parent) {
+    }
+
+    override func Render(file Stream) {
+    }
+
+    shared {
+        func Create(file Stream, parent Id3Tag) Id3ExtendedHeader {
+            let header = ExtendedHeader(file, parent.Version)
+            return Id3ExtendedHeader(header!!, parent)
+        }
+    }
+}
+
+class ExtendedHeader : Header {
+    init(file Stream, version int32) {
+        Identifier = String.Empty
+        Version = version
+        var headerSize int64
+        let originalPosition = file.Position
+        if version >= 0x400 {
+            headerSize = Header.UnSyncSafify(Header.ReadUInt32BE(file))
+            let numFlagBytes = file.ReadByte()
+            ExtendedFlags = Flags(Header.ReadBlock(file, numFlagBytes))
+            if (ExtendedFlags!![1]) {
+                TagIsUpdate = file.ReadByte() != 0
+            }
+            if ExtendedFlags!![2] && file.ReadByte() == 5 {
+                CRC32 = (uint32(file.ReadByte()) << 28) | uint32(Header.UnSyncSafify(Header.ReadUInt32BE(file)))
+            }
+            if ExtendedFlags!![3] && file.ReadByte() == 1 {
+                TagRestrictions = uint8(file.ReadByte())
+            }
+        } else {
+            headerSize = Header.ReadUInt32BE(file)
+            ExtendedFlags = Flags(Header.ReadUInt16BE(file))
+            SizeOfPadding = Header.ReadUInt32BE(file)
+            if (ExtendedFlags!![0]) {
+                CRC32 = Header.ReadUInt32BE(file)
+            }
+        }
+        SeekForwardToPosition(file, originalPosition + headerSize)
+    }
+
+    override prop Identifier string {
+        get;
+        init;
+    }
+
+    override prop HeaderSize int32 -> GetExtendedFlagsSize()
+    prop ExtendedFlags Flags?
+    prop SizeOfPadding uint32
+    prop TagIsUpdate bool
+    prop TagRestrictions uint8
+    prop CRC32 uint32
+
+    prop Version int32 {
+        get;
+        init;
+    }
+
+    override func Render(stream Stream, renderSize int32, version uint16) {
+        if version >= uint16(0x400) {
+            Header.WriteUInt32BE(stream, Header.SyncSafify(HeaderSize + renderSize))
+            stream.WriteByte(uint8(ExtendedFlags!!.Size))
+            stream.Write(ExtendedFlags!!.ToBytes())
+            if (ExtendedFlags!![1]) {
+                stream.WriteByte(uint8((if TagIsUpdate { 1 } else { 0 })))
+            }
+            if (ExtendedFlags!![2]) {
+                stream.WriteByte(5)
+                stream.WriteByte(uint8((CRC32 >> 28)))
+                Header.WriteUInt32BE(stream, Header.SyncSafify(int32((CRC32 & uint32(0xfffffff)))))
+            }
+            if (ExtendedFlags!![3]) {
+                stream.WriteByte(1)
+                stream.WriteByte(TagRestrictions)
+            }
+        } else {
+            Header.WriteUInt32BE(stream, uint32((HeaderSize + renderSize)))
+            stream.Write(ExtendedFlags!!.ToBytes())
+            Header.WriteUInt32BE(stream, SizeOfPadding)
+            if (ExtendedFlags!![0]) {
+                Header.WriteUInt32BE(stream, CRC32)
+            }
+        }
+    }
+
+    func ToString() string -> "ExtendedHeader"
+
+    private func GetExtendedFlagsSize() int32 {
+        if ExtendedFlags == nil {
+            return 0
+        }
+        if Version >= 0x400 {
+            var size = 5 + ExtendedFlags!!.Size
+            if (ExtendedFlags!![1]) {
+                size++
+            }
+            if (ExtendedFlags!![2]) {
+                size += 6
+            }
+            if (ExtendedFlags!![3]) {
+                size += 2
+            }
+            return size
+        } else {
+            return if ExtendedFlags!![0] { 10 } else { 6 }
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Flags.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Flags.gs
@@ -1,0 +1,39 @@
+package Oahu.Decrypt.Mpeg4.ID3
+
+import System
+import System.Linq
+
+class Flags {
+    private var flags []uint8
+
+    init(flags ...uint8) {
+        this.flags = flags
+    }
+
+    init(flags uint16) {
+        this.flags = []uint8{uint8((flags >> 8)), uint8((flags & uint16(0xff)))}
+    }
+
+    prop Size int32 -> this.flags.Length
+
+    prop this[index int32] bool {
+        get {
+            if index < 0 || index >= flags.Length * 8 {
+                throw ArgumentOutOfRangeException(nameof(index), "Index must be within the range of the flags.")
+            }
+            return (int32(flags[index / 8]) & (1 << (7 - (index % 8)))) != 0
+        }
+        set {
+            if index < 0 || index >= flags.Length * 8 {
+                throw ArgumentOutOfRangeException(nameof(index), "Index must be within the range of the flags.")
+            }
+            if value {
+                flags[index / 8] |= uint8((1 << (7 - (index % 8))))
+            } else {
+                flags[index / 8] &= uint8(^(1 << (7 - (index % 8))))
+            }
+        }
+    }
+
+    func ToBytes() []uint8 -> flags.ToArray()
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Frame.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Frame.gs
@@ -1,0 +1,101 @@
+package Oahu.Decrypt.Mpeg4.ID3
+
+import System
+import System.Collections.Generic
+import System.IO
+import System.Linq
+import System.Text
+
+open class Frame(Header Header, Parent Frame) {
+    open prop Size int32 -> Children.Sum((b Frame) -> b.Size)
+
+    prop Children List[Frame] {
+        get;
+        init;
+    }
+
+    open prop Version uint16 -> Parent.Version
+
+    open func Save(file Stream, version uint16) {
+        Header.Render(file, Size, version)
+        Render(file)
+        for child in Children {
+            child!!.Save(file, version)
+        }
+    }
+
+    func ToString() string -> Header.ToString()
+    open func Render(file Stream);
+
+    protected func LoadChildren(file Stream, endPosition int64) {
+        var origPosition = file.Position
+        while file.Position < endPosition && origPosition == file.Position {
+            let child = TagFactory.CreateTag(file, this, out var lengthRead)
+            if child is EmptyFrame {
+                break
+            }
+            origPosition += int64(lengthRead)
+            Children.Add(child)
+        }
+        Header.SeekForwardToPosition(file, endPosition)
+    }
+
+    shared {
+        func ReadSizeString(file Stream, unicode bool, bytes int32) string {
+            let buff = [bytes]uint8
+            file.ReadExactly(buff!!)
+            return (if unicode { Encoding.Unicode } else { Encoding.ASCII }).GetString(buff!!)
+        }
+
+        func ReadNullTerminatedString(file Stream, unicode bool) string {
+            let lst = List[uint8]()
+            if unicode {
+                let blob = [2]uint8
+                file.ReadExactly(blob!!)
+                while blob!![0] != uint8(0) || blob!![1] != uint8(0) {
+                    lst.AddRange(blob!!)
+                    file.ReadExactly(blob!!)
+                }
+                return Encoding.Unicode.GetString(lst.ToArray())
+            } else {
+                var b = uint8(file.ReadByte())
+                while b != uint8(0) {
+                    lst.Add(b)
+                    b = uint8(file.ReadByte())
+                }
+                return Encoding.ASCII.GetString(lst.ToArray())
+            }
+        }
+
+        func IsUnicode(str string) bool -> Encoding.UTF8.GetByteCount(str) != str.Length
+
+        func UnicodeLength(str string) int32 {
+            if str.Length == 0 {
+                return 4
+            }
+            var strLen = Encoding.Unicode.GetByteCount(str)
+            let c0 = str[0]
+            if c0 != '￾' && c0 != '﻿' {
+                strLen += 2
+            }
+            return strLen
+        }
+
+        func UnicodeBytes(str string) []uint8 {
+            let strLen = str.Length
+            if strLen == 0 {
+                return Encoding.Unicode.GetPreamble()
+            }
+            let c0 = str[0]
+            if c0 == '￾' || c0 == '﻿' {
+                return Encoding.Unicode.GetBytes(str)
+            } else {
+                let bts = [2 * (strLen + 1)]uint8
+                let preamble = Encoding.Unicode.GetPreamble()
+                Array.Copy(preamble!!, bts!!, preamble!!.Length)
+                Encoding.Unicode.GetBytes(str, 0, str.Length, bts!!, preamble!!.Length)
+                return bts!!
+            }
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/FrameEntry.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/FrameEntry.gs
@@ -1,0 +1,23 @@
+package Oahu.Decrypt.FrameFilters
+
+import System
+import Oahu.Decrypt.Mpeg4.Chunks
+
+class FrameEntry {
+    prop Chunk ChunkEntry? {
+        get;
+        init;
+    }
+
+    prop SamplesInFrame uint32 {
+        get;
+        init;
+    }
+
+    prop FrameData Memory[uint8] {
+        get;
+        init;
+    }
+
+    prop ExtraData object?
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/FrameFilterBase_TInput.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/FrameFilterBase_TInput.gs
@@ -1,0 +1,94 @@
+package Oahu.Decrypt.FrameFilters
+
+import System
+import System.Threading
+import System.Threading.Channels
+import System.Threading.Tasks
+
+open class FrameFilterBase[TInput]() : IDisposable {
+    private let filterChannel Channel[BufferEntry] = Channel.CreateBounded[BufferEntry](BoundedChannelOptions(2))
+    private var cancellationToken CancellationToken
+    private var filterLoop Task?
+    private var buffer []TInput
+    private var bufferPosition int32 = 0
+
+    init() {
+        buffer = [InputBufferSize]TInput
+    }
+
+    deinit {
+        Dispose(false)
+    }
+
+    protected prop Disposed bool
+
+    protected open prop InputBufferSize int32 {
+        get;
+    }
+
+    open async func AddInputAsync(input TInput) {
+        filterLoop ??= Task.Run(Encoder, cancellationToken)
+        if cancellationToken.IsCancellationRequested {
+            return
+        }
+        buffer[bufferPosition] = input
+        bufferPosition++
+        if bufferPosition == InputBufferSize {
+            if await filterChannel.Writer.WaitToWriteAsync(cancellationToken) {
+                await filterChannel.Writer.WriteAsync(BufferEntry(bufferPosition, buffer), cancellationToken)
+                bufferPosition = 0
+                buffer = [InputBufferSize]TInput
+            }
+        }
+    }
+
+    func CompleteAsync() Task -> CompleteInternalAsync()
+
+    func Dispose() {
+        Dispose(true)
+        GC.SuppressFinalize(this)
+    }
+
+    open func SetCancellationToken(cancellationToken CancellationToken) -> this.cancellationToken = cancellationToken
+    protected open func FlushAsync() Task;
+    protected open func HandleInputDataAsync(input TInput) Task;
+
+    protected open async func CompleteInternalAsync() {
+        try {
+            await filterChannel.Writer.WriteAsync(BufferEntry(bufferPosition, buffer), cancellationToken)
+            filterChannel.Writer.Complete()
+        } catch (ex OperationCanceledException) {
+        }
+        if filterLoop != nil {
+            await filterLoop
+        }
+    }
+
+    protected open func Dispose(disposing bool) {
+        if disposing && !Disposed {
+            if filterLoop?.IsCompleted == false {
+                filterChannel.Writer.TryComplete()
+            }
+        }
+        Disposed = true
+    }
+
+    private async func Encoder() {
+        try {
+            while await filterChannel.Reader.WaitToReadAsync(cancellationToken) {
+                await for messages in filterChannel.Reader.ReadAllAsync(cancellationToken) {
+                    for var i = 0; i < messages!!.NumEntries; i++ {
+                        await HandleInputDataAsync(messages!!.Entries[i])
+                    }
+                }
+            }
+            await FlushAsync()
+        } catch (ex Exception) {
+            filterChannel.Writer.Complete(ex)
+            throw ex
+        }
+    }
+
+    private open data class BufferEntry(NumEntries int32, Entries []TInput) {
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/FrameFinalBase_TInput.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/FrameFinalBase_TInput.gs
@@ -1,0 +1,8 @@
+package Oahu.Decrypt.FrameFilters
+
+import System.Threading.Tasks
+
+open class FrameFinalBase[TInput] : FrameFilterBase[TInput] {
+    protected override func HandleInputDataAsync(input TInput) Task -> PerformFilteringAsync(input)
+    protected open func PerformFilteringAsync(input TInput) Task;
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/FrameHeader.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/FrameHeader.gs
@@ -1,0 +1,63 @@
+package Oahu.Decrypt.Mpeg4.ID3
+
+import System
+import System.IO
+import System.Text
+
+class FrameHeader : Header {
+    init(frameID string, flags uint16, version uint16, size int32 = 0) {
+        Version = version
+        Identifier = frameID
+        Flags = Flags(flags)
+        Size = size
+    }
+
+    override prop Identifier string {
+        get;
+        init;
+    }
+
+    prop Flags Flags {
+        get;
+        init;
+    }
+
+    override prop HeaderSize int32 -> if Version == uint16(0x200) { 6 } else { 10 }
+
+    prop Version uint16 {
+        get;
+        init;
+    }
+
+    override func Render(stream Stream, renderSize int32, version uint16) {
+        stream.Write(Encoding.ASCII.GetBytes(Identifier))
+        let size = if version >= uint16(0x400) { int32(Header.SyncSafify(renderSize)) } else { renderSize }
+        if version == uint16(0x200) {
+            stream.WriteByte(uint8((size >> 16)))
+            stream.WriteByte(uint8((size >> 8)))
+            stream.WriteByte(uint8(size))
+        } else {
+            Header.WriteUInt32BE(stream, uint32(size))
+            stream.Write(Flags.ToBytes())
+        }
+    }
+
+    shared {
+        func Create(file Stream, version uint16) FrameHeader {
+            let originalPosition = file.Position
+            if version == uint16(0x200) {
+                let bts2 = stackalloc [6]uint8
+                file.ReadExactly(bts2)
+                let frameID = Encoding.ASCII.GetString(bts2.Slice(0, 3))
+                let size = (bts2[3] << 16) | (bts2[4] << 8) | int32(bts2[5])
+                return FrameHeader(frameID!!, 0, version, size)
+            } else {
+                let bts = stackalloc [4]uint8
+                file.ReadExactly(bts)
+                let frameID = Encoding.ASCII.GetString(bts)
+                let size = if version >= uint16(0x400) { Header.UnSyncSafify(Header.ReadUInt32BE(file)) } else { int32(Header.ReadUInt32BE(file)) }
+                return FrameHeader(frameID!!, Header.ReadUInt16BE(file), version, size)
+            }
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/FrameTransformBase_TInput_TOutput.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/FrameTransformBase_TInput_TOutput.gs
@@ -1,0 +1,43 @@
+package Oahu.Decrypt.FrameFilters
+
+import System.Threading
+import System.Threading.Tasks
+
+open class FrameTransformBase[TInput, TOutput] : FrameFilterBase[TInput] {
+    private var linked FrameFilterBase[TOutput]?
+
+    open override func SetCancellationToken(cancellationToken CancellationToken) {
+        base.SetCancellationToken(cancellationToken)
+        linked?.SetCancellationToken(cancellationToken)
+    }
+
+    func LinkTo(nextFilter FrameFilterBase[TOutput]) -> linked = nextFilter
+    open func PerformFiltering(input TInput) TOutput;
+    protected open func PerformFinalFiltering() TOutput? -> default
+
+    protected override async func FlushAsync() {
+        if PerformFinalFiltering() is TOutput && linked != nil {
+            await linked!!.AddInputAsync((PerformFinalFiltering() as TOutput)!!)
+        }
+    }
+
+    protected override async func HandleInputDataAsync(input TInput) {
+        let filteredData = PerformFiltering(input)
+        if linked == nil {
+            return
+        }
+        await linked!!.AddInputAsync(filteredData)
+    }
+
+    protected override async func CompleteInternalAsync() {
+        await base.CompleteInternalAsync()
+        await (linked?.CompleteAsync() ?? Task.CompletedTask)
+    }
+
+    protected open override func Dispose(disposing bool) {
+        if disposing && !Disposed {
+            linked?.Dispose()
+        }
+        base.Dispose(disposing)
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/FreeBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/FreeBox.gs
@@ -1,0 +1,38 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.IO
+
+open class FreeBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        for var i = Header.HeaderSize; int64(i) < Header.TotalBoxSize; i++ {
+            file.ReadByte()
+        }
+    }
+
+    private init(header BoxHeader, parent IBox?) : base(header, parent) {
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + Header.TotalBoxSize - int64(Header.HeaderSize)
+
+    protected open override func Render(file Stream) {
+        var totalToWrite = Header.TotalBoxSize - int64(Header.HeaderSize)
+        let blankData = [int32(Math.Min(8 * 1024, totalToWrite))]uint8
+        while totalToWrite > int64(0) {
+            let toWrite = int32(Math.Min(blankData!!.Length, totalToWrite))
+            file.Write(blankData!!, 0, toWrite)
+            totalToWrite -= int64(toWrite)
+        }
+    }
+
+    shared {
+        const MinSize int32 = 8
+
+        func Create(freeSize int64, parent IBox?) FreeBox {
+            let header = BoxHeader(freeSize, "free")
+            let free = FreeBox(header, parent)
+            parent?.Children.Add(free)
+            return free
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/FreeformTagBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/FreeformTagBox.gs
@@ -1,0 +1,33 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.Diagnostics
+import System.IO
+
+@DebuggerDisplay("{DebuggerDisplay,nq}")
+open class FreeformTagBox : AppleTagBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        LoadChildren(file)
+    }
+
+    protected init(header BoxHeader, parent IBox?) : base(header, parent) {
+    }
+
+    prop Mean MeanBox? -> GetChild[MeanBox]()
+    prop Name NameBox? -> GetChild[NameBox]()
+    open override prop TagName string -> "${Mean?.ReverseDnsDomain}:${Name?.Name}'"
+
+    @DebuggerHidden
+    private prop DebuggerDisplay string -> "----:$TagName"
+
+    shared {
+        func Create(parent AppleListBox?, domain string, tagName string, data []uint8, dataType AppleDataType) FreeformTagBox {
+            let header = BoxHeader(8, "----")
+            let tagBox = FreeformTagBox(header, parent)
+            MeanBox.Create(tagBox!!, domain)
+            NameBox.Create(tagBox!!, tagName)
+            AppleDataBox.Create(tagBox!!, data, dataType)
+            parent?.Children.Add(tagBox!!)
+            return tagBox!!
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/FrmaBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/FrmaBox.gs
@@ -1,0 +1,21 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class FrmaBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        DataFormat = file.ReadType()
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(4)
+
+    prop DataFormat string {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        file.WriteType(DataFormat)
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/FtypBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/FtypBox.gs
@@ -1,0 +1,56 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.Collections.Generic
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class FtypBox : Box {
+    init(file Stream, header BoxHeader) : base(header, nil) {
+        CompatibleBrands = List[string]()
+        let endPos = header.FilePosition + header.TotalBoxSize
+        MajorBrand = file.ReadType()
+        MajorVersion = file.ReadInt32BE()
+        while file.Position < endPos {
+            CompatibleBrands.Add(file.ReadType())
+        }
+    }
+
+    private init(header BoxHeader, majorBrand string, majorVersion int32) : base(header, nil) {
+        CompatibleBrands = List[string]()
+        MajorBrand = majorBrand
+        MajorVersion = majorVersion
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(8) + int64(CompatibleBrands.Count * 4)
+    prop MajorBrand string
+    prop MajorVersion int32
+
+    prop CompatibleBrands List[string] {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        file.WriteType(MajorBrand)
+        file.WriteInt32BE(MajorVersion)
+        for brand in CompatibleBrands {
+            file.WriteType(brand)
+        }
+    }
+
+    protected open override func Dispose(disposing bool) {
+        if disposing && !Disposed {
+            CompatibleBrands.Clear()
+        }
+        base.Dispose(disposing)
+    }
+
+    shared {
+        func Create(majorBrand string, majorVersion int32) FtypBox {
+            ArgumentException.ThrowIfNullOrWhiteSpace(majorBrand, nameof(majorBrand))
+            return if majorBrand.Length == 4 { FtypBox(BoxHeader(16, "ftyp"), majorBrand, majorVersion) } else { throw ArgumentException("Major brand must be 4 chars long.", nameof(majorBrand))
+                default(FtypBox) }
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/FullBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/FullBox.gs
@@ -1,0 +1,32 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class FullBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        VersionFlags = file.ReadBlock(4)
+    }
+
+    init(versionFlags []uint8, header BoxHeader, parent IBox?) : base(header, parent) {
+        VersionFlags = versionFlags
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(4)
+
+    prop Version uint8 {
+        get -> VersionFlags[0]
+        set -> VersionFlags[0] = value
+    }
+
+    prop Flags int32 -> VersionFlags[1] << 16 | VersionFlags[2] << 8 | int32(VersionFlags[3])
+
+    protected prop VersionFlags []uint8 {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        file.Write(VersionFlags)
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/HdlrBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/HdlrBox.gs
@@ -1,0 +1,69 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.IO
+import System.Text
+import Oahu.Decrypt.Mpeg4.Util
+
+open class HdlrBox : FullBox {
+    private let reserved []uint8
+
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        let endPos = Header.FilePosition + Header.TotalBoxSize
+        PreDefined = file.ReadUInt32BE()
+        HandlerType = Encoding.UTF8.GetString(file.ReadBlock(4))
+        reserved = file.ReadBlock(12)
+        let readToEnd = file.ReadBlock(int32((endPos - file.Position)))
+        for var i = readToEnd!!.Length - 1; i >= 0 && readToEnd!![i] == uint8(0); i-- {
+            NullTerminatorCount++
+        }
+        HandlerName = Encoding.UTF8.GetString(readToEnd!!, 0, readToEnd!!.Length - NullTerminatorCount)
+    }
+
+    private init(type_ string, name string?, parent IBox) : base([]uint8{uint8(0), uint8(0), uint8(0), uint8(0)}, BoxHeader(8, "hdlr"), parent) {
+        ArgumentException.ThrowIfNullOrEmpty(type_, nameof(type_))
+        if Encoding.UTF8.GetByteCount(type_) != 4 {
+            throw ArgumentException("Type '$type_' must be exactly 4 UTF-8 characters long.", nameof(type_))
+        }
+        HandlerType = type_
+        reserved = [12]uint8
+        HandlerName = name ?? ""
+        NullTerminatorCount = 1
+    }
+
+    prop NullTerminatorCount int32
+    open override prop RenderSize int64 -> base.RenderSize + int64(20) + int64(Encoding.UTF8.GetByteCount(HandlerName)) + int64(NullTerminatorCount)
+
+    prop PreDefined uint32 {
+        get;
+        init;
+    }
+
+    prop HandlerType string {
+        get;
+        init;
+    }
+
+    prop HandlerName string
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.WriteUInt32BE(PreDefined)
+        file.Write(Encoding.UTF8.GetBytes(HandlerType))
+        file.Write(reserved)
+        file.Write(Encoding.UTF8.GetBytes(HandlerName))
+        file.Write([NullTerminatorCount]uint8)
+    }
+
+    shared {
+        func Create(type_ string, name string?, reservedData []uint8, parent IBox) HdlrBox {
+            ArgumentNullException.ThrowIfNull(reservedData, nameof(reservedData))
+            ArgumentNullException.ThrowIfNull(parent, nameof(parent))
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(reservedData.Length, 12, nameof(reservedData))
+            let hdlr = HdlrBox(type_, name, parent)
+            Array.Copy(reservedData, 0, hdlr!!.reserved, 0, reservedData.Length)
+            parent.Children.Add(hdlr!!)
+            return hdlr!!
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Header.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Header.gs
@@ -1,0 +1,62 @@
+package Oahu.Decrypt.Mpeg4.ID3
+
+import System
+import System.IO
+
+open class Header {
+    open prop Identifier string {
+        get;
+    }
+
+    prop Size int32 {
+        get;
+        init;
+    }
+
+    open prop HeaderSize int32 {
+        get;
+    }
+
+    open func Render(stream Stream, renderSize int32, version uint16);
+    func ToString() string -> if Identifier == "\u0000\u0000\u0000\u0000" { "\\0\\0\\0\\0" } else { if Identifier == "\u0000\u0000\u0000" { "\\0\\0\\0" } else { Identifier } }
+
+    func SeekForwardToPosition(file Stream, endPos int64) {
+        if file.Position < endPos {
+            if file.CanSeek {
+                file.Position = endPos
+            } else {
+                let buffer = [4096]uint8
+                while file.Position < endPos {
+                    let bytesToRead = Int32.Min(buffer!!.Length, int32((endPos - file.Position)))
+                    file.ReadExactly(buffer!!, 0, bytesToRead)
+                }
+            }
+        }
+    }
+
+    shared {
+        func ReadUInt16BE(stream Stream) uint16 {
+            let word = stackalloc [2]uint8
+            stream.ReadExactly(word)
+            return uint16((word[0] << 8 | int32(word[1])))
+        }
+
+        func UnSyncSafify(value uint32) int32 -> int32((((value & uint32(0x7f000000)) >> 3) | ((value & uint32(0x7f0000)) >> 2) | ((value & uint32(0x7f00)) >> 1) | (value & uint32(0x7f))))
+        func SyncSafify(value int32) uint32 -> uint32((((value << 3) & 0x7f000000) | ((value << 2) & 0x7f0000) | ((value << 1) & 0x7f00) | (value & 0x7F)))
+
+        func ReadUInt32BE(stream Stream) uint32 {
+            let dword = stackalloc [4]uint8
+            stream.ReadExactly(dword)
+            return uint32((dword[0] << 24 | dword[1] << 16 | dword[2] << 8 | int32(dword[3])))
+        }
+
+        func ReadBlock(stream Stream, numBytes int32) []uint8 {
+            let block = [numBytes]uint8
+            stream.ReadExactly(block!!, 0, numBytes)
+            return block!!
+        }
+
+        func WriteUInt32BE(stream Stream, value uint32) -> stream.Write([]uint8{uint8((value >> 24)), uint8((value >> 16)), uint8((value >> 8)), uint8(value)})
+        func WriteUInt16BE(stream Stream, value uint32) -> stream.Write([]uint8{uint8((value >> 8)), uint8(value)})
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/HeaderBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/HeaderBox.gs
@@ -1,0 +1,50 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class HeaderBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        if Version == uint8(0) {
+            CreationTime = HeaderBox.Datum.AddSeconds(file.ReadUInt32BE())
+            ModificationTime = HeaderBox.Datum.AddSeconds(file.ReadUInt32BE())
+            ReadBeforeDuration(file)
+            Duration = file.ReadUInt32BE()
+        } else {
+            CreationTime = HeaderBox.Datum.AddSeconds(file.ReadUInt64BE())
+            ModificationTime = HeaderBox.Datum.AddSeconds(file.ReadUInt64BE())
+            ReadBeforeDuration(file)
+            Duration = file.ReadUInt64BE()
+        }
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(3 * (if RequireVersionOne { 8 } else { 4 }))
+    prop CreationTime DateTimeOffset
+    prop ModificationTime DateTimeOffset
+    prop Duration uint64
+    private prop RequireVersionOne bool -> Version == uint8(1) || Duration > uint64(UInt32.MaxValue)
+    protected open func ReadBeforeDuration(file Stream);
+    protected open func WriteBeforeDuration(file Stream);
+
+    protected open override func Render(file Stream) {
+        if RequireVersionOne {
+            Version = uint8(1)
+            base.Render(file)
+            file.WriteUInt64BE(uint64((CreationTime - HeaderBox.Datum).TotalSeconds))
+            file.WriteUInt64BE(uint64((ModificationTime - HeaderBox.Datum).TotalSeconds))
+            WriteBeforeDuration(file)
+            file.WriteUInt64BE(Duration)
+        } else {
+            base.Render(file)
+            file.WriteUInt32BE(uint32((CreationTime - HeaderBox.Datum).TotalSeconds))
+            file.WriteUInt32BE(uint32((ModificationTime - HeaderBox.Datum).TotalSeconds))
+            WriteBeforeDuration(file)
+            file.WriteUInt32BE(uint32(Duration))
+        }
+    }
+
+    shared {
+        private let Datum DateTimeOffset = DateTimeOffset(1904, 1, 1, 0, 0, 0, TimeSpan.Zero)
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/HelperExtensions.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/HelperExtensions.gs
@@ -1,0 +1,70 @@
+package Oahu.Decrypt.Mpeg4.Util
+
+import System
+import System.Runtime.Intrinsics
+
+internal class HelperExtensions {
+    shared {
+        private func AllLessThanOrEqual_256[T IComparable[T] unmanaged](ints Span[T], value T, out checkedcount int32) bool {
+            unsafe {
+                let vecSize = 256 / 8 / sizeof(T)
+                let numVectors = ints.Length / vecSize
+                let comparand = Vector256.Create(value)
+                fixed pInts *T = ints {
+                    for var i = 0; i < numVectors; i++ {
+                        let intVector = Vector256.Load(pInts + vecSize * i)
+                        if !Vector256.LessThanOrEqualAll(intVector, comparand) {
+                            checkedcount = vecSize * i
+                            return false
+                        }
+                    }
+                }
+                checkedcount = vecSize * numVectors
+                return true
+            }
+        }
+
+        private func AllLessThanOrEqual_512[T IComparable[T] unmanaged](ints Span[T], value T, out checkedcount int32) bool {
+            unsafe {
+                let vecSize = 512 / 8 / sizeof(T)
+                let numVectors = ints.Length / vecSize
+                let comparand = Vector512.Create(value)
+                fixed pInts *T = ints {
+                    for var i = 0; i < numVectors; i++ {
+                        let intVector = Vector512.Load(pInts + vecSize * i)
+                        if !Vector512.LessThanOrEqualAll(intVector, comparand) {
+                            checkedcount = vecSize * i
+                            return false
+                        }
+                    }
+                }
+                checkedcount = vecSize * numVectors
+                return true
+            }
+        }
+    }
+}
+
+func (ints Span[T]) AllLessThanOrEqual[T IComparable[T] unmanaged](value T) bool {
+    unsafe {
+        var checkedCount int32
+        var result bool
+        if Vector512.IsHardwareAccelerated {
+            result = HelperExtensions.AllLessThanOrEqual_512(ints, value, &checkedCount)
+        } else if Vector256.IsHardwareAccelerated {
+            result = HelperExtensions.AllLessThanOrEqual_256(ints, value, &checkedCount)
+        } else {
+            result = true
+            checkedCount = 0
+        }
+        if !result {
+            return false
+        }
+        for var i = checkedCount; i < ints.Length; i++ {
+            if ints[i].CompareTo(value) == 1 {
+                return false
+            }
+        }
+        return true
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/IAppleData.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/IAppleData.gs
@@ -1,0 +1,66 @@
+package Oahu.Decrypt.Mpeg4
+
+import System
+import System.Buffers.Binary
+
+interface IAppleData[TData IAppleData[TData]] {
+    func Write(destination Span[uint8]);
+
+    shared {
+        prop SizeInBytes int32 {
+            get;
+        }
+
+        func Create(source ReadOnlySpan[uint8]) TData;
+    }
+}
+
+open data class TrackNumber(Track uint16, TotalTracks uint16) : IAppleData[TrackNumber] {
+    func operator implicit(tn (int32, int32)) TrackNumber {
+        ArgumentOutOfRangeException.ThrowIfNegative(tn.Item1, nameof(tn.Item1))
+        ArgumentOutOfRangeException.ThrowIfNegative(tn.Item2, nameof(tn.Item2))
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(tn.Item1, int32(UInt16.MaxValue), nameof(tn.Item1))
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(tn.Item2, int32(UInt16.MaxValue), nameof(tn.Item2))
+        return TrackNumber(uint16(tn.Item1), uint16(tn.Item2))
+    }
+
+    func Write(destination Span[uint8]) {
+        ArgumentOutOfRangeException.ThrowIfLessThan(destination.Length, TrackNumber.SizeInBytes, nameof(destination))
+        BinaryPrimitives.WriteUInt16BigEndian(destination.Slice(2, 4 - 2), Track)
+        BinaryPrimitives.WriteUInt16BigEndian(destination.Slice(4, 6 - 4), TotalTracks)
+    }
+
+    shared {
+        prop SizeInBytes int32 -> 8
+
+        func Create(source ReadOnlySpan[uint8]) TrackNumber {
+            ArgumentOutOfRangeException.ThrowIfLessThan(source.Length, TrackNumber.SizeInBytes, nameof(source))
+            return TrackNumber(BinaryPrimitives.ReadUInt16BigEndian(source.Slice(2, 4 - 2)), BinaryPrimitives.ReadUInt16BigEndian(source.Slice(4, 6 - 4)))
+        }
+    }
+}
+
+open data class DiskNumber(Disk uint16, TotalDisks uint16) : IAppleData[DiskNumber] {
+    func operator implicit(tn (int32, int32)) DiskNumber {
+        ArgumentOutOfRangeException.ThrowIfNegative(tn.Item1, nameof(tn.Item1))
+        ArgumentOutOfRangeException.ThrowIfNegative(tn.Item2, nameof(tn.Item2))
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(tn.Item1, int32(UInt16.MaxValue), nameof(tn.Item1))
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(tn.Item2, int32(UInt16.MaxValue), nameof(tn.Item2))
+        return DiskNumber(uint16(tn.Item1), uint16(tn.Item2))
+    }
+
+    func Write(destination Span[uint8]) {
+        ArgumentOutOfRangeException.ThrowIfLessThan(destination.Length, DiskNumber.SizeInBytes, nameof(destination))
+        BinaryPrimitives.WriteUInt16BigEndian(destination.Slice(2, 4 - 2), Disk)
+        BinaryPrimitives.WriteUInt16BigEndian(destination.Slice(4, 6 - 4), TotalDisks)
+    }
+
+    shared {
+        prop SizeInBytes int32 -> 6
+
+        func Create(source ReadOnlySpan[uint8]) DiskNumber {
+            ArgumentOutOfRangeException.ThrowIfLessThan(source.Length, DiskNumber.SizeInBytes, nameof(source))
+            return DiskNumber(BinaryPrimitives.ReadUInt16BigEndian(source.Slice(2, 4 - 2)), BinaryPrimitives.ReadUInt16BigEndian(source.Slice(4, 6 - 4)))
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/IBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/IBox.gs
@@ -1,0 +1,28 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.Collections.Generic
+import System.IO
+
+interface IBox : IDisposable {
+    prop Parent IBox? {
+        get;
+    }
+
+    prop Header BoxHeader {
+        get;
+    }
+
+    prop Children List[IBox] {
+        get;
+    }
+
+    prop RenderSize int64 {
+        get;
+    }
+
+    func Save(file Stream);
+    func GetFreeBoxes() List[FreeBox];
+    func GetChild[T IBox]() T?;
+    func GetChildren[T IBox]() IEnumerable[T];
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/IChunkOffsets.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/IChunkOffsets.gs
@@ -1,0 +1,22 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+interface IChunkOffsets : IBox {
+    prop EntryCount uint32 {
+        get;
+    }
+
+    prop ChunkOffsets ChunkOffsetList {
+        get;
+    }
+
+    shared {
+        func Create(stbl StblBox, offsets ChunkOffsetList) IChunkOffsets {
+            if offsets.Count == 0 {
+                return StcoBox.CreateBlank(stbl, offsets)
+            }
+            offsets.Sort()
+            let maxOffset = offsets.GetOffsetAtIndex(offsets.Count - 1)
+            return if maxOffset > int64(UInt32.MaxValue) { Co64Box.CreateBlank(stbl, offsets) } else { StcoBox.CreateBlank(stbl, offsets) }
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/IStszBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/IStszBox.gs
@@ -1,0 +1,28 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+interface IStszBox : IBox {
+    prop SampleCount int32 {
+        get;
+    }
+
+    prop MaxSize int32 {
+        get;
+    }
+
+    prop TotalSize int64 {
+        get;
+    }
+
+    func GetSizeAtIndex(index int32) int32;
+    func SumFirstNSizes(firstN int32) int64;
+
+    func GetFrameSizes(firstFrameIndex uint32, numFrames uint32) ([]int32, int32) {
+        let frameSizes = [int32(numFrames)]int32
+        var framesSizeTotal = 0
+        for var i uint32 = uint32(0); i < numFrames; i++ {
+            frameSizes[i] = GetSizeAtIndex(int32((i + firstFrameIndex)))
+            framesSizeTotal += frameSizes[i]
+        }
+        return (frameSizes, framesSizeTotal)
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Id3Header.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Id3Header.gs
@@ -1,0 +1,41 @@
+package Oahu.Decrypt.Mpeg4.ID3
+
+import System
+import System.IO
+
+class Id3Header : Header {
+    internal init(version uint16, file Stream) {
+        Version = version
+        Flags = Flags(uint8(file.ReadByte()))
+        Size = Header.UnSyncSafify(Header.ReadUInt32BE(file))
+    }
+
+    override prop Identifier string -> "ID3"
+    prop Version uint16
+    prop Flags Flags
+    override prop HeaderSize int32 -> 10
+
+    override func Render(stream Stream, renderSize int32, version uint16) {
+        stream.Write([]uint8{0x49, 0x44, 0x33})
+        stream.WriteByte(uint8((version >> 8)))
+        stream.WriteByte(uint8((version & uint16(0xff))))
+        stream.Write(Flags.ToBytes())
+        Header.WriteUInt32BE(stream, Header.SyncSafify(renderSize))
+    }
+
+    shared {
+        func Create(file Stream) Id3Header? {
+            try {
+                let bts = stackalloc [4]uint8
+                file.ReadExactly(bts)
+                if bts[0] == uint8('I') && bts[1] == uint8('D') && bts[2] == uint8('3') && bts[3] == uint8(2) || bts[3] == uint8(3) || bts[3] == uint8(4) {
+                    let version = uint16((bts[3] << 8 | file.ReadByte()))
+                    return Id3Header(version, file)
+                }
+                return nil
+            } catch (ex Exception) {
+                return nil
+            }
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Id3Tag.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Id3Tag.gs
@@ -1,0 +1,47 @@
+package Oahu.Decrypt.Mpeg4.ID3
+
+import System.IO
+import System.Linq
+
+class Id3Tag : Frame {
+    private init(file Stream, header Id3Header) : base(header, default(Frame)) {
+        let endPosition = file.Position + int64(Header.Size)
+        Id3Header = header
+        if (Id3Header.Flags[1]) {
+            Children.Add(Id3ExtendedHeader.Create(file, this))
+        }
+        LoadChildren(file, endPosition)
+    }
+
+    override prop Size int32 -> Children.Sum((f Frame) -> f.Size + f.Header.HeaderSize) + EmptyFrame.GetEmptyFrameSize(Version)
+    override prop Version uint16 -> Id3Header.Version
+
+    private prop Id3Header Id3Header {
+        get;
+        init;
+    }
+
+    func Save(file Stream) {
+        Save(file, Id3Header.Version)
+        EmptyFrame(this).Save(file, Id3Header.Version)
+    }
+
+    func Add(frame Frame) -> Children.Add(frame)
+
+    override func Render(file Stream) {
+    }
+
+    shared {
+        func Create(file Stream) Id3Tag? {
+            let id3Header = Id3Header.Create(file)
+            if id3Header == nil || !((id3Header!!.Version == uint16(0x200) || id3Header!!.Version == uint16(0x300) || id3Header!!.Version == uint16(0x400))) {
+                return nil
+            }
+            try {
+                return Id3Tag(file, id3Header!!)
+            } catch (ex Exception) {
+                return nil
+            }
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/InterleavedIterator_T.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/InterleavedIterator_T.gs
@@ -1,0 +1,48 @@
+package Oahu.Decrypt.Mpeg4.Chunks
+
+import System
+import System.Collections
+import System.Collections.Generic
+import System.Diagnostics.CodeAnalysis
+import System.Linq
+import Oahu.Decrypt.Mpeg4.Boxes
+
+class EnumerableExtensions {
+    private class InterleavedIterator[T](Enumerables []IEnumerable[T], Comparer Comparer[T]) : IEnumerable[T] {
+        func GetEnumerator() IEnumerator[T] {
+            let enumerators = Enumerables.Select((e IEnumerable[T]) -> e.GetEnumerator()).Select((e IEnumerator[T]) -> if e.MoveNext() { e } else { default(IEnumerator[T]?) }).ToArray()
+            while GetNextValue(enumerators, out var currentIndex, out var currentEnumerator) {
+                yield currentEnumerator!!.Current
+                if !currentEnumerator!!.MoveNext() {
+                    enumerators[currentIndex] = nil
+                }
+            }
+        }
+
+        private func GetEnumerator() IEnumerator -> GetEnumerator()
+
+        private func GetNextValue(enumerators []IEnumerator[T]?, out minIndex int32, out minValue IEnumerator[T]?) bool {
+            minIndex = -1
+            minValue = nil
+            for var i = 0; i < enumerators.Length; i++ {
+                if enumerators[i] is IEnumerator[T] && (minValue == nil || Comparer.Compare(minValue!!.Current, (enumerators[i] as IEnumerator[T])!!.Current) > 0) {
+                    var __decon0 = i
+                    var __decon1 = (enumerators[i] as IEnumerator[T])!!
+                    minIndex = __decon0
+                    minValue = __decon1
+                }
+            }
+            return minIndex != -1
+        }
+    }
+}
+
+func (track TrakBox) ChunkEntries() IEnumerable[ChunkEntry] -> ChunkEntryList(track)
+
+func (source IEnumerable[TSource]) InterleaveBy[TSource, TResult, TKey IComparable[TKey]](selector (TSource) -> IEnumerable[TResult], keySelector (TResult) -> TKey) IEnumerable[TResult] {
+    ArgumentNullException.ThrowIfNull(source, nameof(source))
+    ArgumentNullException.ThrowIfNull(selector, nameof(selector))
+    ArgumentNullException.ThrowIfNull(keySelector, nameof(keySelector))
+    let comparer = Comparer[TResult].Create((x TResult, y TResult) -> keySelector(x).CompareTo(keySelector(y)))
+    return InterleavedIterator[TResult](source.Select((s TSource) -> selector(s)).ToArray(), comparer!!)
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/LosslessFilter.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/LosslessFilter.gs
@@ -1,0 +1,54 @@
+package Oahu.Decrypt.FrameFilters.Audio
+
+import System.IO
+import System.Threading.Tasks
+
+internal open class LosslessFilter : FrameFinalBase[FrameEntry] {
+    let Mp4aWriter Mp4aWriter
+    private let chapterQueue ChapterQueue
+    private var lastChunkIndex int64 = -1
+
+    init(outputStream Stream, mp4Audio Mp4File, chapterQueue ChapterQueue) {
+        Mp4aWriter = Mp4aWriter(outputStream, mp4Audio.Ftyp, mp4Audio.Moov)
+        this.chapterQueue = chapterQueue
+    }
+
+    prop Closed bool
+    protected open override prop InputBufferSize int32 -> 1000
+
+    protected open override func FlushAsync() Task {
+        while chapterQueue.TryGetNextChapter(out var chapterEntry) {
+            Mp4aWriter.WriteChapter(chapterEntry!!)
+        }
+        CloseWriter()
+        return Task.CompletedTask
+    }
+
+    protected open override func PerformFilteringAsync(input FrameEntry) Task {
+        let chunkIndex = input.Chunk?.ChunkIndex ?? uint32(lastChunkIndex)
+        var newChunk = chunkIndex > lastChunkIndex
+        while chapterQueue.TryGetNextChapter(out var chapterEntry) {
+            Mp4aWriter.WriteChapter(chapterEntry!!)
+            newChunk = true
+        }
+        Mp4aWriter.AddFrame(input.FrameData.Span, newChunk, input.SamplesInFrame)
+        lastChunkIndex = chunkIndex
+        return Task.CompletedTask
+    }
+
+    protected open override func Dispose(disposing bool) {
+        if disposing && !Disposed {
+            CloseWriter()
+            Mp4aWriter?.Dispose()
+        }
+        base.Dispose(disposing)
+    }
+
+    private func CloseWriter() {
+        if Closed {
+            return
+        }
+        Mp4aWriter.Close()
+        Closed = true
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/LosslessMultipartFilter.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/LosslessMultipartFilter.gs
@@ -1,0 +1,60 @@
+package Oahu.Decrypt.FrameFilters.Audio
+
+import System
+import System.IO
+import Oahu.Decrypt.Mpeg4
+import Oahu.Decrypt.Mpeg4.Boxes
+
+internal open class LosslessMultipartFilter : MultipartFilterBase[FrameEntry, NewSplitCallback] {
+    private let ftyp FtypBox
+    private let moov MoovBox
+    private let newFileCallback (NewSplitCallback) -> void
+    private var mp4writer Mp4aWriter?
+
+    init(splitChapters ChapterInfo, ftyp FtypBox, moov MoovBox, newFileCallback (NewSplitCallback) -> void) : base(splitChapters, SampleRate(moov.AudioTrack.Mdia.Mdhd.Timescale), moov.AudioTrack.Mdia.Minf.Stbl.Stsd.AudioSampleEntry?.ChannelCount == (2 as uint16?)) {
+        this.ftyp = ftyp
+        this.moov = moov
+        this.newFileCallback = newFileCallback
+    }
+
+    prop CurrentWriterOpen bool
+    protected open override prop InputBufferSize int32 -> 1000
+
+    protected open override func CloseCurrentWriter() {
+        if !CurrentWriterOpen {
+            return
+        }
+        mp4writer?.Close()
+        mp4writer?.OutputFile.Close()
+        CurrentWriterOpen = false
+    }
+
+    protected open override func WriteFrameToFile(audioFrame FrameEntry, newChunk bool) {
+        mp4writer?.AddFrame(audioFrame.FrameData.Span, newChunk, audioFrame.SamplesInFrame)
+    }
+
+    protected open override func CreateNewWriter(callback NewSplitCallback) {
+        newFileCallback(callback)
+        let outfile Stream? = callback.OutputFile as Stream
+        if outfile == nil {
+            throw InvalidOperationException("Output file stream null")
+        }
+        CurrentWriterOpen = true
+        mp4writer = Mp4aWriter(outfile, ftyp, moov)
+        mp4writer!!.RemoveTextTrack()
+        if mp4writer!!.Moov.ILst != nil {
+            let tags = MetadataItems(mp4writer!!.Moov.ILst!!)
+            if callback.TrackNumber.HasValue && callback.TrackCount.HasValue {
+                tags!!.TrackNumber = (callback.TrackNumber.Value, callback.TrackCount.Value)
+            }
+            tags!!.Title = callback.TrackTitle ?? tags!!.Title
+        }
+    }
+
+    protected open override func Dispose(disposing bool) {
+        if disposing && !Disposed {
+            CloseCurrentWriter()
+        }
+        base.Dispose(disposing)
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/MdatBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/MdatBox.gs
@@ -1,0 +1,21 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.IO
+import System.Threading
+import System.Threading.Tasks
+import Oahu.Decrypt.Mpeg4.Util
+
+open class MdatBox : Box {
+    init(header BoxHeader) : base(header, nil) {
+    }
+
+    async func ShiftMdatAsync(file Stream, shiftVector int64, progressTracker ProgressTracker? = nil, cancellationToken CancellationToken = default(CancellationToken)) {
+        await Mpeg4Util.ShiftDataBlock(file, Header.FilePosition, Header.TotalBoxSize, shiftVector, progressTracker, cancellationToken).ConfigureAwait(false)
+        this.Header.FilePosition += shiftVector
+    }
+
+    protected open override func Render(file Stream) {
+        throw NotSupportedException()
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/MdhdBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/MdhdBox.gs
@@ -1,0 +1,51 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class MdhdBox : HeaderBox {
+    private var language string
+
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        let blob = file.ReadBlock(4)
+        let reader = BitReader(blob!!)
+        reader!!.Position = 1
+        let c1 = char((reader!!.Read(5) + uint32(0x60)))
+        let c2 = char((reader!!.Read(5) + uint32(0x60)))
+        let c3 = char((reader!!.Read(5) + uint32(0x60)))
+        language = string([]char{c1, c2, c3})
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(8)
+    prop Timescale uint32
+
+    prop Language string {
+        get -> language
+        set {
+            if value.Length != 3 || value[0] < 'a' || value[0] > 'z' || value[1] < 'a' || value[1] > 'z' || value[2] < 'a' || value[2] > 'z' {
+                throw ArgumentException("value must be three, lowercase ASCII characters", nameof(Language))
+            }
+            language = value
+        }
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        let writer = BitWriter()
+        writer!!.Write(0, 1)
+        writer!!.Write(uint32(Language[0]) - uint32(0x60), 5)
+        writer!!.Write(uint32(Language[1]) - uint32(0x60), 5)
+        writer!!.Write(uint32(Language[2]) - uint32(0x60), 5)
+        writer!!.Write(0, 16)
+        file.Write(writer!!.ToByteArray())
+    }
+
+    protected open override func ReadBeforeDuration(file Stream) {
+        Timescale = file.ReadUInt32BE()
+    }
+
+    protected open override func WriteBeforeDuration(file Stream) {
+        file.WriteUInt32BE(Timescale)
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/MdiaBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/MdiaBox.gs
@@ -1,0 +1,17 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+
+open class MdiaBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        LoadChildren(file)
+    }
+
+    prop Mdhd MdhdBox -> GetChildOrThrow[MdhdBox]()
+    prop Hdlr HdlrBox -> GetChildOrThrow[HdlrBox]()
+    prop Minf MinfBox -> GetChildOrThrow[MinfBox]()
+
+    protected open override func Render(file Stream) {
+        return
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/MeanBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/MeanBox.gs
@@ -1,0 +1,38 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.Diagnostics
+import System.IO
+import System.Text
+import Oahu.Decrypt.Mpeg4.Util
+
+@DebuggerDisplay("{DebuggerDisplay,nq}")
+open class MeanBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        let stringSize = RemainingBoxLength(file)
+        let stringData = file.ReadBlock(int32(stringSize))
+        ReverseDnsDomain = Encoding.UTF8.GetString(stringData!!)
+    }
+
+    private init(header BoxHeader, parent IBox?, domain string) : base([4]uint8, header, parent) {
+        ReverseDnsDomain = domain
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(Encoding.UTF8.GetByteCount(ReverseDnsDomain))
+    prop ReverseDnsDomain string
+    private prop DebuggerDisplay string -> "domain: $ReverseDnsDomain"
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.Write(Encoding.UTF8.GetBytes(ReverseDnsDomain))
+    }
+
+    shared {
+        func Create(parent IBox?, domain string) MeanBox {
+            let size = Encoding.UTF8.GetByteCount(domain) + 12
+            let header = BoxHeader(uint32(size), "mean")
+            let meanBox = MeanBox(header, parent, domain)
+            parent?.Children.Add(meanBox)
+            return meanBox
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/MehdBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/MehdBox.gs
@@ -1,0 +1,26 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class MehdBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        FragmentDuration = if Version == uint8(1) { file.ReadUInt64BE() } else { uint64(file.ReadUInt32BE()) }
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64((if Version == uint8(1) { 8 } else { 4 }))
+
+    prop FragmentDuration uint64 {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        if Version == uint8(1) {
+            file.WriteUInt64BE(FragmentDuration)
+        } else {
+            file.WriteUInt32BE(uint32(FragmentDuration))
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/MetaBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/MetaBox.gs
@@ -1,0 +1,20 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+
+class MetaBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        LoadChildren(file)
+    }
+
+    private init(parent IBox) : base([]uint8{uint8(0), uint8(0), uint8(0), uint8(0)}, BoxHeader(8, "meta"), parent) {
+    }
+
+    shared {
+        func CreateEmpty(parent IBox) MetaBox {
+            let meta = MetaBox(parent)
+            parent.Children.Add(meta!!)
+            return meta!!
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/MetadataItems.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/MetadataItems.gs
@@ -1,0 +1,182 @@
+package Oahu.Decrypt.Mpeg4
+
+import System.Buffers.Binary
+import System.IO
+import Oahu.Decrypt.Mpeg4.Boxes
+
+class MetadataItems(AppleListBox AppleListBox) {
+    prop FirstAuthor string? -> Artist?.Split(';')?[0]
+    prop TitleSansUnabridged string? -> Title?.Replace(" (Unabridged)", "")
+    prop BookCopyright string? -> if GetCopyrights() != nil && GetCopyrights()!!!!.Length > 0 { GetCopyrights()!!!![0] } else { default }
+    prop RecordingCopyright string? -> if GetCopyrights() != nil && GetCopyrights()!!!!.Length > 1 { GetCopyrights()!!!![1] } else { default }
+
+    prop Title string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameTitle)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameTitle, value)
+    }
+
+    prop Producer string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameProducer)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameProducer, value)
+    }
+
+    prop Artist string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameArtist)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameArtist, value)
+    }
+
+    prop AlbumArtists string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameAlbumArtist)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameAlbumArtist, value)
+    }
+
+    prop Album string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameAlbum)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameAlbum, value)
+    }
+
+    prop Genres string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameGenres)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameGenres, value)
+    }
+
+    prop ProductID string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameProductId)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameProductId, value)
+    }
+
+    prop Comment string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameComment)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameComment, value)
+    }
+
+    prop LongDescription string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameLongDescription)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameLongDescription, value)
+    }
+
+    prop Copyright string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameCopyright)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameCopyright, value)
+    }
+
+    prop Publisher string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNamePublisher)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNamePublisher, value)
+    }
+
+    prop Year string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameYear)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameYear, value)
+    }
+
+    prop Narrator string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameNarrator)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameNarrator, value)
+    }
+
+    prop Asin string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameAsin)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameAsin, value)
+    }
+
+    prop ReleaseDate string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameReleaseDate)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameReleaseDate, value)
+    }
+
+    prop Acr string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameAcr)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameAcr, value)
+    }
+
+    prop Version string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameVersion)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameVersion, value)
+    }
+
+    prop Encoder string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameEncoder)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameEncoder, value)
+    }
+
+    prop Cover []?uint8 {
+        get -> AppleListBox.GetTagBox(MetadataItems.TagNameCover)?.Data.Data
+        set -> SetCoverArt(value)
+    }
+
+    prop CoverFormat AppleDataType? -> AppleListBox.GetTagBox(MetadataItems.TagNameCover)?.Data.DataType
+
+    prop TrackNumber TrackNumber? {
+        get -> AppleListBox.GetTagData[TrackNumber](MetadataItems.TagNameTrackNumber)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameTrackNumber, value)
+    }
+
+    prop DiskNumber DiskNumber? {
+        get -> AppleListBox.GetTagData[DiskNumber](MetadataItems.TagNameDiskNumber)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameDiskNumber, value)
+    }
+
+    private func GetCopyrights() []?string -> Copyright?.Replace("&#169;", "©")?.Split(';')
+
+    private func SetCoverArt(coverArtBytes []?uint8) {
+        let EditOrAdd = func (dataType AppleDataType) {
+            if AppleListBox.GetTagBox(MetadataItems.TagNameCover) != nil && AppleListBox.GetTagBox(MetadataItems.TagNameCover)!!!!.Data.DataType != dataType {
+                AppleListBox.RemoveTag(AppleListBox.GetTagBox(MetadataItems.TagNameCover)!!!!)
+                AppleListBox.GetTagBox(MetadataItems.TagNameCover)!!!!.Dispose()
+            }
+            AppleListBox.EditOrAddTag(MetadataItems.TagNameCover, coverArtBytes!!, dataType)
+        }
+        if coverArtBytes == nil {
+            AppleListBox.RemoveTag(MetadataItems.TagNameCover)
+        } else if coverArtBytes!!.Length >= 2 && BinaryPrimitives.ReadInt16LittleEndian(coverArtBytes!!) == int16(0x4D42) {
+            EditOrAdd(AppleDataType.BMP)
+        } else if coverArtBytes!!.Length >= 3 && (BinaryPrimitives.ReadInt32LittleEndian(coverArtBytes!!) & 0xFFFFFF) == 0xFFD8FF {
+            EditOrAdd(AppleDataType.JPEG)
+        } else if coverArtBytes!!.Length >= 8 && BinaryPrimitives.ReadInt64LittleEndian(coverArtBytes!!) == 0xA1A0A0D474e5089L {
+            EditOrAdd(AppleDataType.PNG)
+        } else {
+            throw InvalidDataException("Image data is not a jpeg, PNG, or windows bitmap.")
+        }
+    }
+
+    shared {
+        const TagNameTitle string = "©nam"
+        const TagNameProducer string = "©prd"
+        const TagNameArtist string = "©ART"
+        const TagNameAlbumArtist string = "aART"
+        const TagNameAlbum string = "©alb"
+        const TagNameGenres string = "©gen"
+        const TagNameProductId string = "prID"
+        const TagNameComment string = "©cmt"
+        const TagNameLongDescription string = "©des"
+        const TagNameCopyright string = "cprt"
+        const TagNamePublisher string = "©pub"
+        const TagNameYear string = "©day"
+        const TagNameNarrator string = "©nrt"
+        const TagNameAsin string = "CDEK"
+        const TagNameReleaseDate string = "rldt"
+        const TagNameAcr string = "AACR"
+        const TagNameVersion string = "VERS"
+        const TagNameEncoder string = "©too"
+        const TagNameCover string = "covr"
+        const TagNameTrackNumber string = "trkn"
+        const TagNameDiskNumber string = "disk"
+
+        func FromFile(mp4File string) MetadataItems? {
+            using let file = File.Open(mp4File, FileMode.Open, FileAccess.Read, FileShare.Read)
+            var header BoxHeader
+            do {
+                header = BoxHeader(file!!)
+                if header.Type == "moov" {
+                    continue
+                } else if header.Type == "udta" {
+                    break
+                } else {
+                    file!!.Position += header.TotalBoxSize - int64(header.HeaderSize)
+                }
+            } while file!!.Position < file!!.Length
+            return if header?.Type == "udta" && UdtaBox(file!!, header, nil)?.GetChild[MetaBox]()?.GetChild[AppleListBox]() != nil { MetadataItems(UdtaBox(file!!, header, nil)?.GetChild[MetaBox]()?.GetChild[AppleListBox]()!!!!) } else { default(MetadataItems?) }
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/MfhdBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/MfhdBox.gs
@@ -1,0 +1,22 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class MfhdBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        SequenceNumber = file.ReadInt32BE()
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(4)
+
+    prop SequenceNumber int32 {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.WriteInt32BE(SequenceNumber)
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/MinfBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/MinfBox.gs
@@ -1,0 +1,15 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+
+open class MinfBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        LoadChildren(file)
+    }
+
+    prop Stbl StblBox -> GetChildOrThrow[StblBox]()
+
+    protected open override func Render(file Stream) {
+        return
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/MoofBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/MoofBox.gs
@@ -1,0 +1,16 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+
+open class MoofBox : Box {
+    init(file Stream, header BoxHeader) : base(header, nil) {
+        LoadChildren(file)
+    }
+
+    prop Mfhd MfhdBox -> GetChildOrThrow[MfhdBox]()
+    prop Traf TrafBox -> GetChildOrThrow[TrafBox]()
+
+    protected open override func Render(file Stream) {
+        return
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/MoovBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/MoovBox.gs
@@ -1,0 +1,103 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.Collections.Generic
+import System.IO
+import System.Linq
+
+open class MoovBox : Box {
+    init(file Stream, header BoxHeader) : base(header, nil) {
+        LoadChildren(file)
+    }
+
+    prop Mvhd MvhdBox -> GetChildOrThrow[MvhdBox]()
+    prop AudioTrack TrakBox -> Tracks.Where((t TrakBox) -> t.GetChild[MdiaBox]()?.GetChild[HdlrBox]()?.HandlerType == "soun").First()
+    prop VideoTrack TrakBox? -> Tracks.Where((t TrakBox) -> t.GetChild[MdiaBox]()?.GetChild[HdlrBox]()?.HandlerType == "vide").FirstOrDefault()
+    prop TextTrack TrakBox? -> Tracks.Where((t TrakBox) -> t.GetChild[MdiaBox]()?.GetChild[HdlrBox]()?.HandlerType == "text").FirstOrDefault()
+    prop ILst AppleListBox? -> GetChild[UdtaBox]()?.GetChild[MetaBox]()?.GetChild[AppleListBox]()
+    prop Tracks IEnumerable[TrakBox] -> GetChildren[TrakBox]()
+
+    func ShiftChunkOffsets(shiftVector int64) {
+        for track in Tracks {
+            var coBox = track!!.Mdia.Minf.Stbl.COBox
+            let offsets = coBox.ChunkOffsets
+            var requires64Bit = false
+            for var i = 0; i < offsets.Count; i++ {
+                let offset = offsets.GetOffsetAtIndex(i)
+                let newOffset = offset + shiftVector
+                requires64Bit |= newOffset > int64(UInt32.MaxValue)
+                offsets.SetOffsetAtIndex(i, newOffset)
+            }
+            if requires64Bit && coBox is StcoBox {
+                track!!.Mdia.Minf.Stbl.Children.Remove(coBox)
+                coBox = Co64Box.CreateBlank(track!!.Mdia.Minf.Stbl, offsets)
+            } else if !requires64Bit && coBox is Co64Box {
+                track!!.Mdia.Minf.Stbl.Children.Remove(coBox)
+                coBox = StcoBox.CreateBlank(track!!.Mdia.Minf.Stbl, offsets)
+            }
+        }
+    }
+
+    func ShiftChunkOffsetsWithMoovInFront(shiftVector int64) int64 {
+        var shiftVector = shiftVector
+        var shifted int64 = 0
+        do {
+            let moovSize = RenderSize
+            ShiftChunkOffsets(shiftVector)
+            shifted += shiftVector
+            shiftVector = RenderSize - moovSize
+        } while shiftVector != int64(0)
+        return shifted
+    }
+
+    func CreateEmptyMetadata() AppleListBox {
+        let ilist AppleListBox? = ILst as AppleListBox
+        if ilist != nil {
+            return ilist
+        } else {
+            let udata = UdtaBox.CreateEmpty(this)
+            let meta = MetaBox.CreateEmpty(udata!!)
+            let hdlr = HdlrBox.Create("mdir", nil, []uint8{uint8(0x61), uint8(0x70), uint8(0x70), uint8(0x6c)}, meta!!)
+            return AppleListBox.CreateEmpty(meta!!)
+        }
+    }
+
+    func CreateEmptyTextTrack() TrakBox {
+        let txt TrakBox? = TextTrack as TrakBox
+        if txt != nil {
+            return txt
+        } else {
+            using let ms = MemoryStream(MoovBox.EmptyTextTrack)
+            let textTrack = BoxFactory.CreateBox[TrakBox](ms!!, nil)
+            Children.Insert(Children.IndexOf(AudioTrack) + 1, textTrack!!)
+            textTrack!!.Tkhd.TrackID = Mvhd.NextTrackID
+            Mvhd.NextTrackID++
+            let references = GetChildren[TrakBox]().Except([]TrakBox{AudioTrack}).Select((t TrakBox) -> t.Tkhd.TrackID).Order().ToHashSet()
+            let tref TrefBox? = AudioTrack.GetChild[TrefBox]() as TrefBox
+            if tref != nil {
+                let referenceType ITrackReferenceTypeBox? = tref.References.FirstOrDefault((r ITrackReferenceTypeBox) -> r.Header.Type == "chap") as ITrackReferenceTypeBox
+                if referenceType != nil {
+                    referenceType!!.TrackIds = references
+                } else {
+                    tref.AddReference("chap", references)
+                }
+            } else {
+                TrefBox.CreatEmpty(AudioTrack).AddReference("chap", references)
+            }
+            textTrack!!.Mdia.Mdhd.ModificationTime = DateTimeOffset.UtcNow
+            textTrack!!.Mdia.Mdhd.CreationTime = textTrack!!.Mdia.Mdhd.ModificationTime
+            textTrack!!.Tkhd.ModificationTime = textTrack!!.Mdia.Mdhd.CreationTime
+            textTrack!!.Tkhd.CreationTime = textTrack!!.Tkhd.ModificationTime
+            textTrack!!.Mdia.Mdhd.Timescale = AudioTrack.Mdia.Mdhd.Timescale
+            return textTrack!!
+        }
+    }
+
+    protected open override func Render(file Stream) {
+        return
+    }
+
+    shared {
+        private let EmptyTextTrack []uint8 = []uint8{uint8(0x00), uint8(0x00), uint8(0x02), uint8(0x11), uint8(0x74), uint8(0x72), uint8(0x61), uint8(0x6b), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x5c), uint8(0x74), uint8(0x6b), uint8(0x68), uint8(0x64), uint8(0x00), uint8(0x00), uint8(0x10), uint8(0x01), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x01), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x01), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x01), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x40), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0xa0), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0xa0), uint8(0x00), uint8(0x00), uint8(0x01), uint8(0x70), uint8(0x6d), uint8(0x64), uint8(0x69), uint8(0x61), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x20), uint8(0x6d), uint8(0x64), uint8(0x68), uint8(0x64), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x35), uint8(0x33), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x39), uint8(0x68), uint8(0x64), uint8(0x6c), uint8(0x72), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x6d), uint8(0x68), uint8(0x6c), uint8(0x72), uint8(0x74), uint8(0x65), uint8(0x78), uint8(0x74), uint8(0x61), uint8(0x70), uint8(0x70), uint8(0x6c), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x18), uint8(0x41), uint8(0x70), uint8(0x70), uint8(0x6c), uint8(0x65), uint8(0x20), uint8(0x54), uint8(0x65), uint8(0x78), uint8(0x74), uint8(0x20), uint8(0x4d), uint8(0x65), uint8(0x64), uint8(0x69), uint8(0x61), uint8(0x20), uint8(0x48), uint8(0x61), uint8(0x6e), uint8(0x64), uint8(0x6c), uint8(0x65), uint8(0x72), uint8(0x00), uint8(0x00), uint8(0x01), uint8(0x0f), uint8(0x6d), uint8(0x69), uint8(0x6e), uint8(0x66), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x4c), uint8(0x67), uint8(0x6d), uint8(0x68), uint8(0x64), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x18), uint8(0x67), uint8(0x6d), uint8(0x69), uint8(0x6e), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x40), uint8(0x80), uint8(0x00), uint8(0x80), uint8(0x00), uint8(0x80), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x2c), uint8(0x74), uint8(0x65), uint8(0x78), uint8(0x74), uint8(0x00), uint8(0x01), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x01), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x40), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x24), uint8(0x64), uint8(0x69), uint8(0x6e), uint8(0x66), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x1c), uint8(0x64), uint8(0x72), uint8(0x65), uint8(0x66), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x01), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x0c), uint8(0x61), uint8(0x6c), uint8(0x69), uint8(0x73), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x01), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x97), uint8(0x73), uint8(0x74), uint8(0x62), uint8(0x6c), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x4b), uint8(0x73), uint8(0x74), uint8(0x73), uint8(0x64), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x01), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x3b), uint8(0x74), uint8(0x65), uint8(0x78), uint8(0x74), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x01), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x01), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x01), uint8(0xff), uint8(0xff), uint8(0xff), uint8(0xff), uint8(0xff), uint8(0xff), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x10), uint8(0x73), uint8(0x74), uint8(0x74), uint8(0x73), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x10), uint8(0x73), uint8(0x74), uint8(0x73), uint8(0x63), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x10), uint8(0x73), uint8(0x74), uint8(0x63), uint8(0x6f), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x14), uint8(0x73), uint8(0x74), uint8(0x73), uint8(0x7a), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x3d), uint8(0x75), uint8(0x64), uint8(0x74), uint8(0x61), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x35), uint8(0x6d), uint8(0x65), uint8(0x74), uint8(0x61), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x21), uint8(0x68), uint8(0x64), uint8(0x6c), uint8(0x72), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x6d), uint8(0x64), uint8(0x69), uint8(0x72), uint8(0x61), uint8(0x70), uint8(0x70), uint8(0x6c), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x08), uint8(0x69), uint8(0x6c), uint8(0x73), uint8(0x74)}
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Mp4File.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Mp4File.gs
@@ -1,0 +1,147 @@
+package Oahu.Decrypt
+
+import System
+import System.IO
+import System.Linq
+import System.Threading.Tasks
+import Oahu.Decrypt.Chunks
+import Oahu.Decrypt.FrameFilters
+import Oahu.Decrypt.FrameFilters.Audio
+import Oahu.Decrypt.FrameFilters.Text
+import Oahu.Decrypt.Mpeg4
+import Oahu.Decrypt.Mpeg4.Boxes
+import Oahu.Decrypt.Mpeg4.Util
+
+enum FileType { Aax, Aaxc, Mpeg4, Dash }
+enum SampleRate { Hz_96000, Hz_88200, Hz_64000, Hz_48000, Hz_44100, Hz_32000, Hz_24000, Hz_22050, Hz_16000, Hz_12000, Hz_11025, Hz_8000, Hz_7350 }
+
+open class Mp4File : Mpeg4File {
+    init(file Stream, fileSize int64) : base(file, fileSize) {
+        FileType = if Ftyp.CompatibleBrands.Any((b string) -> b == "dash") { FileType.Dash } else { (switch Ftyp.MajorBrand {
+            case "aax ": FileType.Aax
+            case "aaxc": FileType.Aaxc
+            default: FileType.Mpeg4
+        }) }
+    }
+
+    convenience init(file Stream) {
+        init(file, file.Length)
+    }
+
+    convenience init(fileName string, access FileAccess = 1, share FileShare = 1) {
+        init(File.Open(fileName, FileMode.Open, access, share))
+    }
+
+    prop FileType FileType {
+        get;
+        init;
+    }
+
+    prop SampleRate SampleRate -> SampleRate(TimeScale)
+    open func GetAudioFrameFilter() FrameTransformBase[FrameEntry, FrameEntry] -> AacValidateFilter()
+
+    func SaveAsync(keepMoovInFront bool = true) Mp4Operation {
+        let tracker = ProgressTracker{TotalDuration: Duration}
+        let operation = Mp4Operation((t CancellationTokenSource) -> SaveAsync(keepMoovInFront, tracker, t.Token), this, (t Task) -> {
+        })
+        tracker.ProgressUpdated += (_ object?, _ EventArgs) -> operation.OnProgressUpdate(ConversionProgressEventArgs(TimeSpan.Zero, tracker.TotalDuration, tracker.Position, tracker.Speed))
+        return operation
+    }
+
+    func ConvertToMp4aAsync(outputStream Stream, userChapters ChapterInfo? = nil) Mp4Operation {
+        let start = userChapters?.StartOffset ?? TimeSpan.Zero
+        let end = userChapters?.EndOffset ?? TimeSpan.MaxValue
+        let chapterQueue = ChapterQueue(SampleRate, SampleRate)
+        if userChapters != nil {
+            if Moov.TextTrack == nil {
+                Moov.CreateEmptyTextTrack()
+            }
+            chapterQueue.AddRange(userChapters!!)
+        }
+        let filter1 = GetAudioFrameFilter()
+        let filter2 = LosslessFilter(outputStream, this, chapterQueue)
+        filter1.LinkTo(filter2)
+        if Moov.TextTrack != nil && userChapters == nil {
+            let c1 = ChapterFilter()
+            c1.ChapterRead += (_ object?, e FrameEntry) -> chapterQueue.Add(e)
+            let Continuation = func (t Task) {
+                filter1.Dispose()
+                c1.Dispose()
+                outputStream.Close()
+            }
+            return ProcessAudio(start, end, Continuation, (Moov.AudioTrack, filter1), (Moov.TextTrack!!, c1))
+        } else {
+            let Continuation = func (t Task) {
+                filter1.Dispose()
+                outputStream.Close()
+            }
+            return ProcessAudio(start, end, Continuation, (Moov.AudioTrack, filter1))
+        }
+    }
+
+    func ConvertToMultiMp4aAsync(userChapters ChapterInfo, newFileCallback (NewSplitCallback) -> void) Mp4Operation {
+        let f1 = GetAudioFrameFilter()
+        let f2 = LosslessMultipartFilter(userChapters, Ftyp, Moov, newFileCallback)
+        f1.LinkTo(f2)
+        let Continuation = func (t Task) {
+            f1.Dispose()
+        }
+        return ProcessAudio(userChapters.StartOffset, userChapters.EndOffset, Continuation, (Moov.AudioTrack, f1))
+    }
+
+    func GetChapterInfoAsync() Mp4Operation[ChapterInfo?] {
+        let textTrack TrakBox? = Moov.TextTrack as TrakBox
+        if textTrack == nil {
+            return Mp4Operation[ChapterInfo?].FromCompleted(this, nil)
+        }
+        let chapterFilter = ChapterFilter()
+        let chapterQueue = ChapterQueue(SampleRate, SampleRate)
+        chapterFilter.ChapterRead += (s object?, e FrameEntry) -> chapterQueue.Add(e)
+        let Continuation = func (t Task) ChapterInfo? {
+            let chapters = ChapterInfo()
+            while chapterQueue.TryGetNextChapter(out var ch) {
+                chapters.AddChapter(ch!!.Title, TimeSpan.FromSeconds(float64(ch!!.SamplesInFrame) / float64(SampleRate)))
+            }
+            chapterFilter.Dispose()
+            Chapters ??= chapters
+            return chapters
+        }
+        return ProcessAudio(TimeSpan.Zero, TimeSpan.MaxValue, Continuation!!, (Moov.TextTrack!!, chapterFilter))
+    }
+
+    open func ProcessAudio(startTime TimeSpan, endTime TimeSpan, continuation (Task) -> void, filters ...(TrakBox, FrameFilterBase[FrameEntry])) Mp4Operation {
+        let reader = CreateChunkReader(InputStream, startTime, Mp4File.Min(Duration, endTime))
+        for __decon0 in filters {
+            let (track, filter) = __decon0
+            reader.AddTrack(track, filter)
+        }
+        let operation = Mp4Operation(reader.RunAsync, this, continuation)
+        reader.OnProgressUpdateDelegate = operation!!.OnProgressUpdate
+        return operation!!
+    }
+
+    func ProcessAudio[TResult](startTime TimeSpan, endTime TimeSpan, continuation (Task) -> TResult, filters ...(TrakBox, FrameFilterBase[FrameEntry])) Mp4Operation[TResult] {
+        let reader = CreateChunkReader(InputStream, startTime, Mp4File.Min(Duration, endTime))
+        for __decon1 in filters {
+            let (track, filter) = __decon1
+            reader.AddTrack(track, filter)
+        }
+        let operation = Mp4Operation[TResult](reader.RunAsync, this, continuation)
+        reader.OnProgressUpdateDelegate = operation!!.OnProgressUpdate
+        return operation!!
+    }
+
+    protected open func CreateChunkReader(inputStream Stream, startTime TimeSpan, endTime TimeSpan) IChunkReader -> ChunkReader(inputStream, startTime, endTime)
+
+    shared {
+        func RelocateMoovAsync(mp4FilePath string) Mp4Operation {
+            let tracker = ProgressTracker()
+            let moovMover Mp4Operation? = Mp4Operation((t CancellationTokenSource) -> Mpeg4File.RelocateMoovToBeginningAsync(mp4FilePath, tracker, t.Token), nil, (t Task) -> {
+            })
+            tracker.ProgressUpdated += (_ object?, _ EventArgs) -> moovMover!!.OnProgressUpdate(ConversionProgressEventArgs(TimeSpan.Zero, tracker.TotalDuration, tracker.Position, tracker.Speed))
+            return moovMover!!
+        }
+
+        private func Min(t1 TimeSpan, t2 TimeSpan) TimeSpan -> if t1 > t2 { t2 } else { t1 }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Mp4Operation.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Mp4Operation.gs
@@ -1,0 +1,92 @@
+package Oahu.Decrypt
+
+import System
+import System.Linq
+import System.Runtime.CompilerServices
+import System.Threading
+import System.Threading.Tasks
+
+open class Mp4Operation {
+    private let cancellationSource CancellationTokenSource = CancellationTokenSource()
+    private let startAction async (CancellationTokenSource) -> void
+    private let continuationAction ((Task) -> void)?
+    private var lastArgs ConversionProgressEventArgs?
+    private var continuation Task?
+    private var readerTask Task?
+
+    internal convenience init(startAction async (CancellationTokenSource) -> void, mp4File Mp4File?, continuationTask (Task) -> void) {
+        init(startAction, mp4File)
+        continuationAction = continuationTask
+    }
+
+    protected init(startAction async (CancellationTokenSource) -> void, mp4File Mp4File?) {
+        this.startAction = startAction
+        Mp4File = mp4File
+    }
+
+    event ConversionProgressUpdate (object?, ConversionProgressEventArgs) -> void
+    prop IsCompleted bool -> Continuation?.IsCompleted == true
+    prop IsFaulted bool -> readerTask?.IsFaulted == true
+    prop IsCanceled bool -> readerTask?.IsCanceled == true
+    prop IsCompletedSuccessfully bool -> readerTask?.IsCompletedSuccessfully == true && Continuation?.IsCompletedSuccessfully == true
+    prop CurrentProcessPosition TimeSpan -> lastArgs?.ProcessPosition ?? TimeSpan.Zero
+    prop ProcessSpeed float64 -> lastArgs?.ProcessSpeed ?? float64(0.0)
+    prop TaskStatus TaskStatus -> readerTask?.Status ?? TaskStatus.Created
+    prop OperationTask Task -> Continuation
+
+    prop Mp4File Mp4File? {
+        get;
+        init;
+    }
+
+    protected open prop Continuation Task? -> continuation ?? Task.CompletedTask
+
+    func CancelAsync() Task {
+        cancellationSource.Cancel()
+        return if Continuation == nil { Task.FromCanceled(cancellationSource.Token) } else { Continuation!! }
+    }
+
+    func Start() {
+        if readerTask == nil {
+            readerTask = Task.Run(() -> startAction(cancellationSource))
+            SetContinuation(readerTask!!)
+        }
+    }
+
+    func GetAwaiter() ConfiguredTaskAwaitable.ConfiguredTaskAwaiter {
+        Start()
+        return Continuation!!.ConfigureAwait(false).GetAwaiter()
+    }
+
+    internal func OnProgressUpdate(args ConversionProgressEventArgs) {
+        lastArgs = args
+        ConversionProgressUpdate?(this, args)
+    }
+
+    protected open func SetContinuation(readerTask Task) {
+        continuation = readerTask.ContinueWith((t Task) -> {
+            try {
+                continuationAction?(t)
+            } catch (ex Exception) {
+                if t.Exception == nil && !t.IsCanceled {
+                    throw ex
+                }
+                if t.Exception != nil {
+                    throw AggregateException("Two or more errors occurred.", t.Exception!!.InnerExceptions.Append(ex))
+                }
+                throw ex
+            }
+            if t.IsFaulted && t.Exception != nil {
+                throw t.Exception
+            }
+            if t.IsCanceled {
+                throw TaskCanceledException("The decryption operation was cancelled.", nil, cancellationSource.Token)
+            }
+        }, TaskContinuationOptions.ExecuteSynchronously)
+    }
+
+    shared {
+        func FromCompleted(mp4File Mp4File?) Mp4Operation -> Mp4Operation((c CancellationTokenSource) -> Task.CompletedTask, mp4File, (_ Task) -> {
+        })
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Mp4Operation_TOutput.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Mp4Operation_TOutput.gs
@@ -1,0 +1,37 @@
+package Oahu.Decrypt
+
+import System
+import System.Runtime.CompilerServices
+import System.Threading
+import System.Threading.Tasks
+
+open class Mp4Operation[TOutput] : Mp4Operation {
+    private let continuationFunc (Task) -> TOutput?
+    private var continuation Task[TOutput?]?
+
+    internal init(startAction async (CancellationTokenSource) -> void, mp4File Mp4File, continuationFunc (Task) -> TOutput) : base(startAction, mp4File) {
+        this.continuationFunc = continuationFunc
+    }
+
+    prop OperationTask Task[TOutput?] -> continuation ?? Task.FromResult[TOutput](default)
+    protected open override prop Continuation Task -> continuation ?? Task.CompletedTask
+
+    func GetAwaiter() TaskAwaiter[TOutput?] {
+        Start()
+        return (continuation ?? Task.FromResult[TOutput](default)).GetAwaiter()
+    }
+
+    protected open override func SetContinuation(readerTask Task) {
+        continuation = readerTask.ContinueWith((t Task) -> {
+            if t.IsFaulted {
+                continuationFunc(t)
+                throw t.Exception
+            }
+            return continuationFunc(t)
+        }, TaskContinuationOptions.ExecuteSynchronously)
+    }
+
+    shared {
+        func FromCompleted(mp4File Mp4File, result TOutput) Mp4Operation[TOutput] -> Mp4Operation[TOutput]((c CancellationTokenSource) -> Task.CompletedTask, mp4File, (_ Task) -> result)
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Mp4aWriter.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Mp4aWriter.gs
@@ -1,0 +1,377 @@
+package Oahu.Decrypt.FrameFilters.Audio
+
+import System
+import System.Collections.Generic
+import System.Diagnostics
+import System.IO
+import System.Linq
+import Oahu.Decrypt.Mpeg4.Boxes
+import Oahu.Decrypt.Mpeg4.Util
+
+open class Mp4aWriter : IDisposable {
+    let Moov MoovBox
+    private let mdatStart int64
+    private let stts SttsBox
+    private let stsc StscBox
+    private let audioSampleEntry AudioSampleEntry
+    private let audioChunks ChunkOffsetList = ChunkOffsetList()
+    private let textChunks ChunkOffsetList = ChunkOffsetList()
+    private let audioSampleSizes List[uint16] = List[uint16]()
+    private let textSampleSizes List[int32] = List[int32]()
+    private let lockObj object = System.Object()
+    private let chapterTitles List[string] = List[string]()
+    private var lastSamplesPerChunk int64 = -1
+    private var samplesPerChunk uint32 = uint32(0)
+    private var currentChunk uint32 = uint32(0)
+    private var closed bool
+    private var closing bool
+    private var currentFrameDuration uint32
+    private var frameDurationCount uint32
+    private var disposed bool = false
+
+    init(outputFile Stream, ftyp FtypBox, moov MoovBox) {
+        ArgumentNullException.ThrowIfNull(outputFile, nameof(outputFile))
+        ArgumentNullException.ThrowIfNull(ftyp, nameof(ftyp))
+        ArgumentNullException.ThrowIfNull(moov, nameof(moov))
+        if !outputFile.CanWrite {
+            throw ArgumentException("The stream is not writable", nameof(outputFile))
+        }
+        OutputFile = outputFile
+        Moov = Mp4aWriter.MakeBlankMoov(moov)
+        stts = Moov.AudioTrack.Mdia.Minf.Stbl.Stts
+        stsc = Moov.AudioTrack.Mdia.Minf.Stbl.Stsc
+        audioSampleEntry = Moov.AudioTrack.Mdia.Minf.Stbl.Stsd.AudioSampleEntry ?? throw InvalidDataException("Audio track's stsd box does not contain an ${nameof(AudioSampleEntry)}")
+        ftyp.Save(OutputFile)
+        mdatStart = OutputFile.Position
+        OutputFile.WriteUInt32BE(0)
+        OutputFile.WriteType("mdat")
+        OutputFile.WriteInt64BE(0)
+    }
+
+    convenience init(outputFile Stream, ftyp FtypBox, moov MoovBox, ascBytes []uint8) {
+        init(outputFile, ftyp, moov)
+        ArgumentNullException.ThrowIfNull(ascBytes, nameof(ascBytes))
+        audioSampleEntry.Header.ChangeAtomName("mp4a")
+        var esds EsdsBox? = audioSampleEntry.Esds as EsdsBox
+        if esds != nil {
+            audioSampleEntry.Children.Remove(esds)
+        }
+        let dec3 Dec3Box? = audioSampleEntry.Dec3 as Dec3Box
+        if dec3 != nil {
+            audioSampleEntry.Children.Remove(dec3)
+        }
+        esds = EsdsBox.CreateEmpty(audioSampleEntry)
+        let asc = esds.ES_Descriptor.DecoderConfig.AudioSpecificConfig
+        asc!!.AscBlob = ascBytes
+        if asc!!.ChannelConfiguration > 2 {
+            throw NotSupportedException("Only supports maximum of 2-channel audio. (Channels=${asc!!.ChannelConfiguration})")
+        }
+        this.audioSampleEntry.ChannelCount = uint16(asc!!.ChannelConfiguration)
+        SetTimeScale(uint32(asc!!.SamplingFrequency))
+    }
+
+    deinit {
+        Dispose(false)
+    }
+
+    prop OutputFile Stream {
+        get;
+        init;
+    }
+
+    func Close() {
+        {
+            Monitor.Enter(lockObj)
+            try {
+                if closing {
+                    return
+                }
+                closing = true
+            } finally {
+                Monitor.Exit(lockObj)
+            }
+        }
+        if closed || !OutputFile.CanWrite {
+            return
+        }
+        let mdatEnd = OutputFile.Position
+        let mdatSize = mdatEnd - mdatStart
+        this.OutputFile.Position = mdatStart
+        if mdatSize <= int64(UInt32.MaxValue) {
+            OutputFile.WriteUInt32BE(uint32(mdatSize))
+        } else {
+            OutputFile.WriteUInt32BE(1)
+        }
+        OutputFile.WriteType("mdat")
+        if mdatSize > int64(UInt32.MaxValue) {
+            OutputFile.WriteInt64BE(mdatSize)
+        }
+        this.OutputFile.Position = mdatEnd
+        WriteChapterMetadata(chapterTitles)
+        stsc.Samples.Add(StscChunkEntry{FirstChunk: currentChunk, SamplesPerChunk: samplesPerChunk, SampleDescriptionIndex: 1})
+        stts.Samples.Add(SttsBox.SampleEntry{FrameCount: frameDurationCount, FrameDelta: currentFrameDuration})
+        frameDurationCount = uint32(0)
+        Debug.Assert(int64(audioSampleSizes.Count) == stts.Samples.Sum((s SttsBox.SampleEntry) -> s.FrameCount))
+        let stsz IStszBox = StszBox.CreateBlank(Moov.AudioTrack.Mdia.Minf.Stbl, audioSampleSizes)
+        IChunkOffsets.Create(Moov.AudioTrack.Mdia.Minf.Stbl, audioChunks)
+        if Moov.TextTrack != nil {
+            IChunkOffsets.Create(Moov.TextTrack!!.Mdia.Minf.Stbl, textChunks)
+        }
+        SetDuration(uint64(stts.Samples.Sum((s SttsBox.SampleEntry) -> decimal(s.FrameCount) * decimal(s.FrameDelta))))
+        let (maxBitRate, avgBitrate) = Mp4aWriter.CalculateBitrate(Moov.AudioTrack.Mdia.Mdhd.Timescale, Moov.AudioTrack.Mdia.Mdhd.Duration, stsz, stts)
+        let esds EsdsBox? = audioSampleEntry.Esds as EsdsBox
+        if esds != nil {
+            esds.ES_Descriptor.DecoderConfig.MaxBitrate = maxBitRate
+            esds.ES_Descriptor.DecoderConfig.AverageBitrate = avgBitrate
+        }
+        if audioSampleEntry.GetChild[BtrtBox]() == nil {
+            BtrtBox.Create(0, maxBitRate, avgBitrate, audioSampleEntry)
+        }
+        SaveMoov()
+        closed = true
+    }
+
+    func Dispose() {
+        Dispose(true)
+        GC.SuppressFinalize(this)
+    }
+
+    func WriteChapter(entry ChapterEntry) {
+        if Moov.TextTrack == nil {
+            return
+        }
+        if Moov.TextTrack!!.Mdia.Minf.Stbl.Stsz == nil {
+            StszBox.CreateBlank(Moov.TextTrack!!.Mdia.Minf.Stbl, textSampleSizes)
+        }
+        if !Moov.TextTrack!!.Mdia.Minf.Stbl.Stsc.Samples.Any() {
+            Moov.TextTrack!!.Mdia.Minf.Stbl.Stsc.Samples.Add(StscChunkEntry{FirstChunk: 1, SamplesPerChunk: 1, SampleDescriptionIndex: 1})
+        }
+        chapterTitles.Add(entry.Title)
+        Moov.TextTrack!!.Mdia.Minf.Stbl.Stts.Samples.Add(SttsBox.SampleEntry{FrameCount: 1, FrameDelta: entry.SamplesInFrame})
+        textSampleSizes.Add(entry.FrameData.Length)
+        textChunks.Add(OutputFile.Position)
+        OutputFile.Write(entry.FrameData.Span)
+    }
+
+    func RemoveTextTrack() {
+        if Moov.TextTrack == nil || !Moov.Children.Remove(Moov.TextTrack!!) {
+            return
+        }
+        var trackNum uint32 = uint32(1)
+        let trackRemap Dictionary[uint32, uint32] = Dictionary[uint32, uint32]()
+        for t in Moov.GetChildren[TrakBox]().OrderBy((t TrakBox) -> t.Tkhd.TrackID) {
+            trackRemap[t!!.Tkhd.TrackID] = trackNum
+            t!!.Tkhd.TrackID = trackNum
+            trackNum++
+        }
+        Moov.Mvhd.NextTrackID = trackNum
+        for track in Moov.GetChildren[TrakBox]().Select((c TrakBox) -> c.GetChild[TrefBox]()).OfType[TrefBox]() {
+            for tref in track!!.References.ToArray() {
+                if tref!!.Header.Type == "chap" {
+                    track!!.References.Remove(tref!!)
+                    continue
+                }
+                for tid in tref!!.TrackIds.Order().ToArray() {
+                    if !trackRemap.TryGetValue(tid, out var remap) {
+                        tref!!.TrackIds.Remove(tid)
+                    } else if remap != tid {
+                        tref!!.TrackIds.Remove(tid)
+                        tref!!.TrackIds.Add(remap)
+                    }
+                }
+                if tref!!.TrackIds.Count == 0 {
+                    track!!.References.Remove(tref!!)
+                }
+            }
+            if track!!.References.Count == 0 {
+                track!!.Parent!!.Children.Remove(track!!)
+            }
+        }
+    }
+
+    func AddFrame(frame Span[uint8], newChunk bool, frameDelta uint32) {
+        {
+            Monitor.Enter(lockObj)
+            try {
+                if closing {
+                    return
+                }
+                if newChunk {
+                    audioChunks.Add(OutputFile.Position)
+                    if samplesPerChunk > uint32(0) && int64(samplesPerChunk) != lastSamplesPerChunk {
+                        stsc.Samples.Add(StscChunkEntry{FirstChunk: currentChunk, SamplesPerChunk: samplesPerChunk, SampleDescriptionIndex: 1})
+                        lastSamplesPerChunk = samplesPerChunk
+                    }
+                    samplesPerChunk = uint32(0)
+                    currentChunk++
+                }
+                audioSampleSizes.Add(uint16(frame.Length))
+                if currentFrameDuration == uint32(0) {
+                    currentFrameDuration = frameDelta
+                } else if currentFrameDuration != frameDelta {
+                    stts.Samples.Add(SttsBox.SampleEntry{FrameCount: frameDurationCount, FrameDelta: currentFrameDuration})
+                    frameDurationCount = uint32(0)
+                    currentFrameDuration = frameDelta
+                }
+                frameDurationCount++
+                samplesPerChunk++
+            } finally {
+                Monitor.Exit(lockObj)
+            }
+        }
+        OutputFile.Write(frame)
+    }
+
+    protected open func SaveMoov() {
+        Moov.Save(OutputFile)
+    }
+
+    private func SetTimeScale(timeScale uint32) {
+        Debug.Assert(timeScale <= uint32(UInt16.MaxValue))
+        this.audioSampleEntry.SampleRate = uint16(timeScale)
+        Moov.AudioTrack.Mdia.Mdhd.Timescale = timeScale
+        if Moov.TextTrack != nil {
+            Moov.TextTrack!!.Mdia.Mdhd.Timescale = Moov.AudioTrack.Mdia.Mdhd.Timescale
+        }
+    }
+
+    private func SetDuration(duration uint64) {
+        Moov.Mvhd.Duration = duration * uint64(Moov.Mvhd.Timescale) / uint64(Moov.AudioTrack.Mdia.Mdhd.Timescale)
+        Moov.AudioTrack.Mdia.Mdhd.Duration = duration
+        Moov.AudioTrack.Tkhd.Duration = Moov.Mvhd.Duration
+        if Moov.TextTrack != nil {
+            Moov.TextTrack!!.Mdia.Mdhd.Duration = Moov.AudioTrack.Mdia.Mdhd.Duration
+            Moov.TextTrack!!.Tkhd.Duration = Moov.Mvhd.Duration
+        }
+    }
+
+    private func WriteChapterMetadata(chapterTitles IEnumerable[string]) {
+        if Moov.TextTrack == nil {
+            return
+        }
+        let chapterNames AppleListBox? = Moov.TextTrack?.GetChild[UdtaBox]()?.GetChild[MetaBox]()?.GetChild[AppleListBox]()
+        if chapterNames == nil {
+            return
+        }
+        chapterNames!!.Children.Clear()
+        for title in chapterTitles {
+            chapterNames!!.AddTag("©nam", title!!)
+            chapterNames!!.AddTag("©cmt", title!!)
+        }
+    }
+
+    private func Dispose(disposing bool) {
+        if disposing && !disposed {
+            Close()
+            stsc?.Samples.Clear()
+            audioSampleSizes.Clear()
+            audioChunks.Clear()
+            textChunks.Clear()
+            disposed = true
+        }
+    }
+
+    shared {
+        private func CalculateBitrate(timeScale float64, duration uint64, stsz IStszBox, stts SttsBox) (uint32, uint32) {
+            let audioBits = stsz.TotalSize * int64(8)
+            let avgBitrate = uint32((float64(audioBits) * timeScale / float64(duration)))
+            let frameDeltas = stts.EnumerateFrameDeltas().Select((d uint32) -> uint16(d)).ToArray()
+            if int64(stts.SampleTimeCount) != int64(stsz.SampleCount) || int64(stts.SampleTimeCount) != int64(frameDeltas!!.Length) {
+                throw InvalidOperationException("The number of sample deltas (${stts.SampleTimeCount}) doesn't match the number of sample sizes (${stsz.SampleCount}).")
+            }
+            var currentWindowSampleSpan int64 = 0
+            var windowSizeInBytes int64 = 0
+            var maxOneSecondBitrate float64 = 0.0
+            {
+                var i = 0
+                var beginIndex = 0
+                while i < stsz.SampleCount {
+                    while float64(currentWindowSampleSpan) > timeScale {
+                        let bitrate = float64(windowSizeInBytes * int64(8)) * timeScale / float64(currentWindowSampleSpan)
+                        if bitrate > maxOneSecondBitrate {
+                            maxOneSecondBitrate = bitrate
+                        }
+                        windowSizeInBytes -= int64(stsz.GetSizeAtIndex(beginIndex))
+                        currentWindowSampleSpan -= int64(frameDeltas!![beginIndex])
+                        beginIndex++
+                    }
+                    windowSizeInBytes += int64(stsz.GetSizeAtIndex(i))
+                    currentWindowSampleSpan += int64(frameDeltas!![i])
+                    i++
+                }
+            }
+            return (uint32(Math.Round(maxOneSecondBitrate)), avgBitrate)
+        }
+
+        private func MakeBlankMoov(moov MoovBox) MoovBox {
+            var t1 SttsBox? = nil
+            var t2 StscBox? = nil
+            var t3 IStszBox? = nil
+            var t4 IChunkOffsets? = nil
+            if moov.TextTrack != nil {
+                t1 = moov.TextTrack!!.Mdia.Minf.Stbl.Stts
+                t2 = moov.TextTrack!!.Mdia.Minf.Stbl.Stsc
+                t3 = moov.TextTrack!!.Mdia.Minf.Stbl.Stsz
+                t4 = moov.TextTrack!!.Mdia.Minf.Stbl.COBox
+                moov.TextTrack!!.Mdia.Minf.Stbl.Children.Remove(t1!!)
+                moov.TextTrack!!.Mdia.Minf.Stbl.Children.Remove(t2!!)
+                if t3 != nil {
+                    moov.TextTrack!!.Mdia.Minf.Stbl.Children.Remove(t3!!)
+                }
+                moov.TextTrack!!.Mdia.Minf.Stbl.Children.Remove(t4!!)
+            }
+            let a1 = moov.AudioTrack.Mdia.Minf.Stbl.Stts
+            let a2 = moov.AudioTrack.Mdia.Minf.Stbl.Stsc
+            let a3 IStszBox? = moov.AudioTrack.Mdia.Minf.Stbl.Stsz
+            let a4 = moov.AudioTrack.Mdia.Minf.Stbl.COBox
+            moov.AudioTrack.Mdia.Minf.Stbl.Children.Remove(a1)
+            moov.AudioTrack.Mdia.Minf.Stbl.Children.Remove(a2)
+            if a3 != nil {
+                moov.AudioTrack.Mdia.Minf.Stbl.Children.Remove(a3!!)
+            }
+            moov.AudioTrack.Mdia.Minf.Stbl.Children.Remove(a4)
+            let mvex MvexBox? = moov.GetChild[MvexBox]()
+            if mvex != nil {
+                moov.Children.Remove(mvex!!)
+            }
+            let ms = MemoryStream()
+            moov.Save(ms)
+            if mvex != nil {
+                moov.Children.Add(mvex!!)
+            }
+            moov.AudioTrack.Mdia.Minf.Stbl.Children.Add(a1)
+            moov.AudioTrack.Mdia.Minf.Stbl.Children.Add(a2)
+            if a3 != nil {
+                moov.AudioTrack.Mdia.Minf.Stbl.Children.Add(a3!!)
+            }
+            moov.AudioTrack.Mdia.Minf.Stbl.Children.Add(a4)
+            if moov.TextTrack != nil {
+                if t1 != nil {
+                    moov.TextTrack!!.Mdia.Minf.Stbl.Children.Add(t1!!)
+                }
+                if t2 != nil {
+                    moov.TextTrack!!.Mdia.Minf.Stbl.Children.Add(t2!!)
+                }
+                if t3 != nil {
+                    moov.TextTrack!!.Mdia.Minf.Stbl.Children.Add(t3!!)
+                }
+                if t4 != nil {
+                    moov.TextTrack!!.Mdia.Minf.Stbl.Children.Add(t4!!)
+                }
+            }
+            ms.Position = 0
+            let newMoov = BoxFactory.CreateBox[MoovBox](ms, nil)
+            SttsBox.CreateBlank(newMoov.AudioTrack.Mdia.Minf.Stbl)
+            StscBox.CreateBlank(newMoov.AudioTrack.Mdia.Minf.Stbl)
+            newMoov.AudioTrack.Mdia.Mdhd.ModificationTime = DateTimeOffset.UtcNow
+            newMoov.AudioTrack.Mdia.Mdhd.CreationTime = newMoov.AudioTrack.Mdia.Mdhd.ModificationTime
+            if newMoov.TextTrack != nil {
+                SttsBox.CreateBlank(newMoov.TextTrack!!.Mdia.Minf.Stbl)
+                StscBox.CreateBlank(newMoov.TextTrack!!.Mdia.Minf.Stbl)
+                newMoov.TextTrack!!.Mdia.Mdhd.ModificationTime = newMoov.AudioTrack.Mdia.Mdhd.CreationTime
+                newMoov.TextTrack!!.Mdia.Mdhd.CreationTime = newMoov.TextTrack!!.Mdia.Mdhd.ModificationTime
+            }
+            return newMoov
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Mpeg4File.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Mpeg4File.gs
@@ -1,0 +1,229 @@
+package Oahu.Decrypt.Mpeg4
+
+import System
+import System.Collections.Generic
+import System.IO
+import System.Linq
+import System.Threading
+import System.Threading.Tasks
+import Oahu.Decrypt.Mpeg4.Boxes
+import Oahu.Decrypt.Mpeg4.Chunks
+import Oahu.Decrypt.Mpeg4.Util
+
+open class Mpeg4File : IDisposable {
+    private let lazyMetadataItems Lazy[MetadataItems]
+    private var disposed int32
+    private var timescale int32? = nil
+    private var audioChannels int32? = nil
+    private var averageBitrate int32? = nil
+
+    convenience init(file Stream) {
+        init(file, file.Length)
+    }
+
+    convenience init(fileName string, access FileAccess = 1, share FileShare = 1) {
+        init(File.Open(fileName, FileMode.Open, access, share))
+    }
+
+    init(file Stream, fileSize int64) {
+        InputStream = if file.CanSeek { file } else { TrackedReadStream(file, fileSize) }
+        TopLevelBoxes = Mpeg4Util.LoadTopLevelBoxes(InputStream)
+        Ftyp = TopLevelBoxes.OfType[FtypBox]().Single()
+        Moov = TopLevelBoxes.OfType[MoovBox]().Single()
+        Mdat = TopLevelBoxes.OfType[MdatBox]().Single()
+        lazyMetadataItems = Lazy[MetadataItems](() -> MetadataItems(Moov.ILst ?? Moov.CreateEmptyMetadata()))
+        AudioSampleEntry = Moov.AudioTrack.Mdia.Minf.Stbl.Stsd.AudioSampleEntry ?? throw InvalidOperationException("The audio track's AudioSampleEntry is null")
+    }
+
+    deinit {
+        Dispose(false)
+    }
+
+    prop Chapters ChapterInfo?
+
+    prop InputStream Stream {
+        get;
+        init;
+    }
+
+    prop Ftyp FtypBox
+
+    prop Moov MoovBox {
+        get;
+        init;
+    }
+
+    prop Mdat MdatBox {
+        get;
+        init;
+    }
+
+    prop MetadataItems MetadataItems -> lazyMetadataItems.Value
+    open prop Duration TimeSpan -> TimeSpan.FromSeconds(float64(Moov.AudioTrack.Mdia.Mdhd.Duration) / float64(TimeScale))
+    prop MaxBitrate int32 -> int32((AudioSampleEntry.Esds?.ES_Descriptor.DecoderConfig.MaxBitrate ?? uint32(0)))
+
+    prop AudioSampleEntry AudioSampleEntry {
+        get;
+        init;
+    }
+
+    prop TopLevelBoxes List[IBox] {
+        get;
+        init;
+    }
+
+    prop TimeScale int32 -> AudioSampleEntry.Esds?.ES_Descriptor.DecoderConfig.AudioSpecificConfig.SamplingFrequency ?? AudioSampleEntry.Dec3?.SampleRate ?? AudioSampleEntry.Dac4?.SampleRate ?? int32(Moov.AudioTrack.Mdia.Mdhd.Timescale)
+    prop AudioChannels int32 -> AudioSampleEntry.Esds?.ES_Descriptor.DecoderConfig.AudioSpecificConfig.ChannelConfiguration ?? AudioSampleEntry.Dec3?.NumberOfChannels ?? AudioSampleEntry.Dac4?.NumberOfChannels ?? int32(AudioSampleEntry.ChannelCount)
+    prop AverageBitrate int32 -> int32((AudioSampleEntry.Esds?.ES_Descriptor.DecoderConfig.AverageBitrate ?? AudioSampleEntry.Dec3?.AverageBitrate ?? AudioSampleEntry?.Dac4?.AverageBitrate ?? CalculateBitrate()))
+    protected prop Disposed bool -> disposed != 0
+
+    async func SaveAsync(keepMoovInFront bool = true, progressTracker ProgressTracker? = nil, cancellationToken CancellationToken = default(CancellationToken)) {
+        if !InputStream.CanRead || !InputStream.CanWrite || !InputStream.CanSeek {
+            throw InvalidOperationException("${nameof(InputStream)} must be readable, writable and seekable to save")
+        }
+        for box in Moov.GetFreeBoxes() {
+            box!!.Parent?.Children.Remove(box!!)
+        }
+        this.InputStream.Position = 0
+        let moovInFront = Moov.Header.FilePosition < Mdat.Header.FilePosition
+        if moovInFront {
+            var totalSizeChange = Ftyp.RenderSize + Moov.RenderSize - Mdat.Header.FilePosition
+            if totalSizeChange == int64(0) {
+                Ftyp.Save(InputStream)
+                Moov.Save(InputStream)
+            } else if int64(FreeBox.MinSize) + totalSizeChange <= int64(0) {
+                Ftyp.Save(InputStream)
+                Moov.Save(InputStream)
+                FreeBox.Create(-totalSizeChange, nil).Save(InputStream)
+            } else {
+                if keepMoovInFront {
+                    totalSizeChange = Moov.ShiftChunkOffsetsWithMoovInFront(totalSizeChange)
+                    await Mdat.ShiftMdatAsync(InputStream, totalSizeChange, progressTracker, cancellationToken)
+                    this.InputStream.Position = 0
+                    Ftyp.Save(InputStream)
+                    Moov.Save(InputStream)
+                    InputStream.SetLength(Mdat.Header.FilePosition + Mdat.Header.TotalBoxSize)
+                } else {
+                    let freeBoxSize = Mdat.Header.FilePosition - Ftyp.RenderSize
+                    if freeBoxSize < int64(8) {
+                        throw InvalidOperationException("Not enough space to write ftyp box before mdat box")
+                    }
+                    Ftyp.Save(InputStream)
+                    FreeBox.Create(freeBoxSize, nil).Save(InputStream)
+                    this.InputStream.Position = Mdat.Header.FilePosition + Mdat.Header.TotalBoxSize
+                    Moov.Save(InputStream)
+                }
+            }
+        } else {
+            var rewriteMoovAtEnd = true
+            let ftypSizeChange = Ftyp.RenderSize - Ftyp.Header.TotalBoxSize
+            if ftypSizeChange == int64(0) {
+                Ftyp.Save(InputStream)
+            } else if int64(FreeBox.MinSize) + ftypSizeChange <= int64(0) {
+                Ftyp.Save(InputStream)
+                FreeBox.Create(-ftypSizeChange, nil).Save(InputStream)
+            } else {
+                if keepMoovInFront {
+                    var shiftVector = ftypSizeChange + Moov.RenderSize
+                    shiftVector = Moov.ShiftChunkOffsetsWithMoovInFront(shiftVector)
+                    await Mdat.ShiftMdatAsync(InputStream, shiftVector, progressTracker, cancellationToken)
+                    this.InputStream.Position = 0
+                    Ftyp.Save(InputStream)
+                    Moov.Save(InputStream)
+                    InputStream.SetLength(Mdat.Header.FilePosition + Mdat.Header.TotalBoxSize)
+                    rewriteMoovAtEnd = false
+                } else {
+                    Moov.ShiftChunkOffsets(ftypSizeChange)
+                    await Mdat.ShiftMdatAsync(InputStream, ftypSizeChange, progressTracker, cancellationToken)
+                    this.InputStream.Position = 0
+                    Ftyp.Save(InputStream)
+                }
+            }
+            if rewriteMoovAtEnd {
+                this.InputStream.Position = Mdat.Header.FilePosition + Mdat.Header.TotalBoxSize
+                Moov.Save(InputStream)
+                InputStream.SetLength(InputStream.Position)
+            }
+        }
+        await InputStream.FlushAsync(cancellationToken)
+    }
+
+    func GetChaptersFromMetadata() ChapterInfo? {
+        let textTrak TrakBox? = Moov.TextTrack
+        let chapterNames List[string]? = textTrak?.GetChild[UdtaBox]()?.GetChild[MetaBox]()?.GetChild[AppleListBox]()?.Children?.OfType[AppleTagBox]()?.Where((b AppleTagBox) -> b.Header.Type == "©nam")?.Select((b AppleTagBox) -> b.Data.ReadAsString())?.ToList()
+        if chapterNames == nil {
+            return nil
+        }
+        let sampleTimes = textTrak!!.Mdia.Minf.Stbl.Stts.Samples
+        if sampleTimes.Count != chapterNames!!.Count {
+            return nil
+        }
+        let cEntryList = ChunkEntryList(textTrak!!).OrderBy((s ChunkEntry) -> s.ChunkOffset).ToList()
+        if cEntryList!!.Count != chapterNames!!.Count {
+            return nil
+        }
+        let chapterInfo = ChapterInfo()
+        var subtractNext = 0
+        for var i = 0; i < chapterNames!!.Count; i++ {
+            let sif = int32(sampleTimes[i].FrameDelta)
+            let duration = TimeSpan.FromSeconds(Math.Max(0d, sif + subtractNext) / float64(TimeScale))
+            chapterInfo.AddChapter(chapterNames!![int32(cEntryList!![i].ChunkIndex)], duration)
+            subtractNext = if sif < 0 { sif } else { 0 }
+        }
+        Chapters ??= chapterInfo
+        return chapterInfo
+    }
+
+    func Dispose() {
+        Dispose(true)
+        GC.SuppressFinalize(this)
+    }
+
+    protected open func CalculateBitrate() uint32 {
+        let totalSize = Moov.AudioTrack.Mdia.Minf.Stbl.Stsz?.TotalSize
+        return if !totalSize.HasValue || totalSize.Value == int64(0) { uint32(0) } else { uint32(Math.Round(float64(totalSize.Value * int64(8)) / Duration.TotalSeconds, 0)) }
+    }
+
+    protected open func Dispose(disposing bool) {
+        if disposing && Interlocked.CompareExchange(&disposed, 1, 0) == 0 {
+            InputStream.Dispose()
+            for box in TopLevelBoxes {
+                box!!.Dispose()
+            }
+        }
+    }
+
+    shared {
+        async func RelocateMoovToBeginningAsync(mp4FilePath string, progressTracker ProgressTracker? = nil, cancellationToken CancellationToken = default(CancellationToken)) {
+            var boxes List[IBox]
+            {
+                using let fileStream = File.OpenRead(mp4FilePath)
+                boxes = Mpeg4Util.LoadTopLevelBoxes(fileStream)
+            }
+            try {
+                let ftypeSize = boxes.OfType[FtypBox]().Single().RenderSize
+                let moov = boxes.OfType[MoovBox]().Single()
+                if progressTracker != nil {
+                    progressTracker!!.TotalDuration = TimeSpan.FromSeconds(float64(moov.Mvhd.Duration) / float64(moov.Mvhd.Timescale))
+                    if moov.Header.FilePosition == ftypeSize {
+                        progressTracker!!.TotalSize = 1
+                        progressTracker!!.MovedBytes = progressTracker!!.TotalSize
+                        return
+                    }
+                }
+                let mdat = boxes.OfType[MdatBox]().Single()
+                let toShift = ftypeSize + moov.RenderSize - mdat!!.Header.FilePosition
+                let shifted = moov.ShiftChunkOffsetsWithMoovInFront(toShift)
+                using let mpegFile = FileStream(mp4FilePath, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite)
+                await mdat!!.ShiftMdatAsync(mpegFile, shifted, progressTracker, cancellationToken)
+                mpegFile.Position = ftypeSize
+                moov.Save(mpegFile)
+                mpegFile.SetLength(mpegFile.Position + mdat!!.Header.TotalBoxSize)
+            } finally {
+                for box in boxes {
+                    box.Dispose()
+                }
+            }
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Mpeg4Util.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Mpeg4Util.gs
@@ -1,0 +1,95 @@
+package Oahu.Decrypt.Mpeg4.Util
+
+import System
+import System.Collections.Generic
+import System.IO
+import System.Linq
+import System.Threading
+import System.Threading.Tasks
+import Oahu.Decrypt.Mpeg4.Boxes
+
+class Mpeg4Util {
+    shared {
+        func LoadTopLevelBoxes(file Stream) List[IBox] {
+            let boxes = List[IBox]()
+            while file.Position < file.Length && (!boxes.OfType[FtypBox]().Any() || !boxes.OfType[MoovBox]().Any() || !boxes.OfType[MdatBox]().Any()) {
+                let box = BoxFactory.CreateBox(file, nil)
+                boxes.Add(box!!)
+                if box is MdatBox && !boxes.OfType[MoovBox]().Any() {
+                    file.Position = box!!.Header.FilePosition + box!!.Header.TotalBoxSize
+                }
+            }
+            return boxes
+        }
+
+        async func ShiftDataBlock(file Stream, start int64, length int64, shiftVector int64, progressTracker ProgressTracker? = nil, cancellationToken CancellationToken = default(CancellationToken)) {
+            var length = length
+            const MoveBufferSize = 8 * 1024 * 1024
+            if start + shiftVector < int64(0) {
+                throw ArgumentOutOfRangeException(nameof(shiftVector), "Data cannot be shifted to a negative file position.")
+            }
+            if !file.CanRead || !file.CanWrite || !file.CanSeek {
+                throw ArgumentException("Stream must support reading, writing, and seeking.", nameof(file))
+            }
+            if start > file.Length {
+                throw ArgumentOutOfRangeException(nameof(start), "Start index exceeds the file length.")
+            }
+            if start + length > file.Length {
+                throw ArgumentOutOfRangeException(nameof(length), "End of data block is beyond the end of the file.")
+            }
+            let backToFront = shiftVector > int64(0)
+            file.Position = if backToFront { start + length } else { start }
+            if progressTracker != nil {
+                progressTracker!!.TotalSize = length
+                progressTracker!!.MovedBytes = 0
+            }
+            let buffer Memory[uint8] = [MoveBufferSize]uint8
+            var read int32
+            do {
+                let toRead = int32(Math.Min(MoveBufferSize, length))
+                if backToFront {
+                    file.Position -= int64(toRead)
+                }
+                read = await file.ReadAsync(buffer.Slice(0, toRead), cancellationToken)
+                file.Position += shiftVector - int64(read)
+                await file.WriteAsync(buffer.Slice(0, read), cancellationToken)
+                file.Position -= if backToFront { shiftVector + int64(read) } else { shiftVector }
+                if progressTracker != nil {
+                    progressTracker!!.MovedBytes += int64(read)
+                }
+                cancellationToken.ThrowIfCancellationRequested()
+                length -= int64(read)
+            } while length > int64(0)
+            progressTracker?.ReportProgress(true)
+        }
+    }
+}
+
+class ProgressTracker {
+    private let startTime DateTime = DateTime.UtcNow
+    private var nextUpdate DateTime = default
+    private var movedBytes int64
+    event ProgressUpdated (object?, EventArgs) -> void
+
+    prop MovedBytes int64 {
+        get -> movedBytes
+        set {
+            movedBytes = value
+            ReportProgress()
+        }
+    }
+
+    prop TotalDuration TimeSpan
+    prop TotalSize int64
+    prop Speed float64
+    prop Position TimeSpan
+
+    func ReportProgress(forceReport bool = false) {
+        if DateTime.UtcNow > nextUpdate || forceReport {
+            Position = TimeSpan.FromSeconds(TotalDuration.TotalSeconds / float64(TotalSize) * float64(MovedBytes))
+            Speed = Position / (DateTime.UtcNow - startTime)
+            ProgressUpdated?(this, EventArgs.Empty)
+            nextUpdate = DateTime.UtcNow.AddMilliseconds(200.0)
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/MultipartFilterBase.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/MultipartFilterBase.gs
@@ -1,0 +1,75 @@
+package Oahu.Decrypt.FrameFilters.Audio
+
+import System
+import System.Collections.Generic
+import System.Threading.Tasks
+import Oahu.Decrypt.Mpeg4
+
+open class MultipartFilterBase[TInput FrameEntry, TCallback INewSplitCallback[TCallback]] : FrameFinalBase[TInput] {
+    protected let InputStereo bool
+    protected let InputSampleRate SampleRate
+    private let splitChapters IEnumerator[Chapter]
+    private var startSample int64
+    private var endSample int64 = -1
+    private var lastChunkIndex int64 = -1
+    private var currentSample int64
+
+    init(splitChapters ChapterInfo?, inputSampleRate SampleRate, inputStereo bool) {
+        if splitChapters == nil || splitChapters!!.Count == 0 {
+            throw ArgumentException("${nameof(splitChapters)} must contain at least one chapter.")
+        }
+        InputSampleRate = inputSampleRate
+        InputStereo = inputStereo
+        currentSample = TimeToSample(splitChapters!!.StartOffset)
+        startSample = currentSample
+        this.splitChapters = splitChapters!!.GetEnumerator()
+    }
+
+    protected open func CloseCurrentWriter();
+    protected open func WriteFrameToFile(audioFrame TInput, newChunk bool);
+    protected open func CreateNewWriter(callback TCallback);
+
+    protected override func FlushAsync() Task {
+        CloseCurrentWriter()
+        return Task.CompletedTask
+    }
+
+    protected open override func PerformFilteringAsync(input TInput) Task {
+        if input.Chunk == nil {
+            WriteFrameToFile(input, false)
+        } else if currentSample > endSample {
+            CloseCurrentWriter()
+            if GetNextChapter() {
+                CreateNewWriter(TCallback.Create(splitChapters.Current))
+                WriteFrameToFile(input, true)
+                lastChunkIndex = input.Chunk!!.ChunkIndex
+            }
+        } else if currentSample >= startSample {
+            let newChunk = int64(input.Chunk!!.ChunkIndex) > lastChunkIndex
+            if newChunk {
+                lastChunkIndex = input.Chunk!!.ChunkIndex
+            }
+            WriteFrameToFile(input, newChunk)
+        }
+        currentSample += int64(input.SamplesInFrame)
+        return Task.CompletedTask
+    }
+
+    protected open override func Dispose(disposing bool) {
+        if disposing && !Disposed {
+            splitChapters?.Dispose()
+        }
+        base.Dispose(disposing)
+    }
+
+    private func GetNextChapter() bool {
+        if !splitChapters.MoveNext() {
+            return false
+        }
+        startSample = TimeToSample(splitChapters.Current.StartOffset)
+        endSample = TimeToSample(splitChapters.Current.EndOffset)
+        return true
+    }
+
+    private func TimeToSample(time TimeSpan) int64 -> int64(Math.Round(time.TotalSeconds * float64(int32(InputSampleRate))))
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/MvexBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/MvexBox.gs
@@ -1,0 +1,13 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+
+open class MvexBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        LoadChildren(file)
+    }
+
+    protected open override func Render(file Stream) {
+        return
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/MvhdBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/MvhdBox.gs
@@ -1,0 +1,70 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class MvhdBox : HeaderBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        Rate = file.ReadInt32BE()
+        Volume = file.ReadInt16BE()
+        Reserved = file.ReadUInt16BE()
+        Reserved2 = file.ReadUInt64BE()
+        Matrix = file.ReadBlock(4 * 9)
+        Pre_defined = file.ReadBlock(4 * 6)
+        NextTrackID = file.ReadUInt32BE()
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(4) + int64(4) + int64(2) + int64(2) + int64(8) + int64(Matrix.Length) + int64(Pre_defined.Length) + int64(4)
+    prop Timescale uint32
+
+    prop Rate int32 {
+        get;
+        init;
+    }
+
+    prop Volume int16 {
+        get;
+        init;
+    }
+
+    prop Reserved uint16 {
+        get;
+        init;
+    }
+
+    prop Reserved2 uint64 {
+        get;
+        init;
+    }
+
+    prop Matrix []uint8 {
+        get;
+        init;
+    }
+
+    prop Pre_defined []uint8 {
+        get;
+        init;
+    }
+
+    prop NextTrackID uint32
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.WriteInt32BE(Rate)
+        file.WriteInt16BE(Volume)
+        file.WriteUInt16BE(Reserved)
+        file.WriteUInt64BE(Reserved2)
+        file.Write(Matrix)
+        file.Write(Pre_defined)
+        file.WriteUInt32BE(NextTrackID)
+    }
+
+    protected open override func ReadBeforeDuration(file Stream) {
+        Timescale = file.ReadUInt32BE()
+    }
+
+    protected open override func WriteBeforeDuration(file Stream) {
+        file.WriteUInt32BE(Timescale)
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/NameBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/NameBox.gs
@@ -1,0 +1,40 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.Diagnostics
+import System.IO
+import System.Text
+import Oahu.Decrypt.Mpeg4.Util
+
+@DebuggerDisplay("{DebuggerDisplay,nq}")
+open class NameBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        let stringSize = RemainingBoxLength(file)
+        let stringData = file.ReadBlock(int32(stringSize))
+        Name = Encoding.UTF8.GetString(stringData!!)
+    }
+
+    private init(header BoxHeader, parent IBox?, name string) : base([4]uint8, header, parent) {
+        Name = name
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(Encoding.UTF8.GetByteCount(Name))
+    prop Name string
+
+    @DebuggerHidden
+    private prop DebuggerDisplay string -> "name: $Name"
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.Write(Encoding.UTF8.GetBytes(Name))
+    }
+
+    shared {
+        func Create(parent IBox?, name string) NameBox {
+            let size = Encoding.UTF8.GetByteCount(name) + 12
+            let header = BoxHeader(uint32(size), "name")
+            let nameBox = NameBox(header, parent, name)
+            parent?.Children.Add(nameBox)
+            return nameBox
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/NewSplitCallback.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/NewSplitCallback.gs
@@ -1,0 +1,43 @@
+package Oahu.Decrypt
+
+import System.IO
+import Oahu.Decrypt.Mpeg4
+
+interface INewSplitCallback {
+    prop Chapter Chapter {
+        get;
+    }
+
+    prop TrackNumber int32?
+    prop TrackCount int32?
+    prop TrackTitle string?
+    prop OutputFile Stream?
+}
+
+interface INewSplitCallback[T INewSplitCallback[T]] : INewSplitCallback {
+    shared {
+        func Create(chapter Chapter) T;
+    }
+}
+
+class NewSplitCallback : INewSplitCallback[NewSplitCallback] {
+    private init(chapter Chapter) {
+        Chapter = chapter
+    }
+
+    prop Chapter Chapter {
+        get;
+        init;
+    }
+
+    prop TrackNumber int32?
+    prop TrackCount int32?
+    prop TrackTitle string?
+    prop OutputFile Stream?
+
+    shared {
+        func Create(chapter Chapter) NewSplitCallback {
+            return NewSplitCallback(chapter)
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/PsshBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/PsshBox.gs
@@ -1,0 +1,40 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class PsshBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        ProtectionSystemId = Guid(file.ReadBlock(16), true)
+        let initDataSize = file.ReadInt32BE()
+        InitData = file.ReadBlock(initDataSize)
+        let remaining = int32((header.TotalBoxSize - int64(header.HeaderSize) - int64(4) - int64(16) - int64(4) - int64(initDataSize)))
+        ExtraData = file.ReadBlock(remaining)
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(16) + int64(4) + int64(InitData.Length) + int64(ExtraData.Length)
+
+    prop ProtectionSystemId Guid {
+        get;
+        init;
+    }
+
+    prop InitData []uint8 {
+        get;
+        init;
+    }
+
+    prop ExtraData []uint8 {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.Write(ProtectionSystemId.ToByteArray(true))
+        file.WriteInt32BE(InitData.Length)
+        file.Write(InitData)
+        file.Write(ExtraData)
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/SLConfigDescriptor.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/SLConfigDescriptor.gs
@@ -1,0 +1,30 @@
+package Oahu.Decrypt.Mpeg4.Descriptors
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+internal class SLConfigDescriptor : BaseDescriptor {
+    private let blob []uint8
+
+    init(file Stream, header DescriptorHeader) : base(file, header) {
+        Predefined = file.ReadByte()
+        blob = file.ReadBlock(Header.TotalBoxSize - Header.HeaderSize - 1)
+    }
+
+    private init(predefined uint8, blob []uint8) : base(6) {
+        Predefined = predefined
+        this.blob = blob
+    }
+
+    prop Predefined int32
+    override prop InternalSize int32 -> base.InternalSize + 1 + blob.Length
+
+    override func Render(file Stream) {
+        file.WriteByte(uint8(Predefined))
+        file.Write(blob)
+    }
+
+    shared {
+        func CreateMp4() SLConfigDescriptor -> SLConfigDescriptor(2, []uint8{})
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/SaioBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/SaioBox.gs
@@ -1,0 +1,77 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+interface ISaioBox : IBox {
+    prop AuxInfoType uint32 {
+        get;
+    }
+
+    prop AuxInfoTypeParameter uint32 {
+        get;
+    }
+
+    prop EntryCount int32 {
+        get;
+    }
+}
+
+open class SaioBox : FullBox, ISaioBox {
+    private let offsets32 []?uint32
+    private let offsets64 []?int64
+
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        if (Flags & 1) == 1 {
+            AuxInfoType = file.ReadUInt32BE()
+            AuxInfoTypeParameter = file.ReadUInt32BE()
+        }
+        EntryCount = file.ReadInt32BE()
+        if Version == uint8(0) {
+            offsets32 = [EntryCount]uint32
+            for var i = 0; i < EntryCount; i++ {
+                offsets32!![i] = file.ReadUInt32BE()
+            }
+        } else {
+            offsets64 = [EntryCount]int64
+            for var i = 0; i < EntryCount; i++ {
+                offsets64!![i] = file.ReadInt64BE()
+            }
+        }
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64((if (Flags & 1) == 1 { 8 } else { 0 })) + int64(4) + int64((if Version == uint8(0) { (offsets32?.Length ?? 0) * 4 } else { (offsets64?.Length ?? 0) * 8 }))
+
+    prop AuxInfoType uint32 {
+        get;
+        init;
+    }
+
+    prop AuxInfoTypeParameter uint32 {
+        get;
+        init;
+    }
+
+    prop EntryCount int32 {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        if (Flags & 1) == 1 {
+            file.WriteUInt32BE(AuxInfoType)
+            file.WriteUInt32BE(AuxInfoTypeParameter)
+        }
+        file.WriteInt32BE(EntryCount)
+        if offsets32 != nil {
+            for offset in offsets32!! {
+                file.WriteUInt32BE(offset)
+            }
+        } else if offsets64 != nil {
+            for offset in offsets64!! {
+                file.WriteInt64BE(offset)
+            }
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/SaizBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/SaizBox.gs
@@ -1,0 +1,52 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class SaizBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        if (Flags & 1) == 1 {
+            AuxInfoType = file.ReadUInt32BE()
+            AuxInfoTypeParameter = file.ReadUInt32BE()
+        }
+        DefaultInfoSampleSize = uint8(file.ReadByte())
+        let sampleCount = file.ReadInt32BE()
+        SampleInfoSizes = if DefaultInfoSampleSize == uint8(0) { file.ReadBlock(sampleCount) } else { Array.Empty[uint8]() }
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64((if (Flags & 1) == 1 { 8 } else { 0 })) + int64(5) + int64((if DefaultInfoSampleSize == uint8(0) { SampleInfoSizes.Length } else { 0 }))
+
+    prop AuxInfoType uint32 {
+        get;
+        init;
+    }
+
+    prop AuxInfoTypeParameter uint32 {
+        get;
+        init;
+    }
+
+    prop DefaultInfoSampleSize uint8 {
+        get;
+        init;
+    }
+
+    prop SampleInfoSizes []uint8 {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        if (Flags & 1) == 1 {
+            file.WriteUInt32BE(AuxInfoType)
+            file.WriteUInt32BE(AuxInfoTypeParameter)
+        }
+        file.WriteByte(DefaultInfoSampleSize)
+        file.WriteInt32BE(SampleInfoSizes.Length)
+        if DefaultInfoSampleSize == uint8(0) {
+            file.Write(SampleInfoSizes)
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/SampleEntry.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/SampleEntry.gs
@@ -1,0 +1,41 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.Diagnostics
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+@DebuggerDisplay("{DebuggerDisplay,nq}")
+open class SampleEntry : Box {
+    private let reserved []uint8
+
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        reserved = file.ReadBlock(6)
+        DataReferenceIndex = file.ReadUInt16BE()
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(8)
+
+    prop DataReferenceIndex uint16 {
+        get;
+        init;
+    }
+
+    @DebuggerHidden
+    private prop DebuggerDisplay string -> "[${Header.Type}] - " + switch Header.Type {
+        case "text": "Text SampleEntry"
+        case "mp4s": "MpegSampleEntry"
+        case "mp4v": "MP4VisualSampleEntry"
+        case "mp4a": "MP4AudioSampleEntry"
+        case "aavd": "Audible AAX(C) Protected AudioSampleEntry"
+        case "encv": "Protected VisualSampleEntry"
+        case "enca": "Protected AudioSampleEntry"
+        case "ec-3": "EC3SampleEntry"
+        case "ac-4": "AC4SampleEntry"
+        default: "[UNKNOWN]"
+    }
+
+    protected open override func Render(file Stream) {
+        file.Write(reserved)
+        file.WriteUInt16BE(DataReferenceIndex)
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/SchiBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/SchiBox.gs
@@ -1,0 +1,15 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+
+open class SchiBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        LoadChildren(file)
+    }
+
+    prop TrackEncryption TencBox? -> GetChild[TencBox]()
+
+    protected open override func Render(file Stream) {
+        return
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/SchmBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/SchmBox.gs
@@ -1,0 +1,57 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.Collections.Generic
+import System.IO
+import System.Text
+import Oahu.Decrypt.Mpeg4.Util
+
+open class SchmBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        let endPos = Header.FilePosition + Header.TotalBoxSize
+        Type = SchemeType(file.ReadUInt32BE())
+        SchemeVersion = file.ReadUInt32BE()
+        if (Flags & 1) == 1 {
+            let blist = List[uint8]()
+            while file.Position < endPos {
+                let lastByte = uint8(file.ReadByte())
+                if lastByte == uint8(0) {
+                    HasNullTerminator = true
+                    break
+                }
+                blist.Add(lastByte)
+            }
+            SchemeUri = Encoding.UTF8.GetString(blist.ToArray())
+        }
+    }
+
+    enum SchemeType { Unknown, Cenc, Cbc1, Cens, Cbcs }
+    open override prop RenderSize int64 -> base.RenderSize + int64(8) + int64((if (Flags & 1) == 1 && SchemeUri is string { Encoding.UTF8.GetByteCount((SchemeUri as string)!!) + (if HasNullTerminator { 1 } else { 0 }) } else { 0 }))
+    prop HasNullTerminator bool
+
+    prop Type SchemeType {
+        get;
+        init;
+    }
+
+    prop SchemeVersion uint32 {
+        get;
+        init;
+    }
+
+    prop SchemeUri string? {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.WriteUInt32BE(uint32(Type))
+        file.WriteUInt32BE(SchemeVersion)
+        if (Flags & 1) == 1 && SchemeUri is string {
+            file.Write(Encoding.UTF8.GetBytes((SchemeUri as string)!!))
+            if HasNullTerminator {
+                file.WriteByte(0)
+            }
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/SencBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/SencBox.gs
@@ -1,0 +1,36 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.IO
+import System.Linq
+import Oahu.Decrypt.Mpeg4.Util
+
+open class SencBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        let sampleCount = file.ReadInt32BE()
+        if UseSubSampleEncryption {
+            throw NotSupportedException(nameof(UseSubSampleEncryption))
+        }
+        let ivSize = int32(((header.TotalBoxSize - int64(16)) / int64(sampleCount)))
+        IVs = [sampleCount][]uint8
+        for var i = 0; i < sampleCount; i++ {
+            IVs[i] = file.ReadBlock(ivSize)
+        }
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(4) + int64(IVs.Sum((iv []uint8) -> iv.Length))
+    prop UseSubSampleEncryption bool -> (Flags & 2) == 2
+
+    prop IVs [][]uint8 {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.WriteInt32BE(IVs.Length)
+        for iv in IVs {
+            file.Write(iv!!)
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/SidxBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/SidxBox.gs
@@ -1,0 +1,129 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class SidxBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        ReferenceId = file.ReadUInt32BE()
+        Timescale = file.ReadInt32BE()
+        if Version == uint8(0) {
+            EarliestPresentationTime = file.ReadUInt32BE()
+            FirstOffset = file.ReadUInt32BE()
+        } else {
+            EarliestPresentationTime = file.ReadInt64BE()
+            FirstOffset = file.ReadInt64BE()
+        }
+        file.ReadInt16BE()
+        let referenceCount int32 = file.ReadUInt16BE()
+        Segments = [referenceCount]Segment
+        for var i = 0; i < Segments.Length; i++ {
+            Segments[i] = Segment(file)
+        }
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(8) + int64((if Version == uint8(0) { 8 } else { 16 })) + int64(4) + int64(Segments.Length * 12)
+
+    prop ReferenceId uint32 {
+        get;
+        init;
+    }
+
+    prop Timescale int32 {
+        get;
+        init;
+    }
+
+    prop EarliestPresentationTime int64 {
+        get;
+        init;
+    }
+
+    prop FirstOffset int64 {
+        get;
+        init;
+    }
+
+    prop Segments []Segment {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.WriteUInt32BE(ReferenceId)
+        file.WriteInt32BE(Timescale)
+        if Version == uint8(0) {
+            file.WriteUInt32BE(uint32(EarliestPresentationTime))
+            file.WriteUInt32BE(uint32(FirstOffset))
+        } else {
+            file.WriteInt64BE(EarliestPresentationTime)
+            file.WriteInt64BE(FirstOffset)
+        }
+        file.WriteInt16BE(0)
+        file.WriteInt16BE(int16(Segments.Length))
+        for segment in Segments {
+            segment!!.Save(file)
+        }
+    }
+
+    class Segment {
+        private var typeAndSize uint32
+        private var subsegmentDuration uint32
+        private var sap uint32
+
+        internal init(file Stream) {
+            typeAndSize = file.ReadUInt32BE()
+            subsegmentDuration = file.ReadUInt32BE()
+            sap = file.ReadUInt32BE()
+        }
+
+        prop ReferenceType bool {
+            get -> (typeAndSize & 0x80000000U) == 0x80000000U
+            set -> typeAndSize = if value { typeAndSize | 0x80000000U } else { typeAndSize & uint32(0x7FFFFFFF) }
+        }
+
+        prop ReferenceSize int32 {
+            get -> int32((typeAndSize & uint32(0x7FFFFFFF)))
+            set {
+                ArgumentOutOfRangeException.ThrowIfLessThan(value, 0, nameof(ReferenceSize))
+                typeAndSize = (typeAndSize & 0x80000000U) | uint32(value)
+            }
+        }
+
+        prop SubsegmentDuration uint32 {
+            get -> subsegmentDuration
+            set -> subsegmentDuration = value
+        }
+
+        prop StartsWithSAP bool {
+            get -> (sap & 0x80000000U) == 0x80000000U
+            set -> sap = if value { sap | 0x80000000U } else { sap & uint32(0x7FFFFFFF) }
+        }
+
+        prop SapType int32 {
+            get -> int32((sap >> 28)) & 7
+            set {
+                ArgumentOutOfRangeException.ThrowIfLessThan(value, 0, nameof(SapType))
+                ArgumentOutOfRangeException.ThrowIfGreaterThan(value, 7, nameof(SapType))
+                sap = (sap & 0x8FFFFFFFU) | uint32((value << 28))
+            }
+        }
+
+        prop SapDeltaTime int32 {
+            get -> int32(sap) & 0xFFFFFFF
+            set {
+                ArgumentOutOfRangeException.ThrowIfLessThan(value, 0, nameof(SapType))
+                ArgumentOutOfRangeException.ThrowIfGreaterThan(value, 0xFFFFFFF, nameof(SapType))
+                sap = (sap & 0xF0000000U) | uint32(value)
+            }
+        }
+
+        func Save(file Stream) {
+            file.WriteUInt32BE(typeAndSize)
+            file.WriteUInt32BE(subsegmentDuration)
+            file.WriteUInt32BE(sap)
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/SinfBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/SinfBox.gs
@@ -1,0 +1,18 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import System.Linq
+
+open class SinfBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        LoadChildren(file)
+    }
+
+    prop OriginalFormat FrmaBox -> GetChildOrThrow[FrmaBox]()
+    prop SchemeType SchmBox? -> GetChildren[SchmBox]()?.SingleOrDefault()
+    prop SchemeInformation SchiBox? -> GetChildren[SchiBox]()?.SingleOrDefault()
+
+    protected open override func Render(file Stream) {
+        return
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/StblBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/StblBox.gs
@@ -1,0 +1,19 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+
+open class StblBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        LoadChildren(file)
+    }
+
+    prop Stsd StsdBox -> GetChildOrThrow[StsdBox]()
+    prop Stts SttsBox -> GetChildOrThrow[SttsBox]()
+    prop COBox IChunkOffsets -> GetChild[StcoBox]() ?? IChunkOffsets(GetChildOrThrow[Co64Box]())
+    prop Stsz IStszBox? -> GetChild[StszBox]() ?? (GetChild[Stz2Box]() as IStszBox)
+    prop Stsc StscBox -> GetChildOrThrow[StscBox]()
+
+    protected open override func Render(file Stream) {
+        return
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/StcoBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/StcoBox.gs
@@ -1,0 +1,51 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+internal open class StcoBox : FullBox, IChunkOffsets {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        let entryCount = file.ReadUInt32BE()
+        if entryCount > uint32(Int32.MaxValue) {
+            throw NotSupportedException("Oahu.Decrypt.Mpeg4 does not support MPEG-4 files with more than ${Int32.MaxValue} chunk offsets")
+        }
+        ChunkOffsets = ChunkOffsetList.Read32(file, entryCount)
+    }
+
+    private init(chunkOffsets ChunkOffsetList, versionFlags []uint8, header BoxHeader, parent IBox) : base(versionFlags, header, parent) {
+        ChunkOffsets = chunkOffsets
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(4) + int64(ChunkOffsets.Count * 4)
+    prop EntryCount uint32 -> uint32(ChunkOffsets.Count)
+
+    prop ChunkOffsets ChunkOffsetList {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.WriteUInt32BE(EntryCount)
+        ChunkOffsets.Write32(file)
+    }
+
+    protected open override func Dispose(disposing bool) {
+        if disposing & !Disposed {
+            ChunkOffsets.Clear()
+        }
+        base.Dispose(disposing)
+    }
+
+    shared {
+        internal func CreateBlank(parent IBox, chunkOffsets ChunkOffsetList) StcoBox {
+            let size = 4 + 12
+            let header = BoxHeader(uint32(size), "stco")
+            chunkOffsets.Sort()
+            let stcoBox = StcoBox(chunkOffsets, []uint8{uint8(0), uint8(0), uint8(0), uint8(0)}, header, parent)
+            parent.Children.Add(stcoBox)
+            return stcoBox
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/StreamExtensions.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/StreamExtensions.gs
@@ -1,0 +1,161 @@
+package Oahu.Decrypt.Mpeg4.Util
+
+import System
+import System.Buffers
+import System.Buffers.Binary
+import System.IO
+import System.Threading
+import System.Threading.Tasks
+import Oahu.Decrypt.Mpeg4.Boxes
+
+func (stream Stream) WriteHeader(header BoxHeader, renderSize int64) {
+    if header.Version == 1 || renderSize > int64(UInt32.MaxValue) {
+        stream.WriteUInt32BE(1)
+        stream.WriteType(header.Type)
+        stream.WriteInt64BE(renderSize)
+    } else {
+        stream.WriteUInt32BE(uint32(renderSize))
+        stream.WriteType(header.Type)
+    }
+}
+
+async func (inputStream Stream) SeekToOffsetAsync(chunkOffset int64, token CancellationToken) {
+    if inputStream.Position == chunkOffset {
+        return
+    } else if inputStream.CanSeek {
+        inputStream.Position = chunkOffset
+    } else if inputStream.Position < chunkOffset {
+        const bufferSize = 8 * 1024
+        var toRead = Int32.Min(bufferSize, int32((chunkOffset - inputStream.Position)))
+        using let memoryBuff = MemoryPool[uint8].Shared.Rent(toRead)
+        while toRead > 0 {
+            await inputStream.ReadExactlyAsync(memoryBuff!!.Memory.Slice(0, toRead), token)
+            toRead = Int32.Min(bufferSize, int32((chunkOffset - inputStream.Position)))
+        }
+    } else {
+        throw NotSupportedException("Input stream position 0x${inputStream.Position:X8} is past the chunk offset 0x${chunkOffset:X8} and is not seekable.")
+    }
+}
+
+func (inputStream Stream) SeekToOffset(chunkOffset int64) {
+    if inputStream.Position == chunkOffset {
+        return
+    } else if inputStream.CanSeek {
+        inputStream.Position = chunkOffset
+    } else if inputStream.Position < chunkOffset {
+        const bufferSize = 8 * 1024
+        var toRead = Int32.Min(bufferSize, int32((chunkOffset - inputStream.Position)))
+        using let memoryBuff = MemoryPool[uint8].Shared.Rent(toRead)
+        let spanBuff = memoryBuff!!.Memory.Span
+        while toRead > 0 {
+            inputStream.ReadExactly(spanBuff.Slice(0, toRead))
+            toRead = Int32.Min(bufferSize, int32((chunkOffset - inputStream.Position)))
+        }
+    } else {
+        throw NotSupportedException("Input stream position 0x${inputStream.Position:X8} is past the chunk offset 0x${chunkOffset:X8} and is not seekable.")
+    }
+}
+
+async func (inputStream Stream) ReadNextChunkAsync(chunkOffset int64, chunkBuffer Memory[uint8], token CancellationToken) {
+    await inputStream.SeekToOffsetAsync(chunkOffset, token)
+    if await inputStream.ReadAsync(chunkBuffer, token) != chunkBuffer.Length {
+        throw EndOfStreamException("Stream ended at position ${inputStream.Position} before all ${chunkBuffer.Length} bytes were read.")
+    }
+}
+
+func (stream Stream) WriteType(type_ string) {
+    if type_?.Length != 4 {
+        throw ArgumentException("Type must be 4 chars long.")
+    }
+    stream.Write([]uint8{uint8(type_[0]), uint8(type_[1]), uint8(type_[2]), uint8(type_[3])})
+}
+
+func (stream Stream) WriteInt16BE(value int16) {
+    let word = stackalloc [2]uint8
+    BinaryPrimitives.WriteInt16BigEndian(word, value)
+    stream.Write(word)
+}
+
+func (stream Stream) WriteUInt16BE(value uint16) {
+    let word = stackalloc [2]uint8
+    BinaryPrimitives.WriteUInt16BigEndian(word, value)
+    stream.Write(word)
+}
+
+func (stream Stream) WriteInt32BE(value int32) {
+    let dword = stackalloc [4]uint8
+    BinaryPrimitives.WriteInt32BigEndian(dword, value)
+    stream.Write(dword)
+}
+
+func (stream Stream) WriteUInt32BE(value uint32) {
+    let dword = stackalloc [4]uint8
+    BinaryPrimitives.WriteUInt32BigEndian(dword, value)
+    stream.Write(dword)
+}
+
+func (stream Stream) WriteInt64BE(value int64) {
+    let qword = stackalloc [8]uint8
+    BinaryPrimitives.WriteInt64BigEndian(qword, value)
+    stream.Write(qword)
+}
+
+func (stream Stream) WriteUInt64BE(value uint64) {
+    let qword = stackalloc [8]uint8
+    BinaryPrimitives.WriteUInt64BigEndian(qword, value)
+    stream.Write(qword)
+}
+
+func (stream Stream) ReadInt16BE() int16 {
+    let word = stackalloc [2]uint8
+    stream.ReadExactly(word)
+    return BinaryPrimitives.ReadInt16BigEndian(word)
+}
+
+func (stream Stream) ReadUInt16BE() uint16 {
+    let word = stackalloc [2]uint8
+    stream.ReadExactly(word)
+    return BinaryPrimitives.ReadUInt16BigEndian(word)
+}
+
+func (stream Stream) ReadInt32BE() int32 {
+    let dword = stackalloc [4]uint8
+    stream.ReadExactly(dword)
+    return BinaryPrimitives.ReadInt32BigEndian(dword)
+}
+
+func (stream Stream) ReadUInt32BE() uint32 {
+    let dword = stackalloc [4]uint8
+    stream.ReadExactly(dword)
+    return BinaryPrimitives.ReadUInt32BigEndian(dword)
+}
+
+func (stream Stream) ReadInt64BE() int64 {
+    let qword = stackalloc [8]uint8
+    stream.ReadExactly(qword)
+    return BinaryPrimitives.ReadInt64BigEndian(qword)
+}
+
+func (stream Stream) ReadUInt64BE() uint64 {
+    let qword = stackalloc [8]uint8
+    stream.ReadExactly(qword)
+    return BinaryPrimitives.ReadUInt64BigEndian(qword)
+}
+
+func (stream Stream) ReadType() string {
+    let dword = stackalloc [4]uint8
+    stream.ReadExactly(dword)
+    return string([]char{char(dword[0]), char(dword[1]), char(dword[2]), char(dword[3])})
+}
+
+func (stream Stream) ReadBlock(length int32) []uint8 {
+    if length < 0 {
+        throw ArgumentException("Length must be non-negative", nameof(length))
+    } else if length == 0 {
+        return []uint8{}
+    } else {
+        let buffer = [length]uint8
+        stream.ReadExactly(buffer)
+        return buffer
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/StscBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/StscBox.gs
@@ -1,0 +1,93 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.Buffers.Binary
+import System.Collections.Generic
+import System.Diagnostics
+import System.IO
+import System.Runtime.InteropServices
+import Oahu.Decrypt.Mpeg4.Util
+
+struct ChunkFrames {
+    prop FirstFrameIndex uint32 {
+        get;
+        init;
+    }
+
+    prop NumberOfFrames uint32 {
+        get;
+        init;
+    }
+}
+
+open class StscBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        let entryCount = file.ReadUInt32BE()
+        Debug.Assert(entryCount <= uint32(Int32.MaxValue))
+        Samples = List[StscChunkEntry](int32(entryCount))
+        CollectionsMarshal.SetCount(Samples, int32(entryCount))
+        let samples = CollectionsMarshal.AsSpan(Samples)
+        file.ReadExactly(MemoryMarshal.AsBytes(samples))
+        if BitConverter.IsLittleEndian {
+            let uints = MemoryMarshal.Cast[StscChunkEntry, uint32](samples)
+            BinaryPrimitives.ReverseEndianness(uints, uints)
+        }
+    }
+
+    private init(versionFlags []uint8, header BoxHeader, parent IBox) : base(versionFlags, header, parent) {
+        Samples = List[StscChunkEntry]()
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(4) + int64(EntryCount * 3 * 4)
+    prop EntryCount int32 -> Samples.Count
+
+    prop Samples List[StscChunkEntry] {
+        get;
+        init;
+    }
+
+    func CalculateChunkFrameTable(numChunks uint32) []ChunkFrames {
+        let table = [int32(numChunks)]ChunkFrames
+        var firstFrameIndex uint32 = uint32(0)
+        var lastStscIndex = 0
+        for var chunk uint32 = uint32(1); chunk <= numChunks; chunk++ {
+            if lastStscIndex + 1 < Samples.Count && chunk == Samples[lastStscIndex + 1].FirstChunk {
+                lastStscIndex++
+            }
+            table[chunk - uint32(1)] = ChunkFrames{FirstFrameIndex: firstFrameIndex, NumberOfFrames: Samples[lastStscIndex].SamplesPerChunk}
+            firstFrameIndex += Samples[lastStscIndex].SamplesPerChunk
+        }
+        return table
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.WriteUInt32BE(uint32(Samples.Count))
+        for sample in Samples {
+            file.WriteUInt32BE(sample.FirstChunk)
+            file.WriteUInt32BE(sample.SamplesPerChunk)
+            file.WriteUInt32BE(sample.SampleDescriptionIndex)
+        }
+    }
+
+    protected open override func Dispose(disposing bool) {
+        if disposing && !Disposed {
+            Samples.Clear()
+        }
+        base.Dispose(disposing)
+    }
+
+    @StructLayout(0)
+    data struct StscChunkEntry(FirstChunk uint32, SamplesPerChunk uint32, SampleDescriptionIndex uint32) {
+    }
+
+    shared {
+        func CreateBlank(parent IBox) StscBox {
+            let size = 4 + 12
+            let header = BoxHeader(uint32(size), "stsc")
+            let stscBox = StscBox([]uint8{uint8(0), uint8(0), uint8(0), uint8(0)}, header, parent)
+            parent.Children.Add(stscBox)
+            return stscBox
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/StsdBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/StsdBox.gs
@@ -1,0 +1,49 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.Collections.Generic
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class StsdBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        VisualSampleEntries = List[VisualSampleEntry]()
+        EntryCount = file.ReadUInt32BE()
+        let hdlr HdlrBox? = Parent?.Parent?.Parent?.GetChild[HdlrBox]()
+        for var i = 0; int64(i) < int64(EntryCount); i++ {
+            let h = BoxHeader(file)
+            if hdlr?.HandlerType == "soun" {
+                AudioSampleEntry = AudioSampleEntry(file, h, this)
+                Children.Add(AudioSampleEntry!!)
+            } else if hdlr?.HandlerType == "vide" {
+                let entry = VisualSampleEntry(file, h, this)
+                VisualSampleEntries.Add(entry!!)
+                Children.Add(entry!!)
+            } else {
+                let unknownSampleEntry = UnknownBox(file, h, this)
+                Children.Add(unknownSampleEntry)
+            }
+        }
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(4)
+
+    prop EntryCount uint32 {
+        get;
+        init;
+    }
+
+    prop AudioSampleEntry AudioSampleEntry? {
+        get;
+        init;
+    }
+
+    prop VisualSampleEntries List[VisualSampleEntry] {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.WriteUInt32BE(EntryCount)
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/StszBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/StszBox.gs
@@ -1,0 +1,102 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.Buffers.Binary
+import System.Collections.Generic
+import System.IO
+import System.Linq
+import System.Runtime.InteropServices
+import Oahu.Decrypt.Mpeg4.Util
+
+open class StszBox : FullBox, IStszBox {
+    private let origSampleCount int32
+    private let sampleSizes32 List[int32]?
+    private let sampleSizes16 List[uint16]?
+
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        SampleSize = file.ReadInt32BE()
+        let sampleCountU = file.ReadUInt32BE()
+        if sampleCountU > uint32(Int32.MaxValue) {
+            throw NotSupportedException("Oahu.Decrypt.Mpeg4 does not support MPEG-4 files with more than ${Int32.MaxValue} samples")
+        }
+        origSampleCount = int32(sampleCountU)
+        if SampleSize > 0 {
+            return
+        }
+        sampleSizes32 = List[int32](origSampleCount)
+        CollectionsMarshal.SetCount(sampleSizes32!!, origSampleCount)
+        let intListSpan = CollectionsMarshal.AsSpan(sampleSizes32!!)
+        file.ReadExactly(MemoryMarshal.AsBytes(intListSpan))
+        if BitConverter.IsLittleEndian {
+            BinaryPrimitives.ReverseEndianness(intListSpan, intListSpan)
+        }
+        if intListSpan.AllLessThanOrEqual(int32(UInt16.MaxValue)) {
+            sampleSizes16 = List[uint16](origSampleCount)
+            CollectionsMarshal.SetCount(sampleSizes16!!, origSampleCount)
+            let shortListSpan = CollectionsMarshal.AsSpan(sampleSizes16!!)
+            for var i = 0; i < origSampleCount; i++ {
+                shortListSpan[i] = uint16(intListSpan[i])
+            }
+            CollectionsMarshal.SetCount(sampleSizes32!!, 0)
+            sampleSizes32 = nil
+        }
+    }
+
+    private init(versionFlags []uint8, header BoxHeader, parent IBox, sampleSizes List[int32]) : base(versionFlags, header, parent) {
+        sampleSizes32 = sampleSizes
+    }
+
+    private init(versionFlags []uint8, header BoxHeader, parent IBox, sampleSizes List[uint16]) : base(versionFlags, header, parent) {
+        sampleSizes16 = sampleSizes
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(8) + int64(SampleCount * 4)
+
+    prop SampleSize int32 {
+        get;
+        init;
+    }
+
+    prop SampleCount int32 -> sampleSizes32?.Count ?? sampleSizes16?.Count ?? origSampleCount
+    prop MaxSize int32 -> sampleSizes32?.Max() ?? sampleSizes16?.Max() ?? uint16(SampleSize)
+    prop TotalSize int64 -> sampleSizes32?.Sum((s int32) -> int64(s)) ?? sampleSizes16?.Sum((s uint16) -> int64(s)) ?? int64(SampleSize * origSampleCount)
+    func GetSizeAtIndex(index int32) int32 -> sampleSizes32?[index] ?? sampleSizes16?[index] ?? uint16(SampleSize)
+    func SumFirstNSizes(firstN int32) int64 -> sampleSizes32?.Take(firstN).Sum((s int32) -> int64(s)) ?? sampleSizes16?.Take(firstN).Sum((s uint16) -> int64(s)) ?? int64(SampleSize) * int64(firstN)
+
+    protected open override func Render(file Stream) {
+        unsafe {
+            base.Render(file)
+            file.WriteInt32BE(SampleSize)
+            file.WriteUInt32BE(uint32(SampleCount))
+            if sampleSizes32 != nil {
+                let intSpan = CollectionsMarshal.AsSpan(sampleSizes32!!)
+                if BitConverter.IsLittleEndian {
+                    BinaryPrimitives.ReverseEndianness(intSpan, intSpan)
+                }
+                file.Write(MemoryMarshal.AsBytes(intSpan))
+            } else if sampleSizes16 != nil {
+                for size in sampleSizes16!! {
+                    file.WriteInt32BE(size)
+                }
+            }
+        }
+    }
+
+    shared {
+        func CreateBlank(parent IBox, sampleSizes List[int32]) StszBox {
+            let size = 8 + 12
+            let header = BoxHeader(uint32(size), "stsz")
+            let stszBox = StszBox([]uint8{uint8(0), uint8(0), uint8(0), uint8(0)}, header, parent, sampleSizes)
+            parent.Children.Add(stszBox!!)
+            return stszBox!!
+        }
+
+        func CreateBlank(parent IBox, sampleSizes List[uint16]) StszBox {
+            let size = 8 + 12
+            let header = BoxHeader(uint32(size), "stsz")
+            let stszBox = StszBox([]uint8{uint8(0), uint8(0), uint8(0), uint8(0)}, header, parent, sampleSizes)
+            parent.Children.Add(stszBox!!)
+            return stszBox!!
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/SttsBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/SttsBox.gs
@@ -1,0 +1,94 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.Buffers.Binary
+import System.Collections.Generic
+import System.Diagnostics
+import System.IO
+import System.Linq
+import System.Runtime.InteropServices
+import Oahu.Decrypt.Mpeg4.Util
+
+open class SttsBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        Samples = List[SttsBox.SampleEntry]()
+        let entryCount = file.ReadUInt32BE()
+        Debug.Assert(entryCount <= uint32(Int32.MaxValue))
+        Samples = List[SttsBox.SampleEntry](int32(entryCount))
+        CollectionsMarshal.SetCount(Samples, int32(entryCount))
+        let samples = CollectionsMarshal.AsSpan(Samples)
+        file.ReadExactly(MemoryMarshal.AsBytes(samples))
+        if BitConverter.IsLittleEndian {
+            let uints = MemoryMarshal.Cast[SttsBox.SampleEntry, uint32](samples)
+            BinaryPrimitives.ReverseEndianness(uints, uints)
+        }
+    }
+
+    private init(versionFlags []uint8, header BoxHeader, parent IBox?) : base(versionFlags, header, parent) {
+        Samples = List[SttsBox.SampleEntry]()
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(4) + int64(EntryCount * 2 * 4)
+    prop EntryCount int32 -> Samples.Count
+
+    prop Samples List[SttsBox.SampleEntry] {
+        get;
+        init;
+    }
+
+    prop SampleTimeCount uint32 -> uint32(Samples.Sum((s SttsBox.SampleEntry) -> s.FrameCount))
+
+    func EnumerateFrameDeltas(startAt uint32 = 0) sequence[uint32] {
+        var startAt = startAt
+        for entry in Samples {
+            while startAt < entry.FrameCount {
+                yield entry.FrameDelta
+                startAt++
+            }
+            startAt -= entry.FrameCount
+        }
+    }
+
+    func FrameToTime(timeScale float64, frameIndex uint64) TimeSpan {
+        var beginDelta uint64 = uint64(0)
+        var workingIndex = frameIndex
+        for entry in Samples {
+            if workingIndex <= uint64(entry.FrameCount) {
+                return TimeSpan.FromSeconds(float64((beginDelta + workingIndex * uint64(entry.FrameDelta))) / timeScale)
+            }
+            beginDelta += uint64(entry.FrameCount) * uint64(entry.FrameDelta)
+            workingIndex -= uint64(entry.FrameCount)
+        }
+        throw IndexOutOfRangeException("${nameof(frameIndex)} $frameIndex is larger than the number of frames in ${nameof(SttsBox)}")
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.WriteUInt32BE(uint32(Samples.Count))
+        for sample in Samples {
+            file.WriteUInt32BE(sample.FrameCount)
+            file.WriteUInt32BE(sample.FrameDelta)
+        }
+    }
+
+    protected open override func Dispose(disposing bool) {
+        if disposing && !Disposed {
+            Samples.Clear()
+        }
+        base.Dispose(disposing)
+    }
+
+    @StructLayout(0)
+    data struct SampleEntry(FrameCount uint32, FrameDelta uint32) {
+    }
+
+    shared {
+        func CreateBlank(parent IBox) SttsBox {
+            let size = 4 + 12
+            let header = BoxHeader(uint32(size), "stts")
+            let sttsBox = SttsBox([]uint8{uint8(0), uint8(0), uint8(0), uint8(0)}, header, parent)
+            parent.Children.Add(sttsBox)
+            return sttsBox
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Stz2Box.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/Stz2Box.gs
@@ -1,0 +1,94 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.Buffers.Binary
+import System.Collections.Generic
+import System.IO
+import System.Linq
+import System.Runtime.InteropServices
+import Oahu.Decrypt.Mpeg4.Util
+
+open class Stz2Box : FullBox, IStszBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        let reserved = stackalloc [4]uint8
+        file.ReadExactly(reserved)
+        FieldSize = reserved[3]
+        let sampleCount = file.ReadUInt32BE()
+        if !((FieldSize == 8 || FieldSize == 16)) {
+            throw InvalidDataException("Stsz field size ($FieldSize). Valid values are 4, 8, or 16.")
+        }
+        if sampleCount > uint32(Int32.MaxValue) {
+            throw NotSupportedException("Oahu.Decrypt.Mpeg4 does not support MPEG-4 files with more than ${Int32.MaxValue} samples")
+        }
+        SampleSizes = List[uint16](int32(sampleCount))
+        CollectionsMarshal.SetCount(SampleSizes, int32(sampleCount))
+        let shortSpan = CollectionsMarshal.AsSpan(SampleSizes)
+        if FieldSize == 16 {
+            file.ReadExactly(MemoryMarshal.AsBytes(shortSpan))
+            if BitConverter.IsLittleEndian {
+                BinaryPrimitives.ReverseEndianness(shortSpan, shortSpan)
+            }
+        } else {
+            let bytes Span[uint8] = file.ReadBlock(int32(sampleCount))
+            for var i = 0; int64(i) < int64(sampleCount); i++ {
+                shortSpan[i] = bytes[i]
+            }
+        }
+    }
+
+    private init(versionFlags []uint8, header BoxHeader, parent IBox, sampleSizes List[uint16], fieldSize int32) : base(versionFlags, header, parent) {
+        if fieldSize != 16 && fieldSize != 8 && fieldSize != 4 {
+            throw InvalidDataException("Stsz field size ($fieldSize). Valid values are 4, 8, or 16.")
+        }
+        FieldSize = fieldSize
+        SampleSizes = sampleSizes
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(8) + int64(SampleCount * FieldSize / 8) + int64((if FieldSize == 4 && SampleCount % 2 == 1 { 1 } else { 0 }))
+    prop SampleCount int32 -> SampleSizes.Count
+
+    prop SampleSizes List[uint16] {
+        get;
+        init;
+    }
+
+    prop MaxSize int32 -> SampleSizes.Max()
+    prop TotalSize int64 -> SampleSizes.Sum((s uint16) -> int64(s))
+
+    prop FieldSize int32 {
+        get;
+        init;
+    }
+
+    func GetSizeAtIndex(index int32) int32 -> SampleSizes[index]
+    func SumFirstNSizes(firstN int32) int64 -> SampleSizes.Take(firstN).Sum((s uint16) -> int64(s))
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        let fieldSize = stackalloc [4]uint8
+        let shortSpan = CollectionsMarshal.AsSpan(SampleSizes)
+        fieldSize[3] = uint8((if shortSpan.AllLessThanOrEqual(uint16(Byte.MaxValue)) { 8 } else { 16 }))
+        file.Write(fieldSize)
+        file.WriteInt32BE(SampleSizes.Count)
+        if fieldSize[3] == uint8(16) {
+            if BitConverter.IsLittleEndian {
+                BinaryPrimitives.ReverseEndianness(shortSpan, shortSpan)
+            }
+            file.Write(MemoryMarshal.AsBytes(shortSpan))
+        } else {
+            for size in SampleSizes {
+                file.WriteByte(uint8(size))
+            }
+        }
+    }
+
+    shared {
+        func CreateBlank(parent IBox, sampleSizes List[uint16]) Stz2Box {
+            let size = 8 + 12
+            let header = BoxHeader(uint32(size), "stz2")
+            let stszBox = Stz2Box([]uint8{uint8(0), uint8(0), uint8(0), uint8(0)}, header, parent, sampleSizes, 16)
+            parent.Children.Add(stszBox!!)
+            return stszBox!!
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/TEXTFrame.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/TEXTFrame.gs
@@ -1,0 +1,38 @@
+package Oahu.Decrypt.Mpeg4.ID3
+
+import System.IO
+import System.Text
+
+class TEXTFrame : Frame {
+    init(file Stream, header Header, parent Frame) : base(header, parent) {
+        EncodingFlag = uint8(file.ReadByte())
+        Text = Frame.ReadSizeString(file, EncodingFlag == uint8(1), Header.Size - 1)
+    }
+
+    private init(header Header, parent Frame) : base(header, parent) {
+    }
+
+    override prop Size int32 -> 1 + (if Text == nil { 0 } else { if Frame.IsUnicode(Text!!) { Frame.UnicodeLength(Text!!) } else { Text!!.Length } })
+    prop EncodingFlag uint8
+    prop Text string?
+
+    override func Render(file Stream) {
+        if Text == nil {
+            file.WriteByte(0)
+        } else if Frame.IsUnicode(Text!!) {
+            file.WriteByte(1)
+            file.Write(Frame.UnicodeBytes(Text!!))
+        } else {
+            file.WriteByte(0)
+            file.Write(Encoding.ASCII.GetBytes(Text!!))
+        }
+    }
+
+    shared {
+        func Create(parent Frame, frameId string, text string) TEXTFrame {
+            let tit2 = TEXTFrame(FrameHeader(frameId, 0, parent.Version), parent)
+            parent?.Children.Add(tit2!!)
+            return tit2!!
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/TXXXFrame.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/TXXXFrame.gs
@@ -1,0 +1,41 @@
+package Oahu.Decrypt.Mpeg4.ID3
+
+import System.IO
+import System.Text
+
+class TXXXFrame : Frame {
+    init(file Stream, header Header, parent Frame) : base(header, parent) {
+        let startPos = file.Position
+        let unicode = file.ReadByte() == 1
+        FieldName = Frame.ReadNullTerminatedString(file, unicode)
+        FieldValue = Frame.ReadSizeString(file, unicode, int32((startPos + int64(header.Size) - file.Position)))
+    }
+
+    override prop Size int32 -> if Frame.IsUnicode(FieldName) || Frame.IsUnicode(FieldValue) { 1 + Frame.UnicodeLength(FieldName) + 2 + Frame.UnicodeLength(FieldValue) } else { 1 + FieldName.Length + 1 + FieldValue.Length }
+
+    prop FieldName string {
+        get;
+        init;
+    }
+
+    prop FieldValue string {
+        get;
+        init;
+    }
+
+    func ToString() string -> FieldName
+
+    override func Render(file Stream) {
+        if Frame.IsUnicode(FieldName) || Frame.IsUnicode(FieldValue) {
+            file.WriteByte(1)
+            file.Write(Frame.UnicodeBytes(FieldName))
+            file.Write(stackalloc [2]uint8)
+            file.Write(Frame.UnicodeBytes(FieldValue))
+        } else {
+            file.WriteByte(0)
+            file.Write(Encoding.ASCII.GetBytes(FieldName))
+            file.WriteByte(0)
+            file.Write(Encoding.ASCII.GetBytes(FieldValue))
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/TagFactory.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/TagFactory.gs
@@ -1,0 +1,29 @@
+package Oahu.Decrypt.Mpeg4.ID3
+
+import System.IO
+
+internal class TagFactory {
+    shared {
+        func CreateTag(file Stream, parent Frame, out lengthRead int32) Frame {
+            let startPos = file.Position
+            let frameHeader = FrameHeader.Create(file, parent.Version)
+            let frame = TagFactory.CreateTagInternal(frameHeader!!, file, parent)
+            lengthRead = int32((file.Position - startPos))
+            return frame!!
+        }
+
+        private func CreateTagInternal(frameHeader FrameHeader, file Stream, parent Frame) Frame {
+            if parent.Version >= uint16(0x300) && frameHeader.Identifier.StartsWith('T') && frameHeader.Identifier != "TXXX" {
+                return TEXTFrame(file, frameHeader, parent)
+            }
+            return switch frameHeader.Identifier {
+                case "TXXX": TXXXFrame(file, frameHeader, parent)
+                case "APIC": APICFrame(file, frameHeader, parent)
+                case "CHAP": CHAPFrame(file, frameHeader, parent)
+                case "CTOC": CTOCFrame(file, frameHeader, parent)
+                case "\u0000\u0000\u0000" or "\u0000\u0000\u0000\u0000": EmptyFrame(frameHeader, parent)
+                default: UnknownFrame(file, frameHeader, parent)
+            }
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/TencBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/TencBox.gs
@@ -1,0 +1,80 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class TencBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        file.ReadByte()
+        if Version == uint8(0) {
+            file.ReadByte()
+        } else {
+            let value = file.ReadByte()
+            DefaultCryptByteBlock = uint8((value >> 4))
+            DefaultSkipByteBlock = uint8((value & 0xf))
+        }
+        DefaultIsProtected = file.ReadByte() != 0
+        DefaultPerSampleIvSize = uint8(file.ReadByte())
+        DefaultKID = Guid(file.ReadBlock(16), true)
+        if DefaultIsProtected && DefaultPerSampleIvSize == uint8(0) {
+            DefaultConstantIvSize = uint8(file.ReadByte())
+            DefaultConstantIv = file.ReadBlock(DefaultConstantIvSize)
+        } else {
+            DefaultConstantIv = Array.Empty[uint8]()
+        }
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(20) + int64((if (DefaultIsProtected && DefaultPerSampleIvSize == uint8(0)) { uint8(1) + DefaultConstantIvSize } else { 0 }))
+
+    prop DefaultCryptByteBlock uint8 {
+        get;
+        init;
+    }
+
+    prop DefaultSkipByteBlock uint8 {
+        get;
+        init;
+    }
+
+    prop DefaultIsProtected bool {
+        get;
+        init;
+    }
+
+    prop DefaultPerSampleIvSize uint8 {
+        get;
+        init;
+    }
+
+    prop DefaultKID Guid {
+        get;
+        init;
+    }
+
+    prop DefaultConstantIvSize uint8 {
+        get;
+        init;
+    }
+
+    prop DefaultConstantIv []uint8 {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        var value int16 = 0
+        if Version != uint8(0) {
+            value = int16(((DefaultCryptByteBlock << 4) | (DefaultSkipByteBlock & uint8(0xf))))
+        }
+        file.WriteInt16BE(value)
+        file.WriteByte(uint8((if DefaultIsProtected { 1 } else { 0 })))
+        file.WriteByte(DefaultPerSampleIvSize)
+        file.Write(DefaultKID.ToByteArray(true))
+        if DefaultIsProtected && DefaultPerSampleIvSize == uint8(0) {
+            file.WriteByte(uint8(DefaultConstantIv.Length))
+            file.Write(DefaultConstantIv)
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/TfdtBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/TfdtBox.gs
@@ -1,0 +1,26 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class TfdtBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        BaseMediaDecodeTime = if Version == uint8(1) { file.ReadInt64BE() } else { int64(file.ReadUInt32BE()) }
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64((if Version == uint8(1) { 8 } else { 4 }))
+
+    prop BaseMediaDecodeTime int64 {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        if Version == uint8(1) {
+            file.WriteInt64BE(BaseMediaDecodeTime)
+        } else {
+            file.WriteUInt32BE(uint32(BaseMediaDecodeTime))
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/TfhdBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/TfhdBox.gs
@@ -1,0 +1,86 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class TfhdBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        TrackID = file.ReadUInt32BE()
+        if BaseDataOffsetPresent {
+            BaseDataOffset = file.ReadInt64BE()
+        }
+        if SampleDescriptionIndexPresent {
+            SampleDescriptionIndex = file.ReadUInt32BE()
+        }
+        if DefaultSampleDurationPresent {
+            DefaultSampleDuration = file.ReadUInt32BE()
+        }
+        if DefaultSampleSizePresent {
+            DefaultSampleSize = file.ReadUInt32BE()
+        }
+        if DefaultSampleFlagsPresent {
+            DefaultSampleFlags = file.ReadUInt32BE()
+        }
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(4) + int64(OptionalFieldsSize)
+
+    prop TrackID uint32 {
+        get;
+        init;
+    }
+
+    prop BaseDataOffset int64? {
+        get;
+        init;
+    }
+
+    prop SampleDescriptionIndex uint32? {
+        get;
+        init;
+    }
+
+    prop DefaultSampleDuration uint32? {
+        get;
+        init;
+    }
+
+    prop DefaultSampleSize uint32? {
+        get;
+        init;
+    }
+
+    prop DefaultSampleFlags uint32? {
+        get;
+        init;
+    }
+
+    prop DurationIsEmpty bool -> (Flags & 0x010000) == 0x010000
+    prop DefaultBaseIsMoof bool -> (Flags & 0x020000) == 0x020000
+    private prop OptionalFieldsSize int32 -> (if BaseDataOffsetPresent { 8 } else { 0 }) + (if SampleDescriptionIndexPresent { 4 } else { 0 }) + (if DefaultSampleDurationPresent { 4 } else { 0 }) + (if DefaultSampleSizePresent { 4 } else { 0 }) + (if DefaultSampleFlagsPresent { 4 } else { 0 })
+    private prop BaseDataOffsetPresent bool -> (Flags & 1) == 1
+    private prop SampleDescriptionIndexPresent bool -> (Flags & 2) == 2
+    private prop DefaultSampleDurationPresent bool -> (Flags & 8) == 8
+    private prop DefaultSampleSizePresent bool -> (Flags & 16) == 16
+    private prop DefaultSampleFlagsPresent bool -> (Flags & 32) == 32
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.WriteUInt32BE(TrackID)
+        if BaseDataOffset.HasValue {
+            file.WriteInt64BE(BaseDataOffset.Value)
+        }
+        if SampleDescriptionIndex.HasValue {
+            file.WriteUInt32BE(SampleDescriptionIndex.Value)
+        }
+        if DefaultSampleDuration.HasValue {
+            file.WriteUInt32BE(DefaultSampleDuration.Value)
+        }
+        if DefaultSampleSize.HasValue {
+            file.WriteUInt32BE(DefaultSampleSize.Value)
+        }
+        if DefaultSampleFlags.HasValue {
+            file.WriteUInt32BE(DefaultSampleFlags.Value)
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/TkhdBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/TkhdBox.gs
@@ -1,0 +1,74 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class TkhdBox : HeaderBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        file.ReadUInt64BE()
+        Layer = file.ReadInt16BE()
+        AlternateGroup = file.ReadInt16BE()
+        Volume = file.ReadInt16BE()
+        Reserved3 = file.ReadUInt16BE()
+        Matrix = file.ReadBlock(4 * 9)
+        Width = file.ReadUInt32BE()
+        Height = file.ReadUInt32BE()
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(2 * 4) + int64(8) + int64(4 * 2) + int64(Matrix.Length) + int64(2 * 4)
+    prop TrackID uint32
+
+    prop Layer int16 {
+        get;
+        init;
+    }
+
+    prop AlternateGroup int16
+
+    prop Volume int16 {
+        get;
+        init;
+    }
+
+    prop Reserved3 uint16 {
+        get;
+        init;
+    }
+
+    prop Matrix []uint8 {
+        get;
+        init;
+    }
+
+    prop Width uint32 {
+        get;
+        init;
+    }
+
+    prop Height uint32 {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.WriteUInt64BE(0)
+        file.WriteInt16BE(Layer)
+        file.WriteInt16BE(AlternateGroup)
+        file.WriteInt16BE(Volume)
+        file.WriteUInt16BE(Reserved3)
+        file.Write(Matrix)
+        file.WriteUInt32BE(Width)
+        file.WriteUInt32BE(Height)
+    }
+
+    protected open override func ReadBeforeDuration(file Stream) {
+        TrackID = file.ReadUInt32BE()
+        file.ReadUInt32BE()
+    }
+
+    protected open override func WriteBeforeDuration(file Stream) {
+        file.WriteUInt32BE(TrackID)
+        file.WriteUInt32BE(0)
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/TrackedReadStream.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/TrackedReadStream.gs
@@ -1,0 +1,48 @@
+package Oahu.Decrypt.Mpeg4
+
+import System
+import System.IO
+
+open class TrackedReadStream(baseStream Stream, baseStreamLength int64) : Stream {
+    private var readPosition int64 = 0
+    prop CanRead bool -> this.baseStream.CanRead
+    prop CanSeek bool -> this.baseStream.CanSeek
+    prop Length int64 -> baseStreamLength
+    prop CanWrite bool -> this.baseStream.CanWrite
+
+    prop Position int64 {
+        get -> if CanSeek { this.baseStream.Position } else { readPosition }
+        set {
+            if !CanSeek {
+                throw NotSupportedException()
+            }
+            readPosition = value
+            this.baseStream.Position = readPosition
+        }
+    }
+
+    func Flush() {
+        throw NotSupportedException()
+    }
+
+    func Read(buffer []uint8, offset int32, count int32) int32 {
+        this.baseStream.ReadExactly(buffer, offset, count)
+        readPosition += int64(count)
+        return count
+    }
+
+    func Seek(offset int64, origin SeekOrigin) int64 {
+        return if CanSeek { this.baseStream.Seek(offset, origin) } else { throw NotSupportedException()
+            default(int64) }
+    }
+
+    func SetLength(value int64) -> this.baseStream.SetLength(value)
+    func Write(buffer []uint8, offset int32, count int32) -> this.baseStream.Write(buffer, offset, count)
+
+    protected func Dispose(disposing bool) {
+        if disposing {
+            this.baseStream.Dispose()
+        }
+        base.Dispose(disposing)
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/TrackedWriteStream.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/TrackedWriteStream.gs
@@ -1,0 +1,48 @@
+package Oahu.Decrypt.Mpeg4
+
+import System
+import System.IO
+
+open class TrackedWriteStream(baseStream Stream, writePosition int64 = 0) : Stream {
+    prop CanRead bool -> false
+    prop CanSeek bool -> this.baseStream.CanSeek
+    prop Length int64 -> writePosition
+    prop CanWrite bool -> this.baseStream.CanWrite
+
+    prop Position int64 {
+        get -> if CanSeek { this.baseStream.Position } else { writePosition }
+        set {
+            if !CanSeek {
+                throw NotSupportedException()
+            }
+            this.baseStream.Position = value
+        }
+    }
+
+    func Flush() -> this.baseStream.Flush()
+
+    func Read(buffer []uint8, offset int32, count int32) int32 {
+        throw NotSupportedException()
+    }
+
+    func Seek(offset int64, origin SeekOrigin) int64 {
+        return if CanSeek { this.baseStream.Seek(offset, origin) } else { throw NotSupportedException()
+            default(int64) }
+    }
+
+    func SetLength(value int64) {
+        throw NotSupportedException()
+    }
+
+    func Write(buffer []uint8, offset int32, count int32) {
+        this.baseStream.Write(buffer, offset, count)
+        writePosition += int64(count)
+    }
+
+    protected func Dispose(disposing bool) {
+        if disposing {
+            this.baseStream.Dispose()
+        }
+        base.Dispose(disposing)
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/TrafBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/TrafBox.gs
@@ -1,0 +1,20 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+
+open class TrafBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        LoadChildren(file)
+    }
+
+    prop Tfhd TfhdBox -> GetChildOrThrow[TfhdBox]()
+    prop Tfdt TfdtBox? -> GetChild[TfdtBox]()
+    prop Trun TrunBox? -> GetChild[TrunBox]()
+    prop Saiz SaizBox? -> GetChild[SaizBox]()
+    prop Saio SaioBox? -> GetChild[SaioBox]()
+    prop Senc SencBox? -> GetChild[SencBox]()
+
+    protected open override func Render(file Stream) {
+        return
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/TrakBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/TrakBox.gs
@@ -1,0 +1,16 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+
+open class TrakBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        LoadChildren(file)
+    }
+
+    prop Tkhd TkhdBox -> GetChildOrThrow[TkhdBox]()
+    prop Mdia MdiaBox -> GetChildOrThrow[MdiaBox]()
+
+    protected open override func Render(file Stream) {
+        return
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/TrefBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/TrefBox.gs
@@ -1,0 +1,74 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.Collections.Generic
+import System.Diagnostics
+import System.IO
+import System.Linq
+import Oahu.Decrypt.Mpeg4.Util
+
+interface ITrackReferenceTypeBox : IBox {
+    prop TrackIds HashSet[uint32]
+}
+
+open class TrefBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        References = List[ITrackReferenceTypeBox]()
+        while RemainingBoxLength(file) > int64(0) {
+            References.Add(TrackReferenceTypeBox(file, this))
+        }
+    }
+
+    private init(parent IBox) : base(BoxHeader(8, "tref"), parent) {
+        References = List[ITrackReferenceTypeBox]()
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + References.Sum((r ITrackReferenceTypeBox) -> r.RenderSize)
+
+    prop References List[ITrackReferenceTypeBox] {
+        get;
+        init;
+    }
+
+    func AddReference(type_ string, trackIds HashSet[uint32]) TrefBox {
+        References.Add(TrackReferenceTypeBox(type_, trackIds, this))
+        return this
+    }
+
+    protected open override func Render(file Stream) {
+        for box in References {
+            box!!.Save(file)
+        }
+    }
+
+    @DebuggerDisplay("{Header.Type,nq}, {TrackIds}")
+    private open class TrackReferenceTypeBox : Box, ITrackReferenceTypeBox {
+        init(file Stream, parent IBox?) : base(BoxHeader(file), parent) {
+            let numTraks = int32(RemainingBoxLength(file)) / 4
+            TrackIds = HashSet[uint32](numTraks)
+            for var i = 0; i < numTraks; i++ {
+                TrackIds.Add(file.ReadUInt32BE())
+            }
+        }
+
+        init(type_ string, trackIds HashSet[uint32], parent IBox) : base(BoxHeader(12, type_), parent) {
+            TrackIds = trackIds
+        }
+
+        open override prop RenderSize int64 -> base.RenderSize + int64(4 * TrackIds.Count)
+        prop TrackIds HashSet[uint32]
+
+        protected open override func Render(file Stream) {
+            for id in TrackIds {
+                file.WriteUInt32BE(id)
+            }
+        }
+    }
+
+    shared {
+        func CreatEmpty(parent IBox) TrefBox {
+            let tref = TrefBox(parent)
+            parent.Children.Add(tref!!)
+            return tref!!
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/TrunBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/TrunBox.gs
@@ -1,0 +1,77 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class TrunBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        let sampleCount = file.ReadUInt32BE()
+        if DataOffsetPresent {
+            DataOffset = file.ReadInt32BE()
+        }
+        if FirstSampleFlagsPresent {
+            FirstSampleFlags = file.ReadUInt32BE()
+        }
+        Samples = [int32(sampleCount)]SampleInfo
+        for var i = 0; int64(i) < int64(sampleCount); i++ {
+            let sampleDuration uint32? = if SampleDurationPresent { file.ReadUInt32BE() } else { nil }
+            let sampleSize int32? = if SampleSizePresent { file.ReadInt32BE() } else { nil }
+            let sampleFlags uint32? = if SampleFlagsPresent { file.ReadUInt32BE() } else { nil }
+            let sampleCompositionTimeOffset int32? = if SampleCompositionTimeOffsetsPresent { file.ReadInt32BE() } else { nil }
+            Samples[i] = SampleInfo(sampleDuration, sampleSize, sampleFlags, sampleCompositionTimeOffset)
+        }
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(4) + int64((if DataOffsetPresent { 4 } else { 0 })) + int64((if FirstSampleFlagsPresent { 4 } else { 0 })) + int64(SampleInfoSize * Samples.Length)
+
+    prop DataOffset int32 {
+        get;
+        init;
+    }
+
+    prop FirstSampleFlags uint32 {
+        get;
+        init;
+    }
+
+    prop Samples []SampleInfo {
+        get;
+        init;
+    }
+
+    prop SampleDurationPresent bool -> (Flags & 0x100) == 0x100
+    prop SampleSizePresent bool -> (Flags & 0x200) == 0x200
+    private prop DataOffsetPresent bool -> (Flags & 1) == 1
+    private prop FirstSampleFlagsPresent bool -> (Flags & 4) == 4
+    private prop SampleFlagsPresent bool -> (Flags & 0x400) == 0x400
+    private prop SampleCompositionTimeOffsetsPresent bool -> (Flags & 0x800) == 0x800
+    private prop SampleInfoSize int32 -> (if SampleDurationPresent { 4 } else { 0 }) + (if SampleSizePresent { 4 } else { 0 }) + (if SampleFlagsPresent { 4 } else { 0 }) + (if SampleCompositionTimeOffsetsPresent { 4 } else { 0 })
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.WriteInt32BE(Samples.Length)
+        if DataOffsetPresent {
+            file.WriteInt32BE(DataOffset)
+        }
+        if FirstSampleFlagsPresent {
+            file.WriteUInt32BE(FirstSampleFlags)
+        }
+        for var i = 0; i < Samples.Length; i++ {
+            if SampleDurationPresent {
+                file.WriteUInt32BE(Samples[i].SampleDuration ?? uint32(0))
+            }
+            if SampleSizePresent {
+                file.WriteInt32BE(Samples[i].SampleSize ?? 0)
+            }
+            if SampleFlagsPresent {
+                file.WriteUInt32BE(Samples[i].SampleFlags ?? uint32(0))
+            }
+            if SampleCompositionTimeOffsetsPresent {
+                file.WriteInt32BE(Samples[i].SampleCompositionTimeOffset ?? 0)
+            }
+        }
+    }
+
+    class SampleInfo(SampleDuration uint32?, SampleSize int32?, SampleFlags uint32?, SampleCompositionTimeOffset int32?) {
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/UdtaBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/UdtaBox.gs
@@ -1,0 +1,24 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+
+open class UdtaBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        LoadChildren(file)
+    }
+
+    private init(parent IBox) : base(BoxHeader(8, "udta"), parent) {
+    }
+
+    protected open override func Render(file Stream) {
+        return
+    }
+
+    shared {
+        func CreateEmpty(parent IBox) UdtaBox {
+            let udata = UdtaBox(parent)
+            parent.Children.Add(udata!!)
+            return udata!!
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/UnknownBox.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/UnknownBox.gs
@@ -1,0 +1,25 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class UnknownBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        Data = file.ReadBlock(int32((Header.TotalBoxSize - int64(header.HeaderSize))))
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(Data.Length)
+
+    prop Data []uint8 {
+        get;
+        init;
+    }
+
+    func ToString() string {
+        return nameof(UnknownBox) + "-" + Header.Type
+    }
+
+    protected open override func Render(file Stream) {
+        file.Write(Data)
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/UnknownDescriptor.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/UnknownDescriptor.gs
@@ -1,0 +1,18 @@
+package Oahu.Decrypt.Mpeg4.Descriptors
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+class UnknownDescriptor : BaseDescriptor {
+    private let blob []uint8
+
+    init(file Stream, header DescriptorHeader) : base(file, header) {
+        blob = file.ReadBlock(Header.TotalBoxSize - Header.HeaderSize)
+    }
+
+    override prop InternalSize int32 -> base.InternalSize + blob.Length
+
+    override func Render(file Stream) {
+        file.Write(blob)
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/UnknownFrame.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/UnknownFrame.gs
@@ -1,0 +1,21 @@
+package Oahu.Decrypt.Mpeg4.ID3
+
+import System.IO
+import System.Text
+
+class UnknownFrame : Frame {
+    init(file Stream, header Header, parent Frame) : base(header, parent) {
+        Blob = [header.Size]uint8
+        file.ReadExactly(Blob)
+    }
+
+    override prop Size int32 -> Blob.Length
+
+    prop Blob []uint8 {
+        get;
+        init;
+    }
+
+    prop DataText string -> if Blob.Length == 0 { "" } else { (if Blob[0] == uint8(0) { Encoding.ASCII } else { Encoding.Unicode }).GetString(Blob, 1, Blob.Length - 1) }
+    override func Render(file Stream) -> file.Write(Blob)
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/VideoPassthrough.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/VideoPassthrough.gs
@@ -1,0 +1,14 @@
+package Oahu.Decrypt.FrameFilters.Video
+
+import System.Threading.Tasks
+
+internal open class VideoPassthrough : FrameFinalBase[FrameEntry] {
+    protected open override prop InputBufferSize int32 -> 1
+
+    open override func AddInputAsync(input FrameEntry) Task {
+        return Task.CompletedTask
+    }
+
+    protected open override func FlushAsync() Task -> Task.CompletedTask
+    protected open override func PerformFilteringAsync(input FrameEntry) Task -> Task.CompletedTask
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/VisualSampleEntry.gs
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/VisualSampleEntry.gs
@@ -1,0 +1,92 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class VisualSampleEntry : SampleEntry {
+    private let preDefined1 []uint8
+    private let reserved []uint8
+    private let preDefined2 []uint8
+    private let reserved2 []uint8
+    private let preDefined3 []uint8
+
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        preDefined1 = file.ReadBlock(2)
+        reserved = file.ReadBlock(2)
+        preDefined2 = file.ReadBlock(4 * 3)
+        Width = file.ReadUInt16BE()
+        Height = file.ReadUInt16BE()
+        HorizontalResolution = file.ReadUInt32BE()
+        VerticalResolution = file.ReadUInt32BE()
+        reserved2 = file.ReadBlock(4)
+        FrameCount = file.ReadUInt16BE()
+        let compressorNameBytes = file.ReadBlock(32)
+        let displaySize = compressorNameBytes!![0]
+        if displaySize > uint8(31) {
+            throw InvalidOperationException("Compressor name must be 31 characters or fewer.")
+        }
+        CompressorName = System.Text.Encoding.UTF8.GetString(compressorNameBytes!!, 1, displaySize)
+        Depth = file.ReadUInt16BE()
+        preDefined3 = file.ReadBlock(2)
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(preDefined1.Length) + int64(reserved.Length) + int64(preDefined2.Length) + int64(2 * 4) + int64(4 * 2) + int64(reserved2.Length) + int64(preDefined3.Length) + int64(32)
+
+    prop Width uint16 {
+        get;
+        init;
+    }
+
+    prop Height uint16 {
+        get;
+        init;
+    }
+
+    prop HorizontalResolution uint32 {
+        get;
+        init;
+    }
+
+    prop VerticalResolution uint32 {
+        get;
+        init;
+    }
+
+    prop FrameCount uint16 {
+        get;
+        init;
+    }
+
+    prop CompressorName string {
+        get;
+        init;
+    }
+
+    prop Depth uint16 {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.Write(preDefined1)
+        file.Write(reserved)
+        file.Write(preDefined2)
+        file.WriteUInt16BE(Width)
+        file.WriteUInt16BE(Height)
+        file.WriteUInt32BE(HorizontalResolution)
+        file.WriteUInt32BE(VerticalResolution)
+        file.Write(reserved2)
+        file.WriteUInt16BE(FrameCount)
+        let compressorNameBytes = [32]uint8
+        if CompressorName.Length > 31 {
+            throw InvalidOperationException("Compressor name must be 31 characters or fewer.")
+        }
+        compressorNameBytes!![0] = uint8(CompressorName.Length)
+        System.Text.Encoding.UTF8.GetBytes(CompressorName, 0, CompressorName.Length, compressorNameBytes!!, 1)
+        file.Write(compressorNameBytes!!)
+        file.WriteUInt16BE(Depth)
+        file.Write(preDefined3)
+    }
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/compile-5c4100795019.json
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/corpus_Oahu.Decrypt/compile-5c4100795019.json
@@ -1,0 +1,36 @@
+{
+  "schemaVersion": "1.0",
+  "runId": "2026-06-29T23-51-48Z_2644b2",
+  "timestamp": "2026-06-29T23:51:48Z",
+  "gscVersion": "0.2.363+fd47bae91e",
+  "corpusAppId": "corpus/Oahu.Decrypt",
+  "stage": "compile",
+  "category": "compile-error",
+  "diagnostic": {
+    "id": "GS9998",
+    "message": "EmitDiagnosticException: Internal compiler error: an unresolved (error) expression reached code emission. This usually indicates an unsupported or mis-bound construct that earlier phases failed to report.",
+    "severity": "error"
+  },
+  "sourceLocation": {
+    "gsFile": "corpus_Oahu.Decrypt/ChapterQueue.gs",
+    "gsLine": 1,
+    "gsColumn": 1,
+    "csFile": null,
+    "csLine": null,
+    "csColumn": null
+  },
+  "offendingCSharpConstruct": {
+    "kind": "PackageConstruct",
+    "snippet": "package Oahu.Decrypt"
+  },
+  "suggestedIssue": {
+    "title": "[cs2gs] GS9998 compiling translated corpus/Oahu.Decrypt (PackageConstruct)",
+    "body": "The G# emitted for **corpus/Oahu.Decrypt** fails to compile with `gsc` 0.2.363+fd47bae91e.\n\n- Diagnostic: `GS9998` — EmitDiagnosticException: Internal compiler error: an unresolved (error) expression reached code emission. This usually indicates an unsupported or mis-bound construct that earlier phases failed to report.\n- Emitted G#: `corpus_Oahu.Decrypt/ChapterQueue.gs` (1,1)\n- Offending line: `package Oahu.Decrypt`\n\n**Reproduction:** `cs2gs migrate` translates the corpus app, writes the `.gs` shown above, then runs `gsc /target:… /out:… corpus_Oahu.Decrypt/ChapterQueue.gs` which surfaces this error.\n**Fingerprint:** `sha256:5c4100795019fcbd65cc6501abb7369bf4203309b3f4cd05ddd6a827a094a093`",
+    "labels": [
+      "Oats",
+      "bug"
+    ]
+  },
+  "fingerprint": "sha256:5c4100795019fcbd65cc6501abb7369bf4203309b3f4cd05ddd6a827a094a093",
+  "retryHistory": []
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/report.html
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/report.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>cs2gs report — 2026-06-29T23-51-48Z_2644b2</title>
+<style>
+:root{--ok:#1a7f37;--bad:#cf222e;--skip:#6e7781;--bg:#ffffff;--fg:#1f2328;--line:#d0d7de;--panel:#f6f8fa;}
+*{box-sizing:border-box;}
+body{margin:0;padding:1.5rem;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;color:var(--fg);background:var(--bg);line-height:1.45;}
+h1{font-size:1.5rem;margin:0 0 .25rem;}
+h2{font-size:1.2rem;margin:2rem 0 .75rem;border-bottom:1px solid var(--line);padding-bottom:.25rem;}
+h3{font-size:1rem;margin:0 0 .5rem;}
+a{color:#0969da;}
+.run-header .verdict{display:inline-block;font-weight:700;padding:.15rem .6rem;border-radius:999px;color:#fff;}
+.verdict.ok{background:var(--ok);} .verdict.bad{background:var(--bad);}
+.provenance{display:grid;grid-template-columns:max-content 1fr;gap:.15rem 1rem;margin:.75rem 0 0;}
+.provenance dt{font-weight:600;color:var(--skip);} .provenance dd{margin:0;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;}
+table{border-collapse:collapse;width:100%;}
+.matrix th,.matrix td{border:1px solid var(--line);padding:.4rem .6rem;text-align:left;}
+.matrix thead th{background:var(--panel);}
+.cell{font-weight:600;white-space:nowrap;}
+.cell .dot{display:inline-block;width:.65rem;height:.65rem;border-radius:50%;margin-right:.4rem;vertical-align:middle;}
+.cell.pass{color:var(--ok);} .cell.pass .dot{background:var(--ok);}
+.cell.fail{color:var(--bad);} .cell.fail .dot{background:var(--bad);}
+.cell.skip{color:var(--skip);} .cell.skip .dot{background:var(--skip);}
+.gap{border:1px solid var(--line);border-radius:6px;padding:1rem;margin:0 0 1rem;background:var(--panel);}
+.gap-meta{list-style:none;margin:0 0 .5rem;padding:0;display:flex;flex-wrap:wrap;gap:.35rem 1rem;}
+.gap-meta .k{font-weight:600;color:var(--skip);} .gap-meta .v{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;}
+.snippet,.issue-body{background:#0d1117;color:#e6edf3;padding:.6rem .8rem;border-radius:6px;overflow:auto;}
+.snippet code,.issue-body code{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;white-space:pre-wrap;}
+.labels{margin:.5rem 0;} .label{display:inline-block;background:#ddf4ff;color:#0969da;border:1px solid #54aeff66;border-radius:999px;padding:.05rem .55rem;font-size:.8rem;}
+.occurrences ul{margin:.25rem 0;padding-left:1.2rem;} .occurrences .app{font-weight:600;} .occurrences .loc{color:var(--skip);font-family:ui-monospace,monospace;}
+.retry th,.retry td{border:1px solid var(--line);padding:.25rem .5rem;text-align:left;font-size:.85rem;}
+.toggle{margin:.5rem 0;cursor:pointer;background:#fff;border:1px solid var(--line);border-radius:6px;padding:.3rem .7rem;font:inherit;}
+.app-detail{border:1px solid var(--line);border-radius:6px;padding:1rem;margin:0 0 1rem;}
+.state{font-size:.75rem;padding:.1rem .5rem;border-radius:999px;color:#fff;vertical-align:middle;}
+.state.ok{background:var(--ok);} .state.bad{background:var(--bad);}
+.stage-list th,.stage-list td{border:1px solid var(--line);padding:.3rem .6rem;text-align:left;}
+.meta-line .k,.artifact-h{font-weight:600;color:var(--skip);}
+.empty{color:var(--skip);}
+</style>
+</head>
+<body>
+<header class="run-header">
+<h1>cs2gs migration report</h1>
+<p class="verdict bad">Run FAILED — 0/1 apps green</p>
+<dl class="provenance">
+<dt>Run id</dt><dd>2026-06-29T23-51-48Z_2644b2</dd>
+<dt>Timestamp</dt><dd>2026-06-29T23:51:48Z</dd>
+<dt>gsc version</dt><dd>0.2.363+fd47bae91e</dd>
+</dl>
+</header>
+<section aria-labelledby="matrix-h">
+<h2 id="matrix-h">Status matrix</h2>
+<table class="matrix">
+<thead><tr><th scope="col">app</th><th scope="col">translate</th><th scope="col">compile</th><th scope="col">ilverify</th><th scope="col">test-parity</th></tr></thead>
+<tbody>
+<tr><th scope="row"><a href="#app-corpus-oahu-decrypt">corpus/Oahu.Decrypt</a></th><td class="cell pass" aria-label="passed"><span class="dot" aria-hidden="true"></span>PASS</td><td class="cell fail" aria-label="failed"><span class="dot" aria-hidden="true"></span>FAIL (1)</td><td class="cell skip" aria-label="skipped"><span class="dot" aria-hidden="true"></span>SKIP</td><td class="cell skip" aria-label="skipped"><span class="dot" aria-hidden="true"></span>SKIP</td></tr>
+</tbody>
+</table>
+</section>
+<section aria-labelledby="gaps-h">
+<h2 id="gaps-h">Discovered gaps (1)</h2>
+<article class="gap">
+<h3>[cs2gs] GS9998 compiling translated corpus/Oahu.Decrypt (PackageConstruct)</h3>
+<ul class="gap-meta">
+<li><span class="k">fingerprint</span> <span class="v">sha256:5c4100795019fcbd65cc6501abb7369bf4203309b3f4cd05ddd6a827a094a093</span></li>
+<li><span class="k">category</span> <span class="v">compile-error</span></li>
+<li><span class="k">stage</span> <span class="v">compile</span></li>
+<li><span class="k">diagnostic</span> <span class="v">GS9998: EmitDiagnosticException: Internal compiler error: an unresolved (error) expression reached code emission. This usually indicates an unsupported or mis-bound construct that earlier phases failed to report.</span></li>
+<li><span class="k">construct</span> <span class="v">PackageConstruct</span></li>
+</ul>
+<pre class="snippet"><code>package Oahu.Decrypt</code></pre>
+<p class="labels">labels: <span class="label">Oats</span> <span class="label">bug</span></p>
+<details class="occurrences" open><summary>1 occurrence(s)</summary>
+<ul>
+<li><span class="app">corpus/Oahu.Decrypt</span> <span class="loc">corpus_Oahu.Decrypt/ChapterQueue.gs:1:1</span></li>
+</ul>
+</details>
+<button type="button" class="toggle" aria-expanded="false" aria-controls="gap-body-0" data-target="gap-body-0">Suggested issue body</button>
+<pre id="gap-body-0" class="issue-body" hidden><code>The G# emitted for **corpus/Oahu.Decrypt** fails to compile with `gsc` 0.2.363+fd47bae91e.
+
+- Diagnostic: `GS9998` — EmitDiagnosticException: Internal compiler error: an unresolved (error) expression reached code emission. This usually indicates an unsupported or mis-bound construct that earlier phases failed to report.
+- Emitted G#: `corpus_Oahu.Decrypt/ChapterQueue.gs` (1,1)
+- Offending line: `package Oahu.Decrypt`
+
+**Reproduction:** `cs2gs migrate` translates the corpus app, writes the `.gs` shown above, then runs `gsc /target:… /out:… corpus_Oahu.Decrypt/ChapterQueue.gs` which surfaces this error.
+**Fingerprint:** `sha256:5c4100795019fcbd65cc6501abb7369bf4203309b3f4cd05ddd6a827a094a093`</code></pre>
+</article>
+</section>
+<section aria-labelledby="apps-h">
+<h2 id="apps-h">App details</h2>
+<article id="app-corpus-oahu-decrypt" class="app-detail">
+<h3>corpus/Oahu.Decrypt <span class="state bad">failing</span></h3>
+<p class="meta-line"><span class="k">failure category</span> <span class="v">compile-error</span></p>
+<table class="stage-list"><thead><tr><th scope="col">stage</th><th scope="col">status</th><th scope="col">artifacts</th></tr></thead><tbody>
+<tr><td>translate</td><td>passed</td><td>0</td></tr>
+<tr><td>compile</td><td>failed</td><td>1</td></tr>
+<tr><td>ilverify</td><td>skipped</td><td>0</td></tr>
+<tr><td>test-parity</td><td>skipped</td><td>0</td></tr>
+</tbody></table>
+<p class="artifact-h">triage artifacts</p>
+<ul class="artifacts">
+<li><a href="corpus_Oahu.Decrypt/compile-5c4100795019.json">corpus_Oahu.Decrypt/compile-5c4100795019.json</a></li>
+</ul>
+</article>
+</section>
+<script>
+(function(){
+  var buttons = document.querySelectorAll('.toggle');
+  for (var i = 0; i < buttons.length; i++) {
+    buttons[i].addEventListener('click', function(){
+      var id = this.getAttribute('data-target');
+      var target = document.getElementById(id);
+      if (!target) { return; }
+      var hidden = target.hasAttribute('hidden');
+      if (hidden) { target.removeAttribute('hidden'); } else { target.setAttribute('hidden',''); }
+      this.setAttribute('aria-expanded', hidden ? 'true' : 'false');
+    });
+  }
+})();
+</script>
+</body>
+</html>

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/run.json
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/run.json
@@ -1,0 +1,42 @@
+{
+  "runId": "2026-06-29T23-51-48Z_2644b2",
+  "timestamp": "2026-06-29T23:51:48Z",
+  "gscVersion": "0.2.363+fd47bae91e",
+  "gscPath": "/Users/davidobando/GitHub/DavidObando/gsharp/.worktrees/fix-1446/out/bin/Release/Compiler/gsc.dll",
+  "succeeded": false,
+  "apps": [
+    {
+      "appId": "corpus/Oahu.Decrypt",
+      "succeeded": false,
+      "failureCategory": "compile-error",
+      "stages": [
+        {
+          "stage": "translate",
+          "status": "passed",
+          "artifactCount": 0
+        },
+        {
+          "stage": "compile",
+          "status": "failed",
+          "artifactCount": 1
+        },
+        {
+          "stage": "ilverify",
+          "status": "skipped",
+          "artifactCount": 0
+        },
+        {
+          "stage": "test-parity",
+          "status": "skipped",
+          "artifactCount": 0
+        }
+      ],
+      "artifacts": [
+        "corpus_Oahu.Decrypt/compile-5c4100795019.json"
+      ],
+      "fingerprints": [
+        "sha256:5c4100795019fcbd65cc6501abb7369bf4203309b3f4cd05ddd6a827a094a093"
+      ]
+    }
+  ]
+}

--- a/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/summary.json
+++ b/cs2gs-runs/2026-06-29T23-51-48Z_2644b2/summary.json
@@ -1,0 +1,87 @@
+{
+  "runId": "2026-06-29T23-51-48Z_2644b2",
+  "timestamp": "2026-06-29T23:51:48Z",
+  "gscVersion": "0.2.363+fd47bae91e",
+  "succeeded": false,
+  "totalApps": 1,
+  "greenApps": 0,
+  "stageOrder": [
+    "translate",
+    "compile",
+    "ilverify",
+    "test-parity"
+  ],
+  "apps": [
+    {
+      "appId": "corpus/Oahu.Decrypt",
+      "succeeded": false,
+      "failureCategory": "compile-error",
+      "stages": [
+        {
+          "stage": "translate",
+          "status": "passed",
+          "artifactCount": 0
+        },
+        {
+          "stage": "compile",
+          "status": "failed",
+          "artifactCount": 1
+        },
+        {
+          "stage": "ilverify",
+          "status": "skipped",
+          "artifactCount": 0
+        },
+        {
+          "stage": "test-parity",
+          "status": "skipped",
+          "artifactCount": 0
+        }
+      ],
+      "artifacts": [
+        "corpus_Oahu.Decrypt/compile-5c4100795019.json"
+      ],
+      "fingerprints": [
+        "sha256:5c4100795019fcbd65cc6501abb7369bf4203309b3f4cd05ddd6a827a094a093"
+      ]
+    }
+  ],
+  "gaps": [
+    {
+      "fingerprint": "sha256:5c4100795019fcbd65cc6501abb7369bf4203309b3f4cd05ddd6a827a094a093",
+      "category": "compile-error",
+      "stage": "compile",
+      "diagnostic": {
+        "id": "GS9998",
+        "message": "EmitDiagnosticException: Internal compiler error: an unresolved (error) expression reached code emission. This usually indicates an unsupported or mis-bound construct that earlier phases failed to report.",
+        "severity": "error"
+      },
+      "offendingCSharpConstruct": {
+        "kind": "PackageConstruct",
+        "snippet": "package Oahu.Decrypt"
+      },
+      "suggestedIssue": {
+        "title": "[cs2gs] GS9998 compiling translated corpus/Oahu.Decrypt (PackageConstruct)",
+        "body": "The G# emitted for **corpus/Oahu.Decrypt** fails to compile with `gsc` 0.2.363+fd47bae91e.\n\n- Diagnostic: `GS9998` — EmitDiagnosticException: Internal compiler error: an unresolved (error) expression reached code emission. This usually indicates an unsupported or mis-bound construct that earlier phases failed to report.\n- Emitted G#: `corpus_Oahu.Decrypt/ChapterQueue.gs` (1,1)\n- Offending line: `package Oahu.Decrypt`\n\n**Reproduction:** `cs2gs migrate` translates the corpus app, writes the `.gs` shown above, then runs `gsc /target:… /out:… corpus_Oahu.Decrypt/ChapterQueue.gs` which surfaces this error.\n**Fingerprint:** `sha256:5c4100795019fcbd65cc6501abb7369bf4203309b3f4cd05ddd6a827a094a093`",
+        "labels": [
+          "Oats",
+          "bug"
+        ]
+      },
+      "occurrences": [
+        {
+          "appId": "corpus/Oahu.Decrypt",
+          "sourceLocation": {
+            "gsFile": "corpus_Oahu.Decrypt/ChapterQueue.gs",
+            "gsLine": 1,
+            "gsColumn": 1,
+            "csFile": null,
+            "csLine": null,
+            "csColumn": null
+          }
+        }
+      ],
+      "retryHistory": []
+    }
+  ]
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/APICFrame.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/APICFrame.gs
@@ -1,0 +1,48 @@
+package Oahu.Decrypt.Mpeg4.ID3
+
+import System.IO
+import System.Text
+
+class APICFrame : Frame {
+    init(file Stream, header Header, parent Frame) : base(header, parent) {
+        let startPos = file.Position
+        let textEncoding = file.ReadByte()
+        ImageFormat = Frame.ReadNullTerminatedString(file, false)
+        Description = Frame.ReadNullTerminatedString(file, textEncoding == 1)
+        Type = uint8(file.ReadByte())
+        Image = [int32((startPos + int64(header.Size) - file.Position))]uint8
+        file.ReadExactly(Image)
+    }
+
+    override prop Size int32 {
+        get {
+            let fixedSize = 1 + ImageFormat.Length + 1 + 1 + Image.Length
+            if Frame.IsUnicode(Description) {
+                return Frame.UnicodeLength(Description) + 2 + fixedSize
+            } else {
+                return Description.Length + 1 + fixedSize
+            }
+        }
+    }
+
+    prop ImageFormat string
+    prop Description string
+    prop Type uint8
+    prop Image []uint8
+
+    override func Render(file Stream) {
+        let txtFormat = if Frame.IsUnicode(Description) { 1 } else { 0 }
+        file.WriteByte(uint8(txtFormat))
+        file.Write(Encoding.ASCII.GetBytes(ImageFormat))
+        file.WriteByte(0)
+        file.WriteByte(Type)
+        if txtFormat == 0 {
+            file.Write(Encoding.ASCII.GetBytes(Description))
+            file.WriteByte(0)
+        } else {
+            file.Write(Frame.UnicodeBytes(Description))
+            file.Write(stackalloc [2]uint8)
+        }
+        file.Write(Image)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/AacValidateFilter.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/AacValidateFilter.gs
@@ -1,0 +1,20 @@
+package Oahu.Decrypt.FrameFilters.Audio
+
+import System
+
+internal open class AacValidateFilter : FrameTransformBase[FrameEntry, FrameEntry] {
+    protected open override prop InputBufferSize int32 -> 1000
+
+    open override func PerformFiltering(input FrameEntry) FrameEntry {
+        return if AacValidateFilter.ValidateFrame(input.FrameData.Span) { input } else { throw Exception("Aac error!")
+            default(FrameEntry) }
+    }
+
+    shared {
+        private func ValidateFrame(frame ReadOnlySpan[uint8]) bool -> (AacValidateFilter.AV_RB16(frame) & uint16(0xfff0)) != 0xfff0
+
+        private func AV_RB16(frame ReadOnlySpan[uint8]) uint16 {
+            return uint16((frame[0] << 8 | int32(frame[1])))
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/AavdFilter.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/AavdFilter.gs
@@ -1,0 +1,40 @@
+package Oahu.Decrypt.FrameFilters.Audio
+
+import System
+import System.Security.Cryptography
+
+internal open class AavdFilter : AacValidateFilter {
+    private let aes Aes
+    private let iv []uint8
+
+    init(key []?uint8, iv []?uint8) {
+        if key == nil || key!!.Length != AavdFilter.AesBlockSize {
+            throw ArgumentException("${nameof(key)} must be ${AavdFilter.AesBlockSize} bytes long.")
+        }
+        if iv == nil || iv!!.Length != AavdFilter.AesBlockSize {
+            throw ArgumentException("${nameof(iv)} must be ${AavdFilter.AesBlockSize} bytes long.")
+        }
+        this.aes = Aes.Create()
+        this.aes.Key = key
+        this.iv = iv
+    }
+
+    open override func PerformFiltering(input FrameEntry) FrameEntry {
+        if input.FrameData.Length >= 0x10 {
+            let encBlocks = input.FrameData.Slice(0, input.FrameData.Length & 0x7ffffff0).Span
+            aes.DecryptCbc(encBlocks, iv, encBlocks, PaddingMode.None)
+        }
+        return base.PerformFiltering(input)
+    }
+
+    protected open override func Dispose(disposing bool) {
+        if disposing && !Disposed {
+            aes.Dispose()
+        }
+        base.Dispose(disposing)
+    }
+
+    shared {
+        private const AesBlockSize int32 = 16
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/AaxFile.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/AaxFile.gs
@@ -1,0 +1,116 @@
+package Oahu.Decrypt
+
+import System
+import System.Collections.Generic
+import System.IO
+import System.Linq
+import Oahu.Decrypt.FrameFilters
+import Oahu.Decrypt.FrameFilters.Audio
+import Oahu.Decrypt.Mpeg4.Boxes
+import Oahu.Decrypt.Mpeg4.Util
+
+class AaxFile : Mp4File {
+    init(file Stream, fileSize int64, additionalFixups bool = true) : base(file, fileSize) {
+        if FileType != FileType.Aax && FileType != FileType.Aaxc {
+            throw ArgumentException("This instance of ${nameof(Mp4File)} is not an Aax or Aaxc file.")
+        }
+        let esds EsdsBox? = AudioSampleEntry.Esds as EsdsBox
+        if esds != nil {
+            esds.ES_Descriptor.DecoderConfig.AudioSpecificConfig.DependsOnCoreCoder = false
+        }
+        AudioSampleEntry.Header.ChangeAtomName("mp4a")
+        if additionalFixups {
+            let children = AudioSampleEntry.Children
+            for var i = children.Count - 1; i >= 0; i-- {
+                if children[i] is FreeBox {
+                    children.RemoveAt(i)
+                }
+            }
+            Ftyp = FtypBox.Create("isom", 0x200)
+            Ftyp.CompatibleBrands.Add("iso2")
+            Ftyp.CompatibleBrands.Add("mp41")
+            Ftyp.CompatibleBrands.Add("M4A ")
+            Ftyp.CompatibleBrands.Add("M4B ")
+        }
+    }
+
+    convenience init(file Stream) {
+        init(file, file.Length)
+    }
+
+    convenience init(fileName string, access FileAccess = 1, share FileShare = 1) {
+        init(File.Open(fileName, FileMode.Open, access, share))
+    }
+
+    prop Key []?uint8
+    prop IV []?uint8
+
+    override func GetAudioFrameFilter() FrameTransformBase[FrameEntry, FrameEntry] {
+        return if Key != nil && IV != nil { AavdFilter(Key!!, IV!!) } else { throw InvalidOperationException("This instance of ${nameof(AaxFile)} does not have a decryption key set.")
+            default(AavdFilter) }
+    }
+
+    func SetDecryptionKey(activationBytes string) {
+        if String.IsNullOrWhiteSpace(activationBytes) || activationBytes.Length != 8 {
+            throw ArgumentException("${nameof(activationBytes)} must be 4 bytes long.")
+        }
+        let actBytes = ByteUtil.BytesFromHexString(activationBytes)
+        SetDecryptionKey(actBytes)
+    }
+
+    func SetDecryptionKey(activationBytes []?uint8) {
+        if activationBytes == nil || activationBytes!!.Length != 4 {
+            throw ArgumentException("${nameof(activationBytes)} must be 4 bytes long.")
+        }
+        if FileType != FileType.Aax {
+            throw ArgumentException("This instance of ${nameof(AaxFile)} is not an ${FileType.Aax} file.")
+        }
+        let adrm = AudioSampleEntry.GetChild[AdrmBox]() ?? throw InvalidOperationException("This instance of ${nameof(AaxFile)} does not contain an adrm box.")
+        let intermediate_key = Crypto.Sha1((AaxFile.AudibleFixedKey, 0, AaxFile.AudibleFixedKey.Length), (activationBytes!!, 0, activationBytes!!.Length))
+        let intermediate_iv = Crypto.Sha1((AaxFile.AudibleFixedKey, 0, AaxFile.AudibleFixedKey.Length), (intermediate_key, 0, intermediate_key.Length), (activationBytes!!, 0, activationBytes!!.Length))
+        let calculatedChecksum = Crypto.Sha1((intermediate_key, 0, 16), (intermediate_iv, 0, 16))
+        if !ByteUtil.BytesEqual(calculatedChecksum, adrm.Checksum) {
+            throw Exception("Calculated checksum doesn't match AAX file checksum.")
+        }
+        let drmBlob = ByteUtil.CloneBytes(adrm.DrmBlob)
+        Crypto.DecryptInPlace(ByteUtil.CloneBytes(intermediate_key, 0, 16), ByteUtil.CloneBytes(intermediate_iv, 0, 16), drmBlob)
+        if !ByteUtil.BytesEqual(drmBlob, 0, activationBytes!!, 0, 4, true) {
+            throw Exception("Supplied key doesn't match calculated key.")
+        }
+        let file_key = ByteUtil.CloneBytes(drmBlob, 8, 16)
+        let file_iv = Crypto.Sha1((drmBlob, 26, 16), (file_key, 0, 16), (AaxFile.AudibleFixedKey, 0, 16))
+        AudioSampleEntry.Children.Remove(adrm)
+        let aabd IBox? = AudioSampleEntry.Children.FirstOrDefault((b IBox) -> b.Header.Type == "aabd") as IBox
+        if aabd != nil {
+            AudioSampleEntry.Children.Remove(aabd)
+        }
+        SetDecryptionKey(file_key, ByteUtil.CloneBytes(file_iv, 0, 16))
+    }
+
+    func SetDecryptionKey(audible_key string, audible_iv string) {
+        if String.IsNullOrWhiteSpace(audible_key) || audible_key.Length != 32 {
+            throw ArgumentException("${nameof(audible_key)} must be 16 bytes long.")
+        }
+        if String.IsNullOrWhiteSpace(audible_iv) || audible_iv.Length != 32 {
+            throw ArgumentException("${nameof(audible_iv)} must be 16 bytes long.")
+        }
+        let key = ByteUtil.BytesFromHexString(audible_key)
+        let iv = ByteUtil.BytesFromHexString(audible_iv)
+        SetDecryptionKey(key, iv)
+    }
+
+    func SetDecryptionKey(key []?uint8, iv []?uint8) {
+        if key == nil || key!!.Length != 16 {
+            throw ArgumentException("${nameof(key)} must be 16 bytes long.")
+        }
+        if iv == nil || iv!!.Length != 16 {
+            throw ArgumentException("${nameof(iv)} must be 16 bytes long.")
+        }
+        Key = key
+        IV = iv
+    }
+
+    shared {
+        private let AudibleFixedKey []uint8 = []uint8{uint8(0x77), uint8(0x21), uint8(0x4d), uint8(0x4b), uint8(0x19), uint8(0x6a), uint8(0x87), uint8(0xcd), uint8(0x52), uint8(0x00), uint8(0x45), uint8(0xfd), uint8(0x20), uint8(0xa5), uint8(0x1d), uint8(0x67)}
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Ac4BitrateDsi.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Ac4BitrateDsi.gs
@@ -1,0 +1,15 @@
+package Oahu.Decrypt.Mpeg4.Boxes.AC4SpecificBox
+
+import Oahu.Decrypt.Mpeg4.Util
+
+class Ac4BitrateDsi {
+    var BitRateMode BitRateMode
+    var BitRate uint32
+    var BitRatePrecision uint32
+
+    init(reader BitReader) {
+        BitRateMode = BitRateMode(reader.Read(2))
+        BitRate = reader.Read(32)
+        BitRatePrecision = reader.Read(32)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Ac4DsiV1.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Ac4DsiV1.gs
@@ -1,0 +1,61 @@
+package Oahu.Decrypt.Mpeg4.Boxes.AC4SpecificBox
+
+import System
+import Oahu.Decrypt.Mpeg4.Util
+
+class Ac4DsiV1 {
+    var Ac4DsiVersion uint8
+    var BitstreamVersion uint8
+    var FsIndex uint8
+    var FrameRateIndex uint8
+    var NPresentations uint16
+    var BProgramId bool?
+    var ShortProgramId uint16?
+    var BUuid bool?
+    var ProgramUuid Guid?
+    var Ac4BitrateDsi Ac4BitrateDsi
+    var Presentations []object?
+
+    init(reader BitReader) {
+        Ac4DsiVersion = uint8(reader.Read(3))
+        BitstreamVersion = uint8(reader.Read(7))
+        FsIndex = uint8(reader.Read(1))
+        FrameRateIndex = uint8(reader.Read(4))
+        NPresentations = uint16(reader.Read(9))
+        if BitstreamVersion > uint8(1) {
+            BProgramId = reader.ReadBool()
+            if BProgramId.Value {
+                ShortProgramId = uint16(reader.Read(16))
+                BUuid = reader.ReadBool()
+                if BUuid.Value {
+                    ProgramUuid = Guid(reader.Read(32), uint16(reader.Read(16)), uint16(reader.Read(16)), uint8(reader.Read(8)), uint8(reader.Read(8)), uint8(reader.Read(8)), uint8(reader.Read(8)), uint8(reader.Read(8)), uint8(reader.Read(8)), uint8(reader.Read(8)), uint8(reader.Read(8)))
+                }
+            }
+        }
+        Ac4BitrateDsi = Ac4BitrateDsi(reader)
+        reader.ByteAlign()
+        Presentations = [int32(NPresentations)]object
+        for var i = 0; i < int32(NPresentations); i++ {
+            var presentationBytes uint32
+            let presentationVersion = reader.Read(8)
+            var presBytes = reader.Read(8)
+            if presBytes == uint32(255) {
+                let addPresBytes = reader.Read(16)
+                presBytes += addPresBytes
+            }
+            if presentationVersion == uint32(0) {
+                throw NotSupportedException("ac4_presentation_v0_dsi not yet supported")
+            } else {
+                if presentationVersion == uint32(1) || presentationVersion == uint32(2) {
+                    let start = reader.Position
+                    Presentations[i] = Ac4PresentationV1Dsi(presentationVersion, presBytes, reader)
+                    presentationBytes = uint32((reader.Position - start)) / uint32(8)
+                } else {
+                    presentationBytes = uint32(0)
+                }
+            }
+            let skipBytes = presBytes - presentationBytes
+            reader.Position += 8 * int32(skipBytes)
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Ac4Extensions.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Ac4Extensions.gs
@@ -1,0 +1,51 @@
+package Oahu.Decrypt.Mpeg4.Boxes.AC4SpecificBox
+
+import System.Linq
+
+class Ac4Extensions {
+    shared {
+        private let NumChannelsPerGroup []uint8 = []uint8{uint8(2), uint8(1), uint8(2), uint8(2), uint8(2), uint8(2), uint8(1), uint8(2), uint8(2), uint8(1), uint8(1), uint8(1), uint8(1), uint8(2), uint8(1), uint8(1), uint8(2), uint8(2), uint8(2)}
+
+        func ChannelCount(channels ChannelGroups) int32 {
+            var channelCount = 0
+            for var g = 0; g <= 18; g++ {
+                let group = ChannelGroups((1 << g))
+                if channels.HasFlag(group) {
+                    channelCount += int32(Ac4Extensions.NumChannelsPerGroup[g])
+                }
+            }
+            return channelCount
+        }
+    }
+}
+
+func (ac4DsiV1 Ac4DsiV1?) SampleRate() int32? -> if ac4DsiV1 == nil { nil } else { if ac4DsiV1!!.FsIndex == uint8(0) { 44100 } else { 48000 } }
+
+func (ac4DsiV1 Ac4DsiV1?) AverageBitrate() uint32? {
+    if ac4DsiV1 == nil {
+        return nil
+    }
+    if ac4DsiV1!!.Ac4BitrateDsi.BitRate != uint32(0) {
+        return ac4DsiV1!!.Ac4BitrateDsi.BitRate
+    }
+    for presentation in ac4DsiV1!!.Presentations.OfType[Ac4PresentationV1Dsi]().Where((p Ac4PresentationV1Dsi) -> p.BPresentationBitrateInfo) {
+        if presentation!!.Ac4BitrateDsi is Ac4BitrateDsi && (presentation!!.Ac4BitrateDsi as Ac4BitrateDsi)!!.BitRate != uint32(0) {
+            return (presentation!!.Ac4BitrateDsi as Ac4BitrateDsi)!!.BitRate
+        }
+    }
+    return nil
+}
+
+func (ac4DsiV1 Ac4DsiV1?) Channels() ChannelGroups? {
+    if ac4DsiV1 == nil {
+        return nil
+    }
+    for presentation in ac4DsiV1!!.Presentations.OfType[Ac4PresentationV1Dsi]().OrderByDescending((p Ac4PresentationV1Dsi) -> p.PresentationVersion) {
+        if presentation!!.BPresentationChannelCoded == true {
+            return presentation!!.PresentationChannelMaskV1
+        } else if presentation!!.Substream?.BChannelCoded == true {
+            return presentation!!.Substream!!.Substreams[0].DsiSubstreamChannelMask
+        }
+    }
+    return nil
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Ac4PresentationV1Dsi.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Ac4PresentationV1Dsi.gs
@@ -1,0 +1,121 @@
+package Oahu.Decrypt.Mpeg4.Boxes.AC4SpecificBox
+
+import System
+import Oahu.Decrypt.Mpeg4.Util
+
+class Ac4PresentationV1Dsi {
+    var PresentationVersion uint32
+    var PresentationConfigV1 uint8
+    var BAddEmdfSubstreams bool
+    var Mdcompat uint8?
+    var BPresentationId bool?
+    var PresentationId uint8?
+    var DsiFrameRateMultiplyInfo uint8?
+    var DsiFrameRateFractionInfo uint8?
+    var PresentationEmdfVersion uint8?
+    var PresentationKeyId uint16?
+    var BPresentationChannelCoded bool?
+    var DsiPresentationChMode uint8?
+    var PresB4BackChannelsPresent uint8?
+    var PresTopChannelPairs uint8?
+    var PresentationChannelMaskV1 ChannelGroups?
+    var BPresentationCoreDiffers bool?
+    var BPresentationCoreChannelCoded bool?
+    var DsiPresentationChannelModeCore uint8?
+    var BPresentationFilter bool?
+    var BEnablePresentation bool?
+    var NFilterBytes uint8?
+    var FilterData []?uint8
+    var Substream Ac4SubstreamGroupDsi?
+    var BPreVirtualized bool?
+    var NAddEmdfSubstreams uint8?
+    var SubstreamsEmdfs []?(uint8, uint16)
+    var BPresentationBitrateInfo bool
+    var Ac4BitrateDsi Ac4BitrateDsi?
+    var BAlternative bool
+    var AlternativeInfo AlternativeInfo?
+    var DeIndicator uint8?
+    var BExtendedPresentationId bool?
+    var ExtendedPresentationId uint16?
+    var DolbyAtmosIndicator bool?
+
+    init(presentationVersion uint32, presBytes uint32, reader BitReader) {
+        PresentationVersion = presentationVersion
+        let start = reader.Position
+        PresentationConfigV1 = uint8(reader.Read(5))
+        if PresentationConfigV1 == uint8(6) {
+            BAddEmdfSubstreams = true
+        } else {
+            Mdcompat = uint8(reader.Read(3))
+            BPresentationId = reader.ReadBool()
+            if BPresentationId.Value {
+                PresentationId = uint8(reader.Read(5))
+            }
+            DsiFrameRateMultiplyInfo = uint8(reader.Read(2))
+            DsiFrameRateFractionInfo = uint8(reader.Read(2))
+            PresentationEmdfVersion = uint8(reader.Read(5))
+            PresentationKeyId = uint16(reader.Read(10))
+            BPresentationChannelCoded = reader.ReadBool()
+            if BPresentationChannelCoded.Value {
+                DsiPresentationChMode = uint8(reader.Read(5))
+                if DsiPresentationChMode == (11 as uint8?) || DsiPresentationChMode == (12 as uint8?) || DsiPresentationChMode == (13 as uint8?) || DsiPresentationChMode == (14 as uint8?) {
+                    PresB4BackChannelsPresent = uint8(reader.Read(1))
+                    PresTopChannelPairs = uint8(reader.Read(2))
+                }
+                PresentationChannelMaskV1 = ChannelGroups(reader.Read(24))
+            }
+            BPresentationCoreDiffers = reader.ReadBool()
+            if BPresentationCoreDiffers.Value {
+                BPresentationCoreChannelCoded = reader.ReadBool()
+                if BPresentationCoreChannelCoded.Value {
+                    DsiPresentationChannelModeCore = uint8(reader.Read(2))
+                }
+            }
+            BPresentationFilter = reader.ReadBool()
+            if BPresentationFilter.Value {
+                BEnablePresentation = reader.ReadBool()
+                NFilterBytes = uint8(reader.Read(8))
+                FilterData = [int32(NFilterBytes.Value)]uint8
+                for var i = 0; i < int32(NFilterBytes.Value); i++ {
+                    FilterData!![i] = uint8(reader.Read(8))
+                }
+            }
+            if PresentationConfigV1 == uint8(0x1f) {
+                Substream = Ac4SubstreamGroupDsi(reader)
+            } else {
+                throw NotSupportedException()
+            }
+            BPreVirtualized = reader.ReadBool()
+            BAddEmdfSubstreams = reader.ReadBool()
+        }
+        if BAddEmdfSubstreams {
+            NAddEmdfSubstreams = uint8(reader.Read(7))
+            SubstreamsEmdfs = [int32(NAddEmdfSubstreams.Value)](uint8, uint16)
+            for var j = 0; j < (NAddEmdfSubstreams as int32?); j++ {
+                SubstreamsEmdfs!![j] = (uint8(reader.Read(5)), uint16(reader.Read(10)))
+            }
+        }
+        BPresentationBitrateInfo = reader.ReadBool()
+        if BPresentationBitrateInfo {
+            Ac4BitrateDsi = Ac4BitrateDsi(reader)
+        }
+        BAlternative = reader.ReadBool()
+        if BAlternative {
+            reader.ByteAlign()
+            AlternativeInfo = AlternativeInfo(reader)
+        }
+        reader.ByteAlign()
+        let read = reader.Position - start
+        if int64(read) <= int64((presBytes - uint32(1)) * uint32(8)) {
+            DeIndicator = uint8(reader.Read(1))
+            DolbyAtmosIndicator = reader.ReadBool()
+            reader.Read(4)
+            BExtendedPresentationId = reader.ReadBool()
+            if BExtendedPresentationId.Value {
+                ExtendedPresentationId = uint16(reader.Read(9))
+            } else {
+                reader.Read(1)
+            }
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Ac4Substream.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Ac4Substream.gs
@@ -1,0 +1,41 @@
+package Oahu.Decrypt.Mpeg4.Boxes.AC4SpecificBox
+
+import Oahu.Decrypt.Mpeg4.Util
+
+class Ac4Substream {
+    var DsiSfMultiplier uint8
+    var BSubstreamBitrateIndicator bool
+    var SubstreamBitrateIndicator uint8?
+    var DsiSubstreamChannelMask ChannelGroups?
+    var BAjoc bool?
+    var BStaticDmx bool?
+    var NDmxObjectsMinus1 uint8?
+    var NUmxObjectsMinus1 uint8?
+    var BSubstreamContainsBedObjects bool?
+    var BSubstreamContainsDynamicObjects bool?
+    var BSubstreamContainsIsfObjects bool?
+
+    init(info Ac4SubstreamGroupDsi, reader BitReader) {
+        DsiSfMultiplier = uint8(reader.Read(2))
+        BSubstreamBitrateIndicator = reader.ReadBool()
+        if BSubstreamBitrateIndicator {
+            SubstreamBitrateIndicator = uint8(reader.Read(5))
+        }
+        if info.BChannelCoded {
+            DsiSubstreamChannelMask = ChannelGroups(reader.Read(24))
+        } else {
+            BAjoc = reader.ReadBool()
+            if BAjoc.Value {
+                BStaticDmx = reader.ReadBool()
+                if BStaticDmx.Value {
+                    NDmxObjectsMinus1 = uint8(reader.Read(4))
+                }
+                NUmxObjectsMinus1 = uint8(reader.Read(6))
+            }
+            BSubstreamContainsBedObjects = reader.ReadBool()
+            BSubstreamContainsDynamicObjects = reader.ReadBool()
+            BSubstreamContainsIsfObjects = reader.ReadBool()
+            reader.Read(1)
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Ac4SubstreamGroupDsi.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Ac4SubstreamGroupDsi.gs
@@ -1,0 +1,39 @@
+package Oahu.Decrypt.Mpeg4.Boxes.AC4SpecificBox
+
+import Oahu.Decrypt.Mpeg4.Util
+
+class Ac4SubstreamGroupDsi {
+    var BSubstreamsPresent bool
+    var BHsfExt bool
+    var BChannelCoded bool
+    var NSubstreams uint8
+    var Substreams []Ac4Substream
+    var BContentType bool
+    var ContentClassifier uint8?
+    var BLanguageIndicator bool?
+    var NLanguageTagBytes int32?
+    var LanguageTagBytes []?uint8
+
+    init(reader BitReader) {
+        BSubstreamsPresent = reader.ReadBool()
+        BHsfExt = reader.ReadBool()
+        BChannelCoded = reader.ReadBool()
+        NSubstreams = uint8(reader.Read(8))
+        Substreams = [int32(NSubstreams)]Ac4Substream
+        for var i = 0; i < int32(NSubstreams); i++ {
+            Substreams[i] = Ac4Substream(this, reader)
+        }
+        BContentType = reader.ReadBool()
+        if BContentType {
+            ContentClassifier = uint8(reader.Read(3))
+            BLanguageIndicator = reader.ReadBool()
+            if BLanguageIndicator.Value {
+                NLanguageTagBytes = uint8(reader.Read(6))
+                LanguageTagBytes = [NLanguageTagBytes.Value]uint8
+                for var i = 0; i < LanguageTagBytes!!.Length; i++ {
+                    LanguageTagBytes!![i] = uint8(reader.Read(8))
+                }
+            }
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/AdrmBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/AdrmBox.gs
@@ -1,0 +1,39 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class AdrmBox : Box {
+    private let beginBlob []uint8
+    private let middleBlob []uint8
+    private let endBlob []uint8
+
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        beginBlob = file.ReadBlock(8)
+        DrmBlob = file.ReadBlock(56)
+        middleBlob = file.ReadBlock(4)
+        Checksum = file.ReadBlock(20)
+        let len = RemainingBoxLength(file)
+        endBlob = file.ReadBlock(int32(len))
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(beginBlob.Length) + int64(DrmBlob.Length) + int64(middleBlob.Length) + int64(Checksum.Length) + int64(endBlob.Length)
+
+    prop DrmBlob []uint8 {
+        get;
+        init;
+    }
+
+    prop Checksum []uint8 {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        file.Write(beginBlob)
+        file.Write(DrmBlob)
+        file.Write(middleBlob)
+        file.Write(Checksum)
+        file.Write(endBlob)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/AesCtr.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/AesCtr.gs
@@ -1,0 +1,88 @@
+package Oahu.Decrypt.Mpeg4.Util
+
+import System
+import System.Security.Cryptography
+
+unsafe class AesCtr : IDisposable {
+    private let encryptor ICryptoTransform
+    private let aes Aes
+    private let encryptedCounter []uint8 = [AesCtr.AesBlockSize]uint8
+    private var isDisposed bool
+
+    init(key []uint8) {
+        ArgumentNullException.ThrowIfNull(key, nameof(key))
+        if key.Length != AesCtr.AesBlockSize {
+            throw ArgumentException("${nameof(key)} must be exactly ${AesCtr.AesBlockSize} bytes long.")
+        }
+        aes = Aes.Create()
+        this.aes.Padding = PaddingMode.None
+        this.aes.Mode = CipherMode.ECB
+        encryptor = aes.CreateEncryptor(key, nil)
+    }
+
+    func Decrypt(iv []uint8, source ReadOnlySpan[uint8], destination Span[uint8]) {
+        ArgumentNullException.ThrowIfNull(iv, nameof(iv))
+        ArgumentOutOfRangeException.ThrowIfNotEqual(iv.Length, AesCtr.AesBlockSize, nameof(iv))
+        if destination.Length < source.Length {
+            throw ArithmeticException("Destination array is not long enough. (Parameter '${nameof(destination)}')")
+        }
+        const aesNumDwords = AesCtr.AesBlockSize / 4
+        fixed pD *uint8 = destination {
+            fixed pS *uint8 = source {
+                fixed pEc *uint8 = encryptedCounter {
+                    var pD32 = *uint32(pD)
+                    var pS32 = *uint32(pS)
+                    let pEc32 = *uint32(pEc)
+                    var dataPos = 0
+                    var count = source.Length
+                    while count >= AesCtr.AesBlockSize {
+                        encryptor.TransformBlock(iv, 0, AesCtr.AesBlockSize, encryptedCounter, 0)
+                        AesCtr.IncrementBE(iv)
+                        for var i = 0; i < aesNumDwords; i++ {
+                            *pD32 = pEc32[i] ^ *pS32
+                            pD32++
+                            pS32++
+                        }
+                        dataPos += AesCtr.AesBlockSize
+                        count -= AesCtr.AesBlockSize
+                    }
+                    if count > 0 {
+                        encryptor.TransformBlock(iv, 0, AesCtr.AesBlockSize, encryptedCounter, 0)
+                        {
+                            var i = 0
+                            while i < count {
+                                pD[dataPos] = uint8((pEc[i] ^ pS[dataPos]))
+                                i++
+                                dataPos++
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    func Dispose() {
+        Dispose(true)
+        GC.SuppressFinalize(this)
+    }
+
+    private func Dispose(disposing bool) {
+        if disposing & !isDisposed {
+            encryptor.Dispose()
+            aes.Dispose()
+            isDisposed = true
+        }
+    }
+
+    shared {
+        const AesBlockSize int32 = 16
+
+        private func IncrementBE(data []uint8) {
+            var i = data.Length - 1
+            do {
+                data[i]++
+            } while data[i] == uint8(0) && i-- > 0
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/AlternativeInfo.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/AlternativeInfo.gs
@@ -1,0 +1,24 @@
+package Oahu.Decrypt.Mpeg4.Boxes.AC4SpecificBox
+
+import Oahu.Decrypt.Mpeg4.Util
+
+class AlternativeInfo {
+    var NameLen uint16
+    var PresentationName string
+    var NTargets uint8
+    var TargetIds [](uint8, uint8)
+
+    init(reader BitReader) {
+        NameLen = uint16(reader.Read(16))
+        let nameBts = [int32(NameLen)]char
+        for var i = 0; i < int32(NameLen); i++ {
+            nameBts[i] = char(reader.Read(8))
+        }
+        PresentationName = string(nameBts)
+        NTargets = uint8(reader.Read(5))
+        TargetIds = [int32(NTargets)](uint8, uint8)
+        for var i = 0; i < int32(NameLen); i++ {
+            TargetIds[i] = (uint8(reader.Read(3)), uint8(reader.Read(8)))
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/AppleDataBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/AppleDataBox.gs
@@ -1,0 +1,63 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.Diagnostics
+import System.IO
+import System.Text
+import Oahu.Decrypt.Mpeg4.Util
+
+@DebuggerDisplay("{DebuggerDisplay,nq}")
+open class AppleDataBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        DataType = AppleDataType(file.ReadUInt32BE())
+        Flags = file.ReadUInt32BE()
+        let length = RemainingBoxLength(file)
+        Data = file.ReadBlock(int32(length))
+    }
+
+    private init(header BoxHeader, parent IBox, data []uint8, type_ AppleDataType) : base(header, parent) {
+        DataType = type_
+        Flags = uint32(0)
+        Data = data
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(8) + int64(Data.Length)
+
+    prop DataType AppleDataType {
+        get;
+        init;
+    }
+
+    prop Flags uint32 {
+        get;
+        init;
+    }
+
+    prop Data []uint8
+
+    @DebuggerHidden
+    private prop DebuggerDisplay string -> if DataType is AppleDataType { "[UTF-8]: '${Encoding.UTF8.GetString(Data)}'" } else { if DataType is AppleDataType { "[UTF-16]: '${Encoding.Unicode.GetString(Data)}'" } else { "[$DataType]: ${Data.Length} bytes" } }
+
+    func ReadAsString() string {
+        return switch DataType {
+            case AppleDataType.Utf_8: Encoding.UTF8.GetString(Data)
+            case AppleDataType.Utf_16: Encoding.Unicode.GetString(Data)
+            default: throw InvalidDataException("Cannot read AppleDataBox of type $DataType as string.")
+        }
+    }
+
+    protected open override func Render(file Stream) {
+        file.WriteUInt32BE(uint32(DataType))
+        file.WriteUInt32BE(Flags)
+        file.Write(Data)
+    }
+
+    shared {
+        func Create(parent IBox, data []uint8, type_ AppleDataType) AppleDataBox {
+            let size = data.Length + 8
+            let header = BoxHeader(uint32(size), "data")
+            let dataBox = AppleDataBox(header, parent, data, type_)
+            parent.Children.Add(dataBox)
+            return dataBox
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/AppleDataType.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/AppleDataType.gs
@@ -1,0 +1,3 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+enum AppleDataType { ContainsData, Utf_8, Utf_16, Utf_8_Sort, Utf_16_Sort, JPEG, PNG, BE_Signed_Integer, BE_Unsigned_Integer, BE_Float_32, BE_Float_64, BMP, Signed_Byte, BE_Signed_Integer_16, BE_Signed_Integer_32, BE_Signed_Integer_64, Unigned_Byte, BE_Unsigned_Integer_16, BE_Unsigned_Integer_32, BE_Unsigned_Integer_64 }

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/AppleListBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/AppleListBox.gs
@@ -1,0 +1,143 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.Collections.Generic
+import System.IO
+import System.Linq
+import System.Text
+
+open class AppleListBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        let endPos = Header.FilePosition + Header.TotalBoxSize
+        while file.Position < endPos {
+            let tagBoxHeader = BoxHeader(file)
+            let appleTag = if tagBoxHeader.Type == "----" { FreeformTagBox(file, tagBoxHeader, this) } else { AppleTagBox(file, tagBoxHeader, this) }
+            if appleTag.Header.TotalBoxSize == int64(0) {
+                break
+            }
+            Children.Add(appleTag)
+        }
+    }
+
+    private init(parent IBox) : base(BoxHeader(8, "ilst"), parent) {
+    }
+
+    prop TagNames IEnumerable[string] -> Tags.Select((t AppleTagBox) -> t.Header.Type)
+    prop FreeformTagNames IEnumerable[string] -> FreeformTags.Select((t FreeformTagBox) -> t.TagName)
+    prop Tags IEnumerable[AppleTagBox] -> GetChildren[AppleTagBox]()
+    prop FreeformTags IEnumerable[FreeformTagBox] -> GetChildren[FreeformTagBox]()
+
+    func AddTag(name string, data string) {
+        AppleTagBox.Create(this, name, Encoding.UTF8.GetBytes(data), AppleDataType.Utf_8)
+    }
+
+    func AddTag(name string, data []uint8, type_ AppleDataType) {
+        AppleTagBox.Create(this, name, data, type_)
+    }
+
+    func RemoveTag(name string) bool -> GetTagBox(name) != nil && RemoveTag(GetTagBox(name)!!!!)
+    func RemoveFreeformTag(domain string, name string) bool -> GetFreeformTagBox(domain, name) != nil && RemoveTag(GetFreeformTagBox(domain, name)!!!!)
+
+    func RemoveTag(tag AppleTagBox) bool {
+        if Children.Remove(tag) {
+            tag.Dispose()
+            return true
+        } else if tag is FreeformTagBox {
+            if tag.Mean?.ReverseDnsDomain != nil && tag.Name?.Name != nil && GetFreeformTagBox(tag.Mean?.ReverseDnsDomain!!!!, tag.Name?.Name!!!!) != nil && Children.Remove(GetFreeformTagBox(tag.Mean?.ReverseDnsDomain!!!!, tag.Name?.Name!!!!)!!!!) {
+                GetFreeformTagBox(tag.Mean?.ReverseDnsDomain!!!!, tag.Name?.Name!!!!)!!!!.Dispose()
+                return true
+            }
+        } else if GetTagBox(tag.Header.Type) != nil && Children.Remove(GetTagBox(tag.Header.Type)!!!!) {
+            GetTagBox(tag.Header.Type)!!!!.Dispose()
+            return true
+        }
+        return false
+    }
+
+    func EditOrAddTag(name string, data string?) {
+        EditOrAddTag(name, if data == nil { default([]?uint8) } else { Encoding.UTF8.GetBytes(data!!) }, AppleDataType.Utf_8)
+    }
+
+    func EditOrAddTag(name string, data []?uint8) {
+        EditOrAddTag(name, data, AppleDataType.ContainsData)
+    }
+
+    func EditOrAddTag[TData IAppleData[TData]](name string, data TData?) {
+        var bytes []?uint8
+        if data != nil {
+            bytes = [TData.SizeInBytes]uint8
+            data.Write(bytes!!)
+        } else {
+            bytes = nil
+        }
+        EditOrAddTag(name, bytes, AppleDataType.ContainsData)
+    }
+
+    func EditOrAddTag(name string, data []?uint8, type_ AppleDataType) {
+        if GetTagBox(name) != nil {
+            EditExistingTag(GetTagBox(name)!!!!, data, type_)
+        } else if data != nil {
+            AddTag(name, data!!, type_)
+        }
+    }
+
+    func AddFreeformTag(domain string, name string, data string) {
+        FreeformTagBox.Create(this, domain, name, Encoding.UTF8.GetBytes(data), AppleDataType.Utf_8)
+    }
+
+    func AddFreeformTag(domain string, name string, data []uint8, type_ AppleDataType) {
+        FreeformTagBox.Create(this, domain, name, data, type_)
+    }
+
+    func EditOrAddFreeformTag(domain string, name string, data string?) {
+        EditOrAddFreeformTag(domain, name, if data == nil { default([]?uint8) } else { Encoding.UTF8.GetBytes(data!!) }, AppleDataType.Utf_8)
+    }
+
+    func EditOrAddFreeformTag(domain string, name string, data []?uint8) {
+        EditOrAddFreeformTag(domain, name, data, AppleDataType.ContainsData)
+    }
+
+    func EditOrAddFreeformTag(domain string, name string, data []?uint8, type_ AppleDataType) {
+        if GetFreeformTagBox(domain, name) != nil {
+            EditExistingTag(GetFreeformTagBox(domain, name)!!!!, data, type_)
+        } else if data != nil {
+            AddFreeformTag(domain, name, data!!, type_)
+        }
+    }
+
+    func GetTagString(name string) string? -> AppleListBox.GetTagString(GetTagBox(name))
+    func GetFreeformTagString(domain string, name string) string? -> AppleListBox.GetTagString(GetFreeformTagBox(domain, name))
+
+    func GetTagData[TData IAppleData[TData]](name string) TData? -> if GetTagBox(name)?.Data == nil { default } else { if GetTagBox(name)?.Data!!.DataType != AppleDataType.ContainsData { throw InvalidDataException("Apple data type ${GetTagBox(name)?.Data!!.DataType} is not compatible with ${nameof(IAppleData[TData])}")
+        default(TData) } else { if GetTagBox(name)?.Data!!.Data.Length != TData.SizeInBytes { throw InvalidDataException("Tag data size (${GetTagBox(name)?.Data!!.Data.Length}) differs from ${nameof(IAppleData[TData])} size (${TData.SizeInBytes})")
+        default(TData) } else { TData.Create(GetTagBox(name)?.Data!!.Data) } } }
+
+    func GetTagBox(name string) AppleTagBox? -> Tags.FirstOrDefault((t AppleTagBox) -> t.Header.Type == name)
+    func GetFreeformTagBox(domain string, name string) AppleTagBox? -> Tags.OfType[FreeformTagBox]().FirstOrDefault((t FreeformTagBox) -> t.Mean?.ReverseDnsDomain == domain && t.Name?.Name == name)
+
+    protected open override func Render(file Stream) {
+    }
+
+    private func EditExistingTag(tagBox AppleTagBox, data []?uint8, type_ AppleDataType) {
+        if data == nil {
+            RemoveTag(tagBox)
+        } else {
+            let dataBox = tagBox.GetChildOrThrow[AppleDataBox]()
+            dataBox.Data = if dataBox.DataType == type_ { data!! } else { throw InvalidDataException("Existing tag data type ${dataBox.DataType} differs from new edited type $type_")
+                default([]uint8) }
+        }
+    }
+
+    shared {
+        func CreateEmpty(parent IBox) AppleListBox {
+            let ilist = AppleListBox(parent)
+            parent.Children.Add(ilist!!)
+            return ilist!!
+        }
+
+        private func GetTagString(tagBox AppleTagBox?) string? -> if tagBox?.Data == nil { default(string?) } else { (switch tagBox?.Data!!.DataType {
+            case AppleDataType.Utf_8: Encoding.UTF8.GetString(tagBox?.Data!!.Data)
+            case AppleDataType.Utf_16: Encoding.Unicode.GetString(tagBox?.Data!!.Data)
+            default: throw InvalidDataException("Apple data type ${tagBox?.Data!!.DataType} is not a string type")
+        }) }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/AppleTagBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/AppleTagBox.gs
@@ -1,0 +1,40 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.Diagnostics
+import System.IO
+import System.Text
+
+@DebuggerDisplay("{DebuggerDisplay,nq}")
+open class AppleTagBox : Box {
+    init(file Stream, header BoxHeader, parent IBox) : base(header, parent) {
+        LoadChildren(file)
+    }
+
+    protected init(header BoxHeader, parent IBox?) : base(header, parent) {
+    }
+
+    @DebuggerHidden
+    open prop TagName string -> Header.Type
+
+    prop Data AppleDataBox -> GetChildOrThrow[AppleDataBox]()
+    private prop DebuggerDisplay string -> "[AppleTag]: $TagName"
+
+    protected open override func Render(file Stream) {
+        return
+    }
+
+    shared {
+        func Create(parent AppleListBox, name string, data []uint8, dataType AppleDataType) AppleTagBox {
+            if Encoding.ASCII.GetByteCount(name) != 4 {
+                throw ArgumentOutOfRangeException(nameof(name), "${nameof(name)} must be exactly 4 bytes long")
+            }
+            let size = data.Length + 2 + 8
+            let header = BoxHeader(uint32(size), name)
+            let tagBox = AppleTagBox(header, parent)
+            AppleDataBox.Create(tagBox, data, dataType)
+            parent.Children.Add(tagBox)
+            return tagBox
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/AudioCodingMode.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/AudioCodingMode.gs
@@ -1,0 +1,3 @@
+package Oahu.Decrypt.Mpeg4.Boxes.EC3SpecificBox
+
+enum AudioCodingMode { Ch1_Ch2, C, L_R, L_C_R, L_R_S, L_C_R_S, L_R_Ls_Rs, L_C_R_Ls_Rs }

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/AudioSampleEntry.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/AudioSampleEntry.gs
@@ -1,0 +1,50 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class AudioSampleEntry : SampleEntry {
+    private let reserved []uint8
+    private let reserved2 []uint8
+    private let sampleRateLoworder uint16
+
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        reserved = file.ReadBlock(8)
+        ChannelCount = file.ReadUInt16BE()
+        SampleSize = file.ReadUInt16BE()
+        PreDefined = file.ReadInt16BE()
+        reserved2 = file.ReadBlock(2)
+        SampleRate = file.ReadUInt16BE()
+        sampleRateLoworder = file.ReadUInt16BE()
+        LoadChildren(file)
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(20)
+    prop ChannelCount uint16
+
+    prop SampleSize uint16 {
+        get;
+        init;
+    }
+
+    prop PreDefined int16 {
+        get;
+        init;
+    }
+
+    prop SampleRate uint16
+    prop Esds EsdsBox? -> GetChild[EsdsBox]()
+    prop Dec3 Dec3Box? -> GetChild[Dec3Box]()
+    prop Dac4 Dac4Box? -> GetChild[Dac4Box]()
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.Write(reserved)
+        file.WriteUInt16BE(ChannelCount)
+        file.WriteUInt16BE(SampleSize)
+        file.WriteInt16BE(PreDefined)
+        file.Write(reserved2)
+        file.WriteUInt16BE(SampleRate)
+        file.WriteUInt16BE(sampleRateLoworder)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/AudioSpecificConfig.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/AudioSpecificConfig.gs
@@ -1,0 +1,115 @@
+package Oahu.Decrypt.Mpeg4.Descriptors
+
+import System
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+interface IASC {
+    prop AudioObjectType int32
+    prop SamplingFrequency int32
+    prop ChannelConfiguration int32
+    prop FrameLengthFlag bool
+    prop DependsOnCoreCoder bool
+}
+
+class AudioSpecificConfig : BaseDescriptor, IASC {
+    private var ascBlobLength int32 = 0
+    private var bitReader BitReader
+
+    init(file Stream, header DescriptorHeader) : base(file, header) {
+        let ascBlob = file.ReadBlock(Header.TotalBoxSize - Header.HeaderSize)
+        bitReader = AudioSpecificConfig.LoadAscBlob(this, ascBlob!!)
+        ascBlobLength = ascBlob!!.Length
+    }
+
+    private init() : base(5) {
+        bitReader = AudioSpecificConfig.LoadAscBlob(this, []uint8{uint8(0x13), uint8(0x90)})
+        ascBlobLength = 2
+    }
+
+    prop AudioObjectType int32
+    prop SamplingFrequency int32
+    prop ChannelConfiguration int32
+    prop FrameLengthFlag bool
+    prop DependsOnCoreCoder bool
+    override prop InternalSize int32 -> base.InternalSize + ascBlobLength
+
+    prop AscBlob []uint8 {
+        get -> GetAscBlob()
+        set {
+            bitReader = AudioSpecificConfig.LoadAscBlob(this, value)
+            ascBlobLength = value.Length
+        }
+    }
+
+    override func Render(file Stream) {
+        file.Write(AscBlob)
+    }
+
+    private func GetAscBlob() []uint8 {
+        ArgumentOutOfRangeException.ThrowIfLessThan(AudioObjectType, 0, nameof(AudioObjectType))
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(AudioObjectType, 32 + 63, nameof(AudioObjectType))
+        let sampleIndex = Array.IndexOf(AudioSpecificConfig.AscSampleRates, SamplingFrequency)
+        if sampleIndex < 0 {
+            throw ArgumentException("Unsupported SamplingFrequency of $SamplingFrequency. Supported values are [${String.Join(", ", SamplingFrequency)}]", nameof(SamplingFrequency))
+        }
+        ArgumentOutOfRangeException.ThrowIfLessThan(ChannelConfiguration, 1, nameof(ChannelConfiguration))
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(ChannelConfiguration, 7, nameof(ChannelConfiguration))
+        let writer = BitWriter()
+        if AudioObjectType < int32(AudioSpecificConfig.AotEscape) {
+            writer!!.Write(uint32(AudioObjectType), 5)
+        } else {
+            writer!!.Write(AudioSpecificConfig.AotEscape, 5)
+            writer!!.Write(uint32(AudioObjectType) - uint32(32), 6)
+        }
+        writer!!.Write(uint32(sampleIndex), 4)
+        writer!!.Write(uint32(ChannelConfiguration), 4)
+        writer!!.Write(if FrameLengthFlag { 1u } else { uint32(0) }, 1)
+        writer!!.Write(if DependsOnCoreCoder { 1u } else { uint32(0) }, 1)
+        let startPos = bitReader.Position
+        bitReader.CopyTo(writer!!)
+        this.bitReader.Position = startPos
+        return writer!!.ToByteArray()
+    }
+
+    private class InternalAudioSpecificConfig : IASC {
+        prop AudioObjectType int32
+        prop SamplingFrequency int32
+        prop ChannelConfiguration int32
+        prop FrameLengthFlag bool
+        prop DependsOnCoreCoder bool
+    }
+
+    shared {
+        let AscSampleRates []int32 = []int32{96000, 88200, 64000, 48000, 44100, 32000, 24000, 22050, 16000, 12000, 11025, 8000, 7350}
+        let MinSampleRate int32 = AudioSpecificConfig.AscSampleRates[^1]
+        let MaxSampleRate int32 = AudioSpecificConfig.AscSampleRates[0]
+        private const AotEscape uint8 = uint8(31)
+        private let SupportedObjectTypes []uint8 = []uint8{uint8(1), uint8(2), uint8(3), uint8(4), uint8(6), uint8(7), uint8(17), uint8(19), uint8(20), uint8(21), uint8(22), uint8(23), uint8(42)}
+        func CreateEmpty() AudioSpecificConfig -> AudioSpecificConfig()
+
+        func Parse(ascBlob []uint8) IASC {
+            let internalAsc = InternalAudioSpecificConfig()
+            AudioSpecificConfig.LoadAscBlob(internalAsc!!, ascBlob)
+            return internalAsc!!
+        }
+
+        private func LoadAscBlob(asc IASC, ascBlob []uint8) BitReader {
+            let bitReader = BitReader(ascBlob)
+            asc.AudioObjectType = int32(bitReader!!.Read(5))
+            if asc.AudioObjectType == int32(AudioSpecificConfig.AotEscape) {
+                asc.AudioObjectType = int32(bitReader!!.Read(6)) + 32
+            }
+            if Array.IndexOf(AudioSpecificConfig.SupportedObjectTypes, uint8(asc.AudioObjectType)) < 0 {
+                throw NotSupportedException("${nameof(AudioObjectType)} of ${asc.AudioObjectType} is unsupported")
+            }
+            let samplingFrequencyIndex = bitReader!!.Read(4)
+            asc.SamplingFrequency = if samplingFrequencyIndex <= uint32(12) { AudioSpecificConfig.AscSampleRates[samplingFrequencyIndex] } else { throw NotSupportedException("Sampling frequency index of $samplingFrequencyIndex is not supported.")
+                default(int32) }
+            asc.ChannelConfiguration = int32(bitReader!!.Read(4))
+            asc.FrameLengthFlag = bitReader!!.Read(1) != uint32(0)
+            asc.DependsOnCoreCoder = bitReader!!.Read(1) != uint32(0)
+            return bitReader!!
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/BaseDescriptor.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/BaseDescriptor.gs
@@ -1,0 +1,66 @@
+package Oahu.Decrypt.Mpeg4.Descriptors
+
+import System
+import System.Collections.Generic
+import System.IO
+import System.Linq
+
+open class BaseDescriptor {
+    init(file Stream, header DescriptorHeader) {
+        Children = List[BaseDescriptor]()
+        Header = header
+    }
+
+    protected init(tagId uint8) {
+        Children = List[BaseDescriptor]()
+        Header = DescriptorHeader(tagId)
+    }
+
+    prop Header DescriptorHeader {
+        get;
+        init;
+    }
+
+    prop Children List[BaseDescriptor] {
+        get;
+        init;
+    }
+
+    prop RenderSize uint32 -> uint32(1) + uint32(Header.GetEncodedSizeLength(InternalSize)) + uint32(InternalSize)
+    open prop InternalSize int32 -> int32(Children.Sum((c BaseDescriptor) -> c.RenderSize))
+    open func Render(file Stream);
+
+    func GetChild[T BaseDescriptor]() T? {
+        let children = GetChildren[T]()
+        return switch children.Count() {
+            case 0: nil
+            case 1: children.First()
+            default: throw InvalidOperationException("${GetType().Name} has ${children.Count()} children of type ${typeof(T)}. Call ${nameof(GetChildren)} instead.")
+        }
+    }
+
+    func GetChildOrThrow[T BaseDescriptor]() T -> GetChild[T]() ?? throw InvalidDataException("Descriptor does not contain a child of type ${typeof(T)}")
+
+    func GetChildren[T BaseDescriptor]() IEnumerable[T] {
+        return Children.OfType[T]()
+    }
+
+    func Save(file Stream) {
+        file.WriteByte(Header.TagID)
+        ExpandableClass.EncodeSize(file, InternalSize, Header.GetEncodedSizeLength(InternalSize))
+        Render(file)
+        for child in Children {
+            child.Save(file)
+        }
+    }
+
+    protected func LoadChildren(file Stream) {
+        while file.Position < Header.FilePosition + int64(Header.TotalBoxSize) {
+            let child = DescriptorFactory.CreateDescriptor(file)
+            if child.InternalSize == 0 {
+                break
+            }
+            Children.Add(child)
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/BitRateMode.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/BitRateMode.gs
@@ -1,0 +1,3 @@
+package Oahu.Decrypt.Mpeg4.Boxes.AC4SpecificBox
+
+enum BitRateMode { NotSpecified, Constant, Average, Variable }

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/BitReader.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/BitReader.gs
@@ -1,0 +1,93 @@
+package Oahu.Decrypt.Mpeg4.Util
+
+import System
+import System.Linq
+
+class BitReader(bytes []uint8) {
+    private var byteIndex int32 = 0
+    private var bitIndex int32 = 0
+
+    prop Position int32 {
+        get -> byteIndex * 8 + bitIndex
+        set {
+            ArgumentOutOfRangeException.ThrowIfLessThan(value, 0, nameof(Position))
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(value, bytes.Length * 8, nameof(Position))
+            byteIndex = value / 8
+            bitIndex = value % 8
+        }
+    }
+
+    prop Length int32 -> bytes.Length * 8
+    func ReadBool() bool -> Read(1) != uint32(0)
+
+    func ByteAlign() {
+        let bitPad = Position % 8
+        if bitPad != 0 {
+            Position += 8 - bitPad
+        }
+    }
+
+    func Read(numBits int32) uint32 {
+        var numBits = numBits
+        ArgumentOutOfRangeException.ThrowIfLessThan(numBits, 0, nameof(numBits))
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(numBits, 4 * 8, nameof(numBits))
+        var value uint32 = uint32(0)
+        while numBits > 0 {
+            if byteIndex >= bytes.Length {
+                throw InvalidOperationException("Not enough data to read the requested number of bits.")
+            }
+            let bitsToRead = Math.Min(numBits, 8 - bitIndex)
+            let mask = (1u << bitsToRead) - uint32(1)
+            value <<= bitsToRead
+            value |= (uint32(bytes[byteIndex]) >> (8 - bitIndex - bitsToRead)) & mask
+            numBits -= bitsToRead
+            bitIndex += bitsToRead
+            if bitIndex == 8 {
+                byteIndex++
+                bitIndex = 0
+            }
+        }
+        return value
+    }
+
+    func CopyTo(writer BitWriter) {
+        if bitIndex != 0 {
+            let toRead = 8 - bitIndex
+            let value = Read(toRead)
+            writer.Write(value, toRead)
+        }
+        while byteIndex < bytes.Length {
+            writer.Write(bytes[byteIndex], 8)
+            byteIndex++
+        }
+    }
+}
+
+class BitWriter {
+    private var byteIndex int32 = 0
+    private var bitIndex int32 = 0
+    private var bytes []uint8 = []uint8{}
+    prop Position int32 -> byteIndex * 8 + bitIndex
+    func ToByteArray() []uint8 -> bytes.ToArray()
+
+    func Write(value uint32, numBits int32) {
+        var value = value
+        var numBits = numBits
+        ArgumentOutOfRangeException.ThrowIfLessThan(numBits, 0, nameof(numBits))
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(numBits, 4 * 8, nameof(numBits))
+        while numBits > 0 {
+            if bitIndex == 0 {
+                Array.Resize(&bytes, byteIndex + 1)
+            }
+            let bitsToWrite = Math.Min(numBits, 8 - bitIndex)
+            value &= if numBits == 32 { UInt32.MaxValue } else { (1u << numBits) - uint32(1) }
+            bytes[byteIndex] |= uint8(((value >> (numBits - bitsToWrite)) << (8 - bitIndex - bitsToWrite)))
+            numBits -= bitsToWrite
+            bitIndex += bitsToWrite
+            if bitIndex == 8 {
+                byteIndex++
+                bitIndex = 0
+            }
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Box.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Box.gs
@@ -1,0 +1,104 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.Collections.Generic
+import System.IO
+import System.Linq
+import System.Threading
+import Oahu.Decrypt.Mpeg4.Util
+
+open class Box : IBox {
+    private var disposed int32 = 0
+
+    init(header BoxHeader, parent IBox?) {
+        Children = List[IBox]()
+        Header = header
+        Parent = parent
+    }
+
+    deinit {
+        Dispose(false)
+    }
+
+    prop Parent IBox? {
+        get;
+        init;
+    }
+
+    prop Header BoxHeader {
+        get;
+        init;
+    }
+
+    prop Children List[IBox] {
+        get;
+        init;
+    }
+
+    open prop RenderSize int64 -> int64(8) + Children.Sum((b IBox) -> b.RenderSize)
+    protected prop Disposed bool -> disposed != 0
+
+    func GetChild[T IBox]() T? {
+        let children = GetChildren[T]()
+        return switch children.Count() {
+            case 0: default
+            case 1: children.First()
+            default: throw InvalidOperationException("${GetType().Name} has ${children.Count()} children of type ${typeof(T)}. Call ${nameof(GetChildren)} instead.")
+        }
+    }
+
+    func GetChildOrThrow[T IBox]() T -> GetChild[T]() ?? throw InvalidDataException("${Header.Type} does not contain a child of type ${typeof(T)}")
+
+    func GetChildren[T IBox]() IEnumerable[T] {
+        return Children.OfType[T]()
+    }
+
+    func GetFreeBoxes() List[FreeBox] {
+        let freeBoxes = GetChildren[FreeBox]().ToList()
+        for child in Children {
+            freeBoxes.AddRange(child!!.GetFreeBoxes())
+        }
+        return freeBoxes
+    }
+
+    func Save(file Stream) {
+        ObjectDisposedException.ThrowIf(Disposed, this)
+        this.Header.FilePosition = file.Position
+        file.WriteHeader(Header, RenderSize)
+        Render(file)
+        for child in Children {
+            child!!.Save(file)
+        }
+    }
+
+    func Dispose() {
+        Dispose(true)
+        GC.SuppressFinalize(this)
+    }
+
+    protected func RemainingBoxLength(file Stream) int64 -> Header.FilePosition + Header.TotalBoxSize - file.Position
+    protected open func Render(file Stream);
+
+    protected func LoadChildren(file Stream) {
+        let endPos = Header.FilePosition + Header.TotalBoxSize
+        while file.Position < endPos {
+            let child = BoxFactory.CreateBox(file, this)
+            if child.Header.TotalBoxSize == int64(0) {
+                break
+            }
+            Children.Add(child)
+            if child.Header.FilePosition + child.Header.TotalBoxSize != file.Position {
+                break
+            }
+        }
+    }
+
+    protected open func Dispose(disposing bool) {
+        if disposing && Interlocked.CompareExchange(&disposed, 1, 0) == 0 {
+            for child in Children {
+                child?.Dispose()
+            }
+            Children.Clear()
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/BoxFactory.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/BoxFactory.gs
@@ -1,0 +1,72 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.Diagnostics
+import System.IO
+
+class BoxFactory {
+    shared {
+        func CreateBox[T Box](file Stream, parent IBox?) T {
+            let box = BoxFactory.CreateBox(file, parent)
+            return box as T ?? throw InvalidDataException("The ${box!!.Header.Type} box is not of type ${typeof(T)}")
+        }
+
+        func CreateBox(file Stream, parent IBox?) IBox -> BoxFactory.CreateBox(BoxHeader(file), file, parent)
+
+        func CreateBox(header BoxHeader, file Stream, parent IBox?) IBox {
+            let box IBox = switch header.Type {
+                case "free" or "skip": FreeBox(file, header, parent)
+                case "ftyp": FtypBox(file, header)
+                case "mdat": MdatBox(header)
+                case "moov": MoovBox(file, header)
+                case "moof": MoofBox(file, header)
+                case "mvhd": MvhdBox(file, header, parent)
+                case "trak": TrakBox(file, header, parent)
+                case "tkhd": TkhdBox(file, header, parent)
+                case "mdia": MdiaBox(file, header, parent)
+                case "minf": MinfBox(file, header, parent)
+                case "mdhd": MdhdBox(file, header, parent)
+                case "hdlr": HdlrBox(file, header, parent)
+                case "stbl": StblBox(file, header, parent)
+                case "stsd": StsdBox(file, header, parent)
+                case "esds": EsdsBox(file, header, parent)
+                case "btrt": BtrtBox(file, header, parent)
+                case "adrm": AdrmBox(file, header, parent)
+                case "stts": SttsBox(file, header, parent)
+                case "stsc": StscBox(file, header, parent)
+                case "stsz": StszBox(file, header, parent)
+                case "stz2": Stz2Box(file, header, parent)
+                case "stco": StcoBox(file, header, parent)
+                case "co64": Co64Box(file, header, parent)
+                case "udta": UdtaBox(file, header, parent)
+                case "meta": MetaBox(file, header, parent)
+                case "ilst": AppleListBox(file, header, parent)
+                case "data": AppleDataBox(file, header, parent)
+                case "mean": MeanBox(file, header, parent)
+                case "name": NameBox(file, header, parent)
+                case "pssh": PsshBox(file, header, parent)
+                case "sidx": SidxBox(file, header, parent)
+                case "mfhd": MfhdBox(file, header, parent)
+                case "tfhd": TfhdBox(file, header, parent)
+                case "traf": TrafBox(file, header, parent)
+                case "tfdt": TfdtBox(file, header, parent)
+                case "trun": TrunBox(file, header, parent)
+                case "saiz": SaizBox(file, header, parent)
+                case "saio": SaioBox(file, header, parent)
+                case "schm": SchmBox(file, header, parent)
+                case "frma": FrmaBox(file, header, parent)
+                case "tenc": TencBox(file, header, parent)
+                case "schi": SchiBox(file, header, parent)
+                case "sinf": SinfBox(file, header, parent)
+                case "senc": SencBox(file, header, parent)
+                case "mvex": MvexBox(file, header, parent)
+                case "mehd": MehdBox(file, header, parent)
+                case "dec3": Dec3Box(file, header, parent)
+                case "tref": TrefBox(file, header, parent)
+                case "dac4": Dac4Box(file, header, parent)
+                default: UnknownBox(file, header, parent)
+            }
+            Debug.Assert(box.RenderSize == header.TotalBoxSize || box is MdatBox)
+            return box
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/BoxHeader.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/BoxHeader.gs
@@ -1,0 +1,56 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.IO
+import System.Text
+import Oahu.Decrypt.Mpeg4.Util
+
+class BoxHeader {
+    init(file Stream) {
+        FilePosition = file.Position
+        TotalBoxSize = file.ReadUInt32BE()
+        Type = file.ReadType()
+        HeaderSize = uint32(8)
+        if TotalBoxSize == int64(1) {
+            Version = 1
+            TotalBoxSize = file.ReadInt64BE()
+            HeaderSize += uint32(uint32(8))
+        }
+    }
+
+    init(boxSize int64, boxType string) {
+        if boxSize < int64(8) {
+            throw ArgumentException("${nameof(boxSize)} must be at least 8 bytes.")
+        }
+        if String.IsNullOrEmpty(boxType) || Encoding.ASCII.GetByteCount(boxType) != 4 {
+            throw ArgumentException("${nameof(boxType)} must be a 4-byte long ASCII string.")
+        }
+        FilePosition = 0
+        Version = if boxSize > int64(UInt32.MaxValue) { 1 } else { 0 }
+        TotalBoxSize = boxSize
+        Type = boxType
+        HeaderSize = if boxSize > int64(UInt32.MaxValue) { 16u } else { 8u }
+    }
+
+    prop FilePosition int64
+
+    prop TotalBoxSize int64 {
+        get;
+        init;
+    }
+
+    prop Type string
+    prop HeaderSize uint32
+    prop Version int32
+
+    func ChangeAtomName(newAtomName string) {
+        if String.IsNullOrEmpty(newAtomName) || Encoding.UTF8.GetByteCount(newAtomName) != 4 {
+            throw ArgumentException("${nameof(newAtomName)} must be exactly 4 UTF-8 bytes long")
+        }
+        Type = newAtomName
+    }
+
+    func ToString() string {
+        return Type
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/BtrtBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/BtrtBox.gs
@@ -1,0 +1,43 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class BtrtBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        BufferSizeDB = file.ReadUInt32BE()
+        MaxBitrate = file.ReadUInt32BE()
+        AvgBitrate = file.ReadUInt32BE()
+    }
+
+    private init(bufferSizeDB uint32, maxBitrate uint32, avgBitrate uint32, header BoxHeader, parent IBox) : base(header, parent) {
+        BufferSizeDB = bufferSizeDB
+        MaxBitrate = maxBitrate
+        AvgBitrate = avgBitrate
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(12)
+
+    prop BufferSizeDB uint32 {
+        get;
+        init;
+    }
+
+    prop MaxBitrate uint32
+    prop AvgBitrate uint32
+
+    protected open override func Render(file Stream) {
+        file.WriteUInt32BE(BufferSizeDB)
+        file.WriteUInt32BE(MaxBitrate)
+        file.WriteUInt32BE(AvgBitrate)
+    }
+
+    shared {
+        func Create(bufferSizeDB uint32, maxBitrate uint32, avgBitrate uint32, parent Box) BtrtBox {
+            let header = BoxHeader(20, "btrt")
+            let btrt = BtrtBox(bufferSizeDB, maxBitrate, avgBitrate, header, parent)
+            parent.Children.Add(btrt)
+            return btrt
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/ByteUtil.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/ByteUtil.gs
@@ -1,0 +1,44 @@
+package Oahu.Decrypt.Mpeg4.Util
+
+import System
+
+class ByteUtil {
+    shared {
+        func BytesFromHexString(hexString string) []uint8 {
+            let byteCount = hexString.Length / 2
+            let bytes = [byteCount]uint8
+            for var i = 0; i < byteCount; i++ {
+                bytes[i] = Byte.Parse(hexString.Substring(2 * i, 2), System.Globalization.NumberStyles.HexNumber)
+            }
+            return bytes
+        }
+
+        func CloneBytes(src []uint8) []uint8 {
+            return ByteUtil.CloneBytes(src, 0, src.Length)
+        }
+
+        func CloneBytes(src []uint8, srcOffset int32, count int32) []uint8 {
+            let dst = [count]uint8
+            Buffer.BlockCopy(src, srcOffset, dst, 0, count)
+            return dst
+        }
+
+        func BytesEqual(array1 []uint8, array2 []uint8, reverseDirection bool = false) bool {
+            return ByteUtil.BytesEqual(array1, 0, array2, 0, array1.Length, reverseDirection)
+        }
+
+        func BytesEqual(array1 []uint8, startIndex1 int32, array2 []uint8, startIndex2 int32, count int32, reverseDirection bool = false) bool {
+            if array1.Length < startIndex1 + count || array2.Length < startIndex2 + count {
+                return false
+            }
+            let indexDiff = startIndex2 - startIndex1
+            for var i = startIndex1; i < startIndex1 + count; i++ {
+                let array2Index = if reverseDirection { startIndex2 + count - 1 - (i - startIndex1) } else { i + indexDiff }
+                if (array1[i] != array2[array2Index]) {
+                    return false
+                }
+            }
+            return true
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/CHAPFrame.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/CHAPFrame.gs
@@ -1,0 +1,50 @@
+package Oahu.Decrypt.Mpeg4.ID3
+
+import System
+import System.IO
+import System.Linq
+import System.Text
+
+enum ChapterFlags { TopLevel, Ordered }
+
+class CHAPFrame : Frame {
+    init(parent Frame, startTime TimeSpan, endTime TimeSpan, chNum int32, title string, subtitle string? = nil, subtitle2 string? = nil) : base(FrameHeader("CHAP", 0, parent.Version), parent) {
+        ChapterID = title
+        StartTime = startTime
+        EndTime = endTime
+        ByteStart = UInt32.MaxValue
+        ByteEnd = UInt32.MaxValue
+        if subtitle != nil {
+            TEXTFrame.Create(this, "TIT2", subtitle!!)
+        }
+        if subtitle2 != nil {
+            TEXTFrame.Create(this, "TIT3", subtitle2!!)
+        }
+    }
+
+    init(file Stream, header Header, parent Frame) : base(header, parent) {
+        let endPosition = file.Position + int64(Header.Size)
+        ChapterID = Frame.ReadNullTerminatedString(file, false)
+        StartTime = TimeSpan.FromMilliseconds(Header.ReadUInt32BE(file))
+        EndTime = TimeSpan.FromMilliseconds(Header.ReadUInt32BE(file))
+        ByteStart = Header.ReadUInt32BE(file)
+        ByteEnd = Header.ReadUInt32BE(file)
+        LoadChildren(file, endPosition)
+    }
+
+    override prop Size int32 -> Encoding.ASCII.GetByteCount(ChapterID) + 1 + 4 * 4 + Children.Sum((c Frame) -> c.Size + 10)
+    prop ChapterID string
+    prop StartTime TimeSpan
+    prop EndTime TimeSpan
+    prop ByteStart uint32
+    prop ByteEnd uint32
+
+    override func Render(file Stream) {
+        file.Write(Encoding.ASCII.GetBytes(ChapterID))
+        file.WriteByte(0)
+        Header.WriteUInt32BE(file, uint32(Math.Round(StartTime.TotalMilliseconds)))
+        Header.WriteUInt32BE(file, uint32(Math.Round(EndTime.TotalMilliseconds)))
+        Header.WriteUInt32BE(file, ByteStart)
+        Header.WriteUInt32BE(file, ByteEnd)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/CTOCFrame.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/CTOCFrame.gs
@@ -1,0 +1,56 @@
+package Oahu.Decrypt.Mpeg4.ID3
+
+import System.Collections.Generic
+import System.IO
+import System.Linq
+import System.Text
+
+class CTOCFrame : Frame {
+    init(parent Frame, chapterFlags ChapterFlags, elementId string = "TOC1") : base(FrameHeader("CTOC", 0, parent.Version), parent) {
+        ChildElementIDs = List[string]()
+        ChapterFlags = chapterFlags
+        ElementID = elementId
+    }
+
+    init(file Stream, header Header, parent Frame) : base(header, parent) {
+        ChildElementIDs = List[string]()
+        let endPosition = file.Position + int64(Header.Size)
+        ElementID = Frame.ReadNullTerminatedString(file, false)
+        ChapterFlags = ChapterFlags(file.ReadByte())
+        let elemIdCount = file.ReadByte()
+        for var i = 0; i < elemIdCount; i++ {
+            ChildElementIDs.Add(Frame.ReadNullTerminatedString(file, false))
+        }
+        LoadChildren(file, endPosition)
+    }
+
+    override prop Size int32 -> Encoding.ASCII.GetByteCount(ElementID) + 3 + ChildElementIDs.Sum((c string) -> Encoding.ASCII.GetByteCount(c) + 1) + Children.Sum((c Frame) -> c.Size + c.Header.HeaderSize)
+
+    prop ElementID string {
+        get;
+        init;
+    }
+
+    prop ChapterFlags ChapterFlags {
+        get;
+        init;
+    }
+
+    prop ChildElementIDs List[string] {
+        get;
+        init;
+    }
+
+    func Add(chapter CHAPFrame) -> ChildElementIDs.Add(chapter.ChapterID)
+
+    override func Render(file Stream) {
+        file.Write(Encoding.ASCII.GetBytes(ElementID))
+        file.WriteByte(0)
+        file.WriteByte(uint8(ChapterFlags))
+        file.WriteByte(uint8(ChildElementIDs.Count))
+        for ch in ChildElementIDs {
+            file.Write(Encoding.ASCII.GetBytes(ch!!))
+            file.WriteByte(0)
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/ChannelGroups.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/ChannelGroups.gs
@@ -1,0 +1,8 @@
+package Oahu.Decrypt.Mpeg4.Boxes.AC4SpecificBox
+
+import System
+import System.Collections.Generic
+import System.Text
+import System.Threading.Tasks
+
+enum ChannelGroups { Left_Right, Center, LeftSurround_RightSurround, LeftBack_RightBack, TopFrontLeft_TopFrontRight, TopBackLeft_TopBackRight, LFE, TopLeft_TopRight, TopSideLeft_TopSideRight, TopFrontCentre, Tfc, TopCenter, LFE2, BottomFrontLeft_BottomFrontRight, BottomFrontCentre, BackCenter, LeftScreen_RightScreen, LeftWide_RightWide, VerticalHeightLeft_VerticalHeightRight, NOT_CHANNEL_CODED }

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/ChannelLocation.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/ChannelLocation.gs
@@ -1,0 +1,3 @@
+package Oahu.Decrypt.Mpeg4.Boxes.EC3SpecificBox
+
+enum ChannelLocation { Lc_Rc_Pair, Lrs_Rrs_Pair, Cs, Ts, Lsd_Rsd_Pair, Lw_Rw_Pair, Lvh_Rvh_Pair, Cvh, LFE2 }

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Chapter.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Chapter.gs
@@ -1,0 +1,53 @@
+package Oahu.Decrypt.Mpeg4
+
+import System
+import System.IO
+import System.Text
+import Oahu.Decrypt.Mpeg4.Util
+
+open class Chapter {
+    init(title string, start TimeSpan, duration TimeSpan) {
+        ArgumentNullException.ThrowIfNull(title, nameof(title))
+        Title = title
+        StartOffset = start
+        Duration = duration
+        EndOffset = StartOffset + Duration
+    }
+
+    prop Title string {
+        get;
+        init;
+    }
+
+    prop StartOffset TimeSpan {
+        get;
+        init;
+    }
+
+    prop Duration TimeSpan {
+        get;
+        init;
+    }
+
+    prop EndOffset TimeSpan {
+        get;
+        init;
+    }
+
+    prop RenderSize int32 -> 2 + Encoding.UTF8.GetByteCount(Title) + Chapter.Encd.Length
+
+    func WriteChapter(output Stream) {
+        let title = Encoding.UTF8.GetBytes(Title)
+        output.WriteInt16BE(int16(title.Length))
+        output.Write(title)
+        output.Write(Chapter.Encd)
+    }
+
+    func ToString() string {
+        return "$Title {{$StartOffset - $EndOffset}}"
+    }
+
+    shared {
+        private let Encd []uint8 = []uint8{uint8(0), uint8(0), uint8(0), uint8(0xc), uint8('e'), uint8('n'), uint8('c'), uint8('d'), uint8(0), uint8(0), uint8(1), uint8(0)}
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/ChapterFilter.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/ChapterFilter.gs
@@ -1,0 +1,17 @@
+package Oahu.Decrypt.FrameFilters.Text
+
+import System
+import System.Threading.Tasks
+
+open class ChapterFilter : FrameFinalBase[FrameEntry] {
+    event ChapterRead (object?, FrameEntry) -> void
+    protected open override prop InputBufferSize int32 -> 1
+
+    open override func AddInputAsync(input FrameEntry) Task {
+        ChapterRead?(this, input)
+        return Task.CompletedTask
+    }
+
+    protected open override func FlushAsync() Task -> Task.CompletedTask
+    protected open override func PerformFilteringAsync(input FrameEntry) Task -> Task.CompletedTask
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/ChapterInfo.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/ChapterInfo.gs
@@ -1,0 +1,39 @@
+package Oahu.Decrypt.Mpeg4
+
+import System
+import System.Collections
+import System.Collections.Generic
+import System.Linq
+
+open class ChapterInfo : IEnumerable[Chapter] {
+    private let chapterList List[Chapter] = List[Chapter]()
+
+    init(offsetFromBeginning TimeSpan = default(TimeSpan)) {
+        StartOffset = offsetFromBeginning
+    }
+
+    prop StartOffset TimeSpan {
+        get;
+        init;
+    }
+
+    prop EndOffset TimeSpan -> if Count == 0 { StartOffset } else { chapterList.Max((c Chapter) -> c.EndOffset) }
+    prop Chapters IReadOnlyList[Chapter] -> chapterList
+    prop Count int32 -> chapterList.Count
+    prop RenderSize int32 -> chapterList.Sum((c Chapter) -> c.RenderSize)
+
+    func AddChapter(title string, duration TimeSpan) {
+        let startTime = if Count == 0 { StartOffset } else { chapterList[^1].EndOffset }
+        chapterList.Add(Chapter(title, startTime, duration))
+    }
+
+    func Add(title string, duration TimeSpan) -> AddChapter(title, duration)
+
+    func GetEnumerator() IEnumerator[Chapter] {
+        return chapterList.GetEnumerator()
+    }
+
+    private func GetEnumerator() IEnumerator {
+        return GetEnumerator()
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/ChapterQueue.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/ChapterQueue.gs
@@ -1,0 +1,105 @@
+package Oahu.Decrypt
+
+import System
+import System.Collections.Generic
+import System.Diagnostics.CodeAnalysis
+import System.IO
+import System.Text
+import Oahu.Decrypt.FrameFilters
+import Oahu.Decrypt.Mpeg4
+
+class ChapterEntry {
+    init(title string) {
+        ArgumentNullException.ThrowIfNull(title, nameof(title))
+        Title = title
+    }
+
+    prop FrameData Memory[uint8] {
+        get;
+        init;
+    }
+
+    prop SamplesInFrame uint32 {
+        get;
+        init;
+    }
+
+    prop Title string {
+        get;
+        init;
+    }
+}
+
+class ChapterQueue {
+    private let sampleScaleFactor float64
+    private let outputSampleRate SampleRate
+    private let lockObj object = System.Object()
+    private let chapterEntries Queue[ChapterEntry] = Queue[ChapterEntry]()
+    private var subtractNext int32 = 0
+
+    init(inputRate SampleRate, outputRate SampleRate) {
+        outputSampleRate = outputRate
+        sampleScaleFactor = float64(outputRate) / float64(inputRate)
+    }
+
+    func TryGetNextChapter(out chapterEntry ChapterEntry?) bool {
+        {
+            Monitor.Enter(lockObj)
+            try {
+                if chapterEntries.Count > 0 {
+                    chapterEntry = chapterEntries.Dequeue()
+                    return true
+                }
+            } finally {
+                Monitor.Exit(lockObj)
+            }
+        }
+        chapterEntry = nil
+        return false
+    }
+
+    func AddRange(chapters IEnumerable[Chapter]) {
+        for ch in chapters {
+            Add(ch!!)
+        }
+    }
+
+    func Add(chapter Chapter) {
+        let frameData = [chapter.RenderSize]uint8
+        using let ms = MemoryStream(frameData)
+        chapter.WriteChapter(ms!!)
+        let sampleDelta = uint32((chapter.Duration.TotalSeconds * float64(int32(outputSampleRate))))
+        {
+            Monitor.Enter(lockObj)
+            try {
+                chapterEntries.Enqueue(ChapterEntry(chapter.Title))
+            } finally {
+                Monitor.Exit(lockObj)
+            }
+        }
+    }
+
+    func Add(entry FrameEntry) {
+        let frameData ReadOnlySpan[uint8] = entry.FrameData.Span
+        var title = String.Empty
+        if frameData.Length >= 2 {
+            var size = (frameData[0] << 8) | int32(frameData[1])
+            if size > frameData.Length - 2 {
+                size = frameData.Length - 2
+            }
+            if size > 0 {
+                title = Encoding.UTF8.GetString(frameData.Slice(2, size))
+            }
+        }
+        let sif = int32(entry.SamplesInFrame)
+        {
+            Monitor.Enter(lockObj)
+            try {
+                chapterEntries.Enqueue(ChapterEntry(title))
+            } finally {
+                Monitor.Exit(lockObj)
+            }
+        }
+        subtractNext = if sif < 0 { sif } else { 0 }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/ChunkEntry.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/ChunkEntry.gs
@@ -1,0 +1,43 @@
+package Oahu.Decrypt.Mpeg4.Chunks
+
+class ChunkEntry {
+    prop TrackId uint32 {
+        get;
+        init;
+    }
+
+    prop ChunkIndex uint32 {
+        get;
+        init;
+    }
+
+    prop ChunkOffset int64 {
+        get;
+        init;
+    }
+
+    prop FirstSample int64 {
+        get;
+        init;
+    }
+
+    prop ChunkSize int32 {
+        get;
+        init;
+    }
+
+    prop FrameSizes []int32 {
+        get;
+        init;
+    }
+
+    prop FrameDurations []uint32 {
+        get;
+        init;
+    }
+
+    prop ExtraData object? {
+        get;
+        init;
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/ChunkEntryList.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/ChunkEntryList.gs
@@ -1,0 +1,47 @@
+package Oahu.Decrypt.Mpeg4.Chunks
+
+import System
+import System.Collections
+import System.Collections.Generic
+import System.Linq
+import Oahu.Decrypt.Mpeg4.Boxes
+
+class ChunkEntryList : IReadOnlyCollection[ChunkEntry] {
+    private let chunkOffsets ChunkOffsetList
+    private let stsz IStszBox
+    private let stts SttsBox
+    private let chunkFrameTable []ChunkFrames
+    private let trackId uint32
+
+    init(track TrakBox) {
+        trackId = track.Tkhd.TrackID
+        stsz = track.Mdia.Minf.Stbl.Stsz ?? throw ArgumentNullException(nameof(track))
+        let coBox = track.Mdia.Minf.Stbl.COBox
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(coBox!!.EntryCount, uint32(Int32.MaxValue), "COBox.EntryCount")
+        chunkOffsets = coBox!!.ChunkOffsets
+        Count = int32(coBox!!.EntryCount)
+        stts = track.Mdia.Minf.Stbl.Stts
+        chunkFrameTable = track.Mdia.Minf.Stbl.Stsc.CalculateChunkFrameTable(coBox!!.EntryCount)
+    }
+
+    prop Count int32 {
+        get;
+        init;
+    }
+
+    func GetEnumerator() IEnumerator[ChunkEntry] -> EnumerateChunks().GetEnumerator()
+    private func GetEnumerator() IEnumerator -> GetEnumerator()
+
+    private func EnumerateChunks() sequence[ChunkEntry] {
+        var startSample int64 = 0
+        for var chunkIndex = 0; chunkIndex < Count; chunkIndex++ {
+            let chunkOffset = chunkOffsets.GetOffsetAtIndex(chunkIndex)
+            let chunkFrames = chunkFrameTable[chunkIndex]
+            let (frameSizes, totalChunkSize) = stsz.GetFrameSizes(chunkFrames.FirstFrameIndex, chunkFrames.NumberOfFrames)
+            let frameDurations = stts.EnumerateFrameDeltas(chunkFrames.FirstFrameIndex).Take(frameSizes.Length).ToArray()
+            let entry = ChunkEntry{TrackId: trackId, FrameSizes: frameSizes, ChunkIndex: uint32(chunkIndex), ChunkSize: totalChunkSize, ChunkOffset: chunkOffset, FirstSample: startSample, FrameDurations: frameDurations}
+            startSample += entry!!.FrameDurations.Sum((d uint32) -> d)
+            yield entry
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/ChunkOffsetList.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/ChunkOffsetList.gs
@@ -1,0 +1,272 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.Buffers.Binary
+import System.Collections
+import System.Collections.Generic
+import System.IO
+import System.Linq
+import System.Runtime.InteropServices
+import Oahu.Decrypt.Mpeg4.Util
+
+class ChunkOffsetList : ICollection[int64] {
+    private let chunkOffsets32 List[uint32]
+    private var chunkOffsets64 List[int64]?
+
+    init() {
+        chunkOffsets32 = List[uint32]()
+    }
+
+    private init(capacity int32) {
+        chunkOffsets32 = List[uint32](capacity)
+    }
+
+    prop Count int32 -> chunkOffsets32.Count + (chunkOffsets64?.Count ?? 0)
+    prop IsReadOnly bool -> false
+
+    func Clear() {
+        chunkOffsets32.Clear()
+        chunkOffsets64?.Clear()
+        chunkOffsets64 = nil
+    }
+
+    func Sort() {
+        if chunkOffsets64 != nil {
+            chunkOffsets64!!.Sort()
+            let index = ChunkOffsetList.FindLast32bit(CollectionsMarshal.AsSpan(chunkOffsets64!!))
+            if index >= 0 {
+                let countToMove = index + 1
+                let toMove = [countToMove]uint32
+                for var i = 0; i < countToMove; i++ {
+                    toMove[i] = uint32(chunkOffsets64!![i])
+                }
+                chunkOffsets32.AddRange(toMove)
+                chunkOffsets64!!.RemoveRange(0, countToMove)
+                if chunkOffsets64!!.Count == 0 {
+                    chunkOffsets64 = nil
+                }
+            }
+        }
+        chunkOffsets32.Sort()
+    }
+
+    func GetOffsetAtIndex(index int32) int64 {
+        var index = index
+        if index < chunkOffsets32.Count {
+            return chunkOffsets32[index]
+        } else if chunkOffsets64 != nil {
+            index -= chunkOffsets32.Count
+            if index < chunkOffsets64!!.Count {
+                return chunkOffsets64!![index]
+            }
+        }
+        throw IndexOutOfRangeException("Index $index is out of range for chunk offsets.")
+    }
+
+    func SetOffsetAtIndex(index int32, value int64) {
+        var index = index
+        if index < chunkOffsets32.Count {
+            if value > int64(UInt32.MaxValue) {
+                let toMove = chunkOffsets32.Count - index
+                let longs = [toMove]int64
+                longs[0] = value
+                for var i = 1; i < toMove; i++ {
+                    longs[i] = chunkOffsets32[index + i]
+                }
+                CollectionsMarshal.SetCount(chunkOffsets32, index)
+                chunkOffsets64 ??= List[int64](longs.Length)
+                chunkOffsets64!!.InsertRange(0, longs)
+            } else {
+                chunkOffsets32[index] = uint32(value)
+            }
+            return
+        } else if chunkOffsets64 != nil {
+            index -= chunkOffsets32.Count
+            if index < chunkOffsets64!!.Count {
+                chunkOffsets64!![index] = value
+                return
+            }
+        }
+        throw IndexOutOfRangeException("Index $index is out of range for chunk offsets.")
+    }
+
+    func Write32(file Stream) {
+        if chunkOffsets64 != nil && chunkOffsets64!!.Count > 0 {
+            throw InvalidOperationException("Cannot write 32-bit chunk offsets when 64-bit offsets are present.")
+        }
+        let span = CollectionsMarshal.AsSpan(chunkOffsets32)
+        if BitConverter.IsLittleEndian {
+            BinaryPrimitives.ReverseEndianness(span, span)
+        }
+        file.Write(MemoryMarshal.AsBytes(span))
+        if BitConverter.IsLittleEndian {
+            BinaryPrimitives.ReverseEndianness(span, span)
+        }
+    }
+
+    func Write64(file Stream) {
+        for offset32 in chunkOffsets32 {
+            file.WriteInt64BE(offset32)
+        }
+        let span64 = CollectionsMarshal.AsSpan(chunkOffsets64)
+        if BitConverter.IsLittleEndian {
+            BinaryPrimitives.ReverseEndianness(span64, span64)
+        }
+        file.Write(MemoryMarshal.AsBytes(span64))
+        if BitConverter.IsLittleEndian {
+            BinaryPrimitives.ReverseEndianness(span64, span64)
+        }
+    }
+
+    func IndexOf(item int64) int32 {
+        if item <= int64(UInt32.MaxValue) {
+            let index32 = chunkOffsets32.IndexOf(uint32(item))
+            if index32 >= 0 {
+                return index32
+            }
+        } else if chunkOffsets64 != nil {
+            let index64 = chunkOffsets64!!.IndexOf(item)
+            if index64 >= 0 {
+                return chunkOffsets32.Count + index64
+            }
+        }
+        return -1
+    }
+
+    func RemoveAt(index int32) {
+        var index = index
+        if index < chunkOffsets32.Count {
+            chunkOffsets32.RemoveAt(index)
+            return
+        } else if chunkOffsets64 != nil {
+            index -= chunkOffsets32.Count
+            if index < chunkOffsets64!!.Count {
+                chunkOffsets64!!.RemoveAt(index)
+                return
+            }
+        }
+        throw IndexOutOfRangeException()
+    }
+
+    func Add(offset int64) {
+        if offset > int64(UInt32.MaxValue) {
+            chunkOffsets64 ??= List[int64]()
+            chunkOffsets64!!.Add(offset)
+        } else {
+            chunkOffsets32.Add(uint32(offset))
+        }
+    }
+
+    func Contains(item int64) bool -> IndexOf(item) >= 0
+
+    func Remove(item int64) bool {
+        let index = IndexOf(item)
+        if index >= 0 {
+            RemoveAt(index)
+            return true
+        }
+        return false
+    }
+
+    func GetEnumerator() IEnumerator[int64] -> chunkOffsets32.ConvertAll((i uint32) -> int64(i)).Concat(chunkOffsets64 ?? List[int64]()).GetEnumerator()
+
+    func CopyTo(array []int64, arrayIndex int32) {
+        var arrayIndex = arrayIndex
+        {
+            var i = 0
+            while i < chunkOffsets32.Count {
+                array[arrayIndex] = chunkOffsets32[i]
+                i++
+                arrayIndex++
+            }
+        }
+        if chunkOffsets64 != nil {
+            {
+                var i = 0
+                while i < chunkOffsets64!!.Count {
+                    array[arrayIndex] = chunkOffsets64!![i]
+                    i++
+                    arrayIndex++
+                }
+            }
+        }
+    }
+
+    private func GetEnumerator() IEnumerator -> GetEnumerator()
+
+    shared {
+        func Read32(file Stream, entryCount uint32) ChunkOffsetList {
+            let list = ChunkOffsetList(int32(entryCount))
+            CollectionsMarshal.SetCount(list.chunkOffsets32, int32(entryCount))
+            let span = CollectionsMarshal.AsSpan(list.chunkOffsets32)
+            file.ReadExactly(MemoryMarshal.AsBytes(span))
+            if BitConverter.IsLittleEndian {
+                BinaryPrimitives.ReverseEndianness(span, span)
+            }
+            var lastChunkOffset int64 = 0
+            for var i = 0; i < list.chunkOffsets32.Count; i++ {
+                var chunkOffset int64 = list.chunkOffsets32[i]
+                if chunkOffset < lastChunkOffset && lastChunkOffset - chunkOffset > int64(UInt32.MaxValue / uint32(2)) {
+                    if list.chunkOffsets64 == nil {
+                        let count = list.chunkOffsets32.Count - i
+                        list.chunkOffsets64 = List[int64](count)
+                    }
+                    chunkOffset += 1L << 32
+                    list.chunkOffsets32.RemoveAt(i)
+                    i--
+                    list.chunkOffsets64!!.Add(chunkOffset)
+                }
+                lastChunkOffset = chunkOffset
+            }
+            list.chunkOffsets32.Sort()
+            list.chunkOffsets64?.Sort()
+            return list
+        }
+
+        func Read64(file Stream, entryCount uint32) ChunkOffsetList {
+            unsafe {
+                let pLongs = Marshal.AllocHGlobal(8 * IntPtr(entryCount))
+                try {
+                    let longsSpan = Span[int64](pLongs.ToPointer(), int32(entryCount))
+                    file.ReadExactly(MemoryMarshal.AsBytes(longsSpan))
+                    if BitConverter.IsLittleEndian {
+                        BinaryPrimitives.ReverseEndianness(longsSpan, longsSpan)
+                    }
+                    longsSpan.Sort()
+                    let count32Bit = ChunkOffsetList.FindLast32bit(longsSpan) + 1
+                    let list = ChunkOffsetList(count32Bit)
+                    CollectionsMarshal.SetCount(list.chunkOffsets32, count32Bit)
+                    let span = CollectionsMarshal.AsSpan(list.chunkOffsets32)
+                    for var i = 0; i < count32Bit; i++ {
+                        span[i] = uint32(longsSpan[i])
+                    }
+                    let remainder = longsSpan.Slice(count32Bit)
+                    list.chunkOffsets64 = List[int64](remainder.Length)
+                    CollectionsMarshal.SetCount(list.chunkOffsets64!!, remainder.Length)
+                    let span64 = CollectionsMarshal.AsSpan(list.chunkOffsets64!!)
+                    remainder.CopyTo(span64)
+                    return list
+                } finally {
+                    Marshal.FreeHGlobal(pLongs)
+                }
+            }
+        }
+
+        private func FindLast32bit(longsSpan ReadOnlySpan[int64]) int32 {
+            var l = 0
+            var r = longsSpan.Length - 1
+            while l <= r {
+                let mid = l + (r - l) / 2
+                let midValue = longsSpan[mid]
+                if midValue > int64(UInt32.MaxValue) {
+                    r = mid - 1
+                } else if midValue == int64(UInt32.MaxValue) || mid >= r || longsSpan[mid + 1] >= int64(UInt32.MaxValue) {
+                    return mid
+                } else {
+                    l = mid + 1
+                }
+            }
+            return -1
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/ChunkReader.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/ChunkReader.gs
@@ -1,0 +1,148 @@
+package Oahu.Decrypt.Chunks
+
+import System
+import System.Collections.Generic
+import System.IO
+import System.Linq
+import System.Threading
+import System.Threading.Tasks
+import Oahu.Decrypt.FrameFilters
+import Oahu.Decrypt.Mpeg4.Boxes
+import Oahu.Decrypt.Mpeg4.Chunks
+import Oahu.Decrypt.Mpeg4.Util
+
+interface IChunkReader {
+    prop OnProgressUpdateDelegate ((ConversionProgressEventArgs) -> void)?
+    func RunAsync(cancellationSource CancellationTokenSource) Task;
+    func AddTrack(track TrakBox, filter FrameFilterBase[FrameEntry]);
+}
+
+internal open class ChunkReader : IChunkReader {
+    private var beginProcess DateTime
+    private var nextUpdate DateTime
+
+    init(inputStream Stream, startTime TimeSpan, endTime TimeSpan) {
+        TrackEntries = Dictionary[uint32, TrackEntry]()
+        InputStream = inputStream
+        if startTime >= endTime {
+            throw ArgumentException("Start time must be less than end time.", nameof(startTime))
+        }
+        StartTime = startTime
+        EndTime = endTime
+    }
+
+    prop OnProgressUpdateDelegate ((ConversionProgressEventArgs) -> void)?
+
+    protected prop TrackEntries Dictionary[uint32, TrackEntry] {
+        get;
+        init;
+    }
+
+    protected prop InputStream Stream {
+        get;
+        init;
+    }
+
+    protected prop StartTime TimeSpan {
+        get;
+        init;
+    }
+
+    protected prop EndTime TimeSpan {
+        get;
+        init;
+    }
+
+    open func AddTrack(track TrakBox, filter FrameFilterBase[FrameEntry]) {
+        let trackEntry = TrackEntry(track.Tkhd.TrackID, track.Mdia.Mdhd.Timescale, filter, track)
+        TrackEntries.Add(track.Tkhd.TrackID, trackEntry!!)
+    }
+
+    async func RunAsync(cancellationSource CancellationTokenSource) {
+        for filter in TrackEntries.Values.Select((e TrackEntry) -> e.FirstFilter) {
+            filter!!.SetCancellationToken(cancellationSource.Token)
+        }
+        OnInitialProgress()
+        let token = cancellationSource.Token
+        try {
+            for c in EnumerateChunks() {
+                let chunkData Memory[uint8] = [c!!.ChunkSize]uint8
+                await InputStream.ReadNextChunkAsync(c!!.ChunkOffset, chunkData, token)
+                await DispatchChunk(c!!, chunkData, token)
+            }
+        } catch (ex OperationCanceledException) {
+        } catch (ex Exception) {
+            cancellationSource.Cancel()
+            throw ex
+        } finally {
+            OnFinalProgress()
+            await Task.WhenAll(TrackEntries.Values.Select((e TrackEntry) -> e.FirstFilter.CompleteAsync()))
+        }
+    }
+
+    protected open func EnumerateChunks() IEnumerable[ChunkEntry] {
+        let ChunkHasFrameInRange = func (value ChunkEntry) bool {
+            let timeScale = GetTrackEntryFromId(value.TrackId).Timescale
+            let minimumSample = StartTime.TotalSeconds * float64(timeScale)
+            let maximumSample = EndTime.TotalSeconds * float64(timeScale)
+            return float64(value.FirstSample) <= maximumSample && float64((value.FirstSample + value.FrameDurations.Sum((d uint32) -> d))) >= minimumSample
+        }
+        return TrackEntries.Values.Select((e TrackEntry) -> e.TrakBox).InterleaveBy((t TrakBox) -> t.ChunkEntries(), (t ChunkEntry) -> t.ChunkOffset).Where(ChunkHasFrameInRange)
+    }
+
+    protected func GetTrackEntryFromId(trackId uint32) TrackEntry -> if TrackEntries.TryGetValue(trackId, out var trackEntry) { trackEntry!! } else { throw ArgumentOutOfRangeException(nameof(trackId), "Track ID $trackId is not present in this ${nameof(ChunkReader)} instance.")
+        default(TrackEntry) }
+
+    protected open func CreateFrameEntry(chunk ChunkEntry, frameInChunk int32, frameDelta uint32, frameData Memory[uint8]) FrameEntry -> FrameEntry{Chunk: chunk, SamplesInFrame: frameDelta, FrameData: frameData}
+
+    private async func DispatchChunk(chunk ChunkEntry, chunkData Memory[uint8], token CancellationToken) {
+        var sampleIndex = chunk.FirstSample
+        let trackEntry = GetTrackEntryFromId(chunk.TrackId)
+        let startSample = int64((StartTime.TotalSeconds * float64(trackEntry!!.Timescale)))
+        let endSample = int64((EndTime.TotalSeconds * float64(trackEntry!!.Timescale)))
+        var frameDelta uint32
+        {
+            var start = 0
+            var f = 0
+            while f < chunk.FrameSizes.Length {
+                frameDelta = chunk.FrameDurations[f]
+                if startSample >= sampleIndex + int64(frameDelta) {
+                    continue
+                }
+                if endSample < sampleIndex {
+                    break
+                }
+                OnProgressReport(sampleIndex, trackEntry!!.Timescale)
+                let frameData = chunkData.Slice(start, chunk.FrameSizes[f])
+                let frameEntry = CreateFrameEntry(chunk, f, frameDelta, frameData)
+                token.ThrowIfCancellationRequested()
+                await trackEntry!!.FirstFilter.AddInputAsync(frameEntry!!)
+                start += chunk.FrameSizes[f]
+                f++
+                sampleIndex += int64(frameDelta)
+            }
+        }
+    }
+
+    private func OnInitialProgress() {
+        beginProcess = DateTime.UtcNow
+        nextUpdate = beginProcess
+        OnProgressUpdateDelegate?(ConversionProgressEventArgs(StartTime, EndTime, StartTime, 0.0))
+    }
+
+    private func OnFinalProgress() {
+        OnProgressUpdateDelegate?(ConversionProgressEventArgs(StartTime, EndTime, EndTime, (EndTime - StartTime) / (DateTime.UtcNow - beginProcess)))
+    }
+
+    private func OnProgressReport(sampleNumber int64, timeScale uint32) {
+        if DateTime.UtcNow > nextUpdate {
+            let trackPosition = TimeSpan.FromSeconds(float64(sampleNumber) / float64(timeScale))
+            let speed = (trackPosition - StartTime) / (DateTime.UtcNow - beginProcess)
+            OnProgressUpdateDelegate?(ConversionProgressEventArgs(StartTime, EndTime, trackPosition, speed))
+            nextUpdate = DateTime.UtcNow.AddMilliseconds(100.0)
+        }
+    }
+
+    protected open data class TrackEntry(TrackId uint32, Timescale uint32, FirstFilter FrameFilterBase[FrameEntry], TrakBox TrakBox) {
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Co64Box.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Co64Box.gs
@@ -1,0 +1,51 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+internal open class Co64Box : FullBox, IChunkOffsets {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        let entryCount = file.ReadUInt32BE()
+        if entryCount > uint32(Int32.MaxValue) {
+            throw NotSupportedException("Oahu.Decrypt.Mpeg4 does not support MPEG-4 files with more than ${Int32.MaxValue} chunk offsets")
+        }
+        ChunkOffsets = ChunkOffsetList.Read64(file, entryCount)
+    }
+
+    private init(chunkOffsets ChunkOffsetList, versionFlags []uint8, header BoxHeader, parent IBox) : base(versionFlags, header, parent) {
+        ChunkOffsets = chunkOffsets
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(4) + int64(ChunkOffsets.Count * 8)
+    prop EntryCount uint32 -> uint32(ChunkOffsets.Count)
+
+    prop ChunkOffsets ChunkOffsetList {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.WriteUInt32BE(EntryCount)
+        ChunkOffsets.Write64(file)
+    }
+
+    protected open override func Dispose(disposing bool) {
+        if disposing && !Disposed {
+            ChunkOffsets.Clear()
+        }
+        base.Dispose(disposing)
+    }
+
+    shared {
+        internal func CreateBlank(parent IBox, chunkOffsets ChunkOffsetList) Co64Box {
+            let size = 4 + 12
+            let header = BoxHeader(uint32(size), "co64")
+            chunkOffsets.Sort()
+            let co64Box = Co64Box(chunkOffsets, []uint8{uint8(0), uint8(0), uint8(0), uint8(0)}, header, parent)
+            parent.Children.Add(co64Box)
+            return co64Box
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/ConversionProgressEventArgs.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/ConversionProgressEventArgs.gs
@@ -1,0 +1,38 @@
+package Oahu.Decrypt
+
+import System
+
+class ConversionProgressEventArgs : EventArgs {
+    internal init(startTime TimeSpan, endTime TimeSpan, processPosition TimeSpan, processSpeed float64) {
+        StartTime = startTime
+        EndTime = endTime
+        ProcessPosition = processPosition
+        ProcessSpeed = processSpeed
+        FractionCompleted = (processPosition - startTime) / (endTime - startTime)
+    }
+
+    prop ProcessPosition TimeSpan {
+        get;
+        init;
+    }
+
+    prop StartTime TimeSpan {
+        get;
+        init;
+    }
+
+    prop EndTime TimeSpan {
+        get;
+        init;
+    }
+
+    prop ProcessSpeed float64 {
+        get;
+        init;
+    }
+
+    prop FractionCompleted float64 {
+        get;
+        init;
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Crypto.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Crypto.gs
@@ -1,0 +1,25 @@
+package Oahu.Decrypt.Mpeg4.Util
+
+import System.Security.Cryptography
+
+class Crypto {
+    shared {
+        func DecryptInPlace(key []uint8, iv []uint8, encryptedBlocks []uint8) {
+            using let aes = Aes.Create()
+            aes.Mode = CipherMode.CBC
+            aes.Padding = PaddingMode.None
+            using let cbcDecryptor = aes.CreateDecryptor(key, iv)
+            cbcDecryptor.TransformBlock(encryptedBlocks, 0, encryptedBlocks.Length & 0x7ffffff0, encryptedBlocks, 0)
+        }
+
+        func Sha1(blocks ...([]uint8, int32, int32)) []uint8 {
+            using let sha = SHA1.Create()
+            var i = 0
+            for ; i < blocks.Length - 1; i++ {
+                sha.TransformBlock(blocks[i].Item1, blocks[i].Item2, blocks[i].Item3, nil, 0)
+            }
+            sha.TransformFinalBlock(blocks[i].Item1, blocks[i].Item2, blocks[i].Item3)
+            return sha.Hash!!
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Dac4Box.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Dac4Box.gs
@@ -1,0 +1,44 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Boxes.AC4SpecificBox
+import Oahu.Decrypt.Mpeg4.Util
+
+open class Dac4Box : Box {
+    var Ac4DsiV1 Ac4DsiV1?
+    private let ac4Data []uint8
+
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        ac4Data = file.ReadBlock(int32((header.TotalBoxSize - int64(header.HeaderSize))))
+        try {
+            let reader = BitReader(ac4Data)
+            Ac4DsiV1 = Ac4DsiV1(reader!!)
+        } catch (ex Exception) {
+            return
+        }
+        SampleRate = Ac4DsiV1.SampleRate()
+        AverageBitrate = Ac4DsiV1.AverageBitrate()
+        NumberOfChannels = (if Ac4DsiV1.Channels() != nil { Ac4Extensions.ChannelCount(Ac4DsiV1.Channels()!!) } else { nil })
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(ac4Data.Length)
+
+    prop AverageBitrate uint32? {
+        get;
+        init;
+    }
+
+    prop SampleRate int32? {
+        get;
+        init;
+    }
+
+    prop NumberOfChannels int32? {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        file.Write(ac4Data)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/DashChunkEntryies.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/DashChunkEntryies.gs
@@ -1,0 +1,90 @@
+package Oahu.Decrypt.Mpeg4.Chunks
+
+import System
+import System.Collections
+import System.Collections.Generic
+import System.IO
+import System.Linq
+import Oahu.Decrypt.Mpeg4.Boxes
+import Oahu.Decrypt.Mpeg4.Util
+
+class DashChunkEntryies(InputStream Stream, TrackId uint32, Sidx SidxBox, FirstMoof MoofBox, FirstMdat MdatBox, MinimumSample int64, MaximumSample int64) : IEnumerable[ChunkEntry] {
+    func GetEnumerator() IEnumerator[ChunkEntry] -> EnumerateChunks().GetEnumerator()
+    private func GetEnumerator() IEnumerator -> GetEnumerator()
+
+    private func EnumerateChunks() sequence[ChunkEntry] {
+        SkipToFirstMoof(out var moofBox, out var mdatBox, out var startSample)
+        let totalDataSize = Sidx.Segments.Sum((s Segment) -> int64(s.ReferenceSize))
+        let endOfFile = FirstMoof.Header.FilePosition + totalDataSize
+        while InputStream.Position < endOfFile {
+            if startSample > MaximumSample {
+                break
+            }
+            let trackChunk = ValidateMdatSize(moofBox!!, mdatBox!!, startSample)
+            startSample += trackChunk!!.FrameDurations.Sum((d uint32) -> d)
+            if startSample > MinimumSample {
+                yield trackChunk
+            } else {
+                let endOfMdat = InputStream.Position + mdatBox!!.Header.TotalBoxSize - int64(mdatBox!!.Header.HeaderSize)
+                InputStream.SeekToOffset(endOfMdat)
+            }
+            if InputStream.Position < endOfFile {
+                moofBox = BoxFactory.CreateBox[MoofBox](InputStream, nil)
+                mdatBox = BoxFactory.CreateBox[MdatBox](InputStream, nil)
+            }
+        }
+    }
+
+    private func ValidateMdatSize(moofBox MoofBox, mdatBox MdatBox, startSample int64) ChunkEntry {
+        let trun TrunBox? = moofBox.Traf.Trun as TrunBox
+        if trun == nil {
+            throw InvalidDataException("The ${nameof(TrafBox)} doesn't contain a ${nameof(TrunBox)}")
+        }
+        let frameSizes = if trun.SampleSizePresent { trun.Samples.Select((s SampleInfo) -> s.SampleSize).OfType[int32]().ToArray() } else { if moofBox.Traf.Tfhd.DefaultSampleSize is uint32 { Enumerable.Repeat(int32(moofBox.Traf.Tfhd.DefaultSampleSize!!), trun.Samples.Length).ToArray() } else { throw InvalidOperationException("Trun sample infos don't contain sample sizes and no default sample size is set.")
+            default([]int32) } }
+        let mdatSize = mdatBox.Header.TotalBoxSize - int64(mdatBox.Header.HeaderSize)
+        if int64(frameSizes!!.Sum()) != mdatSize {
+            throw InvalidDataException("Mdat box size doesn't match sample sizes in track fragment")
+        }
+        if mdatSize > int64(Int32.MaxValue) {
+            throw InvalidDataException("Mdat is larger than Int32.MaxValue")
+        }
+        let frameDurations = if trun.SampleDurationPresent { trun.Samples.Select((s SampleInfo) -> s.SampleDuration).OfType[uint32]().ToArray() } else { if moofBox.Traf.Tfhd.DefaultSampleDuration is uint32 { Enumerable.Repeat(moofBox.Traf.Tfhd.DefaultSampleDuration!!, trun.Samples.Length).ToArray() } else { throw InvalidOperationException("Trun sample infos don't contain sample durations and no default sample duration is set.")
+            default([]uint32) } }
+        if frameDurations!!.Length != frameSizes!!.Length {
+            throw InvalidDataException("The number of frame sizes (${frameSizes!!.Length}) does not match the number of durations (${frameDurations!!.Length}) in fragment ${moofBox.Mfhd.SequenceNumber}")
+        }
+        var extraData object? = nil
+        if moofBox.Traf.Senc != nil {
+            extraData = if frameSizes!!.Length == moofBox.Traf.Senc!!!!.IVs.Length { moofBox.Traf.Senc!!!!.IVs } else { throw InvalidDataException("The number of IVs (${moofBox.Traf.Senc!!!!.IVs.Length}) does not match the number of samples (${frameSizes!!.Length}) in fragment ${moofBox.Mfhd.SequenceNumber}")
+                default([][]uint8) }
+        }
+        return ChunkEntry{TrackId: TrackId, ChunkIndex: uint32(moofBox.Mfhd.SequenceNumber), ChunkOffset: InputStream.Position, ChunkSize: int32(mdatSize), FirstSample: startSample, FrameSizes: frameSizes, FrameDurations: frameDurations, ExtraData: extraData}
+    }
+
+    private func SkipToFirstMoof(out firstMoof MoofBox, out firstMdat MdatBox, out firstSample int64) {
+        let startPosition = FirstMoof.Header.FilePosition
+        var dataOffset int64 = 0
+        firstSample = 0
+        if Sidx.Segments.Any((s Segment) -> s.ReferenceType || !s.StartsWithSAP || s.SapType != 1 || s.SapDeltaTime != 0) {
+            throw InvalidOperationException("AAXClean doesn't know how to inrepret segment index boxes other than " + "${nameof(SidxBox.Segment.SapType)} = 1, " + "${nameof(SidxBox.Segment.SapDeltaTime)} = 0, " + "${nameof(SidxBox.Segment.StartsWithSAP)} = 1, " + "${nameof(SidxBox.Segment.ReferenceType)} = 0")
+        }
+        for segment in Sidx.Segments {
+            if MinimumSample < firstSample + int64(segment!!.SubsegmentDuration) {
+                break
+            }
+            dataOffset += int64(segment!!.ReferenceSize)
+            firstSample += int64(segment!!.SubsegmentDuration)
+        }
+        if dataOffset == int64(0) {
+            var __decon0 = FirstMoof
+            var __decon1 = FirstMdat
+            firstMoof = __decon0
+            firstMdat = __decon1
+        } else {
+            InputStream.SeekToOffset(startPosition + dataOffset)
+            firstMoof = BoxFactory.CreateBox[MoofBox](InputStream, nil)
+            firstMdat = BoxFactory.CreateBox[MdatBox](InputStream, nil)
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/DashChunkReader.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/DashChunkReader.gs
@@ -1,0 +1,46 @@
+package Oahu.Decrypt.Chunks
+
+import System
+import System.Collections.Generic
+import System.IO
+import System.Linq
+import Oahu.Decrypt.FrameFilters
+import Oahu.Decrypt.Mpeg4.Boxes
+import Oahu.Decrypt.Mpeg4.Chunks
+
+internal open class DashChunkReader : ChunkReader {
+    init(dash DashFile, inputStream Stream, startTime TimeSpan, endTime TimeSpan) : base(inputStream, startTime, endTime) {
+        ArgumentNullException.ThrowIfNull(dash, nameof(dash))
+        ArgumentNullException.ThrowIfNull(inputStream, nameof(inputStream))
+        Dash = dash
+    }
+
+    private prop Dash DashFile {
+        get;
+        init;
+    }
+
+    open override func AddTrack(track TrakBox, filter FrameFilterBase[FrameEntry]) {
+        if TrackEntries.Count > 0 {
+            throw InvalidOperationException("The ${nameof(DashChunkReader)} currently only supports a single track.")
+        }
+        base.AddTrack(track, filter)
+    }
+
+    protected open override func CreateFrameEntry(chunk ChunkEntry, frameInChunk int32, frameDelta uint32, frameData Memory[uint8]) FrameEntry {
+        let entry = base.CreateFrameEntry(chunk, frameInChunk, frameDelta, frameData)
+        let ivs []?[]uint8 = chunk.ExtraData as [][]uint8
+        if ivs != nil {
+            entry!!.ExtraData = if ivs.Length > frameInChunk { ivs[frameInChunk] } else { throw InvalidDataException("There are only ${ivs.Length} in the chunk, but caller requesting frame at index $frameInChunk.")
+                default([]uint8) }
+        }
+        return entry!!
+    }
+
+    protected open override func EnumerateChunks() IEnumerable[ChunkEntry] {
+        let singleTrack = TrackEntries.Values.Single()
+        let minimumSample = int64((StartTime.TotalSeconds * float64(singleTrack!!.Timescale)))
+        let maximumSample = int64((EndTime.TotalSeconds * float64(singleTrack!!.Timescale)))
+        return DashChunkEntryies(InputStream, singleTrack!!.TrackId, Dash.Sidx, Dash.FirstMoof, Dash.FirstMdat, minimumSample, maximumSample)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/DashFile.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/DashFile.gs
@@ -1,0 +1,115 @@
+package Oahu.Decrypt
+
+import System
+import System.Buffers
+import System.IO
+import System.Linq
+import Oahu.Decrypt.Chunks
+import Oahu.Decrypt.FrameFilters
+import Oahu.Decrypt.FrameFilters.Audio
+import Oahu.Decrypt.Mpeg4.Boxes
+import Oahu.Decrypt.Mpeg4.Util
+
+open class DashFile : Mp4File {
+    convenience init(fileName string, access FileAccess = 1, share FileShare = 1) {
+        init(File.Open(fileName, FileMode.Open, access, share))
+    }
+
+    convenience init(file Stream) {
+        init(file, file.Length)
+    }
+
+    init(file Stream, fileLength int64) : base(file, fileLength) {
+        if FileType != FileType.Dash {
+            throw ArgumentException("This instance of ${nameof(Mp4File)} is not a Dash file.")
+        }
+        FirstMoof = TopLevelBoxes.OfType[MoofBox]().Single()
+        let audioSampleEntry = Moov.AudioTrack.Mdia.Minf.Stbl.Stsd.AudioSampleEntry ?? throw InvalidDataException("The audio track doesn't contain an ${nameof(AudioSampleEntry)}")
+        if audioSampleEntry.GetChild[SinfBox]() != nil {
+            if audioSampleEntry.GetChild[SinfBox]()!!!!.SchemeType?.Type != SchmBox.SchemeType.Cenc {
+                throw NotSupportedException("Only ${nameof(SchmBox.SchemeType.Cenc)} dash files are currently supported.")
+            }
+            Tenc = audioSampleEntry.GetChild[SinfBox]()!!!!.SchemeInformation?.TrackEncryption
+            audioSampleEntry!!.Children.Remove(audioSampleEntry.GetChild[SinfBox]()!!!!)
+            audioSampleEntry!!.Header.ChangeAtomName(audioSampleEntry.GetChild[SinfBox]()!!!!.OriginalFormat.DataFormat)
+        }
+        for pssh in Moov.GetChildren[PsshBox]().ToArray() {
+            Moov.Children.Remove(pssh!!)
+        }
+        if AudioSampleEntry.Dec3 != nil || AudioSampleEntry.Dac4 != nil {
+            Ftyp = FtypBox.Create("mp42", 0)
+            Ftyp.CompatibleBrands.Add("dby1")
+            Ftyp.CompatibleBrands.Add("iso8")
+            Ftyp.CompatibleBrands.Add("isom")
+            Ftyp.CompatibleBrands.Add("mp41")
+            Ftyp.CompatibleBrands.Add("M4A ")
+            Ftyp.CompatibleBrands.Add("M4B ")
+        } else {
+            Ftyp = FtypBox.Create("isom", 0x200)
+            Ftyp.CompatibleBrands.Add("iso2")
+            Ftyp.CompatibleBrands.Add("mp41")
+            Ftyp.CompatibleBrands.Add("M4A ")
+            Ftyp.CompatibleBrands.Add("M4B ")
+        }
+    }
+
+    prop FirstMoof MoofBox {
+        get;
+        init;
+    }
+
+    prop FirstMdat MdatBox -> Mdat
+    prop Sidx SidxBox -> TopLevelBoxes.OfType[SidxBox]().Single()
+    open override prop Duration TimeSpan -> TimeSpan.FromSeconds(float64(Moov.GetChildOrThrow[MvexBox]().GetChildOrThrow[MehdBox]().FragmentDuration) / float64(TimeScale))
+
+    prop Tenc TencBox? {
+        get;
+        init;
+    }
+
+    prop Key []?uint8
+    private prop Mdat MdatBox -> base.Mdat
+
+    func SetDecryptionKey(keyId string, decryptionKey string) {
+        if String.IsNullOrWhiteSpace(keyId) || keyId.Length != AesCtr.AesBlockSize * 2 {
+            throw ArgumentException("${nameof(keyId)} must be ${AesCtr.AesBlockSize} bytes long.")
+        }
+        if String.IsNullOrWhiteSpace(decryptionKey) || decryptionKey.Length != AesCtr.AesBlockSize * 2 {
+            throw ArgumentException("${nameof(decryptionKey)} must be ${AesCtr.AesBlockSize} bytes long.")
+        }
+        let keyIdBts = Convert.FromHexString(keyId)
+        let decryptionKeyBts = Convert.FromHexString(decryptionKey)
+        SetDecryptionKey(keyIdBts, decryptionKeyBts)
+    }
+
+    open override func GetAudioFrameFilter() FrameTransformBase[FrameEntry, FrameEntry] {
+        return if Key == nil && Tenc != nil { throw InvalidOperationException("This instance of ${nameof(DashFile)} does not have a decryption key set.")
+            default(DashFilter) } else { DashFilter(Key) }
+    }
+
+    func SetDecryptionKey(keyId []?uint8, decryptionKey []?uint8) {
+        if Tenc == nil {
+            throw InvalidOperationException("This instance of ${nameof(DashFile)} does not contain a ${nameof(TencBox)}.")
+        }
+        if keyId == nil || keyId!!.Length != AesCtr.AesBlockSize {
+            throw ArgumentException("${nameof(keyId)} must be ${AesCtr.AesBlockSize} bytes long.")
+        }
+        if decryptionKey == nil || decryptionKey!!.Length != AesCtr.AesBlockSize {
+            throw ArgumentException("${nameof(decryptionKey)} must be ${AesCtr.AesBlockSize} bytes long.")
+        }
+        let keyUUID = Guid(keyId!!, true)
+        if keyUUID != Tenc!!.DefaultKID {
+            throw InvalidOperationException("Supplied keyId does not match dash default keyId: ${Convert.ToHexString(Tenc!!.DefaultKID.ToByteArray(true))}")
+        }
+        Key = decryptionKey
+    }
+
+    protected open override func CalculateBitrate() uint32 {
+        let totalSize = Sidx.Segments.Sum((s Segment) -> int64(s.ReferenceSize)) * int64(8)
+        let totalDuration = Sidx.Segments.Sum((s Segment) -> int64(s.SubsegmentDuration))
+        let bitRate = totalSize * int64(Sidx.Timescale) / totalDuration
+        return uint32(bitRate)
+    }
+
+    protected open override func CreateChunkReader(inputStream Stream, startTime TimeSpan, endTime TimeSpan) IChunkReader -> DashChunkReader(this, inputStream, startTime, endTime)
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/DashFilter.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/DashFilter.gs
@@ -1,0 +1,41 @@
+package Oahu.Decrypt.FrameFilters.Audio
+
+import Oahu.Decrypt.Mpeg4.Util
+
+internal open class DashFilter : AacValidateFilter {
+    init(key []?uint8) {
+        Key = key
+        AesCtr = if key == nil { default(AesCtr?) } else { AesCtr(key!!) }
+    }
+
+    prop Key []?uint8 {
+        get;
+        init;
+    }
+
+    protected open override prop InputBufferSize int32 -> 1000
+
+    private prop AesCtr AesCtr? {
+        get;
+        init;
+    }
+
+    open override func PerformFiltering(input FrameEntry) FrameEntry {
+        let iv []?uint8 = input.ExtraData as []uint8
+        if iv != nil {
+            if AesCtr == nil {
+                throw NullReferenceException("AesCtr is null but the frame entry has an IV.")
+            }
+            let frameData = input.FrameData.Span
+            AesCtr!!.Decrypt(iv, frameData, frameData)
+        }
+        return base.PerformFiltering(input)
+    }
+
+    protected open override func Dispose(disposing bool) {
+        if disposing && !Disposed {
+            AesCtr?.Dispose()
+        }
+        base.Dispose(disposing)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Dec3Box.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Dec3Box.gs
@@ -1,0 +1,73 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.Diagnostics
+import System.IO
+import System.Linq
+import Oahu.Decrypt.Mpeg4.Boxes.EC3SpecificBox
+import Oahu.Decrypt.Mpeg4.Util
+
+open class Dec3Box : Box {
+    private let ec3Data []uint8
+
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        ec3Data = file.ReadBlock(int32((header.TotalBoxSize - int64(header.HeaderSize))))
+        let reader = BitReader(ec3Data)
+        AverageBitrate = reader!!.Read(13) * uint32(1024)
+        let num_ind_sub = reader!!.Read(3)
+        Debug.Assert(num_ind_sub == uint32(0))
+        IndependentSubstream = [int32(num_ind_sub + uint32(1))]Ec3IndependentSubstream
+        for var i = 0; int64(i) <= int64(num_ind_sub); i++ {
+            IndependentSubstream[i] = Ec3IndependentSubstream(reader!!)
+        }
+        let indSample = IndependentSubstream.First()
+        Debug.Assert(indSample!!.NumDepSub == uint8(0))
+        SampleRate = indSample!!.GetSampleRate()
+        NumberOfChannels = indSample!!.ChannelCount()
+        if reader!!.Length - reader!!.Position < 8 {
+            return
+        }
+        reader!!.Position += 7
+        FlagEc3ExtensionTypeA = reader!!.ReadBool()
+        if FlagEc3ExtensionTypeA.Value {
+            ComplexityIndexTypeA = uint8(reader!!.Read(8))
+        }
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(ec3Data.Length)
+
+    prop AverageBitrate uint32 {
+        get;
+        init;
+    }
+
+    prop SampleRate int32 {
+        get;
+        init;
+    }
+
+    prop NumberOfChannels int32 {
+        get;
+        init;
+    }
+
+    prop IndependentSubstream []Ec3IndependentSubstream {
+        get;
+        init;
+    }
+
+    prop IsAtmos bool -> FlagEc3ExtensionTypeA.HasValue
+
+    prop FlagEc3ExtensionTypeA bool? {
+        get;
+        init;
+    }
+
+    prop ComplexityIndexTypeA uint8? {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        file.Write(ec3Data)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/DecoderConfigDescriptor.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/DecoderConfigDescriptor.gs
@@ -1,0 +1,47 @@
+package Oahu.Decrypt.Mpeg4.Descriptors
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+class DecoderConfigDescriptor : BaseDescriptor {
+    private let blob []uint8
+
+    init(file Stream, header DescriptorHeader) : base(file, header) {
+        ObjectTypeIndication = uint8(file.ReadByte())
+        blob = file.ReadBlock(4)
+        MaxBitrate = file.ReadUInt32BE()
+        AverageBitrate = file.ReadUInt32BE()
+        LoadChildren(file)
+    }
+
+    private init(objectTypeIndication uint8, blob []uint8) : base(4) {
+        ObjectTypeIndication = objectTypeIndication
+        this.blob = blob
+    }
+
+    prop ObjectTypeIndication uint8 {
+        get;
+        init;
+    }
+
+    prop MaxBitrate uint32
+    prop AverageBitrate uint32
+    prop AudioSpecificConfig AudioSpecificConfig -> GetChildOrThrow[AudioSpecificConfig]()
+    override prop InternalSize int32 -> base.InternalSize + 13
+
+    override func Render(file Stream) {
+        file.WriteByte(ObjectTypeIndication)
+        file.Write(blob)
+        file.WriteUInt32BE(MaxBitrate)
+        file.WriteUInt32BE(AverageBitrate)
+    }
+
+    shared {
+        func CreateAudio() DecoderConfigDescriptor {
+            let descriptor = DecoderConfigDescriptor(0x40, []uint8{uint8(0x15), uint8(0x00), uint8(0x00), uint8(0x00)})
+            let asc = AudioSpecificConfig.CreateEmpty()
+            descriptor!!.Children.Add(asc!!)
+            return descriptor!!
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/DescriptorFactory.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/DescriptorFactory.gs
@@ -1,0 +1,18 @@
+package Oahu.Decrypt.Mpeg4.Descriptors
+
+import System.IO
+
+class DescriptorFactory {
+    shared {
+        func CreateDescriptor(file Stream) BaseDescriptor {
+            let header = DescriptorHeader(file)
+            return switch header!!.TagID {
+                case 3: ES_Descriptor(file, header!!)
+                case 4: DecoderConfigDescriptor(file, header!!)
+                case 5: AudioSpecificConfig(file, header!!)
+                case 6: SLConfigDescriptor(file, header!!)
+                default: UnknownDescriptor(file, header!!)
+            }
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/DescriptorHeader.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/DescriptorHeader.gs
@@ -1,0 +1,35 @@
+package Oahu.Decrypt.Mpeg4.Descriptors
+
+import System.IO
+
+class DescriptorHeader {
+    init(file Stream) {
+        FilePosition = file.Position
+        TagID = uint8(file.ReadByte())
+        let start = file.Position
+        let originalInternalSize = ExpandableClass.DecodeSize(file)
+        let originalSizeOfSize = int32((file.Position - start))
+        HeaderSize = originalSizeOfSize + 1
+        TotalBoxSize = HeaderSize + originalInternalSize
+    }
+
+    init(tagId uint8) {
+        TagID = tagId
+        HeaderSize = 1
+    }
+
+    prop FilePosition int64
+
+    prop TotalBoxSize int32 {
+        get;
+        init;
+    }
+
+    prop TagID uint8
+    prop HeaderSize int32
+
+    func GetEncodedSizeLength(internalSize int32) int32 {
+        let minimumEncodeSize = HeaderSize - 1
+        return ExpandableClass.GetSizeByteCount(internalSize, minimumEncodeSize)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/ES_Descriptor.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/ES_Descriptor.gs
@@ -1,0 +1,85 @@
+package Oahu.Decrypt.Mpeg4.Descriptors
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+class ES_Descriptor : BaseDescriptor {
+    private let esFlags uint8
+    private let dependsOnEsId uint16
+    private let urlLength uint8
+    private let urlString []?uint8
+    private let ocrEsId uint16
+
+    init(file Stream, header DescriptorHeader) : base(file, header) {
+        EsId = file.ReadUInt16BE()
+        esFlags = uint8(file.ReadByte())
+        if StreamDependenceFlag == 1 {
+            dependsOnEsId = file.ReadUInt16BE()
+        }
+        if UrlFlag == 1 {
+            urlLength = uint8(file.ReadByte())
+            urlString = file.ReadBlock(urlLength)
+        }
+        if OcrStreamFlag == 1 {
+            ocrEsId = file.ReadUInt16BE()
+        }
+        LoadChildren(file)
+    }
+
+    private init() : base(0x3) {
+        EsId = uint16(0)
+        esFlags = uint8(0)
+    }
+
+    prop EsId uint16 {
+        get;
+        init;
+    }
+
+    prop StreamPriority int32 -> esFlags & uint8(31)
+    prop DecoderConfig DecoderConfigDescriptor -> GetChildOrThrow[DecoderConfigDescriptor]()
+    override prop InternalSize int32 -> base.InternalSize + GetLength()
+    private prop StreamDependenceFlag int32 -> esFlags >> 7
+    private prop UrlFlag int32 -> (esFlags >> 6) & 1
+    private prop OcrStreamFlag int32 -> (esFlags >> 5) & 1
+
+    override func Render(file Stream) {
+        file.WriteUInt16BE(EsId)
+        file.WriteByte(esFlags)
+        if StreamDependenceFlag == 1 {
+            file.WriteUInt16BE(dependsOnEsId)
+        }
+        if UrlFlag == 1 {
+            file.WriteByte(urlLength)
+            file.Write(urlString)
+        }
+        if OcrStreamFlag == 1 {
+            file.WriteUInt16BE(ocrEsId)
+        }
+    }
+
+    private func GetLength() int32 {
+        var length = 3
+        if StreamDependenceFlag == 1 {
+            length += 2
+        }
+        if UrlFlag == 1 {
+            length += uint8(1) + urlLength
+        }
+        if OcrStreamFlag == 1 {
+            length += 2
+        }
+        return length
+    }
+
+    shared {
+        func CreateAudio() ES_Descriptor {
+            let descriptor = ES_Descriptor()
+            let decoder = DecoderConfigDescriptor.CreateAudio()
+            let slConfig = SLConfigDescriptor.CreateMp4()
+            descriptor!!.Children.Add(decoder!!)
+            descriptor!!.Children.Add(slConfig!!)
+            return descriptor!!
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Ec3Extensions.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Ec3Extensions.gs
@@ -1,0 +1,14 @@
+package Oahu.Decrypt.Mpeg4.Boxes.EC3SpecificBox
+
+import System.IO
+
+class Ec3Extensions {
+    shared {
+        private let FfAc3ChannelsTab []uint8 = []uint8{uint8(2), uint8(1), uint8(2), uint8(3), uint8(3), uint8(4), uint8(4), uint8(5)}
+    }
+}
+
+func (indSub Ec3IndependentSubstream) GetSampleRate() int32 -> if indSub.Fscod == uint8(0) { 48000 } else { if indSub.Fscod == uint8(1) { 44100 } else { if indSub.Fscod == uint8(2) { 32000 } else { throw InvalidDataException("${nameof(indSub.Fscod)} value of ${indSub.Fscod} is not valid")
+    default(int32) } } }
+
+func (indSub Ec3IndependentSubstream) ChannelCount() int32 -> int32(Ec3Extensions.FfAc3ChannelsTab[uint8(indSub.Acmod)]) + (if indSub.Lfeon { 1 } else { 0 })

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Ec3IndependentSubstream.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Ec3IndependentSubstream.gs
@@ -1,0 +1,35 @@
+package Oahu.Decrypt.Mpeg4.Boxes.EC3SpecificBox
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+class Ec3IndependentSubstream {
+    var Fscod uint8
+    var Bsid uint8
+    var Asvc bool
+    var Bsmod uint8
+    var Acmod AudioCodingMode
+    var Lfeon bool
+    var NumDepSub uint8
+    var ChanLoc ChannelLocation
+
+    init(reader BitReader) {
+        Fscod = uint8(reader.Read(2))
+        Bsid = uint8(reader.Read(5))
+        if Bsid != uint8(16) {
+            throw InvalidDataException("Invalid bsid value: $Bsid. Expected 16 for E-AC-3.")
+        }
+        reader.Position += 1
+        Asvc = reader.ReadBool()
+        Bsmod = uint8(reader.Read(3))
+        Acmod = AudioCodingMode(reader.Read(3))
+        Lfeon = reader.Read(1) > uint32(0)
+        reader.Position += 3
+        let numDepSub = reader.Read(4)
+        if numDepSub > uint32(0) {
+            ChanLoc = ChannelLocation(reader.Read(9))
+        } else {
+            reader.Position++
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/EmptyFrame.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/EmptyFrame.gs
@@ -1,0 +1,20 @@
+package Oahu.Decrypt.Mpeg4.ID3
+
+import System.IO
+
+internal class EmptyFrame : Frame {
+    convenience init(parent Frame) {
+        init(FrameHeader(EmptyFrame.GetEmptyFrameId(parent.Version), 0, parent.Version), parent)
+    }
+
+    init(header Header, parent Frame) : base(header, parent) {
+    }
+
+    override func Render(file Stream) {
+    }
+
+    shared {
+        func GetEmptyFrameSize(version int32) int32 -> if version == 0x200 { 6 } else { 10 }
+        private func GetEmptyFrameId(version int32) string -> if version == 0x200 { "\u0000\u0000\u0000" } else { "\u0000\u0000\u0000\u0000" }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/EsdsBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/EsdsBox.gs
@@ -1,0 +1,35 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Descriptors
+
+open class EsdsBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        let descroptor = DescriptorFactory.CreateDescriptor(file)
+        ES_Descriptor = descroptor as ES_Descriptor ?? throw InvalidDataException("${descroptor!!.GetType()} is not an ${nameof(ES_Descriptor)}")
+    }
+
+    private init(es_Descriptor ES_Descriptor, parent IBox) : base([]uint8{uint8(0), uint8(0), uint8(0), uint8(0)}, BoxHeader(8, "esds"), parent) {
+        ES_Descriptor = es_Descriptor
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(ES_Descriptor.RenderSize)
+
+    prop ES_Descriptor ES_Descriptor {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        ES_Descriptor.Save(file)
+    }
+
+    shared {
+        func CreateEmpty(parent IBox) EsdsBox {
+            let esds = EsdsBox(ES_Descriptor.CreateAudio(), parent)
+            parent.Children.Add(esds!!)
+            return esds!!
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/ExpandableClass.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/ExpandableClass.gs
@@ -1,0 +1,39 @@
+package Oahu.Decrypt.Mpeg4.Descriptors
+
+import System
+import System.IO
+
+class ExpandableClass {
+    shared {
+        func EncodeSize(file Stream, sizeOfInstance int32, minimumBytes int32) {
+            const IntegerBytes = 4
+            const MaxSize = (1 << (7 * IntegerBytes)) - 1
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(sizeOfInstance, MaxSize, nameof(sizeOfInstance))
+            let size = ExpandableClass.GetSizeByteCount(sizeOfInstance, minimumBytes)
+            for var i = size - 1; i > 0; i-- {
+                let b = 0x80 | ((sizeOfInstance >> (7 * i)) & 0x7f)
+                file.WriteByte(uint8(b))
+            }
+            file.WriteByte(uint8((sizeOfInstance & 0x7f)))
+        }
+
+        func GetSizeByteCount(sizeOfInstance int32, minimumBytes int32) int32 {
+            var sizeOfInstance = sizeOfInstance
+            var r = 0
+            while (1) != 0 {
+                r++
+            }
+            return Math.Max(minimumBytes, r / 7 + 1)
+        }
+
+        func DecodeSize(file Stream) int32 {
+            var b int32
+            var sizeOfInstance = 0
+            do {
+                b = file.ReadByte()
+                sizeOfInstance = (sizeOfInstance << 7) | (b & 0x7f)
+            } while (b & 0x80) != 0
+            return sizeOfInstance
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/ExtendedHeader.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/ExtendedHeader.gs
@@ -1,0 +1,116 @@
+package Oahu.Decrypt.Mpeg4.ID3
+
+import System.IO
+
+class Id3ExtendedHeader : Frame {
+    private init(header Header, parent Frame) : base(header, parent) {
+    }
+
+    override func Render(file Stream) {
+    }
+
+    shared {
+        func Create(file Stream, parent Id3Tag) Id3ExtendedHeader {
+            let header = ExtendedHeader(file, parent.Version)
+            return Id3ExtendedHeader(header!!, parent)
+        }
+    }
+}
+
+class ExtendedHeader : Header {
+    init(file Stream, version int32) {
+        Identifier = String.Empty
+        Version = version
+        var headerSize int64
+        let originalPosition = file.Position
+        if version >= 0x400 {
+            headerSize = Header.UnSyncSafify(Header.ReadUInt32BE(file))
+            let numFlagBytes = file.ReadByte()
+            ExtendedFlags = Flags(Header.ReadBlock(file, numFlagBytes))
+            if (ExtendedFlags!![1]) {
+                TagIsUpdate = file.ReadByte() != 0
+            }
+            if ExtendedFlags!![2] && file.ReadByte() == 5 {
+                CRC32 = (uint32(file.ReadByte()) << 28) | uint32(Header.UnSyncSafify(Header.ReadUInt32BE(file)))
+            }
+            if ExtendedFlags!![3] && file.ReadByte() == 1 {
+                TagRestrictions = uint8(file.ReadByte())
+            }
+        } else {
+            headerSize = Header.ReadUInt32BE(file)
+            ExtendedFlags = Flags(Header.ReadUInt16BE(file))
+            SizeOfPadding = Header.ReadUInt32BE(file)
+            if (ExtendedFlags!![0]) {
+                CRC32 = Header.ReadUInt32BE(file)
+            }
+        }
+        SeekForwardToPosition(file, originalPosition + headerSize)
+    }
+
+    override prop Identifier string {
+        get;
+        init;
+    }
+
+    override prop HeaderSize int32 -> GetExtendedFlagsSize()
+    prop ExtendedFlags Flags?
+    prop SizeOfPadding uint32
+    prop TagIsUpdate bool
+    prop TagRestrictions uint8
+    prop CRC32 uint32
+
+    prop Version int32 {
+        get;
+        init;
+    }
+
+    override func Render(stream Stream, renderSize int32, version uint16) {
+        if version >= uint16(0x400) {
+            Header.WriteUInt32BE(stream, Header.SyncSafify(HeaderSize + renderSize))
+            stream.WriteByte(uint8(ExtendedFlags!!.Size))
+            stream.Write(ExtendedFlags!!.ToBytes())
+            if (ExtendedFlags!![1]) {
+                stream.WriteByte(uint8((if TagIsUpdate { 1 } else { 0 })))
+            }
+            if (ExtendedFlags!![2]) {
+                stream.WriteByte(5)
+                stream.WriteByte(uint8((CRC32 >> 28)))
+                Header.WriteUInt32BE(stream, Header.SyncSafify(int32((CRC32 & uint32(0xfffffff)))))
+            }
+            if (ExtendedFlags!![3]) {
+                stream.WriteByte(1)
+                stream.WriteByte(TagRestrictions)
+            }
+        } else {
+            Header.WriteUInt32BE(stream, uint32((HeaderSize + renderSize)))
+            stream.Write(ExtendedFlags!!.ToBytes())
+            Header.WriteUInt32BE(stream, SizeOfPadding)
+            if (ExtendedFlags!![0]) {
+                Header.WriteUInt32BE(stream, CRC32)
+            }
+        }
+    }
+
+    func ToString() string -> "ExtendedHeader"
+
+    private func GetExtendedFlagsSize() int32 {
+        if ExtendedFlags == nil {
+            return 0
+        }
+        if Version >= 0x400 {
+            var size = 5 + ExtendedFlags!!.Size
+            if (ExtendedFlags!![1]) {
+                size++
+            }
+            if (ExtendedFlags!![2]) {
+                size += 6
+            }
+            if (ExtendedFlags!![3]) {
+                size += 2
+            }
+            return size
+        } else {
+            return if ExtendedFlags!![0] { 10 } else { 6 }
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Flags.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Flags.gs
@@ -1,0 +1,39 @@
+package Oahu.Decrypt.Mpeg4.ID3
+
+import System
+import System.Linq
+
+class Flags {
+    private var flags []uint8
+
+    init(flags ...uint8) {
+        this.flags = flags
+    }
+
+    init(flags uint16) {
+        this.flags = []uint8{uint8((flags >> 8)), uint8((flags & uint16(0xff)))}
+    }
+
+    prop Size int32 -> this.flags.Length
+
+    prop this[index int32] bool {
+        get {
+            if index < 0 || index >= flags.Length * 8 {
+                throw ArgumentOutOfRangeException(nameof(index), "Index must be within the range of the flags.")
+            }
+            return (int32(flags[index / 8]) & (1 << (7 - (index % 8)))) != 0
+        }
+        set {
+            if index < 0 || index >= flags.Length * 8 {
+                throw ArgumentOutOfRangeException(nameof(index), "Index must be within the range of the flags.")
+            }
+            if value {
+                flags[index / 8] |= uint8((1 << (7 - (index % 8))))
+            } else {
+                flags[index / 8] &= uint8(^(1 << (7 - (index % 8))))
+            }
+        }
+    }
+
+    func ToBytes() []uint8 -> flags.ToArray()
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Frame.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Frame.gs
@@ -1,0 +1,101 @@
+package Oahu.Decrypt.Mpeg4.ID3
+
+import System
+import System.Collections.Generic
+import System.IO
+import System.Linq
+import System.Text
+
+open class Frame(Header Header, Parent Frame) {
+    open prop Size int32 -> Children.Sum((b Frame) -> b.Size)
+
+    prop Children List[Frame] {
+        get;
+        init;
+    }
+
+    open prop Version uint16 -> Parent.Version
+
+    open func Save(file Stream, version uint16) {
+        Header.Render(file, Size, version)
+        Render(file)
+        for child in Children {
+            child!!.Save(file, version)
+        }
+    }
+
+    func ToString() string -> Header.ToString()
+    open func Render(file Stream);
+
+    protected func LoadChildren(file Stream, endPosition int64) {
+        var origPosition = file.Position
+        while file.Position < endPosition && origPosition == file.Position {
+            let child = TagFactory.CreateTag(file, this, out var lengthRead)
+            if child is EmptyFrame {
+                break
+            }
+            origPosition += int64(lengthRead)
+            Children.Add(child)
+        }
+        Header.SeekForwardToPosition(file, endPosition)
+    }
+
+    shared {
+        func ReadSizeString(file Stream, unicode bool, bytes int32) string {
+            let buff = [bytes]uint8
+            file.ReadExactly(buff!!)
+            return (if unicode { Encoding.Unicode } else { Encoding.ASCII }).GetString(buff!!)
+        }
+
+        func ReadNullTerminatedString(file Stream, unicode bool) string {
+            let lst = List[uint8]()
+            if unicode {
+                let blob = [2]uint8
+                file.ReadExactly(blob!!)
+                while blob!![0] != uint8(0) || blob!![1] != uint8(0) {
+                    lst.AddRange(blob!!)
+                    file.ReadExactly(blob!!)
+                }
+                return Encoding.Unicode.GetString(lst.ToArray())
+            } else {
+                var b = uint8(file.ReadByte())
+                while b != uint8(0) {
+                    lst.Add(b)
+                    b = uint8(file.ReadByte())
+                }
+                return Encoding.ASCII.GetString(lst.ToArray())
+            }
+        }
+
+        func IsUnicode(str string) bool -> Encoding.UTF8.GetByteCount(str) != str.Length
+
+        func UnicodeLength(str string) int32 {
+            if str.Length == 0 {
+                return 4
+            }
+            var strLen = Encoding.Unicode.GetByteCount(str)
+            let c0 = str[0]
+            if c0 != '￾' && c0 != '﻿' {
+                strLen += 2
+            }
+            return strLen
+        }
+
+        func UnicodeBytes(str string) []uint8 {
+            let strLen = str.Length
+            if strLen == 0 {
+                return Encoding.Unicode.GetPreamble()
+            }
+            let c0 = str[0]
+            if c0 == '￾' || c0 == '﻿' {
+                return Encoding.Unicode.GetBytes(str)
+            } else {
+                let bts = [2 * (strLen + 1)]uint8
+                let preamble = Encoding.Unicode.GetPreamble()
+                Array.Copy(preamble!!, bts!!, preamble!!.Length)
+                Encoding.Unicode.GetBytes(str, 0, str.Length, bts!!, preamble!!.Length)
+                return bts!!
+            }
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/FrameEntry.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/FrameEntry.gs
@@ -1,0 +1,23 @@
+package Oahu.Decrypt.FrameFilters
+
+import System
+import Oahu.Decrypt.Mpeg4.Chunks
+
+class FrameEntry {
+    prop Chunk ChunkEntry? {
+        get;
+        init;
+    }
+
+    prop SamplesInFrame uint32 {
+        get;
+        init;
+    }
+
+    prop FrameData Memory[uint8] {
+        get;
+        init;
+    }
+
+    prop ExtraData object?
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/FrameFilterBase_TInput.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/FrameFilterBase_TInput.gs
@@ -1,0 +1,94 @@
+package Oahu.Decrypt.FrameFilters
+
+import System
+import System.Threading
+import System.Threading.Channels
+import System.Threading.Tasks
+
+open class FrameFilterBase[TInput]() : IDisposable {
+    private let filterChannel Channel[BufferEntry] = Channel.CreateBounded[BufferEntry](BoundedChannelOptions(2))
+    private var cancellationToken CancellationToken
+    private var filterLoop Task?
+    private var buffer []TInput
+    private var bufferPosition int32 = 0
+
+    init() {
+        buffer = [InputBufferSize]TInput
+    }
+
+    deinit {
+        Dispose(false)
+    }
+
+    protected prop Disposed bool
+
+    protected open prop InputBufferSize int32 {
+        get;
+    }
+
+    open async func AddInputAsync(input TInput) {
+        filterLoop ??= Task.Run(Encoder, cancellationToken)
+        if cancellationToken.IsCancellationRequested {
+            return
+        }
+        buffer[bufferPosition] = input
+        bufferPosition++
+        if bufferPosition == InputBufferSize {
+            if await filterChannel.Writer.WaitToWriteAsync(cancellationToken) {
+                await filterChannel.Writer.WriteAsync(BufferEntry(bufferPosition, buffer), cancellationToken)
+                bufferPosition = 0
+                buffer = [InputBufferSize]TInput
+            }
+        }
+    }
+
+    func CompleteAsync() Task -> CompleteInternalAsync()
+
+    func Dispose() {
+        Dispose(true)
+        GC.SuppressFinalize(this)
+    }
+
+    open func SetCancellationToken(cancellationToken CancellationToken) -> this.cancellationToken = cancellationToken
+    protected open func FlushAsync() Task;
+    protected open func HandleInputDataAsync(input TInput) Task;
+
+    protected open async func CompleteInternalAsync() {
+        try {
+            await filterChannel.Writer.WriteAsync(BufferEntry(bufferPosition, buffer), cancellationToken)
+            filterChannel.Writer.Complete()
+        } catch (ex OperationCanceledException) {
+        }
+        if filterLoop != nil {
+            await filterLoop
+        }
+    }
+
+    protected open func Dispose(disposing bool) {
+        if disposing && !Disposed {
+            if filterLoop?.IsCompleted == false {
+                filterChannel.Writer.TryComplete()
+            }
+        }
+        Disposed = true
+    }
+
+    private async func Encoder() {
+        try {
+            while await filterChannel.Reader.WaitToReadAsync(cancellationToken) {
+                await for messages in filterChannel.Reader.ReadAllAsync(cancellationToken) {
+                    for var i = 0; i < messages!!.NumEntries; i++ {
+                        await HandleInputDataAsync(messages!!.Entries[i])
+                    }
+                }
+            }
+            await FlushAsync()
+        } catch (ex Exception) {
+            filterChannel.Writer.Complete(ex)
+            throw ex
+        }
+    }
+
+    private open data class BufferEntry(NumEntries int32, Entries []TInput) {
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/FrameFinalBase_TInput.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/FrameFinalBase_TInput.gs
@@ -1,0 +1,8 @@
+package Oahu.Decrypt.FrameFilters
+
+import System.Threading.Tasks
+
+open class FrameFinalBase[TInput] : FrameFilterBase[TInput] {
+    protected override func HandleInputDataAsync(input TInput) Task -> PerformFilteringAsync(input)
+    protected open func PerformFilteringAsync(input TInput) Task;
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/FrameHeader.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/FrameHeader.gs
@@ -1,0 +1,63 @@
+package Oahu.Decrypt.Mpeg4.ID3
+
+import System
+import System.IO
+import System.Text
+
+class FrameHeader : Header {
+    init(frameID string, flags uint16, version uint16, size int32 = 0) {
+        Version = version
+        Identifier = frameID
+        Flags = Flags(flags)
+        Size = size
+    }
+
+    override prop Identifier string {
+        get;
+        init;
+    }
+
+    prop Flags Flags {
+        get;
+        init;
+    }
+
+    override prop HeaderSize int32 -> if Version == uint16(0x200) { 6 } else { 10 }
+
+    prop Version uint16 {
+        get;
+        init;
+    }
+
+    override func Render(stream Stream, renderSize int32, version uint16) {
+        stream.Write(Encoding.ASCII.GetBytes(Identifier))
+        let size = if version >= uint16(0x400) { int32(Header.SyncSafify(renderSize)) } else { renderSize }
+        if version == uint16(0x200) {
+            stream.WriteByte(uint8((size >> 16)))
+            stream.WriteByte(uint8((size >> 8)))
+            stream.WriteByte(uint8(size))
+        } else {
+            Header.WriteUInt32BE(stream, uint32(size))
+            stream.Write(Flags.ToBytes())
+        }
+    }
+
+    shared {
+        func Create(file Stream, version uint16) FrameHeader {
+            let originalPosition = file.Position
+            if version == uint16(0x200) {
+                let bts2 = stackalloc [6]uint8
+                file.ReadExactly(bts2)
+                let frameID = Encoding.ASCII.GetString(bts2.Slice(0, 3))
+                let size = (bts2[3] << 16) | (bts2[4] << 8) | int32(bts2[5])
+                return FrameHeader(frameID!!, 0, version, size)
+            } else {
+                let bts = stackalloc [4]uint8
+                file.ReadExactly(bts)
+                let frameID = Encoding.ASCII.GetString(bts)
+                let size = if version >= uint16(0x400) { Header.UnSyncSafify(Header.ReadUInt32BE(file)) } else { int32(Header.ReadUInt32BE(file)) }
+                return FrameHeader(frameID!!, Header.ReadUInt16BE(file), version, size)
+            }
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/FrameTransformBase_TInput_TOutput.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/FrameTransformBase_TInput_TOutput.gs
@@ -1,0 +1,43 @@
+package Oahu.Decrypt.FrameFilters
+
+import System.Threading
+import System.Threading.Tasks
+
+open class FrameTransformBase[TInput, TOutput] : FrameFilterBase[TInput] {
+    private var linked FrameFilterBase[TOutput]?
+
+    open override func SetCancellationToken(cancellationToken CancellationToken) {
+        base.SetCancellationToken(cancellationToken)
+        linked?.SetCancellationToken(cancellationToken)
+    }
+
+    func LinkTo(nextFilter FrameFilterBase[TOutput]) -> linked = nextFilter
+    open func PerformFiltering(input TInput) TOutput;
+    protected open func PerformFinalFiltering() TOutput? -> default
+
+    protected override async func FlushAsync() {
+        if PerformFinalFiltering() is TOutput && linked != nil {
+            await linked!!.AddInputAsync((PerformFinalFiltering() as TOutput)!!)
+        }
+    }
+
+    protected override async func HandleInputDataAsync(input TInput) {
+        let filteredData = PerformFiltering(input)
+        if linked == nil {
+            return
+        }
+        await linked!!.AddInputAsync(filteredData)
+    }
+
+    protected override async func CompleteInternalAsync() {
+        await base.CompleteInternalAsync()
+        await (linked?.CompleteAsync() ?? Task.CompletedTask)
+    }
+
+    protected open override func Dispose(disposing bool) {
+        if disposing && !Disposed {
+            linked?.Dispose()
+        }
+        base.Dispose(disposing)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/FreeBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/FreeBox.gs
@@ -1,0 +1,38 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.IO
+
+open class FreeBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        for var i = Header.HeaderSize; int64(i) < Header.TotalBoxSize; i++ {
+            file.ReadByte()
+        }
+    }
+
+    private init(header BoxHeader, parent IBox?) : base(header, parent) {
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + Header.TotalBoxSize - int64(Header.HeaderSize)
+
+    protected open override func Render(file Stream) {
+        var totalToWrite = Header.TotalBoxSize - int64(Header.HeaderSize)
+        let blankData = [int32(Math.Min(8 * 1024, totalToWrite))]uint8
+        while totalToWrite > int64(0) {
+            let toWrite = int32(Math.Min(blankData!!.Length, totalToWrite))
+            file.Write(blankData!!, 0, toWrite)
+            totalToWrite -= int64(toWrite)
+        }
+    }
+
+    shared {
+        const MinSize int32 = 8
+
+        func Create(freeSize int64, parent IBox?) FreeBox {
+            let header = BoxHeader(freeSize, "free")
+            let free = FreeBox(header, parent)
+            parent?.Children.Add(free)
+            return free
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/FreeformTagBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/FreeformTagBox.gs
@@ -1,0 +1,33 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.Diagnostics
+import System.IO
+
+@DebuggerDisplay("{DebuggerDisplay,nq}")
+open class FreeformTagBox : AppleTagBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        LoadChildren(file)
+    }
+
+    protected init(header BoxHeader, parent IBox?) : base(header, parent) {
+    }
+
+    prop Mean MeanBox? -> GetChild[MeanBox]()
+    prop Name NameBox? -> GetChild[NameBox]()
+    open override prop TagName string -> "${Mean?.ReverseDnsDomain}:${Name?.Name}'"
+
+    @DebuggerHidden
+    private prop DebuggerDisplay string -> "----:$TagName"
+
+    shared {
+        func Create(parent AppleListBox?, domain string, tagName string, data []uint8, dataType AppleDataType) FreeformTagBox {
+            let header = BoxHeader(8, "----")
+            let tagBox = FreeformTagBox(header, parent)
+            MeanBox.Create(tagBox!!, domain)
+            NameBox.Create(tagBox!!, tagName)
+            AppleDataBox.Create(tagBox!!, data, dataType)
+            parent?.Children.Add(tagBox!!)
+            return tagBox!!
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/FrmaBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/FrmaBox.gs
@@ -1,0 +1,21 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class FrmaBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        DataFormat = file.ReadType()
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(4)
+
+    prop DataFormat string {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        file.WriteType(DataFormat)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/FtypBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/FtypBox.gs
@@ -1,0 +1,56 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.Collections.Generic
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class FtypBox : Box {
+    init(file Stream, header BoxHeader) : base(header, nil) {
+        CompatibleBrands = List[string]()
+        let endPos = header.FilePosition + header.TotalBoxSize
+        MajorBrand = file.ReadType()
+        MajorVersion = file.ReadInt32BE()
+        while file.Position < endPos {
+            CompatibleBrands.Add(file.ReadType())
+        }
+    }
+
+    private init(header BoxHeader, majorBrand string, majorVersion int32) : base(header, nil) {
+        CompatibleBrands = List[string]()
+        MajorBrand = majorBrand
+        MajorVersion = majorVersion
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(8) + int64(CompatibleBrands.Count * 4)
+    prop MajorBrand string
+    prop MajorVersion int32
+
+    prop CompatibleBrands List[string] {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        file.WriteType(MajorBrand)
+        file.WriteInt32BE(MajorVersion)
+        for brand in CompatibleBrands {
+            file.WriteType(brand)
+        }
+    }
+
+    protected open override func Dispose(disposing bool) {
+        if disposing && !Disposed {
+            CompatibleBrands.Clear()
+        }
+        base.Dispose(disposing)
+    }
+
+    shared {
+        func Create(majorBrand string, majorVersion int32) FtypBox {
+            ArgumentException.ThrowIfNullOrWhiteSpace(majorBrand, nameof(majorBrand))
+            return if majorBrand.Length == 4 { FtypBox(BoxHeader(16, "ftyp"), majorBrand, majorVersion) } else { throw ArgumentException("Major brand must be 4 chars long.", nameof(majorBrand))
+                default(FtypBox) }
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/FullBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/FullBox.gs
@@ -1,0 +1,32 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class FullBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        VersionFlags = file.ReadBlock(4)
+    }
+
+    init(versionFlags []uint8, header BoxHeader, parent IBox?) : base(header, parent) {
+        VersionFlags = versionFlags
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(4)
+
+    prop Version uint8 {
+        get -> VersionFlags[0]
+        set -> VersionFlags[0] = value
+    }
+
+    prop Flags int32 -> VersionFlags[1] << 16 | VersionFlags[2] << 8 | int32(VersionFlags[3])
+
+    protected prop VersionFlags []uint8 {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        file.Write(VersionFlags)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/HdlrBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/HdlrBox.gs
@@ -1,0 +1,69 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.IO
+import System.Text
+import Oahu.Decrypt.Mpeg4.Util
+
+open class HdlrBox : FullBox {
+    private let reserved []uint8
+
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        let endPos = Header.FilePosition + Header.TotalBoxSize
+        PreDefined = file.ReadUInt32BE()
+        HandlerType = Encoding.UTF8.GetString(file.ReadBlock(4))
+        reserved = file.ReadBlock(12)
+        let readToEnd = file.ReadBlock(int32((endPos - file.Position)))
+        for var i = readToEnd!!.Length - 1; i >= 0 && readToEnd!![i] == uint8(0); i-- {
+            NullTerminatorCount++
+        }
+        HandlerName = Encoding.UTF8.GetString(readToEnd!!, 0, readToEnd!!.Length - NullTerminatorCount)
+    }
+
+    private init(type_ string, name string?, parent IBox) : base([]uint8{uint8(0), uint8(0), uint8(0), uint8(0)}, BoxHeader(8, "hdlr"), parent) {
+        ArgumentException.ThrowIfNullOrEmpty(type_, nameof(type_))
+        if Encoding.UTF8.GetByteCount(type_) != 4 {
+            throw ArgumentException("Type '$type_' must be exactly 4 UTF-8 characters long.", nameof(type_))
+        }
+        HandlerType = type_
+        reserved = [12]uint8
+        HandlerName = name ?? ""
+        NullTerminatorCount = 1
+    }
+
+    prop NullTerminatorCount int32
+    open override prop RenderSize int64 -> base.RenderSize + int64(20) + int64(Encoding.UTF8.GetByteCount(HandlerName)) + int64(NullTerminatorCount)
+
+    prop PreDefined uint32 {
+        get;
+        init;
+    }
+
+    prop HandlerType string {
+        get;
+        init;
+    }
+
+    prop HandlerName string
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.WriteUInt32BE(PreDefined)
+        file.Write(Encoding.UTF8.GetBytes(HandlerType))
+        file.Write(reserved)
+        file.Write(Encoding.UTF8.GetBytes(HandlerName))
+        file.Write([NullTerminatorCount]uint8)
+    }
+
+    shared {
+        func Create(type_ string, name string?, reservedData []uint8, parent IBox) HdlrBox {
+            ArgumentNullException.ThrowIfNull(reservedData, nameof(reservedData))
+            ArgumentNullException.ThrowIfNull(parent, nameof(parent))
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(reservedData.Length, 12, nameof(reservedData))
+            let hdlr = HdlrBox(type_, name, parent)
+            Array.Copy(reservedData, 0, hdlr!!.reserved, 0, reservedData.Length)
+            parent.Children.Add(hdlr!!)
+            return hdlr!!
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Header.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Header.gs
@@ -1,0 +1,62 @@
+package Oahu.Decrypt.Mpeg4.ID3
+
+import System
+import System.IO
+
+open class Header {
+    open prop Identifier string {
+        get;
+    }
+
+    prop Size int32 {
+        get;
+        init;
+    }
+
+    open prop HeaderSize int32 {
+        get;
+    }
+
+    open func Render(stream Stream, renderSize int32, version uint16);
+    func ToString() string -> if Identifier == "\u0000\u0000\u0000\u0000" { "\\0\\0\\0\\0" } else { if Identifier == "\u0000\u0000\u0000" { "\\0\\0\\0" } else { Identifier } }
+
+    func SeekForwardToPosition(file Stream, endPos int64) {
+        if file.Position < endPos {
+            if file.CanSeek {
+                file.Position = endPos
+            } else {
+                let buffer = [4096]uint8
+                while file.Position < endPos {
+                    let bytesToRead = Int32.Min(buffer!!.Length, int32((endPos - file.Position)))
+                    file.ReadExactly(buffer!!, 0, bytesToRead)
+                }
+            }
+        }
+    }
+
+    shared {
+        func ReadUInt16BE(stream Stream) uint16 {
+            let word = stackalloc [2]uint8
+            stream.ReadExactly(word)
+            return uint16((word[0] << 8 | int32(word[1])))
+        }
+
+        func UnSyncSafify(value uint32) int32 -> int32((((value & uint32(0x7f000000)) >> 3) | ((value & uint32(0x7f0000)) >> 2) | ((value & uint32(0x7f00)) >> 1) | (value & uint32(0x7f))))
+        func SyncSafify(value int32) uint32 -> uint32((((value << 3) & 0x7f000000) | ((value << 2) & 0x7f0000) | ((value << 1) & 0x7f00) | (value & 0x7F)))
+
+        func ReadUInt32BE(stream Stream) uint32 {
+            let dword = stackalloc [4]uint8
+            stream.ReadExactly(dword)
+            return uint32((dword[0] << 24 | dword[1] << 16 | dword[2] << 8 | int32(dword[3])))
+        }
+
+        func ReadBlock(stream Stream, numBytes int32) []uint8 {
+            let block = [numBytes]uint8
+            stream.ReadExactly(block!!, 0, numBytes)
+            return block!!
+        }
+
+        func WriteUInt32BE(stream Stream, value uint32) -> stream.Write([]uint8{uint8((value >> 24)), uint8((value >> 16)), uint8((value >> 8)), uint8(value)})
+        func WriteUInt16BE(stream Stream, value uint32) -> stream.Write([]uint8{uint8((value >> 8)), uint8(value)})
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/HeaderBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/HeaderBox.gs
@@ -1,0 +1,50 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class HeaderBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        if Version == uint8(0) {
+            CreationTime = HeaderBox.Datum.AddSeconds(file.ReadUInt32BE())
+            ModificationTime = HeaderBox.Datum.AddSeconds(file.ReadUInt32BE())
+            ReadBeforeDuration(file)
+            Duration = file.ReadUInt32BE()
+        } else {
+            CreationTime = HeaderBox.Datum.AddSeconds(file.ReadUInt64BE())
+            ModificationTime = HeaderBox.Datum.AddSeconds(file.ReadUInt64BE())
+            ReadBeforeDuration(file)
+            Duration = file.ReadUInt64BE()
+        }
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(3 * (if RequireVersionOne { 8 } else { 4 }))
+    prop CreationTime DateTimeOffset
+    prop ModificationTime DateTimeOffset
+    prop Duration uint64
+    private prop RequireVersionOne bool -> Version == uint8(1) || Duration > uint64(UInt32.MaxValue)
+    protected open func ReadBeforeDuration(file Stream);
+    protected open func WriteBeforeDuration(file Stream);
+
+    protected open override func Render(file Stream) {
+        if RequireVersionOne {
+            Version = uint8(1)
+            base.Render(file)
+            file.WriteUInt64BE(uint64((CreationTime - HeaderBox.Datum).TotalSeconds))
+            file.WriteUInt64BE(uint64((ModificationTime - HeaderBox.Datum).TotalSeconds))
+            WriteBeforeDuration(file)
+            file.WriteUInt64BE(Duration)
+        } else {
+            base.Render(file)
+            file.WriteUInt32BE(uint32((CreationTime - HeaderBox.Datum).TotalSeconds))
+            file.WriteUInt32BE(uint32((ModificationTime - HeaderBox.Datum).TotalSeconds))
+            WriteBeforeDuration(file)
+            file.WriteUInt32BE(uint32(Duration))
+        }
+    }
+
+    shared {
+        private let Datum DateTimeOffset = DateTimeOffset(1904, 1, 1, 0, 0, 0, TimeSpan.Zero)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/HelperExtensions.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/HelperExtensions.gs
@@ -1,0 +1,70 @@
+package Oahu.Decrypt.Mpeg4.Util
+
+import System
+import System.Runtime.Intrinsics
+
+internal class HelperExtensions {
+    shared {
+        private func AllLessThanOrEqual_256[T IComparable[T] unmanaged](ints Span[T], value T, out checkedcount int32) bool {
+            unsafe {
+                let vecSize = 256 / 8 / sizeof(T)
+                let numVectors = ints.Length / vecSize
+                let comparand = Vector256.Create(value)
+                fixed pInts *T = ints {
+                    for var i = 0; i < numVectors; i++ {
+                        let intVector = Vector256.Load(pInts + vecSize * i)
+                        if !Vector256.LessThanOrEqualAll(intVector, comparand) {
+                            checkedcount = vecSize * i
+                            return false
+                        }
+                    }
+                }
+                checkedcount = vecSize * numVectors
+                return true
+            }
+        }
+
+        private func AllLessThanOrEqual_512[T IComparable[T] unmanaged](ints Span[T], value T, out checkedcount int32) bool {
+            unsafe {
+                let vecSize = 512 / 8 / sizeof(T)
+                let numVectors = ints.Length / vecSize
+                let comparand = Vector512.Create(value)
+                fixed pInts *T = ints {
+                    for var i = 0; i < numVectors; i++ {
+                        let intVector = Vector512.Load(pInts + vecSize * i)
+                        if !Vector512.LessThanOrEqualAll(intVector, comparand) {
+                            checkedcount = vecSize * i
+                            return false
+                        }
+                    }
+                }
+                checkedcount = vecSize * numVectors
+                return true
+            }
+        }
+    }
+}
+
+func (ints Span[T]) AllLessThanOrEqual[T IComparable[T] unmanaged](value T) bool {
+    unsafe {
+        var checkedCount int32
+        var result bool
+        if Vector512.IsHardwareAccelerated {
+            result = HelperExtensions.AllLessThanOrEqual_512(ints, value, &checkedCount)
+        } else if Vector256.IsHardwareAccelerated {
+            result = HelperExtensions.AllLessThanOrEqual_256(ints, value, &checkedCount)
+        } else {
+            result = true
+            checkedCount = 0
+        }
+        if !result {
+            return false
+        }
+        for var i = checkedCount; i < ints.Length; i++ {
+            if ints[i].CompareTo(value) == 1 {
+                return false
+            }
+        }
+        return true
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/IAppleData.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/IAppleData.gs
@@ -1,0 +1,66 @@
+package Oahu.Decrypt.Mpeg4
+
+import System
+import System.Buffers.Binary
+
+interface IAppleData[TData IAppleData[TData]] {
+    func Write(destination Span[uint8]);
+
+    shared {
+        prop SizeInBytes int32 {
+            get;
+        }
+
+        func Create(source ReadOnlySpan[uint8]) TData;
+    }
+}
+
+open data class TrackNumber(Track uint16, TotalTracks uint16) : IAppleData[TrackNumber] {
+    func operator implicit(tn (int32, int32)) TrackNumber {
+        ArgumentOutOfRangeException.ThrowIfNegative(tn.Item1, nameof(tn.Item1))
+        ArgumentOutOfRangeException.ThrowIfNegative(tn.Item2, nameof(tn.Item2))
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(tn.Item1, int32(UInt16.MaxValue), nameof(tn.Item1))
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(tn.Item2, int32(UInt16.MaxValue), nameof(tn.Item2))
+        return TrackNumber(uint16(tn.Item1), uint16(tn.Item2))
+    }
+
+    func Write(destination Span[uint8]) {
+        ArgumentOutOfRangeException.ThrowIfLessThan(destination.Length, TrackNumber.SizeInBytes, nameof(destination))
+        BinaryPrimitives.WriteUInt16BigEndian(destination.Slice(2, 4 - 2), Track)
+        BinaryPrimitives.WriteUInt16BigEndian(destination.Slice(4, 6 - 4), TotalTracks)
+    }
+
+    shared {
+        prop SizeInBytes int32 -> 8
+
+        func Create(source ReadOnlySpan[uint8]) TrackNumber {
+            ArgumentOutOfRangeException.ThrowIfLessThan(source.Length, TrackNumber.SizeInBytes, nameof(source))
+            return TrackNumber(BinaryPrimitives.ReadUInt16BigEndian(source.Slice(2, 4 - 2)), BinaryPrimitives.ReadUInt16BigEndian(source.Slice(4, 6 - 4)))
+        }
+    }
+}
+
+open data class DiskNumber(Disk uint16, TotalDisks uint16) : IAppleData[DiskNumber] {
+    func operator implicit(tn (int32, int32)) DiskNumber {
+        ArgumentOutOfRangeException.ThrowIfNegative(tn.Item1, nameof(tn.Item1))
+        ArgumentOutOfRangeException.ThrowIfNegative(tn.Item2, nameof(tn.Item2))
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(tn.Item1, int32(UInt16.MaxValue), nameof(tn.Item1))
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(tn.Item2, int32(UInt16.MaxValue), nameof(tn.Item2))
+        return DiskNumber(uint16(tn.Item1), uint16(tn.Item2))
+    }
+
+    func Write(destination Span[uint8]) {
+        ArgumentOutOfRangeException.ThrowIfLessThan(destination.Length, DiskNumber.SizeInBytes, nameof(destination))
+        BinaryPrimitives.WriteUInt16BigEndian(destination.Slice(2, 4 - 2), Disk)
+        BinaryPrimitives.WriteUInt16BigEndian(destination.Slice(4, 6 - 4), TotalDisks)
+    }
+
+    shared {
+        prop SizeInBytes int32 -> 6
+
+        func Create(source ReadOnlySpan[uint8]) DiskNumber {
+            ArgumentOutOfRangeException.ThrowIfLessThan(source.Length, DiskNumber.SizeInBytes, nameof(source))
+            return DiskNumber(BinaryPrimitives.ReadUInt16BigEndian(source.Slice(2, 4 - 2)), BinaryPrimitives.ReadUInt16BigEndian(source.Slice(4, 6 - 4)))
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/IBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/IBox.gs
@@ -1,0 +1,28 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.Collections.Generic
+import System.IO
+
+interface IBox : IDisposable {
+    prop Parent IBox? {
+        get;
+    }
+
+    prop Header BoxHeader {
+        get;
+    }
+
+    prop Children List[IBox] {
+        get;
+    }
+
+    prop RenderSize int64 {
+        get;
+    }
+
+    func Save(file Stream);
+    func GetFreeBoxes() List[FreeBox];
+    func GetChild[T IBox]() T?;
+    func GetChildren[T IBox]() IEnumerable[T];
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/IChunkOffsets.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/IChunkOffsets.gs
@@ -1,0 +1,22 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+interface IChunkOffsets : IBox {
+    prop EntryCount uint32 {
+        get;
+    }
+
+    prop ChunkOffsets ChunkOffsetList {
+        get;
+    }
+
+    shared {
+        func Create(stbl StblBox, offsets ChunkOffsetList) IChunkOffsets {
+            if offsets.Count == 0 {
+                return StcoBox.CreateBlank(stbl, offsets)
+            }
+            offsets.Sort()
+            let maxOffset = offsets.GetOffsetAtIndex(offsets.Count - 1)
+            return if maxOffset > int64(UInt32.MaxValue) { Co64Box.CreateBlank(stbl, offsets) } else { StcoBox.CreateBlank(stbl, offsets) }
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/IStszBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/IStszBox.gs
@@ -1,0 +1,28 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+interface IStszBox : IBox {
+    prop SampleCount int32 {
+        get;
+    }
+
+    prop MaxSize int32 {
+        get;
+    }
+
+    prop TotalSize int64 {
+        get;
+    }
+
+    func GetSizeAtIndex(index int32) int32;
+    func SumFirstNSizes(firstN int32) int64;
+
+    func GetFrameSizes(firstFrameIndex uint32, numFrames uint32) ([]int32, int32) {
+        let frameSizes = [int32(numFrames)]int32
+        var framesSizeTotal = 0
+        for var i uint32 = uint32(0); i < numFrames; i++ {
+            frameSizes[i] = GetSizeAtIndex(int32((i + firstFrameIndex)))
+            framesSizeTotal += frameSizes[i]
+        }
+        return (frameSizes, framesSizeTotal)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Id3Header.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Id3Header.gs
@@ -1,0 +1,41 @@
+package Oahu.Decrypt.Mpeg4.ID3
+
+import System
+import System.IO
+
+class Id3Header : Header {
+    internal init(version uint16, file Stream) {
+        Version = version
+        Flags = Flags(uint8(file.ReadByte()))
+        Size = Header.UnSyncSafify(Header.ReadUInt32BE(file))
+    }
+
+    override prop Identifier string -> "ID3"
+    prop Version uint16
+    prop Flags Flags
+    override prop HeaderSize int32 -> 10
+
+    override func Render(stream Stream, renderSize int32, version uint16) {
+        stream.Write([]uint8{0x49, 0x44, 0x33})
+        stream.WriteByte(uint8((version >> 8)))
+        stream.WriteByte(uint8((version & uint16(0xff))))
+        stream.Write(Flags.ToBytes())
+        Header.WriteUInt32BE(stream, Header.SyncSafify(renderSize))
+    }
+
+    shared {
+        func Create(file Stream) Id3Header? {
+            try {
+                let bts = stackalloc [4]uint8
+                file.ReadExactly(bts)
+                if bts[0] == uint8('I') && bts[1] == uint8('D') && bts[2] == uint8('3') && bts[3] == uint8(2) || bts[3] == uint8(3) || bts[3] == uint8(4) {
+                    let version = uint16((bts[3] << 8 | file.ReadByte()))
+                    return Id3Header(version, file)
+                }
+                return nil
+            } catch (ex Exception) {
+                return nil
+            }
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Id3Tag.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Id3Tag.gs
@@ -1,0 +1,47 @@
+package Oahu.Decrypt.Mpeg4.ID3
+
+import System.IO
+import System.Linq
+
+class Id3Tag : Frame {
+    private init(file Stream, header Id3Header) : base(header, default(Frame)) {
+        let endPosition = file.Position + int64(Header.Size)
+        Id3Header = header
+        if (Id3Header.Flags[1]) {
+            Children.Add(Id3ExtendedHeader.Create(file, this))
+        }
+        LoadChildren(file, endPosition)
+    }
+
+    override prop Size int32 -> Children.Sum((f Frame) -> f.Size + f.Header.HeaderSize) + EmptyFrame.GetEmptyFrameSize(Version)
+    override prop Version uint16 -> Id3Header.Version
+
+    private prop Id3Header Id3Header {
+        get;
+        init;
+    }
+
+    func Save(file Stream) {
+        Save(file, Id3Header.Version)
+        EmptyFrame(this).Save(file, Id3Header.Version)
+    }
+
+    func Add(frame Frame) -> Children.Add(frame)
+
+    override func Render(file Stream) {
+    }
+
+    shared {
+        func Create(file Stream) Id3Tag? {
+            let id3Header = Id3Header.Create(file)
+            if id3Header == nil || !((id3Header!!.Version == uint16(0x200) || id3Header!!.Version == uint16(0x300) || id3Header!!.Version == uint16(0x400))) {
+                return nil
+            }
+            try {
+                return Id3Tag(file, id3Header!!)
+            } catch (ex Exception) {
+                return nil
+            }
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/InterleavedIterator_T.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/InterleavedIterator_T.gs
@@ -1,0 +1,48 @@
+package Oahu.Decrypt.Mpeg4.Chunks
+
+import System
+import System.Collections
+import System.Collections.Generic
+import System.Diagnostics.CodeAnalysis
+import System.Linq
+import Oahu.Decrypt.Mpeg4.Boxes
+
+class EnumerableExtensions {
+    private class InterleavedIterator[T](Enumerables []IEnumerable[T], Comparer Comparer[T]) : IEnumerable[T] {
+        func GetEnumerator() IEnumerator[T] {
+            let enumerators = Enumerables.Select((e IEnumerable[T]) -> e.GetEnumerator()).Select((e IEnumerator[T]) -> if e.MoveNext() { e } else { default(IEnumerator[T]?) }).ToArray()
+            while GetNextValue(enumerators, out var currentIndex, out var currentEnumerator) {
+                yield currentEnumerator!!.Current
+                if !currentEnumerator!!.MoveNext() {
+                    enumerators[currentIndex] = nil
+                }
+            }
+        }
+
+        private func GetEnumerator() IEnumerator -> GetEnumerator()
+
+        private func GetNextValue(enumerators []IEnumerator[T]?, out minIndex int32, out minValue IEnumerator[T]?) bool {
+            minIndex = -1
+            minValue = nil
+            for var i = 0; i < enumerators.Length; i++ {
+                if enumerators[i] is IEnumerator[T] && (minValue == nil || Comparer.Compare(minValue!!.Current, (enumerators[i] as IEnumerator[T])!!.Current) > 0) {
+                    var __decon0 = i
+                    var __decon1 = (enumerators[i] as IEnumerator[T])!!
+                    minIndex = __decon0
+                    minValue = __decon1
+                }
+            }
+            return minIndex != -1
+        }
+    }
+}
+
+func (track TrakBox) ChunkEntries() IEnumerable[ChunkEntry] -> ChunkEntryList(track)
+
+func (source IEnumerable[TSource]) InterleaveBy[TSource, TResult, TKey IComparable[TKey]](selector (TSource) -> IEnumerable[TResult], keySelector (TResult) -> TKey) IEnumerable[TResult] {
+    ArgumentNullException.ThrowIfNull(source, nameof(source))
+    ArgumentNullException.ThrowIfNull(selector, nameof(selector))
+    ArgumentNullException.ThrowIfNull(keySelector, nameof(keySelector))
+    let comparer = Comparer[TResult].Create((x TResult, y TResult) -> keySelector(x).CompareTo(keySelector(y)))
+    return InterleavedIterator[TResult](source.Select((s TSource) -> selector(s)).ToArray(), comparer!!)
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/LosslessFilter.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/LosslessFilter.gs
@@ -1,0 +1,54 @@
+package Oahu.Decrypt.FrameFilters.Audio
+
+import System.IO
+import System.Threading.Tasks
+
+internal open class LosslessFilter : FrameFinalBase[FrameEntry] {
+    let Mp4aWriter Mp4aWriter
+    private let chapterQueue ChapterQueue
+    private var lastChunkIndex int64 = -1
+
+    init(outputStream Stream, mp4Audio Mp4File, chapterQueue ChapterQueue) {
+        Mp4aWriter = Mp4aWriter(outputStream, mp4Audio.Ftyp, mp4Audio.Moov)
+        this.chapterQueue = chapterQueue
+    }
+
+    prop Closed bool
+    protected open override prop InputBufferSize int32 -> 1000
+
+    protected open override func FlushAsync() Task {
+        while chapterQueue.TryGetNextChapter(out var chapterEntry) {
+            Mp4aWriter.WriteChapter(chapterEntry!!)
+        }
+        CloseWriter()
+        return Task.CompletedTask
+    }
+
+    protected open override func PerformFilteringAsync(input FrameEntry) Task {
+        let chunkIndex = input.Chunk?.ChunkIndex ?? uint32(lastChunkIndex)
+        var newChunk = chunkIndex > lastChunkIndex
+        while chapterQueue.TryGetNextChapter(out var chapterEntry) {
+            Mp4aWriter.WriteChapter(chapterEntry!!)
+            newChunk = true
+        }
+        Mp4aWriter.AddFrame(input.FrameData.Span, newChunk, input.SamplesInFrame)
+        lastChunkIndex = chunkIndex
+        return Task.CompletedTask
+    }
+
+    protected open override func Dispose(disposing bool) {
+        if disposing && !Disposed {
+            CloseWriter()
+            Mp4aWriter?.Dispose()
+        }
+        base.Dispose(disposing)
+    }
+
+    private func CloseWriter() {
+        if Closed {
+            return
+        }
+        Mp4aWriter.Close()
+        Closed = true
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/LosslessMultipartFilter.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/LosslessMultipartFilter.gs
@@ -1,0 +1,60 @@
+package Oahu.Decrypt.FrameFilters.Audio
+
+import System
+import System.IO
+import Oahu.Decrypt.Mpeg4
+import Oahu.Decrypt.Mpeg4.Boxes
+
+internal open class LosslessMultipartFilter : MultipartFilterBase[FrameEntry, NewSplitCallback] {
+    private let ftyp FtypBox
+    private let moov MoovBox
+    private let newFileCallback (NewSplitCallback) -> void
+    private var mp4writer Mp4aWriter?
+
+    init(splitChapters ChapterInfo, ftyp FtypBox, moov MoovBox, newFileCallback (NewSplitCallback) -> void) : base(splitChapters, SampleRate(moov.AudioTrack.Mdia.Mdhd.Timescale), moov.AudioTrack.Mdia.Minf.Stbl.Stsd.AudioSampleEntry?.ChannelCount == (2 as uint16?)) {
+        this.ftyp = ftyp
+        this.moov = moov
+        this.newFileCallback = newFileCallback
+    }
+
+    prop CurrentWriterOpen bool
+    protected open override prop InputBufferSize int32 -> 1000
+
+    protected open override func CloseCurrentWriter() {
+        if !CurrentWriterOpen {
+            return
+        }
+        mp4writer?.Close()
+        mp4writer?.OutputFile.Close()
+        CurrentWriterOpen = false
+    }
+
+    protected open override func WriteFrameToFile(audioFrame FrameEntry, newChunk bool) {
+        mp4writer?.AddFrame(audioFrame.FrameData.Span, newChunk, audioFrame.SamplesInFrame)
+    }
+
+    protected open override func CreateNewWriter(callback NewSplitCallback) {
+        newFileCallback(callback)
+        let outfile Stream? = callback.OutputFile as Stream
+        if outfile == nil {
+            throw InvalidOperationException("Output file stream null")
+        }
+        CurrentWriterOpen = true
+        mp4writer = Mp4aWriter(outfile, ftyp, moov)
+        mp4writer!!.RemoveTextTrack()
+        if mp4writer!!.Moov.ILst != nil {
+            let tags = MetadataItems(mp4writer!!.Moov.ILst!!)
+            if callback.TrackNumber.HasValue && callback.TrackCount.HasValue {
+                tags!!.TrackNumber = (callback.TrackNumber.Value, callback.TrackCount.Value)
+            }
+            tags!!.Title = callback.TrackTitle ?? tags!!.Title
+        }
+    }
+
+    protected open override func Dispose(disposing bool) {
+        if disposing && !Disposed {
+            CloseCurrentWriter()
+        }
+        base.Dispose(disposing)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/MdatBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/MdatBox.gs
@@ -1,0 +1,21 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.IO
+import System.Threading
+import System.Threading.Tasks
+import Oahu.Decrypt.Mpeg4.Util
+
+open class MdatBox : Box {
+    init(header BoxHeader) : base(header, nil) {
+    }
+
+    async func ShiftMdatAsync(file Stream, shiftVector int64, progressTracker ProgressTracker? = nil, cancellationToken CancellationToken = default(CancellationToken)) {
+        await Mpeg4Util.ShiftDataBlock(file, Header.FilePosition, Header.TotalBoxSize, shiftVector, progressTracker, cancellationToken).ConfigureAwait(false)
+        this.Header.FilePosition += shiftVector
+    }
+
+    protected open override func Render(file Stream) {
+        throw NotSupportedException()
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/MdhdBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/MdhdBox.gs
@@ -1,0 +1,51 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class MdhdBox : HeaderBox {
+    private var language string
+
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        let blob = file.ReadBlock(4)
+        let reader = BitReader(blob!!)
+        reader!!.Position = 1
+        let c1 = char((reader!!.Read(5) + uint32(0x60)))
+        let c2 = char((reader!!.Read(5) + uint32(0x60)))
+        let c3 = char((reader!!.Read(5) + uint32(0x60)))
+        language = string([]char{c1, c2, c3})
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(8)
+    prop Timescale uint32
+
+    prop Language string {
+        get -> language
+        set {
+            if value.Length != 3 || value[0] < 'a' || value[0] > 'z' || value[1] < 'a' || value[1] > 'z' || value[2] < 'a' || value[2] > 'z' {
+                throw ArgumentException("value must be three, lowercase ASCII characters", nameof(Language))
+            }
+            language = value
+        }
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        let writer = BitWriter()
+        writer!!.Write(0, 1)
+        writer!!.Write(uint32(Language[0]) - uint32(0x60), 5)
+        writer!!.Write(uint32(Language[1]) - uint32(0x60), 5)
+        writer!!.Write(uint32(Language[2]) - uint32(0x60), 5)
+        writer!!.Write(0, 16)
+        file.Write(writer!!.ToByteArray())
+    }
+
+    protected open override func ReadBeforeDuration(file Stream) {
+        Timescale = file.ReadUInt32BE()
+    }
+
+    protected open override func WriteBeforeDuration(file Stream) {
+        file.WriteUInt32BE(Timescale)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/MdiaBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/MdiaBox.gs
@@ -1,0 +1,17 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+
+open class MdiaBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        LoadChildren(file)
+    }
+
+    prop Mdhd MdhdBox -> GetChildOrThrow[MdhdBox]()
+    prop Hdlr HdlrBox -> GetChildOrThrow[HdlrBox]()
+    prop Minf MinfBox -> GetChildOrThrow[MinfBox]()
+
+    protected open override func Render(file Stream) {
+        return
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/MeanBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/MeanBox.gs
@@ -1,0 +1,38 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.Diagnostics
+import System.IO
+import System.Text
+import Oahu.Decrypt.Mpeg4.Util
+
+@DebuggerDisplay("{DebuggerDisplay,nq}")
+open class MeanBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        let stringSize = RemainingBoxLength(file)
+        let stringData = file.ReadBlock(int32(stringSize))
+        ReverseDnsDomain = Encoding.UTF8.GetString(stringData!!)
+    }
+
+    private init(header BoxHeader, parent IBox?, domain string) : base([4]uint8, header, parent) {
+        ReverseDnsDomain = domain
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(Encoding.UTF8.GetByteCount(ReverseDnsDomain))
+    prop ReverseDnsDomain string
+    private prop DebuggerDisplay string -> "domain: $ReverseDnsDomain"
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.Write(Encoding.UTF8.GetBytes(ReverseDnsDomain))
+    }
+
+    shared {
+        func Create(parent IBox?, domain string) MeanBox {
+            let size = Encoding.UTF8.GetByteCount(domain) + 12
+            let header = BoxHeader(uint32(size), "mean")
+            let meanBox = MeanBox(header, parent, domain)
+            parent?.Children.Add(meanBox)
+            return meanBox
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/MehdBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/MehdBox.gs
@@ -1,0 +1,26 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class MehdBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        FragmentDuration = if Version == uint8(1) { file.ReadUInt64BE() } else { uint64(file.ReadUInt32BE()) }
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64((if Version == uint8(1) { 8 } else { 4 }))
+
+    prop FragmentDuration uint64 {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        if Version == uint8(1) {
+            file.WriteUInt64BE(FragmentDuration)
+        } else {
+            file.WriteUInt32BE(uint32(FragmentDuration))
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/MetaBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/MetaBox.gs
@@ -1,0 +1,20 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+
+class MetaBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        LoadChildren(file)
+    }
+
+    private init(parent IBox) : base([]uint8{uint8(0), uint8(0), uint8(0), uint8(0)}, BoxHeader(8, "meta"), parent) {
+    }
+
+    shared {
+        func CreateEmpty(parent IBox) MetaBox {
+            let meta = MetaBox(parent)
+            parent.Children.Add(meta!!)
+            return meta!!
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/MetadataItems.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/MetadataItems.gs
@@ -1,0 +1,182 @@
+package Oahu.Decrypt.Mpeg4
+
+import System.Buffers.Binary
+import System.IO
+import Oahu.Decrypt.Mpeg4.Boxes
+
+class MetadataItems(AppleListBox AppleListBox) {
+    prop FirstAuthor string? -> Artist?.Split(';')?[0]
+    prop TitleSansUnabridged string? -> Title?.Replace(" (Unabridged)", "")
+    prop BookCopyright string? -> if GetCopyrights() != nil && GetCopyrights()!!!!.Length > 0 { GetCopyrights()!!!![0] } else { default }
+    prop RecordingCopyright string? -> if GetCopyrights() != nil && GetCopyrights()!!!!.Length > 1 { GetCopyrights()!!!![1] } else { default }
+
+    prop Title string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameTitle)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameTitle, value)
+    }
+
+    prop Producer string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameProducer)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameProducer, value)
+    }
+
+    prop Artist string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameArtist)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameArtist, value)
+    }
+
+    prop AlbumArtists string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameAlbumArtist)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameAlbumArtist, value)
+    }
+
+    prop Album string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameAlbum)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameAlbum, value)
+    }
+
+    prop Genres string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameGenres)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameGenres, value)
+    }
+
+    prop ProductID string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameProductId)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameProductId, value)
+    }
+
+    prop Comment string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameComment)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameComment, value)
+    }
+
+    prop LongDescription string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameLongDescription)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameLongDescription, value)
+    }
+
+    prop Copyright string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameCopyright)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameCopyright, value)
+    }
+
+    prop Publisher string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNamePublisher)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNamePublisher, value)
+    }
+
+    prop Year string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameYear)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameYear, value)
+    }
+
+    prop Narrator string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameNarrator)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameNarrator, value)
+    }
+
+    prop Asin string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameAsin)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameAsin, value)
+    }
+
+    prop ReleaseDate string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameReleaseDate)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameReleaseDate, value)
+    }
+
+    prop Acr string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameAcr)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameAcr, value)
+    }
+
+    prop Version string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameVersion)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameVersion, value)
+    }
+
+    prop Encoder string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameEncoder)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameEncoder, value)
+    }
+
+    prop Cover []?uint8 {
+        get -> AppleListBox.GetTagBox(MetadataItems.TagNameCover)?.Data.Data
+        set -> SetCoverArt(value)
+    }
+
+    prop CoverFormat AppleDataType? -> AppleListBox.GetTagBox(MetadataItems.TagNameCover)?.Data.DataType
+
+    prop TrackNumber TrackNumber? {
+        get -> AppleListBox.GetTagData[TrackNumber](MetadataItems.TagNameTrackNumber)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameTrackNumber, value)
+    }
+
+    prop DiskNumber DiskNumber? {
+        get -> AppleListBox.GetTagData[DiskNumber](MetadataItems.TagNameDiskNumber)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameDiskNumber, value)
+    }
+
+    private func GetCopyrights() []?string -> Copyright?.Replace("&#169;", "©")?.Split(';')
+
+    private func SetCoverArt(coverArtBytes []?uint8) {
+        let EditOrAdd = func (dataType AppleDataType) {
+            if AppleListBox.GetTagBox(MetadataItems.TagNameCover) != nil && AppleListBox.GetTagBox(MetadataItems.TagNameCover)!!!!.Data.DataType != dataType {
+                AppleListBox.RemoveTag(AppleListBox.GetTagBox(MetadataItems.TagNameCover)!!!!)
+                AppleListBox.GetTagBox(MetadataItems.TagNameCover)!!!!.Dispose()
+            }
+            AppleListBox.EditOrAddTag(MetadataItems.TagNameCover, coverArtBytes!!, dataType)
+        }
+        if coverArtBytes == nil {
+            AppleListBox.RemoveTag(MetadataItems.TagNameCover)
+        } else if coverArtBytes!!.Length >= 2 && BinaryPrimitives.ReadInt16LittleEndian(coverArtBytes!!) == int16(0x4D42) {
+            EditOrAdd(AppleDataType.BMP)
+        } else if coverArtBytes!!.Length >= 3 && (BinaryPrimitives.ReadInt32LittleEndian(coverArtBytes!!) & 0xFFFFFF) == 0xFFD8FF {
+            EditOrAdd(AppleDataType.JPEG)
+        } else if coverArtBytes!!.Length >= 8 && BinaryPrimitives.ReadInt64LittleEndian(coverArtBytes!!) == 0xA1A0A0D474e5089L {
+            EditOrAdd(AppleDataType.PNG)
+        } else {
+            throw InvalidDataException("Image data is not a jpeg, PNG, or windows bitmap.")
+        }
+    }
+
+    shared {
+        const TagNameTitle string = "©nam"
+        const TagNameProducer string = "©prd"
+        const TagNameArtist string = "©ART"
+        const TagNameAlbumArtist string = "aART"
+        const TagNameAlbum string = "©alb"
+        const TagNameGenres string = "©gen"
+        const TagNameProductId string = "prID"
+        const TagNameComment string = "©cmt"
+        const TagNameLongDescription string = "©des"
+        const TagNameCopyright string = "cprt"
+        const TagNamePublisher string = "©pub"
+        const TagNameYear string = "©day"
+        const TagNameNarrator string = "©nrt"
+        const TagNameAsin string = "CDEK"
+        const TagNameReleaseDate string = "rldt"
+        const TagNameAcr string = "AACR"
+        const TagNameVersion string = "VERS"
+        const TagNameEncoder string = "©too"
+        const TagNameCover string = "covr"
+        const TagNameTrackNumber string = "trkn"
+        const TagNameDiskNumber string = "disk"
+
+        func FromFile(mp4File string) MetadataItems? {
+            using let file = File.Open(mp4File, FileMode.Open, FileAccess.Read, FileShare.Read)
+            var header BoxHeader
+            do {
+                header = BoxHeader(file!!)
+                if header.Type == "moov" {
+                    continue
+                } else if header.Type == "udta" {
+                    break
+                } else {
+                    file!!.Position += header.TotalBoxSize - int64(header.HeaderSize)
+                }
+            } while file!!.Position < file!!.Length
+            return if header?.Type == "udta" && UdtaBox(file!!, header, nil)?.GetChild[MetaBox]()?.GetChild[AppleListBox]() != nil { MetadataItems(UdtaBox(file!!, header, nil)?.GetChild[MetaBox]()?.GetChild[AppleListBox]()!!!!) } else { default(MetadataItems?) }
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/MfhdBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/MfhdBox.gs
@@ -1,0 +1,22 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class MfhdBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        SequenceNumber = file.ReadInt32BE()
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(4)
+
+    prop SequenceNumber int32 {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.WriteInt32BE(SequenceNumber)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/MinfBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/MinfBox.gs
@@ -1,0 +1,15 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+
+open class MinfBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        LoadChildren(file)
+    }
+
+    prop Stbl StblBox -> GetChildOrThrow[StblBox]()
+
+    protected open override func Render(file Stream) {
+        return
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/MoofBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/MoofBox.gs
@@ -1,0 +1,16 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+
+open class MoofBox : Box {
+    init(file Stream, header BoxHeader) : base(header, nil) {
+        LoadChildren(file)
+    }
+
+    prop Mfhd MfhdBox -> GetChildOrThrow[MfhdBox]()
+    prop Traf TrafBox -> GetChildOrThrow[TrafBox]()
+
+    protected open override func Render(file Stream) {
+        return
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/MoovBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/MoovBox.gs
@@ -1,0 +1,103 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.Collections.Generic
+import System.IO
+import System.Linq
+
+open class MoovBox : Box {
+    init(file Stream, header BoxHeader) : base(header, nil) {
+        LoadChildren(file)
+    }
+
+    prop Mvhd MvhdBox -> GetChildOrThrow[MvhdBox]()
+    prop AudioTrack TrakBox -> Tracks.Where((t TrakBox) -> t.GetChild[MdiaBox]()?.GetChild[HdlrBox]()?.HandlerType == "soun").First()
+    prop VideoTrack TrakBox? -> Tracks.Where((t TrakBox) -> t.GetChild[MdiaBox]()?.GetChild[HdlrBox]()?.HandlerType == "vide").FirstOrDefault()
+    prop TextTrack TrakBox? -> Tracks.Where((t TrakBox) -> t.GetChild[MdiaBox]()?.GetChild[HdlrBox]()?.HandlerType == "text").FirstOrDefault()
+    prop ILst AppleListBox? -> GetChild[UdtaBox]()?.GetChild[MetaBox]()?.GetChild[AppleListBox]()
+    prop Tracks IEnumerable[TrakBox] -> GetChildren[TrakBox]()
+
+    func ShiftChunkOffsets(shiftVector int64) {
+        for track in Tracks {
+            var coBox = track!!.Mdia.Minf.Stbl.COBox
+            let offsets = coBox.ChunkOffsets
+            var requires64Bit = false
+            for var i = 0; i < offsets.Count; i++ {
+                let offset = offsets.GetOffsetAtIndex(i)
+                let newOffset = offset + shiftVector
+                requires64Bit |= newOffset > int64(UInt32.MaxValue)
+                offsets.SetOffsetAtIndex(i, newOffset)
+            }
+            if requires64Bit && coBox is StcoBox {
+                track!!.Mdia.Minf.Stbl.Children.Remove(coBox)
+                coBox = Co64Box.CreateBlank(track!!.Mdia.Minf.Stbl, offsets)
+            } else if !requires64Bit && coBox is Co64Box {
+                track!!.Mdia.Minf.Stbl.Children.Remove(coBox)
+                coBox = StcoBox.CreateBlank(track!!.Mdia.Minf.Stbl, offsets)
+            }
+        }
+    }
+
+    func ShiftChunkOffsetsWithMoovInFront(shiftVector int64) int64 {
+        var shiftVector = shiftVector
+        var shifted int64 = 0
+        do {
+            let moovSize = RenderSize
+            ShiftChunkOffsets(shiftVector)
+            shifted += shiftVector
+            shiftVector = RenderSize - moovSize
+        } while shiftVector != int64(0)
+        return shifted
+    }
+
+    func CreateEmptyMetadata() AppleListBox {
+        let ilist AppleListBox? = ILst as AppleListBox
+        if ilist != nil {
+            return ilist
+        } else {
+            let udata = UdtaBox.CreateEmpty(this)
+            let meta = MetaBox.CreateEmpty(udata!!)
+            let hdlr = HdlrBox.Create("mdir", nil, []uint8{uint8(0x61), uint8(0x70), uint8(0x70), uint8(0x6c)}, meta!!)
+            return AppleListBox.CreateEmpty(meta!!)
+        }
+    }
+
+    func CreateEmptyTextTrack() TrakBox {
+        let txt TrakBox? = TextTrack as TrakBox
+        if txt != nil {
+            return txt
+        } else {
+            using let ms = MemoryStream(MoovBox.EmptyTextTrack)
+            let textTrack = BoxFactory.CreateBox[TrakBox](ms!!, nil)
+            Children.Insert(Children.IndexOf(AudioTrack) + 1, textTrack!!)
+            textTrack!!.Tkhd.TrackID = Mvhd.NextTrackID
+            Mvhd.NextTrackID++
+            let references = GetChildren[TrakBox]().Except([]TrakBox{AudioTrack}).Select((t TrakBox) -> t.Tkhd.TrackID).Order().ToHashSet()
+            let tref TrefBox? = AudioTrack.GetChild[TrefBox]() as TrefBox
+            if tref != nil {
+                let referenceType ITrackReferenceTypeBox? = tref.References.FirstOrDefault((r ITrackReferenceTypeBox) -> r.Header.Type == "chap") as ITrackReferenceTypeBox
+                if referenceType != nil {
+                    referenceType!!.TrackIds = references
+                } else {
+                    tref.AddReference("chap", references)
+                }
+            } else {
+                TrefBox.CreatEmpty(AudioTrack).AddReference("chap", references)
+            }
+            textTrack!!.Mdia.Mdhd.ModificationTime = DateTimeOffset.UtcNow
+            textTrack!!.Mdia.Mdhd.CreationTime = textTrack!!.Mdia.Mdhd.ModificationTime
+            textTrack!!.Tkhd.ModificationTime = textTrack!!.Mdia.Mdhd.CreationTime
+            textTrack!!.Tkhd.CreationTime = textTrack!!.Tkhd.ModificationTime
+            textTrack!!.Mdia.Mdhd.Timescale = AudioTrack.Mdia.Mdhd.Timescale
+            return textTrack!!
+        }
+    }
+
+    protected open override func Render(file Stream) {
+        return
+    }
+
+    shared {
+        private let EmptyTextTrack []uint8 = []uint8{uint8(0x00), uint8(0x00), uint8(0x02), uint8(0x11), uint8(0x74), uint8(0x72), uint8(0x61), uint8(0x6b), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x5c), uint8(0x74), uint8(0x6b), uint8(0x68), uint8(0x64), uint8(0x00), uint8(0x00), uint8(0x10), uint8(0x01), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x01), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x01), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x01), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x40), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0xa0), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0xa0), uint8(0x00), uint8(0x00), uint8(0x01), uint8(0x70), uint8(0x6d), uint8(0x64), uint8(0x69), uint8(0x61), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x20), uint8(0x6d), uint8(0x64), uint8(0x68), uint8(0x64), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x35), uint8(0x33), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x39), uint8(0x68), uint8(0x64), uint8(0x6c), uint8(0x72), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x6d), uint8(0x68), uint8(0x6c), uint8(0x72), uint8(0x74), uint8(0x65), uint8(0x78), uint8(0x74), uint8(0x61), uint8(0x70), uint8(0x70), uint8(0x6c), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x18), uint8(0x41), uint8(0x70), uint8(0x70), uint8(0x6c), uint8(0x65), uint8(0x20), uint8(0x54), uint8(0x65), uint8(0x78), uint8(0x74), uint8(0x20), uint8(0x4d), uint8(0x65), uint8(0x64), uint8(0x69), uint8(0x61), uint8(0x20), uint8(0x48), uint8(0x61), uint8(0x6e), uint8(0x64), uint8(0x6c), uint8(0x65), uint8(0x72), uint8(0x00), uint8(0x00), uint8(0x01), uint8(0x0f), uint8(0x6d), uint8(0x69), uint8(0x6e), uint8(0x66), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x4c), uint8(0x67), uint8(0x6d), uint8(0x68), uint8(0x64), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x18), uint8(0x67), uint8(0x6d), uint8(0x69), uint8(0x6e), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x40), uint8(0x80), uint8(0x00), uint8(0x80), uint8(0x00), uint8(0x80), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x2c), uint8(0x74), uint8(0x65), uint8(0x78), uint8(0x74), uint8(0x00), uint8(0x01), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x01), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x40), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x24), uint8(0x64), uint8(0x69), uint8(0x6e), uint8(0x66), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x1c), uint8(0x64), uint8(0x72), uint8(0x65), uint8(0x66), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x01), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x0c), uint8(0x61), uint8(0x6c), uint8(0x69), uint8(0x73), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x01), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x97), uint8(0x73), uint8(0x74), uint8(0x62), uint8(0x6c), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x4b), uint8(0x73), uint8(0x74), uint8(0x73), uint8(0x64), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x01), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x3b), uint8(0x74), uint8(0x65), uint8(0x78), uint8(0x74), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x01), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x01), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x01), uint8(0xff), uint8(0xff), uint8(0xff), uint8(0xff), uint8(0xff), uint8(0xff), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x10), uint8(0x73), uint8(0x74), uint8(0x74), uint8(0x73), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x10), uint8(0x73), uint8(0x74), uint8(0x73), uint8(0x63), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x10), uint8(0x73), uint8(0x74), uint8(0x63), uint8(0x6f), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x14), uint8(0x73), uint8(0x74), uint8(0x73), uint8(0x7a), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x3d), uint8(0x75), uint8(0x64), uint8(0x74), uint8(0x61), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x35), uint8(0x6d), uint8(0x65), uint8(0x74), uint8(0x61), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x21), uint8(0x68), uint8(0x64), uint8(0x6c), uint8(0x72), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x6d), uint8(0x64), uint8(0x69), uint8(0x72), uint8(0x61), uint8(0x70), uint8(0x70), uint8(0x6c), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x08), uint8(0x69), uint8(0x6c), uint8(0x73), uint8(0x74)}
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Mp4File.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Mp4File.gs
@@ -1,0 +1,147 @@
+package Oahu.Decrypt
+
+import System
+import System.IO
+import System.Linq
+import System.Threading.Tasks
+import Oahu.Decrypt.Chunks
+import Oahu.Decrypt.FrameFilters
+import Oahu.Decrypt.FrameFilters.Audio
+import Oahu.Decrypt.FrameFilters.Text
+import Oahu.Decrypt.Mpeg4
+import Oahu.Decrypt.Mpeg4.Boxes
+import Oahu.Decrypt.Mpeg4.Util
+
+enum FileType { Aax, Aaxc, Mpeg4, Dash }
+enum SampleRate { Hz_96000, Hz_88200, Hz_64000, Hz_48000, Hz_44100, Hz_32000, Hz_24000, Hz_22050, Hz_16000, Hz_12000, Hz_11025, Hz_8000, Hz_7350 }
+
+open class Mp4File : Mpeg4File {
+    init(file Stream, fileSize int64) : base(file, fileSize) {
+        FileType = if Ftyp.CompatibleBrands.Any((b string) -> b == "dash") { FileType.Dash } else { (switch Ftyp.MajorBrand {
+            case "aax ": FileType.Aax
+            case "aaxc": FileType.Aaxc
+            default: FileType.Mpeg4
+        }) }
+    }
+
+    convenience init(file Stream) {
+        init(file, file.Length)
+    }
+
+    convenience init(fileName string, access FileAccess = 1, share FileShare = 1) {
+        init(File.Open(fileName, FileMode.Open, access, share))
+    }
+
+    prop FileType FileType {
+        get;
+        init;
+    }
+
+    prop SampleRate SampleRate -> SampleRate(TimeScale)
+    open func GetAudioFrameFilter() FrameTransformBase[FrameEntry, FrameEntry] -> AacValidateFilter()
+
+    func SaveAsync(keepMoovInFront bool = true) Mp4Operation {
+        let tracker = ProgressTracker{TotalDuration: Duration}
+        let operation = Mp4Operation((t CancellationTokenSource) -> SaveAsync(keepMoovInFront, tracker, t.Token), this, (t Task) -> {
+        })
+        tracker.ProgressUpdated += (_ object?, _ EventArgs) -> operation.OnProgressUpdate(ConversionProgressEventArgs(TimeSpan.Zero, tracker.TotalDuration, tracker.Position, tracker.Speed))
+        return operation
+    }
+
+    func ConvertToMp4aAsync(outputStream Stream, userChapters ChapterInfo? = nil) Mp4Operation {
+        let start = userChapters?.StartOffset ?? TimeSpan.Zero
+        let end = userChapters?.EndOffset ?? TimeSpan.MaxValue
+        let chapterQueue = ChapterQueue(SampleRate, SampleRate)
+        if userChapters != nil {
+            if Moov.TextTrack == nil {
+                Moov.CreateEmptyTextTrack()
+            }
+            chapterQueue.AddRange(userChapters!!)
+        }
+        let filter1 = GetAudioFrameFilter()
+        let filter2 = LosslessFilter(outputStream, this, chapterQueue)
+        filter1.LinkTo(filter2)
+        if Moov.TextTrack != nil && userChapters == nil {
+            let c1 = ChapterFilter()
+            c1.ChapterRead += (_ object?, e FrameEntry) -> chapterQueue.Add(e)
+            let Continuation = func (t Task) {
+                filter1.Dispose()
+                c1.Dispose()
+                outputStream.Close()
+            }
+            return ProcessAudio(start, end, Continuation, (Moov.AudioTrack, filter1), (Moov.TextTrack!!, c1))
+        } else {
+            let Continuation = func (t Task) {
+                filter1.Dispose()
+                outputStream.Close()
+            }
+            return ProcessAudio(start, end, Continuation, (Moov.AudioTrack, filter1))
+        }
+    }
+
+    func ConvertToMultiMp4aAsync(userChapters ChapterInfo, newFileCallback (NewSplitCallback) -> void) Mp4Operation {
+        let f1 = GetAudioFrameFilter()
+        let f2 = LosslessMultipartFilter(userChapters, Ftyp, Moov, newFileCallback)
+        f1.LinkTo(f2)
+        let Continuation = func (t Task) {
+            f1.Dispose()
+        }
+        return ProcessAudio(userChapters.StartOffset, userChapters.EndOffset, Continuation, (Moov.AudioTrack, f1))
+    }
+
+    func GetChapterInfoAsync() Mp4Operation[ChapterInfo?] {
+        let textTrack TrakBox? = Moov.TextTrack as TrakBox
+        if textTrack == nil {
+            return Mp4Operation[ChapterInfo?].FromCompleted(this, nil)
+        }
+        let chapterFilter = ChapterFilter()
+        let chapterQueue = ChapterQueue(SampleRate, SampleRate)
+        chapterFilter.ChapterRead += (s object?, e FrameEntry) -> chapterQueue.Add(e)
+        let Continuation = func (t Task) ChapterInfo? {
+            let chapters = ChapterInfo()
+            while chapterQueue.TryGetNextChapter(out var ch) {
+                chapters.AddChapter(ch!!.Title, TimeSpan.FromSeconds(float64(ch!!.SamplesInFrame) / float64(SampleRate)))
+            }
+            chapterFilter.Dispose()
+            Chapters ??= chapters
+            return chapters
+        }
+        return ProcessAudio(TimeSpan.Zero, TimeSpan.MaxValue, Continuation!!, (Moov.TextTrack!!, chapterFilter))
+    }
+
+    open func ProcessAudio(startTime TimeSpan, endTime TimeSpan, continuation (Task) -> void, filters ...(TrakBox, FrameFilterBase[FrameEntry])) Mp4Operation {
+        let reader = CreateChunkReader(InputStream, startTime, Mp4File.Min(Duration, endTime))
+        for __decon0 in filters {
+            let (track, filter) = __decon0
+            reader.AddTrack(track, filter)
+        }
+        let operation = Mp4Operation(reader.RunAsync, this, continuation)
+        reader.OnProgressUpdateDelegate = operation!!.OnProgressUpdate
+        return operation!!
+    }
+
+    func ProcessAudio[TResult](startTime TimeSpan, endTime TimeSpan, continuation (Task) -> TResult, filters ...(TrakBox, FrameFilterBase[FrameEntry])) Mp4Operation[TResult] {
+        let reader = CreateChunkReader(InputStream, startTime, Mp4File.Min(Duration, endTime))
+        for __decon1 in filters {
+            let (track, filter) = __decon1
+            reader.AddTrack(track, filter)
+        }
+        let operation = Mp4Operation[TResult](reader.RunAsync, this, continuation)
+        reader.OnProgressUpdateDelegate = operation!!.OnProgressUpdate
+        return operation!!
+    }
+
+    protected open func CreateChunkReader(inputStream Stream, startTime TimeSpan, endTime TimeSpan) IChunkReader -> ChunkReader(inputStream, startTime, endTime)
+
+    shared {
+        func RelocateMoovAsync(mp4FilePath string) Mp4Operation {
+            let tracker = ProgressTracker()
+            let moovMover Mp4Operation? = Mp4Operation((t CancellationTokenSource) -> Mpeg4File.RelocateMoovToBeginningAsync(mp4FilePath, tracker, t.Token), nil, (t Task) -> {
+            })
+            tracker.ProgressUpdated += (_ object?, _ EventArgs) -> moovMover!!.OnProgressUpdate(ConversionProgressEventArgs(TimeSpan.Zero, tracker.TotalDuration, tracker.Position, tracker.Speed))
+            return moovMover!!
+        }
+
+        private func Min(t1 TimeSpan, t2 TimeSpan) TimeSpan -> if t1 > t2 { t2 } else { t1 }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Mp4Operation.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Mp4Operation.gs
@@ -1,0 +1,92 @@
+package Oahu.Decrypt
+
+import System
+import System.Linq
+import System.Runtime.CompilerServices
+import System.Threading
+import System.Threading.Tasks
+
+open class Mp4Operation {
+    private let cancellationSource CancellationTokenSource = CancellationTokenSource()
+    private let startAction async (CancellationTokenSource) -> void
+    private let continuationAction ((Task) -> void)?
+    private var lastArgs ConversionProgressEventArgs?
+    private var continuation Task?
+    private var readerTask Task?
+
+    internal convenience init(startAction async (CancellationTokenSource) -> void, mp4File Mp4File?, continuationTask (Task) -> void) {
+        init(startAction, mp4File)
+        continuationAction = continuationTask
+    }
+
+    protected init(startAction async (CancellationTokenSource) -> void, mp4File Mp4File?) {
+        this.startAction = startAction
+        Mp4File = mp4File
+    }
+
+    event ConversionProgressUpdate (object?, ConversionProgressEventArgs) -> void
+    prop IsCompleted bool -> Continuation?.IsCompleted == true
+    prop IsFaulted bool -> readerTask?.IsFaulted == true
+    prop IsCanceled bool -> readerTask?.IsCanceled == true
+    prop IsCompletedSuccessfully bool -> readerTask?.IsCompletedSuccessfully == true && Continuation?.IsCompletedSuccessfully == true
+    prop CurrentProcessPosition TimeSpan -> lastArgs?.ProcessPosition ?? TimeSpan.Zero
+    prop ProcessSpeed float64 -> lastArgs?.ProcessSpeed ?? float64(0.0)
+    prop TaskStatus TaskStatus -> readerTask?.Status ?? TaskStatus.Created
+    prop OperationTask Task -> Continuation
+
+    prop Mp4File Mp4File? {
+        get;
+        init;
+    }
+
+    protected open prop Continuation Task? -> continuation ?? Task.CompletedTask
+
+    func CancelAsync() Task {
+        cancellationSource.Cancel()
+        return if Continuation == nil { Task.FromCanceled(cancellationSource.Token) } else { Continuation!! }
+    }
+
+    func Start() {
+        if readerTask == nil {
+            readerTask = Task.Run(() -> startAction(cancellationSource))
+            SetContinuation(readerTask!!)
+        }
+    }
+
+    func GetAwaiter() ConfiguredTaskAwaitable.ConfiguredTaskAwaiter {
+        Start()
+        return Continuation!!.ConfigureAwait(false).GetAwaiter()
+    }
+
+    internal func OnProgressUpdate(args ConversionProgressEventArgs) {
+        lastArgs = args
+        ConversionProgressUpdate?(this, args)
+    }
+
+    protected open func SetContinuation(readerTask Task) {
+        continuation = readerTask.ContinueWith((t Task) -> {
+            try {
+                continuationAction?(t)
+            } catch (ex Exception) {
+                if t.Exception == nil && !t.IsCanceled {
+                    throw ex
+                }
+                if t.Exception != nil {
+                    throw AggregateException("Two or more errors occurred.", t.Exception!!.InnerExceptions.Append(ex))
+                }
+                throw ex
+            }
+            if t.IsFaulted && t.Exception != nil {
+                throw t.Exception
+            }
+            if t.IsCanceled {
+                throw TaskCanceledException("The decryption operation was cancelled.", nil, cancellationSource.Token)
+            }
+        }, TaskContinuationOptions.ExecuteSynchronously)
+    }
+
+    shared {
+        func FromCompleted(mp4File Mp4File?) Mp4Operation -> Mp4Operation((c CancellationTokenSource) -> Task.CompletedTask, mp4File, (_ Task) -> {
+        })
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Mp4Operation_TOutput.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Mp4Operation_TOutput.gs
@@ -1,0 +1,37 @@
+package Oahu.Decrypt
+
+import System
+import System.Runtime.CompilerServices
+import System.Threading
+import System.Threading.Tasks
+
+open class Mp4Operation[TOutput] : Mp4Operation {
+    private let continuationFunc (Task) -> TOutput?
+    private var continuation Task[TOutput?]?
+
+    internal init(startAction async (CancellationTokenSource) -> void, mp4File Mp4File, continuationFunc (Task) -> TOutput) : base(startAction, mp4File) {
+        this.continuationFunc = continuationFunc
+    }
+
+    prop OperationTask Task[TOutput?] -> continuation ?? Task.FromResult[TOutput](default)
+    protected open override prop Continuation Task -> continuation ?? Task.CompletedTask
+
+    func GetAwaiter() TaskAwaiter[TOutput?] {
+        Start()
+        return (continuation ?? Task.FromResult[TOutput](default)).GetAwaiter()
+    }
+
+    protected open override func SetContinuation(readerTask Task) {
+        continuation = readerTask.ContinueWith((t Task) -> {
+            if t.IsFaulted {
+                continuationFunc(t)
+                throw t.Exception
+            }
+            return continuationFunc(t)
+        }, TaskContinuationOptions.ExecuteSynchronously)
+    }
+
+    shared {
+        func FromCompleted(mp4File Mp4File, result TOutput) Mp4Operation[TOutput] -> Mp4Operation[TOutput]((c CancellationTokenSource) -> Task.CompletedTask, mp4File, (_ Task) -> result)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Mp4aWriter.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Mp4aWriter.gs
@@ -1,0 +1,377 @@
+package Oahu.Decrypt.FrameFilters.Audio
+
+import System
+import System.Collections.Generic
+import System.Diagnostics
+import System.IO
+import System.Linq
+import Oahu.Decrypt.Mpeg4.Boxes
+import Oahu.Decrypt.Mpeg4.Util
+
+open class Mp4aWriter : IDisposable {
+    let Moov MoovBox
+    private let mdatStart int64
+    private let stts SttsBox
+    private let stsc StscBox
+    private let audioSampleEntry AudioSampleEntry
+    private let audioChunks ChunkOffsetList = ChunkOffsetList()
+    private let textChunks ChunkOffsetList = ChunkOffsetList()
+    private let audioSampleSizes List[uint16] = List[uint16]()
+    private let textSampleSizes List[int32] = List[int32]()
+    private let lockObj object = System.Object()
+    private let chapterTitles List[string] = List[string]()
+    private var lastSamplesPerChunk int64 = -1
+    private var samplesPerChunk uint32 = uint32(0)
+    private var currentChunk uint32 = uint32(0)
+    private var closed bool
+    private var closing bool
+    private var currentFrameDuration uint32
+    private var frameDurationCount uint32
+    private var disposed bool = false
+
+    init(outputFile Stream, ftyp FtypBox, moov MoovBox) {
+        ArgumentNullException.ThrowIfNull(outputFile, nameof(outputFile))
+        ArgumentNullException.ThrowIfNull(ftyp, nameof(ftyp))
+        ArgumentNullException.ThrowIfNull(moov, nameof(moov))
+        if !outputFile.CanWrite {
+            throw ArgumentException("The stream is not writable", nameof(outputFile))
+        }
+        OutputFile = outputFile
+        Moov = Mp4aWriter.MakeBlankMoov(moov)
+        stts = Moov.AudioTrack.Mdia.Minf.Stbl.Stts
+        stsc = Moov.AudioTrack.Mdia.Minf.Stbl.Stsc
+        audioSampleEntry = Moov.AudioTrack.Mdia.Minf.Stbl.Stsd.AudioSampleEntry ?? throw InvalidDataException("Audio track's stsd box does not contain an ${nameof(AudioSampleEntry)}")
+        ftyp.Save(OutputFile)
+        mdatStart = OutputFile.Position
+        OutputFile.WriteUInt32BE(0)
+        OutputFile.WriteType("mdat")
+        OutputFile.WriteInt64BE(0)
+    }
+
+    convenience init(outputFile Stream, ftyp FtypBox, moov MoovBox, ascBytes []uint8) {
+        init(outputFile, ftyp, moov)
+        ArgumentNullException.ThrowIfNull(ascBytes, nameof(ascBytes))
+        audioSampleEntry.Header.ChangeAtomName("mp4a")
+        var esds EsdsBox? = audioSampleEntry.Esds as EsdsBox
+        if esds != nil {
+            audioSampleEntry.Children.Remove(esds)
+        }
+        let dec3 Dec3Box? = audioSampleEntry.Dec3 as Dec3Box
+        if dec3 != nil {
+            audioSampleEntry.Children.Remove(dec3)
+        }
+        esds = EsdsBox.CreateEmpty(audioSampleEntry)
+        let asc = esds.ES_Descriptor.DecoderConfig.AudioSpecificConfig
+        asc!!.AscBlob = ascBytes
+        if asc!!.ChannelConfiguration > 2 {
+            throw NotSupportedException("Only supports maximum of 2-channel audio. (Channels=${asc!!.ChannelConfiguration})")
+        }
+        this.audioSampleEntry.ChannelCount = uint16(asc!!.ChannelConfiguration)
+        SetTimeScale(uint32(asc!!.SamplingFrequency))
+    }
+
+    deinit {
+        Dispose(false)
+    }
+
+    prop OutputFile Stream {
+        get;
+        init;
+    }
+
+    func Close() {
+        {
+            Monitor.Enter(lockObj)
+            try {
+                if closing {
+                    return
+                }
+                closing = true
+            } finally {
+                Monitor.Exit(lockObj)
+            }
+        }
+        if closed || !OutputFile.CanWrite {
+            return
+        }
+        let mdatEnd = OutputFile.Position
+        let mdatSize = mdatEnd - mdatStart
+        this.OutputFile.Position = mdatStart
+        if mdatSize <= int64(UInt32.MaxValue) {
+            OutputFile.WriteUInt32BE(uint32(mdatSize))
+        } else {
+            OutputFile.WriteUInt32BE(1)
+        }
+        OutputFile.WriteType("mdat")
+        if mdatSize > int64(UInt32.MaxValue) {
+            OutputFile.WriteInt64BE(mdatSize)
+        }
+        this.OutputFile.Position = mdatEnd
+        WriteChapterMetadata(chapterTitles)
+        stsc.Samples.Add(StscChunkEntry{FirstChunk: currentChunk, SamplesPerChunk: samplesPerChunk, SampleDescriptionIndex: 1})
+        stts.Samples.Add(SttsBox.SampleEntry{FrameCount: frameDurationCount, FrameDelta: currentFrameDuration})
+        frameDurationCount = uint32(0)
+        Debug.Assert(int64(audioSampleSizes.Count) == stts.Samples.Sum((s SttsBox.SampleEntry) -> s.FrameCount))
+        let stsz IStszBox = StszBox.CreateBlank(Moov.AudioTrack.Mdia.Minf.Stbl, audioSampleSizes)
+        IChunkOffsets.Create(Moov.AudioTrack.Mdia.Minf.Stbl, audioChunks)
+        if Moov.TextTrack != nil {
+            IChunkOffsets.Create(Moov.TextTrack!!.Mdia.Minf.Stbl, textChunks)
+        }
+        SetDuration(uint64(stts.Samples.Sum((s SttsBox.SampleEntry) -> decimal(s.FrameCount) * decimal(s.FrameDelta))))
+        let (maxBitRate, avgBitrate) = Mp4aWriter.CalculateBitrate(Moov.AudioTrack.Mdia.Mdhd.Timescale, Moov.AudioTrack.Mdia.Mdhd.Duration, stsz, stts)
+        let esds EsdsBox? = audioSampleEntry.Esds as EsdsBox
+        if esds != nil {
+            esds.ES_Descriptor.DecoderConfig.MaxBitrate = maxBitRate
+            esds.ES_Descriptor.DecoderConfig.AverageBitrate = avgBitrate
+        }
+        if audioSampleEntry.GetChild[BtrtBox]() == nil {
+            BtrtBox.Create(0, maxBitRate, avgBitrate, audioSampleEntry)
+        }
+        SaveMoov()
+        closed = true
+    }
+
+    func Dispose() {
+        Dispose(true)
+        GC.SuppressFinalize(this)
+    }
+
+    func WriteChapter(entry ChapterEntry) {
+        if Moov.TextTrack == nil {
+            return
+        }
+        if Moov.TextTrack!!.Mdia.Minf.Stbl.Stsz == nil {
+            StszBox.CreateBlank(Moov.TextTrack!!.Mdia.Minf.Stbl, textSampleSizes)
+        }
+        if !Moov.TextTrack!!.Mdia.Minf.Stbl.Stsc.Samples.Any() {
+            Moov.TextTrack!!.Mdia.Minf.Stbl.Stsc.Samples.Add(StscChunkEntry{FirstChunk: 1, SamplesPerChunk: 1, SampleDescriptionIndex: 1})
+        }
+        chapterTitles.Add(entry.Title)
+        Moov.TextTrack!!.Mdia.Minf.Stbl.Stts.Samples.Add(SttsBox.SampleEntry{FrameCount: 1, FrameDelta: entry.SamplesInFrame})
+        textSampleSizes.Add(entry.FrameData.Length)
+        textChunks.Add(OutputFile.Position)
+        OutputFile.Write(entry.FrameData.Span)
+    }
+
+    func RemoveTextTrack() {
+        if Moov.TextTrack == nil || !Moov.Children.Remove(Moov.TextTrack!!) {
+            return
+        }
+        var trackNum uint32 = uint32(1)
+        let trackRemap Dictionary[uint32, uint32] = Dictionary[uint32, uint32]()
+        for t in Moov.GetChildren[TrakBox]().OrderBy((t TrakBox) -> t.Tkhd.TrackID) {
+            trackRemap[t!!.Tkhd.TrackID] = trackNum
+            t!!.Tkhd.TrackID = trackNum
+            trackNum++
+        }
+        Moov.Mvhd.NextTrackID = trackNum
+        for track in Moov.GetChildren[TrakBox]().Select((c TrakBox) -> c.GetChild[TrefBox]()).OfType[TrefBox]() {
+            for tref in track!!.References.ToArray() {
+                if tref!!.Header.Type == "chap" {
+                    track!!.References.Remove(tref!!)
+                    continue
+                }
+                for tid in tref!!.TrackIds.Order().ToArray() {
+                    if !trackRemap.TryGetValue(tid, out var remap) {
+                        tref!!.TrackIds.Remove(tid)
+                    } else if remap != tid {
+                        tref!!.TrackIds.Remove(tid)
+                        tref!!.TrackIds.Add(remap)
+                    }
+                }
+                if tref!!.TrackIds.Count == 0 {
+                    track!!.References.Remove(tref!!)
+                }
+            }
+            if track!!.References.Count == 0 {
+                track!!.Parent!!.Children.Remove(track!!)
+            }
+        }
+    }
+
+    func AddFrame(frame Span[uint8], newChunk bool, frameDelta uint32) {
+        {
+            Monitor.Enter(lockObj)
+            try {
+                if closing {
+                    return
+                }
+                if newChunk {
+                    audioChunks.Add(OutputFile.Position)
+                    if samplesPerChunk > uint32(0) && int64(samplesPerChunk) != lastSamplesPerChunk {
+                        stsc.Samples.Add(StscChunkEntry{FirstChunk: currentChunk, SamplesPerChunk: samplesPerChunk, SampleDescriptionIndex: 1})
+                        lastSamplesPerChunk = samplesPerChunk
+                    }
+                    samplesPerChunk = uint32(0)
+                    currentChunk++
+                }
+                audioSampleSizes.Add(uint16(frame.Length))
+                if currentFrameDuration == uint32(0) {
+                    currentFrameDuration = frameDelta
+                } else if currentFrameDuration != frameDelta {
+                    stts.Samples.Add(SttsBox.SampleEntry{FrameCount: frameDurationCount, FrameDelta: currentFrameDuration})
+                    frameDurationCount = uint32(0)
+                    currentFrameDuration = frameDelta
+                }
+                frameDurationCount++
+                samplesPerChunk++
+            } finally {
+                Monitor.Exit(lockObj)
+            }
+        }
+        OutputFile.Write(frame)
+    }
+
+    protected open func SaveMoov() {
+        Moov.Save(OutputFile)
+    }
+
+    private func SetTimeScale(timeScale uint32) {
+        Debug.Assert(timeScale <= uint32(UInt16.MaxValue))
+        this.audioSampleEntry.SampleRate = uint16(timeScale)
+        Moov.AudioTrack.Mdia.Mdhd.Timescale = timeScale
+        if Moov.TextTrack != nil {
+            Moov.TextTrack!!.Mdia.Mdhd.Timescale = Moov.AudioTrack.Mdia.Mdhd.Timescale
+        }
+    }
+
+    private func SetDuration(duration uint64) {
+        Moov.Mvhd.Duration = duration * uint64(Moov.Mvhd.Timescale) / uint64(Moov.AudioTrack.Mdia.Mdhd.Timescale)
+        Moov.AudioTrack.Mdia.Mdhd.Duration = duration
+        Moov.AudioTrack.Tkhd.Duration = Moov.Mvhd.Duration
+        if Moov.TextTrack != nil {
+            Moov.TextTrack!!.Mdia.Mdhd.Duration = Moov.AudioTrack.Mdia.Mdhd.Duration
+            Moov.TextTrack!!.Tkhd.Duration = Moov.Mvhd.Duration
+        }
+    }
+
+    private func WriteChapterMetadata(chapterTitles IEnumerable[string]) {
+        if Moov.TextTrack == nil {
+            return
+        }
+        let chapterNames AppleListBox? = Moov.TextTrack?.GetChild[UdtaBox]()?.GetChild[MetaBox]()?.GetChild[AppleListBox]()
+        if chapterNames == nil {
+            return
+        }
+        chapterNames!!.Children.Clear()
+        for title in chapterTitles {
+            chapterNames!!.AddTag("©nam", title!!)
+            chapterNames!!.AddTag("©cmt", title!!)
+        }
+    }
+
+    private func Dispose(disposing bool) {
+        if disposing && !disposed {
+            Close()
+            stsc?.Samples.Clear()
+            audioSampleSizes.Clear()
+            audioChunks.Clear()
+            textChunks.Clear()
+            disposed = true
+        }
+    }
+
+    shared {
+        private func CalculateBitrate(timeScale float64, duration uint64, stsz IStszBox, stts SttsBox) (uint32, uint32) {
+            let audioBits = stsz.TotalSize * int64(8)
+            let avgBitrate = uint32((float64(audioBits) * timeScale / float64(duration)))
+            let frameDeltas = stts.EnumerateFrameDeltas().Select((d uint32) -> uint16(d)).ToArray()
+            if int64(stts.SampleTimeCount) != int64(stsz.SampleCount) || int64(stts.SampleTimeCount) != int64(frameDeltas!!.Length) {
+                throw InvalidOperationException("The number of sample deltas (${stts.SampleTimeCount}) doesn't match the number of sample sizes (${stsz.SampleCount}).")
+            }
+            var currentWindowSampleSpan int64 = 0
+            var windowSizeInBytes int64 = 0
+            var maxOneSecondBitrate float64 = 0.0
+            {
+                var i = 0
+                var beginIndex = 0
+                while i < stsz.SampleCount {
+                    while float64(currentWindowSampleSpan) > timeScale {
+                        let bitrate = float64(windowSizeInBytes * int64(8)) * timeScale / float64(currentWindowSampleSpan)
+                        if bitrate > maxOneSecondBitrate {
+                            maxOneSecondBitrate = bitrate
+                        }
+                        windowSizeInBytes -= int64(stsz.GetSizeAtIndex(beginIndex))
+                        currentWindowSampleSpan -= int64(frameDeltas!![beginIndex])
+                        beginIndex++
+                    }
+                    windowSizeInBytes += int64(stsz.GetSizeAtIndex(i))
+                    currentWindowSampleSpan += int64(frameDeltas!![i])
+                    i++
+                }
+            }
+            return (uint32(Math.Round(maxOneSecondBitrate)), avgBitrate)
+        }
+
+        private func MakeBlankMoov(moov MoovBox) MoovBox {
+            var t1 SttsBox? = nil
+            var t2 StscBox? = nil
+            var t3 IStszBox? = nil
+            var t4 IChunkOffsets? = nil
+            if moov.TextTrack != nil {
+                t1 = moov.TextTrack!!.Mdia.Minf.Stbl.Stts
+                t2 = moov.TextTrack!!.Mdia.Minf.Stbl.Stsc
+                t3 = moov.TextTrack!!.Mdia.Minf.Stbl.Stsz
+                t4 = moov.TextTrack!!.Mdia.Minf.Stbl.COBox
+                moov.TextTrack!!.Mdia.Minf.Stbl.Children.Remove(t1!!)
+                moov.TextTrack!!.Mdia.Minf.Stbl.Children.Remove(t2!!)
+                if t3 != nil {
+                    moov.TextTrack!!.Mdia.Minf.Stbl.Children.Remove(t3!!)
+                }
+                moov.TextTrack!!.Mdia.Minf.Stbl.Children.Remove(t4!!)
+            }
+            let a1 = moov.AudioTrack.Mdia.Minf.Stbl.Stts
+            let a2 = moov.AudioTrack.Mdia.Minf.Stbl.Stsc
+            let a3 IStszBox? = moov.AudioTrack.Mdia.Minf.Stbl.Stsz
+            let a4 = moov.AudioTrack.Mdia.Minf.Stbl.COBox
+            moov.AudioTrack.Mdia.Minf.Stbl.Children.Remove(a1)
+            moov.AudioTrack.Mdia.Minf.Stbl.Children.Remove(a2)
+            if a3 != nil {
+                moov.AudioTrack.Mdia.Minf.Stbl.Children.Remove(a3!!)
+            }
+            moov.AudioTrack.Mdia.Minf.Stbl.Children.Remove(a4)
+            let mvex MvexBox? = moov.GetChild[MvexBox]()
+            if mvex != nil {
+                moov.Children.Remove(mvex!!)
+            }
+            let ms = MemoryStream()
+            moov.Save(ms)
+            if mvex != nil {
+                moov.Children.Add(mvex!!)
+            }
+            moov.AudioTrack.Mdia.Minf.Stbl.Children.Add(a1)
+            moov.AudioTrack.Mdia.Minf.Stbl.Children.Add(a2)
+            if a3 != nil {
+                moov.AudioTrack.Mdia.Minf.Stbl.Children.Add(a3!!)
+            }
+            moov.AudioTrack.Mdia.Minf.Stbl.Children.Add(a4)
+            if moov.TextTrack != nil {
+                if t1 != nil {
+                    moov.TextTrack!!.Mdia.Minf.Stbl.Children.Add(t1!!)
+                }
+                if t2 != nil {
+                    moov.TextTrack!!.Mdia.Minf.Stbl.Children.Add(t2!!)
+                }
+                if t3 != nil {
+                    moov.TextTrack!!.Mdia.Minf.Stbl.Children.Add(t3!!)
+                }
+                if t4 != nil {
+                    moov.TextTrack!!.Mdia.Minf.Stbl.Children.Add(t4!!)
+                }
+            }
+            ms.Position = 0
+            let newMoov = BoxFactory.CreateBox[MoovBox](ms, nil)
+            SttsBox.CreateBlank(newMoov.AudioTrack.Mdia.Minf.Stbl)
+            StscBox.CreateBlank(newMoov.AudioTrack.Mdia.Minf.Stbl)
+            newMoov.AudioTrack.Mdia.Mdhd.ModificationTime = DateTimeOffset.UtcNow
+            newMoov.AudioTrack.Mdia.Mdhd.CreationTime = newMoov.AudioTrack.Mdia.Mdhd.ModificationTime
+            if newMoov.TextTrack != nil {
+                SttsBox.CreateBlank(newMoov.TextTrack!!.Mdia.Minf.Stbl)
+                StscBox.CreateBlank(newMoov.TextTrack!!.Mdia.Minf.Stbl)
+                newMoov.TextTrack!!.Mdia.Mdhd.ModificationTime = newMoov.AudioTrack.Mdia.Mdhd.CreationTime
+                newMoov.TextTrack!!.Mdia.Mdhd.CreationTime = newMoov.TextTrack!!.Mdia.Mdhd.ModificationTime
+            }
+            return newMoov
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Mpeg4File.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Mpeg4File.gs
@@ -1,0 +1,229 @@
+package Oahu.Decrypt.Mpeg4
+
+import System
+import System.Collections.Generic
+import System.IO
+import System.Linq
+import System.Threading
+import System.Threading.Tasks
+import Oahu.Decrypt.Mpeg4.Boxes
+import Oahu.Decrypt.Mpeg4.Chunks
+import Oahu.Decrypt.Mpeg4.Util
+
+open class Mpeg4File : IDisposable {
+    private let lazyMetadataItems Lazy[MetadataItems]
+    private var disposed int32
+    private var timescale int32? = nil
+    private var audioChannels int32? = nil
+    private var averageBitrate int32? = nil
+
+    convenience init(file Stream) {
+        init(file, file.Length)
+    }
+
+    convenience init(fileName string, access FileAccess = 1, share FileShare = 1) {
+        init(File.Open(fileName, FileMode.Open, access, share))
+    }
+
+    init(file Stream, fileSize int64) {
+        InputStream = if file.CanSeek { file } else { TrackedReadStream(file, fileSize) }
+        TopLevelBoxes = Mpeg4Util.LoadTopLevelBoxes(InputStream)
+        Ftyp = TopLevelBoxes.OfType[FtypBox]().Single()
+        Moov = TopLevelBoxes.OfType[MoovBox]().Single()
+        Mdat = TopLevelBoxes.OfType[MdatBox]().Single()
+        lazyMetadataItems = Lazy[MetadataItems](() -> MetadataItems(Moov.ILst ?? Moov.CreateEmptyMetadata()))
+        AudioSampleEntry = Moov.AudioTrack.Mdia.Minf.Stbl.Stsd.AudioSampleEntry ?? throw InvalidOperationException("The audio track's AudioSampleEntry is null")
+    }
+
+    deinit {
+        Dispose(false)
+    }
+
+    prop Chapters ChapterInfo?
+
+    prop InputStream Stream {
+        get;
+        init;
+    }
+
+    prop Ftyp FtypBox
+
+    prop Moov MoovBox {
+        get;
+        init;
+    }
+
+    prop Mdat MdatBox {
+        get;
+        init;
+    }
+
+    prop MetadataItems MetadataItems -> lazyMetadataItems.Value
+    open prop Duration TimeSpan -> TimeSpan.FromSeconds(float64(Moov.AudioTrack.Mdia.Mdhd.Duration) / float64(TimeScale))
+    prop MaxBitrate int32 -> int32((AudioSampleEntry.Esds?.ES_Descriptor.DecoderConfig.MaxBitrate ?? uint32(0)))
+
+    prop AudioSampleEntry AudioSampleEntry {
+        get;
+        init;
+    }
+
+    prop TopLevelBoxes List[IBox] {
+        get;
+        init;
+    }
+
+    prop TimeScale int32 -> AudioSampleEntry.Esds?.ES_Descriptor.DecoderConfig.AudioSpecificConfig.SamplingFrequency ?? AudioSampleEntry.Dec3?.SampleRate ?? AudioSampleEntry.Dac4?.SampleRate ?? int32(Moov.AudioTrack.Mdia.Mdhd.Timescale)
+    prop AudioChannels int32 -> AudioSampleEntry.Esds?.ES_Descriptor.DecoderConfig.AudioSpecificConfig.ChannelConfiguration ?? AudioSampleEntry.Dec3?.NumberOfChannels ?? AudioSampleEntry.Dac4?.NumberOfChannels ?? int32(AudioSampleEntry.ChannelCount)
+    prop AverageBitrate int32 -> int32((AudioSampleEntry.Esds?.ES_Descriptor.DecoderConfig.AverageBitrate ?? AudioSampleEntry.Dec3?.AverageBitrate ?? AudioSampleEntry?.Dac4?.AverageBitrate ?? CalculateBitrate()))
+    protected prop Disposed bool -> disposed != 0
+
+    async func SaveAsync(keepMoovInFront bool = true, progressTracker ProgressTracker? = nil, cancellationToken CancellationToken = default(CancellationToken)) {
+        if !InputStream.CanRead || !InputStream.CanWrite || !InputStream.CanSeek {
+            throw InvalidOperationException("${nameof(InputStream)} must be readable, writable and seekable to save")
+        }
+        for box in Moov.GetFreeBoxes() {
+            box!!.Parent?.Children.Remove(box!!)
+        }
+        this.InputStream.Position = 0
+        let moovInFront = Moov.Header.FilePosition < Mdat.Header.FilePosition
+        if moovInFront {
+            var totalSizeChange = Ftyp.RenderSize + Moov.RenderSize - Mdat.Header.FilePosition
+            if totalSizeChange == int64(0) {
+                Ftyp.Save(InputStream)
+                Moov.Save(InputStream)
+            } else if int64(FreeBox.MinSize) + totalSizeChange <= int64(0) {
+                Ftyp.Save(InputStream)
+                Moov.Save(InputStream)
+                FreeBox.Create(-totalSizeChange, nil).Save(InputStream)
+            } else {
+                if keepMoovInFront {
+                    totalSizeChange = Moov.ShiftChunkOffsetsWithMoovInFront(totalSizeChange)
+                    await Mdat.ShiftMdatAsync(InputStream, totalSizeChange, progressTracker, cancellationToken)
+                    this.InputStream.Position = 0
+                    Ftyp.Save(InputStream)
+                    Moov.Save(InputStream)
+                    InputStream.SetLength(Mdat.Header.FilePosition + Mdat.Header.TotalBoxSize)
+                } else {
+                    let freeBoxSize = Mdat.Header.FilePosition - Ftyp.RenderSize
+                    if freeBoxSize < int64(8) {
+                        throw InvalidOperationException("Not enough space to write ftyp box before mdat box")
+                    }
+                    Ftyp.Save(InputStream)
+                    FreeBox.Create(freeBoxSize, nil).Save(InputStream)
+                    this.InputStream.Position = Mdat.Header.FilePosition + Mdat.Header.TotalBoxSize
+                    Moov.Save(InputStream)
+                }
+            }
+        } else {
+            var rewriteMoovAtEnd = true
+            let ftypSizeChange = Ftyp.RenderSize - Ftyp.Header.TotalBoxSize
+            if ftypSizeChange == int64(0) {
+                Ftyp.Save(InputStream)
+            } else if int64(FreeBox.MinSize) + ftypSizeChange <= int64(0) {
+                Ftyp.Save(InputStream)
+                FreeBox.Create(-ftypSizeChange, nil).Save(InputStream)
+            } else {
+                if keepMoovInFront {
+                    var shiftVector = ftypSizeChange + Moov.RenderSize
+                    shiftVector = Moov.ShiftChunkOffsetsWithMoovInFront(shiftVector)
+                    await Mdat.ShiftMdatAsync(InputStream, shiftVector, progressTracker, cancellationToken)
+                    this.InputStream.Position = 0
+                    Ftyp.Save(InputStream)
+                    Moov.Save(InputStream)
+                    InputStream.SetLength(Mdat.Header.FilePosition + Mdat.Header.TotalBoxSize)
+                    rewriteMoovAtEnd = false
+                } else {
+                    Moov.ShiftChunkOffsets(ftypSizeChange)
+                    await Mdat.ShiftMdatAsync(InputStream, ftypSizeChange, progressTracker, cancellationToken)
+                    this.InputStream.Position = 0
+                    Ftyp.Save(InputStream)
+                }
+            }
+            if rewriteMoovAtEnd {
+                this.InputStream.Position = Mdat.Header.FilePosition + Mdat.Header.TotalBoxSize
+                Moov.Save(InputStream)
+                InputStream.SetLength(InputStream.Position)
+            }
+        }
+        await InputStream.FlushAsync(cancellationToken)
+    }
+
+    func GetChaptersFromMetadata() ChapterInfo? {
+        let textTrak TrakBox? = Moov.TextTrack
+        let chapterNames List[string]? = textTrak?.GetChild[UdtaBox]()?.GetChild[MetaBox]()?.GetChild[AppleListBox]()?.Children?.OfType[AppleTagBox]()?.Where((b AppleTagBox) -> b.Header.Type == "©nam")?.Select((b AppleTagBox) -> b.Data.ReadAsString())?.ToList()
+        if chapterNames == nil {
+            return nil
+        }
+        let sampleTimes = textTrak!!.Mdia.Minf.Stbl.Stts.Samples
+        if sampleTimes.Count != chapterNames!!.Count {
+            return nil
+        }
+        let cEntryList = ChunkEntryList(textTrak!!).OrderBy((s ChunkEntry) -> s.ChunkOffset).ToList()
+        if cEntryList!!.Count != chapterNames!!.Count {
+            return nil
+        }
+        let chapterInfo = ChapterInfo()
+        var subtractNext = 0
+        for var i = 0; i < chapterNames!!.Count; i++ {
+            let sif = int32(sampleTimes[i].FrameDelta)
+            let duration = TimeSpan.FromSeconds(Math.Max(0d, sif + subtractNext) / float64(TimeScale))
+            chapterInfo.AddChapter(chapterNames!![int32(cEntryList!![i].ChunkIndex)], duration)
+            subtractNext = if sif < 0 { sif } else { 0 }
+        }
+        Chapters ??= chapterInfo
+        return chapterInfo
+    }
+
+    func Dispose() {
+        Dispose(true)
+        GC.SuppressFinalize(this)
+    }
+
+    protected open func CalculateBitrate() uint32 {
+        let totalSize = Moov.AudioTrack.Mdia.Minf.Stbl.Stsz?.TotalSize
+        return if !totalSize.HasValue || totalSize.Value == int64(0) { uint32(0) } else { uint32(Math.Round(float64(totalSize.Value * int64(8)) / Duration.TotalSeconds, 0)) }
+    }
+
+    protected open func Dispose(disposing bool) {
+        if disposing && Interlocked.CompareExchange(&disposed, 1, 0) == 0 {
+            InputStream.Dispose()
+            for box in TopLevelBoxes {
+                box!!.Dispose()
+            }
+        }
+    }
+
+    shared {
+        async func RelocateMoovToBeginningAsync(mp4FilePath string, progressTracker ProgressTracker? = nil, cancellationToken CancellationToken = default(CancellationToken)) {
+            var boxes List[IBox]
+            {
+                using let fileStream = File.OpenRead(mp4FilePath)
+                boxes = Mpeg4Util.LoadTopLevelBoxes(fileStream)
+            }
+            try {
+                let ftypeSize = boxes.OfType[FtypBox]().Single().RenderSize
+                let moov = boxes.OfType[MoovBox]().Single()
+                if progressTracker != nil {
+                    progressTracker!!.TotalDuration = TimeSpan.FromSeconds(float64(moov.Mvhd.Duration) / float64(moov.Mvhd.Timescale))
+                    if moov.Header.FilePosition == ftypeSize {
+                        progressTracker!!.TotalSize = 1
+                        progressTracker!!.MovedBytes = progressTracker!!.TotalSize
+                        return
+                    }
+                }
+                let mdat = boxes.OfType[MdatBox]().Single()
+                let toShift = ftypeSize + moov.RenderSize - mdat!!.Header.FilePosition
+                let shifted = moov.ShiftChunkOffsetsWithMoovInFront(toShift)
+                using let mpegFile = FileStream(mp4FilePath, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite)
+                await mdat!!.ShiftMdatAsync(mpegFile, shifted, progressTracker, cancellationToken)
+                mpegFile.Position = ftypeSize
+                moov.Save(mpegFile)
+                mpegFile.SetLength(mpegFile.Position + mdat!!.Header.TotalBoxSize)
+            } finally {
+                for box in boxes {
+                    box.Dispose()
+                }
+            }
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Mpeg4Util.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Mpeg4Util.gs
@@ -1,0 +1,95 @@
+package Oahu.Decrypt.Mpeg4.Util
+
+import System
+import System.Collections.Generic
+import System.IO
+import System.Linq
+import System.Threading
+import System.Threading.Tasks
+import Oahu.Decrypt.Mpeg4.Boxes
+
+class Mpeg4Util {
+    shared {
+        func LoadTopLevelBoxes(file Stream) List[IBox] {
+            let boxes = List[IBox]()
+            while file.Position < file.Length && (!boxes.OfType[FtypBox]().Any() || !boxes.OfType[MoovBox]().Any() || !boxes.OfType[MdatBox]().Any()) {
+                let box = BoxFactory.CreateBox(file, nil)
+                boxes.Add(box!!)
+                if box is MdatBox && !boxes.OfType[MoovBox]().Any() {
+                    file.Position = box!!.Header.FilePosition + box!!.Header.TotalBoxSize
+                }
+            }
+            return boxes
+        }
+
+        async func ShiftDataBlock(file Stream, start int64, length int64, shiftVector int64, progressTracker ProgressTracker? = nil, cancellationToken CancellationToken = default(CancellationToken)) {
+            var length = length
+            const MoveBufferSize = 8 * 1024 * 1024
+            if start + shiftVector < int64(0) {
+                throw ArgumentOutOfRangeException(nameof(shiftVector), "Data cannot be shifted to a negative file position.")
+            }
+            if !file.CanRead || !file.CanWrite || !file.CanSeek {
+                throw ArgumentException("Stream must support reading, writing, and seeking.", nameof(file))
+            }
+            if start > file.Length {
+                throw ArgumentOutOfRangeException(nameof(start), "Start index exceeds the file length.")
+            }
+            if start + length > file.Length {
+                throw ArgumentOutOfRangeException(nameof(length), "End of data block is beyond the end of the file.")
+            }
+            let backToFront = shiftVector > int64(0)
+            file.Position = if backToFront { start + length } else { start }
+            if progressTracker != nil {
+                progressTracker!!.TotalSize = length
+                progressTracker!!.MovedBytes = 0
+            }
+            let buffer Memory[uint8] = [MoveBufferSize]uint8
+            var read int32
+            do {
+                let toRead = int32(Math.Min(MoveBufferSize, length))
+                if backToFront {
+                    file.Position -= int64(toRead)
+                }
+                read = await file.ReadAsync(buffer.Slice(0, toRead), cancellationToken)
+                file.Position += shiftVector - int64(read)
+                await file.WriteAsync(buffer.Slice(0, read), cancellationToken)
+                file.Position -= if backToFront { shiftVector + int64(read) } else { shiftVector }
+                if progressTracker != nil {
+                    progressTracker!!.MovedBytes += int64(read)
+                }
+                cancellationToken.ThrowIfCancellationRequested()
+                length -= int64(read)
+            } while length > int64(0)
+            progressTracker?.ReportProgress(true)
+        }
+    }
+}
+
+class ProgressTracker {
+    private let startTime DateTime = DateTime.UtcNow
+    private var nextUpdate DateTime = default
+    private var movedBytes int64
+    event ProgressUpdated (object?, EventArgs) -> void
+
+    prop MovedBytes int64 {
+        get -> movedBytes
+        set {
+            movedBytes = value
+            ReportProgress()
+        }
+    }
+
+    prop TotalDuration TimeSpan
+    prop TotalSize int64
+    prop Speed float64
+    prop Position TimeSpan
+
+    func ReportProgress(forceReport bool = false) {
+        if DateTime.UtcNow > nextUpdate || forceReport {
+            Position = TimeSpan.FromSeconds(TotalDuration.TotalSeconds / float64(TotalSize) * float64(MovedBytes))
+            Speed = Position / (DateTime.UtcNow - startTime)
+            ProgressUpdated?(this, EventArgs.Empty)
+            nextUpdate = DateTime.UtcNow.AddMilliseconds(200.0)
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/MultipartFilterBase.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/MultipartFilterBase.gs
@@ -1,0 +1,75 @@
+package Oahu.Decrypt.FrameFilters.Audio
+
+import System
+import System.Collections.Generic
+import System.Threading.Tasks
+import Oahu.Decrypt.Mpeg4
+
+open class MultipartFilterBase[TInput FrameEntry, TCallback INewSplitCallback[TCallback]] : FrameFinalBase[TInput] {
+    protected let InputStereo bool
+    protected let InputSampleRate SampleRate
+    private let splitChapters IEnumerator[Chapter]
+    private var startSample int64
+    private var endSample int64 = -1
+    private var lastChunkIndex int64 = -1
+    private var currentSample int64
+
+    init(splitChapters ChapterInfo?, inputSampleRate SampleRate, inputStereo bool) {
+        if splitChapters == nil || splitChapters!!.Count == 0 {
+            throw ArgumentException("${nameof(splitChapters)} must contain at least one chapter.")
+        }
+        InputSampleRate = inputSampleRate
+        InputStereo = inputStereo
+        currentSample = TimeToSample(splitChapters!!.StartOffset)
+        startSample = currentSample
+        this.splitChapters = splitChapters!!.GetEnumerator()
+    }
+
+    protected open func CloseCurrentWriter();
+    protected open func WriteFrameToFile(audioFrame TInput, newChunk bool);
+    protected open func CreateNewWriter(callback TCallback);
+
+    protected override func FlushAsync() Task {
+        CloseCurrentWriter()
+        return Task.CompletedTask
+    }
+
+    protected open override func PerformFilteringAsync(input TInput) Task {
+        if input.Chunk == nil {
+            WriteFrameToFile(input, false)
+        } else if currentSample > endSample {
+            CloseCurrentWriter()
+            if GetNextChapter() {
+                CreateNewWriter(TCallback.Create(splitChapters.Current))
+                WriteFrameToFile(input, true)
+                lastChunkIndex = input.Chunk!!.ChunkIndex
+            }
+        } else if currentSample >= startSample {
+            let newChunk = int64(input.Chunk!!.ChunkIndex) > lastChunkIndex
+            if newChunk {
+                lastChunkIndex = input.Chunk!!.ChunkIndex
+            }
+            WriteFrameToFile(input, newChunk)
+        }
+        currentSample += int64(input.SamplesInFrame)
+        return Task.CompletedTask
+    }
+
+    protected open override func Dispose(disposing bool) {
+        if disposing && !Disposed {
+            splitChapters?.Dispose()
+        }
+        base.Dispose(disposing)
+    }
+
+    private func GetNextChapter() bool {
+        if !splitChapters.MoveNext() {
+            return false
+        }
+        startSample = TimeToSample(splitChapters.Current.StartOffset)
+        endSample = TimeToSample(splitChapters.Current.EndOffset)
+        return true
+    }
+
+    private func TimeToSample(time TimeSpan) int64 -> int64(Math.Round(time.TotalSeconds * float64(int32(InputSampleRate))))
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/MvexBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/MvexBox.gs
@@ -1,0 +1,13 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+
+open class MvexBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        LoadChildren(file)
+    }
+
+    protected open override func Render(file Stream) {
+        return
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/MvhdBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/MvhdBox.gs
@@ -1,0 +1,70 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class MvhdBox : HeaderBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        Rate = file.ReadInt32BE()
+        Volume = file.ReadInt16BE()
+        Reserved = file.ReadUInt16BE()
+        Reserved2 = file.ReadUInt64BE()
+        Matrix = file.ReadBlock(4 * 9)
+        Pre_defined = file.ReadBlock(4 * 6)
+        NextTrackID = file.ReadUInt32BE()
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(4) + int64(4) + int64(2) + int64(2) + int64(8) + int64(Matrix.Length) + int64(Pre_defined.Length) + int64(4)
+    prop Timescale uint32
+
+    prop Rate int32 {
+        get;
+        init;
+    }
+
+    prop Volume int16 {
+        get;
+        init;
+    }
+
+    prop Reserved uint16 {
+        get;
+        init;
+    }
+
+    prop Reserved2 uint64 {
+        get;
+        init;
+    }
+
+    prop Matrix []uint8 {
+        get;
+        init;
+    }
+
+    prop Pre_defined []uint8 {
+        get;
+        init;
+    }
+
+    prop NextTrackID uint32
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.WriteInt32BE(Rate)
+        file.WriteInt16BE(Volume)
+        file.WriteUInt16BE(Reserved)
+        file.WriteUInt64BE(Reserved2)
+        file.Write(Matrix)
+        file.Write(Pre_defined)
+        file.WriteUInt32BE(NextTrackID)
+    }
+
+    protected open override func ReadBeforeDuration(file Stream) {
+        Timescale = file.ReadUInt32BE()
+    }
+
+    protected open override func WriteBeforeDuration(file Stream) {
+        file.WriteUInt32BE(Timescale)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/NameBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/NameBox.gs
@@ -1,0 +1,40 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.Diagnostics
+import System.IO
+import System.Text
+import Oahu.Decrypt.Mpeg4.Util
+
+@DebuggerDisplay("{DebuggerDisplay,nq}")
+open class NameBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        let stringSize = RemainingBoxLength(file)
+        let stringData = file.ReadBlock(int32(stringSize))
+        Name = Encoding.UTF8.GetString(stringData!!)
+    }
+
+    private init(header BoxHeader, parent IBox?, name string) : base([4]uint8, header, parent) {
+        Name = name
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(Encoding.UTF8.GetByteCount(Name))
+    prop Name string
+
+    @DebuggerHidden
+    private prop DebuggerDisplay string -> "name: $Name"
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.Write(Encoding.UTF8.GetBytes(Name))
+    }
+
+    shared {
+        func Create(parent IBox?, name string) NameBox {
+            let size = Encoding.UTF8.GetByteCount(name) + 12
+            let header = BoxHeader(uint32(size), "name")
+            let nameBox = NameBox(header, parent, name)
+            parent?.Children.Add(nameBox)
+            return nameBox
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/NewSplitCallback.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/NewSplitCallback.gs
@@ -1,0 +1,43 @@
+package Oahu.Decrypt
+
+import System.IO
+import Oahu.Decrypt.Mpeg4
+
+interface INewSplitCallback {
+    prop Chapter Chapter {
+        get;
+    }
+
+    prop TrackNumber int32?
+    prop TrackCount int32?
+    prop TrackTitle string?
+    prop OutputFile Stream?
+}
+
+interface INewSplitCallback[T INewSplitCallback[T]] : INewSplitCallback {
+    shared {
+        func Create(chapter Chapter) T;
+    }
+}
+
+class NewSplitCallback : INewSplitCallback[NewSplitCallback] {
+    private init(chapter Chapter) {
+        Chapter = chapter
+    }
+
+    prop Chapter Chapter {
+        get;
+        init;
+    }
+
+    prop TrackNumber int32?
+    prop TrackCount int32?
+    prop TrackTitle string?
+    prop OutputFile Stream?
+
+    shared {
+        func Create(chapter Chapter) NewSplitCallback {
+            return NewSplitCallback(chapter)
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/PsshBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/PsshBox.gs
@@ -1,0 +1,40 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class PsshBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        ProtectionSystemId = Guid(file.ReadBlock(16), true)
+        let initDataSize = file.ReadInt32BE()
+        InitData = file.ReadBlock(initDataSize)
+        let remaining = int32((header.TotalBoxSize - int64(header.HeaderSize) - int64(4) - int64(16) - int64(4) - int64(initDataSize)))
+        ExtraData = file.ReadBlock(remaining)
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(16) + int64(4) + int64(InitData.Length) + int64(ExtraData.Length)
+
+    prop ProtectionSystemId Guid {
+        get;
+        init;
+    }
+
+    prop InitData []uint8 {
+        get;
+        init;
+    }
+
+    prop ExtraData []uint8 {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.Write(ProtectionSystemId.ToByteArray(true))
+        file.WriteInt32BE(InitData.Length)
+        file.Write(InitData)
+        file.Write(ExtraData)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/SLConfigDescriptor.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/SLConfigDescriptor.gs
@@ -1,0 +1,30 @@
+package Oahu.Decrypt.Mpeg4.Descriptors
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+internal class SLConfigDescriptor : BaseDescriptor {
+    private let blob []uint8
+
+    init(file Stream, header DescriptorHeader) : base(file, header) {
+        Predefined = file.ReadByte()
+        blob = file.ReadBlock(Header.TotalBoxSize - Header.HeaderSize - 1)
+    }
+
+    private init(predefined uint8, blob []uint8) : base(6) {
+        Predefined = predefined
+        this.blob = blob
+    }
+
+    prop Predefined int32
+    override prop InternalSize int32 -> base.InternalSize + 1 + blob.Length
+
+    override func Render(file Stream) {
+        file.WriteByte(uint8(Predefined))
+        file.Write(blob)
+    }
+
+    shared {
+        func CreateMp4() SLConfigDescriptor -> SLConfigDescriptor(2, []uint8{})
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/SaioBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/SaioBox.gs
@@ -1,0 +1,77 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+interface ISaioBox : IBox {
+    prop AuxInfoType uint32 {
+        get;
+    }
+
+    prop AuxInfoTypeParameter uint32 {
+        get;
+    }
+
+    prop EntryCount int32 {
+        get;
+    }
+}
+
+open class SaioBox : FullBox, ISaioBox {
+    private let offsets32 []?uint32
+    private let offsets64 []?int64
+
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        if (Flags & 1) == 1 {
+            AuxInfoType = file.ReadUInt32BE()
+            AuxInfoTypeParameter = file.ReadUInt32BE()
+        }
+        EntryCount = file.ReadInt32BE()
+        if Version == uint8(0) {
+            offsets32 = [EntryCount]uint32
+            for var i = 0; i < EntryCount; i++ {
+                offsets32!![i] = file.ReadUInt32BE()
+            }
+        } else {
+            offsets64 = [EntryCount]int64
+            for var i = 0; i < EntryCount; i++ {
+                offsets64!![i] = file.ReadInt64BE()
+            }
+        }
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64((if (Flags & 1) == 1 { 8 } else { 0 })) + int64(4) + int64((if Version == uint8(0) { (offsets32?.Length ?? 0) * 4 } else { (offsets64?.Length ?? 0) * 8 }))
+
+    prop AuxInfoType uint32 {
+        get;
+        init;
+    }
+
+    prop AuxInfoTypeParameter uint32 {
+        get;
+        init;
+    }
+
+    prop EntryCount int32 {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        if (Flags & 1) == 1 {
+            file.WriteUInt32BE(AuxInfoType)
+            file.WriteUInt32BE(AuxInfoTypeParameter)
+        }
+        file.WriteInt32BE(EntryCount)
+        if offsets32 != nil {
+            for offset in offsets32!! {
+                file.WriteUInt32BE(offset)
+            }
+        } else if offsets64 != nil {
+            for offset in offsets64!! {
+                file.WriteInt64BE(offset)
+            }
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/SaizBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/SaizBox.gs
@@ -1,0 +1,52 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class SaizBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        if (Flags & 1) == 1 {
+            AuxInfoType = file.ReadUInt32BE()
+            AuxInfoTypeParameter = file.ReadUInt32BE()
+        }
+        DefaultInfoSampleSize = uint8(file.ReadByte())
+        let sampleCount = file.ReadInt32BE()
+        SampleInfoSizes = if DefaultInfoSampleSize == uint8(0) { file.ReadBlock(sampleCount) } else { Array.Empty[uint8]() }
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64((if (Flags & 1) == 1 { 8 } else { 0 })) + int64(5) + int64((if DefaultInfoSampleSize == uint8(0) { SampleInfoSizes.Length } else { 0 }))
+
+    prop AuxInfoType uint32 {
+        get;
+        init;
+    }
+
+    prop AuxInfoTypeParameter uint32 {
+        get;
+        init;
+    }
+
+    prop DefaultInfoSampleSize uint8 {
+        get;
+        init;
+    }
+
+    prop SampleInfoSizes []uint8 {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        if (Flags & 1) == 1 {
+            file.WriteUInt32BE(AuxInfoType)
+            file.WriteUInt32BE(AuxInfoTypeParameter)
+        }
+        file.WriteByte(DefaultInfoSampleSize)
+        file.WriteInt32BE(SampleInfoSizes.Length)
+        if DefaultInfoSampleSize == uint8(0) {
+            file.Write(SampleInfoSizes)
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/SampleEntry.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/SampleEntry.gs
@@ -1,0 +1,41 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.Diagnostics
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+@DebuggerDisplay("{DebuggerDisplay,nq}")
+open class SampleEntry : Box {
+    private let reserved []uint8
+
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        reserved = file.ReadBlock(6)
+        DataReferenceIndex = file.ReadUInt16BE()
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(8)
+
+    prop DataReferenceIndex uint16 {
+        get;
+        init;
+    }
+
+    @DebuggerHidden
+    private prop DebuggerDisplay string -> "[${Header.Type}] - " + switch Header.Type {
+        case "text": "Text SampleEntry"
+        case "mp4s": "MpegSampleEntry"
+        case "mp4v": "MP4VisualSampleEntry"
+        case "mp4a": "MP4AudioSampleEntry"
+        case "aavd": "Audible AAX(C) Protected AudioSampleEntry"
+        case "encv": "Protected VisualSampleEntry"
+        case "enca": "Protected AudioSampleEntry"
+        case "ec-3": "EC3SampleEntry"
+        case "ac-4": "AC4SampleEntry"
+        default: "[UNKNOWN]"
+    }
+
+    protected open override func Render(file Stream) {
+        file.Write(reserved)
+        file.WriteUInt16BE(DataReferenceIndex)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/SchiBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/SchiBox.gs
@@ -1,0 +1,15 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+
+open class SchiBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        LoadChildren(file)
+    }
+
+    prop TrackEncryption TencBox? -> GetChild[TencBox]()
+
+    protected open override func Render(file Stream) {
+        return
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/SchmBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/SchmBox.gs
@@ -1,0 +1,57 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.Collections.Generic
+import System.IO
+import System.Text
+import Oahu.Decrypt.Mpeg4.Util
+
+open class SchmBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        let endPos = Header.FilePosition + Header.TotalBoxSize
+        Type = SchemeType(file.ReadUInt32BE())
+        SchemeVersion = file.ReadUInt32BE()
+        if (Flags & 1) == 1 {
+            let blist = List[uint8]()
+            while file.Position < endPos {
+                let lastByte = uint8(file.ReadByte())
+                if lastByte == uint8(0) {
+                    HasNullTerminator = true
+                    break
+                }
+                blist.Add(lastByte)
+            }
+            SchemeUri = Encoding.UTF8.GetString(blist.ToArray())
+        }
+    }
+
+    enum SchemeType { Unknown, Cenc, Cbc1, Cens, Cbcs }
+    open override prop RenderSize int64 -> base.RenderSize + int64(8) + int64((if (Flags & 1) == 1 && SchemeUri is string { Encoding.UTF8.GetByteCount((SchemeUri as string)!!) + (if HasNullTerminator { 1 } else { 0 }) } else { 0 }))
+    prop HasNullTerminator bool
+
+    prop Type SchemeType {
+        get;
+        init;
+    }
+
+    prop SchemeVersion uint32 {
+        get;
+        init;
+    }
+
+    prop SchemeUri string? {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.WriteUInt32BE(uint32(Type))
+        file.WriteUInt32BE(SchemeVersion)
+        if (Flags & 1) == 1 && SchemeUri is string {
+            file.Write(Encoding.UTF8.GetBytes((SchemeUri as string)!!))
+            if HasNullTerminator {
+                file.WriteByte(0)
+            }
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/SencBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/SencBox.gs
@@ -1,0 +1,36 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.IO
+import System.Linq
+import Oahu.Decrypt.Mpeg4.Util
+
+open class SencBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        let sampleCount = file.ReadInt32BE()
+        if UseSubSampleEncryption {
+            throw NotSupportedException(nameof(UseSubSampleEncryption))
+        }
+        let ivSize = int32(((header.TotalBoxSize - int64(16)) / int64(sampleCount)))
+        IVs = [sampleCount][]uint8
+        for var i = 0; i < sampleCount; i++ {
+            IVs[i] = file.ReadBlock(ivSize)
+        }
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(4) + int64(IVs.Sum((iv []uint8) -> iv.Length))
+    prop UseSubSampleEncryption bool -> (Flags & 2) == 2
+
+    prop IVs [][]uint8 {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.WriteInt32BE(IVs.Length)
+        for iv in IVs {
+            file.Write(iv!!)
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/SidxBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/SidxBox.gs
@@ -1,0 +1,129 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class SidxBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        ReferenceId = file.ReadUInt32BE()
+        Timescale = file.ReadInt32BE()
+        if Version == uint8(0) {
+            EarliestPresentationTime = file.ReadUInt32BE()
+            FirstOffset = file.ReadUInt32BE()
+        } else {
+            EarliestPresentationTime = file.ReadInt64BE()
+            FirstOffset = file.ReadInt64BE()
+        }
+        file.ReadInt16BE()
+        let referenceCount int32 = file.ReadUInt16BE()
+        Segments = [referenceCount]Segment
+        for var i = 0; i < Segments.Length; i++ {
+            Segments[i] = Segment(file)
+        }
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(8) + int64((if Version == uint8(0) { 8 } else { 16 })) + int64(4) + int64(Segments.Length * 12)
+
+    prop ReferenceId uint32 {
+        get;
+        init;
+    }
+
+    prop Timescale int32 {
+        get;
+        init;
+    }
+
+    prop EarliestPresentationTime int64 {
+        get;
+        init;
+    }
+
+    prop FirstOffset int64 {
+        get;
+        init;
+    }
+
+    prop Segments []Segment {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.WriteUInt32BE(ReferenceId)
+        file.WriteInt32BE(Timescale)
+        if Version == uint8(0) {
+            file.WriteUInt32BE(uint32(EarliestPresentationTime))
+            file.WriteUInt32BE(uint32(FirstOffset))
+        } else {
+            file.WriteInt64BE(EarliestPresentationTime)
+            file.WriteInt64BE(FirstOffset)
+        }
+        file.WriteInt16BE(0)
+        file.WriteInt16BE(int16(Segments.Length))
+        for segment in Segments {
+            segment!!.Save(file)
+        }
+    }
+
+    class Segment {
+        private var typeAndSize uint32
+        private var subsegmentDuration uint32
+        private var sap uint32
+
+        internal init(file Stream) {
+            typeAndSize = file.ReadUInt32BE()
+            subsegmentDuration = file.ReadUInt32BE()
+            sap = file.ReadUInt32BE()
+        }
+
+        prop ReferenceType bool {
+            get -> (typeAndSize & 0x80000000U) == 0x80000000U
+            set -> typeAndSize = if value { typeAndSize | 0x80000000U } else { typeAndSize & uint32(0x7FFFFFFF) }
+        }
+
+        prop ReferenceSize int32 {
+            get -> int32((typeAndSize & uint32(0x7FFFFFFF)))
+            set {
+                ArgumentOutOfRangeException.ThrowIfLessThan(value, 0, nameof(ReferenceSize))
+                typeAndSize = (typeAndSize & 0x80000000U) | uint32(value)
+            }
+        }
+
+        prop SubsegmentDuration uint32 {
+            get -> subsegmentDuration
+            set -> subsegmentDuration = value
+        }
+
+        prop StartsWithSAP bool {
+            get -> (sap & 0x80000000U) == 0x80000000U
+            set -> sap = if value { sap | 0x80000000U } else { sap & uint32(0x7FFFFFFF) }
+        }
+
+        prop SapType int32 {
+            get -> int32((sap >> 28)) & 7
+            set {
+                ArgumentOutOfRangeException.ThrowIfLessThan(value, 0, nameof(SapType))
+                ArgumentOutOfRangeException.ThrowIfGreaterThan(value, 7, nameof(SapType))
+                sap = (sap & 0x8FFFFFFFU) | uint32((value << 28))
+            }
+        }
+
+        prop SapDeltaTime int32 {
+            get -> int32(sap) & 0xFFFFFFF
+            set {
+                ArgumentOutOfRangeException.ThrowIfLessThan(value, 0, nameof(SapType))
+                ArgumentOutOfRangeException.ThrowIfGreaterThan(value, 0xFFFFFFF, nameof(SapType))
+                sap = (sap & 0xF0000000U) | uint32(value)
+            }
+        }
+
+        func Save(file Stream) {
+            file.WriteUInt32BE(typeAndSize)
+            file.WriteUInt32BE(subsegmentDuration)
+            file.WriteUInt32BE(sap)
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/SinfBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/SinfBox.gs
@@ -1,0 +1,18 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import System.Linq
+
+open class SinfBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        LoadChildren(file)
+    }
+
+    prop OriginalFormat FrmaBox -> GetChildOrThrow[FrmaBox]()
+    prop SchemeType SchmBox? -> GetChildren[SchmBox]()?.SingleOrDefault()
+    prop SchemeInformation SchiBox? -> GetChildren[SchiBox]()?.SingleOrDefault()
+
+    protected open override func Render(file Stream) {
+        return
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/StblBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/StblBox.gs
@@ -1,0 +1,19 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+
+open class StblBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        LoadChildren(file)
+    }
+
+    prop Stsd StsdBox -> GetChildOrThrow[StsdBox]()
+    prop Stts SttsBox -> GetChildOrThrow[SttsBox]()
+    prop COBox IChunkOffsets -> GetChild[StcoBox]() ?? IChunkOffsets(GetChildOrThrow[Co64Box]())
+    prop Stsz IStszBox? -> GetChild[StszBox]() ?? (GetChild[Stz2Box]() as IStszBox)
+    prop Stsc StscBox -> GetChildOrThrow[StscBox]()
+
+    protected open override func Render(file Stream) {
+        return
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/StcoBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/StcoBox.gs
@@ -1,0 +1,51 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+internal open class StcoBox : FullBox, IChunkOffsets {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        let entryCount = file.ReadUInt32BE()
+        if entryCount > uint32(Int32.MaxValue) {
+            throw NotSupportedException("Oahu.Decrypt.Mpeg4 does not support MPEG-4 files with more than ${Int32.MaxValue} chunk offsets")
+        }
+        ChunkOffsets = ChunkOffsetList.Read32(file, entryCount)
+    }
+
+    private init(chunkOffsets ChunkOffsetList, versionFlags []uint8, header BoxHeader, parent IBox) : base(versionFlags, header, parent) {
+        ChunkOffsets = chunkOffsets
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(4) + int64(ChunkOffsets.Count * 4)
+    prop EntryCount uint32 -> uint32(ChunkOffsets.Count)
+
+    prop ChunkOffsets ChunkOffsetList {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.WriteUInt32BE(EntryCount)
+        ChunkOffsets.Write32(file)
+    }
+
+    protected open override func Dispose(disposing bool) {
+        if disposing & !Disposed {
+            ChunkOffsets.Clear()
+        }
+        base.Dispose(disposing)
+    }
+
+    shared {
+        internal func CreateBlank(parent IBox, chunkOffsets ChunkOffsetList) StcoBox {
+            let size = 4 + 12
+            let header = BoxHeader(uint32(size), "stco")
+            chunkOffsets.Sort()
+            let stcoBox = StcoBox(chunkOffsets, []uint8{uint8(0), uint8(0), uint8(0), uint8(0)}, header, parent)
+            parent.Children.Add(stcoBox)
+            return stcoBox
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/StreamExtensions.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/StreamExtensions.gs
@@ -1,0 +1,161 @@
+package Oahu.Decrypt.Mpeg4.Util
+
+import System
+import System.Buffers
+import System.Buffers.Binary
+import System.IO
+import System.Threading
+import System.Threading.Tasks
+import Oahu.Decrypt.Mpeg4.Boxes
+
+func (stream Stream) WriteHeader(header BoxHeader, renderSize int64) {
+    if header.Version == 1 || renderSize > int64(UInt32.MaxValue) {
+        stream.WriteUInt32BE(1)
+        stream.WriteType(header.Type)
+        stream.WriteInt64BE(renderSize)
+    } else {
+        stream.WriteUInt32BE(uint32(renderSize))
+        stream.WriteType(header.Type)
+    }
+}
+
+async func (inputStream Stream) SeekToOffsetAsync(chunkOffset int64, token CancellationToken) {
+    if inputStream.Position == chunkOffset {
+        return
+    } else if inputStream.CanSeek {
+        inputStream.Position = chunkOffset
+    } else if inputStream.Position < chunkOffset {
+        const bufferSize = 8 * 1024
+        var toRead = Int32.Min(bufferSize, int32((chunkOffset - inputStream.Position)))
+        using let memoryBuff = MemoryPool[uint8].Shared.Rent(toRead)
+        while toRead > 0 {
+            await inputStream.ReadExactlyAsync(memoryBuff!!.Memory.Slice(0, toRead), token)
+            toRead = Int32.Min(bufferSize, int32((chunkOffset - inputStream.Position)))
+        }
+    } else {
+        throw NotSupportedException("Input stream position 0x${inputStream.Position:X8} is past the chunk offset 0x${chunkOffset:X8} and is not seekable.")
+    }
+}
+
+func (inputStream Stream) SeekToOffset(chunkOffset int64) {
+    if inputStream.Position == chunkOffset {
+        return
+    } else if inputStream.CanSeek {
+        inputStream.Position = chunkOffset
+    } else if inputStream.Position < chunkOffset {
+        const bufferSize = 8 * 1024
+        var toRead = Int32.Min(bufferSize, int32((chunkOffset - inputStream.Position)))
+        using let memoryBuff = MemoryPool[uint8].Shared.Rent(toRead)
+        let spanBuff = memoryBuff!!.Memory.Span
+        while toRead > 0 {
+            inputStream.ReadExactly(spanBuff.Slice(0, toRead))
+            toRead = Int32.Min(bufferSize, int32((chunkOffset - inputStream.Position)))
+        }
+    } else {
+        throw NotSupportedException("Input stream position 0x${inputStream.Position:X8} is past the chunk offset 0x${chunkOffset:X8} and is not seekable.")
+    }
+}
+
+async func (inputStream Stream) ReadNextChunkAsync(chunkOffset int64, chunkBuffer Memory[uint8], token CancellationToken) {
+    await inputStream.SeekToOffsetAsync(chunkOffset, token)
+    if await inputStream.ReadAsync(chunkBuffer, token) != chunkBuffer.Length {
+        throw EndOfStreamException("Stream ended at position ${inputStream.Position} before all ${chunkBuffer.Length} bytes were read.")
+    }
+}
+
+func (stream Stream) WriteType(type_ string) {
+    if type_?.Length != 4 {
+        throw ArgumentException("Type must be 4 chars long.")
+    }
+    stream.Write([]uint8{uint8(type_[0]), uint8(type_[1]), uint8(type_[2]), uint8(type_[3])})
+}
+
+func (stream Stream) WriteInt16BE(value int16) {
+    let word = stackalloc [2]uint8
+    BinaryPrimitives.WriteInt16BigEndian(word, value)
+    stream.Write(word)
+}
+
+func (stream Stream) WriteUInt16BE(value uint16) {
+    let word = stackalloc [2]uint8
+    BinaryPrimitives.WriteUInt16BigEndian(word, value)
+    stream.Write(word)
+}
+
+func (stream Stream) WriteInt32BE(value int32) {
+    let dword = stackalloc [4]uint8
+    BinaryPrimitives.WriteInt32BigEndian(dword, value)
+    stream.Write(dword)
+}
+
+func (stream Stream) WriteUInt32BE(value uint32) {
+    let dword = stackalloc [4]uint8
+    BinaryPrimitives.WriteUInt32BigEndian(dword, value)
+    stream.Write(dword)
+}
+
+func (stream Stream) WriteInt64BE(value int64) {
+    let qword = stackalloc [8]uint8
+    BinaryPrimitives.WriteInt64BigEndian(qword, value)
+    stream.Write(qword)
+}
+
+func (stream Stream) WriteUInt64BE(value uint64) {
+    let qword = stackalloc [8]uint8
+    BinaryPrimitives.WriteUInt64BigEndian(qword, value)
+    stream.Write(qword)
+}
+
+func (stream Stream) ReadInt16BE() int16 {
+    let word = stackalloc [2]uint8
+    stream.ReadExactly(word)
+    return BinaryPrimitives.ReadInt16BigEndian(word)
+}
+
+func (stream Stream) ReadUInt16BE() uint16 {
+    let word = stackalloc [2]uint8
+    stream.ReadExactly(word)
+    return BinaryPrimitives.ReadUInt16BigEndian(word)
+}
+
+func (stream Stream) ReadInt32BE() int32 {
+    let dword = stackalloc [4]uint8
+    stream.ReadExactly(dword)
+    return BinaryPrimitives.ReadInt32BigEndian(dword)
+}
+
+func (stream Stream) ReadUInt32BE() uint32 {
+    let dword = stackalloc [4]uint8
+    stream.ReadExactly(dword)
+    return BinaryPrimitives.ReadUInt32BigEndian(dword)
+}
+
+func (stream Stream) ReadInt64BE() int64 {
+    let qword = stackalloc [8]uint8
+    stream.ReadExactly(qword)
+    return BinaryPrimitives.ReadInt64BigEndian(qword)
+}
+
+func (stream Stream) ReadUInt64BE() uint64 {
+    let qword = stackalloc [8]uint8
+    stream.ReadExactly(qword)
+    return BinaryPrimitives.ReadUInt64BigEndian(qword)
+}
+
+func (stream Stream) ReadType() string {
+    let dword = stackalloc [4]uint8
+    stream.ReadExactly(dword)
+    return string([]char{char(dword[0]), char(dword[1]), char(dword[2]), char(dword[3])})
+}
+
+func (stream Stream) ReadBlock(length int32) []uint8 {
+    if length < 0 {
+        throw ArgumentException("Length must be non-negative", nameof(length))
+    } else if length == 0 {
+        return []uint8{}
+    } else {
+        let buffer = [length]uint8
+        stream.ReadExactly(buffer)
+        return buffer
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/StscBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/StscBox.gs
@@ -1,0 +1,93 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.Buffers.Binary
+import System.Collections.Generic
+import System.Diagnostics
+import System.IO
+import System.Runtime.InteropServices
+import Oahu.Decrypt.Mpeg4.Util
+
+struct ChunkFrames {
+    prop FirstFrameIndex uint32 {
+        get;
+        init;
+    }
+
+    prop NumberOfFrames uint32 {
+        get;
+        init;
+    }
+}
+
+open class StscBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        let entryCount = file.ReadUInt32BE()
+        Debug.Assert(entryCount <= uint32(Int32.MaxValue))
+        Samples = List[StscChunkEntry](int32(entryCount))
+        CollectionsMarshal.SetCount(Samples, int32(entryCount))
+        let samples = CollectionsMarshal.AsSpan(Samples)
+        file.ReadExactly(MemoryMarshal.AsBytes(samples))
+        if BitConverter.IsLittleEndian {
+            let uints = MemoryMarshal.Cast[StscChunkEntry, uint32](samples)
+            BinaryPrimitives.ReverseEndianness(uints, uints)
+        }
+    }
+
+    private init(versionFlags []uint8, header BoxHeader, parent IBox) : base(versionFlags, header, parent) {
+        Samples = List[StscChunkEntry]()
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(4) + int64(EntryCount * 3 * 4)
+    prop EntryCount int32 -> Samples.Count
+
+    prop Samples List[StscChunkEntry] {
+        get;
+        init;
+    }
+
+    func CalculateChunkFrameTable(numChunks uint32) []ChunkFrames {
+        let table = [int32(numChunks)]ChunkFrames
+        var firstFrameIndex uint32 = uint32(0)
+        var lastStscIndex = 0
+        for var chunk uint32 = uint32(1); chunk <= numChunks; chunk++ {
+            if lastStscIndex + 1 < Samples.Count && chunk == Samples[lastStscIndex + 1].FirstChunk {
+                lastStscIndex++
+            }
+            table[chunk - uint32(1)] = ChunkFrames{FirstFrameIndex: firstFrameIndex, NumberOfFrames: Samples[lastStscIndex].SamplesPerChunk}
+            firstFrameIndex += Samples[lastStscIndex].SamplesPerChunk
+        }
+        return table
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.WriteUInt32BE(uint32(Samples.Count))
+        for sample in Samples {
+            file.WriteUInt32BE(sample.FirstChunk)
+            file.WriteUInt32BE(sample.SamplesPerChunk)
+            file.WriteUInt32BE(sample.SampleDescriptionIndex)
+        }
+    }
+
+    protected open override func Dispose(disposing bool) {
+        if disposing && !Disposed {
+            Samples.Clear()
+        }
+        base.Dispose(disposing)
+    }
+
+    @StructLayout(0)
+    data struct StscChunkEntry(FirstChunk uint32, SamplesPerChunk uint32, SampleDescriptionIndex uint32) {
+    }
+
+    shared {
+        func CreateBlank(parent IBox) StscBox {
+            let size = 4 + 12
+            let header = BoxHeader(uint32(size), "stsc")
+            let stscBox = StscBox([]uint8{uint8(0), uint8(0), uint8(0), uint8(0)}, header, parent)
+            parent.Children.Add(stscBox)
+            return stscBox
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/StsdBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/StsdBox.gs
@@ -1,0 +1,49 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.Collections.Generic
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class StsdBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        VisualSampleEntries = List[VisualSampleEntry]()
+        EntryCount = file.ReadUInt32BE()
+        let hdlr HdlrBox? = Parent?.Parent?.Parent?.GetChild[HdlrBox]()
+        for var i = 0; int64(i) < int64(EntryCount); i++ {
+            let h = BoxHeader(file)
+            if hdlr?.HandlerType == "soun" {
+                AudioSampleEntry = AudioSampleEntry(file, h, this)
+                Children.Add(AudioSampleEntry!!)
+            } else if hdlr?.HandlerType == "vide" {
+                let entry = VisualSampleEntry(file, h, this)
+                VisualSampleEntries.Add(entry!!)
+                Children.Add(entry!!)
+            } else {
+                let unknownSampleEntry = UnknownBox(file, h, this)
+                Children.Add(unknownSampleEntry)
+            }
+        }
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(4)
+
+    prop EntryCount uint32 {
+        get;
+        init;
+    }
+
+    prop AudioSampleEntry AudioSampleEntry? {
+        get;
+        init;
+    }
+
+    prop VisualSampleEntries List[VisualSampleEntry] {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.WriteUInt32BE(EntryCount)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/StszBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/StszBox.gs
@@ -1,0 +1,102 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.Buffers.Binary
+import System.Collections.Generic
+import System.IO
+import System.Linq
+import System.Runtime.InteropServices
+import Oahu.Decrypt.Mpeg4.Util
+
+open class StszBox : FullBox, IStszBox {
+    private let origSampleCount int32
+    private let sampleSizes32 List[int32]?
+    private let sampleSizes16 List[uint16]?
+
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        SampleSize = file.ReadInt32BE()
+        let sampleCountU = file.ReadUInt32BE()
+        if sampleCountU > uint32(Int32.MaxValue) {
+            throw NotSupportedException("Oahu.Decrypt.Mpeg4 does not support MPEG-4 files with more than ${Int32.MaxValue} samples")
+        }
+        origSampleCount = int32(sampleCountU)
+        if SampleSize > 0 {
+            return
+        }
+        sampleSizes32 = List[int32](origSampleCount)
+        CollectionsMarshal.SetCount(sampleSizes32!!, origSampleCount)
+        let intListSpan = CollectionsMarshal.AsSpan(sampleSizes32!!)
+        file.ReadExactly(MemoryMarshal.AsBytes(intListSpan))
+        if BitConverter.IsLittleEndian {
+            BinaryPrimitives.ReverseEndianness(intListSpan, intListSpan)
+        }
+        if intListSpan.AllLessThanOrEqual(int32(UInt16.MaxValue)) {
+            sampleSizes16 = List[uint16](origSampleCount)
+            CollectionsMarshal.SetCount(sampleSizes16!!, origSampleCount)
+            let shortListSpan = CollectionsMarshal.AsSpan(sampleSizes16!!)
+            for var i = 0; i < origSampleCount; i++ {
+                shortListSpan[i] = uint16(intListSpan[i])
+            }
+            CollectionsMarshal.SetCount(sampleSizes32!!, 0)
+            sampleSizes32 = nil
+        }
+    }
+
+    private init(versionFlags []uint8, header BoxHeader, parent IBox, sampleSizes List[int32]) : base(versionFlags, header, parent) {
+        sampleSizes32 = sampleSizes
+    }
+
+    private init(versionFlags []uint8, header BoxHeader, parent IBox, sampleSizes List[uint16]) : base(versionFlags, header, parent) {
+        sampleSizes16 = sampleSizes
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(8) + int64(SampleCount * 4)
+
+    prop SampleSize int32 {
+        get;
+        init;
+    }
+
+    prop SampleCount int32 -> sampleSizes32?.Count ?? sampleSizes16?.Count ?? origSampleCount
+    prop MaxSize int32 -> sampleSizes32?.Max() ?? sampleSizes16?.Max() ?? uint16(SampleSize)
+    prop TotalSize int64 -> sampleSizes32?.Sum((s int32) -> int64(s)) ?? sampleSizes16?.Sum((s uint16) -> int64(s)) ?? int64(SampleSize * origSampleCount)
+    func GetSizeAtIndex(index int32) int32 -> sampleSizes32?[index] ?? sampleSizes16?[index] ?? uint16(SampleSize)
+    func SumFirstNSizes(firstN int32) int64 -> sampleSizes32?.Take(firstN).Sum((s int32) -> int64(s)) ?? sampleSizes16?.Take(firstN).Sum((s uint16) -> int64(s)) ?? int64(SampleSize) * int64(firstN)
+
+    protected open override func Render(file Stream) {
+        unsafe {
+            base.Render(file)
+            file.WriteInt32BE(SampleSize)
+            file.WriteUInt32BE(uint32(SampleCount))
+            if sampleSizes32 != nil {
+                let intSpan = CollectionsMarshal.AsSpan(sampleSizes32!!)
+                if BitConverter.IsLittleEndian {
+                    BinaryPrimitives.ReverseEndianness(intSpan, intSpan)
+                }
+                file.Write(MemoryMarshal.AsBytes(intSpan))
+            } else if sampleSizes16 != nil {
+                for size in sampleSizes16!! {
+                    file.WriteInt32BE(size)
+                }
+            }
+        }
+    }
+
+    shared {
+        func CreateBlank(parent IBox, sampleSizes List[int32]) StszBox {
+            let size = 8 + 12
+            let header = BoxHeader(uint32(size), "stsz")
+            let stszBox = StszBox([]uint8{uint8(0), uint8(0), uint8(0), uint8(0)}, header, parent, sampleSizes)
+            parent.Children.Add(stszBox!!)
+            return stszBox!!
+        }
+
+        func CreateBlank(parent IBox, sampleSizes List[uint16]) StszBox {
+            let size = 8 + 12
+            let header = BoxHeader(uint32(size), "stsz")
+            let stszBox = StszBox([]uint8{uint8(0), uint8(0), uint8(0), uint8(0)}, header, parent, sampleSizes)
+            parent.Children.Add(stszBox!!)
+            return stszBox!!
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/SttsBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/SttsBox.gs
@@ -1,0 +1,94 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.Buffers.Binary
+import System.Collections.Generic
+import System.Diagnostics
+import System.IO
+import System.Linq
+import System.Runtime.InteropServices
+import Oahu.Decrypt.Mpeg4.Util
+
+open class SttsBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        Samples = List[SttsBox.SampleEntry]()
+        let entryCount = file.ReadUInt32BE()
+        Debug.Assert(entryCount <= uint32(Int32.MaxValue))
+        Samples = List[SttsBox.SampleEntry](int32(entryCount))
+        CollectionsMarshal.SetCount(Samples, int32(entryCount))
+        let samples = CollectionsMarshal.AsSpan(Samples)
+        file.ReadExactly(MemoryMarshal.AsBytes(samples))
+        if BitConverter.IsLittleEndian {
+            let uints = MemoryMarshal.Cast[SttsBox.SampleEntry, uint32](samples)
+            BinaryPrimitives.ReverseEndianness(uints, uints)
+        }
+    }
+
+    private init(versionFlags []uint8, header BoxHeader, parent IBox?) : base(versionFlags, header, parent) {
+        Samples = List[SttsBox.SampleEntry]()
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(4) + int64(EntryCount * 2 * 4)
+    prop EntryCount int32 -> Samples.Count
+
+    prop Samples List[SttsBox.SampleEntry] {
+        get;
+        init;
+    }
+
+    prop SampleTimeCount uint32 -> uint32(Samples.Sum((s SttsBox.SampleEntry) -> s.FrameCount))
+
+    func EnumerateFrameDeltas(startAt uint32 = 0) sequence[uint32] {
+        var startAt = startAt
+        for entry in Samples {
+            while startAt < entry.FrameCount {
+                yield entry.FrameDelta
+                startAt++
+            }
+            startAt -= entry.FrameCount
+        }
+    }
+
+    func FrameToTime(timeScale float64, frameIndex uint64) TimeSpan {
+        var beginDelta uint64 = uint64(0)
+        var workingIndex = frameIndex
+        for entry in Samples {
+            if workingIndex <= uint64(entry.FrameCount) {
+                return TimeSpan.FromSeconds(float64((beginDelta + workingIndex * uint64(entry.FrameDelta))) / timeScale)
+            }
+            beginDelta += uint64(entry.FrameCount) * uint64(entry.FrameDelta)
+            workingIndex -= uint64(entry.FrameCount)
+        }
+        throw IndexOutOfRangeException("${nameof(frameIndex)} $frameIndex is larger than the number of frames in ${nameof(SttsBox)}")
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.WriteUInt32BE(uint32(Samples.Count))
+        for sample in Samples {
+            file.WriteUInt32BE(sample.FrameCount)
+            file.WriteUInt32BE(sample.FrameDelta)
+        }
+    }
+
+    protected open override func Dispose(disposing bool) {
+        if disposing && !Disposed {
+            Samples.Clear()
+        }
+        base.Dispose(disposing)
+    }
+
+    @StructLayout(0)
+    data struct SampleEntry(FrameCount uint32, FrameDelta uint32) {
+    }
+
+    shared {
+        func CreateBlank(parent IBox) SttsBox {
+            let size = 4 + 12
+            let header = BoxHeader(uint32(size), "stts")
+            let sttsBox = SttsBox([]uint8{uint8(0), uint8(0), uint8(0), uint8(0)}, header, parent)
+            parent.Children.Add(sttsBox)
+            return sttsBox
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Stz2Box.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/Stz2Box.gs
@@ -1,0 +1,94 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.Buffers.Binary
+import System.Collections.Generic
+import System.IO
+import System.Linq
+import System.Runtime.InteropServices
+import Oahu.Decrypt.Mpeg4.Util
+
+open class Stz2Box : FullBox, IStszBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        let reserved = stackalloc [4]uint8
+        file.ReadExactly(reserved)
+        FieldSize = reserved[3]
+        let sampleCount = file.ReadUInt32BE()
+        if !((FieldSize == 8 || FieldSize == 16)) {
+            throw InvalidDataException("Stsz field size ($FieldSize). Valid values are 4, 8, or 16.")
+        }
+        if sampleCount > uint32(Int32.MaxValue) {
+            throw NotSupportedException("Oahu.Decrypt.Mpeg4 does not support MPEG-4 files with more than ${Int32.MaxValue} samples")
+        }
+        SampleSizes = List[uint16](int32(sampleCount))
+        CollectionsMarshal.SetCount(SampleSizes, int32(sampleCount))
+        let shortSpan = CollectionsMarshal.AsSpan(SampleSizes)
+        if FieldSize == 16 {
+            file.ReadExactly(MemoryMarshal.AsBytes(shortSpan))
+            if BitConverter.IsLittleEndian {
+                BinaryPrimitives.ReverseEndianness(shortSpan, shortSpan)
+            }
+        } else {
+            let bytes Span[uint8] = file.ReadBlock(int32(sampleCount))
+            for var i = 0; int64(i) < int64(sampleCount); i++ {
+                shortSpan[i] = bytes[i]
+            }
+        }
+    }
+
+    private init(versionFlags []uint8, header BoxHeader, parent IBox, sampleSizes List[uint16], fieldSize int32) : base(versionFlags, header, parent) {
+        if fieldSize != 16 && fieldSize != 8 && fieldSize != 4 {
+            throw InvalidDataException("Stsz field size ($fieldSize). Valid values are 4, 8, or 16.")
+        }
+        FieldSize = fieldSize
+        SampleSizes = sampleSizes
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(8) + int64(SampleCount * FieldSize / 8) + int64((if FieldSize == 4 && SampleCount % 2 == 1 { 1 } else { 0 }))
+    prop SampleCount int32 -> SampleSizes.Count
+
+    prop SampleSizes List[uint16] {
+        get;
+        init;
+    }
+
+    prop MaxSize int32 -> SampleSizes.Max()
+    prop TotalSize int64 -> SampleSizes.Sum((s uint16) -> int64(s))
+
+    prop FieldSize int32 {
+        get;
+        init;
+    }
+
+    func GetSizeAtIndex(index int32) int32 -> SampleSizes[index]
+    func SumFirstNSizes(firstN int32) int64 -> SampleSizes.Take(firstN).Sum((s uint16) -> int64(s))
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        let fieldSize = stackalloc [4]uint8
+        let shortSpan = CollectionsMarshal.AsSpan(SampleSizes)
+        fieldSize[3] = uint8((if shortSpan.AllLessThanOrEqual(uint16(Byte.MaxValue)) { 8 } else { 16 }))
+        file.Write(fieldSize)
+        file.WriteInt32BE(SampleSizes.Count)
+        if fieldSize[3] == uint8(16) {
+            if BitConverter.IsLittleEndian {
+                BinaryPrimitives.ReverseEndianness(shortSpan, shortSpan)
+            }
+            file.Write(MemoryMarshal.AsBytes(shortSpan))
+        } else {
+            for size in SampleSizes {
+                file.WriteByte(uint8(size))
+            }
+        }
+    }
+
+    shared {
+        func CreateBlank(parent IBox, sampleSizes List[uint16]) Stz2Box {
+            let size = 8 + 12
+            let header = BoxHeader(uint32(size), "stz2")
+            let stszBox = Stz2Box([]uint8{uint8(0), uint8(0), uint8(0), uint8(0)}, header, parent, sampleSizes, 16)
+            parent.Children.Add(stszBox!!)
+            return stszBox!!
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/TEXTFrame.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/TEXTFrame.gs
@@ -1,0 +1,38 @@
+package Oahu.Decrypt.Mpeg4.ID3
+
+import System.IO
+import System.Text
+
+class TEXTFrame : Frame {
+    init(file Stream, header Header, parent Frame) : base(header, parent) {
+        EncodingFlag = uint8(file.ReadByte())
+        Text = Frame.ReadSizeString(file, EncodingFlag == uint8(1), Header.Size - 1)
+    }
+
+    private init(header Header, parent Frame) : base(header, parent) {
+    }
+
+    override prop Size int32 -> 1 + (if Text == nil { 0 } else { if Frame.IsUnicode(Text!!) { Frame.UnicodeLength(Text!!) } else { Text!!.Length } })
+    prop EncodingFlag uint8
+    prop Text string?
+
+    override func Render(file Stream) {
+        if Text == nil {
+            file.WriteByte(0)
+        } else if Frame.IsUnicode(Text!!) {
+            file.WriteByte(1)
+            file.Write(Frame.UnicodeBytes(Text!!))
+        } else {
+            file.WriteByte(0)
+            file.Write(Encoding.ASCII.GetBytes(Text!!))
+        }
+    }
+
+    shared {
+        func Create(parent Frame, frameId string, text string) TEXTFrame {
+            let tit2 = TEXTFrame(FrameHeader(frameId, 0, parent.Version), parent)
+            parent?.Children.Add(tit2!!)
+            return tit2!!
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/TXXXFrame.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/TXXXFrame.gs
@@ -1,0 +1,41 @@
+package Oahu.Decrypt.Mpeg4.ID3
+
+import System.IO
+import System.Text
+
+class TXXXFrame : Frame {
+    init(file Stream, header Header, parent Frame) : base(header, parent) {
+        let startPos = file.Position
+        let unicode = file.ReadByte() == 1
+        FieldName = Frame.ReadNullTerminatedString(file, unicode)
+        FieldValue = Frame.ReadSizeString(file, unicode, int32((startPos + int64(header.Size) - file.Position)))
+    }
+
+    override prop Size int32 -> if Frame.IsUnicode(FieldName) || Frame.IsUnicode(FieldValue) { 1 + Frame.UnicodeLength(FieldName) + 2 + Frame.UnicodeLength(FieldValue) } else { 1 + FieldName.Length + 1 + FieldValue.Length }
+
+    prop FieldName string {
+        get;
+        init;
+    }
+
+    prop FieldValue string {
+        get;
+        init;
+    }
+
+    func ToString() string -> FieldName
+
+    override func Render(file Stream) {
+        if Frame.IsUnicode(FieldName) || Frame.IsUnicode(FieldValue) {
+            file.WriteByte(1)
+            file.Write(Frame.UnicodeBytes(FieldName))
+            file.Write(stackalloc [2]uint8)
+            file.Write(Frame.UnicodeBytes(FieldValue))
+        } else {
+            file.WriteByte(0)
+            file.Write(Encoding.ASCII.GetBytes(FieldName))
+            file.WriteByte(0)
+            file.Write(Encoding.ASCII.GetBytes(FieldValue))
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/TagFactory.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/TagFactory.gs
@@ -1,0 +1,29 @@
+package Oahu.Decrypt.Mpeg4.ID3
+
+import System.IO
+
+internal class TagFactory {
+    shared {
+        func CreateTag(file Stream, parent Frame, out lengthRead int32) Frame {
+            let startPos = file.Position
+            let frameHeader = FrameHeader.Create(file, parent.Version)
+            let frame = TagFactory.CreateTagInternal(frameHeader!!, file, parent)
+            lengthRead = int32((file.Position - startPos))
+            return frame!!
+        }
+
+        private func CreateTagInternal(frameHeader FrameHeader, file Stream, parent Frame) Frame {
+            if parent.Version >= uint16(0x300) && frameHeader.Identifier.StartsWith('T') && frameHeader.Identifier != "TXXX" {
+                return TEXTFrame(file, frameHeader, parent)
+            }
+            return switch frameHeader.Identifier {
+                case "TXXX": TXXXFrame(file, frameHeader, parent)
+                case "APIC": APICFrame(file, frameHeader, parent)
+                case "CHAP": CHAPFrame(file, frameHeader, parent)
+                case "CTOC": CTOCFrame(file, frameHeader, parent)
+                case "\u0000\u0000\u0000" or "\u0000\u0000\u0000\u0000": EmptyFrame(frameHeader, parent)
+                default: UnknownFrame(file, frameHeader, parent)
+            }
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/TencBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/TencBox.gs
@@ -1,0 +1,80 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class TencBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        file.ReadByte()
+        if Version == uint8(0) {
+            file.ReadByte()
+        } else {
+            let value = file.ReadByte()
+            DefaultCryptByteBlock = uint8((value >> 4))
+            DefaultSkipByteBlock = uint8((value & 0xf))
+        }
+        DefaultIsProtected = file.ReadByte() != 0
+        DefaultPerSampleIvSize = uint8(file.ReadByte())
+        DefaultKID = Guid(file.ReadBlock(16), true)
+        if DefaultIsProtected && DefaultPerSampleIvSize == uint8(0) {
+            DefaultConstantIvSize = uint8(file.ReadByte())
+            DefaultConstantIv = file.ReadBlock(DefaultConstantIvSize)
+        } else {
+            DefaultConstantIv = Array.Empty[uint8]()
+        }
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(20) + int64((if (DefaultIsProtected && DefaultPerSampleIvSize == uint8(0)) { uint8(1) + DefaultConstantIvSize } else { 0 }))
+
+    prop DefaultCryptByteBlock uint8 {
+        get;
+        init;
+    }
+
+    prop DefaultSkipByteBlock uint8 {
+        get;
+        init;
+    }
+
+    prop DefaultIsProtected bool {
+        get;
+        init;
+    }
+
+    prop DefaultPerSampleIvSize uint8 {
+        get;
+        init;
+    }
+
+    prop DefaultKID Guid {
+        get;
+        init;
+    }
+
+    prop DefaultConstantIvSize uint8 {
+        get;
+        init;
+    }
+
+    prop DefaultConstantIv []uint8 {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        var value int16 = 0
+        if Version != uint8(0) {
+            value = int16(((DefaultCryptByteBlock << 4) | (DefaultSkipByteBlock & uint8(0xf))))
+        }
+        file.WriteInt16BE(value)
+        file.WriteByte(uint8((if DefaultIsProtected { 1 } else { 0 })))
+        file.WriteByte(DefaultPerSampleIvSize)
+        file.Write(DefaultKID.ToByteArray(true))
+        if DefaultIsProtected && DefaultPerSampleIvSize == uint8(0) {
+            file.WriteByte(uint8(DefaultConstantIv.Length))
+            file.Write(DefaultConstantIv)
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/TfdtBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/TfdtBox.gs
@@ -1,0 +1,26 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class TfdtBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        BaseMediaDecodeTime = if Version == uint8(1) { file.ReadInt64BE() } else { int64(file.ReadUInt32BE()) }
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64((if Version == uint8(1) { 8 } else { 4 }))
+
+    prop BaseMediaDecodeTime int64 {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        if Version == uint8(1) {
+            file.WriteInt64BE(BaseMediaDecodeTime)
+        } else {
+            file.WriteUInt32BE(uint32(BaseMediaDecodeTime))
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/TfhdBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/TfhdBox.gs
@@ -1,0 +1,86 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class TfhdBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        TrackID = file.ReadUInt32BE()
+        if BaseDataOffsetPresent {
+            BaseDataOffset = file.ReadInt64BE()
+        }
+        if SampleDescriptionIndexPresent {
+            SampleDescriptionIndex = file.ReadUInt32BE()
+        }
+        if DefaultSampleDurationPresent {
+            DefaultSampleDuration = file.ReadUInt32BE()
+        }
+        if DefaultSampleSizePresent {
+            DefaultSampleSize = file.ReadUInt32BE()
+        }
+        if DefaultSampleFlagsPresent {
+            DefaultSampleFlags = file.ReadUInt32BE()
+        }
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(4) + int64(OptionalFieldsSize)
+
+    prop TrackID uint32 {
+        get;
+        init;
+    }
+
+    prop BaseDataOffset int64? {
+        get;
+        init;
+    }
+
+    prop SampleDescriptionIndex uint32? {
+        get;
+        init;
+    }
+
+    prop DefaultSampleDuration uint32? {
+        get;
+        init;
+    }
+
+    prop DefaultSampleSize uint32? {
+        get;
+        init;
+    }
+
+    prop DefaultSampleFlags uint32? {
+        get;
+        init;
+    }
+
+    prop DurationIsEmpty bool -> (Flags & 0x010000) == 0x010000
+    prop DefaultBaseIsMoof bool -> (Flags & 0x020000) == 0x020000
+    private prop OptionalFieldsSize int32 -> (if BaseDataOffsetPresent { 8 } else { 0 }) + (if SampleDescriptionIndexPresent { 4 } else { 0 }) + (if DefaultSampleDurationPresent { 4 } else { 0 }) + (if DefaultSampleSizePresent { 4 } else { 0 }) + (if DefaultSampleFlagsPresent { 4 } else { 0 })
+    private prop BaseDataOffsetPresent bool -> (Flags & 1) == 1
+    private prop SampleDescriptionIndexPresent bool -> (Flags & 2) == 2
+    private prop DefaultSampleDurationPresent bool -> (Flags & 8) == 8
+    private prop DefaultSampleSizePresent bool -> (Flags & 16) == 16
+    private prop DefaultSampleFlagsPresent bool -> (Flags & 32) == 32
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.WriteUInt32BE(TrackID)
+        if BaseDataOffset.HasValue {
+            file.WriteInt64BE(BaseDataOffset.Value)
+        }
+        if SampleDescriptionIndex.HasValue {
+            file.WriteUInt32BE(SampleDescriptionIndex.Value)
+        }
+        if DefaultSampleDuration.HasValue {
+            file.WriteUInt32BE(DefaultSampleDuration.Value)
+        }
+        if DefaultSampleSize.HasValue {
+            file.WriteUInt32BE(DefaultSampleSize.Value)
+        }
+        if DefaultSampleFlags.HasValue {
+            file.WriteUInt32BE(DefaultSampleFlags.Value)
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/TkhdBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/TkhdBox.gs
@@ -1,0 +1,74 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class TkhdBox : HeaderBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        file.ReadUInt64BE()
+        Layer = file.ReadInt16BE()
+        AlternateGroup = file.ReadInt16BE()
+        Volume = file.ReadInt16BE()
+        Reserved3 = file.ReadUInt16BE()
+        Matrix = file.ReadBlock(4 * 9)
+        Width = file.ReadUInt32BE()
+        Height = file.ReadUInt32BE()
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(2 * 4) + int64(8) + int64(4 * 2) + int64(Matrix.Length) + int64(2 * 4)
+    prop TrackID uint32
+
+    prop Layer int16 {
+        get;
+        init;
+    }
+
+    prop AlternateGroup int16
+
+    prop Volume int16 {
+        get;
+        init;
+    }
+
+    prop Reserved3 uint16 {
+        get;
+        init;
+    }
+
+    prop Matrix []uint8 {
+        get;
+        init;
+    }
+
+    prop Width uint32 {
+        get;
+        init;
+    }
+
+    prop Height uint32 {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.WriteUInt64BE(0)
+        file.WriteInt16BE(Layer)
+        file.WriteInt16BE(AlternateGroup)
+        file.WriteInt16BE(Volume)
+        file.WriteUInt16BE(Reserved3)
+        file.Write(Matrix)
+        file.WriteUInt32BE(Width)
+        file.WriteUInt32BE(Height)
+    }
+
+    protected open override func ReadBeforeDuration(file Stream) {
+        TrackID = file.ReadUInt32BE()
+        file.ReadUInt32BE()
+    }
+
+    protected open override func WriteBeforeDuration(file Stream) {
+        file.WriteUInt32BE(TrackID)
+        file.WriteUInt32BE(0)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/TrackedReadStream.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/TrackedReadStream.gs
@@ -1,0 +1,48 @@
+package Oahu.Decrypt.Mpeg4
+
+import System
+import System.IO
+
+open class TrackedReadStream(baseStream Stream, baseStreamLength int64) : Stream {
+    private var readPosition int64 = 0
+    prop CanRead bool -> this.baseStream.CanRead
+    prop CanSeek bool -> this.baseStream.CanSeek
+    prop Length int64 -> baseStreamLength
+    prop CanWrite bool -> this.baseStream.CanWrite
+
+    prop Position int64 {
+        get -> if CanSeek { this.baseStream.Position } else { readPosition }
+        set {
+            if !CanSeek {
+                throw NotSupportedException()
+            }
+            readPosition = value
+            this.baseStream.Position = readPosition
+        }
+    }
+
+    func Flush() {
+        throw NotSupportedException()
+    }
+
+    func Read(buffer []uint8, offset int32, count int32) int32 {
+        this.baseStream.ReadExactly(buffer, offset, count)
+        readPosition += int64(count)
+        return count
+    }
+
+    func Seek(offset int64, origin SeekOrigin) int64 {
+        return if CanSeek { this.baseStream.Seek(offset, origin) } else { throw NotSupportedException()
+            default(int64) }
+    }
+
+    func SetLength(value int64) -> this.baseStream.SetLength(value)
+    func Write(buffer []uint8, offset int32, count int32) -> this.baseStream.Write(buffer, offset, count)
+
+    protected func Dispose(disposing bool) {
+        if disposing {
+            this.baseStream.Dispose()
+        }
+        base.Dispose(disposing)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/TrackedWriteStream.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/TrackedWriteStream.gs
@@ -1,0 +1,48 @@
+package Oahu.Decrypt.Mpeg4
+
+import System
+import System.IO
+
+open class TrackedWriteStream(baseStream Stream, writePosition int64 = 0) : Stream {
+    prop CanRead bool -> false
+    prop CanSeek bool -> this.baseStream.CanSeek
+    prop Length int64 -> writePosition
+    prop CanWrite bool -> this.baseStream.CanWrite
+
+    prop Position int64 {
+        get -> if CanSeek { this.baseStream.Position } else { writePosition }
+        set {
+            if !CanSeek {
+                throw NotSupportedException()
+            }
+            this.baseStream.Position = value
+        }
+    }
+
+    func Flush() -> this.baseStream.Flush()
+
+    func Read(buffer []uint8, offset int32, count int32) int32 {
+        throw NotSupportedException()
+    }
+
+    func Seek(offset int64, origin SeekOrigin) int64 {
+        return if CanSeek { this.baseStream.Seek(offset, origin) } else { throw NotSupportedException()
+            default(int64) }
+    }
+
+    func SetLength(value int64) {
+        throw NotSupportedException()
+    }
+
+    func Write(buffer []uint8, offset int32, count int32) {
+        this.baseStream.Write(buffer, offset, count)
+        writePosition += int64(count)
+    }
+
+    protected func Dispose(disposing bool) {
+        if disposing {
+            this.baseStream.Dispose()
+        }
+        base.Dispose(disposing)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/TrafBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/TrafBox.gs
@@ -1,0 +1,20 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+
+open class TrafBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        LoadChildren(file)
+    }
+
+    prop Tfhd TfhdBox -> GetChildOrThrow[TfhdBox]()
+    prop Tfdt TfdtBox? -> GetChild[TfdtBox]()
+    prop Trun TrunBox? -> GetChild[TrunBox]()
+    prop Saiz SaizBox? -> GetChild[SaizBox]()
+    prop Saio SaioBox? -> GetChild[SaioBox]()
+    prop Senc SencBox? -> GetChild[SencBox]()
+
+    protected open override func Render(file Stream) {
+        return
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/TrakBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/TrakBox.gs
@@ -1,0 +1,16 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+
+open class TrakBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        LoadChildren(file)
+    }
+
+    prop Tkhd TkhdBox -> GetChildOrThrow[TkhdBox]()
+    prop Mdia MdiaBox -> GetChildOrThrow[MdiaBox]()
+
+    protected open override func Render(file Stream) {
+        return
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/TrefBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/TrefBox.gs
@@ -1,0 +1,74 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.Collections.Generic
+import System.Diagnostics
+import System.IO
+import System.Linq
+import Oahu.Decrypt.Mpeg4.Util
+
+interface ITrackReferenceTypeBox : IBox {
+    prop TrackIds HashSet[uint32]
+}
+
+open class TrefBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        References = List[ITrackReferenceTypeBox]()
+        while RemainingBoxLength(file) > int64(0) {
+            References.Add(TrackReferenceTypeBox(file, this))
+        }
+    }
+
+    private init(parent IBox) : base(BoxHeader(8, "tref"), parent) {
+        References = List[ITrackReferenceTypeBox]()
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + References.Sum((r ITrackReferenceTypeBox) -> r.RenderSize)
+
+    prop References List[ITrackReferenceTypeBox] {
+        get;
+        init;
+    }
+
+    func AddReference(type_ string, trackIds HashSet[uint32]) TrefBox {
+        References.Add(TrackReferenceTypeBox(type_, trackIds, this))
+        return this
+    }
+
+    protected open override func Render(file Stream) {
+        for box in References {
+            box!!.Save(file)
+        }
+    }
+
+    @DebuggerDisplay("{Header.Type,nq}, {TrackIds}")
+    private open class TrackReferenceTypeBox : Box, ITrackReferenceTypeBox {
+        init(file Stream, parent IBox?) : base(BoxHeader(file), parent) {
+            let numTraks = int32(RemainingBoxLength(file)) / 4
+            TrackIds = HashSet[uint32](numTraks)
+            for var i = 0; i < numTraks; i++ {
+                TrackIds.Add(file.ReadUInt32BE())
+            }
+        }
+
+        init(type_ string, trackIds HashSet[uint32], parent IBox) : base(BoxHeader(12, type_), parent) {
+            TrackIds = trackIds
+        }
+
+        open override prop RenderSize int64 -> base.RenderSize + int64(4 * TrackIds.Count)
+        prop TrackIds HashSet[uint32]
+
+        protected open override func Render(file Stream) {
+            for id in TrackIds {
+                file.WriteUInt32BE(id)
+            }
+        }
+    }
+
+    shared {
+        func CreatEmpty(parent IBox) TrefBox {
+            let tref = TrefBox(parent)
+            parent.Children.Add(tref!!)
+            return tref!!
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/TrunBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/TrunBox.gs
@@ -1,0 +1,77 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class TrunBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        let sampleCount = file.ReadUInt32BE()
+        if DataOffsetPresent {
+            DataOffset = file.ReadInt32BE()
+        }
+        if FirstSampleFlagsPresent {
+            FirstSampleFlags = file.ReadUInt32BE()
+        }
+        Samples = [int32(sampleCount)]SampleInfo
+        for var i = 0; int64(i) < int64(sampleCount); i++ {
+            let sampleDuration uint32? = if SampleDurationPresent { file.ReadUInt32BE() } else { nil }
+            let sampleSize int32? = if SampleSizePresent { file.ReadInt32BE() } else { nil }
+            let sampleFlags uint32? = if SampleFlagsPresent { file.ReadUInt32BE() } else { nil }
+            let sampleCompositionTimeOffset int32? = if SampleCompositionTimeOffsetsPresent { file.ReadInt32BE() } else { nil }
+            Samples[i] = SampleInfo(sampleDuration, sampleSize, sampleFlags, sampleCompositionTimeOffset)
+        }
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(4) + int64((if DataOffsetPresent { 4 } else { 0 })) + int64((if FirstSampleFlagsPresent { 4 } else { 0 })) + int64(SampleInfoSize * Samples.Length)
+
+    prop DataOffset int32 {
+        get;
+        init;
+    }
+
+    prop FirstSampleFlags uint32 {
+        get;
+        init;
+    }
+
+    prop Samples []SampleInfo {
+        get;
+        init;
+    }
+
+    prop SampleDurationPresent bool -> (Flags & 0x100) == 0x100
+    prop SampleSizePresent bool -> (Flags & 0x200) == 0x200
+    private prop DataOffsetPresent bool -> (Flags & 1) == 1
+    private prop FirstSampleFlagsPresent bool -> (Flags & 4) == 4
+    private prop SampleFlagsPresent bool -> (Flags & 0x400) == 0x400
+    private prop SampleCompositionTimeOffsetsPresent bool -> (Flags & 0x800) == 0x800
+    private prop SampleInfoSize int32 -> (if SampleDurationPresent { 4 } else { 0 }) + (if SampleSizePresent { 4 } else { 0 }) + (if SampleFlagsPresent { 4 } else { 0 }) + (if SampleCompositionTimeOffsetsPresent { 4 } else { 0 })
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.WriteInt32BE(Samples.Length)
+        if DataOffsetPresent {
+            file.WriteInt32BE(DataOffset)
+        }
+        if FirstSampleFlagsPresent {
+            file.WriteUInt32BE(FirstSampleFlags)
+        }
+        for var i = 0; i < Samples.Length; i++ {
+            if SampleDurationPresent {
+                file.WriteUInt32BE(Samples[i].SampleDuration ?? uint32(0))
+            }
+            if SampleSizePresent {
+                file.WriteInt32BE(Samples[i].SampleSize ?? 0)
+            }
+            if SampleFlagsPresent {
+                file.WriteUInt32BE(Samples[i].SampleFlags ?? uint32(0))
+            }
+            if SampleCompositionTimeOffsetsPresent {
+                file.WriteInt32BE(Samples[i].SampleCompositionTimeOffset ?? 0)
+            }
+        }
+    }
+
+    class SampleInfo(SampleDuration uint32?, SampleSize int32?, SampleFlags uint32?, SampleCompositionTimeOffset int32?) {
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/UdtaBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/UdtaBox.gs
@@ -1,0 +1,24 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+
+open class UdtaBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        LoadChildren(file)
+    }
+
+    private init(parent IBox) : base(BoxHeader(8, "udta"), parent) {
+    }
+
+    protected open override func Render(file Stream) {
+        return
+    }
+
+    shared {
+        func CreateEmpty(parent IBox) UdtaBox {
+            let udata = UdtaBox(parent)
+            parent.Children.Add(udata!!)
+            return udata!!
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/UnknownBox.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/UnknownBox.gs
@@ -1,0 +1,25 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class UnknownBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        Data = file.ReadBlock(int32((Header.TotalBoxSize - int64(header.HeaderSize))))
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(Data.Length)
+
+    prop Data []uint8 {
+        get;
+        init;
+    }
+
+    func ToString() string {
+        return nameof(UnknownBox) + "-" + Header.Type
+    }
+
+    protected open override func Render(file Stream) {
+        file.Write(Data)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/UnknownDescriptor.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/UnknownDescriptor.gs
@@ -1,0 +1,18 @@
+package Oahu.Decrypt.Mpeg4.Descriptors
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+class UnknownDescriptor : BaseDescriptor {
+    private let blob []uint8
+
+    init(file Stream, header DescriptorHeader) : base(file, header) {
+        blob = file.ReadBlock(Header.TotalBoxSize - Header.HeaderSize)
+    }
+
+    override prop InternalSize int32 -> base.InternalSize + blob.Length
+
+    override func Render(file Stream) {
+        file.Write(blob)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/UnknownFrame.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/UnknownFrame.gs
@@ -1,0 +1,21 @@
+package Oahu.Decrypt.Mpeg4.ID3
+
+import System.IO
+import System.Text
+
+class UnknownFrame : Frame {
+    init(file Stream, header Header, parent Frame) : base(header, parent) {
+        Blob = [header.Size]uint8
+        file.ReadExactly(Blob)
+    }
+
+    override prop Size int32 -> Blob.Length
+
+    prop Blob []uint8 {
+        get;
+        init;
+    }
+
+    prop DataText string -> if Blob.Length == 0 { "" } else { (if Blob[0] == uint8(0) { Encoding.ASCII } else { Encoding.Unicode }).GetString(Blob, 1, Blob.Length - 1) }
+    override func Render(file Stream) -> file.Write(Blob)
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/VideoPassthrough.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/VideoPassthrough.gs
@@ -1,0 +1,14 @@
+package Oahu.Decrypt.FrameFilters.Video
+
+import System.Threading.Tasks
+
+internal open class VideoPassthrough : FrameFinalBase[FrameEntry] {
+    protected open override prop InputBufferSize int32 -> 1
+
+    open override func AddInputAsync(input FrameEntry) Task {
+        return Task.CompletedTask
+    }
+
+    protected open override func FlushAsync() Task -> Task.CompletedTask
+    protected open override func PerformFilteringAsync(input FrameEntry) Task -> Task.CompletedTask
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/VisualSampleEntry.gs
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/VisualSampleEntry.gs
@@ -1,0 +1,92 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class VisualSampleEntry : SampleEntry {
+    private let preDefined1 []uint8
+    private let reserved []uint8
+    private let preDefined2 []uint8
+    private let reserved2 []uint8
+    private let preDefined3 []uint8
+
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        preDefined1 = file.ReadBlock(2)
+        reserved = file.ReadBlock(2)
+        preDefined2 = file.ReadBlock(4 * 3)
+        Width = file.ReadUInt16BE()
+        Height = file.ReadUInt16BE()
+        HorizontalResolution = file.ReadUInt32BE()
+        VerticalResolution = file.ReadUInt32BE()
+        reserved2 = file.ReadBlock(4)
+        FrameCount = file.ReadUInt16BE()
+        let compressorNameBytes = file.ReadBlock(32)
+        let displaySize = compressorNameBytes!![0]
+        if displaySize > uint8(31) {
+            throw InvalidOperationException("Compressor name must be 31 characters or fewer.")
+        }
+        CompressorName = System.Text.Encoding.UTF8.GetString(compressorNameBytes!!, 1, displaySize)
+        Depth = file.ReadUInt16BE()
+        preDefined3 = file.ReadBlock(2)
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(preDefined1.Length) + int64(reserved.Length) + int64(preDefined2.Length) + int64(2 * 4) + int64(4 * 2) + int64(reserved2.Length) + int64(preDefined3.Length) + int64(32)
+
+    prop Width uint16 {
+        get;
+        init;
+    }
+
+    prop Height uint16 {
+        get;
+        init;
+    }
+
+    prop HorizontalResolution uint32 {
+        get;
+        init;
+    }
+
+    prop VerticalResolution uint32 {
+        get;
+        init;
+    }
+
+    prop FrameCount uint16 {
+        get;
+        init;
+    }
+
+    prop CompressorName string {
+        get;
+        init;
+    }
+
+    prop Depth uint16 {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.Write(preDefined1)
+        file.Write(reserved)
+        file.Write(preDefined2)
+        file.WriteUInt16BE(Width)
+        file.WriteUInt16BE(Height)
+        file.WriteUInt32BE(HorizontalResolution)
+        file.WriteUInt32BE(VerticalResolution)
+        file.Write(reserved2)
+        file.WriteUInt16BE(FrameCount)
+        let compressorNameBytes = [32]uint8
+        if CompressorName.Length > 31 {
+            throw InvalidOperationException("Compressor name must be 31 characters or fewer.")
+        }
+        compressorNameBytes!![0] = uint8(CompressorName.Length)
+        System.Text.Encoding.UTF8.GetBytes(CompressorName, 0, CompressorName.Length, compressorNameBytes!!, 1)
+        file.Write(compressorNameBytes!!)
+        file.WriteUInt16BE(Depth)
+        file.Write(preDefined3)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/compile-50a2b466cb59.json
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/corpus_Oahu.Decrypt/compile-50a2b466cb59.json
@@ -1,0 +1,36 @@
+{
+  "schemaVersion": "1.0",
+  "runId": "2026-06-30T00-10-20Z_03ca51",
+  "timestamp": "2026-06-30T00:10:20Z",
+  "gscVersion": "0.2.365+10dca37a05",
+  "corpusAppId": "corpus/Oahu.Decrypt",
+  "stage": "compile",
+  "category": "compile-error",
+  "diagnostic": {
+    "id": "GS9998",
+    "message": "InvalidOperationException: Variable 'Mvhd' has no local slot or parameter index in the current method.",
+    "severity": "error"
+  },
+  "sourceLocation": {
+    "gsFile": "corpus_Oahu.Decrypt/MoovBox.gs",
+    "gsLine": 72,
+    "gsColumn": 13,
+    "csFile": null,
+    "csLine": null,
+    "csColumn": null
+  },
+  "offendingCSharpConstruct": {
+    "kind": "GSharpConstruct",
+    "snippet": "Children.Insert(Children.IndexOf(AudioTrack) + 1, textTrack!!)"
+  },
+  "suggestedIssue": {
+    "title": "[cs2gs] GS9998 compiling translated corpus/Oahu.Decrypt (GSharpConstruct)",
+    "body": "The G# emitted for **corpus/Oahu.Decrypt** fails to compile with `gsc` 0.2.365+10dca37a05.\n\n- Diagnostic: `GS9998` — InvalidOperationException: Variable 'Mvhd' has no local slot or parameter index in the current method.\n- Emitted G#: `corpus_Oahu.Decrypt/MoovBox.gs` (72,13)\n- Offending line: `Children.Insert(Children.IndexOf(AudioTrack) + 1, textTrack!!)`\n\n**Reproduction:** `cs2gs migrate` translates the corpus app, writes the `.gs` shown above, then runs `gsc /target:… /out:… corpus_Oahu.Decrypt/MoovBox.gs` which surfaces this error.\n**Fingerprint:** `sha256:50a2b466cb5950a1e9b7eadf7796a89b218728d04062d0360396f5c30253e372`",
+    "labels": [
+      "Oats",
+      "bug"
+    ]
+  },
+  "fingerprint": "sha256:50a2b466cb5950a1e9b7eadf7796a89b218728d04062d0360396f5c30253e372",
+  "retryHistory": []
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/report.html
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/report.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>cs2gs report — 2026-06-30T00-10-20Z_03ca51</title>
+<style>
+:root{--ok:#1a7f37;--bad:#cf222e;--skip:#6e7781;--bg:#ffffff;--fg:#1f2328;--line:#d0d7de;--panel:#f6f8fa;}
+*{box-sizing:border-box;}
+body{margin:0;padding:1.5rem;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;color:var(--fg);background:var(--bg);line-height:1.45;}
+h1{font-size:1.5rem;margin:0 0 .25rem;}
+h2{font-size:1.2rem;margin:2rem 0 .75rem;border-bottom:1px solid var(--line);padding-bottom:.25rem;}
+h3{font-size:1rem;margin:0 0 .5rem;}
+a{color:#0969da;}
+.run-header .verdict{display:inline-block;font-weight:700;padding:.15rem .6rem;border-radius:999px;color:#fff;}
+.verdict.ok{background:var(--ok);} .verdict.bad{background:var(--bad);}
+.provenance{display:grid;grid-template-columns:max-content 1fr;gap:.15rem 1rem;margin:.75rem 0 0;}
+.provenance dt{font-weight:600;color:var(--skip);} .provenance dd{margin:0;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;}
+table{border-collapse:collapse;width:100%;}
+.matrix th,.matrix td{border:1px solid var(--line);padding:.4rem .6rem;text-align:left;}
+.matrix thead th{background:var(--panel);}
+.cell{font-weight:600;white-space:nowrap;}
+.cell .dot{display:inline-block;width:.65rem;height:.65rem;border-radius:50%;margin-right:.4rem;vertical-align:middle;}
+.cell.pass{color:var(--ok);} .cell.pass .dot{background:var(--ok);}
+.cell.fail{color:var(--bad);} .cell.fail .dot{background:var(--bad);}
+.cell.skip{color:var(--skip);} .cell.skip .dot{background:var(--skip);}
+.gap{border:1px solid var(--line);border-radius:6px;padding:1rem;margin:0 0 1rem;background:var(--panel);}
+.gap-meta{list-style:none;margin:0 0 .5rem;padding:0;display:flex;flex-wrap:wrap;gap:.35rem 1rem;}
+.gap-meta .k{font-weight:600;color:var(--skip);} .gap-meta .v{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;}
+.snippet,.issue-body{background:#0d1117;color:#e6edf3;padding:.6rem .8rem;border-radius:6px;overflow:auto;}
+.snippet code,.issue-body code{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;white-space:pre-wrap;}
+.labels{margin:.5rem 0;} .label{display:inline-block;background:#ddf4ff;color:#0969da;border:1px solid #54aeff66;border-radius:999px;padding:.05rem .55rem;font-size:.8rem;}
+.occurrences ul{margin:.25rem 0;padding-left:1.2rem;} .occurrences .app{font-weight:600;} .occurrences .loc{color:var(--skip);font-family:ui-monospace,monospace;}
+.retry th,.retry td{border:1px solid var(--line);padding:.25rem .5rem;text-align:left;font-size:.85rem;}
+.toggle{margin:.5rem 0;cursor:pointer;background:#fff;border:1px solid var(--line);border-radius:6px;padding:.3rem .7rem;font:inherit;}
+.app-detail{border:1px solid var(--line);border-radius:6px;padding:1rem;margin:0 0 1rem;}
+.state{font-size:.75rem;padding:.1rem .5rem;border-radius:999px;color:#fff;vertical-align:middle;}
+.state.ok{background:var(--ok);} .state.bad{background:var(--bad);}
+.stage-list th,.stage-list td{border:1px solid var(--line);padding:.3rem .6rem;text-align:left;}
+.meta-line .k,.artifact-h{font-weight:600;color:var(--skip);}
+.empty{color:var(--skip);}
+</style>
+</head>
+<body>
+<header class="run-header">
+<h1>cs2gs migration report</h1>
+<p class="verdict bad">Run FAILED — 0/1 apps green</p>
+<dl class="provenance">
+<dt>Run id</dt><dd>2026-06-30T00-10-20Z_03ca51</dd>
+<dt>Timestamp</dt><dd>2026-06-30T00:10:20Z</dd>
+<dt>gsc version</dt><dd>0.2.365+10dca37a05</dd>
+</dl>
+</header>
+<section aria-labelledby="matrix-h">
+<h2 id="matrix-h">Status matrix</h2>
+<table class="matrix">
+<thead><tr><th scope="col">app</th><th scope="col">translate</th><th scope="col">compile</th><th scope="col">ilverify</th><th scope="col">test-parity</th></tr></thead>
+<tbody>
+<tr><th scope="row"><a href="#app-corpus-oahu-decrypt">corpus/Oahu.Decrypt</a></th><td class="cell pass" aria-label="passed"><span class="dot" aria-hidden="true"></span>PASS</td><td class="cell fail" aria-label="failed"><span class="dot" aria-hidden="true"></span>FAIL (1)</td><td class="cell skip" aria-label="skipped"><span class="dot" aria-hidden="true"></span>SKIP</td><td class="cell skip" aria-label="skipped"><span class="dot" aria-hidden="true"></span>SKIP</td></tr>
+</tbody>
+</table>
+</section>
+<section aria-labelledby="gaps-h">
+<h2 id="gaps-h">Discovered gaps (1)</h2>
+<article class="gap">
+<h3>[cs2gs] GS9998 compiling translated corpus/Oahu.Decrypt (GSharpConstruct)</h3>
+<ul class="gap-meta">
+<li><span class="k">fingerprint</span> <span class="v">sha256:50a2b466cb5950a1e9b7eadf7796a89b218728d04062d0360396f5c30253e372</span></li>
+<li><span class="k">category</span> <span class="v">compile-error</span></li>
+<li><span class="k">stage</span> <span class="v">compile</span></li>
+<li><span class="k">diagnostic</span> <span class="v">GS9998: InvalidOperationException: Variable &#39;Mvhd&#39; has no local slot or parameter index in the current method.</span></li>
+<li><span class="k">construct</span> <span class="v">GSharpConstruct</span></li>
+</ul>
+<pre class="snippet"><code>Children.Insert(Children.IndexOf(AudioTrack) + 1, textTrack!!)</code></pre>
+<p class="labels">labels: <span class="label">Oats</span> <span class="label">bug</span></p>
+<details class="occurrences" open><summary>1 occurrence(s)</summary>
+<ul>
+<li><span class="app">corpus/Oahu.Decrypt</span> <span class="loc">corpus_Oahu.Decrypt/MoovBox.gs:72:13</span></li>
+</ul>
+</details>
+<button type="button" class="toggle" aria-expanded="false" aria-controls="gap-body-0" data-target="gap-body-0">Suggested issue body</button>
+<pre id="gap-body-0" class="issue-body" hidden><code>The G# emitted for **corpus/Oahu.Decrypt** fails to compile with `gsc` 0.2.365+10dca37a05.
+
+- Diagnostic: `GS9998` — InvalidOperationException: Variable &#39;Mvhd&#39; has no local slot or parameter index in the current method.
+- Emitted G#: `corpus_Oahu.Decrypt/MoovBox.gs` (72,13)
+- Offending line: `Children.Insert(Children.IndexOf(AudioTrack) + 1, textTrack!!)`
+
+**Reproduction:** `cs2gs migrate` translates the corpus app, writes the `.gs` shown above, then runs `gsc /target:… /out:… corpus_Oahu.Decrypt/MoovBox.gs` which surfaces this error.
+**Fingerprint:** `sha256:50a2b466cb5950a1e9b7eadf7796a89b218728d04062d0360396f5c30253e372`</code></pre>
+</article>
+</section>
+<section aria-labelledby="apps-h">
+<h2 id="apps-h">App details</h2>
+<article id="app-corpus-oahu-decrypt" class="app-detail">
+<h3>corpus/Oahu.Decrypt <span class="state bad">failing</span></h3>
+<p class="meta-line"><span class="k">failure category</span> <span class="v">compile-error</span></p>
+<table class="stage-list"><thead><tr><th scope="col">stage</th><th scope="col">status</th><th scope="col">artifacts</th></tr></thead><tbody>
+<tr><td>translate</td><td>passed</td><td>0</td></tr>
+<tr><td>compile</td><td>failed</td><td>1</td></tr>
+<tr><td>ilverify</td><td>skipped</td><td>0</td></tr>
+<tr><td>test-parity</td><td>skipped</td><td>0</td></tr>
+</tbody></table>
+<p class="artifact-h">triage artifacts</p>
+<ul class="artifacts">
+<li><a href="corpus_Oahu.Decrypt/compile-50a2b466cb59.json">corpus_Oahu.Decrypt/compile-50a2b466cb59.json</a></li>
+</ul>
+</article>
+</section>
+<script>
+(function(){
+  var buttons = document.querySelectorAll('.toggle');
+  for (var i = 0; i < buttons.length; i++) {
+    buttons[i].addEventListener('click', function(){
+      var id = this.getAttribute('data-target');
+      var target = document.getElementById(id);
+      if (!target) { return; }
+      var hidden = target.hasAttribute('hidden');
+      if (hidden) { target.removeAttribute('hidden'); } else { target.setAttribute('hidden',''); }
+      this.setAttribute('aria-expanded', hidden ? 'true' : 'false');
+    });
+  }
+})();
+</script>
+</body>
+</html>

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/run.json
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/run.json
@@ -1,0 +1,42 @@
+{
+  "runId": "2026-06-30T00-10-20Z_03ca51",
+  "timestamp": "2026-06-30T00:10:20Z",
+  "gscVersion": "0.2.365+10dca37a05",
+  "gscPath": "/Users/davidobando/GitHub/DavidObando/gsharp/.worktrees/fix-1446/out/bin/Release/Compiler/gsc.dll",
+  "succeeded": false,
+  "apps": [
+    {
+      "appId": "corpus/Oahu.Decrypt",
+      "succeeded": false,
+      "failureCategory": "compile-error",
+      "stages": [
+        {
+          "stage": "translate",
+          "status": "passed",
+          "artifactCount": 0
+        },
+        {
+          "stage": "compile",
+          "status": "failed",
+          "artifactCount": 1
+        },
+        {
+          "stage": "ilverify",
+          "status": "skipped",
+          "artifactCount": 0
+        },
+        {
+          "stage": "test-parity",
+          "status": "skipped",
+          "artifactCount": 0
+        }
+      ],
+      "artifacts": [
+        "corpus_Oahu.Decrypt/compile-50a2b466cb59.json"
+      ],
+      "fingerprints": [
+        "sha256:50a2b466cb5950a1e9b7eadf7796a89b218728d04062d0360396f5c30253e372"
+      ]
+    }
+  ]
+}

--- a/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/summary.json
+++ b/cs2gs-runs/2026-06-30T00-10-20Z_03ca51/summary.json
@@ -1,0 +1,87 @@
+{
+  "runId": "2026-06-30T00-10-20Z_03ca51",
+  "timestamp": "2026-06-30T00:10:20Z",
+  "gscVersion": "0.2.365+10dca37a05",
+  "succeeded": false,
+  "totalApps": 1,
+  "greenApps": 0,
+  "stageOrder": [
+    "translate",
+    "compile",
+    "ilverify",
+    "test-parity"
+  ],
+  "apps": [
+    {
+      "appId": "corpus/Oahu.Decrypt",
+      "succeeded": false,
+      "failureCategory": "compile-error",
+      "stages": [
+        {
+          "stage": "translate",
+          "status": "passed",
+          "artifactCount": 0
+        },
+        {
+          "stage": "compile",
+          "status": "failed",
+          "artifactCount": 1
+        },
+        {
+          "stage": "ilverify",
+          "status": "skipped",
+          "artifactCount": 0
+        },
+        {
+          "stage": "test-parity",
+          "status": "skipped",
+          "artifactCount": 0
+        }
+      ],
+      "artifacts": [
+        "corpus_Oahu.Decrypt/compile-50a2b466cb59.json"
+      ],
+      "fingerprints": [
+        "sha256:50a2b466cb5950a1e9b7eadf7796a89b218728d04062d0360396f5c30253e372"
+      ]
+    }
+  ],
+  "gaps": [
+    {
+      "fingerprint": "sha256:50a2b466cb5950a1e9b7eadf7796a89b218728d04062d0360396f5c30253e372",
+      "category": "compile-error",
+      "stage": "compile",
+      "diagnostic": {
+        "id": "GS9998",
+        "message": "InvalidOperationException: Variable 'Mvhd' has no local slot or parameter index in the current method.",
+        "severity": "error"
+      },
+      "offendingCSharpConstruct": {
+        "kind": "GSharpConstruct",
+        "snippet": "Children.Insert(Children.IndexOf(AudioTrack) + 1, textTrack!!)"
+      },
+      "suggestedIssue": {
+        "title": "[cs2gs] GS9998 compiling translated corpus/Oahu.Decrypt (GSharpConstruct)",
+        "body": "The G# emitted for **corpus/Oahu.Decrypt** fails to compile with `gsc` 0.2.365+10dca37a05.\n\n- Diagnostic: `GS9998` — InvalidOperationException: Variable 'Mvhd' has no local slot or parameter index in the current method.\n- Emitted G#: `corpus_Oahu.Decrypt/MoovBox.gs` (72,13)\n- Offending line: `Children.Insert(Children.IndexOf(AudioTrack) + 1, textTrack!!)`\n\n**Reproduction:** `cs2gs migrate` translates the corpus app, writes the `.gs` shown above, then runs `gsc /target:… /out:… corpus_Oahu.Decrypt/MoovBox.gs` which surfaces this error.\n**Fingerprint:** `sha256:50a2b466cb5950a1e9b7eadf7796a89b218728d04062d0360396f5c30253e372`",
+        "labels": [
+          "Oats",
+          "bug"
+        ]
+      },
+      "occurrences": [
+        {
+          "appId": "corpus/Oahu.Decrypt",
+          "sourceLocation": {
+            "gsFile": "corpus_Oahu.Decrypt/MoovBox.gs",
+            "gsLine": 72,
+            "gsColumn": 13,
+            "csFile": null,
+            "csLine": null,
+            "csColumn": null
+          }
+        }
+      ],
+      "retryHistory": []
+    }
+  ]
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/APICFrame.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/APICFrame.gs
@@ -1,0 +1,48 @@
+package Oahu.Decrypt.Mpeg4.ID3
+
+import System.IO
+import System.Text
+
+class APICFrame : Frame {
+    init(file Stream, header Header, parent Frame) : base(header, parent) {
+        let startPos = file.Position
+        let textEncoding = file.ReadByte()
+        ImageFormat = Frame.ReadNullTerminatedString(file, false)
+        Description = Frame.ReadNullTerminatedString(file, textEncoding == 1)
+        Type = uint8(file.ReadByte())
+        Image = [int32((startPos + int64(header.Size) - file.Position))]uint8
+        file.ReadExactly(Image)
+    }
+
+    override prop Size int32 {
+        get {
+            let fixedSize = 1 + ImageFormat.Length + 1 + 1 + Image.Length
+            if Frame.IsUnicode(Description) {
+                return Frame.UnicodeLength(Description) + 2 + fixedSize
+            } else {
+                return Description.Length + 1 + fixedSize
+            }
+        }
+    }
+
+    prop ImageFormat string
+    prop Description string
+    prop Type uint8
+    prop Image []uint8
+
+    override func Render(file Stream) {
+        let txtFormat = if Frame.IsUnicode(Description) { 1 } else { 0 }
+        file.WriteByte(uint8(txtFormat))
+        file.Write(Encoding.ASCII.GetBytes(ImageFormat))
+        file.WriteByte(0)
+        file.WriteByte(Type)
+        if txtFormat == 0 {
+            file.Write(Encoding.ASCII.GetBytes(Description))
+            file.WriteByte(0)
+        } else {
+            file.Write(Frame.UnicodeBytes(Description))
+            file.Write(stackalloc [2]uint8)
+        }
+        file.Write(Image)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/AacValidateFilter.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/AacValidateFilter.gs
@@ -1,0 +1,20 @@
+package Oahu.Decrypt.FrameFilters.Audio
+
+import System
+
+internal open class AacValidateFilter : FrameTransformBase[FrameEntry, FrameEntry] {
+    protected open override prop InputBufferSize int32 -> 1000
+
+    open override func PerformFiltering(input FrameEntry) FrameEntry {
+        return if AacValidateFilter.ValidateFrame(input.FrameData.Span) { input } else { throw Exception("Aac error!")
+            default(FrameEntry) }
+    }
+
+    shared {
+        private func ValidateFrame(frame ReadOnlySpan[uint8]) bool -> (AacValidateFilter.AV_RB16(frame) & uint16(0xfff0)) != 0xfff0
+
+        private func AV_RB16(frame ReadOnlySpan[uint8]) uint16 {
+            return uint16((frame[0] << 8 | int32(frame[1])))
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/AavdFilter.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/AavdFilter.gs
@@ -1,0 +1,40 @@
+package Oahu.Decrypt.FrameFilters.Audio
+
+import System
+import System.Security.Cryptography
+
+internal open class AavdFilter : AacValidateFilter {
+    private let aes Aes
+    private let iv []uint8
+
+    init(key []?uint8, iv []?uint8) {
+        if key == nil || key!!.Length != AavdFilter.AesBlockSize {
+            throw ArgumentException("${nameof(key)} must be ${AavdFilter.AesBlockSize} bytes long.")
+        }
+        if iv == nil || iv!!.Length != AavdFilter.AesBlockSize {
+            throw ArgumentException("${nameof(iv)} must be ${AavdFilter.AesBlockSize} bytes long.")
+        }
+        this.aes = Aes.Create()
+        this.aes.Key = key
+        this.iv = iv
+    }
+
+    open override func PerformFiltering(input FrameEntry) FrameEntry {
+        if input.FrameData.Length >= 0x10 {
+            let encBlocks = input.FrameData.Slice(0, input.FrameData.Length & 0x7ffffff0).Span
+            aes.DecryptCbc(encBlocks, iv, encBlocks, PaddingMode.None)
+        }
+        return base.PerformFiltering(input)
+    }
+
+    protected open override func Dispose(disposing bool) {
+        if disposing && !Disposed {
+            aes.Dispose()
+        }
+        base.Dispose(disposing)
+    }
+
+    shared {
+        private const AesBlockSize int32 = 16
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/AaxFile.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/AaxFile.gs
@@ -1,0 +1,116 @@
+package Oahu.Decrypt
+
+import System
+import System.Collections.Generic
+import System.IO
+import System.Linq
+import Oahu.Decrypt.FrameFilters
+import Oahu.Decrypt.FrameFilters.Audio
+import Oahu.Decrypt.Mpeg4.Boxes
+import Oahu.Decrypt.Mpeg4.Util
+
+class AaxFile : Mp4File {
+    init(file Stream, fileSize int64, additionalFixups bool = true) : base(file, fileSize) {
+        if FileType != FileType.Aax && FileType != FileType.Aaxc {
+            throw ArgumentException("This instance of ${nameof(Mp4File)} is not an Aax or Aaxc file.")
+        }
+        let esds EsdsBox? = AudioSampleEntry.Esds as EsdsBox
+        if esds != nil {
+            esds.ES_Descriptor.DecoderConfig.AudioSpecificConfig.DependsOnCoreCoder = false
+        }
+        AudioSampleEntry.Header.ChangeAtomName("mp4a")
+        if additionalFixups {
+            let children = AudioSampleEntry.Children
+            for var i = children.Count - 1; i >= 0; i-- {
+                if children[i] is FreeBox {
+                    children.RemoveAt(i)
+                }
+            }
+            Ftyp = FtypBox.Create("isom", 0x200)
+            Ftyp.CompatibleBrands.Add("iso2")
+            Ftyp.CompatibleBrands.Add("mp41")
+            Ftyp.CompatibleBrands.Add("M4A ")
+            Ftyp.CompatibleBrands.Add("M4B ")
+        }
+    }
+
+    convenience init(file Stream) {
+        init(file, file.Length)
+    }
+
+    convenience init(fileName string, access FileAccess = 1, share FileShare = 1) {
+        init(File.Open(fileName, FileMode.Open, access, share))
+    }
+
+    prop Key []?uint8
+    prop IV []?uint8
+
+    override func GetAudioFrameFilter() FrameTransformBase[FrameEntry, FrameEntry] {
+        return if Key != nil && IV != nil { AavdFilter(Key!!, IV!!) } else { throw InvalidOperationException("This instance of ${nameof(AaxFile)} does not have a decryption key set.")
+            default(AavdFilter) }
+    }
+
+    func SetDecryptionKey(activationBytes string) {
+        if String.IsNullOrWhiteSpace(activationBytes) || activationBytes.Length != 8 {
+            throw ArgumentException("${nameof(activationBytes)} must be 4 bytes long.")
+        }
+        let actBytes = ByteUtil.BytesFromHexString(activationBytes)
+        SetDecryptionKey(actBytes)
+    }
+
+    func SetDecryptionKey(activationBytes []?uint8) {
+        if activationBytes == nil || activationBytes!!.Length != 4 {
+            throw ArgumentException("${nameof(activationBytes)} must be 4 bytes long.")
+        }
+        if FileType != FileType.Aax {
+            throw ArgumentException("This instance of ${nameof(AaxFile)} is not an ${FileType.Aax} file.")
+        }
+        let adrm = AudioSampleEntry.GetChild[AdrmBox]() ?? throw InvalidOperationException("This instance of ${nameof(AaxFile)} does not contain an adrm box.")
+        let intermediate_key = Crypto.Sha1((AaxFile.AudibleFixedKey, 0, AaxFile.AudibleFixedKey.Length), (activationBytes!!, 0, activationBytes!!.Length))
+        let intermediate_iv = Crypto.Sha1((AaxFile.AudibleFixedKey, 0, AaxFile.AudibleFixedKey.Length), (intermediate_key, 0, intermediate_key.Length), (activationBytes!!, 0, activationBytes!!.Length))
+        let calculatedChecksum = Crypto.Sha1((intermediate_key, 0, 16), (intermediate_iv, 0, 16))
+        if !ByteUtil.BytesEqual(calculatedChecksum, adrm.Checksum) {
+            throw Exception("Calculated checksum doesn't match AAX file checksum.")
+        }
+        let drmBlob = ByteUtil.CloneBytes(adrm.DrmBlob)
+        Crypto.DecryptInPlace(ByteUtil.CloneBytes(intermediate_key, 0, 16), ByteUtil.CloneBytes(intermediate_iv, 0, 16), drmBlob)
+        if !ByteUtil.BytesEqual(drmBlob, 0, activationBytes!!, 0, 4, true) {
+            throw Exception("Supplied key doesn't match calculated key.")
+        }
+        let file_key = ByteUtil.CloneBytes(drmBlob, 8, 16)
+        let file_iv = Crypto.Sha1((drmBlob, 26, 16), (file_key, 0, 16), (AaxFile.AudibleFixedKey, 0, 16))
+        AudioSampleEntry.Children.Remove(adrm)
+        let aabd IBox? = AudioSampleEntry.Children.FirstOrDefault((b IBox) -> b.Header.Type == "aabd") as IBox
+        if aabd != nil {
+            AudioSampleEntry.Children.Remove(aabd)
+        }
+        SetDecryptionKey(file_key, ByteUtil.CloneBytes(file_iv, 0, 16))
+    }
+
+    func SetDecryptionKey(audible_key string, audible_iv string) {
+        if String.IsNullOrWhiteSpace(audible_key) || audible_key.Length != 32 {
+            throw ArgumentException("${nameof(audible_key)} must be 16 bytes long.")
+        }
+        if String.IsNullOrWhiteSpace(audible_iv) || audible_iv.Length != 32 {
+            throw ArgumentException("${nameof(audible_iv)} must be 16 bytes long.")
+        }
+        let key = ByteUtil.BytesFromHexString(audible_key)
+        let iv = ByteUtil.BytesFromHexString(audible_iv)
+        SetDecryptionKey(key, iv)
+    }
+
+    func SetDecryptionKey(key []?uint8, iv []?uint8) {
+        if key == nil || key!!.Length != 16 {
+            throw ArgumentException("${nameof(key)} must be 16 bytes long.")
+        }
+        if iv == nil || iv!!.Length != 16 {
+            throw ArgumentException("${nameof(iv)} must be 16 bytes long.")
+        }
+        Key = key
+        IV = iv
+    }
+
+    shared {
+        private let AudibleFixedKey []uint8 = []uint8{uint8(0x77), uint8(0x21), uint8(0x4d), uint8(0x4b), uint8(0x19), uint8(0x6a), uint8(0x87), uint8(0xcd), uint8(0x52), uint8(0x00), uint8(0x45), uint8(0xfd), uint8(0x20), uint8(0xa5), uint8(0x1d), uint8(0x67)}
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Ac4BitrateDsi.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Ac4BitrateDsi.gs
@@ -1,0 +1,15 @@
+package Oahu.Decrypt.Mpeg4.Boxes.AC4SpecificBox
+
+import Oahu.Decrypt.Mpeg4.Util
+
+class Ac4BitrateDsi {
+    var BitRateMode BitRateMode
+    var BitRate uint32
+    var BitRatePrecision uint32
+
+    init(reader BitReader) {
+        BitRateMode = BitRateMode(reader.Read(2))
+        BitRate = reader.Read(32)
+        BitRatePrecision = reader.Read(32)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Ac4DsiV1.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Ac4DsiV1.gs
@@ -1,0 +1,61 @@
+package Oahu.Decrypt.Mpeg4.Boxes.AC4SpecificBox
+
+import System
+import Oahu.Decrypt.Mpeg4.Util
+
+class Ac4DsiV1 {
+    var Ac4DsiVersion uint8
+    var BitstreamVersion uint8
+    var FsIndex uint8
+    var FrameRateIndex uint8
+    var NPresentations uint16
+    var BProgramId bool?
+    var ShortProgramId uint16?
+    var BUuid bool?
+    var ProgramUuid Guid?
+    var Ac4BitrateDsi Ac4BitrateDsi
+    var Presentations []object?
+
+    init(reader BitReader) {
+        Ac4DsiVersion = uint8(reader.Read(3))
+        BitstreamVersion = uint8(reader.Read(7))
+        FsIndex = uint8(reader.Read(1))
+        FrameRateIndex = uint8(reader.Read(4))
+        NPresentations = uint16(reader.Read(9))
+        if BitstreamVersion > uint8(1) {
+            BProgramId = reader.ReadBool()
+            if BProgramId.Value {
+                ShortProgramId = uint16(reader.Read(16))
+                BUuid = reader.ReadBool()
+                if BUuid.Value {
+                    ProgramUuid = Guid(reader.Read(32), uint16(reader.Read(16)), uint16(reader.Read(16)), uint8(reader.Read(8)), uint8(reader.Read(8)), uint8(reader.Read(8)), uint8(reader.Read(8)), uint8(reader.Read(8)), uint8(reader.Read(8)), uint8(reader.Read(8)), uint8(reader.Read(8)))
+                }
+            }
+        }
+        Ac4BitrateDsi = Ac4BitrateDsi(reader)
+        reader.ByteAlign()
+        Presentations = [int32(NPresentations)]object
+        for var i = 0; i < int32(NPresentations); i++ {
+            var presentationBytes uint32
+            let presentationVersion = reader.Read(8)
+            var presBytes = reader.Read(8)
+            if presBytes == uint32(255) {
+                let addPresBytes = reader.Read(16)
+                presBytes += addPresBytes
+            }
+            if presentationVersion == uint32(0) {
+                throw NotSupportedException("ac4_presentation_v0_dsi not yet supported")
+            } else {
+                if presentationVersion == uint32(1) || presentationVersion == uint32(2) {
+                    let start = reader.Position
+                    Presentations[i] = Ac4PresentationV1Dsi(presentationVersion, presBytes, reader)
+                    presentationBytes = uint32((reader.Position - start)) / uint32(8)
+                } else {
+                    presentationBytes = uint32(0)
+                }
+            }
+            let skipBytes = presBytes - presentationBytes
+            reader.Position += 8 * int32(skipBytes)
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Ac4Extensions.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Ac4Extensions.gs
@@ -1,0 +1,51 @@
+package Oahu.Decrypt.Mpeg4.Boxes.AC4SpecificBox
+
+import System.Linq
+
+class Ac4Extensions {
+    shared {
+        private let NumChannelsPerGroup []uint8 = []uint8{uint8(2), uint8(1), uint8(2), uint8(2), uint8(2), uint8(2), uint8(1), uint8(2), uint8(2), uint8(1), uint8(1), uint8(1), uint8(1), uint8(2), uint8(1), uint8(1), uint8(2), uint8(2), uint8(2)}
+
+        func ChannelCount(channels ChannelGroups) int32 {
+            var channelCount = 0
+            for var g = 0; g <= 18; g++ {
+                let group = ChannelGroups((1 << g))
+                if channels.HasFlag(group) {
+                    channelCount += int32(Ac4Extensions.NumChannelsPerGroup[g])
+                }
+            }
+            return channelCount
+        }
+    }
+}
+
+func (ac4DsiV1 Ac4DsiV1?) SampleRate() int32? -> if ac4DsiV1 == nil { nil } else { if ac4DsiV1!!.FsIndex == uint8(0) { 44100 } else { 48000 } }
+
+func (ac4DsiV1 Ac4DsiV1?) AverageBitrate() uint32? {
+    if ac4DsiV1 == nil {
+        return nil
+    }
+    if ac4DsiV1!!.Ac4BitrateDsi.BitRate != uint32(0) {
+        return ac4DsiV1!!.Ac4BitrateDsi.BitRate
+    }
+    for presentation in ac4DsiV1!!.Presentations.OfType[Ac4PresentationV1Dsi]().Where((p Ac4PresentationV1Dsi) -> p.BPresentationBitrateInfo) {
+        if presentation!!.Ac4BitrateDsi is Ac4BitrateDsi && (presentation!!.Ac4BitrateDsi as Ac4BitrateDsi)!!.BitRate != uint32(0) {
+            return (presentation!!.Ac4BitrateDsi as Ac4BitrateDsi)!!.BitRate
+        }
+    }
+    return nil
+}
+
+func (ac4DsiV1 Ac4DsiV1?) Channels() ChannelGroups? {
+    if ac4DsiV1 == nil {
+        return nil
+    }
+    for presentation in ac4DsiV1!!.Presentations.OfType[Ac4PresentationV1Dsi]().OrderByDescending((p Ac4PresentationV1Dsi) -> p.PresentationVersion) {
+        if presentation!!.BPresentationChannelCoded == true {
+            return presentation!!.PresentationChannelMaskV1
+        } else if presentation!!.Substream?.BChannelCoded == true {
+            return presentation!!.Substream!!.Substreams[0].DsiSubstreamChannelMask
+        }
+    }
+    return nil
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Ac4PresentationV1Dsi.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Ac4PresentationV1Dsi.gs
@@ -1,0 +1,121 @@
+package Oahu.Decrypt.Mpeg4.Boxes.AC4SpecificBox
+
+import System
+import Oahu.Decrypt.Mpeg4.Util
+
+class Ac4PresentationV1Dsi {
+    var PresentationVersion uint32
+    var PresentationConfigV1 uint8
+    var BAddEmdfSubstreams bool
+    var Mdcompat uint8?
+    var BPresentationId bool?
+    var PresentationId uint8?
+    var DsiFrameRateMultiplyInfo uint8?
+    var DsiFrameRateFractionInfo uint8?
+    var PresentationEmdfVersion uint8?
+    var PresentationKeyId uint16?
+    var BPresentationChannelCoded bool?
+    var DsiPresentationChMode uint8?
+    var PresB4BackChannelsPresent uint8?
+    var PresTopChannelPairs uint8?
+    var PresentationChannelMaskV1 ChannelGroups?
+    var BPresentationCoreDiffers bool?
+    var BPresentationCoreChannelCoded bool?
+    var DsiPresentationChannelModeCore uint8?
+    var BPresentationFilter bool?
+    var BEnablePresentation bool?
+    var NFilterBytes uint8?
+    var FilterData []?uint8
+    var Substream Ac4SubstreamGroupDsi?
+    var BPreVirtualized bool?
+    var NAddEmdfSubstreams uint8?
+    var SubstreamsEmdfs []?(uint8, uint16)
+    var BPresentationBitrateInfo bool
+    var Ac4BitrateDsi Ac4BitrateDsi?
+    var BAlternative bool
+    var AlternativeInfo AlternativeInfo?
+    var DeIndicator uint8?
+    var BExtendedPresentationId bool?
+    var ExtendedPresentationId uint16?
+    var DolbyAtmosIndicator bool?
+
+    init(presentationVersion uint32, presBytes uint32, reader BitReader) {
+        PresentationVersion = presentationVersion
+        let start = reader.Position
+        PresentationConfigV1 = uint8(reader.Read(5))
+        if PresentationConfigV1 == uint8(6) {
+            BAddEmdfSubstreams = true
+        } else {
+            Mdcompat = uint8(reader.Read(3))
+            BPresentationId = reader.ReadBool()
+            if BPresentationId.Value {
+                PresentationId = uint8(reader.Read(5))
+            }
+            DsiFrameRateMultiplyInfo = uint8(reader.Read(2))
+            DsiFrameRateFractionInfo = uint8(reader.Read(2))
+            PresentationEmdfVersion = uint8(reader.Read(5))
+            PresentationKeyId = uint16(reader.Read(10))
+            BPresentationChannelCoded = reader.ReadBool()
+            if BPresentationChannelCoded.Value {
+                DsiPresentationChMode = uint8(reader.Read(5))
+                if DsiPresentationChMode == (11 as uint8?) || DsiPresentationChMode == (12 as uint8?) || DsiPresentationChMode == (13 as uint8?) || DsiPresentationChMode == (14 as uint8?) {
+                    PresB4BackChannelsPresent = uint8(reader.Read(1))
+                    PresTopChannelPairs = uint8(reader.Read(2))
+                }
+                PresentationChannelMaskV1 = ChannelGroups(reader.Read(24))
+            }
+            BPresentationCoreDiffers = reader.ReadBool()
+            if BPresentationCoreDiffers.Value {
+                BPresentationCoreChannelCoded = reader.ReadBool()
+                if BPresentationCoreChannelCoded.Value {
+                    DsiPresentationChannelModeCore = uint8(reader.Read(2))
+                }
+            }
+            BPresentationFilter = reader.ReadBool()
+            if BPresentationFilter.Value {
+                BEnablePresentation = reader.ReadBool()
+                NFilterBytes = uint8(reader.Read(8))
+                FilterData = [int32(NFilterBytes.Value)]uint8
+                for var i = 0; i < int32(NFilterBytes.Value); i++ {
+                    FilterData!![i] = uint8(reader.Read(8))
+                }
+            }
+            if PresentationConfigV1 == uint8(0x1f) {
+                Substream = Ac4SubstreamGroupDsi(reader)
+            } else {
+                throw NotSupportedException()
+            }
+            BPreVirtualized = reader.ReadBool()
+            BAddEmdfSubstreams = reader.ReadBool()
+        }
+        if BAddEmdfSubstreams {
+            NAddEmdfSubstreams = uint8(reader.Read(7))
+            SubstreamsEmdfs = [int32(NAddEmdfSubstreams.Value)](uint8, uint16)
+            for var j = 0; j < (NAddEmdfSubstreams as int32?); j++ {
+                SubstreamsEmdfs!![j] = (uint8(reader.Read(5)), uint16(reader.Read(10)))
+            }
+        }
+        BPresentationBitrateInfo = reader.ReadBool()
+        if BPresentationBitrateInfo {
+            Ac4BitrateDsi = Ac4BitrateDsi(reader)
+        }
+        BAlternative = reader.ReadBool()
+        if BAlternative {
+            reader.ByteAlign()
+            AlternativeInfo = AlternativeInfo(reader)
+        }
+        reader.ByteAlign()
+        let read = reader.Position - start
+        if int64(read) <= int64((presBytes - uint32(1)) * uint32(8)) {
+            DeIndicator = uint8(reader.Read(1))
+            DolbyAtmosIndicator = reader.ReadBool()
+            reader.Read(4)
+            BExtendedPresentationId = reader.ReadBool()
+            if BExtendedPresentationId.Value {
+                ExtendedPresentationId = uint16(reader.Read(9))
+            } else {
+                reader.Read(1)
+            }
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Ac4Substream.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Ac4Substream.gs
@@ -1,0 +1,41 @@
+package Oahu.Decrypt.Mpeg4.Boxes.AC4SpecificBox
+
+import Oahu.Decrypt.Mpeg4.Util
+
+class Ac4Substream {
+    var DsiSfMultiplier uint8
+    var BSubstreamBitrateIndicator bool
+    var SubstreamBitrateIndicator uint8?
+    var DsiSubstreamChannelMask ChannelGroups?
+    var BAjoc bool?
+    var BStaticDmx bool?
+    var NDmxObjectsMinus1 uint8?
+    var NUmxObjectsMinus1 uint8?
+    var BSubstreamContainsBedObjects bool?
+    var BSubstreamContainsDynamicObjects bool?
+    var BSubstreamContainsIsfObjects bool?
+
+    init(info Ac4SubstreamGroupDsi, reader BitReader) {
+        DsiSfMultiplier = uint8(reader.Read(2))
+        BSubstreamBitrateIndicator = reader.ReadBool()
+        if BSubstreamBitrateIndicator {
+            SubstreamBitrateIndicator = uint8(reader.Read(5))
+        }
+        if info.BChannelCoded {
+            DsiSubstreamChannelMask = ChannelGroups(reader.Read(24))
+        } else {
+            BAjoc = reader.ReadBool()
+            if BAjoc.Value {
+                BStaticDmx = reader.ReadBool()
+                if BStaticDmx.Value {
+                    NDmxObjectsMinus1 = uint8(reader.Read(4))
+                }
+                NUmxObjectsMinus1 = uint8(reader.Read(6))
+            }
+            BSubstreamContainsBedObjects = reader.ReadBool()
+            BSubstreamContainsDynamicObjects = reader.ReadBool()
+            BSubstreamContainsIsfObjects = reader.ReadBool()
+            reader.Read(1)
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Ac4SubstreamGroupDsi.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Ac4SubstreamGroupDsi.gs
@@ -1,0 +1,39 @@
+package Oahu.Decrypt.Mpeg4.Boxes.AC4SpecificBox
+
+import Oahu.Decrypt.Mpeg4.Util
+
+class Ac4SubstreamGroupDsi {
+    var BSubstreamsPresent bool
+    var BHsfExt bool
+    var BChannelCoded bool
+    var NSubstreams uint8
+    var Substreams []Ac4Substream
+    var BContentType bool
+    var ContentClassifier uint8?
+    var BLanguageIndicator bool?
+    var NLanguageTagBytes int32?
+    var LanguageTagBytes []?uint8
+
+    init(reader BitReader) {
+        BSubstreamsPresent = reader.ReadBool()
+        BHsfExt = reader.ReadBool()
+        BChannelCoded = reader.ReadBool()
+        NSubstreams = uint8(reader.Read(8))
+        Substreams = [int32(NSubstreams)]Ac4Substream
+        for var i = 0; i < int32(NSubstreams); i++ {
+            Substreams[i] = Ac4Substream(this, reader)
+        }
+        BContentType = reader.ReadBool()
+        if BContentType {
+            ContentClassifier = uint8(reader.Read(3))
+            BLanguageIndicator = reader.ReadBool()
+            if BLanguageIndicator.Value {
+                NLanguageTagBytes = uint8(reader.Read(6))
+                LanguageTagBytes = [NLanguageTagBytes.Value]uint8
+                for var i = 0; i < LanguageTagBytes!!.Length; i++ {
+                    LanguageTagBytes!![i] = uint8(reader.Read(8))
+                }
+            }
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/AdrmBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/AdrmBox.gs
@@ -1,0 +1,39 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class AdrmBox : Box {
+    private let beginBlob []uint8
+    private let middleBlob []uint8
+    private let endBlob []uint8
+
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        beginBlob = file.ReadBlock(8)
+        DrmBlob = file.ReadBlock(56)
+        middleBlob = file.ReadBlock(4)
+        Checksum = file.ReadBlock(20)
+        let len = RemainingBoxLength(file)
+        endBlob = file.ReadBlock(int32(len))
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(beginBlob.Length) + int64(DrmBlob.Length) + int64(middleBlob.Length) + int64(Checksum.Length) + int64(endBlob.Length)
+
+    prop DrmBlob []uint8 {
+        get;
+        init;
+    }
+
+    prop Checksum []uint8 {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        file.Write(beginBlob)
+        file.Write(DrmBlob)
+        file.Write(middleBlob)
+        file.Write(Checksum)
+        file.Write(endBlob)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/AesCtr.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/AesCtr.gs
@@ -1,0 +1,88 @@
+package Oahu.Decrypt.Mpeg4.Util
+
+import System
+import System.Security.Cryptography
+
+unsafe class AesCtr : IDisposable {
+    private let encryptor ICryptoTransform
+    private let aes Aes
+    private let encryptedCounter []uint8 = [AesCtr.AesBlockSize]uint8
+    private var isDisposed bool
+
+    init(key []uint8) {
+        ArgumentNullException.ThrowIfNull(key, nameof(key))
+        if key.Length != AesCtr.AesBlockSize {
+            throw ArgumentException("${nameof(key)} must be exactly ${AesCtr.AesBlockSize} bytes long.")
+        }
+        aes = Aes.Create()
+        this.aes.Padding = PaddingMode.None
+        this.aes.Mode = CipherMode.ECB
+        encryptor = aes.CreateEncryptor(key, nil)
+    }
+
+    func Decrypt(iv []uint8, source ReadOnlySpan[uint8], destination Span[uint8]) {
+        ArgumentNullException.ThrowIfNull(iv, nameof(iv))
+        ArgumentOutOfRangeException.ThrowIfNotEqual(iv.Length, AesCtr.AesBlockSize, nameof(iv))
+        if destination.Length < source.Length {
+            throw ArithmeticException("Destination array is not long enough. (Parameter '${nameof(destination)}')")
+        }
+        const aesNumDwords = AesCtr.AesBlockSize / 4
+        fixed pD *uint8 = destination {
+            fixed pS *uint8 = source {
+                fixed pEc *uint8 = encryptedCounter {
+                    var pD32 = *uint32(pD)
+                    var pS32 = *uint32(pS)
+                    let pEc32 = *uint32(pEc)
+                    var dataPos = 0
+                    var count = source.Length
+                    while count >= AesCtr.AesBlockSize {
+                        encryptor.TransformBlock(iv, 0, AesCtr.AesBlockSize, encryptedCounter, 0)
+                        AesCtr.IncrementBE(iv)
+                        for var i = 0; i < aesNumDwords; i++ {
+                            *pD32 = pEc32[i] ^ *pS32
+                            pD32++
+                            pS32++
+                        }
+                        dataPos += AesCtr.AesBlockSize
+                        count -= AesCtr.AesBlockSize
+                    }
+                    if count > 0 {
+                        encryptor.TransformBlock(iv, 0, AesCtr.AesBlockSize, encryptedCounter, 0)
+                        {
+                            var i = 0
+                            while i < count {
+                                pD[dataPos] = uint8((pEc[i] ^ pS[dataPos]))
+                                i++
+                                dataPos++
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    func Dispose() {
+        Dispose(true)
+        GC.SuppressFinalize(this)
+    }
+
+    private func Dispose(disposing bool) {
+        if disposing & !isDisposed {
+            encryptor.Dispose()
+            aes.Dispose()
+            isDisposed = true
+        }
+    }
+
+    shared {
+        const AesBlockSize int32 = 16
+
+        private func IncrementBE(data []uint8) {
+            var i = data.Length - 1
+            do {
+                data[i]++
+            } while data[i] == uint8(0) && i-- > 0
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/AlternativeInfo.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/AlternativeInfo.gs
@@ -1,0 +1,24 @@
+package Oahu.Decrypt.Mpeg4.Boxes.AC4SpecificBox
+
+import Oahu.Decrypt.Mpeg4.Util
+
+class AlternativeInfo {
+    var NameLen uint16
+    var PresentationName string
+    var NTargets uint8
+    var TargetIds [](uint8, uint8)
+
+    init(reader BitReader) {
+        NameLen = uint16(reader.Read(16))
+        let nameBts = [int32(NameLen)]char
+        for var i = 0; i < int32(NameLen); i++ {
+            nameBts[i] = char(reader.Read(8))
+        }
+        PresentationName = string(nameBts)
+        NTargets = uint8(reader.Read(5))
+        TargetIds = [int32(NTargets)](uint8, uint8)
+        for var i = 0; i < int32(NameLen); i++ {
+            TargetIds[i] = (uint8(reader.Read(3)), uint8(reader.Read(8)))
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/AppleDataBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/AppleDataBox.gs
@@ -1,0 +1,63 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.Diagnostics
+import System.IO
+import System.Text
+import Oahu.Decrypt.Mpeg4.Util
+
+@DebuggerDisplay("{DebuggerDisplay,nq}")
+open class AppleDataBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        DataType = AppleDataType(file.ReadUInt32BE())
+        Flags = file.ReadUInt32BE()
+        let length = RemainingBoxLength(file)
+        Data = file.ReadBlock(int32(length))
+    }
+
+    private init(header BoxHeader, parent IBox, data []uint8, type_ AppleDataType) : base(header, parent) {
+        DataType = type_
+        Flags = uint32(0)
+        Data = data
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(8) + int64(Data.Length)
+
+    prop DataType AppleDataType {
+        get;
+        init;
+    }
+
+    prop Flags uint32 {
+        get;
+        init;
+    }
+
+    prop Data []uint8
+
+    @DebuggerHidden
+    private prop DebuggerDisplay string -> if DataType is AppleDataType { "[UTF-8]: '${Encoding.UTF8.GetString(Data)}'" } else { if DataType is AppleDataType { "[UTF-16]: '${Encoding.Unicode.GetString(Data)}'" } else { "[$DataType]: ${Data.Length} bytes" } }
+
+    func ReadAsString() string {
+        return switch DataType {
+            case AppleDataType.Utf_8: Encoding.UTF8.GetString(Data)
+            case AppleDataType.Utf_16: Encoding.Unicode.GetString(Data)
+            default: throw InvalidDataException("Cannot read AppleDataBox of type $DataType as string.")
+        }
+    }
+
+    protected open override func Render(file Stream) {
+        file.WriteUInt32BE(uint32(DataType))
+        file.WriteUInt32BE(Flags)
+        file.Write(Data)
+    }
+
+    shared {
+        func Create(parent IBox, data []uint8, type_ AppleDataType) AppleDataBox {
+            let size = data.Length + 8
+            let header = BoxHeader(uint32(size), "data")
+            let dataBox = AppleDataBox(header, parent, data, type_)
+            parent.Children.Add(dataBox)
+            return dataBox
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/AppleDataType.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/AppleDataType.gs
@@ -1,0 +1,3 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+enum AppleDataType { ContainsData, Utf_8, Utf_16, Utf_8_Sort, Utf_16_Sort, JPEG, PNG, BE_Signed_Integer, BE_Unsigned_Integer, BE_Float_32, BE_Float_64, BMP, Signed_Byte, BE_Signed_Integer_16, BE_Signed_Integer_32, BE_Signed_Integer_64, Unigned_Byte, BE_Unsigned_Integer_16, BE_Unsigned_Integer_32, BE_Unsigned_Integer_64 }

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/AppleListBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/AppleListBox.gs
@@ -1,0 +1,143 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.Collections.Generic
+import System.IO
+import System.Linq
+import System.Text
+
+open class AppleListBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        let endPos = Header.FilePosition + Header.TotalBoxSize
+        while file.Position < endPos {
+            let tagBoxHeader = BoxHeader(file)
+            let appleTag = if tagBoxHeader.Type == "----" { FreeformTagBox(file, tagBoxHeader, this) } else { AppleTagBox(file, tagBoxHeader, this) }
+            if appleTag.Header.TotalBoxSize == int64(0) {
+                break
+            }
+            Children.Add(appleTag)
+        }
+    }
+
+    private init(parent IBox) : base(BoxHeader(8, "ilst"), parent) {
+    }
+
+    prop TagNames IEnumerable[string] -> Tags.Select((t AppleTagBox) -> t.Header.Type)
+    prop FreeformTagNames IEnumerable[string] -> FreeformTags.Select((t FreeformTagBox) -> t.TagName)
+    prop Tags IEnumerable[AppleTagBox] -> GetChildren[AppleTagBox]()
+    prop FreeformTags IEnumerable[FreeformTagBox] -> GetChildren[FreeformTagBox]()
+
+    func AddTag(name string, data string) {
+        AppleTagBox.Create(this, name, Encoding.UTF8.GetBytes(data), AppleDataType.Utf_8)
+    }
+
+    func AddTag(name string, data []uint8, type_ AppleDataType) {
+        AppleTagBox.Create(this, name, data, type_)
+    }
+
+    func RemoveTag(name string) bool -> GetTagBox(name) != nil && RemoveTag(GetTagBox(name)!!!!)
+    func RemoveFreeformTag(domain string, name string) bool -> GetFreeformTagBox(domain, name) != nil && RemoveTag(GetFreeformTagBox(domain, name)!!!!)
+
+    func RemoveTag(tag AppleTagBox) bool {
+        if Children.Remove(tag) {
+            tag.Dispose()
+            return true
+        } else if tag is FreeformTagBox {
+            if tag.Mean?.ReverseDnsDomain != nil && tag.Name?.Name != nil && GetFreeformTagBox(tag.Mean?.ReverseDnsDomain!!!!, tag.Name?.Name!!!!) != nil && Children.Remove(GetFreeformTagBox(tag.Mean?.ReverseDnsDomain!!!!, tag.Name?.Name!!!!)!!!!) {
+                GetFreeformTagBox(tag.Mean?.ReverseDnsDomain!!!!, tag.Name?.Name!!!!)!!!!.Dispose()
+                return true
+            }
+        } else if GetTagBox(tag.Header.Type) != nil && Children.Remove(GetTagBox(tag.Header.Type)!!!!) {
+            GetTagBox(tag.Header.Type)!!!!.Dispose()
+            return true
+        }
+        return false
+    }
+
+    func EditOrAddTag(name string, data string?) {
+        EditOrAddTag(name, if data == nil { default([]?uint8) } else { Encoding.UTF8.GetBytes(data!!) }, AppleDataType.Utf_8)
+    }
+
+    func EditOrAddTag(name string, data []?uint8) {
+        EditOrAddTag(name, data, AppleDataType.ContainsData)
+    }
+
+    func EditOrAddTag[TData IAppleData[TData]](name string, data TData?) {
+        var bytes []?uint8
+        if data != nil {
+            bytes = [TData.SizeInBytes]uint8
+            data.Write(bytes!!)
+        } else {
+            bytes = nil
+        }
+        EditOrAddTag(name, bytes, AppleDataType.ContainsData)
+    }
+
+    func EditOrAddTag(name string, data []?uint8, type_ AppleDataType) {
+        if GetTagBox(name) != nil {
+            EditExistingTag(GetTagBox(name)!!!!, data, type_)
+        } else if data != nil {
+            AddTag(name, data!!, type_)
+        }
+    }
+
+    func AddFreeformTag(domain string, name string, data string) {
+        FreeformTagBox.Create(this, domain, name, Encoding.UTF8.GetBytes(data), AppleDataType.Utf_8)
+    }
+
+    func AddFreeformTag(domain string, name string, data []uint8, type_ AppleDataType) {
+        FreeformTagBox.Create(this, domain, name, data, type_)
+    }
+
+    func EditOrAddFreeformTag(domain string, name string, data string?) {
+        EditOrAddFreeformTag(domain, name, if data == nil { default([]?uint8) } else { Encoding.UTF8.GetBytes(data!!) }, AppleDataType.Utf_8)
+    }
+
+    func EditOrAddFreeformTag(domain string, name string, data []?uint8) {
+        EditOrAddFreeformTag(domain, name, data, AppleDataType.ContainsData)
+    }
+
+    func EditOrAddFreeformTag(domain string, name string, data []?uint8, type_ AppleDataType) {
+        if GetFreeformTagBox(domain, name) != nil {
+            EditExistingTag(GetFreeformTagBox(domain, name)!!!!, data, type_)
+        } else if data != nil {
+            AddFreeformTag(domain, name, data!!, type_)
+        }
+    }
+
+    func GetTagString(name string) string? -> AppleListBox.GetTagString(GetTagBox(name))
+    func GetFreeformTagString(domain string, name string) string? -> AppleListBox.GetTagString(GetFreeformTagBox(domain, name))
+
+    func GetTagData[TData IAppleData[TData]](name string) TData? -> if GetTagBox(name)?.Data == nil { default } else { if GetTagBox(name)?.Data!!.DataType != AppleDataType.ContainsData { throw InvalidDataException("Apple data type ${GetTagBox(name)?.Data!!.DataType} is not compatible with ${nameof(IAppleData[TData])}")
+        default(TData) } else { if GetTagBox(name)?.Data!!.Data.Length != TData.SizeInBytes { throw InvalidDataException("Tag data size (${GetTagBox(name)?.Data!!.Data.Length}) differs from ${nameof(IAppleData[TData])} size (${TData.SizeInBytes})")
+        default(TData) } else { TData.Create(GetTagBox(name)?.Data!!.Data) } } }
+
+    func GetTagBox(name string) AppleTagBox? -> Tags.FirstOrDefault((t AppleTagBox) -> t.Header.Type == name)
+    func GetFreeformTagBox(domain string, name string) AppleTagBox? -> Tags.OfType[FreeformTagBox]().FirstOrDefault((t FreeformTagBox) -> t.Mean?.ReverseDnsDomain == domain && t.Name?.Name == name)
+
+    protected open override func Render(file Stream) {
+    }
+
+    private func EditExistingTag(tagBox AppleTagBox, data []?uint8, type_ AppleDataType) {
+        if data == nil {
+            RemoveTag(tagBox)
+        } else {
+            let dataBox = tagBox.GetChildOrThrow[AppleDataBox]()
+            dataBox.Data = if dataBox.DataType == type_ { data!! } else { throw InvalidDataException("Existing tag data type ${dataBox.DataType} differs from new edited type $type_")
+                default([]uint8) }
+        }
+    }
+
+    shared {
+        func CreateEmpty(parent IBox) AppleListBox {
+            let ilist = AppleListBox(parent)
+            parent.Children.Add(ilist!!)
+            return ilist!!
+        }
+
+        private func GetTagString(tagBox AppleTagBox?) string? -> if tagBox?.Data == nil { default(string?) } else { (switch tagBox?.Data!!.DataType {
+            case AppleDataType.Utf_8: Encoding.UTF8.GetString(tagBox?.Data!!.Data)
+            case AppleDataType.Utf_16: Encoding.Unicode.GetString(tagBox?.Data!!.Data)
+            default: throw InvalidDataException("Apple data type ${tagBox?.Data!!.DataType} is not a string type")
+        }) }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/AppleTagBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/AppleTagBox.gs
@@ -1,0 +1,40 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.Diagnostics
+import System.IO
+import System.Text
+
+@DebuggerDisplay("{DebuggerDisplay,nq}")
+open class AppleTagBox : Box {
+    init(file Stream, header BoxHeader, parent IBox) : base(header, parent) {
+        LoadChildren(file)
+    }
+
+    protected init(header BoxHeader, parent IBox?) : base(header, parent) {
+    }
+
+    @DebuggerHidden
+    open prop TagName string -> Header.Type
+
+    prop Data AppleDataBox -> GetChildOrThrow[AppleDataBox]()
+    private prop DebuggerDisplay string -> "[AppleTag]: $TagName"
+
+    protected open override func Render(file Stream) {
+        return
+    }
+
+    shared {
+        func Create(parent AppleListBox, name string, data []uint8, dataType AppleDataType) AppleTagBox {
+            if Encoding.ASCII.GetByteCount(name) != 4 {
+                throw ArgumentOutOfRangeException(nameof(name), "${nameof(name)} must be exactly 4 bytes long")
+            }
+            let size = data.Length + 2 + 8
+            let header = BoxHeader(uint32(size), name)
+            let tagBox = AppleTagBox(header, parent)
+            AppleDataBox.Create(tagBox, data, dataType)
+            parent.Children.Add(tagBox)
+            return tagBox
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/AudioCodingMode.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/AudioCodingMode.gs
@@ -1,0 +1,3 @@
+package Oahu.Decrypt.Mpeg4.Boxes.EC3SpecificBox
+
+enum AudioCodingMode { Ch1_Ch2, C, L_R, L_C_R, L_R_S, L_C_R_S, L_R_Ls_Rs, L_C_R_Ls_Rs }

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/AudioSampleEntry.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/AudioSampleEntry.gs
@@ -1,0 +1,50 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class AudioSampleEntry : SampleEntry {
+    private let reserved []uint8
+    private let reserved2 []uint8
+    private let sampleRateLoworder uint16
+
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        reserved = file.ReadBlock(8)
+        ChannelCount = file.ReadUInt16BE()
+        SampleSize = file.ReadUInt16BE()
+        PreDefined = file.ReadInt16BE()
+        reserved2 = file.ReadBlock(2)
+        SampleRate = file.ReadUInt16BE()
+        sampleRateLoworder = file.ReadUInt16BE()
+        LoadChildren(file)
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(20)
+    prop ChannelCount uint16
+
+    prop SampleSize uint16 {
+        get;
+        init;
+    }
+
+    prop PreDefined int16 {
+        get;
+        init;
+    }
+
+    prop SampleRate uint16
+    prop Esds EsdsBox? -> GetChild[EsdsBox]()
+    prop Dec3 Dec3Box? -> GetChild[Dec3Box]()
+    prop Dac4 Dac4Box? -> GetChild[Dac4Box]()
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.Write(reserved)
+        file.WriteUInt16BE(ChannelCount)
+        file.WriteUInt16BE(SampleSize)
+        file.WriteInt16BE(PreDefined)
+        file.Write(reserved2)
+        file.WriteUInt16BE(SampleRate)
+        file.WriteUInt16BE(sampleRateLoworder)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/AudioSpecificConfig.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/AudioSpecificConfig.gs
@@ -1,0 +1,115 @@
+package Oahu.Decrypt.Mpeg4.Descriptors
+
+import System
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+interface IASC {
+    prop AudioObjectType int32
+    prop SamplingFrequency int32
+    prop ChannelConfiguration int32
+    prop FrameLengthFlag bool
+    prop DependsOnCoreCoder bool
+}
+
+class AudioSpecificConfig : BaseDescriptor, IASC {
+    private var ascBlobLength int32 = 0
+    private var bitReader BitReader
+
+    init(file Stream, header DescriptorHeader) : base(file, header) {
+        let ascBlob = file.ReadBlock(Header.TotalBoxSize - Header.HeaderSize)
+        bitReader = AudioSpecificConfig.LoadAscBlob(this, ascBlob!!)
+        ascBlobLength = ascBlob!!.Length
+    }
+
+    private init() : base(5) {
+        bitReader = AudioSpecificConfig.LoadAscBlob(this, []uint8{uint8(0x13), uint8(0x90)})
+        ascBlobLength = 2
+    }
+
+    prop AudioObjectType int32
+    prop SamplingFrequency int32
+    prop ChannelConfiguration int32
+    prop FrameLengthFlag bool
+    prop DependsOnCoreCoder bool
+    override prop InternalSize int32 -> base.InternalSize + ascBlobLength
+
+    prop AscBlob []uint8 {
+        get -> GetAscBlob()
+        set {
+            bitReader = AudioSpecificConfig.LoadAscBlob(this, value)
+            ascBlobLength = value.Length
+        }
+    }
+
+    override func Render(file Stream) {
+        file.Write(AscBlob)
+    }
+
+    private func GetAscBlob() []uint8 {
+        ArgumentOutOfRangeException.ThrowIfLessThan(AudioObjectType, 0, nameof(AudioObjectType))
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(AudioObjectType, 32 + 63, nameof(AudioObjectType))
+        let sampleIndex = Array.IndexOf(AudioSpecificConfig.AscSampleRates, SamplingFrequency)
+        if sampleIndex < 0 {
+            throw ArgumentException("Unsupported SamplingFrequency of $SamplingFrequency. Supported values are [${String.Join(", ", SamplingFrequency)}]", nameof(SamplingFrequency))
+        }
+        ArgumentOutOfRangeException.ThrowIfLessThan(ChannelConfiguration, 1, nameof(ChannelConfiguration))
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(ChannelConfiguration, 7, nameof(ChannelConfiguration))
+        let writer = BitWriter()
+        if AudioObjectType < int32(AudioSpecificConfig.AotEscape) {
+            writer!!.Write(uint32(AudioObjectType), 5)
+        } else {
+            writer!!.Write(AudioSpecificConfig.AotEscape, 5)
+            writer!!.Write(uint32(AudioObjectType) - uint32(32), 6)
+        }
+        writer!!.Write(uint32(sampleIndex), 4)
+        writer!!.Write(uint32(ChannelConfiguration), 4)
+        writer!!.Write(if FrameLengthFlag { 1u } else { uint32(0) }, 1)
+        writer!!.Write(if DependsOnCoreCoder { 1u } else { uint32(0) }, 1)
+        let startPos = bitReader.Position
+        bitReader.CopyTo(writer!!)
+        this.bitReader.Position = startPos
+        return writer!!.ToByteArray()
+    }
+
+    private class InternalAudioSpecificConfig : IASC {
+        prop AudioObjectType int32
+        prop SamplingFrequency int32
+        prop ChannelConfiguration int32
+        prop FrameLengthFlag bool
+        prop DependsOnCoreCoder bool
+    }
+
+    shared {
+        let AscSampleRates []int32 = []int32{96000, 88200, 64000, 48000, 44100, 32000, 24000, 22050, 16000, 12000, 11025, 8000, 7350}
+        let MinSampleRate int32 = AudioSpecificConfig.AscSampleRates[^1]
+        let MaxSampleRate int32 = AudioSpecificConfig.AscSampleRates[0]
+        private const AotEscape uint8 = uint8(31)
+        private let SupportedObjectTypes []uint8 = []uint8{uint8(1), uint8(2), uint8(3), uint8(4), uint8(6), uint8(7), uint8(17), uint8(19), uint8(20), uint8(21), uint8(22), uint8(23), uint8(42)}
+        func CreateEmpty() AudioSpecificConfig -> AudioSpecificConfig()
+
+        func Parse(ascBlob []uint8) IASC {
+            let internalAsc = InternalAudioSpecificConfig()
+            AudioSpecificConfig.LoadAscBlob(internalAsc!!, ascBlob)
+            return internalAsc!!
+        }
+
+        private func LoadAscBlob(asc IASC, ascBlob []uint8) BitReader {
+            let bitReader = BitReader(ascBlob)
+            asc.AudioObjectType = int32(bitReader!!.Read(5))
+            if asc.AudioObjectType == int32(AudioSpecificConfig.AotEscape) {
+                asc.AudioObjectType = int32(bitReader!!.Read(6)) + 32
+            }
+            if Array.IndexOf(AudioSpecificConfig.SupportedObjectTypes, uint8(asc.AudioObjectType)) < 0 {
+                throw NotSupportedException("${nameof(AudioObjectType)} of ${asc.AudioObjectType} is unsupported")
+            }
+            let samplingFrequencyIndex = bitReader!!.Read(4)
+            asc.SamplingFrequency = if samplingFrequencyIndex <= uint32(12) { AudioSpecificConfig.AscSampleRates[samplingFrequencyIndex] } else { throw NotSupportedException("Sampling frequency index of $samplingFrequencyIndex is not supported.")
+                default(int32) }
+            asc.ChannelConfiguration = int32(bitReader!!.Read(4))
+            asc.FrameLengthFlag = bitReader!!.Read(1) != uint32(0)
+            asc.DependsOnCoreCoder = bitReader!!.Read(1) != uint32(0)
+            return bitReader!!
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/BaseDescriptor.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/BaseDescriptor.gs
@@ -1,0 +1,66 @@
+package Oahu.Decrypt.Mpeg4.Descriptors
+
+import System
+import System.Collections.Generic
+import System.IO
+import System.Linq
+
+open class BaseDescriptor {
+    init(file Stream, header DescriptorHeader) {
+        Children = List[BaseDescriptor]()
+        Header = header
+    }
+
+    protected init(tagId uint8) {
+        Children = List[BaseDescriptor]()
+        Header = DescriptorHeader(tagId)
+    }
+
+    prop Header DescriptorHeader {
+        get;
+        init;
+    }
+
+    prop Children List[BaseDescriptor] {
+        get;
+        init;
+    }
+
+    prop RenderSize uint32 -> uint32(1) + uint32(Header.GetEncodedSizeLength(InternalSize)) + uint32(InternalSize)
+    open prop InternalSize int32 -> int32(Children.Sum((c BaseDescriptor) -> c.RenderSize))
+    open func Render(file Stream);
+
+    func GetChild[T BaseDescriptor]() T? {
+        let children = GetChildren[T]()
+        return switch children.Count() {
+            case 0: nil
+            case 1: children.First()
+            default: throw InvalidOperationException("${GetType().Name} has ${children.Count()} children of type ${typeof(T)}. Call ${nameof(GetChildren)} instead.")
+        }
+    }
+
+    func GetChildOrThrow[T BaseDescriptor]() T -> GetChild[T]() ?? throw InvalidDataException("Descriptor does not contain a child of type ${typeof(T)}")
+
+    func GetChildren[T BaseDescriptor]() IEnumerable[T] {
+        return Children.OfType[T]()
+    }
+
+    func Save(file Stream) {
+        file.WriteByte(Header.TagID)
+        ExpandableClass.EncodeSize(file, InternalSize, Header.GetEncodedSizeLength(InternalSize))
+        Render(file)
+        for child in Children {
+            child.Save(file)
+        }
+    }
+
+    protected func LoadChildren(file Stream) {
+        while file.Position < Header.FilePosition + int64(Header.TotalBoxSize) {
+            let child = DescriptorFactory.CreateDescriptor(file)
+            if child.InternalSize == 0 {
+                break
+            }
+            Children.Add(child)
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/BitRateMode.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/BitRateMode.gs
@@ -1,0 +1,3 @@
+package Oahu.Decrypt.Mpeg4.Boxes.AC4SpecificBox
+
+enum BitRateMode { NotSpecified, Constant, Average, Variable }

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/BitReader.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/BitReader.gs
@@ -1,0 +1,93 @@
+package Oahu.Decrypt.Mpeg4.Util
+
+import System
+import System.Linq
+
+class BitReader(bytes []uint8) {
+    private var byteIndex int32 = 0
+    private var bitIndex int32 = 0
+
+    prop Position int32 {
+        get -> byteIndex * 8 + bitIndex
+        set {
+            ArgumentOutOfRangeException.ThrowIfLessThan(value, 0, nameof(Position))
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(value, bytes.Length * 8, nameof(Position))
+            byteIndex = value / 8
+            bitIndex = value % 8
+        }
+    }
+
+    prop Length int32 -> bytes.Length * 8
+    func ReadBool() bool -> Read(1) != uint32(0)
+
+    func ByteAlign() {
+        let bitPad = Position % 8
+        if bitPad != 0 {
+            Position += 8 - bitPad
+        }
+    }
+
+    func Read(numBits int32) uint32 {
+        var numBits = numBits
+        ArgumentOutOfRangeException.ThrowIfLessThan(numBits, 0, nameof(numBits))
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(numBits, 4 * 8, nameof(numBits))
+        var value uint32 = uint32(0)
+        while numBits > 0 {
+            if byteIndex >= bytes.Length {
+                throw InvalidOperationException("Not enough data to read the requested number of bits.")
+            }
+            let bitsToRead = Math.Min(numBits, 8 - bitIndex)
+            let mask = (1u << bitsToRead) - uint32(1)
+            value <<= bitsToRead
+            value |= (uint32(bytes[byteIndex]) >> (8 - bitIndex - bitsToRead)) & mask
+            numBits -= bitsToRead
+            bitIndex += bitsToRead
+            if bitIndex == 8 {
+                byteIndex++
+                bitIndex = 0
+            }
+        }
+        return value
+    }
+
+    func CopyTo(writer BitWriter) {
+        if bitIndex != 0 {
+            let toRead = 8 - bitIndex
+            let value = Read(toRead)
+            writer.Write(value, toRead)
+        }
+        while byteIndex < bytes.Length {
+            writer.Write(bytes[byteIndex], 8)
+            byteIndex++
+        }
+    }
+}
+
+class BitWriter {
+    private var byteIndex int32 = 0
+    private var bitIndex int32 = 0
+    private var bytes []uint8 = []uint8{}
+    prop Position int32 -> byteIndex * 8 + bitIndex
+    func ToByteArray() []uint8 -> bytes.ToArray()
+
+    func Write(value uint32, numBits int32) {
+        var value = value
+        var numBits = numBits
+        ArgumentOutOfRangeException.ThrowIfLessThan(numBits, 0, nameof(numBits))
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(numBits, 4 * 8, nameof(numBits))
+        while numBits > 0 {
+            if bitIndex == 0 {
+                Array.Resize(&bytes, byteIndex + 1)
+            }
+            let bitsToWrite = Math.Min(numBits, 8 - bitIndex)
+            value &= if numBits == 32 { UInt32.MaxValue } else { (1u << numBits) - uint32(1) }
+            bytes[byteIndex] |= uint8(((value >> (numBits - bitsToWrite)) << (8 - bitIndex - bitsToWrite)))
+            numBits -= bitsToWrite
+            bitIndex += bitsToWrite
+            if bitIndex == 8 {
+                byteIndex++
+                bitIndex = 0
+            }
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Box.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Box.gs
@@ -1,0 +1,104 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.Collections.Generic
+import System.IO
+import System.Linq
+import System.Threading
+import Oahu.Decrypt.Mpeg4.Util
+
+open class Box : IBox {
+    private var disposed int32 = 0
+
+    init(header BoxHeader, parent IBox?) {
+        Children = List[IBox]()
+        Header = header
+        Parent = parent
+    }
+
+    deinit {
+        Dispose(false)
+    }
+
+    prop Parent IBox? {
+        get;
+        init;
+    }
+
+    prop Header BoxHeader {
+        get;
+        init;
+    }
+
+    prop Children List[IBox] {
+        get;
+        init;
+    }
+
+    open prop RenderSize int64 -> int64(8) + Children.Sum((b IBox) -> b.RenderSize)
+    protected prop Disposed bool -> disposed != 0
+
+    func GetChild[T IBox]() T? {
+        let children = GetChildren[T]()
+        return switch children.Count() {
+            case 0: default
+            case 1: children.First()
+            default: throw InvalidOperationException("${GetType().Name} has ${children.Count()} children of type ${typeof(T)}. Call ${nameof(GetChildren)} instead.")
+        }
+    }
+
+    func GetChildOrThrow[T IBox]() T -> GetChild[T]() ?? throw InvalidDataException("${Header.Type} does not contain a child of type ${typeof(T)}")
+
+    func GetChildren[T IBox]() IEnumerable[T] {
+        return Children.OfType[T]()
+    }
+
+    func GetFreeBoxes() List[FreeBox] {
+        let freeBoxes = GetChildren[FreeBox]().ToList()
+        for child in Children {
+            freeBoxes.AddRange(child!!.GetFreeBoxes())
+        }
+        return freeBoxes
+    }
+
+    func Save(file Stream) {
+        ObjectDisposedException.ThrowIf(Disposed, this)
+        this.Header.FilePosition = file.Position
+        file.WriteHeader(Header, RenderSize)
+        Render(file)
+        for child in Children {
+            child!!.Save(file)
+        }
+    }
+
+    func Dispose() {
+        Dispose(true)
+        GC.SuppressFinalize(this)
+    }
+
+    protected func RemainingBoxLength(file Stream) int64 -> Header.FilePosition + Header.TotalBoxSize - file.Position
+    protected open func Render(file Stream);
+
+    protected func LoadChildren(file Stream) {
+        let endPos = Header.FilePosition + Header.TotalBoxSize
+        while file.Position < endPos {
+            let child = BoxFactory.CreateBox(file, this)
+            if child.Header.TotalBoxSize == int64(0) {
+                break
+            }
+            Children.Add(child)
+            if child.Header.FilePosition + child.Header.TotalBoxSize != file.Position {
+                break
+            }
+        }
+    }
+
+    protected open func Dispose(disposing bool) {
+        if disposing && Interlocked.CompareExchange(&disposed, 1, 0) == 0 {
+            for child in Children {
+                child?.Dispose()
+            }
+            Children.Clear()
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/BoxFactory.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/BoxFactory.gs
@@ -1,0 +1,72 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.Diagnostics
+import System.IO
+
+class BoxFactory {
+    shared {
+        func CreateBox[T Box](file Stream, parent IBox?) T {
+            let box = BoxFactory.CreateBox(file, parent)
+            return box as T ?? throw InvalidDataException("The ${box!!.Header.Type} box is not of type ${typeof(T)}")
+        }
+
+        func CreateBox(file Stream, parent IBox?) IBox -> BoxFactory.CreateBox(BoxHeader(file), file, parent)
+
+        func CreateBox(header BoxHeader, file Stream, parent IBox?) IBox {
+            let box IBox = switch header.Type {
+                case "free" or "skip": FreeBox(file, header, parent)
+                case "ftyp": FtypBox(file, header)
+                case "mdat": MdatBox(header)
+                case "moov": MoovBox(file, header)
+                case "moof": MoofBox(file, header)
+                case "mvhd": MvhdBox(file, header, parent)
+                case "trak": TrakBox(file, header, parent)
+                case "tkhd": TkhdBox(file, header, parent)
+                case "mdia": MdiaBox(file, header, parent)
+                case "minf": MinfBox(file, header, parent)
+                case "mdhd": MdhdBox(file, header, parent)
+                case "hdlr": HdlrBox(file, header, parent)
+                case "stbl": StblBox(file, header, parent)
+                case "stsd": StsdBox(file, header, parent)
+                case "esds": EsdsBox(file, header, parent)
+                case "btrt": BtrtBox(file, header, parent)
+                case "adrm": AdrmBox(file, header, parent)
+                case "stts": SttsBox(file, header, parent)
+                case "stsc": StscBox(file, header, parent)
+                case "stsz": StszBox(file, header, parent)
+                case "stz2": Stz2Box(file, header, parent)
+                case "stco": StcoBox(file, header, parent)
+                case "co64": Co64Box(file, header, parent)
+                case "udta": UdtaBox(file, header, parent)
+                case "meta": MetaBox(file, header, parent)
+                case "ilst": AppleListBox(file, header, parent)
+                case "data": AppleDataBox(file, header, parent)
+                case "mean": MeanBox(file, header, parent)
+                case "name": NameBox(file, header, parent)
+                case "pssh": PsshBox(file, header, parent)
+                case "sidx": SidxBox(file, header, parent)
+                case "mfhd": MfhdBox(file, header, parent)
+                case "tfhd": TfhdBox(file, header, parent)
+                case "traf": TrafBox(file, header, parent)
+                case "tfdt": TfdtBox(file, header, parent)
+                case "trun": TrunBox(file, header, parent)
+                case "saiz": SaizBox(file, header, parent)
+                case "saio": SaioBox(file, header, parent)
+                case "schm": SchmBox(file, header, parent)
+                case "frma": FrmaBox(file, header, parent)
+                case "tenc": TencBox(file, header, parent)
+                case "schi": SchiBox(file, header, parent)
+                case "sinf": SinfBox(file, header, parent)
+                case "senc": SencBox(file, header, parent)
+                case "mvex": MvexBox(file, header, parent)
+                case "mehd": MehdBox(file, header, parent)
+                case "dec3": Dec3Box(file, header, parent)
+                case "tref": TrefBox(file, header, parent)
+                case "dac4": Dac4Box(file, header, parent)
+                default: UnknownBox(file, header, parent)
+            }
+            Debug.Assert(box.RenderSize == header.TotalBoxSize || box is MdatBox)
+            return box
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/BoxHeader.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/BoxHeader.gs
@@ -1,0 +1,56 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.IO
+import System.Text
+import Oahu.Decrypt.Mpeg4.Util
+
+class BoxHeader {
+    init(file Stream) {
+        FilePosition = file.Position
+        TotalBoxSize = file.ReadUInt32BE()
+        Type = file.ReadType()
+        HeaderSize = uint32(8)
+        if TotalBoxSize == int64(1) {
+            Version = 1
+            TotalBoxSize = file.ReadInt64BE()
+            HeaderSize += uint32(uint32(8))
+        }
+    }
+
+    init(boxSize int64, boxType string) {
+        if boxSize < int64(8) {
+            throw ArgumentException("${nameof(boxSize)} must be at least 8 bytes.")
+        }
+        if String.IsNullOrEmpty(boxType) || Encoding.ASCII.GetByteCount(boxType) != 4 {
+            throw ArgumentException("${nameof(boxType)} must be a 4-byte long ASCII string.")
+        }
+        FilePosition = 0
+        Version = if boxSize > int64(UInt32.MaxValue) { 1 } else { 0 }
+        TotalBoxSize = boxSize
+        Type = boxType
+        HeaderSize = if boxSize > int64(UInt32.MaxValue) { 16u } else { 8u }
+    }
+
+    prop FilePosition int64
+
+    prop TotalBoxSize int64 {
+        get;
+        init;
+    }
+
+    prop Type string
+    prop HeaderSize uint32
+    prop Version int32
+
+    func ChangeAtomName(newAtomName string) {
+        if String.IsNullOrEmpty(newAtomName) || Encoding.UTF8.GetByteCount(newAtomName) != 4 {
+            throw ArgumentException("${nameof(newAtomName)} must be exactly 4 UTF-8 bytes long")
+        }
+        Type = newAtomName
+    }
+
+    func ToString() string {
+        return Type
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/BtrtBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/BtrtBox.gs
@@ -1,0 +1,43 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class BtrtBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        BufferSizeDB = file.ReadUInt32BE()
+        MaxBitrate = file.ReadUInt32BE()
+        AvgBitrate = file.ReadUInt32BE()
+    }
+
+    private init(bufferSizeDB uint32, maxBitrate uint32, avgBitrate uint32, header BoxHeader, parent IBox) : base(header, parent) {
+        BufferSizeDB = bufferSizeDB
+        MaxBitrate = maxBitrate
+        AvgBitrate = avgBitrate
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(12)
+
+    prop BufferSizeDB uint32 {
+        get;
+        init;
+    }
+
+    prop MaxBitrate uint32
+    prop AvgBitrate uint32
+
+    protected open override func Render(file Stream) {
+        file.WriteUInt32BE(BufferSizeDB)
+        file.WriteUInt32BE(MaxBitrate)
+        file.WriteUInt32BE(AvgBitrate)
+    }
+
+    shared {
+        func Create(bufferSizeDB uint32, maxBitrate uint32, avgBitrate uint32, parent Box) BtrtBox {
+            let header = BoxHeader(20, "btrt")
+            let btrt = BtrtBox(bufferSizeDB, maxBitrate, avgBitrate, header, parent)
+            parent.Children.Add(btrt)
+            return btrt
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/ByteUtil.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/ByteUtil.gs
@@ -1,0 +1,44 @@
+package Oahu.Decrypt.Mpeg4.Util
+
+import System
+
+class ByteUtil {
+    shared {
+        func BytesFromHexString(hexString string) []uint8 {
+            let byteCount = hexString.Length / 2
+            let bytes = [byteCount]uint8
+            for var i = 0; i < byteCount; i++ {
+                bytes[i] = Byte.Parse(hexString.Substring(2 * i, 2), System.Globalization.NumberStyles.HexNumber)
+            }
+            return bytes
+        }
+
+        func CloneBytes(src []uint8) []uint8 {
+            return ByteUtil.CloneBytes(src, 0, src.Length)
+        }
+
+        func CloneBytes(src []uint8, srcOffset int32, count int32) []uint8 {
+            let dst = [count]uint8
+            Buffer.BlockCopy(src, srcOffset, dst, 0, count)
+            return dst
+        }
+
+        func BytesEqual(array1 []uint8, array2 []uint8, reverseDirection bool = false) bool {
+            return ByteUtil.BytesEqual(array1, 0, array2, 0, array1.Length, reverseDirection)
+        }
+
+        func BytesEqual(array1 []uint8, startIndex1 int32, array2 []uint8, startIndex2 int32, count int32, reverseDirection bool = false) bool {
+            if array1.Length < startIndex1 + count || array2.Length < startIndex2 + count {
+                return false
+            }
+            let indexDiff = startIndex2 - startIndex1
+            for var i = startIndex1; i < startIndex1 + count; i++ {
+                let array2Index = if reverseDirection { startIndex2 + count - 1 - (i - startIndex1) } else { i + indexDiff }
+                if (array1[i] != array2[array2Index]) {
+                    return false
+                }
+            }
+            return true
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/CHAPFrame.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/CHAPFrame.gs
@@ -1,0 +1,50 @@
+package Oahu.Decrypt.Mpeg4.ID3
+
+import System
+import System.IO
+import System.Linq
+import System.Text
+
+enum ChapterFlags { TopLevel, Ordered }
+
+class CHAPFrame : Frame {
+    init(parent Frame, startTime TimeSpan, endTime TimeSpan, chNum int32, title string, subtitle string? = nil, subtitle2 string? = nil) : base(FrameHeader("CHAP", 0, parent.Version), parent) {
+        ChapterID = title
+        StartTime = startTime
+        EndTime = endTime
+        ByteStart = UInt32.MaxValue
+        ByteEnd = UInt32.MaxValue
+        if subtitle != nil {
+            TEXTFrame.Create(this, "TIT2", subtitle!!)
+        }
+        if subtitle2 != nil {
+            TEXTFrame.Create(this, "TIT3", subtitle2!!)
+        }
+    }
+
+    init(file Stream, header Header, parent Frame) : base(header, parent) {
+        let endPosition = file.Position + int64(Header.Size)
+        ChapterID = Frame.ReadNullTerminatedString(file, false)
+        StartTime = TimeSpan.FromMilliseconds(Header.ReadUInt32BE(file))
+        EndTime = TimeSpan.FromMilliseconds(Header.ReadUInt32BE(file))
+        ByteStart = Header.ReadUInt32BE(file)
+        ByteEnd = Header.ReadUInt32BE(file)
+        LoadChildren(file, endPosition)
+    }
+
+    override prop Size int32 -> Encoding.ASCII.GetByteCount(ChapterID) + 1 + 4 * 4 + Children.Sum((c Frame) -> c.Size + 10)
+    prop ChapterID string
+    prop StartTime TimeSpan
+    prop EndTime TimeSpan
+    prop ByteStart uint32
+    prop ByteEnd uint32
+
+    override func Render(file Stream) {
+        file.Write(Encoding.ASCII.GetBytes(ChapterID))
+        file.WriteByte(0)
+        Header.WriteUInt32BE(file, uint32(Math.Round(StartTime.TotalMilliseconds)))
+        Header.WriteUInt32BE(file, uint32(Math.Round(EndTime.TotalMilliseconds)))
+        Header.WriteUInt32BE(file, ByteStart)
+        Header.WriteUInt32BE(file, ByteEnd)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/CTOCFrame.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/CTOCFrame.gs
@@ -1,0 +1,56 @@
+package Oahu.Decrypt.Mpeg4.ID3
+
+import System.Collections.Generic
+import System.IO
+import System.Linq
+import System.Text
+
+class CTOCFrame : Frame {
+    init(parent Frame, chapterFlags ChapterFlags, elementId string = "TOC1") : base(FrameHeader("CTOC", 0, parent.Version), parent) {
+        ChildElementIDs = List[string]()
+        ChapterFlags = chapterFlags
+        ElementID = elementId
+    }
+
+    init(file Stream, header Header, parent Frame) : base(header, parent) {
+        ChildElementIDs = List[string]()
+        let endPosition = file.Position + int64(Header.Size)
+        ElementID = Frame.ReadNullTerminatedString(file, false)
+        ChapterFlags = ChapterFlags(file.ReadByte())
+        let elemIdCount = file.ReadByte()
+        for var i = 0; i < elemIdCount; i++ {
+            ChildElementIDs.Add(Frame.ReadNullTerminatedString(file, false))
+        }
+        LoadChildren(file, endPosition)
+    }
+
+    override prop Size int32 -> Encoding.ASCII.GetByteCount(ElementID) + 3 + ChildElementIDs.Sum((c string) -> Encoding.ASCII.GetByteCount(c) + 1) + Children.Sum((c Frame) -> c.Size + c.Header.HeaderSize)
+
+    prop ElementID string {
+        get;
+        init;
+    }
+
+    prop ChapterFlags ChapterFlags {
+        get;
+        init;
+    }
+
+    prop ChildElementIDs List[string] {
+        get;
+        init;
+    }
+
+    func Add(chapter CHAPFrame) -> ChildElementIDs.Add(chapter.ChapterID)
+
+    override func Render(file Stream) {
+        file.Write(Encoding.ASCII.GetBytes(ElementID))
+        file.WriteByte(0)
+        file.WriteByte(uint8(ChapterFlags))
+        file.WriteByte(uint8(ChildElementIDs.Count))
+        for ch in ChildElementIDs {
+            file.Write(Encoding.ASCII.GetBytes(ch!!))
+            file.WriteByte(0)
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/ChannelGroups.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/ChannelGroups.gs
@@ -1,0 +1,8 @@
+package Oahu.Decrypt.Mpeg4.Boxes.AC4SpecificBox
+
+import System
+import System.Collections.Generic
+import System.Text
+import System.Threading.Tasks
+
+enum ChannelGroups { Left_Right, Center, LeftSurround_RightSurround, LeftBack_RightBack, TopFrontLeft_TopFrontRight, TopBackLeft_TopBackRight, LFE, TopLeft_TopRight, TopSideLeft_TopSideRight, TopFrontCentre, Tfc, TopCenter, LFE2, BottomFrontLeft_BottomFrontRight, BottomFrontCentre, BackCenter, LeftScreen_RightScreen, LeftWide_RightWide, VerticalHeightLeft_VerticalHeightRight, NOT_CHANNEL_CODED }

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/ChannelLocation.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/ChannelLocation.gs
@@ -1,0 +1,3 @@
+package Oahu.Decrypt.Mpeg4.Boxes.EC3SpecificBox
+
+enum ChannelLocation { Lc_Rc_Pair, Lrs_Rrs_Pair, Cs, Ts, Lsd_Rsd_Pair, Lw_Rw_Pair, Lvh_Rvh_Pair, Cvh, LFE2 }

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Chapter.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Chapter.gs
@@ -1,0 +1,53 @@
+package Oahu.Decrypt.Mpeg4
+
+import System
+import System.IO
+import System.Text
+import Oahu.Decrypt.Mpeg4.Util
+
+open class Chapter {
+    init(title string, start TimeSpan, duration TimeSpan) {
+        ArgumentNullException.ThrowIfNull(title, nameof(title))
+        Title = title
+        StartOffset = start
+        Duration = duration
+        EndOffset = StartOffset + Duration
+    }
+
+    prop Title string {
+        get;
+        init;
+    }
+
+    prop StartOffset TimeSpan {
+        get;
+        init;
+    }
+
+    prop Duration TimeSpan {
+        get;
+        init;
+    }
+
+    prop EndOffset TimeSpan {
+        get;
+        init;
+    }
+
+    prop RenderSize int32 -> 2 + Encoding.UTF8.GetByteCount(Title) + Chapter.Encd.Length
+
+    func WriteChapter(output Stream) {
+        let title = Encoding.UTF8.GetBytes(Title)
+        output.WriteInt16BE(int16(title.Length))
+        output.Write(title)
+        output.Write(Chapter.Encd)
+    }
+
+    func ToString() string {
+        return "$Title {{$StartOffset - $EndOffset}}"
+    }
+
+    shared {
+        private let Encd []uint8 = []uint8{uint8(0), uint8(0), uint8(0), uint8(0xc), uint8('e'), uint8('n'), uint8('c'), uint8('d'), uint8(0), uint8(0), uint8(1), uint8(0)}
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/ChapterFilter.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/ChapterFilter.gs
@@ -1,0 +1,17 @@
+package Oahu.Decrypt.FrameFilters.Text
+
+import System
+import System.Threading.Tasks
+
+open class ChapterFilter : FrameFinalBase[FrameEntry] {
+    event ChapterRead (object?, FrameEntry) -> void
+    protected open override prop InputBufferSize int32 -> 1
+
+    open override func AddInputAsync(input FrameEntry) Task {
+        ChapterRead?(this, input)
+        return Task.CompletedTask
+    }
+
+    protected open override func FlushAsync() Task -> Task.CompletedTask
+    protected open override func PerformFilteringAsync(input FrameEntry) Task -> Task.CompletedTask
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/ChapterInfo.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/ChapterInfo.gs
@@ -1,0 +1,39 @@
+package Oahu.Decrypt.Mpeg4
+
+import System
+import System.Collections
+import System.Collections.Generic
+import System.Linq
+
+open class ChapterInfo : IEnumerable[Chapter] {
+    private let chapterList List[Chapter] = List[Chapter]()
+
+    init(offsetFromBeginning TimeSpan = default(TimeSpan)) {
+        StartOffset = offsetFromBeginning
+    }
+
+    prop StartOffset TimeSpan {
+        get;
+        init;
+    }
+
+    prop EndOffset TimeSpan -> if Count == 0 { StartOffset } else { chapterList.Max((c Chapter) -> c.EndOffset) }
+    prop Chapters IReadOnlyList[Chapter] -> chapterList
+    prop Count int32 -> chapterList.Count
+    prop RenderSize int32 -> chapterList.Sum((c Chapter) -> c.RenderSize)
+
+    func AddChapter(title string, duration TimeSpan) {
+        let startTime = if Count == 0 { StartOffset } else { chapterList[^1].EndOffset }
+        chapterList.Add(Chapter(title, startTime, duration))
+    }
+
+    func Add(title string, duration TimeSpan) -> AddChapter(title, duration)
+
+    func GetEnumerator() IEnumerator[Chapter] {
+        return chapterList.GetEnumerator()
+    }
+
+    private func GetEnumerator() IEnumerator {
+        return GetEnumerator()
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/ChapterQueue.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/ChapterQueue.gs
@@ -1,0 +1,105 @@
+package Oahu.Decrypt
+
+import System
+import System.Collections.Generic
+import System.Diagnostics.CodeAnalysis
+import System.IO
+import System.Text
+import Oahu.Decrypt.FrameFilters
+import Oahu.Decrypt.Mpeg4
+
+class ChapterEntry {
+    init(title string) {
+        ArgumentNullException.ThrowIfNull(title, nameof(title))
+        Title = title
+    }
+
+    prop FrameData Memory[uint8] {
+        get;
+        init;
+    }
+
+    prop SamplesInFrame uint32 {
+        get;
+        init;
+    }
+
+    prop Title string {
+        get;
+        init;
+    }
+}
+
+class ChapterQueue {
+    private let sampleScaleFactor float64
+    private let outputSampleRate SampleRate
+    private let lockObj object = System.Object()
+    private let chapterEntries Queue[ChapterEntry] = Queue[ChapterEntry]()
+    private var subtractNext int32 = 0
+
+    init(inputRate SampleRate, outputRate SampleRate) {
+        outputSampleRate = outputRate
+        sampleScaleFactor = float64(outputRate) / float64(inputRate)
+    }
+
+    func TryGetNextChapter(out chapterEntry ChapterEntry?) bool {
+        {
+            Monitor.Enter(lockObj)
+            try {
+                if chapterEntries.Count > 0 {
+                    chapterEntry = chapterEntries.Dequeue()
+                    return true
+                }
+            } finally {
+                Monitor.Exit(lockObj)
+            }
+        }
+        chapterEntry = nil
+        return false
+    }
+
+    func AddRange(chapters IEnumerable[Chapter]) {
+        for ch in chapters {
+            Add(ch!!)
+        }
+    }
+
+    func Add(chapter Chapter) {
+        let frameData = [chapter.RenderSize]uint8
+        using let ms = MemoryStream(frameData)
+        chapter.WriteChapter(ms!!)
+        let sampleDelta = uint32((chapter.Duration.TotalSeconds * float64(int32(outputSampleRate))))
+        {
+            Monitor.Enter(lockObj)
+            try {
+                chapterEntries.Enqueue(ChapterEntry(chapter.Title))
+            } finally {
+                Monitor.Exit(lockObj)
+            }
+        }
+    }
+
+    func Add(entry FrameEntry) {
+        let frameData ReadOnlySpan[uint8] = entry.FrameData.Span
+        var title = String.Empty
+        if frameData.Length >= 2 {
+            var size = (frameData[0] << 8) | int32(frameData[1])
+            if size > frameData.Length - 2 {
+                size = frameData.Length - 2
+            }
+            if size > 0 {
+                title = Encoding.UTF8.GetString(frameData.Slice(2, size))
+            }
+        }
+        let sif = int32(entry.SamplesInFrame)
+        {
+            Monitor.Enter(lockObj)
+            try {
+                chapterEntries.Enqueue(ChapterEntry(title))
+            } finally {
+                Monitor.Exit(lockObj)
+            }
+        }
+        subtractNext = if sif < 0 { sif } else { 0 }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/ChunkEntry.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/ChunkEntry.gs
@@ -1,0 +1,43 @@
+package Oahu.Decrypt.Mpeg4.Chunks
+
+class ChunkEntry {
+    prop TrackId uint32 {
+        get;
+        init;
+    }
+
+    prop ChunkIndex uint32 {
+        get;
+        init;
+    }
+
+    prop ChunkOffset int64 {
+        get;
+        init;
+    }
+
+    prop FirstSample int64 {
+        get;
+        init;
+    }
+
+    prop ChunkSize int32 {
+        get;
+        init;
+    }
+
+    prop FrameSizes []int32 {
+        get;
+        init;
+    }
+
+    prop FrameDurations []uint32 {
+        get;
+        init;
+    }
+
+    prop ExtraData object? {
+        get;
+        init;
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/ChunkEntryList.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/ChunkEntryList.gs
@@ -1,0 +1,47 @@
+package Oahu.Decrypt.Mpeg4.Chunks
+
+import System
+import System.Collections
+import System.Collections.Generic
+import System.Linq
+import Oahu.Decrypt.Mpeg4.Boxes
+
+class ChunkEntryList : IReadOnlyCollection[ChunkEntry] {
+    private let chunkOffsets ChunkOffsetList
+    private let stsz IStszBox
+    private let stts SttsBox
+    private let chunkFrameTable []ChunkFrames
+    private let trackId uint32
+
+    init(track TrakBox) {
+        trackId = track.Tkhd.TrackID
+        stsz = track.Mdia.Minf.Stbl.Stsz ?? throw ArgumentNullException(nameof(track))
+        let coBox = track.Mdia.Minf.Stbl.COBox
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(coBox!!.EntryCount, uint32(Int32.MaxValue), "COBox.EntryCount")
+        chunkOffsets = coBox!!.ChunkOffsets
+        Count = int32(coBox!!.EntryCount)
+        stts = track.Mdia.Minf.Stbl.Stts
+        chunkFrameTable = track.Mdia.Minf.Stbl.Stsc.CalculateChunkFrameTable(coBox!!.EntryCount)
+    }
+
+    prop Count int32 {
+        get;
+        init;
+    }
+
+    func GetEnumerator() IEnumerator[ChunkEntry] -> EnumerateChunks().GetEnumerator()
+    private func GetEnumerator() IEnumerator -> GetEnumerator()
+
+    private func EnumerateChunks() sequence[ChunkEntry] {
+        var startSample int64 = 0
+        for var chunkIndex = 0; chunkIndex < Count; chunkIndex++ {
+            let chunkOffset = chunkOffsets.GetOffsetAtIndex(chunkIndex)
+            let chunkFrames = chunkFrameTable[chunkIndex]
+            let (frameSizes, totalChunkSize) = stsz.GetFrameSizes(chunkFrames.FirstFrameIndex, chunkFrames.NumberOfFrames)
+            let frameDurations = stts.EnumerateFrameDeltas(chunkFrames.FirstFrameIndex).Take(frameSizes.Length).ToArray()
+            let entry = ChunkEntry{TrackId: trackId, FrameSizes: frameSizes, ChunkIndex: uint32(chunkIndex), ChunkSize: totalChunkSize, ChunkOffset: chunkOffset, FirstSample: startSample, FrameDurations: frameDurations}
+            startSample += entry!!.FrameDurations.Sum((d uint32) -> d)
+            yield entry
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/ChunkOffsetList.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/ChunkOffsetList.gs
@@ -1,0 +1,272 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.Buffers.Binary
+import System.Collections
+import System.Collections.Generic
+import System.IO
+import System.Linq
+import System.Runtime.InteropServices
+import Oahu.Decrypt.Mpeg4.Util
+
+class ChunkOffsetList : ICollection[int64] {
+    private let chunkOffsets32 List[uint32]
+    private var chunkOffsets64 List[int64]?
+
+    init() {
+        chunkOffsets32 = List[uint32]()
+    }
+
+    private init(capacity int32) {
+        chunkOffsets32 = List[uint32](capacity)
+    }
+
+    prop Count int32 -> chunkOffsets32.Count + (chunkOffsets64?.Count ?? 0)
+    prop IsReadOnly bool -> false
+
+    func Clear() {
+        chunkOffsets32.Clear()
+        chunkOffsets64?.Clear()
+        chunkOffsets64 = nil
+    }
+
+    func Sort() {
+        if chunkOffsets64 != nil {
+            chunkOffsets64!!.Sort()
+            let index = ChunkOffsetList.FindLast32bit(CollectionsMarshal.AsSpan(chunkOffsets64!!))
+            if index >= 0 {
+                let countToMove = index + 1
+                let toMove = [countToMove]uint32
+                for var i = 0; i < countToMove; i++ {
+                    toMove[i] = uint32(chunkOffsets64!![i])
+                }
+                chunkOffsets32.AddRange(toMove)
+                chunkOffsets64!!.RemoveRange(0, countToMove)
+                if chunkOffsets64!!.Count == 0 {
+                    chunkOffsets64 = nil
+                }
+            }
+        }
+        chunkOffsets32.Sort()
+    }
+
+    func GetOffsetAtIndex(index int32) int64 {
+        var index = index
+        if index < chunkOffsets32.Count {
+            return chunkOffsets32[index]
+        } else if chunkOffsets64 != nil {
+            index -= chunkOffsets32.Count
+            if index < chunkOffsets64!!.Count {
+                return chunkOffsets64!![index]
+            }
+        }
+        throw IndexOutOfRangeException("Index $index is out of range for chunk offsets.")
+    }
+
+    func SetOffsetAtIndex(index int32, value int64) {
+        var index = index
+        if index < chunkOffsets32.Count {
+            if value > int64(UInt32.MaxValue) {
+                let toMove = chunkOffsets32.Count - index
+                let longs = [toMove]int64
+                longs[0] = value
+                for var i = 1; i < toMove; i++ {
+                    longs[i] = chunkOffsets32[index + i]
+                }
+                CollectionsMarshal.SetCount(chunkOffsets32, index)
+                chunkOffsets64 ??= List[int64](longs.Length)
+                chunkOffsets64!!.InsertRange(0, longs)
+            } else {
+                chunkOffsets32[index] = uint32(value)
+            }
+            return
+        } else if chunkOffsets64 != nil {
+            index -= chunkOffsets32.Count
+            if index < chunkOffsets64!!.Count {
+                chunkOffsets64!![index] = value
+                return
+            }
+        }
+        throw IndexOutOfRangeException("Index $index is out of range for chunk offsets.")
+    }
+
+    func Write32(file Stream) {
+        if chunkOffsets64 != nil && chunkOffsets64!!.Count > 0 {
+            throw InvalidOperationException("Cannot write 32-bit chunk offsets when 64-bit offsets are present.")
+        }
+        let span = CollectionsMarshal.AsSpan(chunkOffsets32)
+        if BitConverter.IsLittleEndian {
+            BinaryPrimitives.ReverseEndianness(span, span)
+        }
+        file.Write(MemoryMarshal.AsBytes(span))
+        if BitConverter.IsLittleEndian {
+            BinaryPrimitives.ReverseEndianness(span, span)
+        }
+    }
+
+    func Write64(file Stream) {
+        for offset32 in chunkOffsets32 {
+            file.WriteInt64BE(offset32)
+        }
+        let span64 = CollectionsMarshal.AsSpan(chunkOffsets64)
+        if BitConverter.IsLittleEndian {
+            BinaryPrimitives.ReverseEndianness(span64, span64)
+        }
+        file.Write(MemoryMarshal.AsBytes(span64))
+        if BitConverter.IsLittleEndian {
+            BinaryPrimitives.ReverseEndianness(span64, span64)
+        }
+    }
+
+    func IndexOf(item int64) int32 {
+        if item <= int64(UInt32.MaxValue) {
+            let index32 = chunkOffsets32.IndexOf(uint32(item))
+            if index32 >= 0 {
+                return index32
+            }
+        } else if chunkOffsets64 != nil {
+            let index64 = chunkOffsets64!!.IndexOf(item)
+            if index64 >= 0 {
+                return chunkOffsets32.Count + index64
+            }
+        }
+        return -1
+    }
+
+    func RemoveAt(index int32) {
+        var index = index
+        if index < chunkOffsets32.Count {
+            chunkOffsets32.RemoveAt(index)
+            return
+        } else if chunkOffsets64 != nil {
+            index -= chunkOffsets32.Count
+            if index < chunkOffsets64!!.Count {
+                chunkOffsets64!!.RemoveAt(index)
+                return
+            }
+        }
+        throw IndexOutOfRangeException()
+    }
+
+    func Add(offset int64) {
+        if offset > int64(UInt32.MaxValue) {
+            chunkOffsets64 ??= List[int64]()
+            chunkOffsets64!!.Add(offset)
+        } else {
+            chunkOffsets32.Add(uint32(offset))
+        }
+    }
+
+    func Contains(item int64) bool -> IndexOf(item) >= 0
+
+    func Remove(item int64) bool {
+        let index = IndexOf(item)
+        if index >= 0 {
+            RemoveAt(index)
+            return true
+        }
+        return false
+    }
+
+    func GetEnumerator() IEnumerator[int64] -> chunkOffsets32.ConvertAll((i uint32) -> int64(i)).Concat(chunkOffsets64 ?? List[int64]()).GetEnumerator()
+
+    func CopyTo(array []int64, arrayIndex int32) {
+        var arrayIndex = arrayIndex
+        {
+            var i = 0
+            while i < chunkOffsets32.Count {
+                array[arrayIndex] = chunkOffsets32[i]
+                i++
+                arrayIndex++
+            }
+        }
+        if chunkOffsets64 != nil {
+            {
+                var i = 0
+                while i < chunkOffsets64!!.Count {
+                    array[arrayIndex] = chunkOffsets64!![i]
+                    i++
+                    arrayIndex++
+                }
+            }
+        }
+    }
+
+    private func GetEnumerator() IEnumerator -> GetEnumerator()
+
+    shared {
+        func Read32(file Stream, entryCount uint32) ChunkOffsetList {
+            let list = ChunkOffsetList(int32(entryCount))
+            CollectionsMarshal.SetCount(list.chunkOffsets32, int32(entryCount))
+            let span = CollectionsMarshal.AsSpan(list.chunkOffsets32)
+            file.ReadExactly(MemoryMarshal.AsBytes(span))
+            if BitConverter.IsLittleEndian {
+                BinaryPrimitives.ReverseEndianness(span, span)
+            }
+            var lastChunkOffset int64 = 0
+            for var i = 0; i < list.chunkOffsets32.Count; i++ {
+                var chunkOffset int64 = list.chunkOffsets32[i]
+                if chunkOffset < lastChunkOffset && lastChunkOffset - chunkOffset > int64(UInt32.MaxValue / uint32(2)) {
+                    if list.chunkOffsets64 == nil {
+                        let count = list.chunkOffsets32.Count - i
+                        list.chunkOffsets64 = List[int64](count)
+                    }
+                    chunkOffset += 1L << 32
+                    list.chunkOffsets32.RemoveAt(i)
+                    i--
+                    list.chunkOffsets64!!.Add(chunkOffset)
+                }
+                lastChunkOffset = chunkOffset
+            }
+            list.chunkOffsets32.Sort()
+            list.chunkOffsets64?.Sort()
+            return list
+        }
+
+        func Read64(file Stream, entryCount uint32) ChunkOffsetList {
+            unsafe {
+                let pLongs = Marshal.AllocHGlobal(8 * IntPtr(entryCount))
+                try {
+                    let longsSpan = Span[int64](pLongs.ToPointer(), int32(entryCount))
+                    file.ReadExactly(MemoryMarshal.AsBytes(longsSpan))
+                    if BitConverter.IsLittleEndian {
+                        BinaryPrimitives.ReverseEndianness(longsSpan, longsSpan)
+                    }
+                    longsSpan.Sort()
+                    let count32Bit = ChunkOffsetList.FindLast32bit(longsSpan) + 1
+                    let list = ChunkOffsetList(count32Bit)
+                    CollectionsMarshal.SetCount(list.chunkOffsets32, count32Bit)
+                    let span = CollectionsMarshal.AsSpan(list.chunkOffsets32)
+                    for var i = 0; i < count32Bit; i++ {
+                        span[i] = uint32(longsSpan[i])
+                    }
+                    let remainder = longsSpan.Slice(count32Bit)
+                    list.chunkOffsets64 = List[int64](remainder.Length)
+                    CollectionsMarshal.SetCount(list.chunkOffsets64!!, remainder.Length)
+                    let span64 = CollectionsMarshal.AsSpan(list.chunkOffsets64!!)
+                    remainder.CopyTo(span64)
+                    return list
+                } finally {
+                    Marshal.FreeHGlobal(pLongs)
+                }
+            }
+        }
+
+        private func FindLast32bit(longsSpan ReadOnlySpan[int64]) int32 {
+            var l = 0
+            var r = longsSpan.Length - 1
+            while l <= r {
+                let mid = l + (r - l) / 2
+                let midValue = longsSpan[mid]
+                if midValue > int64(UInt32.MaxValue) {
+                    r = mid - 1
+                } else if midValue == int64(UInt32.MaxValue) || mid >= r || longsSpan[mid + 1] >= int64(UInt32.MaxValue) {
+                    return mid
+                } else {
+                    l = mid + 1
+                }
+            }
+            return -1
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/ChunkReader.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/ChunkReader.gs
@@ -1,0 +1,148 @@
+package Oahu.Decrypt.Chunks
+
+import System
+import System.Collections.Generic
+import System.IO
+import System.Linq
+import System.Threading
+import System.Threading.Tasks
+import Oahu.Decrypt.FrameFilters
+import Oahu.Decrypt.Mpeg4.Boxes
+import Oahu.Decrypt.Mpeg4.Chunks
+import Oahu.Decrypt.Mpeg4.Util
+
+interface IChunkReader {
+    prop OnProgressUpdateDelegate ((ConversionProgressEventArgs) -> void)?
+    func RunAsync(cancellationSource CancellationTokenSource) Task;
+    func AddTrack(track TrakBox, filter FrameFilterBase[FrameEntry]);
+}
+
+internal open class ChunkReader : IChunkReader {
+    private var beginProcess DateTime
+    private var nextUpdate DateTime
+
+    init(inputStream Stream, startTime TimeSpan, endTime TimeSpan) {
+        TrackEntries = Dictionary[uint32, TrackEntry]()
+        InputStream = inputStream
+        if startTime >= endTime {
+            throw ArgumentException("Start time must be less than end time.", nameof(startTime))
+        }
+        StartTime = startTime
+        EndTime = endTime
+    }
+
+    prop OnProgressUpdateDelegate ((ConversionProgressEventArgs) -> void)?
+
+    protected prop TrackEntries Dictionary[uint32, TrackEntry] {
+        get;
+        init;
+    }
+
+    protected prop InputStream Stream {
+        get;
+        init;
+    }
+
+    protected prop StartTime TimeSpan {
+        get;
+        init;
+    }
+
+    protected prop EndTime TimeSpan {
+        get;
+        init;
+    }
+
+    open func AddTrack(track TrakBox, filter FrameFilterBase[FrameEntry]) {
+        let trackEntry = TrackEntry(track.Tkhd.TrackID, track.Mdia.Mdhd.Timescale, filter, track)
+        TrackEntries.Add(track.Tkhd.TrackID, trackEntry!!)
+    }
+
+    async func RunAsync(cancellationSource CancellationTokenSource) {
+        for filter in TrackEntries.Values.Select((e TrackEntry) -> e.FirstFilter) {
+            filter!!.SetCancellationToken(cancellationSource.Token)
+        }
+        OnInitialProgress()
+        let token = cancellationSource.Token
+        try {
+            for c in EnumerateChunks() {
+                let chunkData Memory[uint8] = [c!!.ChunkSize]uint8
+                await InputStream.ReadNextChunkAsync(c!!.ChunkOffset, chunkData, token)
+                await DispatchChunk(c!!, chunkData, token)
+            }
+        } catch (ex OperationCanceledException) {
+        } catch (ex Exception) {
+            cancellationSource.Cancel()
+            throw ex
+        } finally {
+            OnFinalProgress()
+            await Task.WhenAll(TrackEntries.Values.Select((e TrackEntry) -> e.FirstFilter.CompleteAsync()))
+        }
+    }
+
+    protected open func EnumerateChunks() IEnumerable[ChunkEntry] {
+        let ChunkHasFrameInRange = func (value ChunkEntry) bool {
+            let timeScale = GetTrackEntryFromId(value.TrackId).Timescale
+            let minimumSample = StartTime.TotalSeconds * float64(timeScale)
+            let maximumSample = EndTime.TotalSeconds * float64(timeScale)
+            return float64(value.FirstSample) <= maximumSample && float64((value.FirstSample + value.FrameDurations.Sum((d uint32) -> d))) >= minimumSample
+        }
+        return TrackEntries.Values.Select((e TrackEntry) -> e.TrakBox).InterleaveBy((t TrakBox) -> t.ChunkEntries(), (t ChunkEntry) -> t.ChunkOffset).Where(ChunkHasFrameInRange)
+    }
+
+    protected func GetTrackEntryFromId(trackId uint32) TrackEntry -> if TrackEntries.TryGetValue(trackId, out var trackEntry) { trackEntry!! } else { throw ArgumentOutOfRangeException(nameof(trackId), "Track ID $trackId is not present in this ${nameof(ChunkReader)} instance.")
+        default(TrackEntry) }
+
+    protected open func CreateFrameEntry(chunk ChunkEntry, frameInChunk int32, frameDelta uint32, frameData Memory[uint8]) FrameEntry -> FrameEntry{Chunk: chunk, SamplesInFrame: frameDelta, FrameData: frameData}
+
+    private async func DispatchChunk(chunk ChunkEntry, chunkData Memory[uint8], token CancellationToken) {
+        var sampleIndex = chunk.FirstSample
+        let trackEntry = GetTrackEntryFromId(chunk.TrackId)
+        let startSample = int64((StartTime.TotalSeconds * float64(trackEntry!!.Timescale)))
+        let endSample = int64((EndTime.TotalSeconds * float64(trackEntry!!.Timescale)))
+        var frameDelta uint32
+        {
+            var start = 0
+            var f = 0
+            while f < chunk.FrameSizes.Length {
+                frameDelta = chunk.FrameDurations[f]
+                if startSample >= sampleIndex + int64(frameDelta) {
+                    continue
+                }
+                if endSample < sampleIndex {
+                    break
+                }
+                OnProgressReport(sampleIndex, trackEntry!!.Timescale)
+                let frameData = chunkData.Slice(start, chunk.FrameSizes[f])
+                let frameEntry = CreateFrameEntry(chunk, f, frameDelta, frameData)
+                token.ThrowIfCancellationRequested()
+                await trackEntry!!.FirstFilter.AddInputAsync(frameEntry!!)
+                start += chunk.FrameSizes[f]
+                f++
+                sampleIndex += int64(frameDelta)
+            }
+        }
+    }
+
+    private func OnInitialProgress() {
+        beginProcess = DateTime.UtcNow
+        nextUpdate = beginProcess
+        OnProgressUpdateDelegate?(ConversionProgressEventArgs(StartTime, EndTime, StartTime, 0.0))
+    }
+
+    private func OnFinalProgress() {
+        OnProgressUpdateDelegate?(ConversionProgressEventArgs(StartTime, EndTime, EndTime, (EndTime - StartTime) / (DateTime.UtcNow - beginProcess)))
+    }
+
+    private func OnProgressReport(sampleNumber int64, timeScale uint32) {
+        if DateTime.UtcNow > nextUpdate {
+            let trackPosition = TimeSpan.FromSeconds(float64(sampleNumber) / float64(timeScale))
+            let speed = (trackPosition - StartTime) / (DateTime.UtcNow - beginProcess)
+            OnProgressUpdateDelegate?(ConversionProgressEventArgs(StartTime, EndTime, trackPosition, speed))
+            nextUpdate = DateTime.UtcNow.AddMilliseconds(100.0)
+        }
+    }
+
+    protected open data class TrackEntry(TrackId uint32, Timescale uint32, FirstFilter FrameFilterBase[FrameEntry], TrakBox TrakBox) {
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Co64Box.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Co64Box.gs
@@ -1,0 +1,51 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+internal open class Co64Box : FullBox, IChunkOffsets {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        let entryCount = file.ReadUInt32BE()
+        if entryCount > uint32(Int32.MaxValue) {
+            throw NotSupportedException("Oahu.Decrypt.Mpeg4 does not support MPEG-4 files with more than ${Int32.MaxValue} chunk offsets")
+        }
+        ChunkOffsets = ChunkOffsetList.Read64(file, entryCount)
+    }
+
+    private init(chunkOffsets ChunkOffsetList, versionFlags []uint8, header BoxHeader, parent IBox) : base(versionFlags, header, parent) {
+        ChunkOffsets = chunkOffsets
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(4) + int64(ChunkOffsets.Count * 8)
+    prop EntryCount uint32 -> uint32(ChunkOffsets.Count)
+
+    prop ChunkOffsets ChunkOffsetList {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.WriteUInt32BE(EntryCount)
+        ChunkOffsets.Write64(file)
+    }
+
+    protected open override func Dispose(disposing bool) {
+        if disposing && !Disposed {
+            ChunkOffsets.Clear()
+        }
+        base.Dispose(disposing)
+    }
+
+    shared {
+        internal func CreateBlank(parent IBox, chunkOffsets ChunkOffsetList) Co64Box {
+            let size = 4 + 12
+            let header = BoxHeader(uint32(size), "co64")
+            chunkOffsets.Sort()
+            let co64Box = Co64Box(chunkOffsets, []uint8{uint8(0), uint8(0), uint8(0), uint8(0)}, header, parent)
+            parent.Children.Add(co64Box)
+            return co64Box
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/ConversionProgressEventArgs.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/ConversionProgressEventArgs.gs
@@ -1,0 +1,38 @@
+package Oahu.Decrypt
+
+import System
+
+class ConversionProgressEventArgs : EventArgs {
+    internal init(startTime TimeSpan, endTime TimeSpan, processPosition TimeSpan, processSpeed float64) {
+        StartTime = startTime
+        EndTime = endTime
+        ProcessPosition = processPosition
+        ProcessSpeed = processSpeed
+        FractionCompleted = (processPosition - startTime) / (endTime - startTime)
+    }
+
+    prop ProcessPosition TimeSpan {
+        get;
+        init;
+    }
+
+    prop StartTime TimeSpan {
+        get;
+        init;
+    }
+
+    prop EndTime TimeSpan {
+        get;
+        init;
+    }
+
+    prop ProcessSpeed float64 {
+        get;
+        init;
+    }
+
+    prop FractionCompleted float64 {
+        get;
+        init;
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Crypto.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Crypto.gs
@@ -1,0 +1,25 @@
+package Oahu.Decrypt.Mpeg4.Util
+
+import System.Security.Cryptography
+
+class Crypto {
+    shared {
+        func DecryptInPlace(key []uint8, iv []uint8, encryptedBlocks []uint8) {
+            using let aes = Aes.Create()
+            aes.Mode = CipherMode.CBC
+            aes.Padding = PaddingMode.None
+            using let cbcDecryptor = aes.CreateDecryptor(key, iv)
+            cbcDecryptor.TransformBlock(encryptedBlocks, 0, encryptedBlocks.Length & 0x7ffffff0, encryptedBlocks, 0)
+        }
+
+        func Sha1(blocks ...([]uint8, int32, int32)) []uint8 {
+            using let sha = SHA1.Create()
+            var i = 0
+            for ; i < blocks.Length - 1; i++ {
+                sha.TransformBlock(blocks[i].Item1, blocks[i].Item2, blocks[i].Item3, nil, 0)
+            }
+            sha.TransformFinalBlock(blocks[i].Item1, blocks[i].Item2, blocks[i].Item3)
+            return sha.Hash!!
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Dac4Box.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Dac4Box.gs
@@ -1,0 +1,44 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Boxes.AC4SpecificBox
+import Oahu.Decrypt.Mpeg4.Util
+
+open class Dac4Box : Box {
+    var Ac4DsiV1 Ac4DsiV1?
+    private let ac4Data []uint8
+
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        ac4Data = file.ReadBlock(int32((header.TotalBoxSize - int64(header.HeaderSize))))
+        try {
+            let reader = BitReader(ac4Data)
+            Ac4DsiV1 = Ac4DsiV1(reader!!)
+        } catch (ex Exception) {
+            return
+        }
+        SampleRate = Ac4DsiV1.SampleRate()
+        AverageBitrate = Ac4DsiV1.AverageBitrate()
+        NumberOfChannels = (if Ac4DsiV1.Channels() != nil { Ac4Extensions.ChannelCount(Ac4DsiV1.Channels()!!) } else { nil })
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(ac4Data.Length)
+
+    prop AverageBitrate uint32? {
+        get;
+        init;
+    }
+
+    prop SampleRate int32? {
+        get;
+        init;
+    }
+
+    prop NumberOfChannels int32? {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        file.Write(ac4Data)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/DashChunkEntryies.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/DashChunkEntryies.gs
@@ -1,0 +1,90 @@
+package Oahu.Decrypt.Mpeg4.Chunks
+
+import System
+import System.Collections
+import System.Collections.Generic
+import System.IO
+import System.Linq
+import Oahu.Decrypt.Mpeg4.Boxes
+import Oahu.Decrypt.Mpeg4.Util
+
+class DashChunkEntryies(InputStream Stream, TrackId uint32, Sidx SidxBox, FirstMoof MoofBox, FirstMdat MdatBox, MinimumSample int64, MaximumSample int64) : IEnumerable[ChunkEntry] {
+    func GetEnumerator() IEnumerator[ChunkEntry] -> EnumerateChunks().GetEnumerator()
+    private func GetEnumerator() IEnumerator -> GetEnumerator()
+
+    private func EnumerateChunks() sequence[ChunkEntry] {
+        SkipToFirstMoof(out var moofBox, out var mdatBox, out var startSample)
+        let totalDataSize = Sidx.Segments.Sum((s Segment) -> int64(s.ReferenceSize))
+        let endOfFile = FirstMoof.Header.FilePosition + totalDataSize
+        while InputStream.Position < endOfFile {
+            if startSample > MaximumSample {
+                break
+            }
+            let trackChunk = ValidateMdatSize(moofBox!!, mdatBox!!, startSample)
+            startSample += trackChunk!!.FrameDurations.Sum((d uint32) -> d)
+            if startSample > MinimumSample {
+                yield trackChunk
+            } else {
+                let endOfMdat = InputStream.Position + mdatBox!!.Header.TotalBoxSize - int64(mdatBox!!.Header.HeaderSize)
+                InputStream.SeekToOffset(endOfMdat)
+            }
+            if InputStream.Position < endOfFile {
+                moofBox = BoxFactory.CreateBox[MoofBox](InputStream, nil)
+                mdatBox = BoxFactory.CreateBox[MdatBox](InputStream, nil)
+            }
+        }
+    }
+
+    private func ValidateMdatSize(moofBox MoofBox, mdatBox MdatBox, startSample int64) ChunkEntry {
+        let trun TrunBox? = moofBox.Traf.Trun as TrunBox
+        if trun == nil {
+            throw InvalidDataException("The ${nameof(TrafBox)} doesn't contain a ${nameof(TrunBox)}")
+        }
+        let frameSizes = if trun.SampleSizePresent { trun.Samples.Select((s SampleInfo) -> s.SampleSize).OfType[int32]().ToArray() } else { if moofBox.Traf.Tfhd.DefaultSampleSize is uint32 { Enumerable.Repeat(int32(moofBox.Traf.Tfhd.DefaultSampleSize!!), trun.Samples.Length).ToArray() } else { throw InvalidOperationException("Trun sample infos don't contain sample sizes and no default sample size is set.")
+            default([]int32) } }
+        let mdatSize = mdatBox.Header.TotalBoxSize - int64(mdatBox.Header.HeaderSize)
+        if int64(frameSizes!!.Sum()) != mdatSize {
+            throw InvalidDataException("Mdat box size doesn't match sample sizes in track fragment")
+        }
+        if mdatSize > int64(Int32.MaxValue) {
+            throw InvalidDataException("Mdat is larger than Int32.MaxValue")
+        }
+        let frameDurations = if trun.SampleDurationPresent { trun.Samples.Select((s SampleInfo) -> s.SampleDuration).OfType[uint32]().ToArray() } else { if moofBox.Traf.Tfhd.DefaultSampleDuration is uint32 { Enumerable.Repeat(moofBox.Traf.Tfhd.DefaultSampleDuration!!, trun.Samples.Length).ToArray() } else { throw InvalidOperationException("Trun sample infos don't contain sample durations and no default sample duration is set.")
+            default([]uint32) } }
+        if frameDurations!!.Length != frameSizes!!.Length {
+            throw InvalidDataException("The number of frame sizes (${frameSizes!!.Length}) does not match the number of durations (${frameDurations!!.Length}) in fragment ${moofBox.Mfhd.SequenceNumber}")
+        }
+        var extraData object? = nil
+        if moofBox.Traf.Senc != nil {
+            extraData = if frameSizes!!.Length == moofBox.Traf.Senc!!!!.IVs.Length { moofBox.Traf.Senc!!!!.IVs } else { throw InvalidDataException("The number of IVs (${moofBox.Traf.Senc!!!!.IVs.Length}) does not match the number of samples (${frameSizes!!.Length}) in fragment ${moofBox.Mfhd.SequenceNumber}")
+                default([][]uint8) }
+        }
+        return ChunkEntry{TrackId: TrackId, ChunkIndex: uint32(moofBox.Mfhd.SequenceNumber), ChunkOffset: InputStream.Position, ChunkSize: int32(mdatSize), FirstSample: startSample, FrameSizes: frameSizes, FrameDurations: frameDurations, ExtraData: extraData}
+    }
+
+    private func SkipToFirstMoof(out firstMoof MoofBox, out firstMdat MdatBox, out firstSample int64) {
+        let startPosition = FirstMoof.Header.FilePosition
+        var dataOffset int64 = 0
+        firstSample = 0
+        if Sidx.Segments.Any((s Segment) -> s.ReferenceType || !s.StartsWithSAP || s.SapType != 1 || s.SapDeltaTime != 0) {
+            throw InvalidOperationException("AAXClean doesn't know how to inrepret segment index boxes other than " + "${nameof(SidxBox.Segment.SapType)} = 1, " + "${nameof(SidxBox.Segment.SapDeltaTime)} = 0, " + "${nameof(SidxBox.Segment.StartsWithSAP)} = 1, " + "${nameof(SidxBox.Segment.ReferenceType)} = 0")
+        }
+        for segment in Sidx.Segments {
+            if MinimumSample < firstSample + int64(segment!!.SubsegmentDuration) {
+                break
+            }
+            dataOffset += int64(segment!!.ReferenceSize)
+            firstSample += int64(segment!!.SubsegmentDuration)
+        }
+        if dataOffset == int64(0) {
+            var __decon0 = FirstMoof
+            var __decon1 = FirstMdat
+            firstMoof = __decon0
+            firstMdat = __decon1
+        } else {
+            InputStream.SeekToOffset(startPosition + dataOffset)
+            firstMoof = BoxFactory.CreateBox[MoofBox](InputStream, nil)
+            firstMdat = BoxFactory.CreateBox[MdatBox](InputStream, nil)
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/DashChunkReader.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/DashChunkReader.gs
@@ -1,0 +1,46 @@
+package Oahu.Decrypt.Chunks
+
+import System
+import System.Collections.Generic
+import System.IO
+import System.Linq
+import Oahu.Decrypt.FrameFilters
+import Oahu.Decrypt.Mpeg4.Boxes
+import Oahu.Decrypt.Mpeg4.Chunks
+
+internal open class DashChunkReader : ChunkReader {
+    init(dash DashFile, inputStream Stream, startTime TimeSpan, endTime TimeSpan) : base(inputStream, startTime, endTime) {
+        ArgumentNullException.ThrowIfNull(dash, nameof(dash))
+        ArgumentNullException.ThrowIfNull(inputStream, nameof(inputStream))
+        Dash = dash
+    }
+
+    private prop Dash DashFile {
+        get;
+        init;
+    }
+
+    open override func AddTrack(track TrakBox, filter FrameFilterBase[FrameEntry]) {
+        if TrackEntries.Count > 0 {
+            throw InvalidOperationException("The ${nameof(DashChunkReader)} currently only supports a single track.")
+        }
+        base.AddTrack(track, filter)
+    }
+
+    protected open override func CreateFrameEntry(chunk ChunkEntry, frameInChunk int32, frameDelta uint32, frameData Memory[uint8]) FrameEntry {
+        let entry = base.CreateFrameEntry(chunk, frameInChunk, frameDelta, frameData)
+        let ivs []?[]uint8 = chunk.ExtraData as [][]uint8
+        if ivs != nil {
+            entry!!.ExtraData = if ivs.Length > frameInChunk { ivs[frameInChunk] } else { throw InvalidDataException("There are only ${ivs.Length} in the chunk, but caller requesting frame at index $frameInChunk.")
+                default([]uint8) }
+        }
+        return entry!!
+    }
+
+    protected open override func EnumerateChunks() IEnumerable[ChunkEntry] {
+        let singleTrack = TrackEntries.Values.Single()
+        let minimumSample = int64((StartTime.TotalSeconds * float64(singleTrack!!.Timescale)))
+        let maximumSample = int64((EndTime.TotalSeconds * float64(singleTrack!!.Timescale)))
+        return DashChunkEntryies(InputStream, singleTrack!!.TrackId, Dash.Sidx, Dash.FirstMoof, Dash.FirstMdat, minimumSample, maximumSample)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/DashFile.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/DashFile.gs
@@ -1,0 +1,115 @@
+package Oahu.Decrypt
+
+import System
+import System.Buffers
+import System.IO
+import System.Linq
+import Oahu.Decrypt.Chunks
+import Oahu.Decrypt.FrameFilters
+import Oahu.Decrypt.FrameFilters.Audio
+import Oahu.Decrypt.Mpeg4.Boxes
+import Oahu.Decrypt.Mpeg4.Util
+
+open class DashFile : Mp4File {
+    convenience init(fileName string, access FileAccess = 1, share FileShare = 1) {
+        init(File.Open(fileName, FileMode.Open, access, share))
+    }
+
+    convenience init(file Stream) {
+        init(file, file.Length)
+    }
+
+    init(file Stream, fileLength int64) : base(file, fileLength) {
+        if FileType != FileType.Dash {
+            throw ArgumentException("This instance of ${nameof(Mp4File)} is not a Dash file.")
+        }
+        FirstMoof = TopLevelBoxes.OfType[MoofBox]().Single()
+        let audioSampleEntry = Moov.AudioTrack.Mdia.Minf.Stbl.Stsd.AudioSampleEntry ?? throw InvalidDataException("The audio track doesn't contain an ${nameof(AudioSampleEntry)}")
+        if audioSampleEntry.GetChild[SinfBox]() != nil {
+            if audioSampleEntry.GetChild[SinfBox]()!!!!.SchemeType?.Type != SchmBox.SchemeType.Cenc {
+                throw NotSupportedException("Only ${nameof(SchmBox.SchemeType.Cenc)} dash files are currently supported.")
+            }
+            Tenc = audioSampleEntry.GetChild[SinfBox]()!!!!.SchemeInformation?.TrackEncryption
+            audioSampleEntry!!.Children.Remove(audioSampleEntry.GetChild[SinfBox]()!!!!)
+            audioSampleEntry!!.Header.ChangeAtomName(audioSampleEntry.GetChild[SinfBox]()!!!!.OriginalFormat.DataFormat)
+        }
+        for pssh in Moov.GetChildren[PsshBox]().ToArray() {
+            Moov.Children.Remove(pssh!!)
+        }
+        if AudioSampleEntry.Dec3 != nil || AudioSampleEntry.Dac4 != nil {
+            Ftyp = FtypBox.Create("mp42", 0)
+            Ftyp.CompatibleBrands.Add("dby1")
+            Ftyp.CompatibleBrands.Add("iso8")
+            Ftyp.CompatibleBrands.Add("isom")
+            Ftyp.CompatibleBrands.Add("mp41")
+            Ftyp.CompatibleBrands.Add("M4A ")
+            Ftyp.CompatibleBrands.Add("M4B ")
+        } else {
+            Ftyp = FtypBox.Create("isom", 0x200)
+            Ftyp.CompatibleBrands.Add("iso2")
+            Ftyp.CompatibleBrands.Add("mp41")
+            Ftyp.CompatibleBrands.Add("M4A ")
+            Ftyp.CompatibleBrands.Add("M4B ")
+        }
+    }
+
+    prop FirstMoof MoofBox {
+        get;
+        init;
+    }
+
+    prop FirstMdat MdatBox -> Mdat
+    prop Sidx SidxBox -> TopLevelBoxes.OfType[SidxBox]().Single()
+    open override prop Duration TimeSpan -> TimeSpan.FromSeconds(float64(Moov.GetChildOrThrow[MvexBox]().GetChildOrThrow[MehdBox]().FragmentDuration) / float64(TimeScale))
+
+    prop Tenc TencBox? {
+        get;
+        init;
+    }
+
+    prop Key []?uint8
+    private prop Mdat MdatBox -> base.Mdat
+
+    func SetDecryptionKey(keyId string, decryptionKey string) {
+        if String.IsNullOrWhiteSpace(keyId) || keyId.Length != AesCtr.AesBlockSize * 2 {
+            throw ArgumentException("${nameof(keyId)} must be ${AesCtr.AesBlockSize} bytes long.")
+        }
+        if String.IsNullOrWhiteSpace(decryptionKey) || decryptionKey.Length != AesCtr.AesBlockSize * 2 {
+            throw ArgumentException("${nameof(decryptionKey)} must be ${AesCtr.AesBlockSize} bytes long.")
+        }
+        let keyIdBts = Convert.FromHexString(keyId)
+        let decryptionKeyBts = Convert.FromHexString(decryptionKey)
+        SetDecryptionKey(keyIdBts, decryptionKeyBts)
+    }
+
+    open override func GetAudioFrameFilter() FrameTransformBase[FrameEntry, FrameEntry] {
+        return if Key == nil && Tenc != nil { throw InvalidOperationException("This instance of ${nameof(DashFile)} does not have a decryption key set.")
+            default(DashFilter) } else { DashFilter(Key) }
+    }
+
+    func SetDecryptionKey(keyId []?uint8, decryptionKey []?uint8) {
+        if Tenc == nil {
+            throw InvalidOperationException("This instance of ${nameof(DashFile)} does not contain a ${nameof(TencBox)}.")
+        }
+        if keyId == nil || keyId!!.Length != AesCtr.AesBlockSize {
+            throw ArgumentException("${nameof(keyId)} must be ${AesCtr.AesBlockSize} bytes long.")
+        }
+        if decryptionKey == nil || decryptionKey!!.Length != AesCtr.AesBlockSize {
+            throw ArgumentException("${nameof(decryptionKey)} must be ${AesCtr.AesBlockSize} bytes long.")
+        }
+        let keyUUID = Guid(keyId!!, true)
+        if keyUUID != Tenc!!.DefaultKID {
+            throw InvalidOperationException("Supplied keyId does not match dash default keyId: ${Convert.ToHexString(Tenc!!.DefaultKID.ToByteArray(true))}")
+        }
+        Key = decryptionKey
+    }
+
+    protected open override func CalculateBitrate() uint32 {
+        let totalSize = Sidx.Segments.Sum((s Segment) -> int64(s.ReferenceSize)) * int64(8)
+        let totalDuration = Sidx.Segments.Sum((s Segment) -> int64(s.SubsegmentDuration))
+        let bitRate = totalSize * int64(Sidx.Timescale) / totalDuration
+        return uint32(bitRate)
+    }
+
+    protected open override func CreateChunkReader(inputStream Stream, startTime TimeSpan, endTime TimeSpan) IChunkReader -> DashChunkReader(this, inputStream, startTime, endTime)
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/DashFilter.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/DashFilter.gs
@@ -1,0 +1,41 @@
+package Oahu.Decrypt.FrameFilters.Audio
+
+import Oahu.Decrypt.Mpeg4.Util
+
+internal open class DashFilter : AacValidateFilter {
+    init(key []?uint8) {
+        Key = key
+        AesCtr = if key == nil { default(AesCtr?) } else { AesCtr(key!!) }
+    }
+
+    prop Key []?uint8 {
+        get;
+        init;
+    }
+
+    protected open override prop InputBufferSize int32 -> 1000
+
+    private prop AesCtr AesCtr? {
+        get;
+        init;
+    }
+
+    open override func PerformFiltering(input FrameEntry) FrameEntry {
+        let iv []?uint8 = input.ExtraData as []uint8
+        if iv != nil {
+            if AesCtr == nil {
+                throw NullReferenceException("AesCtr is null but the frame entry has an IV.")
+            }
+            let frameData = input.FrameData.Span
+            AesCtr!!.Decrypt(iv, frameData, frameData)
+        }
+        return base.PerformFiltering(input)
+    }
+
+    protected open override func Dispose(disposing bool) {
+        if disposing && !Disposed {
+            AesCtr?.Dispose()
+        }
+        base.Dispose(disposing)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Dec3Box.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Dec3Box.gs
@@ -1,0 +1,73 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.Diagnostics
+import System.IO
+import System.Linq
+import Oahu.Decrypt.Mpeg4.Boxes.EC3SpecificBox
+import Oahu.Decrypt.Mpeg4.Util
+
+open class Dec3Box : Box {
+    private let ec3Data []uint8
+
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        ec3Data = file.ReadBlock(int32((header.TotalBoxSize - int64(header.HeaderSize))))
+        let reader = BitReader(ec3Data)
+        AverageBitrate = reader!!.Read(13) * uint32(1024)
+        let num_ind_sub = reader!!.Read(3)
+        Debug.Assert(num_ind_sub == uint32(0))
+        IndependentSubstream = [int32(num_ind_sub + uint32(1))]Ec3IndependentSubstream
+        for var i = 0; int64(i) <= int64(num_ind_sub); i++ {
+            IndependentSubstream[i] = Ec3IndependentSubstream(reader!!)
+        }
+        let indSample = IndependentSubstream.First()
+        Debug.Assert(indSample!!.NumDepSub == uint8(0))
+        SampleRate = indSample!!.GetSampleRate()
+        NumberOfChannels = indSample!!.ChannelCount()
+        if reader!!.Length - reader!!.Position < 8 {
+            return
+        }
+        reader!!.Position += 7
+        FlagEc3ExtensionTypeA = reader!!.ReadBool()
+        if FlagEc3ExtensionTypeA.Value {
+            ComplexityIndexTypeA = uint8(reader!!.Read(8))
+        }
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(ec3Data.Length)
+
+    prop AverageBitrate uint32 {
+        get;
+        init;
+    }
+
+    prop SampleRate int32 {
+        get;
+        init;
+    }
+
+    prop NumberOfChannels int32 {
+        get;
+        init;
+    }
+
+    prop IndependentSubstream []Ec3IndependentSubstream {
+        get;
+        init;
+    }
+
+    prop IsAtmos bool -> FlagEc3ExtensionTypeA.HasValue
+
+    prop FlagEc3ExtensionTypeA bool? {
+        get;
+        init;
+    }
+
+    prop ComplexityIndexTypeA uint8? {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        file.Write(ec3Data)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/DecoderConfigDescriptor.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/DecoderConfigDescriptor.gs
@@ -1,0 +1,47 @@
+package Oahu.Decrypt.Mpeg4.Descriptors
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+class DecoderConfigDescriptor : BaseDescriptor {
+    private let blob []uint8
+
+    init(file Stream, header DescriptorHeader) : base(file, header) {
+        ObjectTypeIndication = uint8(file.ReadByte())
+        blob = file.ReadBlock(4)
+        MaxBitrate = file.ReadUInt32BE()
+        AverageBitrate = file.ReadUInt32BE()
+        LoadChildren(file)
+    }
+
+    private init(objectTypeIndication uint8, blob []uint8) : base(4) {
+        ObjectTypeIndication = objectTypeIndication
+        this.blob = blob
+    }
+
+    prop ObjectTypeIndication uint8 {
+        get;
+        init;
+    }
+
+    prop MaxBitrate uint32
+    prop AverageBitrate uint32
+    prop AudioSpecificConfig AudioSpecificConfig -> GetChildOrThrow[AudioSpecificConfig]()
+    override prop InternalSize int32 -> base.InternalSize + 13
+
+    override func Render(file Stream) {
+        file.WriteByte(ObjectTypeIndication)
+        file.Write(blob)
+        file.WriteUInt32BE(MaxBitrate)
+        file.WriteUInt32BE(AverageBitrate)
+    }
+
+    shared {
+        func CreateAudio() DecoderConfigDescriptor {
+            let descriptor = DecoderConfigDescriptor(0x40, []uint8{uint8(0x15), uint8(0x00), uint8(0x00), uint8(0x00)})
+            let asc = AudioSpecificConfig.CreateEmpty()
+            descriptor!!.Children.Add(asc!!)
+            return descriptor!!
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/DescriptorFactory.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/DescriptorFactory.gs
@@ -1,0 +1,18 @@
+package Oahu.Decrypt.Mpeg4.Descriptors
+
+import System.IO
+
+class DescriptorFactory {
+    shared {
+        func CreateDescriptor(file Stream) BaseDescriptor {
+            let header = DescriptorHeader(file)
+            return switch header!!.TagID {
+                case 3: ES_Descriptor(file, header!!)
+                case 4: DecoderConfigDescriptor(file, header!!)
+                case 5: AudioSpecificConfig(file, header!!)
+                case 6: SLConfigDescriptor(file, header!!)
+                default: UnknownDescriptor(file, header!!)
+            }
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/DescriptorHeader.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/DescriptorHeader.gs
@@ -1,0 +1,35 @@
+package Oahu.Decrypt.Mpeg4.Descriptors
+
+import System.IO
+
+class DescriptorHeader {
+    init(file Stream) {
+        FilePosition = file.Position
+        TagID = uint8(file.ReadByte())
+        let start = file.Position
+        let originalInternalSize = ExpandableClass.DecodeSize(file)
+        let originalSizeOfSize = int32((file.Position - start))
+        HeaderSize = originalSizeOfSize + 1
+        TotalBoxSize = HeaderSize + originalInternalSize
+    }
+
+    init(tagId uint8) {
+        TagID = tagId
+        HeaderSize = 1
+    }
+
+    prop FilePosition int64
+
+    prop TotalBoxSize int32 {
+        get;
+        init;
+    }
+
+    prop TagID uint8
+    prop HeaderSize int32
+
+    func GetEncodedSizeLength(internalSize int32) int32 {
+        let minimumEncodeSize = HeaderSize - 1
+        return ExpandableClass.GetSizeByteCount(internalSize, minimumEncodeSize)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/ES_Descriptor.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/ES_Descriptor.gs
@@ -1,0 +1,85 @@
+package Oahu.Decrypt.Mpeg4.Descriptors
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+class ES_Descriptor : BaseDescriptor {
+    private let esFlags uint8
+    private let dependsOnEsId uint16
+    private let urlLength uint8
+    private let urlString []?uint8
+    private let ocrEsId uint16
+
+    init(file Stream, header DescriptorHeader) : base(file, header) {
+        EsId = file.ReadUInt16BE()
+        esFlags = uint8(file.ReadByte())
+        if StreamDependenceFlag == 1 {
+            dependsOnEsId = file.ReadUInt16BE()
+        }
+        if UrlFlag == 1 {
+            urlLength = uint8(file.ReadByte())
+            urlString = file.ReadBlock(urlLength)
+        }
+        if OcrStreamFlag == 1 {
+            ocrEsId = file.ReadUInt16BE()
+        }
+        LoadChildren(file)
+    }
+
+    private init() : base(0x3) {
+        EsId = uint16(0)
+        esFlags = uint8(0)
+    }
+
+    prop EsId uint16 {
+        get;
+        init;
+    }
+
+    prop StreamPriority int32 -> esFlags & uint8(31)
+    prop DecoderConfig DecoderConfigDescriptor -> GetChildOrThrow[DecoderConfigDescriptor]()
+    override prop InternalSize int32 -> base.InternalSize + GetLength()
+    private prop StreamDependenceFlag int32 -> esFlags >> 7
+    private prop UrlFlag int32 -> (esFlags >> 6) & 1
+    private prop OcrStreamFlag int32 -> (esFlags >> 5) & 1
+
+    override func Render(file Stream) {
+        file.WriteUInt16BE(EsId)
+        file.WriteByte(esFlags)
+        if StreamDependenceFlag == 1 {
+            file.WriteUInt16BE(dependsOnEsId)
+        }
+        if UrlFlag == 1 {
+            file.WriteByte(urlLength)
+            file.Write(urlString)
+        }
+        if OcrStreamFlag == 1 {
+            file.WriteUInt16BE(ocrEsId)
+        }
+    }
+
+    private func GetLength() int32 {
+        var length = 3
+        if StreamDependenceFlag == 1 {
+            length += 2
+        }
+        if UrlFlag == 1 {
+            length += uint8(1) + urlLength
+        }
+        if OcrStreamFlag == 1 {
+            length += 2
+        }
+        return length
+    }
+
+    shared {
+        func CreateAudio() ES_Descriptor {
+            let descriptor = ES_Descriptor()
+            let decoder = DecoderConfigDescriptor.CreateAudio()
+            let slConfig = SLConfigDescriptor.CreateMp4()
+            descriptor!!.Children.Add(decoder!!)
+            descriptor!!.Children.Add(slConfig!!)
+            return descriptor!!
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Ec3Extensions.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Ec3Extensions.gs
@@ -1,0 +1,14 @@
+package Oahu.Decrypt.Mpeg4.Boxes.EC3SpecificBox
+
+import System.IO
+
+class Ec3Extensions {
+    shared {
+        private let FfAc3ChannelsTab []uint8 = []uint8{uint8(2), uint8(1), uint8(2), uint8(3), uint8(3), uint8(4), uint8(4), uint8(5)}
+    }
+}
+
+func (indSub Ec3IndependentSubstream) GetSampleRate() int32 -> if indSub.Fscod == uint8(0) { 48000 } else { if indSub.Fscod == uint8(1) { 44100 } else { if indSub.Fscod == uint8(2) { 32000 } else { throw InvalidDataException("${nameof(indSub.Fscod)} value of ${indSub.Fscod} is not valid")
+    default(int32) } } }
+
+func (indSub Ec3IndependentSubstream) ChannelCount() int32 -> int32(Ec3Extensions.FfAc3ChannelsTab[uint8(indSub.Acmod)]) + (if indSub.Lfeon { 1 } else { 0 })

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Ec3IndependentSubstream.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Ec3IndependentSubstream.gs
@@ -1,0 +1,35 @@
+package Oahu.Decrypt.Mpeg4.Boxes.EC3SpecificBox
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+class Ec3IndependentSubstream {
+    var Fscod uint8
+    var Bsid uint8
+    var Asvc bool
+    var Bsmod uint8
+    var Acmod AudioCodingMode
+    var Lfeon bool
+    var NumDepSub uint8
+    var ChanLoc ChannelLocation
+
+    init(reader BitReader) {
+        Fscod = uint8(reader.Read(2))
+        Bsid = uint8(reader.Read(5))
+        if Bsid != uint8(16) {
+            throw InvalidDataException("Invalid bsid value: $Bsid. Expected 16 for E-AC-3.")
+        }
+        reader.Position += 1
+        Asvc = reader.ReadBool()
+        Bsmod = uint8(reader.Read(3))
+        Acmod = AudioCodingMode(reader.Read(3))
+        Lfeon = reader.Read(1) > uint32(0)
+        reader.Position += 3
+        let numDepSub = reader.Read(4)
+        if numDepSub > uint32(0) {
+            ChanLoc = ChannelLocation(reader.Read(9))
+        } else {
+            reader.Position++
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/EmptyFrame.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/EmptyFrame.gs
@@ -1,0 +1,20 @@
+package Oahu.Decrypt.Mpeg4.ID3
+
+import System.IO
+
+internal class EmptyFrame : Frame {
+    convenience init(parent Frame) {
+        init(FrameHeader(EmptyFrame.GetEmptyFrameId(parent.Version), 0, parent.Version), parent)
+    }
+
+    init(header Header, parent Frame) : base(header, parent) {
+    }
+
+    override func Render(file Stream) {
+    }
+
+    shared {
+        func GetEmptyFrameSize(version int32) int32 -> if version == 0x200 { 6 } else { 10 }
+        private func GetEmptyFrameId(version int32) string -> if version == 0x200 { "\u0000\u0000\u0000" } else { "\u0000\u0000\u0000\u0000" }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/EsdsBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/EsdsBox.gs
@@ -1,0 +1,35 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Descriptors
+
+open class EsdsBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        let descroptor = DescriptorFactory.CreateDescriptor(file)
+        ES_Descriptor = descroptor as ES_Descriptor ?? throw InvalidDataException("${descroptor!!.GetType()} is not an ${nameof(ES_Descriptor)}")
+    }
+
+    private init(es_Descriptor ES_Descriptor, parent IBox) : base([]uint8{uint8(0), uint8(0), uint8(0), uint8(0)}, BoxHeader(8, "esds"), parent) {
+        ES_Descriptor = es_Descriptor
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(ES_Descriptor.RenderSize)
+
+    prop ES_Descriptor ES_Descriptor {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        ES_Descriptor.Save(file)
+    }
+
+    shared {
+        func CreateEmpty(parent IBox) EsdsBox {
+            let esds = EsdsBox(ES_Descriptor.CreateAudio(), parent)
+            parent.Children.Add(esds!!)
+            return esds!!
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/ExpandableClass.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/ExpandableClass.gs
@@ -1,0 +1,39 @@
+package Oahu.Decrypt.Mpeg4.Descriptors
+
+import System
+import System.IO
+
+class ExpandableClass {
+    shared {
+        func EncodeSize(file Stream, sizeOfInstance int32, minimumBytes int32) {
+            const IntegerBytes = 4
+            const MaxSize = (1 << (7 * IntegerBytes)) - 1
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(sizeOfInstance, MaxSize, nameof(sizeOfInstance))
+            let size = ExpandableClass.GetSizeByteCount(sizeOfInstance, minimumBytes)
+            for var i = size - 1; i > 0; i-- {
+                let b = 0x80 | ((sizeOfInstance >> (7 * i)) & 0x7f)
+                file.WriteByte(uint8(b))
+            }
+            file.WriteByte(uint8((sizeOfInstance & 0x7f)))
+        }
+
+        func GetSizeByteCount(sizeOfInstance int32, minimumBytes int32) int32 {
+            var sizeOfInstance = sizeOfInstance
+            var r = 0
+            while (1) != 0 {
+                r++
+            }
+            return Math.Max(minimumBytes, r / 7 + 1)
+        }
+
+        func DecodeSize(file Stream) int32 {
+            var b int32
+            var sizeOfInstance = 0
+            do {
+                b = file.ReadByte()
+                sizeOfInstance = (sizeOfInstance << 7) | (b & 0x7f)
+            } while (b & 0x80) != 0
+            return sizeOfInstance
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/ExtendedHeader.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/ExtendedHeader.gs
@@ -1,0 +1,116 @@
+package Oahu.Decrypt.Mpeg4.ID3
+
+import System.IO
+
+class Id3ExtendedHeader : Frame {
+    private init(header Header, parent Frame) : base(header, parent) {
+    }
+
+    override func Render(file Stream) {
+    }
+
+    shared {
+        func Create(file Stream, parent Id3Tag) Id3ExtendedHeader {
+            let header = ExtendedHeader(file, parent.Version)
+            return Id3ExtendedHeader(header!!, parent)
+        }
+    }
+}
+
+class ExtendedHeader : Header {
+    init(file Stream, version int32) {
+        Identifier = String.Empty
+        Version = version
+        var headerSize int64
+        let originalPosition = file.Position
+        if version >= 0x400 {
+            headerSize = Header.UnSyncSafify(Header.ReadUInt32BE(file))
+            let numFlagBytes = file.ReadByte()
+            ExtendedFlags = Flags(Header.ReadBlock(file, numFlagBytes))
+            if (ExtendedFlags!![1]) {
+                TagIsUpdate = file.ReadByte() != 0
+            }
+            if ExtendedFlags!![2] && file.ReadByte() == 5 {
+                CRC32 = (uint32(file.ReadByte()) << 28) | uint32(Header.UnSyncSafify(Header.ReadUInt32BE(file)))
+            }
+            if ExtendedFlags!![3] && file.ReadByte() == 1 {
+                TagRestrictions = uint8(file.ReadByte())
+            }
+        } else {
+            headerSize = Header.ReadUInt32BE(file)
+            ExtendedFlags = Flags(Header.ReadUInt16BE(file))
+            SizeOfPadding = Header.ReadUInt32BE(file)
+            if (ExtendedFlags!![0]) {
+                CRC32 = Header.ReadUInt32BE(file)
+            }
+        }
+        SeekForwardToPosition(file, originalPosition + headerSize)
+    }
+
+    override prop Identifier string {
+        get;
+        init;
+    }
+
+    override prop HeaderSize int32 -> GetExtendedFlagsSize()
+    prop ExtendedFlags Flags?
+    prop SizeOfPadding uint32
+    prop TagIsUpdate bool
+    prop TagRestrictions uint8
+    prop CRC32 uint32
+
+    prop Version int32 {
+        get;
+        init;
+    }
+
+    override func Render(stream Stream, renderSize int32, version uint16) {
+        if version >= uint16(0x400) {
+            Header.WriteUInt32BE(stream, Header.SyncSafify(HeaderSize + renderSize))
+            stream.WriteByte(uint8(ExtendedFlags!!.Size))
+            stream.Write(ExtendedFlags!!.ToBytes())
+            if (ExtendedFlags!![1]) {
+                stream.WriteByte(uint8((if TagIsUpdate { 1 } else { 0 })))
+            }
+            if (ExtendedFlags!![2]) {
+                stream.WriteByte(5)
+                stream.WriteByte(uint8((CRC32 >> 28)))
+                Header.WriteUInt32BE(stream, Header.SyncSafify(int32((CRC32 & uint32(0xfffffff)))))
+            }
+            if (ExtendedFlags!![3]) {
+                stream.WriteByte(1)
+                stream.WriteByte(TagRestrictions)
+            }
+        } else {
+            Header.WriteUInt32BE(stream, uint32((HeaderSize + renderSize)))
+            stream.Write(ExtendedFlags!!.ToBytes())
+            Header.WriteUInt32BE(stream, SizeOfPadding)
+            if (ExtendedFlags!![0]) {
+                Header.WriteUInt32BE(stream, CRC32)
+            }
+        }
+    }
+
+    func ToString() string -> "ExtendedHeader"
+
+    private func GetExtendedFlagsSize() int32 {
+        if ExtendedFlags == nil {
+            return 0
+        }
+        if Version >= 0x400 {
+            var size = 5 + ExtendedFlags!!.Size
+            if (ExtendedFlags!![1]) {
+                size++
+            }
+            if (ExtendedFlags!![2]) {
+                size += 6
+            }
+            if (ExtendedFlags!![3]) {
+                size += 2
+            }
+            return size
+        } else {
+            return if ExtendedFlags!![0] { 10 } else { 6 }
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Flags.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Flags.gs
@@ -1,0 +1,39 @@
+package Oahu.Decrypt.Mpeg4.ID3
+
+import System
+import System.Linq
+
+class Flags {
+    private var flags []uint8
+
+    init(flags ...uint8) {
+        this.flags = flags
+    }
+
+    init(flags uint16) {
+        this.flags = []uint8{uint8((flags >> 8)), uint8((flags & uint16(0xff)))}
+    }
+
+    prop Size int32 -> this.flags.Length
+
+    prop this[index int32] bool {
+        get {
+            if index < 0 || index >= flags.Length * 8 {
+                throw ArgumentOutOfRangeException(nameof(index), "Index must be within the range of the flags.")
+            }
+            return (int32(flags[index / 8]) & (1 << (7 - (index % 8)))) != 0
+        }
+        set {
+            if index < 0 || index >= flags.Length * 8 {
+                throw ArgumentOutOfRangeException(nameof(index), "Index must be within the range of the flags.")
+            }
+            if value {
+                flags[index / 8] |= uint8((1 << (7 - (index % 8))))
+            } else {
+                flags[index / 8] &= uint8(^(1 << (7 - (index % 8))))
+            }
+        }
+    }
+
+    func ToBytes() []uint8 -> flags.ToArray()
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Frame.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Frame.gs
@@ -1,0 +1,101 @@
+package Oahu.Decrypt.Mpeg4.ID3
+
+import System
+import System.Collections.Generic
+import System.IO
+import System.Linq
+import System.Text
+
+open class Frame(Header Header, Parent Frame) {
+    open prop Size int32 -> Children.Sum((b Frame) -> b.Size)
+
+    prop Children List[Frame] {
+        get;
+        init;
+    }
+
+    open prop Version uint16 -> Parent.Version
+
+    open func Save(file Stream, version uint16) {
+        Header.Render(file, Size, version)
+        Render(file)
+        for child in Children {
+            child!!.Save(file, version)
+        }
+    }
+
+    func ToString() string -> Header.ToString()
+    open func Render(file Stream);
+
+    protected func LoadChildren(file Stream, endPosition int64) {
+        var origPosition = file.Position
+        while file.Position < endPosition && origPosition == file.Position {
+            let child = TagFactory.CreateTag(file, this, out var lengthRead)
+            if child is EmptyFrame {
+                break
+            }
+            origPosition += int64(lengthRead)
+            Children.Add(child)
+        }
+        Header.SeekForwardToPosition(file, endPosition)
+    }
+
+    shared {
+        func ReadSizeString(file Stream, unicode bool, bytes int32) string {
+            let buff = [bytes]uint8
+            file.ReadExactly(buff!!)
+            return (if unicode { Encoding.Unicode } else { Encoding.ASCII }).GetString(buff!!)
+        }
+
+        func ReadNullTerminatedString(file Stream, unicode bool) string {
+            let lst = List[uint8]()
+            if unicode {
+                let blob = [2]uint8
+                file.ReadExactly(blob!!)
+                while blob!![0] != uint8(0) || blob!![1] != uint8(0) {
+                    lst.AddRange(blob!!)
+                    file.ReadExactly(blob!!)
+                }
+                return Encoding.Unicode.GetString(lst.ToArray())
+            } else {
+                var b = uint8(file.ReadByte())
+                while b != uint8(0) {
+                    lst.Add(b)
+                    b = uint8(file.ReadByte())
+                }
+                return Encoding.ASCII.GetString(lst.ToArray())
+            }
+        }
+
+        func IsUnicode(str string) bool -> Encoding.UTF8.GetByteCount(str) != str.Length
+
+        func UnicodeLength(str string) int32 {
+            if str.Length == 0 {
+                return 4
+            }
+            var strLen = Encoding.Unicode.GetByteCount(str)
+            let c0 = str[0]
+            if c0 != '￾' && c0 != '﻿' {
+                strLen += 2
+            }
+            return strLen
+        }
+
+        func UnicodeBytes(str string) []uint8 {
+            let strLen = str.Length
+            if strLen == 0 {
+                return Encoding.Unicode.GetPreamble()
+            }
+            let c0 = str[0]
+            if c0 == '￾' || c0 == '﻿' {
+                return Encoding.Unicode.GetBytes(str)
+            } else {
+                let bts = [2 * (strLen + 1)]uint8
+                let preamble = Encoding.Unicode.GetPreamble()
+                Array.Copy(preamble!!, bts!!, preamble!!.Length)
+                Encoding.Unicode.GetBytes(str, 0, str.Length, bts!!, preamble!!.Length)
+                return bts!!
+            }
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/FrameEntry.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/FrameEntry.gs
@@ -1,0 +1,23 @@
+package Oahu.Decrypt.FrameFilters
+
+import System
+import Oahu.Decrypt.Mpeg4.Chunks
+
+class FrameEntry {
+    prop Chunk ChunkEntry? {
+        get;
+        init;
+    }
+
+    prop SamplesInFrame uint32 {
+        get;
+        init;
+    }
+
+    prop FrameData Memory[uint8] {
+        get;
+        init;
+    }
+
+    prop ExtraData object?
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/FrameFilterBase_TInput.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/FrameFilterBase_TInput.gs
@@ -1,0 +1,94 @@
+package Oahu.Decrypt.FrameFilters
+
+import System
+import System.Threading
+import System.Threading.Channels
+import System.Threading.Tasks
+
+open class FrameFilterBase[TInput]() : IDisposable {
+    private let filterChannel Channel[BufferEntry] = Channel.CreateBounded[BufferEntry](BoundedChannelOptions(2))
+    private var cancellationToken CancellationToken
+    private var filterLoop Task?
+    private var buffer []TInput
+    private var bufferPosition int32 = 0
+
+    init() {
+        buffer = [InputBufferSize]TInput
+    }
+
+    deinit {
+        Dispose(false)
+    }
+
+    protected prop Disposed bool
+
+    protected open prop InputBufferSize int32 {
+        get;
+    }
+
+    open async func AddInputAsync(input TInput) {
+        filterLoop ??= Task.Run(Encoder, cancellationToken)
+        if cancellationToken.IsCancellationRequested {
+            return
+        }
+        buffer[bufferPosition] = input
+        bufferPosition++
+        if bufferPosition == InputBufferSize {
+            if await filterChannel.Writer.WaitToWriteAsync(cancellationToken) {
+                await filterChannel.Writer.WriteAsync(BufferEntry(bufferPosition, buffer), cancellationToken)
+                bufferPosition = 0
+                buffer = [InputBufferSize]TInput
+            }
+        }
+    }
+
+    func CompleteAsync() Task -> CompleteInternalAsync()
+
+    func Dispose() {
+        Dispose(true)
+        GC.SuppressFinalize(this)
+    }
+
+    open func SetCancellationToken(cancellationToken CancellationToken) -> this.cancellationToken = cancellationToken
+    protected open func FlushAsync() Task;
+    protected open func HandleInputDataAsync(input TInput) Task;
+
+    protected open async func CompleteInternalAsync() {
+        try {
+            await filterChannel.Writer.WriteAsync(BufferEntry(bufferPosition, buffer), cancellationToken)
+            filterChannel.Writer.Complete()
+        } catch (ex OperationCanceledException) {
+        }
+        if filterLoop != nil {
+            await filterLoop
+        }
+    }
+
+    protected open func Dispose(disposing bool) {
+        if disposing && !Disposed {
+            if filterLoop?.IsCompleted == false {
+                filterChannel.Writer.TryComplete()
+            }
+        }
+        Disposed = true
+    }
+
+    private async func Encoder() {
+        try {
+            while await filterChannel.Reader.WaitToReadAsync(cancellationToken) {
+                await for messages in filterChannel.Reader.ReadAllAsync(cancellationToken) {
+                    for var i = 0; i < messages!!.NumEntries; i++ {
+                        await HandleInputDataAsync(messages!!.Entries[i])
+                    }
+                }
+            }
+            await FlushAsync()
+        } catch (ex Exception) {
+            filterChannel.Writer.Complete(ex)
+            throw ex
+        }
+    }
+
+    private open data class BufferEntry(NumEntries int32, Entries []TInput) {
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/FrameFinalBase_TInput.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/FrameFinalBase_TInput.gs
@@ -1,0 +1,8 @@
+package Oahu.Decrypt.FrameFilters
+
+import System.Threading.Tasks
+
+open class FrameFinalBase[TInput] : FrameFilterBase[TInput] {
+    protected override func HandleInputDataAsync(input TInput) Task -> PerformFilteringAsync(input)
+    protected open func PerformFilteringAsync(input TInput) Task;
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/FrameHeader.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/FrameHeader.gs
@@ -1,0 +1,63 @@
+package Oahu.Decrypt.Mpeg4.ID3
+
+import System
+import System.IO
+import System.Text
+
+class FrameHeader : Header {
+    init(frameID string, flags uint16, version uint16, size int32 = 0) {
+        Version = version
+        Identifier = frameID
+        Flags = Flags(flags)
+        Size = size
+    }
+
+    override prop Identifier string {
+        get;
+        init;
+    }
+
+    prop Flags Flags {
+        get;
+        init;
+    }
+
+    override prop HeaderSize int32 -> if Version == uint16(0x200) { 6 } else { 10 }
+
+    prop Version uint16 {
+        get;
+        init;
+    }
+
+    override func Render(stream Stream, renderSize int32, version uint16) {
+        stream.Write(Encoding.ASCII.GetBytes(Identifier))
+        let size = if version >= uint16(0x400) { int32(Header.SyncSafify(renderSize)) } else { renderSize }
+        if version == uint16(0x200) {
+            stream.WriteByte(uint8((size >> 16)))
+            stream.WriteByte(uint8((size >> 8)))
+            stream.WriteByte(uint8(size))
+        } else {
+            Header.WriteUInt32BE(stream, uint32(size))
+            stream.Write(Flags.ToBytes())
+        }
+    }
+
+    shared {
+        func Create(file Stream, version uint16) FrameHeader {
+            let originalPosition = file.Position
+            if version == uint16(0x200) {
+                let bts2 = stackalloc [6]uint8
+                file.ReadExactly(bts2)
+                let frameID = Encoding.ASCII.GetString(bts2.Slice(0, 3))
+                let size = (bts2[3] << 16) | (bts2[4] << 8) | int32(bts2[5])
+                return FrameHeader(frameID!!, 0, version, size)
+            } else {
+                let bts = stackalloc [4]uint8
+                file.ReadExactly(bts)
+                let frameID = Encoding.ASCII.GetString(bts)
+                let size = if version >= uint16(0x400) { Header.UnSyncSafify(Header.ReadUInt32BE(file)) } else { int32(Header.ReadUInt32BE(file)) }
+                return FrameHeader(frameID!!, Header.ReadUInt16BE(file), version, size)
+            }
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/FrameTransformBase_TInput_TOutput.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/FrameTransformBase_TInput_TOutput.gs
@@ -1,0 +1,43 @@
+package Oahu.Decrypt.FrameFilters
+
+import System.Threading
+import System.Threading.Tasks
+
+open class FrameTransformBase[TInput, TOutput] : FrameFilterBase[TInput] {
+    private var linked FrameFilterBase[TOutput]?
+
+    open override func SetCancellationToken(cancellationToken CancellationToken) {
+        base.SetCancellationToken(cancellationToken)
+        linked?.SetCancellationToken(cancellationToken)
+    }
+
+    func LinkTo(nextFilter FrameFilterBase[TOutput]) -> linked = nextFilter
+    open func PerformFiltering(input TInput) TOutput;
+    protected open func PerformFinalFiltering() TOutput? -> default
+
+    protected override async func FlushAsync() {
+        if PerformFinalFiltering() is TOutput && linked != nil {
+            await linked!!.AddInputAsync((PerformFinalFiltering() as TOutput)!!)
+        }
+    }
+
+    protected override async func HandleInputDataAsync(input TInput) {
+        let filteredData = PerformFiltering(input)
+        if linked == nil {
+            return
+        }
+        await linked!!.AddInputAsync(filteredData)
+    }
+
+    protected override async func CompleteInternalAsync() {
+        await base.CompleteInternalAsync()
+        await (linked?.CompleteAsync() ?? Task.CompletedTask)
+    }
+
+    protected open override func Dispose(disposing bool) {
+        if disposing && !Disposed {
+            linked?.Dispose()
+        }
+        base.Dispose(disposing)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/FreeBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/FreeBox.gs
@@ -1,0 +1,38 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.IO
+
+open class FreeBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        for var i = Header.HeaderSize; int64(i) < Header.TotalBoxSize; i++ {
+            file.ReadByte()
+        }
+    }
+
+    private init(header BoxHeader, parent IBox?) : base(header, parent) {
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + Header.TotalBoxSize - int64(Header.HeaderSize)
+
+    protected open override func Render(file Stream) {
+        var totalToWrite = Header.TotalBoxSize - int64(Header.HeaderSize)
+        let blankData = [int32(Math.Min(8 * 1024, totalToWrite))]uint8
+        while totalToWrite > int64(0) {
+            let toWrite = int32(Math.Min(blankData!!.Length, totalToWrite))
+            file.Write(blankData!!, 0, toWrite)
+            totalToWrite -= int64(toWrite)
+        }
+    }
+
+    shared {
+        const MinSize int32 = 8
+
+        func Create(freeSize int64, parent IBox?) FreeBox {
+            let header = BoxHeader(freeSize, "free")
+            let free = FreeBox(header, parent)
+            parent?.Children.Add(free)
+            return free
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/FreeformTagBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/FreeformTagBox.gs
@@ -1,0 +1,33 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.Diagnostics
+import System.IO
+
+@DebuggerDisplay("{DebuggerDisplay,nq}")
+open class FreeformTagBox : AppleTagBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        LoadChildren(file)
+    }
+
+    protected init(header BoxHeader, parent IBox?) : base(header, parent) {
+    }
+
+    prop Mean MeanBox? -> GetChild[MeanBox]()
+    prop Name NameBox? -> GetChild[NameBox]()
+    open override prop TagName string -> "${Mean?.ReverseDnsDomain}:${Name?.Name}'"
+
+    @DebuggerHidden
+    private prop DebuggerDisplay string -> "----:$TagName"
+
+    shared {
+        func Create(parent AppleListBox?, domain string, tagName string, data []uint8, dataType AppleDataType) FreeformTagBox {
+            let header = BoxHeader(8, "----")
+            let tagBox = FreeformTagBox(header, parent)
+            MeanBox.Create(tagBox!!, domain)
+            NameBox.Create(tagBox!!, tagName)
+            AppleDataBox.Create(tagBox!!, data, dataType)
+            parent?.Children.Add(tagBox!!)
+            return tagBox!!
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/FrmaBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/FrmaBox.gs
@@ -1,0 +1,21 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class FrmaBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        DataFormat = file.ReadType()
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(4)
+
+    prop DataFormat string {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        file.WriteType(DataFormat)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/FtypBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/FtypBox.gs
@@ -1,0 +1,56 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.Collections.Generic
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class FtypBox : Box {
+    init(file Stream, header BoxHeader) : base(header, nil) {
+        CompatibleBrands = List[string]()
+        let endPos = header.FilePosition + header.TotalBoxSize
+        MajorBrand = file.ReadType()
+        MajorVersion = file.ReadInt32BE()
+        while file.Position < endPos {
+            CompatibleBrands.Add(file.ReadType())
+        }
+    }
+
+    private init(header BoxHeader, majorBrand string, majorVersion int32) : base(header, nil) {
+        CompatibleBrands = List[string]()
+        MajorBrand = majorBrand
+        MajorVersion = majorVersion
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(8) + int64(CompatibleBrands.Count * 4)
+    prop MajorBrand string
+    prop MajorVersion int32
+
+    prop CompatibleBrands List[string] {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        file.WriteType(MajorBrand)
+        file.WriteInt32BE(MajorVersion)
+        for brand in CompatibleBrands {
+            file.WriteType(brand)
+        }
+    }
+
+    protected open override func Dispose(disposing bool) {
+        if disposing && !Disposed {
+            CompatibleBrands.Clear()
+        }
+        base.Dispose(disposing)
+    }
+
+    shared {
+        func Create(majorBrand string, majorVersion int32) FtypBox {
+            ArgumentException.ThrowIfNullOrWhiteSpace(majorBrand, nameof(majorBrand))
+            return if majorBrand.Length == 4 { FtypBox(BoxHeader(16, "ftyp"), majorBrand, majorVersion) } else { throw ArgumentException("Major brand must be 4 chars long.", nameof(majorBrand))
+                default(FtypBox) }
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/FullBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/FullBox.gs
@@ -1,0 +1,32 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class FullBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        VersionFlags = file.ReadBlock(4)
+    }
+
+    init(versionFlags []uint8, header BoxHeader, parent IBox?) : base(header, parent) {
+        VersionFlags = versionFlags
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(4)
+
+    prop Version uint8 {
+        get -> VersionFlags[0]
+        set -> VersionFlags[0] = value
+    }
+
+    prop Flags int32 -> VersionFlags[1] << 16 | VersionFlags[2] << 8 | int32(VersionFlags[3])
+
+    protected prop VersionFlags []uint8 {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        file.Write(VersionFlags)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/HdlrBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/HdlrBox.gs
@@ -1,0 +1,69 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.IO
+import System.Text
+import Oahu.Decrypt.Mpeg4.Util
+
+open class HdlrBox : FullBox {
+    private let reserved []uint8
+
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        let endPos = Header.FilePosition + Header.TotalBoxSize
+        PreDefined = file.ReadUInt32BE()
+        HandlerType = Encoding.UTF8.GetString(file.ReadBlock(4))
+        reserved = file.ReadBlock(12)
+        let readToEnd = file.ReadBlock(int32((endPos - file.Position)))
+        for var i = readToEnd!!.Length - 1; i >= 0 && readToEnd!![i] == uint8(0); i-- {
+            NullTerminatorCount++
+        }
+        HandlerName = Encoding.UTF8.GetString(readToEnd!!, 0, readToEnd!!.Length - NullTerminatorCount)
+    }
+
+    private init(type_ string, name string?, parent IBox) : base([]uint8{uint8(0), uint8(0), uint8(0), uint8(0)}, BoxHeader(8, "hdlr"), parent) {
+        ArgumentException.ThrowIfNullOrEmpty(type_, nameof(type_))
+        if Encoding.UTF8.GetByteCount(type_) != 4 {
+            throw ArgumentException("Type '$type_' must be exactly 4 UTF-8 characters long.", nameof(type_))
+        }
+        HandlerType = type_
+        reserved = [12]uint8
+        HandlerName = name ?? ""
+        NullTerminatorCount = 1
+    }
+
+    prop NullTerminatorCount int32
+    open override prop RenderSize int64 -> base.RenderSize + int64(20) + int64(Encoding.UTF8.GetByteCount(HandlerName)) + int64(NullTerminatorCount)
+
+    prop PreDefined uint32 {
+        get;
+        init;
+    }
+
+    prop HandlerType string {
+        get;
+        init;
+    }
+
+    prop HandlerName string
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.WriteUInt32BE(PreDefined)
+        file.Write(Encoding.UTF8.GetBytes(HandlerType))
+        file.Write(reserved)
+        file.Write(Encoding.UTF8.GetBytes(HandlerName))
+        file.Write([NullTerminatorCount]uint8)
+    }
+
+    shared {
+        func Create(type_ string, name string?, reservedData []uint8, parent IBox) HdlrBox {
+            ArgumentNullException.ThrowIfNull(reservedData, nameof(reservedData))
+            ArgumentNullException.ThrowIfNull(parent, nameof(parent))
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(reservedData.Length, 12, nameof(reservedData))
+            let hdlr = HdlrBox(type_, name, parent)
+            Array.Copy(reservedData, 0, hdlr!!.reserved, 0, reservedData.Length)
+            parent.Children.Add(hdlr!!)
+            return hdlr!!
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Header.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Header.gs
@@ -1,0 +1,62 @@
+package Oahu.Decrypt.Mpeg4.ID3
+
+import System
+import System.IO
+
+open class Header {
+    open prop Identifier string {
+        get;
+    }
+
+    prop Size int32 {
+        get;
+        init;
+    }
+
+    open prop HeaderSize int32 {
+        get;
+    }
+
+    open func Render(stream Stream, renderSize int32, version uint16);
+    func ToString() string -> if Identifier == "\u0000\u0000\u0000\u0000" { "\\0\\0\\0\\0" } else { if Identifier == "\u0000\u0000\u0000" { "\\0\\0\\0" } else { Identifier } }
+
+    func SeekForwardToPosition(file Stream, endPos int64) {
+        if file.Position < endPos {
+            if file.CanSeek {
+                file.Position = endPos
+            } else {
+                let buffer = [4096]uint8
+                while file.Position < endPos {
+                    let bytesToRead = Int32.Min(buffer!!.Length, int32((endPos - file.Position)))
+                    file.ReadExactly(buffer!!, 0, bytesToRead)
+                }
+            }
+        }
+    }
+
+    shared {
+        func ReadUInt16BE(stream Stream) uint16 {
+            let word = stackalloc [2]uint8
+            stream.ReadExactly(word)
+            return uint16((word[0] << 8 | int32(word[1])))
+        }
+
+        func UnSyncSafify(value uint32) int32 -> int32((((value & uint32(0x7f000000)) >> 3) | ((value & uint32(0x7f0000)) >> 2) | ((value & uint32(0x7f00)) >> 1) | (value & uint32(0x7f))))
+        func SyncSafify(value int32) uint32 -> uint32((((value << 3) & 0x7f000000) | ((value << 2) & 0x7f0000) | ((value << 1) & 0x7f00) | (value & 0x7F)))
+
+        func ReadUInt32BE(stream Stream) uint32 {
+            let dword = stackalloc [4]uint8
+            stream.ReadExactly(dword)
+            return uint32((dword[0] << 24 | dword[1] << 16 | dword[2] << 8 | int32(dword[3])))
+        }
+
+        func ReadBlock(stream Stream, numBytes int32) []uint8 {
+            let block = [numBytes]uint8
+            stream.ReadExactly(block!!, 0, numBytes)
+            return block!!
+        }
+
+        func WriteUInt32BE(stream Stream, value uint32) -> stream.Write([]uint8{uint8((value >> 24)), uint8((value >> 16)), uint8((value >> 8)), uint8(value)})
+        func WriteUInt16BE(stream Stream, value uint32) -> stream.Write([]uint8{uint8((value >> 8)), uint8(value)})
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/HeaderBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/HeaderBox.gs
@@ -1,0 +1,50 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class HeaderBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        if Version == uint8(0) {
+            CreationTime = HeaderBox.Datum.AddSeconds(file.ReadUInt32BE())
+            ModificationTime = HeaderBox.Datum.AddSeconds(file.ReadUInt32BE())
+            ReadBeforeDuration(file)
+            Duration = file.ReadUInt32BE()
+        } else {
+            CreationTime = HeaderBox.Datum.AddSeconds(file.ReadUInt64BE())
+            ModificationTime = HeaderBox.Datum.AddSeconds(file.ReadUInt64BE())
+            ReadBeforeDuration(file)
+            Duration = file.ReadUInt64BE()
+        }
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(3 * (if RequireVersionOne { 8 } else { 4 }))
+    prop CreationTime DateTimeOffset
+    prop ModificationTime DateTimeOffset
+    prop Duration uint64
+    private prop RequireVersionOne bool -> Version == uint8(1) || Duration > uint64(UInt32.MaxValue)
+    protected open func ReadBeforeDuration(file Stream);
+    protected open func WriteBeforeDuration(file Stream);
+
+    protected open override func Render(file Stream) {
+        if RequireVersionOne {
+            Version = uint8(1)
+            base.Render(file)
+            file.WriteUInt64BE(uint64((CreationTime - HeaderBox.Datum).TotalSeconds))
+            file.WriteUInt64BE(uint64((ModificationTime - HeaderBox.Datum).TotalSeconds))
+            WriteBeforeDuration(file)
+            file.WriteUInt64BE(Duration)
+        } else {
+            base.Render(file)
+            file.WriteUInt32BE(uint32((CreationTime - HeaderBox.Datum).TotalSeconds))
+            file.WriteUInt32BE(uint32((ModificationTime - HeaderBox.Datum).TotalSeconds))
+            WriteBeforeDuration(file)
+            file.WriteUInt32BE(uint32(Duration))
+        }
+    }
+
+    shared {
+        private let Datum DateTimeOffset = DateTimeOffset(1904, 1, 1, 0, 0, 0, TimeSpan.Zero)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/HelperExtensions.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/HelperExtensions.gs
@@ -1,0 +1,70 @@
+package Oahu.Decrypt.Mpeg4.Util
+
+import System
+import System.Runtime.Intrinsics
+
+internal class HelperExtensions {
+    shared {
+        private func AllLessThanOrEqual_256[T IComparable[T] unmanaged](ints Span[T], value T, out checkedcount int32) bool {
+            unsafe {
+                let vecSize = 256 / 8 / sizeof(T)
+                let numVectors = ints.Length / vecSize
+                let comparand = Vector256.Create(value)
+                fixed pInts *T = ints {
+                    for var i = 0; i < numVectors; i++ {
+                        let intVector = Vector256.Load(pInts + vecSize * i)
+                        if !Vector256.LessThanOrEqualAll(intVector, comparand) {
+                            checkedcount = vecSize * i
+                            return false
+                        }
+                    }
+                }
+                checkedcount = vecSize * numVectors
+                return true
+            }
+        }
+
+        private func AllLessThanOrEqual_512[T IComparable[T] unmanaged](ints Span[T], value T, out checkedcount int32) bool {
+            unsafe {
+                let vecSize = 512 / 8 / sizeof(T)
+                let numVectors = ints.Length / vecSize
+                let comparand = Vector512.Create(value)
+                fixed pInts *T = ints {
+                    for var i = 0; i < numVectors; i++ {
+                        let intVector = Vector512.Load(pInts + vecSize * i)
+                        if !Vector512.LessThanOrEqualAll(intVector, comparand) {
+                            checkedcount = vecSize * i
+                            return false
+                        }
+                    }
+                }
+                checkedcount = vecSize * numVectors
+                return true
+            }
+        }
+    }
+}
+
+func (ints Span[T]) AllLessThanOrEqual[T IComparable[T] unmanaged](value T) bool {
+    unsafe {
+        var checkedCount int32
+        var result bool
+        if Vector512.IsHardwareAccelerated {
+            result = HelperExtensions.AllLessThanOrEqual_512(ints, value, &checkedCount)
+        } else if Vector256.IsHardwareAccelerated {
+            result = HelperExtensions.AllLessThanOrEqual_256(ints, value, &checkedCount)
+        } else {
+            result = true
+            checkedCount = 0
+        }
+        if !result {
+            return false
+        }
+        for var i = checkedCount; i < ints.Length; i++ {
+            if ints[i].CompareTo(value) == 1 {
+                return false
+            }
+        }
+        return true
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/IAppleData.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/IAppleData.gs
@@ -1,0 +1,66 @@
+package Oahu.Decrypt.Mpeg4
+
+import System
+import System.Buffers.Binary
+
+interface IAppleData[TData IAppleData[TData]] {
+    func Write(destination Span[uint8]);
+
+    shared {
+        prop SizeInBytes int32 {
+            get;
+        }
+
+        func Create(source ReadOnlySpan[uint8]) TData;
+    }
+}
+
+open data class TrackNumber(Track uint16, TotalTracks uint16) : IAppleData[TrackNumber] {
+    func operator implicit(tn (int32, int32)) TrackNumber {
+        ArgumentOutOfRangeException.ThrowIfNegative(tn.Item1, nameof(tn.Item1))
+        ArgumentOutOfRangeException.ThrowIfNegative(tn.Item2, nameof(tn.Item2))
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(tn.Item1, int32(UInt16.MaxValue), nameof(tn.Item1))
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(tn.Item2, int32(UInt16.MaxValue), nameof(tn.Item2))
+        return TrackNumber(uint16(tn.Item1), uint16(tn.Item2))
+    }
+
+    func Write(destination Span[uint8]) {
+        ArgumentOutOfRangeException.ThrowIfLessThan(destination.Length, TrackNumber.SizeInBytes, nameof(destination))
+        BinaryPrimitives.WriteUInt16BigEndian(destination.Slice(2, 4 - 2), Track)
+        BinaryPrimitives.WriteUInt16BigEndian(destination.Slice(4, 6 - 4), TotalTracks)
+    }
+
+    shared {
+        prop SizeInBytes int32 -> 8
+
+        func Create(source ReadOnlySpan[uint8]) TrackNumber {
+            ArgumentOutOfRangeException.ThrowIfLessThan(source.Length, TrackNumber.SizeInBytes, nameof(source))
+            return TrackNumber(BinaryPrimitives.ReadUInt16BigEndian(source.Slice(2, 4 - 2)), BinaryPrimitives.ReadUInt16BigEndian(source.Slice(4, 6 - 4)))
+        }
+    }
+}
+
+open data class DiskNumber(Disk uint16, TotalDisks uint16) : IAppleData[DiskNumber] {
+    func operator implicit(tn (int32, int32)) DiskNumber {
+        ArgumentOutOfRangeException.ThrowIfNegative(tn.Item1, nameof(tn.Item1))
+        ArgumentOutOfRangeException.ThrowIfNegative(tn.Item2, nameof(tn.Item2))
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(tn.Item1, int32(UInt16.MaxValue), nameof(tn.Item1))
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(tn.Item2, int32(UInt16.MaxValue), nameof(tn.Item2))
+        return DiskNumber(uint16(tn.Item1), uint16(tn.Item2))
+    }
+
+    func Write(destination Span[uint8]) {
+        ArgumentOutOfRangeException.ThrowIfLessThan(destination.Length, DiskNumber.SizeInBytes, nameof(destination))
+        BinaryPrimitives.WriteUInt16BigEndian(destination.Slice(2, 4 - 2), Disk)
+        BinaryPrimitives.WriteUInt16BigEndian(destination.Slice(4, 6 - 4), TotalDisks)
+    }
+
+    shared {
+        prop SizeInBytes int32 -> 6
+
+        func Create(source ReadOnlySpan[uint8]) DiskNumber {
+            ArgumentOutOfRangeException.ThrowIfLessThan(source.Length, DiskNumber.SizeInBytes, nameof(source))
+            return DiskNumber(BinaryPrimitives.ReadUInt16BigEndian(source.Slice(2, 4 - 2)), BinaryPrimitives.ReadUInt16BigEndian(source.Slice(4, 6 - 4)))
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/IBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/IBox.gs
@@ -1,0 +1,28 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.Collections.Generic
+import System.IO
+
+interface IBox : IDisposable {
+    prop Parent IBox? {
+        get;
+    }
+
+    prop Header BoxHeader {
+        get;
+    }
+
+    prop Children List[IBox] {
+        get;
+    }
+
+    prop RenderSize int64 {
+        get;
+    }
+
+    func Save(file Stream);
+    func GetFreeBoxes() List[FreeBox];
+    func GetChild[T IBox]() T?;
+    func GetChildren[T IBox]() IEnumerable[T];
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/IChunkOffsets.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/IChunkOffsets.gs
@@ -1,0 +1,22 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+interface IChunkOffsets : IBox {
+    prop EntryCount uint32 {
+        get;
+    }
+
+    prop ChunkOffsets ChunkOffsetList {
+        get;
+    }
+
+    shared {
+        func Create(stbl StblBox, offsets ChunkOffsetList) IChunkOffsets {
+            if offsets.Count == 0 {
+                return StcoBox.CreateBlank(stbl, offsets)
+            }
+            offsets.Sort()
+            let maxOffset = offsets.GetOffsetAtIndex(offsets.Count - 1)
+            return if maxOffset > int64(UInt32.MaxValue) { Co64Box.CreateBlank(stbl, offsets) } else { StcoBox.CreateBlank(stbl, offsets) }
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/IStszBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/IStszBox.gs
@@ -1,0 +1,28 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+interface IStszBox : IBox {
+    prop SampleCount int32 {
+        get;
+    }
+
+    prop MaxSize int32 {
+        get;
+    }
+
+    prop TotalSize int64 {
+        get;
+    }
+
+    func GetSizeAtIndex(index int32) int32;
+    func SumFirstNSizes(firstN int32) int64;
+
+    func GetFrameSizes(firstFrameIndex uint32, numFrames uint32) ([]int32, int32) {
+        let frameSizes = [int32(numFrames)]int32
+        var framesSizeTotal = 0
+        for var i uint32 = uint32(0); i < numFrames; i++ {
+            frameSizes[i] = GetSizeAtIndex(int32((i + firstFrameIndex)))
+            framesSizeTotal += frameSizes[i]
+        }
+        return (frameSizes, framesSizeTotal)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Id3Header.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Id3Header.gs
@@ -1,0 +1,41 @@
+package Oahu.Decrypt.Mpeg4.ID3
+
+import System
+import System.IO
+
+class Id3Header : Header {
+    internal init(version uint16, file Stream) {
+        Version = version
+        Flags = Flags(uint8(file.ReadByte()))
+        Size = Header.UnSyncSafify(Header.ReadUInt32BE(file))
+    }
+
+    override prop Identifier string -> "ID3"
+    prop Version uint16
+    prop Flags Flags
+    override prop HeaderSize int32 -> 10
+
+    override func Render(stream Stream, renderSize int32, version uint16) {
+        stream.Write([]uint8{0x49, 0x44, 0x33})
+        stream.WriteByte(uint8((version >> 8)))
+        stream.WriteByte(uint8((version & uint16(0xff))))
+        stream.Write(Flags.ToBytes())
+        Header.WriteUInt32BE(stream, Header.SyncSafify(renderSize))
+    }
+
+    shared {
+        func Create(file Stream) Id3Header? {
+            try {
+                let bts = stackalloc [4]uint8
+                file.ReadExactly(bts)
+                if bts[0] == uint8('I') && bts[1] == uint8('D') && bts[2] == uint8('3') && bts[3] == uint8(2) || bts[3] == uint8(3) || bts[3] == uint8(4) {
+                    let version = uint16((bts[3] << 8 | file.ReadByte()))
+                    return Id3Header(version, file)
+                }
+                return nil
+            } catch (ex Exception) {
+                return nil
+            }
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Id3Tag.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Id3Tag.gs
@@ -1,0 +1,47 @@
+package Oahu.Decrypt.Mpeg4.ID3
+
+import System.IO
+import System.Linq
+
+class Id3Tag : Frame {
+    private init(file Stream, header Id3Header) : base(header, default(Frame)) {
+        let endPosition = file.Position + int64(Header.Size)
+        Id3Header = header
+        if (Id3Header.Flags[1]) {
+            Children.Add(Id3ExtendedHeader.Create(file, this))
+        }
+        LoadChildren(file, endPosition)
+    }
+
+    override prop Size int32 -> Children.Sum((f Frame) -> f.Size + f.Header.HeaderSize) + EmptyFrame.GetEmptyFrameSize(Version)
+    override prop Version uint16 -> Id3Header.Version
+
+    private prop Id3Header Id3Header {
+        get;
+        init;
+    }
+
+    func Save(file Stream) {
+        Save(file, Id3Header.Version)
+        EmptyFrame(this).Save(file, Id3Header.Version)
+    }
+
+    func Add(frame Frame) -> Children.Add(frame)
+
+    override func Render(file Stream) {
+    }
+
+    shared {
+        func Create(file Stream) Id3Tag? {
+            let id3Header = Id3Header.Create(file)
+            if id3Header == nil || !((id3Header!!.Version == uint16(0x200) || id3Header!!.Version == uint16(0x300) || id3Header!!.Version == uint16(0x400))) {
+                return nil
+            }
+            try {
+                return Id3Tag(file, id3Header!!)
+            } catch (ex Exception) {
+                return nil
+            }
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/InterleavedIterator_T.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/InterleavedIterator_T.gs
@@ -1,0 +1,48 @@
+package Oahu.Decrypt.Mpeg4.Chunks
+
+import System
+import System.Collections
+import System.Collections.Generic
+import System.Diagnostics.CodeAnalysis
+import System.Linq
+import Oahu.Decrypt.Mpeg4.Boxes
+
+class EnumerableExtensions {
+    private class InterleavedIterator[T](Enumerables []IEnumerable[T], Comparer Comparer[T]) : IEnumerable[T] {
+        func GetEnumerator() IEnumerator[T] {
+            let enumerators = Enumerables.Select((e IEnumerable[T]) -> e.GetEnumerator()).Select((e IEnumerator[T]) -> if e.MoveNext() { e } else { default(IEnumerator[T]?) }).ToArray()
+            while GetNextValue(enumerators, out var currentIndex, out var currentEnumerator) {
+                yield currentEnumerator!!.Current
+                if !currentEnumerator!!.MoveNext() {
+                    enumerators[currentIndex] = nil
+                }
+            }
+        }
+
+        private func GetEnumerator() IEnumerator -> GetEnumerator()
+
+        private func GetNextValue(enumerators []IEnumerator[T]?, out minIndex int32, out minValue IEnumerator[T]?) bool {
+            minIndex = -1
+            minValue = nil
+            for var i = 0; i < enumerators.Length; i++ {
+                if enumerators[i] is IEnumerator[T] && (minValue == nil || Comparer.Compare(minValue!!.Current, (enumerators[i] as IEnumerator[T])!!.Current) > 0) {
+                    var __decon0 = i
+                    var __decon1 = (enumerators[i] as IEnumerator[T])!!
+                    minIndex = __decon0
+                    minValue = __decon1
+                }
+            }
+            return minIndex != -1
+        }
+    }
+}
+
+func (track TrakBox) ChunkEntries() IEnumerable[ChunkEntry] -> ChunkEntryList(track)
+
+func (source IEnumerable[TSource]) InterleaveBy[TSource, TResult, TKey IComparable[TKey]](selector (TSource) -> IEnumerable[TResult], keySelector (TResult) -> TKey) IEnumerable[TResult] {
+    ArgumentNullException.ThrowIfNull(source, nameof(source))
+    ArgumentNullException.ThrowIfNull(selector, nameof(selector))
+    ArgumentNullException.ThrowIfNull(keySelector, nameof(keySelector))
+    let comparer = Comparer[TResult].Create((x TResult, y TResult) -> keySelector(x).CompareTo(keySelector(y)))
+    return InterleavedIterator[TResult](source.Select((s TSource) -> selector(s)).ToArray(), comparer!!)
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/LosslessFilter.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/LosslessFilter.gs
@@ -1,0 +1,54 @@
+package Oahu.Decrypt.FrameFilters.Audio
+
+import System.IO
+import System.Threading.Tasks
+
+internal open class LosslessFilter : FrameFinalBase[FrameEntry] {
+    let Mp4aWriter Mp4aWriter
+    private let chapterQueue ChapterQueue
+    private var lastChunkIndex int64 = -1
+
+    init(outputStream Stream, mp4Audio Mp4File, chapterQueue ChapterQueue) {
+        Mp4aWriter = Mp4aWriter(outputStream, mp4Audio.Ftyp, mp4Audio.Moov)
+        this.chapterQueue = chapterQueue
+    }
+
+    prop Closed bool
+    protected open override prop InputBufferSize int32 -> 1000
+
+    protected open override func FlushAsync() Task {
+        while chapterQueue.TryGetNextChapter(out var chapterEntry) {
+            Mp4aWriter.WriteChapter(chapterEntry!!)
+        }
+        CloseWriter()
+        return Task.CompletedTask
+    }
+
+    protected open override func PerformFilteringAsync(input FrameEntry) Task {
+        let chunkIndex = input.Chunk?.ChunkIndex ?? uint32(lastChunkIndex)
+        var newChunk = chunkIndex > lastChunkIndex
+        while chapterQueue.TryGetNextChapter(out var chapterEntry) {
+            Mp4aWriter.WriteChapter(chapterEntry!!)
+            newChunk = true
+        }
+        Mp4aWriter.AddFrame(input.FrameData.Span, newChunk, input.SamplesInFrame)
+        lastChunkIndex = chunkIndex
+        return Task.CompletedTask
+    }
+
+    protected open override func Dispose(disposing bool) {
+        if disposing && !Disposed {
+            CloseWriter()
+            Mp4aWriter?.Dispose()
+        }
+        base.Dispose(disposing)
+    }
+
+    private func CloseWriter() {
+        if Closed {
+            return
+        }
+        Mp4aWriter.Close()
+        Closed = true
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/LosslessMultipartFilter.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/LosslessMultipartFilter.gs
@@ -1,0 +1,60 @@
+package Oahu.Decrypt.FrameFilters.Audio
+
+import System
+import System.IO
+import Oahu.Decrypt.Mpeg4
+import Oahu.Decrypt.Mpeg4.Boxes
+
+internal open class LosslessMultipartFilter : MultipartFilterBase[FrameEntry, NewSplitCallback] {
+    private let ftyp FtypBox
+    private let moov MoovBox
+    private let newFileCallback (NewSplitCallback) -> void
+    private var mp4writer Mp4aWriter?
+
+    init(splitChapters ChapterInfo, ftyp FtypBox, moov MoovBox, newFileCallback (NewSplitCallback) -> void) : base(splitChapters, SampleRate(moov.AudioTrack.Mdia.Mdhd.Timescale), moov.AudioTrack.Mdia.Minf.Stbl.Stsd.AudioSampleEntry?.ChannelCount == (2 as uint16?)) {
+        this.ftyp = ftyp
+        this.moov = moov
+        this.newFileCallback = newFileCallback
+    }
+
+    prop CurrentWriterOpen bool
+    protected open override prop InputBufferSize int32 -> 1000
+
+    protected open override func CloseCurrentWriter() {
+        if !CurrentWriterOpen {
+            return
+        }
+        mp4writer?.Close()
+        mp4writer?.OutputFile.Close()
+        CurrentWriterOpen = false
+    }
+
+    protected open override func WriteFrameToFile(audioFrame FrameEntry, newChunk bool) {
+        mp4writer?.AddFrame(audioFrame.FrameData.Span, newChunk, audioFrame.SamplesInFrame)
+    }
+
+    protected open override func CreateNewWriter(callback NewSplitCallback) {
+        newFileCallback(callback)
+        let outfile Stream? = callback.OutputFile as Stream
+        if outfile == nil {
+            throw InvalidOperationException("Output file stream null")
+        }
+        CurrentWriterOpen = true
+        mp4writer = Mp4aWriter(outfile, ftyp, moov)
+        mp4writer!!.RemoveTextTrack()
+        if mp4writer!!.Moov.ILst != nil {
+            let tags = MetadataItems(mp4writer!!.Moov.ILst!!)
+            if callback.TrackNumber.HasValue && callback.TrackCount.HasValue {
+                tags!!.TrackNumber = (callback.TrackNumber.Value, callback.TrackCount.Value)
+            }
+            tags!!.Title = callback.TrackTitle ?? tags!!.Title
+        }
+    }
+
+    protected open override func Dispose(disposing bool) {
+        if disposing && !Disposed {
+            CloseCurrentWriter()
+        }
+        base.Dispose(disposing)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/MdatBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/MdatBox.gs
@@ -1,0 +1,21 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.IO
+import System.Threading
+import System.Threading.Tasks
+import Oahu.Decrypt.Mpeg4.Util
+
+open class MdatBox : Box {
+    init(header BoxHeader) : base(header, nil) {
+    }
+
+    async func ShiftMdatAsync(file Stream, shiftVector int64, progressTracker ProgressTracker? = nil, cancellationToken CancellationToken = default(CancellationToken)) {
+        await Mpeg4Util.ShiftDataBlock(file, Header.FilePosition, Header.TotalBoxSize, shiftVector, progressTracker, cancellationToken).ConfigureAwait(false)
+        this.Header.FilePosition += shiftVector
+    }
+
+    protected open override func Render(file Stream) {
+        throw NotSupportedException()
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/MdhdBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/MdhdBox.gs
@@ -1,0 +1,51 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class MdhdBox : HeaderBox {
+    private var language string
+
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        let blob = file.ReadBlock(4)
+        let reader = BitReader(blob!!)
+        reader!!.Position = 1
+        let c1 = char((reader!!.Read(5) + uint32(0x60)))
+        let c2 = char((reader!!.Read(5) + uint32(0x60)))
+        let c3 = char((reader!!.Read(5) + uint32(0x60)))
+        language = string([]char{c1, c2, c3})
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(8)
+    prop Timescale uint32
+
+    prop Language string {
+        get -> language
+        set {
+            if value.Length != 3 || value[0] < 'a' || value[0] > 'z' || value[1] < 'a' || value[1] > 'z' || value[2] < 'a' || value[2] > 'z' {
+                throw ArgumentException("value must be three, lowercase ASCII characters", nameof(Language))
+            }
+            language = value
+        }
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        let writer = BitWriter()
+        writer!!.Write(0, 1)
+        writer!!.Write(uint32(Language[0]) - uint32(0x60), 5)
+        writer!!.Write(uint32(Language[1]) - uint32(0x60), 5)
+        writer!!.Write(uint32(Language[2]) - uint32(0x60), 5)
+        writer!!.Write(0, 16)
+        file.Write(writer!!.ToByteArray())
+    }
+
+    protected open override func ReadBeforeDuration(file Stream) {
+        Timescale = file.ReadUInt32BE()
+    }
+
+    protected open override func WriteBeforeDuration(file Stream) {
+        file.WriteUInt32BE(Timescale)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/MdiaBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/MdiaBox.gs
@@ -1,0 +1,17 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+
+open class MdiaBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        LoadChildren(file)
+    }
+
+    prop Mdhd MdhdBox -> GetChildOrThrow[MdhdBox]()
+    prop Hdlr HdlrBox -> GetChildOrThrow[HdlrBox]()
+    prop Minf MinfBox -> GetChildOrThrow[MinfBox]()
+
+    protected open override func Render(file Stream) {
+        return
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/MeanBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/MeanBox.gs
@@ -1,0 +1,38 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.Diagnostics
+import System.IO
+import System.Text
+import Oahu.Decrypt.Mpeg4.Util
+
+@DebuggerDisplay("{DebuggerDisplay,nq}")
+open class MeanBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        let stringSize = RemainingBoxLength(file)
+        let stringData = file.ReadBlock(int32(stringSize))
+        ReverseDnsDomain = Encoding.UTF8.GetString(stringData!!)
+    }
+
+    private init(header BoxHeader, parent IBox?, domain string) : base([4]uint8, header, parent) {
+        ReverseDnsDomain = domain
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(Encoding.UTF8.GetByteCount(ReverseDnsDomain))
+    prop ReverseDnsDomain string
+    private prop DebuggerDisplay string -> "domain: $ReverseDnsDomain"
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.Write(Encoding.UTF8.GetBytes(ReverseDnsDomain))
+    }
+
+    shared {
+        func Create(parent IBox?, domain string) MeanBox {
+            let size = Encoding.UTF8.GetByteCount(domain) + 12
+            let header = BoxHeader(uint32(size), "mean")
+            let meanBox = MeanBox(header, parent, domain)
+            parent?.Children.Add(meanBox)
+            return meanBox
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/MehdBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/MehdBox.gs
@@ -1,0 +1,26 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class MehdBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        FragmentDuration = if Version == uint8(1) { file.ReadUInt64BE() } else { uint64(file.ReadUInt32BE()) }
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64((if Version == uint8(1) { 8 } else { 4 }))
+
+    prop FragmentDuration uint64 {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        if Version == uint8(1) {
+            file.WriteUInt64BE(FragmentDuration)
+        } else {
+            file.WriteUInt32BE(uint32(FragmentDuration))
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/MetaBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/MetaBox.gs
@@ -1,0 +1,20 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+
+class MetaBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        LoadChildren(file)
+    }
+
+    private init(parent IBox) : base([]uint8{uint8(0), uint8(0), uint8(0), uint8(0)}, BoxHeader(8, "meta"), parent) {
+    }
+
+    shared {
+        func CreateEmpty(parent IBox) MetaBox {
+            let meta = MetaBox(parent)
+            parent.Children.Add(meta!!)
+            return meta!!
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/MetadataItems.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/MetadataItems.gs
@@ -1,0 +1,182 @@
+package Oahu.Decrypt.Mpeg4
+
+import System.Buffers.Binary
+import System.IO
+import Oahu.Decrypt.Mpeg4.Boxes
+
+class MetadataItems(AppleListBox AppleListBox) {
+    prop FirstAuthor string? -> Artist?.Split(';')?[0]
+    prop TitleSansUnabridged string? -> Title?.Replace(" (Unabridged)", "")
+    prop BookCopyright string? -> if GetCopyrights() != nil && GetCopyrights()!!!!.Length > 0 { GetCopyrights()!!!![0] } else { default }
+    prop RecordingCopyright string? -> if GetCopyrights() != nil && GetCopyrights()!!!!.Length > 1 { GetCopyrights()!!!![1] } else { default }
+
+    prop Title string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameTitle)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameTitle, value)
+    }
+
+    prop Producer string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameProducer)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameProducer, value)
+    }
+
+    prop Artist string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameArtist)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameArtist, value)
+    }
+
+    prop AlbumArtists string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameAlbumArtist)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameAlbumArtist, value)
+    }
+
+    prop Album string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameAlbum)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameAlbum, value)
+    }
+
+    prop Genres string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameGenres)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameGenres, value)
+    }
+
+    prop ProductID string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameProductId)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameProductId, value)
+    }
+
+    prop Comment string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameComment)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameComment, value)
+    }
+
+    prop LongDescription string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameLongDescription)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameLongDescription, value)
+    }
+
+    prop Copyright string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameCopyright)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameCopyright, value)
+    }
+
+    prop Publisher string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNamePublisher)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNamePublisher, value)
+    }
+
+    prop Year string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameYear)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameYear, value)
+    }
+
+    prop Narrator string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameNarrator)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameNarrator, value)
+    }
+
+    prop Asin string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameAsin)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameAsin, value)
+    }
+
+    prop ReleaseDate string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameReleaseDate)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameReleaseDate, value)
+    }
+
+    prop Acr string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameAcr)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameAcr, value)
+    }
+
+    prop Version string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameVersion)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameVersion, value)
+    }
+
+    prop Encoder string? {
+        get -> AppleListBox.GetTagString(MetadataItems.TagNameEncoder)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameEncoder, value)
+    }
+
+    prop Cover []?uint8 {
+        get -> AppleListBox.GetTagBox(MetadataItems.TagNameCover)?.Data.Data
+        set -> SetCoverArt(value)
+    }
+
+    prop CoverFormat AppleDataType? -> AppleListBox.GetTagBox(MetadataItems.TagNameCover)?.Data.DataType
+
+    prop TrackNumber TrackNumber? {
+        get -> AppleListBox.GetTagData[TrackNumber](MetadataItems.TagNameTrackNumber)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameTrackNumber, value)
+    }
+
+    prop DiskNumber DiskNumber? {
+        get -> AppleListBox.GetTagData[DiskNumber](MetadataItems.TagNameDiskNumber)
+        set -> AppleListBox.EditOrAddTag(MetadataItems.TagNameDiskNumber, value)
+    }
+
+    private func GetCopyrights() []?string -> Copyright?.Replace("&#169;", "©")?.Split(';')
+
+    private func SetCoverArt(coverArtBytes []?uint8) {
+        let EditOrAdd = func (dataType AppleDataType) {
+            if AppleListBox.GetTagBox(MetadataItems.TagNameCover) != nil && AppleListBox.GetTagBox(MetadataItems.TagNameCover)!!!!.Data.DataType != dataType {
+                AppleListBox.RemoveTag(AppleListBox.GetTagBox(MetadataItems.TagNameCover)!!!!)
+                AppleListBox.GetTagBox(MetadataItems.TagNameCover)!!!!.Dispose()
+            }
+            AppleListBox.EditOrAddTag(MetadataItems.TagNameCover, coverArtBytes!!, dataType)
+        }
+        if coverArtBytes == nil {
+            AppleListBox.RemoveTag(MetadataItems.TagNameCover)
+        } else if coverArtBytes!!.Length >= 2 && BinaryPrimitives.ReadInt16LittleEndian(coverArtBytes!!) == int16(0x4D42) {
+            EditOrAdd(AppleDataType.BMP)
+        } else if coverArtBytes!!.Length >= 3 && (BinaryPrimitives.ReadInt32LittleEndian(coverArtBytes!!) & 0xFFFFFF) == 0xFFD8FF {
+            EditOrAdd(AppleDataType.JPEG)
+        } else if coverArtBytes!!.Length >= 8 && BinaryPrimitives.ReadInt64LittleEndian(coverArtBytes!!) == 0xA1A0A0D474e5089L {
+            EditOrAdd(AppleDataType.PNG)
+        } else {
+            throw InvalidDataException("Image data is not a jpeg, PNG, or windows bitmap.")
+        }
+    }
+
+    shared {
+        const TagNameTitle string = "©nam"
+        const TagNameProducer string = "©prd"
+        const TagNameArtist string = "©ART"
+        const TagNameAlbumArtist string = "aART"
+        const TagNameAlbum string = "©alb"
+        const TagNameGenres string = "©gen"
+        const TagNameProductId string = "prID"
+        const TagNameComment string = "©cmt"
+        const TagNameLongDescription string = "©des"
+        const TagNameCopyright string = "cprt"
+        const TagNamePublisher string = "©pub"
+        const TagNameYear string = "©day"
+        const TagNameNarrator string = "©nrt"
+        const TagNameAsin string = "CDEK"
+        const TagNameReleaseDate string = "rldt"
+        const TagNameAcr string = "AACR"
+        const TagNameVersion string = "VERS"
+        const TagNameEncoder string = "©too"
+        const TagNameCover string = "covr"
+        const TagNameTrackNumber string = "trkn"
+        const TagNameDiskNumber string = "disk"
+
+        func FromFile(mp4File string) MetadataItems? {
+            using let file = File.Open(mp4File, FileMode.Open, FileAccess.Read, FileShare.Read)
+            var header BoxHeader
+            do {
+                header = BoxHeader(file!!)
+                if header.Type == "moov" {
+                    continue
+                } else if header.Type == "udta" {
+                    break
+                } else {
+                    file!!.Position += header.TotalBoxSize - int64(header.HeaderSize)
+                }
+            } while file!!.Position < file!!.Length
+            return if header?.Type == "udta" && UdtaBox(file!!, header, nil)?.GetChild[MetaBox]()?.GetChild[AppleListBox]() != nil { MetadataItems(UdtaBox(file!!, header, nil)?.GetChild[MetaBox]()?.GetChild[AppleListBox]()!!!!) } else { default(MetadataItems?) }
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/MfhdBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/MfhdBox.gs
@@ -1,0 +1,22 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class MfhdBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        SequenceNumber = file.ReadInt32BE()
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(4)
+
+    prop SequenceNumber int32 {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.WriteInt32BE(SequenceNumber)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/MinfBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/MinfBox.gs
@@ -1,0 +1,15 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+
+open class MinfBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        LoadChildren(file)
+    }
+
+    prop Stbl StblBox -> GetChildOrThrow[StblBox]()
+
+    protected open override func Render(file Stream) {
+        return
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/MoofBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/MoofBox.gs
@@ -1,0 +1,16 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+
+open class MoofBox : Box {
+    init(file Stream, header BoxHeader) : base(header, nil) {
+        LoadChildren(file)
+    }
+
+    prop Mfhd MfhdBox -> GetChildOrThrow[MfhdBox]()
+    prop Traf TrafBox -> GetChildOrThrow[TrafBox]()
+
+    protected open override func Render(file Stream) {
+        return
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/MoovBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/MoovBox.gs
@@ -1,0 +1,103 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.Collections.Generic
+import System.IO
+import System.Linq
+
+open class MoovBox : Box {
+    init(file Stream, header BoxHeader) : base(header, nil) {
+        LoadChildren(file)
+    }
+
+    prop Mvhd MvhdBox -> GetChildOrThrow[MvhdBox]()
+    prop AudioTrack TrakBox -> Tracks.Where((t TrakBox) -> t.GetChild[MdiaBox]()?.GetChild[HdlrBox]()?.HandlerType == "soun").First()
+    prop VideoTrack TrakBox? -> Tracks.Where((t TrakBox) -> t.GetChild[MdiaBox]()?.GetChild[HdlrBox]()?.HandlerType == "vide").FirstOrDefault()
+    prop TextTrack TrakBox? -> Tracks.Where((t TrakBox) -> t.GetChild[MdiaBox]()?.GetChild[HdlrBox]()?.HandlerType == "text").FirstOrDefault()
+    prop ILst AppleListBox? -> GetChild[UdtaBox]()?.GetChild[MetaBox]()?.GetChild[AppleListBox]()
+    prop Tracks IEnumerable[TrakBox] -> GetChildren[TrakBox]()
+
+    func ShiftChunkOffsets(shiftVector int64) {
+        for track in Tracks {
+            var coBox = track!!.Mdia.Minf.Stbl.COBox
+            let offsets = coBox.ChunkOffsets
+            var requires64Bit = false
+            for var i = 0; i < offsets.Count; i++ {
+                let offset = offsets.GetOffsetAtIndex(i)
+                let newOffset = offset + shiftVector
+                requires64Bit |= newOffset > int64(UInt32.MaxValue)
+                offsets.SetOffsetAtIndex(i, newOffset)
+            }
+            if requires64Bit && coBox is StcoBox {
+                track!!.Mdia.Minf.Stbl.Children.Remove(coBox)
+                coBox = Co64Box.CreateBlank(track!!.Mdia.Minf.Stbl, offsets)
+            } else if !requires64Bit && coBox is Co64Box {
+                track!!.Mdia.Minf.Stbl.Children.Remove(coBox)
+                coBox = StcoBox.CreateBlank(track!!.Mdia.Minf.Stbl, offsets)
+            }
+        }
+    }
+
+    func ShiftChunkOffsetsWithMoovInFront(shiftVector int64) int64 {
+        var shiftVector = shiftVector
+        var shifted int64 = 0
+        do {
+            let moovSize = RenderSize
+            ShiftChunkOffsets(shiftVector)
+            shifted += shiftVector
+            shiftVector = RenderSize - moovSize
+        } while shiftVector != int64(0)
+        return shifted
+    }
+
+    func CreateEmptyMetadata() AppleListBox {
+        let ilist AppleListBox? = ILst as AppleListBox
+        if ilist != nil {
+            return ilist
+        } else {
+            let udata = UdtaBox.CreateEmpty(this)
+            let meta = MetaBox.CreateEmpty(udata!!)
+            let hdlr = HdlrBox.Create("mdir", nil, []uint8{uint8(0x61), uint8(0x70), uint8(0x70), uint8(0x6c)}, meta!!)
+            return AppleListBox.CreateEmpty(meta!!)
+        }
+    }
+
+    func CreateEmptyTextTrack() TrakBox {
+        let txt TrakBox? = TextTrack as TrakBox
+        if txt != nil {
+            return txt
+        } else {
+            using let ms = MemoryStream(MoovBox.EmptyTextTrack)
+            let textTrack = BoxFactory.CreateBox[TrakBox](ms!!, nil)
+            Children.Insert(Children.IndexOf(AudioTrack) + 1, textTrack!!)
+            textTrack!!.Tkhd.TrackID = Mvhd.NextTrackID
+            Mvhd.NextTrackID++
+            let references = GetChildren[TrakBox]().Except([]TrakBox{AudioTrack}).Select((t TrakBox) -> t.Tkhd.TrackID).Order().ToHashSet()
+            let tref TrefBox? = AudioTrack.GetChild[TrefBox]() as TrefBox
+            if tref != nil {
+                let referenceType ITrackReferenceTypeBox? = tref.References.FirstOrDefault((r ITrackReferenceTypeBox) -> r.Header.Type == "chap") as ITrackReferenceTypeBox
+                if referenceType != nil {
+                    referenceType!!.TrackIds = references
+                } else {
+                    tref.AddReference("chap", references)
+                }
+            } else {
+                TrefBox.CreatEmpty(AudioTrack).AddReference("chap", references)
+            }
+            textTrack!!.Mdia.Mdhd.ModificationTime = DateTimeOffset.UtcNow
+            textTrack!!.Mdia.Mdhd.CreationTime = textTrack!!.Mdia.Mdhd.ModificationTime
+            textTrack!!.Tkhd.ModificationTime = textTrack!!.Mdia.Mdhd.CreationTime
+            textTrack!!.Tkhd.CreationTime = textTrack!!.Tkhd.ModificationTime
+            textTrack!!.Mdia.Mdhd.Timescale = AudioTrack.Mdia.Mdhd.Timescale
+            return textTrack!!
+        }
+    }
+
+    protected open override func Render(file Stream) {
+        return
+    }
+
+    shared {
+        private let EmptyTextTrack []uint8 = []uint8{uint8(0x00), uint8(0x00), uint8(0x02), uint8(0x11), uint8(0x74), uint8(0x72), uint8(0x61), uint8(0x6b), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x5c), uint8(0x74), uint8(0x6b), uint8(0x68), uint8(0x64), uint8(0x00), uint8(0x00), uint8(0x10), uint8(0x01), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x01), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x01), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x01), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x40), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0xa0), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0xa0), uint8(0x00), uint8(0x00), uint8(0x01), uint8(0x70), uint8(0x6d), uint8(0x64), uint8(0x69), uint8(0x61), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x20), uint8(0x6d), uint8(0x64), uint8(0x68), uint8(0x64), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x35), uint8(0x33), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x39), uint8(0x68), uint8(0x64), uint8(0x6c), uint8(0x72), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x6d), uint8(0x68), uint8(0x6c), uint8(0x72), uint8(0x74), uint8(0x65), uint8(0x78), uint8(0x74), uint8(0x61), uint8(0x70), uint8(0x70), uint8(0x6c), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x18), uint8(0x41), uint8(0x70), uint8(0x70), uint8(0x6c), uint8(0x65), uint8(0x20), uint8(0x54), uint8(0x65), uint8(0x78), uint8(0x74), uint8(0x20), uint8(0x4d), uint8(0x65), uint8(0x64), uint8(0x69), uint8(0x61), uint8(0x20), uint8(0x48), uint8(0x61), uint8(0x6e), uint8(0x64), uint8(0x6c), uint8(0x65), uint8(0x72), uint8(0x00), uint8(0x00), uint8(0x01), uint8(0x0f), uint8(0x6d), uint8(0x69), uint8(0x6e), uint8(0x66), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x4c), uint8(0x67), uint8(0x6d), uint8(0x68), uint8(0x64), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x18), uint8(0x67), uint8(0x6d), uint8(0x69), uint8(0x6e), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x40), uint8(0x80), uint8(0x00), uint8(0x80), uint8(0x00), uint8(0x80), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x2c), uint8(0x74), uint8(0x65), uint8(0x78), uint8(0x74), uint8(0x00), uint8(0x01), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x01), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x40), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x24), uint8(0x64), uint8(0x69), uint8(0x6e), uint8(0x66), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x1c), uint8(0x64), uint8(0x72), uint8(0x65), uint8(0x66), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x01), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x0c), uint8(0x61), uint8(0x6c), uint8(0x69), uint8(0x73), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x01), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x97), uint8(0x73), uint8(0x74), uint8(0x62), uint8(0x6c), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x4b), uint8(0x73), uint8(0x74), uint8(0x73), uint8(0x64), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x01), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x3b), uint8(0x74), uint8(0x65), uint8(0x78), uint8(0x74), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x01), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x01), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x01), uint8(0xff), uint8(0xff), uint8(0xff), uint8(0xff), uint8(0xff), uint8(0xff), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x10), uint8(0x73), uint8(0x74), uint8(0x74), uint8(0x73), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x10), uint8(0x73), uint8(0x74), uint8(0x73), uint8(0x63), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x10), uint8(0x73), uint8(0x74), uint8(0x63), uint8(0x6f), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x14), uint8(0x73), uint8(0x74), uint8(0x73), uint8(0x7a), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x3d), uint8(0x75), uint8(0x64), uint8(0x74), uint8(0x61), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x35), uint8(0x6d), uint8(0x65), uint8(0x74), uint8(0x61), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x21), uint8(0x68), uint8(0x64), uint8(0x6c), uint8(0x72), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x6d), uint8(0x64), uint8(0x69), uint8(0x72), uint8(0x61), uint8(0x70), uint8(0x70), uint8(0x6c), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x00), uint8(0x08), uint8(0x69), uint8(0x6c), uint8(0x73), uint8(0x74)}
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Mp4File.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Mp4File.gs
@@ -1,0 +1,147 @@
+package Oahu.Decrypt
+
+import System
+import System.IO
+import System.Linq
+import System.Threading.Tasks
+import Oahu.Decrypt.Chunks
+import Oahu.Decrypt.FrameFilters
+import Oahu.Decrypt.FrameFilters.Audio
+import Oahu.Decrypt.FrameFilters.Text
+import Oahu.Decrypt.Mpeg4
+import Oahu.Decrypt.Mpeg4.Boxes
+import Oahu.Decrypt.Mpeg4.Util
+
+enum FileType { Aax, Aaxc, Mpeg4, Dash }
+enum SampleRate { Hz_96000, Hz_88200, Hz_64000, Hz_48000, Hz_44100, Hz_32000, Hz_24000, Hz_22050, Hz_16000, Hz_12000, Hz_11025, Hz_8000, Hz_7350 }
+
+open class Mp4File : Mpeg4File {
+    init(file Stream, fileSize int64) : base(file, fileSize) {
+        FileType = if Ftyp.CompatibleBrands.Any((b string) -> b == "dash") { FileType.Dash } else { (switch Ftyp.MajorBrand {
+            case "aax ": FileType.Aax
+            case "aaxc": FileType.Aaxc
+            default: FileType.Mpeg4
+        }) }
+    }
+
+    convenience init(file Stream) {
+        init(file, file.Length)
+    }
+
+    convenience init(fileName string, access FileAccess = 1, share FileShare = 1) {
+        init(File.Open(fileName, FileMode.Open, access, share))
+    }
+
+    prop FileType FileType {
+        get;
+        init;
+    }
+
+    prop SampleRate SampleRate -> SampleRate(TimeScale)
+    open func GetAudioFrameFilter() FrameTransformBase[FrameEntry, FrameEntry] -> AacValidateFilter()
+
+    func SaveAsync(keepMoovInFront bool = true) Mp4Operation {
+        let tracker = ProgressTracker{TotalDuration: Duration}
+        let operation = Mp4Operation((t CancellationTokenSource) -> SaveAsync(keepMoovInFront, tracker, t.Token), this, (t Task) -> {
+        })
+        tracker.ProgressUpdated += (_ object?, _ EventArgs) -> operation.OnProgressUpdate(ConversionProgressEventArgs(TimeSpan.Zero, tracker.TotalDuration, tracker.Position, tracker.Speed))
+        return operation
+    }
+
+    func ConvertToMp4aAsync(outputStream Stream, userChapters ChapterInfo? = nil) Mp4Operation {
+        let start = userChapters?.StartOffset ?? TimeSpan.Zero
+        let end = userChapters?.EndOffset ?? TimeSpan.MaxValue
+        let chapterQueue = ChapterQueue(SampleRate, SampleRate)
+        if userChapters != nil {
+            if Moov.TextTrack == nil {
+                Moov.CreateEmptyTextTrack()
+            }
+            chapterQueue.AddRange(userChapters!!)
+        }
+        let filter1 = GetAudioFrameFilter()
+        let filter2 = LosslessFilter(outputStream, this, chapterQueue)
+        filter1.LinkTo(filter2)
+        if Moov.TextTrack != nil && userChapters == nil {
+            let c1 = ChapterFilter()
+            c1.ChapterRead += (_ object?, e FrameEntry) -> chapterQueue.Add(e)
+            let Continuation = func (t Task) {
+                filter1.Dispose()
+                c1.Dispose()
+                outputStream.Close()
+            }
+            return ProcessAudio(start, end, Continuation, (Moov.AudioTrack, filter1), (Moov.TextTrack!!, c1))
+        } else {
+            let Continuation = func (t Task) {
+                filter1.Dispose()
+                outputStream.Close()
+            }
+            return ProcessAudio(start, end, Continuation, (Moov.AudioTrack, filter1))
+        }
+    }
+
+    func ConvertToMultiMp4aAsync(userChapters ChapterInfo, newFileCallback (NewSplitCallback) -> void) Mp4Operation {
+        let f1 = GetAudioFrameFilter()
+        let f2 = LosslessMultipartFilter(userChapters, Ftyp, Moov, newFileCallback)
+        f1.LinkTo(f2)
+        let Continuation = func (t Task) {
+            f1.Dispose()
+        }
+        return ProcessAudio(userChapters.StartOffset, userChapters.EndOffset, Continuation, (Moov.AudioTrack, f1))
+    }
+
+    func GetChapterInfoAsync() Mp4Operation[ChapterInfo?] {
+        let textTrack TrakBox? = Moov.TextTrack as TrakBox
+        if textTrack == nil {
+            return Mp4Operation[ChapterInfo?].FromCompleted(this, nil)
+        }
+        let chapterFilter = ChapterFilter()
+        let chapterQueue = ChapterQueue(SampleRate, SampleRate)
+        chapterFilter.ChapterRead += (s object?, e FrameEntry) -> chapterQueue.Add(e)
+        let Continuation = func (t Task) ChapterInfo? {
+            let chapters = ChapterInfo()
+            while chapterQueue.TryGetNextChapter(out var ch) {
+                chapters.AddChapter(ch!!.Title, TimeSpan.FromSeconds(float64(ch!!.SamplesInFrame) / float64(SampleRate)))
+            }
+            chapterFilter.Dispose()
+            Chapters ??= chapters
+            return chapters
+        }
+        return ProcessAudio(TimeSpan.Zero, TimeSpan.MaxValue, Continuation!!, (Moov.TextTrack!!, chapterFilter))
+    }
+
+    open func ProcessAudio(startTime TimeSpan, endTime TimeSpan, continuation (Task) -> void, filters ...(TrakBox, FrameFilterBase[FrameEntry])) Mp4Operation {
+        let reader = CreateChunkReader(InputStream, startTime, Mp4File.Min(Duration, endTime))
+        for __decon0 in filters {
+            let (track, filter) = __decon0
+            reader.AddTrack(track, filter)
+        }
+        let operation = Mp4Operation(reader.RunAsync, this, continuation)
+        reader.OnProgressUpdateDelegate = operation!!.OnProgressUpdate
+        return operation!!
+    }
+
+    func ProcessAudio[TResult](startTime TimeSpan, endTime TimeSpan, continuation (Task) -> TResult, filters ...(TrakBox, FrameFilterBase[FrameEntry])) Mp4Operation[TResult] {
+        let reader = CreateChunkReader(InputStream, startTime, Mp4File.Min(Duration, endTime))
+        for __decon1 in filters {
+            let (track, filter) = __decon1
+            reader.AddTrack(track, filter)
+        }
+        let operation = Mp4Operation[TResult](reader.RunAsync, this, continuation)
+        reader.OnProgressUpdateDelegate = operation!!.OnProgressUpdate
+        return operation!!
+    }
+
+    protected open func CreateChunkReader(inputStream Stream, startTime TimeSpan, endTime TimeSpan) IChunkReader -> ChunkReader(inputStream, startTime, endTime)
+
+    shared {
+        func RelocateMoovAsync(mp4FilePath string) Mp4Operation {
+            let tracker = ProgressTracker()
+            let moovMover Mp4Operation? = Mp4Operation((t CancellationTokenSource) -> Mpeg4File.RelocateMoovToBeginningAsync(mp4FilePath, tracker, t.Token), nil, (t Task) -> {
+            })
+            tracker.ProgressUpdated += (_ object?, _ EventArgs) -> moovMover!!.OnProgressUpdate(ConversionProgressEventArgs(TimeSpan.Zero, tracker.TotalDuration, tracker.Position, tracker.Speed))
+            return moovMover!!
+        }
+
+        private func Min(t1 TimeSpan, t2 TimeSpan) TimeSpan -> if t1 > t2 { t2 } else { t1 }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Mp4Operation.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Mp4Operation.gs
@@ -1,0 +1,92 @@
+package Oahu.Decrypt
+
+import System
+import System.Linq
+import System.Runtime.CompilerServices
+import System.Threading
+import System.Threading.Tasks
+
+open class Mp4Operation {
+    private let cancellationSource CancellationTokenSource = CancellationTokenSource()
+    private let startAction async (CancellationTokenSource) -> void
+    private let continuationAction ((Task) -> void)?
+    private var lastArgs ConversionProgressEventArgs?
+    private var continuation Task?
+    private var readerTask Task?
+
+    internal convenience init(startAction async (CancellationTokenSource) -> void, mp4File Mp4File?, continuationTask (Task) -> void) {
+        init(startAction, mp4File)
+        continuationAction = continuationTask
+    }
+
+    protected init(startAction async (CancellationTokenSource) -> void, mp4File Mp4File?) {
+        this.startAction = startAction
+        Mp4File = mp4File
+    }
+
+    event ConversionProgressUpdate (object?, ConversionProgressEventArgs) -> void
+    prop IsCompleted bool -> Continuation?.IsCompleted == true
+    prop IsFaulted bool -> readerTask?.IsFaulted == true
+    prop IsCanceled bool -> readerTask?.IsCanceled == true
+    prop IsCompletedSuccessfully bool -> readerTask?.IsCompletedSuccessfully == true && Continuation?.IsCompletedSuccessfully == true
+    prop CurrentProcessPosition TimeSpan -> lastArgs?.ProcessPosition ?? TimeSpan.Zero
+    prop ProcessSpeed float64 -> lastArgs?.ProcessSpeed ?? float64(0.0)
+    prop TaskStatus TaskStatus -> readerTask?.Status ?? TaskStatus.Created
+    prop OperationTask Task -> Continuation
+
+    prop Mp4File Mp4File? {
+        get;
+        init;
+    }
+
+    protected open prop Continuation Task? -> continuation ?? Task.CompletedTask
+
+    func CancelAsync() Task {
+        cancellationSource.Cancel()
+        return if Continuation == nil { Task.FromCanceled(cancellationSource.Token) } else { Continuation!! }
+    }
+
+    func Start() {
+        if readerTask == nil {
+            readerTask = Task.Run(() -> startAction(cancellationSource))
+            SetContinuation(readerTask!!)
+        }
+    }
+
+    func GetAwaiter() ConfiguredTaskAwaitable.ConfiguredTaskAwaiter {
+        Start()
+        return Continuation!!.ConfigureAwait(false).GetAwaiter()
+    }
+
+    internal func OnProgressUpdate(args ConversionProgressEventArgs) {
+        lastArgs = args
+        ConversionProgressUpdate?(this, args)
+    }
+
+    protected open func SetContinuation(readerTask Task) {
+        continuation = readerTask.ContinueWith((t Task) -> {
+            try {
+                continuationAction?(t)
+            } catch (ex Exception) {
+                if t.Exception == nil && !t.IsCanceled {
+                    throw ex
+                }
+                if t.Exception != nil {
+                    throw AggregateException("Two or more errors occurred.", t.Exception!!.InnerExceptions.Append(ex))
+                }
+                throw ex
+            }
+            if t.IsFaulted && t.Exception != nil {
+                throw t.Exception
+            }
+            if t.IsCanceled {
+                throw TaskCanceledException("The decryption operation was cancelled.", nil, cancellationSource.Token)
+            }
+        }, TaskContinuationOptions.ExecuteSynchronously)
+    }
+
+    shared {
+        func FromCompleted(mp4File Mp4File?) Mp4Operation -> Mp4Operation((c CancellationTokenSource) -> Task.CompletedTask, mp4File, (_ Task) -> {
+        })
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Mp4Operation_TOutput.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Mp4Operation_TOutput.gs
@@ -1,0 +1,37 @@
+package Oahu.Decrypt
+
+import System
+import System.Runtime.CompilerServices
+import System.Threading
+import System.Threading.Tasks
+
+open class Mp4Operation[TOutput] : Mp4Operation {
+    private let continuationFunc (Task) -> TOutput?
+    private var continuation Task[TOutput?]?
+
+    internal init(startAction async (CancellationTokenSource) -> void, mp4File Mp4File, continuationFunc (Task) -> TOutput) : base(startAction, mp4File) {
+        this.continuationFunc = continuationFunc
+    }
+
+    prop OperationTask Task[TOutput?] -> continuation ?? Task.FromResult[TOutput](default)
+    protected open override prop Continuation Task -> continuation ?? Task.CompletedTask
+
+    func GetAwaiter() TaskAwaiter[TOutput?] {
+        Start()
+        return (continuation ?? Task.FromResult[TOutput](default)).GetAwaiter()
+    }
+
+    protected open override func SetContinuation(readerTask Task) {
+        continuation = readerTask.ContinueWith((t Task) -> {
+            if t.IsFaulted {
+                continuationFunc(t)
+                throw t.Exception
+            }
+            return continuationFunc(t)
+        }, TaskContinuationOptions.ExecuteSynchronously)
+    }
+
+    shared {
+        func FromCompleted(mp4File Mp4File, result TOutput) Mp4Operation[TOutput] -> Mp4Operation[TOutput]((c CancellationTokenSource) -> Task.CompletedTask, mp4File, (_ Task) -> result)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Mp4aWriter.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Mp4aWriter.gs
@@ -1,0 +1,377 @@
+package Oahu.Decrypt.FrameFilters.Audio
+
+import System
+import System.Collections.Generic
+import System.Diagnostics
+import System.IO
+import System.Linq
+import Oahu.Decrypt.Mpeg4.Boxes
+import Oahu.Decrypt.Mpeg4.Util
+
+open class Mp4aWriter : IDisposable {
+    let Moov MoovBox
+    private let mdatStart int64
+    private let stts SttsBox
+    private let stsc StscBox
+    private let audioSampleEntry AudioSampleEntry
+    private let audioChunks ChunkOffsetList = ChunkOffsetList()
+    private let textChunks ChunkOffsetList = ChunkOffsetList()
+    private let audioSampleSizes List[uint16] = List[uint16]()
+    private let textSampleSizes List[int32] = List[int32]()
+    private let lockObj object = System.Object()
+    private let chapterTitles List[string] = List[string]()
+    private var lastSamplesPerChunk int64 = -1
+    private var samplesPerChunk uint32 = uint32(0)
+    private var currentChunk uint32 = uint32(0)
+    private var closed bool
+    private var closing bool
+    private var currentFrameDuration uint32
+    private var frameDurationCount uint32
+    private var disposed bool = false
+
+    init(outputFile Stream, ftyp FtypBox, moov MoovBox) {
+        ArgumentNullException.ThrowIfNull(outputFile, nameof(outputFile))
+        ArgumentNullException.ThrowIfNull(ftyp, nameof(ftyp))
+        ArgumentNullException.ThrowIfNull(moov, nameof(moov))
+        if !outputFile.CanWrite {
+            throw ArgumentException("The stream is not writable", nameof(outputFile))
+        }
+        OutputFile = outputFile
+        Moov = Mp4aWriter.MakeBlankMoov(moov)
+        stts = Moov.AudioTrack.Mdia.Minf.Stbl.Stts
+        stsc = Moov.AudioTrack.Mdia.Minf.Stbl.Stsc
+        audioSampleEntry = Moov.AudioTrack.Mdia.Minf.Stbl.Stsd.AudioSampleEntry ?? throw InvalidDataException("Audio track's stsd box does not contain an ${nameof(AudioSampleEntry)}")
+        ftyp.Save(OutputFile)
+        mdatStart = OutputFile.Position
+        OutputFile.WriteUInt32BE(0)
+        OutputFile.WriteType("mdat")
+        OutputFile.WriteInt64BE(0)
+    }
+
+    convenience init(outputFile Stream, ftyp FtypBox, moov MoovBox, ascBytes []uint8) {
+        init(outputFile, ftyp, moov)
+        ArgumentNullException.ThrowIfNull(ascBytes, nameof(ascBytes))
+        audioSampleEntry.Header.ChangeAtomName("mp4a")
+        var esds EsdsBox? = audioSampleEntry.Esds as EsdsBox
+        if esds != nil {
+            audioSampleEntry.Children.Remove(esds)
+        }
+        let dec3 Dec3Box? = audioSampleEntry.Dec3 as Dec3Box
+        if dec3 != nil {
+            audioSampleEntry.Children.Remove(dec3)
+        }
+        esds = EsdsBox.CreateEmpty(audioSampleEntry)
+        let asc = esds.ES_Descriptor.DecoderConfig.AudioSpecificConfig
+        asc!!.AscBlob = ascBytes
+        if asc!!.ChannelConfiguration > 2 {
+            throw NotSupportedException("Only supports maximum of 2-channel audio. (Channels=${asc!!.ChannelConfiguration})")
+        }
+        this.audioSampleEntry.ChannelCount = uint16(asc!!.ChannelConfiguration)
+        SetTimeScale(uint32(asc!!.SamplingFrequency))
+    }
+
+    deinit {
+        Dispose(false)
+    }
+
+    prop OutputFile Stream {
+        get;
+        init;
+    }
+
+    func Close() {
+        {
+            Monitor.Enter(lockObj)
+            try {
+                if closing {
+                    return
+                }
+                closing = true
+            } finally {
+                Monitor.Exit(lockObj)
+            }
+        }
+        if closed || !OutputFile.CanWrite {
+            return
+        }
+        let mdatEnd = OutputFile.Position
+        let mdatSize = mdatEnd - mdatStart
+        this.OutputFile.Position = mdatStart
+        if mdatSize <= int64(UInt32.MaxValue) {
+            OutputFile.WriteUInt32BE(uint32(mdatSize))
+        } else {
+            OutputFile.WriteUInt32BE(1)
+        }
+        OutputFile.WriteType("mdat")
+        if mdatSize > int64(UInt32.MaxValue) {
+            OutputFile.WriteInt64BE(mdatSize)
+        }
+        this.OutputFile.Position = mdatEnd
+        WriteChapterMetadata(chapterTitles)
+        stsc.Samples.Add(StscChunkEntry{FirstChunk: currentChunk, SamplesPerChunk: samplesPerChunk, SampleDescriptionIndex: 1})
+        stts.Samples.Add(SttsBox.SampleEntry{FrameCount: frameDurationCount, FrameDelta: currentFrameDuration})
+        frameDurationCount = uint32(0)
+        Debug.Assert(int64(audioSampleSizes.Count) == stts.Samples.Sum((s SttsBox.SampleEntry) -> s.FrameCount))
+        let stsz IStszBox = StszBox.CreateBlank(Moov.AudioTrack.Mdia.Minf.Stbl, audioSampleSizes)
+        IChunkOffsets.Create(Moov.AudioTrack.Mdia.Minf.Stbl, audioChunks)
+        if Moov.TextTrack != nil {
+            IChunkOffsets.Create(Moov.TextTrack!!.Mdia.Minf.Stbl, textChunks)
+        }
+        SetDuration(uint64(stts.Samples.Sum((s SttsBox.SampleEntry) -> decimal(s.FrameCount) * decimal(s.FrameDelta))))
+        let (maxBitRate, avgBitrate) = Mp4aWriter.CalculateBitrate(Moov.AudioTrack.Mdia.Mdhd.Timescale, Moov.AudioTrack.Mdia.Mdhd.Duration, stsz, stts)
+        let esds EsdsBox? = audioSampleEntry.Esds as EsdsBox
+        if esds != nil {
+            esds.ES_Descriptor.DecoderConfig.MaxBitrate = maxBitRate
+            esds.ES_Descriptor.DecoderConfig.AverageBitrate = avgBitrate
+        }
+        if audioSampleEntry.GetChild[BtrtBox]() == nil {
+            BtrtBox.Create(0, maxBitRate, avgBitrate, audioSampleEntry)
+        }
+        SaveMoov()
+        closed = true
+    }
+
+    func Dispose() {
+        Dispose(true)
+        GC.SuppressFinalize(this)
+    }
+
+    func WriteChapter(entry ChapterEntry) {
+        if Moov.TextTrack == nil {
+            return
+        }
+        if Moov.TextTrack!!.Mdia.Minf.Stbl.Stsz == nil {
+            StszBox.CreateBlank(Moov.TextTrack!!.Mdia.Minf.Stbl, textSampleSizes)
+        }
+        if !Moov.TextTrack!!.Mdia.Minf.Stbl.Stsc.Samples.Any() {
+            Moov.TextTrack!!.Mdia.Minf.Stbl.Stsc.Samples.Add(StscChunkEntry{FirstChunk: 1, SamplesPerChunk: 1, SampleDescriptionIndex: 1})
+        }
+        chapterTitles.Add(entry.Title)
+        Moov.TextTrack!!.Mdia.Minf.Stbl.Stts.Samples.Add(SttsBox.SampleEntry{FrameCount: 1, FrameDelta: entry.SamplesInFrame})
+        textSampleSizes.Add(entry.FrameData.Length)
+        textChunks.Add(OutputFile.Position)
+        OutputFile.Write(entry.FrameData.Span)
+    }
+
+    func RemoveTextTrack() {
+        if Moov.TextTrack == nil || !Moov.Children.Remove(Moov.TextTrack!!) {
+            return
+        }
+        var trackNum uint32 = uint32(1)
+        let trackRemap Dictionary[uint32, uint32] = Dictionary[uint32, uint32]()
+        for t in Moov.GetChildren[TrakBox]().OrderBy((t TrakBox) -> t.Tkhd.TrackID) {
+            trackRemap[t!!.Tkhd.TrackID] = trackNum
+            t!!.Tkhd.TrackID = trackNum
+            trackNum++
+        }
+        Moov.Mvhd.NextTrackID = trackNum
+        for track in Moov.GetChildren[TrakBox]().Select((c TrakBox) -> c.GetChild[TrefBox]()).OfType[TrefBox]() {
+            for tref in track!!.References.ToArray() {
+                if tref!!.Header.Type == "chap" {
+                    track!!.References.Remove(tref!!)
+                    continue
+                }
+                for tid in tref!!.TrackIds.Order().ToArray() {
+                    if !trackRemap.TryGetValue(tid, out var remap) {
+                        tref!!.TrackIds.Remove(tid)
+                    } else if remap != tid {
+                        tref!!.TrackIds.Remove(tid)
+                        tref!!.TrackIds.Add(remap)
+                    }
+                }
+                if tref!!.TrackIds.Count == 0 {
+                    track!!.References.Remove(tref!!)
+                }
+            }
+            if track!!.References.Count == 0 {
+                track!!.Parent!!.Children.Remove(track!!)
+            }
+        }
+    }
+
+    func AddFrame(frame Span[uint8], newChunk bool, frameDelta uint32) {
+        {
+            Monitor.Enter(lockObj)
+            try {
+                if closing {
+                    return
+                }
+                if newChunk {
+                    audioChunks.Add(OutputFile.Position)
+                    if samplesPerChunk > uint32(0) && int64(samplesPerChunk) != lastSamplesPerChunk {
+                        stsc.Samples.Add(StscChunkEntry{FirstChunk: currentChunk, SamplesPerChunk: samplesPerChunk, SampleDescriptionIndex: 1})
+                        lastSamplesPerChunk = samplesPerChunk
+                    }
+                    samplesPerChunk = uint32(0)
+                    currentChunk++
+                }
+                audioSampleSizes.Add(uint16(frame.Length))
+                if currentFrameDuration == uint32(0) {
+                    currentFrameDuration = frameDelta
+                } else if currentFrameDuration != frameDelta {
+                    stts.Samples.Add(SttsBox.SampleEntry{FrameCount: frameDurationCount, FrameDelta: currentFrameDuration})
+                    frameDurationCount = uint32(0)
+                    currentFrameDuration = frameDelta
+                }
+                frameDurationCount++
+                samplesPerChunk++
+            } finally {
+                Monitor.Exit(lockObj)
+            }
+        }
+        OutputFile.Write(frame)
+    }
+
+    protected open func SaveMoov() {
+        Moov.Save(OutputFile)
+    }
+
+    private func SetTimeScale(timeScale uint32) {
+        Debug.Assert(timeScale <= uint32(UInt16.MaxValue))
+        this.audioSampleEntry.SampleRate = uint16(timeScale)
+        Moov.AudioTrack.Mdia.Mdhd.Timescale = timeScale
+        if Moov.TextTrack != nil {
+            Moov.TextTrack!!.Mdia.Mdhd.Timescale = Moov.AudioTrack.Mdia.Mdhd.Timescale
+        }
+    }
+
+    private func SetDuration(duration uint64) {
+        Moov.Mvhd.Duration = duration * uint64(Moov.Mvhd.Timescale) / uint64(Moov.AudioTrack.Mdia.Mdhd.Timescale)
+        Moov.AudioTrack.Mdia.Mdhd.Duration = duration
+        Moov.AudioTrack.Tkhd.Duration = Moov.Mvhd.Duration
+        if Moov.TextTrack != nil {
+            Moov.TextTrack!!.Mdia.Mdhd.Duration = Moov.AudioTrack.Mdia.Mdhd.Duration
+            Moov.TextTrack!!.Tkhd.Duration = Moov.Mvhd.Duration
+        }
+    }
+
+    private func WriteChapterMetadata(chapterTitles IEnumerable[string]) {
+        if Moov.TextTrack == nil {
+            return
+        }
+        let chapterNames AppleListBox? = Moov.TextTrack?.GetChild[UdtaBox]()?.GetChild[MetaBox]()?.GetChild[AppleListBox]()
+        if chapterNames == nil {
+            return
+        }
+        chapterNames!!.Children.Clear()
+        for title in chapterTitles {
+            chapterNames!!.AddTag("©nam", title!!)
+            chapterNames!!.AddTag("©cmt", title!!)
+        }
+    }
+
+    private func Dispose(disposing bool) {
+        if disposing && !disposed {
+            Close()
+            stsc?.Samples.Clear()
+            audioSampleSizes.Clear()
+            audioChunks.Clear()
+            textChunks.Clear()
+            disposed = true
+        }
+    }
+
+    shared {
+        private func CalculateBitrate(timeScale float64, duration uint64, stsz IStszBox, stts SttsBox) (uint32, uint32) {
+            let audioBits = stsz.TotalSize * int64(8)
+            let avgBitrate = uint32((float64(audioBits) * timeScale / float64(duration)))
+            let frameDeltas = stts.EnumerateFrameDeltas().Select((d uint32) -> uint16(d)).ToArray()
+            if int64(stts.SampleTimeCount) != int64(stsz.SampleCount) || int64(stts.SampleTimeCount) != int64(frameDeltas!!.Length) {
+                throw InvalidOperationException("The number of sample deltas (${stts.SampleTimeCount}) doesn't match the number of sample sizes (${stsz.SampleCount}).")
+            }
+            var currentWindowSampleSpan int64 = 0
+            var windowSizeInBytes int64 = 0
+            var maxOneSecondBitrate float64 = 0.0
+            {
+                var i = 0
+                var beginIndex = 0
+                while i < stsz.SampleCount {
+                    while float64(currentWindowSampleSpan) > timeScale {
+                        let bitrate = float64(windowSizeInBytes * int64(8)) * timeScale / float64(currentWindowSampleSpan)
+                        if bitrate > maxOneSecondBitrate {
+                            maxOneSecondBitrate = bitrate
+                        }
+                        windowSizeInBytes -= int64(stsz.GetSizeAtIndex(beginIndex))
+                        currentWindowSampleSpan -= int64(frameDeltas!![beginIndex])
+                        beginIndex++
+                    }
+                    windowSizeInBytes += int64(stsz.GetSizeAtIndex(i))
+                    currentWindowSampleSpan += int64(frameDeltas!![i])
+                    i++
+                }
+            }
+            return (uint32(Math.Round(maxOneSecondBitrate)), avgBitrate)
+        }
+
+        private func MakeBlankMoov(moov MoovBox) MoovBox {
+            var t1 SttsBox? = nil
+            var t2 StscBox? = nil
+            var t3 IStszBox? = nil
+            var t4 IChunkOffsets? = nil
+            if moov.TextTrack != nil {
+                t1 = moov.TextTrack!!.Mdia.Minf.Stbl.Stts
+                t2 = moov.TextTrack!!.Mdia.Minf.Stbl.Stsc
+                t3 = moov.TextTrack!!.Mdia.Minf.Stbl.Stsz
+                t4 = moov.TextTrack!!.Mdia.Minf.Stbl.COBox
+                moov.TextTrack!!.Mdia.Minf.Stbl.Children.Remove(t1!!)
+                moov.TextTrack!!.Mdia.Minf.Stbl.Children.Remove(t2!!)
+                if t3 != nil {
+                    moov.TextTrack!!.Mdia.Minf.Stbl.Children.Remove(t3!!)
+                }
+                moov.TextTrack!!.Mdia.Minf.Stbl.Children.Remove(t4!!)
+            }
+            let a1 = moov.AudioTrack.Mdia.Minf.Stbl.Stts
+            let a2 = moov.AudioTrack.Mdia.Minf.Stbl.Stsc
+            let a3 IStszBox? = moov.AudioTrack.Mdia.Minf.Stbl.Stsz
+            let a4 = moov.AudioTrack.Mdia.Minf.Stbl.COBox
+            moov.AudioTrack.Mdia.Minf.Stbl.Children.Remove(a1)
+            moov.AudioTrack.Mdia.Minf.Stbl.Children.Remove(a2)
+            if a3 != nil {
+                moov.AudioTrack.Mdia.Minf.Stbl.Children.Remove(a3!!)
+            }
+            moov.AudioTrack.Mdia.Minf.Stbl.Children.Remove(a4)
+            let mvex MvexBox? = moov.GetChild[MvexBox]()
+            if mvex != nil {
+                moov.Children.Remove(mvex!!)
+            }
+            let ms = MemoryStream()
+            moov.Save(ms)
+            if mvex != nil {
+                moov.Children.Add(mvex!!)
+            }
+            moov.AudioTrack.Mdia.Minf.Stbl.Children.Add(a1)
+            moov.AudioTrack.Mdia.Minf.Stbl.Children.Add(a2)
+            if a3 != nil {
+                moov.AudioTrack.Mdia.Minf.Stbl.Children.Add(a3!!)
+            }
+            moov.AudioTrack.Mdia.Minf.Stbl.Children.Add(a4)
+            if moov.TextTrack != nil {
+                if t1 != nil {
+                    moov.TextTrack!!.Mdia.Minf.Stbl.Children.Add(t1!!)
+                }
+                if t2 != nil {
+                    moov.TextTrack!!.Mdia.Minf.Stbl.Children.Add(t2!!)
+                }
+                if t3 != nil {
+                    moov.TextTrack!!.Mdia.Minf.Stbl.Children.Add(t3!!)
+                }
+                if t4 != nil {
+                    moov.TextTrack!!.Mdia.Minf.Stbl.Children.Add(t4!!)
+                }
+            }
+            ms.Position = 0
+            let newMoov = BoxFactory.CreateBox[MoovBox](ms, nil)
+            SttsBox.CreateBlank(newMoov.AudioTrack.Mdia.Minf.Stbl)
+            StscBox.CreateBlank(newMoov.AudioTrack.Mdia.Minf.Stbl)
+            newMoov.AudioTrack.Mdia.Mdhd.ModificationTime = DateTimeOffset.UtcNow
+            newMoov.AudioTrack.Mdia.Mdhd.CreationTime = newMoov.AudioTrack.Mdia.Mdhd.ModificationTime
+            if newMoov.TextTrack != nil {
+                SttsBox.CreateBlank(newMoov.TextTrack!!.Mdia.Minf.Stbl)
+                StscBox.CreateBlank(newMoov.TextTrack!!.Mdia.Minf.Stbl)
+                newMoov.TextTrack!!.Mdia.Mdhd.ModificationTime = newMoov.AudioTrack.Mdia.Mdhd.CreationTime
+                newMoov.TextTrack!!.Mdia.Mdhd.CreationTime = newMoov.TextTrack!!.Mdia.Mdhd.ModificationTime
+            }
+            return newMoov
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Mpeg4File.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Mpeg4File.gs
@@ -1,0 +1,229 @@
+package Oahu.Decrypt.Mpeg4
+
+import System
+import System.Collections.Generic
+import System.IO
+import System.Linq
+import System.Threading
+import System.Threading.Tasks
+import Oahu.Decrypt.Mpeg4.Boxes
+import Oahu.Decrypt.Mpeg4.Chunks
+import Oahu.Decrypt.Mpeg4.Util
+
+open class Mpeg4File : IDisposable {
+    private let lazyMetadataItems Lazy[MetadataItems]
+    private var disposed int32
+    private var timescale int32? = nil
+    private var audioChannels int32? = nil
+    private var averageBitrate int32? = nil
+
+    convenience init(file Stream) {
+        init(file, file.Length)
+    }
+
+    convenience init(fileName string, access FileAccess = 1, share FileShare = 1) {
+        init(File.Open(fileName, FileMode.Open, access, share))
+    }
+
+    init(file Stream, fileSize int64) {
+        InputStream = if file.CanSeek { file } else { TrackedReadStream(file, fileSize) }
+        TopLevelBoxes = Mpeg4Util.LoadTopLevelBoxes(InputStream)
+        Ftyp = TopLevelBoxes.OfType[FtypBox]().Single()
+        Moov = TopLevelBoxes.OfType[MoovBox]().Single()
+        Mdat = TopLevelBoxes.OfType[MdatBox]().Single()
+        lazyMetadataItems = Lazy[MetadataItems](() -> MetadataItems(Moov.ILst ?? Moov.CreateEmptyMetadata()))
+        AudioSampleEntry = Moov.AudioTrack.Mdia.Minf.Stbl.Stsd.AudioSampleEntry ?? throw InvalidOperationException("The audio track's AudioSampleEntry is null")
+    }
+
+    deinit {
+        Dispose(false)
+    }
+
+    prop Chapters ChapterInfo?
+
+    prop InputStream Stream {
+        get;
+        init;
+    }
+
+    prop Ftyp FtypBox
+
+    prop Moov MoovBox {
+        get;
+        init;
+    }
+
+    prop Mdat MdatBox {
+        get;
+        init;
+    }
+
+    prop MetadataItems MetadataItems -> lazyMetadataItems.Value
+    open prop Duration TimeSpan -> TimeSpan.FromSeconds(float64(Moov.AudioTrack.Mdia.Mdhd.Duration) / float64(TimeScale))
+    prop MaxBitrate int32 -> int32((AudioSampleEntry.Esds?.ES_Descriptor.DecoderConfig.MaxBitrate ?? uint32(0)))
+
+    prop AudioSampleEntry AudioSampleEntry {
+        get;
+        init;
+    }
+
+    prop TopLevelBoxes List[IBox] {
+        get;
+        init;
+    }
+
+    prop TimeScale int32 -> AudioSampleEntry.Esds?.ES_Descriptor.DecoderConfig.AudioSpecificConfig.SamplingFrequency ?? AudioSampleEntry.Dec3?.SampleRate ?? AudioSampleEntry.Dac4?.SampleRate ?? int32(Moov.AudioTrack.Mdia.Mdhd.Timescale)
+    prop AudioChannels int32 -> AudioSampleEntry.Esds?.ES_Descriptor.DecoderConfig.AudioSpecificConfig.ChannelConfiguration ?? AudioSampleEntry.Dec3?.NumberOfChannels ?? AudioSampleEntry.Dac4?.NumberOfChannels ?? int32(AudioSampleEntry.ChannelCount)
+    prop AverageBitrate int32 -> int32((AudioSampleEntry.Esds?.ES_Descriptor.DecoderConfig.AverageBitrate ?? AudioSampleEntry.Dec3?.AverageBitrate ?? AudioSampleEntry?.Dac4?.AverageBitrate ?? CalculateBitrate()))
+    protected prop Disposed bool -> disposed != 0
+
+    async func SaveAsync(keepMoovInFront bool = true, progressTracker ProgressTracker? = nil, cancellationToken CancellationToken = default(CancellationToken)) {
+        if !InputStream.CanRead || !InputStream.CanWrite || !InputStream.CanSeek {
+            throw InvalidOperationException("${nameof(InputStream)} must be readable, writable and seekable to save")
+        }
+        for box in Moov.GetFreeBoxes() {
+            box!!.Parent?.Children.Remove(box!!)
+        }
+        this.InputStream.Position = 0
+        let moovInFront = Moov.Header.FilePosition < Mdat.Header.FilePosition
+        if moovInFront {
+            var totalSizeChange = Ftyp.RenderSize + Moov.RenderSize - Mdat.Header.FilePosition
+            if totalSizeChange == int64(0) {
+                Ftyp.Save(InputStream)
+                Moov.Save(InputStream)
+            } else if int64(FreeBox.MinSize) + totalSizeChange <= int64(0) {
+                Ftyp.Save(InputStream)
+                Moov.Save(InputStream)
+                FreeBox.Create(-totalSizeChange, nil).Save(InputStream)
+            } else {
+                if keepMoovInFront {
+                    totalSizeChange = Moov.ShiftChunkOffsetsWithMoovInFront(totalSizeChange)
+                    await Mdat.ShiftMdatAsync(InputStream, totalSizeChange, progressTracker, cancellationToken)
+                    this.InputStream.Position = 0
+                    Ftyp.Save(InputStream)
+                    Moov.Save(InputStream)
+                    InputStream.SetLength(Mdat.Header.FilePosition + Mdat.Header.TotalBoxSize)
+                } else {
+                    let freeBoxSize = Mdat.Header.FilePosition - Ftyp.RenderSize
+                    if freeBoxSize < int64(8) {
+                        throw InvalidOperationException("Not enough space to write ftyp box before mdat box")
+                    }
+                    Ftyp.Save(InputStream)
+                    FreeBox.Create(freeBoxSize, nil).Save(InputStream)
+                    this.InputStream.Position = Mdat.Header.FilePosition + Mdat.Header.TotalBoxSize
+                    Moov.Save(InputStream)
+                }
+            }
+        } else {
+            var rewriteMoovAtEnd = true
+            let ftypSizeChange = Ftyp.RenderSize - Ftyp.Header.TotalBoxSize
+            if ftypSizeChange == int64(0) {
+                Ftyp.Save(InputStream)
+            } else if int64(FreeBox.MinSize) + ftypSizeChange <= int64(0) {
+                Ftyp.Save(InputStream)
+                FreeBox.Create(-ftypSizeChange, nil).Save(InputStream)
+            } else {
+                if keepMoovInFront {
+                    var shiftVector = ftypSizeChange + Moov.RenderSize
+                    shiftVector = Moov.ShiftChunkOffsetsWithMoovInFront(shiftVector)
+                    await Mdat.ShiftMdatAsync(InputStream, shiftVector, progressTracker, cancellationToken)
+                    this.InputStream.Position = 0
+                    Ftyp.Save(InputStream)
+                    Moov.Save(InputStream)
+                    InputStream.SetLength(Mdat.Header.FilePosition + Mdat.Header.TotalBoxSize)
+                    rewriteMoovAtEnd = false
+                } else {
+                    Moov.ShiftChunkOffsets(ftypSizeChange)
+                    await Mdat.ShiftMdatAsync(InputStream, ftypSizeChange, progressTracker, cancellationToken)
+                    this.InputStream.Position = 0
+                    Ftyp.Save(InputStream)
+                }
+            }
+            if rewriteMoovAtEnd {
+                this.InputStream.Position = Mdat.Header.FilePosition + Mdat.Header.TotalBoxSize
+                Moov.Save(InputStream)
+                InputStream.SetLength(InputStream.Position)
+            }
+        }
+        await InputStream.FlushAsync(cancellationToken)
+    }
+
+    func GetChaptersFromMetadata() ChapterInfo? {
+        let textTrak TrakBox? = Moov.TextTrack
+        let chapterNames List[string]? = textTrak?.GetChild[UdtaBox]()?.GetChild[MetaBox]()?.GetChild[AppleListBox]()?.Children?.OfType[AppleTagBox]()?.Where((b AppleTagBox) -> b.Header.Type == "©nam")?.Select((b AppleTagBox) -> b.Data.ReadAsString())?.ToList()
+        if chapterNames == nil {
+            return nil
+        }
+        let sampleTimes = textTrak!!.Mdia.Minf.Stbl.Stts.Samples
+        if sampleTimes.Count != chapterNames!!.Count {
+            return nil
+        }
+        let cEntryList = ChunkEntryList(textTrak!!).OrderBy((s ChunkEntry) -> s.ChunkOffset).ToList()
+        if cEntryList!!.Count != chapterNames!!.Count {
+            return nil
+        }
+        let chapterInfo = ChapterInfo()
+        var subtractNext = 0
+        for var i = 0; i < chapterNames!!.Count; i++ {
+            let sif = int32(sampleTimes[i].FrameDelta)
+            let duration = TimeSpan.FromSeconds(Math.Max(0d, sif + subtractNext) / float64(TimeScale))
+            chapterInfo.AddChapter(chapterNames!![int32(cEntryList!![i].ChunkIndex)], duration)
+            subtractNext = if sif < 0 { sif } else { 0 }
+        }
+        Chapters ??= chapterInfo
+        return chapterInfo
+    }
+
+    func Dispose() {
+        Dispose(true)
+        GC.SuppressFinalize(this)
+    }
+
+    protected open func CalculateBitrate() uint32 {
+        let totalSize = Moov.AudioTrack.Mdia.Minf.Stbl.Stsz?.TotalSize
+        return if !totalSize.HasValue || totalSize.Value == int64(0) { uint32(0) } else { uint32(Math.Round(float64(totalSize.Value * int64(8)) / Duration.TotalSeconds, 0)) }
+    }
+
+    protected open func Dispose(disposing bool) {
+        if disposing && Interlocked.CompareExchange(&disposed, 1, 0) == 0 {
+            InputStream.Dispose()
+            for box in TopLevelBoxes {
+                box!!.Dispose()
+            }
+        }
+    }
+
+    shared {
+        async func RelocateMoovToBeginningAsync(mp4FilePath string, progressTracker ProgressTracker? = nil, cancellationToken CancellationToken = default(CancellationToken)) {
+            var boxes List[IBox]
+            {
+                using let fileStream = File.OpenRead(mp4FilePath)
+                boxes = Mpeg4Util.LoadTopLevelBoxes(fileStream)
+            }
+            try {
+                let ftypeSize = boxes.OfType[FtypBox]().Single().RenderSize
+                let moov = boxes.OfType[MoovBox]().Single()
+                if progressTracker != nil {
+                    progressTracker!!.TotalDuration = TimeSpan.FromSeconds(float64(moov.Mvhd.Duration) / float64(moov.Mvhd.Timescale))
+                    if moov.Header.FilePosition == ftypeSize {
+                        progressTracker!!.TotalSize = 1
+                        progressTracker!!.MovedBytes = progressTracker!!.TotalSize
+                        return
+                    }
+                }
+                let mdat = boxes.OfType[MdatBox]().Single()
+                let toShift = ftypeSize + moov.RenderSize - mdat!!.Header.FilePosition
+                let shifted = moov.ShiftChunkOffsetsWithMoovInFront(toShift)
+                using let mpegFile = FileStream(mp4FilePath, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite)
+                await mdat!!.ShiftMdatAsync(mpegFile, shifted, progressTracker, cancellationToken)
+                mpegFile.Position = ftypeSize
+                moov.Save(mpegFile)
+                mpegFile.SetLength(mpegFile.Position + mdat!!.Header.TotalBoxSize)
+            } finally {
+                for box in boxes {
+                    box.Dispose()
+                }
+            }
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Mpeg4Util.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Mpeg4Util.gs
@@ -1,0 +1,95 @@
+package Oahu.Decrypt.Mpeg4.Util
+
+import System
+import System.Collections.Generic
+import System.IO
+import System.Linq
+import System.Threading
+import System.Threading.Tasks
+import Oahu.Decrypt.Mpeg4.Boxes
+
+class Mpeg4Util {
+    shared {
+        func LoadTopLevelBoxes(file Stream) List[IBox] {
+            let boxes = List[IBox]()
+            while file.Position < file.Length && (!boxes.OfType[FtypBox]().Any() || !boxes.OfType[MoovBox]().Any() || !boxes.OfType[MdatBox]().Any()) {
+                let box = BoxFactory.CreateBox(file, nil)
+                boxes.Add(box!!)
+                if box is MdatBox && !boxes.OfType[MoovBox]().Any() {
+                    file.Position = box!!.Header.FilePosition + box!!.Header.TotalBoxSize
+                }
+            }
+            return boxes
+        }
+
+        async func ShiftDataBlock(file Stream, start int64, length int64, shiftVector int64, progressTracker ProgressTracker? = nil, cancellationToken CancellationToken = default(CancellationToken)) {
+            var length = length
+            const MoveBufferSize = 8 * 1024 * 1024
+            if start + shiftVector < int64(0) {
+                throw ArgumentOutOfRangeException(nameof(shiftVector), "Data cannot be shifted to a negative file position.")
+            }
+            if !file.CanRead || !file.CanWrite || !file.CanSeek {
+                throw ArgumentException("Stream must support reading, writing, and seeking.", nameof(file))
+            }
+            if start > file.Length {
+                throw ArgumentOutOfRangeException(nameof(start), "Start index exceeds the file length.")
+            }
+            if start + length > file.Length {
+                throw ArgumentOutOfRangeException(nameof(length), "End of data block is beyond the end of the file.")
+            }
+            let backToFront = shiftVector > int64(0)
+            file.Position = if backToFront { start + length } else { start }
+            if progressTracker != nil {
+                progressTracker!!.TotalSize = length
+                progressTracker!!.MovedBytes = 0
+            }
+            let buffer Memory[uint8] = [MoveBufferSize]uint8
+            var read int32
+            do {
+                let toRead = int32(Math.Min(MoveBufferSize, length))
+                if backToFront {
+                    file.Position -= int64(toRead)
+                }
+                read = await file.ReadAsync(buffer.Slice(0, toRead), cancellationToken)
+                file.Position += shiftVector - int64(read)
+                await file.WriteAsync(buffer.Slice(0, read), cancellationToken)
+                file.Position -= if backToFront { shiftVector + int64(read) } else { shiftVector }
+                if progressTracker != nil {
+                    progressTracker!!.MovedBytes += int64(read)
+                }
+                cancellationToken.ThrowIfCancellationRequested()
+                length -= int64(read)
+            } while length > int64(0)
+            progressTracker?.ReportProgress(true)
+        }
+    }
+}
+
+class ProgressTracker {
+    private let startTime DateTime = DateTime.UtcNow
+    private var nextUpdate DateTime = default
+    private var movedBytes int64
+    event ProgressUpdated (object?, EventArgs) -> void
+
+    prop MovedBytes int64 {
+        get -> movedBytes
+        set {
+            movedBytes = value
+            ReportProgress()
+        }
+    }
+
+    prop TotalDuration TimeSpan
+    prop TotalSize int64
+    prop Speed float64
+    prop Position TimeSpan
+
+    func ReportProgress(forceReport bool = false) {
+        if DateTime.UtcNow > nextUpdate || forceReport {
+            Position = TimeSpan.FromSeconds(TotalDuration.TotalSeconds / float64(TotalSize) * float64(MovedBytes))
+            Speed = Position / (DateTime.UtcNow - startTime)
+            ProgressUpdated?(this, EventArgs.Empty)
+            nextUpdate = DateTime.UtcNow.AddMilliseconds(200.0)
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/MultipartFilterBase.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/MultipartFilterBase.gs
@@ -1,0 +1,75 @@
+package Oahu.Decrypt.FrameFilters.Audio
+
+import System
+import System.Collections.Generic
+import System.Threading.Tasks
+import Oahu.Decrypt.Mpeg4
+
+open class MultipartFilterBase[TInput FrameEntry, TCallback INewSplitCallback[TCallback]] : FrameFinalBase[TInput] {
+    protected let InputStereo bool
+    protected let InputSampleRate SampleRate
+    private let splitChapters IEnumerator[Chapter]
+    private var startSample int64
+    private var endSample int64 = -1
+    private var lastChunkIndex int64 = -1
+    private var currentSample int64
+
+    init(splitChapters ChapterInfo?, inputSampleRate SampleRate, inputStereo bool) {
+        if splitChapters == nil || splitChapters!!.Count == 0 {
+            throw ArgumentException("${nameof(splitChapters)} must contain at least one chapter.")
+        }
+        InputSampleRate = inputSampleRate
+        InputStereo = inputStereo
+        currentSample = TimeToSample(splitChapters!!.StartOffset)
+        startSample = currentSample
+        this.splitChapters = splitChapters!!.GetEnumerator()
+    }
+
+    protected open func CloseCurrentWriter();
+    protected open func WriteFrameToFile(audioFrame TInput, newChunk bool);
+    protected open func CreateNewWriter(callback TCallback);
+
+    protected override func FlushAsync() Task {
+        CloseCurrentWriter()
+        return Task.CompletedTask
+    }
+
+    protected open override func PerformFilteringAsync(input TInput) Task {
+        if input.Chunk == nil {
+            WriteFrameToFile(input, false)
+        } else if currentSample > endSample {
+            CloseCurrentWriter()
+            if GetNextChapter() {
+                CreateNewWriter(TCallback.Create(splitChapters.Current))
+                WriteFrameToFile(input, true)
+                lastChunkIndex = input.Chunk!!.ChunkIndex
+            }
+        } else if currentSample >= startSample {
+            let newChunk = int64(input.Chunk!!.ChunkIndex) > lastChunkIndex
+            if newChunk {
+                lastChunkIndex = input.Chunk!!.ChunkIndex
+            }
+            WriteFrameToFile(input, newChunk)
+        }
+        currentSample += int64(input.SamplesInFrame)
+        return Task.CompletedTask
+    }
+
+    protected open override func Dispose(disposing bool) {
+        if disposing && !Disposed {
+            splitChapters?.Dispose()
+        }
+        base.Dispose(disposing)
+    }
+
+    private func GetNextChapter() bool {
+        if !splitChapters.MoveNext() {
+            return false
+        }
+        startSample = TimeToSample(splitChapters.Current.StartOffset)
+        endSample = TimeToSample(splitChapters.Current.EndOffset)
+        return true
+    }
+
+    private func TimeToSample(time TimeSpan) int64 -> int64(Math.Round(time.TotalSeconds * float64(int32(InputSampleRate))))
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/MvexBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/MvexBox.gs
@@ -1,0 +1,13 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+
+open class MvexBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        LoadChildren(file)
+    }
+
+    protected open override func Render(file Stream) {
+        return
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/MvhdBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/MvhdBox.gs
@@ -1,0 +1,70 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class MvhdBox : HeaderBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        Rate = file.ReadInt32BE()
+        Volume = file.ReadInt16BE()
+        Reserved = file.ReadUInt16BE()
+        Reserved2 = file.ReadUInt64BE()
+        Matrix = file.ReadBlock(4 * 9)
+        Pre_defined = file.ReadBlock(4 * 6)
+        NextTrackID = file.ReadUInt32BE()
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(4) + int64(4) + int64(2) + int64(2) + int64(8) + int64(Matrix.Length) + int64(Pre_defined.Length) + int64(4)
+    prop Timescale uint32
+
+    prop Rate int32 {
+        get;
+        init;
+    }
+
+    prop Volume int16 {
+        get;
+        init;
+    }
+
+    prop Reserved uint16 {
+        get;
+        init;
+    }
+
+    prop Reserved2 uint64 {
+        get;
+        init;
+    }
+
+    prop Matrix []uint8 {
+        get;
+        init;
+    }
+
+    prop Pre_defined []uint8 {
+        get;
+        init;
+    }
+
+    prop NextTrackID uint32
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.WriteInt32BE(Rate)
+        file.WriteInt16BE(Volume)
+        file.WriteUInt16BE(Reserved)
+        file.WriteUInt64BE(Reserved2)
+        file.Write(Matrix)
+        file.Write(Pre_defined)
+        file.WriteUInt32BE(NextTrackID)
+    }
+
+    protected open override func ReadBeforeDuration(file Stream) {
+        Timescale = file.ReadUInt32BE()
+    }
+
+    protected open override func WriteBeforeDuration(file Stream) {
+        file.WriteUInt32BE(Timescale)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/NameBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/NameBox.gs
@@ -1,0 +1,40 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.Diagnostics
+import System.IO
+import System.Text
+import Oahu.Decrypt.Mpeg4.Util
+
+@DebuggerDisplay("{DebuggerDisplay,nq}")
+open class NameBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        let stringSize = RemainingBoxLength(file)
+        let stringData = file.ReadBlock(int32(stringSize))
+        Name = Encoding.UTF8.GetString(stringData!!)
+    }
+
+    private init(header BoxHeader, parent IBox?, name string) : base([4]uint8, header, parent) {
+        Name = name
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(Encoding.UTF8.GetByteCount(Name))
+    prop Name string
+
+    @DebuggerHidden
+    private prop DebuggerDisplay string -> "name: $Name"
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.Write(Encoding.UTF8.GetBytes(Name))
+    }
+
+    shared {
+        func Create(parent IBox?, name string) NameBox {
+            let size = Encoding.UTF8.GetByteCount(name) + 12
+            let header = BoxHeader(uint32(size), "name")
+            let nameBox = NameBox(header, parent, name)
+            parent?.Children.Add(nameBox)
+            return nameBox
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/NewSplitCallback.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/NewSplitCallback.gs
@@ -1,0 +1,43 @@
+package Oahu.Decrypt
+
+import System.IO
+import Oahu.Decrypt.Mpeg4
+
+interface INewSplitCallback {
+    prop Chapter Chapter {
+        get;
+    }
+
+    prop TrackNumber int32?
+    prop TrackCount int32?
+    prop TrackTitle string?
+    prop OutputFile Stream?
+}
+
+interface INewSplitCallback[T INewSplitCallback[T]] : INewSplitCallback {
+    shared {
+        func Create(chapter Chapter) T;
+    }
+}
+
+class NewSplitCallback : INewSplitCallback[NewSplitCallback] {
+    private init(chapter Chapter) {
+        Chapter = chapter
+    }
+
+    prop Chapter Chapter {
+        get;
+        init;
+    }
+
+    prop TrackNumber int32?
+    prop TrackCount int32?
+    prop TrackTitle string?
+    prop OutputFile Stream?
+
+    shared {
+        func Create(chapter Chapter) NewSplitCallback {
+            return NewSplitCallback(chapter)
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/PsshBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/PsshBox.gs
@@ -1,0 +1,40 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class PsshBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        ProtectionSystemId = Guid(file.ReadBlock(16), true)
+        let initDataSize = file.ReadInt32BE()
+        InitData = file.ReadBlock(initDataSize)
+        let remaining = int32((header.TotalBoxSize - int64(header.HeaderSize) - int64(4) - int64(16) - int64(4) - int64(initDataSize)))
+        ExtraData = file.ReadBlock(remaining)
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(16) + int64(4) + int64(InitData.Length) + int64(ExtraData.Length)
+
+    prop ProtectionSystemId Guid {
+        get;
+        init;
+    }
+
+    prop InitData []uint8 {
+        get;
+        init;
+    }
+
+    prop ExtraData []uint8 {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.Write(ProtectionSystemId.ToByteArray(true))
+        file.WriteInt32BE(InitData.Length)
+        file.Write(InitData)
+        file.Write(ExtraData)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/SLConfigDescriptor.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/SLConfigDescriptor.gs
@@ -1,0 +1,30 @@
+package Oahu.Decrypt.Mpeg4.Descriptors
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+internal class SLConfigDescriptor : BaseDescriptor {
+    private let blob []uint8
+
+    init(file Stream, header DescriptorHeader) : base(file, header) {
+        Predefined = file.ReadByte()
+        blob = file.ReadBlock(Header.TotalBoxSize - Header.HeaderSize - 1)
+    }
+
+    private init(predefined uint8, blob []uint8) : base(6) {
+        Predefined = predefined
+        this.blob = blob
+    }
+
+    prop Predefined int32
+    override prop InternalSize int32 -> base.InternalSize + 1 + blob.Length
+
+    override func Render(file Stream) {
+        file.WriteByte(uint8(Predefined))
+        file.Write(blob)
+    }
+
+    shared {
+        func CreateMp4() SLConfigDescriptor -> SLConfigDescriptor(2, []uint8{})
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/SaioBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/SaioBox.gs
@@ -1,0 +1,77 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+interface ISaioBox : IBox {
+    prop AuxInfoType uint32 {
+        get;
+    }
+
+    prop AuxInfoTypeParameter uint32 {
+        get;
+    }
+
+    prop EntryCount int32 {
+        get;
+    }
+}
+
+open class SaioBox : FullBox, ISaioBox {
+    private let offsets32 []?uint32
+    private let offsets64 []?int64
+
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        if (Flags & 1) == 1 {
+            AuxInfoType = file.ReadUInt32BE()
+            AuxInfoTypeParameter = file.ReadUInt32BE()
+        }
+        EntryCount = file.ReadInt32BE()
+        if Version == uint8(0) {
+            offsets32 = [EntryCount]uint32
+            for var i = 0; i < EntryCount; i++ {
+                offsets32!![i] = file.ReadUInt32BE()
+            }
+        } else {
+            offsets64 = [EntryCount]int64
+            for var i = 0; i < EntryCount; i++ {
+                offsets64!![i] = file.ReadInt64BE()
+            }
+        }
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64((if (Flags & 1) == 1 { 8 } else { 0 })) + int64(4) + int64((if Version == uint8(0) { (offsets32?.Length ?? 0) * 4 } else { (offsets64?.Length ?? 0) * 8 }))
+
+    prop AuxInfoType uint32 {
+        get;
+        init;
+    }
+
+    prop AuxInfoTypeParameter uint32 {
+        get;
+        init;
+    }
+
+    prop EntryCount int32 {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        if (Flags & 1) == 1 {
+            file.WriteUInt32BE(AuxInfoType)
+            file.WriteUInt32BE(AuxInfoTypeParameter)
+        }
+        file.WriteInt32BE(EntryCount)
+        if offsets32 != nil {
+            for offset in offsets32!! {
+                file.WriteUInt32BE(offset)
+            }
+        } else if offsets64 != nil {
+            for offset in offsets64!! {
+                file.WriteInt64BE(offset)
+            }
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/SaizBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/SaizBox.gs
@@ -1,0 +1,52 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class SaizBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        if (Flags & 1) == 1 {
+            AuxInfoType = file.ReadUInt32BE()
+            AuxInfoTypeParameter = file.ReadUInt32BE()
+        }
+        DefaultInfoSampleSize = uint8(file.ReadByte())
+        let sampleCount = file.ReadInt32BE()
+        SampleInfoSizes = if DefaultInfoSampleSize == uint8(0) { file.ReadBlock(sampleCount) } else { Array.Empty[uint8]() }
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64((if (Flags & 1) == 1 { 8 } else { 0 })) + int64(5) + int64((if DefaultInfoSampleSize == uint8(0) { SampleInfoSizes.Length } else { 0 }))
+
+    prop AuxInfoType uint32 {
+        get;
+        init;
+    }
+
+    prop AuxInfoTypeParameter uint32 {
+        get;
+        init;
+    }
+
+    prop DefaultInfoSampleSize uint8 {
+        get;
+        init;
+    }
+
+    prop SampleInfoSizes []uint8 {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        if (Flags & 1) == 1 {
+            file.WriteUInt32BE(AuxInfoType)
+            file.WriteUInt32BE(AuxInfoTypeParameter)
+        }
+        file.WriteByte(DefaultInfoSampleSize)
+        file.WriteInt32BE(SampleInfoSizes.Length)
+        if DefaultInfoSampleSize == uint8(0) {
+            file.Write(SampleInfoSizes)
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/SampleEntry.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/SampleEntry.gs
@@ -1,0 +1,41 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.Diagnostics
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+@DebuggerDisplay("{DebuggerDisplay,nq}")
+open class SampleEntry : Box {
+    private let reserved []uint8
+
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        reserved = file.ReadBlock(6)
+        DataReferenceIndex = file.ReadUInt16BE()
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(8)
+
+    prop DataReferenceIndex uint16 {
+        get;
+        init;
+    }
+
+    @DebuggerHidden
+    private prop DebuggerDisplay string -> "[${Header.Type}] - " + switch Header.Type {
+        case "text": "Text SampleEntry"
+        case "mp4s": "MpegSampleEntry"
+        case "mp4v": "MP4VisualSampleEntry"
+        case "mp4a": "MP4AudioSampleEntry"
+        case "aavd": "Audible AAX(C) Protected AudioSampleEntry"
+        case "encv": "Protected VisualSampleEntry"
+        case "enca": "Protected AudioSampleEntry"
+        case "ec-3": "EC3SampleEntry"
+        case "ac-4": "AC4SampleEntry"
+        default: "[UNKNOWN]"
+    }
+
+    protected open override func Render(file Stream) {
+        file.Write(reserved)
+        file.WriteUInt16BE(DataReferenceIndex)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/SchiBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/SchiBox.gs
@@ -1,0 +1,15 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+
+open class SchiBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        LoadChildren(file)
+    }
+
+    prop TrackEncryption TencBox? -> GetChild[TencBox]()
+
+    protected open override func Render(file Stream) {
+        return
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/SchmBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/SchmBox.gs
@@ -1,0 +1,57 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.Collections.Generic
+import System.IO
+import System.Text
+import Oahu.Decrypt.Mpeg4.Util
+
+open class SchmBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        let endPos = Header.FilePosition + Header.TotalBoxSize
+        Type = SchemeType(file.ReadUInt32BE())
+        SchemeVersion = file.ReadUInt32BE()
+        if (Flags & 1) == 1 {
+            let blist = List[uint8]()
+            while file.Position < endPos {
+                let lastByte = uint8(file.ReadByte())
+                if lastByte == uint8(0) {
+                    HasNullTerminator = true
+                    break
+                }
+                blist.Add(lastByte)
+            }
+            SchemeUri = Encoding.UTF8.GetString(blist.ToArray())
+        }
+    }
+
+    enum SchemeType { Unknown, Cenc, Cbc1, Cens, Cbcs }
+    open override prop RenderSize int64 -> base.RenderSize + int64(8) + int64((if (Flags & 1) == 1 && SchemeUri is string { Encoding.UTF8.GetByteCount((SchemeUri as string)!!) + (if HasNullTerminator { 1 } else { 0 }) } else { 0 }))
+    prop HasNullTerminator bool
+
+    prop Type SchemeType {
+        get;
+        init;
+    }
+
+    prop SchemeVersion uint32 {
+        get;
+        init;
+    }
+
+    prop SchemeUri string? {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.WriteUInt32BE(uint32(Type))
+        file.WriteUInt32BE(SchemeVersion)
+        if (Flags & 1) == 1 && SchemeUri is string {
+            file.Write(Encoding.UTF8.GetBytes((SchemeUri as string)!!))
+            if HasNullTerminator {
+                file.WriteByte(0)
+            }
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/SencBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/SencBox.gs
@@ -1,0 +1,36 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.IO
+import System.Linq
+import Oahu.Decrypt.Mpeg4.Util
+
+open class SencBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        let sampleCount = file.ReadInt32BE()
+        if UseSubSampleEncryption {
+            throw NotSupportedException(nameof(UseSubSampleEncryption))
+        }
+        let ivSize = int32(((header.TotalBoxSize - int64(16)) / int64(sampleCount)))
+        IVs = [sampleCount][]uint8
+        for var i = 0; i < sampleCount; i++ {
+            IVs[i] = file.ReadBlock(ivSize)
+        }
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(4) + int64(IVs.Sum((iv []uint8) -> iv.Length))
+    prop UseSubSampleEncryption bool -> (Flags & 2) == 2
+
+    prop IVs [][]uint8 {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.WriteInt32BE(IVs.Length)
+        for iv in IVs {
+            file.Write(iv!!)
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/SidxBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/SidxBox.gs
@@ -1,0 +1,129 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class SidxBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        ReferenceId = file.ReadUInt32BE()
+        Timescale = file.ReadInt32BE()
+        if Version == uint8(0) {
+            EarliestPresentationTime = file.ReadUInt32BE()
+            FirstOffset = file.ReadUInt32BE()
+        } else {
+            EarliestPresentationTime = file.ReadInt64BE()
+            FirstOffset = file.ReadInt64BE()
+        }
+        file.ReadInt16BE()
+        let referenceCount int32 = file.ReadUInt16BE()
+        Segments = [referenceCount]Segment
+        for var i = 0; i < Segments.Length; i++ {
+            Segments[i] = Segment(file)
+        }
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(8) + int64((if Version == uint8(0) { 8 } else { 16 })) + int64(4) + int64(Segments.Length * 12)
+
+    prop ReferenceId uint32 {
+        get;
+        init;
+    }
+
+    prop Timescale int32 {
+        get;
+        init;
+    }
+
+    prop EarliestPresentationTime int64 {
+        get;
+        init;
+    }
+
+    prop FirstOffset int64 {
+        get;
+        init;
+    }
+
+    prop Segments []Segment {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.WriteUInt32BE(ReferenceId)
+        file.WriteInt32BE(Timescale)
+        if Version == uint8(0) {
+            file.WriteUInt32BE(uint32(EarliestPresentationTime))
+            file.WriteUInt32BE(uint32(FirstOffset))
+        } else {
+            file.WriteInt64BE(EarliestPresentationTime)
+            file.WriteInt64BE(FirstOffset)
+        }
+        file.WriteInt16BE(0)
+        file.WriteInt16BE(int16(Segments.Length))
+        for segment in Segments {
+            segment!!.Save(file)
+        }
+    }
+
+    class Segment {
+        private var typeAndSize uint32
+        private var subsegmentDuration uint32
+        private var sap uint32
+
+        internal init(file Stream) {
+            typeAndSize = file.ReadUInt32BE()
+            subsegmentDuration = file.ReadUInt32BE()
+            sap = file.ReadUInt32BE()
+        }
+
+        prop ReferenceType bool {
+            get -> (typeAndSize & 0x80000000U) == 0x80000000U
+            set -> typeAndSize = if value { typeAndSize | 0x80000000U } else { typeAndSize & uint32(0x7FFFFFFF) }
+        }
+
+        prop ReferenceSize int32 {
+            get -> int32((typeAndSize & uint32(0x7FFFFFFF)))
+            set {
+                ArgumentOutOfRangeException.ThrowIfLessThan(value, 0, nameof(ReferenceSize))
+                typeAndSize = (typeAndSize & 0x80000000U) | uint32(value)
+            }
+        }
+
+        prop SubsegmentDuration uint32 {
+            get -> subsegmentDuration
+            set -> subsegmentDuration = value
+        }
+
+        prop StartsWithSAP bool {
+            get -> (sap & 0x80000000U) == 0x80000000U
+            set -> sap = if value { sap | 0x80000000U } else { sap & uint32(0x7FFFFFFF) }
+        }
+
+        prop SapType int32 {
+            get -> int32((sap >> 28)) & 7
+            set {
+                ArgumentOutOfRangeException.ThrowIfLessThan(value, 0, nameof(SapType))
+                ArgumentOutOfRangeException.ThrowIfGreaterThan(value, 7, nameof(SapType))
+                sap = (sap & 0x8FFFFFFFU) | uint32((value << 28))
+            }
+        }
+
+        prop SapDeltaTime int32 {
+            get -> int32(sap) & 0xFFFFFFF
+            set {
+                ArgumentOutOfRangeException.ThrowIfLessThan(value, 0, nameof(SapType))
+                ArgumentOutOfRangeException.ThrowIfGreaterThan(value, 0xFFFFFFF, nameof(SapType))
+                sap = (sap & 0xF0000000U) | uint32(value)
+            }
+        }
+
+        func Save(file Stream) {
+            file.WriteUInt32BE(typeAndSize)
+            file.WriteUInt32BE(subsegmentDuration)
+            file.WriteUInt32BE(sap)
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/SinfBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/SinfBox.gs
@@ -1,0 +1,18 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import System.Linq
+
+open class SinfBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        LoadChildren(file)
+    }
+
+    prop OriginalFormat FrmaBox -> GetChildOrThrow[FrmaBox]()
+    prop SchemeType SchmBox? -> GetChildren[SchmBox]()?.SingleOrDefault()
+    prop SchemeInformation SchiBox? -> GetChildren[SchiBox]()?.SingleOrDefault()
+
+    protected open override func Render(file Stream) {
+        return
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/StblBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/StblBox.gs
@@ -1,0 +1,19 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+
+open class StblBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        LoadChildren(file)
+    }
+
+    prop Stsd StsdBox -> GetChildOrThrow[StsdBox]()
+    prop Stts SttsBox -> GetChildOrThrow[SttsBox]()
+    prop COBox IChunkOffsets -> GetChild[StcoBox]() ?? IChunkOffsets(GetChildOrThrow[Co64Box]())
+    prop Stsz IStszBox? -> GetChild[StszBox]() ?? (GetChild[Stz2Box]() as IStszBox)
+    prop Stsc StscBox -> GetChildOrThrow[StscBox]()
+
+    protected open override func Render(file Stream) {
+        return
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/StcoBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/StcoBox.gs
@@ -1,0 +1,51 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+internal open class StcoBox : FullBox, IChunkOffsets {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        let entryCount = file.ReadUInt32BE()
+        if entryCount > uint32(Int32.MaxValue) {
+            throw NotSupportedException("Oahu.Decrypt.Mpeg4 does not support MPEG-4 files with more than ${Int32.MaxValue} chunk offsets")
+        }
+        ChunkOffsets = ChunkOffsetList.Read32(file, entryCount)
+    }
+
+    private init(chunkOffsets ChunkOffsetList, versionFlags []uint8, header BoxHeader, parent IBox) : base(versionFlags, header, parent) {
+        ChunkOffsets = chunkOffsets
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(4) + int64(ChunkOffsets.Count * 4)
+    prop EntryCount uint32 -> uint32(ChunkOffsets.Count)
+
+    prop ChunkOffsets ChunkOffsetList {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.WriteUInt32BE(EntryCount)
+        ChunkOffsets.Write32(file)
+    }
+
+    protected open override func Dispose(disposing bool) {
+        if disposing & !Disposed {
+            ChunkOffsets.Clear()
+        }
+        base.Dispose(disposing)
+    }
+
+    shared {
+        internal func CreateBlank(parent IBox, chunkOffsets ChunkOffsetList) StcoBox {
+            let size = 4 + 12
+            let header = BoxHeader(uint32(size), "stco")
+            chunkOffsets.Sort()
+            let stcoBox = StcoBox(chunkOffsets, []uint8{uint8(0), uint8(0), uint8(0), uint8(0)}, header, parent)
+            parent.Children.Add(stcoBox)
+            return stcoBox
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/StreamExtensions.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/StreamExtensions.gs
@@ -1,0 +1,161 @@
+package Oahu.Decrypt.Mpeg4.Util
+
+import System
+import System.Buffers
+import System.Buffers.Binary
+import System.IO
+import System.Threading
+import System.Threading.Tasks
+import Oahu.Decrypt.Mpeg4.Boxes
+
+func (stream Stream) WriteHeader(header BoxHeader, renderSize int64) {
+    if header.Version == 1 || renderSize > int64(UInt32.MaxValue) {
+        stream.WriteUInt32BE(1)
+        stream.WriteType(header.Type)
+        stream.WriteInt64BE(renderSize)
+    } else {
+        stream.WriteUInt32BE(uint32(renderSize))
+        stream.WriteType(header.Type)
+    }
+}
+
+async func (inputStream Stream) SeekToOffsetAsync(chunkOffset int64, token CancellationToken) {
+    if inputStream.Position == chunkOffset {
+        return
+    } else if inputStream.CanSeek {
+        inputStream.Position = chunkOffset
+    } else if inputStream.Position < chunkOffset {
+        const bufferSize = 8 * 1024
+        var toRead = Int32.Min(bufferSize, int32((chunkOffset - inputStream.Position)))
+        using let memoryBuff = MemoryPool[uint8].Shared.Rent(toRead)
+        while toRead > 0 {
+            await inputStream.ReadExactlyAsync(memoryBuff!!.Memory.Slice(0, toRead), token)
+            toRead = Int32.Min(bufferSize, int32((chunkOffset - inputStream.Position)))
+        }
+    } else {
+        throw NotSupportedException("Input stream position 0x${inputStream.Position:X8} is past the chunk offset 0x${chunkOffset:X8} and is not seekable.")
+    }
+}
+
+func (inputStream Stream) SeekToOffset(chunkOffset int64) {
+    if inputStream.Position == chunkOffset {
+        return
+    } else if inputStream.CanSeek {
+        inputStream.Position = chunkOffset
+    } else if inputStream.Position < chunkOffset {
+        const bufferSize = 8 * 1024
+        var toRead = Int32.Min(bufferSize, int32((chunkOffset - inputStream.Position)))
+        using let memoryBuff = MemoryPool[uint8].Shared.Rent(toRead)
+        let spanBuff = memoryBuff!!.Memory.Span
+        while toRead > 0 {
+            inputStream.ReadExactly(spanBuff.Slice(0, toRead))
+            toRead = Int32.Min(bufferSize, int32((chunkOffset - inputStream.Position)))
+        }
+    } else {
+        throw NotSupportedException("Input stream position 0x${inputStream.Position:X8} is past the chunk offset 0x${chunkOffset:X8} and is not seekable.")
+    }
+}
+
+async func (inputStream Stream) ReadNextChunkAsync(chunkOffset int64, chunkBuffer Memory[uint8], token CancellationToken) {
+    await inputStream.SeekToOffsetAsync(chunkOffset, token)
+    if await inputStream.ReadAsync(chunkBuffer, token) != chunkBuffer.Length {
+        throw EndOfStreamException("Stream ended at position ${inputStream.Position} before all ${chunkBuffer.Length} bytes were read.")
+    }
+}
+
+func (stream Stream) WriteType(type_ string) {
+    if type_?.Length != 4 {
+        throw ArgumentException("Type must be 4 chars long.")
+    }
+    stream.Write([]uint8{uint8(type_[0]), uint8(type_[1]), uint8(type_[2]), uint8(type_[3])})
+}
+
+func (stream Stream) WriteInt16BE(value int16) {
+    let word = stackalloc [2]uint8
+    BinaryPrimitives.WriteInt16BigEndian(word, value)
+    stream.Write(word)
+}
+
+func (stream Stream) WriteUInt16BE(value uint16) {
+    let word = stackalloc [2]uint8
+    BinaryPrimitives.WriteUInt16BigEndian(word, value)
+    stream.Write(word)
+}
+
+func (stream Stream) WriteInt32BE(value int32) {
+    let dword = stackalloc [4]uint8
+    BinaryPrimitives.WriteInt32BigEndian(dword, value)
+    stream.Write(dword)
+}
+
+func (stream Stream) WriteUInt32BE(value uint32) {
+    let dword = stackalloc [4]uint8
+    BinaryPrimitives.WriteUInt32BigEndian(dword, value)
+    stream.Write(dword)
+}
+
+func (stream Stream) WriteInt64BE(value int64) {
+    let qword = stackalloc [8]uint8
+    BinaryPrimitives.WriteInt64BigEndian(qword, value)
+    stream.Write(qword)
+}
+
+func (stream Stream) WriteUInt64BE(value uint64) {
+    let qword = stackalloc [8]uint8
+    BinaryPrimitives.WriteUInt64BigEndian(qword, value)
+    stream.Write(qword)
+}
+
+func (stream Stream) ReadInt16BE() int16 {
+    let word = stackalloc [2]uint8
+    stream.ReadExactly(word)
+    return BinaryPrimitives.ReadInt16BigEndian(word)
+}
+
+func (stream Stream) ReadUInt16BE() uint16 {
+    let word = stackalloc [2]uint8
+    stream.ReadExactly(word)
+    return BinaryPrimitives.ReadUInt16BigEndian(word)
+}
+
+func (stream Stream) ReadInt32BE() int32 {
+    let dword = stackalloc [4]uint8
+    stream.ReadExactly(dword)
+    return BinaryPrimitives.ReadInt32BigEndian(dword)
+}
+
+func (stream Stream) ReadUInt32BE() uint32 {
+    let dword = stackalloc [4]uint8
+    stream.ReadExactly(dword)
+    return BinaryPrimitives.ReadUInt32BigEndian(dword)
+}
+
+func (stream Stream) ReadInt64BE() int64 {
+    let qword = stackalloc [8]uint8
+    stream.ReadExactly(qword)
+    return BinaryPrimitives.ReadInt64BigEndian(qword)
+}
+
+func (stream Stream) ReadUInt64BE() uint64 {
+    let qword = stackalloc [8]uint8
+    stream.ReadExactly(qword)
+    return BinaryPrimitives.ReadUInt64BigEndian(qword)
+}
+
+func (stream Stream) ReadType() string {
+    let dword = stackalloc [4]uint8
+    stream.ReadExactly(dword)
+    return string([]char{char(dword[0]), char(dword[1]), char(dword[2]), char(dword[3])})
+}
+
+func (stream Stream) ReadBlock(length int32) []uint8 {
+    if length < 0 {
+        throw ArgumentException("Length must be non-negative", nameof(length))
+    } else if length == 0 {
+        return []uint8{}
+    } else {
+        let buffer = [length]uint8
+        stream.ReadExactly(buffer)
+        return buffer
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/StscBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/StscBox.gs
@@ -1,0 +1,93 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.Buffers.Binary
+import System.Collections.Generic
+import System.Diagnostics
+import System.IO
+import System.Runtime.InteropServices
+import Oahu.Decrypt.Mpeg4.Util
+
+struct ChunkFrames {
+    prop FirstFrameIndex uint32 {
+        get;
+        init;
+    }
+
+    prop NumberOfFrames uint32 {
+        get;
+        init;
+    }
+}
+
+open class StscBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        let entryCount = file.ReadUInt32BE()
+        Debug.Assert(entryCount <= uint32(Int32.MaxValue))
+        Samples = List[StscChunkEntry](int32(entryCount))
+        CollectionsMarshal.SetCount(Samples, int32(entryCount))
+        let samples = CollectionsMarshal.AsSpan(Samples)
+        file.ReadExactly(MemoryMarshal.AsBytes(samples))
+        if BitConverter.IsLittleEndian {
+            let uints = MemoryMarshal.Cast[StscChunkEntry, uint32](samples)
+            BinaryPrimitives.ReverseEndianness(uints, uints)
+        }
+    }
+
+    private init(versionFlags []uint8, header BoxHeader, parent IBox) : base(versionFlags, header, parent) {
+        Samples = List[StscChunkEntry]()
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(4) + int64(EntryCount * 3 * 4)
+    prop EntryCount int32 -> Samples.Count
+
+    prop Samples List[StscChunkEntry] {
+        get;
+        init;
+    }
+
+    func CalculateChunkFrameTable(numChunks uint32) []ChunkFrames {
+        let table = [int32(numChunks)]ChunkFrames
+        var firstFrameIndex uint32 = uint32(0)
+        var lastStscIndex = 0
+        for var chunk uint32 = uint32(1); chunk <= numChunks; chunk++ {
+            if lastStscIndex + 1 < Samples.Count && chunk == Samples[lastStscIndex + 1].FirstChunk {
+                lastStscIndex++
+            }
+            table[chunk - uint32(1)] = ChunkFrames{FirstFrameIndex: firstFrameIndex, NumberOfFrames: Samples[lastStscIndex].SamplesPerChunk}
+            firstFrameIndex += Samples[lastStscIndex].SamplesPerChunk
+        }
+        return table
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.WriteUInt32BE(uint32(Samples.Count))
+        for sample in Samples {
+            file.WriteUInt32BE(sample.FirstChunk)
+            file.WriteUInt32BE(sample.SamplesPerChunk)
+            file.WriteUInt32BE(sample.SampleDescriptionIndex)
+        }
+    }
+
+    protected open override func Dispose(disposing bool) {
+        if disposing && !Disposed {
+            Samples.Clear()
+        }
+        base.Dispose(disposing)
+    }
+
+    @StructLayout(0)
+    data struct StscChunkEntry(FirstChunk uint32, SamplesPerChunk uint32, SampleDescriptionIndex uint32) {
+    }
+
+    shared {
+        func CreateBlank(parent IBox) StscBox {
+            let size = 4 + 12
+            let header = BoxHeader(uint32(size), "stsc")
+            let stscBox = StscBox([]uint8{uint8(0), uint8(0), uint8(0), uint8(0)}, header, parent)
+            parent.Children.Add(stscBox)
+            return stscBox
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/StsdBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/StsdBox.gs
@@ -1,0 +1,49 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.Collections.Generic
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class StsdBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        VisualSampleEntries = List[VisualSampleEntry]()
+        EntryCount = file.ReadUInt32BE()
+        let hdlr HdlrBox? = Parent?.Parent?.Parent?.GetChild[HdlrBox]()
+        for var i = 0; int64(i) < int64(EntryCount); i++ {
+            let h = BoxHeader(file)
+            if hdlr?.HandlerType == "soun" {
+                AudioSampleEntry = AudioSampleEntry(file, h, this)
+                Children.Add(AudioSampleEntry!!)
+            } else if hdlr?.HandlerType == "vide" {
+                let entry = VisualSampleEntry(file, h, this)
+                VisualSampleEntries.Add(entry!!)
+                Children.Add(entry!!)
+            } else {
+                let unknownSampleEntry = UnknownBox(file, h, this)
+                Children.Add(unknownSampleEntry)
+            }
+        }
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(4)
+
+    prop EntryCount uint32 {
+        get;
+        init;
+    }
+
+    prop AudioSampleEntry AudioSampleEntry? {
+        get;
+        init;
+    }
+
+    prop VisualSampleEntries List[VisualSampleEntry] {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.WriteUInt32BE(EntryCount)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/StszBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/StszBox.gs
@@ -1,0 +1,102 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.Buffers.Binary
+import System.Collections.Generic
+import System.IO
+import System.Linq
+import System.Runtime.InteropServices
+import Oahu.Decrypt.Mpeg4.Util
+
+open class StszBox : FullBox, IStszBox {
+    private let origSampleCount int32
+    private let sampleSizes32 List[int32]?
+    private let sampleSizes16 List[uint16]?
+
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        SampleSize = file.ReadInt32BE()
+        let sampleCountU = file.ReadUInt32BE()
+        if sampleCountU > uint32(Int32.MaxValue) {
+            throw NotSupportedException("Oahu.Decrypt.Mpeg4 does not support MPEG-4 files with more than ${Int32.MaxValue} samples")
+        }
+        origSampleCount = int32(sampleCountU)
+        if SampleSize > 0 {
+            return
+        }
+        sampleSizes32 = List[int32](origSampleCount)
+        CollectionsMarshal.SetCount(sampleSizes32!!, origSampleCount)
+        let intListSpan = CollectionsMarshal.AsSpan(sampleSizes32!!)
+        file.ReadExactly(MemoryMarshal.AsBytes(intListSpan))
+        if BitConverter.IsLittleEndian {
+            BinaryPrimitives.ReverseEndianness(intListSpan, intListSpan)
+        }
+        if intListSpan.AllLessThanOrEqual(int32(UInt16.MaxValue)) {
+            sampleSizes16 = List[uint16](origSampleCount)
+            CollectionsMarshal.SetCount(sampleSizes16!!, origSampleCount)
+            let shortListSpan = CollectionsMarshal.AsSpan(sampleSizes16!!)
+            for var i = 0; i < origSampleCount; i++ {
+                shortListSpan[i] = uint16(intListSpan[i])
+            }
+            CollectionsMarshal.SetCount(sampleSizes32!!, 0)
+            sampleSizes32 = nil
+        }
+    }
+
+    private init(versionFlags []uint8, header BoxHeader, parent IBox, sampleSizes List[int32]) : base(versionFlags, header, parent) {
+        sampleSizes32 = sampleSizes
+    }
+
+    private init(versionFlags []uint8, header BoxHeader, parent IBox, sampleSizes List[uint16]) : base(versionFlags, header, parent) {
+        sampleSizes16 = sampleSizes
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(8) + int64(SampleCount * 4)
+
+    prop SampleSize int32 {
+        get;
+        init;
+    }
+
+    prop SampleCount int32 -> sampleSizes32?.Count ?? sampleSizes16?.Count ?? origSampleCount
+    prop MaxSize int32 -> sampleSizes32?.Max() ?? sampleSizes16?.Max() ?? uint16(SampleSize)
+    prop TotalSize int64 -> sampleSizes32?.Sum((s int32) -> int64(s)) ?? sampleSizes16?.Sum((s uint16) -> int64(s)) ?? int64(SampleSize * origSampleCount)
+    func GetSizeAtIndex(index int32) int32 -> sampleSizes32?[index] ?? sampleSizes16?[index] ?? uint16(SampleSize)
+    func SumFirstNSizes(firstN int32) int64 -> sampleSizes32?.Take(firstN).Sum((s int32) -> int64(s)) ?? sampleSizes16?.Take(firstN).Sum((s uint16) -> int64(s)) ?? int64(SampleSize) * int64(firstN)
+
+    protected open override func Render(file Stream) {
+        unsafe {
+            base.Render(file)
+            file.WriteInt32BE(SampleSize)
+            file.WriteUInt32BE(uint32(SampleCount))
+            if sampleSizes32 != nil {
+                let intSpan = CollectionsMarshal.AsSpan(sampleSizes32!!)
+                if BitConverter.IsLittleEndian {
+                    BinaryPrimitives.ReverseEndianness(intSpan, intSpan)
+                }
+                file.Write(MemoryMarshal.AsBytes(intSpan))
+            } else if sampleSizes16 != nil {
+                for size in sampleSizes16!! {
+                    file.WriteInt32BE(size)
+                }
+            }
+        }
+    }
+
+    shared {
+        func CreateBlank(parent IBox, sampleSizes List[int32]) StszBox {
+            let size = 8 + 12
+            let header = BoxHeader(uint32(size), "stsz")
+            let stszBox = StszBox([]uint8{uint8(0), uint8(0), uint8(0), uint8(0)}, header, parent, sampleSizes)
+            parent.Children.Add(stszBox!!)
+            return stszBox!!
+        }
+
+        func CreateBlank(parent IBox, sampleSizes List[uint16]) StszBox {
+            let size = 8 + 12
+            let header = BoxHeader(uint32(size), "stsz")
+            let stszBox = StszBox([]uint8{uint8(0), uint8(0), uint8(0), uint8(0)}, header, parent, sampleSizes)
+            parent.Children.Add(stszBox!!)
+            return stszBox!!
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/SttsBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/SttsBox.gs
@@ -1,0 +1,94 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.Buffers.Binary
+import System.Collections.Generic
+import System.Diagnostics
+import System.IO
+import System.Linq
+import System.Runtime.InteropServices
+import Oahu.Decrypt.Mpeg4.Util
+
+open class SttsBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        Samples = List[SttsBox.SampleEntry]()
+        let entryCount = file.ReadUInt32BE()
+        Debug.Assert(entryCount <= uint32(Int32.MaxValue))
+        Samples = List[SttsBox.SampleEntry](int32(entryCount))
+        CollectionsMarshal.SetCount(Samples, int32(entryCount))
+        let samples = CollectionsMarshal.AsSpan(Samples)
+        file.ReadExactly(MemoryMarshal.AsBytes(samples))
+        if BitConverter.IsLittleEndian {
+            let uints = MemoryMarshal.Cast[SttsBox.SampleEntry, uint32](samples)
+            BinaryPrimitives.ReverseEndianness(uints, uints)
+        }
+    }
+
+    private init(versionFlags []uint8, header BoxHeader, parent IBox?) : base(versionFlags, header, parent) {
+        Samples = List[SttsBox.SampleEntry]()
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(4) + int64(EntryCount * 2 * 4)
+    prop EntryCount int32 -> Samples.Count
+
+    prop Samples List[SttsBox.SampleEntry] {
+        get;
+        init;
+    }
+
+    prop SampleTimeCount uint32 -> uint32(Samples.Sum((s SttsBox.SampleEntry) -> s.FrameCount))
+
+    func EnumerateFrameDeltas(startAt uint32 = 0) sequence[uint32] {
+        var startAt = startAt
+        for entry in Samples {
+            while startAt < entry.FrameCount {
+                yield entry.FrameDelta
+                startAt++
+            }
+            startAt -= entry.FrameCount
+        }
+    }
+
+    func FrameToTime(timeScale float64, frameIndex uint64) TimeSpan {
+        var beginDelta uint64 = uint64(0)
+        var workingIndex = frameIndex
+        for entry in Samples {
+            if workingIndex <= uint64(entry.FrameCount) {
+                return TimeSpan.FromSeconds(float64((beginDelta + workingIndex * uint64(entry.FrameDelta))) / timeScale)
+            }
+            beginDelta += uint64(entry.FrameCount) * uint64(entry.FrameDelta)
+            workingIndex -= uint64(entry.FrameCount)
+        }
+        throw IndexOutOfRangeException("${nameof(frameIndex)} $frameIndex is larger than the number of frames in ${nameof(SttsBox)}")
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.WriteUInt32BE(uint32(Samples.Count))
+        for sample in Samples {
+            file.WriteUInt32BE(sample.FrameCount)
+            file.WriteUInt32BE(sample.FrameDelta)
+        }
+    }
+
+    protected open override func Dispose(disposing bool) {
+        if disposing && !Disposed {
+            Samples.Clear()
+        }
+        base.Dispose(disposing)
+    }
+
+    @StructLayout(0)
+    data struct SampleEntry(FrameCount uint32, FrameDelta uint32) {
+    }
+
+    shared {
+        func CreateBlank(parent IBox) SttsBox {
+            let size = 4 + 12
+            let header = BoxHeader(uint32(size), "stts")
+            let sttsBox = SttsBox([]uint8{uint8(0), uint8(0), uint8(0), uint8(0)}, header, parent)
+            parent.Children.Add(sttsBox)
+            return sttsBox
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Stz2Box.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/Stz2Box.gs
@@ -1,0 +1,94 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.Buffers.Binary
+import System.Collections.Generic
+import System.IO
+import System.Linq
+import System.Runtime.InteropServices
+import Oahu.Decrypt.Mpeg4.Util
+
+open class Stz2Box : FullBox, IStszBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        let reserved = stackalloc [4]uint8
+        file.ReadExactly(reserved)
+        FieldSize = reserved[3]
+        let sampleCount = file.ReadUInt32BE()
+        if !((FieldSize == 8 || FieldSize == 16)) {
+            throw InvalidDataException("Stsz field size ($FieldSize). Valid values are 4, 8, or 16.")
+        }
+        if sampleCount > uint32(Int32.MaxValue) {
+            throw NotSupportedException("Oahu.Decrypt.Mpeg4 does not support MPEG-4 files with more than ${Int32.MaxValue} samples")
+        }
+        SampleSizes = List[uint16](int32(sampleCount))
+        CollectionsMarshal.SetCount(SampleSizes, int32(sampleCount))
+        let shortSpan = CollectionsMarshal.AsSpan(SampleSizes)
+        if FieldSize == 16 {
+            file.ReadExactly(MemoryMarshal.AsBytes(shortSpan))
+            if BitConverter.IsLittleEndian {
+                BinaryPrimitives.ReverseEndianness(shortSpan, shortSpan)
+            }
+        } else {
+            let bytes Span[uint8] = file.ReadBlock(int32(sampleCount))
+            for var i = 0; int64(i) < int64(sampleCount); i++ {
+                shortSpan[i] = bytes[i]
+            }
+        }
+    }
+
+    private init(versionFlags []uint8, header BoxHeader, parent IBox, sampleSizes List[uint16], fieldSize int32) : base(versionFlags, header, parent) {
+        if fieldSize != 16 && fieldSize != 8 && fieldSize != 4 {
+            throw InvalidDataException("Stsz field size ($fieldSize). Valid values are 4, 8, or 16.")
+        }
+        FieldSize = fieldSize
+        SampleSizes = sampleSizes
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(8) + int64(SampleCount * FieldSize / 8) + int64((if FieldSize == 4 && SampleCount % 2 == 1 { 1 } else { 0 }))
+    prop SampleCount int32 -> SampleSizes.Count
+
+    prop SampleSizes List[uint16] {
+        get;
+        init;
+    }
+
+    prop MaxSize int32 -> SampleSizes.Max()
+    prop TotalSize int64 -> SampleSizes.Sum((s uint16) -> int64(s))
+
+    prop FieldSize int32 {
+        get;
+        init;
+    }
+
+    func GetSizeAtIndex(index int32) int32 -> SampleSizes[index]
+    func SumFirstNSizes(firstN int32) int64 -> SampleSizes.Take(firstN).Sum((s uint16) -> int64(s))
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        let fieldSize = stackalloc [4]uint8
+        let shortSpan = CollectionsMarshal.AsSpan(SampleSizes)
+        fieldSize[3] = uint8((if shortSpan.AllLessThanOrEqual(uint16(Byte.MaxValue)) { 8 } else { 16 }))
+        file.Write(fieldSize)
+        file.WriteInt32BE(SampleSizes.Count)
+        if fieldSize[3] == uint8(16) {
+            if BitConverter.IsLittleEndian {
+                BinaryPrimitives.ReverseEndianness(shortSpan, shortSpan)
+            }
+            file.Write(MemoryMarshal.AsBytes(shortSpan))
+        } else {
+            for size in SampleSizes {
+                file.WriteByte(uint8(size))
+            }
+        }
+    }
+
+    shared {
+        func CreateBlank(parent IBox, sampleSizes List[uint16]) Stz2Box {
+            let size = 8 + 12
+            let header = BoxHeader(uint32(size), "stz2")
+            let stszBox = Stz2Box([]uint8{uint8(0), uint8(0), uint8(0), uint8(0)}, header, parent, sampleSizes, 16)
+            parent.Children.Add(stszBox!!)
+            return stszBox!!
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/TEXTFrame.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/TEXTFrame.gs
@@ -1,0 +1,38 @@
+package Oahu.Decrypt.Mpeg4.ID3
+
+import System.IO
+import System.Text
+
+class TEXTFrame : Frame {
+    init(file Stream, header Header, parent Frame) : base(header, parent) {
+        EncodingFlag = uint8(file.ReadByte())
+        Text = Frame.ReadSizeString(file, EncodingFlag == uint8(1), Header.Size - 1)
+    }
+
+    private init(header Header, parent Frame) : base(header, parent) {
+    }
+
+    override prop Size int32 -> 1 + (if Text == nil { 0 } else { if Frame.IsUnicode(Text!!) { Frame.UnicodeLength(Text!!) } else { Text!!.Length } })
+    prop EncodingFlag uint8
+    prop Text string?
+
+    override func Render(file Stream) {
+        if Text == nil {
+            file.WriteByte(0)
+        } else if Frame.IsUnicode(Text!!) {
+            file.WriteByte(1)
+            file.Write(Frame.UnicodeBytes(Text!!))
+        } else {
+            file.WriteByte(0)
+            file.Write(Encoding.ASCII.GetBytes(Text!!))
+        }
+    }
+
+    shared {
+        func Create(parent Frame, frameId string, text string) TEXTFrame {
+            let tit2 = TEXTFrame(FrameHeader(frameId, 0, parent.Version), parent)
+            parent?.Children.Add(tit2!!)
+            return tit2!!
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/TXXXFrame.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/TXXXFrame.gs
@@ -1,0 +1,41 @@
+package Oahu.Decrypt.Mpeg4.ID3
+
+import System.IO
+import System.Text
+
+class TXXXFrame : Frame {
+    init(file Stream, header Header, parent Frame) : base(header, parent) {
+        let startPos = file.Position
+        let unicode = file.ReadByte() == 1
+        FieldName = Frame.ReadNullTerminatedString(file, unicode)
+        FieldValue = Frame.ReadSizeString(file, unicode, int32((startPos + int64(header.Size) - file.Position)))
+    }
+
+    override prop Size int32 -> if Frame.IsUnicode(FieldName) || Frame.IsUnicode(FieldValue) { 1 + Frame.UnicodeLength(FieldName) + 2 + Frame.UnicodeLength(FieldValue) } else { 1 + FieldName.Length + 1 + FieldValue.Length }
+
+    prop FieldName string {
+        get;
+        init;
+    }
+
+    prop FieldValue string {
+        get;
+        init;
+    }
+
+    func ToString() string -> FieldName
+
+    override func Render(file Stream) {
+        if Frame.IsUnicode(FieldName) || Frame.IsUnicode(FieldValue) {
+            file.WriteByte(1)
+            file.Write(Frame.UnicodeBytes(FieldName))
+            file.Write(stackalloc [2]uint8)
+            file.Write(Frame.UnicodeBytes(FieldValue))
+        } else {
+            file.WriteByte(0)
+            file.Write(Encoding.ASCII.GetBytes(FieldName))
+            file.WriteByte(0)
+            file.Write(Encoding.ASCII.GetBytes(FieldValue))
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/TagFactory.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/TagFactory.gs
@@ -1,0 +1,29 @@
+package Oahu.Decrypt.Mpeg4.ID3
+
+import System.IO
+
+internal class TagFactory {
+    shared {
+        func CreateTag(file Stream, parent Frame, out lengthRead int32) Frame {
+            let startPos = file.Position
+            let frameHeader = FrameHeader.Create(file, parent.Version)
+            let frame = TagFactory.CreateTagInternal(frameHeader!!, file, parent)
+            lengthRead = int32((file.Position - startPos))
+            return frame!!
+        }
+
+        private func CreateTagInternal(frameHeader FrameHeader, file Stream, parent Frame) Frame {
+            if parent.Version >= uint16(0x300) && frameHeader.Identifier.StartsWith('T') && frameHeader.Identifier != "TXXX" {
+                return TEXTFrame(file, frameHeader, parent)
+            }
+            return switch frameHeader.Identifier {
+                case "TXXX": TXXXFrame(file, frameHeader, parent)
+                case "APIC": APICFrame(file, frameHeader, parent)
+                case "CHAP": CHAPFrame(file, frameHeader, parent)
+                case "CTOC": CTOCFrame(file, frameHeader, parent)
+                case "\u0000\u0000\u0000" or "\u0000\u0000\u0000\u0000": EmptyFrame(frameHeader, parent)
+                default: UnknownFrame(file, frameHeader, parent)
+            }
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/TencBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/TencBox.gs
@@ -1,0 +1,80 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class TencBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        file.ReadByte()
+        if Version == uint8(0) {
+            file.ReadByte()
+        } else {
+            let value = file.ReadByte()
+            DefaultCryptByteBlock = uint8((value >> 4))
+            DefaultSkipByteBlock = uint8((value & 0xf))
+        }
+        DefaultIsProtected = file.ReadByte() != 0
+        DefaultPerSampleIvSize = uint8(file.ReadByte())
+        DefaultKID = Guid(file.ReadBlock(16), true)
+        if DefaultIsProtected && DefaultPerSampleIvSize == uint8(0) {
+            DefaultConstantIvSize = uint8(file.ReadByte())
+            DefaultConstantIv = file.ReadBlock(DefaultConstantIvSize)
+        } else {
+            DefaultConstantIv = Array.Empty[uint8]()
+        }
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(20) + int64((if (DefaultIsProtected && DefaultPerSampleIvSize == uint8(0)) { uint8(1) + DefaultConstantIvSize } else { 0 }))
+
+    prop DefaultCryptByteBlock uint8 {
+        get;
+        init;
+    }
+
+    prop DefaultSkipByteBlock uint8 {
+        get;
+        init;
+    }
+
+    prop DefaultIsProtected bool {
+        get;
+        init;
+    }
+
+    prop DefaultPerSampleIvSize uint8 {
+        get;
+        init;
+    }
+
+    prop DefaultKID Guid {
+        get;
+        init;
+    }
+
+    prop DefaultConstantIvSize uint8 {
+        get;
+        init;
+    }
+
+    prop DefaultConstantIv []uint8 {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        var value int16 = 0
+        if Version != uint8(0) {
+            value = int16(((DefaultCryptByteBlock << 4) | (DefaultSkipByteBlock & uint8(0xf))))
+        }
+        file.WriteInt16BE(value)
+        file.WriteByte(uint8((if DefaultIsProtected { 1 } else { 0 })))
+        file.WriteByte(DefaultPerSampleIvSize)
+        file.Write(DefaultKID.ToByteArray(true))
+        if DefaultIsProtected && DefaultPerSampleIvSize == uint8(0) {
+            file.WriteByte(uint8(DefaultConstantIv.Length))
+            file.Write(DefaultConstantIv)
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/TfdtBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/TfdtBox.gs
@@ -1,0 +1,26 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class TfdtBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        BaseMediaDecodeTime = if Version == uint8(1) { file.ReadInt64BE() } else { int64(file.ReadUInt32BE()) }
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64((if Version == uint8(1) { 8 } else { 4 }))
+
+    prop BaseMediaDecodeTime int64 {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        if Version == uint8(1) {
+            file.WriteInt64BE(BaseMediaDecodeTime)
+        } else {
+            file.WriteUInt32BE(uint32(BaseMediaDecodeTime))
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/TfhdBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/TfhdBox.gs
@@ -1,0 +1,86 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class TfhdBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        TrackID = file.ReadUInt32BE()
+        if BaseDataOffsetPresent {
+            BaseDataOffset = file.ReadInt64BE()
+        }
+        if SampleDescriptionIndexPresent {
+            SampleDescriptionIndex = file.ReadUInt32BE()
+        }
+        if DefaultSampleDurationPresent {
+            DefaultSampleDuration = file.ReadUInt32BE()
+        }
+        if DefaultSampleSizePresent {
+            DefaultSampleSize = file.ReadUInt32BE()
+        }
+        if DefaultSampleFlagsPresent {
+            DefaultSampleFlags = file.ReadUInt32BE()
+        }
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(4) + int64(OptionalFieldsSize)
+
+    prop TrackID uint32 {
+        get;
+        init;
+    }
+
+    prop BaseDataOffset int64? {
+        get;
+        init;
+    }
+
+    prop SampleDescriptionIndex uint32? {
+        get;
+        init;
+    }
+
+    prop DefaultSampleDuration uint32? {
+        get;
+        init;
+    }
+
+    prop DefaultSampleSize uint32? {
+        get;
+        init;
+    }
+
+    prop DefaultSampleFlags uint32? {
+        get;
+        init;
+    }
+
+    prop DurationIsEmpty bool -> (Flags & 0x010000) == 0x010000
+    prop DefaultBaseIsMoof bool -> (Flags & 0x020000) == 0x020000
+    private prop OptionalFieldsSize int32 -> (if BaseDataOffsetPresent { 8 } else { 0 }) + (if SampleDescriptionIndexPresent { 4 } else { 0 }) + (if DefaultSampleDurationPresent { 4 } else { 0 }) + (if DefaultSampleSizePresent { 4 } else { 0 }) + (if DefaultSampleFlagsPresent { 4 } else { 0 })
+    private prop BaseDataOffsetPresent bool -> (Flags & 1) == 1
+    private prop SampleDescriptionIndexPresent bool -> (Flags & 2) == 2
+    private prop DefaultSampleDurationPresent bool -> (Flags & 8) == 8
+    private prop DefaultSampleSizePresent bool -> (Flags & 16) == 16
+    private prop DefaultSampleFlagsPresent bool -> (Flags & 32) == 32
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.WriteUInt32BE(TrackID)
+        if BaseDataOffset.HasValue {
+            file.WriteInt64BE(BaseDataOffset.Value)
+        }
+        if SampleDescriptionIndex.HasValue {
+            file.WriteUInt32BE(SampleDescriptionIndex.Value)
+        }
+        if DefaultSampleDuration.HasValue {
+            file.WriteUInt32BE(DefaultSampleDuration.Value)
+        }
+        if DefaultSampleSize.HasValue {
+            file.WriteUInt32BE(DefaultSampleSize.Value)
+        }
+        if DefaultSampleFlags.HasValue {
+            file.WriteUInt32BE(DefaultSampleFlags.Value)
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/TkhdBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/TkhdBox.gs
@@ -1,0 +1,74 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class TkhdBox : HeaderBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        file.ReadUInt64BE()
+        Layer = file.ReadInt16BE()
+        AlternateGroup = file.ReadInt16BE()
+        Volume = file.ReadInt16BE()
+        Reserved3 = file.ReadUInt16BE()
+        Matrix = file.ReadBlock(4 * 9)
+        Width = file.ReadUInt32BE()
+        Height = file.ReadUInt32BE()
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(2 * 4) + int64(8) + int64(4 * 2) + int64(Matrix.Length) + int64(2 * 4)
+    prop TrackID uint32
+
+    prop Layer int16 {
+        get;
+        init;
+    }
+
+    prop AlternateGroup int16
+
+    prop Volume int16 {
+        get;
+        init;
+    }
+
+    prop Reserved3 uint16 {
+        get;
+        init;
+    }
+
+    prop Matrix []uint8 {
+        get;
+        init;
+    }
+
+    prop Width uint32 {
+        get;
+        init;
+    }
+
+    prop Height uint32 {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.WriteUInt64BE(0)
+        file.WriteInt16BE(Layer)
+        file.WriteInt16BE(AlternateGroup)
+        file.WriteInt16BE(Volume)
+        file.WriteUInt16BE(Reserved3)
+        file.Write(Matrix)
+        file.WriteUInt32BE(Width)
+        file.WriteUInt32BE(Height)
+    }
+
+    protected open override func ReadBeforeDuration(file Stream) {
+        TrackID = file.ReadUInt32BE()
+        file.ReadUInt32BE()
+    }
+
+    protected open override func WriteBeforeDuration(file Stream) {
+        file.WriteUInt32BE(TrackID)
+        file.WriteUInt32BE(0)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/TrackedReadStream.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/TrackedReadStream.gs
@@ -1,0 +1,48 @@
+package Oahu.Decrypt.Mpeg4
+
+import System
+import System.IO
+
+open class TrackedReadStream(baseStream Stream, baseStreamLength int64) : Stream {
+    private var readPosition int64 = 0
+    prop CanRead bool -> this.baseStream.CanRead
+    prop CanSeek bool -> this.baseStream.CanSeek
+    prop Length int64 -> baseStreamLength
+    prop CanWrite bool -> this.baseStream.CanWrite
+
+    prop Position int64 {
+        get -> if CanSeek { this.baseStream.Position } else { readPosition }
+        set {
+            if !CanSeek {
+                throw NotSupportedException()
+            }
+            readPosition = value
+            this.baseStream.Position = readPosition
+        }
+    }
+
+    func Flush() {
+        throw NotSupportedException()
+    }
+
+    func Read(buffer []uint8, offset int32, count int32) int32 {
+        this.baseStream.ReadExactly(buffer, offset, count)
+        readPosition += int64(count)
+        return count
+    }
+
+    func Seek(offset int64, origin SeekOrigin) int64 {
+        return if CanSeek { this.baseStream.Seek(offset, origin) } else { throw NotSupportedException()
+            default(int64) }
+    }
+
+    func SetLength(value int64) -> this.baseStream.SetLength(value)
+    func Write(buffer []uint8, offset int32, count int32) -> this.baseStream.Write(buffer, offset, count)
+
+    protected func Dispose(disposing bool) {
+        if disposing {
+            this.baseStream.Dispose()
+        }
+        base.Dispose(disposing)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/TrackedWriteStream.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/TrackedWriteStream.gs
@@ -1,0 +1,48 @@
+package Oahu.Decrypt.Mpeg4
+
+import System
+import System.IO
+
+open class TrackedWriteStream(baseStream Stream, writePosition int64 = 0) : Stream {
+    prop CanRead bool -> false
+    prop CanSeek bool -> this.baseStream.CanSeek
+    prop Length int64 -> writePosition
+    prop CanWrite bool -> this.baseStream.CanWrite
+
+    prop Position int64 {
+        get -> if CanSeek { this.baseStream.Position } else { writePosition }
+        set {
+            if !CanSeek {
+                throw NotSupportedException()
+            }
+            this.baseStream.Position = value
+        }
+    }
+
+    func Flush() -> this.baseStream.Flush()
+
+    func Read(buffer []uint8, offset int32, count int32) int32 {
+        throw NotSupportedException()
+    }
+
+    func Seek(offset int64, origin SeekOrigin) int64 {
+        return if CanSeek { this.baseStream.Seek(offset, origin) } else { throw NotSupportedException()
+            default(int64) }
+    }
+
+    func SetLength(value int64) {
+        throw NotSupportedException()
+    }
+
+    func Write(buffer []uint8, offset int32, count int32) {
+        this.baseStream.Write(buffer, offset, count)
+        writePosition += int64(count)
+    }
+
+    protected func Dispose(disposing bool) {
+        if disposing {
+            this.baseStream.Dispose()
+        }
+        base.Dispose(disposing)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/TrafBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/TrafBox.gs
@@ -1,0 +1,20 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+
+open class TrafBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        LoadChildren(file)
+    }
+
+    prop Tfhd TfhdBox -> GetChildOrThrow[TfhdBox]()
+    prop Tfdt TfdtBox? -> GetChild[TfdtBox]()
+    prop Trun TrunBox? -> GetChild[TrunBox]()
+    prop Saiz SaizBox? -> GetChild[SaizBox]()
+    prop Saio SaioBox? -> GetChild[SaioBox]()
+    prop Senc SencBox? -> GetChild[SencBox]()
+
+    protected open override func Render(file Stream) {
+        return
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/TrakBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/TrakBox.gs
@@ -1,0 +1,16 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+
+open class TrakBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        LoadChildren(file)
+    }
+
+    prop Tkhd TkhdBox -> GetChildOrThrow[TkhdBox]()
+    prop Mdia MdiaBox -> GetChildOrThrow[MdiaBox]()
+
+    protected open override func Render(file Stream) {
+        return
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/TrefBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/TrefBox.gs
@@ -1,0 +1,74 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.Collections.Generic
+import System.Diagnostics
+import System.IO
+import System.Linq
+import Oahu.Decrypt.Mpeg4.Util
+
+interface ITrackReferenceTypeBox : IBox {
+    prop TrackIds HashSet[uint32]
+}
+
+open class TrefBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        References = List[ITrackReferenceTypeBox]()
+        while RemainingBoxLength(file) > int64(0) {
+            References.Add(TrackReferenceTypeBox(file, this))
+        }
+    }
+
+    private init(parent IBox) : base(BoxHeader(8, "tref"), parent) {
+        References = List[ITrackReferenceTypeBox]()
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + References.Sum((r ITrackReferenceTypeBox) -> r.RenderSize)
+
+    prop References List[ITrackReferenceTypeBox] {
+        get;
+        init;
+    }
+
+    func AddReference(type_ string, trackIds HashSet[uint32]) TrefBox {
+        References.Add(TrackReferenceTypeBox(type_, trackIds, this))
+        return this
+    }
+
+    protected open override func Render(file Stream) {
+        for box in References {
+            box!!.Save(file)
+        }
+    }
+
+    @DebuggerDisplay("{Header.Type,nq}, {TrackIds}")
+    private open class TrackReferenceTypeBox : Box, ITrackReferenceTypeBox {
+        init(file Stream, parent IBox?) : base(BoxHeader(file), parent) {
+            let numTraks = int32(RemainingBoxLength(file)) / 4
+            TrackIds = HashSet[uint32](numTraks)
+            for var i = 0; i < numTraks; i++ {
+                TrackIds.Add(file.ReadUInt32BE())
+            }
+        }
+
+        init(type_ string, trackIds HashSet[uint32], parent IBox) : base(BoxHeader(12, type_), parent) {
+            TrackIds = trackIds
+        }
+
+        open override prop RenderSize int64 -> base.RenderSize + int64(4 * TrackIds.Count)
+        prop TrackIds HashSet[uint32]
+
+        protected open override func Render(file Stream) {
+            for id in TrackIds {
+                file.WriteUInt32BE(id)
+            }
+        }
+    }
+
+    shared {
+        func CreatEmpty(parent IBox) TrefBox {
+            let tref = TrefBox(parent)
+            parent.Children.Add(tref!!)
+            return tref!!
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/TrunBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/TrunBox.gs
@@ -1,0 +1,77 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class TrunBox : FullBox {
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        let sampleCount = file.ReadUInt32BE()
+        if DataOffsetPresent {
+            DataOffset = file.ReadInt32BE()
+        }
+        if FirstSampleFlagsPresent {
+            FirstSampleFlags = file.ReadUInt32BE()
+        }
+        Samples = [int32(sampleCount)]SampleInfo
+        for var i = 0; int64(i) < int64(sampleCount); i++ {
+            let sampleDuration uint32? = if SampleDurationPresent { file.ReadUInt32BE() } else { nil }
+            let sampleSize int32? = if SampleSizePresent { file.ReadInt32BE() } else { nil }
+            let sampleFlags uint32? = if SampleFlagsPresent { file.ReadUInt32BE() } else { nil }
+            let sampleCompositionTimeOffset int32? = if SampleCompositionTimeOffsetsPresent { file.ReadInt32BE() } else { nil }
+            Samples[i] = SampleInfo(sampleDuration, sampleSize, sampleFlags, sampleCompositionTimeOffset)
+        }
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(4) + int64((if DataOffsetPresent { 4 } else { 0 })) + int64((if FirstSampleFlagsPresent { 4 } else { 0 })) + int64(SampleInfoSize * Samples.Length)
+
+    prop DataOffset int32 {
+        get;
+        init;
+    }
+
+    prop FirstSampleFlags uint32 {
+        get;
+        init;
+    }
+
+    prop Samples []SampleInfo {
+        get;
+        init;
+    }
+
+    prop SampleDurationPresent bool -> (Flags & 0x100) == 0x100
+    prop SampleSizePresent bool -> (Flags & 0x200) == 0x200
+    private prop DataOffsetPresent bool -> (Flags & 1) == 1
+    private prop FirstSampleFlagsPresent bool -> (Flags & 4) == 4
+    private prop SampleFlagsPresent bool -> (Flags & 0x400) == 0x400
+    private prop SampleCompositionTimeOffsetsPresent bool -> (Flags & 0x800) == 0x800
+    private prop SampleInfoSize int32 -> (if SampleDurationPresent { 4 } else { 0 }) + (if SampleSizePresent { 4 } else { 0 }) + (if SampleFlagsPresent { 4 } else { 0 }) + (if SampleCompositionTimeOffsetsPresent { 4 } else { 0 })
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.WriteInt32BE(Samples.Length)
+        if DataOffsetPresent {
+            file.WriteInt32BE(DataOffset)
+        }
+        if FirstSampleFlagsPresent {
+            file.WriteUInt32BE(FirstSampleFlags)
+        }
+        for var i = 0; i < Samples.Length; i++ {
+            if SampleDurationPresent {
+                file.WriteUInt32BE(Samples[i].SampleDuration ?? uint32(0))
+            }
+            if SampleSizePresent {
+                file.WriteInt32BE(Samples[i].SampleSize ?? 0)
+            }
+            if SampleFlagsPresent {
+                file.WriteUInt32BE(Samples[i].SampleFlags ?? uint32(0))
+            }
+            if SampleCompositionTimeOffsetsPresent {
+                file.WriteInt32BE(Samples[i].SampleCompositionTimeOffset ?? 0)
+            }
+        }
+    }
+
+    class SampleInfo(SampleDuration uint32?, SampleSize int32?, SampleFlags uint32?, SampleCompositionTimeOffset int32?) {
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/UdtaBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/UdtaBox.gs
@@ -1,0 +1,24 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+
+open class UdtaBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        LoadChildren(file)
+    }
+
+    private init(parent IBox) : base(BoxHeader(8, "udta"), parent) {
+    }
+
+    protected open override func Render(file Stream) {
+        return
+    }
+
+    shared {
+        func CreateEmpty(parent IBox) UdtaBox {
+            let udata = UdtaBox(parent)
+            parent.Children.Add(udata!!)
+            return udata!!
+        }
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/UnknownBox.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/UnknownBox.gs
@@ -1,0 +1,25 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class UnknownBox : Box {
+    init(file Stream, header BoxHeader, parent IBox?) : base(header, parent) {
+        Data = file.ReadBlock(int32((Header.TotalBoxSize - int64(header.HeaderSize))))
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(Data.Length)
+
+    prop Data []uint8 {
+        get;
+        init;
+    }
+
+    func ToString() string {
+        return nameof(UnknownBox) + "-" + Header.Type
+    }
+
+    protected open override func Render(file Stream) {
+        file.Write(Data)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/UnknownDescriptor.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/UnknownDescriptor.gs
@@ -1,0 +1,18 @@
+package Oahu.Decrypt.Mpeg4.Descriptors
+
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+class UnknownDescriptor : BaseDescriptor {
+    private let blob []uint8
+
+    init(file Stream, header DescriptorHeader) : base(file, header) {
+        blob = file.ReadBlock(Header.TotalBoxSize - Header.HeaderSize)
+    }
+
+    override prop InternalSize int32 -> base.InternalSize + blob.Length
+
+    override func Render(file Stream) {
+        file.Write(blob)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/UnknownFrame.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/UnknownFrame.gs
@@ -1,0 +1,21 @@
+package Oahu.Decrypt.Mpeg4.ID3
+
+import System.IO
+import System.Text
+
+class UnknownFrame : Frame {
+    init(file Stream, header Header, parent Frame) : base(header, parent) {
+        Blob = [header.Size]uint8
+        file.ReadExactly(Blob)
+    }
+
+    override prop Size int32 -> Blob.Length
+
+    prop Blob []uint8 {
+        get;
+        init;
+    }
+
+    prop DataText string -> if Blob.Length == 0 { "" } else { (if Blob[0] == uint8(0) { Encoding.ASCII } else { Encoding.Unicode }).GetString(Blob, 1, Blob.Length - 1) }
+    override func Render(file Stream) -> file.Write(Blob)
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/VideoPassthrough.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/VideoPassthrough.gs
@@ -1,0 +1,14 @@
+package Oahu.Decrypt.FrameFilters.Video
+
+import System.Threading.Tasks
+
+internal open class VideoPassthrough : FrameFinalBase[FrameEntry] {
+    protected open override prop InputBufferSize int32 -> 1
+
+    open override func AddInputAsync(input FrameEntry) Task {
+        return Task.CompletedTask
+    }
+
+    protected open override func FlushAsync() Task -> Task.CompletedTask
+    protected open override func PerformFilteringAsync(input FrameEntry) Task -> Task.CompletedTask
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/VisualSampleEntry.gs
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/VisualSampleEntry.gs
@@ -1,0 +1,92 @@
+package Oahu.Decrypt.Mpeg4.Boxes
+
+import System
+import System.IO
+import Oahu.Decrypt.Mpeg4.Util
+
+open class VisualSampleEntry : SampleEntry {
+    private let preDefined1 []uint8
+    private let reserved []uint8
+    private let preDefined2 []uint8
+    private let reserved2 []uint8
+    private let preDefined3 []uint8
+
+    init(file Stream, header BoxHeader, parent IBox?) : base(file, header, parent) {
+        preDefined1 = file.ReadBlock(2)
+        reserved = file.ReadBlock(2)
+        preDefined2 = file.ReadBlock(4 * 3)
+        Width = file.ReadUInt16BE()
+        Height = file.ReadUInt16BE()
+        HorizontalResolution = file.ReadUInt32BE()
+        VerticalResolution = file.ReadUInt32BE()
+        reserved2 = file.ReadBlock(4)
+        FrameCount = file.ReadUInt16BE()
+        let compressorNameBytes = file.ReadBlock(32)
+        let displaySize = compressorNameBytes!![0]
+        if displaySize > uint8(31) {
+            throw InvalidOperationException("Compressor name must be 31 characters or fewer.")
+        }
+        CompressorName = System.Text.Encoding.UTF8.GetString(compressorNameBytes!!, 1, displaySize)
+        Depth = file.ReadUInt16BE()
+        preDefined3 = file.ReadBlock(2)
+    }
+
+    open override prop RenderSize int64 -> base.RenderSize + int64(preDefined1.Length) + int64(reserved.Length) + int64(preDefined2.Length) + int64(2 * 4) + int64(4 * 2) + int64(reserved2.Length) + int64(preDefined3.Length) + int64(32)
+
+    prop Width uint16 {
+        get;
+        init;
+    }
+
+    prop Height uint16 {
+        get;
+        init;
+    }
+
+    prop HorizontalResolution uint32 {
+        get;
+        init;
+    }
+
+    prop VerticalResolution uint32 {
+        get;
+        init;
+    }
+
+    prop FrameCount uint16 {
+        get;
+        init;
+    }
+
+    prop CompressorName string {
+        get;
+        init;
+    }
+
+    prop Depth uint16 {
+        get;
+        init;
+    }
+
+    protected open override func Render(file Stream) {
+        base.Render(file)
+        file.Write(preDefined1)
+        file.Write(reserved)
+        file.Write(preDefined2)
+        file.WriteUInt16BE(Width)
+        file.WriteUInt16BE(Height)
+        file.WriteUInt32BE(HorizontalResolution)
+        file.WriteUInt32BE(VerticalResolution)
+        file.Write(reserved2)
+        file.WriteUInt16BE(FrameCount)
+        let compressorNameBytes = [32]uint8
+        if CompressorName.Length > 31 {
+            throw InvalidOperationException("Compressor name must be 31 characters or fewer.")
+        }
+        compressorNameBytes!![0] = uint8(CompressorName.Length)
+        System.Text.Encoding.UTF8.GetBytes(CompressorName, 0, CompressorName.Length, compressorNameBytes!!, 1)
+        file.Write(compressorNameBytes!!)
+        file.WriteUInt16BE(Depth)
+        file.Write(preDefined3)
+    }
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/compile-7b77e7aaf7d9.json
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/corpus_Oahu.Decrypt/compile-7b77e7aaf7d9.json
@@ -1,0 +1,36 @@
+{
+  "schemaVersion": "1.0",
+  "runId": "2026-06-30T00-14-43Z_dda962",
+  "timestamp": "2026-06-30T00:14:43Z",
+  "gscVersion": "0.2.365+10dca37a05",
+  "corpusAppId": "corpus/Oahu.Decrypt",
+  "stage": "compile",
+  "category": "compile-error",
+  "diagnostic": {
+    "id": "GS9998",
+    "message": "NotSupportedException: TypeBuilder generic instantiation does not support resolving members. Use TypeBuilder.GetConstructor instead.",
+    "severity": "error"
+  },
+  "sourceLocation": {
+    "gsFile": "corpus_Oahu.Decrypt/Mp4File.gs",
+    "gsLine": 45,
+    "gsColumn": 121,
+    "csFile": null,
+    "csLine": null,
+    "csColumn": null
+  },
+  "offendingCSharpConstruct": {
+    "kind": "LetConstruct",
+    "snippet": "let operation = Mp4Operation((t CancellationTokenSource) -> SaveAsync(keepMoovInFront, tracker, t.Token), this, (t Task) -> {"
+  },
+  "suggestedIssue": {
+    "title": "[cs2gs] GS9998 compiling translated corpus/Oahu.Decrypt (LetConstruct)",
+    "body": "The G# emitted for **corpus/Oahu.Decrypt** fails to compile with `gsc` 0.2.365+10dca37a05.\n\n- Diagnostic: `GS9998` — NotSupportedException: TypeBuilder generic instantiation does not support resolving members. Use TypeBuilder.GetConstructor instead.\n- Emitted G#: `corpus_Oahu.Decrypt/Mp4File.gs` (45,121)\n- Offending line: `let operation = Mp4Operation((t CancellationTokenSource) -> SaveAsync(keepMoovInFront, tracker, t.Token), this, (t Task) -> {`\n\n**Reproduction:** `cs2gs migrate` translates the corpus app, writes the `.gs` shown above, then runs `gsc /target:… /out:… corpus_Oahu.Decrypt/Mp4File.gs` which surfaces this error.\n**Fingerprint:** `sha256:7b77e7aaf7d9bb58831daf5803511b22506b23838d3f7e52eeec6f18a7780da4`",
+    "labels": [
+      "Oats",
+      "bug"
+    ]
+  },
+  "fingerprint": "sha256:7b77e7aaf7d9bb58831daf5803511b22506b23838d3f7e52eeec6f18a7780da4",
+  "retryHistory": []
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/report.html
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/report.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>cs2gs report — 2026-06-30T00-14-43Z_dda962</title>
+<style>
+:root{--ok:#1a7f37;--bad:#cf222e;--skip:#6e7781;--bg:#ffffff;--fg:#1f2328;--line:#d0d7de;--panel:#f6f8fa;}
+*{box-sizing:border-box;}
+body{margin:0;padding:1.5rem;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;color:var(--fg);background:var(--bg);line-height:1.45;}
+h1{font-size:1.5rem;margin:0 0 .25rem;}
+h2{font-size:1.2rem;margin:2rem 0 .75rem;border-bottom:1px solid var(--line);padding-bottom:.25rem;}
+h3{font-size:1rem;margin:0 0 .5rem;}
+a{color:#0969da;}
+.run-header .verdict{display:inline-block;font-weight:700;padding:.15rem .6rem;border-radius:999px;color:#fff;}
+.verdict.ok{background:var(--ok);} .verdict.bad{background:var(--bad);}
+.provenance{display:grid;grid-template-columns:max-content 1fr;gap:.15rem 1rem;margin:.75rem 0 0;}
+.provenance dt{font-weight:600;color:var(--skip);} .provenance dd{margin:0;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;}
+table{border-collapse:collapse;width:100%;}
+.matrix th,.matrix td{border:1px solid var(--line);padding:.4rem .6rem;text-align:left;}
+.matrix thead th{background:var(--panel);}
+.cell{font-weight:600;white-space:nowrap;}
+.cell .dot{display:inline-block;width:.65rem;height:.65rem;border-radius:50%;margin-right:.4rem;vertical-align:middle;}
+.cell.pass{color:var(--ok);} .cell.pass .dot{background:var(--ok);}
+.cell.fail{color:var(--bad);} .cell.fail .dot{background:var(--bad);}
+.cell.skip{color:var(--skip);} .cell.skip .dot{background:var(--skip);}
+.gap{border:1px solid var(--line);border-radius:6px;padding:1rem;margin:0 0 1rem;background:var(--panel);}
+.gap-meta{list-style:none;margin:0 0 .5rem;padding:0;display:flex;flex-wrap:wrap;gap:.35rem 1rem;}
+.gap-meta .k{font-weight:600;color:var(--skip);} .gap-meta .v{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;}
+.snippet,.issue-body{background:#0d1117;color:#e6edf3;padding:.6rem .8rem;border-radius:6px;overflow:auto;}
+.snippet code,.issue-body code{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;white-space:pre-wrap;}
+.labels{margin:.5rem 0;} .label{display:inline-block;background:#ddf4ff;color:#0969da;border:1px solid #54aeff66;border-radius:999px;padding:.05rem .55rem;font-size:.8rem;}
+.occurrences ul{margin:.25rem 0;padding-left:1.2rem;} .occurrences .app{font-weight:600;} .occurrences .loc{color:var(--skip);font-family:ui-monospace,monospace;}
+.retry th,.retry td{border:1px solid var(--line);padding:.25rem .5rem;text-align:left;font-size:.85rem;}
+.toggle{margin:.5rem 0;cursor:pointer;background:#fff;border:1px solid var(--line);border-radius:6px;padding:.3rem .7rem;font:inherit;}
+.app-detail{border:1px solid var(--line);border-radius:6px;padding:1rem;margin:0 0 1rem;}
+.state{font-size:.75rem;padding:.1rem .5rem;border-radius:999px;color:#fff;vertical-align:middle;}
+.state.ok{background:var(--ok);} .state.bad{background:var(--bad);}
+.stage-list th,.stage-list td{border:1px solid var(--line);padding:.3rem .6rem;text-align:left;}
+.meta-line .k,.artifact-h{font-weight:600;color:var(--skip);}
+.empty{color:var(--skip);}
+</style>
+</head>
+<body>
+<header class="run-header">
+<h1>cs2gs migration report</h1>
+<p class="verdict bad">Run FAILED — 0/1 apps green</p>
+<dl class="provenance">
+<dt>Run id</dt><dd>2026-06-30T00-14-43Z_dda962</dd>
+<dt>Timestamp</dt><dd>2026-06-30T00:14:43Z</dd>
+<dt>gsc version</dt><dd>0.2.365+10dca37a05</dd>
+</dl>
+</header>
+<section aria-labelledby="matrix-h">
+<h2 id="matrix-h">Status matrix</h2>
+<table class="matrix">
+<thead><tr><th scope="col">app</th><th scope="col">translate</th><th scope="col">compile</th><th scope="col">ilverify</th><th scope="col">test-parity</th></tr></thead>
+<tbody>
+<tr><th scope="row"><a href="#app-corpus-oahu-decrypt">corpus/Oahu.Decrypt</a></th><td class="cell pass" aria-label="passed"><span class="dot" aria-hidden="true"></span>PASS</td><td class="cell fail" aria-label="failed"><span class="dot" aria-hidden="true"></span>FAIL (1)</td><td class="cell skip" aria-label="skipped"><span class="dot" aria-hidden="true"></span>SKIP</td><td class="cell skip" aria-label="skipped"><span class="dot" aria-hidden="true"></span>SKIP</td></tr>
+</tbody>
+</table>
+</section>
+<section aria-labelledby="gaps-h">
+<h2 id="gaps-h">Discovered gaps (1)</h2>
+<article class="gap">
+<h3>[cs2gs] GS9998 compiling translated corpus/Oahu.Decrypt (LetConstruct)</h3>
+<ul class="gap-meta">
+<li><span class="k">fingerprint</span> <span class="v">sha256:7b77e7aaf7d9bb58831daf5803511b22506b23838d3f7e52eeec6f18a7780da4</span></li>
+<li><span class="k">category</span> <span class="v">compile-error</span></li>
+<li><span class="k">stage</span> <span class="v">compile</span></li>
+<li><span class="k">diagnostic</span> <span class="v">GS9998: NotSupportedException: TypeBuilder generic instantiation does not support resolving members. Use TypeBuilder.GetConstructor instead.</span></li>
+<li><span class="k">construct</span> <span class="v">LetConstruct</span></li>
+</ul>
+<pre class="snippet"><code>let operation = Mp4Operation((t CancellationTokenSource) -&gt; SaveAsync(keepMoovInFront, tracker, t.Token), this, (t Task) -&gt; {</code></pre>
+<p class="labels">labels: <span class="label">Oats</span> <span class="label">bug</span></p>
+<details class="occurrences" open><summary>1 occurrence(s)</summary>
+<ul>
+<li><span class="app">corpus/Oahu.Decrypt</span> <span class="loc">corpus_Oahu.Decrypt/Mp4File.gs:45:121</span></li>
+</ul>
+</details>
+<button type="button" class="toggle" aria-expanded="false" aria-controls="gap-body-0" data-target="gap-body-0">Suggested issue body</button>
+<pre id="gap-body-0" class="issue-body" hidden><code>The G# emitted for **corpus/Oahu.Decrypt** fails to compile with `gsc` 0.2.365+10dca37a05.
+
+- Diagnostic: `GS9998` — NotSupportedException: TypeBuilder generic instantiation does not support resolving members. Use TypeBuilder.GetConstructor instead.
+- Emitted G#: `corpus_Oahu.Decrypt/Mp4File.gs` (45,121)
+- Offending line: `let operation = Mp4Operation((t CancellationTokenSource) -&gt; SaveAsync(keepMoovInFront, tracker, t.Token), this, (t Task) -&gt; {`
+
+**Reproduction:** `cs2gs migrate` translates the corpus app, writes the `.gs` shown above, then runs `gsc /target:… /out:… corpus_Oahu.Decrypt/Mp4File.gs` which surfaces this error.
+**Fingerprint:** `sha256:7b77e7aaf7d9bb58831daf5803511b22506b23838d3f7e52eeec6f18a7780da4`</code></pre>
+</article>
+</section>
+<section aria-labelledby="apps-h">
+<h2 id="apps-h">App details</h2>
+<article id="app-corpus-oahu-decrypt" class="app-detail">
+<h3>corpus/Oahu.Decrypt <span class="state bad">failing</span></h3>
+<p class="meta-line"><span class="k">failure category</span> <span class="v">compile-error</span></p>
+<table class="stage-list"><thead><tr><th scope="col">stage</th><th scope="col">status</th><th scope="col">artifacts</th></tr></thead><tbody>
+<tr><td>translate</td><td>passed</td><td>0</td></tr>
+<tr><td>compile</td><td>failed</td><td>1</td></tr>
+<tr><td>ilverify</td><td>skipped</td><td>0</td></tr>
+<tr><td>test-parity</td><td>skipped</td><td>0</td></tr>
+</tbody></table>
+<p class="artifact-h">triage artifacts</p>
+<ul class="artifacts">
+<li><a href="corpus_Oahu.Decrypt/compile-7b77e7aaf7d9.json">corpus_Oahu.Decrypt/compile-7b77e7aaf7d9.json</a></li>
+</ul>
+</article>
+</section>
+<script>
+(function(){
+  var buttons = document.querySelectorAll('.toggle');
+  for (var i = 0; i < buttons.length; i++) {
+    buttons[i].addEventListener('click', function(){
+      var id = this.getAttribute('data-target');
+      var target = document.getElementById(id);
+      if (!target) { return; }
+      var hidden = target.hasAttribute('hidden');
+      if (hidden) { target.removeAttribute('hidden'); } else { target.setAttribute('hidden',''); }
+      this.setAttribute('aria-expanded', hidden ? 'true' : 'false');
+    });
+  }
+})();
+</script>
+</body>
+</html>

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/run.json
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/run.json
@@ -1,0 +1,42 @@
+{
+  "runId": "2026-06-30T00-14-43Z_dda962",
+  "timestamp": "2026-06-30T00:14:43Z",
+  "gscVersion": "0.2.365+10dca37a05",
+  "gscPath": "/Users/davidobando/GitHub/DavidObando/gsharp/.worktrees/fix-1446/out/bin/Release/Compiler/gsc.dll",
+  "succeeded": false,
+  "apps": [
+    {
+      "appId": "corpus/Oahu.Decrypt",
+      "succeeded": false,
+      "failureCategory": "compile-error",
+      "stages": [
+        {
+          "stage": "translate",
+          "status": "passed",
+          "artifactCount": 0
+        },
+        {
+          "stage": "compile",
+          "status": "failed",
+          "artifactCount": 1
+        },
+        {
+          "stage": "ilverify",
+          "status": "skipped",
+          "artifactCount": 0
+        },
+        {
+          "stage": "test-parity",
+          "status": "skipped",
+          "artifactCount": 0
+        }
+      ],
+      "artifacts": [
+        "corpus_Oahu.Decrypt/compile-7b77e7aaf7d9.json"
+      ],
+      "fingerprints": [
+        "sha256:7b77e7aaf7d9bb58831daf5803511b22506b23838d3f7e52eeec6f18a7780da4"
+      ]
+    }
+  ]
+}

--- a/cs2gs-runs/2026-06-30T00-14-43Z_dda962/summary.json
+++ b/cs2gs-runs/2026-06-30T00-14-43Z_dda962/summary.json
@@ -1,0 +1,87 @@
+{
+  "runId": "2026-06-30T00-14-43Z_dda962",
+  "timestamp": "2026-06-30T00:14:43Z",
+  "gscVersion": "0.2.365+10dca37a05",
+  "succeeded": false,
+  "totalApps": 1,
+  "greenApps": 0,
+  "stageOrder": [
+    "translate",
+    "compile",
+    "ilverify",
+    "test-parity"
+  ],
+  "apps": [
+    {
+      "appId": "corpus/Oahu.Decrypt",
+      "succeeded": false,
+      "failureCategory": "compile-error",
+      "stages": [
+        {
+          "stage": "translate",
+          "status": "passed",
+          "artifactCount": 0
+        },
+        {
+          "stage": "compile",
+          "status": "failed",
+          "artifactCount": 1
+        },
+        {
+          "stage": "ilverify",
+          "status": "skipped",
+          "artifactCount": 0
+        },
+        {
+          "stage": "test-parity",
+          "status": "skipped",
+          "artifactCount": 0
+        }
+      ],
+      "artifacts": [
+        "corpus_Oahu.Decrypt/compile-7b77e7aaf7d9.json"
+      ],
+      "fingerprints": [
+        "sha256:7b77e7aaf7d9bb58831daf5803511b22506b23838d3f7e52eeec6f18a7780da4"
+      ]
+    }
+  ],
+  "gaps": [
+    {
+      "fingerprint": "sha256:7b77e7aaf7d9bb58831daf5803511b22506b23838d3f7e52eeec6f18a7780da4",
+      "category": "compile-error",
+      "stage": "compile",
+      "diagnostic": {
+        "id": "GS9998",
+        "message": "NotSupportedException: TypeBuilder generic instantiation does not support resolving members. Use TypeBuilder.GetConstructor instead.",
+        "severity": "error"
+      },
+      "offendingCSharpConstruct": {
+        "kind": "LetConstruct",
+        "snippet": "let operation = Mp4Operation((t CancellationTokenSource) -> SaveAsync(keepMoovInFront, tracker, t.Token), this, (t Task) -> {"
+      },
+      "suggestedIssue": {
+        "title": "[cs2gs] GS9998 compiling translated corpus/Oahu.Decrypt (LetConstruct)",
+        "body": "The G# emitted for **corpus/Oahu.Decrypt** fails to compile with `gsc` 0.2.365+10dca37a05.\n\n- Diagnostic: `GS9998` — NotSupportedException: TypeBuilder generic instantiation does not support resolving members. Use TypeBuilder.GetConstructor instead.\n- Emitted G#: `corpus_Oahu.Decrypt/Mp4File.gs` (45,121)\n- Offending line: `let operation = Mp4Operation((t CancellationTokenSource) -> SaveAsync(keepMoovInFront, tracker, t.Token), this, (t Task) -> {`\n\n**Reproduction:** `cs2gs migrate` translates the corpus app, writes the `.gs` shown above, then runs `gsc /target:… /out:… corpus_Oahu.Decrypt/Mp4File.gs` which surfaces this error.\n**Fingerprint:** `sha256:7b77e7aaf7d9bb58831daf5803511b22506b23838d3f7e52eeec6f18a7780da4`",
+        "labels": [
+          "Oats",
+          "bug"
+        ]
+      },
+      "occurrences": [
+        {
+          "appId": "corpus/Oahu.Decrypt",
+          "sourceLocation": {
+            "gsFile": "corpus_Oahu.Decrypt/Mp4File.gs",
+            "gsLine": 45,
+            "gsColumn": 121,
+            "csFile": null,
+            "csLine": null,
+            "csColumn": null
+          }
+        }
+      ],
+      "retryHistory": []
+    }
+  ]
+}

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -597,6 +597,23 @@ internal sealed partial class ExpressionBinder
                 implicitField.StructType,
                 implicitField.Field);
         }
+        else if (variable is ImplicitPropertyVariableSymbol implicitPropReceiver
+            && implicitPropReceiver.Property.HasGetter)
+        {
+            // Issue #1446 (follow-up to #689/#1339): the property counterpart
+            // of the implicit-field case above. A bare instance-property name
+            // used as the *receiver* of a member write (`Prop.Member = v`,
+            // `Prop.Member++`) resolves to an ImplicitPropertyVariableSymbol,
+            // which likewise has no local slot. Synthesize `this.Prop` (a
+            // getter call) so the receiver carries a real BoundExpression —
+            // for a reference-typed property this yields the live object whose
+            // member the write then mutates, symmetric with the read path.
+            implicitFieldReceiverExpr = new BoundPropertyAccessExpression(
+                null,
+                new BoundVariableExpression(null, implicitPropReceiver.Receiver),
+                implicitPropReceiver.StructType,
+                implicitPropReceiver.Property);
+        }
 
         // Stream B: instance-CLR receiver → property/field write via reflection.
         if (variable.Type is not StructSymbol && variable.Type is not NullableTypeSymbol && variable.Type?.ClrType != null)

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -1440,6 +1440,41 @@ internal sealed partial class ExpressionBinder
             return new BoundBlockExpression(syntax, ImmutableArray.Create<BoundStatement>(declaration), assignment);
         }
 
+        // Issue #1446: the property counterpart of the implicit-field case
+        // above. A bare instance auto-property name resolves to an
+        // ImplicitPropertyVariableSymbol, which likewise has no local slot.
+        // Initialise a temp local from the property getter (for an array
+        // property this is the array reference, so the subsequent stelem
+        // mutates the underlying array), then do the indexed write to that
+        // real local. Mirrors the read-side property rebinding from #1339.
+        if (variable is ImplicitPropertyVariableSymbol implicitProp)
+        {
+            if (!implicitProp.Property.HasGetter)
+            {
+                Diagnostics.ReportCannotAssign(syntax.TargetIdentifier.Location, implicitProp.Property.Name);
+                return new BoundErrorExpression(null);
+            }
+
+            var propertyAccess = new BoundPropertyAccessExpression(
+                null,
+                new BoundVariableExpression(null, implicitProp.Receiver),
+                implicitProp.StructType,
+                implicitProp.Property);
+
+            var tempName = $"<idxAsn{System.Threading.Interlocked.Increment(ref binderCtx.SyntheticLocalCounter)}>";
+            var tempVar = new LocalVariableSymbol(tempName, isReadOnly: true, propertyAccess.Type);
+            scope.TryDeclareVariable(tempVar);
+            var declaration = new BoundVariableDeclaration(syntax, tempVar, propertyAccess);
+
+            var assignment = BindIndexedAssignmentToVariable(tempVar, syntax.Index, syntax.Value, syntax.TargetIdentifier.Location);
+            if (assignment is BoundErrorExpression)
+            {
+                return assignment;
+            }
+
+            return new BoundBlockExpression(syntax, ImmutableArray.Create<BoundStatement>(declaration), assignment);
+        }
+
         return BindIndexedAssignmentToVariable(variable, syntax.Index, syntax.Value, syntax.TargetIdentifier.Location);
     }
 

--- a/test/Compiler.Tests/Emit/Issue1446PropertyIndexAssignEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1446PropertyIndexAssignEmitTests.cs
@@ -1,0 +1,160 @@
+// <copyright file="Issue1446PropertyIndexAssignEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1446 — writing to an array element through a bare instance
+/// auto-property (<c>Prop[i] = v</c>) crashed emission with GS9998
+/// "Variable 'Prop' has no local slot or parameter index in the current
+/// method." The bare property name resolved to an
+/// <c>ImplicitPropertyVariableSymbol</c>, which (unlike the implicit-field
+/// case from #674) had no special handling in <c>BindIndexAssignmentExpression</c>
+/// and fell through to a bare-variable load. The fix initialises a temp local
+/// from the property getter (the array reference) and stores into that.
+/// </summary>
+public class Issue1446PropertyIndexAssignEmitTests
+{
+    [Fact]
+    public void EndToEnd_InitArrayPropertyElementWriteInCtor_Runs()
+    {
+        var source = """
+            package Probe1446a
+            import System
+
+            open class Holder1446a {
+                init() {
+                    Items = [3]int32
+                    Items[0] = 10
+                    Items[1] = 20
+                    Items[2] = 30
+                }
+                prop Items []int32 { get; init; }
+            }
+
+            func Main() {
+                let h = Holder1446a()
+                Console.WriteLine(h.Items[0] + h.Items[1] + h.Items[2])
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("60\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_MutableArrayPropertyElementWriteInMethod_Runs()
+    {
+        var source = """
+            package Probe1446b
+            import System
+
+            open class Holder1446b {
+                prop Data []string { get; set; }
+                func Fill() {
+                    Data = [2]string
+                    Data[0] = "a"
+                    Data[1] = "b"
+                }
+            }
+
+            func Main() {
+                let h = Holder1446b()
+                h.Fill()
+                Console.WriteLine(h.Data[0] + h.Data[1])
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("ab\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1446_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue1448PropertyReceiverMemberAssignEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1448PropertyReceiverMemberAssignEmitTests.cs
@@ -1,0 +1,170 @@
+// <copyright file="Issue1448PropertyReceiverMemberAssignEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1448 — writing to a member through a bare instance-property receiver
+/// (<c>Prop.Member = v</c>, <c>Prop.Member++</c>) crashed emission with GS9998
+/// "Variable 'Prop' has no local slot or parameter index in the current
+/// method." A bare property receiver resolved to an
+/// <c>ImplicitPropertyVariableSymbol</c>, but <c>BindFieldAssignmentExpression</c>
+/// synthesized an expression receiver only for the implicit-field case (#689).
+/// The fix synthesizes <c>this.Prop</c> (a getter call) as the member-write
+/// receiver, mirroring the implicit-field handling and the read-side fix #1339.
+/// </summary>
+public class Issue1448PropertyReceiverMemberAssignEmitTests
+{
+    [Fact]
+    public void EndToEnd_MemberAssignAndIncrementThroughComputedProperty_Runs()
+    {
+        var source = """
+            package Probe1448a
+            import System
+
+            open class Inner1448a {
+                prop NextTrackID int32 { get; set; }
+            }
+
+            open class Outer1448a {
+                private let innerField Inner1448a
+                init() { innerField = Inner1448a() }
+                prop Mvhd Inner1448a -> innerField
+
+                func Bump() {
+                    Mvhd.NextTrackID = 5
+                    Mvhd.NextTrackID++
+                }
+            }
+
+            func Main() {
+                let o = Outer1448a()
+                o.Bump()
+                Console.WriteLine(o.Mvhd.NextTrackID)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("6\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_MemberAssignThroughAutoProperty_Runs()
+    {
+        var source = """
+            package Probe1448b
+            import System
+
+            open class Leaf1448b {
+                prop Value string { get; set; }
+            }
+
+            open class Root1448b {
+                init() { Child = Leaf1448b() }
+                prop Child Leaf1448b { get; init; }
+
+                func SetIt() {
+                    Child.Value = "hello"
+                }
+            }
+
+            func Main() {
+                let r = Root1448b()
+                r.SetIt()
+                Console.WriteLine(r.Child.Value)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("hello\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1448_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Two sibling emit crashes where a **bare instance auto-property used in a write
position** had no local slot, crashing emission with
`GS9998: Variable '<Prop>' has no local slot or parameter index`. The bare
property name resolves to an `ImplicitPropertyVariableSymbol`, which only had
write-path handling for the implicit-*field* case (#674/#689). The read-side was
already fixed in #1339; these are the two write-side counterparts.

### Fixes #1446 — array-element write through a property (`Prop[i] = v`)

`BindIndexAssignmentExpression` only special-cased `ImplicitFieldVariableSymbol`.
Now initialises a temp local from the property getter (the array reference, so
the subsequent `stelem` mutates the underlying array), then does the indexed
write to that real local.

### Fixes #1448 — member write through a property receiver (`Prop.Member = v`, `Prop.Member++`)

`BindFieldAssignmentExpression` synthesized an expression receiver only for the
implicit-field case. Now synthesizes `this.Prop` (a getter call) as the
member-write receiver; for a reference-typed property this yields the live
object whose member the write then mutates.

Both mirror the existing implicit-field handling and the read-side property
rebinding from #1339, generalised to any array-typed / reference-typed instance
property.

## Tests

- `Issue1446PropertyIndexAssignEmitTests` — `init` and `get;set;` array-property
  element writes (compile + IL-verify + run).
- `Issue1448PropertyReceiverMemberAssignEmitTests` — member assign + increment
  through computed and auto properties (compile + IL-verify + run).

Core.Tests: 4788 pass.

## Impact

Each crash previously bailed the whole Oahu.Decrypt compilation, masking all
other per-file diagnostics (`Dec3Box` `IndependentSubstream[i] = …`;
`MoovBox.CreateEmptyTextTrack` `Mvhd.NextTrackID = …` / `++`).

Fixes #1446
Fixes #1448

Refs #914
