### PR TITLE
Fix generic self-type encoding in state machines and base calls (#1465)

### DIFF
--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Async.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Async.cs
@@ -54,7 +54,7 @@ internal sealed partial class MethodBodyEmitter
     {
         // ldarg.0 (this)
         // ldflda builder
-        var builderFieldHandle = this.outer.cache.StructFieldDefs[node.BuilderField];
+        var builderFieldHandle = this.outer.ResolveFieldToken(node.SmClass, node.BuilderField);
         this.il.OpCode(ILOpCode.Ldarg_0);
         this.il.OpCode(ILOpCode.Ldflda);
         this.il.Token(builderFieldHandle);
@@ -69,11 +69,9 @@ internal sealed partial class MethodBodyEmitter
             .First(m => m.Name == "MoveNext" && m.IsGenericMethodDefinition && m.GetParameters().Length == 1);
         var openRef = this.outer.GetMethodReference(openMoveNext.GetGenericMethodDefinition());
 
-        var smTypeDef = this.outer.cache.StructTypeDefs[node.SmClass];
-
         var sigBlob = new BlobBuilder();
         var argsEncoder = new BlobEncoder(sigBlob).MethodSpecificationSignature(1);
-        argsEncoder.AddArgument().Type(smTypeDef, isValueType: false); // class, not struct
+        this.outer.EncodeTypeSymbolIntoSignature(argsEncoder.AddArgument(), node.SmClass); // class, not struct
 
         var methodSpec = this.outer.emitCtx.Metadata.AddMethodSpecification(openRef, this.outer.emitCtx.Metadata.GetOrAddBlob(sigBlob));
         this.il.OpCode(ILOpCode.Call);

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
@@ -1329,7 +1329,23 @@ internal sealed partial class MethodBodyEmitter
     /// <summary>ADR-0039: Emits the field address (ldflda) for a user struct field.</summary>
     private void EmitFieldAddress(BoundFieldAccessExpression fa)
     {
-        if (!this.outer.cache.StructFieldDefs.TryGetValue(fa.Field, out var fieldHandle))
+        // Issue #1465: a field declared on a generic user struct (e.g. an async
+        // state-machine reified over its enclosing class's type parameters) must
+        // be addressed through a MemberRef parented at the constructed self
+        // TypeSpec (`SM`1<!T>`), not the raw open FieldDef. Mirror the
+        // generic-aware resolution used by the value-read path so `ldflda`
+        // (struct builder SetResult/SetException etc.) matches verification.
+        EntityHandle fieldHandle;
+        var containing = fa.StructType;
+        if (containing != null && ReflectionMetadataEmitter.IsUserGenericTypeReference(containing))
+        {
+            fieldHandle = this.outer.ResolveFieldToken(containing, fa.Field);
+        }
+        else if (this.outer.cache.StructFieldDefs.TryGetValue(fa.Field, out var defHandle))
+        {
+            fieldHandle = defHandle;
+        }
+        else
         {
             throw new InvalidOperationException(
                 $"Cannot take address of field '{fa.Field.Name}': no emitted FieldDef.");

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -364,6 +364,72 @@ internal sealed class ReflectionMetadataEmitter
         }
     }
 
+    /// <summary>
+    /// Issue #1465: reifies an async state-machine struct over an
+    /// ordinal-aligned copy of the type parameters in scope at its kickoff
+    /// method — the enclosing generic type's parameters first, then the
+    /// kickoff method's own type parameters (Roslyn ordering). References to
+    /// those parameters inside MoveNext / hoisted-field signatures then encode
+    /// as the SM type's own <c>ELEMENT_TYPE_VAR</c> slots, and references to
+    /// the SM type from the kickoff method self-instantiate as
+    /// <c>SM&lt;!0,…&gt;</c> using the enclosing type's parameters.
+    /// </summary>
+    /// <param name="smStruct">The materialized state-machine struct.</param>
+    /// <param name="kickoff">The async kickoff method.</param>
+    private void RegisterStateMachineEnclosingGenerics(StructSymbol smStruct, FunctionSymbol kickoff)
+    {
+        var classTPs = kickoff?.ReceiverType is StructSymbol receiver
+            ? (receiver.Definition ?? receiver).TypeParameters
+            : ImmutableArray<TypeParameterSymbol>.Empty;
+        var methodTPs = kickoff == null || kickoff.TypeParameters.IsDefaultOrEmpty
+            ? ImmutableArray<TypeParameterSymbol>.Empty
+            : kickoff.TypeParameters;
+
+        if (classTPs.IsDefaultOrEmpty && methodTPs.IsDefaultOrEmpty)
+        {
+            return;
+        }
+
+        var total = classTPs.Length + methodTPs.Length;
+        var smTPs = ImmutableArray.CreateBuilder<TypeParameterSymbol>(total);
+        var remap = new Dictionary<TypeParameterSymbol, int>(total);
+        var ordinal = 0;
+        foreach (var src in classTPs)
+        {
+            smTPs.Add(CloneAsClassTypeParameter(src, ordinal));
+            remap[src] = ordinal;
+            ordinal++;
+        }
+
+        foreach (var src in methodTPs)
+        {
+            smTPs.Add(CloneAsClassTypeParameter(src, ordinal));
+            remap[src] = ordinal;
+            ordinal++;
+        }
+
+        smStruct.SetTypeParameters(smTPs.MoveToImmutable());
+        this.iteratorStateMachineRemapsByClass[smStruct] = remap;
+    }
+
+    private static TypeParameterSymbol CloneAsClassTypeParameter(TypeParameterSymbol src, int ordinal)
+    {
+        return new TypeParameterSymbol(
+            src.Name,
+            ordinal,
+            src.Constraint,
+            src.Variance,
+            src.InterfaceConstraint)
+        {
+            HasReferenceTypeConstraint = src.HasReferenceTypeConstraint,
+            HasValueTypeConstraint = src.HasValueTypeConstraint,
+            HasDefaultConstructorConstraint = src.HasDefaultConstructorConstraint,
+            ClrInterfaceConstraint = src.ClrInterfaceConstraint,
+            ClassConstraint = src.ClassConstraint,
+            IsMethodTypeParameter = false,
+        };
+    }
+
     private ReflectionMetadataEmitter(BoundProgram program, ReferenceResolver references, string assemblyName, bool metadataOnly)
     {
         this.emitCtx = new EmitContext(program, references, assemblyName, metadataOnly);
@@ -657,6 +723,8 @@ internal sealed class ReflectionMetadataEmitter
             this.customAttrEncoder.NextParameterHandle,
             this.EncodeTypeSymbol,
             this.EncodeClrType,
+            this.GetStructTypeToken,
+            this.ResolveFieldToken,
             this.BuildMoveNextBodyBytes);
 
         if (asyncRewriteResult != null)
@@ -738,6 +806,17 @@ internal sealed class ReflectionMetadataEmitter
         foreach (var plan in this.stateMachines.AsyncStateMachinePlans)
         {
             var smStruct = plan.StateMachine.MaterializeAsStructSymbol();
+
+            // Issue #1465: when the async kickoff method lives inside a
+            // generic type (or is itself a generic method), the synthesized
+            // state-machine type must be reified over an ordinal-aligned copy
+            // of the enclosing type's (and the method's) type parameters —
+            // mirroring Roslyn's `<M>d__0<T>`. Without this the hoisted
+            // `<>4__this` field, the `this`-proxy, and the self-call targets
+            // inside MoveNext reference the class's `!0` from a non-generic
+            // SM context, producing unverifiable IL.
+            this.RegisterStateMachineEnclosingGenerics(smStruct, plan.StateMachine.KickoffMethod);
+
             asyncSmStructs.Add(smStruct);
             asyncSmPlansByStruct[smStruct] = plan;
         }
@@ -2137,7 +2216,15 @@ internal sealed class ReflectionMetadataEmitter
         foreach (var s in smStructsOrdered)
         {
             var smMethodListRow = structFirstMethodRows[s];
-            this.typeDefEmitter.EmitNestedStructTypeDef(s, structFirstFieldRow[s], smMethodListRow);
+
+            // Issue #1465: push the SM's enclosing-type/method TP → SM-TP
+            // remap so hoisted-field signatures (e.g. `<>4__this`) translate
+            // method-type-parameter references into the SM type's own Var
+            // slots. A no-op when the SM is non-generic.
+            using (this.PushSmRemap(s))
+            {
+                this.typeDefEmitter.EmitNestedStructTypeDef(s, structFirstFieldRow[s], smMethodListRow);
+            }
 
             var iAsyncSmType = typeof(System.Runtime.CompilerServices.IAsyncStateMachine);
             var iAsyncSmRef = this.GetTypeReference(iAsyncSmType);
@@ -2490,7 +2577,16 @@ internal sealed class ReflectionMetadataEmitter
                     EmitClassMethodBodies(ns);
                     break;
                 case StructSymbol ns:
-                    EmitStructMethodBodies(ns);
+                    // Issue #1465: async state-machine structs are reified
+                    // over their enclosing-type/method type parameters; push
+                    // the SM TP remap so MoveNext bodies and signatures
+                    // translate method-TP references to the SM's own Var
+                    // slots. A no-op for non-generic structs.
+                    using (this.PushSmRemap(ns))
+                    {
+                        EmitStructMethodBodies(ns);
+                    }
+
                     break;
 
                 // Enums own no method bodies.
@@ -6689,6 +6785,34 @@ internal sealed class ReflectionMetadataEmitter
     }
 
     /// <summary>
+    /// Issue #1465: returns the metadata token for a state-machine (or any
+    /// user) struct type used as an operand (<c>initobj</c>) or type
+    /// argument. A non-generic struct uses its bare <c>TypeDef</c>; a generic
+    /// struct uses the constructed (or self-) <c>TypeSpec</c> so references
+    /// from a generic context carry the correct <c>Var</c> instantiation.
+    /// </summary>
+    /// <param name="structSym">The struct symbol.</param>
+    /// <returns>The type token.</returns>
+    internal EntityHandle GetStructTypeToken(StructSymbol structSym)
+    {
+        return IsUserGenericTypeReference(structSym)
+            ? this.GetUserStructTypeSpec(structSym)
+            : this.cache.StructTypeDefs[structSym];
+    }
+
+    /// <summary>
+    /// Issue #1465: internal forwarder so the body emitter can encode a
+    /// <see cref="TypeSymbol"/> into a signature blob (e.g. a MethodSpec type
+    /// argument) using the same generic-aware path as the rest of the emitter.
+    /// </summary>
+    /// <param name="encoder">The signature type encoder to write into.</param>
+    /// <param name="type">The type symbol to encode.</param>
+    internal void EncodeTypeSymbolIntoSignature(SignatureTypeEncoder encoder, TypeSymbol type)
+    {
+        this.EncodeTypeSymbol(encoder, type);
+    }
+
+    /// <summary>
     /// ADR-0087 §3 R3: returns a <c>MemberRef</c> handle for a field
     /// on a user-declared generic type, parented at the
     /// <c>TypeSpec</c> for <paramref name="containingType"/>.
@@ -6840,6 +6964,34 @@ internal sealed class ReflectionMetadataEmitter
     }
 
     /// <summary>
+    /// Issue #1465: encodes a function's emitted return type into a signature
+    /// blob. For an <c>async</c> kickoff method the emitted return is the
+    /// wrapped builder task type (<c>Task</c> / <c>Task&lt;T&gt;</c>), not the
+    /// declared inner result type carried on <see cref="FunctionSymbol.Type"/>.
+    /// MemberRef signatures built for calls into such a method on a generic
+    /// receiver must match the emitted MethodDef, otherwise verification fails
+    /// with a spurious <c>MissingMethod</c>.
+    /// </summary>
+    /// <param name="encoder">The return-type encoder.</param>
+    /// <param name="fn">The function whose emitted return type to encode.</param>
+    private void EncodeFunctionReturnSymbol(ReturnTypeEncoder encoder, FunctionSymbol fn)
+    {
+        if (fn.IsAsync && fn.StateMachineType != null)
+        {
+            foreach (var plan in this.stateMachines.AsyncStateMachinePlans)
+            {
+                if (plan.KickoffMethod == fn)
+                {
+                    this.EncodeAsyncReturnType(encoder, plan);
+                    return;
+                }
+            }
+        }
+
+        EncodeReturnSymbol(encoder, fn.Type, fn.ReturnRefKind);
+    }
+
+    /// <summary>
     /// ADR-0087 §3 R3: encodes a method signature blob from a
     /// <see cref="FunctionSymbol"/>, using the OPEN definition's type
     /// information so <c>VAR(idx)</c> placeholders are produced for
@@ -6856,7 +7008,7 @@ internal sealed class ReflectionMetadataEmitter
                 genericParameterCount: openMethod.TypeParameters.IsDefaultOrEmpty ? 0 : openMethod.TypeParameters.Length)
             .Parameters(
                 paramCount,
-                r => EncodeReturnSymbol(r, openMethod.Type, openMethod.ReturnRefKind),
+                r => EncodeFunctionReturnSymbol(r, openMethod),
                 ps =>
                 {
                     foreach (var p in openMethod.Parameters)

--- a/src/Core/CodeAnalysis/Emit/StateMachineEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/StateMachineEmitter.cs
@@ -132,6 +132,12 @@ internal sealed class StateMachineEmitter
     private readonly Action<SignatureTypeEncoder, TypeSymbol> encodeTypeSymbol;
     private readonly Action<SignatureTypeEncoder, Type> encodeClrType;
 
+    // Issue #1465: resolve a state-machine struct type token / field token
+    // through the generic-aware path (TypeSpec / MemberRef when the SM is
+    // reified over its enclosing type's parameters).
+    private readonly Func<StructSymbol, EntityHandle> getStructTypeToken;
+    private readonly Func<StructSymbol, FieldSymbol, EntityHandle> resolveFieldToken;
+
     // PR-E-8-style callback: drives the still-private BodyEmitter nested class
     // on RME to build the MoveNext body bytes (PDB metadata included). Returns
     // -1 bodyOffset under MetadataOnly.
@@ -151,6 +157,8 @@ internal sealed class StateMachineEmitter
         Func<ParameterHandle> nextParameterHandle,
         Action<SignatureTypeEncoder, TypeSymbol> encodeTypeSymbol,
         Action<SignatureTypeEncoder, Type> encodeClrType,
+        Func<StructSymbol, EntityHandle> getStructTypeToken,
+        Func<StructSymbol, FieldSymbol, EntityHandle> resolveFieldToken,
         Func<AsyncStateMachinePlan, MoveNextBodyResult> buildMoveNextBodyBytes)
     {
         this.emitCtx = emitCtx ?? throw new ArgumentNullException(nameof(emitCtx));
@@ -166,6 +174,8 @@ internal sealed class StateMachineEmitter
         this.nextParameterHandle = nextParameterHandle ?? throw new ArgumentNullException(nameof(nextParameterHandle));
         this.encodeTypeSymbol = encodeTypeSymbol ?? throw new ArgumentNullException(nameof(encodeTypeSymbol));
         this.encodeClrType = encodeClrType ?? throw new ArgumentNullException(nameof(encodeClrType));
+        this.getStructTypeToken = getStructTypeToken ?? throw new ArgumentNullException(nameof(getStructTypeToken));
+        this.resolveFieldToken = resolveFieldToken ?? throw new ArgumentNullException(nameof(resolveFieldToken));
         this.buildMoveNextBodyBytes = buildMoveNextBodyBytes ?? throw new ArgumentNullException(nameof(buildMoveNextBodyBytes));
     }
 
@@ -276,10 +286,13 @@ internal sealed class StateMachineEmitter
         public ImmutableArray<TypeParameterSymbol> ClassTypeParameters { get; }
 
         /// <summary>
-        /// Issue #810: returns the emit-time remap from each outer-method
-        /// type parameter to its corresponding class-type-parameter ordinal,
-        /// or <see langword="null"/> when this iterator has no type
-        /// parameters. Used by
+        /// Issue #810 + #1465: returns the emit-time remap from each
+        /// outer-method type parameter to its corresponding class-type-parameter
+        /// ordinal on the synthesized state machine, or <see langword="null"/>
+        /// when this iterator method has no method-level type parameters. The
+        /// state machine's leading type parameters mirror the enclosing generic
+        /// type's parameters, so a method type parameter maps to the slot
+        /// offset by the enclosing class type-parameter count. Used by
         /// <see cref="ReflectionMetadataEmitter.activeIteratorStateMachineRemap"/>.
         /// </summary>
         public Dictionary<TypeParameterSymbol, int> BuildRemap()
@@ -289,10 +302,11 @@ internal sealed class StateMachineEmitter
                 return null;
             }
 
+            var offset = this.ClassTypeParameters.Length - this.OuterMethodTypeParameters.Length;
             var map = new Dictionary<TypeParameterSymbol, int>(this.OuterMethodTypeParameters.Length);
             for (var i = 0; i < this.OuterMethodTypeParameters.Length; i++)
             {
-                map[this.OuterMethodTypeParameters[i]] = i;
+                map[this.OuterMethodTypeParameters[i]] = offset + i;
             }
 
             return map;
@@ -376,41 +390,57 @@ internal sealed class StateMachineEmitter
             // rows so CLR access checks succeed at runtime.
             var packageName = plan.Function.Package?.Name ?? hostPackage?.Name ?? string.Empty;
 
-            // Issue #810: when the iterator is generic, the synthesized
-            // state-machine class must itself be generic over a matching
-            // set of class-level type parameters (mirroring Roslyn's
-            // `<Empty>d__0<T>`). Build class TPs (`IsMethodTypeParameter=false`,
-            // so EncodeTypeSymbol writes them as `Var(idx)`) before the
-            // class is materialized — every field/parameter/local that
-            // mentions the outer method's TP is then substituted to the
-            // class TP via the activeIteratorStateMachineRemap encode-time
-            // hook. The class TPs themselves are not used directly in any
-            // bound expression — the substitution lives at the encoder.
+            // Issue #810 + #1465: when the iterator method has type parameters
+            // in scope — the enclosing GENERIC type's parameters and/or the
+            // method's own type parameters — the synthesized state-machine
+            // class must itself be generic over an ordinal-aligned copy of
+            // them (mirroring Roslyn's `<Empty>d__0<T>`). The enclosing type's
+            // parameters come first (ordinals 0..k-1), then the method's own
+            // (ordinals k..). Class TPs (`IsMethodTypeParameter=false`) encode
+            // as `Var(idx)`; a method-TP reference inside the body is
+            // translated to the matching class-TP slot via the
+            // activeIteratorStateMachineRemap encode-time hook. The class TPs
+            // themselves are not used directly in any bound expression — the
+            // substitution lives at the encoder.
+            var enclosingClassTPs = plan.Function.ReceiverType is StructSymbol iterRecv
+                ? (iterRecv.Definition ?? iterRecv).TypeParameters
+                : ImmutableArray<TypeParameterSymbol>.Empty;
+            if (enclosingClassTPs.IsDefault)
+            {
+                enclosingClassTPs = ImmutableArray<TypeParameterSymbol>.Empty;
+            }
+
             var outerMethodTPs = plan.Function.TypeParameters.IsDefaultOrEmpty
                 ? ImmutableArray<TypeParameterSymbol>.Empty
                 : plan.Function.TypeParameters;
+
+            // Combined in-scope type parameters: enclosing class first, then
+            // method. Drives the SM's own generic parameters and the
+            // self-instantiation type arguments used by the kickoff.
+            var scopeTPs = enclosingClassTPs.AddRange(outerMethodTPs);
             ImmutableArray<TypeParameterSymbol> classTPs;
-            if (outerMethodTPs.IsDefaultOrEmpty)
+            if (scopeTPs.IsDefaultOrEmpty)
             {
                 classTPs = ImmutableArray<TypeParameterSymbol>.Empty;
             }
             else
             {
-                var b = ImmutableArray.CreateBuilder<TypeParameterSymbol>(outerMethodTPs.Length);
-                foreach (var outerTP in outerMethodTPs)
+                var b = ImmutableArray.CreateBuilder<TypeParameterSymbol>(scopeTPs.Length);
+                for (var ti = 0; ti < scopeTPs.Length; ti++)
                 {
+                    var scopeTP = scopeTPs[ti];
                     var classTP = new TypeParameterSymbol(
-                        outerTP.Name,
-                        outerTP.Ordinal,
-                        outerTP.Constraint,
-                        outerTP.Variance,
-                        outerTP.InterfaceConstraint)
+                        scopeTP.Name,
+                        ti,
+                        scopeTP.Constraint,
+                        scopeTP.Variance,
+                        scopeTP.InterfaceConstraint)
                     {
-                        HasReferenceTypeConstraint = outerTP.HasReferenceTypeConstraint,
-                        HasValueTypeConstraint = outerTP.HasValueTypeConstraint,
-                        HasDefaultConstructorConstraint = outerTP.HasDefaultConstructorConstraint,
-                        ClrInterfaceConstraint = outerTP.ClrInterfaceConstraint,
-                        ClassConstraint = outerTP.ClassConstraint,
+                        HasReferenceTypeConstraint = scopeTP.HasReferenceTypeConstraint,
+                        HasValueTypeConstraint = scopeTP.HasValueTypeConstraint,
+                        HasDefaultConstructorConstraint = scopeTP.HasDefaultConstructorConstraint,
+                        ClrInterfaceConstraint = scopeTP.ClrInterfaceConstraint,
+                        ClassConstraint = scopeTP.ClassConstraint,
                         IsMethodTypeParameter = false,
                     };
                     b.Add(classTP);
@@ -501,7 +531,7 @@ internal sealed class StateMachineEmitter
             // symbolic encoder so the GetEnumerator signature stays
             // strongly typed as `IEnumerator<Shape>`.
             var elementNeedsSymbolicEnumerator =
-                ContainsOuterMethodTypeParameter(plan.ElementType, outerMethodTPs)
+                ContainsOuterMethodTypeParameter(plan.ElementType, scopeTPs)
                 || plan.ElementType?.ClrType == null;
             var getEnumeratorType = elementNeedsSymbolicEnumerator
                 ? (TypeSymbol)ImportedTypeSymbol.GetConstructed(
@@ -548,7 +578,7 @@ internal sealed class StateMachineEmitter
             // outer method's TPs.
             var kickoffSmType = classTPs.IsDefaultOrEmpty
                 ? smClass
-                : StructSymbol.Construct(smClass, outerMethodTPs.CastArray<TypeSymbol>());
+                : StructSymbol.Construct(smClass, scopeTPs.CastArray<TypeSymbol>());
 
             this.lambdaBodies[getEnumerator] = Lowerer.Lower(new BoundBlockStatement(null,
                 ImmutableArray.Create<BoundStatement>(
@@ -1349,10 +1379,10 @@ internal sealed class StateMachineEmitter
     public int EmitAsyncKickoffBody(FunctionSymbol function, AsyncStateMachinePlan plan)
     {
         var smStruct = plan.StateMachine.MaterializeAsStructSymbol();
-        var smTypeDef = this.cache.StructTypeDefs[smStruct];
+        var smTypeDef = this.getStructTypeToken(smStruct);
         var builderInfo = plan.StateMachine.BuilderInfo;
-        var stateFieldHandle = this.cache.StructFieldDefs[plan.FieldMap.StateField];
-        var builderFieldHandle = this.cache.StructFieldDefs[plan.FieldMap.BuilderField];
+        var stateFieldHandle = this.resolveFieldToken(smStruct, plan.FieldMap.StateField);
+        var builderFieldHandle = this.resolveFieldToken(smStruct, plan.FieldMap.BuilderField);
 
         var il = new InstructionEncoder(new BlobBuilder());
 
@@ -1373,7 +1403,7 @@ internal sealed class StateMachineEmitter
         // Copy this (for instance methods)
         if (plan.FieldMap.ThisField != null && function.IsInstanceMethod)
         {
-            var thisFieldHandle = this.cache.StructFieldDefs[plan.FieldMap.ThisField];
+            var thisFieldHandle = this.resolveFieldToken(smStruct, plan.FieldMap.ThisField);
             il.LoadLocalAddress(0);
             il.LoadArgument(0);
             il.OpCode(ILOpCode.Stfld);
@@ -1385,7 +1415,7 @@ internal sealed class StateMachineEmitter
         var paramIndex = 0;
         foreach (var copy in plan.KickoffPlan.ParameterCopies)
         {
-            var fieldHandle = this.cache.StructFieldDefs[copy.Field];
+            var fieldHandle = this.resolveFieldToken(smStruct, copy.Field);
             il.LoadLocalAddress(0);
             il.LoadArgument(paramIndex + paramSlotShift);
             il.OpCode(ILOpCode.Stfld);
@@ -1430,10 +1460,12 @@ internal sealed class StateMachineEmitter
 
         il.OpCode(ILOpCode.Ret);
 
-        // Locals: one local of the state-machine struct type.
+        // Locals: one local of the state-machine struct type. Issue #1465:
+        // encode through EncodeTypeSymbol so a generic SM is written as the
+        // self-instantiated GENERICINST rather than a bare VALUETYPE token.
         var localsSigBlob = new BlobBuilder();
         var localsEncoder = new BlobEncoder(localsSigBlob).LocalVariableSignature(1);
-        localsEncoder.AddVariable().Type().Type(smTypeDef, isValueType: true);
+        this.encodeTypeSymbol(localsEncoder.AddVariable().Type(), smStruct);
         var localsSignature = this.emitCtx.Metadata.AddStandaloneSignature(this.emitCtx.Metadata.GetOrAddBlob(localsSigBlob));
 
         return this.emitCtx.MethodBodyStream.AddMethodBody(
@@ -1457,11 +1489,12 @@ internal sealed class StateMachineEmitter
                 : startOpenMethod,
             builderFieldType);
 
-        // Build MethodSpec signature: instantiation with SM struct type.
-        var smTypeDef = this.cache.StructTypeDefs[smStruct];
+        // Build MethodSpec signature: instantiation with the SM struct type.
+        // Issue #1465: encode through EncodeTypeSymbol so a generic SM is
+        // written as the self-instantiated GENERICINST<SM><!0,…>.
         var sigBlob = new BlobBuilder();
         var argsEncoder = new BlobEncoder(sigBlob).MethodSpecificationSignature(1);
-        argsEncoder.AddArgument().Type(smTypeDef, isValueType: true);
+        this.encodeTypeSymbol(argsEncoder.AddArgument(), smStruct);
 
         return this.emitCtx.Metadata.AddMethodSpecification(openRef, this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
     }
@@ -1520,7 +1553,7 @@ internal sealed class StateMachineEmitter
             throw new InvalidOperationException("Cannot emit AwaitOnCompleted: no active async plan.");
         }
 
-        var builderFieldHandle = this.cache.StructFieldDefs[builderField];
+        var builderFieldHandle = this.resolveFieldToken(smStruct, builderField);
 
         // ldarg.0 (this)
         // ldflda builder
@@ -1555,7 +1588,6 @@ internal sealed class StateMachineEmitter
                 : openMethod,
             builderField.Type);
 
-        var smTypeDef = this.cache.StructTypeDefs[smStruct];
         var sigBlob = new BlobBuilder();
         var argsEncoder = new BlobEncoder(sigBlob).MethodSpecificationSignature(2);
 
@@ -1569,8 +1601,10 @@ internal sealed class StateMachineEmitter
             this.encodeClrType(argsEncoder.AddArgument(), node.AwaiterClrType);
         }
 
-        // Second type arg: TStateMachine (the SM TypeDef)
-        argsEncoder.AddArgument().Type(smTypeDef, isValueType: smIsValueType);
+        // Second type arg: TStateMachine. Issue #1465: encode through
+        // EncodeTypeSymbol so a generic SM is written as the self-instantiated
+        // GENERICINST<SM><!0,…> rather than a bare TypeDef token.
+        this.encodeTypeSymbol(argsEncoder.AddArgument(), smStruct);
 
         var methodSpec = this.emitCtx.Metadata.AddMethodSpecification(openRef, this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
         il.OpCode(ILOpCode.Call);

--- a/test/Compiler.Tests/Emit/Issue1465GenericSelfEncodingEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1465GenericSelfEncodingEmitTests.cs
@@ -1,0 +1,232 @@
+// <copyright file="Issue1465GenericSelfEncodingEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1465 — inside the instance methods of a GENERIC class, references to
+/// the class's own type parameters were mis-encoded in IL: the async/iterator
+/// state-machine nested type was emitted as NON-generic, so <c>this</c>,
+/// type-parameter-typed parameters, hoisted state-machine fields, and self/base
+/// calls referenced a dangling <c>!0</c> (ilverify rendered <c>T0</c> /
+/// <c>value 'T'</c>) instead of the class generic <c>ELEMENT_TYPE_VAR</c>. The
+/// fix reifies the state-machine over ordinal-aligned copies of the enclosing
+/// class's type parameters (any arity) and routes all dedicated raw-handle
+/// token sites through generic-aware helpers. These tests assert the emitted IL
+/// verifies clean and runs; each would fail ilverify on the pre-fix compiler.
+/// </summary>
+public class Issue1465GenericSelfEncodingEmitTests
+{
+    [Fact]
+    public void EndToEnd_GenericClassAsyncSelfCall_VerifiesAndRuns()
+    {
+        var source = """
+            package Probe1465a
+            import System
+            import System.Threading.Tasks
+
+            open class FilterBase1465a[T] {
+                open async func AddInputAsync(input T) {
+                    await CompleteInternalAsync()
+                }
+                protected open async func CompleteInternalAsync() {
+                    await FlushAsync()
+                }
+                protected open func FlushAsync() Task {
+                    return Task.CompletedTask
+                }
+            }
+            class AudioFilter1465a : FilterBase1465a[int32] {
+            }
+            func Main() {
+                Console.WriteLine("ok")
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("ok\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_GenericArity2ClassAsyncSelfCall_VerifiesAndRuns()
+    {
+        var source = """
+            package Probe1465b
+            import System
+            import System.Threading.Tasks
+
+            open class Pair1465b[K, V] {
+                open async func ConsumeAsync(key K, value V) {
+                    await ForwardAsync(key, value)
+                }
+                protected open async func ForwardAsync(key K, value V) {
+                    await DoneAsync()
+                }
+                protected open func DoneAsync() Task {
+                    return Task.CompletedTask
+                }
+            }
+            class StringIntPair1465b : Pair1465b[string, int32] {
+            }
+            func Main() {
+                Console.WriteLine("ok2")
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("ok2\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_IteratorInGenericClass_VerifiesAndRuns()
+    {
+        var source = """
+            package Probe1465d
+            import System
+            import System.Collections.Generic
+
+            open class Holder1465d[T] {
+                var items []T
+                func Init(a T, b T) {
+                    items = [2]T
+                    items[0] = a
+                    items[1] = b
+                }
+                open func Enumerate() sequence[T] {
+                    yield items[0]
+                    yield items[1]
+                }
+            }
+            func Main() {
+                var h = Holder1465d[int32]()
+                h.Init(5, 9)
+                for x in h.Enumerate() {
+                    Console.WriteLine(x)
+                }
+                Console.WriteLine("ok4")
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("5\n9\nok4\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_BaseCallIntoGenericBase_VerifiesAndRuns()
+    {
+        var source = """
+            package Probe1465c
+            import System
+
+            open class FrameFilterBase1465c[T] {
+                open func Dispose(disposing bool) {
+                    Console.WriteLine("base dispose")
+                }
+            }
+            open class AavdFilterBase1465c : FrameFilterBase1465c[int32] {
+            }
+            class AavdFilter1465c : AavdFilterBase1465c {
+                override func Dispose(disposing bool) {
+                    base.Dispose(disposing)
+                }
+            }
+            func Main() {
+                var f = AavdFilter1465c()
+                f.Dispose(true)
+                Console.WriteLine("ok3")
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("base dispose\nok3\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1465_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
Inside the instance methods of a GENERIC class, references to the class's own type parameters were mis-encoded in IL: the async/iterator state-machine nested type was emitted as NON-generic, so `this`, type-parameter-typed parameters, hoisted state-machine fields, and self/base calls referenced a dangling `!0` (ilverify rendered `T0` / `value 'T'`) instead of the class generic `ELEMENT_TYPE_VAR` (`!0`). This produced unverifiable IL plus a spurious `MissingMethod` on the async state machine.

## Root cause
gsharp emitted async/iterator state-machine nested types as non-generic. CLR nested types do **not** inherit the enclosing type's generic parameters — they must redeclare them. An SM that references the class's `!0` from a non-generic SM context is therefore invalid.

## Fix
Reify each state machine over an ordinal-aligned copy of the type parameters in scope at its kickoff method — the enclosing class's parameters first (ordinals `0..k-1`), then the method's own (ordinals `k..`) — mirroring Roslyn's `<M>d__0<T>`. All dedicated raw-handle token sites (kickoff stub, AwaitOnCompleted, async-iterator MoveNext, `ldflda` builder access, async-method MemberRef return type) now route through generic-aware helpers. The change is ordinal-based and uniform across any arity and shape (`G[T]`, `G[T1,T2]`, derived chains, sync + async + iterator bodies); it does not special-case any type or arity.

### Files
- **ReflectionMetadataEmitter.cs** — reify async state machines over enclosing class + method type parameters; encode the wrapped `Task` return for async-method MemberRefs; add generic-aware struct-token/field/signature helpers; push the SM remap around SM TypeDef + method-body emission.
- **StateMachineEmitter.cs** — resolve kickoff/await SM-type and builder-field tokens through generic-aware helpers; make iterator state machines generic over the enclosing class's type parameters too (offset method-TP remap).
- **MethodBodyEmitter.Async.cs** — resolve the async-iterator MoveNext builder field and SM type-argument through generic-aware helpers.
- **MethodBodyEmitter.MemberAccess.cs** — take field addresses (`ldflda`) on generic user structs through a TypeSpec-parented MemberRef, not the open FieldDef.
- **Issue1465GenericSelfEncodingEmitTests.cs** — end-to-end ilverify + run coverage: generic async self-call (the minimal repro), arity-2 async, iterator-in-generic-class, and base-call-into-generic-base.

## Verification
- The minimal repro and all four test shapes ilverify with **zero** errors and run correctly. Each would fail ilverify on `main`.
- Full Core.Tests: **4788 passed / 1 skipped**. The byte-identical RefactoringBaseline gate still matches (its fixtures don't exercise generic-class state machines), so no baseline regeneration was needed.
- Nearby generic/iterator/base-call emit tests (#810, #641, #1254, #986): 37 passed, no regressions.

Fixes #1465

Refs #914
