### PR TITLE
Fix #1502: emit reified Func/Action<UserType> for source-defined user-type delegate args

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -707,6 +707,26 @@ internal sealed partial class ExpressionBinder
         for (var i = 0; i < syntax.Arguments.Count; i++)
         {
             var argName = argumentNames.IsDefault ? null : argumentNames[i];
+
+            // Issue #1502: when the constructed type carries a same-compilation
+            // user-defined type argument (e.g. `Lazy[Foo]`), the closed CLR ctor
+            // parameter shape is type-erased (`Func<object>`), so target-typing a
+            // lambda against it would infer `() -> object` and emit a synthesized
+            // method returning `object` boxed — yielding an unverifiable
+            // `Func<object>` where the reified `Lazy<Foo>::.ctor` expects
+            // `Func<Foo>`. Recover the symbolic delegate shape (`() -> Foo`) from
+            // the OPEN ctor's parameter type substituted with the real symbolic
+            // type arguments so the lambda method returns `Foo` and the delegate
+            // materialises as `Func<Foo>`.
+            var inner = OverloadResolver.UnwrapNamedArgumentValue(syntax.Arguments[i]);
+            if (inner is LambdaExpressionSyntax ctorLambdaSyntax
+                && TryResolveSymbolicDelegateTargetForCtor(
+                    openGenericDefinition, symbolicTypeArgs, sourceArgIndex: i, argName: argName, out var symbolicTarget))
+            {
+                boundArguments.Add(lambdas.BindLambdaExpression(ctorLambdaSyntax, symbolicTarget));
+                continue;
+            }
+
             boundArguments.Add(BindCallArgumentWithDelegateTargetTyping(
                 syntax.Arguments[i], ctorParameterLists, sourceArgIndex: i, argName: argName, paramOffset: 0));
         }
@@ -966,6 +986,92 @@ internal sealed partial class ExpressionBinder
             {
                 // Candidates disagree on the delegate shape — leave the lambda
                 // to be bound without a target (overload resolution decides).
+                target = null;
+                return false;
+            }
+        }
+
+        return target != null;
+    }
+
+    /// <summary>
+    /// Issue #1502: resolves the symbolic delegate target shape for a lambda
+    /// argument at <paramref name="sourceArgIndex"/> (or named
+    /// <paramref name="argName"/>) of a constructed-generic CLR constructor whose
+    /// type arguments include a same-compilation user-defined type. The closed
+    /// CLR ctor parameter is type-erased (e.g. <c>Func&lt;object&gt;</c>); this
+    /// recovers the real shape (e.g. <c>() -&gt; Foo</c>) by substituting the
+    /// receiver's symbolic type arguments through the OPEN constructor's
+    /// parameter type. Returns <see langword="false"/> (deferring to the ordinary
+    /// erased path) when there is no symbolic substitution in effect, when the
+    /// candidate ctors disagree on the delegate shape, or when no open ctor
+    /// exposes a delegate parameter at that position.
+    /// </summary>
+    private static bool TryResolveSymbolicDelegateTargetForCtor(
+        Type openGenericDefinition,
+        ImmutableArray<TypeSymbol> symbolicTypeArgs,
+        int sourceArgIndex,
+        string argName,
+        out FunctionTypeSymbol target)
+    {
+        target = null;
+        if (openGenericDefinition == null || symbolicTypeArgs.IsDefaultOrEmpty)
+        {
+            return false;
+        }
+
+        ConstructorInfo[] openCtors;
+        try
+        {
+            openCtors = openGenericDefinition.GetConstructors(BindingFlags.Public | BindingFlags.Instance);
+        }
+        catch (Exception ex) when (ClrTypeUtilities.IsMetadataLoadFailure(ex))
+        {
+            return false;
+        }
+
+        foreach (var ctor in openCtors)
+        {
+            var parameters = ctor.GetParameters();
+            int paramIndex;
+            if (!string.IsNullOrEmpty(argName))
+            {
+                paramIndex = -1;
+                for (var p = 0; p < parameters.Length; p++)
+                {
+                    if (string.Equals(parameters[p].Name, argName, StringComparison.Ordinal))
+                    {
+                        paramIndex = p;
+                        break;
+                    }
+                }
+
+                if (paramIndex < 0)
+                {
+                    continue;
+                }
+            }
+            else
+            {
+                paramIndex = sourceArgIndex;
+                if (paramIndex < 0 || paramIndex >= parameters.Length)
+                {
+                    continue;
+                }
+            }
+
+            if (!TryBuildSymbolicDelegateTarget(parameters[paramIndex].ParameterType, openGenericDefinition, symbolicTypeArgs, out var candidate)
+                || candidate == null)
+            {
+                continue;
+            }
+
+            if (target == null)
+            {
+                target = candidate;
+            }
+            else if (!ReferenceEquals(target, candidate) && !target.Equals(candidate))
+            {
                 target = null;
                 return false;
             }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -704,6 +704,7 @@ internal sealed partial class ExpressionBinder
         var ctorParameterLists = ctors.Select(c => c.GetParameters()).ToList();
 
         var boundArguments = ImmutableArray.CreateBuilder<BoundExpression>(syntax.Arguments.Count);
+        var symbolicCtorDelegateArgs = new HashSet<int>();
         for (var i = 0; i < syntax.Arguments.Count; i++)
         {
             var argName = argumentNames.IsDefault ? null : argumentNames[i];
@@ -724,6 +725,7 @@ internal sealed partial class ExpressionBinder
                     openGenericDefinition, symbolicTypeArgs, sourceArgIndex: i, argName: argName, out var symbolicTarget))
             {
                 boundArguments.Add(lambdas.BindLambdaExpression(ctorLambdaSyntax, symbolicTarget));
+                symbolicCtorDelegateArgs.Add(i);
                 continue;
             }
 
@@ -747,7 +749,24 @@ internal sealed partial class ExpressionBinder
             // Issue #658: use the overload-resolution variant that provides a
             // surrogate CLR type for user-defined G# classes (whose ClrType is
             // null at bind time) so overload resolution can proceed.
-            var t = GetEffectiveArgumentClrTypeForOverloadResolution(boundArguments[i].Type);
+            // Issue #1502 follow-up: only for a lambda that target-typed a
+            // constructed-generic ctor's delegate parameter, erase an inner
+            // same-compilation enum to `object` (covariant ride-through) so the
+            // lambda's `Func<…>` matches the erased `Lazy<object>` ctor's
+            // `Func<object>` parameter. Other delegate args (and generic-method
+            // inference elsewhere) keep the default enum→int ride-through.
+            System.Type t;
+            var priorErase = eraseDelegateInnerEnumToObject;
+            eraseDelegateInnerEnumToObject = symbolicCtorDelegateArgs.Contains(i);
+            try
+            {
+                t = GetEffectiveArgumentClrTypeForOverloadResolution(boundArguments[i].Type);
+            }
+            finally
+            {
+                eraseDelegateInnerEnumToObject = priorErase;
+            }
+
             if (t == null && boundArguments[i].Type != TypeSymbol.Null)
             {
                 argsAllTyped = false;

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -71,6 +71,18 @@ internal sealed partial class ExpressionBinder
     private readonly Func<FunctionSymbol> getCurrentFunction;
     private readonly Func<StatementSyntax, BoundStatement> bindStatement;
 
+    // Issue #1502 follow-up: when true, a same-compilation enum (or `Enum?`)
+    // appearing inside a delegate shape is erased to `object` (the covariant
+    // reference ride-through) instead of its default scalar ride-through
+    // (`int`/`int?`, issue #661). This is only enabled while computing the
+    // effective CLR delegate shape of a lambda that target-types a delegate
+    // parameter of a *constructed-generic constructor* (e.g. `Lazy[Color]`
+    // closes to `Lazy<object>` whose ctor wants `Func<object>`). For generic
+    // *method* inference (LINQ `Where`/`Select` over `[]Color`) the enum must
+    // stay `int` so the lambda's `Func<int,bool>` unifies with the source's
+    // `IEnumerable<int>`; that path leaves this flag false.
+    private bool eraseDelegateInnerEnumToObject;
+
     public ExpressionBinder(
         BinderContext binderCtx,
         MemberLookup memberLookup,
@@ -1268,20 +1280,22 @@ internal sealed partial class ExpressionBinder
     /// <summary>
     /// Issue #1502: erases an inner parameter/return type of a delegate shape
     /// for overload resolution. Same-compilation user value types (a G# enum or
-    /// <c>UserEnum?</c>) have no <see cref="TypeSymbol.ClrType"/> and are always
-    /// erased to <c>object</c> when they appear as a constructed-generic type
-    /// argument (e.g. <c>Lazy[Color]</c> closes to <c>Lazy&lt;object&gt;</c>).
-    /// The default scalar ride-through maps such an enum to <c>int</c> (issue
-    /// #661), but <c>Func&lt;int&gt;</c> is not assignable to the erased
-    /// <c>Func&lt;object&gt;</c> ctor parameter (no value-type covariance), so
-    /// overload resolution would mis-select a competing <c>T value</c> ctor.
-    /// Erase these to the reference ride-through (<c>object</c>) so the delegate
-    /// shape stays covariant-compatible; the real type is recovered downstream
-    /// via the symbolic delegate-target binding and symbolic ctor emit.
+    /// <c>UserEnum?</c>) have no <see cref="TypeSymbol.ClrType"/>. By default
+    /// they ride through as their scalar CLR backing (<c>int</c>/<c>int?</c>,
+    /// issue #661) so that LINQ/extension generic-method inference unifies the
+    /// lambda parameter with an <c>IEnumerable&lt;int&gt;</c> source. When the
+    /// delegate is instead a constructor argument of a constructed-generic type
+    /// (e.g. <c>Lazy[Color]</c> closes to <c>Lazy&lt;object&gt;</c> whose ctor
+    /// wants <c>Func&lt;object&gt;</c>), value types are not covariant so
+    /// <c>Func&lt;int&gt;</c> would mis-resolve; in that context the caller sets
+    /// <see cref="eraseDelegateInnerEnumToObject"/> so the enum erases to
+    /// <c>object</c> instead. The real type is recovered downstream via the
+    /// symbolic delegate-target binding and symbolic ctor emit.
     /// </summary>
     private Type EraseDelegateInnerClrTypeForOverloadResolution(TypeSymbol typeSymbol)
     {
-        if (typeSymbol.ClrType == null
+        if (eraseDelegateInnerEnumToObject
+            && typeSymbol.ClrType == null
             && (typeSymbol is EnumSymbol
                 || typeSymbol is NullableTypeSymbol { UnderlyingType: EnumSymbol }))
         {

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -1236,7 +1236,7 @@ internal sealed partial class ExpressionBinder
         var erasedParameters = ImmutableArray.CreateBuilder<TypeSymbol>(functionType.ParameterTypes.Length);
         foreach (var parameterType in functionType.ParameterTypes)
         {
-            var parameterClr = GetEffectiveArgumentClrTypeForOverloadResolution(parameterType);
+            var parameterClr = EraseDelegateInnerClrTypeForOverloadResolution(parameterType);
             if (parameterClr == null)
             {
                 return false;
@@ -1252,7 +1252,7 @@ internal sealed partial class ExpressionBinder
         }
         else
         {
-            var returnClr = GetEffectiveArgumentClrTypeForOverloadResolution(functionType.ReturnType);
+            var returnClr = EraseDelegateInnerClrTypeForOverloadResolution(functionType.ReturnType);
             if (returnClr == null)
             {
                 return false;
@@ -1263,6 +1263,32 @@ internal sealed partial class ExpressionBinder
 
         erased = FunctionTypeSymbol.Get(erasedParameters.ToImmutable(), erasedReturn).ClrType;
         return erased != null;
+    }
+
+    /// <summary>
+    /// Issue #1502: erases an inner parameter/return type of a delegate shape
+    /// for overload resolution. Same-compilation user value types (a G# enum or
+    /// <c>UserEnum?</c>) have no <see cref="TypeSymbol.ClrType"/> and are always
+    /// erased to <c>object</c> when they appear as a constructed-generic type
+    /// argument (e.g. <c>Lazy[Color]</c> closes to <c>Lazy&lt;object&gt;</c>).
+    /// The default scalar ride-through maps such an enum to <c>int</c> (issue
+    /// #661), but <c>Func&lt;int&gt;</c> is not assignable to the erased
+    /// <c>Func&lt;object&gt;</c> ctor parameter (no value-type covariance), so
+    /// overload resolution would mis-select a competing <c>T value</c> ctor.
+    /// Erase these to the reference ride-through (<c>object</c>) so the delegate
+    /// shape stays covariant-compatible; the real type is recovered downstream
+    /// via the symbolic delegate-target binding and symbolic ctor emit.
+    /// </summary>
+    private Type EraseDelegateInnerClrTypeForOverloadResolution(TypeSymbol typeSymbol)
+    {
+        if (typeSymbol.ClrType == null
+            && (typeSymbol is EnumSymbol
+                || typeSymbol is NullableTypeSymbol { UnderlyingType: EnumSymbol }))
+        {
+            return typeof(object);
+        }
+
+        return GetEffectiveArgumentClrTypeForOverloadResolution(typeSymbol);
     }
 
     private bool TryBindClrMethodGroup(BoundExpression receiver, Type declaringType, bool wantStatic, string name, out BoundExpression methodGroup)

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Closures.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Closures.cs
@@ -49,6 +49,19 @@ internal sealed partial class MethodBodyEmitter
     //    to the target delegate type via `dup / ldvirtftn Invoke / newobj`.
     private void EmitFunctionToDelegateConversion(BoundExpression source, FunctionTypeSymbol sourceFn, Type targetDelegateHostType)
     {
+        // Issue #1502: when the SOURCE function type carries a source-defined
+        // user type (Struct/Class/Interface/Enum/Delegate) or a type parameter
+        // in any parameter/return position, the reflection-resolved target
+        // delegate type erases that argument to System.Object (`Func<object>`
+        // instead of `Func<UserType>`) because MapToReferenceClrType has no
+        // MetadataLoadContext Type for a type emitted in the current
+        // compilation. Route the literal / method-group materialisation through
+        // the symbolic TypeSpec path (passing overrideDelegateType == null lets
+        // EmitFunctionLiteral / EmitMethodGroup select GetFunctionDelegateCtorRef)
+        // so the on-stack delegate value and the newobj ctor parent are the
+        // reified `Func<UserType>` / `Action<UserType>` matching the target.
+        bool sourceNeedsSymbolic = this.outer.FunctionTypeNeedsSymbolicDelegate(sourceFn);
+
         // Issue #323: when the target is the abstract System.Delegate /
         // System.MulticastDelegate base type, there is no concrete delegate
         // to instantiate. Materialize the function value as its natural
@@ -60,7 +73,31 @@ internal sealed partial class MethodBodyEmitter
 
         if (source is BoundFunctionLiteralExpression literal)
         {
-            this.EmitFunctionLiteral(literal, overrideDelegateType: targetDelegateType);
+            // Issue #1502: an async lambda whose Task-wrapped delegate shape
+            // needs symbolic encoding (`Func<...,Task<TOutput>>`) is emitted
+            // through the reified TypeSpec ctor ref.
+            if (literal.Function.IsAsync)
+            {
+                FunctionSymbol planKey = literal.Function;
+                if (this.outer.closures.ClosureInfos.TryGetValue(literal, out var closureForAsync))
+                {
+                    planKey = closureForAsync.InvokeMethod;
+                }
+
+                var asyncSymbolicCtor = planKey.StateMachineType != null
+                    ? this.outer.TryGetSymbolicAsyncDelegateCtorRef(literal.FunctionType, planKey)
+                    : null;
+                if (asyncSymbolicCtor.HasValue)
+                {
+                    this.EmitFunctionLiteral(literal, overrideDelegateType: null, symbolicDelegateCtorRef: asyncSymbolicCtor.Value);
+                    return;
+                }
+
+                this.EmitFunctionLiteral(literal, overrideDelegateType: targetDelegateType);
+                return;
+            }
+
+            this.EmitFunctionLiteral(literal, overrideDelegateType: sourceNeedsSymbolic ? null : targetDelegateType);
             return;
         }
 
@@ -70,22 +107,35 @@ internal sealed partial class MethodBodyEmitter
         // target delegate type.
         if (source is BoundMethodGroupExpression methodGroup)
         {
-            this.EmitMethodGroup(methodGroup, overrideDelegateType: targetDelegateType);
+            this.EmitMethodGroup(methodGroup, overrideDelegateType: sourceNeedsSymbolic ? null : targetDelegateType);
             return;
         }
 
         // Delegate-to-delegate adaptation: wrap the existing delegate's
-        // Invoke method in a new delegate of the target type.
-        var sourceDelegateType = this.outer.ResolveDelegateClrType(sourceFn);
-        var sourceInvoke = sourceDelegateType.GetMethod("Invoke")
-            ?? throw new InvalidOperationException(
-                $"Delegate type '{sourceDelegateType.FullName}' has no Invoke method.");
+        // Invoke method in a new delegate of the target type. Issue #1502:
+        // when the source shape needs symbolic encoding, take the reified
+        // Invoke / .ctor MemberRefs parented at the `Func<UserType>` TypeSpec
+        // rather than reflecting over the type-erased `Func<object>`.
         this.EmitExpression(source);
         this.il.OpCode(ILOpCode.Dup);
         this.il.OpCode(ILOpCode.Ldvirtftn);
-        this.il.Token(this.outer.GetMethodReference(sourceInvoke));
+        if (sourceNeedsSymbolic)
+        {
+            this.il.Token(this.outer.GetFunctionDelegateInvokeRef(sourceFn));
+        }
+        else
+        {
+            var sourceDelegateType = this.outer.ResolveDelegateClrType(sourceFn);
+            var sourceInvoke = sourceDelegateType.GetMethod("Invoke")
+                ?? throw new InvalidOperationException(
+                    $"Delegate type '{sourceDelegateType.FullName}' has no Invoke method.");
+            this.il.Token(this.outer.GetMethodReference(sourceInvoke));
+        }
+
         this.il.OpCode(ILOpCode.Newobj);
-        this.il.Token(this.outer.GetDelegateCtorReference(targetDelegateType));
+        this.il.Token(sourceNeedsSymbolic
+            ? this.outer.GetFunctionDelegateCtorRef(sourceFn)
+            : this.outer.GetDelegateCtorReference(targetDelegateType));
     }
 
     /// <summary>
@@ -367,6 +417,17 @@ internal sealed partial class MethodBodyEmitter
 
             if (planKey.StateMachineType != null)
             {
+                // Issue #1502: when the Task-wrapped delegate shape carries a
+                // source-defined user type or a type-parameter result/parameter
+                // (`Func<...,Task<TOutput>>`), route through the symbolic
+                // TypeSpec ctor ref instead of the type-erased reflection type.
+                var asyncSymbolicCtor = this.outer.TryGetSymbolicAsyncDelegateCtorRef(literal.FunctionType, planKey);
+                if (asyncSymbolicCtor.HasValue)
+                {
+                    this.EmitFunctionLiteral(literal, overrideDelegateType: null, symbolicDelegateCtorRef: asyncSymbolicCtor.Value);
+                    return;
+                }
+
                 asyncDelegateOverride = this.outer.ResolveAsyncDelegateClrType(literal.FunctionType, planKey);
             }
         }
@@ -467,7 +528,7 @@ internal sealed partial class MethodBodyEmitter
             {
                 this.il.Token(symbolicDelegateCtorRef.Value);
             }
-            else if (overrideDelegateType == null && literal.FunctionType.ClrType == null)
+            else if (overrideDelegateType == null && (literal.FunctionType.ClrType == null || this.outer.FunctionTypeNeedsSymbolicDelegate(literal.FunctionType)))
             {
                 this.il.Token(this.outer.GetFunctionDelegateCtorRef(literal.FunctionType));
             }
@@ -503,7 +564,7 @@ internal sealed partial class MethodBodyEmitter
         {
             this.il.Token(symbolicDelegateCtorRef.Value);
         }
-        else if (overrideDelegateType == null && literal.FunctionType.ClrType == null)
+        else if (overrideDelegateType == null && (literal.FunctionType.ClrType == null || this.outer.FunctionTypeNeedsSymbolicDelegate(literal.FunctionType)))
         {
             this.il.Token(this.outer.GetFunctionDelegateCtorRef(literal.FunctionType));
         }
@@ -537,7 +598,9 @@ internal sealed partial class MethodBodyEmitter
         }
 
         Type delegateType = null;
-        if (overrideDelegateType != null || methodGroup.FunctionType.ClrType != null)
+        if (overrideDelegateType != null
+            || (methodGroup.FunctionType.ClrType != null
+                && !this.outer.FunctionTypeNeedsSymbolicDelegate(methodGroup.FunctionType)))
         {
             delegateType = overrideDelegateType ?? this.outer.ResolveDelegateClrType(methodGroup.FunctionType);
         }

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -10095,6 +10095,37 @@ internal sealed class ReflectionMetadataEmitter
         return false;
     }
 
+    // Issue #1502: a GSharp function type must be materialised as a CLR
+    // delegate (Func/Action) through the SYMBOLIC TypeSpec path
+    // (EncodeFunctionTypeSymbol / GetFunctionDelegateCtorRef) — rather than
+    // the reflection path (ResolveDelegateClrType) — whenever any of its
+    // parameter/return types is a type parameter OR a source-defined
+    // user type (Struct/Class/Interface/Enum/Delegate), possibly nested
+    // (e.g. `List[UserClass]`, `Func<UserStruct>`, `UserClass[]`). The
+    // reflection path resolves such an argument through
+    // MapToReferenceClrType, which returns null for a type emitted in the
+    // current compilation (no MetadataLoadContext Type) and therefore
+    // erases the argument to System.Object — producing an unverifiable
+    // `Func<object>` where `Func<UserType>` is required.
+    internal bool FunctionTypeNeedsSymbolicDelegate(FunctionTypeSymbol fnType)
+    {
+        if (fnType == null)
+        {
+            return false;
+        }
+
+        foreach (var param in fnType.ParameterTypes)
+        {
+            if (TypeSymbol.ContainsTypeParameter(param) || ArgIsSymbolicUserDefined(param))
+            {
+                return true;
+            }
+        }
+
+        return TypeSymbol.ContainsTypeParameter(fnType.ReturnType)
+            || ArgIsSymbolicUserDefined(fnType.ReturnType);
+    }
+
     // Issue #504: a NullableTypeSymbol whose underlying CLR type is a value
     // type maps to the CLR struct `System.Nullable<T>` — a distinct CLR
     // value type with its own layout and ctor. NullableTypeSymbol over a
@@ -10651,6 +10682,63 @@ internal sealed class ReflectionMetadataEmitter
 
         args[arity] = this.MapToReferenceClrType(taskClrType);
         return openDef.MakeGenericType(args);
+    }
+
+    // Issue #1502: the async delegate equivalent of FunctionTypeNeedsSymbolicDelegate.
+    // For an async lambda materialised as a CLR delegate (`Func<...,Task<T>>`),
+    // ResolveAsyncDelegateClrType wraps the return in Task<T> via
+    // MapToReferenceClrType — which erases a source-defined user type or a
+    // type-parameter result (e.g. `Task<TOutput>` for `Mp4Operation`1::
+    // SetContinuation`) to `Task<object>`. When the Task-wrapped delegate shape
+    // needs symbolic encoding, return the MemberRef for its reified
+    // `.ctor(object, IntPtr)` parented at the `Func<...,Task<T>>` TypeSpec;
+    // otherwise return null so the caller keeps the reflection path.
+    internal EntityHandle? TryGetSymbolicAsyncDelegateCtorRef(FunctionTypeSymbol fnType, FunctionSymbol function)
+    {
+        AsyncStateMachinePlan plan = null;
+        foreach (var p in this.stateMachines.AsyncStateMachinePlans)
+        {
+            if (p.KickoffMethod == function)
+            {
+                plan = p;
+                break;
+            }
+        }
+
+        if (plan == null)
+        {
+            return null;
+        }
+
+        var builderInfo = plan.StateMachine.BuilderInfo;
+
+        // async void → Action shape (no Task<T> wrapping). Symbolic only when a
+        // parameter is itself user-defined / type-parameter-bearing.
+        if (builderInfo.Kind == AsyncMethodBuilderKind.Void)
+        {
+            var voidFn = FunctionTypeSymbol.Get(fnType.ParameterTypes, TypeSymbol.Void);
+            return this.FunctionTypeNeedsSymbolicDelegate(voidFn)
+                ? this.GetFunctionDelegateCtorRef(voidFn)
+                : (EntityHandle?)null;
+        }
+
+        if (builderInfo.TaskProperty?.PropertyType is not Type taskClrType
+            || plan.StateMachine.ResultTypeSymbol is not TypeSymbol resultSym)
+        {
+            return null;
+        }
+
+        TypeSymbol taskReturn = taskClrType.IsConstructedGenericType
+            ? ImportedTypeSymbol.GetConstructed(
+                taskClrType,
+                taskClrType.GetGenericTypeDefinition(),
+                ImmutableArray.Create(resultSym))
+            : ImportedTypeSymbol.Get(taskClrType);
+
+        var asyncFn = FunctionTypeSymbol.Get(fnType.ParameterTypes, taskReturn);
+        return this.FunctionTypeNeedsSymbolicDelegate(asyncFn)
+            ? this.GetFunctionDelegateCtorRef(asyncFn)
+            : (EntityHandle?)null;
     }
 
     // Map a host-runtime Type onto the MetadataLoadContext type from the

--- a/test/Compiler.Tests/Emit/Issue1502DelegateUserTypeArgEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1502DelegateUserTypeArgEmitTests.cs
@@ -1,0 +1,290 @@
+// <copyright file="Issue1502DelegateUserTypeArgEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1502 — converting a G# lambda (or method group) to a CLR generic
+/// delegate (<c>System.Func&lt;…&gt;</c>/<c>System.Action&lt;…&gt;</c>) erased a
+/// SOURCE-DEFINED user type (or type-parameter) delegate type argument to
+/// <c>System.Object</c>. The lambda emitted as <c>Func&lt;object&gt;</c> where
+/// <c>Func&lt;UserType&gt;</c> was required, so the <c>newobj</c> at the delegate
+/// construction site failed ilverify
+/// (<c>StackUnexpected [found Func`1&lt;object&gt;][expected Func`1&lt;Foo&gt;]</c>).
+/// <para>
+/// The fix has two parts: (1) the binder now recovers the symbolic delegate
+/// target (<c>() -&gt; Foo</c>) from the OPEN constructor parameter substituted
+/// with the real symbolic type arguments, so the synthesized lambda method
+/// returns <c>Foo</c> rather than boxed <c>object</c>; and (2) the emitter routes
+/// the delegate ctor / on-stack delegate type through the symbolic
+/// <c>FunctionTypeSymbol</c> path whenever the function type carries a
+/// type-parameter or same-compilation user type, so the reified
+/// <c>Func&lt;Foo&gt;</c>/<c>Action&lt;Foo&gt;</c> is emitted.
+/// </para>
+/// Every facet failed ilverify (or threw <c>InvalidProgramException</c>) on
+/// current main and passes after the fix. Each uses a UNIQUE package/type name
+/// because the in-process <c>FunctionTypeSymbol</c> cache is name-keyed.
+/// </summary>
+public class Issue1502DelegateUserTypeArgEmitTests
+{
+    [Fact]
+    public void EndToEnd_FuncUserClass_LazyLambda_Runs()
+    {
+        const string source = """
+            package i1502funcclass
+            import System
+
+            class Foo { prop N int32 { get; init; } init(n int32) { N = n } }
+
+            class C { shared { func Make() Lazy[Foo] -> Lazy[Foo](() -> Foo(42)) } }
+
+            func Main() { System.Console.WriteLine(C.Make().Value.N) }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_FuncUserStruct_LazyLambda_Runs()
+    {
+        const string source = """
+            package i1502funcstruct
+            import System
+
+            struct Bar(V int32) { }
+
+            class C { shared { func Make() Lazy[Bar] -> Lazy[Bar](() -> Bar(7)) } }
+
+            func Main() { System.Console.WriteLine(C.Make().Value.V) }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("7\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_ActionUserClass_ForEachLambda_Runs()
+    {
+        const string source = """
+            package i1502actionclass
+            import System
+            import System.Collections.Generic
+
+            class Foo { prop N int32 { get; init; } init(n int32) { N = n } }
+
+            func Main() {
+                var lst = List[Foo]()
+                lst.Add(Foo(5))
+                lst.ForEach((x Foo) -> System.Console.WriteLine(x.N))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("5\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_FuncUserEnum_LazyLambda_Runs()
+    {
+        const string source = """
+            package i1502funcenum
+            import System
+
+            enum Color { Red, Green, Blue }
+
+            class C { shared { func Make() Lazy[Color] -> Lazy[Color](() -> Color.Green) } }
+
+            func Main() { System.Console.WriteLine(C.Make().Value) }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("1\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_FuncNestedGenericUserClass_LazyLambda_Runs()
+    {
+        const string source = """
+            package i1502nested
+            import System
+            import System.Collections.Generic
+
+            class Foo { prop N int32 { get; init; } init(n int32) { N = n } }
+
+            class C { shared { func Make() int32 {
+                let lz = Lazy[List[Foo]](() -> {
+                    var l = List[Foo]()
+                    l.Add(Foo(9))
+                    return l
+                })
+                return lz.Value.Count
+            } } }
+
+            func Main() { System.Console.WriteLine(C.Make()) }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("1\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_FuncUserClass_LazyMethodGroup_Runs()
+    {
+        const string source = """
+            package i1502methodgroup
+            import System
+
+            class Foo { prop N int32 { get; init; } init(n int32) { N = n } }
+
+            func MakeFoo() Foo -> Foo(11)
+
+            class C { shared { func Make() Lazy[Foo] -> Lazy[Foo](MakeFoo) } }
+
+            func Main() { System.Console.WriteLine(C.Make().Value.N) }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("11\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_FuncTypeParameter_LazyLambda_Runs()
+    {
+        const string source = """
+            package i1502typeparam
+            import System
+
+            func Wrap[T](v T) T {
+                let lz = Lazy[T](() -> v)
+                return lz.Value
+            }
+
+            func Main() { System.Console.WriteLine(Wrap[int32](7)) }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("7\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_Control_FuncInt32_LazyLambda_Runs()
+    {
+        const string source = """
+            package i1502ctrlint
+            import System
+
+            class C { shared { func Make() Lazy[int32] -> Lazy[int32](() -> 42) } }
+
+            func Main() { System.Console.WriteLine(C.Make().Value) }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_Control_FuncString_LazyLambda_Runs()
+    {
+        const string source = """
+            package i1502ctrlstr
+            import System
+
+            class C { shared { func Make() Lazy[string] -> Lazy[string](() -> "x") } }
+
+            func Main() { System.Console.WriteLine(C.Make().Value) }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("x\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1502_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue1502DelegateUserTypeArgEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1502DelegateUserTypeArgEmitTests.cs
@@ -206,6 +206,63 @@ public class Issue1502DelegateUserTypeArgEmitTests
         Assert.Equal("x\n", output);
     }
 
+    [Fact]
+    public void EndToEnd_LinqWhereCount_OverUserEnumArray_Runs()
+    {
+        // Issue #1502 follow-up regression: the enum delegate-arg erasure must
+        // be scoped to the constructed-generic ctor covariance case only. A
+        // LINQ `Where` over `[]Shade` infers `TSource` from BOTH the source
+        // (`IEnumerable<int>` via the #661 enum scalar ride-through) AND the
+        // lambda parameter; if the lambda param were erased to `object` the
+        // `Func<object,bool>` could not unify with `IEnumerable<int>` and
+        // `Where` would not resolve (GS0159). The enum must stay `int` here.
+        const string source = """
+            package i1502linqwhereenum
+            import System
+            import System.Linq
+
+            enum Shade { Dim, Mid, Bright }
+
+            func CountDim(xs []Shade) int32 -> xs.Where((s Shade) -> s == Shade.Dim).Count()
+
+            func Main() {
+                var xs = []Shade{Shade.Dim, Shade.Mid, Shade.Bright, Shade.Dim}
+                System.Console.WriteLine(CountDim(xs))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("2\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_LinqSelectOverUserEnumArray_ThenLazyCtor_Runs()
+    {
+        // Both shapes coexist in one compilation: a generic-method inference
+        // path (`Select` over `[]Hue`, enum→int) and a constructed-generic ctor
+        // covariance path (`Lazy[Hue]`, enum→object). The fix keeps them
+        // independent.
+        const string source = """
+            package i1502linqselectlazyenum
+            import System
+            import System.Linq
+
+            enum Hue { Zero, One, Two }
+
+            func Make() Lazy[Hue] -> Lazy[Hue](() -> Hue.Two)
+
+            func Main() {
+                var xs = []Hue{Hue.Zero, Hue.One, Hue.Two}
+                var n = xs.Where((h Hue) -> h != Hue.Zero).Count()
+                System.Console.WriteLine(n)
+                System.Console.WriteLine(Make().Value)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("2\n2\n", output);
+    }
+
     private static string CompileAndRun(string source)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_1502_exe_").FullName;


### PR DESCRIPTION
## Problem

Converting a G# lambda (or method group) to a CLR generic delegate (`System.Func<...>`/`System.Action<...>`) erased any **source-defined user type** (and type-parameter) delegate type argument to `System.Object`. The lambda emitted as `Func<object>` where `Func<UserType>` was required, so the `newobj` at the delegate construction site failed ilverify:

```
[StackUnexpected] demo.C::Make()[0x10][found ref Func`1<object>][expected ref Func`1<demo.Foo>]
```

## Root cause (two parts)

**1. Binder erasure (before emit ever ran).** When a constructed CLR type carries a same-compilation user-type argument (e.g. `Lazy[Foo]`), the closed ctor parameter is type-erased to `Func<object>`. Target-typing the lambda against it inferred `() -> object`, so the synthesized lambda method genuinely returned boxed `object` — a `Func<Foo>` over it would itself be unverifiable.

**2. Emit routing.** The symbolic TypeSpec path (`GetFunctionDelegateCtorRef` / `EncodeFunctionTypeSymbol`, which already encode user types correctly) was taken **only** when `FunctionType.ClrType == null` (type-parameter-bearing). A function type whose args are non-generic source-defined user types has a type-erased `Func<object>` `ClrType`, so it took the reflection branch (`ResolveDelegateClrType` -> `MapToReferenceClrType(...) ?? object`) and erased.

## The fix

### Binder (`ExpressionBinder.Calls.cs`, `ExpressionBinder.cs`)
- `TryResolveSymbolicDelegateTargetForCtor` recovers the symbolic delegate shape (`() -> Foo`) from the **open** ctor parameter substituted with the real symbolic type arguments (reusing the existing `TryBuildSymbolicDelegateTarget` / `MapOpenClrTypeToSymbolic` machinery), and binds the ctor lambda against it — so the lambda method returns `Foo`, not boxed `object`.
- A user **enum** return additionally mis-selected a competing `Lazy(T value)` ctor: the delegate shape erased the enum to `Func<int>` (issue #661), which is not assignable to the erased `Func<object>` param (no value-type covariance). `EraseDelegateInnerClrTypeForOverloadResolution` now erases a same-compilation enum to the `object` ride-through for overload resolution, consistent with how the constructed generic erases it.

### Emit (`ReflectionMetadataEmitter.cs`, `MethodBodyEmitter.Closures.cs`)
New shared predicate `FunctionTypeNeedsSymbolicDelegate(fnType)` — true when any `ParameterType`/`ReturnType` satisfies `TypeSymbol.ContainsTypeParameter(t)` **or** `ArgIsSymbolicUserDefined(t)` (recursively, e.g. `List[UserClass]`, `Func<UserStruct>`). Routes the delegate ctor / on-stack delegate type through the symbolic path. Applied **consistently at every delegate-construction branch**:
- `EmitFunctionLiteral` — capture-bearing branch **and** no-capture branch.
- `EmitMethodGroup`.
- `EmitFunctionToDelegateConversion` — literal, method-group, and delegate-to-delegate adaptation (`GetFunctionDelegateInvokeRef` / `GetFunctionDelegateCtorRef`). A genuine concrete BCL `overrideDelegateType` is still honored; the decisive question is whether the source function type needs symbolic encoding.
- The async-aware `EmitFunctionLiteral` overload + new `TryGetSymbolicAsyncDelegateCtorRef`, which builds the reified `Func<...,Task<T>>` ctor ref so a `ContinueWith`/`SetContinuation`-style lambda returning a type parameter emits `Task<TOutput>` not `Task<object>` (handles async-void -> Action shape too).

After the fix the on-stack delegate value and the `newobj` ctor parent are the reified `Func<UserType>`/`Action<UserType>`/`Task<UserType>` TypeSpec — for both lambdas and method groups.

## Before / after (repro A — `Lazy[Foo](() -> Foo(42))`)

- **Before:** ilverify `StackUnexpected` at `demo.C::Make()` offset 0x10: found `Func1<object>`, expected `Func1<demo.Foo>` (arity backtick omitted).
- **After:** `All Classes and Methods ... Verified.` and the program prints `42`.

## Tests

`test/Compiler.Tests/Emit/Issue1502DelegateUserTypeArgEmitTests.cs` (verbatim `CompileAndRun` from the #1467 suite — ilverify + in-process run; unique package/type name per method). All 9 pass:

| Test | Shape | Runtime |
| --- | --- | --- |
| `FuncUserClass_LazyLambda` | `Func<UserClass>` (repro) | `42` |
| `FuncUserStruct_LazyLambda` | `Func<UserStruct>` | `7` |
| `ActionUserClass_ForEachLambda` | `Action<UserClass>` | `5` |
| `FuncUserEnum_LazyLambda` | `Func<UserEnum>` | `1` |
| `FuncNestedGenericUserClass_LazyLambda` | `Func<List[UserClass]>` | `1` |
| `FuncUserClass_LazyMethodGroup` | method group -> `Func<UserClass>` | `11` |
| `FuncTypeParameter_LazyLambda` | `Func<T>` over generic `T` | `7` |
| `Control_FuncInt32_LazyLambda` | `Func<int32>` control | `42` |
| `Control_FuncString_LazyLambda` | `Func<string>` control | `x` |

## Validation

- New tests: **9 passed**.
- `Core.Tests`: **4834 passed / 1 skipped / 0 failed**.
- **Refactoring baseline NOT regenerated** — `RefactoringBaselineTests` stayed green (no baseline assembly exercises a same-compilation user-type CLR-delegate arg), so no byte-level diff was required.

Fixes #1502

Refs #914
