### PR TITLE
Fold all brace-delimited regions in the language server (Fixes #1508)

### DIFF
--- a/src/LanguageServer/FoldingComputer.cs
+++ b/src/LanguageServer/FoldingComputer.cs
@@ -1,4 +1,4 @@
-// <copyright file="FoldingHandler.cs" company="GSharp">
+// <copyright file="FoldingComputer.cs" company="GSharp">
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
@@ -15,21 +15,112 @@ namespace GSharp.LanguageServer;
 /// </summary>
 public static class FoldingComputer
 {
+    /// <summary>
+    /// Computes folding ranges for every multi-line, brace-delimited region in the document.
+    /// </summary>
+    /// <remarks>
+    /// The computer walks the full syntax tree (via <see cref="SyntaxNode.GetChildren"/>) rather
+    /// than only the root members, and emits one region per node that directly owns a matching
+    /// <c>{</c>/<c>}</c> pair. That single rule covers, at any nesting depth:
+    /// <list type="bullet">
+    /// <item>block statements — function, constructor, and deinitializer bodies, property and
+    /// event accessor bodies, and the bodies of <c>if</c>/<c>else</c>, <c>for</c> (all variants),
+    /// <c>while</c>, <c>do</c>/<c>while</c>, <c>scope</c>, <c>fixed</c>, <c>using</c>, and the
+    /// <c>try</c>/<c>catch</c>/<c>finally</c> blocks;</item>
+    /// <item>type declarations — <c>struct</c>/<c>class</c>, <c>interface</c>, and <c>enum</c>, as
+    /// well as <c>shared</c> blocks;</item>
+    /// <item>property and event declarations; and</item>
+    /// <item><c>switch</c> and <c>select</c> statements.</item>
+    /// </list>
+    /// Body-less members (extern/P-Invoke functions, <c>;</c>-bodied members, interface method
+    /// stubs) expose no brace pair and are naturally skipped. A range is only emitted when it
+    /// spans more than one line, so single-line blocks never produce a degenerate fold. Results
+    /// are de-duplicated and returned in source order, keeping the function deterministic for a
+    /// given <see cref="DocumentContent"/>.
+    /// </remarks>
+    /// <param name="content">The document content to compute folding ranges for.</param>
+    /// <returns>The folding ranges, ordered by start line then end line.</returns>
     public static IEnumerable<FoldingRange> ComputeFoldings(DocumentContent content)
     {
-        // TODO: Functions are only at the root for the moment
-        foreach (FunctionDeclarationSyntax function in content.SyntaxTree.Root.Members.OfType<FunctionDeclarationSyntax>())
+        var seen = new HashSet<(int StartLine, int EndLine)>();
+        var ranges = new List<FoldingRange>();
+
+        foreach (SyntaxNode node in DescendantNodesAndSelf(content.SyntaxTree.Root))
         {
-            int startLine = content.Lines.Count(charNumber => charNumber < function.Body.Span.Start);
-            int endLine = content.Lines.Count(charNumber => charNumber < function.Body.Span.End);
-            yield return new FoldingRange
+            FoldingRange range = TryComputeBraceFold(node, content);
+            if (range != null && seen.Add((range.StartLine, range.EndLine)))
             {
-                StartLine = startLine,
-                EndLine = endLine,
-                Kind = FoldingRangeKind.Region,
-                EndCharacter = 0,
-                StartCharacter = 0,
-            };
+                ranges.Add(range);
+            }
         }
+
+        ranges.Sort((left, right) =>
+        {
+            int byStart = left.StartLine.CompareTo(right.StartLine);
+            return byStart != 0 ? byStart : left.EndLine.CompareTo(right.EndLine);
+        });
+
+        return ranges;
+    }
+
+    private static IEnumerable<SyntaxNode> DescendantNodesAndSelf(SyntaxNode root)
+    {
+        var stack = new Stack<SyntaxNode>();
+        stack.Push(root);
+
+        while (stack.Count > 0)
+        {
+            SyntaxNode node = stack.Pop();
+            yield return node;
+
+            foreach (SyntaxNode child in node.GetChildren().Reverse())
+            {
+                stack.Push(child);
+            }
+        }
+    }
+
+    private static FoldingRange TryComputeBraceFold(SyntaxNode node, DocumentContent content)
+    {
+        SyntaxToken openBrace = null;
+        SyntaxToken closeBrace = null;
+
+        foreach (SyntaxNode child in node.GetChildren())
+        {
+            if (child is not SyntaxToken token)
+            {
+                continue;
+            }
+
+            if (token.Kind == SyntaxKind.OpenBraceToken)
+            {
+                openBrace ??= token;
+            }
+            else if (token.Kind == SyntaxKind.CloseBraceToken)
+            {
+                closeBrace = token;
+            }
+        }
+
+        if (openBrace == null || closeBrace == null)
+        {
+            return null;
+        }
+
+        int startLine = content.Lines.Count(offset => offset < openBrace.Span.Start);
+        int endLine = content.Lines.Count(offset => offset < closeBrace.Span.End);
+        if (endLine <= startLine)
+        {
+            return null;
+        }
+
+        return new FoldingRange
+        {
+            StartLine = startLine,
+            EndLine = endLine,
+            Kind = FoldingRangeKind.Region,
+            EndCharacter = 0,
+            StartCharacter = 0,
+        };
     }
 }

--- a/test/LanguageServer.Tests/FoldingComputerTests.cs
+++ b/test/LanguageServer.Tests/FoldingComputerTests.cs
@@ -48,4 +48,205 @@ public class FoldingComputerTests
         var content = new DocumentContent(tree, [9]);
         Assert.Empty(FoldingComputer.ComputeFoldings(content));
     }
+
+    [Fact]
+    public void ComputeFoldings_ClassMethods_FoldTypeAndEachBody()
+    {
+        const string source =
+            "package P\n" +              // 0
+            "\n" +                        // 1
+            "class Service {\n" +         // 2
+            "    func Start() {\n" +      // 3
+            "    }\n" +                   // 4
+            "    func Stop() {\n" +       // 5
+            "    }\n" +                   // 6
+            "}\n";                        // 7
+
+        var folds = Fold(source);
+
+        // The class itself and both method bodies fold; ordered by start line.
+        Assert.Equal(new[] { (2, 7), (3, 4), (5, 6) }, folds);
+    }
+
+    [Fact]
+    public void ComputeFoldings_StructMethods_FoldTypeAndBody()
+    {
+        const string source =
+            "package P\n" +              // 0
+            "\n" +                        // 1
+            "struct Point {\n" +          // 2
+            "    func Norm() int32 {\n" + // 3
+            "        return 0\n" +        // 4
+            "    }\n" +                   // 5
+            "}\n";                        // 6
+
+        var folds = Fold(source);
+
+        Assert.Equal(new[] { (2, 6), (3, 5) }, folds);
+    }
+
+    [Fact]
+    public void ComputeFoldings_ConstructorBody_Folds()
+    {
+        const string source =
+            "package P\n" +      // 0
+            "\n" +                // 1
+            "class C {\n" +       // 2
+            "    init() {\n" +    // 3
+            "    }\n" +           // 4
+            "}\n";                // 5
+
+        var folds = Fold(source);
+
+        Assert.Equal(new[] { (2, 5), (3, 4) }, folds);
+    }
+
+    [Fact]
+    public void ComputeFoldings_PropertyWithAccessorBody_FoldsTypePropertyAndAccessor()
+    {
+        const string source =
+            "package P\n" +                  // 0
+            "\n" +                            // 1
+            "class Counter {\n" +             // 2
+            "    var n int32\n" +             // 3
+            "    prop Doubled int32 {\n" +    // 4
+            "        get {\n" +               // 5
+            "            return n\n" +        // 6
+            "        }\n" +                   // 7
+            "    }\n" +                       // 8
+            "}\n";                            // 9
+
+        var folds = Fold(source);
+
+        // The type, the property brace region, and the get accessor body all fold.
+        Assert.Equal(new[] { (2, 9), (4, 8), (5, 7) }, folds);
+    }
+
+    [Fact]
+    public void ComputeFoldings_ForBlockInsideMethod_Folds()
+    {
+        const string source =
+            "package P\n" +               // 0
+            "\n" +                         // 1
+            "func main() {\n" +           // 2
+            "    for i in 0..10 {\n" +    // 3
+            "    }\n" +                   // 4
+            "}\n";                        // 5
+
+        var folds = Fold(source);
+
+        Assert.Equal(new[] { (2, 5), (3, 4) }, folds);
+    }
+
+    [Fact]
+    public void ComputeFoldings_DeepNesting_BlockInMethodInClass()
+    {
+        const string source =
+            "package P\n" +          // 0
+            "\n" +                    // 1
+            "class C {\n" +          // 2
+            "    func M() {\n" +     // 3
+            "        if true {\n" +  // 4
+            "        }\n" +          // 5
+            "    }\n" +              // 6
+            "}\n";                    // 7
+
+        var folds = Fold(source);
+
+        // class -> method body -> if-block, each folds independently.
+        Assert.Equal(new[] { (2, 7), (3, 6), (4, 5) }, folds);
+    }
+
+    [Fact]
+    public void ComputeFoldings_TryCatchFinally_FoldsEachBlock()
+    {
+        const string source =
+            "package P\n" +               // 0
+            "\n" +                         // 1
+            "func main() {\n" +           // 2
+            "    try {\n" +               // 3
+            "    } catch (e error) {\n" + // 4
+            "    } finally {\n" +         // 5
+            "    }\n" +                   // 6
+            "}\n";                        // 7
+
+        var folds = Fold(source);
+
+        // main body plus the try, catch, and finally blocks.
+        Assert.Equal(new[] { (2, 7), (3, 4), (4, 5), (5, 6) }, folds);
+    }
+
+    [Fact]
+    public void ComputeFoldings_SwitchStatement_Folds()
+    {
+        const string source =
+            "package P\n" +                    // 0
+            "\n" +                              // 1
+            "func main() {\n" +                // 2
+            "    var n = 0\n" +                // 3
+            "    switch n {\n" +               // 4
+            "        default { }\n" +          // 5
+            "    }\n" +                        // 6
+            "}\n";                              // 7
+
+        var folds = Fold(source);
+
+        // main body and the switch block (the single-line default case does not fold).
+        Assert.Equal(new[] { (2, 7), (4, 6) }, folds);
+    }
+
+    [Fact]
+    public void ComputeFoldings_SingleLineBlock_DoesNotFold()
+    {
+        const string source =
+            "package P\n" +      // 0
+            "\n" +                // 1
+            "func A() { }\n";     // 2 (open and close brace share a line)
+
+        Assert.Empty(Fold(source));
+    }
+
+    [Fact]
+    public void ComputeFoldings_Interface_Folds()
+    {
+        const string source =
+            "package P\n" +                // 0
+            "\n" +                          // 1
+            "interface IShape {\n" +       // 2
+            "    func Area() int32;\n" +   // 3
+            "    func Name() string;\n" +  // 4
+            "}\n";                          // 5
+
+        var folds = Fold(source);
+
+        // The interface declaration folds; its bodiless method stubs do not.
+        Assert.Equal(new[] { (2, 5) }, folds);
+    }
+
+    [Fact]
+    public void ComputeFoldings_Enum_Folds()
+    {
+        const string source =
+            "package P\n" +      // 0
+            "\n" +                // 1
+            "enum Color {\n" +   // 2
+            "    Red,\n" +       // 3
+            "    Green\n" +      // 4
+            "}\n";                // 5
+
+        var folds = Fold(source);
+
+        Assert.Equal(new[] { (2, 5) }, folds);
+    }
+
+    private static (int StartLine, int EndLine)[] Fold(string source)
+    {
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var content = LanguageServerTestHelpers.Content(source);
+        return FoldingComputer.ComputeFoldings(content)
+            .Select(f => (f.StartLine, f.EndLine))
+            .ToArray();
+    }
 }


### PR DESCRIPTION
## Summary
The language-server folding-range provider previously walked only `content.SyntaxTree.Root.Members` and folded the bodies of **top-level functions** only. Methods inside types, the type declarations themselves, and block-bearing statements never produced folding ranges, so editors could not collapse the most common regions in idiomatic OO G# files. This removes the interim `// TODO: Functions are only at the root for the moment` limitation.

## What changed
`FoldingComputer.ComputeFoldings` now **walks the full syntax tree** via `SyntaxNode.GetChildren()` (pre-order DFS in source order) and emits a `Region` fold for every node that **directly owns a matching `{`/`}` pair**. That single, general rule covers, at any nesting depth:

- **Block statements** — function, constructor, and deinitializer bodies; property and event accessor bodies; and the bodies of `if`/`else`, `for` (all variants), `while`, `do`/`while`, `scope`, `fixed`, `using`, and `try`/`catch`/`finally` blocks.
- **Type declarations** — `struct`/`class`, `interface`, `enum`, and `shared` blocks.
- **Property and event declarations.**
- **`switch` and `select` statements.**

Semantics:
- Line mapping uses the existing newline-offset convention (`content.Lines.Count(offset => offset < brace.Span.Start|End)`), computed from the owning node's open/close brace tokens.
- A range is emitted **only when it spans more than one line** (`endLine > startLine`), so single-line blocks never produce degenerate folds.
- Body-less members (extern/P-Invoke functions, `;`-bodied members, interface method stubs) expose no brace pair and are naturally skipped.
- Results are **de-duplicated** and returned in **source order** (by start line, then end line), keeping the function pure and deterministic given a `DocumentContent`.
- The interim `TODO` is removed.

## Tests
Both existing tests still pass (top-level functions fold; a bare `package P` yields empty). New regression tests cover:
- methods inside a `class` and a `struct` (type + each member body fold),
- constructor bodies,
- properties with block accessor bodies (type + property region + accessor body),
- a `for` block inside a method,
- deep nesting (block inside method inside class),
- `try`/`catch`/`finally` (each block folds),
- `switch` statements,
- single-line blocks (no degenerate fold),
- `interface` and `enum` declarations.

Each test asserts exact `startLine`/`endLine` values and `Assert.Empty(tree.Diagnostics)` on the parsed source.

## Validation
- `dotnet build GSharp.sln -c Release -graph` -> **0 warnings / 0 errors**.
- `dotnet test test/LanguageServer.Tests/LanguageServer.Tests.csproj -c Release` -> **376 passed, 0 failed** (13 in `FoldingComputerTests`).

This is a language-server-only change (no compiler emit, no `SyntaxKind`/`BoundNodeKind`, no samples), so no coverage-matrix update or refactoring-baseline regeneration is required.

Fixes #1508
