### PR TITLE
Fix unverifiable IL for nested types of generic user types (#1521)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -2733,8 +2733,10 @@ public sealed class Binder
         // validated so a malformed `Outer[bad].Inner` is diagnosed here rather
         // than falling through to a confusing CLR-path error.
         var deepest = definitions[segmentTexts.Length - 1];
+        var constructedSegments = new TypeSymbol[segmentTexts.Length];
         for (var i = 0; i < segmentTexts.Length; i++)
         {
+            constructedSegments[i] = definitions[i];
             if (!syntax.SegmentHasTypeArguments(i))
             {
                 continue;
@@ -2748,13 +2750,84 @@ public sealed class Binder
                 return null;
             }
 
+            constructedSegments[i] = constructed;
             if (i == segmentTexts.Length - 1)
             {
                 deepest = constructed;
             }
         }
 
+        // Issue #1521: when the deepest segment is a type nested inside one or
+        // more constructed generic enclosing segments (e.g. `Box[int32].Tag`),
+        // thread the flattened enclosing construction's type arguments
+        // (outermost-first) onto the nested type so a use-site reference /
+        // slot encodes `Box`1+Tag`1<int32>` rather than the open
+        // self-instantiation `Box`1+Tag`1<!0>`. This mirrors the enclosing-arg
+        // threading the binder applies to a nested type surfaced from within a
+        // constructed enclosing member (e.g. the return of `Box[int32].MakeTag()`),
+        // so the two representations are reference-equal and interconvertible.
+        if (deepest is StructSymbol deepestStruct && deepestStruct.TypeArguments.IsDefaultOrEmpty)
+        {
+            var enclosingArgs = CollectConstructedEnclosingArguments(constructedSegments, segmentTexts.Length - 1);
+            if (!enclosingArgs.IsDefaultOrEmpty)
+            {
+                deepest = StructSymbol.ConstructNested(deepestStruct.Definition ?? deepestStruct, enclosingArgs);
+            }
+        }
+
         return deepest;
+    }
+
+    /// <summary>
+    /// Issue #1521: gathers the flattened type arguments of the constructed
+    /// generic enclosing segments (outermost-first) of a nested type-clause
+    /// chain, aligned 1:1 with <see cref="StructSymbol.CollectEnclosingTypeParameters"/>.
+    /// Returns <c>default</c> when no enclosing segment is a constructed
+    /// generic, or when a generic enclosing segment was left open (its
+    /// parameters could not be threaded), so the caller keeps the open nested
+    /// definition unchanged.
+    /// </summary>
+    /// <param name="constructedSegments">The per-segment constructed (or open) type symbols.</param>
+    /// <param name="deepestIndex">The index of the deepest (nested) segment; enclosing segments are those before it.</param>
+    /// <returns>The flattened enclosing type-argument vector, or <c>default</c>.</returns>
+    private static ImmutableArray<TypeSymbol> CollectConstructedEnclosingArguments(TypeSymbol[] constructedSegments, int deepestIndex)
+    {
+        ImmutableArray<TypeSymbol>.Builder builder = null;
+        for (var i = 0; i < deepestIndex; i++)
+        {
+            var seg = constructedSegments[i];
+            var ownParams = seg switch
+            {
+                StructSymbol s => (s.Definition ?? s).TypeParameters,
+                InterfaceSymbol iface => (iface.Definition ?? iface).TypeParameters,
+                _ => ImmutableArray<TypeParameterSymbol>.Empty,
+            };
+
+            if (ownParams.IsDefaultOrEmpty)
+            {
+                // Non-generic enclosing segment contributes no enclosing params.
+                continue;
+            }
+
+            var ownArgs = seg switch
+            {
+                StructSymbol s => s.TypeArguments,
+                InterfaceSymbol iface => iface.TypeArguments,
+                _ => ImmutableArray<TypeSymbol>.Empty,
+            };
+
+            if (ownArgs.IsDefaultOrEmpty || ownArgs.Length != ownParams.Length)
+            {
+                // A generic enclosing segment was left open — cannot thread a
+                // concrete enclosing-argument vector, so keep the nested type open.
+                return default;
+            }
+
+            builder ??= ImmutableArray.CreateBuilder<TypeSymbol>();
+            builder.AddRange(ownArgs);
+        }
+
+        return builder?.ToImmutable() ?? default;
     }
 
     /// <summary>
@@ -3959,6 +4032,22 @@ public sealed class Binder
             return structChanged
                 ? StructSymbol.Construct(ss.Definition, newStructArgs.MoveToImmutable())
                 : type;
+        }
+
+        // Issue #1521: a member-signature type that is a reference to a type
+        // nested inside the generic being constructed (e.g. the return type
+        // `Tag` of `Box[T].MakeTag()`, or a field/local typed `Tag`) must thread
+        // the receiver's type-argument map through the enclosing construction so
+        // it surfaces as `Box[int32].Tag`. `Tag` declares no own type arguments,
+        // so the emitter parents its use-site references/slots at
+        // `Box`1+Tag`1<int32>` rather than the open `Box`1+Tag`1<!0>`.
+        if (type is StructSymbol nestedRef && nestedRef.TypeArguments.IsDefaultOrEmpty)
+        {
+            var newEnclosing = StructSymbol.SubstituteEnclosingArguments(nestedRef, t => SubstituteType(t, substitution));
+            if (!newEnclosing.IsDefault)
+            {
+                return StructSymbol.ConstructNested(nestedRef.Definition ?? nestedRef, newEnclosing);
+            }
         }
 
         // Issue #1250: same recursion for a constructed generic user interface

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -7067,25 +7067,7 @@ internal sealed class ReflectionMetadataEmitter
                 $"User generic type '{def.Name}' has no emitted TypeDef when constructing TypeSpec.");
         }
 
-        ImmutableArray<TypeSymbol> typeArgs;
-        if (!structSym.TypeArguments.IsDefaultOrEmpty)
-        {
-            typeArgs = structSym.TypeArguments;
-        }
-        else
-        {
-            // Open definition → encode self-instantiation using the
-            // definition's own type parameters as arguments. Each will
-            // encode as `VAR(idx)` via EncodeTypeSymbol after R2.
-            var defTps = def.TypeParameters;
-            var bld = ImmutableArray.CreateBuilder<TypeSymbol>(defTps.Length);
-            foreach (var tp in defTps)
-            {
-                bld.Add(tp);
-            }
-
-            typeArgs = bld.MoveToImmutable();
-        }
+        var typeArgs = ResolveUserStructTypeSpecArguments(structSym, def);
 
         var sigBlob = new BlobBuilder();
         var encoder = new BlobEncoder(sigBlob).TypeSpecificationSignature();
@@ -7098,6 +7080,51 @@ internal sealed class ReflectionMetadataEmitter
         var spec = (EntityHandle)this.emitCtx.Metadata.AddTypeSpecification(this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
         this.userStructTypeSpecCache[(structSym, this.activeIteratorStateMachineRemap)] = spec;
         return spec;
+    }
+
+    /// <summary>
+    /// ADR-0087 §3 R3 / issue #1521: resolves the type-argument vector encoded
+    /// for a reference to a user-declared generic struct (or a type nested
+    /// inside one). A constructed instance uses its own
+    /// <see cref="StructSymbol.TypeArguments"/> (<c>Box`1&lt;int32&gt;</c>); a
+    /// constructed reference to a nested type uses the enclosing construction's
+    /// <see cref="StructSymbol.EnclosingTypeArguments"/>
+    /// (<c>Box`1+Tag`1&lt;int32&gt;</c>); the open definition (including a nested
+    /// type referenced from within its enclosing generic's own members) uses the
+    /// self-instantiation over the definition's own type parameters, each of
+    /// which encodes as <c>VAR(idx)</c> (<c>Box`1+Tag`1&lt;!0&gt;</c>).
+    /// </summary>
+    /// <param name="structSym">The struct reference being encoded.</param>
+    /// <param name="def">The struct's emitted definition.</param>
+    /// <returns>The type-argument vector aligned with <paramref name="def"/>'s type parameters.</returns>
+    private static ImmutableArray<TypeSymbol> ResolveUserStructTypeSpecArguments(StructSymbol structSym, StructSymbol def)
+    {
+        if (!structSym.TypeArguments.IsDefaultOrEmpty)
+        {
+            return structSym.TypeArguments;
+        }
+
+        // Issue #1521: a constructed reference to a type nested inside a generic
+        // enclosing type threads the enclosing construction's arguments as the
+        // reified nested type's argument vector (`Box`1+Tag`1<int32>`).
+        if (!structSym.EnclosingTypeArguments.IsDefaultOrEmpty)
+        {
+            return structSym.EnclosingTypeArguments;
+        }
+
+        // Open definition → encode self-instantiation using the definition's
+        // own type parameters as arguments. Each will encode as `VAR(idx)` via
+        // EncodeTypeSymbol. For a nested type referenced from within its
+        // enclosing generic's own members these are the reified enclosing
+        // parameters, so the reference correctly threads `!0…`.
+        var defTps = def.TypeParameters;
+        var bld = ImmutableArray.CreateBuilder<TypeSymbol>(defTps.Length);
+        foreach (var tp in defTps)
+        {
+            bld.Add(tp);
+        }
+
+        return bld.MoveToImmutable();
     }
 
     /// <summary>
@@ -10035,22 +10062,7 @@ internal sealed class ReflectionMetadataEmitter
 
             if (IsUserGenericTypeReference(structSym))
             {
-                ImmutableArray<TypeSymbol> typeArgs;
-                if (!structSym.TypeArguments.IsDefaultOrEmpty)
-                {
-                    typeArgs = structSym.TypeArguments;
-                }
-                else
-                {
-                    var defTps = defSym.TypeParameters;
-                    var bld = ImmutableArray.CreateBuilder<TypeSymbol>(defTps.Length);
-                    foreach (var defTp in defTps)
-                    {
-                        bld.Add(defTp);
-                    }
-
-                    typeArgs = bld.MoveToImmutable();
-                }
+                var typeArgs = ResolveUserStructTypeSpecArguments(structSym, defSym);
 
                 var gi = encoder.GenericInstantiation(typeDef, typeArgs.Length, isValueType: !defSym.IsClass);
                 foreach (var arg in typeArgs)

--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -20,6 +20,13 @@ public sealed class StructSymbol : TypeSymbol
 {
     private static readonly ConcurrentDictionary<(StructSymbol Def, string ArgsKey), StructSymbol> ConstructedCache = new();
 
+    // Issue #1521: identity cache for constructed references to types nested
+    // inside a generic enclosing type (`Box[int32].Tag`), keyed by the nested
+    // definition and the flattened enclosing type-argument vector so two
+    // references to the same construction share one symbol (preserving
+    // reference equality and TypeSpec caching in the emitter).
+    private static readonly ConcurrentDictionary<(StructSymbol Def, string ArgsKey), StructSymbol> ConstructedNestedCache = new();
+
     // Issue #1341: backing stores for the generically-erased member tables whose
     // reads are forwarded to Definition on a constructed instance. On a
     // definition (or non-generic type) these hold the canonical member set; on a
@@ -353,6 +360,29 @@ public sealed class StructSymbol : TypeSymbol
 
     /// <summary>Gets the type arguments when this is a constructed instance of a generic definition (Phase 4.3 / ADR-0020). Empty for generic definitions and for non-generic types.</summary>
     public ImmutableArray<TypeSymbol> TypeArguments { get; private set; } = ImmutableArray<TypeSymbol>.Empty;
+
+    /// <summary>
+    /// Gets the flattened type arguments of the enclosing construction when this
+    /// is a reference to a type nested inside a <em>generic</em> enclosing type
+    /// used from a <em>constructed</em> context (issue #1521) — e.g. the return
+    /// type <c>Tag</c> of <c>Box[int32].MakeTag()</c> surfaces as
+    /// <c>Box[int32].Tag</c>. The arguments are ordered outermost-first
+    /// (CLR order), aligned 1:1 with the enclosing generic parameters the
+    /// emitter reifies the nested type over (ECMA-335 §II.10.3.1), so a
+    /// use-site reference / local / field slot encodes
+    /// <c>Box`1+Tag`1&lt;int32&gt;</c> rather than the open self-instantiation
+    /// <c>Box`1+Tag`1&lt;!0&gt;</c>. Empty for a top-level type, for an open
+    /// nested type referenced from within its own enclosing generic's members
+    /// (which threads <c>!0…</c>), and for a nested type of a non-generic type.
+    /// </summary>
+    public ImmutableArray<TypeSymbol> EnclosingTypeArguments { get; private set; } = ImmutableArray<TypeSymbol>.Empty;
+
+    /// <summary>
+    /// Gets a value indicating whether this is a constructed reference to a type
+    /// nested inside a generic enclosing type (issue #1521) — it carries
+    /// <see cref="EnclosingTypeArguments"/> but declares no own type arguments.
+    /// </summary>
+    public bool IsConstructedNestedType => !EnclosingTypeArguments.IsDefaultOrEmpty;
 
     /// <summary>
     /// Gets, for a synthesized closure / capture-box class that was reified
@@ -1118,8 +1148,76 @@ public sealed class StructSymbol : TypeSymbol
     }
 
     /// <summary>
-    /// Issue #1254: finds the constructed generic base instantiation in this
-    /// type's base-class chain whose definition satisfies
+    /// Issue #1521: constructs a reference to a type declared as a nested type
+    /// inside a <em>generic</em> enclosing type, closed over the enclosing
+    /// construction's type arguments (e.g. <c>Box[int32].Tag</c>). The nested
+    /// type has no own type parameters (the CLR models it as
+    /// <c>Box`1+Tag`1</c>, redeclaring the encloser's parameters — ECMA-335
+    /// §II.10.3.1); the enclosing arguments are recorded on
+    /// <see cref="EnclosingTypeArguments"/> and the member types that mention an
+    /// enclosing type parameter are substituted lazily (see
+    /// <see cref="GetSubstitutionMap"/>). The emitter threads
+    /// <see cref="EnclosingTypeArguments"/> as the nested type's type-argument
+    /// vector so a constructed use site encodes <c>Box`1+Tag`1&lt;int32&gt;</c>
+    /// instead of the open self-instantiation <c>Box`1+Tag`1&lt;!0&gt;</c>.
+    /// </summary>
+    /// <param name="nestedDefinition">The open nested-type definition (its <see cref="Definition"/> is used).</param>
+    /// <param name="enclosingTypeArguments">The flattened enclosing construction arguments in CLR order (outermost first), aligned with <see cref="CollectEnclosingTypeParameters(TypeSymbol)"/>.</param>
+    /// <returns>A constructed nested reference, or <paramref name="nestedDefinition"/> unchanged when no enclosing arguments apply.</returns>
+    public static StructSymbol ConstructNested(StructSymbol nestedDefinition, ImmutableArray<TypeSymbol> enclosingTypeArguments)
+    {
+        if (nestedDefinition == null || enclosingTypeArguments.IsDefaultOrEmpty)
+        {
+            return nestedDefinition;
+        }
+
+        var def = nestedDefinition.Definition ?? nestedDefinition;
+        var key = BuildArgsKey(enclosingTypeArguments);
+        return ConstructedNestedCache.GetOrAdd((def, key), _ => CreateConstructedNested(def, enclosingTypeArguments));
+    }
+
+    /// <summary>
+    /// Issue #1521: gathers the flattened generic parameters of every enclosing
+    /// type of <paramref name="nested"/>, in CLR order (outermost first). A type
+    /// nested inside <c>Outer[U].Inner[T]</c> sees <c>[U, T]</c>. Mirrors the
+    /// emitter's reification order so a nested type's
+    /// <see cref="EnclosingTypeArguments"/> line up 1:1 with the enclosing
+    /// parameters its <c>TypeDef</c> is reified over.
+    /// </summary>
+    /// <param name="nested">The nested type (definition or constructed reference).</param>
+    /// <returns>The flattened enclosing type parameters, or empty when not nested in a generic.</returns>
+    public static ImmutableArray<TypeParameterSymbol> CollectEnclosingTypeParameters(TypeSymbol nested)
+    {
+        List<ImmutableArray<TypeParameterSymbol>> levels = null;
+        for (var c = EnclosingTypeOf(nested); c != null; c = EnclosingTypeOf(c))
+        {
+            var tps = EnclosingTypeParametersOf(c);
+            if (!tps.IsDefaultOrEmpty)
+            {
+                levels ??= new List<ImmutableArray<TypeParameterSymbol>>();
+
+                // Prepend so the outermost enclosing type's parameters come first.
+                levels.Insert(0, tps);
+            }
+        }
+
+        if (levels == null)
+        {
+            return ImmutableArray<TypeParameterSymbol>.Empty;
+        }
+
+        var builder = ImmutableArray.CreateBuilder<TypeParameterSymbol>();
+        foreach (var level in levels)
+        {
+            builder.AddRange(level);
+        }
+
+        return builder.ToImmutable();
+    }
+
+    /// <summary>
+    /// Walks this type and its base-class chain looking for a constructed
+    /// generic ancestor whose definition satisfies
     /// <paramref name="declaringDefinitionPredicate"/>, composing the
     /// type-argument substitution across each inheritance hop so the returned
     /// symbol carries fully-resolved type arguments in this type's context.
@@ -1145,6 +1243,18 @@ public sealed class StructSymbol : TypeSymbol
         Dictionary<TypeParameterSymbol, TypeSymbol> running = null;
         for (var c = this; c != null; c = c.BaseClass)
         {
+            // Issue #1521: a constructed reference to a type nested inside a
+            // generic enclosing type (`Box[int32].Tag`) already carries the
+            // enclosing arguments on EnclosingTypeArguments and declares no own
+            // type arguments to compose. When such a receiver directly declares
+            // the sought member, return it verbatim so the field/method
+            // reference is parented at its own `Box`1+Tag`1<int32>` TypeSpec
+            // rather than a rebuilt open self-instantiation.
+            if (c.IsConstructedNestedType && declaringDefinitionPredicate(c.Definition ?? c))
+            {
+                return c;
+            }
+
             // Compose this level's type-argument mapping into the running
             // substitution before testing the predicate so a matching base's
             // arguments are already resolved in this type's context.
@@ -1277,6 +1387,49 @@ public sealed class StructSymbol : TypeSymbol
         Declaration = declaration;
     }
 
+    /// <summary>
+    /// Issue #1521: threads a type substitution through the enclosing
+    /// construction of a reference to a type nested inside a generic enclosing
+    /// type. For an open nested reference (<c>Box.Tag</c>) the starting vector is
+    /// the flattened enclosing type parameters; for an already-constructed
+    /// nested reference (<c>Box[T].Tag</c>) it is the recorded
+    /// <see cref="EnclosingTypeArguments"/>. Each element is mapped through
+    /// <paramref name="substituteOne"/>. Returns the new enclosing-argument
+    /// vector when at least one element changed, or <c>default</c> when
+    /// <paramref name="nested"/> is not nested in a generic or nothing changed.
+    /// </summary>
+    /// <param name="nested">The nested-type reference (definition or constructed).</param>
+    /// <param name="substituteOne">Substitution applied to each enclosing argument (the caller's recursion).</param>
+    /// <returns>The substituted enclosing-argument vector, or <c>default</c>.</returns>
+    internal static ImmutableArray<TypeSymbol> SubstituteEnclosingArguments(StructSymbol nested, Func<TypeSymbol, TypeSymbol> substituteOne)
+    {
+        if (nested == null || !nested.TypeArguments.IsDefaultOrEmpty)
+        {
+            return default;
+        }
+
+        var enclosingParams = CollectEnclosingTypeParameters(nested);
+        if (enclosingParams.IsDefaultOrEmpty)
+        {
+            return default;
+        }
+
+        var current = nested.IsConstructedNestedType
+            ? nested.EnclosingTypeArguments
+            : ImmutableArray.CreateRange(enclosingParams, static p => (TypeSymbol)p);
+
+        var builder = ImmutableArray.CreateBuilder<TypeSymbol>(current.Length);
+        var changed = false;
+        foreach (var arg in current)
+        {
+            var substituted = substituteOne(arg);
+            changed |= !ReferenceEquals(substituted, arg);
+            builder.Add(substituted);
+        }
+
+        return changed ? builder.MoveToImmutable() : default;
+    }
+
     private static string BuildArgsKey(ImmutableArray<TypeSymbol> typeArguments)
     {
         var parts = new string[typeArguments.Length];
@@ -1287,6 +1440,21 @@ public sealed class StructSymbol : TypeSymbol
 
         return string.Join(",", parts);
     }
+
+    private static TypeSymbol EnclosingTypeOf(TypeSymbol type) => type switch
+    {
+        StructSymbol s => s.ContainingType,
+        InterfaceSymbol i => i.ContainingType,
+        EnumSymbol e => e.ContainingType,
+        _ => null,
+    };
+
+    private static ImmutableArray<TypeParameterSymbol> EnclosingTypeParametersOf(TypeSymbol type) => type switch
+    {
+        StructSymbol s => (s.Definition ?? s).TypeParameters,
+        InterfaceSymbol i => (i.Definition ?? i).TypeParameters,
+        _ => ImmutableArray<TypeParameterSymbol>.Empty,
+    };
 
     private static StructSymbol CreateConstructed(StructSymbol definition, ImmutableArray<TypeSymbol> typeArguments)
     {
@@ -1392,6 +1560,47 @@ public sealed class StructSymbol : TypeSymbol
         return constructed;
     }
 
+    // Issue #1521: materializes a constructed reference to a type nested inside
+    // a generic enclosing type (`Box[int32].Tag`). Unlike CreateConstructed the
+    // nested type declares no own type parameters — its member types mention the
+    // ENCLOSING type's parameters — so the substitution map is keyed by the
+    // flattened enclosing parameters (see GetSubstitutionMap) rather than the
+    // nested type's own (empty) parameters. Instance-member reads forward to the
+    // definition and substitute lazily against that map, so a field/property/
+    // return of the nested type whose type is an enclosing parameter surfaces
+    // closed (e.g. `Tag.V : int32` on `Box[int32].Tag`).
+    private static StructSymbol CreateConstructedNested(StructSymbol definition, ImmutableArray<TypeSymbol> enclosingTypeArguments)
+    {
+        var constructed = new StructSymbol(
+            definition.Name,
+            definition.Fields,
+            definition.Accessibility,
+            definition.Declaration,
+            definition.PackageName,
+            definition.IsData,
+            definition.IsInline,
+            definition.IsClass,
+            definition.PrimaryConstructorParameters,
+            definition.IsOpen,
+            definition.BaseClass);
+
+        constructed.Definition = definition;
+        constructed.EnclosingTypeArguments = enclosingTypeArguments;
+        constructed.ContainingType = definition.ContainingType;
+        constructed.SetInterfaces(definition.Interfaces);
+        if (!definition.ImplementedClrInterfaces.IsDefaultOrEmpty)
+        {
+            constructed.SetImplementedClrInterfaces(definition.ImplementedClrInterfaces);
+        }
+
+        if (definition.ImportedBaseType != null)
+        {
+            constructed.SetImportedBaseType(definition.ImportedBaseType);
+        }
+
+        return constructed;
+    }
+
     // Issue #1341: builds (once) the type-parameter -> type-argument map used to
     // substitute the definition's instance-member types for this constructed
     // instance. Generic definitions are immutable in their type parameters and
@@ -1412,6 +1621,23 @@ public sealed class StructSymbol : TypeSymbol
             for (var i = 0; i < count; i++)
             {
                 map[def.TypeParameters[i]] = TypeArguments[i];
+            }
+        }
+
+        // Issue #1521: a constructed reference to a type nested inside a generic
+        // enclosing type carries the enclosing construction's arguments on
+        // EnclosingTypeArguments and declares no own type parameters. Its member
+        // types mention the ENCLOSING type's parameters, so key the substitution
+        // by the flattened enclosing parameters (outermost first) so a member
+        // typed as an enclosing parameter (`Tag.V : T`) surfaces closed
+        // (`int32`) on the construction (`Box[int32].Tag`).
+        if (!EnclosingTypeArguments.IsDefaultOrEmpty)
+        {
+            var enclosingParams = CollectEnclosingTypeParameters(this);
+            var count = System.Math.Min(enclosingParams.Length, EnclosingTypeArguments.Length);
+            for (var i = 0; i < count; i++)
+            {
+                map[enclosingParams[i]] = EnclosingTypeArguments[i];
             }
         }
 
@@ -1654,6 +1880,21 @@ public sealed class StructSymbol : TypeSymbol
             return structChanged
                 ? StructSymbol.Construct(ss.Definition, substitutedStructArgs.MoveToImmutable())
                 : type;
+        }
+
+        // Issue #1521: a member type that is a reference to a type nested inside
+        // the generic being constructed (e.g. a field/return typed `Tag` on
+        // `Box[T]`, where `Tag` is `struct Box[T].Tag`) must thread the
+        // enclosing construction so it surfaces as `Box[int32].Tag` on
+        // `Box[int32]`. `Tag` declares no own type arguments, so this is
+        // distinct from the constructed-generic branch above.
+        if (type is StructSymbol nestedRef && nestedRef.TypeArguments.IsDefaultOrEmpty)
+        {
+            var newEnclosing = SubstituteEnclosingArguments(nestedRef, t => SubstituteTypeForConstruction(t, subst));
+            if (!newEnclosing.IsDefault)
+            {
+                return ConstructNested(nestedRef.Definition ?? nestedRef, newEnclosing);
+            }
         }
 
         if (type is InterfaceSymbol iface && !iface.TypeArguments.IsDefaultOrEmpty)

--- a/test/Compiler.Tests/Emit/Issue1521NestedTypeInGenericEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1521NestedTypeInGenericEmitTests.cs
@@ -1,0 +1,323 @@
+// <copyright file="Issue1521NestedTypeInGenericEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1521 — a type declared as a nested type inside a <b>generic</b> user
+/// type (<c>struct Tag</c> inside <c>struct Box[T any]</c>) emitted
+/// unverifiable IL. Referencing/constructing the nested type from a
+/// <em>constructed</em> context (e.g. <c>b.MakeTag().Name</c> where
+/// <c>b : Box[int32]</c>) parented the member reference at the <b>open</b>
+/// self-instantiation <c>Box`1+Tag`1&lt;!0&gt;</c> instead of the constructed
+/// <c>Box`1+Tag`1&lt;int32&gt;</c>, so ilverify reported
+/// <c>StackUnexpected</c> and the runtime threw a type-load error.
+/// <para>
+/// The fix threads the enclosing construction's type arguments onto the nested
+/// type as <see cref="GSharp.Core.CodeAnalysis.Symbols.StructSymbol.EnclosingTypeArguments"/>:
+/// from a constructed context the nested reference/slot encodes the concrete
+/// enclosing arguments (<c>&lt;int32&gt;</c>); from within the enclosing
+/// generic's own members it stays the open self-instantiation
+/// (<c>&lt;!0&gt;</c>). The same threading is applied by the binder both for a
+/// nested type surfaced from a constructed enclosing member (return of
+/// <c>Box[int32].MakeTag()</c>) and for an external per-segment nested
+/// type-clause (<c>Box[int32].Tag</c>, issue #1506 syntax), so the two
+/// representations are reference-equal and interconvertible.
+/// </para>
+/// Each test uses a UNIQUE package/type name because the in-process
+/// <c>FunctionTypeSymbol</c> cache is name-keyed and not cleared between tests.
+/// </summary>
+public class Issue1521NestedTypeInGenericEmitTests
+{
+    [Fact]
+    public void EndToEnd_BaseRepro_NestedStructInSingleParamGeneric_VerifiesAndRuns()
+    {
+        // The exact issue repro: `b.MakeTag().Name` (nested type surfaced from a
+        // constructed enclosing member) PLUS the external `Box[int32].Tag`
+        // per-segment type-clause used in local/parameter positions.
+        const string source = """
+            package Issue1521BaseRepro
+            import System
+
+            struct Issue1521Box[T any] {
+                var Value T
+                struct TagBase { var Name string }
+                func MakeTag() TagBase { return TagBase{Name: "hi"} }
+            }
+
+            func Issue1521GrabBase(t Issue1521Box[int32].TagBase) string { return t.Name }
+
+            func Main() {
+                var b = Issue1521Box[int32]{Value: 5}
+                System.Console.WriteLine(b.MakeTag().Name)
+                var t Issue1521Box[int32].TagBase = b.MakeTag()
+                System.Console.WriteLine(Issue1521GrabBase(t))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("hi\nhi\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_MultiArity_NestedStructInTwoParamGeneric_VerifiesAndRuns()
+    {
+        // Generalization: a nested type of a MULTI-parameter generic must thread
+        // the full flattened enclosing vector (`Pair`2+Tag`2<int32, string>`),
+        // both internally (return of MakeTag) and externally (type-clause).
+        const string source = """
+            package Issue1521MultiArity
+            import System
+
+            struct Issue1521Pair[K any, V any] {
+                var A K
+                var B V
+                struct TagPair { var Name string }
+                func MakeTag() TagPair { return TagPair{Name: "pair"} }
+            }
+
+            func Issue1521GrabPair(t Issue1521Pair[int32, string].TagPair) string { return t.Name }
+
+            func Main() {
+                var p = Issue1521Pair[int32, string]{A: 1, B: "x"}
+                System.Console.WriteLine(p.MakeTag().Name)
+                var t Issue1521Pair[int32, string].TagPair = p.MakeTag()
+                System.Console.WriteLine(Issue1521GrabPair(t))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("pair\npair\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_NestedTypeAsFieldParamReturnLocal_VerifiesAndRuns()
+    {
+        // Generalization: the nested type used as a FIELD of the enclosing
+        // generic, a PARAMETER and LOCAL of its members, and a RETURN — every
+        // signature/slot position that previously risked encoding `<!0>` in a
+        // constructed context.
+        const string source = """
+            package Issue1521FieldParamLocal
+            import System
+
+            struct Issue1521BoxFPL[T any] {
+                var Value T
+                struct TagFPL { var Name string }
+                var Marker TagFPL
+                func Init() { Marker = TagFPL{Name: "field"} }
+                func Combine(a TagFPL) string {
+                    var local TagFPL = a
+                    return local.Name
+                }
+                func MakeTag() TagFPL { return TagFPL{Name: "ret"} }
+            }
+
+            func Main() {
+                var b = Issue1521BoxFPL[int32]{Value: 5}
+                b.Init()
+                System.Console.WriteLine(b.Combine(b.Marker))
+                System.Console.WriteLine(b.MakeTag().Name)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("field\nret\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_NestedMemberUsesOuterTypeParameter_VerifiesAndRuns()
+    {
+        // Generalization: the nested type's OWN member references the enclosing
+        // type parameter (`TagT.V : T`). On a constructed context this must
+        // surface `T` as `int32` (both in the field signature and in the
+        // `newobj`/field-access token), which is impossible with the open
+        // `<!0>` self-instantiation.
+        const string source = """
+            package Issue1521OuterTypeParam
+            import System
+
+            struct Issue1521BoxT[T any] {
+                var Value T
+                struct TagT { var V T }
+                func MakeTag() TagT { return TagT{V: Value} }
+            }
+
+            func Main() {
+                var b = Issue1521BoxT[int32]{Value: 7}
+                System.Console.WriteLine(b.MakeTag().V)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("7\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_NestedEnumInGeneric_VerifiesAndRuns()
+    {
+        // Generalization: a nested ENUM inside a generic (a non-generic nested
+        // type) must reference/emit cleanly from a constructed context.
+        const string source = """
+            package Issue1521NestedEnum
+            import System
+
+            struct Issue1521BoxEnum[T any] {
+                var Value T
+                enum KindEnum { A, B, C }
+                func MakeKind() KindEnum { return KindEnum.B }
+            }
+
+            func Main() {
+                var b = Issue1521BoxEnum[int32]{Value: 5}
+                System.Console.WriteLine(b.MakeKind().ToString())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("B\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_NestedInterfaceInGeneric_VerifiesAndRuns()
+    {
+        // Generalization: a nested INTERFACE and a nested struct implementing it
+        // inside a generic must reference/emit cleanly from a constructed
+        // context.
+        const string source = """
+            package Issue1521NestedInterface
+            import System
+
+            struct Issue1521BoxIface[T any] {
+                var Value T
+                interface GreeterIface { func Greet() string; }
+                struct ImplIface : GreeterIface { func Greet() string { return "hello" } }
+                func MakeGreeter() GreeterIface { return ImplIface{} }
+            }
+
+            func Main() {
+                var b = Issue1521BoxIface[int32]{Value: 5}
+                var g = b.MakeGreeter()
+                System.Console.WriteLine(g.Greet())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("hello\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_NonGenericNestedControl_StillVerifiesAndRuns()
+    {
+        // Control: the SAME nested-type shape inside a NON-generic enclosing type
+        // verified clean before the fix and must remain clean after it.
+        const string source = """
+            package Issue1521NonGenericControl
+            import System
+
+            struct Issue1521Outer {
+                struct TagCtl { var Name string }
+                func Make() TagCtl { return TagCtl{Name: "ctl"} }
+            }
+
+            func Main() {
+                var o = Issue1521Outer{}
+                System.Console.WriteLine(o.Make().Name)
+                var t Issue1521Outer.TagCtl = o.Make()
+                System.Console.WriteLine(t.Name)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("ctl\nctl\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1521_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1506PerSegmentNestedTypeBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1506PerSegmentNestedTypeBinderTests.cs
@@ -105,10 +105,11 @@ public class Issue1506PerSegmentNestedTypeBinderTests
     public void UserGenericOuter_NestedType_ResolvesAgainstConstructedOuter()
     {
         // A user-declared generic outer's nested type resolves through the
-        // enclosing-type chain, validating the outer's arguments. (End-to-end
-        // emit of nested types declared inside user generics is a separate,
-        // pre-existing limitation outside issue #1506's scope; this asserts the
-        // binder resolution the issue requires.)
+        // enclosing-type chain, validating the outer's arguments. Issue #1521:
+        // the nested type is now threaded with the enclosing construction's
+        // arguments (`Box[int32].Tag` carries EnclosingTypeArguments=[int32]) so
+        // a use-site reference/slot emits `Box`1+Tag`1<int32>` rather than the
+        // open self-instantiation `Box`1+Tag`1<!0>`.
         var scope = BindSource("""
             package p
             struct Box[T] {
@@ -129,8 +130,17 @@ public class Issue1506PerSegmentNestedTypeBinderTests
 
         var tag = (StructSymbol)scope.TypeAliases["Tag"];
         var box = (StructSymbol)scope.TypeAliases["Box`1"];
-        Assert.Same(tag, paramType);
-        Assert.Same(box, tag.ContainingType);
+
+        // Issue #1521: the resolved parameter type is a constructed-nested
+        // reference (distinct from the open Tag definition) closed over the
+        // enclosing outer's `int32` argument, but sharing the open definition
+        // and the open enclosing type as its ContainingType.
+        var paramStruct = Assert.IsType<StructSymbol>(paramType);
+        Assert.True(paramStruct.IsConstructedNestedType);
+        Assert.Same(tag, paramStruct.Definition);
+        Assert.Same(box, paramStruct.ContainingType);
+        var enclosingArg = Assert.Single(paramStruct.EnclosingTypeArguments);
+        Assert.Equal("int32", enclosingArg.Name);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

A type declared as a **nested type inside a generic user type** (e.g. `struct Tag` inside `struct Box[T any]`) emitted **unverifiable IL** when referenced or constructed from a constructed context. Referencing the nested type produced an assembly that failed `ilverify` with a `StackUnexpected` mismatch and failed at runtime with a type-load error. The identical nested type inside a **non-generic** type verified clean.

The value on the stack was correctly `Box`1+Tag`1<int32>` (from `b.MakeTag()` where `b : Box[int32]`), but the subsequent `.Name` field access was parented at a MemberRef/TypeSpec encoded as the **open** self-instantiation `Box`1+Tag`1<!0>` instead of the **constructed** `Box`1+Tag`1<int32>`.

## Root cause

A nested type of a generic is CLR-modeled as `Box`1+Tag`1` (reified over the enclosing parameters, per #1467). At a use site the encoder chose the type-argument vector from `StructSymbol.TypeArguments`, which is **empty** for a nested type with no own parameters, so it fell back to the open self-instantiation `<!0>` — wrong for a constructed use site. The enclosing construction's arguments (`int32`) were never threaded onto the nested-type symbol.

## The fix — context-correct enclosing type-argument threading

- **New `StructSymbol.EnclosingTypeArguments`** carries the flattened enclosing construction arguments (outermost-first, aligned 1:1 with the emitter's reification order), plus `ConstructNested`/`CreateConstructedNested` factories (cached, so identical constructions are reference-equal) and lazy member substitution via `GetSubstitutionMap` keyed by the flattened enclosing parameters (so `Tag { var V T }` surfaces `V : int32` on `Box[int32].Tag`).
- **Binder** produces a constructed-nested symbol in both contexts:
  - a nested type surfaced from a constructed enclosing member (return of `Box[int32].MakeTag()`, a field/param/local) — via `SubstituteType` (Binder) and `SubstituteTypeForConstruction` (StructSymbol);
  - the external per-segment type-clause `Box[int32].Tag` (#1506 syntax) — via `TryResolveUserNestedTypeChain`.

  Both route through the cached `ConstructNested`, so the two representations are reference-equal and interconvertible (fixes the `GS0155 Cannot convert type 'Tag' to 'Tag'` mismatch).
- **Emitter** selects the vector through a shared `ResolveUserStructTypeSpecArguments` helper used by both `GetUserStructTypeSpec` and `EncodeTypeSymbol`: concrete enclosing arguments in a constructed context (`<int32>`), the open self-instantiation from within the enclosing generic's own members (`<!0>`). Member references on the nested type parent at the same constructed TypeSpec via `FindConstructedGenericBase`.

### Why it generalizes
- **Any arity** — `Pair[K,V].Tag` threads the full flattened enclosing vector in CLR order.
- **Any usage** — nested type as field / parameter / return / local; a nested type whose own member references the outer `T`.
- **Nested enum / interface** inside a generic.
- **Internal vs constructed contexts** are distinguished by whether an enclosing type parameter was actually substituted (open `!0…` threading preserved for the generic's own members).

## Validation
- Base repro compiles, `ilverify`s **clean**, and runs → `hi` (previously `StackUnexpected` + runtime type-load error).
- Generalized cases verified clean + correct runtime output: multi-arity `Pair[int32,string].Tag`; field/param/return/local; nested-member-uses-outer-`T`; external `Box[int32].Tag` type-clause; nested enum; nested interface + impl; non-generic-nested control.
- `dotnet build GSharp.sln -c Release -graph` → 0 warnings / 0 errors.
- `dotnet test test/Core.Tests` → **4888 passed**, 1 intentional skip (`RegenerateBaseline`). `RefactoringBaselineTests` unaffected (136 passed) — no IL change to existing baseline samples.
- New emit regression suite `Issue1521NestedTypeInGenericEmitTests` (7 tests) — 4 fail before the fix with the exact `<int32>` vs `<!0>` `StackUnexpected` error and all 7 pass after; the control/enum/interface pass both before and after.

## Scope note (not a regression)
Multi-level nesting where an **intermediate** enclosing type is itself generic (`Outer[U].Middle[T].Inner`) remains a separate, pre-existing reification limitation — `RegisterNestedTypeEnclosingGenerics` intentionally does not reify nested types that declare their own type parameters. It fails identically on `main` (confirmed by stash-and-compare) and is unchanged by this PR.

Fixes #1521
