### PR TITLE
Fix generic closure capture emitting non-generic display/box classes

### DIFF
--- a/src/Core/CodeAnalysis/Emit/ClosureEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ClosureEmitter.cs
@@ -364,6 +364,38 @@ internal sealed class ClosureEmitter
 
         closureClass.SetMethods(ImmutableArray.Create(invokeMethod));
 
+        // Issue #1477: when the lambda is declared inside a generic type (or
+        // generic method) and captures a value whose type references an
+        // enclosing type parameter (a `T`-typed value, `this` of `G[T]`, or a
+        // boxed `Box[T]`), the display class must itself be generic over those
+        // parameters — otherwise each capture field's `VAR` slot has no generic
+        // parameter in scope, producing an illegal field type (TypeLoadException
+        // at load) and unverifiable IL (`StackUnexpected`/`DelegateCtor`) at the
+        // capture site. Reify the display class generic over exactly the
+        // referenced enclosing parameters (mirroring the state-machine
+        // treatment); the emitter's outer-TP → own-TP remap then routes every
+        // field / Invoke signature through a valid `VAR(idx)` slot, and the
+        // returned constructed instance carries the original parameters as type
+        // arguments for the capture-site `newobj`/field stores/delegate ctor.
+        var enclosingRefSink = new List<TypeSymbol>();
+        foreach (var captured in capturedVariables)
+        {
+            enclosingRefSink.Add(captured.Type);
+        }
+
+        foreach (var parameter in parameters)
+        {
+            enclosingRefSink.Add(parameter.Type);
+        }
+
+        enclosingRefSink.Add(returnType);
+        var origTPs = SynthesizedClosureReifier.CollectOrdered(enclosingRefSink);
+        StructSymbol constructedClass = closureClass;
+        if (!origTPs.IsDefaultOrEmpty)
+        {
+            constructedClass = SynthesizedClosureReifier.Reify(closureClass, origTPs);
+        }
+
         var rewriter = new CaptureRewriter(closureClass, captureFields, invokeMethod.ThisParameter);
         var rewrittenBody = (BoundBlockStatement)rewriter.RewriteStatement(body);
         if (rewriter.UnsupportedCapture != null)
@@ -374,7 +406,7 @@ internal sealed class ClosureEmitter
 
         this.lambdaBodies[invokeMethod] = (BoundBlockStatement)Lowerer.Lower(rewrittenBody);
         this.SynthesizedClosureClasses.Add(closureClass);
-        var info = new ClosureInfo(closureClass, invokeMethod, captureFields);
+        var info = new ClosureInfo(closureClass, invokeMethod, captureFields, constructedClass);
         this.ClosureInvokeToInfo[invokeMethod] = info;
         return info;
     }
@@ -420,13 +452,29 @@ internal sealed class ClosureEmitter
     public sealed class ClosureInfo
     {
         public ClosureInfo(StructSymbol classSym, FunctionSymbol invokeMethod, Dictionary<VariableSymbol, FieldSymbol> captureFields)
+            : this(classSym, invokeMethod, captureFields, classSym)
+        {
+        }
+
+        public ClosureInfo(StructSymbol classSym, FunctionSymbol invokeMethod, Dictionary<VariableSymbol, FieldSymbol> captureFields, StructSymbol constructedClassSym)
         {
             this.ClassSym = classSym;
             this.InvokeMethod = invokeMethod;
             this.CaptureFields = captureFields;
+            this.ConstructedClassSym = constructedClassSym;
         }
 
         public StructSymbol ClassSym { get; }
+
+        /// <summary>
+        /// Gets the constructed display-class instance to reference at the
+        /// capture site (<c>newobj</c> / field stores / delegate ctor /
+        /// <c>ldftn Invoke</c>). Equals <see cref="ClassSym"/> for a non-generic
+        /// closure; for a generic-encloser closure it is the open definition
+        /// constructed over the enclosing type parameters
+        /// (<c>DisplayClass&lt;!0,…&gt;</c>) — issue #1477.
+        /// </summary>
+        public StructSymbol ConstructedClassSym { get; }
 
         public FunctionSymbol InvokeMethod { get; }
 

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Closures.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Closures.cs
@@ -407,8 +407,20 @@ internal sealed partial class MethodBodyEmitter
                     $"Closure invoke method '{closure.InvokeMethod.Name}' has no emitted MethodDef.");
             }
 
+            // Issue #1477: when the display class was reified generic over its
+            // enclosing type parameters, the capture-site newobj / stfld / ldftn
+            // tokens must be MemberRefs parented at the CONSTRUCTED closure
+            // TypeSpec (`Closure`1<…enclosing args…>`) — a bare MethodDef/FieldDef
+            // of a member on a generic type is an illegal capture-store/delegate
+            // function token (TypeLoadException + ilverify StackUnexpected/
+            // DelegateCtor). Reuse the existing user-generic token machinery.
+            var constructedClosure = closure.ConstructedClassSym;
+            var closureIsGeneric = ReflectionMetadataEmitter.IsUserGenericTypeReference(constructedClosure);
+
             this.il.OpCode(ILOpCode.Newobj);
-            this.il.Token(ctorHandle);
+            this.il.Token(closureIsGeneric
+                ? this.outer.ResolveUserCtorTokenForDefault(constructedClosure)
+                : ctorHandle);
 
             foreach (var captured in literal.CapturedVariables)
             {
@@ -418,7 +430,16 @@ internal sealed partial class MethodBodyEmitter
                         $"Closure for '{literal.Function.Name}' has no field for captured '{captured.Name}'.");
                 }
 
-                if (!this.outer.cache.StructFieldDefs.TryGetValue(field, out var fieldHandle))
+                EntityHandle fieldToken;
+                if (closureIsGeneric)
+                {
+                    fieldToken = this.outer.ResolveFieldToken(constructedClosure, field);
+                }
+                else if (this.outer.cache.StructFieldDefs.TryGetValue(field, out var fieldHandle))
+                {
+                    fieldToken = fieldHandle;
+                }
+                else
                 {
                     throw new InvalidOperationException(
                         $"Closure field '{field.Name}' has no emitted FieldDef.");
@@ -427,11 +448,13 @@ internal sealed partial class MethodBodyEmitter
                 this.il.OpCode(ILOpCode.Dup);
                 this.EmitCapturedVariableLoad(captured);
                 this.il.OpCode(ILOpCode.Stfld);
-                this.il.Token(fieldHandle);
+                this.il.Token(fieldToken);
             }
 
             this.il.OpCode(ILOpCode.Ldftn);
-            this.il.Token(invokeHandle);
+            this.il.Token(closureIsGeneric
+                ? this.outer.ResolveClosureInvokeFtnToken(constructedClosure, closure.ClassSym, closure.InvokeMethod)
+                : invokeHandle);
             this.il.OpCode(ILOpCode.Newobj);
 
             // ADR-0087 §3 R6: when the literal's effective delegate

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -501,6 +501,44 @@ internal sealed class ReflectionMetadataEmitter
         }
     }
 
+    // Issue #1477: builds the outer-TP → own-TP-ordinal remap for every
+    // synthesized closure / capture-box class that was reified generic over its
+    // enclosing type parameters (SynthesizedClosureReifier records the original
+    // referenced parameters on ReifiedFromTypeParameters in declaration order,
+    // 1:1 with the class's own freshly cloned parameters). Registering the
+    // remap on the shared state-machine remap channel makes EncodeTypeSymbol
+    // translate every enclosing-type-parameter reference in a capture field /
+    // Invoke signature into the synthesized class's own VAR(idx) slot.
+    private void RegisterSynthesizedClosureReifiedGenerics()
+    {
+        void Register(StructSymbol s)
+        {
+            var origTPs = s.ReifiedFromTypeParameters;
+            if (origTPs.IsDefaultOrEmpty)
+            {
+                return;
+            }
+
+            var remap = new Dictionary<TypeParameterSymbol, int>(origTPs.Length);
+            for (var i = 0; i < origTPs.Length; i++)
+            {
+                remap[origTPs[i]] = i;
+            }
+
+            this.iteratorStateMachineRemapsByClass[s] = remap;
+        }
+
+        foreach (var s in this.emitCtx.Program.Structs)
+        {
+            Register(s);
+        }
+
+        foreach (var s in this.closures.SynthesizedClosureClasses)
+        {
+            Register(s);
+        }
+    }
+
     private ReflectionMetadataEmitter(BoundProgram program, ReferenceResolver references, string assemblyName, bool metadataOnly)
     {
         this.emitCtx = new EmitContext(program, references, assemblyName, metadataOnly);
@@ -868,6 +906,14 @@ internal sealed class ReflectionMetadataEmitter
         // type variable, and references to the nested type construct a real
         // `Nested`1<!0>` TypeSpec.
         this.RegisterNestedTypeEnclosingGenerics();
+
+        // Issue #1477: register the outer-TP → own-TP-ordinal remap for each
+        // synthesized closure / capture-box class that was reified generic over
+        // its enclosing type parameters (recorded on
+        // ReifiedFromTypeParameters). This reuses the state-machine remap
+        // channel so EncodeTypeSymbol routes every capture-field / Invoke
+        // signature through a valid VAR(idx) slot of the synthesized class.
+        this.RegisterSynthesizedClosureReifiedGenerics();
 
         // Phase 3.B.4: user-defined interface TypeDefs (planned below).
         // Synthesized closure classes are appended after user aggregates so
@@ -1777,7 +1823,15 @@ internal sealed class ReflectionMetadataEmitter
         // interface-implementation metadata.
         void EmitClassTypeDefRow(StructSymbol c)
         {
-            this.typeDefEmitter.EmitStructTypeDef(c, structFirstFieldRow[c], classCtorRows[c]);
+            // Issue #1477: a synthesized closure / capture-box class reified
+            // generic over enclosing type parameters needs its remap active so
+            // its capture-field signatures encode the class's own VAR(idx)
+            // slots. No-op for every other class (unregistered → restore:false).
+            using (this.PushSmRemap(c))
+            {
+                this.typeDefEmitter.EmitStructTypeDef(c, structFirstFieldRow[c], classCtorRows[c]);
+            }
+
             EmitInterfaceImplRows(c);
         }
 
@@ -2567,7 +2621,14 @@ internal sealed class ReflectionMetadataEmitter
 
         foreach (var c in topClasses)
         {
-            EmitClassMethodBodies(c);
+            // Issue #1477: keep the synthesized closure / capture-box class's
+            // remap active while emitting its ctor + Invoke bodies/signatures
+            // so enclosing type-parameter references resolve to the class's own
+            // VAR(idx) slots. No-op for every other class.
+            using (this.PushSmRemap(c))
+            {
+                EmitClassMethodBodies(c);
+            }
         }
 
         // 4b. Non-SM struct methods.
@@ -2668,7 +2729,17 @@ internal sealed class ReflectionMetadataEmitter
                     EmitInterfaceMethodBodies(ni);
                     break;
                 case StructSymbol ns when ns.IsClass:
-                    EmitClassMethodBodies(ns);
+                    // Issue #1477: a closure / capture-box class synthesized for
+                    // a lambda inside a GENERIC METHOD is nested in the (possibly
+                    // non-generic) declaring type and was reified generic over
+                    // the method's type parameters; push its remap so the Invoke
+                    // signature + body translate method-TP references to the
+                    // class's own Var slots. No-op for every other nested class.
+                    using (this.PushSmRemap(ns))
+                    {
+                        EmitClassMethodBodies(ns);
+                    }
+
                     break;
                 case StructSymbol ns:
                     // Issue #1465: async state-machine structs are reified
@@ -5946,8 +6017,11 @@ internal sealed class ReflectionMetadataEmitter
 
             // Issue #810: inside an iterator state-machine method body,
             // outer-method TPs are remapped to the SM class's own TPs.
+            // Issue #1477: a synthesized closure / capture-box class is also
+            // generic over enclosing TYPE parameters, so any TP present in the
+            // active remap (class or method) maps to the synthesized class's
+            // own VAR(idx) slot.
             if (this.activeIteratorStateMachineRemap != null
-                && tpSym.IsMethodTypeParameter
                 && this.activeIteratorStateMachineRemap.TryGetValue(tpSym, out var smClassOrd))
             {
                 encoder.GenericTypeParameter(smClassOrd);
@@ -6799,9 +6873,9 @@ internal sealed class ReflectionMetadataEmitter
             || openDef.IsSameAs(typeof(ValueTuple<,,,,,,,>));
     }
 
-    private readonly Dictionary<StructSymbol, EntityHandle> userStructTypeSpecCache = new(ReferenceEqualityComparer.Instance);
-    private readonly Dictionary<(StructSymbol Containing, FieldSymbol DefField), EntityHandle> userStructFieldRefCache = new();
-    private readonly Dictionary<(StructSymbol Containing, EntityHandle OpenMember), EntityHandle> userStructMethodRefCache = new();
+    private readonly Dictionary<(StructSymbol Sym, object Remap), EntityHandle> userStructTypeSpecCache = new();
+    private readonly Dictionary<(StructSymbol Containing, FieldSymbol DefField, object Remap), EntityHandle> userStructFieldRefCache = new();
+    private readonly Dictionary<(StructSymbol Containing, EntityHandle OpenMember, object Remap), EntityHandle> userStructMethodRefCache = new();
     private readonly Dictionary<InterfaceSymbol, EntityHandle> userInterfaceTypeSpecCache = new(ReferenceEqualityComparer.Instance);
     private readonly Dictionary<(InterfaceSymbol Containing, EntityHandle OpenMember), EntityHandle> userInterfaceMethodRefCache = new();
     private readonly Dictionary<(InterfaceSymbol Containing, FieldSymbol DefField), EntityHandle> userInterfaceFieldRefCache = new();
@@ -6839,7 +6913,7 @@ internal sealed class ReflectionMetadataEmitter
     /// </summary>
     internal EntityHandle GetUserStructTypeSpec(StructSymbol structSym)
     {
-        if (this.userStructTypeSpecCache.TryGetValue(structSym, out var cached))
+        if (this.userStructTypeSpecCache.TryGetValue((structSym, this.activeIteratorStateMachineRemap), out var cached))
         {
             return cached;
         }
@@ -6880,7 +6954,7 @@ internal sealed class ReflectionMetadataEmitter
         }
 
         var spec = (EntityHandle)this.emitCtx.Metadata.AddTypeSpecification(this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
-        this.userStructTypeSpecCache[structSym] = spec;
+        this.userStructTypeSpecCache[(structSym, this.activeIteratorStateMachineRemap)] = spec;
         return spec;
     }
 
@@ -6939,7 +7013,7 @@ internal sealed class ReflectionMetadataEmitter
             defField = fieldOnContaining;
         }
 
-        var key = (containingType, defField);
+        var key = (containingType, defField, (object)this.activeIteratorStateMachineRemap);
         if (this.userStructFieldRefCache.TryGetValue(key, out var cached))
         {
             return cached;
@@ -7048,7 +7122,7 @@ internal sealed class ReflectionMetadataEmitter
         string methodName,
         BlobBuilder signature)
     {
-        var key = (containingType, openMethodDef);
+        var key = (containingType, openMethodDef, (object)this.activeIteratorStateMachineRemap);
         if (this.userStructMethodRefCache.TryGetValue(key, out var cached))
         {
             return cached;
@@ -7206,6 +7280,43 @@ internal sealed class ReflectionMetadataEmitter
         }
 
         return this.GetUserStructMethodRef(containingType, openDef, method.Name, this.EncodeOpenMethodSignature(method));
+    }
+
+    /// <summary>
+    /// Issue #1477: resolves the <c>ldftn</c> function token for a synthesized
+    /// generic closure's <c>Invoke</c> method at the capture site. The parent
+    /// <c>TypeSpec</c> must encode the CONSTRUCTED closure
+    /// (<c>Closure`1&lt;…enclosing args…&gt;</c>) under the AMBIENT (capture-site)
+    /// remap, but the MemberRef signature must encode the open <c>Invoke</c>
+    /// parameters under the CLOSURE's OWN remap so enclosing-type-parameter
+    /// references resolve to the closure's <c>VAR(idx)</c> slots (which is how
+    /// the closure's MethodDef signature was emitted). For a non-generic closure
+    /// the bare <c>MethodDef</c> is returned.
+    /// </summary>
+    /// <param name="constructedClosure">The constructed closure reference.</param>
+    /// <param name="closureDef">The open closure definition (for the sig remap).</param>
+    /// <param name="invoke">The closure's <c>Invoke</c> method.</param>
+    /// <returns>The function token suitable for <c>ldftn</c>.</returns>
+    internal EntityHandle ResolveClosureInvokeFtnToken(StructSymbol constructedClosure, StructSymbol closureDef, FunctionSymbol invoke)
+    {
+        if (!this.cache.MethodHandles.TryGetValue(invoke, out var openDef))
+        {
+            throw new InvalidOperationException(
+                $"Closure invoke method '{invoke.Name}' has no emitted handle.");
+        }
+
+        if (!IsUserGenericTypeReference(constructedClosure))
+        {
+            return openDef;
+        }
+
+        BlobBuilder sig;
+        using (this.PushSmRemap(closureDef))
+        {
+            sig = this.EncodeOpenMethodSignature(invoke);
+        }
+
+        return this.GetUserStructMethodRef(constructedClosure, openDef, invoke.Name, sig);
     }
 
     /// <summary>
@@ -9406,6 +9517,15 @@ internal sealed class ReflectionMetadataEmitter
                 && this.activeIteratorStateMachineRemap.TryGetValue(tp, out var classOrdinal))
             {
                 encoder.GenericTypeParameter(classOrdinal);
+            }
+
+            // Issue #1477: a synthesized closure / capture-box class is generic
+            // over enclosing TYPE parameters too, so any TP in the active remap
+            // (class or method) encodes the synthesized class's own Var(idx).
+            else if (this.activeIteratorStateMachineRemap != null
+                && this.activeIteratorStateMachineRemap.TryGetValue(tp, out var classOrdinal2))
+            {
+                encoder.GenericTypeParameter(classOrdinal2);
             }
 
             // ADR-0087 §3 R2: a user-declared open type parameter encodes as

--- a/src/Core/CodeAnalysis/Lowering/CaptureBoxingRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/CaptureBoxingRewriter.cs
@@ -196,7 +196,27 @@ internal static class CaptureBoxingRewriter
 
             counter++;
             var boxClass = CreateBoxClass(variable, counter, packageName);
-            var fieldSymbol = boxClass.Fields[0];
+
+            // Issue #1477: when the captured variable's type references an
+            // enclosing generic type / method type parameter (a `T`-typed
+            // local, or a value whose type is `G[T]`/`Box[T]`/`(…) -> T`), the
+            // box class must be generic over those parameters; otherwise its
+            // `Value` field's `VAR` slot has no generic parameter in scope,
+            // producing an illegal field type (TypeLoadException at load) and
+            // unverifiable IL at the capture site. Reify the box generic over
+            // the referenced parameters (mirroring the state-machine treatment)
+            // and reference the CONSTRUCTED instance everywhere downstream so
+            // the local slot, `newobj`, and field stores carry the right
+            // `Box<…enclosing args…>` TypeSpec; the open definition (added to
+            // newStructs) gets the TypeDef + generic-param rows.
+            var origTPs = SynthesizedClosureReifier.CollectOrdered(new[] { variable.Type });
+            StructSymbol boxReference = boxClass;
+            FieldSymbol fieldSymbol = boxClass.Fields[0];
+            if (!origTPs.IsDefaultOrEmpty)
+            {
+                boxReference = SynthesizedClosureReifier.Reify(boxClass, origTPs);
+                fieldSymbol = boxReference.Fields[0];
+            }
 
             // For captured locals: a new LocalVariableSymbol of the box type
             // replaces the original; the binder-emitted slot is reclaimed
@@ -207,9 +227,9 @@ internal static class CaptureBoxingRewriter
             var slotName = variable is ParameterSymbol p
                 ? "<>__boxed_" + p.Name
                 : variable.Name;
-            var boxLocal = new LocalVariableSymbol(slotName, isReadOnly: false, type: boxClass);
+            var boxLocal = new LocalVariableSymbol(slotName, isReadOnly: false, type: boxReference);
 
-            boxInfo[variable] = new BoxedVariable(variable, boxLocal, boxClass, fieldSymbol);
+            boxInfo[variable] = new BoxedVariable(variable, boxLocal, boxReference, fieldSymbol);
             newStructs.Add(boxClass);
         }
 

--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -354,6 +354,19 @@ public sealed class StructSymbol : TypeSymbol
     /// <summary>Gets the type arguments when this is a constructed instance of a generic definition (Phase 4.3 / ADR-0020). Empty for generic definitions and for non-generic types.</summary>
     public ImmutableArray<TypeSymbol> TypeArguments { get; private set; } = ImmutableArray<TypeSymbol>.Empty;
 
+    /// <summary>
+    /// Gets, for a synthesized closure / capture-box class that was reified
+    /// generic over enclosing type/method type parameters (issue #1477), the
+    /// ordered list of the ORIGINAL enclosing
+    /// <see cref="TypeParameterSymbol"/>s its fresh class type parameters
+    /// (<see cref="TypeParameters"/>) clone 1:1. The emitter consumes this to
+    /// build the outer-TP → own-TP-ordinal remap (mirroring the iterator/async
+    /// state-machine treatment) so member signatures encode a valid
+    /// <c>VAR(idx)</c> slot. Empty for every other type. Each entry at index
+    /// <c>i</c> corresponds to <see cref="TypeParameters"/><c>[i]</c>.
+    /// </summary>
+    public ImmutableArray<TypeParameterSymbol> ReifiedFromTypeParameters { get; private set; } = ImmutableArray<TypeParameterSymbol>.Empty;
+
     /// <summary>Gets a value indicating whether this is a generic definition (has type parameters and no type arguments).</summary>
     public bool IsGenericDefinition => !TypeParameters.IsDefaultOrEmpty && TypeArguments.IsDefaultOrEmpty;
 
@@ -729,6 +742,18 @@ public sealed class StructSymbol : TypeSymbol
     public void SetTypeParameters(ImmutableArray<TypeParameterSymbol> typeParameters)
     {
         TypeParameters = typeParameters;
+    }
+
+    /// <summary>
+    /// Issue #1477: records the ordered original enclosing type parameters that
+    /// this synthesized closure / capture-box class's fresh type parameters
+    /// clone 1:1 (see <see cref="ReifiedFromTypeParameters"/>). Called once at
+    /// synthesis time alongside <see cref="SetTypeParameters"/>.
+    /// </summary>
+    /// <param name="reifiedFrom">The original enclosing type parameters, aligned to <see cref="TypeParameters"/>.</param>
+    public void SetReifiedFromTypeParameters(ImmutableArray<TypeParameterSymbol> reifiedFrom)
+    {
+        ReifiedFromTypeParameters = reifiedFrom;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Symbols/SynthesizedClosureReifier.cs
+++ b/src/Core/CodeAnalysis/Symbols/SynthesizedClosureReifier.cs
@@ -1,0 +1,132 @@
+// <copyright file="SynthesizedClosureReifier.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace GSharp.Core.CodeAnalysis.Symbols;
+
+/// <summary>
+/// Issue #1477: shared helper that makes a synthesized closure / capture-box
+/// class generic over the enclosing generic type / method type parameters its
+/// members reference. When a lambda inside a generic type (or generic method)
+/// captures a value whose type references an enclosing type parameter (a
+/// <c>T</c>-typed value, or <c>this</c> of <c>G&lt;T&gt;</c>), the synthesized
+/// display / box class must declare its OWN type parameters that mirror those
+/// enclosing parameters 1:1; otherwise its capture field's <c>VAR</c> slot has
+/// no generic parameter in scope, producing an illegal field type
+/// (<c>System.TypeLoadException</c> at load) and unverifiable IL.
+/// </summary>
+/// <remarks>
+/// The reification mirrors the iterator / async state-machine treatment
+/// (<c>RegisterStateMachineEnclosingGenerics</c>): the synthesized class is
+/// reified over fresh class-level type parameters that clone each referenced
+/// enclosing parameter, and the original parameters are recorded on
+/// <see cref="StructSymbol.ReifiedFromTypeParameters"/> so the emitter can build
+/// the outer-TP → own-TP-ordinal remap that routes every member signature
+/// through a valid <c>VAR(idx)</c> slot. A constructed instance carrying the
+/// original parameters as type arguments is returned for use at the capture
+/// site (so the <c>newobj</c> / field stores reference
+/// <c>DisplayClass&lt;…enclosing args…&gt;</c>).
+/// </remarks>
+internal static class SynthesizedClosureReifier
+{
+    /// <summary>
+    /// Collects, in a stable canonical order (enclosing TYPE parameters first
+    /// by ordinal, then enclosing METHOD parameters by ordinal), the distinct
+    /// type parameters referenced by <paramref name="types"/>.
+    /// </summary>
+    /// <param name="types">The member / signature types to scan.</param>
+    /// <returns>The ordered distinct referenced type parameters; empty when none.</returns>
+    public static ImmutableArray<TypeParameterSymbol> CollectOrdered(IEnumerable<TypeSymbol> types)
+    {
+        var referenced = new List<TypeParameterSymbol>();
+        foreach (var t in types)
+        {
+            TypeSymbol.CollectReferencedTypeParameters(t, referenced);
+        }
+
+        if (referenced.Count == 0)
+        {
+            return ImmutableArray<TypeParameterSymbol>.Empty;
+        }
+
+        // Canonical order: class type parameters (Var) before method type
+        // parameters (MVar), each by their original ordinal. This keeps the
+        // synthesized class's parameter list deterministic regardless of the
+        // member-scan order.
+        referenced.Sort(static (a, b) =>
+        {
+            var ak = a.IsMethodTypeParameter ? 1 : 0;
+            var bk = b.IsMethodTypeParameter ? 1 : 0;
+            if (ak != bk)
+            {
+                return ak - bk;
+            }
+
+            return a.Ordinal - b.Ordinal;
+        });
+
+        return referenced.ToImmutableArray();
+    }
+
+    /// <summary>
+    /// Clones <paramref name="src"/> as a class-level type parameter at
+    /// <paramref name="ordinal"/> (carrying its constraints), suitable for
+    /// declaration on a synthesized closure / box class.
+    /// </summary>
+    /// <param name="src">The original enclosing type parameter.</param>
+    /// <param name="ordinal">The ordinal for the fresh class type parameter.</param>
+    /// <returns>The cloned class type parameter.</returns>
+    public static TypeParameterSymbol CloneAsClassTypeParameter(TypeParameterSymbol src, int ordinal)
+    {
+        return new TypeParameterSymbol(
+            src.Name,
+            ordinal,
+            src.Constraint,
+            src.Variance,
+            src.InterfaceConstraint)
+        {
+            HasReferenceTypeConstraint = src.HasReferenceTypeConstraint,
+            HasValueTypeConstraint = src.HasValueTypeConstraint,
+            HasDefaultConstructorConstraint = src.HasDefaultConstructorConstraint,
+            ClrInterfaceConstraint = src.ClrInterfaceConstraint,
+            ClassConstraint = src.ClassConstraint,
+            IsMethodTypeParameter = false,
+        };
+    }
+
+    /// <summary>
+    /// Reifies <paramref name="definition"/> generic over the
+    /// <paramref name="origTPs"/> it references: declares fresh class type
+    /// parameters that clone them 1:1, records the originals via
+    /// <see cref="StructSymbol.SetReifiedFromTypeParameters"/>, and returns a
+    /// constructed instance whose type arguments are the originals (for use at
+    /// the capture site). The definition's member signatures continue to
+    /// reference the original parameters; the emitter's remap routes them
+    /// through the new class slots.
+    /// </summary>
+    /// <param name="definition">The synthesized closure / box class definition.</param>
+    /// <param name="origTPs">The ordered referenced enclosing type parameters.</param>
+    /// <returns>The constructed instance over the original parameters.</returns>
+    public static StructSymbol Reify(StructSymbol definition, ImmutableArray<TypeParameterSymbol> origTPs)
+    {
+        var clones = ImmutableArray.CreateBuilder<TypeParameterSymbol>(origTPs.Length);
+        for (var i = 0; i < origTPs.Length; i++)
+        {
+            clones.Add(CloneAsClassTypeParameter(origTPs[i], i));
+        }
+
+        definition.SetTypeParameters(clones.MoveToImmutable());
+        definition.SetReifiedFromTypeParameters(origTPs);
+
+        var args = ImmutableArray.CreateBuilder<TypeSymbol>(origTPs.Length);
+        foreach (var tp in origTPs)
+        {
+            args.Add(tp);
+        }
+
+        return StructSymbol.Construct(definition, args.MoveToImmutable());
+    }
+}

--- a/src/Core/CodeAnalysis/Symbols/TypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/TypeSymbol.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 
 namespace GSharp.Core.CodeAnalysis.Symbols;
 
@@ -375,6 +376,120 @@ public class TypeSymbol : Symbol
                 return false;
             default:
                 return false;
+        }
+    }
+
+    /// <summary>
+    /// Issue #1477: collects, in stable first-seen order, every distinct
+    /// <see cref="TypeParameterSymbol"/> structurally referenced by
+    /// <paramref name="type"/> — recursing through nullable / slice / array /
+    /// map / function / tuple wrappers and the type arguments of constructed
+    /// user (<see cref="StructSymbol"/> / <see cref="InterfaceSymbol"/> /
+    /// <see cref="DelegateTypeSymbol"/>) and imported generic types. Used by
+    /// the closure / capture-box emitter to discover which enclosing type
+    /// parameters a synthesized display class must be made generic over.
+    /// </summary>
+    /// <param name="type">The type to inspect (may be <see langword="null"/>).</param>
+    /// <param name="sink">The ordered set to add referenced type parameters to.</param>
+    public static void CollectReferencedTypeParameters(TypeSymbol type, List<TypeParameterSymbol> sink)
+    {
+        switch (type)
+        {
+            case null:
+                return;
+            case TypeParameterSymbol tp:
+                if (!sink.Contains(tp))
+                {
+                    sink.Add(tp);
+                }
+
+                return;
+            case NullableTypeSymbol n:
+                CollectReferencedTypeParameters(n.UnderlyingType, sink);
+                return;
+            case SliceTypeSymbol s:
+                CollectReferencedTypeParameters(s.ElementType, sink);
+                return;
+            case ArrayTypeSymbol a:
+                CollectReferencedTypeParameters(a.ElementType, sink);
+                return;
+            case SequenceTypeSymbol sq:
+                CollectReferencedTypeParameters(sq.ElementType, sink);
+                return;
+            case AsyncSequenceTypeSymbol asq:
+                CollectReferencedTypeParameters(asq.ElementType, sink);
+                return;
+            case MapTypeSymbol m:
+                CollectReferencedTypeParameters(m.KeyType, sink);
+                CollectReferencedTypeParameters(m.ValueType, sink);
+                return;
+            case FunctionTypeSymbol fn:
+                foreach (var param in fn.ParameterTypes)
+                {
+                    CollectReferencedTypeParameters(param, sink);
+                }
+
+                CollectReferencedTypeParameters(fn.ReturnType, sink);
+                return;
+            case TupleTypeSymbol tup:
+                foreach (var elem in tup.ElementTypes)
+                {
+                    CollectReferencedTypeParameters(elem, sink);
+                }
+
+                return;
+            case ByRefTypeSymbol br:
+                CollectReferencedTypeParameters(br.PointeeType, sink);
+                return;
+            case StructSymbol ss when !ss.TypeArguments.IsDefaultOrEmpty:
+                foreach (var arg in ss.TypeArguments)
+                {
+                    CollectReferencedTypeParameters(arg, sink);
+                }
+
+                return;
+            case StructSymbol ssOpen when !ssOpen.TypeParameters.IsDefaultOrEmpty:
+                // Issue #1477: a captured `this` of a generic type `G[T]` is the
+                // OPEN definition (TypeParameters set, no TypeArguments) — its
+                // own parameters ARE the enclosing parameters the capture field
+                // references (`G`1<!0>`), so collect them.
+                foreach (var tp in ssOpen.TypeParameters)
+                {
+                    CollectReferencedTypeParameters(tp, sink);
+                }
+
+                return;
+            case InterfaceSymbol iface when !iface.TypeArguments.IsDefaultOrEmpty:
+                foreach (var arg in iface.TypeArguments)
+                {
+                    CollectReferencedTypeParameters(arg, sink);
+                }
+
+                return;
+            case InterfaceSymbol ifaceOpen when !ifaceOpen.TypeParameters.IsDefaultOrEmpty:
+                foreach (var tp in ifaceOpen.TypeParameters)
+                {
+                    CollectReferencedTypeParameters(tp, sink);
+                }
+
+                return;
+            case DelegateTypeSymbol del:
+                foreach (var param in del.Parameters)
+                {
+                    CollectReferencedTypeParameters(param.Type, sink);
+                }
+
+                CollectReferencedTypeParameters(del.ReturnType, sink);
+                return;
+            case ImportedTypeSymbol it when !it.TypeArguments.IsDefaultOrEmpty:
+                foreach (var arg in it.TypeArguments)
+                {
+                    CollectReferencedTypeParameters(arg, sink);
+                }
+
+                return;
+            default:
+                return;
         }
     }
 

--- a/test/Compiler.Tests/Emit/Issue1477GenericClosureCaptureEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1477GenericClosureCaptureEmitTests.cs
@@ -1,0 +1,228 @@
+// <copyright file="Issue1477GenericClosureCaptureEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1477 — a lambda declared inside a generic type (or generic method)
+/// that captures a value whose type references an enclosing generic
+/// type/method parameter (a <c>T</c>-typed parameter/local, <c>this</c> of
+/// <c>G[T]</c>, or a boxed <c>Box[T]</c>) used to emit a NON-generic
+/// synthesized display / capture-box class. Its capture field was then typed
+/// <c>!0</c> with no generic parameter in scope — an illegal field type that
+/// faulted at load (<c>System.TypeLoadException</c>) and produced unverifiable
+/// IL (<c>StackUnexpected</c> at the capture store + <c>DelegateCtor</c> at the
+/// delegate construction). The fix reifies the synthesized class generic over
+/// exactly the referenced enclosing parameters (Roslyn semantics) and parents
+/// the capture-site <c>newobj</c> / field stores / <c>ldftn Invoke</c> at the
+/// constructed display-class TypeSpec.
+/// <list type="bullet">
+/// <item>Facet A — a generic static factory whose lambda captures a
+/// <c>T</c>-typed parameter, value-type instantiation (<c>Op[int]</c>).</item>
+/// <item>Facet B — the same shape with a reference-type instantiation
+/// (<c>Op[string]</c>).</item>
+/// <item>Facet C — a lambda capturing <c>this</c> / an instance field of
+/// <c>G[T]</c> (mirrors <c>Mp4Operation`1.SetContinuation</c>).</item>
+/// <item>Facet D — a generic METHOD (MVAR) whose lambda captures the method's
+/// type-parameter-typed local.</item>
+/// </list>
+/// All four faulted on current main and pass (clean ilverify + correct runtime
+/// output) after the fix.
+/// </summary>
+public class Issue1477GenericClosureCaptureEmitTests
+{
+    [Fact]
+    public void EndToEnd_FacetA_GenericFactoryCapturesTypeParamValue_ValueType_Runs()
+    {
+        var source = """
+            package Cap1477A
+            import System
+            import System.Threading.Tasks
+
+            open class OpA[T] {
+                private let cf (Task) -> T
+                init(cf (Task) -> T) { this.cf = cf }
+                func Run(t Task) T -> cf(t)
+                shared {
+                    func FromCompleted(result T) OpA[T] -> OpA[T]((_ Task) -> result)
+                }
+            }
+
+            func Main() {
+                let o = OpA[int].FromCompleted(5)
+                Console.WriteLine(o.Run(Task.CompletedTask))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("5\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_FacetB_GenericFactoryCapturesTypeParamValue_ReferenceType_Runs()
+    {
+        var source = """
+            package Cap1477B
+            import System
+            import System.Threading.Tasks
+
+            open class OpB[T] {
+                private let cf (Task) -> T
+                init(cf (Task) -> T) { this.cf = cf }
+                func Run(t Task) T -> cf(t)
+                shared {
+                    func FromCompleted(result T) OpB[T] -> OpB[T]((_ Task) -> result)
+                }
+            }
+
+            func Main() {
+                let o = OpB[string].FromCompleted("hello")
+                Console.WriteLine(o.Run(Task.CompletedTask))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("hello\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_FacetC_LambdaCapturesThisOfGenericType_Runs()
+    {
+        var source = """
+            package Cap1477C
+            import System
+
+            open class HolderC[T] {
+                let value T
+                init(value T) { this.value = value }
+                func MakeGetter() () -> T -> () -> this.value
+            }
+
+            func Main() {
+                let h = HolderC[int](42)
+                let g = h.MakeGetter()
+                Console.WriteLine(g())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_FacetD_GenericMethodLambdaCapturesMethodTypeParamLocal_Runs()
+    {
+        var source = """
+            package Cap1477D
+            import System
+
+            class UtilD {
+                shared {
+                    func MakeGetter[U](item U) () -> U {
+                        let local = item
+                        return () -> local
+                    }
+                }
+            }
+
+            func Main() {
+                let g = UtilD.MakeGetter[int](99)
+                Console.WriteLine(g())
+                let gs = UtilD.MakeGetter[string]("world")
+                Console.WriteLine(gs())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("99\nworld\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1477_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
A lambda inside a generic type or method that captures a value whose type references an enclosing generic parameter (a T-typed value, this of G[T], or a boxed Box[T]) emitted a non-generic synthesized capture-box and display/closure class. The capture field was typed !0 with no generic parameter in scope, an illegal field type that faulted at load (TypeLoadException) and produced unverifiable IL (StackUnexpected at the capture store, DelegateCtor at the delegate construction).

Reify the synthesized box and closure classes generic over exactly the referenced enclosing type/method parameters (Roslyn semantics) and parent the capture-site newobj / field stores / ldftn Invoke at the constructed display-class TypeSpec, reusing the existing iterator/async state-machine remap machinery.

Fixes #1477

Refs #914