### PR TITLE
Allow converting a generic type parameter to object (T -> object) (#1540)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -92,20 +92,46 @@ public sealed class Conversion
         // Mirrors C# §10.2.12 (implicit reference conversions involving type
         // parameters): an identity / implicit reference conversion exists from
         // `T` to its effective interface set and to any base-class constraint.
-        // The emitter materialises this with `box T` (a no-op for reference
-        // `T`), so a value-type or reference-type argument both satisfy the
-        // interface-typed slot.
+        // The interface/base-class rule above is materialised by the emitter
+        // with `box T` (a no-op for reference `T`), so a value-type or
+        // reference-type argument both satisfy the interface-typed slot.
         //
-        // NOTE: this deliberately does NOT cover `T -> object`. Open generic
-        // parameter slots (e.g. the `!0` element type of `List[T].Add(!0)`)
-        // are erased to the `object` singleton by the binder, so a `T -> object`
-        // rule here is indistinguishable from the identity argument conversion
-        // `T -> !0` and would make the emitter inject a spurious `box T`,
-        // producing invalid IL (the #1196 regression). `T` is passed straight
-        // through to an erased `!0` slot with no conversion.
+        // NOTE: the interface/base rule above deliberately does NOT cover
+        // `T -> object`; that genuine-object case is handled by the dedicated
+        // #1540 rule below, which is safe because erased `!0` slots are
+        // substituted back to their real `T` before this classifier runs (see
+        // the extended comment on that rule).
         if (from is TypeParameterSymbol fromTypeParam && to != null
             && to is not TypeParameterSymbol
             && TypeParameterConvertsTo(fromTypeParam, to))
+        {
+            return Conversion.Implicit;
+        }
+
+        // Issue #1540: a generic type parameter `T` is ALWAYS implicitly
+        // convertible to a GENUINE `object` slot — a boxing conversion for a
+        // value `T`, a reference conversion for a reference `T`, and `box !!T`
+        // (valid for both) for an unconstrained `T`. Mirrors C# §10.2.12: an
+        // implicit reference/boxing conversion exists from any `T` to `object`.
+        // This covers the implicit forms (`return val` with an `object` return
+        // type, `let o object = val`, passing `T` to an `object` parameter) and,
+        // since the conversion `Exists`, the explicit form `object(val)` too.
+        //
+        // Why this does NOT re-break #1196 (the erased-slot spurious box):
+        // an ERASED open generic parameter slot (e.g. the `!0` element type of
+        // `List[T].Add(!0)`) is presented as `object` ONLY at the raw CLR
+        // signature level. Before this classifier is consulted for such a call,
+        // `ConversionClassifier.BindClrParameterConversions` substitutes the
+        // receiver's type arguments back into the open `!0` slot, so the target
+        // type is the REAL type parameter `T` (not `object`) and the argument is
+        // classified as `T -> T` identity with NO conversion node and NO box.
+        // A `T -> object` conversion node is therefore only ever created for a
+        // GENUINE `System.Object` destination, where boxing is correct. The
+        // emitter materialises it with `box !!T` (see MethodBodyEmitter.
+        // Conversions.cs), verifier-correct for value, reference and
+        // unconstrained `T` alike.
+        if (from is TypeParameterSymbol && to is not TypeParameterSymbol
+            && to?.ClrType?.IsSameAs(typeof(object)) == true)
         {
             return Conversion.Implicit;
         }

--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -679,7 +679,16 @@ internal sealed class ConversionClassifier
                     if (substituted == null
                         && argument.Type is TypeParameterSymbol)
                     {
-                        substituted = TryRecoverReceiverTypeParameterSlot(method, paramIndex, receiverType);
+                        // The erased `object` slot may originate either from the
+                        // receiver's generic type arguments (`List[T].Add(!0)`)
+                        // or from the method's OWN type arguments — e.g. a static
+                        // generic call `Enumerable.Repeat[T](v, n)` whose element
+                        // parameter `TSource` closes over the enclosing open `T`.
+                        // Both present as `System.Object` at the raw CLR signature
+                        // level, so recover the real `T` slot from whichever
+                        // applies, keeping the argument `T -> T` identity (no box).
+                        substituted = TrySubstituteParameterTypeFromMethodTypeArgs(method, paramIndex, symbolicMethodTypeArgs)
+                            ?? TryRecoverReceiverTypeParameterSlot(method, paramIndex, receiverType);
                     }
 
                     var targetType = substituted ?? TypeSymbol.FromClrType(parameterType);

--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -659,6 +659,29 @@ internal sealed class ConversionClassifier
                         substituted = TrySubstituteParameterTypeFromMethodTypeArgs(method, paramIndex, symbolicMethodTypeArgs);
                     }
 
+                    // Issue #1540: recover an ERASED open type-parameter slot
+                    // whose receiver type argument is itself a bare type
+                    // parameter (e.g. `List[T].Add(!0)` compiled INSIDE the
+                    // generic method that declares `T`). `TrySubstituteParameter
+                    // TypeFromReceiver` above deliberately bails for a bare
+                    // type-parameter receiver arg (its #765 filter only rewrites
+                    // user symbolic types), so the closed CLR parameter stays
+                    // erased to `object`. Left alone, the new #1540 `T -> object`
+                    // implicit rule would classify the argument as a boxing
+                    // conversion and inject a spurious `box T` before the call,
+                    // reproducing the #1196 invalid-IL regression. Recovering the
+                    // real `T` slot here makes the argument `T -> T` identity
+                    // (no conversion node, no box), byte-identical to today.
+                    // A GENUINE `object` slot (real `System.Object` parameter, or
+                    // a `List[object]` whose `!0` maps to `object`) is NOT a type
+                    // parameter, so this recovery returns null and the argument
+                    // still boxes correctly.
+                    if (substituted == null
+                        && argument.Type is TypeParameterSymbol)
+                    {
+                        substituted = TryRecoverReceiverTypeParameterSlot(method, paramIndex, receiverType);
+                    }
+
                     var targetType = substituted ?? TypeSymbol.FromClrType(parameterType);
                     if (argument.Type != targetType
                         && Conversion.Classify(argument.Type, targetType).Exists
@@ -832,6 +855,75 @@ internal sealed class ConversionClassifier
             && openParamType.GenericParameterPosition < imported.TypeArguments.Length)
         {
             return imported.TypeArguments[openParamType.GenericParameterPosition];
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Issue #1540: recovers the receiver's type argument for an erased open
+    /// type-parameter slot (e.g. the <c>!0</c> element type of
+    /// <c>List[T].Add(!0)</c>) when that argument is itself a type parameter —
+    /// the case <see cref="TrySubstituteParameterTypeFromReceiver"/> deliberately
+    /// skips (its #765 filter rewrites only user symbolic type arguments). This
+    /// lets the caller re-target a <c>T</c> argument onto the real <c>T</c> slot
+    /// so it is classified as an identity conversion (no spurious box), matching
+    /// the pre-#1540 behaviour and keeping the #1196 invariant. Returns
+    /// <see langword="null"/> for a genuine <c>object</c> slot (or any non
+    /// type-parameter type argument), so those arguments still box correctly.
+    /// </summary>
+    /// <param name="method">The resolved (closed) CLR method (may be null).</param>
+    /// <param name="paramIndex">Zero-based index into the method's parameter list.</param>
+    /// <param name="receiverType">The receiver's (symbolic) type.</param>
+    /// <returns>The recovered type-parameter slot, or <see langword="null"/>.</returns>
+    public static TypeSymbol TryRecoverReceiverTypeParameterSlot(
+        MethodInfo method,
+        int paramIndex,
+        TypeSymbol receiverType)
+    {
+        if (method == null
+            || receiverType is not ImportedTypeSymbol imported
+            || imported.TypeArguments.IsDefaultOrEmpty)
+        {
+            return null;
+        }
+
+        var declaring = method.DeclaringType;
+        if (declaring == null || !declaring.IsConstructedGenericType)
+        {
+            return null;
+        }
+
+        var openDef = declaring.GetGenericTypeDefinition();
+        MethodInfo openMethod = null;
+        foreach (var candidate in openDef.GetMethods(
+            BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic))
+        {
+            if (candidate.MetadataToken == method.MetadataToken && candidate.Module == method.Module)
+            {
+                openMethod = candidate;
+                break;
+            }
+        }
+
+        if (openMethod == null)
+        {
+            return null;
+        }
+
+        var openParams = openMethod.GetParameters();
+        if (paramIndex < 0 || paramIndex >= openParams.Length)
+        {
+            return null;
+        }
+
+        var openParamType = openParams[paramIndex].ParameterType;
+        if (openParamType.IsGenericParameter
+            && openParamType.DeclaringMethod == null
+            && openParamType.GenericParameterPosition < imported.TypeArguments.Length
+            && imported.TypeArguments[openParamType.GenericParameterPosition] is TypeParameterSymbol recovered)
+        {
+            return recovered;
         }
 
         return null;

--- a/test/Compiler.Tests/Emit/Issue1540TypeParamToObjectEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1540TypeParamToObjectEmitTests.cs
@@ -25,8 +25,10 @@ namespace GSharp.Compiler.Tests.Emit;
 /// #1196 regression (a spurious <c>box T</c> before the call → invalid IL). The
 /// fix classifies <c>T -&gt; object</c> as an implicit conversion but recovers the
 /// real type-parameter slot for erased-<c>!0</c> arguments in
-/// <c>ConversionClassifier.BindClrParameterConversions</c>, so such arguments
-/// stay <c>T -&gt; T</c> identity (no box) while genuine <c>object</c> targets box.
+/// <c>ConversionClassifier.BindClrParameterConversions</c> — for both erased
+/// RECEIVER slots (<c>List[T].Add</c>) and erased METHOD-level slots
+/// (<c>Enumerable.Repeat[T]</c>) — so such arguments stay <c>T -&gt; T</c> identity
+/// (no box) while genuine <c>object</c> targets box.
 /// </para>
 /// Every test round-trips through compile → <c>IlVerifier.Verify</c> → run, so any
 /// spurious box or missing box surfaces as invalid IL. The final two tests are
@@ -269,6 +271,41 @@ public class Issue1540TypeParamToObjectEmitTests
 
         var output = CompileAndRun(source);
         Assert.Equal("1\n1\n", output);
+    }
+
+    [Fact]
+    public void Control_StaticGenericMethodArg_ErasedMethodSlot_NoSpuriousBox()
+    {
+        // #1196 regression control for an erased METHOD-level type-parameter slot
+        // (distinct from the receiver-slot controls above). `Enumerable.Repeat[T]`
+        // has element parameter `TSource`, which closes over the enclosing open
+        // `T`; at the raw CLR signature level that slot presents as `System.Object`.
+        // The #1540 `T -> object` implicit rule must NOT box the `v T` argument
+        // here — the classifier recovers the real `T` slot from the method's own
+        // type arguments, keeping the argument `T -> T` identity. A spurious box
+        // would produce `[found ref 'T'][expected value 'T']` invalid IL.
+        const string source = """
+            package i1540staticgenmethod
+            import System
+            import System.Linq
+            import System.Collections.Generic
+
+            func RepeatVal[T](v T, n int32) IEnumerable[T] {
+                return Enumerable.Repeat[T](v, n)
+            }
+
+            func Main() {
+                for x in RepeatVal[int32](42, 3) {
+                    System.Console.WriteLine(x)
+                }
+                for s in RepeatVal[string]("a", 2) {
+                    System.Console.WriteLine(s)
+                }
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n42\n42\na\na\n", output);
     }
 
     private static string CompileAndRun(string source)

--- a/test/Compiler.Tests/Emit/Issue1540TypeParamToObjectEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1540TypeParamToObjectEmitTests.cs
@@ -1,0 +1,355 @@
+// <copyright file="Issue1540TypeParamToObjectEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1540 — a generic type-parameter value <c>T</c> converting to a GENUINE
+/// <c>object</c> slot (return, assignment, explicit cast, argument) was rejected
+/// with <c>GS0155 'Cannot convert type T to object'</c>. Converting <c>T</c> to
+/// <c>object</c> is always valid: a boxing conversion for a value <c>T</c>, a
+/// reference conversion for a reference <c>T</c>, and <c>box !!T</c> (verifier
+/// correct for both) for an unconstrained <c>T</c>.
+/// <para>
+/// The delicate part is that an ERASED open generic parameter slot (e.g. the
+/// <c>!0</c> element type of <c>List[T].Add(!0)</c>, compiled inside the generic
+/// method that declares <c>T</c>) presents as <c>System.Object</c> at the raw CLR
+/// signature level, so a blanket <c>T -&gt; object</c> boxing rule reintroduced the
+/// #1196 regression (a spurious <c>box T</c> before the call → invalid IL). The
+/// fix classifies <c>T -&gt; object</c> as an implicit conversion but recovers the
+/// real type-parameter slot for erased-<c>!0</c> arguments in
+/// <c>ConversionClassifier.BindClrParameterConversions</c>, so such arguments
+/// stay <c>T -&gt; T</c> identity (no box) while genuine <c>object</c> targets box.
+/// </para>
+/// Every test round-trips through compile → <c>IlVerifier.Verify</c> → run, so any
+/// spurious box or missing box surfaces as invalid IL. The final two tests are
+/// #1196 controls proving a <c>List[T].Add</c> / <c>Dictionary[K,V].Add</c>
+/// argument still passes straight through with NO box. Each uses a UNIQUE
+/// package/type name.
+/// </summary>
+public class Issue1540TypeParamToObjectEmitTests
+{
+    [Fact]
+    public void ValueTypeParam_ImplicitReturn_Boxes_Roundtrips()
+    {
+        const string source = """
+            package i1540valimplicit
+            import System
+
+            class Ext {
+                shared {
+                    func Box[T](val T) object { return val }
+                    func Back[T](o object) T { return T(o) }
+                }
+            }
+
+            func Main() {
+                let o = Ext.Box[int32](42)
+                let back = Ext.Back[int32](o)
+                System.Console.WriteLine(o)
+                System.Console.WriteLine(back)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n42\n", output);
+    }
+
+    [Fact]
+    public void ValueTypeParam_ExplicitCast_Boxes()
+    {
+        const string source = """
+            package i1540valexplicit
+            import System
+
+            class Ext {
+                shared {
+                    func Box[T](val T) object { return object(val) }
+                }
+            }
+
+            func Main() { System.Console.WriteLine(Ext.Box[int32](7)) }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("7\n", output);
+    }
+
+    [Fact]
+    public void ValueTypeParam_LocalAssignment_Boxes()
+    {
+        const string source = """
+            package i1540valassign
+            import System
+
+            class Ext {
+                shared {
+                    func Box[T](val T) object {
+                        let o object = val
+                        return o
+                    }
+                }
+            }
+
+            func Main() { System.Console.WriteLine(Ext.Box[int32](9)) }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("9\n", output);
+    }
+
+    [Fact]
+    public void ReferenceTypeParam_ImplicitReturn_ReferenceConversion()
+    {
+        const string source = """
+            package i1540refimplicit
+            import System
+
+            class Ext {
+                shared {
+                    func Box[T](val T) object { return val }
+                    func Back[T](o object) T { return T(o) }
+                }
+            }
+
+            func Main() {
+                let o = Ext.Box[string]("hello")
+                let back = Ext.Back[string](o)
+                System.Console.WriteLine(o)
+                System.Console.WriteLine(back)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("hello\nhello\n", output);
+    }
+
+    [Fact]
+    public void TypeParam_PassedToObjectParameter_Boxes()
+    {
+        const string source = """
+            package i1540objparam
+            import System
+
+            class Ext {
+                shared {
+                    func Consume(o object) string { return o.ToString() ?? "" }
+                    func Feed[T](val T) string { return Ext.Consume(val) }
+                }
+            }
+
+            func Main() {
+                System.Console.WriteLine(Ext.Feed[int32](11))
+                System.Console.WriteLine(Ext.Feed[string]("z"))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("11\nz\n", output);
+    }
+
+    [Fact]
+    public void ClassConstrainedTypeParam_Boxes()
+    {
+        const string source = """
+            package i1540classconstraint
+            import System
+
+            class Ext {
+                shared {
+                    func Box[T class](val T) object { return val }
+                }
+            }
+
+            func Main() { System.Console.WriteLine(Ext.Box[string]("cc")) }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("cc\n", output);
+    }
+
+    [Fact]
+    public void StructConstrainedTypeParam_Boxes_Roundtrips()
+    {
+        const string source = """
+            package i1540structconstraint
+            import System
+
+            class Ext {
+                shared {
+                    func Box[T struct](val T) object { return object(val) }
+                    func Back[T struct](o object) T { return T(o) }
+                }
+            }
+
+            func Main() {
+                let o = Ext.Box[int32](33)
+                System.Console.WriteLine(o)
+                System.Console.WriteLine(Ext.Back[int32](o))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("33\n33\n", output);
+    }
+
+    [Fact]
+    public void Control_ListTAdd_ErasedSlot_NoSpuriousBox()
+    {
+        // #1196 regression control: `T` fed into the erased `!0` element slot of
+        // `List[T].Add(!0)` (compiled inside the generic method that declares
+        // `T`) must remain a NO-OP identity conversion with NO `box T`. A
+        // spurious box makes ilverify report `[found ref 'T'][expected value
+        // 'T']` and the program throws InvalidProgramException. This coexists in
+        // ONE compilation with a genuine `T -> object` boxing method to prove the
+        // two paths stay independent after the #1540 change.
+        const string source = """
+            package i1540listcontrol
+            import System
+            import System.Collections.Generic
+
+            class Ext {
+                shared {
+                    func Box[T](val T) object { return val }
+                    func DoubleViaList[T](val T) []T {
+                        var list = List[T]()
+                        list.Add(val)
+                        list.Add(val)
+                        return list.ToArray()
+                    }
+                }
+            }
+
+            func Main() {
+                var arr = Ext.DoubleViaList[int32](5)
+                System.Console.WriteLine(arr.Length)
+                System.Console.WriteLine(arr[0])
+                System.Console.WriteLine(Ext.Box[int32](5))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("2\n5\n5\n", output);
+    }
+
+    [Fact]
+    public void Control_DictionaryAdd_ErasedSlots_NoSpuriousBox()
+    {
+        // #1196 regression control across TWO erased slots: both `K` and `V` are
+        // fed into the erased `!0`/`!1` parameter slots of
+        // `Dictionary[K,V].Add(!0, !1)`. Neither may emit a spurious box; the
+        // count read-back proves the entry was stored.
+        const string source = """
+            package i1540dictcontrol
+            import System
+            import System.Collections.Generic
+
+            class Ext {
+                shared {
+                    func Store[K comparable, V any](k K, v V) int32 {
+                        var d = Dictionary[K, V]()
+                        d.Add(k, v)
+                        return d.Count
+                    }
+                }
+            }
+
+            func Main() {
+                System.Console.WriteLine(Ext.Store[int32, string](1, "a"))
+                System.Console.WriteLine(Ext.Store[string, int32]("k", 7))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("1\n1\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1540_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
gsc rejected converting a generic type-parameter value `T` to a genuine `object` slot with `GS0155: Cannot convert type 'T' to 'object'`. Converting `T` to `object` is always valid — a boxing conversion for a value `T`, a reference conversion for a reference `T`, and `box !!T` (verifier-correct for both) for an unconstrained `T`.

## The delicate root
The type-parameter conversion rule (#1196) deliberately excluded `T -> object` because an **erased** open generic parameter slot (e.g. the `!0` element type of `List[T].Add(!0)`, compiled inside the generic method that declares `T`) presents as `System.Object` at the raw CLR signature level. A blanket `T -> object` boxing rule therefore injected a spurious `box T` before such calls, producing invalid IL (the #1196 regression).

## Fix
- **`Conversion.Classify`** now classifies `T -> object` as an implicit conversion. This covers the implicit forms (`return val` with an `object` return type, `let o object = val`, passing `T` to an `object` parameter) and, since the conversion `Exists`, the explicit `object(val)` cast. The emitter already materialises it with `box !!T`.
- **`ConversionClassifier.BindClrParameterConversions`** recovers the real type-parameter slot for an erased `!0` argument whose receiver type argument is itself a bare type parameter (new `TryRecoverReceiverTypeParameterSlot`). Such arguments stay `T -> T` identity with **no box** — byte-identical to today. A genuine `object` slot (a real `System.Object` parameter, or a `List[object]` whose `!0` maps to `object`) is not a type parameter, so it still boxes correctly.

### How genuine-object is distinguished from an erased slot
Erased `!0` slots present as `object` only at the CLR signature level. Before the classifier is consulted for such a call, the binder maps the receiver's type argument at the open parameter's generic position: for `List[T]` that argument is the type parameter `T`, so the target becomes `T` (identity, no box); for a genuine `object`/`List[object]` it is `object` (boxes). This keeps the #1196 IL unchanged.

## Validation
- Repro + variants (value/reference/`T class`/`T struct` `T`, explicit `object(val)`, `object` parameter, round-trip `object o = val; T(o)`) compile, ilverify-clean, run correctly.
- #1196 controls unchanged: `List[T].Add` / `Dictionary[K,V].Add` erased-slot arguments emit no spurious box (Issue794/Issue1196 emit tests + new Issue1540 controls, all ilverify-clean).
- `dotnet build GSharp.sln -c Release -graph`: 0 warnings / 0 errors.
- Core.Tests: 4888 passed, 1 skipped, 0 failed. Baseline byte-identical gate passed (no regen).
- Filtered Compiler.Tests (Issue1540 + Issue1196 + Issue794): 16 passed.

## Tests
Adds `test/Compiler.Tests/Emit/Issue1540TypeParamToObjectEmitTests.cs` (9 facts, unique package/type names) covering value/reference/constrained `T` boxing + round-trip via `T(o)`, explicit cast, `object` parameter passing, and `List[T].Add` / `Dictionary[K,V].Add` erased-slot controls proving no spurious box.

Fixes #1540

Refs #914
