### PR TITLE
Remap reified closure type-parameter constraints (#1499)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -1243,7 +1243,17 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundImportedInstanceCallExpression(null, newReceiver, node.Method, node.Type, args, node.ArgumentRefKinds, node.TypeArgumentSymbols);
+        return new BoundImportedInstanceCallExpression(
+            null,
+            newReceiver,
+            node.Method,
+            node.Type,
+            args,
+            node.ArgumentRefKinds,
+            node.TypeArgumentSymbols,
+            node.ConstrainedReceiverTypeParameter,
+            node.ConstrainedInterfaceType,
+            node.IsNonVirtualBaseCall);
     }
 
     /// <summary>Rewrites an array creation expression.</summary>

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -391,43 +391,29 @@ internal sealed class ReflectionMetadataEmitter
         }
 
         var total = classTPs.Length + methodTPs.Length;
-        var smTPs = ImmutableArray.CreateBuilder<TypeParameterSymbol>(total);
+        var origCombined = ImmutableArray.CreateBuilder<TypeParameterSymbol>(total);
+        origCombined.AddRange(classTPs);
+        origCombined.AddRange(methodTPs);
+
+        // Issue #1499: remap self-/cross-referential constraints from the
+        // enclosing parameters onto the state machine's cloned set.
+        var smTPs = SynthesizedClosureReifier.CloneWithRemappedConstraints(origCombined.MoveToImmutable());
         var remap = new Dictionary<TypeParameterSymbol, int>(total);
         var ordinal = 0;
         foreach (var src in classTPs)
         {
-            smTPs.Add(CloneAsClassTypeParameter(src, ordinal));
             remap[src] = ordinal;
             ordinal++;
         }
 
         foreach (var src in methodTPs)
         {
-            smTPs.Add(CloneAsClassTypeParameter(src, ordinal));
             remap[src] = ordinal;
             ordinal++;
         }
 
-        smStruct.SetTypeParameters(smTPs.MoveToImmutable());
+        smStruct.SetTypeParameters(smTPs);
         this.iteratorStateMachineRemapsByClass[smStruct] = remap;
-    }
-
-    private static TypeParameterSymbol CloneAsClassTypeParameter(TypeParameterSymbol src, int ordinal)
-    {
-        return new TypeParameterSymbol(
-            src.Name,
-            ordinal,
-            src.Constraint,
-            src.Variance,
-            src.InterfaceConstraint)
-        {
-            HasReferenceTypeConstraint = src.HasReferenceTypeConstraint,
-            HasValueTypeConstraint = src.HasValueTypeConstraint,
-            HasDefaultConstructorConstraint = src.HasDefaultConstructorConstraint,
-            ClrInterfaceConstraint = src.ClrInterfaceConstraint,
-            ClassConstraint = src.ClassConstraint,
-            IsMethodTypeParameter = false,
-        };
     }
 
     // Issue #1467: gathers the flattened generic parameters of every enclosing
@@ -491,13 +477,9 @@ internal sealed class ReflectionMetadataEmitter
                 continue;
             }
 
-            var clones = ImmutableArray.CreateBuilder<TypeParameterSymbol>(enclosing.Length);
-            for (var i = 0; i < enclosing.Length; i++)
-            {
-                clones.Add(CloneAsClassTypeParameter(enclosing[i], i));
-            }
-
-            s.SetTypeParameters(clones.MoveToImmutable());
+            // Issue #1499: remap self-/cross-referential constraints onto the
+            // nested type's cloned enclosing-parameter set.
+            s.SetTypeParameters(SynthesizedClosureReifier.CloneWithRemappedConstraints(enclosing));
         }
     }
 

--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -1240,6 +1240,30 @@ public sealed class StructSymbol : TypeSymbol
     }
 
     /// <summary>
+    /// Issue #1499: applies a type-parameter <paramref name="substitution"/> to
+    /// <paramref name="type"/>, recursively rewriting the generic arguments of
+    /// any constructed generic (struct / interface / imported CLR) type and the
+    /// element / underlying / function-signature types it contains. Shares the
+    /// same traversal used when constructing a generic instantiation, so it is
+    /// the canonical way for the symbol layer to remap a constraint reference
+    /// type (e.g. <c>IComparable[T]</c> → <c>IComparable[clone]</c>) onto a
+    /// cloned type-parameter set. Returns the original instance unchanged when
+    /// the substitution touches nothing.
+    /// </summary>
+    /// <param name="type">The type whose type-parameter references to remap.</param>
+    /// <param name="substitution">The original → replacement type-parameter map.</param>
+    /// <returns>The substituted type, or <paramref name="type"/> when unchanged.</returns>
+    internal static TypeSymbol SubstituteTypeParameters(TypeSymbol type, Dictionary<TypeParameterSymbol, TypeSymbol> substitution)
+    {
+        if (type == null || substitution == null || substitution.Count == 0)
+        {
+            return type;
+        }
+
+        return SubstituteTypeForConstruction(type, substitution);
+    }
+
+    /// <summary>
     /// ADR-0105 Phase 2 — re-points this (reused) struct symbol at the
     /// declaration node of a freshly-parsed syntax tree whose declaration is
     /// byte-identical to the previous one (a body-only edit). Only the backing

--- a/src/Core/CodeAnalysis/Symbols/SynthesizedClosureReifier.cs
+++ b/src/Core/CodeAnalysis/Symbols/SynthesizedClosureReifier.cs
@@ -72,29 +72,75 @@ internal static class SynthesizedClosureReifier
     }
 
     /// <summary>
-    /// Clones <paramref name="src"/> as a class-level type parameter at
-    /// <paramref name="ordinal"/> (carrying its constraints), suitable for
-    /// declaration on a synthesized closure / box class.
+    /// Issue #1499: clones <paramref name="origTPs"/> 1:1 as class-level type
+    /// parameters whose constraint reference types are remapped from the
+    /// originals onto the freshly cloned set. Uses a TWO-PASS approach:
+    /// (1) create every clone (name / ordinal / kind / reference-, value- and
+    /// default-constructor-constraint flags / variance) and build the
+    /// <c>original → clone</c> substitution map; (2) for each clone substitute
+    /// that map into the original's <see cref="TypeParameterSymbol.InterfaceConstraint"/>,
+    /// <see cref="TypeParameterSymbol.ClrInterfaceConstraint"/> and
+    /// <see cref="TypeParameterSymbol.ClassConstraint"/> so a constraint that
+    /// references an original parameter (self-referential <c>T IComparable[T]</c>,
+    /// cross-referential <c>T IEnumerable[U]</c> / <c>T Base[U]</c>, or nested
+    /// <c>T Base[Dict[T, U]]</c>) instead references the corresponding clone(s).
+    /// Because all clones exist before any constraint is rebuilt, interdependent
+    /// constraints across the set resolve correctly. Reuses the symbol layer's
+    /// <see cref="StructSymbol.SubstituteTypeParameters"/> so the remap walks
+    /// generic arguments recursively rather than hand-rolling a partial clone.
     /// </summary>
-    /// <param name="src">The original enclosing type parameter.</param>
-    /// <param name="ordinal">The ordinal for the fresh class type parameter.</param>
-    /// <returns>The cloned class type parameter.</returns>
-    public static TypeParameterSymbol CloneAsClassTypeParameter(TypeParameterSymbol src, int ordinal)
+    /// <param name="origTPs">The ordered enclosing type parameters to clone.</param>
+    /// <returns>The cloned type parameters with remapped constraints.</returns>
+    public static ImmutableArray<TypeParameterSymbol> CloneWithRemappedConstraints(ImmutableArray<TypeParameterSymbol> origTPs)
     {
-        return new TypeParameterSymbol(
-            src.Name,
-            ordinal,
-            src.Constraint,
-            src.Variance,
-            src.InterfaceConstraint)
+        if (origTPs.IsDefaultOrEmpty)
         {
-            HasReferenceTypeConstraint = src.HasReferenceTypeConstraint,
-            HasValueTypeConstraint = src.HasValueTypeConstraint,
-            HasDefaultConstructorConstraint = src.HasDefaultConstructorConstraint,
-            ClrInterfaceConstraint = src.ClrInterfaceConstraint,
-            ClassConstraint = src.ClassConstraint,
-            IsMethodTypeParameter = false,
-        };
+            return ImmutableArray<TypeParameterSymbol>.Empty;
+        }
+
+        var clones = new TypeParameterSymbol[origTPs.Length];
+        var subst = new Dictionary<TypeParameterSymbol, TypeSymbol>(origTPs.Length);
+        for (var i = 0; i < origTPs.Length; i++)
+        {
+            var src = origTPs[i];
+
+            // Pass 1: create the clone with its simple flags. Constraint
+            // reference types are deferred to pass 2 so cross-referential
+            // constraints can see every clone before being rebuilt.
+            clones[i] = new TypeParameterSymbol(
+                src.Name,
+                i,
+                src.Constraint,
+                src.Variance)
+            {
+                HasReferenceTypeConstraint = src.HasReferenceTypeConstraint,
+                HasValueTypeConstraint = src.HasValueTypeConstraint,
+                HasDefaultConstructorConstraint = src.HasDefaultConstructorConstraint,
+                HasUnmanagedConstraint = src.HasUnmanagedConstraint,
+                IsMethodTypeParameter = false,
+            };
+            subst[src] = clones[i];
+        }
+
+        for (var i = 0; i < origTPs.Length; i++)
+        {
+            var src = origTPs[i];
+            var clone = clones[i];
+
+            if (src.InterfaceConstraint != null)
+            {
+                clone.InterfaceConstraint =
+                    StructSymbol.SubstituteTypeParameters(src.InterfaceConstraint, subst) as InterfaceSymbol
+                    ?? src.InterfaceConstraint;
+            }
+
+            clone.ClrInterfaceConstraint =
+                StructSymbol.SubstituteTypeParameters(src.ClrInterfaceConstraint, subst);
+            clone.ClassConstraint =
+                StructSymbol.SubstituteTypeParameters(src.ClassConstraint, subst);
+        }
+
+        return ImmutableArray.Create(clones);
     }
 
     /// <summary>
@@ -112,13 +158,9 @@ internal static class SynthesizedClosureReifier
     /// <returns>The constructed instance over the original parameters.</returns>
     public static StructSymbol Reify(StructSymbol definition, ImmutableArray<TypeParameterSymbol> origTPs)
     {
-        var clones = ImmutableArray.CreateBuilder<TypeParameterSymbol>(origTPs.Length);
-        for (var i = 0; i < origTPs.Length; i++)
-        {
-            clones.Add(CloneAsClassTypeParameter(origTPs[i], i));
-        }
+        var clones = CloneWithRemappedConstraints(origTPs);
 
-        definition.SetTypeParameters(clones.MoveToImmutable());
+        definition.SetTypeParameters(clones);
         definition.SetReifiedFromTypeParameters(origTPs);
 
         var args = ImmutableArray.CreateBuilder<TypeSymbol>(origTPs.Length);

--- a/test/Compiler.Tests/Emit/Issue1499ClosureConstraintRemapEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1499ClosureConstraintRemapEmitTests.cs
@@ -1,0 +1,241 @@
+// <copyright file="Issue1499ClosureConstraintRemapEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1499 — when a lambda is reified into a GENERIC synthesized closure /
+/// capture-box class (generic over captured enclosing type parameters, per
+/// #1477), the cloned closure type parameters must REMAP self-/cross-referential
+/// generic constraints onto the clone set. A constraint such as
+/// <c>TKey IComparable[TKey]</c> copied onto the closure clone previously still
+/// referenced the ORIGINAL <c>TKey</c> (out of scope inside the reified class),
+/// so the emitted <c>GenericParamConstraint</c> was unsatisfiable at the capture
+/// site (<c>UnsatisfiedMethodParentInst</c>/<c>UnsatisfiedFieldParentInst</c>)
+/// and the constrained member call inside the closure's <c>Invoke</c> erased its
+/// constraint type argument to <c>object</c>
+/// (<c>StackUnexpected [found value 'TKey'][expected ref 'object']</c>).
+/// <para>
+/// The fix is a two-pass clone in <c>SynthesizedClosureReifier</c> that
+/// substitutes the original → clone type-parameter map into every cloned
+/// constraint, plus preserving the constrained-call metadata through
+/// <c>BoundTreeRewriter.RewriteImportedInstanceCallExpression</c> (which the
+/// closure lowering invokes) so the lambda body still binds to the GENERIC
+/// interface method (<c>IComparable[T].CompareTo(T)</c>, no box) rather than the
+/// non-generic <c>object</c> overload.
+/// </para>
+/// Each facet ilverifies clean and runs; the controls (unconstrained captured
+/// TP, non-generic user-interface constraint) must not regress.
+/// </summary>
+public class Issue1499ClosureConstraintRemapEmitTests
+{
+    [Fact]
+    public void EndToEnd_SelfReferentialIComparableConstraint_ConstrainedCallInClosure_Runs()
+    {
+        var source = """
+            package Issue1499Cmp
+            import System
+            class C {
+                shared {
+                    func Make[TResult, TKey IComparable[TKey]](keySelector (TResult) -> TKey) (TResult, TResult) -> int32 ->
+                        (x TResult, y TResult) -> keySelector(x).CompareTo(keySelector(y))
+                }
+            }
+            func Main() {
+                let f = C.Make[int32, int32]((v int32) -> v)
+                System.Console.WriteLine(f(3, 5))
+                System.Console.WriteLine(f(5, 3))
+                System.Console.WriteLine(f(4, 4))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("-1\n1\n0\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_SelfReferentialIEquatableConstraint_EqualsCallInClosure_Runs()
+    {
+        var source = """
+            package Issue1499Eq
+            import System
+            class C {
+                shared {
+                    func Make[TResult, TKey IEquatable[TKey]](keySelector (TResult) -> TKey) (TResult, TResult) -> bool ->
+                        (x TResult, y TResult) -> keySelector(x).Equals(keySelector(y))
+                }
+            }
+            func Main() {
+                let f = C.Make[int32, int32]((v int32) -> v)
+                System.Console.WriteLine(f(4, 4))
+                System.Console.WriteLine(f(4, 5))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\nFalse\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_TwoCapturedTypeParameters_SecondSelfReferentiallyConstrained_Runs()
+    {
+        var source = """
+            package Issue1499TwoTp
+            import System
+            class C {
+                shared {
+                    func Make[T, U IComparable[U]](sel (T) -> U) (T, T) -> int32 ->
+                        (a T, b T) -> sel(a).CompareTo(sel(b))
+                }
+            }
+            func Main() {
+                let f = C.Make[string, int32]((s string) -> s.Length)
+                System.Console.WriteLine(f("aa", "bbbb"))
+                System.Console.WriteLine(f("xxxxx", "y"))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("-1\n1\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_UnconstrainedCapturedTypeParameter_Control_Runs()
+    {
+        var source = """
+            package Issue1499Unconstrained
+            import System
+            class C {
+                shared {
+                    func Make[T](item T) () -> T ->
+                        () -> item
+                }
+            }
+            func Main() {
+                let f = C.Make[int32](77)
+                System.Console.WriteLine(f())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("77\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_NonGenericUserInterfaceConstraint_Control_Runs()
+    {
+        var source = """
+            package Issue1499NonGenericIface
+            import System
+            interface ILabeled {
+                func Label() string;
+            }
+            data struct Tag(Name string) : ILabeled {
+                func Label() string -> Name
+            }
+            class C {
+                shared {
+                    func Make[T ILabeled](item T) () -> string ->
+                        () -> item.Label()
+                }
+            }
+            func Main() {
+                let t = Tag("hello")
+                let f = C.Make[Tag](t)
+                System.Console.WriteLine(f())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("hello\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1499_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
## Problem

A constrained member call inside a lambda that gets reified into a **generic** synthesized closure / capture-box class produced unverifiable IL:

```
[UnsatisfiedMethodParentInst] demo.C::Make(...) Method parent instantiation has unsatisfied class type parameter constraints.
[UnsatisfiedFieldParentInst]  demo.C::Make(...) Field parent instantiation has unsatisfied class type parameter constraints.
[StackUnexpected] demo.C+<closure_<lambda1>_1>`2::Invoke(!0, !0)[offset 0x22][found value 'TKey'][expected ref 'object']
[StackUnexpected] ... [found value 'TKey'][expected ref System.IComparable`1<object>]
```

Minimal repro:

```gsharp
package demo
import System
class C {
    shared {
        func Make[TResult, TKey IComparable[TKey]](keySelector (TResult) -> TKey) (TResult, TResult) -> int32 ->
            (x TResult, y TResult) -> keySelector(x).CompareTo(keySelector(y))
    }
}
func Main() {
    let f = C.Make[int32, int32]((v int32) -> v)
    System.Console.WriteLine(f(3, 5))
}
```

## Root cause

When a lambda is reified into a generic synthesized closure class (generic over captured enclosing type parameters, per #1477), the cloned closure type parameters did **not** remap self-/cross-referential generic constraints:

1. **`SynthesizedClosureReifier`** copied `Constraint` / `InterfaceConstraint` / `ClrInterfaceConstraint` / `ClassConstraint` **by reference** and cloned each TP independently. A constraint like `TKey IComparable[TKey]` stayed pointed at the **original** `TKey` (out of scope inside the reified class), so the emitted `GenericParamConstraint` was unsatisfiable by the capture-site instantiation.
2. **`BoundTreeRewriter.RewriteImportedInstanceCallExpression`** dropped `ConstrainedReceiverTypeParameter` / `ConstrainedInterfaceType` / `IsNonVirtualBaseCall` when rebuilding the node. The closure-lowering rewrite of the lambda body therefore lost the constrained-call metadata, so the call inside `Invoke` re-emitted as a plain `callvirt` on the non-generic `IComparable<object>::CompareTo(object)` overload (constraint type argument erased to `object`, no box).

## Fix (generalized, two-pass remap)

- `SynthesizedClosureReifier.CloneWithRemappedConstraints` creates **all** clones first, builds an `original -> clone` substitution map, then substitutes that map into every clone's `InterfaceConstraint`, `ClrInterfaceConstraint` and `ClassConstraint`. This handles self-referential (`T IComparable[T]`), two-TP (`T`, `U IComparable[U]`), and nested generic constraint shapes. It **reuses** the symbol-layer substitution machinery via the new `StructSymbol.SubstituteTypeParameters` (which walks generic arguments recursively) rather than hand-rolling a partial clone. Reference/value/new()/unmanaged flags, variance and `IsMethodTypeParameter=false` round-trip unchanged.
- The iterator **state-machine** and **nested-type** reification paths (`ReflectionMetadataEmitter`) now share the same helper, so they get the remap too (and don't regress).
- `BoundTreeRewriter.RewriteImportedInstanceCallExpression` now preserves the constrained-call metadata, so the call inside the closure rebinds to the **generic** interface method (`IComparable[T].CompareTo(T)`, no box).

## Before / after ilverify (repro)

**Before:** 7 errors — `UnsatisfiedMethodParentInst` (x3) + `UnsatisfiedFieldParentInst` (x2) + `StackUnexpected [found value 'TKey'][expected ref 'object']` + `[expected ref IComparable<object>]`.

**After:** `All Classes and Methods Verified.` and running the program prints `-1`.

## Tests

Added `test/Compiler.Tests/Emit/Issue1499ClosureConstraintRemapEmitTests.cs` (CompileAndRun helper copied verbatim from the #1467 emit tests; unique package/type names per method):

- `EndToEnd_SelfReferentialIComparableConstraint_ConstrainedCallInClosure_Runs` — the repro (`T IComparable[T]`), asserts `-1 / 1 / 0`.
- `EndToEnd_SelfReferentialIEquatableConstraint_EqualsCallInClosure_Runs` — `T IEquatable[T]`, `.Equals` in a closure.
- `EndToEnd_TwoCapturedTypeParameters_SecondSelfReferentiallyConstrained_Runs` — `T`, `U IComparable[U]` comparing `U` values.
- `EndToEnd_UnconstrainedCapturedTypeParameter_Control_Runs` — control: unconstrained captured TP still verifies.
- `EndToEnd_NonGenericUserInterfaceConstraint_Control_Runs` — control: non-generic user interface constraint, method called inside the lambda.

All 5 ilverify clean and run. `Compiler.Tests` Issue1499 filter: **5 passed**. `Core.Tests`: **4833 passed / 1 skipped**. The RefactoringBaseline byte-comparison did **not** need regeneration.

Fixes #1499

Refs #914
