### PR TITLE
Apply element-wise implicit conversion to variadic (...T) tail arguments

### DIFF
--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -466,6 +466,61 @@ internal sealed class OverloadResolver
     }
 
     /// <summary>
+    /// Issue #1493: coerces a single trailing argument bound for a G# variadic
+    /// (<c>...T</c>) element slot to the variadic element type, applying the same
+    /// implicit conversions a fixed parameter of that type would accept —
+    /// reference upcast, interface conversion, tuple-element conversions, nullable
+    /// lifting, implicit constant narrowing, and user-defined implicit conversions.
+    /// Returns the (possibly conversion-wrapped) argument so the emitter packs the
+    /// element with the variadic element type rather than the argument's static
+    /// type; reports GS0154 and sets <paramref name="hasErrors"/> when no implicit
+    /// conversion exists. This keeps overload applicability and final coercion in
+    /// agreement with the non-variadic / array-literal element paths.
+    /// </summary>
+    private BoundExpression CoerceVariadicElement(
+        BoundExpression argument,
+        TypeSymbol elementType,
+        TextLocation location,
+        string parameterName,
+        ref bool hasErrors)
+    {
+        var argType = argument.Type;
+
+        // Unknown/error argument, or an open (unsubstituted) element type whose
+        // members are erased: leave the argument untouched. Open element types
+        // follow the type-erased model where the emitter boxes as needed.
+        if (argType == null || argType == TypeSymbol.Error || elementType is TypeParameterSymbol)
+        {
+            return argument;
+        }
+
+        if (argType == elementType)
+        {
+            return argument;
+        }
+
+        var conversion = Conversion.Classify(argType, elementType);
+        if (conversion.Exists && (conversion.IsImplicit || conversion.IsIdentity))
+        {
+            return conversions.BindConversion(location, argument, elementType);
+        }
+
+        if (ExpressionBinder.IsImplicitConstantNarrowingArgument(argument, elementType))
+        {
+            return conversions.BindConversion(location, argument, elementType);
+        }
+
+        if (conversions.TryApplyUserDefinedImplicitArgumentConversion(argument, elementType, out var udc))
+        {
+            return udc;
+        }
+
+        Diagnostics.ReportWrongArgumentType(location, parameterName, elementType, argType);
+        hasErrors = true;
+        return argument;
+    }
+
+    /// <summary>
     /// Issue #1281: C# §10.2.11 implicit constant expression conversion at a call
     /// site. When <paramref name="argument"/> is a constant integer expression
     /// whose value fits the (possibly narrower or cross-sign) integer parameter
@@ -912,6 +967,53 @@ internal sealed class OverloadResolver
             }
 
             return false;
+        }
+
+        // Issue #1493: validate the variadic tail too, so a non-generic
+        // variadic candidate is only applicable when each trailing argument
+        // implicitly converts to the variadic element type — keeping
+        // applicability/ranking in agreement with the final element coercion.
+        if (isVariadic
+            && candidate.Parameters[candidate.Parameters.Length - 1].Type is SliceTypeSymbol variadicSlice)
+        {
+            var elementType = variadicSlice.ElementType;
+            var tailStart = fixedParamCount;
+
+            // A single trailing argument already typed as the slice itself is a
+            // pass-through (`f(existingSlice)`); accept it as-is.
+            var isSlicePassThrough = argumentCount - tailStart == 1
+                && tailStart < boundArguments.Count
+                && boundArguments[tailStart]?.Type == candidate.Parameters[candidate.Parameters.Length - 1].Type;
+
+            if (!isSlicePassThrough && !(elementType is TypeParameterSymbol))
+            {
+                for (var i = tailStart; i < argumentCount && i < boundArguments.Count; i++)
+                {
+                    var argType = boundArguments[i]?.Type;
+                    if (argType == null)
+                    {
+                        continue;
+                    }
+
+                    var conversion = Conversion.Classify(argType, elementType);
+                    if (conversion.Exists && (conversion.IsImplicit || conversion.IsIdentity))
+                    {
+                        continue;
+                    }
+
+                    if (ExpressionBinder.IsImplicitConstantNarrowingArgument(boundArguments[i], elementType))
+                    {
+                        continue;
+                    }
+
+                    if (conversions.TryApplyUserDefinedImplicitArgumentConversion(boundArguments[i], elementType, out _))
+                    {
+                        continue;
+                    }
+
+                    return false;
+                }
+            }
         }
 
         return true;
@@ -1907,16 +2009,17 @@ internal sealed class OverloadResolver
 
             if (!passThrough)
             {
+                // Issue #1493: coerce each trailing element to the variadic
+                // element type, applying any valid implicit conversion before
+                // the elements are packed.
                 for (var i = fixedPrimaryCount; i < requestedArgCount; i++)
                 {
-                    var argument = boundArguments[i];
-                    if (argument.Type != elementType
-                        && argument.Type != TypeSymbol.Error
-                        && !Conversion.Classify(argument.Type, elementType).IsImplicit)
-                    {
-                        Diagnostics.ReportWrongArgumentType(parameterSyntaxV[i].Location, variadicParam.Name, elementType, argument.Type);
-                        hasErrorsV = true;
-                    }
+                    boundArguments[i] = CoerceVariadicElement(
+                        boundArguments[i],
+                        elementType,
+                        parameterSyntaxV[i].Location,
+                        variadicParam.Name,
+                        ref hasErrorsV);
                 }
             }
 
@@ -2369,16 +2472,18 @@ internal sealed class OverloadResolver
             if (!passThrough)
             {
                 var hasVariadicErrors = false;
+
+                // Issue #1493: coerce each trailing element to the variadic
+                // element type, applying any valid implicit conversion before
+                // packing.
                 for (var i = fixedCtorParamCount; i < requestedArgCount; i++)
                 {
-                    var argument = boundArguments[i];
-                    if (argument.Type != elementType
-                        && argument.Type != TypeSymbol.Error
-                        && !Conversion.Classify(argument.Type, elementType).IsImplicit)
-                    {
-                        Diagnostics.ReportWrongArgumentType(parameterSyntax[i].Location, variadicParam.Name, elementType, argument.Type);
-                        hasVariadicErrors = true;
-                    }
+                    boundArguments[i] = CoerceVariadicElement(
+                        boundArguments[i],
+                        elementType,
+                        parameterSyntax[i].Location,
+                        variadicParam.Name,
+                        ref hasVariadicErrors);
                 }
 
                 if (hasVariadicErrors)
@@ -3206,10 +3311,24 @@ internal sealed class OverloadResolver
             var passThrough = trailing == 1 && boundArguments[fixedCount].Type == sliceType;
             if (!passThrough)
             {
+                // Issue #1493: coerce each trailing element to the variadic
+                // element type before packing so implicit conversions apply.
+                var elementType = sliceType.ElementType;
+                var hasElementErrors = false;
                 var packed = ImmutableArray.CreateBuilder<BoundExpression>(trailing);
                 for (var i = fixedCount; i < syntax.Arguments.Count; i++)
                 {
-                    packed.Add(boundArguments[i]);
+                    packed.Add(CoerceVariadicElement(
+                        boundArguments[i],
+                        elementType,
+                        syntax.Arguments[i].Location,
+                        calleeName,
+                        ref hasElementErrors));
+                }
+
+                if (hasElementErrors)
+                {
+                    return false;
                 }
 
                 var rebuilt = ImmutableArray.CreateBuilder<BoundExpression>(fixedCount + 1);
@@ -4443,22 +4562,27 @@ internal sealed class OverloadResolver
             }
             else
             {
+                // Issue #1493: coerce each trailing element to the variadic
+                // element type so an implicit conversion (reference upcast,
+                // tuple-element, interface, ...) is applied before packing —
+                // the emitter then builds the element with the element type.
+                var convertedElements = new BoundExpression[syntax.Arguments.Count - fixedParamCount];
                 for (var i = fixedParamCount; i < syntax.Arguments.Count; i++)
                 {
-                    var argument = boundArguments[i];
-                    if (argument.Type != elementType && argument.Type != TypeSymbol.Error)
-                    {
-                        Diagnostics.ReportWrongArgumentType(syntax.Arguments[i].Location, variadicParam.Name, elementType, argument.Type);
-                        hasErrors = true;
-                    }
+                    convertedElements[i - fixedParamCount] = CoerceVariadicElement(
+                        boundArguments[i],
+                        elementType,
+                        syntax.Arguments[i].Location,
+                        variadicParam.Name,
+                        ref hasErrors);
                 }
 
                 if (!hasErrors)
                 {
-                    var packed = ImmutableArray.CreateBuilder<BoundExpression>(syntax.Arguments.Count - fixedParamCount);
-                    for (var i = fixedParamCount; i < syntax.Arguments.Count; i++)
+                    var packed = ImmutableArray.CreateBuilder<BoundExpression>(convertedElements.Length);
+                    foreach (var element in convertedElements)
                     {
-                        packed.Add(boundArguments[i]);
+                        packed.Add(element);
                     }
 
                     var finalArgs = ImmutableArray.CreateBuilder<BoundExpression>(fixedParamCount + 1);
@@ -4953,23 +5077,20 @@ internal sealed class OverloadResolver
             if (!passThrough)
             {
                 var hasVariadicErrors = false;
+                var converted = new BoundExpression[trailingCount];
                 for (var i = fixedCallableParamCount; i < permutedArguments.Length; i++)
                 {
-                    var argument = permutedArguments[i];
-                    if (elementType is TypeParameterSymbol)
-                    {
-                        // Open element type: leave argument untouched, the
-                        // emitter boxes as needed (type-erased model).
-                        continue;
-                    }
-
-                    if (argument.Type != elementType
-                        && argument.Type != TypeSymbol.Error
-                        && !Conversion.Classify(argument.Type, elementType).IsImplicit)
-                    {
-                        Diagnostics.ReportWrongArgumentType(permutedSyntax[i].Location, variadicParam.Name, elementType, argument.Type);
-                        hasVariadicErrors = true;
-                    }
+                    // Issue #1493: coerce each trailing element to the variadic
+                    // element type so an implicit conversion is applied before
+                    // packing (the emitter then builds the element with the
+                    // element type rather than the argument's static type).
+                    var elementLocation = permutedSyntax[i]?.Location ?? ce.Location;
+                    converted[i - fixedCallableParamCount] = CoerceVariadicElement(
+                        permutedArguments[i],
+                        elementType,
+                        elementLocation,
+                        variadicParam.Name,
+                        ref hasVariadicErrors);
                 }
 
                 if (hasVariadicErrors)
@@ -4978,9 +5099,9 @@ internal sealed class OverloadResolver
                 }
 
                 var packed = ImmutableArray.CreateBuilder<BoundExpression>(trailingCount);
-                for (var i = fixedCallableParamCount; i < permutedArguments.Length; i++)
+                foreach (var element in converted)
                 {
-                    packed.Add(permutedArguments[i]);
+                    packed.Add(element);
                 }
 
                 var newArgs = ImmutableArray.CreateBuilder<BoundExpression>(fixedCallableParamCount + 1);

--- a/test/Compiler.Tests/Emit/Issue1493VariadicTupleConversionEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1493VariadicTupleConversionEmitTests.cs
@@ -1,0 +1,221 @@
+// <copyright file="Issue1493VariadicTupleConversionEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1493 — when a value is passed as an element of a variadic
+/// (<c>...T</c>) parameter, gsc must apply the same element-wise implicit
+/// conversion (reference upcast, tuple-element conversion, interface
+/// conversion, ...) that a fixed parameter of the element type would apply,
+/// so the packed array element is built with the variadic ELEMENT type rather
+/// than the argument's static (derived) type. Before the fix the packing path
+/// either emitted invalid IL (ilverify <c>StackUnexpected</c>) or wrongly
+/// rejected the call with GS0154. The facets below mirror the Oahu corpus:
+/// <list type="bullet">
+/// <item>Facet A — a tuple literal whose second element is a derived class is
+/// passed to a multi-overload variadic <c>...(Track, FilterBase)</c>; the
+/// derived element must be up-cast inside the packed <c>ValueTuple</c>.</item>
+/// <item>Facet B — the single-overload manifestation, which previously failed
+/// applicability with GS0154.</item>
+/// <item>Facet C — a plain (non-tuple) derived element passed to a
+/// <c>...FilterBase</c> variadic.</item>
+/// <item>Facet D — a class implementing an interface passed to a
+/// <c>...IFilter</c> variadic.</item>
+/// </list>
+/// All four ilverify clean and run after the fix.
+/// </summary>
+public class Issue1493VariadicTupleConversionEmitTests
+{
+    [Fact]
+    public void EndToEnd_FacetA_TupleElementUpcastMultipleOverloads_Runs()
+    {
+        var source = """
+            package Probe1493a
+            import System
+
+            open class FilterBaseA[T] { init() { } }
+            open class TransformBaseA[A, B] : FilterBaseA[A] { init() : base() { } }
+            class TrackA { init() { } }
+
+            class OpA {
+                init() { }
+                open func GetFilter() TransformBaseA[int32, int32] -> TransformBaseA[int32, int32]()
+                open func Process(cont (int32) -> void, filters ...(TrackA, FilterBaseA[int32])) int32 -> filters.Length
+                func Process[R](cont (int32) -> R, filters ...(TrackA, FilterBaseA[int32])) int32 -> filters.Length
+                func Run() int32 {
+                    let t = TrackA()
+                    let filter1 = GetFilter()
+                    let cont = func (x int32) { }
+                    return Process(cont, (t, filter1))
+                }
+            }
+
+            func Main() {
+                Console.WriteLine(OpA().Run())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("1\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_FacetB_TupleElementUpcastSingleOverload_Runs()
+    {
+        var source = """
+            package Probe1493b
+            import System
+
+            open class FilterBaseB[T] { init() { } }
+            open class TransformBaseB[A, B] : FilterBaseB[A] { init() : base() { } }
+            class TrackB { init() { } }
+
+            func ProcessB(label int32, filters ...(TrackB, FilterBaseB[int32])) int32 -> filters.Length
+            func GetFilterB() TransformBaseB[int32, int32] -> TransformBaseB[int32, int32]()
+
+            func Main() {
+                let t = TrackB()
+                let f = GetFilterB()
+                Console.WriteLine(ProcessB(1, (t, f)))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("1\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_FacetC_NonTupleDerivedToBaseElement_Runs()
+    {
+        var source = """
+            package Probe1493c
+            import System
+
+            open class FilterBaseC[T] { init() { } }
+            open class TransformBaseC[A, B] : FilterBaseC[A] { init() : base() { } }
+
+            func ProcessC(xs ...FilterBaseC[int32]) int32 -> xs.Length
+            func GetFilterC() TransformBaseC[int32, int32] -> TransformBaseC[int32, int32]()
+
+            func Main() {
+                let f = GetFilterC()
+                Console.WriteLine(ProcessC(f))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("1\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_FacetD_DerivedToInterfaceElement_Runs()
+    {
+        var source = """
+            package Probe1493d
+            import System
+
+            interface IFilterD { }
+            open class FilterImplD : IFilterD { init() { } }
+
+            func ProcessD(xs ...IFilterD) int32 -> xs.Length
+
+            func Main() {
+                let f = FilterImplD()
+                Console.WriteLine(ProcessD(f))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("1\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1493_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
When a value is passed as an element of a **variadic** (`...T`) parameter, gsc was packing the element with the argument's *static* (derived) type rather than converting it to the variadic **element** type. For a tuple literal this produced invalid IL — the packed `ValueTuple` carried the derived element type and ilverify reported `StackUnexpected`. In the single-overload manifestation gsc instead wrongly rejected the call with **GS0154**. Non-variadic contexts (fixed params, explicit array literals) already converted correctly; only the variadic packing path was broken.

## Fix
- Added a shared `CoerceVariadicElement` helper in `OverloadResolver` that runs each trailing argument through the existing conversion machinery (`Conversion.Classify` + `ConversionClassifier.BindConversion`, implicit-constant narrowing, user-defined implicit conversions) toward the variadic element type, inserting the conversion node so emit up-casts the element.
- Used the helper from every user-call / constructor / function-type variadic packing site.
- Extended the overload applicability check (`IsConvertibilityApplicable`) to validate variadic tail element conversions so resolution/ranking agree with the final coercion.

This generalizes to **any** implicit conversion valid for a fixed parameter (reference upcast, interface conversion, tuple-element conversions, nullable lifting, constant narrowing) for any `G[T]` / derived type — not just the 2-tuple shape.

## Verification
- Repro A (multi-overload tuple upcast): before → ilverify `StackUnexpected`; after → **Verified**.
- Repro B (single-overload tuple upcast): before → **GS0154**; after → compiles + ilverifies clean.
- Generalization: non-tuple derived→base element and derived→interface element both ilverify clean.
- Controls (explicit array literal, pre-typed tuple variable) unchanged.
- New tests: `test/Compiler.Tests/Emit/Issue1493VariadicTupleConversionEmitTests.cs` (4 facets, all pass).
- Full `Core.Tests`: 4798 passed / 1 skipped. Refactoring baseline unchanged (no regeneration needed).

Fixes #1493

Refs #914
