### PR TITLE
Lower default targeting T? over an open type parameter via the symbolic parameter type

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -573,6 +573,11 @@ internal sealed class ConversionClassifier
     /// <param name="receiverType">Optional receiver type carrying the
     /// symbolic type arguments referenced by <paramref name="method"/>'s
     /// declaring generic.</param>
+    /// <param name="symbolicMethodTypeArgs">Optional symbolic method
+    /// type-argument vector (issue #1471). Recovers the real parameter type for
+    /// a bare <c>default</c> argument when a method type-argument erased to the
+    /// reference-context <c>object</c> placeholder (e.g.
+    /// <c>Task.FromResult[T?](default)</c>).</param>
     /// <returns>The (possibly rebound) argument array.</returns>
     public ImmutableArray<BoundExpression> BindClrParameterConversions(
         ImmutableArray<BoundExpression> arguments,
@@ -581,7 +586,8 @@ internal sealed class ConversionClassifier
         ImmutableArray<int> parameterMapping = default,
         int receiverArgCount = 0,
         MethodInfo method = null,
-        TypeSymbol receiverType = null)
+        TypeSymbol receiverType = null,
+        ImmutableArray<TypeSymbol> symbolicMethodTypeArgs = default)
     {
         ImmutableArray<BoundExpression>.Builder builder = null;
         for (var i = 0; i < arguments.Length; i++)
@@ -603,7 +609,20 @@ internal sealed class ConversionClassifier
                 // Error-typed default that produces invalid IL.
                 if (!parameterType.IsByRef && argument is BoundDefaultExpression { Type: var defType } && defType == TypeSymbol.Error)
                 {
-                    var defSubstituted = TrySubstituteParameterTypeFromReceiver(method, paramIndex, receiverType);
+                    // Issue #1471: a generic-method call closed over an open
+                    // type parameter (e.g. `Task.FromResult[T?](default)` for an
+                    // unconstrained `T`) erases its method type-argument to the
+                    // reference-context `object` placeholder, so the closed CLR
+                    // parameter type is `object` and `default` would lower to a
+                    // `BoundDefaultExpression(object)` → `ldnull`. For an open
+                    // `T` (or `T?` over an open `T`) that is unverifiable and
+                    // throws `InvalidProgramException` at runtime. Recover the
+                    // symbolic parameter type from the method's type-argument
+                    // vector so the default lowers against the real type
+                    // parameter and emits the verifiable `ldloca; initobj; ldloc`
+                    // slot shape uniformly for ref and value instantiations.
+                    var defSubstituted = TrySubstituteParameterTypeFromReceiver(method, paramIndex, receiverType)
+                        ?? TrySubstituteParameterTypeFromMethodTypeArgs(method, paramIndex, symbolicMethodTypeArgs);
                     var defTargetType = defSubstituted ?? TypeSymbol.FromClrType(parameterType);
                     if (defTargetType != null && defTargetType != TypeSymbol.Error)
                     {
@@ -803,6 +822,66 @@ internal sealed class ConversionClassifier
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Issue #1471: recovers the symbolic parameter type for a generic CLR
+    /// method invoked with a method-level type-argument vector that includes an
+    /// open type parameter (or a same-compilation user type). The closed CLR
+    /// method erases such arguments to the reference-context <see cref="object"/>
+    /// placeholder, so the closed parameter type is <c>object</c>; mapping the
+    /// open method parameter through <paramref name="methodTypeArgs"/> recovers
+    /// the real symbol (e.g. <c>T?</c> for <c>Task.FromResult[T?]</c>). Returns
+    /// <see langword="null"/> when no symbolic recovery applies, so concrete
+    /// instantiations keep flowing through the erased CLR shape unchanged.
+    /// </summary>
+    /// <param name="method">The resolved (closed) CLR method (may be null).</param>
+    /// <param name="paramIndex">Zero-based index into the method's parameter list.</param>
+    /// <param name="methodTypeArgs">The symbolic method type-argument vector.</param>
+    /// <returns>The recovered symbolic parameter type, or <see langword="null"/>.</returns>
+    public static TypeSymbol TrySubstituteParameterTypeFromMethodTypeArgs(
+        MethodInfo method,
+        int paramIndex,
+        ImmutableArray<TypeSymbol> methodTypeArgs)
+    {
+        if (method == null
+            || !method.IsGenericMethod
+            || methodTypeArgs.IsDefaultOrEmpty
+            || paramIndex < 0)
+        {
+            return null;
+        }
+
+        var openMethod = method.IsGenericMethodDefinition ? method : method.GetGenericMethodDefinition();
+        var openParams = openMethod.GetParameters();
+        if (paramIndex >= openParams.Length)
+        {
+            return null;
+        }
+
+        var openParamType = openParams[paramIndex].ParameterType;
+        if (openParamType.IsByRef)
+        {
+            openParamType = openParamType.GetElementType();
+        }
+
+        if (openParamType == null)
+        {
+            return null;
+        }
+
+        var mapped = MemberLookup.MapOpenClrTypeToSymbolic(
+            openParamType,
+            openDefinition: null,
+            typeArguments: default,
+            openMethodDefinition: openMethod,
+            methodTypeArguments: methodTypeArgs);
+
+        return mapped != null
+            && mapped != TypeSymbol.Error
+            && (TypeSymbol.ContainsTypeParameter(mapped) || TypeSymbol.ContainsSameCompilationUserType(mapped))
+            ? mapped
+            : null;
     }
 
     // ----- Method-group → delegate conversions -----

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -2608,26 +2608,25 @@ internal sealed partial class ExpressionBinder
                 // before CLR parameter conversion, mirroring the instance path.
                 var staticDelegateArgs = RebindFunctionLiteralDelegateArguments(staticHandlerArgs, staticParameters, staticDownstreamMapping);
 
-                // Issue #506 follow-up: ensure value-type → object boxing fires
-                // for fixed-arity CLR static calls (e.g. `String.Format("{0}", 42)`
-                // selecting the fixed `(string, object)` overload).
-                var staticConvertedArgs = conversions.BindClrParameterConversions(staticDelegateArgs, staticParameters, ce, staticDownstreamMapping);
-                var staticArguments = OverloadResolver.BuildOrderedCallArguments(staticConvertedArgs, staticDownstreamMapping, staticParameters);
-                var refKinds = ComputeArgumentRefKinds(staticParameters);
-                overloads.ValidateRefArguments(staticArguments, refKinds, methodName, ce.Location);
-
-                // Issue #1325: when the type arguments were inferred (no explicit
-                // `[...]` list), recover the symbolic method type-argument vector
-                // from the argument symbols so a same-compilation user value type
-                // (erased to `object` in the closed CLR method) is emitted as its
-                // real TypeDef token in the MethodSpec — e.g.
-                // `MemoryMarshal.AsBytes<E>` rather than the constraint-violating
-                // `AsBytes<object>`. Mirrors the instance/inherited call paths.
+                // Issue #1325 / #1471: recover the symbolic method type-argument
+                // vector before parameter conversion so a bare `default`
+                // argument closed over an open type parameter (e.g.
+                // `Task.FromResult[T?](default)`) materialises against the real
+                // type parameter instead of the erased `object` placeholder.
                 var staticSymbolicArgs = MemberLookup.BuildSymbolicArgTypeVector(
                     receiverType: null,
                     ImmutableArray.CreateRange(arguments.Select(a => a?.Type)));
                 var staticSymbolicTypeArgs = MemberLookup.BuildSymbolicMethodTypeArgs(staticFn.Method, typeArgSymbols, staticSymbolicArgs);
                 var staticTypeArgSymbolsForCall = !staticSymbolicTypeArgs.IsDefault ? staticSymbolicTypeArgs : typeArgSymbols;
+
+                // Issue #506 follow-up: ensure value-type → object boxing fires
+                // for fixed-arity CLR static calls (e.g. `String.Format("{0}", 42)`
+                // selecting the fixed `(string, object)` overload).
+                var staticConvertedArgs = conversions.BindClrParameterConversions(staticDelegateArgs, staticParameters, ce, staticDownstreamMapping, method: staticFn.Method, symbolicMethodTypeArgs: staticTypeArgSymbolsForCall);
+                var staticArguments = OverloadResolver.BuildOrderedCallArguments(staticConvertedArgs, staticDownstreamMapping, staticParameters);
+                var refKinds = ComputeArgumentRefKinds(staticParameters);
+                overloads.ValidateRefArguments(staticArguments, refKinds, methodName, ce.Location);
+
                 BoundExpression staticCall = new BoundImportedCallExpression(null, staticFn, staticArguments, refKinds, staticTypeArgSymbolsForCall);
                 return WrapWithHandlerPrelude(staticCall, staticHandlerPrelude, ce);
             }
@@ -3035,7 +3034,7 @@ internal sealed partial class ExpressionBinder
                             var instRebound = RebindFormattableInterpolationArguments(instExpandedArgs, ce.Arguments, instParameters, instDownstreamMapping);
                             var instHandlerArgs = ApplyInterpolatedStringHandlers(instParameters, instRebound, receiver, ce.Location, instDownstreamMapping, out var instHandlerPrelude, out var instUpdatedReceiver);
                             var instDelegateArgs = RebindFunctionLiteralDelegateArguments(instHandlerArgs, instParameters, instDownstreamMapping);
-                            var instConvertedArgs = conversions.BindClrParameterConversions(instDelegateArgs, instParameters, ce, instDownstreamMapping, method: resolution.Best, receiverType: receiver?.Type);
+                            var instConvertedArgs = conversions.BindClrParameterConversions(instDelegateArgs, instParameters, ce, instDownstreamMapping, method: resolution.Best, receiverType: receiver?.Type, symbolicMethodTypeArgs: instTypeArgSymbolsForCall);
                             var instArguments = OverloadResolver.BuildOrderedCallArguments(instConvertedArgs, instDownstreamMapping, instParameters);
                             var instRefKinds = ComputeArgumentRefKinds(instParameters);
                             overloads.ValidateRefArguments(instArguments, instRefKinds, methodName, ce.Location);
@@ -3702,7 +3701,7 @@ internal sealed partial class ExpressionBinder
                 var inheritedDownstreamMapping = resolution.IsExpanded ? default : inheritedMapping;
                 var inheritedHandlerArgs = ApplyInterpolatedStringHandlers(inheritedParameters, inheritedExpandedArgs, receiver, ce.Location, inheritedDownstreamMapping, out var inheritedHandlerPrelude, out var inheritedUpdatedReceiver);
                 var inheritedDelegateArgs = RebindFunctionLiteralDelegateArguments(inheritedHandlerArgs, inheritedParameters, inheritedDownstreamMapping);
-                var inheritedConvertedArgs = conversions.BindClrParameterConversions(inheritedDelegateArgs, inheritedParameters, ce, inheritedDownstreamMapping);
+                var inheritedConvertedArgs = conversions.BindClrParameterConversions(inheritedDelegateArgs, inheritedParameters, ce, inheritedDownstreamMapping, method: resolution.Best, receiverType: receiver?.Type, symbolicMethodTypeArgs: inheritedTypeArgSymbolsForCall);
                 var inheritedArguments = OverloadResolver.BuildOrderedCallArguments(inheritedConvertedArgs, inheritedDownstreamMapping, inheritedParameters);
                 var refKinds = ComputeArgumentRefKinds(inheritedParameters);
                 overloads.ValidateRefArguments(inheritedArguments, refKinds, methodName, ce.Location);

--- a/test/Compiler.Tests/Emit/Issue1471TypeParamNullableDefaultEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1471TypeParamNullableDefaultEmitTests.cs
@@ -1,0 +1,185 @@
+// <copyright file="Issue1471TypeParamNullableDefaultEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1471 — a bare <c>default</c> whose target type is <c>T?</c> for an
+/// unconstrained open type parameter <c>T</c>, flowing as an argument to a
+/// generic method instantiated with <c>T?</c> (e.g.
+/// <c>Task.FromResult[T?](default)</c>), used to lower to a
+/// <c>BoundDefaultExpression(object)</c> because the method type-argument erased
+/// to the reference-context <c>object</c> placeholder. That emitted <c>ldnull</c>
+/// against the bare type parameter <c>!T</c> the callee expects, which is
+/// unverifiable (<c>StackUnexpected: found Nullobjref, expected value 'T'</c>)
+/// and throws <c>InvalidProgramException</c> at runtime for a value-type
+/// instantiation. The binder now recovers the symbolic parameter type from the
+/// method's type-argument vector so the default emits the verifiable
+/// <c>ldloca; initobj; ldloc</c> slot shape for both reference and value
+/// instantiations.
+/// <list type="bullet">
+/// <item>Facet A — the minimal repro instantiated with a VALUE type
+/// (<c>int32</c>): <c>default(int32)</c> = <c>0</c>.</item>
+/// <item>Facet B — instantiated with a REFERENCE type (<c>string</c>):
+/// <c>default(string)</c> = <c>null</c>.</item>
+/// <item>Facet C — a default argument to a user generic function other than
+/// <c>Task.FromResult</c>, proving the fix is general.</item>
+/// </list>
+/// </summary>
+public class Issue1471TypeParamNullableDefaultEmitTests
+{
+    [Fact]
+    public void EndToEnd_FacetA_TaskFromResultDefaultValueTypeInstantiation_RunsAndPrintsZero()
+    {
+        var source = """
+            package Probe1471a
+            import System
+            import System.Threading.Tasks
+
+            class Box1471A[T] {
+                func Make() Task[T?] -> Task.FromResult[T?](default)
+            }
+
+            func Main() {
+                Console.WriteLine(Box1471A[int32]().Make().Result)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("0\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_FacetB_TaskFromResultDefaultReferenceTypeInstantiation_RunsAndPrintsNullSentinel()
+    {
+        var source = """
+            package Probe1471b
+            import System
+            import System.Threading.Tasks
+
+            class Box1471B[T] {
+                func Make() Task[T?] -> Task.FromResult[T?](default)
+            }
+
+            func Main() {
+                let result = Box1471B[string]().Make().Result
+                Console.WriteLine("[" + (result ?? "null") + "]")
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("[null]\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_FacetC_DefaultArgumentToUserGenericFunction_Runs()
+    {
+        var source = """
+            package Probe1471c
+            import System
+
+            func Identity1471C[U](u U?) U? -> u
+
+            class Box1471C[T] {
+                func Make() T? -> Identity1471C[T](default)
+            }
+
+            func Main() {
+                let result = Box1471C[string]().Make()
+                Console.WriteLine("[" + (result ?? "null") + "]")
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("[null]\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1471_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
A bare `default` argument to a generic CLR method instantiated with `T?` for an unconstrained open type parameter `T` (e.g. `Task.FromResult[T?](default)`) lowered to `BoundDefaultExpression(object)` because the method type-argument erased to the reference-context `object` placeholder. That emitted `ldnull` against the bare `!T` slot the callee expects, which is unverifiable (`StackUnexpected: found Nullobjref, expected value 'T'`) and threw `InvalidProgramException` at runtime for value-type instantiations. gsc reported 0 errors.

`BindClrParameterConversions` now recovers the symbolic parameter type from the method's type-argument vector (`TrySubstituteParameterTypeFromMethodTypeArgs`) so a bare default materialises against the real type parameter and emits the verifiable `ldloca; initobj; ldloc` slot shape uniformly for reference and value instantiations. The static, instance, and inherited imported-call sites pass the symbolic method type-argument vector through.

Fixes #1471

Refs #914
