### PR TITLE
Consolidate the three divergent ContainsTypeParameter recursions (#1481)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -3556,6 +3556,24 @@ public sealed class Binder
             return ReferenceEquals(inner, aseq.ElementType) ? type : AsyncSequenceTypeSymbol.Get(inner);
         }
 
+        if (type is MapTypeSymbol map)
+        {
+            // Issue #1481: substitute through `map[K, V]` so a call like
+            // `entries[int32](items)` lowers its return type from the open
+            // `sequence[map[string, T]]` to the closed
+            // `sequence[map[string, int32]]`. Without this branch the map's
+            // key/value types stay parametric, so the for-in at the call site
+            // encodes its `IEnumerable<Dictionary<string, !!0>>` GetEnumerator
+            // reference against the unsubstituted method type parameter and
+            // fails verification against the closed kickoff return. Directly
+            // analogous to the tuple branch below (#813).
+            var newKey = SubstituteType(map.KeyType, substitution);
+            var newValue = SubstituteType(map.ValueType, substitution);
+            return ReferenceEquals(newKey, map.KeyType) && ReferenceEquals(newValue, map.ValueType)
+                ? type
+                : MapTypeSymbol.Get(newKey, newValue);
+        }
+
         if (type is TupleTypeSymbol tup)
         {
             // Issue #813: substitute through `(T1, T2, …)` so a call like

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
@@ -959,6 +959,36 @@ internal sealed partial class MethodBodyEmitter
         // sequence per entry. Using set_Item rather than Add so duplicate keys
         // overwrite (matching Go semantics; ParseMapEntries does not dedup).
         var dictType = literal.MapType.ClrType;
+
+        // Issue #1481: when the map's key or value structurally references an
+        // in-scope type parameter (e.g. `map[string, T]`), the erased CLR
+        // `Dictionary<…>` type is unavailable (ClrType is null). Route the
+        // construction through the reified TypeSpec-parented MemberRefs so the
+        // value verifies against the iterator state machine's reified
+        // `Dictionary<…, !0>` field — mirrors the symbolic tuple-literal path.
+        if (dictType == null)
+        {
+            this.il.OpCode(ILOpCode.Newobj);
+            this.il.Token(this.outer.GetMapCtorReference(literal.MapType));
+
+            if (literal.Entries.Length == 0)
+            {
+                return;
+            }
+
+            var symbolicSetItemRef = this.outer.GetMapSetItemReference(literal.MapType);
+            foreach (var entry in literal.Entries)
+            {
+                this.il.OpCode(ILOpCode.Dup);
+                this.EmitExpression(entry.Key);
+                this.EmitExpression(entry.Value);
+                this.il.OpCode(ILOpCode.Callvirt);
+                this.il.Token(symbolicSetItemRef);
+            }
+
+            return;
+        }
+
         var ctor = dictType.GetConstructor(Type.EmptyTypes)
             ?? throw new InvalidOperationException(
                 $"Dictionary type '{dictType.FullName}' has no parameterless constructor.");

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
@@ -522,6 +522,23 @@ internal sealed partial class MethodBodyEmitter
             }
         }
 
+        // Issue #1481: a `map[K, V]` is a CLR reference type
+        // (`System.Collections.Generic.Dictionary<,>`) and a function type is a
+        // reference-typed delegate. When the key/value/signature structurally
+        // references an in-scope type parameter (e.g. `map[string, T]`,
+        // `func(T) -> int32`), the symbol carries no ClrType during emit, so
+        // the CLR-backed `object`-widening rule above cannot fire. Widening
+        // such a reference to `object` is still a no-op (the slot already holds
+        // the reference). This unblocks a generic iterator whose element type
+        // is a `map[…]` / function: the synthesized non-generic
+        // `IEnumerator.Current` getter converts the strongly-typed reified
+        // `<>2__current` field to `object`.
+        if ((a is MapTypeSymbol || a is FunctionTypeSymbol)
+            && (b?.ClrType.IsSameAs(typeof(object)) == true || b == TypeSymbol.Object))
+        {
+            return true;
+        }
+
         if (a is StructSymbol aClass && b is StructSymbol bClass && aClass.IsClass && bClass.IsClass)
         {
             // Issue #1248: a constructed generic class's base-type reference is

--- a/src/Core/CodeAnalysis/Emit/MethodBodyPlanner.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyPlanner.cs
@@ -831,7 +831,7 @@ internal sealed class MethodBodyPlanner
         // loop in RME — outer-method TPs translate to Var(idx)). For closed
         // element types we keep the original CLR-erased path so existing
         // closed-iterator behaviour is unchanged.
-        var elementContainsTp = ContainsTypeParameter(elementType);
+        var elementContainsTp = TypeSymbol.ContainsTypeParameter(elementType);
 
         // Issue #990: a user-declared element type (a `class` or `data
         // struct` emitted in this same assembly) has no ClrType, so the
@@ -883,75 +883,6 @@ internal sealed class MethodBodyPlanner
         var gi = encoder.GenericInstantiation(openHandle, genericArgumentCount: 1, isValueType: false);
         this.encodeTypeSymbol(gi.AddArgument(), elementType);
         return this.emitCtx.Metadata.AddTypeSpecification(this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
-    }
-
-    /// <summary>
-    /// Issue #810: recursively returns true if <paramref name="t"/>
-    /// directly or transitively references a <see cref="TypeParameterSymbol"/>.
-    /// Used to decide between TypeSpec and CLR-erased interface
-    /// implementations for the iterator SM class.
-    /// </summary>
-    private static bool ContainsTypeParameter(TypeSymbol t)
-    {
-        switch (t)
-        {
-            case null:
-                return false;
-            case TypeParameterSymbol:
-                return true;
-            case ArrayTypeSymbol a:
-                return ContainsTypeParameter(a.ElementType);
-            case SliceTypeSymbol s:
-                return ContainsTypeParameter(s.ElementType);
-            case SequenceTypeSymbol seq:
-                return ContainsTypeParameter(seq.ElementType);
-            case AsyncSequenceTypeSymbol aseq:
-                return ContainsTypeParameter(aseq.ElementType);
-            case NullableTypeSymbol nu:
-                return ContainsTypeParameter(nu.UnderlyingType);
-            case ImportedTypeSymbol it when !it.TypeArguments.IsDefaultOrEmpty:
-                foreach (var arg in it.TypeArguments)
-                {
-                    if (ContainsTypeParameter(arg))
-                    {
-                        return true;
-                    }
-                }
-
-                return false;
-            case StructSymbol st when !st.TypeArguments.IsDefaultOrEmpty:
-                foreach (var arg in st.TypeArguments)
-                {
-                    if (ContainsTypeParameter(arg))
-                    {
-                        return true;
-                    }
-                }
-
-                return false;
-            case TupleTypeSymbol tup:
-                // Issue #813: a value-tuple element type mentioning an
-                // outer-method TP must also drive the symbolic
-                // `IEnumerable<…>` / `IEnumerator<…>` interface
-                // implementations on the iterator SM class so the
-                // TypeSpec carries `ValueTuple<…, !0>` instead of the
-                // type-erased `IEnumerable<object>`. Without this the
-                // SM's interface row references the wrong shape and a
-                // for-in over `Indexed[int32](source)` throws
-                // `EntryPointNotFoundException` from the runtime's
-                // `IEnumerable<(int32,T)>.GetEnumerator()` lookup.
-                foreach (var elem in tup.ElementTypes)
-                {
-                    if (ContainsTypeParameter(elem))
-                    {
-                        return true;
-                    }
-                }
-
-                return false;
-            default:
-                return false;
-        }
     }
 
     public void AddAsyncIteratorInterfaceImplementations(StructSymbol smClass, AsyncIteratorPlan plan)

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -9314,6 +9314,80 @@ internal sealed class ReflectionMetadataEmitter
     }
 
     /// <summary>
+    /// Issue #1481: builds a <c>TypeSpec</c> encoding
+    /// <c>System.Collections.Generic.Dictionary`2&lt;K, V&gt;</c> with the key
+    /// and value routed through <see cref="EncodeTypeSymbol"/>, so an in-scope
+    /// type parameter survives as a <c>Var</c>/<c>MVar</c> slot. Used when a
+    /// <c>map[K, V]</c> literal's <see cref="TypeSymbol.ClrType"/> is null
+    /// (e.g. <c>map[string, T]</c>) — the erased CLR fast-path is unavailable
+    /// and the body construction must be parented at this reified TypeSpec so
+    /// the value stored into the iterator state machine's reified
+    /// <c>Dictionary&lt;…, !0&gt;</c> field verifies. Mirrors
+    /// <see cref="GetTupleTypeSpec"/>.
+    /// </summary>
+    private EntityHandle GetMapTypeSpec(MapTypeSymbol mapType)
+    {
+        var dictionaryOpen = typeof(System.Collections.Generic.Dictionary<,>);
+        var sigBlob = new BlobBuilder();
+        var genInst = new BlobEncoder(sigBlob).TypeSpecificationSignature()
+            .GenericInstantiation(
+                this.GetTypeReference(dictionaryOpen),
+                genericArgumentCount: 2,
+                isValueType: false);
+        this.EncodeTypeSymbol(genInst.AddArgument(), mapType.KeyType);
+        this.EncodeTypeSymbol(genInst.AddArgument(), mapType.ValueType);
+        return this.emitCtx.Metadata.AddTypeSpecification(
+            this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
+    }
+
+    /// <summary>
+    /// Issue #1481: gets a MemberRef for the parameterless
+    /// <c>Dictionary`2::.ctor()</c> parented at the reified
+    /// <see cref="GetMapTypeSpec"/> TypeSpec, for a <c>map[K, V]</c> literal
+    /// whose <see cref="TypeSymbol.ClrType"/> is null. Mirrors
+    /// <see cref="GetTupleCtorReference"/>.
+    /// </summary>
+    internal MemberReferenceHandle GetMapCtorReference(MapTypeSymbol mapType)
+    {
+        var parent = this.GetMapTypeSpec(mapType);
+        var sigBlob = new BlobBuilder();
+        new BlobEncoder(sigBlob).MethodSignature(isInstanceMethod: true)
+            .Parameters(0, returnType: r => r.Void(), parameters: _ => { });
+        return this.emitCtx.Metadata.AddMemberReference(
+            parent: parent,
+            name: this.emitCtx.Metadata.GetOrAddString(".ctor"),
+            signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
+    }
+
+    /// <summary>
+    /// Issue #1481: gets a MemberRef for
+    /// <c>Dictionary`2::set_Item(!0, !1)</c> parented at the reified
+    /// <see cref="GetMapTypeSpec"/> TypeSpec, used to populate a
+    /// <c>map[K, V]</c> literal whose <see cref="TypeSymbol.ClrType"/> is null.
+    /// The parameter signature references the dictionary's own generic
+    /// parameters (<c>!0</c>/<c>!1</c>), as required for a MemberRef on a
+    /// constructed generic type.
+    /// </summary>
+    internal MemberReferenceHandle GetMapSetItemReference(MapTypeSymbol mapType)
+    {
+        var parent = this.GetMapTypeSpec(mapType);
+        var sigBlob = new BlobBuilder();
+        new BlobEncoder(sigBlob).MethodSignature(isInstanceMethod: true)
+            .Parameters(
+                2,
+                returnType: r => r.Void(),
+                parameters: ps =>
+                {
+                    ps.AddParameter().Type().GenericTypeParameter(0);
+                    ps.AddParameter().Type().GenericTypeParameter(1);
+                });
+        return this.emitCtx.Metadata.AddMemberReference(
+            parent: parent,
+            name: this.emitCtx.Metadata.GetOrAddString("set_Item"),
+            signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
+    }
+
+    /// <summary>
     /// Issue #491 (ADR-0060 follow-up): encodes a single local-variable signature slot.
     /// A <see cref="ByRefTypeSymbol"/> entry signals a ref-aliasing local (<c>let ref</c> /
     /// <c>var ref</c>) whose slot must carry <c>ELEMENT_TYPE_BYREF</c> wrapping the pointee
@@ -9797,6 +9871,29 @@ internal sealed class ReflectionMetadataEmitter
             // `Func<object, object>`, and the call site bridged the
             // value-type boundary through `Delegate.DynamicInvoke`.
             this.EncodeFunctionTypeSymbol(encoder, openFn);
+        }
+        else if (type is MapTypeSymbol openMap)
+        {
+            // Issue #1481: a `map[K, V]` whose erased CLR form is unavailable
+            // because a key or value is (or structurally contains) an in-scope
+            // type parameter — e.g. `map[string, T]` — has a null ClrType, so
+            // the fast-path above cannot fire. Encode it as
+            // `GENERICINST System.Collections.Generic.Dictionary`2<K, V>` with
+            // each argument routed through EncodeTypeSymbol so the `Var`/`MVar`
+            // slot survives. Without this the encoder threw
+            // "Cannot encode signature for type 'map[string,T]'", so a generic
+            // iterator yielding `map[string, T]` could not be emitted at all,
+            // and the iterator's `IEnumerable<…>` / `IEnumerator<…>` rows could
+            // not carry the strongly-typed `Dictionary<…, !0>` shape. The
+            // matching body construction is reified through
+            // <see cref="GetMapCtorReference"/> / <see cref="GetMapSetItemReference"/>.
+            var dictionaryOpen = typeof(System.Collections.Generic.Dictionary<,>);
+            var giMap = encoder.GenericInstantiation(
+                this.GetTypeReference(dictionaryOpen),
+                genericArgumentCount: 2,
+                isValueType: false);
+            this.EncodeTypeSymbol(giMap.AddArgument(), openMap.KeyType);
+            this.EncodeTypeSymbol(giMap.AddArgument(), openMap.ValueType);
         }
         else
         {

--- a/src/Core/CodeAnalysis/Emit/StateMachineEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/StateMachineEmitter.cs
@@ -531,7 +531,7 @@ internal sealed class StateMachineEmitter
             // symbolic encoder so the GetEnumerator signature stays
             // strongly typed as `IEnumerator<Shape>`.
             var elementNeedsSymbolicEnumerator =
-                ContainsOuterMethodTypeParameter(plan.ElementType, scopeTPs)
+                TypeSymbol.ContainsOuterMethodTypeParameter(plan.ElementType, scopeTPs)
                 || plan.ElementType?.ClrType == null;
             var getEnumeratorType = elementNeedsSymbolicEnumerator
                 ? (TypeSymbol)ImportedTypeSymbol.GetConstructed(
@@ -595,75 +595,6 @@ internal sealed class StateMachineEmitter
                     thisProxyField, plan.Function.ThisParameter != null ? new BoundVariableExpression(null, plan.Function.ThisParameter) : null)))));
             this.IteratorStateMachineInfos[smClass] = new IteratorStateMachineInfo(plan, smClass, outerMethodTPs, classTPs);
             this.closures.SynthesizedClosureClasses.Add(smClass);
-        }
-    }
-
-    /// <summary>
-    /// Issue #810: returns <see langword="true"/> when <paramref name="type"/>
-    /// references any of the outer method's type parameters (directly or
-    /// nested inside an array/slice/sequence/imported-generic). Used to
-    /// decide whether the GetEnumerator return type needs a symbolic
-    /// (TypeSpec-encoded) `IEnumerator&lt;T&gt;` instead of the
-    /// CLR-erased `IEnumerator&lt;object&gt;` shape.
-    /// </summary>
-    private static bool ContainsOuterMethodTypeParameter(TypeSymbol type, ImmutableArray<TypeParameterSymbol> outerMethodTPs)
-    {
-        if (outerMethodTPs.IsDefaultOrEmpty || type == null)
-        {
-            return false;
-        }
-
-        switch (type)
-        {
-            case TypeParameterSymbol tp:
-                foreach (var outer in outerMethodTPs)
-                {
-                    if (ReferenceEquals(tp, outer))
-                    {
-                        return true;
-                    }
-                }
-
-                return false;
-            case ArrayTypeSymbol a:
-                return ContainsOuterMethodTypeParameter(a.ElementType, outerMethodTPs);
-            case SliceTypeSymbol s:
-                return ContainsOuterMethodTypeParameter(s.ElementType, outerMethodTPs);
-            case SequenceTypeSymbol seq:
-                return ContainsOuterMethodTypeParameter(seq.ElementType, outerMethodTPs);
-            case AsyncSequenceTypeSymbol aseq:
-                return ContainsOuterMethodTypeParameter(aseq.ElementType, outerMethodTPs);
-            case NullableTypeSymbol nu:
-                return ContainsOuterMethodTypeParameter(nu.UnderlyingType, outerMethodTPs);
-            case ImportedTypeSymbol it when !it.TypeArguments.IsDefaultOrEmpty:
-                foreach (var arg in it.TypeArguments)
-                {
-                    if (ContainsOuterMethodTypeParameter(arg, outerMethodTPs))
-                    {
-                        return true;
-                    }
-                }
-
-                return false;
-            case TupleTypeSymbol tup:
-                // Issue #813: a tuple element type that mentions an
-                // outer-method TP (e.g. `(int32, T)` from
-                // `sequence[(int32, T)]`) must drive the same
-                // symbolic-IEnumerator routing as the open-generic
-                // sequence cases above, so the SM's GetEnumerator return
-                // encodes as `IEnumerator<ValueTuple<int32,!0>>` rather
-                // than the type-erased `IEnumerator<object>`.
-                foreach (var elem in tup.ElementTypes)
-                {
-                    if (ContainsOuterMethodTypeParameter(elem, outerMethodTPs))
-                    {
-                        return true;
-                    }
-                }
-
-                return false;
-            default:
-                return false;
         }
     }
 

--- a/src/Core/CodeAnalysis/Symbols/TypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/TypeSymbol.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 
 namespace GSharp.Core.CodeAnalysis.Symbols;
 
@@ -314,50 +315,55 @@ public class TypeSymbol : Symbol
     }
 
     /// <summary>
-    /// #313: returns <c>true</c> if <paramref name="type"/> is, or structurally
-    /// contains, an in-scope generic <see cref="TypeParameterSymbol"/> (e.g.
-    /// <c>T</c>, <c>T?</c>, <c>[]T</c>, or <c>List[T]</c>). Such a type is an
-    /// open/partially-constructed generic whose emit form is type-erased to
-    /// <c>System.Object</c> under the type-erased generic model (ADR-0004).
+    /// Issue #1481: the single canonical structural walk over the
+    /// <see cref="TypeSymbol"/> lattice, parameterized by a leaf predicate.
+    /// Returns <c>true</c> when any <see cref="TypeParameterSymbol"/> reachable
+    /// from <paramref name="type"/> (directly or nested inside any composite
+    /// type-kind that can structurally carry one) satisfies
+    /// <paramref name="match"/>.
+    /// <para>This replaces three previously hand-copied, divergent recursions —
+    /// the canonical <see cref="ContainsTypeParameter"/> and two emit-layer
+    /// copies (<c>MethodBodyPlanner.ContainsTypeParameter</c> and
+    /// <c>StateMachineEmitter.ContainsOuterMethodTypeParameter</c>) — which had
+    /// drifted apart in which kinds they descended into (the emit copies
+    /// omitted <see cref="MapTypeSymbol"/> / <see cref="FunctionTypeSymbol"/>,
+    /// erasing generic iterator element types to the <c>&lt;object&gt;</c>
+    /// shape). Every composite kind is now handled here in exactly one place;
+    /// the public wrappers differ only in their leaf predicate.</para>
     /// </summary>
-    /// <param name="type">The type to inspect.</param>
-    /// <returns><c>true</c> if the type references an in-scope type parameter.</returns>
-    public static bool ContainsTypeParameter(TypeSymbol type)
+    /// <param name="type">The type to inspect (may be <see langword="null"/>).</param>
+    /// <param name="match">Leaf predicate applied to each referenced type parameter.</param>
+    /// <returns><c>true</c> if some referenced type parameter satisfies <paramref name="match"/>.</returns>
+    public static bool AnyTypeParameter(TypeSymbol type, Func<TypeParameterSymbol, bool> match)
     {
         switch (type)
         {
             case null:
                 return false;
-            case TypeParameterSymbol:
-                return true;
+            case TypeParameterSymbol tp:
+                return match(tp);
             case NullableTypeSymbol n:
-                return ContainsTypeParameter(n.UnderlyingType);
+                return AnyTypeParameter(n.UnderlyingType, match);
             case SliceTypeSymbol s:
-                return ContainsTypeParameter(s.ElementType);
+                return AnyTypeParameter(s.ElementType, match);
             case ArrayTypeSymbol a:
-                return ContainsTypeParameter(a.ElementType);
+                return AnyTypeParameter(a.ElementType, match);
+            case SequenceTypeSymbol seq:
+                return AnyTypeParameter(seq.ElementType, match);
+            case AsyncSequenceTypeSymbol aseq:
+                return AnyTypeParameter(aseq.ElementType, match);
             case MapTypeSymbol m:
-                return ContainsTypeParameter(m.KeyType) || ContainsTypeParameter(m.ValueType);
+                return AnyTypeParameter(m.KeyType, match) || AnyTypeParameter(m.ValueType, match);
             case FunctionTypeSymbol fn:
                 foreach (var param in fn.ParameterTypes)
                 {
-                    if (ContainsTypeParameter(param))
+                    if (AnyTypeParameter(param, match))
                     {
                         return true;
                     }
                 }
 
-                return ContainsTypeParameter(fn.ReturnType);
-            case ImportedTypeSymbol it when !it.TypeArguments.IsDefaultOrEmpty:
-                foreach (var arg in it.TypeArguments)
-                {
-                    if (ContainsTypeParameter(arg))
-                    {
-                        return true;
-                    }
-                }
-
-                return false;
+                return AnyTypeParameter(fn.ReturnType, match);
             case TupleTypeSymbol tup:
                 // Issue #813: value-tuple element types must propagate
                 // "contains type parameter" so callers like
@@ -367,7 +373,49 @@ public class TypeSymbol : Symbol
                 // type-erased `IEnumerable<object>` shape.
                 foreach (var elem in tup.ElementTypes)
                 {
-                    if (ContainsTypeParameter(elem))
+                    if (AnyTypeParameter(elem, match))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            case ByRefTypeSymbol br:
+                return AnyTypeParameter(br.PointeeType, match);
+            case StructSymbol st when !st.TypeArguments.IsDefaultOrEmpty:
+                foreach (var arg in st.TypeArguments)
+                {
+                    if (AnyTypeParameter(arg, match))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            case InterfaceSymbol iface when !iface.TypeArguments.IsDefaultOrEmpty:
+                foreach (var arg in iface.TypeArguments)
+                {
+                    if (AnyTypeParameter(arg, match))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            case DelegateTypeSymbol del:
+                foreach (var param in del.Parameters)
+                {
+                    if (AnyTypeParameter(param.Type, match))
+                    {
+                        return true;
+                    }
+                }
+
+                return AnyTypeParameter(del.ReturnType, match);
+            case ImportedTypeSymbol it when !it.TypeArguments.IsDefaultOrEmpty:
+                foreach (var arg in it.TypeArguments)
+                {
+                    if (AnyTypeParameter(arg, match))
                     {
                         return true;
                     }
@@ -377,6 +425,41 @@ public class TypeSymbol : Symbol
             default:
                 return false;
         }
+    }
+
+    /// <summary>
+    /// #313: returns <c>true</c> if <paramref name="type"/> is, or structurally
+    /// contains, an in-scope generic <see cref="TypeParameterSymbol"/> (e.g.
+    /// <c>T</c>, <c>T?</c>, <c>[]T</c>, or <c>List[T]</c>). Such a type is an
+    /// open/partially-constructed generic whose emit form is type-erased to
+    /// <c>System.Object</c> under the type-erased generic model (ADR-0004).
+    /// </summary>
+    /// <param name="type">The type to inspect.</param>
+    /// <returns><c>true</c> if the type references an in-scope type parameter.</returns>
+    public static bool ContainsTypeParameter(TypeSymbol type) => AnyTypeParameter(type, static _ => true);
+
+    /// <summary>
+    /// Issue #810 / #1481: returns <see langword="true"/> when
+    /// <paramref name="type"/> structurally references any of the supplied
+    /// <paramref name="outerMethodTypeParameters"/>. Used by the iterator
+    /// state-machine emitter to decide whether the <c>GetEnumerator</c> return
+    /// and the SM's <c>IEnumerable&lt;…&gt;</c> / <c>IEnumerator&lt;…&gt;</c>
+    /// interface rows need a symbolic (TypeSpec-encoded) strongly-typed shape
+    /// rather than the CLR-erased <c>&lt;object&gt;</c> form. Shares the single
+    /// <see cref="AnyTypeParameter"/> walker with
+    /// <see cref="ContainsTypeParameter"/>; only the leaf predicate differs.
+    /// </summary>
+    /// <param name="type">The type to inspect.</param>
+    /// <param name="outerMethodTypeParameters">The outer method's in-scope type parameters.</param>
+    /// <returns><c>true</c> if the type references one of the outer-method type parameters.</returns>
+    public static bool ContainsOuterMethodTypeParameter(TypeSymbol type, ImmutableArray<TypeParameterSymbol> outerMethodTypeParameters)
+    {
+        if (outerMethodTypeParameters.IsDefaultOrEmpty)
+        {
+            return false;
+        }
+
+        return AnyTypeParameter(type, outerMethodTypeParameters.Contains);
     }
 
     /// <summary>

--- a/test/Compiler.Tests/Emit/Issue1481MapFunctionIteratorEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1481MapFunctionIteratorEmitTests.cs
@@ -1,0 +1,374 @@
+// <copyright file="Issue1481MapFunctionIteratorEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1481 — a generic iterator whose element type is built from a
+/// <c>map[K, T]</c> or a function type (<c>func(T) -&gt; int32</c>) must emit
+/// strongly-typed <c>IEnumerable&lt;…&gt;</c> / <c>IEnumerator&lt;…&gt;</c>
+/// interface rows that preserve the iterator's type parameter as a reified
+/// <c>Var(0)</c> slot — not the type-erased <c>&lt;object&gt;</c> shape.
+/// <para>
+/// Before the fix, the emit layer re-implemented the "does this type
+/// structurally reference a type parameter?" walk three separate times, and
+/// the two emit-layer copies omitted <c>MapTypeSymbol</c> /
+/// <c>FunctionTypeSymbol</c>. A generic iterator yielding <c>map[string, T]</c>
+/// could not even be emitted (the signature encoder threw
+/// "Cannot encode signature for type 'map[string,T]'"). The fix:
+/// </para>
+/// <list type="bullet">
+///   <item>Consolidates the three walks into the single canonical
+///         <c>TypeSymbol.AnyTypeParameter</c> walker (covered by the
+///         Core-side unit tests).</item>
+///   <item>Teaches the signature encoder to reify a null-ClrType
+///         <c>map[K, V]</c> as <c>GENERICINST Dictionary`2&lt;K, V&gt;</c>,
+///         with a matching reified body construction
+///         (<c>GetMapCtorReference</c> / <c>GetMapSetItemReference</c>).</item>
+///   <item>Recognises that <c>map</c> / function reference values widen to
+///         <c>object</c> as a no-op in the non-generic
+///         <c>IEnumerator.Current</c> getter.</item>
+///   <item>Substitutes through <c>map[K, V]</c> at a closed generic call site
+///         so the consuming <c>for</c>-loop binds the strongly-typed
+///         element.</item>
+/// </list>
+/// Every user type in this file carries a unique <c>Issue1481</c>-prefixed
+/// name because the name-keyed function-type cache is not cleared between
+/// in-process emit tests.
+/// </summary>
+public class Issue1481MapFunctionIteratorEmitTests
+{
+    #region State-machine reflection — reified interface rows
+
+    [Fact]
+    public void StateMachineClass_MapElement_ImplementsIEnumerableOfReifiedDictionary()
+    {
+        // `sequence[map[string, T]]`: the synthesized SM class must list a
+        // generic `IEnumerable<Dictionary<string, T>>` interface closed over
+        // its own Var(0), not the type-erased `IEnumerable<object>` shape.
+        var source = """
+            package Probe
+            import System.Collections.Generic
+
+            class Issue1481MapRows {
+                shared {
+                    func MapRowsEntries[T any](items []T) sequence[map[string, T]] {
+                        for v in items {
+                            let m = map[string, T]{}
+                            yield m
+                        }
+                    }
+                }
+            }
+            """;
+
+        var assembly = CompileLibrary(source);
+        var smType = SingleStateMachine(assembly, "<MapRowsEntries>d__");
+
+        Assert.True(smType.IsGenericTypeDefinition);
+        var typeParams = smType.GetGenericArguments();
+        Assert.Single(typeParams);
+
+        AssertImplementsEnumerableOf(smType, i =>
+        {
+            if (!i.IsGenericType || i.GetGenericTypeDefinition() != typeof(Dictionary<,>))
+            {
+                return false;
+            }
+
+            var dictArgs = i.GetGenericArguments();
+            return dictArgs[0] == typeof(string) && dictArgs[1] == typeParams[0];
+        });
+
+        // The `<>2__current` field and get_Current must agree with the rows.
+        var currentField = smType.GetField("<>2__current", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        Assert.NotNull(currentField);
+        var fieldType = currentField!.FieldType;
+        Assert.True(fieldType.IsGenericType && fieldType.GetGenericTypeDefinition() == typeof(Dictionary<,>));
+        Assert.Equal(typeof(string), fieldType.GetGenericArguments()[0]);
+        Assert.Equal(typeParams[0], fieldType.GetGenericArguments()[1]);
+    }
+
+    [Fact]
+    public void StateMachineClass_FunctionElement_ImplementsIEnumerableOfReifiedFunc()
+    {
+        // `sequence[(T) -> int32]`: the SM must list a generic
+        // `IEnumerable<Func<T, int>>` interface closed over its own Var(0).
+        var source = """
+            package Probe
+            import System.Collections.Generic
+
+            class Issue1481FuncRows {
+                shared {
+                    func FuncRowsEntries[T any](items []T) sequence[(T) -> int32] {
+                        for v in items {
+                            yield func(x T) int32 { return 0 }
+                        }
+                    }
+                }
+            }
+            """;
+
+        var assembly = CompileLibrary(source);
+        var smType = SingleStateMachine(assembly, "<FuncRowsEntries>d__");
+
+        var typeParams = smType.GetGenericArguments();
+        Assert.Single(typeParams);
+
+        AssertImplementsEnumerableOf(smType, i =>
+        {
+            if (!i.IsGenericType || i.GetGenericTypeDefinition() != typeof(Func<,>))
+            {
+                return false;
+            }
+
+            var funcArgs = i.GetGenericArguments();
+            return funcArgs[0] == typeParams[0] && funcArgs[1] == typeof(int);
+        });
+    }
+
+    [Fact]
+    public void StateMachineClass_MapOfListElement_StaysErased_AndVerifies()
+    {
+        // `sequence[map[string, List[T]]]`: under the type-erased generic
+        // model (ADR-0004) `List[T]` is genuinely `List<object>` at runtime,
+        // so this map has a non-null erased ClrType and MUST stay
+        // `Dictionary<string, List<object>>` — reifying it would be a lie.
+        // This guards against over-reification: the rows stay erased AND the
+        // assembly still ilverifies (verified inside CompileLibrary).
+        var source = """
+            package Probe
+            import System.Collections.Generic
+
+            class Issue1481MapListRows {
+                shared {
+                    func MapListEntries[T any](items []T) sequence[map[string, List[T]]] {
+                        for v in items {
+                            let m = map[string, List[T]]{}
+                            yield m
+                        }
+                    }
+                }
+            }
+            """;
+
+        var assembly = CompileLibrary(source);
+        var smType = SingleStateMachine(assembly, "<MapListEntries>d__");
+
+        AssertImplementsEnumerableOf(smType, i =>
+        {
+            if (!i.IsGenericType || i.GetGenericTypeDefinition() != typeof(Dictionary<,>))
+            {
+                return false;
+            }
+
+            var dictArgs = i.GetGenericArguments();
+            if (dictArgs[0] != typeof(string))
+            {
+                return false;
+            }
+
+            // Value is the erased List<object> — NOT closed over the SM's Var(0).
+            return dictArgs[1].IsGenericType
+                && dictArgs[1].GetGenericTypeDefinition() == typeof(List<>)
+                && dictArgs[1].GetGenericArguments()[0] == typeof(object);
+        });
+    }
+
+    #endregion
+
+    #region End-to-end execution — strongly-typed element values
+
+    [Fact]
+    public void MapIterator_RunsEndToEnd_WithStronglyTypedIntValues()
+    {
+        // Consuming a closed `MapRun[int32]` must surface `map[string, int32]`
+        // elements whose indexer returns a strongly-typed `int32` (not `T`),
+        // proving the closed call-site substitution descends into the map.
+        var source = """
+            package Probe
+            import System.Collections.Generic
+
+            class Issue1481MapRun {
+                shared {
+                    func MapRunEntries[T any](items []T) sequence[map[string, T]] {
+                        for v in items {
+                            let m = map[string, T]{"key": v}
+                            yield m
+                        }
+                    }
+                }
+            }
+
+            public var total = 0
+            public var count = 0
+            for d in Issue1481MapRun.MapRunEntries[int32]([]int32{5, 9, 14}) {
+                total = total + d["key"]
+                count = count + 1
+            }
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal(3, GetIntField(assembly, "count"));
+        Assert.Equal(28, GetIntField(assembly, "total"));
+    }
+
+    [Fact]
+    public void MapIterator_RunsEndToEnd_WithStronglyTypedStringValues()
+    {
+        var source = """
+            package Probe
+            import System.Collections.Generic
+
+            class Issue1481MapRunStr {
+                shared {
+                    func MapRunStrEntries[T any](items []T) sequence[map[string, T]] {
+                        for v in items {
+                            let m = map[string, T]{"key": v}
+                            yield m
+                        }
+                    }
+                }
+            }
+
+            public var concat = ""
+            for d in Issue1481MapRunStr.MapRunStrEntries[string]([]string{"a", "b", "c"}) {
+                concat = concat + d["key"]
+            }
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal("abc", GetStringField(assembly, "concat"));
+    }
+
+    [Fact]
+    public void FunctionIterator_RunsEndToEnd()
+    {
+        // A generic iterator yielding `func(T) -> int32` values must emit and
+        // verify, and the yielded delegates must be invokable at runtime.
+        var source = """
+            package Probe
+            import System.Collections.Generic
+
+            class Issue1481FuncRun {
+                shared {
+                    func FuncRunEntries[T any](items []T) sequence[(T) -> int32] {
+                        for v in items {
+                            yield func(x T) int32 { return 11 }
+                        }
+                    }
+                }
+            }
+
+            public var total = 0
+            for f in Issue1481FuncRun.FuncRunEntries[int32]([]int32{1, 2, 3}) {
+                total = total + f(0)
+            }
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal(33, GetIntField(assembly, "total"));
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static Type SingleStateMachine(Assembly assembly, string prefix)
+        => assembly.GetTypes()
+            .Single(t => t.IsNested && t.Name.StartsWith(prefix, StringComparison.Ordinal));
+
+    private static void AssertImplementsEnumerableOf(Type smType, Func<Type, bool> elementMatches)
+    {
+        var ok = smType.GetInterfaces().Any(i =>
+            i.IsGenericType
+            && i.GetGenericTypeDefinition() == typeof(IEnumerable<>)
+            && elementMatches(i.GetGenericArguments()[0]));
+        Assert.True(
+            ok,
+            $"State machine '{smType.FullName}' must implement the expected reified IEnumerable<…> row. " +
+            $"Actual interfaces: {string.Join(", ", smType.GetInterfaces().Select(i => i.FullName))}");
+    }
+
+    private static Assembly CompileAndRun(string source)
+    {
+        var outPath = CompileToFile(source, target: "exe");
+
+        var bytes = File.ReadAllBytes(outPath);
+        var assembly = Assembly.Load(bytes);
+
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+        entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+
+        return assembly;
+    }
+
+    private static Assembly CompileLibrary(string source)
+    {
+        var outPath = CompileToFile(source, target: "library");
+        return Assembly.LoadFile(outPath);
+    }
+
+    private static string CompileToFile(string source, string target)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1481_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:" + target,
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+        IlVerifier.Verify(outPath);
+        return outPath;
+    }
+
+    private static int GetIntField(Assembly assembly, string name)
+    {
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var field = program.GetField(name, BindingFlags.Public | BindingFlags.Static);
+        return (int)field!.GetValue(null)!;
+    }
+
+    private static string GetStringField(Assembly assembly, string name)
+    {
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var field = program.GetField(name, BindingFlags.Public | BindingFlags.Static);
+        return (string)field!.GetValue(null)!;
+    }
+
+    #endregion
+}

--- a/test/Core.Tests/CodeAnalysis/Symbols/AnyTypeParameterWalkerTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/AnyTypeParameterWalkerTests.cs
@@ -1,0 +1,133 @@
+// <copyright file="AnyTypeParameterWalkerTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis.Symbols;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Symbols;
+
+/// <summary>
+/// Issue #1481 — the single canonical structural type-parameter walk
+/// (<see cref="TypeSymbol.AnyTypeParameter"/>) and its two public wrappers
+/// (<see cref="TypeSymbol.ContainsTypeParameter"/> and
+/// <see cref="TypeSymbol.ContainsOuterMethodTypeParameter"/>). These replace
+/// three previously hand-copied, divergent recursions; the two emit-layer
+/// copies omitted <see cref="MapTypeSymbol"/> / <see cref="FunctionTypeSymbol"/>
+/// (and one also omitted <see cref="StructSymbol"/> arguments), erasing
+/// generic iterator element types. The walker must descend into every
+/// composite kind that can structurally carry a type parameter.
+/// </summary>
+public class AnyTypeParameterWalkerTests
+{
+    private static TypeParameterSymbol Tp(string name, int ordinal = 0)
+        => new(name, ordinal, TypeParameterConstraint.Any, TypeParameterVariance.None);
+
+    [Fact]
+    public void ContainsTypeParameter_BareTypeParameter_True()
+    {
+        Assert.True(TypeSymbol.ContainsTypeParameter(Tp("T")));
+    }
+
+    [Fact]
+    public void ContainsTypeParameter_NoTypeParameter_False()
+    {
+        Assert.False(TypeSymbol.ContainsTypeParameter(TypeSymbol.Int32));
+        Assert.False(TypeSymbol.ContainsTypeParameter(MapTypeSymbol.Get(TypeSymbol.String, TypeSymbol.Int32)));
+        Assert.False(TypeSymbol.ContainsTypeParameter(null));
+    }
+
+    [Fact]
+    public void ContainsTypeParameter_MapKeyOrValue_True()
+    {
+        // The two emit-layer copies omitted MapTypeSymbol entirely — this is
+        // the core regression the consolidation fixes.
+        var t = Tp("T");
+        Assert.True(TypeSymbol.ContainsTypeParameter(MapTypeSymbol.Get(TypeSymbol.String, t)));
+        Assert.True(TypeSymbol.ContainsTypeParameter(MapTypeSymbol.Get(t, TypeSymbol.String)));
+    }
+
+    [Fact]
+    public void ContainsTypeParameter_FunctionParamOrReturn_True()
+    {
+        // Also omitted by both emit copies.
+        var t = Tp("T");
+        var paramOpen = FunctionTypeSymbol.Get(ImmutableArray.Create<TypeSymbol>(t), TypeSymbol.Int32);
+        var returnOpen = FunctionTypeSymbol.Get(ImmutableArray.Create(TypeSymbol.Int32), t);
+        Assert.True(TypeSymbol.ContainsTypeParameter(paramOpen));
+        Assert.True(TypeSymbol.ContainsTypeParameter(returnOpen));
+    }
+
+    [Fact]
+    public void ContainsTypeParameter_SequenceAndAsyncSequence_True()
+    {
+        var t = Tp("T");
+        Assert.True(TypeSymbol.ContainsTypeParameter(SequenceTypeSymbol.Get(t)));
+        Assert.True(TypeSymbol.ContainsTypeParameter(AsyncSequenceTypeSymbol.Get(t)));
+    }
+
+    [Fact]
+    public void ContainsTypeParameter_NestedComposite_True()
+    {
+        // sequence[map[string, (T) -> int32]] — every wrapper kind nested.
+        var t = Tp("T");
+        var fn = FunctionTypeSymbol.Get(ImmutableArray.Create<TypeSymbol>(t), TypeSymbol.Int32);
+        var map = MapTypeSymbol.Get(TypeSymbol.String, fn);
+        var seq = SequenceTypeSymbol.Get(map);
+        Assert.True(TypeSymbol.ContainsTypeParameter(seq));
+    }
+
+    [Fact]
+    public void ContainsTypeParameter_SliceArrayNullableTuple_True()
+    {
+        var t = Tp("T");
+        Assert.True(TypeSymbol.ContainsTypeParameter(SliceTypeSymbol.Get(t)));
+        Assert.True(TypeSymbol.ContainsTypeParameter(ArrayTypeSymbol.Get(t, 3)));
+        Assert.True(TypeSymbol.ContainsTypeParameter(NullableTypeSymbol.Get(t)));
+        Assert.True(TypeSymbol.ContainsTypeParameter(
+            TupleTypeSymbol.Get(ImmutableArray.Create(TypeSymbol.Int32, (TypeSymbol)t))));
+    }
+
+    [Fact]
+    public void AnyTypeParameter_LeafPredicate_OnlyMatchesPredicate()
+    {
+        // The leaf predicate must be consulted per referenced parameter.
+        var t = Tp("T", 0);
+        var u = Tp("U", 1);
+        var map = MapTypeSymbol.Get(t, u);
+
+        Assert.True(TypeSymbol.AnyTypeParameter(map, tp => tp == t));
+        Assert.True(TypeSymbol.AnyTypeParameter(map, tp => tp == u));
+        Assert.False(TypeSymbol.AnyTypeParameter(map, _ => false));
+        Assert.True(TypeSymbol.AnyTypeParameter(map, _ => true));
+    }
+
+    [Fact]
+    public void ContainsOuterMethodTypeParameter_OnlyMatchesSuppliedParameters()
+    {
+        // The StateMachineEmitter copy used membership in the outer-method
+        // parameter set rather than "is any type parameter". A type parameter
+        // that is NOT in the supplied set must not match — and, unlike the old
+        // copy, map / function composites must now be descended into.
+        var outer = Tp("T", 0);
+        var unrelated = Tp("X", 5);
+        var outerSet = ImmutableArray.Create(outer);
+
+        var mapWithOuter = MapTypeSymbol.Get(TypeSymbol.String, outer);
+        var mapWithUnrelated = MapTypeSymbol.Get(TypeSymbol.String, unrelated);
+        var funcWithOuter = FunctionTypeSymbol.Get(ImmutableArray.Create<TypeSymbol>(outer), TypeSymbol.Int32);
+
+        Assert.True(TypeSymbol.ContainsOuterMethodTypeParameter(mapWithOuter, outerSet));
+        Assert.True(TypeSymbol.ContainsOuterMethodTypeParameter(funcWithOuter, outerSet));
+        Assert.False(TypeSymbol.ContainsOuterMethodTypeParameter(mapWithUnrelated, outerSet));
+    }
+
+    [Fact]
+    public void ContainsOuterMethodTypeParameter_EmptyOrDefaultSet_False()
+    {
+        var t = Tp("T");
+        Assert.False(TypeSymbol.ContainsOuterMethodTypeParameter(t, ImmutableArray<TypeParameterSymbol>.Empty));
+        Assert.False(TypeSymbol.ContainsOuterMethodTypeParameter(t, default));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1481.

The emit layer re-implemented "does this type structurally reference a type parameter?" **three** separate times, and the copies had diverged in which composite type-kinds they recursed into. The two emit-layer copies omitted `MapTypeSymbol` and `FunctionTypeSymbol`, so a generic iterator / async-iterator whose element type was built from a `map[...]` or a function type **erased** its `IEnumerable<T>` / `IEnumerator<T>` interface rows and `GetEnumerator` signature to the type-erased `<object>` shape (and a `map[string, T]` iterator could not even be emitted — the signature encoder threw `Cannot encode signature for type 'map[string,T]'`).

## Consolidation (the issue's named deliverable)

Introduce **one** structural walker parameterized by a leaf predicate and route everything through it:

- `TypeSymbol.AnyTypeParameter(type, Func<TypeParameterSymbol,bool> match)` — the single canonical walk, covering the **union** of every composite kind any of the three prior copies handled: `Nullable`, `Slice`, `Array`, `Sequence`, `AsyncSequence`, `Map` (key+value), `Function` (params+return), `Tuple`, `ByRef`, `StructSymbol`/`InterfaceSymbol`/`ImportedType` type-args, and `Delegate`.
- `ContainsTypeParameter(type)` = `AnyTypeParameter(type, _ => true)`.
- `ContainsOuterMethodTypeParameter(type, outerTPs)` = `AnyTypeParameter(type, outerTPs.Contains)`.
- The two private emit-layer copies (`MethodBodyPlanner.ContainsTypeParameter` and `StateMachineEmitter.ContainsOuterMethodTypeParameter`) are **deleted**; both call sites route through the canonical walker, so the kinds can no longer drift.

## Reifying generic map / function iterator element types (the observable fix)

Mirrors the existing tuple (#649/#813) reified-iterator mechanism, which keys on a **null `ClrType`** element type:

- **Signature encoder** (`ReflectionMetadataEmitter`): encode a null-`ClrType` `map[K, V]` as a `GENERICINST` of `Dictionary<K, V>`, plus `GetMapTypeSpec` / `GetMapCtorReference` / `GetMapSetItemReference` helpers.
- **Body** (`MethodBodyEmitter.EmitMapLiteral`): emit a reified `newobj` + `set_Item` body for a null-`ClrType` map literal so the stored value matches the SM's reified `Dictionary<..., !0>` field.
- **`IsReferenceCompatible`**: widen a `map`/function reference to `object` as a no-op for the synthesized non-generic `IEnumerator.Current` getter.
- **`Binder.SubstituteType`**: descend into `map[K, V]` so a closed call site lowers `sequence[map[string, T]]` to `sequence[map[string, int32]]`.

`map[string, List[T]]` correctly **stays erased** — under ADR-0004 `List[T]` is genuinely `List<object>` at runtime, so reifying it would be a runtime lie. A regression test guards against over-reification.

## Tests added

- `test/Core.Tests/CodeAnalysis/Symbols/AnyTypeParameterWalkerTests.cs` — unit-covers the unified walker and both wrappers across Map, Function, Sequence, AsyncSequence, Slice, Array, Nullable, Tuple, ByRef and nested composites, including the leaf-predicate behavior.
- `test/Compiler.Tests/Emit/Issue1481MapFunctionIteratorEmitTests.cs` — emit regression tests proving generic iterators yielding `map[string, T]` and `(T) -> int32` element types emit reified `IEnumerable<...>`/`IEnumerator<...>` rows (T preserved, not erased to `object`), run end-to-end, and ilverify clean; plus the `map[string, List[T]]` stays-erased guard.

## Validation

- `dotnet build GSharp.sln -c Release -graph` — 0 warnings / 0 errors.
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release --no-build` — 4798 passed, 1 skipped (the intentionally-skipped `RegenerateBaseline`). The byte-identical `RefactoringBaselineTests` passes unchanged.
- New Core walker tests — 10 passed.
- Issue1481 emit suite — 6 passed; nearby `Issue813`/`Issue990`/`Issue1002` iterator emit tests — 19 passed (capped parallelism).

## Scope notes (honest)

- **Async generic iterators** remain a separate pre-existing binder gap (a generic `async` iterator is rejected at the binder with GS0136 regardless of element type), so there is no async map/function variant to reify here. Not a regression.
- **`map[string, List[T]]`** stays type-erased by design (model-correct under ADR-0004), as covered by the guard test.
