### PR TITLE
Fix unverifiable IL for null-coalesce over 'as'-cast to a reference type parameter

### DIFF
--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
@@ -287,6 +287,46 @@ internal sealed partial class MethodBodyEmitter
                 return;
             }
 
+            // Issue #1516: NullCoalesce over a bare reference-typed type
+            // parameter LHS — e.g. `x as T ?? fallback` where `T : SomeClass`,
+            // interface-constrained, or unconstrained. `BoundAsExpression.Type`
+            // for a reference target is the bare `T`, so the LHS is a
+            // `TypeParameterSymbol` directly (NOT wrapped in
+            // `NullableTypeSymbol`), and the Issue #831 branch above misses
+            // it. The opaque `!!T` stack value cannot be probed with the
+            // bottom `dup; brtrue` shape (ECMA-335 III.1.8), so mirror the
+            // #831 box-probe spill: store the LHS to a `T`-typed slot, probe
+            // its non-nullness via `box !!T; brfalse fallback`, and either
+            // reload the slot (non-null) or evaluate RHS (fallback).
+            if (SlotPlanner.IsReferenceTypeParameterCoalesceProbe(b, out var bareTp))
+            {
+                if (!this.nullableCoalesceSpillSlots.TryGetValue(b, out var bareSlot))
+                {
+                    throw new InvalidOperationException(
+                        "No scratch slot pre-allocated for bare reference-typed type-parameter '??' LHS — "
+                        + "check NullableValueTypeCoalesceCollector and the prepass in CollectLocalsAndLabels.");
+                }
+
+                var bareToken = this.outer.GetElementTypeToken(bareTp);
+                var fallback = this.il.DefineLabel();
+                var end = this.il.DefineLabel();
+
+                this.EmitExpression(b.Left);
+                this.il.StoreLocal(bareSlot);
+                this.il.LoadLocal(bareSlot);
+                this.il.OpCode(ILOpCode.Box);
+                this.il.Token(bareToken);
+                this.il.Branch(ILOpCode.Brfalse, fallback);
+
+                this.il.LoadLocal(bareSlot);
+                this.il.Branch(ILOpCode.Br, end);
+
+                this.il.MarkLabel(fallback);
+                this.EmitExpression(b.Right);
+                this.il.MarkLabel(end);
+                return;
+            }
+
             // Defensive: any other value-typed LHS (raw struct or enum)
             // remains unsupported by `??`. Today the encoder rejects
             // nullable user-defined structs/enums, so this branch is

--- a/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
+++ b/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
@@ -1195,11 +1195,24 @@ internal sealed class SlotPlanner
 
         protected override void VisitBinaryExpression(BoundBinaryExpression node)
         {
-            if (node.Op.Kind == BoundBinaryOperatorKind.NullCoalesce
-                && node.Left.Type is NullableTypeSymbol n)
+            if (node.Op.Kind == BoundBinaryOperatorKind.NullCoalesce)
             {
-                bool needsSlot = n.UnderlyingType?.ClrType is { IsValueType: true }
-                    || (n.UnderlyingType is TypeParameterSymbol tp && !tp.HasValueTypeConstraint);
+                bool needsSlot = false;
+
+                if (node.Left.Type is NullableTypeSymbol n)
+                {
+                    needsSlot = n.UnderlyingType?.ClrType is { IsValueType: true }
+                        || (n.UnderlyingType is TypeParameterSymbol tp && !tp.HasValueTypeConstraint);
+                }
+                else if (IsReferenceTypeParameterCoalesceProbe(node, out _))
+                {
+                    // Issue #1516: bare reference-typed type-parameter LHS
+                    // (e.g. `x as T ?? fallback` where `T : SomeClass`,
+                    // interface-constrained, or unconstrained). The LHS
+                    // type is the bare `T`, not `T?`, so the value-type
+                    // and `NullableTypeSymbol(TP)` cases above miss it.
+                    needsSlot = true;
+                }
 
                 if (needsSlot)
                 {
@@ -1209,6 +1222,31 @@ internal sealed class SlotPlanner
 
             base.VisitBinaryExpression(node);
         }
+    }
+
+    // Issue #1516: a `??` whose LHS is a bare reference-typed type
+    // parameter (NOT wrapped in a `NullableTypeSymbol`). This shape arises
+    // from `x as T ?? fallback` because `BoundAsExpression.Type` for a
+    // reference target is the bare `T`. The opaque `!!T` stack value cannot
+    // be probed with `dup; brtrue` (ECMA-335 III.1.8), so — exactly like
+    // the Issue #831 `NullableTypeSymbol(TP)` path — the emitter spills the
+    // LHS to a `T`-typed scratch slot and probes via `box !!T; brfalse`.
+    // The collector and emitter both call this helper so they agree
+    // precisely on which nodes need a pre-allocated slot.
+    internal static bool IsReferenceTypeParameterCoalesceProbe(
+        BoundBinaryExpression node,
+        out TypeParameterSymbol typeParameter)
+    {
+        if (node.Op.Kind == BoundBinaryOperatorKind.NullCoalesce
+            && node.Left.Type is TypeParameterSymbol tp
+            && !tp.HasValueTypeConstraint)
+        {
+            typeParameter = tp;
+            return true;
+        }
+
+        typeParameter = null;
+        return false;
     }
 
     // PR N-4 / §6.1 / C# §7.3.7: walks the bound tree collecting every

--- a/test/Compiler.Tests/Emit/Issue1516CoalesceAsTypeParamEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1516CoalesceAsTypeParamEmitTests.cs
@@ -1,0 +1,260 @@
+// <copyright file="Issue1516CoalesceAsTypeParamEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1516 — null-coalescing (<c>??</c>) directly over an <c>as</c>-cast to
+/// a REFERENCE-typed type parameter emitted unverifiable IL
+/// (<c>StackUnexpected</c>). <c>BoundAsExpression.Type</c> for a reference
+/// target is the BARE type parameter <c>T</c> (not <c>T?</c>), so the
+/// <c>??</c> LHS is a <c>TypeParameterSymbol</c> directly — which the Issue
+/// #831 box-probe path (gated on <c>NullableTypeSymbol(TP)</c>) missed in both
+/// the slot collector and the emit branch. Emission fell through to the bottom
+/// <c>dup; brtrue</c> shape, which the verifier rejects for an opaque
+/// <c>!!T</c> stack value (ECMA-335 III.1.8).
+/// <para>
+/// The fix generalizes the box-probe spill to also cover a bare
+/// reference-typed type-parameter LHS (<c>TypeParameterSymbol</c> that is NOT
+/// struct-constrained): the collector pre-allocates a <c>T</c>-typed scratch
+/// slot and the emitter spills the LHS, probes via <c>box !!T; brfalse
+/// fallback</c>, and reloads the slot (non-null) or evaluates the RHS
+/// (fallback). Every facet failed ilverify on current main and passes after
+/// the fix. Each uses a UNIQUE package/type name because the in-process
+/// <c>FunctionTypeSymbol</c> cache is name-keyed.
+/// </para>
+/// </summary>
+public class Issue1516CoalesceAsTypeParamEmitTests
+{
+    [Fact]
+    public void EndToEnd_AsClassConstrainedT_CoalesceThrow_MatchedPath_Runs()
+    {
+        const string source = """
+            package i1516matchedthrow
+            import System
+            import System.IO
+
+            open class Box {
+                let name string
+                init(name string) { this.name = name }
+                prop Name string -> name
+            }
+
+            class FooBox : Box {
+                init(name string) : base(name) {}
+            }
+
+            class Factory {
+                shared {
+                    func Make[T Box](src Box) T {
+                        return src as T ?? throw InvalidDataException("nope")
+                    }
+                }
+            }
+
+            func Main() {
+                var b Box = FooBox("x")
+                System.Console.WriteLine(Factory.Make[FooBox](b).Name)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("x\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_AsClassConstrainedT_CoalesceFallback_FallbackPath_Runs()
+    {
+        // The cast `src as T` FAILS (a BarBox is not a FooBox), so the
+        // fallback expression must be taken and returned.
+        const string source = """
+            package i1516fallbacktaken
+            import System
+
+            open class Box {
+                let name string
+                init(name string) { this.name = name }
+                prop Name string -> name
+            }
+
+            class FooBox : Box {
+                init(name string) : base(name) {}
+            }
+
+            class BarBox : Box {
+                init(name string) : base(name) {}
+            }
+
+            class Factory {
+                shared {
+                    func Make[T Box](src Box, fallback T) T {
+                        return src as T ?? fallback
+                    }
+                }
+            }
+
+            func Main() {
+                var b Box = BarBox("bar")
+                var fb FooBox = FooBox("fallback")
+                System.Console.WriteLine(Factory.Make[FooBox](b, fb).Name)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("fallback\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_AsUnconstrainedT_Coalesce_BothPaths_Runs()
+    {
+        // Unconstrained `T` used as a reference: the matched path prints the
+        // cast value ("hello"); the fallback path prints the fallback ("fb2")
+        // because boxing an int32 cannot be cast to string.
+        const string source = """
+            package i1516unconstrained
+            import System
+
+            class Holder {
+                shared {
+                    func Get[T](src object, fallback T) T {
+                        return src as T ?? fallback
+                    }
+                }
+            }
+
+            func Main() {
+                var s object = "hello"
+                System.Console.WriteLine(Holder.Get[string](s, "fb"))
+                var n object = 5
+                System.Console.WriteLine(Holder.Get[string](n, "fb2"))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("hello\nfb2\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_Control_NullableTypeParamCoalesce_NoRegression_Runs()
+    {
+        // Control: `maybe T? ?? fallback` over a NullableTypeSymbol(TP) LHS
+        // (the Issue #831 path) must remain ilverify-clean and correct.
+        const string source = """
+            package i1516controlnullable
+            import System
+
+            open class Box {
+                let name string
+                init(name string) { this.name = name }
+                prop Name string -> name
+            }
+
+            class Factory {
+                shared {
+                    func Coalesce[T Box](maybe T?, fallback T) T {
+                        return maybe ?? fallback
+                    }
+                }
+            }
+
+            func Main() {
+                var present Box = Box("present")
+                var fb Box = Box("fb")
+                System.Console.WriteLine(Factory.Coalesce[Box](present as Box, fb).Name)
+                System.Console.WriteLine(Factory.Coalesce[Box](nil, fb).Name)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("present\nfb\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1516_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
Null-coalescing (`??`) directly over an `as`-cast to a **reference-typed type parameter** (`x as T ?? fallback`) emitted unverifiable IL (`StackUnexpected`). The code ran correctly but `ilverify` rejected it, blocking the Oahu.Decrypt migration (`BoxFactory.CreateBox[T Box]`).

## Root cause
`BoundAsExpression.Type` for a reference target is the **bare** `T`, not `T?`. So for `x as T` where `T : Box`, the `??` LHS is a `TypeParameterSymbol` directly. The Issue #831 box-probe spill path only matched a `NullableTypeSymbol(TP)` LHS, so the bare-`T` case was missed in **both** the slot collector (`SlotPlanner.NullableValueTypeCoalesceCollector`) and the emit branch (`MethodBodyEmitter.Operators.cs`). No scratch slot was allocated and emission fell through to the bottom `dup; brtrue` shape, which the verifier rejects for an opaque `!!T` stack value (ECMA-335 III.1.8).

## Fix
Generalize the box-probe spill to also cover a bare reference-typed type-parameter LHS (`TypeParameterSymbol` that is not struct-constrained), via a shared `SlotPlanner.IsReferenceTypeParameterCoalesceProbe` helper used by both the collector and emitter so they agree exactly:
- collector pre-allocates a `T`-typed scratch slot,
- emitter spills the LHS, probes via `box !!T; brfalse fallback`, reloads the slot on non-null or evaluates the RHS on fallback.

The existing `NullableTypeSymbol(TP)` and value-type `Nullable<T>` paths are untouched. Generalizes to any reference/unconstrained type-parameter `??` LHS (class-constrained, interface-constrained, or unconstrained), not only `Box`/`CreateBox`.

## Tests
New emit tests in `test/Compiler.Tests/Emit/Issue1516CoalesceAsTypeParamEmitTests.cs` cover: (a) `as T ?? throw` matched path returns the cast value; (b) `as T ?? fallback` where the cast fails so fallback is taken; (c) unconstrained-`T` variant exercising both paths; (d) a `T? ?? fallback` control proving no regression. All assert real runtime values and are ilverify-clean.

## Validation
- Repro: ilverify-clean and prints `x`.
- New tests: 4 passed.
- Regression (Issue831/Issue575/Coalesce/Nullable): 248 passed.
- Core.Tests whole: 4840 passed / 1 skip / 0 fail.

Fixes #1516

Refs #914