### PR TITLE
Fix conditional/?? target-typing to sibling interface (#1480)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundBinaryOperator.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundBinaryOperator.cs
@@ -316,6 +316,22 @@ public sealed record BoundBinaryOperator
     }
 
     /// <summary>
+    /// Issue #1480: builds a target-typed null-coalescing operator whose result
+    /// is the supplied <paramref name="resultType"/> (the contextual target type)
+    /// for the case where the operand underlyings share no natural common type
+    /// but both implicitly convert to the target (e.g. sibling classes
+    /// <c>A</c>/<c>B</c> coalesced at a common interface <c>IShape</c>). Used by
+    /// the binder's target-typed coalesce path; the operand conversions to the
+    /// result type are inserted by the caller.
+    /// </summary>
+    /// <param name="leftType">The left operand type.</param>
+    /// <param name="rightType">The right operand type.</param>
+    /// <param name="resultType">The contextual target (result) type.</param>
+    /// <returns>A null-coalescing operator with <see cref="Type"/> = <paramref name="resultType"/>.</returns>
+    internal static BoundBinaryOperator MakeNullCoalesce(TypeSymbol leftType, TypeSymbol rightType, TypeSymbol resultType)
+        => new BoundBinaryOperator(SyntaxKind.QuestionQuestionToken, BoundBinaryOperatorKind.NullCoalesce, leftType, rightType, resultType);
+
+    /// <summary>
     /// PR N-4: returns true for operator kinds that have a lifted
     /// counterpart per C# §7.3.7 — arithmetic, bitwise, equality, and
     /// ordering. Logical short-circuit (&amp;&amp;, ||), null-coalesce, and

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
@@ -1204,7 +1204,25 @@ internal sealed partial class ExpressionBinder
     }
 
     private BoundExpression BindBinaryExpression(BinaryExpressionSyntax syntax)
+        => BindBinaryExpression(syntax, coalesceTargetType: null);
+
+    private BoundExpression BindBinaryExpression(BinaryExpressionSyntax syntax, TypeSymbol coalesceTargetType)
     {
+        // Issue #1480: when a `??` argument has no contextual target type and the
+        // overload binder requested deferral (DeferTargetlessConditional), a
+        // no-common-type failure is parked as a placeholder retaining the syntax
+        // rather than reported, then re-bound once the parameter type is known.
+        // Consume the flag immediately so nested sub-expressions bind normally.
+        var deferTargetlessCoalesce = syntax.OperatorToken.Kind == SyntaxKind.QuestionQuestionToken
+            && coalesceTargetType == null
+            && binderCtx.DeferTargetlessConditional;
+        if (syntax.OperatorToken.Kind == SyntaxKind.QuestionQuestionToken)
+        {
+            binderCtx.DeferTargetlessConditional = false;
+        }
+
+        var coalesceDiagMark = Diagnostics.Count;
+
         var boundLeft = BindExpression(syntax.Left);
 
         // ADR-0069 / issue #700: `&&` short-circuits — the right operand is
@@ -1256,6 +1274,21 @@ internal sealed partial class ExpressionBinder
             ref boundRight,
             syntax.Left.Location,
             syntax.Right.Location);
+
+        // Issue #1480: target-typed null-coalescing. When `a ?? b` has no natural
+        // common operand type (so the standard bind produced no operator) but the
+        // consuming context supplies a target type both operands implicitly
+        // convert to (e.g. sibling classes `A`/`B` each implementing `IShape`,
+        // coalesced where an `IShape` is expected), synthesize a NullCoalesce
+        // operator whose result is the target type. The operand conversions to
+        // the target are inserted by the NullCoalesce tail below; the emitter's
+        // interface-merge cast (#1480) realigns each branch's stack type.
+        if (boundOperator == null
+            && syntax.OperatorToken.Kind == SyntaxKind.QuestionQuestionToken
+            && TryBindTargetTypedNullCoalesce(boundLeft, boundRight, coalesceTargetType, out var targetTypedCoalesce))
+        {
+            boundOperator = targetTypedCoalesce;
+        }
 
         if (boundOperator == null)
         {
@@ -1326,6 +1359,18 @@ internal sealed partial class ExpressionBinder
                 return new BoundErrorExpression(null);
             }
 
+            // Issue #1480: a `??` whose operands share no natural common type and
+            // has no contextual target is deferred (rather than reported as
+            // GS0129) when it is a bare call/constructor argument awaiting its
+            // parameter type — the argument-binding loop set
+            // DeferTargetlessConditional. The retained syntax is re-bound with
+            // the parameter type as its target by FinalizeBranchyArgument.
+            if (deferTargetlessCoalesce)
+            {
+                Diagnostics.TruncateTo(coalesceDiagMark);
+                return new BoundErrorExpression(syntax);
+            }
+
             Diagnostics.ReportUndefinedBinaryOperator(syntax.OperatorToken.Location, syntax.OperatorToken.Text, boundLeft.Type, boundRight.Type);
             return new BoundErrorExpression(null);
         }
@@ -1350,9 +1395,54 @@ internal sealed partial class ExpressionBinder
     }
 
     /// <summary>
+    /// Issue #1480: attempts to bind a target-typed null-coalescing operator.
+    /// Succeeds when a non-null contextual <paramref name="target"/> is supplied
+    /// and BOTH operands implicitly convert to it — the left operand's non-null
+    /// underlying type and the right operand's type. This covers the C# §12.15
+    /// target-typed case where the two operands share no natural common type but
+    /// the result is consumed at a type both convert to (e.g. sibling classes
+    /// each implementing a common interface). A <c>never</c> (throw) right
+    /// operand is left to the normal <c>x ?? throw</c> path.
+    /// </summary>
+    /// <param name="boundLeft">The bound left operand.</param>
+    /// <param name="boundRight">The bound right operand.</param>
+    /// <param name="target">The contextual target type, or <see langword="null"/>.</param>
+    /// <param name="op">The synthesized NullCoalesce operator on success.</param>
+    /// <returns><see langword="true"/> when a target-typed operator was built.</returns>
+    private bool TryBindTargetTypedNullCoalesce(BoundExpression boundLeft, BoundExpression boundRight, TypeSymbol target, out BoundBinaryOperator op)
+    {
+        op = null;
+        if (target == null
+            || target == TypeSymbol.Error
+            || target == TypeSymbol.Void
+            || boundLeft.Type == TypeSymbol.Error
+            || boundRight.Type == TypeSymbol.Error
+            || boundRight.Type == TypeSymbol.Never)
+        {
+            return false;
+        }
+
+        var leftUnderlying = boundLeft.Type is NullableTypeSymbol leftNullable ? leftNullable.UnderlyingType : boundLeft.Type;
+        if (leftUnderlying == null || leftUnderlying == TypeSymbol.Null)
+        {
+            return false;
+        }
+
+        var leftConv = Conversion.Classify(leftUnderlying, target);
+        var rightConv = Conversion.Classify(boundRight.Type, target);
+        if (leftConv.Exists && leftConv.IsImplicit && rightConv.Exists && rightConv.IsImplicit)
+        {
+            op = BoundBinaryOperator.MakeNullCoalesce(boundLeft.Type, boundRight.Type, target);
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Issue #1246: shared numeric-operand adaptation for binding a binary
     /// operator. Attempts an exact per-type bind first, then — when that fails —
-    /// applies, in order, the same adaptations <see cref="BindBinaryExpression"/>
+    /// applies, in order, the same adaptations <c>BindBinaryExpression</c>
     /// performs: constant-integer-literal adaptation (#1144), directional
     /// implicit integer widening (#1150), the value-type and heterogeneous
     /// nullable mixed-mode lifts, and lifted (nullable) numeric widening (#1236).

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -219,6 +219,18 @@ internal sealed partial class ExpressionBinder
             return conversions.BindConversion(syntax.Location, boundConditional, targetType);
         }
 
+        // Issue #1480: a null-coalescing operator (`a ?? b`) likewise honors the
+        // contextual target type. When the operand underlyings share no natural
+        // common type but both implicitly convert to the target (e.g. sibling
+        // classes coalesced at a shared interface), bind with the target so the
+        // result is target-typed rather than reported as GS0129.
+        if (syntax is BinaryExpressionSyntax binaryExpr
+            && binaryExpr.OperatorToken.Kind == SyntaxKind.QuestionQuestionToken)
+        {
+            var boundCoalesce = BindBinaryExpression(binaryExpr, targetType);
+            return conversions.BindConversion(syntax.Location, boundCoalesce, targetType);
+        }
+
         return conversions.BindConversion(syntax, targetType);
     }
 
@@ -844,7 +856,9 @@ internal sealed partial class ExpressionBinder
 
         return syntax is IfExpressionSyntax
             or ConditionalExpressionSyntax
-            or SwitchExpressionSyntax;
+            or SwitchExpressionSyntax
+            || (syntax is BinaryExpressionSyntax binary
+                && binary.OperatorToken.Kind == SyntaxKind.QuestionQuestionToken);
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -1091,7 +1091,7 @@ internal sealed class OverloadResolver
     /// a no-common-type unification failure is deferred (the binder returns a
     /// placeholder retaining the syntax) instead of being reported prematurely
     /// without the parameter's target type. The deferred placeholder is later
-    /// re-bound by <see cref="FinalizeBranchyArgument"/> (or centrally by
+    /// re-bound by <c>FinalizeBranchyArgument</c> (or centrally by
     /// <c>ConversionClassifier.BindConversion</c>) once the applicable
     /// parameter type is known.
     /// </summary>
@@ -1132,21 +1132,64 @@ internal sealed class OverloadResolver
     /// <param name="expectedType">The resolved parameter target type.</param>
     /// <returns>The finalized argument.</returns>
     private BoundExpression FinalizeBranchyArgument(BoundExpression argument, TypeSymbol expectedType)
-    {
-        if (!ExpressionBinder.IsDeferredBranchyArgumentPlaceholder(argument, out var branchySyntax))
-        {
-            return argument;
-        }
+        => FinalizeBranchyArgument(argument, argumentSyntax: null, expectedType);
 
-        if (expectedType != null
+    /// <summary>
+    /// Issue #1238 / #1480: finalizes a branchy (<c>if</c>/ternary/<c>switch</c>
+    /// or <c>??</c>) call argument against the resolved parameter type. Two cases
+    /// are handled: (1) a deferred placeholder (produced when the branches could
+    /// not unify without a target) is re-bound with the target so each branch is
+    /// target-typed; (2) Issue #1480 — a branchy argument that DID unify to a
+    /// natural common type (e.g. the arms' shared base class) but whose result is
+    /// not implicitly convertible to the parameter type is re-bound with the
+    /// parameter type as its target, so sibling arms can unify to a contextual
+    /// interface (or wider base) the consumer requires. Non-branchy arguments and
+    /// arguments already convertible to the target are returned unchanged.
+    /// </summary>
+    /// <param name="argument">The (possibly placeholder) bound argument.</param>
+    /// <param name="argumentSyntax">The original argument syntax, when known.</param>
+    /// <param name="expectedType">The resolved parameter target type.</param>
+    /// <returns>The finalized argument.</returns>
+    private BoundExpression FinalizeBranchyArgument(BoundExpression argument, ExpressionSyntax argumentSyntax, TypeSymbol expectedType)
+    {
+        var targetUsable = expectedType != null
             && expectedType != TypeSymbol.Error
             && expectedType != TypeSymbol.Void
-            && !TypeSymbol.ContainsTypeParameter(expectedType))
+            && !TypeSymbol.ContainsTypeParameter(expectedType);
+
+        if (ExpressionBinder.IsDeferredBranchyArgumentPlaceholder(argument, out var branchySyntax))
         {
-            return bindExpressionWithTargetType(branchySyntax, expectedType);
+            return targetUsable
+                ? bindExpressionWithTargetType(branchySyntax, expectedType)
+                : bindExpression(branchySyntax);
         }
 
-        return bindExpression(branchySyntax);
+        // Issue #1480: a branchy argument that unified to its natural common type
+        // (e.g. the arms' shared base class) but does not implicitly convert to
+        // the parameter type is re-bound with the parameter type as its target so
+        // sibling arms can unify to the contextual interface/base the call
+        // requires (mirroring the return / typed-let target-typing paths).
+        if (targetUsable
+            && argument != null
+            && argument is not BoundErrorExpression
+            && argument.Type != null
+            && argument.Type != TypeSymbol.Error
+            && argument.Type != expectedType
+            && !Conversion.Classify(argument.Type, expectedType).IsImplicit)
+        {
+            var inner = argumentSyntax;
+            while (inner is ParenthesizedExpressionSyntax parenthesized)
+            {
+                inner = parenthesized.Expression;
+            }
+
+            if (inner != null && ExpressionBinder.IsTargetTypedBranchyArgumentSyntax(inner))
+            {
+                return bindExpressionWithTargetType(inner, expectedType);
+            }
+        }
+
+        return argument;
     }
 
     /// <summary>
@@ -2054,10 +2097,10 @@ internal sealed class OverloadResolver
             // Issue #1238: re-bind a deferred target-typed conditional argument
             // against the constructor parameter type before the convertibility
             // checks below.
-            if (ExpressionBinder.IsDeferredBranchyArgumentPlaceholder(argument, out _))
-            {
-                boundArguments[i] = argument = FinalizeBranchyArgument(argument, parameter.Type);
-            }
+            boundArguments[i] = argument = FinalizeBranchyArgument(
+                argument,
+                i < parameterSyntax.Length ? parameterSyntax[i] : null,
+                parameter.Type);
 
             // ADR-0055 Tier 4 (#369): an interpolated-string argument targeting an
             // IFormattable/FormattableString constructor parameter lowers to
@@ -2409,10 +2452,10 @@ internal sealed class OverloadResolver
             // Issue #1238: re-bind a deferred target-typed conditional argument
             // against the constructor parameter type before the convertibility
             // checks below.
-            if (ExpressionBinder.IsDeferredBranchyArgumentPlaceholder(argument, out _))
-            {
-                boundArguments[i] = argument = FinalizeBranchyArgument(argument, effectiveParamTypes[i]);
-            }
+            boundArguments[i] = argument = FinalizeBranchyArgument(
+                argument,
+                i < parameterSyntax.Length ? parameterSyntax[i] : null,
+                effectiveParamTypes[i]);
 
             // Issue #1214: target the type-argument-substituted parameter type
             // for a closed generic construction (equal to parameter.Type for a
@@ -2805,10 +2848,10 @@ internal sealed class OverloadResolver
             // Issue #1238: re-bind a deferred target-typed conditional argument
             // against the constructor parameter type before the error/convert
             // checks below.
-            if (ExpressionBinder.IsDeferredBranchyArgumentPlaceholder(argument, out _))
-            {
-                argument = FinalizeBranchyArgument(argument, parameter.Type);
-            }
+            argument = FinalizeBranchyArgument(
+                argument,
+                i < parameterSyntax.Length ? parameterSyntax[i] : null,
+                parameter.Type);
 
             if (argument.Type == TypeSymbol.Error)
             {
@@ -4067,10 +4110,10 @@ internal sealed class OverloadResolver
             // each branch is target-typed before the convertibility checks
             // below (which would otherwise reject the suppressed-error
             // placeholder).
-            if (ExpressionBinder.IsDeferredBranchyArgumentPlaceholder(argument, out _))
-            {
-                boundArguments[i] = argument = FinalizeBranchyArgument(argument, expectedType);
-            }
+            boundArguments[i] = argument = FinalizeBranchyArgument(
+                argument,
+                i < parameterSyntax.Length ? parameterSyntax[i] : null,
+                expectedType);
 
             // bound against the resolved parameter's delegate target so its
             // omitted parameter type(s) and inferred return type are filled in

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.cs
@@ -808,6 +808,19 @@ internal sealed class StatementBinder
         }
     }
 
+    /// <summary>
+    /// Issue #1480: returns <see langword="true"/> when the expression is a
+    /// null-coalescing (<c>??</c>) binary expression. Such expressions honor the
+    /// contextual target type in target-typed positions (typed local, return,
+    /// assignment, argument) so sibling operands can unify to a common interface
+    /// or base class supplied by the consumer.
+    /// </summary>
+    /// <param name="syntax">The candidate expression syntax.</param>
+    /// <returns><see langword="true"/> for a <c>??</c> binary expression.</returns>
+    private static bool IsNullCoalescingExpression(ExpressionSyntax syntax)
+        => syntax is BinaryExpressionSyntax binary
+            && binary.OperatorToken.Kind == SyntaxKind.QuestionQuestionToken;
+
     private BoundStatement BindVariableDeclaration(VariableDeclarationSyntax syntax)
     {
         // Issue #491 (ADR-0060 follow-up): a `let ref` / `var ref` declaration introduces a
@@ -893,7 +906,8 @@ internal sealed class StatementBinder
             else if (type != null
                 && (syntax.Initializer is IfExpressionSyntax
                     || syntax.Initializer is ConditionalExpressionSyntax
-                    || syntax.Initializer is SwitchExpressionSyntax))
+                    || syntax.Initializer is SwitchExpressionSyntax
+                    || IsNullCoalescingExpression(syntax.Initializer)))
             {
                 // Issue #1158: when a typed local is initialised with an
                 // if-/conditional-/switch-expression, thread the declared type
@@ -3889,7 +3903,8 @@ internal sealed class StatementBinder
             // (C#-style target-typing) before the conversion below.
             if ((syntax.Expression is SwitchExpressionSyntax
                     || syntax.Expression is IfExpressionSyntax
-                    || syntax.Expression is ConditionalExpressionSyntax)
+                    || syntax.Expression is ConditionalExpressionSyntax
+                    || IsNullCoalescingExpression(syntax.Expression))
                 && function != null
                 && !function.IsReturnTypeInferred
                 && function.Type != TypeSymbol.Void

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
@@ -1478,10 +1478,49 @@ internal sealed partial class MethodBodyEmitter
         this.EmitExpression(node.Condition);
         this.il.Branch(ILOpCode.Brfalse, falseLabel);
         this.EmitExpression(node.WhenTrue);
+        this.EmitInterfaceMergeCastIfNeeded(node.WhenTrue, node.Type);
         this.il.Branch(ILOpCode.Br, doneLabel);
         this.il.MarkLabel(falseLabel);
         this.EmitExpression(node.WhenFalse);
+        this.EmitInterfaceMergeCastIfNeeded(node.WhenFalse, node.Type);
         this.il.MarkLabel(doneLabel);
+    }
+
+    /// <summary>
+    /// Issue #1480: when a conditional/if-expression or null-coalescing (<c>??</c>)
+    /// result type is an interface (or a nullable interface), a class branch that
+    /// implements that interface is a reference-level no-op at emit time — the
+    /// value left on the stack is the concrete class, not the interface. At the
+    /// branches' merge point the CLR verifier computes the least-common type of
+    /// the two branch classes, which is their shared <em>base class</em> (the
+    /// verifier merge never yields an interface), so the merged value fails to
+    /// satisfy the interface-typed consumer
+    /// (<c>StackUnexpected [found ref 'Base'][expected ref 'IShape']</c>) →
+    /// unverifiable IL / <see cref="System.InvalidProgramException"/>. Emit an
+    /// explicit <c>castclass</c> to the interface on each value branch so both
+    /// branches leave exactly the interface reference and the merge is the
+    /// interface itself. The cast is verifiable because the binder already proved
+    /// every branch implicitly converts to the interface. A <c>never</c> (throw)
+    /// or <c>nil</c> branch leaves no class value to realign and is skipped.
+    /// </summary>
+    /// <param name="branch">The bound branch expression.</param>
+    /// <param name="resultType">The conditional/coalesce result type.</param>
+    private void EmitInterfaceMergeCastIfNeeded(BoundExpression branch, TypeSymbol resultType)
+    {
+        var castTarget = resultType is NullableTypeSymbol nrt ? nrt.UnderlyingType : resultType;
+        if (!IsInterfaceTargetType(castTarget))
+        {
+            return;
+        }
+
+        var branchType = branch?.Type;
+        if (branchType == TypeSymbol.Never || branchType == TypeSymbol.Null)
+        {
+            return;
+        }
+
+        this.il.OpCode(ILOpCode.Castclass);
+        this.il.Token(this.outer.GetElementTypeToken(castTarget));
     }
 
     /// <summary>ADR-0039: Emits a dereference (load indirect) from a managed pointer.</summary>

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
@@ -301,12 +301,15 @@ internal sealed partial class MethodBodyEmitter
                     + "(or box-before-brtrue) emit path is required when nullable value types are supported.");
             }
 
+            var resultType = b.Type;
             this.EmitExpression(b.Left);
+            this.EmitInterfaceMergeCastIfNeeded(b.Left, resultType);
             this.il.OpCode(ILOpCode.Dup);
             var done = this.il.DefineLabel();
             this.il.Branch(ILOpCode.Brtrue, done);
             this.il.OpCode(ILOpCode.Pop);
             this.EmitExpression(b.Right);
+            this.EmitInterfaceMergeCastIfNeeded(b.Right, resultType);
             this.il.MarkLabel(done);
             return;
         }

--- a/test/Compiler.Tests/Emit/Issue1480ConditionalTargetTypingEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1480ConditionalTargetTypingEmitTests.cs
@@ -1,0 +1,253 @@
+// <copyright file="Issue1480ConditionalTargetTypingEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1480 — a conditional (<c>?:</c>/<c>if</c>-expression) or null-coalescing
+/// (<c>??</c>) whose arms are sibling types sharing only a common BASE CLASS while
+/// each implements a required INTERFACE was emitted as the common base value with NO
+/// cast where the interface was expected. The CLR verifier merges the two arm classes
+/// to their common base (never to an interface), producing unverifiable IL
+/// (<c>StackUnexpected [found ref 'Base'][expected ref 'IShape']</c>) and a runtime
+/// <c>InvalidProgramException</c>. The fix emits a <c>castclass</c> to the interface
+/// result type on each value branch of conditionals and <c>??</c>, and threads the
+/// contextual target type into <c>??</c> binding across all target-typed contexts.
+/// Each facet uses a UNIQUE package + type names so the emitted assemblies do not
+/// collide.
+/// </summary>
+public class Issue1480ConditionalTargetTypingEmitTests
+{
+    [Fact]
+    public void FacetA_ExpressionBodiedConditionalToInterface_VerifiesAndRuns()
+    {
+        var source = """
+            package Issue1480A
+            import System
+            interface IShapeA { prop Tag int { get } }
+            open class BaseA { }
+            class Aa : BaseA, IShapeA { prop Tag int -> 1 }
+            class Ba : BaseA, IShapeA { prop Tag int -> 2 }
+
+            func PickExpr(cond bool, a Aa, b Ba) IShapeA -> cond ? a : b
+            func Main() {
+                Console.WriteLine(PickExpr(true, Aa(), Ba()).Tag)
+                Console.WriteLine(PickExpr(false, Aa(), Ba()).Tag)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("1\n2\n", output);
+    }
+
+    [Fact]
+    public void FacetB_ReturnConditionalToInterface_VerifiesAndRuns()
+    {
+        var source = """
+            package Issue1480B
+            import System
+            interface IShapeB { prop Tag int { get } }
+            open class BaseB { }
+            class Ab : BaseB, IShapeB { prop Tag int -> 10 }
+            class Bb : BaseB, IShapeB { prop Tag int -> 20 }
+
+            func PickRet(cond bool, a Ab, b Bb) IShapeB { return cond ? a : b }
+            func Main() {
+                Console.WriteLine(PickRet(true, Ab(), Bb()).Tag)
+                Console.WriteLine(PickRet(false, Ab(), Bb()).Tag)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("10\n20\n", output);
+    }
+
+    [Fact]
+    public void FacetC_TypedLocalConditionalToInterface_VerifiesAndRuns()
+    {
+        var source = """
+            package Issue1480C
+            import System
+            interface IShapeC { prop Tag int { get } }
+            open class BaseC { }
+            class Ac : BaseC, IShapeC { prop Tag int -> 3 }
+            class Bc : BaseC, IShapeC { prop Tag int -> 4 }
+
+            func PickLocal(cond bool, a Ac, b Bc) IShapeC {
+                let x IShapeC = cond ? a : b
+                return x
+            }
+            func Main() {
+                Console.WriteLine(PickLocal(true, Ac(), Bc()).Tag)
+                Console.WriteLine(PickLocal(false, Ac(), Bc()).Tag)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("3\n4\n", output);
+    }
+
+    [Fact]
+    public void FacetD_NullCoalesceToInterface_VerifiesAndRuns()
+    {
+        // Mirrors the corpus StblBox::get_COBox shape: a nullable concrete class
+        // implementing the interface, coalesced with a conversion-call cast of a
+        // sibling concrete class to the interface.
+        var source = """
+            package Issue1480D
+            import System
+            interface IShapeD { prop Tag int { get } }
+            open class BaseD { }
+            class Ad : BaseD, IShapeD { prop Tag int -> 5 }
+            class Bd : BaseD, IShapeD { prop Tag int -> 6 }
+
+            func PickCoalesce(a Ad?, b Bd) IShapeD -> a ?? IShapeD(b)
+            func Main() {
+                Console.WriteLine(PickCoalesce(Ad(), Bd()).Tag)
+                Console.WriteLine(PickCoalesce(nil, Bd()).Tag)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("5\n6\n", output);
+    }
+
+    [Fact]
+    public void FacetE_ConditionalToCommonBaseClass_VerifiesAndRuns()
+    {
+        // Arms unify to a common BASE CLASS target (not an interface): no cast is
+        // required, the verifier merge already yields a subtype of the base.
+        var source = """
+            package Issue1480E
+            import System
+            open class BaseE { func Name() string -> "base" }
+            class Ae : BaseE { func Name() string -> "a" }
+            class Be : BaseE { func Name() string -> "b" }
+
+            func PickBase(cond bool, a Ae, b Be) BaseE -> cond ? a : b
+            func Main() {
+                Console.WriteLine(PickBase(true, Ae(), Be()).Name())
+                Console.WriteLine(PickBase(false, Ae(), Be()).Name())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("base\nbase\n", output);
+    }
+
+    [Fact]
+    public void FacetF_ConditionalWithoutTargetUsesBestCommonType_VerifiesAndRuns()
+    {
+        // Regression: with NO contextual target type the conditional still binds to
+        // the best-common-type (the shared base class) and a base method is callable.
+        var source = """
+            package Issue1480F
+            import System
+            open class BaseF { func Name() string -> "base" }
+            class Af : BaseF, IShapeF { prop Tag int -> 7 }
+            class Bf : BaseF, IShapeF { prop Tag int -> 8 }
+            interface IShapeF { prop Tag int { get } }
+
+            func NoTarget(cond bool, a Af, b Bf) string {
+                let y = cond ? a : b
+                return y.Name()
+            }
+            func Main() {
+                Console.WriteLine(NoTarget(true, Af(), Bf()))
+                Console.WriteLine(NoTarget(false, Af(), Bf()))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("base\nbase\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1480_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
A conditional (`?:`/`if`-expression) or null-coalescing (`??`) whose arms are sibling classes sharing only a common base class while each implements a required interface was emitted as the common base value with no cast where the interface was expected. The CLR verifier merges the two branch classes to their shared base (never to an interface), so the merged value failed the interface-typed consumer (`StackUnexpected found ref 'Base' expected ref 'IShape'`), producing unverifiable IL and a runtime `InvalidProgramException`.

**Emitter** (`MethodBodyEmitter.Expressions.cs`, `MethodBodyEmitter.Operators.cs`): emit a `castclass` to the interface result type on each value branch of conditionals and `??` (skipping `never`/`nil` branches), so both branches leave exactly the interface reference and the merge is the interface itself. The cast is verifiable because the binder already proved every branch converts. For class/base-class targets no cast is needed.

**Binder** (`ExpressionBinder.cs`, `ExpressionBinder.Operators.cs`, `StatementBinder.cs`, `BoundBinaryOperator.cs`, `OverloadResolver.cs`): thread the contextual target type into `??` binding across every target-typed context — typed-local initializers, return statements, expression-bodied bodies (desugared to `return`), and call/constructor argument positions. Argument finalization now also re-binds a branchy argument that unified to its natural common base but is not convertible to the parameter type, so sibling arms unify to the contextual interface/base.

Corpus (Oahu.Decrypt) ilverify artifacts: 33 → 31, StackUnexpected 11 → 9 (clears `IChunkOffsets::Create` and `StblBox::get_COBox`), no new categories, benign `Unverifiable` localloc unchanged at 8.

Fixes #1480

Refs #914