### PR TITLE
Emit default(Nullable<UserT>) for null-conditional over user value types

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -518,7 +518,8 @@ internal sealed class ConversionClassifier
             && type is NullableTypeSymbol nilTargetNullable
             && (nilTargetNullable.UnderlyingType?.ClrType is { IsValueType: true }
                 || nilTargetNullable.UnderlyingType is TypeParameterSymbol
-                || nilTargetNullable.UnderlyingType is EnumSymbol))
+                || nilTargetNullable.UnderlyingType is EnumSymbol
+                || (nilTargetNullable.UnderlyingType is StructSymbol nilTargetStruct && !nilTargetStruct.IsClass)))
         {
             return new BoundDefaultExpression(null, type);
         }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -1173,9 +1173,19 @@ internal sealed partial class ExpressionBinder
         // underlying* is a value type — even if `whenNotNull.Type` is
         // already nullable. The emitter inspects `WhenNotNull.Type` to
         // decide whether to wrap with `newobj` or pass through.
+        //
+        // Issue #1475: the slot must be allocated for ANY value-type
+        // underlying recognised by SYMBOL — user `EnumSymbol`, value-type
+        // `StructSymbol`, a value-constrained type parameter, tuple — not only
+        // when the underlying carries a runtime `ClrType.IsValueType`. User
+        // enums/structs have a null `ClrType`, so the old gate skipped them and
+        // emit fell to the reference (`ldnull`) branch, producing unverifiable
+        // IL (`StackUnexpected`/`PathStackUnexpected`). Routing through the
+        // canonical symbol-level value-type predicate keeps BCL behaviour
+        // identical while covering user value types.
         LocalVariableSymbol resultSlot = null;
         if (resultType is NullableTypeSymbol nullableResult
-            && nullableResult.UnderlyingType?.ClrType is { IsValueType: true })
+            && GSharp.Core.CodeAnalysis.Emit.ReflectionMetadataEmitter.IsValueTypeSymbol(nullableResult.UnderlyingType))
         {
             var resultSlotName = "$nres_" + binderCtx.NullConditionalCaptureCounter.ToString(System.Globalization.CultureInfo.InvariantCulture);
             resultSlot = new LocalVariableSymbol(resultSlotName, isReadOnly: false, type: resultType);
@@ -3273,9 +3283,15 @@ internal sealed partial class ExpressionBinder
             ? whenNotNull.Type
             : (TypeSymbol)NullableTypeSymbol.Get(whenNotNull.Type);
 
+        // Issue #1475: allocate the result slot for ANY value-type underlying
+        // recognised by symbol (user enum/struct, value-constrained type
+        // parameter, tuple), not only when `ClrType.IsValueType`. Mirrors the
+        // member-access `?.` path so `?[]` over a user value type also
+        // materialises `default(Nullable<T>)` on the nil branch instead of
+        // `ldnull`.
         LocalVariableSymbol resultSlot = null;
         if (resultType is NullableTypeSymbol nullableResult
-            && nullableResult.UnderlyingType?.ClrType is { IsValueType: true })
+            && GSharp.Core.CodeAnalysis.Emit.ReflectionMetadataEmitter.IsValueTypeSymbol(nullableResult.UnderlyingType))
         {
             var resultSlotName = "$nres_" + binderCtx.NullConditionalCaptureCounter.ToString(System.Globalization.CultureInfo.InvariantCulture);
             resultSlot = new LocalVariableSymbol(resultSlotName, isReadOnly: false, type: resultType);

--- a/src/Core/CodeAnalysis/Emit/MetadataTokenCache.cs
+++ b/src/Core/CodeAnalysis/Emit/MetadataTokenCache.cs
@@ -158,6 +158,17 @@ internal sealed class MetadataTokenCache
         = new Dictionary<EnumSymbol, MemberReferenceHandle>();
 
     /// <summary>
+    /// Gets the cache mapping a user-defined value-type <see cref="StructSymbol"/>
+    /// to the <see cref="MemberReferenceHandle"/> for
+    /// <c>System.Nullable`1&lt;S&gt;::.ctor(!0)</c> (issue #1475). The parent
+    /// TypeSpec closes <c>Nullable&lt;&gt;</c> over the struct's emitted
+    /// TypeDef/TypeSpec, so one MemberRef per struct serves every
+    /// null-conditional / <c>S -&gt; S?</c> lift site.
+    /// </summary>
+    public Dictionary<StructSymbol, MemberReferenceHandle> NullableUserStructCtorMemberRefs { get; }
+        = new Dictionary<StructSymbol, MemberReferenceHandle>();
+
+    /// <summary>
     /// Gets the cache mapping a <see cref="FieldInfo"/> to its
     /// <see cref="MemberReferenceHandle"/>.
     /// </summary>

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
@@ -1196,9 +1196,46 @@ internal sealed partial class MethodBodyEmitter
             // `default(Nullable<T>)`.
             var slot = this.locals[nc.ResultSlot];
             var nullableType = (NullableTypeSymbol)nc.Type;
-            var innerClr = nullableType.UnderlyingType.ClrType
-                ?? throw new InvalidOperationException(
-                    $"Null-conditional value-type result '{nullableType.UnderlyingType.Name}' has no CLR type.");
+            var underlying = nullableType.UnderlyingType;
+
+            // Issue #1475: a user-declared value-type underlying (enum or
+            // struct) has no runtime `ClrType`, so the BCL-backed
+            // `TryConstructNullable` path below cannot fire. Materialise the
+            // nil-branch `default(Nullable<UserT>)` and the not-null-branch
+            // `newobj Nullable<UserT>::.ctor(!0)` purely from emitted
+            // TypeDef/TypeSpec tokens — mirroring the issue #1298 enum lift in
+            // MethodBodyEmitter.Conversions. The same token path also serves a
+            // value-constrained open type parameter (issue #814).
+            if (underlying?.ClrType is not { IsValueType: true })
+            {
+                var nullableToken = this.outer.GetElementTypeToken(nullableType);
+
+                // nil branch: ldloca slot; initobj Nullable<UserT>; ldloc slot
+                this.il.LoadLocalAddress(slot);
+                this.il.OpCode(ILOpCode.Initobj);
+                this.il.Token(nullableToken);
+                this.il.LoadLocal(slot);
+                this.il.Branch(ILOpCode.Br, end);
+
+                // not-null branch: produce UserT then wrap, or — when
+                // WhenNotNull already produces Nullable<UserT> (ADR-0073 /
+                // issue #710 chained `?.`/`?[]`) — emit it directly.
+                this.il.MarkLabel(nonNull);
+                this.EmitExpression(nc.WhenNotNull);
+                if (nc.WhenNotNull.Type is not NullableTypeSymbol)
+                {
+                    var ctorToken = underlying is Symbols.TypeParameterSymbol
+                        ? this.outer.GetNullableCtorMemberRefForOpenTypeParameter(nullableType)
+                        : this.outer.GetNullableCtorMemberRefForUserValueType(nullableType);
+                    this.il.OpCode(ILOpCode.Newobj);
+                    this.il.Token(ctorToken);
+                }
+
+                this.il.MarkLabel(end);
+                return;
+            }
+
+            var innerClr = underlying.ClrType;
 
             // Issue #571: construct Nullable<T> through the ReferenceResolver so
             // the open generic definition lives in the same load context as the

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
@@ -662,7 +662,9 @@ internal sealed partial class MethodBodyEmitter
     }
 
     private static bool IsNullableUserEnum(TypeSymbol type)
-        => type is NullableTypeSymbol nullable && nullable.UnderlyingType is EnumSymbol;
+        => type is NullableTypeSymbol nullable
+            && (nullable.UnderlyingType is EnumSymbol
+                || (nullable.UnderlyingType is StructSymbol s && !s.IsClass));
 
     /// <summary>
     /// Issue #831: matches `T? == nil` / `T? != nil` (and the symmetric

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -5817,11 +5817,17 @@ internal sealed class ReflectionMetadataEmitter
         // naming the generic instantiation `System.Nullable<E>`. This is the
         // token consumed by `box Nullable<E>` in the lifted enum-equality emit
         // (and by `initobj` when zero-initialising such a slot).
-        if (element is NullableTypeSymbol nullableEnumElement
-            && nullableEnumElement.UnderlyingType is EnumSymbol)
+        //
+        // Issue #1475: the same TypeSpec form applies to `S?` over a
+        // user-declared value-type struct (no runtime `ClrType`). Recognise
+        // both user value-type underlyings here so the null-conditional emit
+        // can `initobj`/`box` the `Nullable<UserT>` slot.
+        if (element is NullableTypeSymbol nullableUserVtElement
+            && (nullableUserVtElement.UnderlyingType is EnumSymbol
+                || (nullableUserVtElement.UnderlyingType is StructSymbol userVtStruct && !userVtStruct.IsClass)))
         {
             var sigBlob = new BlobBuilder();
-            this.EncodeTypeSymbol(new BlobEncoder(sigBlob).TypeSpecificationSignature(), nullableEnumElement);
+            this.EncodeTypeSymbol(new BlobEncoder(sigBlob).TypeSpecificationSignature(), nullableUserVtElement);
             return this.emitCtx.Metadata.AddTypeSpecification(this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
         }
 
@@ -8851,6 +8857,60 @@ internal sealed class ReflectionMetadataEmitter
     }
 
     /// <summary>
+    /// Issue #1475: gets a MemberRef for <c>System.Nullable`1&lt;S&gt;::.ctor(!0)</c>
+    /// where <c>S</c> is a user-declared value-type struct emitted in this
+    /// assembly (or a user enum, by delegation). The struct has no runtime CLR
+    /// type, so the BCL-backed ctor path cannot construct it; instead the
+    /// parent TypeSpec closes <c>Nullable&lt;&gt;</c> over the struct's emitted
+    /// TypeDef/TypeSpec and the ctor signature refers to that argument as
+    /// <c>!0</c>. Mirrors <see cref="GetNullableCtorMemberRefForUserEnum"/>.
+    /// </summary>
+    /// <param name="nullableOfUserVt">A <c>Nullable&lt;S&gt;</c> over a user value type (enum or value struct).</param>
+    /// <returns>The constructor MemberRef.</returns>
+    internal MemberReferenceHandle GetNullableCtorMemberRefForUserValueType(NullableTypeSymbol nullableOfUserVt)
+    {
+        // A user enum already has a dedicated cache + helper; reuse it so a
+        // single MemberRef serves both the lift (issue #1298) and the
+        // null-conditional (issue #1475) sites.
+        if (nullableOfUserVt?.UnderlyingType is EnumSymbol)
+        {
+            return this.GetNullableCtorMemberRefForUserEnum(nullableOfUserVt);
+        }
+
+        if (nullableOfUserVt?.UnderlyingType is not StructSymbol structSym || structSym.IsClass)
+        {
+            throw new InvalidOperationException(
+                "GetNullableCtorMemberRefForUserValueType requires Nullable<user enum or value struct>.");
+        }
+
+        if (this.cache.NullableUserStructCtorMemberRefs.TryGetValue(structSym, out var cached))
+        {
+            return cached;
+        }
+
+        var parentBlob = new BlobBuilder();
+        this.EncodeTypeSymbol(new BlobEncoder(parentBlob).TypeSpecificationSignature(), nullableOfUserVt);
+        var parent = this.emitCtx.Metadata.AddTypeSpecification(this.emitCtx.Metadata.GetOrAddBlob(parentBlob));
+
+        var sigBlob = new BlobBuilder();
+        new BlobEncoder(sigBlob).MethodSignature(isInstanceMethod: true)
+            .Parameters(
+                parameterCount: 1,
+                returnType: r => r.Void(),
+                parameters: ps =>
+                {
+                    ps.AddParameter().Type().GenericTypeParameter(0);
+                });
+
+        var handle = this.emitCtx.Metadata.AddMemberReference(
+            parent: parent,
+            name: this.emitCtx.Metadata.GetOrAddString(".ctor"),
+            signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
+        this.cache.NullableUserStructCtorMemberRefs[structSym] = handle;
+        return handle;
+    }
+
+    /// <summary>
     /// Phase 4 emit parity: get a MemberRef for a CLR field on a possibly
     /// generic declaring type (e.g. <c>KeyValuePair&lt;K, V&gt;.Key</c>).
     /// </summary>
@@ -9268,8 +9328,26 @@ internal sealed class ReflectionMetadataEmitter
 
             if (inner is StructSymbol nestedStruct && !nestedStruct.IsClass)
             {
-                throw new NotSupportedException(
-                    $"Nullable user-defined struct '{inner.Name}?' is not yet supported by the emitter.");
+                // Issue #1475: `S?` over a user-declared value-type struct
+                // lowers to `System.Nullable<S>` — a generic instantiation
+                // whose single argument is the struct's emitted TypeDef (or a
+                // GENERICINST for a constructed user-generic struct). Mirrors
+                // the user-enum branch below and the struct-constrained
+                // type-parameter branch above.
+                var nestedStructDef = nestedStruct.Definition ?? nestedStruct;
+                if (!this.cache.StructTypeDefs.ContainsKey(nestedStructDef))
+                {
+                    throw new InvalidOperationException(
+                        $"Struct '{nestedStruct.Name}' has no emitted TypeDef.");
+                }
+
+                var nullableOpenForStruct = typeof(System.Nullable<>);
+                var giNullableStruct = encoder.GenericInstantiation(
+                    this.GetTypeReference(nullableOpenForStruct),
+                    genericArgumentCount: 1,
+                    isValueType: true);
+                this.EncodeTypeSymbol(giNullableStruct.AddArgument(), nestedStruct);
+                return;
             }
 
             if (inner is EnumSymbol nestedEnum)

--- a/test/Compiler.Tests/Emit/Issue1475NullConditionalUserValueTypeEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1475NullConditionalUserValueTypeEmitTests.cs
@@ -1,0 +1,208 @@
+// <copyright file="Issue1475NullConditionalUserValueTypeEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1475 — a null-conditional access <c>recv?.Member</c> whose result is a
+/// value-type <c>Nullable&lt;T&gt;</c> where <c>T</c> is a user-declared value
+/// type (enum or struct, with no runtime <c>ClrType</c>) previously emitted
+/// <c>ldnull</c> for the receiver-null branch instead of
+/// <c>default(Nullable&lt;T&gt;)</c>. That produced unverifiable IL
+/// (<c>StackUnexpected</c>/<c>PathStackUnexpected</c>: "found Nullobjref,
+/// expected value 'System.Nullable`1&lt;...&gt;'") and an
+/// <c>InvalidProgramException</c> at runtime. BCL value-type underlyings
+/// (e.g. <c>int32?</c>) already worked.
+/// <list type="bullet">
+/// <item>Facet A — <c>?.</c> yielding <c>Nullable&lt;user-enum&gt;</c>: the
+/// minimal repro; null receiver then non-null.</item>
+/// <item>Facet B — <c>?.</c> yielding <c>Nullable&lt;user-STRUCT&gt;</c>, proving
+/// the fix generalises to struct underlyings, not just enums.</item>
+/// <item>Facet C — chained <c>a?.b?.c</c> where the intermediate is already a
+/// <c>Nullable&lt;userT&gt;</c> (ADR-0073 / #710): the not-null branch must NOT
+/// double-wrap.</item>
+/// </list>
+/// Each test uses a UNIQUE package + user-type names because the in-process emit
+/// tests share a process and a name-keyed type cache.
+/// </summary>
+public class Issue1475NullConditionalUserValueTypeEmitTests
+{
+    [Fact]
+    public void EndToEnd_FacetA_NullConditionalUserEnum_Runs()
+    {
+        var source = """
+            package N1475A
+            import System
+            enum ColA1475 { Red; Green }
+            class InnerA1475 {
+                prop C ColA1475 { get; init; }
+            }
+            class BoxA1475 {
+                var inner InnerA1475?
+                prop ColorOpt ColA1475? -> inner?.C
+            }
+            func Main() {
+                let b = BoxA1475()
+                Console.WriteLine(b.ColorOpt == nil)
+                b.inner = InnerA1475() { C = ColA1475.Green }
+                Console.WriteLine(b.ColorOpt == nil)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\nFalse\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_FacetB_NullConditionalUserStruct_Runs()
+    {
+        var source = """
+            package N1475B
+            import System
+            struct PtB1475 {
+                var X int32
+                var Y int32
+            }
+            class InnerB1475 {
+                prop P PtB1475 { get; init; }
+            }
+            class BoxB1475 {
+                var inner InnerB1475?
+                prop PointOpt PtB1475? -> inner?.P
+            }
+            func Main() {
+                let b = BoxB1475()
+                Console.WriteLine(b.PointOpt == nil)
+                b.inner = InnerB1475() { P = PtB1475{X: 3, Y: 4} }
+                Console.WriteLine(b.PointOpt == nil)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\nFalse\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_FacetC_ChainedNullConditionalUserStruct_NoDoubleWrap_Runs()
+    {
+        var source = """
+            package N1475C
+            import System
+            struct PtC1475 {
+                var X int32
+                var Y int32
+            }
+            class InnerC1475 {
+                prop P PtC1475 { get; init; }
+            }
+            class MidC1475 {
+                var inner InnerC1475?
+                prop PointOpt PtC1475? -> inner?.P
+            }
+            class BoxC1475 {
+                var mid MidC1475?
+                prop Chained PtC1475? -> mid?.PointOpt
+            }
+            func Main() {
+                let b = BoxC1475()
+                Console.WriteLine(b.Chained == nil)
+                let m = MidC1475()
+                m.inner = InnerC1475() { P = PtC1475{X: 3, Y: 4} }
+                b.mid = m
+                Console.WriteLine(b.Chained == nil)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\nFalse\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1475_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
A null-conditional access `recv?.Member` whose result is `Nullable<T>` where T is a user-declared value type (enum or struct, lacking a runtime `ClrType`) emitted `ldnull` for the receiver-null branch instead of `default(Nullable<T>)`, yielding unverifiable IL (`StackUnexpected`/`PathStackUnexpected`) and a runtime `InvalidProgramException`. Only user types were affected; BCL value-type underlyings (e.g. `int32?`) already worked.

## Fix
- **Binder** (`ExpressionBinder.Access.cs`, both `?.` and `?[]`): allocate the synthetic result slot whenever the result's underlying is a value type *by symbol* (`ReflectionMetadataEmitter.IsValueTypeSymbol`) rather than only when `UnderlyingType.ClrType.IsValueType`. BCL behavior is unchanged.
- **Emit** (`MethodBodyEmitter.Expressions.cs`, `EmitNullConditionalAccess`): when the underlying has no `ClrType` (user enum/struct), materialize the nil branch via `ldloca; initobj Nullable<UserT>; ldloc` and wrap the not-null value via `newobj Nullable<UserT>::.ctor(!0)` using emitted TypeDef/TypeSpec tokens. Reuses `GetElementTypeToken` and a new generalized `GetNullableCtorMemberRefForUserValueType` (mirroring the #1298 user-enum machinery and delegating to it for enums). Preserves the ADR-0073 / #710 chained `?.` no-double-wrap behavior.
- **Generalization for structs**: extended `EncodeTypeSymbol` and `GetElementTypeToken` to encode `Nullable<user-struct>` (previously threw `NotSupportedException`), the `nil -> Nullable` lowering (`ConversionClassifier`), and the boxed nil-compare equality (`MethodBodyEmitter.Operators`) so user-struct underlyings are consumable via `== nil`.

## Verification
- Minimal repro (`?.` yielding `Nullable<user-enum>`): ilverify clean, prints `True`/`False`, exit 0.
- New tests `Issue1475NullConditionalUserValueTypeEmitTests` (3 facets: user-enum, user-struct, chained `a?.b?.c` no-double-wrap) — all pass.
- Null-conditional / nullable regression suite (230 tests) — pass.
- `Core.Tests` whole suite — 4788 pass / 1 skip; byte-identical `RefactoringBaselineTests` gate unaffected.
- **Oahu.Decrypt corpus**: 59 -> 55 ilverify artifacts. `get_CoverFormat` and `DashFile::.ctor` cleared (each in both `StackUnexpected` and `PathStackUnexpected`): StackUnexpected 17->15, PathStackUnexpected 2->0. Benign `Unverifiable` (localloc) unchanged at 21; no new categories.

Fixes #1475

Refs #914
