### PR TITLE
Fix spurious GS0266 for void-returning delegate overloads

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -3620,6 +3620,20 @@ public sealed class Binder
     {
         if (parameterType is TypeParameterSymbol tp)
         {
+            // Issue #1531: `void` is never a valid type argument, so a type
+            // parameter must not be inferred from a void source. This arises
+            // when a void-returning delegate/method-group argument is matched
+            // against a `(...)->TResult` (type-parameter-return) delegate
+            // parameter: binding `TResult := void` would wrongly make that
+            // value-returning overload applicable and tie it with the intended
+            // `(...)->void` overload (spurious GS0266). Skipping the binding
+            // leaves the type parameter un-inferred, so the candidate is
+            // rejected and the `(...)->void` overload wins unambiguously.
+            if (argumentType == TypeSymbol.Void)
+            {
+                return;
+            }
+
             // First seen value wins. Cross-arg consistency is verified later
             // by the post-substitution argument-type check.
             if (!substitution.ContainsKey(tp))

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
@@ -3423,6 +3423,22 @@ internal static class OverloadResolution
                 }
             }
 
+            // Issue #1531: a void-returning source delegate/method-group must not
+            // make a value-returning delegate parameter whose return is (or
+            // contains) a method type parameter applicable. C# forbids inferring
+            // a type argument from a void return, so a `(...)->TResult` overload
+            // is not applicable when the supplied delegate returns void. Failing
+            // inference here prunes that overload, leaving a `(...)->void`
+            // overload as the unique match instead of a spurious GS0266.
+            if (parameterDelegateReturn is not null
+                && argumentDelegateReturn is not null
+                && string.Equals(argumentDelegateReturn.FullName, "System.Void", StringComparison.Ordinal)
+                && !string.Equals(parameterDelegateReturn.FullName, "System.Void", StringComparison.Ordinal)
+                && parameterDelegateReturn.ContainsGenericParameters)
+            {
+                return false;
+            }
+
             return UnifyForInference(parameterDelegateReturn, argumentDelegateReturn, bounds);
         }
 

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -837,6 +837,15 @@ internal sealed class OverloadResolver
             // Apply a small penalty to variadic candidates (per ADR §6.6).
             var score = defaultsUsed + (isVariadic ? 1 : 0);
 
+            // For generic candidates, compute the inferred method-type
+            // substitution so delegate parameter return types can be closed
+            // when scoring the value-return discard penalty below.
+            Dictionary<TypeParameterSymbol, TypeSymbol> candSubstitution = null;
+            if (cand.IsGeneric)
+            {
+                TryInferCandidateSubstitution(cand, boundArguments, argumentCount, out candSubstitution);
+            }
+
             // Score argument-type compatibility: +1 per exact-type match.
             for (var i = 0; i < paramCountForScore && i < boundArguments.Count; i++)
             {
@@ -845,6 +854,20 @@ internal sealed class OverloadResolver
                 if (argType != null && paramType != null && argType == paramType)
                 {
                     score -= 10;
+                }
+
+                // Issue #1531 control: a value-returning delegate/method-group
+                // argument that maps onto a `(...)->void` delegate parameter
+                // discards its result. Penalize that mapping so a sibling
+                // `(...)->TResult` overload (whose delegate return closes to the
+                // argument's actual return type) is preferred — matching C#'s
+                // "better conversion from a method group" rule — instead of
+                // tying and reporting a spurious GS0266. Scoped strictly to the
+                // value-return-to-void-delegate shape, so it never disturbs the
+                // concrete-over-generic or defaulted-parameter preferences.
+                if (IsValueReturnDiscardedToVoidDelegate(argType, paramType, candSubstitution))
+                {
+                    score += 1;
                 }
             }
 
@@ -1101,12 +1124,31 @@ internal sealed class OverloadResolver
         ImmutableArray<BoundExpression>.Builder boundArguments,
         int argumentCount)
     {
+        return TryInferCandidateSubstitution(candidate, boundArguments, argumentCount, out _);
+    }
+
+    /// <summary>
+    /// Computes the method-type-parameter substitution inferred from the
+    /// supplied argument types for a generic <paramref name="candidate"/>, and
+    /// reports whether every type parameter received a binding. Shared by the
+    /// #1124 applicability filter (<see cref="AllMethodTypeParametersInferable"/>)
+    /// and the Phase-2 exact-match scoring, which substitutes the inferred
+    /// bindings into each open delegate parameter type so a value-returning
+    /// delegate/method-group argument prefers the `(...)->TResult` overload over
+    /// the `(...)->void` one (issue #1531 control).
+    /// </summary>
+    private bool TryInferCandidateSubstitution(
+        FunctionSymbol candidate,
+        ImmutableArray<BoundExpression>.Builder boundArguments,
+        int argumentCount,
+        out Dictionary<TypeParameterSymbol, TypeSymbol> substitution)
+    {
+        substitution = new Dictionary<TypeParameterSymbol, TypeSymbol>();
         if (!candidate.IsGeneric)
         {
             return true;
         }
 
-        var substitution = new Dictionary<TypeParameterSymbol, TypeSymbol>();
         var parameterOffset = candidate.ExplicitReceiverParameter == null ? 0 : 1;
         var paramLen = candidate.Parameters.Length - parameterOffset;
         var isVariadic = paramLen > 0 && candidate.Parameters[candidate.Parameters.Length - 1].IsVariadic;
@@ -1148,6 +1190,42 @@ internal sealed class OverloadResolver
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// Issue #1531 control: returns <see langword="true"/> when
+    /// <paramref name="argType"/> is a value-returning delegate/function type
+    /// and <paramref name="paramType"/> is a delegate parameter whose return
+    /// type is (or, via <paramref name="candSubstitution"/>, closes to)
+    /// <c>void</c> — i.e. the argument's result would be discarded. Used to
+    /// prefer a sibling <c>(...)-&gt;TResult</c> overload over a
+    /// <c>(...)-&gt;void</c> one when a value-returning argument is supplied.
+    /// </summary>
+    private bool IsValueReturnDiscardedToVoidDelegate(
+        TypeSymbol argType,
+        TypeSymbol paramType,
+        Dictionary<TypeParameterSymbol, TypeSymbol> candSubstitution)
+    {
+        if (argType is not FunctionTypeSymbol argFn
+            || paramType is not FunctionTypeSymbol paramFn
+            || argFn.ParameterTypes.Length != paramFn.ParameterTypes.Length)
+        {
+            return false;
+        }
+
+        var argReturn = argFn.ReturnType;
+        if (argReturn == null || argReturn == TypeSymbol.Void || argReturn == TypeSymbol.Error)
+        {
+            return false;
+        }
+
+        var paramReturn = paramFn.ReturnType;
+        if (candSubstitution != null && paramReturn != null && TypeSymbol.ContainsTypeParameter(paramReturn))
+        {
+            paramReturn = substituteType(paramReturn, candSubstitution) ?? paramReturn;
+        }
+
+        return paramReturn == TypeSymbol.Void;
     }
 
     /// <summary>

--- a/test/Compiler.Tests/Emit/Issue1531VoidDelegateOverloadEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1531VoidDelegateOverloadEmitTests.cs
@@ -1,0 +1,286 @@
+// <copyright file="Issue1531VoidDelegateOverloadEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1531 — a void-returning delegate / method-group argument wrongly made
+/// a value-returning <c>(...)-&gt;TResult</c> (type-parameter-return) overload
+/// applicable (generic inference bound <c>TResult := void</c>), so it competed
+/// with the intended <c>(...)-&gt;void</c> overload and gsc reported a spurious
+/// <c>GS0266</c> ambiguity. C# resolves this to the void overload unambiguously
+/// because a void-returning delegate cannot bind <c>Func&lt;…,TResult&gt;</c>.
+/// <para>
+/// The fix refuses to infer any method type parameter from a <c>void</c> source,
+/// which prunes the <c>(...)-&gt;TResult</c> overload for a void argument, and
+/// substitutes inferred type arguments into open delegate parameters during
+/// Phase-2 scoring so a genuinely value-returning argument still selects the
+/// <c>(...)-&gt;TResult</c> overload (the control) instead of tying.
+/// </para>
+/// Each test uses a UNIQUE package/type name because the in-process
+/// <c>FunctionTypeSymbol</c> cache is name-keyed.
+/// </summary>
+public class Issue1531VoidDelegateOverloadEmitTests
+{
+    [Fact]
+    public void EndToEnd_VoidMethodGroup_Arity1_PicksVoidOverload()
+    {
+        const string source = """
+            package i1531mg1
+            import System
+            class Ext {
+                shared {
+                    func Run[T1](d (T1) -> void, p1 T1) { d(p1) }
+                    func Run[T1, TResult](d (T1) -> TResult, p1 T1) TResult { return d(p1) }
+                }
+            }
+            func Sink(x int32) { Console.WriteLine(x) }
+            func Main() { Ext.Run(Sink, 42) }
+            """;
+
+        Assert.Equal("42\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EndToEnd_VoidMethodGroup_Arity0_PicksVoidOverload()
+    {
+        const string source = """
+            package i1531mg0
+            import System
+            class Ext {
+                shared {
+                    func Run(d () -> void) { d() }
+                    func Run[TResult](d () -> TResult) TResult { return d() }
+                }
+            }
+            func Sink() { Console.WriteLine("zero") }
+            func Main() { Ext.Run(Sink) }
+            """;
+
+        Assert.Equal("zero\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EndToEnd_VoidMethodGroup_Arity2_PicksVoidOverload()
+    {
+        const string source = """
+            package i1531mg2
+            import System
+            class Ext {
+                shared {
+                    func Run[T1, T2](d (T1, T2) -> void, p1 T1, p2 T2) { d(p1, p2) }
+                    func Run[T1, T2, TResult](d (T1, T2) -> TResult, p1 T1, p2 T2) TResult { return d(p1, p2) }
+                }
+            }
+            func Sink(a int32, b int32) { Console.WriteLine(a + b) }
+            func Main() { Ext.Run(Sink, 1, 2) }
+            """;
+
+        Assert.Equal("3\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EndToEnd_VoidMethodGroup_Arity3_PicksVoidOverload()
+    {
+        const string source = """
+            package i1531mg3
+            import System
+            class Ext {
+                shared {
+                    func Run[T1, T2, T3](d (T1, T2, T3) -> void, p1 T1, p2 T2, p3 T3) { d(p1, p2, p3) }
+                    func Run[T1, T2, T3, TResult](d (T1, T2, T3) -> TResult, p1 T1, p2 T2, p3 T3) TResult { return d(p1, p2, p3) }
+                }
+            }
+            func Sink(a int32, b int32, c int32) { Console.WriteLine(a + b + c) }
+            func Main() { Ext.Run(Sink, 1, 2, 3) }
+            """;
+
+        Assert.Equal("6\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EndToEnd_VoidLambda_PicksVoidOverload()
+    {
+        const string source = """
+            package i1531lam
+            import System
+            class Ext {
+                shared {
+                    func Run[T1](d (T1) -> void, p1 T1) { d(p1) }
+                    func Run[T1, TResult](d (T1) -> TResult, p1 T1) TResult { return d(p1) }
+                }
+            }
+            func Main() { Ext.Run((x int32) -> { Console.WriteLine(x) }, 42) }
+            """;
+
+        Assert.Equal("42\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EndToEnd_VoidMethodGroup_InstanceMethod_PicksVoidOverload()
+    {
+        const string source = """
+            package i1531inst
+            import System
+            class Ext {
+                func Run[T1](d (T1) -> void, p1 T1) { d(p1) }
+                func Run[T1, TResult](d (T1) -> TResult, p1 T1) TResult { return d(p1) }
+            }
+            func Sink(x int32) { Console.WriteLine(x) }
+            func Main() {
+                var e = Ext()
+                e.Run(Sink, 7)
+                e.Run((x int32) -> { Console.WriteLine(x + 100) }, 7)
+            }
+            """;
+
+        Assert.Equal("7\n107\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EndToEnd_ValueMethodGroup_Control_PicksTResultOverload()
+    {
+        const string source = """
+            package i1531valmg
+            import System
+            class Ext {
+                shared {
+                    func Run[T1](d (T1) -> void, p1 T1) { d(p1) }
+                    func Run[T1, TResult](d (T1) -> TResult, p1 T1) TResult { return d(p1) }
+                }
+            }
+            func Val(x int32) int32 { return x * 2 }
+            func Main() { Console.WriteLine(Ext.Run(Val, 10)) }
+            """;
+
+        Assert.Equal("20\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EndToEnd_ValueLambda_Control_PicksTResultOverload()
+    {
+        const string source = """
+            package i1531vallam
+            import System
+            class Ext {
+                shared {
+                    func Run[T1](d (T1) -> void, p1 T1) { d(p1) }
+                    func Run[T1, TResult](d (T1) -> TResult, p1 T1) TResult { return d(p1) }
+                }
+            }
+            func Main() { Console.WriteLine(Ext.Run((x int32) -> x * 3, 4)) }
+            """;
+
+        Assert.Equal("12\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EndToEnd_ValueLambda_ToVoidOnlyParameter_DiscardStillWorks()
+    {
+        const string source = """
+            package i1531discard
+            import System
+            class Ext {
+                shared {
+                    func RunVoid[T1](d (T1) -> void, p1 T1) { d(p1) }
+                }
+            }
+            func Main() {
+                Ext.RunVoid((x int32) -> { Console.WriteLine(x) }, 5)
+                Ext.RunVoid((x int32) -> x * 2, 9)
+                Console.WriteLine("done")
+            }
+            """;
+
+        Assert.Equal("5\ndone\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1531_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
## Problem

A **void-returning delegate / method-group argument** wrongly made a value-returning `(...)->TResult` (type-parameter-return) overload applicable: generic inference bound `TResult := void`, so it competed with the intended `(...)->void` overload and gsc reported a spurious `GS0266` ambiguity. C# resolves this to the void overload unambiguously because a void-returning delegate cannot bind `Func<...,TResult>`.

## Fix

- **`Binder.InferTypeArguments`**: refuse to infer a method type parameter from a `void` source (`void` is not a valid type argument), pruning the `(...)->TResult` overload as un-inferable so the `(...)->void` overload wins.
- **`OverloadResolution.UnifyForInference`**: mirror the same guard on the CLR metadata inference path for delegate return types.
- **`OverloadResolver`**: add a targeted Phase-2 scoring penalty so a genuinely value-returning delegate/method-group argument still selects the `(...)->TResult` overload (value-return-to-void-delegate discard is disfavored) without disturbing the concrete-over-generic or defaulted-parameter tie-breaks.

## Coverage

Arity 0..3, method-group **and** lambda arguments, static **and** instance methods. New end-to-end emit test (`Issue1531VoidDelegateOverloadEmitTests`) asserts the void cases compile/verify/run and the value-returning control still selects the `TResult` overload (and the value-lambda→void-only discard still works).

## Validation

- Repro + all variants compile, ilverify clean, and run correctly.
- `dotnet build GSharp.sln -c Release -graph`: 0 warnings / 0 errors.
- Core.Tests: 4888 passed, 1 skipped (RegenerateBaseline). RefactoringBaseline gate green — no baseline regeneration needed.
- Compiler.Tests `~Issue1531`: 9/9 passed; delegate/overload/Issue1502 emit filter: 141/141 passed.

Fixes #1531

Refs #914