### PR TITLE
Generalize async try/finally exit handling: Pattern C pending-branch dispatch (return/goto/break/continue through an awaited finally)

### DIFF
--- a/src/Core/CodeAnalysis/Lowering/Async/AsyncExceptionHandlerRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AsyncExceptionHandlerRewriter.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using GSharp.Core.CodeAnalysis.Binding;
 using GSharp.Core.CodeAnalysis.Symbols;
@@ -50,15 +51,42 @@ namespace GSharp.Core.CodeAnalysis.Lowering.Async;
 /// }
 /// </code>
 ///
-/// <para><b>Deferred:</b> Pending-branch dispatch for <c>return</c>/<c>goto</c>/
-/// <c>break</c> out of a try-with-async-finally (spec §8, Pattern C). A clean
-/// pass-through is emitted for now; early returns from a try whose finally has
-/// await are not yet supported and will produce correct but potentially
-/// surprising behavior (the return value is computed but the finally runs
-/// before the method actually returns, which is the normal CLR semantic — the
-/// issue arises only if the return target must be funneled through the rewritten
-/// code, which for our state-machine path is handled by MoveNextBodyRewriter's
-/// exit label).</para>
+/// <para><b>Pattern C — non-fall-through exits out of a try whose finally
+/// awaits (issue #1484):</b> Every way control leaves a <c>try</c> whose
+/// <c>finally</c> awaits must run the finally <i>after</i> the awaited work
+/// completes and only then resume that exit. The exception exit is already
+/// generalized by Pattern B; Pattern C generalizes the remaining
+/// non-fall-through exits — <c>return</c> and the intra-method branches
+/// (<c>goto</c>/<c>break</c>/<c>continue</c>, all of which reach this pass as
+/// <see cref="BoundGotoStatement"/>/<see cref="BoundConditionalGotoStatement"/>
+/// after the general <see cref="Lowerer"/> desugars loops) — that target a
+/// label outside the protected region (or, for <c>return</c>, leave the
+/// method). Mirroring the pending-exception machinery, each such exit is
+/// replaced by an assignment to a small <c>pendingBranch</c> discriminator
+/// (plus a <c>pendingReturnValue</c> local for value returns, captured at the
+/// point of the original return so evaluation order is preserved) followed by a
+/// <c>goto</c> to the lifted-finally tail. After the finally body and the
+/// pending-exception rethrow, a dispatch on the discriminator resumes the
+/// captured exit:</para>
+/// <code>
+/// int pendingBranch = 0;          // 0 == fall-through
+/// T pendingReturnValue = default; // only when a value-return is captured
+/// try { body; /* `return v;` => { pendingReturnValue = v; pendingBranch = 1; goto finallyTail; } */ }
+/// catch (Exception ex) { pendingException = ex; }
+/// finallyTail:
+/// finallyBody;                    // await is now outside the finally region
+/// if (pendingException != null) { ...Capture(pendingException).Throw(); }
+/// if (pendingBranch == 1) { return pendingReturnValue; }  // resume captured return
+/// if (pendingBranch == 2) { goto someOuterLabel; }        // resume captured goto/break/continue
+/// // pendingBranch == 0 falls through and continues normally
+/// </code>
+/// <para>The rewrite is compositional: an exit that crosses multiple awaited
+/// finallys is captured one level at a time, because each level's dispatch
+/// re-emits a real <c>return</c>/<c>goto</c> that the next enclosing lifted
+/// try captures in turn. The discriminator and pending-return-value locals are
+/// ordinary user-style locals, so <see cref="AsyncCaptureWalker"/> hoists them
+/// into state-machine fields exactly like the pending-exception local, keeping
+/// them live across the awaited finally.</para>
 /// </remarks>
 public static class AsyncExceptionHandlerRewriter
 {
@@ -90,6 +118,19 @@ public static class AsyncExceptionHandlerRewriter
     private sealed class Rewriter : BoundTreeRewriter
     {
         private int localOrdinal;
+
+        /// <summary>
+        /// Creates a fresh synthesized local with a deterministic, collision-free
+        /// name. Used by the Pattern C exit funneler for its pending-branch
+        /// discriminator and pending-return-value locals.
+        /// </summary>
+        /// <param name="prefix">A short role hint embedded in the generated name.</param>
+        /// <param name="type">The local's type.</param>
+        /// <returns>The new local variable symbol.</returns>
+        internal LocalVariableSymbol NewLocal(string prefix, TypeSymbol type)
+        {
+            return new LocalVariableSymbol($"<>{prefix}_{localOrdinal++}", isReadOnly: false, type);
+        }
 
         protected override BoundStatement RewriteTryStatement(BoundTryStatement node)
         {
@@ -304,6 +345,37 @@ public static class AsyncExceptionHandlerRewriter
             TypeSymbol exceptionType,
             bool anyCatchHasAwait)
         {
+            // Pattern C (issue #1484): funnel every non-fall-through exit that
+            // leaves the try body through the lifted finally. Each `return` or
+            // intra-method branch (`goto`/`break`/`continue`, all surfaced as
+            // BoundGotoStatement/BoundConditionalGotoStatement after lowering)
+            // whose target lies outside the protected region is replaced by an
+            // assignment to a pending-branch discriminator (and, for value
+            // returns, a pending-return-value local captured at the point of the
+            // original return so evaluation order is preserved) plus a `goto` to
+            // the lifted-finally tail. The captured exits are re-emitted after
+            // the finally body and the pending-exception rethrow.
+            var funneler = new ExitFunneler(this, LabelCollector.Collect(tryBody));
+            tryBody = funneler.Funnel(tryBody);
+            if (funneler.HasCapturedExits)
+            {
+                statements.Add(new BoundVariableDeclaration(
+                    null,
+                    funneler.PendingBranchLocal,
+                    new BoundLiteralExpression(null, 0)));
+                if (funneler.PendingReturnValueLocal != null)
+                {
+                    // default(T): correct for any return type — `0`/zeroed bytes
+                    // for value types (a typed null literal would emit an invalid
+                    // `ldnull` for e.g. int32) and null for reference types. The
+                    // value is always overwritten before the dispatch reads it.
+                    statements.Add(new BoundVariableDeclaration(
+                        null,
+                        funneler.PendingReturnValueLocal,
+                        new BoundDefaultExpression(null, funneler.PendingReturnValueLocal.Type)));
+                }
+            }
+
             // Build inner try: original try body + original catches.
             // Typed catches with await KEEP their original type (issue #419)
             // and capture into a per-clause local plus pendingException so the
@@ -417,6 +489,15 @@ public static class AsyncExceptionHandlerRewriter
                 statements.Add(new BoundLabelStatement(null, endLabel));
             }
 
+            // Pattern C: place the lifted-finally tail label that funneled exits
+            // branch to. It sits AFTER the lifted catch handlers and BEFORE the
+            // finally body so a captured `return`/`goto`/`break`/`continue` runs
+            // the finally exactly like the normal-completion and exception paths.
+            if (funneler.HasCapturedExits)
+            {
+                statements.Add(new BoundLabelStatement(null, funneler.FinallyTailLabel));
+            }
+
             // Emit the finally body (now outside any handler region)
             if (finallyBlock is BoundBlockStatement finallyBlockStmt)
             {
@@ -451,6 +532,33 @@ public static class AsyncExceptionHandlerRewriter
             // trace and defeat production diagnostics (issue #418 P1-11).
             statements.Add(BuildEdiCaptureThrow(new BoundVariableExpression(null, pendingExLocal), exceptionType));
             statements.Add(new BoundLabelStatement(null, rethrowEndLabel));
+
+            // Pattern C: dispatch the captured branch AFTER the pending-exception
+            // rethrow. The exception and branch exits are mutually exclusive
+            // (a funneled `goto finallyTail` is a `leave`, not a throw, so it
+            // never sets pendingException), and ordering the rethrow first keeps
+            // the exception semantics identical to Pattern B. A discriminator of
+            // 0 means fall-through and continues normally past the dispatch.
+            if (funneler.HasCapturedExits)
+            {
+                foreach (var arm in funneler.DispatchArms)
+                {
+                    var skipLabel = MakeLabel("branch_skip");
+                    var armCondition = new BoundBinaryExpression(
+                        null,
+                        new BoundVariableExpression(null, funneler.PendingBranchLocal),
+                        BoundBinaryOperator.Bind(
+                            CodeAnalysis.Syntax.SyntaxKind.EqualsEqualsToken,
+                            TypeSymbol.Int32,
+                            TypeSymbol.Int32),
+                        new BoundLiteralExpression(null, arm.Discriminator));
+
+                    // if (pendingBranch != value) goto skip; <exit>; skip:
+                    statements.Add(new BoundConditionalGotoStatement(null, skipLabel, armCondition, jumpIfTrue: false));
+                    statements.Add(arm.Exit);
+                    statements.Add(new BoundLabelStatement(null, skipLabel));
+                }
+            }
         }
 
         /// <summary>
@@ -510,6 +618,208 @@ public static class AsyncExceptionHandlerRewriter
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// One captured Pattern C exit: a discriminator value paired with the
+        /// statement to re-emit (a <c>return</c> of the pending-return-value, or
+        /// a <c>goto</c> to the original target) when the dispatch after the
+        /// lifted finally observes that value.
+        /// </summary>
+        private readonly struct DispatchArm
+        {
+            public DispatchArm(int discriminator, BoundStatement exit)
+            {
+                Discriminator = discriminator;
+                Exit = exit;
+            }
+
+            public int Discriminator { get; }
+
+            public BoundStatement Exit { get; }
+        }
+
+        /// <summary>
+        /// Collects every label DEFINED inside a statement subtree (the targets
+        /// of <see cref="BoundLabelStatement"/>). The Pattern C exit funneler
+        /// uses this set to decide whether a <c>goto</c>/conditional-goto leaves
+        /// the protected region: a branch whose target label is in this set
+        /// stays inside the try and must NOT run the lifted finally, whereas a
+        /// branch to any other label (or a <c>return</c>) exits the try and is
+        /// funneled.
+        /// </summary>
+        private sealed class LabelCollector : BoundTreeWalker
+        {
+            private readonly HashSet<BoundLabel> labels = new HashSet<BoundLabel>();
+
+            public static HashSet<BoundLabel> Collect(BoundStatement body)
+            {
+                var collector = new LabelCollector();
+                collector.VisitStatement(body);
+                return collector.labels;
+            }
+
+            public override void VisitStatement(BoundStatement node)
+            {
+                if (node is BoundLabelStatement labelStatement)
+                {
+                    labels.Add(labelStatement.Label);
+                }
+
+                base.VisitStatement(node);
+            }
+        }
+
+        /// <summary>
+        /// Rewrites the try body of a finally-with-await, replacing every
+        /// non-fall-through exit that leaves the try (a <c>return</c>, or a
+        /// <c>goto</c>/conditional-goto whose target label is outside the try)
+        /// with a pending-branch capture followed by <c>goto finallyTail</c>.
+        /// The captured exits are surfaced via <see cref="DispatchArms"/> so the
+        /// caller can re-emit them after the lifted finally body. Implements
+        /// Pattern C (issue #1484) symmetrically with the pending-exception
+        /// machinery.
+        /// </summary>
+        private sealed class ExitFunneler : BoundTreeRewriter
+        {
+            private const int ReturnDiscriminator = 1;
+
+            private readonly Rewriter owner;
+            private readonly HashSet<BoundLabel> innerLabels;
+            private readonly Dictionary<BoundLabel, int> gotoDiscriminators = new Dictionary<BoundLabel, int>();
+            private readonly List<DispatchArm> dispatchArms = new List<DispatchArm>();
+
+            private BoundLabel finallyTailLabel;
+            private LocalVariableSymbol pendingBranchLocal;
+            private LocalVariableSymbol pendingReturnValueLocal;
+            private bool returnCaptured;
+            private int nextGotoDiscriminator = ReturnDiscriminator + 1;
+
+            public ExitFunneler(Rewriter owner, HashSet<BoundLabel> innerLabels)
+            {
+                this.owner = owner;
+                this.innerLabels = innerLabels;
+            }
+
+            /// <summary>Gets a value indicating whether any exit was captured.</summary>
+            public bool HasCapturedExits => dispatchArms.Count > 0;
+
+            /// <summary>Gets the lifted-finally tail label (only valid once an exit is captured).</summary>
+            public BoundLabel FinallyTailLabel => finallyTailLabel;
+
+            /// <summary>Gets the pending-branch discriminator local (only valid once an exit is captured).</summary>
+            public LocalVariableSymbol PendingBranchLocal => pendingBranchLocal;
+
+            /// <summary>Gets the pending-return-value local, or null when no value-return was captured.</summary>
+            public LocalVariableSymbol PendingReturnValueLocal => pendingReturnValueLocal;
+
+            /// <summary>Gets the captured exits, in first-encounter order.</summary>
+            public IReadOnlyList<DispatchArm> DispatchArms => dispatchArms;
+
+            public BoundStatement Funnel(BoundStatement body) => RewriteStatement(body);
+
+            protected override BoundStatement RewriteReturnStatement(BoundReturnStatement node)
+            {
+                // A `return` always leaves the try (and the method), so it is
+                // always funneled. The return expression is evaluated here, in
+                // the try body, and stashed into the pending-return-value local
+                // BEFORE the finally runs; the actual transfer happens after.
+                EnsureFinallyTail();
+                var stmts = ImmutableArray.CreateBuilder<BoundStatement>();
+
+                if (node.Expression != null)
+                {
+                    if (pendingReturnValueLocal == null)
+                    {
+                        pendingReturnValueLocal = owner.NewLocal("pending_ret", node.Expression.Type);
+                    }
+
+                    stmts.Add(new BoundExpressionStatement(
+                        null,
+                        new BoundAssignmentExpression(null, pendingReturnValueLocal, node.Expression)));
+                }
+
+                if (!returnCaptured)
+                {
+                    returnCaptured = true;
+                    var resume = node.Expression != null
+                        ? new BoundReturnStatement(null, new BoundVariableExpression(null, pendingReturnValueLocal), node.IsRef)
+                        : new BoundReturnStatement(null, null);
+                    dispatchArms.Add(new DispatchArm(ReturnDiscriminator, resume));
+                }
+
+                stmts.Add(AssignBranch(ReturnDiscriminator));
+                stmts.Add(new BoundGotoStatement(null, finallyTailLabel));
+                return new BoundBlockStatement(null, stmts.ToImmutable());
+            }
+
+            protected override BoundStatement RewriteGotoStatement(BoundGotoStatement node)
+            {
+                if (innerLabels.Contains(node.Label))
+                {
+                    // Target is inside the try — stays in the protected region.
+                    return node;
+                }
+
+                EnsureFinallyTail();
+                var discriminator = GetGotoDiscriminator(node.Label);
+                return new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(
+                    AssignBranch(discriminator),
+                    new BoundGotoStatement(null, finallyTailLabel)));
+            }
+
+            protected override BoundStatement RewriteConditionalGotoStatement(BoundConditionalGotoStatement node)
+            {
+                if (innerLabels.Contains(node.Label))
+                {
+                    return node;
+                }
+
+                EnsureFinallyTail();
+                var discriminator = GetGotoDiscriminator(node.Label);
+
+                // if (cond == JumpIfTrue) { pendingBranch = d; goto finallyTail; }
+                // Re-emit the condition once, jumping past the capture when the
+                // branch is NOT taken (the original JumpIfTrue is negated for the
+                // skip test).
+                var skipLabel = MakeLabel("exit_skip");
+                return new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(
+                    new BoundConditionalGotoStatement(null, skipLabel, node.Condition, jumpIfTrue: !node.JumpIfTrue),
+                    AssignBranch(discriminator),
+                    new BoundGotoStatement(null, finallyTailLabel),
+                    new BoundLabelStatement(null, skipLabel)));
+            }
+
+            private int GetGotoDiscriminator(BoundLabel target)
+            {
+                if (!gotoDiscriminators.TryGetValue(target, out var discriminator))
+                {
+                    discriminator = nextGotoDiscriminator++;
+                    gotoDiscriminators[target] = discriminator;
+                    dispatchArms.Add(new DispatchArm(discriminator, new BoundGotoStatement(null, target)));
+                }
+
+                return discriminator;
+            }
+
+            private BoundStatement AssignBranch(int discriminator)
+            {
+                return new BoundExpressionStatement(
+                    null,
+                    new BoundAssignmentExpression(
+                        null,
+                        pendingBranchLocal,
+                        new BoundLiteralExpression(null, discriminator)));
+            }
+
+            private void EnsureFinallyTail()
+            {
+                if (finallyTailLabel == null)
+                {
+                    finallyTailLabel = MakeLabel("finally_tail");
+                    pendingBranchLocal = owner.NewLocal("pending_branch", TypeSymbol.Int32);
+                }
+            }
         }
     }
 }

--- a/test/Compiler.Tests/Emit/Issue1484AsyncFinallyExitEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1484AsyncFinallyExitEmitTests.cs
@@ -1,0 +1,378 @@
+// <copyright file="Issue1484AsyncFinallyExitEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// End-to-end emit regression tests for issue #1484: generalized async
+/// try/finally exit handling (Pattern C). Every non-fall-through exit that
+/// leaves a <c>try</c> whose <c>finally</c> awaits — <c>return</c>, <c>break</c>,
+/// <c>continue</c> (the latter two surfaced to the async rewriter as
+/// <see cref="GSharp.Core.CodeAnalysis.Binding.BoundGotoStatement"/> after
+/// lowering) — must run the awaited finally first and then perform the exit
+/// with the correct value/target. Before the fix the awaited finally was
+/// skipped on those paths.
+///
+/// <para>Each test gives every package / function / global a UNIQUE name
+/// because the in-process compiler's <c>FunctionTypeSymbol</c> cache is not
+/// cleared between tests. Every emitted assembly is run through ilverify via
+/// <see cref="IlVerifier"/> so the funneled control flow is proven verifiable.</para>
+/// </summary>
+public class Issue1484AsyncFinallyExitEmitTests
+{
+    // (a) Early `return <value>` out of a try-with-async-finally inside a loop
+    //     (the exact issue #1484 repro). The finally must run on the iteration
+    //     that returns, BEFORE the early return transfers control.
+    [Fact]
+    public void EarlyReturn_Through_Awaited_Finally_Runs_Finally_Then_Returns()
+    {
+        var source = """
+            package AsyncPatternCReturnPkg
+
+            import System
+            import System.Threading.Tasks
+
+            public var flushCountRet = 0
+            public var resultRet = 0
+
+            async func flushRet() int32 {
+                await Task.Delay(1)
+                return 1
+            }
+
+            async func pickRet(items []int32) int32 {
+                for i in 0 ... items.Length {
+                    try {
+                        if items[i] > 0 {
+                            return items[i]
+                        }
+                    } finally {
+                        flushCountRet = flushCountRet + await flushRet()
+                    }
+                }
+                return -1
+            }
+
+            resultRet = pickRet([]int32{0, 5, 9}).Result
+            """;
+
+        var (program, _) = CompileAndRun(source, "gs1484_return_");
+
+        // i=0: finally runs (flush=1); i=1: items[1]==5>0 → return 5, but the
+        // finally runs FIRST (flush=2) → result 5, flushCount 2.
+        Assert.Equal(5, ReadInt(program, "resultRet"));
+        Assert.Equal(2, ReadInt(program, "flushCountRet"));
+    }
+
+    // (b) `break` out of a loop from inside a try-with-async-finally.
+    [Fact]
+    public void Break_Through_Awaited_Finally_Runs_Finally_Then_Breaks()
+    {
+        var source = """
+            package AsyncPatternCBreakPkg
+
+            import System
+            import System.Threading.Tasks
+
+            public var flushCountBrk = 0
+            public var resultBrk = 0
+
+            async func flushBrk() int32 {
+                await Task.Delay(1)
+                return 1
+            }
+
+            async func pickBrk(items []int32) int32 {
+                var found = -1
+                for i in 0 ... items.Length {
+                    try {
+                        if items[i] > 0 {
+                            found = items[i]
+                            break
+                        }
+                    } finally {
+                        flushCountBrk = flushCountBrk + await flushBrk()
+                    }
+                }
+                return found
+            }
+
+            resultBrk = pickBrk([]int32{0, 5, 9}).Result
+            """;
+
+        var (program, _) = CompileAndRun(source, "gs1484_break_");
+
+        // i=0 finally (flush=1); i=1 sets found=5 then breaks, finally runs
+        // first (flush=2). Loop stops → found 5.
+        Assert.Equal(5, ReadInt(program, "resultBrk"));
+        Assert.Equal(2, ReadInt(program, "flushCountBrk"));
+    }
+
+    // (c) `continue` from inside a try-with-async-finally.
+    [Fact]
+    public void Continue_Through_Awaited_Finally_Runs_Finally_Then_Continues()
+    {
+        var source = """
+            package AsyncPatternCContinuePkg
+
+            import System
+            import System.Threading.Tasks
+
+            public var flushCountCont = 0
+            public var resultCont = 0
+
+            async func flushCont() int32 {
+                await Task.Delay(1)
+                return 1
+            }
+
+            async func sumCont(items []int32) int32 {
+                var total = 0
+                for i in 0 ... items.Length {
+                    try {
+                        if items[i] == 0 {
+                            continue
+                        }
+                        total = total + items[i]
+                    } finally {
+                        flushCountCont = flushCountCont + await flushCont()
+                    }
+                }
+                return total
+            }
+
+            resultCont = sumCont([]int32{0, 5, 9}).Result
+            """;
+
+        var (program, _) = CompileAndRun(source, "gs1484_continue_");
+
+        // Every iteration runs the finally (flush=3). i=0 continues (the finally
+        // still runs), i=1 adds 5, i=2 adds 9 → total 14.
+        Assert.Equal(14, ReadInt(program, "resultCont"));
+        Assert.Equal(3, ReadInt(program, "flushCountCont"));
+    }
+
+    // (d) An early `return` from a try whose body itself contains an `await`
+    //     before the return — exercises the funneled `leave` out of a protected
+    //     region that holds a resume point (the goto-shaped exit path).
+    [Fact]
+    public void Return_After_Await_In_Try_Body_Through_Awaited_Finally()
+    {
+        var source = """
+            package AsyncPatternCAwaitBodyPkg
+
+            import System
+            import System.Threading.Tasks
+
+            public var flushCountAwb = 0
+            public var resultAwb = 0
+
+            async func flushAwb() int32 {
+                await Task.Delay(1)
+                return 1
+            }
+
+            async func valueAwb(n int32) int32 {
+                await Task.Delay(1)
+                return n
+            }
+
+            async func computeAwb() int32 {
+                try {
+                    let v = await valueAwb(41)
+                    return v + 1
+                } finally {
+                    flushCountAwb = flushCountAwb + await flushAwb()
+                }
+            }
+
+            resultAwb = computeAwb().Result
+            """;
+
+        var (program, _) = CompileAndRun(source, "gs1484_awaitbody_");
+
+        Assert.Equal(42, ReadInt(program, "resultAwb"));
+        Assert.Equal(1, ReadInt(program, "flushCountAwb"));
+    }
+
+    // (e) Regression: an exception thrown through the awaited finally still runs
+    //     the finally and propagates with its original message preserved.
+    [Fact]
+    public void Exception_Through_Awaited_Finally_Still_Runs_Finally_And_Propagates()
+    {
+        var source = """
+            package AsyncPatternCThrowPkg
+
+            import System
+            import System.Threading.Tasks
+
+            public var flushCountThr = 0
+            public var caughtThr = ""
+
+            async func flushThr() int32 {
+                await Task.Delay(1)
+                return 1
+            }
+
+            async func throwThr() int32 {
+                try {
+                    throw Exception("boomThr")
+                } finally {
+                    flushCountThr = flushCountThr + await flushThr()
+                }
+                return -1
+            }
+
+            async func runThr() int32 {
+                try {
+                    let v = await throwThr()
+                } catch (e Exception) {
+                    caughtThr = e.Message
+                }
+                return 0
+            }
+
+            let _ = runThr().Result
+            """;
+
+        var (program, _) = CompileAndRun(source, "gs1484_throw_");
+
+        // The finally still runs (flush=1) and the exception propagates with its
+        // original message intact.
+        Assert.Equal(1, ReadInt(program, "flushCountThr"));
+        Assert.Equal("boomThr", ReadString(program, "caughtThr"));
+    }
+
+    // (f) Nested try/finally with awaited finallys and an early return crossing
+    //     BOTH — each finally must run, in inner-then-outer order.
+    [Fact]
+    public void Return_Crossing_Two_Awaited_Finallys_Runs_Both()
+    {
+        var source = """
+            package AsyncPatternCNestedPkg
+
+            import System
+            import System.Threading.Tasks
+
+            public var innerCountNst = 0
+            public var outerCountNst = 0
+            public var orderNst = 0
+            public var resultNst = 0
+
+            async func flushNst() int32 {
+                await Task.Delay(1)
+                return 1
+            }
+
+            async func nestedNst(x int32) int32 {
+                try {
+                    try {
+                        if x > 0 {
+                            return x
+                        }
+                    } finally {
+                        innerCountNst = innerCountNst + await flushNst()
+                        orderNst = orderNst * 10 + 1
+                    }
+                } finally {
+                    outerCountNst = outerCountNst + await flushNst()
+                    orderNst = orderNst * 10 + 2
+                }
+                return -1
+            }
+
+            resultNst = nestedNst(7).Result
+            """;
+
+        var (program, _) = CompileAndRun(source, "gs1484_nested_");
+
+        Assert.Equal(7, ReadInt(program, "resultNst"));
+        Assert.Equal(1, ReadInt(program, "innerCountNst"));
+        Assert.Equal(1, ReadInt(program, "outerCountNst"));
+
+        // Inner finally runs before the outer finally: 0 -> 1 -> 12.
+        Assert.Equal(12, ReadInt(program, "orderNst"));
+    }
+
+    private static int ReadInt(Type program, string fieldName)
+    {
+        var field = program.GetField(fieldName, BindingFlags.Public | BindingFlags.Static)
+            ?? throw new InvalidOperationException($"Field '{fieldName}' not found.");
+        return (int)field.GetValue(null)!;
+    }
+
+    private static string ReadString(Type program, string fieldName)
+    {
+        var field = program.GetField(fieldName, BindingFlags.Public | BindingFlags.Static)
+            ?? throw new InvalidOperationException($"Field '{fieldName}' not found.");
+        return (string)field.GetValue(null)!;
+    }
+
+    private static (Type Program, Assembly Assembly) CompileAndRun(string source, string tempPrefix)
+    {
+        var assembly = CompileToAssembly(source, tempPrefix);
+        var program = FindProgram(assembly);
+        var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+        entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+        return (program, assembly);
+    }
+
+    private static Type FindProgram(Assembly assembly)
+    {
+        foreach (var t in assembly.GetTypes())
+        {
+            if (t.Name == "<Program>")
+            {
+                return t;
+            }
+        }
+
+        throw new InvalidOperationException("No <Program> type found.");
+    }
+
+    private static Assembly CompileToAssembly(string source, string tempPrefix)
+    {
+        var tempDir = Directory.CreateTempSubdirectory(tempPrefix).FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+        IlVerifier.Verify(outPath);
+
+        var bytes = File.ReadAllBytes(outPath);
+        return Assembly.Load(bytes);
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Lowering/Async/AsyncExceptionHandlerRewriterTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Async/AsyncExceptionHandlerRewriterTests.cs
@@ -85,6 +85,69 @@ ImmutableArray.Create<BoundStatement>(
     }
 
     [Fact]
+    public void TryFinally_WithAwait_FunnelsEarlyReturnThroughLiftedFinally()
+    {
+        // Arrange: try { return 7 } finally { await ... } — Pattern C (#1484).
+        // The early return leaves a try whose finally awaits, so it must be
+        // captured into a pending-branch discriminator and resumed AFTER the
+        // lifted finally, not emitted as a raw pass-through return.
+        var tryBlock = new BoundBlockStatement(
+            null,
+            ImmutableArray.Create<BoundStatement>(
+                new BoundReturnStatement(null, new BoundLiteralExpression(null, 7))));
+        var awaitExpr = new BoundAwaitExpression(null, new BoundLiteralExpression(null, 0), TypeSymbol.Int32);
+        var finallyBlock = new BoundBlockStatement(
+            null,
+            ImmutableArray.Create<BoundStatement>(new BoundExpressionStatement(null, awaitExpr)));
+        var tryStmt = new BoundTryStatement(null, tryBlock, ImmutableArray<BoundCatchClause>.Empty, finallyBlock);
+        var body = new BoundBlockStatement(null, ImmutableArray.Create<BoundStatement>(tryStmt));
+
+        // Act
+        var result = AsyncExceptionHandlerRewriter.Rewrite(body);
+
+        // Assert: the try is rewritten and a pending-branch discriminator plus a
+        // pending-return-value local are declared.
+        Assert.NotSame(body, result);
+        var innerBlock = Assert.IsType<BoundBlockStatement>(result.Statements[0]);
+        var decls = innerBlock.Statements.OfType<BoundVariableDeclaration>().ToList();
+        Assert.Contains(decls, d => d.Variable.Name.Contains("<>pending_branch_"));
+        Assert.Contains(decls, d => d.Variable.Name.Contains("<>pending_ret_"));
+
+        // The rewritten inner try must NOT contain a raw return anymore — the
+        // return was funneled into a pending-branch capture + goto.
+        var innerTry = innerBlock.Statements.OfType<BoundTryStatement>().First();
+        Assert.False(ContainsReturn(innerTry.TryBlock), "Early return must be funneled, not left in the try body.");
+
+        // A raw return IS re-emitted after the lifted finally (the dispatch),
+        // outside any protected region.
+        Assert.True(
+            innerBlock.Statements.Skip(1).Any(ContainsReturn),
+            "A resume `return` should be dispatched after the lifted finally.");
+
+        // The lifted await still appears outside the protected region.
+        Assert.True(
+            innerBlock.Statements.Any(s => AsyncBoundTreeQueries.HasAwait(s) && !(s is BoundTryStatement)),
+            "Await should be lifted outside the try region.");
+    }
+
+    private static bool ContainsReturn(BoundStatement statement)
+    {
+        switch (statement)
+        {
+            case BoundReturnStatement:
+                return true;
+            case BoundBlockStatement block:
+                return block.Statements.Any(ContainsReturn);
+            case BoundTryStatement tryStmt:
+                return ContainsReturn(tryStmt.TryBlock)
+                    || tryStmt.CatchClauses.Any(c => ContainsReturn(c.Body))
+                    || (tryStmt.FinallyBlock != null && ContainsReturn(tryStmt.FinallyBlock));
+            default:
+                return false;
+        }
+    }
+
+    [Fact]
     public void TryCatch_WithoutAwait_PassesThroughUnchanged()
     {
         // Arrange: try { x = 1 } catch (e Exception) { x = 2 } — no await


### PR DESCRIPTION
## Summary

`AsyncExceptionHandlerRewriter` lifts an awaiting `finally` out of its protected region (Pattern B) so the spiller / MoveNext passes can suspend across it, and it generalizes the **exception** exit path. But the **non-fall-through control-flow exits** — `return` / `goto` / `break` / `continue` that leave a `try { … } finally { await … }` — were emitted as a clean pass-through, so the awaited finally was **skipped** on those paths.

This PR implements **Pattern C**: every non-fall-through exit that leaves the try is funneled through the lifted finally before resuming, mirroring the existing pending-exception machinery.

### Reproduction (fixed)

An early `return` out of a `try` whose `finally` awaits, inside a loop:

- **Before:** the awaited finally on the returning iteration was skipped.
- **After:** the awaited finally runs on every iteration (including the one that returns), then the captured return resumes with the correct value.

## How it works

The four exit kinds are now funneled through the lifted finally:

1. Inside the try body, each exit whose target is **outside** the protected region (or, for `return`, leaves the method) is replaced by an assignment to a small `pendingBranch` discriminator — plus a `pendingReturnValue` local for value returns, captured **at the point of the original return** so evaluation order is preserved — followed by `goto finallyTail`.
2. The finally body is emitted once (as before).
3. After the finally, dispatch runs the **existing pending-exception rethrow first** (exception semantics, `ExceptionDispatchInfo.Capture` stack-trace preservation per #418/#419, and per-clause typed-catch dispatch are all unchanged), then resumes the captured branch: each discriminator value re-emits its original `return <pendingReturnValue>` / `goto <target>`. A discriminator of `0` falls through and continues normally.

`break`/`continue`/`goto` reach this pass as `BoundGotoStatement` / `BoundConditionalGotoStatement` (the general `Lowerer` desugars loops before the async pass runs). A branch whose target label is **inside** the try is left untouched, so only true exits run the lifted finally. The rewrite is compositional, so an exit crossing **multiple** awaited finallys runs each in order. The discriminator and pending-return-value locals are hoisted into state-machine fields exactly like the pending-exception local.

The **"Deferred" / Pattern-C carve-out** is removed from the rewriter's `<remarks>` and replaced with documentation of Pattern C as implemented.

## Tests added

End-to-end, ilverify-clean emit regression tests (`test/Compiler.Tests/Emit/Issue1484AsyncFinallyExitEmitTests.cs`):

- (a) early `return <value>` out of a try-with-async-finally inside a loop — the exact repro
- (b) `break` out of a loop from inside such a try
- (c) `continue` from inside such a try
- (d) value return after an `await` in the try body (value captured before the finally)
- (e) the exception path still runs the awaited finally and propagates with a preserved stack trace (regression)
- (f) nested try/finally with two awaited finallys crossed by a single early return (both run, in order)

Plus a bound-tree unit test (`AsyncExceptionHandlerRewriterTests`) asserting an early `return` is funneled through the lifted finally.

## Validation

- Full solution build: clean (0 warnings / 0 errors)
- Manual repro: awaited finally now runs on the returning iteration and the correct value is returned
- New emit tests: pass (ilverify-clean)
- Full `Core.Tests`: 4834 passed, 1 skipped
- Nearby async / await / try-finally / iterator / channel / range / sequence `Compiler.Tests` slices: pass
- `RefactoringBaselineTests`: pass with **no** baseline regeneration (the baseline try/finally samples are non-async, so the emitted IL is byte-identical)

Fixes #1484
