### PR TITLE
Support generic types nested in generic types (Outer[U].Middle[T])

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -2766,12 +2766,21 @@ public sealed class Binder
         // threading the binder applies to a nested type surfaced from within a
         // constructed enclosing member (e.g. the return of `Box[int32].MakeTag()`),
         // so the two representations are reference-equal and interconvertible.
-        if (deepest is StructSymbol deepestStruct && deepestStruct.TypeArguments.IsDefaultOrEmpty)
+        //
+        // Issue #1537: when the deepest segment ITSELF carries own type
+        // arguments (`Outer[int32].Middle[string]`), thread BOTH the enclosing
+        // construction's arguments and the nested type's own arguments so member
+        // lookup substitutes both levels and the emitter encodes
+        // `Outer`1+Middle`2<int32, string>`.
+        if (deepest is StructSymbol deepestStruct)
         {
             var enclosingArgs = CollectConstructedEnclosingArguments(constructedSegments, segmentTexts.Length - 1);
             if (!enclosingArgs.IsDefaultOrEmpty)
             {
-                deepest = StructSymbol.ConstructNested(deepestStruct.Definition ?? deepestStruct, enclosingArgs);
+                var ownArgs = deepestStruct.TypeArguments;
+                deepest = ownArgs.IsDefaultOrEmpty
+                    ? StructSymbol.ConstructNested(deepestStruct.Definition ?? deepestStruct, enclosingArgs)
+                    : StructSymbol.ConstructNestedGeneric(deepestStruct.Definition ?? deepestStruct, enclosingArgs, ownArgs);
             }
         }
 

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -569,6 +569,17 @@ internal sealed class DeclarationBinder
             if (syntax.TypeParameterList != null)
             {
                 binderCtx.CurrentTypeParameters = new Dictionary<string, TypeParameterSymbol>();
+
+                // Issue #1537: a nested generic type's own type-parameter
+                // constraints may reference the enclosing type's parameters
+                // (e.g. `struct Middle[T U]` nested in `Outer[U]`), so seed the
+                // enclosing parameters (outermost-first) before binding the
+                // nested type's list.
+                foreach (var tp in CollectEnclosingTypeParameters(containingType))
+                {
+                    binderCtx.CurrentTypeParameters[tp.Name] = tp;
+                }
+
                 typeParameters = BindTypeParameterList(
                     syntax.TypeParameterList,
                     bareSymbols =>
@@ -656,12 +667,30 @@ internal sealed class DeclarationBinder
         var previousTypeParameters = binderCtx.CurrentTypeParameters;
         try
         {
-            if (!structSymbol.TypeParameters.IsDefaultOrEmpty)
+            // Issue #1537: a nested type's members may reference the ENCLOSING
+            // type's type parameters (e.g. a field of type `U` inside
+            // `Middle[T]` nested in `Outer[U]`). Seed the member-binding scope
+            // with every enclosing type parameter (outermost-first, so an inner
+            // level shadows an outer one on a name clash) BEFORE the type's own
+            // parameters, mirroring CLR nested-generic scoping (ECMA-335
+            // §II.10.3.1). The emitter reifies such a nested type over the
+            // combined [enclosing, own] parameter list and remaps each reference
+            // to the correct VAR ordinal, so these references encode verifiably.
+            var enclosingTypeParameters = CollectEnclosingTypeParameters(structSymbol.ContainingType);
+            if (!structSymbol.TypeParameters.IsDefaultOrEmpty || enclosingTypeParameters.Count > 0)
             {
                 binderCtx.CurrentTypeParameters = new Dictionary<string, TypeParameterSymbol>();
-                foreach (var tp in structSymbol.TypeParameters)
+                foreach (var tp in enclosingTypeParameters)
                 {
                     binderCtx.CurrentTypeParameters[tp.Name] = tp;
+                }
+
+                if (!structSymbol.TypeParameters.IsDefaultOrEmpty)
+                {
+                    foreach (var tp in structSymbol.TypeParameters)
+                    {
+                        binderCtx.CurrentTypeParameters[tp.Name] = tp;
+                    }
                 }
             }
 
@@ -671,6 +700,41 @@ internal sealed class DeclarationBinder
         {
             binderCtx.CurrentTypeParameters = previousTypeParameters;
         }
+    }
+
+    /// <summary>
+    /// Issue #1537: collects the type parameters of <paramref name="enclosingType"/>
+    /// and all of ITS enclosing types, outermost-first, so a nested type's
+    /// members and its own type-parameter constraints can reference them.
+    /// Returns an empty list for a top-level type (<paramref name="enclosingType"/>
+    /// is <see langword="null"/>) or when every encloser is non-generic.
+    /// </summary>
+    /// <param name="enclosingType">The immediately enclosing type, or <see langword="null"/>.</param>
+    /// <returns>The enclosing type parameters, outermost-first.</returns>
+    private static List<TypeParameterSymbol> CollectEnclosingTypeParameters(TypeSymbol enclosingType)
+    {
+        List<ImmutableArray<TypeParameterSymbol>> levels = null;
+        for (var c = enclosingType as StructSymbol; c != null; c = c.ContainingType as StructSymbol)
+        {
+            if (!c.TypeParameters.IsDefaultOrEmpty)
+            {
+                levels ??= new List<ImmutableArray<TypeParameterSymbol>>();
+
+                // Prepend so the outermost enclosing type's parameters come first.
+                levels.Insert(0, c.TypeParameters);
+            }
+        }
+
+        var result = new List<TypeParameterSymbol>();
+        if (levels != null)
+        {
+            foreach (var level in levels)
+            {
+                result.AddRange(level);
+            }
+        }
+
+        return result;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -1053,6 +1053,40 @@ internal sealed partial class ExpressionBinder
         => TryResolveUserNestedTypeExpression(accessor, out nestedType);
 
     /// <summary>
+    /// Issue #942/#1537: returns the leftmost (root) identifier of a candidate
+    /// user-type-naming chain — the head of a bare name, generic name,
+    /// per-segment index, or accessor — WITHOUT binding any bracketed contents.
+    /// Used to gate the nested-type-chain probe on the head naming a user
+    /// aggregate TYPE before any bracket is speculatively bound as a type
+    /// argument, so a genuine indexer whose index is an identifier
+    /// (<c>xs[i]</c>) is never probed as a constructed nested type. Mirrors the
+    /// shapes accepted by <see cref="TryFlattenUserTypeExpressionSegments"/> so
+    /// the gate never rejects a chain the core would otherwise flatten.
+    /// </summary>
+    /// <param name="expr">The candidate type-naming expression.</param>
+    /// <param name="headName">The resolved root identifier on success.</param>
+    /// <returns>Whether a root identifier could be extracted.</returns>
+    private static bool TryGetUserTypeChainHead(ExpressionSyntax expr, out string headName)
+    {
+        switch (expr)
+        {
+            case NameExpressionSyntax name:
+                headName = name.IdentifierToken.Text;
+                return true;
+            case GenericNameExpressionSyntax generic:
+                headName = generic.Identifier.Text;
+                return true;
+            case IndexExpressionSyntax index when !index.IsNullConditional:
+                return TryGetUserTypeChainHead(index.Target, out headName);
+            case AccessorExpressionSyntax accessor when !accessor.IsNullConditional:
+                return TryGetUserTypeChainHead(accessor.LeftPart, out headName);
+            default:
+                headName = null;
+                return false;
+        }
+    }
+
+    /// <summary>
     /// Issue #1069/#1506/#1521/#1537: resolves an expression that names a
     /// (possibly nested, possibly per-segment generic) user type — e.g.
     /// <c>Outer.Middle</c>, <c>Outer[int32].Middle</c>,
@@ -1072,6 +1106,42 @@ internal sealed partial class ExpressionBinder
     /// <param name="nestedType">The resolved (possibly constructed) type symbol.</param>
     /// <returns>Whether the expression resolved to a user nested type.</returns>
     private bool TryResolveUserNestedTypeExpression(ExpressionSyntax expr, out TypeSymbol nestedType)
+    {
+        nestedType = null;
+
+        // Issue #942 regression guard: this probe speculatively binds each
+        // bracketed segment's contents as TYPE arguments to decide whether
+        // `expr` names a constructed nested type (#1537) rather than an indexer
+        // receiver. In a genuine per-segment nested-type chain the ROOT names a
+        // user aggregate TYPE (`Outer` in `Outer[int32].Middle[string]`); in a
+        // real indexer the root is a VALUE — a local/parameter/field such as
+        // `xs` in `xs[i]`. Gate on the head naming a user aggregate type (and
+        // NOT a value) BEFORE binding any bracket as a type — mirroring
+        // TryResolveConstructedGenericTypeReceiver — so a real indexer whose
+        // index is an identifier is never probed as a nested type (which would
+        // look the index up as a type and report a spurious GS0113).
+        if (!TryGetUserTypeChainHead(expr, out var headName)
+            || scope.TryLookupSymbol(headName) is VariableSymbol
+            || !scope.TryLookupTypeAlias(headName, out var headCandidate)
+            || !IsUserAggregateType(headCandidate))
+        {
+            return false;
+        }
+
+        return TryResolveUserNestedTypeExpressionCore(expr, out nestedType);
+    }
+
+    /// <summary>
+    /// Issue #1537: the flatten-and-construct core of
+    /// <see cref="TryResolveUserNestedTypeExpression"/>. Invoked only after the
+    /// wrapper has confirmed the chain head names a user aggregate type, so the
+    /// speculative type-argument binding it performs cannot mistake a genuine
+    /// indexer receiver for a nested-type chain.
+    /// </summary>
+    /// <param name="expr">The type-naming expression (accessor or index chain).</param>
+    /// <param name="nestedType">The resolved (possibly constructed) type symbol.</param>
+    /// <returns>Whether the expression resolved to a user nested type.</returns>
+    private bool TryResolveUserNestedTypeExpressionCore(ExpressionSyntax expr, out TypeSymbol nestedType)
     {
         nestedType = null;
         var segments = new List<(string Name, ImmutableArray<TypeSymbol> Args)>();
@@ -1184,6 +1254,34 @@ internal sealed partial class ExpressionBinder
     /// <param name="segments">The accumulator for resolved segments (outermost-first).</param>
     /// <returns>Whether the expression is a well-formed user-type name chain.</returns>
     private bool TryFlattenUserTypeExpressionSegments(ExpressionSyntax expr, List<(string Name, ImmutableArray<TypeSymbol> Args)> segments)
+    {
+        // Issue #942 regression guard: flattening speculatively binds each
+        // bracketed segment's contents as TYPE arguments. When the expression is
+        // NOT a well-formed user-type name chain (e.g. a genuine indexer whose
+        // index is a value), that speculative bind can report a type diagnostic
+        // (GS0113) even though this probe ultimately returns false and the caller
+        // falls back to normal binding. Snapshot the diagnostic bag and roll it
+        // back on failure so the probe is side-effect-free for ANY chain shape.
+        var diagMark = Diagnostics.Count;
+        if (TryFlattenUserTypeExpressionSegmentsCore(expr, segments))
+        {
+            return true;
+        }
+
+        Diagnostics.TruncateTo(diagMark);
+        return false;
+    }
+
+    /// <summary>
+    /// Issue #1537: the recursive core of
+    /// <see cref="TryFlattenUserTypeExpressionSegments"/>. The wrapper snapshots
+    /// and rolls back the diagnostic bag around this method so a failed probe
+    /// never leaks the speculative type-argument-binding diagnostics it emits.
+    /// </summary>
+    /// <param name="expr">The type-naming expression.</param>
+    /// <param name="segments">The accumulator for resolved segments (outermost-first).</param>
+    /// <returns>Whether the expression is a well-formed user-type name chain.</returns>
+    private bool TryFlattenUserTypeExpressionSegmentsCore(ExpressionSyntax expr, List<(string Name, ImmutableArray<TypeSymbol> Args)> segments)
     {
         switch (expr)
         {

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -901,6 +901,34 @@ internal sealed partial class ExpressionBinder
                     break;
             }
         }
+        else if (leftPart is IndexExpressionSyntax nestedTypeIndex
+            && !nestedTypeIndex.IsNullConditional
+            && TryResolveUserNestedTypeExpression(nestedTypeIndex, out var nestedTypeIndexSymbol))
+        {
+            // Issue #1537: a per-segment generic nested-type chain whose deepest
+            // segment carries a SINGLE type argument parses as an index over the
+            // preceding accessor (`Outer[int32].Middle[string]` is
+            // `((Outer[int32]).Middle)[string]`), so it never reaches the
+            // NAME-target index branch above. Resolve it as the constructed
+            // nested type receiver (`Outer`1+Middle`2<int32, string>`) so the
+            // trailing member access / composite literal binds against a type
+            // whose members substitute every enclosing level.
+            switch (nestedTypeIndexSymbol)
+            {
+                case EnumSymbol nestedIndexEnum:
+                    enumSymbol = nestedIndexEnum;
+                    break;
+                case StructSymbol nestedIndexStruct:
+                    userStructSymbol = nestedIndexStruct;
+                    break;
+                case InterfaceSymbol nestedIndexInterface:
+                    userInterfaceSymbol = nestedIndexInterface;
+                    break;
+                default:
+                    receiver = BindExpression(leftPart);
+                    break;
+            }
+        }
         else
         {
             receiver = BindExpression(leftPart);
@@ -1022,36 +1050,236 @@ internal sealed partial class ExpressionBinder
     /// the chain is not a pure user nested-type reference.
     /// </summary>
     private bool TryResolveQualifiedUserNestedType(AccessorExpressionSyntax accessor, out TypeSymbol nestedType)
+        => TryResolveUserNestedTypeExpression(accessor, out nestedType);
+
+    /// <summary>
+    /// Issue #1069/#1506/#1521/#1537: resolves an expression that names a
+    /// (possibly nested, possibly per-segment generic) user type — e.g.
+    /// <c>Outer.Middle</c>, <c>Outer[int32].Middle</c>,
+    /// <c>Outer[int32].Middle[string]</c>, or the arbitrarily deep
+    /// <c>Outer[int32].Middle[string].Inner[bool]</c> — to its constructed type
+    /// symbol. The chain is flattened to per-segment (name, own type-arguments)
+    /// pairs, each segment is resolved as a nested type of the previous one, and
+    /// the deepest segment is constructed threading BOTH the flattened enclosing
+    /// construction's arguments (outermost-first, occupying the low ordinals)
+    /// and its own arguments, so member lookup substitutes every level and the
+    /// emitter encodes the reified nested type (<c>Outer`1+Middle`2&lt;int32,
+    /// string&gt;</c>). Generalizes to arbitrary depth and mixed generic /
+    /// non-generic levels; a fully non-generic chain returns the definition
+    /// unchanged (preserving #1069 behavior).
+    /// </summary>
+    /// <param name="expr">The type-naming expression (accessor or index chain).</param>
+    /// <param name="nestedType">The resolved (possibly constructed) type symbol.</param>
+    /// <returns>Whether the expression resolved to a user nested type.</returns>
+    private bool TryResolveUserNestedTypeExpression(ExpressionSyntax expr, out TypeSymbol nestedType)
     {
         nestedType = null;
-
-        if (accessor.RightPart is not NameExpressionSyntax rightName)
+        var segments = new List<(string Name, ImmutableArray<TypeSymbol> Args)>();
+        if (!TryFlattenUserTypeExpressionSegments(expr, segments) || segments.Count < 2)
         {
             return false;
         }
 
-        TypeSymbol container;
-        switch (accessor.LeftPart)
+        var headArity = segments[0].Args.IsDefaultOrEmpty ? -1 : segments[0].Args.Length;
+        if (!scope.TryLookupTypeAlias(segments[0].Name, headArity, out var headDef) || !IsUserAggregateType(headDef))
         {
-            case NameExpressionSyntax leftName
-                when scope.TryLookupTypeAlias(leftName.IdentifierToken.Text, out var leftType)
-                    && IsUserAggregateType(leftType):
-                container = leftType;
+            return false;
+        }
+
+        var definitions = new TypeSymbol[segments.Count];
+        definitions[0] = headDef;
+        for (var i = 1; i < segments.Count; i++)
+        {
+            var containerDef = (definitions[i - 1] as StructSymbol)?.Definition ?? definitions[i - 1];
+            var arity = segments[i].Args.IsDefaultOrEmpty ? -1 : segments[i].Args.Length;
+            if (!scope.TryLookupNestedTypeAlias(containerDef, segments[i].Name, arity, out var nested))
+            {
+                return false;
+            }
+
+            definitions[i] = nested;
+        }
+
+        // Thread the flattened enclosing construction's arguments (the own
+        // arguments of every generic enclosing segment, outermost-first) onto
+        // the deepest segment, together with its own arguments. A generic
+        // enclosing segment left without matching arguments cannot be threaded,
+        // so the whole chain stays open (mirrors the type-clause path's
+        // CollectConstructedEnclosingArguments).
+        var enclosingBuilder = ImmutableArray.CreateBuilder<TypeSymbol>();
+        for (var i = 0; i < segments.Count - 1; i++)
+        {
+            var ownParams = definitions[i] switch
+            {
+                StructSymbol s => (s.Definition ?? s).TypeParameters,
+                InterfaceSymbol iface => (iface.Definition ?? iface).TypeParameters,
+                _ => ImmutableArray<TypeParameterSymbol>.Empty,
+            };
+
+            if (ownParams.IsDefaultOrEmpty)
+            {
+                continue;
+            }
+
+            if (segments[i].Args.IsDefaultOrEmpty || segments[i].Args.Length != ownParams.Length)
+            {
+                enclosingBuilder = null;
                 break;
-            case AccessorExpressionSyntax leftAccessor
-                when TryResolveQualifiedUserNestedType(leftAccessor, out var leftNested):
-                container = leftNested;
-                break;
+            }
+
+            enclosingBuilder.AddRange(segments[i].Args);
+        }
+
+        var enclosingArgs = enclosingBuilder != null && enclosingBuilder.Count > 0
+            ? enclosingBuilder.ToImmutable()
+            : default;
+        var ownArgs = segments[segments.Count - 1].Args;
+
+        switch (definitions[segments.Count - 1])
+        {
+            case StructSymbol nestedStruct:
+                var def = nestedStruct.Definition ?? nestedStruct;
+                if (!enclosingArgs.IsDefaultOrEmpty && !ownArgs.IsDefaultOrEmpty)
+                {
+                    nestedType = StructSymbol.ConstructNestedGeneric(def, enclosingArgs, ownArgs);
+                }
+                else if (!enclosingArgs.IsDefaultOrEmpty)
+                {
+                    nestedType = StructSymbol.ConstructNested(def, enclosingArgs);
+                }
+                else if (!ownArgs.IsDefaultOrEmpty)
+                {
+                    nestedType = StructSymbol.Construct(def, ownArgs);
+                }
+                else
+                {
+                    nestedType = def;
+                }
+
+                return true;
+
+            case InterfaceSymbol nestedIface:
+                var ifaceDef = nestedIface.Definition ?? nestedIface;
+                nestedType = !ownArgs.IsDefaultOrEmpty
+                    ? InterfaceSymbol.Construct(ifaceDef, ownArgs)
+                    : ifaceDef;
+                return true;
+
+            default:
+                nestedType = definitions[segments.Count - 1];
+                return true;
+        }
+    }
+
+    /// <summary>
+    /// Issue #1537: flattens a user-type-naming expression into its ordered
+    /// per-segment (simple name, bound own type-arguments) pairs. Because
+    /// per-segment generics parse as an index over the preceding accessor
+    /// (<c>Outer[int32].Middle[string]</c> is
+    /// <c>((Outer[int32]).Middle)[string]</c>) and multi-argument segments parse
+    /// as generic-name expressions, every shape (name, generic-name, index,
+    /// accessor) is handled so arbitrary depth and arity flatten uniformly.
+    /// </summary>
+    /// <param name="expr">The type-naming expression.</param>
+    /// <param name="segments">The accumulator for resolved segments (outermost-first).</param>
+    /// <returns>Whether the expression is a well-formed user-type name chain.</returns>
+    private bool TryFlattenUserTypeExpressionSegments(ExpressionSyntax expr, List<(string Name, ImmutableArray<TypeSymbol> Args)> segments)
+    {
+        switch (expr)
+        {
+            case NameExpressionSyntax name:
+                segments.Add((name.IdentifierToken.Text, default));
+                return true;
+
+            case GenericNameExpressionSyntax generic:
+                if (!TryBindGenericSegmentArguments(generic, out var genericArgs))
+                {
+                    return false;
+                }
+
+                segments.Add((generic.Identifier.Text, genericArgs));
+                return true;
+
+            case IndexExpressionSyntax index when !index.IsNullConditional:
+                if (index.Target is NameExpressionSyntax indexTargetName)
+                {
+                    if (!TryBindTypeArgumentExpressions(index.Index, out var rootArgs))
+                    {
+                        return false;
+                    }
+
+                    segments.Add((indexTargetName.IdentifierToken.Text, rootArgs));
+                    return true;
+                }
+
+                if (!TryFlattenUserTypeExpressionSegments(index.Target, segments) || segments.Count == 0)
+                {
+                    return false;
+                }
+
+                var last = segments[segments.Count - 1];
+                if (!last.Args.IsDefaultOrEmpty)
+                {
+                    return false;
+                }
+
+                if (!TryBindTypeArgumentExpressions(index.Index, out var lastArgs))
+                {
+                    return false;
+                }
+
+                segments[segments.Count - 1] = (last.Name, lastArgs);
+                return true;
+
+            case AccessorExpressionSyntax accessor when !accessor.IsNullConditional:
+                if (!TryFlattenUserTypeExpressionSegments(accessor.LeftPart, segments))
+                {
+                    return false;
+                }
+
+                switch (accessor.RightPart)
+                {
+                    case NameExpressionSyntax rightName:
+                        segments.Add((rightName.IdentifierToken.Text, default));
+                        return true;
+                    case GenericNameExpressionSyntax rightGeneric
+                        when TryBindGenericSegmentArguments(rightGeneric, out var rightArgs):
+                        segments.Add((rightGeneric.Identifier.Text, rightArgs));
+                        return true;
+                    default:
+                        return false;
+                }
+
             default:
                 return false;
         }
+    }
 
-        if (!scope.TryLookupNestedTypeAlias(container, rightName.IdentifierToken.Text, preferredArity: -1, out var candidate))
+    /// <summary>
+    /// Issue #1537: binds the type-argument clauses of a generic-name segment
+    /// (<c>Middle[string]</c>) to their type symbols for nested-type chain
+    /// resolution in expression position.
+    /// </summary>
+    /// <param name="generic">The generic-name segment.</param>
+    /// <param name="typeArgs">The bound type arguments on success.</param>
+    /// <returns>Whether all type-argument clauses bound successfully.</returns>
+    private bool TryBindGenericSegmentArguments(GenericNameExpressionSyntax generic, out ImmutableArray<TypeSymbol> typeArgs)
+    {
+        typeArgs = default;
+        var argClauses = generic.TypeArgumentList.Arguments;
+        var builder = ImmutableArray.CreateBuilder<TypeSymbol>(argClauses.Count);
+        foreach (var clause in argClauses)
         {
-            return false;
+            var bound = bindTypeClause(clause);
+            if (bound == null)
+            {
+                return false;
+            }
+
+            builder.Add(bound);
         }
 
-        nestedType = candidate;
+        typeArgs = builder.ToImmutable();
         return true;
     }
 
@@ -1564,6 +1792,21 @@ internal sealed partial class ExpressionBinder
         switch (rightPart)
         {
             case AccessorExpressionSyntax nested:
+                // Issue #1537: the left portion may name a nested TYPE of the
+                // constructed receiver (`Middle[string]` under `Outer[int32]`),
+                // with the rightPart a composite literal / member / call on that
+                // nested type — i.e. a per-segment generic chain of depth ≥ 3
+                // (`Outer[int32].Middle[string].Inner{…}`) parses right-leaning
+                // so the inner segments arrive here rather than at the top-level
+                // accessor. Resolve the nested-type chain under the receiver
+                // (threading the flattened enclosing arguments) and bind the
+                // tail against it. Falls through to the value/static-member path
+                // when the left portion is not a nested type.
+                if (TryResolveNestedTypeChainUnderReceiver(structSym, nested.LeftPart, out var innerReceiver))
+                {
+                    return BindUserTypeStaticAccessorStep(innerReceiver, nested.RightPart);
+                }
+
                 var head = BindUserTypeStaticAccessorStep(structSym, nested.LeftPart);
                 if (head is BoundErrorExpression)
                 {
@@ -1574,6 +1817,19 @@ internal sealed partial class ExpressionBinder
 
             case CallExpressionSyntax ce:
                 return BindUserTypeStaticCall(structSym, ce);
+
+            // Issue #1537: a composite literal for a type nested inside a
+            // CONSTRUCTED generic enclosing type
+            // (`Outer[int32].Middle[string]{…}`, `Box[int32].Tag{…}`). The outer
+            // segment (`Outer[int32]`) resolves to the constructed struct
+            // receiver `structSym`; resolve the nested type under its definition
+            // and bind the literal against it, threading the enclosing
+            // construction's flattened arguments so member types substitute the
+            // enclosing parameters and the emitter encodes the reified nested
+            // type. Mirrors the #1069 peel-off path in BindAccessorExpression
+            // that already handles a NON-generic enclosing segment.
+            case StructLiteralExpressionSyntax structLiteral:
+                return BindQualifiedNestedStructLiteral(structSym, structLiteral);
 
             case NameExpressionSyntax ne:
                 return BindUserTypeStaticMemberAccess(structSym, ne);
@@ -1604,6 +1860,153 @@ internal sealed partial class ExpressionBinder
             default:
                 return new BoundErrorExpression(null);
         }
+    }
+
+    /// <summary>
+    /// Issue #1537: binds a composite literal naming a type nested inside a
+    /// CONSTRUCTED generic enclosing type
+    /// (<c>Outer[int32].Middle[string]{…}</c>, <c>Box[int32].Tag{…}</c>). The
+    /// nested type is resolved under <paramref name="outerConstructed"/>'s
+    /// definition, and the enclosing construction's flattened type arguments
+    /// (its own enclosing arguments followed by its own arguments, outermost
+    /// first — aligned with <see cref="StructSymbol.CollectEnclosingTypeParameters(TypeSymbol)"/>)
+    /// are threaded onto the constructed nested symbol so member types
+    /// substitute the enclosing parameters and the emitter encodes the reified
+    /// nested type. Generalizes to arbitrary depth: at each level the outer
+    /// segment already carries the flattened arguments of everything above it.
+    /// </summary>
+    /// <param name="outerConstructed">The constructed generic enclosing segment (e.g. <c>Outer[int32]</c>).</param>
+    /// <param name="structLiteral">The nested composite literal (e.g. <c>Middle[string]{…}</c>).</param>
+    /// <returns>The bound nested struct literal, or a bound error expression.</returns>
+    private BoundExpression BindQualifiedNestedStructLiteral(StructSymbol outerConstructed, StructLiteralExpressionSyntax structLiteral)
+    {
+        var container = outerConstructed.Definition ?? outerConstructed;
+        var literalArity = structLiteral.TypeArgumentList != null ? structLiteral.TypeArgumentList.Arguments.Count : -1;
+        if (!scope.TryLookupNestedTypeAlias(container, structLiteral.TypeIdentifier.Text, literalArity, out var nestedType)
+            || nestedType is not StructSymbol nestedStructDef)
+        {
+            Diagnostics.ReportUnableToFindType(structLiteral.TypeIdentifier.Location, structLiteral.TypeIdentifier.Text);
+            return new BoundErrorExpression(null);
+        }
+
+        // The enclosing construction already flattens its own enclosing chain in
+        // EnclosingTypeArguments; append its own TypeArguments so the nested
+        // type sees the full outermost-first vector.
+        var enclosingArgs = FlattenConstructedEnclosingArguments(outerConstructed);
+        return BindStructLiteralExpression(structLiteral, nestedStructDef.Definition ?? nestedStructDef, enclosingArgs);
+    }
+
+    /// <summary>
+    /// Issue #1537: resolves a nested-type-naming expression evaluated UNDER a
+    /// constructed generic receiver — e.g. <c>Middle[string]</c> (or the deeper
+    /// <c>Middle[string].Deeper[y]</c>) under a receiver <c>Outer[int32]</c> —
+    /// to the constructed nested type symbol, threading the receiver's flattened
+    /// enclosing arguments plus each intervening segment's own arguments so the
+    /// deepest segment carries the full outermost-first argument vector
+    /// (<c>Outer`1+Middle`2&lt;int32, string&gt;</c>). Returns <see langword="false"/>
+    /// (without diagnostics) when the expression does not name a nested type of
+    /// the receiver, so the caller can fall back to the value/static-member path.
+    /// </summary>
+    /// <param name="receiver">The constructed generic receiver the chain is nested under.</param>
+    /// <param name="typeExpr">The nested-type-naming expression.</param>
+    /// <param name="constructed">The resolved constructed nested type on success.</param>
+    /// <returns>Whether the expression named a nested type of the receiver.</returns>
+    private bool TryResolveNestedTypeChainUnderReceiver(StructSymbol receiver, ExpressionSyntax typeExpr, out StructSymbol constructed)
+    {
+        constructed = null;
+        var segments = new List<(string Name, ImmutableArray<TypeSymbol> Args)>();
+        if (!TryFlattenUserTypeExpressionSegments(typeExpr, segments) || segments.Count == 0)
+        {
+            return false;
+        }
+
+        var enclosingArgs = FlattenConstructedEnclosingArguments(receiver);
+        TypeSymbol containerDef = receiver.Definition ?? receiver;
+        for (var i = 0; i < segments.Count; i++)
+        {
+            var arity = segments[i].Args.IsDefaultOrEmpty ? -1 : segments[i].Args.Length;
+            var lookupContainer = (containerDef as StructSymbol)?.Definition ?? containerDef;
+            if (!scope.TryLookupNestedTypeAlias(lookupContainer, segments[i].Name, arity, out var nested))
+            {
+                return false;
+            }
+
+            if (i < segments.Count - 1)
+            {
+                // Enclosing segment: accumulate its own arguments (if generic)
+                // onto the flattened vector threaded into the next level.
+                if (!segments[i].Args.IsDefaultOrEmpty)
+                {
+                    enclosingArgs = enclosingArgs.IsDefaultOrEmpty
+                        ? segments[i].Args
+                        : enclosingArgs.AddRange(segments[i].Args);
+                }
+
+                containerDef = nested;
+                continue;
+            }
+
+            if (nested is not StructSymbol nestedStruct)
+            {
+                return false;
+            }
+
+            var def = nestedStruct.Definition ?? nestedStruct;
+            var ownArgs = segments[i].Args;
+            if (!enclosingArgs.IsDefaultOrEmpty && !ownArgs.IsDefaultOrEmpty)
+            {
+                constructed = StructSymbol.ConstructNestedGeneric(def, enclosingArgs, ownArgs);
+            }
+            else if (!enclosingArgs.IsDefaultOrEmpty)
+            {
+                constructed = StructSymbol.ConstructNested(def, enclosingArgs);
+            }
+            else if (!ownArgs.IsDefaultOrEmpty)
+            {
+                constructed = StructSymbol.Construct(def, ownArgs);
+            }
+            else
+            {
+                constructed = def;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Issue #1537: flattens the type arguments of a constructed generic
+    /// enclosing segment into the outermost-first vector its nested types are
+    /// reified over — the segment's own <see cref="StructSymbol.EnclosingTypeArguments"/>
+    /// (from levels above it) followed by its own <see cref="StructSymbol.TypeArguments"/>.
+    /// Returns <c>default</c> when the segment carries no type arguments (a
+    /// non-generic enclosing type contributes nothing to thread).
+    /// </summary>
+    /// <param name="outerConstructed">The constructed (or open) enclosing segment.</param>
+    /// <returns>The flattened enclosing-argument vector, or <c>default</c>.</returns>
+    private static ImmutableArray<TypeSymbol> FlattenConstructedEnclosingArguments(StructSymbol outerConstructed)
+    {
+        var enclosing = outerConstructed.EnclosingTypeArguments;
+        var own = outerConstructed.TypeArguments;
+        if (enclosing.IsDefaultOrEmpty && own.IsDefaultOrEmpty)
+        {
+            return default;
+        }
+
+        var builder = ImmutableArray.CreateBuilder<TypeSymbol>();
+        if (!enclosing.IsDefaultOrEmpty)
+        {
+            builder.AddRange(enclosing);
+        }
+
+        if (!own.IsDefaultOrEmpty)
+        {
+            builder.AddRange(own);
+        }
+
+        return builder.ToImmutable();
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
@@ -481,7 +481,20 @@ internal sealed partial class ExpressionBinder
     /// resolving the type by the literal's simple name — which would otherwise
     /// bind to the top-level homonym holding the simple key.
     /// </summary>
-    private BoundExpression BindStructLiteralExpression(StructLiteralExpressionSyntax syntax, StructSymbol resolvedDefinition)
+    /// <param name="syntax">The struct-literal syntax.</param>
+    /// <param name="resolvedDefinition">The pre-resolved struct definition, or <c>null</c> to resolve by simple name.</param>
+    /// <param name="enclosingTypeArguments">
+    /// Issue #1521 / #1537: when the literal names a type nested inside a
+    /// CONSTRUCTED generic enclosing type (<c>Outer[int32].Middle[string]{…}</c>
+    /// or <c>Box[int32].Tag{…}</c>), the flattened enclosing construction's type
+    /// arguments (outermost-first). Threaded onto the constructed struct symbol
+    /// so member types substitute the enclosing arguments and the emitter
+    /// encodes the reified nested type (<c>Outer`1+Middle`2&lt;int32,string&gt;</c>).
+    /// </param>
+    private BoundExpression BindStructLiteralExpression(
+        StructLiteralExpressionSyntax syntax,
+        StructSymbol resolvedDefinition,
+        ImmutableArray<TypeSymbol> enclosingTypeArguments = default)
     {
         var typeName = syntax.TypeIdentifier.Text;
 
@@ -611,12 +624,27 @@ internal sealed partial class ExpressionBinder
                 typeArgs.Add(substitution[tp]);
             }
 
-            structSymbol = StructSymbol.Construct(structSymbol, typeArgs.MoveToImmutable());
+            // Issue #1537: a generic nested type of a constructed generic
+            // enclosing type (`Outer[int32].Middle[string]{…}`) threads BOTH the
+            // enclosing arguments and its own arguments so member types
+            // substitute both levels and the emitter encodes the reified nested
+            // type (`Outer`1+Middle`2<int32, string>`).
+            structSymbol = enclosingTypeArguments.IsDefaultOrEmpty
+                ? StructSymbol.Construct(structSymbol, typeArgs.MoveToImmutable())
+                : StructSymbol.ConstructNestedGeneric(structSymbol, enclosingTypeArguments, typeArgs.MoveToImmutable());
         }
         else if (syntax.TypeArgumentList != null)
         {
             Diagnostics.ReportWrongTypeArgumentCount(syntax.TypeArgumentList.Location, typeName, 0, syntax.TypeArgumentList.Arguments.Count);
             return new BoundErrorExpression(null);
+        }
+        else if (!enclosingTypeArguments.IsDefaultOrEmpty)
+        {
+            // Issue #1521: a NON-generic nested type of a constructed generic
+            // enclosing type (`Box[int32].Tag{…}`) threads only the enclosing
+            // arguments so member types typed as an enclosing parameter surface
+            // closed and the emitter encodes `Box`1+Tag`1<int32>`.
+            structSymbol = StructSymbol.ConstructNested(structSymbol, enclosingTypeArguments);
         }
 
         var seenFieldNames = new HashSet<string>();

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -5335,6 +5335,31 @@ internal sealed class OverloadResolver
         Dictionary<TypeParameterSymbol, TypeSymbol> map = null;
         for (var c = start; c != null; c = c.BaseClass)
         {
+            // Issue #1537: a receiver that is a generic type nested inside a
+            // generic enclosing type (e.g. `Outer[int32].Middle[string]`)
+            // carries the enclosing construction's arguments on
+            // EnclosingTypeArguments (`[int32]`) separately from its own
+            // arguments (`[string]`). An instance method's signature may mention
+            // the ENCLOSING type's parameters (a method returning `U`), so map
+            // each enclosing parameter to its construction argument in addition
+            // to the own parameter -> own argument mappings below.
+            if (!c.EnclosingTypeArguments.IsDefaultOrEmpty)
+            {
+                var enclosingParams = StructSymbol.CollectEnclosingTypeParameters(c);
+                var enclosingCount = System.Math.Min(enclosingParams.Length, c.EnclosingTypeArguments.Length);
+                for (var i = 0; i < enclosingCount; i++)
+                {
+                    var arg = c.EnclosingTypeArguments[i];
+                    if (arg is TypeParameterSymbol tpEnc && map != null && map.TryGetValue(tpEnc, out var resolvedEnc))
+                    {
+                        arg = resolvedEnc;
+                    }
+
+                    map ??= new Dictionary<TypeParameterSymbol, TypeSymbol>();
+                    map[enclosingParams[i]] = arg;
+                }
+            }
+
             if (c.Definition == null
                 || ReferenceEquals(c.Definition, c)
                 || c.TypeArguments.IsDefaultOrEmpty

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -332,6 +332,16 @@ internal sealed class ReflectionMetadataEmitter
     // (so its field-signature MemberRef matches the FieldDef blob exactly).
     internal readonly Dictionary<StructSymbol, Dictionary<TypeParameterSymbol, int>> iteratorStateMachineRemapsByClass = new Dictionary<StructSymbol, Dictionary<TypeParameterSymbol, int>>();
 
+    // Issue #1537: for each user-declared type nested inside a generic enclosing
+    // type that the emitter reifies over the flattened enclosing+own parameter
+    // list (RegisterNestedTypeEnclosingGenerics), the number of ENCLOSING
+    // parameters `k` (the low ordinals `0..k-1` of the reified TypeDef, ECMA-335
+    // §II.10.3.1). The nested type's own parameters occupy `k..k+m-1`.
+    // ResolveUserStructTypeSpecArguments consults this to split a use-site's
+    // combined type-argument vector into its enclosing and own halves. Keyed by
+    // the nested type's DEFINITION.
+    private readonly Dictionary<StructSymbol, int> nestedTypeEnclosingArity = new Dictionary<StructSymbol, int>(ReferenceEqualityComparer.Instance);
+
     /// <summary>
     /// Issue #810: push the SM remap for <paramref name="smClass"/> so that
     /// every <see cref="EncodeTypeSymbol"/> call made before the returned
@@ -428,21 +438,101 @@ internal sealed class ReflectionMetadataEmitter
         this.iteratorStateMachineRemapsByClass[smStruct] = remap;
     }
 
-    // Issue #1467: gathers the flattened generic parameters of every enclosing
-    // type of <paramref name="nested"/>, in CLR order (outermost first). A type
-    // nested inside `Outer[U].Inner[T]` sees `[U, T]`.
-    private static ImmutableArray<TypeParameterSymbol> CollectEnclosingTypeParameters(StructSymbol nested)
+    // Issue #1467 / #1537: reifies every user-declared type nested inside a
+    // generic type over an ordinal-aligned clone of the flattened enclosing +
+    // own type-parameter list (ECMA-335 §II.10.3.1): the enclosing parameters
+    // occupy the low ordinals `0..k-1` (outermost first), the nested type's OWN
+    // parameters are re-ordinalized to `k..k+m-1`. A per-class remap translates
+    // every reference to an original enclosing/own parameter (whose declared
+    // ordinal no longer matches its reified slot) into the correct `VAR(idx)`.
+    // A nested type with no own parameters (`Box[T].Tag`) reifies to arity `k`
+    // (issue #1467); one that declares its own (`Outer[U].Middle[T]`) reifies to
+    // arity `k + m` (`Outer`1+Middle`2`, issue #1537).
+    private void RegisterNestedTypeEnclosingGenerics()
+    {
+        // Snapshot every type's ORIGINAL own type parameters before any
+        // reification mutates them, so a DEEPER nested type collects its
+        // enclosing types' ORIGINAL parameters (not the reified clones) no
+        // matter the processing order.
+        var originalOwnParams = new Dictionary<StructSymbol, ImmutableArray<TypeParameterSymbol>>(ReferenceEqualityComparer.Instance);
+        foreach (var s in this.emitCtx.Program.Structs)
+        {
+            var def = s.Definition ?? s;
+            if (!originalOwnParams.ContainsKey(def))
+            {
+                originalOwnParams[def] = def.TypeParameters;
+            }
+        }
+
+        foreach (var s in this.emitCtx.Program.Structs)
+        {
+            if (s.ContainingType is not StructSymbol)
+            {
+                continue;
+            }
+
+            var enclosing = CollectOriginalEnclosingTypeParameters(s, originalOwnParams);
+            if (enclosing.IsDefaultOrEmpty)
+            {
+                continue;
+            }
+
+            var def = s.Definition ?? s;
+            var own = originalOwnParams.TryGetValue(def, out var snapshot) ? snapshot : def.TypeParameters;
+
+            var combined = ImmutableArray.CreateBuilder<TypeParameterSymbol>(
+                enclosing.Length + (own.IsDefaultOrEmpty ? 0 : own.Length));
+            combined.AddRange(enclosing);
+            if (!own.IsDefaultOrEmpty)
+            {
+                combined.AddRange(own);
+            }
+
+            var combinedList = combined.ToImmutable();
+
+            // Issue #1499: remap self-/cross-referential constraints onto the
+            // nested type's cloned combined-parameter set.
+            s.SetTypeParameters(SynthesizedClosureReifier.CloneWithRemappedConstraints(combinedList));
+
+            // Record the enclosing arity so a use site can split its combined
+            // type-argument vector into enclosing/own halves.
+            this.nestedTypeEnclosingArity[def] = enclosing.Length;
+
+            // Build the original-parameter -> reified-slot remap so member
+            // signatures/bodies encode the correct VAR(idx). An enclosing
+            // parameter of a single generic level keeps its ordinal (remap is a
+            // no-op then); a re-ordinalized own parameter or an enclosing
+            // parameter of a DEEPER level (whose ordinals collide) is translated.
+            var remap = new Dictionary<TypeParameterSymbol, int>(combinedList.Length);
+            for (var i = 0; i < combinedList.Length; i++)
+            {
+                remap[combinedList[i]] = i;
+            }
+
+            this.iteratorStateMachineRemapsByClass[s] = remap;
+        }
+    }
+
+    // Issue #1537: gathers the flattened ORIGINAL generic parameters of every
+    // enclosing type of <paramref name="nested"/>, in CLR order (outermost
+    // first), reading each enclosing type's pre-reification parameters from
+    // <paramref name="originalOwnParams"/> so a deeply-nested type sees the
+    // originals even after an intermediate enclosing type has been reified.
+    private static ImmutableArray<TypeParameterSymbol> CollectOriginalEnclosingTypeParameters(
+        StructSymbol nested,
+        Dictionary<StructSymbol, ImmutableArray<TypeParameterSymbol>> originalOwnParams)
     {
         List<ImmutableArray<TypeParameterSymbol>> levels = null;
         for (var c = nested.ContainingType as StructSymbol; c != null; c = c.ContainingType as StructSymbol)
         {
             var def = c.Definition ?? c;
-            if (!def.TypeParameters.IsDefaultOrEmpty)
+            var tps = originalOwnParams.TryGetValue(def, out var snapshot) ? snapshot : def.TypeParameters;
+            if (!tps.IsDefaultOrEmpty)
             {
                 levels ??= new List<ImmutableArray<TypeParameterSymbol>>();
 
                 // Prepend so the outermost enclosing type's parameters come first.
-                levels.Insert(0, def.TypeParameters);
+                levels.Insert(0, tps);
             }
         }
 
@@ -458,41 +548,6 @@ internal sealed class ReflectionMetadataEmitter
         }
 
         return builder.ToImmutable();
-    }
-
-    // Issue #1467: reifies every user-declared type nested inside a generic
-    // type over an ordinal-aligned clone of the enclosing type-parameter list
-    // (ECMA-335 §II.10.3.1). The enclosing parameters keep their original
-    // ordinals (outermost first), so a member that references an enclosing
-    // type parameter — whose `TypeParameterSymbol.Ordinal` already matches —
-    // encodes the correct `VAR` slot without any remap. Nested types that
-    // declare their OWN generic parameters are left untouched (their own
-    // parameters would need re-ordinalization, which is out of scope here and
-    // does not occur in the issue corpus).
-    private void RegisterNestedTypeEnclosingGenerics()
-    {
-        foreach (var s in this.emitCtx.Program.Structs)
-        {
-            if (s.ContainingType is not StructSymbol)
-            {
-                continue;
-            }
-
-            if (!s.TypeParameters.IsDefaultOrEmpty)
-            {
-                continue;
-            }
-
-            var enclosing = CollectEnclosingTypeParameters(s);
-            if (enclosing.IsDefaultOrEmpty)
-            {
-                continue;
-            }
-
-            // Issue #1499: remap self-/cross-referential constraints onto the
-            // nested type's cloned enclosing-parameter set.
-            s.SetTypeParameters(SynthesizedClosureReifier.CloneWithRemappedConstraints(enclosing));
-        }
     }
 
     // Issue #1477: builds the outer-TP → own-TP-ordinal remap for every
@@ -2000,7 +2055,16 @@ internal sealed class ReflectionMetadataEmitter
                     EmitClassTypeDefRow(ns);
                     break;
                 case StructSymbol ns:
-                    this.typeDefEmitter.EmitStructTypeDef(ns, structFirstFieldRow[ns], nestedMethodListRow[ns]);
+                    // Issue #1537: a nested struct reified over its enclosing +
+                    // own type parameters needs its remap active so field
+                    // signatures (and the TypeDef's own generic-param
+                    // constraints) encode the correct re-ordinalized VAR(idx)
+                    // slots. No-op for every other struct.
+                    using (this.PushSmRemap(ns))
+                    {
+                        this.typeDefEmitter.EmitStructTypeDef(ns, structFirstFieldRow[ns], nestedMethodListRow[ns]);
+                    }
+
                     EmitInterfaceImplRows(ns);
                     break;
                 case EnumSymbol ne:
@@ -7097,8 +7161,91 @@ internal sealed class ReflectionMetadataEmitter
     /// <param name="structSym">The struct reference being encoded.</param>
     /// <param name="def">The struct's emitted definition.</param>
     /// <returns>The type-argument vector aligned with <paramref name="def"/>'s type parameters.</returns>
-    private static ImmutableArray<TypeSymbol> ResolveUserStructTypeSpecArguments(StructSymbol structSym, StructSymbol def)
+    private ImmutableArray<TypeSymbol> ResolveUserStructTypeSpecArguments(StructSymbol structSym, StructSymbol def)
     {
+        // Issue #1537: a type nested inside a generic enclosing type is reified
+        // over the flattened enclosing+own parameter list (`Outer`1+Middle`2`),
+        // so its use-site argument vector is built from TWO halves — the
+        // enclosing arguments (`0..k-1`) then the nested type's own arguments
+        // (`k..k+m-1`). Each half is concrete when the reference carries it and
+        // the open reified parameters (encoded `VAR(idx)`) otherwise, so the
+        // vector is context-correct for constructed and open references alike.
+        if (this.nestedTypeEnclosingArity.TryGetValue(def, out var enclosingArity) && enclosingArity > 0)
+        {
+            var defTps = def.TypeParameters;
+            var total = defTps.Length;
+
+            // A self-reference from within the nested type's OWN body (the
+            // implicit `this` receiver, e.g. reading `FromU` inside a `Middle`
+            // method) is the self-instantiation over the reified definition's
+            // full parameter list, so its argument vector already spans BOTH
+            // halves (`<U, T>` == `<!0, !1>`). Emit it verbatim — splitting it
+            // into halves would double-count the enclosing slots.
+            if (structSym.EnclosingTypeArguments.IsDefaultOrEmpty
+                && structSym.TypeArguments.Length == total)
+            {
+                return structSym.TypeArguments;
+            }
+
+            var builder = ImmutableArray.CreateBuilder<TypeSymbol>(total);
+
+            // Enclosing half (`0..k-1`): the threaded enclosing arguments when
+            // present (constructed use site, `<int32, …>`), else the reified
+            // enclosing parameters (open reference from within the enclosing
+            // generic's members, `<!0, …>`).
+            if (!structSym.EnclosingTypeArguments.IsDefaultOrEmpty)
+            {
+                for (var i = 0; i < enclosingArity && i < structSym.EnclosingTypeArguments.Length; i++)
+                {
+                    builder.Add(structSym.EnclosingTypeArguments[i]);
+                }
+
+                for (var i = builder.Count; i < enclosingArity && i < total; i++)
+                {
+                    builder.Add(defTps[i]);
+                }
+            }
+            else
+            {
+                for (var i = 0; i < enclosingArity && i < total; i++)
+                {
+                    builder.Add(defTps[i]);
+                }
+            }
+
+            // Own half (`k..k+m-1`): the nested type's own arguments when
+            // present (`Middle[string]`), else its reified own parameters (open,
+            // `<…, !k>`).
+            if (!structSym.TypeArguments.IsDefaultOrEmpty)
+            {
+                builder.AddRange(structSym.TypeArguments);
+                for (var i = builder.Count; i < total; i++)
+                {
+                    builder.Add(defTps[i]);
+                }
+            }
+            else
+            {
+                for (var i = enclosingArity; i < total; i++)
+                {
+                    builder.Add(defTps[i]);
+                }
+            }
+
+            if (builder.Count > total)
+            {
+                var trimmed = ImmutableArray.CreateBuilder<TypeSymbol>(total);
+                for (var i = 0; i < total; i++)
+                {
+                    trimmed.Add(builder[i]);
+                }
+
+                return trimmed.MoveToImmutable();
+            }
+
+            return builder.ToImmutable();
+        }
+
         if (!structSym.TypeArguments.IsDefaultOrEmpty)
         {
             return structSym.TypeArguments;
@@ -7117,9 +7264,9 @@ internal sealed class ReflectionMetadataEmitter
         // EncodeTypeSymbol. For a nested type referenced from within its
         // enclosing generic's own members these are the reified enclosing
         // parameters, so the reference correctly threads `!0…`.
-        var defTps = def.TypeParameters;
-        var bld = ImmutableArray.CreateBuilder<TypeSymbol>(defTps.Length);
-        foreach (var tp in defTps)
+        var openTps = def.TypeParameters;
+        var bld = ImmutableArray.CreateBuilder<TypeSymbol>(openTps.Length);
+        foreach (var tp in openTps)
         {
             bld.Add(tp);
         }

--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -27,6 +27,14 @@ public sealed class StructSymbol : TypeSymbol
     // reference equality and TypeSpec caching in the emitter).
     private static readonly ConcurrentDictionary<(StructSymbol Def, string ArgsKey), StructSymbol> ConstructedNestedCache = new();
 
+    // Issue #1537: identity cache for constructed references to a GENERIC type
+    // nested inside a generic enclosing type (`Outer[int32].Middle[string]`),
+    // keyed by the nested definition, the flattened enclosing type-argument
+    // vector, and the nested type's own type-argument vector. Distinct from
+    // ConstructedNestedCache (which keys only the enclosing args for a nested
+    // type with no own parameters) so the two representations never collide.
+    private static readonly ConcurrentDictionary<(StructSymbol Def, string EnclosingKey, string OwnKey), StructSymbol> ConstructedNestedGenericCache = new();
+
     // Issue #1341: backing stores for the generically-erased member tables whose
     // reads are forwarded to Definition on a constructed instance. On a
     // definition (or non-generic type) these hold the canonical member set; on a
@@ -48,6 +56,16 @@ public sealed class StructSymbol : TypeSymbol
     // definition's body still observes the substituted members afterward,
     // making member lookup independent of source-file binding order.
     private Dictionary<TypeParameterSymbol, TypeSymbol> substitutionMap;
+
+    // Issue #1537: for a constructed reference to a GENERIC type nested inside a
+    // generic enclosing type (`Outer[int32].Middle[string]`), the nested
+    // definition's own type parameters captured at construction time (before the
+    // emitter re-ordinalizes the nested TypeDef's parameters over the flattened
+    // enclosing+own list, ECMA-335 §II.10.3.1). Used to key the own-argument
+    // half of the substitution map so a member typed as the nested type's own
+    // parameter (`Middle.Label : T`) surfaces closed regardless of when the map
+    // is first computed. Empty for every other symbol.
+    private ImmutableArray<TypeParameterSymbol> nestedOwnTypeParameters = ImmutableArray<TypeParameterSymbol>.Empty;
     private ImmutableArray<FieldSymbol> substitutedFields;
     private ImmutableArray<FieldSymbol> substitutedFieldsSource;
     private bool substitutedFieldsComputed;
@@ -1177,6 +1195,61 @@ public sealed class StructSymbol : TypeSymbol
     }
 
     /// <summary>
+    /// Issue #1537: constructs a reference to a <em>generic</em> type declared
+    /// as a nested type inside a <em>generic</em> enclosing type, closed over
+    /// BOTH the enclosing construction's type arguments and the nested type's
+    /// own type arguments (e.g. <c>Outer[int32].Middle[string]</c>). The nested
+    /// type declares its own type parameters, so the CLR models it as
+    /// <c>Outer`1+Middle`2</c> — redeclaring the encloser's parameters first,
+    /// then its own (ECMA-335 §II.10.3.1). The enclosing arguments are recorded
+    /// on <see cref="EnclosingTypeArguments"/> and the own arguments on
+    /// <see cref="TypeArguments"/>; a member whose type mentions either an
+    /// enclosing parameter (<c>U</c>) or the nested type's own parameter
+    /// (<c>T</c>) is substituted through the combined map (see
+    /// <see cref="GetSubstitutionMap"/>). The emitter threads the combined
+    /// vector <c>[enclosing…, own…]</c> so a constructed use site encodes
+    /// <c>Outer`1+Middle`2&lt;int32, string&gt;</c>.
+    /// </summary>
+    /// <param name="nestedDefinition">The open nested-type definition (its <see cref="Definition"/> is used).</param>
+    /// <param name="enclosingTypeArguments">The flattened enclosing construction arguments in CLR order (outermost first), aligned with <see cref="CollectEnclosingTypeParameters(TypeSymbol)"/>. May be empty when the enclosing type is open but the nested type carries own arguments.</param>
+    /// <param name="ownTypeArguments">The nested type's own type arguments.</param>
+    /// <returns>A constructed nested-generic reference, or <paramref name="nestedDefinition"/> unchanged when neither vector applies.</returns>
+    public static StructSymbol ConstructNestedGeneric(
+        StructSymbol nestedDefinition,
+        ImmutableArray<TypeSymbol> enclosingTypeArguments,
+        ImmutableArray<TypeSymbol> ownTypeArguments)
+    {
+        if (nestedDefinition == null)
+        {
+            return nestedDefinition;
+        }
+
+        // No own arguments: fall back to the enclosing-only construction so the
+        // two representations remain reference-equal and share one cache.
+        if (ownTypeArguments.IsDefaultOrEmpty)
+        {
+            return ConstructNested(nestedDefinition, enclosingTypeArguments);
+        }
+
+        // No enclosing arguments to thread: this is an ordinary construction of
+        // the nested type over its own parameters (e.g. `Middle[string]`
+        // referenced from within the enclosing generic's own members, where the
+        // enclosing parameters stay open). Route through Construct so the own
+        // arguments substitute exactly as for a top-level generic.
+        if (enclosingTypeArguments.IsDefaultOrEmpty)
+        {
+            return Construct(nestedDefinition.Definition ?? nestedDefinition, ownTypeArguments);
+        }
+
+        var def = nestedDefinition.Definition ?? nestedDefinition;
+        var enclosingKey = BuildArgsKey(enclosingTypeArguments);
+        var ownKey = BuildArgsKey(ownTypeArguments);
+        return ConstructedNestedGenericCache.GetOrAdd(
+            (def, enclosingKey, ownKey),
+            _ => CreateConstructedNestedGeneric(def, enclosingTypeArguments, ownTypeArguments));
+    }
+
+    /// <summary>
     /// Issue #1521: gathers the flattened generic parameters of every enclosing
     /// type of <paramref name="nested"/>, in CLR order (outermost first). A type
     /// nested inside <c>Outer[U].Inner[T]</c> sees <c>[U, T]</c>. Mirrors the
@@ -1601,6 +1674,60 @@ public sealed class StructSymbol : TypeSymbol
         return constructed;
     }
 
+    // Issue #1537: materializes a constructed reference to a GENERIC type nested
+    // inside a generic enclosing type (`Outer[int32].Middle[string]`). Combines
+    // the treatment of CreateConstructed (own type arguments) and
+    // CreateConstructedNested (enclosing type arguments): the nested type
+    // declares its own parameters AND its members may mention the enclosing
+    // type's parameters, so the substitution map (GetSubstitutionMap) is keyed
+    // by BOTH the nested type's own parameters (-> own arguments) and the
+    // flattened enclosing parameters (-> enclosing arguments). Instance-member
+    // reads forward to the definition and substitute lazily against that map, so
+    // a field/return typed as either an own parameter (`Middle.Label : T`) or an
+    // enclosing parameter (`Middle.Owner : U`) surfaces closed.
+    private static StructSymbol CreateConstructedNestedGeneric(
+        StructSymbol definition,
+        ImmutableArray<TypeSymbol> enclosingTypeArguments,
+        ImmutableArray<TypeSymbol> ownTypeArguments)
+    {
+        var constructed = new StructSymbol(
+            definition.Name,
+            definition.Fields,
+            definition.Accessibility,
+            definition.Declaration,
+            definition.PackageName,
+            definition.IsData,
+            definition.IsInline,
+            definition.IsClass,
+            definition.PrimaryConstructorParameters,
+            definition.IsOpen,
+            definition.BaseClass);
+
+        constructed.Definition = definition;
+        constructed.TypeArguments = ownTypeArguments;
+        constructed.EnclosingTypeArguments = enclosingTypeArguments;
+
+        // Capture the nested type's own type parameters BEFORE the emitter
+        // re-ordinalizes the nested TypeDef over the flattened enclosing+own
+        // list (RegisterNestedTypeEnclosingGenerics), so the substitution map's
+        // own-argument half keeps pairing each original own parameter with its
+        // argument no matter when it is first computed.
+        constructed.nestedOwnTypeParameters = definition.TypeParameters;
+        constructed.ContainingType = definition.ContainingType;
+        constructed.SetInterfaces(definition.Interfaces);
+        if (!definition.ImplementedClrInterfaces.IsDefaultOrEmpty)
+        {
+            constructed.SetImplementedClrInterfaces(definition.ImplementedClrInterfaces);
+        }
+
+        if (definition.ImportedBaseType != null)
+        {
+            constructed.SetImportedBaseType(definition.ImportedBaseType);
+        }
+
+        return constructed;
+    }
+
     // Issue #1341: builds (once) the type-parameter -> type-argument map used to
     // substitute the definition's instance-member types for this constructed
     // instance. Generic definitions are immutable in their type parameters and
@@ -1615,12 +1742,19 @@ public sealed class StructSymbol : TypeSymbol
         var def = Definition;
         var map = new Dictionary<TypeParameterSymbol, TypeSymbol>(
             def.TypeParameters.IsDefaultOrEmpty ? 0 : def.TypeParameters.Length);
-        if (!def.TypeParameters.IsDefaultOrEmpty && !TypeArguments.IsDefaultOrEmpty)
+
+        // Issue #1537: for a constructed nested-generic reference the emitter
+        // re-ordinalizes the definition's TypeParameters over the flattened
+        // enclosing+own list, so use the own parameters captured at construction
+        // time to pair with TypeArguments. For every other constructed instance
+        // the definition's TypeParameters are the own parameters.
+        var ownParams = !nestedOwnTypeParameters.IsDefaultOrEmpty ? nestedOwnTypeParameters : def.TypeParameters;
+        if (!ownParams.IsDefaultOrEmpty && !TypeArguments.IsDefaultOrEmpty)
         {
-            var count = System.Math.Min(def.TypeParameters.Length, TypeArguments.Length);
+            var count = System.Math.Min(ownParams.Length, TypeArguments.Length);
             for (var i = 0; i < count; i++)
             {
-                map[def.TypeParameters[i]] = TypeArguments[i];
+                map[ownParams[i]] = TypeArguments[i];
             }
         }
 

--- a/test/Compiler.Tests/Emit/Issue1537GenericNestedInGenericEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1537GenericNestedInGenericEmitTests.cs
@@ -1,0 +1,394 @@
+// <copyright file="Issue1537GenericNestedInGenericEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1537 — a <b>generic</b> type nested inside a <b>generic</b> type
+/// (<c>struct Middle[T any]</c> inside <c>struct Outer[U any]</c>) constructed
+/// externally through the per-segment type-clause syntax
+/// (<c>Outer[int32].Middle[string]</c>) failed at BIND time with
+/// <c>GS0159 Cannot find function</c> and, once bound, could not be emitted
+/// verifiably. This is the follow-up to issue #1521, which only covered a
+/// NON-generic nested type of a generic (<c>Box[T].Tag</c>).
+/// <para>
+/// The fix threads a COMBINED type-argument vector — the enclosing
+/// construction's arguments first, then the nested type's own arguments — from
+/// both the binder (member lookup substitutes enclosing <c>U</c> and own
+/// <c>T</c>) and the emitter (the nested <c>TypeDef</c> is reified over the
+/// flattened <c>[U, T]</c> parameter list per ECMA-335 §II.10.3.1, so
+/// <c>Middle</c> emits as <c>Outer`1+Middle`2</c>). Both the constructed
+/// external use site (<c>&lt;int32, string&gt;</c>) and the open self/internal
+/// reference (<c>&lt;!0, !1&gt;</c>) encode with the correct combined vector,
+/// generalised to arbitrary nesting depth and arity.
+/// </para>
+/// Each test uses a UNIQUE package/type name because the in-process
+/// <c>FunctionTypeSymbol</c> cache is name-keyed and not cleared between tests.
+/// </summary>
+public class Issue1537GenericNestedInGenericEmitTests
+{
+    [Fact]
+    public void EndToEnd_BaseRepro_GenericNestedInGeneric_VerifiesAndRuns()
+    {
+        // The exact issue repro: external construction of a generic nested type
+        // of a generic via `Outer[int32].Middle[string]`, then a member call on
+        // the result. Before the fix member lookup failed with GS0159.
+        const string source = """
+            package Issue1537BaseRepro
+            import System
+
+            struct Issue1537Outer[U any] {
+                struct Issue1537Middle[T any] {
+                    var Label string
+                    func Hello() string { return "hi" }
+                }
+            }
+
+            func Main() {
+                var m = Issue1537Outer[int32].Issue1537Middle[string]{Label: "x"}
+                System.Console.WriteLine(m.Hello())
+                System.Console.WriteLine(m.Label)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("hi\nx\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_MultiArityAtEachLevel_VerifiesAndRuns()
+    {
+        // Generalization: multi-parameter arity at BOTH levels
+        // (`Outer`2+Middle`4<int32, bool, string, int64>`). The combined vector
+        // must be [A, B, C, D] with the enclosing pair on the low ordinals.
+        const string source = """
+            package Issue1537MultiArity
+            import System
+
+            struct Issue1537OuterMA[A any, B any] {
+                struct Issue1537MiddleMA[C any, D any] {
+                    var Tag string
+                    func Ping() string { return "ma" }
+                }
+            }
+
+            func Main() {
+                var m = Issue1537OuterMA[int32, bool].Issue1537MiddleMA[string, int64]{Tag: "z"}
+                System.Console.WriteLine(m.Ping())
+                System.Console.WriteLine(m.Tag)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("ma\nz\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_NestedMemberUsesOuterTypeParameter_VerifiesAndRuns()
+    {
+        // Generalization: the nested type has a field AND a method mentioning
+        // the ENCLOSING type parameter `U`. On the constructed context these
+        // must surface `U` as `int32` in the field signature, the field-access
+        // token, and the method's return signature.
+        const string source = """
+            package Issue1537OuterTypeParam
+            import System
+
+            struct Issue1537OuterUP[U any] {
+                struct Issue1537MiddleUP[T any] {
+                    var OwnT T
+                    var FromU U
+                    func Combine() U { return FromU }
+                }
+            }
+
+            func Main() {
+                var m = Issue1537OuterUP[int32].Issue1537MiddleUP[string]{OwnT: "s", FromU: 42}
+                System.Console.WriteLine(m.OwnT)
+                System.Console.WriteLine(m.Combine())
+                System.Console.WriteLine(m.FromU)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("s\n42\n42\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_TripleNesting_NonGenericInnermost_VerifiesAndRuns()
+    {
+        // Generalization: three levels of nesting where the innermost is
+        // non-generic (`Outer[int32].Middle[string].Inner`). The Inner TypeDef
+        // is reified over the flattened `[U, T]` enclosing list.
+        const string source = """
+            package Issue1537TripleNonGen
+            import System
+
+            struct Issue1537OuterTNG[U any] {
+                struct Issue1537MiddleTNG[T any] {
+                    struct Issue1537InnerTNG {
+                        var Note string
+                        func Speak() string { return "tng" }
+                    }
+                }
+            }
+
+            func Main() {
+                var i = Issue1537OuterTNG[int32].Issue1537MiddleTNG[string].Issue1537InnerTNG{Note: "n"}
+                System.Console.WriteLine(i.Speak())
+                System.Console.WriteLine(i.Note)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("tng\nn\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_TripleNesting_GenericInnermost_VerifiesAndRuns()
+    {
+        // Generalization: three levels of nesting where the innermost is ALSO
+        // generic (`Outer[int32].Middle[string].Inner[bool]`). Inner is reified
+        // over the flattened `[U, T, W]` list — arity 3.
+        const string source = """
+            package Issue1537TripleGen
+            import System
+
+            struct Issue1537OuterTG[U any] {
+                struct Issue1537MiddleTG[T any] {
+                    struct Issue1537InnerTG[W any] {
+                        var Note string
+                        func Speak() string { return "tg" }
+                    }
+                }
+            }
+
+            func Main() {
+                var i = Issue1537OuterTG[int32].Issue1537MiddleTG[string].Issue1537InnerTG[bool]{Note: "n"}
+                System.Console.WriteLine(i.Speak())
+                System.Console.WriteLine(i.Note)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("tg\nn\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_NestedTypeAsFieldParamReturnLocal_VerifiesAndRuns()
+    {
+        // Generalization: the generic-nested-in-generic type used as a
+        // top-level function PARAMETER, RETURN, and LOCAL, plus a member access
+        // on each — every signature/slot position that risks a `<!0, !1>`
+        // encoding in a constructed context.
+        const string source = """
+            package Issue1537FieldParam
+            import System
+
+            struct Issue1537OuterFP[U any] {
+                struct Issue1537MiddleFP[T any] {
+                    var Label string
+                    func Tag() string { return "fp" }
+                }
+            }
+
+            func Issue1537Grab(m Issue1537OuterFP[int32].Issue1537MiddleFP[string]) string {
+                var local Issue1537OuterFP[int32].Issue1537MiddleFP[string] = m
+                return local.Label
+            }
+
+            func Issue1537Make() Issue1537OuterFP[int32].Issue1537MiddleFP[string] {
+                return Issue1537OuterFP[int32].Issue1537MiddleFP[string]{Label: "r"}
+            }
+
+            func Main() {
+                var m = Issue1537Make()
+                System.Console.WriteLine(m.Tag())
+                System.Console.WriteLine(Issue1537Grab(m))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("fp\nr\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_InternalConstructionControlB_StillVerifiesAndRuns()
+    {
+        // Control B: a generic nested type of a generic constructed from WITHIN
+        // the enclosing generic's own member (open, `<!0, !1>` context). This
+        // worked before the fix and must keep working after the nested type is
+        // reified to arity 2.
+        const string source = """
+            package Issue1537ControlB
+            import System
+
+            struct Issue1537OuterCB[U any] {
+                struct Issue1537MiddleCB[T any] {
+                    var Label string
+                    func Hello() string { return "hi" }
+                }
+                func Make() string {
+                    var m = Issue1537MiddleCB[string]{Label: "y"}
+                    return m.Hello()
+                }
+            }
+
+            func Main() {
+                var o = Issue1537OuterCB[int32]{}
+                System.Console.WriteLine(o.Make())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("hi\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_NonGenericOuterControlA_StillVerifiesAndRuns()
+    {
+        // Control A: a generic nested type of a NON-generic outer
+        // (`Outer.Middle[string]`). Enclosing arity is 0, so the nested type is
+        // NOT reified — this must stay unaffected by the #1537 changes.
+        const string source = """
+            package Issue1537ControlA
+            import System
+
+            struct Issue1537OuterCA {
+                struct Issue1537MiddleCA[T any] {
+                    var Label string
+                    func Hello() string { return "hi" }
+                }
+            }
+
+            func Main() {
+                var m = Issue1537OuterCA.Issue1537MiddleCA[string]{Label: "x"}
+                System.Console.WriteLine(m.Hello())
+                System.Console.WriteLine(m.Label)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("hi\nx\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_Issue1521NonOwnParamsGuard_StillVerifiesAndRuns()
+    {
+        // Guard: the #1521 case (a NON-generic nested type of a generic,
+        // `Box[int32].Tag`) must keep binding, verifying and running — the
+        // #1537 combined-vector threading must not regress the enclosing-only
+        // path.
+        const string source = """
+            package Issue1537Box1521Guard
+            import System
+
+            struct Issue1537BoxGuard[T any] {
+                var Value T
+                struct TagGuard { var Name string }
+                func MakeTag() TagGuard { return TagGuard{Name: "guard"} }
+            }
+
+            func Issue1537GrabGuard(t Issue1537BoxGuard[int32].TagGuard) string { return t.Name }
+
+            func Main() {
+                var b = Issue1537BoxGuard[int32]{Value: 5}
+                System.Console.WriteLine(b.MakeTag().Name)
+                var t Issue1537BoxGuard[int32].TagGuard = b.MakeTag()
+                System.Console.WriteLine(Issue1537GrabGuard(t))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("guard\nguard\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1537_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1537GenericNestedInGenericBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1537GenericNestedInGenericBinderTests.cs
@@ -1,0 +1,227 @@
+// <copyright file="Issue1537GenericNestedInGenericBinderTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1537: member access on a <b>generic</b> type nested inside a
+/// <b>generic</b> type, constructed externally through the per-segment
+/// type-clause syntax (<c>Outer[int32].Middle[string]</c>), failed at bind time
+/// with <c>GS0159 Cannot find function</c> because the produced
+/// <see cref="StructSymbol"/> did not expose members whose signatures substitute
+/// BOTH the enclosing type arguments (<c>U → int32</c>) and the nested type's
+/// own arguments (<c>T → string</c>).
+/// <para>
+/// These tests assert the resolution binds without diagnostics AND that the
+/// member types are substituted correctly: a function whose declared return
+/// type equals the expected substituted member type only binds cleanly when the
+/// substitution is correct (a wrong substitution surfaces a conversion
+/// diagnostic). Symbol-level assertions confirm the constructed nested symbol
+/// carries the enclosing arguments separately from its own arguments.
+/// </para>
+/// Each test uses a UNIQUE package/type name because the in-process
+/// <c>FunctionTypeSymbol</c> cache is name-keyed and not cleared between tests.
+/// </summary>
+public class Issue1537GenericNestedInGenericBinderTests
+{
+    [Fact]
+    public void BaseRepro_MemberAccessOnGenericNestedInGeneric_BindsWithoutGs0159()
+    {
+        // The verbatim issue repro: before the fix this reported
+        // `GS0159 Cannot find function Hello` (and a cascade for WriteLine).
+        var diagnostics = GetDiagnostics("""
+            package Issue1537BinderBase
+            import System
+            struct Issue1537BOuter[U any] {
+                struct Issue1537BMiddle[T any] {
+                    var Label string
+                    func Hello() string { return "hi" }
+                }
+            }
+            func Main() {
+                var m = Issue1537BOuter[int32].Issue1537BMiddle[string]{Label: "x"}
+                System.Console.WriteLine(m.Hello())
+                System.Console.WriteLine(m.Label)
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void OwnTypeArgument_SubstitutesToConcreteType()
+    {
+        // The nested type's OWN parameter `T` must surface as `string` on the
+        // construction: a field typed `T` read into a `string` return only
+        // binds cleanly when `T → string`.
+        var diagnostics = GetDiagnostics("""
+            package Issue1537BinderOwn
+            struct Issue1537OwnOuter[U any] {
+                struct Issue1537OwnMiddle[T any] {
+                    var Own T
+                }
+            }
+            func GetOwn(m Issue1537OwnOuter[int32].Issue1537OwnMiddle[string]) string {
+                return m.Own
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void EnclosingTypeArgument_SubstitutesToConcreteType()
+    {
+        // The ENCLOSING parameter `U` referenced by a nested member must surface
+        // as `int32` on the construction: a field typed `U` read into an `int32`
+        // return only binds cleanly when `U → int32` (a wrong `U → object`
+        // substitution would report a conversion diagnostic).
+        var diagnostics = GetDiagnostics("""
+            package Issue1537BinderEnclosing
+            struct Issue1537EncOuter[U any] {
+                struct Issue1537EncMiddle[T any] {
+                    var FromU U
+                    func Combine() U { return FromU }
+                }
+            }
+            func GetFromU(m Issue1537EncOuter[int32].Issue1537EncMiddle[string]) int32 {
+                return m.FromU
+            }
+            func GetCombine(m Issue1537EncOuter[int32].Issue1537EncMiddle[string]) int32 {
+                return m.Combine()
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void MultiArityAtEachLevel_BindsWithoutDiagnostics()
+    {
+        var diagnostics = GetDiagnostics("""
+            package Issue1537BinderMultiArity
+            struct Issue1537MAOuter[A any, B any] {
+                struct Issue1537MAMiddle[C any, D any] {
+                    var First A
+                    var Third C
+                }
+            }
+            func GetFirst(m Issue1537MAOuter[int32, bool].Issue1537MAMiddle[string, int64]) int32 {
+                return m.First
+            }
+            func GetThird(m Issue1537MAOuter[int32, bool].Issue1537MAMiddle[string, int64]) string {
+                return m.Third
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void TripleNesting_GenericInnermost_BindsWithoutDiagnostics()
+    {
+        var diagnostics = GetDiagnostics("""
+            package Issue1537BinderTriple
+            struct Issue1537TOuter[U any] {
+                struct Issue1537TMiddle[T any] {
+                    struct Issue1537TInner[W any] {
+                        var FromU U
+                        var FromT T
+                        var Own W
+                    }
+                }
+            }
+            func GetU(i Issue1537TOuter[int32].Issue1537TMiddle[string].Issue1537TInner[bool]) int32 {
+                return i.FromU
+            }
+            func GetT(i Issue1537TOuter[int32].Issue1537TMiddle[string].Issue1537TInner[bool]) string {
+                return i.FromT
+            }
+            func GetOwn(i Issue1537TOuter[int32].Issue1537TMiddle[string].Issue1537TInner[bool]) bool {
+                return i.Own
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void Issue1521NonOwnParamsGuard_StillBindsWithoutDiagnostics()
+    {
+        // Guard: the #1521 case (a NON-generic nested type of a generic) must
+        // keep binding — the #1537 combined-vector threading must not regress
+        // the enclosing-only path.
+        var diagnostics = GetDiagnostics("""
+            package Issue1537BinderGuard
+            struct Issue1537GBox[T any] {
+                var Value T
+                struct Issue1537GTag { var Name string }
+            }
+            func GrabName(t Issue1537GBox[int32].Issue1537GTag) string {
+                return t.Name
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void DeepestSegment_CarriesEnclosingAndOwnArguments()
+    {
+        // Symbol-level assertion: the constructed deepest segment
+        // (`Outer[int32].Middle[string]`) is a constructed-nested reference that
+        // carries the enclosing argument (`int32`) on EnclosingTypeArguments AND
+        // its own argument (`string`) on TypeArguments, sharing the open nested
+        // definition and the open enclosing type as its ContainingType.
+        var scope = BindGlobalScope("""
+            package Issue1537BinderSymbol
+            struct Issue1537SOuter[U any] {
+                struct Issue1537SMiddle[T any] {
+                    var Own T
+                    var FromU U
+                }
+            }
+            func Use(m Issue1537SOuter[int32].Issue1537SMiddle[string]) { }
+            """);
+
+        Assert.Empty(scope.Diagnostics);
+
+        var use = scope.Functions.Single(f => f.Name == "Use");
+        var paramStruct = Assert.IsType<StructSymbol>(use.Parameters.Single().Type);
+
+        Assert.True(paramStruct.IsConstructedNestedType);
+        Assert.Equal("Issue1537SMiddle", paramStruct.Name);
+
+        var enclosingArg = Assert.Single(paramStruct.EnclosingTypeArguments);
+        Assert.Equal("int32", enclosingArg.Name);
+
+        var ownArg = Assert.Single(paramStruct.TypeArguments);
+        Assert.Equal("string", ownArg.Name);
+    }
+
+    private static IReadOnlyList<Diagnostic> GetDiagnostics(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return result.Diagnostics;
+    }
+
+    private static BoundGlobalScope BindGlobalScope(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        return Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+    }
+}


### PR DESCRIPTION
## The gap (Fixes #1537)

A **generic** type nested inside a **generic** type, constructed externally via the per-segment type-clause syntax (`Outer[int32].Middle[string]`), failed at **bind** time with `GS0159: Cannot find function` (plus a cascade because the receiver became error-typed) and could not be emitted verifiably.

This is the follow-up to #1521, which fixed a **non-generic** nested type of a generic (`Box[T].Tag`). This issue is the gap for a nested type that declares its **own** type parameters (`Middle[T]`) under a constructed enclosing segment (`Outer[U]`).

## The fix

Threads a **combined type-argument vector** — enclosing construction arguments first, then the nested type's own arguments — through both the binder and the emitter, with correct **re-ordinalization**: enclosing params occupy the low ordinals `0..k-1`, the nested type's own params occupy `k..k+m-1`. Generalized to arbitrary nesting depth and any arity at each level.

### Binder
- `StructSymbol.ConstructNestedGeneric` / `GetSubstitutionMap` substitute **both** the enclosing args (`EnclosingTypeArguments`) and the nested type's own args.
- `Binder.TryResolveUserNestedTypeChain` and the ExpressionBinder expression-path resolution flatten an arbitrary-depth per-segment chain, binding each segment's own arguments under the constructed enclosing segment.
- `DeclarationBinder` seeds the enclosing type parameters into a nested type's member/constraint scope so a nested member can reference an outer parameter (e.g. a field/method of type `U`).
- `OverloadResolver.TryBuildReceiverSubstitution` maps each enclosing parameter to its construction argument, so an instance method returning/using an enclosing parameter surfaces the concrete type.

### Emit
- `RegisterNestedTypeEnclosingGenerics` reifies a nested type that declares its own parameters over the flattened `[enclosing, own]` list (`Outer` + backtick-1 + `+Middle` + backtick-2) per ECMA-335 §II.10.3.1 — i.e. `Middle` inside `Outer[U]` has arity 2 `[U, T]` — remapping each reference to the correct `VAR` ordinal.
- `ResolveUserStructTypeSpecArguments` builds the combined vector context-correct: concrete enclosing/own halves at a constructed external use site, open reified parameters (`<!0, !1>`) for internal/self references.

## Result

The repro now binds, ilverify-verifies clean, and runs (prints `hi`). Generalized cases validated: multi-arity at each level, a nested member that uses an outer type parameter, triple nesting (generic and non-generic innermost), and field/param/return/local usage. All existing behavior is preserved — the non-generic-outer control, the internal-construction control, the #1521 non-own-params case, and non-nested generics are unaffected.

## Tests

- **Emit**: `test/Compiler.Tests/Emit/Issue1537GenericNestedInGenericEmitTests.cs` (9 tests — compile + ilverify + run) covering the base repro, multi-arity, outer-type-parameter-using member, triple nesting (both innermost variants), field/param/return/local, both controls, and a #1521 guard.
- **Binder**: `test/Core.Tests/CodeAnalysis/Binding/Issue1537GenericNestedInGenericBinderTests.cs` (7 tests) asserting member access binds without `GS0159` and that member types substitute correctly (enclosing + own), plus a symbol-level assertion of the combined argument threading.

Full `Core.Tests` green (4888 passed); `RefactoringBaselineTests` and the coverage matrix are untouched.
