### PR TITLE
Fix generic closure inference and captured-field emit (#1512)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -643,6 +643,22 @@ internal sealed class ConversionClassifier
                     // sequence at the call site).
                     var substituted = TrySubstituteParameterTypeFromReceiver(
                         method, paramIndex, receiverType);
+
+                    // Issue #1512: a lambda argument bound to a generic method's
+                    // delegate parameter (e.g. `Func<Task,TResult>`) must convert
+                    // to the SYMBOLIC delegate target recovered from the method's
+                    // inferred type arguments (`Func<Task,T>`), not the closed CLR
+                    // erasure (`Func<Task,object>`). Converting to the erased shape
+                    // rebinds the literal's return to `object`, so the emitted
+                    // delegate is `Func<Task,object>` and fails ilverify at the
+                    // call's `newobj`. Only applied to function-literal arguments
+                    // so non-lambda argument coercion is unaffected.
+                    if (substituted == null
+                        && argument is BoundFunctionLiteralExpression)
+                    {
+                        substituted = TrySubstituteParameterTypeFromMethodTypeArgs(method, paramIndex, symbolicMethodTypeArgs);
+                    }
+
                     var targetType = substituted ?? TypeSymbol.FromClrType(parameterType);
                     if (argument.Type != targetType
                         && Conversion.Classify(argument.Type, targetType).Exists

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -1833,6 +1833,99 @@ internal sealed partial class ExpressionBinder
         return true;
     }
 
+    /// <summary>
+    /// Issue #1512: builds a symbolic <see cref="FunctionTypeSymbol"/> for a
+    /// lambda argument bound to a generic CLR/imported method whose delegate
+    /// parameter mentions a method type parameter (e.g.
+    /// <c>Task.ContinueWith&lt;TResult&gt;(Func&lt;Task,TResult&gt;)</c>). The
+    /// CLOSED method's parameter is type-erased (<c>Func&lt;Task,object&gt;</c>),
+    /// which would force the lambda's bound function type — and therefore its
+    /// synthesized return — to <c>object</c>, so the delegate emits as
+    /// <c>Func&lt;Task,object&gt;</c> instead of <c>Func&lt;Task,T&gt;</c>. This
+    /// recovers the real shape by substituting the inferred symbolic method type
+    /// arguments (and any receiver-level type arguments) through the OPEN
+    /// method's delegate parameter via <see cref="MemberLookup.MapOpenClrTypeToSymbolic(Type, Type, ImmutableArray{TypeSymbol}, MethodInfo, ImmutableArray{TypeSymbol})"/>.
+    /// Returns <see langword="false"/> (deferring to the erased target) when the
+    /// parameter is not a delegate, the method is not generic, or no recovered
+    /// position contains a type parameter / same-compilation user type.
+    /// </summary>
+    private static bool TryBuildSymbolicDelegateTargetForMethodParam(
+        MethodInfo closedMethod,
+        int paramIndex,
+        ImmutableArray<TypeSymbol> symbolicMethodTypeArgs,
+        TypeSymbol receiverType,
+        out FunctionTypeSymbol target)
+    {
+        target = null;
+        if (closedMethod == null
+            || !closedMethod.IsGenericMethod
+            || symbolicMethodTypeArgs.IsDefaultOrEmpty
+            || !symbolicMethodTypeArgs.Any(s => s != null
+                && (TypeSymbol.ContainsTypeParameter(s) || TypeSymbol.ContainsSameCompilationUserType(s))))
+        {
+            return false;
+        }
+
+        MethodInfo openMethod;
+        ParameterInfo[] openParams;
+        try
+        {
+            openMethod = closedMethod.IsGenericMethodDefinition ? closedMethod : closedMethod.GetGenericMethodDefinition();
+            openParams = openMethod.GetParameters();
+        }
+        catch (Exception ex) when (ClrTypeUtilities.IsMetadataLoadFailure(ex))
+        {
+            return false;
+        }
+
+        if (paramIndex < 0 || paramIndex >= openParams.Length)
+        {
+            return false;
+        }
+
+        var openParamType = openParams[paramIndex].ParameterType;
+        var invoke = openParamType?.GetMethodSafe("Invoke");
+        if (invoke == null)
+        {
+            return false;
+        }
+
+        Type receiverOpenDef = null;
+        ImmutableArray<TypeSymbol> receiverTypeArgs = default;
+        if (receiverType is ImportedTypeSymbol imp && imp.OpenDefinition != null && !imp.TypeArguments.IsDefaultOrEmpty)
+        {
+            receiverOpenDef = imp.OpenDefinition;
+            receiverTypeArgs = imp.TypeArguments;
+        }
+
+        var invokeParameters = invoke.GetParameters();
+        var parameterTypes = ImmutableArray.CreateBuilder<TypeSymbol>(invokeParameters.Length);
+        foreach (var parameter in invokeParameters)
+        {
+            parameterTypes.Add(MemberLookup.MapOpenClrTypeToSymbolic(
+                parameter.ParameterType, receiverOpenDef, receiverTypeArgs, openMethod, symbolicMethodTypeArgs));
+        }
+
+        var returnType = invoke.ReturnType.IsSameAs(typeof(void))
+            ? TypeSymbol.Void
+            : MemberLookup.MapOpenClrTypeToSymbolic(invoke.ReturnType, receiverOpenDef, receiverTypeArgs, openMethod, symbolicMethodTypeArgs);
+
+        var candidate = FunctionTypeSymbol.Get(parameterTypes.ToImmutable(), returnType);
+
+        // Only override the erased target when the recovered shape actually
+        // carries a type parameter or same-compilation user type; otherwise the
+        // ordinary closed-CLR delegate target is already correct.
+        var carries = (returnType != null && (TypeSymbol.ContainsTypeParameter(returnType) || TypeSymbol.ContainsSameCompilationUserType(returnType)))
+            || parameterTypes.Any(p => p != null && (TypeSymbol.ContainsTypeParameter(p) || TypeSymbol.ContainsSameCompilationUserType(p)));
+        if (!carries)
+        {
+            return false;
+        }
+
+        target = candidate;
+        return true;
+    }
+
     private void ResolveDeferredArrowLambdaArguments(
         BoundExpression receiver,
         ImportedClassSymbol classSymbol,
@@ -2728,21 +2821,24 @@ internal sealed partial class ExpressionBinder
                 var staticRebound = RebindFormattableInterpolationArguments(staticExpandedArgs, ce.Arguments, staticParameters, staticDownstreamMapping);
                 var staticHandlerArgs = ApplyInterpolatedStringHandlers(staticParameters, staticRebound, receiver: null, ce.Location, staticDownstreamMapping, out var staticHandlerPrelude, out _);
 
-                // Issue #889: void-ize value-returning func/arrow literals passed
-                // to void-returning delegate parameters (System.Action / Action<...>)
-                // before CLR parameter conversion, mirroring the instance path.
-                var staticDelegateArgs = RebindFunctionLiteralDelegateArguments(staticHandlerArgs, staticParameters, staticDownstreamMapping);
-
                 // Issue #1325 / #1471: recover the symbolic method type-argument
                 // vector before parameter conversion so a bare `default`
                 // argument closed over an open type parameter (e.g.
                 // `Task.FromResult[T?](default)`) materialises against the real
                 // type parameter instead of the erased `object` placeholder.
+                // Issue #1512: computed BEFORE the delegate rebind so a lambda
+                // argument whose return is a method type parameter recovers its
+                // symbolic delegate target rather than erasing to `object`.
                 var staticSymbolicArgs = MemberLookup.BuildSymbolicArgTypeVector(
                     receiverType: null,
                     ImmutableArray.CreateRange(arguments.Select(a => a?.Type)));
                 var staticSymbolicTypeArgs = MemberLookup.BuildSymbolicMethodTypeArgs(staticFn.Method, typeArgSymbols, staticSymbolicArgs);
                 var staticTypeArgSymbolsForCall = !staticSymbolicTypeArgs.IsDefault ? staticSymbolicTypeArgs : typeArgSymbols;
+
+                // Issue #889: void-ize value-returning func/arrow literals passed
+                // to void-returning delegate parameters (System.Action / Action<...>)
+                // before CLR parameter conversion, mirroring the instance path.
+                var staticDelegateArgs = RebindFunctionLiteralDelegateArguments(staticHandlerArgs, staticParameters, staticDownstreamMapping, staticFn.Method, staticTypeArgSymbolsForCall);
 
                 // Issue #506 follow-up: ensure value-type → object boxing fires
                 // for fixed-arity CLR static calls (e.g. `String.Format("{0}", 42)`
@@ -3143,7 +3239,21 @@ internal sealed partial class ExpressionBinder
                             // against the resolved by-ref parameter so the new
                             // local is declared with the inferred pointee type.
                             arguments = RebindInlineOutVarArguments(ce, arguments, resolution.Best, resolution.ParameterMapping, receiver?.Type);
-                            var instSymbolicArgs = MemberLookup.BuildSymbolicArgTypeVector(effectiveReceiverType, ImmutableArray.CreateRange(arguments.Select(a => a?.Type)));
+
+                            // Issue #1512: for a genuine INSTANCE method the receiver
+                            // is `this`, not a formal parameter — `GetParameters()`
+                            // excludes it. The method-type-argument inference vector
+                            // must therefore align with the method's parameters and
+                            // must NOT carry the receiver as slot 0 (unlike the
+                            // extension-method path, where the receiver IS param 0).
+                            // Including it shifted every real argument by one slot, so
+                            // a method type parameter inferable only from a lambda
+                            // argument (e.g. `TResult` of
+                            // `Task.ContinueWith<TResult>(Func<Task,TResult>)`) was
+                            // never unified and the call collapsed to `<object>`. The
+                            // receiver still drives return-type Var substitution via
+                            // `ResolveCallReturnTypeFromSymbolicTypeArgs` below.
+                            var instSymbolicArgs = MemberLookup.BuildSymbolicArgTypeVector(null, ImmutableArray.CreateRange(arguments.Select(a => a?.Type)));
                             var instSymbolicTypeArgs = MemberLookup.BuildSymbolicMethodTypeArgs(resolution.Best, typeArgSymbols, instSymbolicArgs);
                             var instTypeArgSymbolsForCall = !instSymbolicTypeArgs.IsDefault ? instSymbolicTypeArgs : typeArgSymbols;
                             var returnType = ResolveImportedGenericReturnType(resolution.Best, typeArgSymbols)
@@ -3158,7 +3268,7 @@ internal sealed partial class ExpressionBinder
                             var instDownstreamMapping = resolution.IsExpanded ? default : instMapping;
                             var instRebound = RebindFormattableInterpolationArguments(instExpandedArgs, ce.Arguments, instParameters, instDownstreamMapping);
                             var instHandlerArgs = ApplyInterpolatedStringHandlers(instParameters, instRebound, receiver, ce.Location, instDownstreamMapping, out var instHandlerPrelude, out var instUpdatedReceiver);
-                            var instDelegateArgs = RebindFunctionLiteralDelegateArguments(instHandlerArgs, instParameters, instDownstreamMapping);
+                            var instDelegateArgs = RebindFunctionLiteralDelegateArguments(instHandlerArgs, instParameters, instDownstreamMapping, resolution.Best, instTypeArgSymbolsForCall, effectiveReceiverType);
                             var instConvertedArgs = conversions.BindClrParameterConversions(instDelegateArgs, instParameters, ce, instDownstreamMapping, method: resolution.Best, receiverType: receiver?.Type, symbolicMethodTypeArgs: instTypeArgSymbolsForCall);
                             var instArguments = OverloadResolver.BuildOrderedCallArguments(instConvertedArgs, instDownstreamMapping, instParameters);
                             var instRefKinds = ComputeArgumentRefKinds(instParameters);
@@ -3811,7 +3921,12 @@ internal sealed partial class ExpressionBinder
                     return true;
                 }
 
-                var inheritedSymbolicArgs = MemberLookup.BuildSymbolicArgTypeVector(receiver?.Type, ImmutableArray.CreateRange(arguments.Select(a => a?.Type)));
+                // Issue #1512: an instance method (incl. one inherited from an
+                // imported generic base) excludes the receiver from its formal
+                // parameter list, so the method-type-argument inference vector must
+                // not carry the receiver as slot 0 — otherwise lambda-only-inferable
+                // method type parameters never unify and erase to `<object>`.
+                var inheritedSymbolicArgs = MemberLookup.BuildSymbolicArgTypeVector(null, ImmutableArray.CreateRange(arguments.Select(a => a?.Type)));
                 var inheritedSymbolicTypeArgs = MemberLookup.BuildSymbolicMethodTypeArgs(resolution.Best, typeArgSymbols, inheritedSymbolicArgs);
                 var inheritedTypeArgSymbolsForCall = !inheritedSymbolicTypeArgs.IsDefault ? inheritedSymbolicTypeArgs : typeArgSymbols;
                 var returnType = ResolveImportedGenericReturnType(resolution.Best, typeArgSymbols)
@@ -3825,7 +3940,7 @@ internal sealed partial class ExpressionBinder
                     : arguments;
                 var inheritedDownstreamMapping = resolution.IsExpanded ? default : inheritedMapping;
                 var inheritedHandlerArgs = ApplyInterpolatedStringHandlers(inheritedParameters, inheritedExpandedArgs, receiver, ce.Location, inheritedDownstreamMapping, out var inheritedHandlerPrelude, out var inheritedUpdatedReceiver);
-                var inheritedDelegateArgs = RebindFunctionLiteralDelegateArguments(inheritedHandlerArgs, inheritedParameters, inheritedDownstreamMapping);
+                var inheritedDelegateArgs = RebindFunctionLiteralDelegateArguments(inheritedHandlerArgs, inheritedParameters, inheritedDownstreamMapping, resolution.Best, inheritedTypeArgSymbolsForCall, receiver?.Type);
                 var inheritedConvertedArgs = conversions.BindClrParameterConversions(inheritedDelegateArgs, inheritedParameters, ce, inheritedDownstreamMapping, method: resolution.Best, receiverType: receiver?.Type, symbolicMethodTypeArgs: inheritedTypeArgSymbolsForCall);
                 var inheritedArguments = OverloadResolver.BuildOrderedCallArguments(inheritedConvertedArgs, inheritedDownstreamMapping, inheritedParameters);
                 var refKinds = ComputeArgumentRefKinds(inheritedParameters);
@@ -4245,7 +4360,10 @@ internal sealed partial class ExpressionBinder
     private ImmutableArray<BoundExpression> RebindFunctionLiteralDelegateArguments(
         ImmutableArray<BoundExpression> arguments,
         ParameterInfo[] parameters,
-        ImmutableArray<int> parameterMapping = default)
+        ImmutableArray<int> parameterMapping = default,
+        MethodInfo method = null,
+        ImmutableArray<TypeSymbol> symbolicMethodTypeArgs = default,
+        TypeSymbol receiverType = null)
     {
         ImmutableArray<BoundExpression>.Builder builder = null;
         for (var i = 0; i < arguments.Length; i++)
@@ -4258,7 +4376,24 @@ internal sealed partial class ExpressionBinder
                 && MemberLookup.TryGetDelegateFunctionType(parameters[paramIndex].ParameterType, out var targetFunctionType)
                 && literal.FunctionType != targetFunctionType)
             {
-                rebound = lambdas.CreateErasedFunctionLiteralAdapter(literal, targetFunctionType);
+                // Issue #1512: when the call is a generic method whose delegate
+                // parameter mentions a method type parameter, the closed CLR
+                // parameter type erases that slot to `object`, so the literal
+                // would be rebound to e.g. `(Task) -> object` and emit a
+                // `Func<Task,object>` delegate where `Func<Task,T>` is required.
+                // Prefer the symbolic delegate target recovered from the OPEN
+                // method parameter substituted with the inferred symbolic method
+                // type arguments — including when it already equals the literal's
+                // bound function type, so the erasing rebind below is skipped.
+                if (TryBuildSymbolicDelegateTargetForMethodParam(method, paramIndex, symbolicMethodTypeArgs, receiverType, out var symbolicTarget))
+                {
+                    targetFunctionType = symbolicTarget;
+                }
+
+                if (literal.FunctionType != targetFunctionType)
+                {
+                    rebound = lambdas.CreateErasedFunctionLiteralAdapter(literal, targetFunctionType);
+                }
             }
 
             if (rebound != argument && builder == null)

--- a/src/Core/CodeAnalysis/Emit/ClosureEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ClosureEmitter.cs
@@ -273,12 +273,18 @@ internal sealed class ClosureEmitter
             // the CLR nested-type access to the encloser's family/private members
             // (and the encloser's inherited protected members). Without nesting the
             // synthesized Invoke method triggers MethodAccessException/
-            // FieldAccessException at runtime. Generic enclosing types are skipped:
-            // a nested type would have to re-declare the encloser's type parameters,
-            // which the closure synthesis does not model, and the public-member case
-            // those closures already handle does not need nesting.
+            // FieldAccessException at runtime.
+            //
+            // Issue #1512: this nesting must also apply when the enclosing type is
+            // generic. A closure capturing a generic encloser is reified over a
+            // clone of the encloser's type parameters (SynthesizedClosureReifier),
+            // so the closure's own ordinal-aligned parameter list already matches
+            // what a nested type inside the encloser must re-declare per
+            // ECMA-335 §II.10.3.1 (e.g. `<closure>`1` nested in `Op`1` shares the
+            // single `T`). Without nesting, the reified closure was emitted as a
+            // top-level type and its Invoke could not read the generic encloser's
+            // private captured field ("Field is not visible").
             if (literal.Function?.LexicalEnclosingType is StructSymbol enclosing
-                && enclosing.TypeParameters.IsDefaultOrEmpty
                 && info.ClassSym.ContainingType == null)
             {
                 info.ClassSym.SetContainingType(enclosing);

--- a/test/Compiler.Tests/Emit/Issue1512GenericClosureInferenceEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1512GenericClosureInferenceEmitTests.cs
@@ -1,0 +1,279 @@
+// <copyright file="Issue1512GenericClosureInferenceEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1512 — two independent emit bugs that both surface when a generic
+/// class passes a lambda returning (or parameterized by) a type parameter to a
+/// generic method.
+/// <para>
+/// Facet A — generic-method type-argument inference erased a type-parameter
+/// lambda return to <c>object</c>. <c>Task.ContinueWith&lt;TResult&gt;</c> (and
+/// any generic CLR/imported method inferring a type argument from a lambda whose
+/// parameter/return is a type parameter) selected <c>ContinueWith&lt;object&gt;</c>
+/// instead of <c>ContinueWith&lt;T&gt;</c>, producing <c>Task&lt;object&gt;</c>
+/// where <c>Task&lt;T&gt;</c> was required and failing ilverify with
+/// <c>StackUnexpected [found Task`1&lt;object&gt;][expected Task`1&lt;T0&gt;]</c>.
+/// </para>
+/// <para>
+/// Facet B — a lambda lowered into a generic closure class (reified over its
+/// enclosing type parameters) was emitted as a top-level type, so its
+/// synthesized <c>Invoke</c> could not access the enclosing generic class's
+/// <c>private</c> captured field, failing ilverify with
+/// <c>FieldAccess … Field is not visible</c>. Nesting the reified closure inside
+/// its enclosing type (matching the non-generic closure path) grants the CLR
+/// nested-type access to the encloser's private members.
+/// </para>
+/// Every test uses a UNIQUE package/type name because the in-process
+/// <c>FunctionTypeSymbol</c> cache is name-keyed. The <c>CompileAndRun</c> helper
+/// runs <c>IlVerifier.Verify</c> and then executes the program, so each test
+/// asserts both ilverify-cleanliness and a real runtime value.
+/// </summary>
+public class Issue1512GenericClosureInferenceEmitTests
+{
+    [Fact]
+    public void FacetA_TaskContinueWith_ReturnsTypeParameter_Runs()
+    {
+        const string source = """
+            package i1512facetataskcw
+            import System
+            import System.Threading.Tasks
+
+            class Op[T] {
+                var cont Task[T]?
+                init() { }
+                func SetIt(readerTask Task, v T) Task[T] {
+                    let r = readerTask.ContinueWith((t Task) -> v)
+                    cont = r
+                    return r
+                }
+            }
+
+            func Main() {
+                var o = Op[int32]()
+                var r = o.SetIt(Task.CompletedTask, 42)
+                System.Console.WriteLine(r.Result)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void FacetA_EnumerableSelect_ReturnsTypeParameter_Runs()
+    {
+        // A non-Task generic-method inference shape: `Enumerable.Select`'s
+        // TResult is inferred from a lambda whose return is the enclosing type
+        // parameter T (here bound to string).
+        const string source = """
+            package i1512facetaselect
+            import System
+            import System.Collections.Generic
+            import System.Linq
+
+            class Box[T] {
+                func Mapped(src List[int32], f (int32) -> T) IEnumerable[T] {
+                    return src.Select(f)
+                }
+            }
+
+            func Main() {
+                var b = Box[string]()
+                var lst = List[int32]()
+                lst.Add(3)
+                lst.Add(4)
+                var sum = 0
+                for v in b.Mapped(lst, (x int32) -> "v" + x.ToString()) {
+                    System.Console.WriteLine(v)
+                }
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("v3\nv4\n", output);
+    }
+
+    [Fact]
+    public void FacetB_GenericClosure_CapturesPrivateField_Int_Runs()
+    {
+        const string source = """
+            package i1512facetbint
+            import System
+
+            class Op[T] {
+                private let fn (int32) -> T
+                init(fn (int32) -> T) { this.fn = fn }
+                func Use() (int32) -> T {
+                    let g = (x int32) -> fn(x)
+                    return g
+                }
+            }
+
+            func Main() {
+                var o = Op[int32]((x int32) -> x + 1)
+                let h = o.Use()
+                System.Console.WriteLine(h(5))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("6\n", output);
+    }
+
+    [Fact]
+    public void FacetB_GenericClosure_CapturesPrivateField_StructTypeArg_Runs()
+    {
+        // Generalizes Facet B to a user struct type argument (not int32): the
+        // reified closure is constructed over `Pt` and still reaches the
+        // enclosing generic class's private captured field.
+        const string source = """
+            package i1512facetbstruct
+            import System
+
+            struct Pt(x int32) { }
+
+            class Holder[T] {
+                private let make (int32) -> T
+                init(make (int32) -> T) { this.make = make }
+                func Build() (int32) -> T {
+                    let g = (n int32) -> make(n)
+                    return g
+                }
+            }
+
+            func Main() {
+                var h = Holder[Pt]((n int32) -> Pt(n * 2))
+                let f = h.Build()
+                var p = f(21)
+                System.Console.WriteLine(p.x)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void Combined_FacetA_And_FacetB_TogetherInOneType_Runs()
+    {
+        // Both root causes in one generic type: the captured private field `fn`
+        // (Facet B) is invoked inside a lambda passed to `Task.ContinueWith`
+        // whose TResult must infer to T (Facet A).
+        const string source = """
+            package i1512combined
+            import System
+            import System.Threading.Tasks
+
+            class Op[T] {
+                private let fn (Task) -> T
+                var cont Task[T]?
+                init(fn (Task) -> T) { this.fn = fn }
+                func SetContinuation(readerTask Task) Task[T] {
+                    let r = readerTask.ContinueWith((t Task) -> fn(t))
+                    cont = r
+                    return r
+                }
+            }
+
+            func Main() {
+                var o = Op[int32]((t Task) -> 7)
+                var r = o.SetContinuation(Task.CompletedTask)
+                System.Console.WriteLine(r.Result)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("7\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1512_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

A generic class that passes a lambda returning (or parameterized by) a type parameter to a generic method triggered two **independent** emit bugs, both blocking the Oahu.Decrypt ilverify migration. Both are fixed here.

### Facet A — generic-method type-argument inference erased a type-parameter lambda return to `object`
For an instance call the receiver is `this`, not a formal parameter, but the method-type-argument inference vector carried it as slot 0, shifting every real argument by one. A method type parameter inferable only from a lambda (e.g. `TResult` of `Task.ContinueWith<TResult>(Func<Task,TResult>)`) was never unified → the call collapsed to `<object>` and emitted `Task<object>` (ilverify `StackUnexpected [found Task\`1<object>][expected Task\`1<T0>]`).

- The inference vector now **excludes the receiver** for instance/inherited imported calls.
- Even with correct inference, the closed CLR delegate parameter erases the lambda's function type to `Func<Task,object>`. The binder now **recovers the symbolic delegate target** from the OPEN method parameter substituted with the inferred symbolic method type arguments (in both the delegate rebind and CLR parameter conversion), so `Func<Task,T>` is emitted.

### Facet B — generic closure captured-field "Field is not visible"
A lambda lowered into a generic closure (reified over a clone of its enclosing type parameters) was emitted as a **top-level** type, so its synthesized `Invoke` could not read the enclosing generic class's `private` captured field (ilverify `FieldAccess … Field is not visible`).

The reified closure's own ordinal-aligned parameter list already matches what a nested type inside the encloser must re-declare per ECMA-335 §II.10.3.1, so the closure is now **nested inside its enclosing type** (matching the non-generic closure path), granting CLR nested-type access to the encloser's private members.

## Tests
New `test/Compiler.Tests/Emit/Issue1512GenericClosureInferenceEmitTests.cs` (ilverify + runtime), covering both facets, each generalized beyond Task/`int32` (Enumerable.Select; struct type arg) plus the combined construct.

## Validation
- Repros `cw.gs`, `cap.gs` (prints 6), `cont.gs`, plus non-Task and struct generalizations: all ilverify-clean.
- `--filter Issue1512`: 5/5 passed.
- Regression `--filter Issue1499|Issue1502|Issue1162|Issue903`: 33/33; `Issue1477|Issue1500|Issue1335|Closure`: 68/68.
- `Core.Tests`: 4836 passed, 1 skipped, 0 failed (no baseline regression).

Fixes #1512

Refs #914