### PR TITLE
Recognize IReadOnlyDictionary in `for k, v in` dictionary destructuring (#1483)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -362,20 +362,51 @@ internal sealed class MemberLookup
     }
 
     /// <summary>
-    /// Probes <paramref name="clrType"/> for an
-    /// <c>IDictionary&lt;TKey, TValue&gt;</c> implementation and returns the
-    /// key/value type arguments when present.
+    /// Probes <paramref name="clrType"/> for a member-mapping shape and returns
+    /// the key/value type arguments when present. Recognizes the broader
+    /// read-only mapping family: any interface whose generic type definition is
+    /// <c>IDictionary&lt;TKey, TValue&gt;</c> or
+    /// <c>IReadOnlyDictionary&lt;TKey, TValue&gt;</c> — mirroring how the
+    /// enumerable probe accepts the whole <c>IEnumerable&lt;T&gt;</c> family
+    /// rather than one concrete type (issue #1483). This lets
+    /// <c>for k, v in d</c> key/value destructure receivers that surface only
+    /// through the read-only contract (e.g. immutable dictionaries or user
+    /// types implementing only <c>IReadOnlyDictionary&lt;,&gt;</c>).
+    /// <para>
+    /// When a type implements BOTH interfaces (e.g. <c>Dictionary&lt;K, V&gt;</c>),
+    /// the writable <c>IDictionary&lt;,&gt;</c> is preferred. This is enforced
+    /// with a two-pass probe — the first pass scans for <c>IDictionary&lt;,&gt;</c>
+    /// and only when none is found does the second pass scan for
+    /// <c>IReadOnlyDictionary&lt;,&gt;</c> — so enumeration order can never pick
+    /// the read-only interface over an available writable one (they may even
+    /// carry different type arguments in pathological types).
+    /// </para>
     /// </summary>
     /// <param name="clrType">The CLR type to probe.</param>
     /// <param name="keyType">The dictionary's key type, on success.</param>
     /// <param name="valueType">The dictionary's value type, on success.</param>
     /// <returns><see langword="true"/> when the type implements
-    /// <c>IDictionary&lt;,&gt;</c>.</returns>
+    /// <c>IDictionary&lt;,&gt;</c> or <c>IReadOnlyDictionary&lt;,&gt;</c>.</returns>
     public static bool TryGetClrDictionaryTypes(Type clrType, out Type keyType, out Type valueType)
     {
+        // First pass: prefer the writable IDictionary<,> (write scenarios) when
+        // a type implements both contracts.
         foreach (var iface in EnumerateSelfAndInterfaces(clrType))
         {
             if (iface.IsGenericType && iface.GetGenericTypeDefinition().FullName == "System.Collections.Generic.IDictionary`2")
+            {
+                var args = iface.GetGenericArguments();
+                keyType = args[0];
+                valueType = args[1];
+                return true;
+            }
+        }
+
+        // Second pass: only when no writable IDictionary<,> was found, accept the
+        // read-only IReadOnlyDictionary<,> mapping family.
+        foreach (var iface in EnumerateSelfAndInterfaces(clrType))
+        {
+            if (iface.IsGenericType && iface.GetGenericTypeDefinition().FullName == "System.Collections.Generic.IReadOnlyDictionary`2")
             {
                 var args = iface.GetGenericArguments();
                 keyType = args[0];

--- a/test/Compiler.Tests/Emit/Issue1483ReadOnlyDictionaryForRangeEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1483ReadOnlyDictionaryForRangeEmitTests.cs
@@ -1,0 +1,159 @@
+// <copyright file="Issue1483ReadOnlyDictionaryForRangeEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1483: end-to-end emit + IL-verify coverage for <c>for k, v in d</c>
+/// over a receiver typed only as <c>IReadOnlyDictionary[K, V]</c>. Pre-fix the
+/// binder failed to recognize the read-only mapping family and mis-lowered the
+/// loop as <c>ForRangeKind.Enumerable</c> — binding <c>k</c> to an
+/// <c>int32</c> running index and <c>v</c> to <c>KeyValuePair[K, V]</c>. These
+/// tests prove the loop now key/value destructures: <c>k</c> is the string KEY
+/// and <c>v</c> is the int32 VALUE, and the produced assembly IL-verifies.
+/// </summary>
+public class Issue1483ReadOnlyDictionaryForRangeEmitTests
+{
+    [Fact]
+    public void ReadOnlyDictionary_Receiver_ForKV_Destructures_Key_And_Value()
+    {
+        // A single-entry dictionary keeps iteration deterministic. `firstKey`
+        // returns `k` as a string (impossible under the enumerable
+        // mis-binding, where `k` is an int32 index), and `sumValues` adds `v`
+        // as an int32 (impossible if `v` were a KeyValuePair). The receivers
+        // are typed as IReadOnlyDictionary[string, int32]; a Dictionary is
+        // passed in via the read-only interface upcast.
+        var source = """
+            package P1483
+            import System
+            import System.Collections.Generic
+
+            func Issue1483FirstKey(d IReadOnlyDictionary[string, int32]) string {
+                for k, v in d {
+                    return k
+                }
+                return "none"
+            }
+
+            func Issue1483SumValues(d IReadOnlyDictionary[string, int32]) int32 {
+                var total = 0
+                for k, v in d {
+                    total = total + v
+                }
+                return total
+            }
+
+            var d = Dictionary[string, int32]()
+            d["solo"] = 7
+            Console.WriteLine(Issue1483FirstKey(d))
+            Console.WriteLine(Issue1483SumValues(d))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("solo\n7\n", output);
+    }
+
+    [Fact]
+    public void ReadOnlyDictionary_Receiver_ForKV_SumsValues_OrderIndependent()
+    {
+        // Multiple entries: summing values and key lengths is order-independent,
+        // so the result is deterministic regardless of dictionary enumeration
+        // order. Proves both K (string, via len) and V (int32) destructure.
+        var source = """
+            package P1483b
+            import System
+            import System.Collections.Generic
+            import Gsharp.Extensions.Go
+
+            func Issue1483Fold(d IReadOnlyDictionary[string, int32]) int32 {
+                var acc = 0
+                for k, v in d {
+                    acc = acc + v + len(k)
+                }
+                return acc
+            }
+
+            var d = Dictionary[string, int32]()
+            d["a"] = 10
+            d["bb"] = 20
+            Console.WriteLine(Issue1483Fold(d))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("33\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1483_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit == 0, $"compile failed ({compileExit}): {compileOut}{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var runtimeConfigPath = Path.ChangeExtension(outPath, "runtimeconfig.json");
+            File.WriteAllText(runtimeConfigPath, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet", "exec \"" + outPath + "\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            using var proc = Process.Start(psi)!;
+            string stdout = proc.StandardOutput.ReadToEnd();
+            string stderr = proc.StandardError.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+            {
+                throw new Xunit.Sdk.XunitException("exited " + proc.ExitCode + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+            }
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1483ReadOnlyDictionaryForRangeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1483ReadOnlyDictionaryForRangeTests.cs
@@ -1,0 +1,341 @@
+// <copyright file="Issue1483ReadOnlyDictionaryForRangeTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1483: <c>for k, v in &lt;collection&gt;</c> recovered the key/value
+/// types for dictionary destructuring via
+/// <see cref="MemberLookup.TryGetClrDictionaryTypes"/>, which previously
+/// matched ONLY <c>IDictionary&lt;TKey, TValue&gt;</c> by exact name. A type
+/// implementing only <c>IReadOnlyDictionary&lt;TKey, TValue&gt;</c> (not
+/// <c>IDictionary</c>) fell through to the generic-<c>IEnumerable</c> path and
+/// mis-lowered as <see cref="ForRangeKind.Enumerable"/> — binding
+/// <c>k</c> to the <c>int32</c> running index and <c>v</c> to
+/// <c>KeyValuePair&lt;,&gt;</c> instead of key/value destructuring.
+///
+/// The fix generalizes the probe to recognize the read-only mapping family:
+/// any interface whose generic type definition is <c>IDictionary&lt;,&gt;</c>
+/// or <c>IReadOnlyDictionary&lt;,&gt;</c>, preferring the writable
+/// <c>IDictionary&lt;,&gt;</c> when both are present (two-pass probe). These
+/// tests cover the reflection-level probe directly plus the binder-level
+/// destructuring it drives.
+/// </summary>
+public class Issue1483ReadOnlyDictionaryForRangeTests
+{
+    // ---------------------------------------------------------------
+    // Reflection-level probe: TryGetClrDictionaryTypes recognizes the
+    // read-only mapping family and prefers IDictionary<,>.
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void Probe_ReadOnlyDictionaryInterface_YieldsKeyAndValue()
+    {
+        var ok = MemberLookup.TryGetClrDictionaryTypes(
+            typeof(IReadOnlyDictionary<string, int>),
+            out var keyType,
+            out var valueType);
+
+        Assert.True(ok);
+        Assert.Equal(typeof(string), keyType);
+        Assert.Equal(typeof(int), valueType);
+    }
+
+    [Fact]
+    public void Probe_UserTypeImplementingOnlyReadOnlyDictionary_IsRecognized()
+    {
+        // Generalization guard: a custom CLR type that implements ONLY
+        // IReadOnlyDictionary<,> (no IDictionary) must be recognized — not
+        // just the exact BCL IReadOnlyDictionary reference type.
+        var ok = MemberLookup.TryGetClrDictionaryTypes(
+            typeof(Issue1483ReadOnlyMapFixture),
+            out var keyType,
+            out var valueType);
+
+        Assert.True(ok);
+        Assert.Equal(typeof(string), keyType);
+        Assert.Equal(typeof(int), valueType);
+    }
+
+    [Fact]
+    public void Probe_DictionaryImplementingBoth_StillUsesIDictionaryArgs()
+    {
+        // Regression: Dictionary<K, V> implements both IDictionary<K, V> and
+        // IReadOnlyDictionary<K, V> (same args). Behavior must be unchanged.
+        var ok = MemberLookup.TryGetClrDictionaryTypes(
+            typeof(Dictionary<string, int>),
+            out var keyType,
+            out var valueType);
+
+        Assert.True(ok);
+        Assert.Equal(typeof(string), keyType);
+        Assert.Equal(typeof(int), valueType);
+    }
+
+    [Fact]
+    public void Probe_IDictionaryInterface_StillRecognized()
+    {
+        var ok = MemberLookup.TryGetClrDictionaryTypes(
+            typeof(IDictionary<string, int>),
+            out var keyType,
+            out var valueType);
+
+        Assert.True(ok);
+        Assert.Equal(typeof(string), keyType);
+        Assert.Equal(typeof(int), valueType);
+    }
+
+    [Fact]
+    public void Probe_TypeImplementingBoth_PrefersWritableIDictionary()
+    {
+        // CRITICAL preference rule: when a type implements BOTH contracts the
+        // writable IDictionary<,> wins. The pathological fixture below carries
+        // DIFFERENT type arguments on each interface so the two-pass probe's
+        // preference is observable: it must return the IDictionary<int, int>
+        // arguments, never the IReadOnlyDictionary<string, string> ones.
+        var ok = MemberLookup.TryGetClrDictionaryTypes(
+            typeof(Issue1483DualMapFixture),
+            out var keyType,
+            out var valueType);
+
+        Assert.True(ok);
+        Assert.Equal(typeof(int), keyType);
+        Assert.Equal(typeof(int), valueType);
+    }
+
+    [Fact]
+    public void Probe_PlainEnumerable_IsNotADictionary()
+    {
+        var ok = MemberLookup.TryGetClrDictionaryTypes(
+            typeof(List<int>),
+            out var keyType,
+            out var valueType);
+
+        Assert.False(ok);
+        Assert.Null(keyType);
+        Assert.Null(valueType);
+    }
+
+    // ---------------------------------------------------------------
+    // Binder-level: `for k, v in d` destructures the read-only mapping
+    // family into K/V. The body below only type-checks when k:K and v:V
+    // (the Enumerable mis-binding would surface k:int32 and
+    // v:KeyValuePair[K, V], failing both annotated declarations).
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void ForRange_OverReadOnlyDictionaryInterface_Destructures_K_And_V()
+    {
+        // The issue repro: a receiver typed only as IReadOnlyDictionary[K, V].
+        const string source = @"
+package p
+import System.Collections.Generic
+class C {
+    func dump(d IReadOnlyDictionary[string, int32]) int32 {
+        for k, v in d {
+            var ks string = k
+            var vi int32 = v
+        }
+        return 0
+    }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void ForRange_OverUserReadOnlyDictionaryClrType_Destructures_K_And_V()
+    {
+        // A custom user CLR type implementing ONLY IReadOnlyDictionary<,> is
+        // recognized exactly like the BCL interface.
+        const string source = @"
+package p
+import GSharp.Core.Tests.CodeAnalysis.Binding
+class C {
+    func dump(d Issue1483ReadOnlyMapFixture) int32 {
+        for k, v in d {
+            var ks string = k
+            var vi int32 = v
+        }
+        return 0
+    }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void ForRange_OverDictionary_StillDestructures_K_And_V()
+    {
+        // Regression: Dictionary[K, V] (implements both) keeps destructuring
+        // into K/V via the preferred IDictionary path.
+        const string source = @"
+package p
+import System.Collections.Generic
+class C {
+    func dump(d Dictionary[string, int32]) int32 {
+        for k, v in d {
+            var ks string = k
+            var vi int32 = v
+        }
+        return 0
+    }
+}
+";
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    private static ImmutableArrayOfDiagnostic GetDiagnostics(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var parseDiagnostics = tree.Diagnostics;
+        var bindDiagnostics = compilation.GlobalScope.Diagnostics;
+        var programDiagnostics = compilation.BoundProgram.Diagnostics;
+        var all = parseDiagnostics
+            .Concat(bindDiagnostics)
+            .Concat(programDiagnostics)
+            .Where(d => d.IsError)
+            .ToImmutableArray();
+        return new ImmutableArrayOfDiagnostic(all);
+    }
+
+    /// <summary>
+    /// Thin wrapper so the test cases can call <c>Assert.Empty</c> against a
+    /// <see cref="ImmutableArray{T}"/> without exposing the GSharp diagnostic
+    /// surface to xUnit's enumerable inference.
+    /// </summary>
+    private readonly struct ImmutableArrayOfDiagnostic : IReadOnlyCollection<Diagnostic>
+    {
+        private readonly ImmutableArray<Diagnostic> diagnostics;
+
+        public ImmutableArrayOfDiagnostic(ImmutableArray<Diagnostic> diagnostics)
+        {
+            this.diagnostics = diagnostics;
+        }
+
+        public int Count => this.diagnostics.Length;
+
+        public IEnumerator<Diagnostic> GetEnumerator()
+        {
+            foreach (var diagnostic in this.diagnostics)
+            {
+                yield return diagnostic;
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}
+
+/// <summary>
+/// A functional CLR fixture implementing ONLY
+/// <see cref="IReadOnlyDictionary{TKey, TValue}"/> (string -&gt; int) and not
+/// <see cref="IDictionary{TKey, TValue}"/>. Models read-only mappings such as
+/// immutable dictionaries surfaced through the read-only contract.
+/// </summary>
+public sealed class Issue1483ReadOnlyMapFixture : IReadOnlyDictionary<string, int>
+{
+    private readonly Dictionary<string, int> inner = new()
+    {
+        ["a"] = 1,
+        ["bb"] = 2,
+    };
+
+    /// <inheritdoc/>
+    public IEnumerable<string> Keys => this.inner.Keys;
+
+    /// <inheritdoc/>
+    public IEnumerable<int> Values => this.inner.Values;
+
+    /// <inheritdoc/>
+    public int Count => this.inner.Count;
+
+    /// <inheritdoc/>
+    public int this[string key] => this.inner[key];
+
+    /// <inheritdoc/>
+    public bool ContainsKey(string key) => this.inner.ContainsKey(key);
+
+    /// <inheritdoc/>
+    public bool TryGetValue(string key, out int value) => this.inner.TryGetValue(key, out value);
+
+    /// <inheritdoc/>
+    public IEnumerator<KeyValuePair<string, int>> GetEnumerator() => this.inner.GetEnumerator();
+
+    /// <inheritdoc/>
+    IEnumerator IEnumerable.GetEnumerator() => this.inner.GetEnumerator();
+}
+
+/// <summary>
+/// A pathological CLR fixture implementing BOTH
+/// <see cref="IDictionary{TKey, TValue}"/> (int -&gt; int) and
+/// <see cref="IReadOnlyDictionary{TKey, TValue}"/> (string -&gt; string) with
+/// DIFFERENT type arguments. Used purely to assert the two-pass probe prefers
+/// the writable <c>IDictionary&lt;,&gt;</c>; its members are never invoked.
+/// </summary>
+public sealed class Issue1483DualMapFixture : IDictionary<int, int>, IReadOnlyDictionary<string, string>
+{
+    string IReadOnlyDictionary<string, string>.this[string key] => throw new NotImplementedException();
+
+    int IDictionary<int, int>.this[int key]
+    {
+        get => throw new NotImplementedException();
+        set => throw new NotImplementedException();
+    }
+
+    ICollection<int> IDictionary<int, int>.Keys => throw new NotImplementedException();
+
+    ICollection<int> IDictionary<int, int>.Values => throw new NotImplementedException();
+
+    IEnumerable<string> IReadOnlyDictionary<string, string>.Keys => throw new NotImplementedException();
+
+    IEnumerable<string> IReadOnlyDictionary<string, string>.Values => throw new NotImplementedException();
+
+    int ICollection<KeyValuePair<int, int>>.Count => throw new NotImplementedException();
+
+    int IReadOnlyCollection<KeyValuePair<string, string>>.Count => throw new NotImplementedException();
+
+    bool ICollection<KeyValuePair<int, int>>.IsReadOnly => throw new NotImplementedException();
+
+    void IDictionary<int, int>.Add(int key, int value) => throw new NotImplementedException();
+
+    void ICollection<KeyValuePair<int, int>>.Add(KeyValuePair<int, int> item) => throw new NotImplementedException();
+
+    void ICollection<KeyValuePair<int, int>>.Clear() => throw new NotImplementedException();
+
+    bool ICollection<KeyValuePair<int, int>>.Contains(KeyValuePair<int, int> item) => throw new NotImplementedException();
+
+    bool IDictionary<int, int>.ContainsKey(int key) => throw new NotImplementedException();
+
+    bool IReadOnlyDictionary<string, string>.ContainsKey(string key) => throw new NotImplementedException();
+
+    void ICollection<KeyValuePair<int, int>>.CopyTo(KeyValuePair<int, int>[] array, int arrayIndex) => throw new NotImplementedException();
+
+    bool IDictionary<int, int>.Remove(int key) => throw new NotImplementedException();
+
+    bool ICollection<KeyValuePair<int, int>>.Remove(KeyValuePair<int, int> item) => throw new NotImplementedException();
+
+    bool IDictionary<int, int>.TryGetValue(int key, out int value) => throw new NotImplementedException();
+
+    bool IReadOnlyDictionary<string, string>.TryGetValue(string key, out string value) => throw new NotImplementedException();
+
+    IEnumerator<KeyValuePair<int, int>> IEnumerable<KeyValuePair<int, int>>.GetEnumerator() => throw new NotImplementedException();
+
+    IEnumerator<KeyValuePair<string, string>> IEnumerable<KeyValuePair<string, string>>.GetEnumerator() => throw new NotImplementedException();
+
+    IEnumerator IEnumerable.GetEnumerator() => throw new NotImplementedException();
+}


### PR DESCRIPTION
## Summary

`for k, v in <collection>` recovered the key/value types for dictionary destructuring via `MemberLookup.TryGetClrDictionaryTypes`, which recognized **only** `IDictionary<TKey,TValue>` by exact name. A type that implements only `IReadOnlyDictionary<TKey,TValue>` (not `IDictionary`) was not recognized as a dictionary and fell through to the generic-`IEnumerable` path — mis-lowering as `ForRangeKind.Enumerable` and binding `k` to the `int32` running index and `v` to `KeyValuePair<,>` instead of key/value destructuring.

## Fix

Generalize the probe to recognize the broader **read-only mapping family**: accept any interface whose generic type definition is `IDictionary``2` **or** `IReadOnlyDictionary``2`, returning its `TKey`/`TValue` — mirroring how the enumerable probe already accepts the whole `IEnumerable<T>` family rather than one concrete type.

When a type implements **both** contracts (e.g. `Dictionary<K,V>`), the writable `IDictionary<,>` is preferred (write scenarios). This is enforced with a **two-pass probe**:
1. First pass scans `EnumerateSelfAndInterfaces` for `IDictionary``2` and returns on match.
2. Only when none is found does the second pass scan for `IReadOnlyDictionary``2`.

This guarantees enumeration order can never pick `IReadOnlyDictionary` over an available `IDictionary` (they may even carry different type arguments in pathological types). The change is generalized — any BCL or user type implementing only the read-only contract is recognized, not just the exact BCL `IReadOnlyDictionary` reference type.

## Tests added

- **Reflection-level probe** (`Issue1483ReadOnlyDictionaryForRangeTests`): read-only interface yields K/V; a user CLR type implementing only `IReadOnlyDictionary<,>` is recognized; `Dictionary<K,V>` and `IDictionary<,>` still recognized (regression); a pathological fixture implementing both interfaces with **different** type args proves the `IDictionary`-preference two-pass; a plain enumerable is not a dictionary.
- **Binder-level destructuring**: `for k, v in d` over `IReadOnlyDictionary[K,V]` (the repro), over a custom read-only CLR type, and over `Dictionary[K,V]` (regression) all destructure to `k:K, v:V`.
- **End-to-end emit** (`Issue1483ReadOnlyDictionaryForRangeEmitTests`): proves the lowered loop iterates the string key and int32 value correctly and the assembly IL-verifies.

## Validation

- `dotnet build GSharp.sln -c Release -graph` — 0 warnings / 0 errors
- Full `Core.Tests` — 4833 passed, 1 skipped (intentional baseline)
- New emit slice + related dictionary/for-range emit slices (capped parallelism) — all pass

Fixes #1483