### PR TITLE
Reify same-compilation user types in lambda delegate slots (#1457)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -645,9 +645,10 @@ internal sealed class LambdaBinder
         for (var i = 0; i < literal.Function.Parameters.Length; i++)
         {
             var original = literal.Function.Parameters[i];
-            var adapterParameterType = i < targetFunctionType.ParameterTypes.Length
-                ? GetErasedDelegateSlotType(targetFunctionType.ParameterTypes[i])
+            var targetSlot = i < targetFunctionType.ParameterTypes.Length
+                ? targetFunctionType.ParameterTypes[i]
                 : TypeSymbol.Object;
+            var adapterParameterType = GetAdapterSlotType(original.Type, targetSlot);
             var adapterParameter = new ParameterSymbol(
                 original.Name,
                 adapterParameterType,
@@ -662,7 +663,7 @@ internal sealed class LambdaBinder
 
         var adapterReturnType = targetFunctionType.ReturnType == TypeSymbol.Void
             ? TypeSymbol.Void
-            : GetErasedDelegateSlotType(targetFunctionType.ReturnType);
+            : GetAdapterSlotType(literal.Function.Type, targetFunctionType.ReturnType);
 
         // ADR-0102 follow-up / issue #818: preserve the target's variadic
         // flag shape through the erased adapter so call-site dispatch keeps
@@ -1164,6 +1165,27 @@ internal sealed class LambdaBinder
     private static TypeSymbol GetErasedDelegateSlotType(TypeSymbol type)
     {
         return TypeSymbol.ContainsTypeParameter(type) ? TypeSymbol.Object : type;
+    }
+
+    // Issue #1457: chooses the adapter slot type for one delegate
+    // parameter/return position. The erased adapter exists to widen
+    // type-parameter slots to System.Object so the lambda MethodDef matches
+    // the runtime delegate's Invoke shape. But when the literal's own slot is
+    // a same-compilation user type (a `data struct`, user class, enum, …) the
+    // host-reflection target slot has already been erased to `object` (the
+    // user type has no host CLR Type yet). Erasing to that `object` would
+    // realise the delegate as `Func<object, …>` and force an unverifiable
+    // `object -> UserType` unbox in the body. Preserve the literal's concrete
+    // slot instead so the delegate reifies as `Func<UserType, …>` through the
+    // TypeSpec path (ADR-0087 §3 R6), matching the reified generic call site.
+    private static TypeSymbol GetAdapterSlotType(TypeSymbol literalSlot, TypeSymbol targetSlot)
+    {
+        if (literalSlot != null && TypeSymbol.ContainsSameCompilationUserType(literalSlot))
+        {
+            return literalSlot;
+        }
+
+        return GetErasedDelegateSlotType(targetSlot);
     }
 
     // ADR-0087 §3 R6: returns true when the literal's signature already

--- a/src/Core/CodeAnalysis/Symbols/FunctionTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/FunctionTypeSymbol.cs
@@ -19,6 +19,17 @@ public sealed class FunctionTypeSymbol : TypeSymbol
 
     private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<TypeParameterSymbol, object> TypeParameterIds = new System.Runtime.CompilerServices.ConditionalWeakTable<TypeParameterSymbol, object>();
 
+    // Issue #1457: a same-compilation user type (a struct/class/enum/interface/
+    // delegate still being compiled) has no host CLR Type and is identified
+    // across compilations only by its (re-usable) display name. Keying the
+    // process-wide function-type cache by that name would alias a `func(Item) R`
+    // built in one compilation with a same-named `Item` from another concurrent
+    // compilation, so the emitter would look up a TypeDef the current emit never
+    // registered ("Struct 'Item' has no emitted TypeDef"). Key such slots by the
+    // symbol instance identity instead so they isolate per compilation while
+    // still sharing within one.
+    private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<TypeSymbol, object> UserTypeIds = new System.Runtime.CompilerServices.ConditionalWeakTable<TypeSymbol, object>();
+
     private static long typeParameterIdSeed;
 
     private FunctionTypeSymbol(string name, ImmutableArray<TypeSymbol> parameterTypes, ImmutableArray<bool> isVariadic, TypeSymbol returnType)
@@ -192,6 +203,19 @@ public sealed class FunctionTypeSymbol : TypeSymbol
 
     private static void AppendIdentityKey(System.Text.StringBuilder builder, TypeSymbol type)
     {
+        // Issue #1457: any slot that references a same-compilation user type
+        // (directly or nested, e.g. `Item`, `List[Item]`, `(Item, int)`) must be
+        // keyed by symbol-instance identity rather than by name, so the cached
+        // entry never aliases a same-named user type from another compilation.
+        // Type parameters and function types keep their dedicated handling below.
+        if (type is not null and not TypeParameterSymbol and not FunctionTypeSymbol
+            && ContainsSameCompilationUserType(type))
+        {
+            var uid = (long)UserTypeIds.GetValue(type, _ => NextTypeParameterId());
+            builder.Append("!ut").Append(uid);
+            return;
+        }
+
         switch (type)
         {
             case TypeParameterSymbol tp:

--- a/test/Compiler.Tests/Emit/Issue1457UserTypeDelegateEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1457UserTypeDelegateEmitTests.cs
@@ -1,0 +1,204 @@
+// <copyright file="Issue1457UserTypeDelegateEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1457 — a <c>func</c> literal / lambda whose signature mentions a
+/// same-compilation user type (especially a user value type such as a
+/// <c>data struct</c>) was realised with the wrong delegate type. A LINQ
+/// <c>Sum&lt;TSource&gt;(IEnumerable&lt;TSource&gt;, Func&lt;TSource,long&gt;)</c>
+/// bound with <c>TSource = SampleEntry</c> emitted <c>Func&lt;object,int64&gt;</c>
+/// instead of <c>Func&lt;SampleEntry,int64&gt;</c>, forcing an unverifiable
+/// <c>object -&gt; SampleEntry</c> unbox (GS9998) — or, after a naive unbox patch,
+/// an ilverify <c>StackUnexpected</c> + runtime segfault. The fix preserves the
+/// same-compilation user type in the erased-adapter slots so the delegate reifies
+/// through the <c>Func`N</c>/<c>Action`N</c> TypeSpec path (ADR-0087 §3 R6),
+/// matching the reified generic call site.
+/// </summary>
+public class Issue1457UserTypeDelegateEmitTests
+{
+    [Fact]
+    public void EndToEnd_SumOverUserValueTypeSelector_Runs()
+    {
+        var source = """
+            package Probe1457a
+            import System
+            import System.Linq
+            import System.Collections.Generic
+
+            data struct SampleEntryA(FrameCount uint32, FrameDelta uint32)
+
+            func Main() {
+                let lst = List[SampleEntryA]()
+                lst.Add(SampleEntryA(1, 2))
+                let s = uint32(lst.Sum((e SampleEntryA) -> e.FrameCount))
+                Console.WriteLine(s)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("1\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_WhereAndSelectOverUserValueType_Runs()
+    {
+        var source = """
+            package Probe1457b
+            import System
+            import System.Linq
+            import System.Collections.Generic
+
+            data struct EntryB(Id uint32, Name string)
+
+            func Main() {
+                let lst = List[EntryB]()
+                lst.Add(EntryB(1, "alpha"))
+                lst.Add(EntryB(2, "beta"))
+                let filtered = lst.Where((e EntryB) -> e.Id > 1u).ToList()
+                Console.WriteLine(filtered.Count)
+                let names = lst.Select((e EntryB) -> e.Name).ToList()
+                Console.WriteLine(names[0])
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("1\nalpha\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_SumOverUserReferenceType_Runs()
+    {
+        var source = """
+            package Probe1457c
+            import System
+            import System.Linq
+            import System.Collections.Generic
+
+            class WidgetC {
+                var Cost int32
+                init(c int32) { this.Cost = c }
+            }
+
+            func Main() {
+                let widgets = List[WidgetC]()
+                widgets.Add(WidgetC(10))
+                widgets.Add(WidgetC(20))
+                let total = widgets.Sum((w WidgetC) -> w.Cost)
+                Console.WriteLine(total)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("30\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_FuncLiteralStoredInVariableThenInvoked_Runs()
+    {
+        var source = """
+            package Probe1457d
+            import System
+
+            data struct PointD(X int32, Y int32)
+
+            func Main() {
+                let f = (p PointD) -> p.X + p.Y
+                Console.WriteLine(f(PointD(3, 4)))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("7\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1457_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

A `func` literal / lambda whose signature mentions a same-compilation user type (e.g. a `data struct`) was realised with the **wrong delegate type**. A LINQ `Sum<TSource>(IEnumerable<TSource>, Func<TSource,long>)` bound with `TSource = SampleEntry` emitted `Func<object,int64>` instead of `Func<SampleEntry,int64>`, forcing an unverifiable `object -> SampleEntry` unbox (`GS9998`) — or, after a naive unbox patch, an ilverify `StackUnexpected` mismatch and a runtime segfault.

## Root cause

When widening a function literal to a delegate-typed parameter, `CreateErasedFunctionLiteralAdapter` took the adapter slot types from the host-reflection target (`Func<object,long>` — the user type has no host CLR `Type` yet, so substitution erased it to `object`). The adapter therefore typed its parameter `object` and inserted an `object -> SampleEntry` body conversion. The reified `Func`N`/`Action`N` TypeSpec path (ADR-0087 §3 R6) was never selected because the adapter's function type had a non-null (erased) `ClrType`.

## Fix

- **`LambdaBinder.CreateErasedFunctionLiteralAdapter`** now preserves the literal's own slot type for any parameter/return position whose declared type carries a same-compilation user type (struct/class/enum/interface/delegate, plus nested shapes), via the new `GetAdapterSlotType` predicate. The adapter's function type then has a null host `ClrType`, so every existing delegate-realization decision site (`FunctionType.ClrType == null` in `MethodBodyEmitter.Closures`/`.Calls`) routes ctor `newobj` and `Invoke` through the reified TypeSpec. No `object`->user-type unbox is generated. Non-user-type slots keep the existing erased behaviour, so IL for those shapes is unchanged (the byte-identical refactoring baseline is untouched).
- **`FunctionTypeSymbol`** process-wide cache keyed same-compilation user-type slots by display name, which aliased a `func(Item) R` from one compilation with a same-named `Item` from another concurrent compilation. Once such delegates are reified, that alias made the emitter look up a TypeDef the current emit never registered (`Struct 'Item' has no emitted TypeDef`). User-type slots are now keyed by symbol-instance identity (like type parameters), isolating them per compilation while still sharing within one.

## Validation

- Repro compiles clean, **ilverify clean**, runs printing `1`.
- New end-to-end emit tests (`Issue1457UserTypeDelegateEmitTests`): Sum over a user value type, a user reference type, Where/Select over a user value type, and a stored func literal invoked directly — all pass.
- `Core.Tests`: 4788 passed / 1 skipped (RefactoringBaseline unchanged).
- Full `GSharp.sln` build: 0 warnings / 0 errors.

Fixes #1457

Refs #914
