### PR TITLE
Box nullable type-parameter values converting to object/interface (#1455)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -392,6 +392,35 @@ public sealed class Conversion
             }
         }
 
+        // Issue #1455: a nullable wrapper over an open type parameter (`T?`)
+        // boxes implicitly to `object` (and reference-upcasts to any interface
+        // in `T`'s effective constraint set). Unlike the bare `T -> object`
+        // case — deliberately excluded above because an erased `!0` parameter
+        // slot is indistinguishable from a genuine `object` and would inject a
+        // spurious box (#1196 regression) — a `T?` argument is NEVER identity
+        // with an erased `!0`/`T` slot, so the boxing here is always genuine
+        // and unambiguous. This wraps the implicit-boxing argument/return/
+        // delegate-covariance positions (where no explicit cast is written) in
+        // a BoundConversionExpression so emit materialises `box !!T`
+        // (ref/unconstrained `T`) or `box Nullable<!!T>` (value-type
+        // constrained `T`). Scoped to `object` and constraint-satisfying
+        // interface targets so no narrowing or otherwise-invalid conversion is
+        // admitted.
+        if (from is NullableTypeSymbol fromNullableTypeParam
+            && fromNullableTypeParam.UnderlyingType is TypeParameterSymbol nullableUnderlyingTypeParam
+            && to is not NullableTypeSymbol)
+        {
+            if (to?.ClrType.IsSameAs(typeof(object)) == true)
+            {
+                return Conversion.Implicit;
+            }
+
+            if (IsInterfaceLikeType(to) && TypeParameterConvertsTo(nullableUnderlyingTypeParam, to))
+            {
+                return Conversion.Implicit;
+            }
+        }
+
         // Phase 3.C.2: nil literal is never assignable to a non-nullable type.
         if (from == TypeSymbol.Null && !(to is NullableTypeSymbol))
         {

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
@@ -397,11 +397,23 @@ internal sealed partial class MethodBodyEmitter
         // `object`), emit `box T` so the JIT materialises the value-or-
         // reference boxed slot. The JIT elides the box when T resolves to a
         // reference type at runtime, so no perf regression.
-        if (from is TypeParameterSymbol fromTp
+        //
+        // Issue #1455: the same widening reaches emit through a NULLABLE
+        // wrapper over the type parameter (`T?`) — e.g. a lambda whose body
+        // returns `T?` flowing into a `Func<..., object>` parameter via
+        // delegate-return covariance, or `Task.FromResult(default)` over
+        // `T?`. `T?` shares `T`'s CLR representation for a ref-constrained or
+        // unconstrained `T` (`box !!T`), and is `Nullable<!!T>` for a
+        // value-type-constrained `T` (`box Nullable<!!T>` correctly yields a
+        // null reference for the missing-value case). `GetElementTypeToken`
+        // already selects the right token for the nullable wrapper in either
+        // constraint case, so we box the wrapper symbol directly.
+        if ((from is TypeParameterSymbol
+                || (from is NullableTypeSymbol fromNullableTp && fromNullableTp.UnderlyingType is TypeParameterSymbol))
             && (to?.ClrType.IsSameAs(typeof(object)) == true || IsInterfaceTargetType(to)))
         {
             this.il.OpCode(ILOpCode.Box);
-            this.il.Token(this.outer.GetElementTypeToken(fromTp));
+            this.il.Token(this.outer.GetElementTypeToken(from));
             return;
         }
 
@@ -412,6 +424,23 @@ internal sealed partial class MethodBodyEmitter
         // slot needs `unbox.any` to surface as its native value type.
         if ((from?.ClrType.IsSameAs(typeof(object)) == true || IsInterfaceSourceType(from))
             && to?.ClrType != null && to.ClrType.IsValueType)
+        {
+            this.il.OpCode(ILOpCode.Unbox_any);
+            this.il.Token(this.outer.GetElementTypeToken(to));
+            return;
+        }
+
+        // Issue #1455 (symmetric direction): `object`/interface → type
+        // parameter, including a nullable wrapper over one (`T?`). The boxed
+        // reference held in the `object`/interface slot is surfaced with
+        // `unbox.any T` (or `unbox.any Nullable<!!T>`). The JIT picks the
+        // value-vs-reference shape from the instantiated `T` at call time, so
+        // this verifies for any closing instantiation. `GetElementTypeToken`
+        // resolves the correct token for both the bare and nullable-wrapped
+        // type parameter.
+        if ((from?.ClrType.IsSameAs(typeof(object)) == true || IsInterfaceSourceType(from))
+            && (to is TypeParameterSymbol
+                || (to is NullableTypeSymbol toNullableTp && toNullableTp.UnderlyingType is TypeParameterSymbol)))
         {
             this.il.OpCode(ILOpCode.Unbox_any);
             this.il.Token(this.outer.GetElementTypeToken(to));

--- a/test/Compiler.Tests/Emit/Issue1455NullableTypeParamToObjectEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1455NullableTypeParamToObjectEmitTests.cs
@@ -1,0 +1,225 @@
+// <copyright file="Issue1455NullableTypeParamToObjectEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1455 — a NULLABLE generic type-parameter value (<c>T?</c>) converting
+/// to <c>object</c> (or an interface) crashed emit with GS9998
+/// "Conversion from 'TOutput?' to 'object' is not yet supported by the emitter".
+/// The bare type-parameter box branch only matched <c>T</c>, never the
+/// <see cref="GSharp.Core.CodeAnalysis.Symbols.NullableTypeSymbol"/> wrapper, so
+/// a <c>T?</c> source fell through to the unsupported-conversion throw — and a
+/// closely related argument-position case silently emitted UNVERIFIABLE IL
+/// (missing <c>box</c>). The fix boxes the underlying type-parameter token for a
+/// nullable wrapper in both the box and unbox conversion branches, and adds the
+/// matching implicit boxing classification so argument / return / interface
+/// positions reach that branch instead of being rejected.
+/// </summary>
+public class Issue1455NullableTypeParamToObjectEmitTests
+{
+    [Fact]
+    public void EndToEnd_NullableTypeParamArgumentToObjectList_BoxesAndRuns()
+    {
+        // The #1445-family argument-position case from the issue: a `T?` value
+        // flows into a `List[object].Add(object)` slot. Before the fix this
+        // compiled but produced unverifiable IL (no `box`); IlVerifier.Verify
+        // inside the helper asserts the emitted body is now verifiable.
+        var source = """
+            package Probe1455Arg
+            import System
+            import System.Collections.Generic
+
+            open class Holder[TOutput] {
+                private var value TOutput
+                init(v TOutput) { this.value = v }
+                func GetMaybe() TOutput? { return this.value }
+                func Stash() List[object] {
+                    let lst = List[object]()
+                    lst.Add(GetMaybe())
+                    return lst
+                }
+            }
+
+            func Main() {
+                let h = Holder[int32](7)
+                Console.WriteLine(h.Stash()[0]!!.ToString()!!)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("7\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_NullableTypeParamReturnedAsObject_BoxesAndRuns()
+    {
+        // The actual GS9998 throw path: an implicit `T? -> object` widening
+        // reaches MethodBodyEmitter.EmitConversion in a regular method body.
+        // Before the fix the box branch only matched a bare `T`, so the
+        // nullable wrapper fell through to the NotSupportedException throw.
+        var source = """
+            package Probe1455Ret
+            import System
+
+            open class Holder[TOutput] {
+                private var value TOutput
+                init(v TOutput) { this.value = v }
+                func GetMaybe() TOutput? { return this.value }
+                func AsObject() object -> GetMaybe()
+            }
+
+            func Main() {
+                let h = Holder[int32](42)
+                Console.WriteLine(h.AsObject()!!.ToString()!!)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_NullableTypeParamToConstraintInterface_BoxesAndRuns()
+    {
+        // The interface-target variant: a `T?` over an `IComparable`-constrained
+        // type parameter reference-converts to the interface. Scoped to targets
+        // the type parameter actually satisfies (a bare `object` or an interface
+        // in its constraint set), so unrelated interface targets stay rejected.
+        var source = """
+            package Probe1455Iface
+            import System
+
+            open class Holder[T IComparable] {
+                private var value T
+                init(v T) { this.value = v }
+                func GetMaybe() T? -> this.value
+                func AsComparable() IComparable -> GetMaybe()
+            }
+
+            func Main() {
+                let h = Holder[int32](9)
+                Console.WriteLine(h.AsComparable()!!.CompareTo(9).ToString()!!)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("0\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_NullableValueTypeParamToObject_BoxesNullableAndRuns()
+    {
+        // The value-type-constrained case: `T?` over `[T struct]` is stored as
+        // `Nullable<T>`, so the emitter boxes the `Nullable<T>` token (which
+        // yields a boxed `T` for a present value, a null reference otherwise).
+        var source = """
+            package Probe1455Struct
+            import System
+
+            open class Holder[T struct] {
+                private var value T
+                init(v T) { this.value = v }
+                func GetMaybe() T? -> this.value
+                func AsObject() object -> GetMaybe()
+            }
+
+            func Main() {
+                let h = Holder[int32](5)
+                Console.WriteLine(h.AsObject()!!.ToString()!!)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("5\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1455_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
## Root cause

A nullable generic type-parameter value (`T?`) converting to `object` (or an interface) crashed gsc emit with `GS9998` "Conversion from 'TOutput?' to 'object' is not yet supported by the emitter". A closely related argument-position case (the #1445 family) silently emitted **unverifiable IL** (missing `box`).

`MethodBodyEmitter.Conversions.cs` boxed a bare `TypeParameterSymbol` -> `object`/interface, but `T?` is a `NullableTypeSymbol` **wrapper** around the type parameter, so `from is TypeParameterSymbol` was false and execution fell through to the unsupported-conversion `throw`. Separately, the binder deliberately does **not** classify `T -> object` (an erased `!0` parameter slot is indistinguishable from a genuine `object`, so a box there would reintroduce the #1196 regression) — but it also never classified `T? -> object`, so argument/return positions were rejected (GS0155) or never reached the box path.

The exact throwing conversion (instrumented at the throw site) was `from = TOutput?` (`NullableTypeSymbol`, underlying `TOutput` = `TypeParameterSymbol`), `to = object`, reached from a regular method body via `EmitConversion(BoundConversionExpression)`.

## Fix

- **Emit** (`MethodBodyEmitter.Conversions.cs`): generalize the box branch — and the symmetric `object`/interface -> type-parameter `unbox.any` branch — to accept a nullable wrapper over a type parameter, boxing/unboxing the wrapper token directly. `GetElementTypeToken` already resolves `box !!T` for a ref/unconstrained `T` (shares `T`'s CLR representation) and `box Nullable<!!T>` for a value-type-constrained `T` (yields a null reference for the missing-value case).
- **Binder** (`Conversion.cs`): classify `T? -> object` (and `T? ->` a constraint-satisfying interface) as an implicit boxing conversion. Scoped to the nullable wrapper and to `object`/constraint-satisfying interface targets, so the bare-`T` erasure ambiguity (#1196) is not reintroduced and no narrowing or otherwise-invalid conversion is admitted.

A `T?` argument is never identity with an erased `!0`/`T` slot, so this boxing is always genuine and unambiguous.

## Tests added

`test/Compiler.Tests/Emit/Issue1455NullableTypeParamToObjectEmitTests.cs` — 4 end-to-end emit tests (compile -> `IlVerifier.Verify` -> execute), all passing:
- `EndToEnd_NullableTypeParamArgumentToObjectList_BoxesAndRuns` (argument position into `List[object].Add`, the #1445-family unverifiable case -> now verifies clean)
- `EndToEnd_NullableTypeParamReturnedAsObject_BoxesAndRuns` (the GS9998 throw's emit path: implicit `T? -> object` widening)
- `EndToEnd_NullableTypeParamToConstraintInterface_BoxesAndRuns` (`IComparable`-constrained interface target)
- `EndToEnd_NullableValueTypeParamToObject_BoxesNullableAndRuns` (`[T struct]` -> `box Nullable<T>`)

## Verification

- **ilverify clean** on both paths: the issue's `TOutput?` argument repro (`List[object].Add`) now verifies clean and prints `7`; the return/interface/`[T struct]` repros verify clean and run.
- **Core.Tests**: 4788 passed / 1 skipped (no regressions).
- **Compiler.Tests** (conversion/nullable/#1196/#1052/#814 emit filters): 256 passed.
- **Decrypt baseline harness**: the `TOutput?` -> `object` GS9998 throw is **cleared**. The next (separate, pre-existing) masking diagnostic now surfaces — `GS9998 NotSupportedException: Conversion from 'object' to 'SampleEntry'` (an `object` -> user-struct unbox, unrelated to #1455 and out of scope here).

Fixes #1455

Refs #914
