### PR TITLE
Sanitize verbatim/keyword identifier references in cs2gs

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue1528VerbatimIdentifierTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1528VerbatimIdentifierTranslationTests.cs
@@ -1,0 +1,93 @@
+// <copyright file="Issue1528VerbatimIdentifierTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #1528: a C# verbatim identifier whose bare name collides with a G#
+/// reserved word (e.g. <c>@default</c>, a field literally named <c>default</c>)
+/// must be sanitized consistently at every emission site. The declaration path
+/// already routed through <c>SanitizeIdentifier</c> (emitting <c>default_</c>),
+/// but two <c>TranslateIdentifierName</c> qualifier paths (implicit-receiver and
+/// bare-static-member) and the <c>GenericNameSyntax</c>-as-expression paths
+/// emitted the raw identifier text, so a bare <c>@default</c> reference became the
+/// unparsable <c>TreeDecomposition.@default</c> (GS0005: unexpected AtToken) and
+/// mismatched its own <c>default_</c> declaration. All reference sites must now
+/// sanitize to <c>default_</c>.
+/// </summary>
+public class Issue1528VerbatimIdentifierTranslationTests
+{
+    private const string Source = @"
+namespace Corpus.Issue1528
+{
+    public class Holder<T>
+        where T : new()
+    {
+        private static Holder<T> @default;
+
+        public static Holder<T> Instance()
+        {
+            if (@default is null)
+            {
+                @default = new Holder<T>();
+            }
+
+            return @default;
+        }
+    }
+}
+";
+
+    [Fact]
+    public void VerbatimKeywordStaticFieldReference_IsSanitizedConsistently()
+    {
+        string rendered = Render();
+
+        // The declaration and every reference use the sanitized `default_` name.
+        Assert.Contains("default_", rendered, StringComparison.Ordinal);
+
+        // The unparsable verbatim/keyword forms never leak into the output.
+        Assert.DoesNotContain("@default", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain(".default ", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain(".default\n", rendered, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SanitizedOutput_RoundTripParses()
+    {
+        string rendered = Render();
+
+        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+
+        Assert.True(
+            result.Success,
+            "Sanitized G# must round-trip-parse. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + rendered);
+    }
+
+    private static string Render()
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Holder.cs", Source) });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        return GSharpPrinter.Print(unit);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -5429,7 +5429,7 @@ public sealed class CSharpToGSharpTranslator
                         return new TypeExpression(typeRef);
                     }
 
-                    return new IdentifierExpression(generic.Identifier.Text);
+                    return new IdentifierExpression(SanitizeIdentifier(generic.Identifier.Text));
 
                 case ThisExpressionSyntax:
                     return new ThisExpression();
@@ -6299,7 +6299,7 @@ public sealed class CSharpToGSharpTranslator
                 {
                     return new MemberAccessExpression(
                         new IdentifierExpression(this.currentReceiverName),
-                        identifier.Identifier.Text);
+                        SanitizeIdentifier(identifier.Identifier.Text));
                 }
             }
 
@@ -6320,7 +6320,7 @@ public sealed class CSharpToGSharpTranslator
             {
                 return new MemberAccessExpression(
                     new IdentifierExpression(owner.Name),
-                    identifier.Identifier.Text);
+                    SanitizeIdentifier(identifier.Identifier.Text));
             }
 
             return new IdentifierExpression(SanitizeIdentifier(identifier.Identifier.Text));
@@ -6676,7 +6676,7 @@ public sealed class CSharpToGSharpTranslator
             // lift them onto the G# bracket-type-argument form `Foo[T](...)`.
             if (invocation.Expression is GenericNameSyntax generic)
             {
-                target = new IdentifierExpression(generic.Identifier.Text);
+                target = new IdentifierExpression(SanitizeIdentifier(generic.Identifier.Text));
                 typeArguments = this.MapTypeArguments(generic);
             }
             else if (invocation.Expression is MemberAccessExpressionSyntax member


### PR DESCRIPTION
While migrating **Oahu.Foundation**, the cs2gs translate stage failed to round-trip-parse `TreeDecomposition.gs`:
```
CS2GS-ROUNDTRIP: Emitted G# did not round-trip-parse: GS0005: Unexpected token <AtToken>, expected <IdentifierToken>.
```

## Root cause
The C# source declares a verbatim-identifier static field `static TreeDecomposition<T> @default;` (bare name `default` collides with a keyword). `SanitizeIdentifier` already strips the `@` and suffixes G#-reserved words (`default` -> `default_`), and the declaration path used it. But two `TranslateIdentifierName` qualifier paths (implicit-receiver and bare-static-member) and the two `GenericNameSyntax`-as-expression paths emitted the raw identifier text, so a bare `@default` reference became `TreeDecomposition.@default` — which does not parse (`@` is the attribute marker; `default` is a G# keyword) and mismatches the sanitized `default_` declaration.

## Fix
Route all four identifier-text emission sites through the idempotent `SanitizeIdentifier`. Verbatim/keyword references now sanitize consistently with their declarations.

## Verification
- New `Issue1528VerbatimIdentifierTranslationTests` (2 tests): sanitized-consistency + round-trip parse — pass.
- Full cs2gs suite: 345/345 pass. Core.Tests: 4888 pass / 1 skip.
- `cs2gs migrate --app corpus/Oahu.Foundation` now advances PAST translate (translate: PASS) into the compile stage (remaining Foundation compile errors tracked separately).

Fixes #1528

Refs #914