### PR TITLE
Fix GS0190 for generic async iterators (#1489)

### DIFF
--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -896,6 +896,19 @@ internal sealed class ReflectionMetadataEmitter
             }
         }
 
+        // Issue #1489: same registration for GENERIC async-iterator SM classes
+        // so their field / method / interface signatures translate the kickoff
+        // method's type-parameter references (MVar) into the SM class's own
+        // class-type-parameter slots (Var) during emit.
+        foreach (var kvp in this.stateMachines.AsyncIteratorStateMachineGenericInfos)
+        {
+            var remap = kvp.Value.BuildRemap();
+            if (remap != null)
+            {
+                this.iteratorStateMachineRemapsByClass[kvp.Key] = remap;
+            }
+        }
+
         // Issue #1467: a user-declared type nested inside a generic type must
         // declare the enclosing type's generic parameters (ECMA-335 §II.10.3.1:
         // a nested type's generic parameters include the encloser's). Reify

--- a/src/Core/CodeAnalysis/Emit/StateMachineEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/StateMachineEmitter.cs
@@ -208,6 +208,16 @@ internal sealed class StateMachineEmitter
     public Dictionary<StructSymbol, AsyncIteratorPlan> AsyncIteratorInfos { get; } = [];
 
     /// <summary>
+    /// Gets the per-async-iterator-SM generic reification info (issue #1489).
+    /// Populated by <see cref="SynthesizeAsyncIteratorStateMachines"/> only for
+    /// async iterators whose kickoff method has type parameters in scope. The
+    /// root reads it to register the outer-method-TP → class-TP-ordinal remap
+    /// so field/method/interface signatures encode the SM class's own
+    /// <c>Var(idx)</c> slots instead of the kickoff's <c>MVar(idx)</c>.
+    /// </summary>
+    public Dictionary<StructSymbol, IteratorStateMachineGenericInfo> AsyncIteratorStateMachineGenericInfos { get; } = [];
+
+    /// <summary>
     /// Gets per-async-iterator-SM emit-time context (builder field + builder
     /// info). Read by <see cref="EmitAwaitOnCompletedCall"/> and by
     /// <c>BodyEmitter</c> via the root emitter when threading the async
@@ -294,6 +304,54 @@ internal sealed class StateMachineEmitter
         /// type's parameters, so a method type parameter maps to the slot
         /// offset by the enclosing class type-parameter count. Used by
         /// <see cref="ReflectionMetadataEmitter.activeIteratorStateMachineRemap"/>.
+        /// </summary>
+        public Dictionary<TypeParameterSymbol, int> BuildRemap()
+        {
+            if (this.OuterMethodTypeParameters.IsDefaultOrEmpty)
+            {
+                return null;
+            }
+
+            var offset = this.ClassTypeParameters.Length - this.OuterMethodTypeParameters.Length;
+            var map = new Dictionary<TypeParameterSymbol, int>(this.OuterMethodTypeParameters.Length);
+            for (var i = 0; i < this.OuterMethodTypeParameters.Length; i++)
+            {
+                map[this.OuterMethodTypeParameters[i]] = offset + i;
+            }
+
+            return map;
+        }
+    }
+
+    /// <summary>
+    /// Issue #1489: minimal carrier for an async-iterator SM's generic
+    /// reification — the outer (kickoff) method's type parameters and the
+    /// state-machine class's own ordinal-aligned type parameters. Used to
+    /// build the outer-method-TP → class-TP-ordinal remap (mirroring
+    /// <see cref="IteratorStateMachineInfo.BuildRemap"/>) without a sync
+    /// iterator plan.
+    /// </summary>
+    public sealed class IteratorStateMachineGenericInfo
+    {
+        public IteratorStateMachineGenericInfo(
+            ImmutableArray<TypeParameterSymbol> outerMethodTypeParameters,
+            ImmutableArray<TypeParameterSymbol> classTypeParameters)
+        {
+            this.OuterMethodTypeParameters = outerMethodTypeParameters;
+            this.ClassTypeParameters = classTypeParameters;
+        }
+
+        public ImmutableArray<TypeParameterSymbol> OuterMethodTypeParameters { get; }
+
+        public ImmutableArray<TypeParameterSymbol> ClassTypeParameters { get; }
+
+        /// <summary>
+        /// Returns the emit-time remap from each outer-method type parameter to
+        /// its class-type-parameter ordinal on the synthesized state machine,
+        /// or <see langword="null"/> when the method has no type parameters.
+        /// The leading class type parameters mirror the enclosing generic
+        /// type's parameters, so a method type parameter maps to the slot
+        /// offset by the enclosing class type-parameter count.
         /// </summary>
         public Dictionary<TypeParameterSymbol, int> BuildRemap()
         {
@@ -642,6 +700,60 @@ internal sealed class StateMachineEmitter
             var packageName = plan.Function.Package?.Name ?? hostPackage?.Name ?? string.Empty;
             var elementType = plan.ElementType;
 
+            // Issue #1489 (async sibling of #810/#1465): when the async
+            // iterator method has type parameters in scope — the enclosing
+            // GENERIC type's parameters and/or the method's own type
+            // parameters — the synthesized state-machine class must itself be
+            // generic over an ordinal-aligned copy of them (mirroring the sync
+            // iterator path and Roslyn's `<gen>d__0<T>`). The enclosing type's
+            // parameters come first (ordinals 0..k-1), then the method's own
+            // (ordinals k..). A method-TP reference inside a field/method
+            // signature is translated to the matching class-TP slot via the
+            // activeIteratorStateMachineRemap encode-time hook (registered in
+            // RME from AsyncIteratorStateMachineGenericInfos).
+            var enclosingClassTPs = plan.Function.ReceiverType is StructSymbol aiRecv
+                ? (aiRecv.Definition ?? aiRecv).TypeParameters
+                : ImmutableArray<TypeParameterSymbol>.Empty;
+            if (enclosingClassTPs.IsDefault)
+            {
+                enclosingClassTPs = ImmutableArray<TypeParameterSymbol>.Empty;
+            }
+
+            var outerMethodTPs = plan.Function.TypeParameters.IsDefaultOrEmpty
+                ? ImmutableArray<TypeParameterSymbol>.Empty
+                : plan.Function.TypeParameters;
+
+            var scopeTPs = enclosingClassTPs.AddRange(outerMethodTPs);
+            ImmutableArray<TypeParameterSymbol> classTPs;
+            if (scopeTPs.IsDefaultOrEmpty)
+            {
+                classTPs = ImmutableArray<TypeParameterSymbol>.Empty;
+            }
+            else
+            {
+                var tpb = ImmutableArray.CreateBuilder<TypeParameterSymbol>(scopeTPs.Length);
+                for (var ti = 0; ti < scopeTPs.Length; ti++)
+                {
+                    var scopeTP = scopeTPs[ti];
+                    tpb.Add(new TypeParameterSymbol(
+                        scopeTP.Name,
+                        ti,
+                        scopeTP.Constraint,
+                        scopeTP.Variance,
+                        scopeTP.InterfaceConstraint)
+                    {
+                        HasReferenceTypeConstraint = scopeTP.HasReferenceTypeConstraint,
+                        HasValueTypeConstraint = scopeTP.HasValueTypeConstraint,
+                        HasDefaultConstructorConstraint = scopeTP.HasDefaultConstructorConstraint,
+                        ClrInterfaceConstraint = scopeTP.ClrInterfaceConstraint,
+                        ClassConstraint = scopeTP.ClassConstraint,
+                        IsMethodTypeParameter = false,
+                    });
+                }
+
+                classTPs = tpb.MoveToImmutable();
+            }
+
             // Fields
             var stateField = new FieldSymbol("<>1__state", TypeSymbol.Int32, Accessibility.Public);
             var currentField = new FieldSymbol("<>2__current", elementType, Accessibility.Public);
@@ -711,6 +823,20 @@ internal sealed class StateMachineEmitter
                 isData: false,
                 isInline: false,
                 isClass: true);
+
+            // Issue #1489: stamp the async-iterator SM class with its
+            // class-level type parameters so `EmitNestedStructTypeDef` mangles
+            // the name (`<gen>d__1` → `<gen>d__1`1`) and emits `GenericParam`
+            // rows. Done after construction so the StructSymbol's internal
+            // generic flags are flipped without re-running the cached
+            // `Construct` path. The matching outer-method-TP → class-TP remap
+            // is registered by RME from `AsyncIteratorStateMachineGenericInfos`.
+            if (!classTPs.IsDefaultOrEmpty)
+            {
+                smClass.SetTypeParameters(classTPs);
+                this.AsyncIteratorStateMachineGenericInfos[smClass] =
+                    new IteratorStateMachineGenericInfo(outerMethodTPs, classTPs);
+            }
 
             // Methods: MoveNext, get_Current, MoveNextAsync, DisposeAsync, GetAsyncEnumerator
             var moveNext = new FunctionSymbol("MoveNext", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Void, null, hostPackage, Accessibility.Public, (TypeSymbol)smClass);
@@ -835,16 +961,32 @@ internal sealed class StateMachineEmitter
                 ImmutableArray.Create<BoundStatement>(
                 new BoundReturnStatement(null, null))));
 
-            // Kickoff body: new SM { state = -3, params..., <>4__this = this }
+            // Kickoff body: new SM { state = -3, params..., <>4__this = this }.
+            // Issue #1489: when the SM is generic, the kickoff literal target
+            // must be the CONSTRUCTED instance `<gen>d__1<MVar(0),…>` (over the
+            // type parameters still in scope at the kickoff method) so the
+            // emitted `newobj`/`stfld` tokens land on a TypeSpec carrying the
+            // right type arguments. Non-generic iterators keep the open class.
+            var kickoffSmType = classTPs.IsDefaultOrEmpty
+                ? smClass
+                : StructSymbol.Construct(smClass, scopeTPs.CastArray<TypeSymbol>());
             this.IteratorKickoffBodies[plan.Function] = Lowerer.Lower(new BoundBlockStatement(null,
                 ImmutableArray.Create<BoundStatement>(
-                new BoundReturnStatement(null, this.CreateAsyncIteratorKickoffLiteral(smClass, stateField, builderField, parameterFields, plan.Function.Parameters, thisProxyField, plan.Function)))));
+                new BoundReturnStatement(null, this.CreateAsyncIteratorKickoffLiteral(kickoffSmType, stateField, builderField, parameterFields, plan.Function.Parameters, thisProxyField, plan.Function)))));
 
             this.AsyncIteratorInfos[smClass] = plan;
             this.closures.SynthesizedClosureClasses.Add(smClass);
 
-            // Resolve builder info for async iterator emit context.
-            var returnClrType = plan.Function.Type?.ClrType;
+            // Resolve builder info for async iterator emit context. Issue #1489:
+            // a generic async iterator's return type is an AsyncSequenceTypeSymbol
+            // over an open type parameter, whose ClrType is null — but the
+            // builder for EVERY async iterator is the element-agnostic,
+            // non-generic AsyncIteratorMethodBuilder. Resolve against a closed
+            // IAsyncEnumerable<object> placeholder so the builder members
+            // (Create / MoveNext / AwaitOnCompleted / AwaitUnsafeOnCompleted)
+            // are always bound regardless of element shape.
+            var returnClrType = plan.Function.Type?.ClrType
+                ?? typeof(System.Collections.Generic.IAsyncEnumerable<object>);
             var aiBuilderInfo = AsyncMethodBuilderInfo.Resolve(returnClrType, this.emitCtx.References);
             this.AsyncIteratorEmitContexts[smClass] = new AsyncIteratorEmitContext(smClass, builderField, aiBuilderInfo);
         }

--- a/src/Core/CodeAnalysis/Lowering/Async/AsyncEmitPrecheck.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AsyncEmitPrecheck.cs
@@ -80,21 +80,12 @@ public static class AsyncEmitPrecheck
 
     /// <summary>
     /// Determines whether the given async function is an async iterator
-    /// (returns IAsyncEnumerable or IAsyncEnumerator).
+    /// (returns IAsyncEnumerable or IAsyncEnumerator), including the symbolic
+    /// open-generic forms (issue #1489) via the shared
+    /// <see cref="AsyncIteratorDetection"/> helper.
     /// </summary>
     private static bool IsAsyncIterator(FunctionSymbol function)
-    {
-        var returnClrType = function.Type?.ClrType;
-        if (returnClrType == null || !returnClrType.IsGenericType)
-        {
-            return false;
-        }
-
-        var openDef = returnClrType.GetGenericTypeDefinition();
-        var fullName = openDef?.FullName;
-        return fullName == "System.Collections.Generic.IAsyncEnumerable`1"
-            || fullName == "System.Collections.Generic.IAsyncEnumerator`1";
-    }
+        => AsyncIteratorDetection.IsAsyncIteratorFunction(function);
 
     private static TextLocation LocateAsyncFunction(FunctionSymbol function)
     {

--- a/src/Core/CodeAnalysis/Lowering/Async/AsyncIteratorDetection.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AsyncIteratorDetection.cs
@@ -1,0 +1,139 @@
+// <copyright file="AsyncIteratorDetection.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Core.CodeAnalysis.Symbols;
+
+namespace GSharp.Core.CodeAnalysis.Lowering.Async;
+
+/// <summary>
+/// Single source of truth for "is this an async iterator?" detection and
+/// element-type extraction across the async/iterator lowering pipeline.
+/// </summary>
+/// <remarks>
+/// <para>Issue #1489: the async-iterator pipeline historically carried three
+/// divergent copies of this predicate. The <see cref="Iterators.AsyncIteratorRewriter"/>
+/// recognised the symbolic <see cref="AsyncSequenceTypeSymbol"/> form (issue
+/// #798) and the open <see cref="ImportedTypeSymbol"/> form (issue #1002),
+/// while <see cref="AsyncStateMachineRewriter"/> and
+/// <see cref="AsyncEmitPrecheck"/> keyed off a <em>closed</em> CLR
+/// <c>IAsyncEnumerable`1</c> / <c>IAsyncEnumerator`1</c> return type only.</para>
+/// <para>For a GENERIC async iterator (<c>async func gen[T](x T) sequence[T]</c>)
+/// the return type is an <see cref="AsyncSequenceTypeSymbol"/> over an open
+/// type parameter whose <see cref="TypeSymbol.ClrType"/> is <see langword="null"/>,
+/// so the CLR-only copies failed to recognise it. The function was then
+/// mis-routed into the plain-async state-machine pass (where the method builder
+/// could not be resolved) and ultimately reported as <c>GS0190</c>. Routing
+/// every site through this helper keeps the three checks in lock-step so the
+/// symbolic open-generic form is recognised consistently.</para>
+/// </remarks>
+public static class AsyncIteratorDetection
+{
+    /// <summary>
+    /// Determines whether <paramref name="function"/> is an async iterator —
+    /// one whose declared return type is <c>sequence[T]</c>
+    /// (<see cref="AsyncSequenceTypeSymbol"/>) or
+    /// <c>IAsyncEnumerable[T]</c> / <c>IAsyncEnumerator[T]</c> in any of its
+    /// closed-CLR, open-imported, or user-element forms.
+    /// </summary>
+    /// <param name="function">The function symbol to inspect.</param>
+    /// <returns><see langword="true"/> when the function is an async iterator.</returns>
+    public static bool IsAsyncIteratorFunction(FunctionSymbol function)
+        => function != null && GetElementType(function.Type) != null;
+
+    /// <summary>
+    /// Determines whether <paramref name="type"/> is an async-iterator return
+    /// type (see <see cref="IsAsyncIteratorFunction"/>).
+    /// </summary>
+    /// <param name="type">The candidate return type.</param>
+    /// <returns><see langword="true"/> when the type is an async-iterator return type.</returns>
+    public static bool IsAsyncIteratorReturnType(TypeSymbol type) => GetElementType(type) != null;
+
+    /// <summary>
+    /// Determines whether <paramref name="type"/> is an
+    /// <c>IAsyncEnumerable[T]</c> async-iterator return type (as opposed to
+    /// <c>IAsyncEnumerator[T]</c>) — only the enumerable form exposes
+    /// <c>GetAsyncEnumerator</c>. Recognises the symbolic <c>sequence[T]</c>
+    /// alias (<see cref="AsyncSequenceTypeSymbol"/>) and the open
+    /// <see cref="ImportedTypeSymbol"/> form so an open type parameter is not
+    /// misclassified via the null/erased CLR projection (issue #1489).
+    /// </summary>
+    /// <param name="type">The candidate async-iterator return type.</param>
+    /// <returns><see langword="true"/> for the enumerable form.</returns>
+    public static bool IsAsyncEnumerable(TypeSymbol type)
+    {
+        // sequence[T] in an async return position aliases IAsyncEnumerable<T>.
+        if (type is AsyncSequenceTypeSymbol)
+        {
+            return true;
+        }
+
+        if (type is ImportedTypeSymbol imported
+            && imported.OpenDefinition?.FullName == "System.Collections.Generic.IAsyncEnumerable`1")
+        {
+            return true;
+        }
+
+        var clr = type?.ClrType;
+        if (clr == null || !clr.IsGenericType)
+        {
+            return false;
+        }
+
+        return clr.GetGenericTypeDefinition().FullName == "System.Collections.Generic.IAsyncEnumerable`1";
+    }
+
+    /// <summary>
+    /// Extracts the element type from an async-iterator return type, honouring
+    /// the symbolic forms (issue #798 <see cref="AsyncSequenceTypeSymbol"/>,
+    /// issue #1002 open <see cref="ImportedTypeSymbol"/>) so an open type
+    /// parameter is preserved rather than collapsed to <c>object</c> via the
+    /// CLR-erased projection.
+    /// </summary>
+    /// <param name="type">The candidate async-iterator return type.</param>
+    /// <returns>The element type, or <see langword="null"/> when
+    /// <paramref name="type"/> is not an async-iterator return type.</returns>
+    public static TypeSymbol GetElementType(TypeSymbol type)
+    {
+        // Issue #798: `async sequence[T]` (AsyncSequenceTypeSymbol) carries
+        // its element symbolically; honor it directly so an open T does not
+        // collapse via the ClrType branch.
+        if (type is AsyncSequenceTypeSymbol aseq)
+        {
+            return aseq.ElementType;
+        }
+
+        // Issue #1002 (parallel to #990): `IAsyncEnumerable[Shape]` /
+        // `IAsyncEnumerator[Shape]` where `Shape` is a same-compilation user
+        // class — or any open type parameter — is modelled as an
+        // ImportedTypeSymbol carrying the element symbolically in
+        // `TypeArguments`. Its `ClrType` is the erased
+        // `IAsyncEnumerable<object>`; honour the symbolic argument so the
+        // state machine emits the strongly-typed interface rows.
+        if (type is ImportedTypeSymbol imported
+            && imported.OpenDefinition != null
+            && !imported.TypeArguments.IsDefaultOrEmpty
+            && imported.TypeArguments.Length == 1
+            && (imported.OpenDefinition.FullName == "System.Collections.Generic.IAsyncEnumerable`1"
+                || imported.OpenDefinition.FullName == "System.Collections.Generic.IAsyncEnumerator`1"))
+        {
+            return imported.TypeArguments[0];
+        }
+
+        var clr = type?.ClrType;
+        if (clr == null || !clr.IsGenericType || clr.IsGenericTypeDefinition)
+        {
+            return null;
+        }
+
+        var def = clr.GetGenericTypeDefinition();
+        var fullName = def?.FullName;
+        if (fullName == "System.Collections.Generic.IAsyncEnumerable`1"
+            || fullName == "System.Collections.Generic.IAsyncEnumerator`1")
+        {
+            return TypeSymbol.FromClrType(clr.GetGenericArguments()[0]);
+        }
+
+        return null;
+    }
+}

--- a/src/Core/CodeAnalysis/Lowering/Async/AsyncStateMachineRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AsyncStateMachineRewriter.cs
@@ -153,18 +153,7 @@ public static class AsyncStateMachineRewriter
     }
 
     private static bool IsAsyncIteratorFunction(FunctionSymbol function)
-    {
-        var clr = function.Type?.ClrType;
-        if (clr == null || !clr.IsGenericType || clr.IsGenericTypeDefinition)
-        {
-            return false;
-        }
-
-        var def = clr.GetGenericTypeDefinition();
-        var fullName = def?.FullName;
-        return fullName == "System.Collections.Generic.IAsyncEnumerable`1"
-            || fullName == "System.Collections.Generic.IAsyncEnumerator`1";
-    }
+        => AsyncIteratorDetection.IsAsyncIteratorFunction(function);
 
     private sealed class AwaitStateCollector : BoundTreeWalker
     {

--- a/src/Core/CodeAnalysis/Lowering/Iterators/AsyncIteratorRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/Iterators/AsyncIteratorRewriter.cs
@@ -94,27 +94,7 @@ public static class AsyncIteratorRewriter
     }
 
     private static bool IsAsyncIteratorFunction(FunctionSymbol function)
-    {
-        // Issue #798: a generic `async sequence[T]` (AsyncSequenceTypeSymbol)
-        // with open T projects to a null ClrType. Recognize the symbolic
-        // form alongside the IAsyncEnumerable[T] / IAsyncEnumerator[T]
-        // shapes so the async iterator rewriter still rewrites it.
-        if (function.Type is AsyncSequenceTypeSymbol)
-        {
-            return true;
-        }
-
-        var clr = function.Type?.ClrType;
-        if (clr == null || !clr.IsGenericType || clr.IsGenericTypeDefinition)
-        {
-            return false;
-        }
-
-        var def = clr.GetGenericTypeDefinition();
-        var fullName = def?.FullName;
-        return fullName == "System.Collections.Generic.IAsyncEnumerable`1"
-            || fullName == "System.Collections.Generic.IAsyncEnumerator`1";
-    }
+        => AsyncIteratorDetection.IsAsyncIteratorFunction(function);
 
     private static bool ContainsYield(BoundStatement statement)
     {
@@ -124,52 +104,7 @@ public static class AsyncIteratorRewriter
     }
 
     private static TypeSymbol GetAsyncIteratorElementType(TypeSymbol type)
-    {
-        // Issue #798: `async sequence[T]` (AsyncSequenceTypeSymbol) carries
-        // its element symbolically; honor it directly so an open T does not
-        // collapse via the ClrType branch.
-        if (type is AsyncSequenceTypeSymbol aseq)
-        {
-            return aseq.ElementType;
-        }
-
-        // Issue #1002 (parallel to #990): `IAsyncEnumerable[Shape]` where
-        // `Shape` is a same-compilation user class is modelled as an
-        // ImportedTypeSymbol carrying `Shape` symbolically in
-        // `TypeArguments`. Its `ClrType` is the erased
-        // `IAsyncEnumerable<object>` (user types have no ClrType yet, so
-        // `MakeGenericType` falls back to `object`). If we go through the
-        // ClrType branch below we'd extract `typeof(object)` as the
-        // element type and the synthesized state machine would advertise
-        // `IAsyncEnumerable<object>` — invalid under generic invariance
-        // (ilverify StackUnexpected). Honour the symbolic argument so the
-        // SM emits the strongly-typed `IAsyncEnumerable<Shape>` /
-        // `IAsyncEnumerator<Shape>`.
-        if (type is ImportedTypeSymbol imported
-            && imported.OpenDefinition != null
-            && !imported.TypeArguments.IsDefaultOrEmpty
-            && imported.TypeArguments.Length == 1
-            && (imported.OpenDefinition.FullName == "System.Collections.Generic.IAsyncEnumerable`1"
-                || imported.OpenDefinition.FullName == "System.Collections.Generic.IAsyncEnumerator`1"))
-        {
-            return imported.TypeArguments[0];
-        }
-
-        var clr = type?.ClrType;
-        if (clr == null || !clr.IsGenericType || clr.IsGenericTypeDefinition)
-        {
-            return null;
-        }
-
-        var def = clr.GetGenericTypeDefinition();
-        if (def.FullName == "System.Collections.Generic.IAsyncEnumerable`1" ||
-            def.FullName == "System.Collections.Generic.IAsyncEnumerator`1")
-        {
-            return TypeSymbol.FromClrType(clr.GetGenericArguments()[0]);
-        }
-
-        return null;
-    }
+        => AsyncIteratorDetection.GetElementType(type);
 
     private static ImmutableArray<VariableSymbol> CollectHoistedLocals(BoundStatement body)
     {
@@ -360,16 +295,6 @@ public sealed class AsyncIteratorPlan
     /// </summary>
     public bool IsEnumerable
     {
-        get
-        {
-            var clr = Function.Type?.ClrType;
-            if (clr == null || !clr.IsGenericType)
-            {
-                return false;
-            }
-
-            var def = clr.GetGenericTypeDefinition();
-            return def.FullName == "System.Collections.Generic.IAsyncEnumerable`1";
-        }
+        get => AsyncIteratorDetection.IsAsyncEnumerable(Function.Type);
     }
 }

--- a/test/Compiler.Tests/Emit/Issue1489GenericAsyncIteratorEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1489GenericAsyncIteratorEmitTests.cs
@@ -1,0 +1,550 @@
+// <copyright file="Issue1489GenericAsyncIteratorEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1489 — a GENERIC async iterator (both <c>async</c> and returning
+/// <c>sequence[…]</c> / <c>IAsyncEnumerable[…]</c> over the function's own
+/// type parameter) must synthesize a generic state machine, emit strongly-typed
+/// <c>IAsyncEnumerable&lt;…&gt;</c> / <c>IAsyncEnumerator&lt;…&gt;</c> rows that
+/// preserve the type parameter as a reified <c>Var(0)</c> slot, and run
+/// end-to-end ilverify-clean.
+/// <para>
+/// Before the fix, async-iterator detection and method-builder resolution were
+/// re-implemented across four <em>ClrType-only</em> predicates
+/// (<c>AsyncIteratorRewriter</c>, <c>AsyncStateMachineRewriter</c>,
+/// <c>AsyncEmitPrecheck</c>, and <c>AsyncIteratorPlan.IsEnumerable</c>). For a
+/// generic async iterator the return type is an <c>AsyncSequenceTypeSymbol</c>
+/// over an open type parameter whose <c>ClrType</c> is <see langword="null"/>,
+/// so three of those copies failed to recognise it: the function was mis-routed
+/// into the plain-async state-machine pass (where the builder could not be
+/// resolved) and reported as GS0190. The fix routes every site through the
+/// shared <c>AsyncIteratorDetection</c> helper and teaches
+/// <c>SynthesizeAsyncIteratorStateMachines</c> to reify the SM class generic
+/// over the kickoff method's type parameters — mirroring the sync generic
+/// iterator path (#810/#1465) and the #1481 element-shape reification.
+/// </para>
+/// Every type / function / package in this file carries a unique
+/// <c>Issue1489</c>-prefixed name because the name-keyed FunctionTypeSymbol
+/// cache is not cleared between in-process emit tests.
+/// </summary>
+public class Issue1489GenericAsyncIteratorEmitTests
+{
+    #region State-machine reflection — reified interface rows preserve T
+
+    [Fact]
+    public void StateMachine_BareElement_IsGeneric_ImplementsAsyncEnumerableOfVar0()
+    {
+        // `async sequence[T]`: the synthesized SM class must be generic and
+        // implement both IAsyncEnumerable<T> AND IAsyncEnumerator<T> closed
+        // over its own Var(0) — not the type-erased <object> shape, and not
+        // only the enumerator (the #1489 IsEnumerable gap dropped the
+        // IAsyncEnumerable row + GetAsyncEnumerator entirely).
+        var source = """
+            package Probe
+            import System.Collections.Generic
+
+            class Issue1489BareRows {
+                shared {
+                    async func BareRowsEntries[T any](items []T) sequence[T] {
+                        for v in items {
+                            yield v
+                        }
+                    }
+                }
+            }
+            """;
+
+        var assembly = CompileLibrary(source);
+        var smType = SingleStateMachine(assembly, "<BareRowsEntries>d__");
+
+        Assert.True(smType.IsGenericTypeDefinition);
+        var typeParams = smType.GetGenericArguments();
+        Assert.Single(typeParams);
+
+        AssertImplementsGenericOf(smType, typeof(IAsyncEnumerable<>), args => args[0] == typeParams[0]);
+        AssertImplementsGenericOf(smType, typeof(IAsyncEnumerator<>), args => args[0] == typeParams[0]);
+
+        var currentField = smType.GetField("<>2__current", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        Assert.NotNull(currentField);
+        Assert.Equal(typeParams[0], currentField!.FieldType);
+
+        var getAsyncEnumerator = smType.GetMethod(
+            "GetAsyncEnumerator",
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        Assert.NotNull(getAsyncEnumerator);
+        var ret = getAsyncEnumerator!.ReturnType;
+        Assert.True(ret.IsGenericType && ret.GetGenericTypeDefinition() == typeof(IAsyncEnumerator<>));
+        Assert.Equal(typeParams[0], ret.GetGenericArguments()[0]);
+    }
+
+    [Fact]
+    public void StateMachine_MapElement_ImplementsAsyncEnumerableOfReifiedDictionary()
+    {
+        // `async sequence[map[string, T]]`: the SM must list a generic
+        // IAsyncEnumerable<Dictionary<string, T>> closed over its own Var(0).
+        var source = """
+            package Probe
+            import System.Collections.Generic
+            import System.Threading.Tasks
+
+            class Issue1489MapRows {
+                shared {
+                    async func MapRowsEntries[T any](items []T) sequence[map[string, T]] {
+                        for v in items {
+                            await Task.Delay(1)
+                            let m = map[string, T]{}
+                            yield m
+                        }
+                    }
+                }
+            }
+            """;
+
+        var assembly = CompileLibrary(source);
+        var smType = SingleStateMachine(assembly, "<MapRowsEntries>d__");
+
+        Assert.True(smType.IsGenericTypeDefinition);
+        var typeParams = smType.GetGenericArguments();
+        Assert.Single(typeParams);
+
+        AssertImplementsGenericOf(smType, typeof(IAsyncEnumerable<>), args =>
+        {
+            var element = args[0];
+            return element.IsGenericType
+                && element.GetGenericTypeDefinition() == typeof(Dictionary<,>)
+                && element.GetGenericArguments()[0] == typeof(string)
+                && element.GetGenericArguments()[1] == typeParams[0];
+        });
+
+        var currentField = smType.GetField("<>2__current", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        Assert.NotNull(currentField);
+        var fieldType = currentField!.FieldType;
+        Assert.True(fieldType.IsGenericType && fieldType.GetGenericTypeDefinition() == typeof(Dictionary<,>));
+        Assert.Equal(typeof(string), fieldType.GetGenericArguments()[0]);
+        Assert.Equal(typeParams[0], fieldType.GetGenericArguments()[1]);
+    }
+
+    [Fact]
+    public void StateMachine_FunctionElement_ImplementsAsyncEnumerableOfReifiedFunc()
+    {
+        // `async sequence[(T) -> int32]`: the SM must list a generic
+        // IAsyncEnumerable<Func<T, int>> closed over its own Var(0).
+        var source = """
+            package Probe
+            import System.Collections.Generic
+            import System.Threading.Tasks
+
+            class Issue1489FuncRows {
+                shared {
+                    async func FuncRowsEntries[T any](items []T) sequence[(T) -> int32] {
+                        for v in items {
+                            await Task.Delay(1)
+                            yield func(x T) int32 { return 0 }
+                        }
+                    }
+                }
+            }
+            """;
+
+        var assembly = CompileLibrary(source);
+        var smType = SingleStateMachine(assembly, "<FuncRowsEntries>d__");
+
+        Assert.True(smType.IsGenericTypeDefinition);
+        var typeParams = smType.GetGenericArguments();
+        Assert.Single(typeParams);
+
+        AssertImplementsGenericOf(smType, typeof(IAsyncEnumerable<>), args =>
+        {
+            var element = args[0];
+            return element.IsGenericType
+                && element.GetGenericTypeDefinition() == typeof(Func<,>)
+                && element.GetGenericArguments()[0] == typeParams[0]
+                && element.GetGenericArguments()[1] == typeof(int);
+        });
+    }
+
+    #endregion
+
+    #region End-to-end execution — values preserve T across await suspension
+
+    [Fact]
+    public void BareElement_RunsEndToEnd_WithStronglyTypedIntValues()
+    {
+        // The #1489 repro: `async func gen[T](x T) sequence[T]` consumed via
+        // `await for`. The yielded values must be strongly-typed int32 and the
+        // body actually suspends on an await between yields.
+        var source = """
+            package Probe
+            import System.Collections.Generic
+            import System.Threading.Tasks
+
+            class Issue1489BareRun {
+                shared {
+                    async func BareRunEntries[T any](items []T) sequence[T] {
+                        for v in items {
+                            await Task.Delay(1)
+                            yield v
+                        }
+                    }
+                }
+            }
+
+            public var total = 0
+            public var count = 0
+            async func Issue1489BareRunMain() {
+                await for n in Issue1489BareRun.BareRunEntries[int32]([]int32{5, 9, 14}) {
+                    total = total + n
+                    count = count + 1
+                }
+            }
+            Issue1489BareRunMain().Wait()
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal(3, GetIntField(assembly, "count"));
+        Assert.Equal(28, GetIntField(assembly, "total"));
+    }
+
+    [Fact]
+    public void BareElement_RunsEndToEnd_WithStronglyTypedStringValues()
+    {
+        var source = """
+            package Probe
+            import System.Collections.Generic
+            import System.Threading.Tasks
+
+            class Issue1489BareRunStr {
+                shared {
+                    async func BareRunStrEntries[T any](items []T) sequence[T] {
+                        for v in items {
+                            await Task.Delay(1)
+                            yield v
+                        }
+                    }
+                }
+            }
+
+            public var concat = ""
+            async func Issue1489BareRunStrMain() {
+                await for s in Issue1489BareRunStr.BareRunStrEntries[string]([]string{"a", "b", "c"}) {
+                    concat = concat + s
+                }
+            }
+            Issue1489BareRunStrMain().Wait()
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal("abc", GetStringField(assembly, "concat"));
+    }
+
+    [Fact]
+    public void MapElement_RunsEndToEnd_WithStronglyTypedIntValues()
+    {
+        // Consuming `MapRun[int32]` must surface `map[string, int32]` elements
+        // whose indexer returns a strongly-typed int32 (not T), proving the
+        // closed call-site substitution descends into the map.
+        var source = """
+            package Probe
+            import System.Collections.Generic
+            import System.Threading.Tasks
+
+            class Issue1489MapRun {
+                shared {
+                    async func MapRunEntries[T any](items []T) sequence[map[string, T]] {
+                        for v in items {
+                            await Task.Delay(1)
+                            let m = map[string, T]{"key": v}
+                            yield m
+                        }
+                    }
+                }
+            }
+
+            public var total = 0
+            async func Issue1489MapRunMain() {
+                await for d in Issue1489MapRun.MapRunEntries[int32]([]int32{5, 9, 14}) {
+                    total = total + d["key"]
+                }
+            }
+            Issue1489MapRunMain().Wait()
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal(28, GetIntField(assembly, "total"));
+    }
+
+    [Fact]
+    public void FunctionElement_RunsEndToEnd()
+    {
+        // A generic async iterator yielding `func(T) -> int32` values must emit,
+        // verify, and the yielded delegates must be invokable at runtime.
+        var source = """
+            package Probe
+            import System.Collections.Generic
+            import System.Threading.Tasks
+
+            class Issue1489FuncRun {
+                shared {
+                    async func FuncRunEntries[T any](items []T) sequence[(T) -> int32] {
+                        for v in items {
+                            await Task.Delay(1)
+                            yield func(x T) int32 { return 11 }
+                        }
+                    }
+                }
+            }
+
+            public var total = 0
+            async func Issue1489FuncRunMain() {
+                await for f in Issue1489FuncRun.FuncRunEntries[int32]([]int32{1, 2, 3}) {
+                    total = total + f(0)
+                }
+            }
+            Issue1489FuncRunMain().Wait()
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal(33, GetIntField(assembly, "total"));
+    }
+
+    [Fact]
+    public void MixedYieldAndAwait_SuspendsBetweenYields_AccumulatesCorrectly()
+    {
+        // The body interleaves awaits and yields (and awaits AFTER the final
+        // yield), exercising real suspension/resume across the generic SM.
+        var source = """
+            package Probe
+            import System.Collections.Generic
+            import System.Threading.Tasks
+
+            class Issue1489Mixed {
+                shared {
+                    async func MixedEntries[T any](a T, b T, c T) sequence[T] {
+                        await Task.Delay(1)
+                        yield a
+                        await Task.Delay(1)
+                        yield b
+                        await Task.Delay(1)
+                        yield c
+                        await Task.Delay(1)
+                    }
+                }
+            }
+
+            public var total = 0
+            public var count = 0
+            async func Issue1489MixedMain() {
+                await for n in Issue1489Mixed.MixedEntries[int32](4, 8, 16) {
+                    total = total + n
+                    count = count + 1
+                }
+            }
+            Issue1489MixedMain().Wait()
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal(3, GetIntField(assembly, "count"));
+        Assert.Equal(28, GetIntField(assembly, "total"));
+    }
+
+    [Fact]
+    public void GenericAsyncIterator_InGenericClass_ClassAndMethodTypeParameters()
+    {
+        // The most complex shape: an async iterator method declaring its own
+        // type parameter V, nested inside a GENERIC class Holder[U]. The SM is
+        // reified over [U, V] (enclosing class TP first, then method TP).
+        var source = """
+            package Probe
+            import System.Collections.Generic
+            import System.Threading.Tasks
+
+            class Issue1489Holder[U any] {
+                async func Produce[V any](items []V) sequence[V] {
+                    for v in items {
+                        await Task.Delay(1)
+                        yield v
+                    }
+                }
+            }
+
+            public var total = 0
+            async func Issue1489HolderMain() {
+                let h = Issue1489Holder[string]()
+                await for n in h.Produce[int32]([]int32{4, 5, 6}) {
+                    total = total + n
+                }
+            }
+            Issue1489HolderMain().Wait()
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal(15, GetIntField(assembly, "total"));
+    }
+
+    #endregion
+
+    #region Regression controls — non-generic async + sync generic still work
+
+    [Fact]
+    public void Control_NonGenericAsyncIterator_StillRuns()
+    {
+        var source = """
+            package Probe
+            import System.Collections.Generic
+            import System.Threading.Tasks
+
+            class Issue1489NonGeneric {
+                shared {
+                    async func Nums() sequence[int32] {
+                        yield 1
+                        await Task.Delay(1)
+                        yield 2
+                    }
+                }
+            }
+
+            public var sum = 0
+            async func Issue1489NonGenericMain() {
+                await for n in Issue1489NonGeneric.Nums() {
+                    sum = sum + n
+                }
+            }
+            Issue1489NonGenericMain().Wait()
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal(3, GetIntField(assembly, "sum"));
+    }
+
+    [Fact]
+    public void Control_SyncGenericIterator_StillRuns()
+    {
+        var source = """
+            package Probe
+            import System.Collections.Generic
+
+            class Issue1489SyncGeneric {
+                shared {
+                    func Entries[T any](items []T) sequence[T] {
+                        for v in items {
+                            yield v
+                        }
+                    }
+                }
+            }
+
+            public var total = 0
+            for n in Issue1489SyncGeneric.Entries[int32]([]int32{7, 8, 9}) {
+                total = total + n
+            }
+            """;
+
+        var assembly = CompileAndRun(source);
+        Assert.Equal(24, GetIntField(assembly, "total"));
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static Type SingleStateMachine(Assembly assembly, string prefix)
+        => assembly.GetTypes()
+            .Single(t => t.IsNested && t.Name.StartsWith(prefix, StringComparison.Ordinal));
+
+    private static void AssertImplementsGenericOf(Type smType, Type openInterface, Func<Type[], bool> argsMatch)
+    {
+        var ok = smType.GetInterfaces().Any(i =>
+            i.IsGenericType
+            && i.GetGenericTypeDefinition() == openInterface
+            && argsMatch(i.GetGenericArguments()));
+        Assert.True(
+            ok,
+            $"State machine '{smType.FullName}' must implement the expected reified " +
+            $"{openInterface.Name} row. Actual interfaces: " +
+            string.Join(", ", smType.GetInterfaces().Select(i => i.FullName)));
+    }
+
+    private static Assembly CompileAndRun(string source)
+    {
+        var outPath = CompileToFile(source, target: "exe");
+
+        var bytes = File.ReadAllBytes(outPath);
+        var assembly = Assembly.Load(bytes);
+
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+        entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+
+        return assembly;
+    }
+
+    private static Assembly CompileLibrary(string source)
+    {
+        var outPath = CompileToFile(source, target: "library");
+        return Assembly.LoadFile(outPath);
+    }
+
+    private static string CompileToFile(string source, string target)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1489_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:" + target,
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+        IlVerifier.Verify(outPath);
+        return outPath;
+    }
+
+    private static int GetIntField(Assembly assembly, string name)
+    {
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var field = program.GetField(name, BindingFlags.Public | BindingFlags.Static);
+        return (int)field!.GetValue(null)!;
+    }
+
+    private static string GetStringField(Assembly assembly, string name)
+    {
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var field = program.GetField(name, BindingFlags.Public | BindingFlags.Static);
+        return (string)field!.GetValue(null)!;
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

A **generic async iterator** — a function that is both `async` and returns `sequence[T]` / `IAsyncEnumerable[T]` over its own type parameter — failed state-machine synthesis with **GS0190** ("Could not synthesize the state machine for this async function; the awaitable's method-builder type could not be resolved.").

```gsharp
async func gen[T](x T) sequence[T] {  // GS0190 before this change
    yield x
}
```

Non-generic async iterators and sync generic iterators both compiled fine; only the **async × generic** combination failed.

## Root cause

The async-iterator pipeline carried **four divergent** "is this an async iterator?" / builder-resolution checks. Only `AsyncIteratorRewriter` recognized the symbolic open-generic form (`AsyncSequenceTypeSymbol`); `AsyncStateMachineRewriter`, `AsyncEmitPrecheck`, and `AsyncIteratorPlan.IsEnumerable` were **ClrType-only**. For a generic async iterator the return type is an `AsyncSequenceTypeSymbol` over an open type parameter whose `ClrType` is `null`, so the CLR-only copies returned `false`: the function was mis-routed into the plain-async state-machine pass (where the builder could not be resolved), and the emit precheck then gated it with GS0190.

This is the same CLR-erasure / duplicated-predicate smell addressed by #1481/#1482/#1483.

## Changes

- **Unified detection** — new `AsyncIteratorDetection` is the single source of truth for async-iterator detection and element-type extraction. It recognizes the symbolic `AsyncSequenceTypeSymbol` form (#798), the open `ImportedTypeSymbol` `IAsyncEnumerable`/`IAsyncEnumerator` forms (#1002), and the closed CLR forms. `AsyncIteratorRewriter`, `AsyncStateMachineRewriter`, `AsyncEmitPrecheck`, and `AsyncIteratorPlan.IsEnumerable` all route through it so the four checks stay in lock-step.
- **Generic async-iterator state machine** — `SynthesizeAsyncIteratorStateMachines` now reifies the SM class generic over the kickoff method's in-scope type parameters (enclosing generic type's parameters first, then the method's own), mirroring the sync iterator path (#810/#1465). The `IAsyncEnumerable<T>`/`IAsyncEnumerator<T>` interface rows, `<>2__current`, `get_Current`, and `GetAsyncEnumerator` are reified **symbolically and preserve `T`** (not erased to `object`).
- **Element shapes supported** — bare `T`, `map[string, T]` → `Dictionary<string, T>`, and `func(T) -> int32` → `Func<T, int>` (the #1481 siblings), plus method type parameters nested inside a generic class (SM reified over `[U, V]`).
- **Plumbing** — register the outer-method-TP → class-TP-ordinal remap in `ReflectionMetadataEmitter`, construct the kickoff literal over the constructed SM type, and resolve the element-agnostic `AsyncIteratorMethodBuilder` against `IAsyncEnumerable<object>` when the return ClrType is `null`.

## Tests

New `Issue1489GenericAsyncIteratorEmitTests` (11 tests, all ilverify-clean):

- **Reflection** asserts the synthesized SM is a generic type definition implementing reified `IAsyncEnumerable<Var0>` **and** `IAsyncEnumerator<Var0>`, with `<>2__current` / `GetAsyncEnumerator` strongly typed — for bare-`T`, `map[string, T]` → `Dictionary<string, Var0>`, and `func(T) -> int32` → `Func<Var0, int>`.
- **End-to-end** execution via `await for`: int + string values preserve `T`; map and func elements run; a **mixed yield/await** body actually suspends between yields; and a generic-class method-TP shape (`Holder[U].Produce[V]`).
- **Regression controls**: non-generic async iterator and sync generic iterator still emit and behave.

Existing async-iterator / `await for` / `AsyncSequenceAlias` / #798 / #1002 / #1481 / #990 slices and the full Core.Tests suite (incl. the byte-identical RefactoringBaselineTests) pass unchanged — no baseline regeneration was required.

Fixes #1489
