### PR TITLE
Seed lambda capture analysis with inline out-var declarations (Fixes #1451)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -1205,9 +1205,42 @@ internal sealed class LambdaBinder
         var paramSet = new HashSet<VariableSymbol>(parameters);
         var seen = new HashSet<VariableSymbol>();
         var captured = ImmutableArray.CreateBuilder<VariableSymbol>();
-        var collector = new CapturedVariableCollector(paramSet, seen, captured);
+
+        // Issue #1451: pre-seed the collector's `declared` set with every inline
+        // `out var x` local declared *in this body*. Loop lowering (while/for/do)
+        // emits the loop body before the controlling condition, so the out-var's
+        // reads can be walked before its declaration; a single in-order pass would
+        // then misclassify the out-var as an enclosing-scope capture. Gathering the
+        // declarations up front removes that order dependency. The pre-pass is a
+        // BoundTreeWalker, so it is opaque at nested function literals — out-vars
+        // declared by a nested lambda stay in that lambda's scope.
+        var outVarCollector = new InlineOutVarDeclarationCollector();
+        outVarCollector.RewriteStatement(body);
+
+        var collector = new CapturedVariableCollector(paramSet, seen, captured, outVarCollector.Declared);
         collector.RewriteStatement(body);
         return captured.ToImmutable();
+    }
+
+    // Issue #1451: collects the locals declared by inline `out var`/`out let`
+    // arguments (`BoundAddressOfExpression(BoundVariableExpression(local))` where
+    // the local's declaring syntax is an inline RefArgumentExpressionSyntax) within
+    // a single body. Implemented as a BoundTreeRewriter (not a walker) only so it
+    // shares the FunctionLiteral-opaque traversal; it never mutates the tree.
+    private sealed class InlineOutVarDeclarationCollector : BoundTreeRewriter
+    {
+        public HashSet<VariableSymbol> Declared { get; } = [];
+
+        protected override BoundExpression RewriteAddressOfExpression(BoundAddressOfExpression node)
+        {
+            if (node.Operand is BoundVariableExpression outVarExpr
+                && outVarExpr.Variable.DeclaringSyntax is RefArgumentExpressionSyntax { IsInlineDeclaration: true })
+            {
+                this.Declared.Add(outVarExpr.Variable);
+            }
+
+            return base.RewriteAddressOfExpression(node);
+        }
     }
 
     // ADR-0076 / issue #716: walks a bound block-expression body collecting
@@ -1339,11 +1372,12 @@ internal sealed class LambdaBinder
         public CapturedVariableCollector(
             HashSet<VariableSymbol> parameters,
             HashSet<VariableSymbol> seen,
-            ImmutableArray<VariableSymbol>.Builder captured)
+            ImmutableArray<VariableSymbol>.Builder captured,
+            IEnumerable<VariableSymbol> preDeclared = null)
         {
             this.parameters = parameters;
             this.seen = seen;
-            this.declared = [];
+            this.declared = preDeclared != null ? [.. preDeclared] : [];
             this.captured = captured;
         }
 
@@ -1448,6 +1482,30 @@ internal sealed class LambdaBinder
             }
 
             return base.RewritePattern(node);
+        }
+
+        protected override BoundExpression RewriteAddressOfExpression(BoundAddressOfExpression node)
+        {
+            // Issue #1451 (generalization of #1437): an inline `out var x` argument
+            // declares a body-local via BoundAddressOfExpression(BoundVariableExpression(local))
+            // — NOT a BoundVariableDeclaration. Recording it here keeps the in-order
+            // case correct, but loop lowering (while/for/do) emits the body *before*
+            // the condition that declares the out-var, so the uses are walked first;
+            // a same-pass record is too late (RecordReference already classified the
+            // use as a capture). The authoritative seeding therefore happens up front
+            // via InlineOutVarDeclarationCollector (see CollectCapturedVariables) — this
+            // override is kept for the in-order path and as defense in depth. Without
+            // the declared-record, CaptureBoxingRewriter hoists `x` into a heap box,
+            // desynchronizing its declaration site (the original local, for which the
+            // emit local-slot planner allocates a slot) from its boxed reads, crashing
+            // emit with GS9998 "Variable 'x' has no local slot".
+            if (node.Operand is BoundVariableExpression outVarExpr
+                && outVarExpr.Variable.DeclaringSyntax is RefArgumentExpressionSyntax { IsInlineDeclaration: true })
+            {
+                this.declared.Add(outVarExpr.Variable);
+            }
+
+            return base.RewriteAddressOfExpression(node);
         }
 
         protected override BoundExpression RewriteNullConditionalAccessExpression(BoundNullConditionalAccessExpression node)

--- a/test/Compiler.Tests/Emit/Issue1451OutVarInLambdaEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1451OutVarInLambdaEmitTests.cs
@@ -1,0 +1,186 @@
+// <copyright file="Issue1451OutVarInLambdaEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1451 — an inline <c>out var x</c> declared *inside* a lambda / `func`
+/// literal body crashed emit with GS9998 "Variable 'x' has no local slot or
+/// parameter index in the current method." The out-var binds to
+/// <c>BoundAddressOfExpression(BoundVariableExpression(local))</c> (not a
+/// BoundVariableDeclaration), and loop lowering emits the loop body before the
+/// declaring condition, so the lambda's capture analysis misclassified the
+/// out-var as an enclosing-scope capture and boxed it, desynchronizing it from
+/// its emit local slot. The fix pre-seeds the lambda capture collector with every
+/// inline out-var declared in the body. The same out-var in a non-lambda function
+/// always worked (the control).
+/// </summary>
+public class Issue1451OutVarInLambdaEmitTests
+{
+    [Fact]
+    public void EndToEnd_OutVarInWhileConditionInsideLambda_Runs()
+    {
+        var source = """
+            package Probe1451a
+            import System
+
+            open class Counter {
+                private var n int32
+                init() { this.n = 3 }
+                func TryNext(out v int32) bool {
+                    if this.n <= 0 {
+                        v = 0
+                        return false
+                    }
+                    v = this.n
+                    this.n = this.n - 1
+                    return true
+                }
+            }
+
+            func MakeSummer() (int32) -> int32 {
+                let c = Counter()
+                let sum = func (seed int32) int32 {
+                    var total = seed
+                    while c.TryNext(out var x) {
+                        total = total + x
+                    }
+                    return total
+                }
+                return sum
+            }
+
+            func Main() {
+                let s = MakeSummer()
+                Console.WriteLine(s(100))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("106\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_OutVarStraightLineInsideLambda_Runs()
+    {
+        var source = """
+            package Probe1451b
+            import System
+
+            open class Box {
+                func TryGet(out v int32) bool {
+                    v = 41
+                    return true
+                }
+            }
+
+            func MakeReader() () -> int32 {
+                let b = Box()
+                let read = func () int32 {
+                    if b.TryGet(out var got) {
+                        return got + 1
+                    }
+                    return -1
+                }
+                return read
+            }
+
+            func Main() {
+                let r = MakeReader()
+                Console.WriteLine(r())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1451_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
## Problem

An inline `out var x` declared **inside a lambda / `func` literal body** crashed emit with `GS9998` — `InvalidOperationException: Variable 'x' has no local slot or parameter index in the current method`. The same `out var` in a regular (non-lambda) function compiled and ran fine.

## Root cause

An inline `out var x` does not produce a `BoundVariableDeclaration`; it binds to `BoundAddressOfExpression(BoundVariableExpression(local))` in the argument position. The lambda capture analyzer (`CapturedVariableCollector`, Issue #1437) records body-local declarations in a `declared` set so they aren't misclassified as captures, but it only handled `let`/`var`/catch/select/range/ellipsis/fixed/pattern forms — not the out-var form.

Worse, loop lowering (`while`/`for`/`do`) emits the loop body *before* the controlling condition that declares the out-var, so even an in-pass record at the declaration site is too late: the out-var's reads in the body are walked first and already classified as captures. The `CaptureBoxingRewriter` then hoists the local into a heap box, desynchronizing its declaration site (the original local, for which the emit local-slot planner allocates a slot) from its boxed reads → GS9998.

## Fix

Pre-seed the capture collector's `declared` set with **every inline out-var declared in the body**, via a `FunctionLiteral`-opaque pre-pass (`InlineOutVarDeclarationCollector`) before the reference-collecting walk. This removes the order dependency and generalizes the #1437 body-local-declaration handling to the out-var form. (A defense-in-depth in-pass override is also kept for the in-order case.)

## Tests

`test/Compiler.Tests/Emit/Issue1451OutVarInLambdaEmitTests.cs` (both pass, end-to-end compile + ilverify + run):
- `EndToEnd_OutVarInWhileConditionInsideLambda_Runs` (the lowered-loop case → 106)
- `EndToEnd_OutVarStraightLineInsideLambda_Runs` (straight-line case → 42)

## Verification

- Core.Tests: 4788 passed / 1 skipped (no regressions).
- ilverify clean on both repros.
- Oahu.Decrypt baseline: the `Mp4File.gs` out-var GS9998 crash is cleared (the next, unrelated masking diagnostic now surfaces in `ChapterQueue.gs`).

Fixes #1451

Refs #914
