### PR TITLE
Preserve user element type for any CLR generic G[Entry] property (#1418)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -4143,53 +4143,42 @@ internal sealed partial class ExpressionBinder
             // null `ClrType` during binding, so the closed reflection property
             // reports the erased `object`; surface the symbolic projection.
             //
-            // The override is restricted to a TOP-LEVEL user type (after
-            // unwrapping nullable/slice/array). A member typed as a constructed
-            // generic over a user element (e.g. a `ChannelWriter[Entry]`
-            // property) is generally left to the closed reflection fallback,
-            // because method/extension lookup on such a non-interned constructed
-            // generic is not yet supported (#1305); surfacing it would regress
-            // those call sites.
+            // Issue #1418 generalizes the #1304/#1328/#1344 progression: surface
+            // the symbolic projection whenever it carries a same-compilation
+            // user type ANYWHERE — whether the member is the user type itself
+            // (`IEnumerator[Ch].Current` -> `Ch`, #1304), a constructed generic
+            // that is an enumerable collection (`Dictionary[K, V].Values` ->
+            // `ValueCollection[K, V]`, #1328), a channel reader/writer
+            // (`Channel[Entry].Reader` -> `ChannelReader[Entry]`, #1344), or any
+            // OTHER constructed CLR generic over a user element
+            // (`TaskCompletionSource[Entry].Task` -> `Task[Entry]`,
+            // `Lazy[Entry]`, `IReadOnlyList[Entry]`, …). In every case the
+            // mapped type keeps the type-erased closed `ClrType` (e.g.
+            // `Task<object>`) for member/extension lookup — which resolves
+            // against the erased shape exactly as before (proven by #1088) —
+            // while its symbolic `[Entry]` argument keeps the element type from
+            // collapsing to `object` for downstream projections (`await`,
+            // `await for`, `.Result`, the `for … in` surface, LINQ terminals).
             //
-            // Issue #1328: an exception is a constructed generic that is itself
-            // an enumerable COLLECTION over a same-compilation user element —
-            // e.g. `Dictionary[K, V].Values` -> `ValueCollection[K, V]` (and
-            // `.Keys` -> `KeyCollection[K, V]`). Such a wrapper's erased
-            // `ClrType` (`ValueCollection<K, object>`) still implements
-            // `IEnumerable<V>`, so member/extension lookup (`.Single()`,
-            // `.ToList()`, the `for … in` enumerable surface) resolves against
-            // it exactly as for an `IEnumerable[V]`/`List[V]` receiver, while
-            // the symbolic `[K, V]` arguments let the element-type recovery
-            // surface the user `V` instead of erasing to `object`. This matches
-            // the #903/#1305 machinery already proven for `IEnumerable[User]`.
+            // The earlier #1305 worry — that surfacing a constructed generic
+            // over a user element would regress method lookup — does not
+            // materialize precisely because lookup reads `ClrType`, not the
+            // symbolic arguments; #1328 and #1344 already proved this for the
+            // collection and channel shapes, and `ContainsSameCompilationUserType`
+            // simply removes the type-specific allow-list.
             //
-            // Issue #1328 also: when the OPEN property type is itself a bare
-            // generic parameter (e.g. `KeyValuePair[K, V].Key` -> `K`,
-            // `.Value` -> `V`), the receiver's closed `ClrType` may have erased
-            // *every* type argument to `object` because a SIBLING argument is a
-            // same-compilation user type (a constructed generic over a user
-            // element erases the whole closed shape — so `KeyValuePair[uint32,
-            // E]` closes to `KeyValuePair<object, object>`, erasing the
-            // perfectly concrete `uint32` too). The symbolic projection is then
-            // authoritative for the member, so prefer it. This is safe because
-            // a bare-parameter property cannot be a constructed generic over a
-            // user element (the #1305 ChannelWriter[Entry] concern), so it does
-            // not regress those call sites.
-            //
-            // Issue #1344: a `Channel[Entry].Reader` (`ChannelReader[Entry]`)
-            // and `.Writer` (`ChannelWriter[Entry]`) are also constructed
-            // generics over a same-compilation user element. They are not
-            // enumerable collections, but the reader exposes
-            // `ReadAllAsync()` -> `IAsyncEnumerable[Entry]`; if the property
-            // erases to `ChannelReader[object]`, the async stream erases to
-            // `IAsyncEnumerable[object]` and the `await for` loop variable
-            // collapses to `object`. Surface the symbolic `[Entry]` so the
-            // element type survives; member/method lookup still resolves
-            // against the erased CLR shape (proven by #1088).
+            // When the OPEN property type is itself a bare generic parameter
+            // (e.g. `KeyValuePair[K, V].Key` -> `K`, `.Value` -> `V`), the
+            // receiver's closed `ClrType` may have erased *every* type argument
+            // to `object` because a SIBLING argument is a same-compilation user
+            // type (a constructed generic over a user element erases the whole
+            // closed shape — so `KeyValuePair[uint32, E]` closes to
+            // `KeyValuePair<object, object>`, erasing the concrete `uint32`
+            // too). The symbolic projection is then authoritative, so prefer it
+            // via the `openPropType.IsGenericParameter` arm even when the mapped
+            // result no longer mentions the user type.
             return TypeSymbol.ContainsTypeParameter(mapped)
-                || TypeSymbol.IsSameCompilationUserTypeTopLevel(mapped)
-                || IsUserElementEnumerableCollection(mapped)
-                || IsUserElementChannelReaderWriter(mapped)
+                || TypeSymbol.ContainsSameCompilationUserType(mapped)
                 || openPropType.IsGenericParameter
                 ? mapped
                 : null;
@@ -4199,48 +4188,6 @@ internal sealed partial class ExpressionBinder
             return null;
         }
     }
-
-    /// <summary>
-    /// Issue #1328: returns <see langword="true"/> when <paramref name="mapped"/>
-    /// is a constructed imported generic that (a) carries a same-compilation
-    /// user type among its symbolic arguments and (b) whose type-erased
-    /// <see cref="TypeSymbol.ClrType"/> still implements
-    /// <c>IEnumerable&lt;T&gt;</c> — i.e. an enumerable collection wrapper such
-    /// as <c>Dictionary[K, V].Values</c> (<c>ValueCollection[K, V]</c>) or
-    /// <c>.Keys</c> (<c>KeyCollection[K, V]</c>). Surfacing the symbolic form
-    /// of such a wrapper preserves the user element type through the
-    /// <c>for … in</c> enumerable surface and LINQ terminals
-    /// (<c>.Single()</c>/<c>.ToList()</c>), while member/extension lookup still
-    /// resolves against the erased CLR shape (which implements the same
-    /// <c>IEnumerable&lt;object&gt;</c>). Unlike a general constructed generic
-    /// (e.g. <c>ChannelWriter[Entry]</c>, #1305), the enumerable surface is the
-    /// proven #903/#1304 path, so this is safe to surface.
-    /// </summary>
-    /// <param name="mapped">The symbolic projection produced by <see cref="MemberLookup.MapOpenClrTypeToSymbolic(Type, ImportedTypeSymbol)"/>.</param>
-    /// <returns><see langword="true"/> when the mapped type is a user-element enumerable collection wrapper.</returns>
-    private static bool IsUserElementEnumerableCollection(TypeSymbol mapped)
-        => mapped is ImportedTypeSymbol { ClrType: { } clr }
-            && TypeSymbol.ContainsSameCompilationUserType(mapped)
-            && MemberLookup.TryGetClrEnumerableElementType(clr, out _);
-
-    /// <summary>
-    /// Issue #1344: returns <see langword="true"/> when <paramref name="mapped"/>
-    /// is a constructed <c>System.Threading.Channels.ChannelReader&lt;T&gt;</c>
-    /// or <c>ChannelWriter&lt;T&gt;</c> over a same-compilation user element.
-    /// Such a reader/writer is not an enumerable collection, but the reader
-    /// exposes <c>ReadAllAsync()</c> -> <c>IAsyncEnumerable[T]</c>; surfacing the
-    /// symbolic argument keeps the user element type instead of erasing to
-    /// <c>object</c>, so an <c>await for</c> over <c>reader.ReadAllAsync()</c>
-    /// binds member access on the loop element. Member/method lookup still
-    /// resolves against the erased closed shape (proven by #1088).
-    /// </summary>
-    /// <param name="mapped">The symbolic projection produced by <see cref="MemberLookup.MapOpenClrTypeToSymbolic(Type, ImportedTypeSymbol)"/>.</param>
-    /// <returns><see langword="true"/> when the mapped type is a user-element channel reader/writer.</returns>
-    private static bool IsUserElementChannelReaderWriter(TypeSymbol mapped)
-        => mapped is ImportedTypeSymbol { OpenDefinition: { } def }
-            && (def.FullName == "System.Threading.Channels.ChannelReader`1"
-                || def.FullName == "System.Threading.Channels.ChannelWriter`1")
-            && TypeSymbol.ContainsSameCompilationUserType(mapped);
 
     private static bool IsReadOnlyRefReturn(PropertyInfo indexer, MethodInfo getter)
     {

--- a/test/Compiler.Tests/Emit/Issue1418GenericUserElementErasureEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1418GenericUserElementErasureEmitTests.cs
@@ -1,0 +1,263 @@
+// <copyright file="Issue1418GenericUserElementErasureEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1418 (follow-up to #1344): generalizes user-element preservation
+/// across <em>any</em> constructed CLR generic <c>G[Entry]</c> surfaced from a
+/// property, not just the enumerable-collection (#1328) and channel-reader
+/// /writer (#1344) shapes that were previously allow-listed.
+/// <para>
+/// A same-compilation user type used as a CLR generic argument is erased to
+/// <c>System.Object</c> on the closed type. When a property's open type is a
+/// constructed generic over the receiver's type parameter (e.g.
+/// <c>TaskCompletionSource[Entry].Task</c> -> <c>Task&lt;TResult&gt;</c>, or
+/// <c>LinkedList[Entry].First</c> -> <c>LinkedListNode&lt;T&gt;</c>), the closed
+/// reflection type reports <c>Task[object]</c> / <c>LinkedListNode[object]</c>,
+/// collapsing the element type for every downstream projection
+/// (<c>await</c>, <c>.Result</c>, chained member access). The fix surfaces the
+/// symbolic <c>[Entry]</c> projection whenever it carries a same-compilation
+/// user type anywhere, while member lookup still resolves against the erased
+/// closed shape (proven by #1088).
+/// </para>
+/// These tests compile, IL-verify, and run each repro end-to-end.
+/// </summary>
+public class Issue1418GenericUserElementErasureEmitTests
+{
+    [Fact]
+    public void TaskCompletionSourceTask_UserElement_AwaitBindsAndRuns()
+    {
+        // `TaskCompletionSource[Entry].Task` -> `Task[Entry]` is neither an
+        // enumerable collection nor a channel; before #1418 it erased to
+        // `Task[object]`, so `await tcs.Task` bound the result as `object` and
+        // `e.V` failed GS0158.
+        var source = """
+            package P
+            import System
+            import System.Threading.Tasks
+
+            class Issue1418TaskEntry { var V int32 = 0 }
+
+            public var total = 0
+            async func Consume(tcs TaskCompletionSource[Issue1418TaskEntry]) {
+                let e = await tcs.Task
+                total = total + e.V
+            }
+
+            let tcs = TaskCompletionSource[Issue1418TaskEntry]()
+            var a = Issue1418TaskEntry()
+            a.V = 42
+            tcs.SetResult(a)
+            Consume(tcs).Wait()
+            Console.WriteLine(total)
+            """;
+
+        Assert.Equal("42\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void TaskCompletionSourceTask_UserElement_ResultBindsAndRuns()
+    {
+        // The same symbolic `Task[Entry]` flowing through the synchronous
+        // `.Result` surface (open type `TResult`, a bare parameter on the now
+        // preserved `Task[Entry]`).
+        var source = """
+            package P
+            import System
+            import System.Threading.Tasks
+
+            class Issue1418ResultEntry { var V int32 = 0 }
+
+            let tcs = TaskCompletionSource[Issue1418ResultEntry]()
+            var a = Issue1418ResultEntry()
+            a.V = 7
+            tcs.SetResult(a)
+            let e = tcs.Task.Result
+            Console.WriteLine(e.V)
+            """;
+
+        Assert.Equal("7\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void LinkedListNodeProperty_UserElement_ChainedAccessBindsAndRuns()
+    {
+        // `LinkedList[Entry].First` -> `LinkedListNode[Entry]` is a NON-enumerable
+        // constructed generic property; before #1418 it erased to
+        // `LinkedListNode[object]`, so `node.Value` bound as `object` and
+        // `node.Value.V` failed GS0158. (`LinkedList` itself is enumerable, but
+        // the `.First` PROPERTY type — `LinkedListNode<T>` — is not.)
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            class Issue1418NodeEntry { var V int32 = 0 }
+
+            let ll = LinkedList[Issue1418NodeEntry]()
+            var a = Issue1418NodeEntry()
+            a.V = 11
+            ll.AddLast(a)
+            let node = ll.First
+            Console.WriteLine(node.Value.V)
+            """;
+
+        Assert.Equal("11\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void ChannelReaderWriter_UserElement_StillBindsAndRuns()
+    {
+        // Regression guard: the #1344 channel shape, previously handled by a
+        // dedicated allow-list now folded into the general rule, keeps working.
+        var source = """
+            package P
+            import System
+            import System.Threading.Channels
+
+            class Issue1418ChanEntry { var V int32 = 0 }
+
+            public var total = 0
+            async func Consume(ch Channel[Issue1418ChanEntry]) {
+                await for m in ch.Reader.ReadAllAsync() {
+                    total = total + m.V
+                }
+            }
+
+            let ch = Channel.CreateUnbounded[Issue1418ChanEntry]()
+            var a = Issue1418ChanEntry()
+            a.V = 5
+            var w1 = ch.Writer.TryWrite(a)
+            var b = Issue1418ChanEntry()
+            b.V = 9
+            var w2 = ch.Writer.TryWrite(b)
+            ch.Writer.Complete()
+            Consume(ch).Wait()
+            Console.WriteLine(total)
+            """;
+
+        Assert.Equal("14\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void DictionaryValuesCollection_UserElement_StillBindsAndRuns()
+    {
+        // Regression guard: the #1328 enumerable-collection shape
+        // (`Dictionary[K, Entry].Values` -> `ValueCollection[K, Entry]`), also
+        // folded into the general rule, keeps preserving the element type
+        // through the `for … in` surface.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            class Issue1418DictEntry { var V int32 = 0 }
+
+            let d = Dictionary[int32, Issue1418DictEntry]()
+            var a = Issue1418DictEntry()
+            a.V = 3
+            d[1] = a
+            var b = Issue1418DictEntry()
+            b.V = 8
+            d[2] = b
+            var total = 0
+            for e in d.Values {
+                total = total + e.V
+            }
+            Console.WriteLine(total)
+            """;
+
+        Assert.Equal("11\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1418_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+            string Ref(string name) => "/r:" + Path.Combine(runtimeDir, name);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    Ref("System.Private.CoreLib.dll"),
+                    Ref("System.Runtime.dll"),
+                    Ref("System.Console.dll"),
+                    Ref("System.Collections.dll"),
+                    Ref("System.Threading.dll"),
+                    Ref("System.Threading.Channels.dll"),
+                    Ref("System.Threading.Tasks.dll"),
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #1344. Fixes #1418.

Same-compilation user types used as CLR generic arguments are erased to `System.Object` on the closed type. When a property's **open type is a constructed generic** over the receiver's type parameter, the closed reflection type reports `G[object]`, collapsing the element type for every downstream projection (`await`, `await for`, `.Result`, chained member access, the `for … in` surface, LINQ terminals).

`#1304` / `#1328` / `#1344` fixed this **incrementally with a type-specific allow-list** in `ResolveInstancePropertyTypeFromReceiver`:

- `#1304`: top-level user types (`IEnumerator[Ch].Current` → `Ch`),
- `#1328`: enumerable collections (`Dictionary[K, V].Values` → `ValueCollection[K, V]`),
- `#1344`: channel reader/writer (`Channel[Entry].Reader` → `ChannelReader[Entry]`).

The issue asks: *why not generalize to any generic type `G[T]`?* There is no technical limitation — so this removes the allow-list.

### Change

Surface the symbolic projection whenever it carries a same-compilation user type **anywhere**, via the existing `TypeSymbol.ContainsSameCompilationUserType`. That predicate subsumes all three special cases (`IsSameCompilationUserTypeTopLevel`, `IsUserElementEnumerableCollection`, `IsUserElementChannelReaderWriter`), which are now deleted (net −53 lines).

```csharp
return TypeSymbol.ContainsTypeParameter(mapped)
    || TypeSymbol.ContainsSameCompilationUserType(mapped)   // was 3 type-specific predicates
    || openPropType.IsGenericParameter
    ? mapped : null;
```

### Why it is safe

The mapped type keeps its **type-erased closed `ClrType`** (e.g. `Task<object>`) for member/extension lookup — which resolves against the erased shape exactly as before (proven by `#1088`) — while its symbolic `[Entry]` argument keeps the element type from collapsing to `object`. The earlier `#1305` worry (that surfacing a constructed generic over a user element would regress method lookup) does not materialize precisely because lookup reads `ClrType`, not the symbolic arguments; `#1328` and `#1344` already proved this for the collection and channel shapes.

### Newly-supported example (failed before this PR)

```gsharp
class Entry { var V int32 = 0 }
async func Consume(tcs TaskCompletionSource[Entry]) {
    let e = await tcs.Task   // tcs.Task : Task[Entry] (was Task[object] → GS0158 on e.V)
    total = total + e.V
}
```

### Tests

Adds `Issue1418GenericUserElementErasureEmitTests` (compile + IL-verify + run):

- `TaskCompletionSource[Entry].Task` via `await` — a `Task[Entry]` (non-enumerable, non-channel) generic.
- `TaskCompletionSource[Entry].Task.Result` — the same symbolic `Task[Entry]` through the synchronous surface.
- `LinkedList[Entry].First` → `LinkedListNode[Entry]` — a non-enumerable constructed-generic **property**, chained to `.Value.V`.
- Regression guards that the previously allow-listed channel (`#1344`) and dictionary-values (`#1328`) shapes still work.

### Validation

- New tests: 5/5 pass (full ilverify, no ignore-list).
- `Core.Tests`: 4788 pass.
- Generic-erasure family (`#794`/`#903`/`#1088`/`#1304`/`#1305`/`#1320`/`#1325`/`#1328`/`#1330`/`#1334`/`#1339`/`#1344`/`#1416` …): 89 pass.
- Broader property/member/generic/async/await regression batches: 97 pass.
- Release build: 0 warnings, 0 errors.
