### PR TITLE
Fix if-expression bare default arm emitting ldnull over open generics (#1496)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
@@ -1161,6 +1161,28 @@ internal sealed partial class ExpressionBinder
 
     private BoundExpression ConvertConditionalBranch(TextLocation location, BoundExpression branch, TypeSymbol target)
     {
+        // Issue #1496: a bare `default` arm is bound to a placeholder
+        // `BoundDefaultExpression(syntax, TypeSymbol.Error)` (see
+        // BindDefaultExpression) that must acquire the concrete conditional
+        // result type before emit. The `?:` path pre-types this from the
+        // sibling arm, but the if-expression path (BindIfExpression) does not,
+        // so the placeholder would otherwise reach the early-out below and
+        // surface to the emitter as an `Error`-typed node — which emits a
+        // bogus `ldnull` instead of a zero-initialized value of the merge
+        // target (`initobj` for value types / type parameters / nullable open
+        // generics). Materialise it against the computed merge target here so
+        // BOTH `if` and `?:` (and any future caller) are covered. This runs
+        // before the `branch.Type == TypeSymbol.Error` early-out, which is kept
+        // for genuine error cascades where `target` is itself Error/Void.
+        if (branch is BoundDefaultExpression bareDefault
+            && bareDefault.Type == TypeSymbol.Error
+            && target != null
+            && target != TypeSymbol.Error
+            && target != TypeSymbol.Void)
+        {
+            return new BoundDefaultExpression(bareDefault.Syntax, target);
+        }
+
         if (target == TypeSymbol.Error || branch.Type == TypeSymbol.Error)
         {
             return branch;

--- a/test/Compiler.Tests/Emit/Issue1496IfExpressionDefaultEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1496IfExpressionDefaultEmitTests.cs
@@ -1,0 +1,288 @@
+// <copyright file="Issue1496IfExpressionDefaultEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1496 — an if-expression (<c>if cond { ... } else { ... }</c>) with a
+/// bare <c>default</c> arm whose merge type is an open type parameter, a
+/// nullable open generic, an erased user generic, or a value type emitted
+/// <c>ldnull</c> for the <c>default</c> arm instead of a zero-initialized value,
+/// producing unverifiable IL (<c>found Nullobjref expected value 'T'</c>). The
+/// ternary <c>cond ? value : default</c> path already pre-typed the bare default
+/// from its sibling; the if-expression path did not, so the placeholder
+/// <c>BoundDefaultExpression(syntax, TypeSymbol.Error)</c> survived to emit.
+/// The fix materialises the bare default against the conditional merge target at
+/// the shared <c>ConvertConditionalBranch</c> choke point, covering both <c>if</c>
+/// and <c>?:</c>.
+///
+/// One facet per distinct result-type IL shape: interface-constrained <c>T?</c>,
+/// <c>[T struct] T?</c>, <c>[T class] T?</c>, unconstrained <c>T</c>, an erased
+/// user generic <c>G[T]</c>, a concrete struct (<c>initobj</c>), a reference type
+/// (still <c>ldnull</c>, no regression), and both-<c>default</c> arms with a
+/// target type. Each uses a UNIQUE package/type name to avoid the in-process,
+/// name-keyed <c>FunctionTypeSymbol</c> cache contaminating sibling tests.
+/// </summary>
+public class Issue1496IfExpressionDefaultEmitTests
+{
+    [Fact]
+    public void EndToEnd_InterfaceConstrainedNullable_DefaultArmIsNull_Runs()
+    {
+        var source = """
+            package P1496Iface
+            import System
+            interface ITag1496[T] { func Tag() string; }
+            class TagBox1496 : ITag1496[TagBox1496] { func Tag() string -> "tb" }
+            class HolderIf1496[T ITag1496[T]] {
+                func GetOrDefault(present bool, value T) T? -> if !present { default } else { value }
+            }
+            func Main() {
+                var h = HolderIf1496[TagBox1496]()
+                Console.WriteLine(h.GetOrDefault(false, TagBox1496()) == nil)
+                Console.WriteLine(h.GetOrDefault(true, TagBox1496()) == nil)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\nFalse\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_StructConstrainedNullable_DefaultArmIsNull_Runs()
+    {
+        var source = """
+            package P1496Struct
+            import System
+            struct MyVal1496 { var n int32 }
+            class HolderSt1496[T struct] {
+                func GetOrDefault(present bool, value T) T? -> if !present { default } else { value }
+            }
+            func Main() {
+                var h = HolderSt1496[MyVal1496]()
+                Console.WriteLine(h.GetOrDefault(false, MyVal1496{n: 9}) == nil)
+                Console.WriteLine(h.GetOrDefault(true, MyVal1496{n: 9}) == nil)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\nFalse\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_ClassConstrainedNullable_DefaultArmIsNull_Runs()
+    {
+        var source = """
+            package P1496Class
+            import System
+            class Ref1496 { var n int32 }
+            class HolderCl1496[T class] {
+                func GetOrDefault(present bool, value T) T? -> if !present { default } else { value }
+            }
+            func Main() {
+                var h = HolderCl1496[Ref1496]()
+                Console.WriteLine(h.GetOrDefault(false, Ref1496()) == nil)
+                Console.WriteLine(h.GetOrDefault(true, Ref1496()) == nil)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\nFalse\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_UnconstrainedTypeParameter_DefaultArmIsZero_Runs()
+    {
+        var source = """
+            package P1496UnconstrainedT
+            import System
+            class HolderU1496[T] {
+                func Pick(c bool, v T) T -> if c { default } else { v }
+            }
+            func Main() {
+                var hi = HolderU1496[int32]()
+                Console.WriteLine(hi.Pick(true, 7))
+                Console.WriteLine(hi.Pick(false, 7))
+                var hs = HolderU1496[string]()
+                Console.WriteLine(hs.Pick(true, "x") == nil)
+                Console.WriteLine(hs.Pick(false, "x"))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("0\n7\nTrue\nx\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_ErasedUserGenericNullable_DefaultArmIsNull_Runs()
+    {
+        var source = """
+            package P1496Box
+            import System
+            class Box1496[T] { var v T }
+            class Maker1496[T] {
+                func GetOrDefault(present bool, b Box1496[T]) Box1496[T]? -> if !present { default } else { b }
+            }
+            func Main() {
+                var m = Maker1496[int32]()
+                Console.WriteLine(m.GetOrDefault(false, Box1496[int32]()) == nil)
+                Console.WriteLine(m.GetOrDefault(true, Box1496[int32]()) == nil)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\nFalse\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_ConcreteStruct_DefaultArmInitObjZeroValue_Runs()
+    {
+        var source = """
+            package P1496ConcreteStruct
+            import System
+            struct Point1496 {
+                var x int32
+                var y int32
+            }
+            class Sc1496 {
+                func Get(c bool) Point1496 -> if c { default } else { Point1496{x: 3, y: 4} }
+            }
+            func Main() {
+                var s = Sc1496()
+                Console.WriteLine(s.Get(true).x)
+                Console.WriteLine(s.Get(false).x)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("0\n3\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_ReferenceType_DefaultArmStillNullAndVerifies_Runs()
+    {
+        var source = """
+            package P1496RefDefault
+            import System
+            class Sr1496 {
+                func Get(c bool, s string) string -> if c { default } else { s }
+            }
+            func Main() {
+                var s = Sr1496()
+                Console.WriteLine(s.Get(true, "hi") == nil)
+                Console.WriteLine(s.Get(false, "hi"))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\nhi\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_BothArmsBareDefaultWithTargetType_DefaultIsNull_Runs()
+    {
+        var source = """
+            package P1496BothDefault
+            import System
+            class HolderBd1496[T struct] {
+                func Pick(c bool) T? -> if c { default } else { default }
+            }
+            func Main() {
+                var h = HolderBd1496[int32]()
+                Console.WriteLine(h.Pick(true) == nil)
+                Console.WriteLine(h.Pick(false) == nil)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\nTrue\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1496_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
## Problem

An **if-expression** `if cond { ... } else { ... }` with a bare `default` arm whose merge type is an open type parameter, a nullable open generic, an erased user generic `G[T]`, or a value type emitted **`ldnull`** for the `default` arm instead of a zero-initialized value. The arm's `Nullobjref` stack type then conflicts with the sibling arm / merge point, producing unverifiable IL:

```
[StackUnexpected] ... [found Nullobjref 'NullReference'][expected value 'T']
```

The equivalent ternary `cond ? value : default` already verified — the bug was specific to the if-expression binder.

## Root cause

- `BindDefaultExpression` binds a *bare* `default` to a placeholder `BoundDefaultExpression(syntax, TypeSymbol.Error)`, relying on a downstream conversion to materialise the concrete type.
- The `?:` path (`BindConditionalExpression`) special-cases a bare-`default` arm: it binds the sibling first and rebuilds the default with the sibling's type before unification — that is why `?:` worked.
- `BindIfExpression` has no such step, so the bare-`default` block arm stays as the `TypeSymbol.Error` placeholder.
- `ConvertConditionalBranch` early-outs on `branch.Type == TypeSymbol.Error` and returns the placeholder **unchanged**, so it is never materialised to the computed result type.
- At emit, `EmitDefault` sees the `Error`-typed node and emits `ldnull`.

## Fix (generalized)

Materialise the bare-`default` placeholder at the single shared choke point `ConvertConditionalBranch`, **before** the `Error` early-out: when `branch` is a bare `BoundDefaultExpression` typed `TypeSymbol.Error` and `target` is a valid non-Error, non-Void type, return `new BoundDefaultExpression(branch.Syntax, target)`. This covers **both** `if` and `?:` (and any future caller). The existing early-out is preserved for genuine error cascades where `target` is also Error. `EmitDefault` is unchanged — once the node carries the concrete merge type, the existing `initobj`/null logic is correct.

`ComputeConditionalResultType` already resolves the merge type for the if path (including both-`default` arms) via target-typing, so no change was needed there.

## Before / after ilverify (repro from the issue)

Before:
```
[IL]: Error [StackUnexpected]: [demo.Holder`1::GetOrDefault(bool, !0)][offset 0x10][found Nullobjref 'NullReference'][expected value 'T']
[IL]: Error [PathStackUnexpected]: [demo.Holder`1::GetOrDefault(bool, !0)][offset 0x0F][found Nullobjref 'NullReference'][expected value 'T']
```
After:
```
All Classes and Methods in /tmp/gd_1496.dll Verified.
```

## Tests

New `test/Compiler.Tests/Emit/Issue1496IfExpressionDefaultEmitTests.cs` (8 facets, each unique package/type name, ilverify + runtime assertion):

- `EndToEnd_InterfaceConstrainedNullable_DefaultArmIsNull_Runs`
- `EndToEnd_StructConstrainedNullable_DefaultArmIsNull_Runs`
- `EndToEnd_ClassConstrainedNullable_DefaultArmIsNull_Runs`
- `EndToEnd_UnconstrainedTypeParameter_DefaultArmIsZero_Runs`
- `EndToEnd_ErasedUserGenericNullable_DefaultArmIsNull_Runs`
- `EndToEnd_ConcreteStruct_DefaultArmInitObjZeroValue_Runs`
- `EndToEnd_ReferenceType_DefaultArmStillNullAndVerifies_Runs`
- `EndToEnd_BothArmsBareDefaultWithTargetType_DefaultIsNull_Runs`

All 8 pass. Core.Tests: 4824 passed / 1 skipped, no failures; refactoring baseline did not need regeneration (binder-only fix for a previously-broken construct).

## Controls (no regression)

`?:`, direct `default` return, explicit `default(T)`, reference-type defaults (still `ldnull`, verifies), and targetless-deferral diagnostics are unaffected.

Fixes #1496

Refs #914
