### PR TITLE
Spill stackalloc used as a sub-expression to fix LocallocStackNotEmpty

### DIFF
--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
@@ -767,6 +767,32 @@ internal sealed partial class MethodBodyEmitter
     // ADR-0124 / ADR-0122).
     private void EmitStackAlloc(BoundStackAllocExpression node)
     {
+        // Issue #1522: a `stackalloc` that was spilled by the method-body
+        // planner (any non-statement-root position) has already had its
+        // `localloc` + result materialised into a pre-allocated local at an
+        // empty-stack point (see MaterializeSpilledStackAllocs). At the operand
+        // position we simply load that local, keeping the evaluation stack legal
+        // for the surrounding call/operator. The materialisation guard tolerates
+        // the (unexpected) case of a spilled node reached before its statement's
+        // pre-pass ran by materialising in place — still correct, only the IL
+        // legality that spilling guarantees would be lost on that path.
+        if (this.stackAllocResultSlots.TryGetValue(node, out var resultSlot))
+        {
+            if (this.materializedStackAllocs.Add(node))
+            {
+                this.EmitStackAllocCore(node);
+                this.il.StoreLocal(resultSlot);
+            }
+
+            this.il.LoadLocal(resultSlot);
+            return;
+        }
+
+        this.EmitStackAllocCore(node);
+    }
+
+    private void EmitStackAllocCore(BoundStackAllocExpression node)
+    {
         if (!this.receiverSpillSlots.TryGetValue(node, out var countSlot))
         {
             throw new InvalidOperationException(

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
@@ -63,6 +63,8 @@ internal sealed partial class MethodBodyEmitter
     private readonly Dictionary<BoundScopeStatement, (int Tasks, int Cts, int Awaiter)> scopeFrameSlots;
     private readonly Dictionary<BoundSelectStatement, SelectSlots> selectStatementSlots;
     private readonly Dictionary<BoundExpression, int> receiverSpillSlots;
+    private readonly Dictionary<BoundStackAllocExpression, int> stackAllocResultSlots;
+    private readonly HashSet<BoundStackAllocExpression> materializedStackAllocs = new HashSet<BoundStackAllocExpression>();
     private readonly Dictionary<BoundBinaryExpression, int> nullableCoalesceSpillSlots;
     private readonly Dictionary<BoundExpression, int> indexAssignmentValueSlots;
     private readonly Dictionary<BoundGoStatement, BoundScopeStatement> goEnclosingScopes;
@@ -132,7 +134,8 @@ internal sealed partial class MethodBodyEmitter
         Lowering.Async.AsyncStateMachinePlan asyncPlan = null,
         StateMachineEmitter.AsyncIteratorEmitContext asyncIteratorEmitCtx = null,
         Dictionary<VariableSymbol, object> constValues = null,
-        ClosureEmitter.ClosureInfo enclosingClosure = null)
+        ClosureEmitter.ClosureInfo enclosingClosure = null,
+        Dictionary<BoundStackAllocExpression, int> stackAllocResultSlots = null)
     {
         this.outer = outer;
         this.il = il;
@@ -160,6 +163,7 @@ internal sealed partial class MethodBodyEmitter
         this.asyncIteratorEmitCtx = asyncIteratorEmitCtx;
         this.constValues = constValues;
         this.enclosingClosure = enclosingClosure;
+        this.stackAllocResultSlots = stackAllocResultSlots ?? new Dictionary<BoundStackAllocExpression, int>();
     }
 
     public IReadOnlyList<SequencePoint> SequencePoints => this.sequencePoints;
@@ -218,6 +222,7 @@ internal sealed partial class MethodBodyEmitter
         }
 
         this.RecordSequencePointFor(statement);
+        this.MaterializeSpilledStackAllocs(statement);
         switch (statement)
         {
             case BoundBlockStatement block:
@@ -360,6 +365,34 @@ internal sealed partial class MethodBodyEmitter
             endLine: location.EndLine + 1,
             endColumn: location.EndCharacter + 1));
         this.lastSequencePointIlOffset = ilOffset;
+    }
+
+    // Issue #1522: before a statement's own IL is emitted (evaluation stack is
+    // empty here), materialise every spilled `stackalloc` sub-expression that
+    // this statement contains, in source order, into its pre-allocated result
+    // local. The `localloc` therefore runs at an empty stack, satisfying
+    // ECMA-335 III.3.47; the original operand position later loads the result
+    // local. Nested statements are handled by their own EmitStatement pass, so
+    // this walker does not descend past the first statement boundary.
+    private void MaterializeSpilledStackAllocs(BoundStatement statement)
+    {
+        if (this.stackAllocResultSlots.Count == 0)
+        {
+            return;
+        }
+
+        var spilled = new List<BoundStackAllocExpression>();
+        new SpilledStackAllocCollector(this.stackAllocResultSlots, spilled).Visit(statement);
+        foreach (var sa in spilled)
+        {
+            if (!this.materializedStackAllocs.Add(sa))
+            {
+                continue;
+            }
+
+            this.EmitStackAllocCore(sa);
+            this.il.StoreLocal(this.stackAllocResultSlots[sa]);
+        }
     }
 
     private static bool IsObjectStackType(TypeSymbol type)
@@ -982,6 +1015,48 @@ internal sealed partial class MethodBodyEmitter
             }
 
             base.VisitAssignmentExpression(node);
+        }
+    }
+
+    // Issue #1522: collects the spilled `stackalloc` sub-expressions directly
+    // contained in a single statement, in source (evaluation) order, without
+    // descending into nested statements (each of those runs its own
+    // materialisation pass in EmitStatement).
+    private sealed class SpilledStackAllocCollector : BoundTreeWalker
+    {
+        private readonly IReadOnlyDictionary<BoundStackAllocExpression, int> spilled;
+        private readonly List<BoundStackAllocExpression> sink;
+        private bool entered;
+
+        public SpilledStackAllocCollector(
+            IReadOnlyDictionary<BoundStackAllocExpression, int> spilled,
+            List<BoundStackAllocExpression> sink)
+        {
+            this.spilled = spilled;
+            this.sink = sink;
+        }
+
+        public override void VisitStatement(BoundStatement node)
+        {
+            if (this.entered)
+            {
+                return;
+            }
+
+            this.entered = true;
+            base.VisitStatement(node);
+        }
+
+        public override void VisitExpression(BoundExpression node)
+        {
+            // Post-order: a stackalloc nested inside another spilled
+            // stackalloc's count/initializer must be materialised first so the
+            // outer materialisation reads it back with an empty stack.
+            base.VisitExpression(node);
+            if (node is BoundStackAllocExpression sa && this.spilled.ContainsKey(sa))
+            {
+                this.sink.Add(sa);
+            }
         }
     }
 

--- a/src/Core/CodeAnalysis/Emit/MethodBodyPlanner.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyPlanner.cs
@@ -340,7 +340,8 @@ internal sealed class MethodBodyPlanner
         Dictionary<BoundGoStatement, BoundScopeStatement> goEnclosingScopes,
         Dictionary<BoundBinaryExpression, LiftedBinarySlots> liftedBinarySlots,
         Dictionary<BoundBinaryExpression, int> nullableCoalesceSpillSlots,
-        InstructionEncoder il)
+        InstructionEncoder il,
+        Dictionary<BoundStackAllocExpression, int> stackAllocResultSlots = null)
     {
         this.CollectStatements(body.Statements, function, locals, localTypes, labels, appendSlots, il, pass: 1);
         this.CollectBlockExpressionLocals(body, locals, localTypes);
@@ -481,6 +482,32 @@ internal sealed class MethodBodyPlanner
             var slot = localTypes.Count;
             localTypes.Add(TypeSymbol.Int32);
             receiverSpillSlots[sa] = slot;
+        }
+
+        // Issue #1522: a `stackalloc` used as a sub-expression (method/ctor
+        // argument, or any operand evaluated with a non-empty stack) must be
+        // spilled to a result local so its `localloc` runs at an empty stack
+        // (ECMA-335 III.3.47). Reserve a result-typed local — `Span<T>` for the
+        // safe form or `T*`/`void*` for the pointer form — for every stackalloc
+        // that is NOT in a statement-root (stack-empty) position. The emitter
+        // materialises the localloc into this local at an empty-stack point and
+        // then loads it at the original operand position. `.locals init`
+        // zero-inits the block and the localloc lifetime is the whole frame, so
+        // spilling the Span/pointer to a local is safe.
+        if (stackAllocResultSlots != null)
+        {
+            var rootStackAllocs = this.CollectRootStackAllocs(body);
+            foreach (var sa in this.CollectStackAllocs(body))
+            {
+                if (rootStackAllocs.Contains(sa) || stackAllocResultSlots.ContainsKey(sa))
+                {
+                    continue;
+                }
+
+                var slot = localTypes.Count;
+                localTypes.Add(sa.Type);
+                stackAllocResultSlots[sa] = slot;
+            }
         }
 
         foreach (var receiver in this.CollectReceiverSpills(body, function, locals))
@@ -1134,6 +1161,13 @@ internal sealed class MethodBodyPlanner
     {
         var sink = new List<BoundStackAllocExpression>();
         this.slotPlanner.CollectStackAllocs((BoundStatement)root, sink);
+        return sink;
+    }
+
+    private HashSet<BoundStackAllocExpression> CollectRootStackAllocs(BoundNode root)
+    {
+        var sink = new HashSet<BoundStackAllocExpression>();
+        this.slotPlanner.CollectRootStackAllocs((BoundStatement)root, sink);
         return sink;
     }
 

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -3350,6 +3350,7 @@ internal sealed class ReflectionMetadataEmitter
             var scopeFrameSlots = new Dictionary<BoundScopeStatement, (int Tasks, int Cts, int Awaiter)>();
             var selectStatementSlots = new Dictionary<BoundSelectStatement, SelectSlots>();
             var receiverSpillSlots = new Dictionary<BoundExpression, int>();
+            var stackAllocResultSlots = new Dictionary<BoundStackAllocExpression, int>();
             var indexAssignmentValueSlots = new Dictionary<BoundExpression, int>();
             var goEnclosingScopes = new Dictionary<BoundGoStatement, BoundScopeStatement>();
             var liftedBinarySlots = new Dictionary<BoundBinaryExpression, LiftedBinarySlots>();
@@ -3380,7 +3381,8 @@ internal sealed class ReflectionMetadataEmitter
                 goEnclosingScopes,
                 liftedBinarySlots,
                 nullableCoalesceSpillSlots,
-                il);
+                il,
+                stackAllocResultSlots);
 
             // MoveNext is instance on the SM struct: arg0 = this.
             var parameters = new Dictionary<ParameterSymbol, int>
@@ -3425,7 +3427,8 @@ internal sealed class ReflectionMetadataEmitter
                 constValues: constValues,
                 structThisParameter: moveNextBody.ThisParameter,
                 asyncFieldMap: plan.FieldMap,
-                asyncPlan: plan);
+                asyncPlan: plan,
+                stackAllocResultSlots: stackAllocResultSlots);
 
             try
             {
@@ -3602,6 +3605,7 @@ internal sealed class ReflectionMetadataEmitter
         var scopeFrameSlots = new Dictionary<BoundScopeStatement, (int Tasks, int Cts, int Awaiter)>();
         var selectStatementSlots = new Dictionary<BoundSelectStatement, SelectSlots>();
         var receiverSpillSlots = new Dictionary<BoundExpression, int>();
+        var stackAllocResultSlots = new Dictionary<BoundStackAllocExpression, int>();
         var indexAssignmentValueSlots = new Dictionary<BoundExpression, int>();
         var goEnclosingScopes = new Dictionary<BoundGoStatement, BoundScopeStatement>();
         var liftedBinarySlots = new Dictionary<BoundBinaryExpression, LiftedBinarySlots>();
@@ -3629,7 +3633,8 @@ internal sealed class ReflectionMetadataEmitter
             goEnclosingScopes,
             liftedBinarySlots,
             nullableCoalesceSpillSlots,
-            il);
+            il,
+            stackAllocResultSlots);
 
         var parameters = new Dictionary<ParameterSymbol, int>();
 
@@ -3667,7 +3672,8 @@ internal sealed class ReflectionMetadataEmitter
             goEnclosingScopes,
             liftedBinarySlots: liftedBinarySlots,
             nullableCoalesceSpillSlots: nullableCoalesceSpillSlots,
-            constValues: constValues);
+            constValues: constValues,
+            stackAllocResultSlots: stackAllocResultSlots);
 
         try
         {
@@ -3713,6 +3719,7 @@ internal sealed class ReflectionMetadataEmitter
         var scopeFrameSlots = new Dictionary<BoundScopeStatement, (int Tasks, int Cts, int Awaiter)>();
         var selectStatementSlots = new Dictionary<BoundSelectStatement, SelectSlots>();
         var receiverSpillSlots = new Dictionary<BoundExpression, int>();
+        var stackAllocResultSlots = new Dictionary<BoundStackAllocExpression, int>();
         var indexAssignmentValueSlots = new Dictionary<BoundExpression, int>();
         var goEnclosingScopes = new Dictionary<BoundGoStatement, BoundScopeStatement>();
         var liftedBinarySlots = new Dictionary<BoundBinaryExpression, LiftedBinarySlots>();
@@ -3740,7 +3747,8 @@ internal sealed class ReflectionMetadataEmitter
             goEnclosingScopes,
             liftedBinarySlots,
             nullableCoalesceSpillSlots,
-            il);
+            il,
+            stackAllocResultSlots);
 
         var parameters = new Dictionary<ParameterSymbol, int>
         {
@@ -3781,7 +3789,8 @@ internal sealed class ReflectionMetadataEmitter
             goEnclosingScopes,
             liftedBinarySlots: liftedBinarySlots,
             nullableCoalesceSpillSlots: nullableCoalesceSpillSlots,
-            constValues: constValues);
+            constValues: constValues,
+            stackAllocResultSlots: stackAllocResultSlots);
 
         // base()
         il.LoadArgument(0);
@@ -3835,6 +3844,7 @@ internal sealed class ReflectionMetadataEmitter
         var scopeFrameSlots = new Dictionary<BoundScopeStatement, (int Tasks, int Cts, int Awaiter)>();
         var selectStatementSlots = new Dictionary<BoundSelectStatement, SelectSlots>();
         var receiverSpillSlots = new Dictionary<BoundExpression, int>();
+        var stackAllocResultSlots = new Dictionary<BoundStackAllocExpression, int>();
         var indexAssignmentValueSlots = new Dictionary<BoundExpression, int>();
         var goEnclosingScopes = new Dictionary<BoundGoStatement, BoundScopeStatement>();
         var liftedBinarySlots = new Dictionary<BoundBinaryExpression, LiftedBinarySlots>();
@@ -3862,7 +3872,8 @@ internal sealed class ReflectionMetadataEmitter
             goEnclosingScopes,
             liftedBinarySlots,
             nullableCoalesceSpillSlots,
-            il);
+            il,
+            stackAllocResultSlots);
 
         var paramSlots = new Dictionary<ParameterSymbol, int>
         {
@@ -3907,7 +3918,8 @@ internal sealed class ReflectionMetadataEmitter
             goEnclosingScopes,
             liftedBinarySlots: liftedBinarySlots,
             nullableCoalesceSpillSlots: nullableCoalesceSpillSlots,
-            constValues: constValues);
+            constValues: constValues,
+            stackAllocResultSlots: stackAllocResultSlots);
 
         // base()
         il.LoadArgument(0);
@@ -4000,6 +4012,7 @@ internal sealed class ReflectionMetadataEmitter
         var scopeFrameSlots = new Dictionary<BoundScopeStatement, (int Tasks, int Cts, int Awaiter)>();
         var selectStatementSlots = new Dictionary<BoundSelectStatement, SelectSlots>();
         var receiverSpillSlots = new Dictionary<BoundExpression, int>();
+        var stackAllocResultSlots = new Dictionary<BoundStackAllocExpression, int>();
         var indexAssignmentValueSlots = new Dictionary<BoundExpression, int>();
         var goEnclosingScopes = new Dictionary<BoundGoStatement, BoundScopeStatement>();
         var liftedBinarySlots = new Dictionary<BoundBinaryExpression, LiftedBinarySlots>();
@@ -4037,7 +4050,8 @@ internal sealed class ReflectionMetadataEmitter
                 goEnclosingScopes,
                 liftedBinarySlots,
                 nullableCoalesceSpillSlots,
-                il);
+                il,
+                stackAllocResultSlots);
         }
 
         // Issue #640: pre-scan instance field initializer expressions for locals.
@@ -4066,7 +4080,8 @@ internal sealed class ReflectionMetadataEmitter
                 goEnclosingScopes,
                 liftedBinarySlots,
                 nullableCoalesceSpillSlots,
-                il);
+                il,
+                stackAllocResultSlots);
         }
 
         var paramSlots = new Dictionary<ParameterSymbol, int>
@@ -4112,7 +4127,8 @@ internal sealed class ReflectionMetadataEmitter
             goEnclosingScopes,
             liftedBinarySlots: liftedBinarySlots,
             nullableCoalesceSpillSlots: nullableCoalesceSpillSlots,
-            constValues: constValues);
+            constValues: constValues,
+            stackAllocResultSlots: stackAllocResultSlots);
 
         // base(args)
         il.LoadArgument(0);
@@ -4198,6 +4214,7 @@ internal sealed class ReflectionMetadataEmitter
         var scopeFrameSlots = new Dictionary<BoundScopeStatement, (int Tasks, int Cts, int Awaiter)>();
         var selectStatementSlots = new Dictionary<BoundSelectStatement, SelectSlots>();
         var receiverSpillSlots = new Dictionary<BoundExpression, int>();
+        var stackAllocResultSlots = new Dictionary<BoundStackAllocExpression, int>();
         var indexAssignmentValueSlots = new Dictionary<BoundExpression, int>();
         var goEnclosingScopes = new Dictionary<BoundGoStatement, BoundScopeStatement>();
         var liftedBinarySlots = new Dictionary<BoundBinaryExpression, LiftedBinarySlots>();
@@ -4238,7 +4255,8 @@ internal sealed class ReflectionMetadataEmitter
                 goEnclosingScopes,
                 liftedBinarySlots,
                 nullableCoalesceSpillSlots,
-                il);
+                il,
+                stackAllocResultSlots);
         }
 
         // Issue #640: pre-scan instance field initializer expressions for locals.
@@ -4270,7 +4288,8 @@ internal sealed class ReflectionMetadataEmitter
                 goEnclosingScopes,
                 liftedBinarySlots,
                 nullableCoalesceSpillSlots,
-                il);
+                il,
+                stackAllocResultSlots);
         }
 
         MethodBodyPlanner.CollectConstValues(body, constValues);
@@ -4295,7 +4314,8 @@ internal sealed class ReflectionMetadataEmitter
             goEnclosingScopes,
             liftedBinarySlots,
             nullableCoalesceSpillSlots,
-            il);
+            il,
+            stackAllocResultSlots);
 
         // Slot 0 is the implicit `this`; user parameters shift up by one.
         var paramSlots = new Dictionary<ParameterSymbol, int>
@@ -4341,7 +4361,8 @@ internal sealed class ReflectionMetadataEmitter
             goEnclosingScopes,
             liftedBinarySlots: liftedBinarySlots,
             nullableCoalesceSpillSlots: nullableCoalesceSpillSlots,
-            constValues: constValues);
+            constValues: constValues,
+            stackAllocResultSlots: stackAllocResultSlots);
 
         // ADR-0065 §2: a `convenience init(...)` does NOT chain to the base
         // constructor itself — the user-authored body begins with an
@@ -4423,6 +4444,7 @@ internal sealed class ReflectionMetadataEmitter
         var scopeFrameSlots = new Dictionary<BoundScopeStatement, (int Tasks, int Cts, int Awaiter)>();
         var selectStatementSlots = new Dictionary<BoundSelectStatement, SelectSlots>();
         var receiverSpillSlots = new Dictionary<BoundExpression, int>();
+        var stackAllocResultSlots = new Dictionary<BoundStackAllocExpression, int>();
         var indexAssignmentValueSlots = new Dictionary<BoundExpression, int>();
         var goEnclosingScopes = new Dictionary<BoundGoStatement, BoundScopeStatement>();
         var liftedBinarySlots = new Dictionary<BoundBinaryExpression, LiftedBinarySlots>();
@@ -4451,7 +4473,8 @@ internal sealed class ReflectionMetadataEmitter
             goEnclosingScopes,
             liftedBinarySlots,
             nullableCoalesceSpillSlots,
-            il);
+            il,
+            stackAllocResultSlots);
 
         // Slot 0 is the implicit `this`; deinit has no user parameters.
         var paramSlots = new Dictionary<ParameterSymbol, int>
@@ -4493,7 +4516,8 @@ internal sealed class ReflectionMetadataEmitter
             goEnclosingScopes,
             liftedBinarySlots: liftedBinarySlots,
             nullableCoalesceSpillSlots: nullableCoalesceSpillSlots,
-            constValues: constValues);
+            constValues: constValues,
+            stackAllocResultSlots: stackAllocResultSlots);
 
         // Wrap the user body in try { … } finally { base.Finalize(); }.
         // Matches the IL shape Roslyn emits for `~Type()`. The base
@@ -4622,6 +4646,7 @@ internal sealed class ReflectionMetadataEmitter
                 var scopeFrameSlots = new Dictionary<BoundScopeStatement, (int Tasks, int Cts, int Awaiter)>();
                 var selectStatementSlots = new Dictionary<BoundSelectStatement, SelectSlots>();
                 var receiverSpillSlots = new Dictionary<BoundExpression, int>();
+                var stackAllocResultSlots = new Dictionary<BoundStackAllocExpression, int>();
                 var indexAssignmentValueSlots = new Dictionary<BoundExpression, int>();
                 var goEnclosingScopes = new Dictionary<BoundGoStatement, BoundScopeStatement>();
                 var liftedBinarySlots = new Dictionary<BoundBinaryExpression, LiftedBinarySlots>();
@@ -4652,7 +4677,8 @@ internal sealed class ReflectionMetadataEmitter
                     goEnclosingScopes,
                     liftedBinarySlots,
                     nullableCoalesceSpillSlots,
-                    il);
+                    il,
+                    stackAllocResultSlots);
 
                 // For instance methods, IL slot 0 is the implicit `this`, so user
                 // parameters shift up by one. Both the synthesized `ThisParameter`
@@ -4733,7 +4759,8 @@ internal sealed class ReflectionMetadataEmitter
                     constValues: constValues,
                     structThisParameter: structThis,
                     asyncIteratorEmitCtx: aiEmitCtx,
-                    enclosingClosure: enclosingClosureInfo);
+                    enclosingClosure: enclosingClosureInfo,
+                    stackAllocResultSlots: stackAllocResultSlots);
 
                 // 6.2 SilentEmitFailure invariant: wrap the per-function
                 // EmitBlock in a try/catch so any exception that escapes the

--- a/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
+++ b/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
@@ -144,6 +144,18 @@ internal sealed class SlotPlanner
     public void CollectStackAllocs(BoundStatement root, List<BoundStackAllocExpression> sink)
         => new StackAllocCollector(sink).Visit(root);
 
+    // Issue #1522: collects the `stackalloc` nodes that occupy a stack-empty
+    // (statement-root) position — the whole value of an expression statement, a
+    // `return`, a local `var`-declaration initializer, or the right-hand side of
+    // a local-variable assignment. Those emit their `localloc` with an empty
+    // evaluation stack and are therefore already valid. Every OTHER stackalloc
+    // is a sub-expression (a method/ctor argument or nested operand) that would
+    // otherwise emit `localloc` while a receiver or prior arguments sit on the
+    // stack (ECMA-335 III.3.47 violation, ilverify `LocallocStackNotEmpty`) and
+    // must be spilled to a result local at an empty-stack point first.
+    public void CollectRootStackAllocs(BoundStatement root, HashSet<BoundStackAllocExpression> sink)
+        => new RootStackAllocCollector(sink).Visit(root);
+
     public void CollectReceiverSpills(
         BoundStatement root,
         FunctionSymbol function,
@@ -855,6 +867,55 @@ internal sealed class SlotPlanner
             }
 
             base.VisitExpression(node);
+        }
+    }
+
+    // Issue #1522: marks the stackalloc nodes that are emitted at an empty
+    // evaluation stack (statement-root positions) so the planner/emitter can
+    // spill every OTHER (sub-expression) stackalloc to a result local.
+    private sealed class RootStackAllocCollector : BoundTreeWalker
+    {
+        private readonly HashSet<BoundStackAllocExpression> sink;
+
+        public RootStackAllocCollector(HashSet<BoundStackAllocExpression> sink)
+        {
+            this.sink = sink;
+        }
+
+        public override void VisitStatement(BoundStatement node)
+        {
+            switch (node)
+            {
+                case BoundExpressionStatement es:
+                    // A bare `stackalloc` statement, or a local-variable
+                    // assignment `x = stackalloc …` (the RHS of an assignment to
+                    // a VariableSymbol is emitted at an empty stack).
+                    this.AddIfStackAlloc(es.Expression);
+                    if (es.Expression is BoundAssignmentExpression asn)
+                    {
+                        this.AddIfStackAlloc(asn.Expression);
+                    }
+
+                    break;
+                case BoundReturnStatement rs:
+                    this.AddIfStackAlloc(rs.Expression);
+                    break;
+                case BoundVariableDeclaration vd:
+                    this.AddIfStackAlloc(vd.Initializer);
+                    break;
+                default:
+                    break;
+            }
+
+            base.VisitStatement(node);
+        }
+
+        private void AddIfStackAlloc(BoundExpression expression)
+        {
+            if (expression is BoundStackAllocExpression sa)
+            {
+                this.sink.Add(sa);
+            }
         }
     }
 

--- a/test/Compiler.Tests/Emit/Issue1522StackAllocArgEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1522StackAllocArgEmitTests.cs
@@ -1,0 +1,213 @@
+// <copyright file="Issue1522StackAllocArgEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1522 — a <c>stackalloc [n]T</c> used as a METHOD/CONSTRUCTOR ARGUMENT
+/// (or any operand evaluated with a non-empty evaluation stack) emitted its CIL
+/// <c>localloc</c> INLINE while the receiver and/or previously-evaluated
+/// arguments were still on the stack. ECMA-335 III.3.47 requires the stack to be
+/// empty (except the size item) at <c>localloc</c>, so ilverify reported
+/// <c>LocallocStackNotEmpty</c> (plus a paired <c>Unverifiable</c> at the same
+/// offset). The JIT accepted it, but the IL was invalid.
+/// <para>
+/// The fix spills every non-statement-root <c>stackalloc</c> to a pre-allocated
+/// result local: the method-body planner reserves a result-typed slot
+/// (<c>Span&lt;T&gt;</c> for the safe form, <c>T*</c>/<c>void*</c> for the
+/// pointer form) and the emitter materialises the <c>localloc</c> into that
+/// local at an empty-stack point (statement start, in source order) before
+/// loading it at the original operand position.
+/// </para>
+/// A residual bare <c>Unverifiable</c> on the <c>localloc</c> instruction itself
+/// is by-design (localloc is valid-but-never-verifiable, see ADR-0124) and is
+/// the ONLY tolerated code — <c>LocallocStackNotEmpty</c> is NOT ignored, so a
+/// regression re-fails the gate. Each test uses a UNIQUE package/type name
+/// because the in-process <c>FunctionTypeSymbol</c> cache is name-keyed.
+/// </summary>
+public class Issue1522StackAllocArgEmitTests
+{
+    // Only the inherent `localloc` Unverifiable is tolerated. LocallocStackNotEmpty
+    // is deliberately NOT ignored so this gate still catches the original bug.
+    private static readonly string[] LocallocIlVerifyIgnored =
+    {
+        "Unverifiable",
+    };
+
+    [Fact]
+    public void InstanceMethodArgument_SpillsStackAlloc_VerifiesAndRuns()
+    {
+        // The repro from the issue: an instance-method call whose receiver is on
+        // the stack when the stackalloc argument is evaluated.
+        const string source = """
+            package i1522instance
+            import System
+
+            class Sink1522Inst { func Take(s Span[uint8]) int32 -> s.Length }
+
+            func Use(sink Sink1522Inst) int32 { return sink.Take(stackalloc [2]uint8) }
+
+            func Main() { Console.WriteLine(Use(Sink1522Inst())) }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("2\n", output);
+    }
+
+    [Fact]
+    public void StaticMethodSecondArgument_SpillsStackAlloc_VerifiesAndRuns()
+    {
+        // A static method's 2nd argument: the first argument (10) is already on
+        // the stack when the stackalloc is evaluated.
+        const string source = """
+            package i1522static
+            import System
+
+            func Foo1522(a int32, s Span[uint8]) int32 -> a + s.Length
+
+            func Use() int32 { return Foo1522(10, stackalloc [2]uint8) }
+
+            func Main() { Console.WriteLine(Use()) }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("12\n", output);
+    }
+
+    [Fact]
+    public void ConstructorArgument_SpillsStackAlloc_VerifiesAndRuns()
+    {
+        // A constructor argument (the newobj is pending on the eval stack).
+        const string source = """
+            package i1522ctor
+            import System
+
+            class Thing1522 {
+                var N int32 = 0
+                init(s Span[uint8]) { N = s.Length }
+            }
+
+            func Use() int32 {
+                var t = Thing1522(stackalloc [3]uint8)
+                return t.N
+            }
+
+            func Main() { Console.WriteLine(Use()) }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("3\n", output);
+    }
+
+    [Fact]
+    public void StatementPositionStackAlloc_StillVerifiesAndRuns()
+    {
+        // Regression guard: a statement-root `var x = stackalloc …` is NOT
+        // spilled (it already emits at an empty stack) and keeps working.
+        const string source = """
+            package i1522stmt
+            import System
+
+            func Use() int32 {
+                var buf = stackalloc [4]uint8
+                buf[0] = uint8(1)
+                buf[3] = uint8(9)
+                return buf.Length + int32(buf[3])
+            }
+
+            func Main() { Console.WriteLine(Use()) }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("13\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1522_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath, ignoredErrorCodes: LocallocIlVerifyIgnored);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
## Problem

A `stackalloc [n]T` passed as a **method/constructor argument** (or any operand evaluated with a non-empty evaluation stack) emitted its CIL `localloc` **inline**, while the receiver and/or previously-evaluated arguments were still on the evaluation stack. ECMA-335 III.3.47 requires the stack be empty (except the size item) at `localloc`, so ilverify reported `LocallocStackNotEmpty` (plus a paired `Unverifiable` at the same offset). The JIT accepted it, but the IL was invalid.

### Repro (before)
```gsharp
package Probe
import System
class Sink1522 { func Take(s Span[uint8]) int32 -> s.Length }
func Use(sink Sink1522) int32 { return sink.Take(stackalloc [2]uint8) }
func Main() { Console.WriteLine(Use(Sink1522())) }
```
```
Error [LocallocStackNotEmpty]: ...Use(...)][offset 0xC] Stack must be empty before localloc...
```

## Fix

Spill every **non-statement-root** stackalloc to a pre-allocated result local, mirroring Roslyn's stackalloc spilling:

- **SlotPlanner** — `RootStackAllocCollector` marks stackallocs in stack-empty (statement-root) positions: a bare expression statement, a `return`, a local `var`-declaration initializer, or a local-variable assignment RHS. Every other stackalloc is a sub-expression and gets spilled.
- **MethodBodyPlanner** — reserves a result-typed local (`Span<T>` for the safe form, `T*`/`void*` for the pointer form) for each non-root stackalloc.
- **MethodBodyEmitter** — materialises the `localloc` + result into that local at an empty-stack point (statement start, post-order so nested spilled stackallocs evaluate first), then loads it at the original operand position.

`.locals init` zero-inits the block and the localloc lifetime is the whole frame, so spilling the Span/pointer to a local is safe. Statement-position stackallocs (`var s = stackalloc …`) are unchanged and stay **byte-identical** (RefactoringBaselineTests passes; no baseline regen). The residual bare `Unverifiable` on the `localloc` instruction itself is by-design.

## Generalization covered
- instance-method argument (receiver on stack) — the repro
- static-method Nth argument (prior args on stack)
- constructor argument
- nested/operand positions where the stack is non-empty

## Validation
- Repro + static-2nd-arg + ctor-arg variants: **no `LocallocStackNotEmpty`** (only the benign localloc `Unverifiable`), and run correctly (`2`, `12`, `3`).
- `dotnet build GSharp.sln -c Release -graph` → 0 warnings / 0 errors.
- `Core.Tests` (Release): 4861 passed, 1 skipped (RegenerateBaseline).
- New `Issue1522StackAllocArgEmitTests` + existing `Issue1024` stackalloc tests: 14 passed.

Fixes #1522

Refs #914
