### PR TITLE
Allocate box for captured inline out-var locals (#1453)

### DIFF
--- a/src/Core/CodeAnalysis/Lowering/CaptureBoxingRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/CaptureBoxingRewriter.cs
@@ -345,6 +345,64 @@ internal static class CaptureBoxingRewriter
         public FieldSymbol BoxField { get; }
     }
 
+    /// <summary>
+    /// Issue #1453: finds captured locals that are introduced (rather than
+    /// declared) by an <c>out</c>/<c>ref</c> address-of within a single
+    /// statement — i.e. inline <c>out var x</c> captures that have no
+    /// <see cref="BoundVariableDeclaration"/>. The scan is shallow: it stops at
+    /// nested <see cref="BoundBlockStatement"/>s (those are handled when the
+    /// rewriter recurses into them, so a loop body gets a fresh box) and at
+    /// function literals (already opaque to <see cref="BoundTreeWalker"/>).
+    /// </summary>
+    private sealed class OutVarBoxIntroductionScanner : BoundTreeWalker
+    {
+        private readonly Dictionary<VariableSymbol, BoxedVariable> boxInfo;
+        private readonly HashSet<VariableSymbol> allocated;
+        private readonly List<BoxedVariable> found = new List<BoxedVariable>();
+        private readonly HashSet<VariableSymbol> foundSet = new HashSet<VariableSymbol>();
+
+        private OutVarBoxIntroductionScanner(
+            Dictionary<VariableSymbol, BoxedVariable> boxInfo,
+            HashSet<VariableSymbol> allocated)
+        {
+            this.boxInfo = boxInfo;
+            this.allocated = allocated;
+        }
+
+        public static List<BoxedVariable> Scan(
+            BoundStatement statement,
+            Dictionary<VariableSymbol, BoxedVariable> boxInfo,
+            HashSet<VariableSymbol> allocated)
+        {
+            var scanner = new OutVarBoxIntroductionScanner(boxInfo, allocated);
+            scanner.VisitStatement(statement);
+            return scanner.found;
+        }
+
+        /// <inheritdoc/>
+        protected override void VisitBlockStatement(BoundBlockStatement node)
+        {
+            // Stop: a nested block introduces its own scope. Its out-var boxes
+            // are allocated when the rewriter recurses into that block, keeping
+            // loop-body captures fresh per iteration.
+        }
+
+        /// <inheritdoc/>
+        protected override void VisitAddressOfExpression(BoundAddressOfExpression node)
+        {
+            if (node.Operand is BoundVariableExpression bve
+                && this.boxInfo.TryGetValue(bve.Variable, out var bi)
+                && bi.Original is not ParameterSymbol
+                && !this.allocated.Contains(bve.Variable)
+                && this.foundSet.Add(bve.Variable))
+            {
+                this.found.Add(bi);
+            }
+
+            base.VisitAddressOfExpression(node);
+        }
+    }
+
     private sealed class CaptureWalker : BoundTreeRewriter
     {
         private readonly HashSet<VariableSymbol> sink;
@@ -382,6 +440,14 @@ internal static class CaptureBoxingRewriter
         private readonly Dictionary<VariableSymbol, BoxedVariable> boxInfo;
         private readonly HashSet<VariableSymbol> dropFromCapture;
 
+        // Issue #1453: boxed local originals whose box has already been
+        // allocated (a `new Box()` statement emitted). Ordinary captured
+        // locals are allocated at their BoundVariableDeclaration; inline
+        // `out var x` captures have no declaration, so RewriteBlockStatement
+        // allocates their box at the introducing statement. This set
+        // distinguishes the two so out-var boxes are allocated exactly once.
+        private readonly HashSet<VariableSymbol> allocated = new HashSet<VariableSymbol>();
+
         public BoxingRewriter(
             Dictionary<VariableSymbol, BoxedVariable> boxInfo,
             HashSet<VariableSymbol> dropFromCapture)
@@ -398,6 +464,68 @@ internal static class CaptureBoxingRewriter
         /// </summary>
         public Dictionary<FunctionSymbol, BoundBlockStatement> RewrittenLambdaBodies { get; }
             = new Dictionary<FunctionSymbol, BoundBlockStatement>();
+
+        /// <inheritdoc/>
+        protected override BoundStatement RewriteBlockStatement(BoundBlockStatement node)
+        {
+            // Issue #1453: an inline `out var x` that is captured by a nested
+            // lambda is hoisted into a Box like any other captured local, but
+            // unlike `var x = e` it has no BoundVariableDeclaration, so
+            // RewriteVariableDeclaration never allocates its box and emit later
+            // fails with "Variable 'x' has no local slot".
+            //
+            // Allocate the box for such declaration-less captured locals at the
+            // statement that first introduces them (their `out`/`ref` address-of
+            // site), scoped to the block that contains that statement. Doing it
+            // at block level means a loop body gets a fresh box per iteration,
+            // mirroring how `var x = e` inside a loop body is handled.
+            ImmutableArray<BoundStatement>.Builder builder = null;
+
+            for (var i = 0; i < node.Statements.Length; i++)
+            {
+                var oldStatement = node.Statements[i];
+
+                // Find declaration-less captured locals introduced (as an
+                // address-of operand) directly within this statement, before it
+                // is rewritten into box-field accesses. Mark them allocated up
+                // front so recursion into nested scopes does not re-allocate.
+                var introduced = OutVarBoxIntroductionScanner.Scan(oldStatement, this.boxInfo, this.allocated);
+                foreach (var bi in introduced)
+                {
+                    this.allocated.Add(bi.Original);
+                }
+
+                var newStatement = this.RewriteStatement(oldStatement);
+
+                var changed = introduced.Count > 0 || !ReferenceEquals(newStatement, oldStatement);
+                if (changed && builder == null)
+                {
+                    builder = ImmutableArray.CreateBuilder<BoundStatement>(node.Statements.Length + introduced.Count);
+                    for (var j = 0; j < i; j++)
+                    {
+                        builder.Add(node.Statements[j]);
+                    }
+                }
+
+                if (builder != null)
+                {
+                    foreach (var bi in introduced)
+                    {
+                        builder.Add(new BoundVariableDeclaration(
+                            null,
+                            bi.BoxLocal,
+                            new BoundConstructorCallExpression(
+                                null,
+                                bi.BoxClass,
+                                ImmutableArray<BoundExpression>.Empty)));
+                    }
+
+                    builder.Add(newStatement);
+                }
+            }
+
+            return builder == null ? node : new BoundBlockStatement(null, builder.ToImmutable());
+        }
 
         /// <inheritdoc/>
         protected override BoundExpression RewriteVariableExpression(BoundVariableExpression node)
@@ -544,6 +672,7 @@ internal static class CaptureBoxingRewriter
                 // The original `n`'s slot is reclaimed by the new LocalVariableSymbol
                 // of type Box_n. Note `Lowerer.Flatten` will inline this nested
                 // block into the enclosing block during the post-binding lower pass.
+                this.allocated.Add(bi.Original);
                 var initializer = this.RewriteExpression(node.Initializer);
                 var stmts = ImmutableArray.Create<BoundStatement>(
                     new BoundVariableDeclaration(

--- a/test/Compiler.Tests/Emit/Issue1453CapturedOutVarEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1453CapturedOutVarEmitTests.cs
@@ -1,0 +1,304 @@
+// <copyright file="Issue1453CapturedOutVarEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1453 — an inline <c>out var x</c> whose value is captured by a nested
+/// lambda crashed emit with <c>GS9998: Variable 'x' has no local slot.</c>
+/// <para>
+/// Root cause: a captured local is hoisted into a per-variable <c>Box</c> class
+/// by <see cref="GSharp.Core.CodeAnalysis.Lowering.CaptureBoxingRewriter"/>, but
+/// the box local is only allocated (<c>var box = new Box()</c>) when the rewriter
+/// visits the original's <c>BoundVariableDeclaration</c>. An inline <c>out var x</c>
+/// produces <b>no declaration</b> — it binds straight to an address-of in the
+/// call's <c>out</c> argument — so the box local was never declared, leaving it
+/// without an IL slot.
+/// </para>
+/// <para>
+/// The fix allocates the box for such declaration-less captured locals at the
+/// statement that first introduces them (their address-of site), scoped to the
+/// enclosing block. Block-level allocation means a loop body gets a fresh box
+/// per iteration, matching how an ordinary <c>var x = e</c> inside a loop body
+/// behaves — the closures below observe per-iteration values, not a shared one.
+/// </para>
+/// Each test compiles, IL-verifies (inside <see cref="CompileAndRun"/>), and runs.
+/// </summary>
+public class Issue1453CapturedOutVarEmitTests
+{
+    [Fact]
+    public void EndToEnd_TopLevelCapturedOutVar_VerifiesAndRuns()
+    {
+        // The headline repro: an inline `out var captured` read by a lambda.
+        var source = """
+            package Probe1453Top
+            import System
+
+            open class Q1453Top {
+                func TryGet(out v int32) bool {
+                    v = 42
+                    return true
+                }
+            }
+
+            func Main() {
+                let q = Q1453Top()
+                q.TryGet(out var captured)
+                let f = func () int32 {
+                    return captured + 1
+                }
+                Console.WriteLine(f())
+            }
+            """;
+
+        Assert.Equal("43\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EndToEnd_CapturedOutVarInLoopBody_GetsFreshBoxPerIteration()
+    {
+        // Each iteration's `out var c` must be a fresh box: the three captured
+        // closures return 100, 101, 102 (sum 303), not a shared final 102 (306).
+        var source = """
+            package Probe1453Loop
+            import System
+            import System.Collections.Generic
+
+            open class Q1453Loop {
+                func TryGet(out v int32) bool {
+                    v = 100
+                    return true
+                }
+            }
+
+            func Main() {
+                let q = Q1453Loop()
+                var fns = List[(() -> int32)]()
+                for i in 0 ... 3 {
+                    q.TryGet(out var c)
+                    c = c + i
+                    let f = func () int32 {
+                        return c
+                    }
+                    fns.Add(f)
+                }
+                var total = 0
+                for g in fns {
+                    total = total + g()
+                }
+                Console.WriteLine(total)
+            }
+            """;
+
+        Assert.Equal("303\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EndToEnd_MultipleCapturedOutVarsInOneCall_VerifiesAndRuns()
+    {
+        // Two inline out-vars introduced by a single call, both captured.
+        var source = """
+            package Probe1453Multi
+            import System
+
+            open class Q1453Multi {
+                func TryTwo(out a int32, out b int32) bool {
+                    a = 7
+                    b = 9
+                    return true
+                }
+            }
+
+            func Main() {
+                let q = Q1453Multi()
+                q.TryTwo(out var x, out var y)
+                let f = func () int32 {
+                    return x + y
+                }
+                Console.WriteLine(f())
+            }
+            """;
+
+        Assert.Equal("16\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EndToEnd_CapturedOutVarInLoopCondition_VerifiesAndRuns()
+    {
+        // An out-var introduced in a loop *condition* is attributed to the
+        // enclosing block (one box), and its capture in the body is valid.
+        var source = """
+            package Probe1453Cond
+            import System
+
+            open class Q1453Cond {
+                func TryGet(out v int32) bool {
+                    v = 100
+                    return true
+                }
+            }
+
+            func Main() {
+                let q = Q1453Cond()
+                var sum = 0
+                var count = 0
+                for count < 2 && q.TryGet(out var w) {
+                    let f = func () int32 {
+                        return w
+                    }
+                    sum = sum + f()
+                    count = count + 1
+                }
+                Console.WriteLine(sum)
+            }
+            """;
+
+        Assert.Equal("200\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EndToEnd_NonCapturedOutVar_StaysVerifiable()
+    {
+        // Control: an inline out-var that is *not* captured must keep its
+        // ordinary local slot (the box rewriter never runs for it).
+        var source = """
+            package Probe1453Plain
+            import System
+
+            open class Q1453Plain {
+                func TryGet(out v int32) bool {
+                    v = 42
+                    return true
+                }
+            }
+
+            func Main() {
+                let q = Q1453Plain()
+                q.TryGet(out var captured)
+                Console.WriteLine(captured)
+            }
+            """;
+
+        Assert.Equal("42\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EndToEnd_OrdinaryCapturedLocalAndOutVarTogether_VerifiesAndRuns()
+    {
+        // Control: a normally-declared captured local (`var n = ...`) still
+        // boxes at its declaration, and coexists with a captured out-var in
+        // the same scope without double-allocating either box.
+        var source = """
+            package Probe1453Mixed
+            import System
+
+            open class Q1453Mixed {
+                func TryGet(out v int32) bool {
+                    v = 40
+                    return true
+                }
+            }
+
+            func Main() {
+                let q = Q1453Mixed()
+                var n = 2
+                q.TryGet(out var captured)
+                let f = func () int32 {
+                    return captured + n
+                }
+                Console.WriteLine(f())
+            }
+            """;
+
+        Assert.Equal("42\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1453_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1453. An inline `out var x` whose value is captured by a nested lambda crashed `gsc` during emit with:

```
GS9998: Variable 'x' has no local slot.
```

### Root cause

`CaptureBoxingRewriter` hoists each captured local into a per-variable `Box` class and rewrites reads/writes through `box.Value`. The box local itself was only **allocated** (`var box = new Box()`) when the rewriter visited the original's `BoundVariableDeclaration`. An inline `out var x` produces **no declaration** — it binds straight to an address-of in the call's `out` argument — so the box local was never declared and ended up with no IL slot.

### Fix

Allocate the box for declaration-less captured locals at the statement that first introduces them (their `out`/`ref` address-of site), scoped to the enclosing block:

- A new `RewriteBlockStatement` override walks each statement; a shallow `OutVarBoxIntroductionScanner` (stops at nested blocks and lambda bodies) finds captured locals introduced by an address-of that have not been allocated yet, and injects `var box = new Box()` before the introducing statement.
- An `allocated` set — also marked at the ordinary declaration site — ensures each box is allocated **exactly once**, so the same path correctly handles out-vars in loop conditions, in loop bodies, multiple out-vars per call, and out-vars mixed with ordinary captured locals.
- Block-level allocation means a loop body gets a **fresh box per iteration**, matching how ordinary `var x = e` inside a loop body behaves (closures observe per-iteration values).

The existing write-through path was already correct: the base rewriter recurses into the address-of operand, turning `&x` into `&(box.Value)` (a field-address), which `EmitAddressOf` already lowers to `ldflda`. Only the missing box allocation needed fixing.

### Tests

Adds `Issue1453CapturedOutVarEmitTests` — ilverify-gated, compile-and-run regression tests covering:
- the headline repro (top-level captured out-var),
- per-iteration box freshness in a loop body (3 closures return 100/101/102 → 303, not a shared 306),
- multiple captured out-vars in a single call,
- a captured out-var introduced in a loop condition,
- a non-captured out-var control (keeps its ordinary slot),
- an ordinary captured local coexisting with a captured out-var.

### Validation

- New tests: 6/6 pass (ilverify-clean + correct runtime output).
- `Core.Tests`: 4788 pass.
- Targeted closure/capture/lambda + out-var emit suites: 142 + 40 pass.
- Release build: 0 warnings, 0 errors.
