### PR TITLE
Fix inherited auto-property access lowering to private backing field (#1486)

### DIFF
--- a/src/Core/CodeAnalysis/Lowering/Lowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/Lowerer.cs
@@ -457,10 +457,14 @@ public sealed class Lowerer : BoundTreeRewriter
     protected override BoundExpression RewritePropertyAccessExpression(BoundPropertyAccessExpression node)
     {
         // ADR-0051: auto-properties lower to backing field access, but ONLY when
-        // we are inside the declaring type. From outside the type, the backing
-        // field is private so we must go through the accessor method (callvirt).
+        // we are inside the type that DIRECTLY declares the property. The backing
+        // field is private (DeclarationBinder), so it is only legal to touch from
+        // its exact declaring type. Issue #1486: an INHERITED auto-property read
+        // from a derived method must instead dispatch through the accessor
+        // (callvirt get_X) — node.StructType is the receiver's static type, not
+        // the property's declaring type, so it cannot gate this on its own.
         if (node.Property.IsAutoProperty && node.Property.BackingField != null
-            && this.declaringType != null && node.StructType == this.declaringType)
+            && this.declaringType != null && DeclaresPropertyDirectly(this.declaringType, node.Property))
         {
             return new BoundFieldAccessExpression(null, node.Receiver, node.StructType, node.Property.BackingField, node.NarrowedType);
         }
@@ -474,9 +478,13 @@ public sealed class Lowerer : BoundTreeRewriter
     protected override BoundExpression RewritePropertyAssignmentExpression(BoundPropertyAssignmentExpression node)
     {
         // ADR-0051: auto-properties lower to backing field assignment, but ONLY
-        // when we are inside the declaring type (same rationale as read access).
+        // when we are inside the type that DIRECTLY declares the property (same
+        // private-backing-field rationale as read access). Issue #1486: writing
+        // an INHERITED auto-property from a derived method must dispatch through
+        // the accessor (callvirt set_X) instead of touching the base's private
+        // backing field.
         if (node.Property.IsAutoProperty && node.Property.BackingField != null
-            && this.declaringType != null && node.StructType == this.declaringType)
+            && this.declaringType != null && DeclaresPropertyDirectly(this.declaringType, node.Property))
         {
             var value = RewriteExpression(node.Value);
 
@@ -495,6 +503,39 @@ public sealed class Lowerer : BoundTreeRewriter
         // Computed properties (or non-variable receivers, or external access)
         // remain as BoundPropertyAssignmentExpression.
         return base.RewritePropertyAssignmentExpression(node);
+    }
+
+    /// <summary>
+    /// Issue #1486: determines whether <paramref name="type"/> DIRECTLY declares
+    /// <paramref name="prop"/> (an own, non-inherited property), so the private
+    /// backing field is legally accessible. <see cref="StructSymbol.Properties"/>
+    /// lists only own properties. On a constructed generic instance the property
+    /// is a substituted clone, but <see cref="PropertySymbol.BackingField"/> is
+    /// carried by reference from the definition, so it gives a stable identity to
+    /// match against the type's own properties for any base/derived depth and for
+    /// both generic and non-generic types.
+    /// </summary>
+    private static bool DeclaresPropertyDirectly(StructSymbol type, PropertySymbol prop)
+    {
+        if (type == null || prop == null)
+        {
+            return false;
+        }
+
+        foreach (var own in type.Properties)
+        {
+            if (ReferenceEquals(own, prop))
+            {
+                return true;
+            }
+
+            if (prop.BackingField != null && ReferenceEquals(own.BackingField, prop.BackingField))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private BoundStatement LowerAwaitForRange(VariableSymbol valueVariable, BoundExpression stream, BoundStatement body, BoundLabel breakLabel, BoundLabel continueLabel)

--- a/test/Compiler.Tests/Emit/Issue1486InheritedAutoPropertyEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1486InheritedAutoPropertyEmitTests.cs
@@ -1,0 +1,193 @@
+// <copyright file="Issue1486InheritedAutoPropertyEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1486 — reading (or writing) an INHERITED auto-property from a DERIVED
+/// class lowered to a direct <c>ldfld</c>/<c>stfld</c> of the base class's PRIVATE
+/// <c>&lt;X&gt;k__BackingField</c> instead of dispatching through the accessor.
+/// That emitted invalid IL (ilverify <c>FieldAccess: Field is not visible</c>) and
+/// threw <see cref="FieldAccessException"/> at runtime. After the fix the direct
+/// backing-field lowering fires only when the enclosing type DIRECTLY declares the
+/// property; an inherited access dispatches through <c>get_X</c>/<c>set_X</c>.
+/// </summary>
+public class Issue1486InheritedAutoPropertyEmitTests
+{
+    [Fact]
+    public void EndToEnd_DerivedReadsInheritedAutoProperty_VerifiesAndRuns()
+    {
+        var source = """
+            package Issue1486a
+            import System
+
+            open class Issue1486Base {
+                init() { Value = 7 }
+                prop Value int32 { get; init; }
+            }
+
+            class Issue1486Derived : Issue1486Base {
+                init() : base() { }
+                shared {
+                    func Make() int32 {
+                        let d = Issue1486Derived()
+                        return d.Value
+                    }
+                }
+            }
+
+            func Main() {
+                Console.WriteLine(Issue1486Derived.Make())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("7\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_DerivedWritesThenReadsInheritedAutoProperty_VerifiesAndRuns()
+    {
+        var source = """
+            package Issue1486b
+            import System
+
+            open class Issue1486BaseW {
+                prop Value int32 { get; set; }
+            }
+
+            class Issue1486DerivedW : Issue1486BaseW {
+                shared {
+                    func Make() int32 {
+                        let d = Issue1486DerivedW()
+                        d.Value = 42
+                        return d.Value
+                    }
+                }
+            }
+
+            func Main() {
+                Console.WriteLine(Issue1486DerivedW.Make())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_OwnAutoPropertyStillWorks_VerifiesAndRuns()
+    {
+        var source = """
+            package Issue1486c
+            import System
+
+            class Issue1486Own {
+                init() { Value = 99 }
+                prop Value int32 { get; init; }
+                shared {
+                    func Make() int32 {
+                        let o = Issue1486Own()
+                        return o.Value
+                    }
+                }
+            }
+
+            func Main() {
+                Console.WriteLine(Issue1486Own.Make())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("99\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1486_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Reading or writing an **inherited auto-property** from a **derived** class lowered to a direct `ldfld`/`stfld` of the base class's **private** `<X>k__BackingField`, instead of dispatching through the property accessor. This emitted invalid IL (ilverify `FieldAccess: Field is not visible`) and threw `FieldAccessException` at runtime.

## Root cause
`RewritePropertyAccessExpression` and `RewritePropertyAssignmentExpression` in `Lowerer.cs` gated the direct backing-field lowering on `node.StructType == this.declaringType`. But `node.StructType` is the receiver's static type, not the property's declaring type. For an inherited auto-property accessed inside a derived method, receiver type == `this.declaringType` == the derived type, so the guard wrongly passed and emitted a direct access to the base's private backing field.

## Fix
Replace the condition with a new `DeclaresPropertyDirectly(StructSymbol, PropertySymbol)` helper that fires the direct backing-field lowering only when `this.declaringType` directly declares the property (an own, non-inherited property) — for any base/derived depth and for both generic and non-generic types. Inherited accesses fall through to the accessor (`callvirt get_X` / `set_X`). Identity matching uses the property's `BackingField` reference, which is carried by reference through generic substitution.

## Verification
- ilverify on the issue repro: before `Error [FieldAccess]: ... Field is not visible.` -> after `All Classes and Methods ... Verified.`
- New emit tests (`Issue1486InheritedAutoPropertyEmitTests`): derived reads inherited `{ get; init; }`, derived writes-then-reads inherited `{ get; set; }`, and own (non-inherited) auto-property still works — all compile, ilverify clean, and return the correct runtime values.
- Full `Core.Tests` suite: 4788 passed / 1 skipped, including the byte-identical refactoring-baseline gate (no regeneration needed).

Fixes #1486

Refs #914
