### PR TITLE
Fix GS9998 emitting delegate ctor over a constructed-generic delegate type (#1449)

### DIFF
--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Closures.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Closures.cs
@@ -80,14 +80,12 @@ internal sealed partial class MethodBodyEmitter
         var sourceInvoke = sourceDelegateType.GetMethod("Invoke")
             ?? throw new InvalidOperationException(
                 $"Delegate type '{sourceDelegateType.FullName}' has no Invoke method.");
-        var targetCtor = targetDelegateType.GetConstructors()[0];
-
         this.EmitExpression(source);
         this.il.OpCode(ILOpCode.Dup);
         this.il.OpCode(ILOpCode.Ldvirtftn);
         this.il.Token(this.outer.GetMethodReference(sourceInvoke));
         this.il.OpCode(ILOpCode.Newobj);
-        this.il.Token(this.outer.GetCtorReference(targetCtor));
+        this.il.Token(this.outer.GetDelegateCtorReference(targetDelegateType));
     }
 
     /// <summary>
@@ -453,8 +451,7 @@ internal sealed partial class MethodBodyEmitter
             else
             {
                 var delegateTypeC = overrideDelegateType ?? this.outer.ResolveDelegateClrType(literal.FunctionType);
-                var delegateCtorC = delegateTypeC.GetConstructors()[0];
-                this.il.Token(this.outer.GetCtorReference(delegateCtorC));
+                this.il.Token(this.outer.GetDelegateCtorReference(delegateTypeC));
             }
 
             return;
@@ -490,8 +487,7 @@ internal sealed partial class MethodBodyEmitter
         else
         {
             var delegateType = overrideDelegateType ?? this.outer.ResolveDelegateClrType(literal.FunctionType);
-            var delegateCtor = delegateType.GetConstructors()[0];
-            this.il.Token(this.outer.GetCtorReference(delegateCtor));
+            this.il.Token(this.outer.GetDelegateCtorReference(delegateType));
         }
     }
 
@@ -572,8 +568,7 @@ internal sealed partial class MethodBodyEmitter
         }
         else
         {
-            var delegateCtor = delegateType.GetConstructors()[0];
-            this.il.Token(this.outer.GetCtorReference(delegateCtor));
+            this.il.Token(this.outer.GetDelegateCtorReference(delegateType));
         }
     }
 
@@ -595,7 +590,6 @@ internal sealed partial class MethodBodyEmitter
                 $"CLR method group '{methodGroup.MethodName}' has no resolved target delegate type.");
 
         var delegateType = this.outer.ResolveTargetDelegateClrType(hostDelegate);
-        var delegateCtor = delegateType.GetConstructors()[0];
         var methodRef = this.outer.GetMethodReference(method);
 
         if (method.IsStatic)
@@ -637,7 +631,7 @@ internal sealed partial class MethodBodyEmitter
         }
 
         this.il.OpCode(ILOpCode.Newobj);
-        this.il.Token(this.outer.GetCtorReference(delegateCtor));
+        this.il.Token(this.outer.GetDelegateCtorReference(delegateType));
     }
 
     // Phase 4 emit parity: load a captured variable. In a MoveNext body,

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -8675,6 +8675,49 @@ internal sealed class ReflectionMetadataEmitter
     }
 
     /// <summary>
+    /// Issue #1449: Gets a MemberRef for a delegate's canonical
+    /// <c>(object, IntPtr)</c> constructor in a TypeBuilder-safe way.
+    /// <para>
+    /// Calling <see cref="Type.GetConstructors()"/> on a constructed generic
+    /// delegate type (e.g. <c>Func&lt;…&gt;</c> / <c>Action&lt;…&gt;</c>) that
+    /// is realized as a reflection-emit <c>TypeBuilderInstantiation</c> throws
+    /// <see cref="NotSupportedException"/> ("TypeBuilder generic instantiation
+    /// does not support resolving members. Use TypeBuilder.GetConstructor
+    /// instead."). This happens both when a type argument is a
+    /// <see cref="TypeBuilder"/> closed in the same compilation (#671) and when
+    /// the instantiation is constructed against the in-progress assembly even
+    /// though every type argument is a runtime type (#1449). In either case the
+    /// MemberRef is built from the open generic definition's canonical ctor
+    /// signature parented at the constructed-generic TypeSpec instead.
+    /// </para>
+    /// </summary>
+    /// <param name="delegateType">The (possibly constructed-generic) delegate CLR type.</param>
+    /// <returns>A MemberRef handle for the delegate's <c>(object, IntPtr)</c> constructor.</returns>
+    internal MemberReferenceHandle GetDelegateCtorReference(Type delegateType)
+    {
+        if (delegateType.IsConstructedGenericType)
+        {
+            ConstructorInfo ctor;
+            try
+            {
+                ctor = delegateType.GetConstructors()[0];
+            }
+            catch (NotSupportedException)
+            {
+                // Reflection-emit limitation: GetConstructors() throws on a
+                // generic delegate realized as a TypeBuilderInstantiation. Build
+                // the MemberRef from the open definition's canonical
+                // (object, IntPtr) delegate ctor parented at the TypeSpec.
+                return this.GetCtorReferenceOnConstructedGeneric(delegateType, paramCount: 2);
+            }
+
+            return this.GetCtorReference(ctor);
+        }
+
+        return this.GetCtorReference(delegateType.GetConstructors()[0]);
+    }
+
+    /// <summary>
     /// Issue #649: Gets the TypeSpec handle for a <c>ValueTuple&lt;...&gt;</c> whose element
     /// types include G#-defined types (StructSymbol) that lack a CLR backing type.
     /// Encodes each element type via <see cref="EncodeTypeSymbol"/> so user-defined types

--- a/test/Compiler.Tests/Emit/Issue1449DelegateCtorOverTypeBuilderEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1449DelegateCtorOverTypeBuilderEmitTests.cs
@@ -1,0 +1,199 @@
+// <copyright file="Issue1449DelegateCtorOverTypeBuilderEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1449 — emitting a function-literal event handler whose delegate type
+/// is a constructed generic (<c>Action&lt;object, EventArgs&gt;</c>) crashed
+/// with GS9998 "NotSupportedException: TypeBuilder generic instantiation does
+/// not support resolving members." The delegate's CLR type is realized as a
+/// reflection-emit <c>TypeBuilderInstantiation</c> (the event sender slot is a
+/// host-runtime <c>object</c> while the <c>EventArgs</c> argument is loaded
+/// through the reference <see cref="System.Reflection.MetadataLoadContext"/>),
+/// so calling <c>GetConstructors()</c> on it throws. The emitter now resolves
+/// the delegate's canonical <c>(object, IntPtr)</c> constructor from the open
+/// generic definition instead.
+/// <para>
+/// Reproducing the crash requires compiling with explicit reference assemblies
+/// so the BCL types flow through a MetadataLoadContext (matching how gsc is
+/// driven in real builds); the in-process default reference set resolves every
+/// type to a host runtime type and never produces the mixed-context
+/// instantiation. The tests therefore pass the host shared framework as
+/// <c>/r:</c> references.
+/// </para>
+/// </summary>
+public class Issue1449DelegateCtorOverTypeBuilderEmitTests
+{
+    [Fact]
+    public void EndToEnd_NonCapturingEventHandlerLambda_Runs()
+    {
+        // Action<object, EventArgs>-shaped delegate ctor over a
+        // TypeBuilderInstantiation, no-capture closure branch.
+        var source = """
+            package Issue1449NoCapture
+            import System
+
+            class Notifier1449NC {
+                event Updated (object?, EventArgs) -> void
+
+                func Raise() {
+                    Updated?(this, EventArgs())
+                }
+            }
+
+            func Main() {
+                let n = Notifier1449NC()
+                n.Updated += (s object?, e EventArgs) -> Console.WriteLine("handled")
+                n.Raise()
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("handled\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_CapturingEventHandlerLambda_Runs()
+    {
+        // Same constructed-generic delegate ctor, but the handler captures an
+        // outer variable so it flows through the capture-bearing closure
+        // branch.
+        var source = """
+            package Issue1449Capture
+            import System
+
+            class Counter1449C {
+                var total int32 = 0
+            }
+
+            class Notifier1449C {
+                event Updated (object?, EventArgs) -> void
+
+                func Raise() {
+                    Updated?(this, EventArgs())
+                }
+            }
+
+            func Main() {
+                let c = Counter1449C()
+                let n = Notifier1449C()
+                n.Updated += (s object?, e EventArgs) -> Console.WriteLine(c.total + 5)
+                n.Raise()
+                n.Raise()
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("5\n5\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1449_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            // Issue #1449 only reproduces when BCL types are resolved through a
+            // MetadataLoadContext (engaged by passing explicit /r: references),
+            // which is how gsc is invoked in real builds. Reference the host
+            // shared framework so EventArgs is an MLC type while the event
+            // sender stays a host-runtime object — the mixed-context
+            // instantiation that produced the original crash.
+            var runtimeDir = RuntimeEnvironment.GetRuntimeDirectory();
+            var args = new List<string>
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+            };
+            foreach (var refDll in Directory.GetFiles(runtimeDir, "*.dll"))
+            {
+                args.Add("/r:" + refDll);
+            }
+
+            args.Add(srcPath);
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Root cause

`gsc` crashed with `NotSupportedException: TypeBuilder generic instantiation does not support resolving members. Use TypeBuilder.GetConstructor instead.` (surfaced as `GS9998`) when emitting a `newobj` for a delegate whose CLR type is a **constructed generic** (`Func<...>` / `Action<...>`) that reflection-emit realizes as a `TypeBuilderInstantiation`. The closure / event-subscription emit paths in `MethodBodyEmitter.Closures.cs` resolved the delegate ctor via `delegateType.GetConstructors()[0]`, which throws on such a type.

The real-world trigger (Oahu.Decrypt `Mp4File`) is a user event typed `(object?, EventArgs) -> void`. Its synthesized `Action<object, EventArgs>` mixes a **host runtime** `object` with an **MLC-loaded** `EventArgs` when reference assemblies are supplied (`/r:`), so `MakeGenericType` yields a `TypeBuilderInstantiation` *even though no type argument is itself a `TypeBuilder`*. The existing `ContainsTypeBuilderGenericArgument` guard inspects only generic args for `is TypeBuilder`, so it missed this case.

## Fix

Add a TypeBuilder-safe `GetDelegateCtorReference(Type)` helper in `ReflectionMetadataEmitter`. For constructed-generic delegate types it attempts `GetConstructors()` and, on `NotSupportedException`, falls back to building the MemberRef from the open definition's canonical `(object, IntPtr)` delegate-ctor signature parented at the constructed-generic TypeSpec (`GetCtorReferenceOnConstructedGeneric`). All five delegate-ctor `newobj` sites in `MethodBodyEmitter.Closures.cs` now route through it. Surgical, with no behavior change for non-generic / runtime-only delegate types.

## Tests

`test/Compiler.Tests/Emit/Issue1449DelegateCtorOverTypeBuilderEmitTests.cs`:
- `EndToEnd_NonCapturingEventHandlerLambda_Runs` — `Action`-shaped event handler, non-capturing.
- `EndToEnd_CapturingEventHandlerLambda_Runs` — capturing closure branch.

Both compile **with reference assemblies** (the configuration that reproduces the crash), assert `ilverify` passes, execute via `dotnet exec`, and assert program output.

## Verification

- New Issue1449 tests: **2 passed**.
- `Core.Tests`: **4788 passed, 1 skipped** — no regressions.
- `ilverify` clean on both repros.
- Decrypt baseline: the `GS9998` crash at `Mp4File.gs (45,121)` is **cleared**. A different, unrelated diagnostic now surfaces at `Mp4File.gs (99,38)` (`InvalidOperationException: Variable 'ch' has no local slot`) — out of scope for #1449.

Fixes #1449

Refs #914
