### PR TITLE
Emit closed delegate TypeSpec for function-type events with user-type args

### DIFF
--- a/src/Core/CodeAnalysis/Emit/MemberDefEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MemberDefEmitter.cs
@@ -991,6 +991,13 @@ internal sealed class MemberDefEmitter
             {
                 return this.getTypeHandleForMember(clrType);
             }
+
+            // Issue #1473: a function-type delegate whose closed type arguments include a
+            // user-declared type has no runtime CLR Type, so ClrType is null. Build the concrete
+            // closed delegate (Action`n / Func`n) TypeSpec via the same encodeTypeSymbol machinery
+            // used by the backing-field signature and Interlocked.CompareExchange<T> spec, so the
+            // EventDef type and the accessor-body castclass token agree with the CAS loop.
+            return this.GetEventTypeSpecHandle(type);
         }
 
         if (type.ClrType != null)
@@ -1010,6 +1017,19 @@ internal sealed class MemberDefEmitter
 
         // Fallback: encode as System.Delegate.
         return this.getTypeReference(typeof(System.Delegate));
+    }
+
+    /// <summary>
+    /// Issue #1473: encodes the event handler type symbol into a TypeSpec EntityHandle, used when
+    /// the type has no runtime CLR <see cref="Type"/> (e.g. a function-type delegate closed over a
+    /// user-declared type argument). Mirrors the TypeSpec machinery in
+    /// <see cref="GetInterlockedCompareExchangeSpec"/> and the backing-field signature.
+    /// </summary>
+    private EntityHandle GetEventTypeSpecHandle(TypeSymbol type)
+    {
+        var sigBlob = new BlobBuilder();
+        this.encodeTypeSymbol(new BlobEncoder(sigBlob).TypeSpecificationSignature(), type);
+        return this.emitCtx.Metadata.AddTypeSpecification(this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
     }
 
     /// <summary>

--- a/test/Compiler.Tests/Emit/Issue1473FunctionTypeEventEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1473FunctionTypeEventEmitTests.cs
@@ -1,0 +1,201 @@
+// <copyright file="Issue1473FunctionTypeEventEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1473 — a field-like event whose handler is a function-type delegate
+/// (<c>event E (args) -&gt; ret</c>, mapped by G# to <c>System.Action&lt;...&gt;</c>/
+/// <c>System.Func&lt;...&gt;</c>) emitted invalid IL in its generated <c>add_</c>/
+/// <c>remove_</c> accessors when a type argument of the delegate is a user-declared
+/// type. The closed delegate has no runtime CLR <see cref="Type"/>, so the EventDef
+/// type and accessor-body <c>castclass</c> fell back to <c>System.Delegate</c>, which
+/// disagreed with the <c>Interlocked.CompareExchange&lt;T&gt;</c> CAS loop spec and
+/// failed ilverify with <c>StackUnexpected</c>. The fix encodes the concrete closed
+/// delegate as a TypeSpec so all tokens agree.
+/// <list type="bullet">
+/// <item>Facet A — the minimal repro: an instance function-type event
+/// <c>(object?, Args) -&gt; void</c> with a user <c>Args</c>; subscribe, fire,
+/// unsubscribe.</item>
+/// <item>Facet B — a <c>Func</c>-shaped function-type event (non-void return) of a
+/// different arity with a user-type argument, to prove generality.</item>
+/// <item>Facet C — a STATIC field-like function-type event with a user-type argument,
+/// exercising the static add/remove accessor path (<c>EmitStaticEventAddAccessor</c>/
+/// <c>EmitStaticEventRemoveAccessor</c>). G# has no call-form raise for static
+/// field-like events, so this facet exercises subscribe/unsubscribe and relies on
+/// the in-harness ilverify pass to prove the static accessor IL is valid.</item>
+/// </list>
+/// All three failed ilverify on current main and pass after the fix.
+/// </summary>
+public class Issue1473FunctionTypeEventEmitTests
+{
+    [Fact]
+    public void EndToEnd_FacetA_InstanceActionEventWithUserArg_Runs()
+    {
+        var source = """
+            package EN1473A
+            import System
+            class ArgsA1473 : EventArgs {
+                prop Value int32 { get; init; }
+            }
+            class SourceA1473 {
+                event Fired (object?, ArgsA1473) -> void
+                func Fire() {
+                    Fired?(this, ArgsA1473() { Value = 7 })
+                }
+            }
+            func Main() {
+                let s = SourceA1473()
+                s.Fired += (sender object?, a ArgsA1473) -> Console.WriteLine(a.Value)
+                s.Fire()
+                s.Fired -= (sender object?, a ArgsA1473) -> Console.WriteLine(a.Value)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("7\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_FacetB_InstanceFuncEventWithUserArg_Runs()
+    {
+        var source = """
+            package EN1473B
+            import System
+            class PayloadB1473 {
+                prop Amount int32 { get; init; }
+            }
+            class SourceB1473 {
+                event Compute (PayloadB1473) -> string
+                func Invoke(p PayloadB1473) string {
+                    let r = Compute?(p)
+                    return r ?? "none"
+                }
+            }
+            func Main() {
+                let s = SourceB1473()
+                s.Compute += (p PayloadB1473) -> p.Amount.ToString()
+                let r = s.Invoke(PayloadB1473() { Amount = 21 })
+                Console.WriteLine(r)
+                s.Compute -= (p PayloadB1473) -> p.Amount.ToString()
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("21\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_FacetC_StaticActionEventWithUserArg_Runs()
+    {
+        var source = """
+            package EN1473C
+            import System
+            class ArgsC1473 : EventArgs {
+                prop Value int32 { get; init; }
+            }
+            class SourceC1473 {
+                shared {
+                    event Pinged (object?, ArgsC1473) -> void
+                }
+            }
+            func Main() {
+                SourceC1473.Pinged += (sender object?, a ArgsC1473) -> Console.WriteLine(a.Value)
+                SourceC1473.Pinged -= (sender object?, a ArgsC1473) -> Console.WriteLine(a.Value)
+                Console.WriteLine("static-ok")
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("static-ok\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1473_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
A field-like event whose handler is a function-type delegate (`Action`/`Func`) closed over a user-declared type argument has no runtime CLR `Type`, so `GetEventTypeHandle` fell through to a `System.Delegate` fallback. That handle was used for the EventDef type and the accessor-body `castclass`, disagreeing with the `Interlocked.CompareExchange<T>` CAS spec (which already encodes the closed delegate) and failing ilverify with `StackUnexpected`.

The fix encodes the type symbol into a closed-delegate TypeSpec via the same `encodeTypeSymbol` machinery, so the EventDef type, accessor `castclass`, and CAS spec all agree — for instance and static, add and remove accessors. Named-BCL-delegate events (non-null `ClrType`) are unchanged.

Oahu.Decrypt corpus: 63 → 59 ilverify artifacts; StackUnexpected 21 → 17, eliminating `ChapterFilter::add_/remove_ChapterRead` and `Mp4Operation::add_/remove_ConversionProgressUpdate`; benign `Unverifiable` (21) unchanged; no new categories.

Fixes #1473

Refs #914