### PR TITLE
Thread nil-guard narrowing into short-circuit && / || operands (#1545)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -776,6 +776,17 @@ internal sealed partial class ExpressionBinder
                 }
         }
 
+        // ADR-0069 addendum / issue #1545: nil-guard leaf. Threads
+        // `x == nil` / `x != nil` narrowing into the right operand of
+        // `&&`/`||`, mirroring the type-test (`x is T`) cases above. Uses the
+        // shared leaf classifier kept in sync with
+        // StatementBinder.TryClassifyNilGuard.
+        if (SmartCastStability.TryClassifyNilGuardLeaf(condition, restrictBareVariableToLocalsAndParams: true, out var nilTarget, out var nilUnderlying, out var nonNilWhenTrue))
+        {
+            var nonNilFrame = new Dictionary<AccessPath, TypeSymbol> { [nilTarget] = nilUnderlying };
+            return nonNilWhenTrue ? (nonNilFrame, null) : (null, nonNilFrame);
+        }
+
         return (null, null);
     }
 

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -781,7 +781,7 @@ internal sealed partial class ExpressionBinder
         // `&&`/`||`, mirroring the type-test (`x is T`) cases above. Uses the
         // shared leaf classifier kept in sync with
         // StatementBinder.TryClassifyNilGuard.
-        if (SmartCastStability.TryClassifyNilGuardLeaf(condition, restrictBareVariableToLocalsAndParams: true, out var nilTarget, out var nilUnderlying, out var nonNilWhenTrue))
+        if (SmartCastStability.TryClassifyNilGuardLeaf(condition, restrictBareVariableToLocalsAndParams: true, referenceNullableOnly: true, out var nilTarget, out var nilUnderlying, out var nonNilWhenTrue))
         {
             var nonNilFrame = new Dictionary<AccessPath, TypeSymbol> { [nilTarget] = nilUnderlying };
             return nonNilWhenTrue ? (nonNilFrame, null) : (null, nonNilFrame);

--- a/src/Core/CodeAnalysis/Binding/SmartCastStability.cs
+++ b/src/Core/CodeAnalysis/Binding/SmartCastStability.cs
@@ -128,4 +128,89 @@ internal static class SmartCastStability
         currentType = null;
         return false;
     }
+
+    /// <summary>
+    /// ADR-0069 addendum / issues #700/#712/#1180/#1545: recognises the leaf
+    /// nil-guard comparison (<c>x == nil</c> / <c>x != nil</c>) where the
+    /// non-nil operand is a stable, narrowable target of <see
+    /// cref="NullableTypeSymbol"/> type. The target may be a bare local or
+    /// parameter, or a stable immutable member path. This is the single shared
+    /// leaf used by BOTH the if-condition classifier
+    /// (<c>StatementBinder.TryClassifyNilGuard</c>) and the short-circuit
+    /// operand classifier (<c>ExpressionBinder.ClassifyTypeTestNarrowing</c>)
+    /// so the two nil-guard classifiers stay consistent.
+    /// </summary>
+    /// <param name="condition">The candidate comparison expression.</param>
+    /// <param name="restrictBareVariableToLocalsAndParams">
+    /// When <c>true</c>, a bare variable target is only accepted when it is a
+    /// local or parameter, matching the soundness restriction the type-test
+    /// (<c>x is T</c>) short-circuit classifier applies — a mutable global could
+    /// be reassigned by a side effect between the guard and the use across
+    /// <c>&amp;&amp;</c>/<c>||</c>. When <c>false</c> (the if-statement
+    /// classifier, which has flow-based mutation invalidation), any variable is
+    /// accepted. Stable member paths are always subject to their own
+    /// stable-root rules regardless of this flag.
+    /// </param>
+    /// <param name="target">The narrowed access path, when successful.</param>
+    /// <param name="underlying">The non-nullable underlying type to narrow to.</param>
+    /// <param name="nonNilWhenTrue">
+    /// <c>true</c> for <c>x != nil</c> (the target is non-nil when the
+    /// comparison is true); <c>false</c> for <c>x == nil</c> (the target is
+    /// non-nil when the comparison is false).
+    /// </param>
+    /// <returns><c>true</c> when a nil-guard leaf was recognised.</returns>
+    public static bool TryClassifyNilGuardLeaf(BoundExpression condition, bool restrictBareVariableToLocalsAndParams, out AccessPath target, out TypeSymbol underlying, out bool nonNilWhenTrue)
+    {
+        target = null;
+        underlying = null;
+        nonNilWhenTrue = false;
+
+        if (condition is not BoundBinaryExpression be)
+        {
+            return false;
+        }
+
+        if (be.Op.Kind is not (BoundBinaryOperatorKind.Equals or BoundBinaryOperatorKind.NotEquals))
+        {
+            return false;
+        }
+
+        TypeSymbol targetType = null;
+        if (be.Left is BoundVariableExpression lv && IsAcceptableBareVariable(lv.Variable, restrictBareVariableToLocalsAndParams) && StatementBinder.IsNilLiteral(be.Right))
+        {
+            target = lv.Variable;
+            targetType = lv.Variable.Type;
+        }
+        else if (be.Right is BoundVariableExpression rv && IsAcceptableBareVariable(rv.Variable, restrictBareVariableToLocalsAndParams) && StatementBinder.IsNilLiteral(be.Left))
+        {
+            target = rv.Variable;
+            targetType = rv.Variable.Type;
+        }
+        else if (StatementBinder.IsNilLiteral(be.Right) && TryGetStableMemberPath(be.Left, out var leftPath, out var leftType))
+        {
+            target = leftPath;
+            targetType = leftType;
+        }
+        else if (StatementBinder.IsNilLiteral(be.Left) && TryGetStableMemberPath(be.Right, out var rightPath, out var rightType))
+        {
+            target = rightPath;
+            targetType = rightType;
+        }
+
+        if (target == null || targetType is not NullableTypeSymbol nullable)
+        {
+            target = null;
+            return false;
+        }
+
+        underlying = nullable.UnderlyingType;
+        nonNilWhenTrue = be.Op.Kind == BoundBinaryOperatorKind.NotEquals;
+        return true;
+    }
+
+    private static bool IsAcceptableBareVariable(VariableSymbol variable, bool restrictToLocalsAndParams)
+    {
+        // ParameterSymbol derives from LocalVariableSymbol and is covered here.
+        return !restrictToLocalsAndParams || variable is LocalVariableSymbol;
+    }
 }

--- a/src/Core/CodeAnalysis/Binding/SmartCastStability.cs
+++ b/src/Core/CodeAnalysis/Binding/SmartCastStability.cs
@@ -151,6 +151,14 @@ internal static class SmartCastStability
     /// accepted. Stable member paths are always subject to their own
     /// stable-root rules regardless of this flag.
     /// </param>
+    /// <param name="referenceNullableOnly">
+    /// When <c>true</c> (the <c>&amp;&amp;</c>/<c>||</c> short-circuit
+    /// classifier), a nullable VALUE type (e.g. <c>int32?</c>) is rejected
+    /// because narrowing it to its non-nullable form is not an IL no-op and the
+    /// variable-load path does not emit the required unwrap (issue #1545). When
+    /// <c>false</c> (the if-statement classifier), value-type nullables are
+    /// accepted, preserving that path's pre-existing behaviour.
+    /// </param>
     /// <param name="target">The narrowed access path, when successful.</param>
     /// <param name="underlying">The non-nullable underlying type to narrow to.</param>
     /// <param name="nonNilWhenTrue">
@@ -159,7 +167,7 @@ internal static class SmartCastStability
     /// non-nil when the comparison is false).
     /// </param>
     /// <returns><c>true</c> when a nil-guard leaf was recognised.</returns>
-    public static bool TryClassifyNilGuardLeaf(BoundExpression condition, bool restrictBareVariableToLocalsAndParams, out AccessPath target, out TypeSymbol underlying, out bool nonNilWhenTrue)
+    public static bool TryClassifyNilGuardLeaf(BoundExpression condition, bool restrictBareVariableToLocalsAndParams, bool referenceNullableOnly, out AccessPath target, out TypeSymbol underlying, out bool nonNilWhenTrue)
     {
         target = null;
         underlying = null;
@@ -198,6 +206,21 @@ internal static class SmartCastStability
         }
 
         if (target == null || targetType is not NullableTypeSymbol nullable)
+        {
+            target = null;
+            return false;
+        }
+
+        // Issue #1545: narrowing a nullable VALUE type (`int32?` → `int32`)
+        // requires an unwrap the variable-load path does not currently emit, so
+        // the narrowed static type and the `System.Nullable<T>` storage diverge
+        // and the method fails ilverify (a pre-existing latent gap; see the
+        // separately-tracked value-type nil-narrowing emit bug). For a nullable
+        // REFERENCE type the narrowed type and its storage are the same CLR type,
+        // so narrowing is an IL no-op and is safe. The short-circuit
+        // (`&&`/`||`) caller passes `referenceNullableOnly: true` to stay on the
+        // safe side; the statement classifier keeps its pre-existing behaviour.
+        if (referenceNullableOnly && NullableLifting.IsValueTypeNullable(nullable))
         {
             target = null;
             return false;

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.cs
@@ -1871,7 +1871,7 @@ internal sealed class StatementBinder
         // support only single-variable/stable-path guards here at the leaf;
         // conjunctions, disjunctions and pattern-based narrowing compose via the
         // cases above.
-        if (!SmartCastStability.TryClassifyNilGuardLeaf(condition, restrictBareVariableToLocalsAndParams: false, out var target, out var underlying, out var nonNilWhenTrue))
+        if (!SmartCastStability.TryClassifyNilGuardLeaf(condition, restrictBareVariableToLocalsAndParams: false, referenceNullableOnly: false, out var target, out var underlying, out var nonNilWhenTrue))
         {
             return (null, null);
         }

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.cs
@@ -1865,52 +1865,24 @@ internal sealed class StatementBinder
                 }
         }
 
-        // Phase 3.C.4: recognise the canonical narrowing patterns. We support
-        // only single-variable guards here at the leaf; conjunctions, disjunctions
-        // and pattern-based narrowing compose via the cases above.
-        if (condition is not BoundBinaryExpression be)
+        // Phase 3.C.4: recognise the canonical narrowing patterns via the shared
+        // leaf classifier (SmartCastStability.TryClassifyNilGuardLeaf), kept in
+        // sync with ExpressionBinder.ClassifyTypeTestNarrowing (issue #1545). We
+        // support only single-variable/stable-path guards here at the leaf;
+        // conjunctions, disjunctions and pattern-based narrowing compose via the
+        // cases above.
+        if (!SmartCastStability.TryClassifyNilGuardLeaf(condition, restrictBareVariableToLocalsAndParams: false, out var target, out var underlying, out var nonNilWhenTrue))
         {
             return (null, null);
         }
 
-        AccessPath target = null;
-        TypeSymbol targetType = null;
-        if (be.Left is BoundVariableExpression lv && IsNilLiteral(be.Right))
-        {
-            target = lv.Variable;
-            targetType = lv.Variable.Type;
-        }
-        else if (be.Right is BoundVariableExpression rv && IsNilLiteral(be.Left))
-        {
-            target = rv.Variable;
-            targetType = rv.Variable.Type;
-        }
-        else if (IsNilLiteral(be.Right) && SmartCastStability.TryGetStableMemberPath(be.Left, out var leftPath, out var leftType))
-        {
-            // ADR-0069 addendum / issue #1180: nil-guard on a stable immutable
-            // member path narrows it to its non-nullable underlying type.
-            target = leftPath;
-            targetType = leftType;
-        }
-        else if (IsNilLiteral(be.Left) && SmartCastStability.TryGetStableMemberPath(be.Right, out var rightPath, out var rightType))
-        {
-            target = rightPath;
-            targetType = rightType;
-        }
-
-        if (target == null || targetType is not NullableTypeSymbol nullable)
-        {
-            return (null, null);
-        }
-
-        var underlying = nullable.UnderlyingType;
         Dictionary<AccessPath, TypeSymbol> nonNilFrame = null;
         Dictionary<AccessPath, TypeSymbol> nilFrame = null;
-        if (be.Op.Kind == BoundBinaryOperatorKind.NotEquals)
+        if (nonNilWhenTrue)
         {
             nonNilFrame = new Dictionary<AccessPath, TypeSymbol> { [target] = underlying };
         }
-        else if (be.Op.Kind == BoundBinaryOperatorKind.Equals)
+        else
         {
             nilFrame = new Dictionary<AccessPath, TypeSymbol> { [target] = underlying };
         }

--- a/test/Compiler.Tests/Emit/Issue1545ShortCircuitNilNarrowingEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1545ShortCircuitNilNarrowingEmitTests.cs
@@ -26,6 +26,15 @@ namespace GSharp.Compiler.Tests.Emit;
 /// Every facet failed to compile on current main and passes after the fix. Each
 /// uses a UNIQUE package/type name because the in-process
 /// <c>FunctionTypeSymbol</c> cache is name-keyed for user types.
+/// <para>
+/// The short-circuit path intentionally restricts nil-guard narrowing to
+/// nullable REFERENCE types: narrowing a nullable value type (<c>int32?</c>)
+/// is not an IL no-op and the variable-load path does not emit the required
+/// unwrap, so applying it produced invalid IL (regressed Issue1518's
+/// <c>v != nil &amp;&amp; v!! &gt; 0</c>). Value-type nullables still work in the
+/// guard via the nullable-lifted operator or an explicit <c>!!</c> — see
+/// <see cref="Control_ValueTypeNullable_ShortCircuitGuard_NotNarrowedButRuns"/>.
+/// </para>
 /// </summary>
 public class Issue1545ShortCircuitNilNarrowingEmitTests
 {
@@ -242,6 +251,34 @@ public class Issue1545ShortCircuitNilNarrowingEmitTests
         var (exit, output) = CompileOnly(source);
         Assert.NotEqual(0, exit);
         Assert.Contains("GS0129", output);
+    }
+
+    [Fact]
+    public void Control_ValueTypeNullable_ShortCircuitGuard_NotNarrowedButRuns()
+    {
+        // A nullable VALUE type in a short-circuit guard is intentionally NOT
+        // narrowed (that would need an unwrap the load path doesn't emit, giving
+        // invalid IL). The idiom still runs: `v!!` unwraps explicitly and the
+        // lifted `>` handles the un-narrowed operand. Both must produce valid,
+        // ilverify-clean IL and the correct runtime result.
+        const string source = """
+            package i1545vt
+
+            import System
+            import System.Linq
+
+            func CountForced(xs []int32?) int32 -> xs.Where((v int32?) -> v != nil && v!! > 0).Count()
+            func CountLifted(xs []int32?) int32 -> xs.Where((v int32?) -> v != nil && v > 0).Count()
+
+            func Main() {
+                var xs = []int32?{1, nil, 2, nil, 3}
+                Console.WriteLine(CountForced(xs))
+                Console.WriteLine(CountLifted(xs))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("3\n3\n", output);
     }
 
     private static (int Exit, string Output) CompileOnly(string source)

--- a/test/Compiler.Tests/Emit/Issue1545ShortCircuitNilNarrowingEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1545ShortCircuitNilNarrowingEmitTests.cs
@@ -1,0 +1,370 @@
+// <copyright file="Issue1545ShortCircuitNilNarrowingEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1545 — gsc threaded type-test narrowing (<c>x is T</c>, issues
+/// #700/#712) into the right operand of <c>&amp;&amp;</c>/<c>||</c>, but did NOT
+/// thread <em>nil-guard</em> narrowing (<c>x == nil</c> / <c>x != nil</c>). So
+/// the canonical short-circuit null-guard idiom
+/// (<c>x == nil || x.Member</c> / <c>x != nil &amp;&amp; x.Member</c>) failed
+/// with GS0158 even though the receiver is provably non-nil where used.
+/// <para>
+/// The fix adds the nil-guard leaf to
+/// <c>ExpressionBinder.ClassifyTypeTestNarrowing</c> via a shared static leaf
+/// (<c>SmartCastStability.TryClassifyNilGuardLeaf</c>) reused by the
+/// if-condition classifier (<c>StatementBinder.TryClassifyNilGuard</c>).
+/// </para>
+/// Every facet failed to compile on current main and passes after the fix. Each
+/// uses a UNIQUE package/type name because the in-process
+/// <c>FunctionTypeSymbol</c> cache is name-keyed for user types.
+/// </summary>
+public class Issue1545ShortCircuitNilNarrowingEmitTests
+{
+    [Fact]
+    public void EndToEnd_OrGuard_NullableArray_Runs()
+    {
+        const string source = """
+            package i1545orarray
+            import System
+
+            func OrGuard(x []?uint8) bool -> x == nil || x.Length < 8
+
+            func Main() {
+                var big = []uint8{1,2,3,4,5,6,7,8,9,10}
+                var small = []uint8{1,2,3}
+                System.Console.WriteLine(OrGuard(nil))
+                System.Console.WriteLine(OrGuard(big))
+                System.Console.WriteLine(OrGuard(small))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\nFalse\nTrue\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_AndGuard_NullableArray_Runs()
+    {
+        const string source = """
+            package i1545andarray
+            import System
+
+            func AndGuard(x []?uint8) bool -> x != nil && x.Length >= 8
+
+            func Main() {
+                var big = []uint8{1,2,3,4,5,6,7,8,9,10}
+                var small = []uint8{1,2,3}
+                System.Console.WriteLine(AndGuard(nil))
+                System.Console.WriteLine(AndGuard(big))
+                System.Console.WriteLine(AndGuard(small))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("False\nTrue\nFalse\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_OrGuard_NullableStringReference_Runs()
+    {
+        const string source = """
+            package i1545orstring
+            import System
+
+            func IsBlank(s string?) bool -> s == nil || s.Length == 0
+
+            func Main() {
+                System.Console.WriteLine(IsBlank(nil))
+                System.Console.WriteLine(IsBlank(""))
+                System.Console.WriteLine(IsBlank("abc"))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\nTrue\nFalse\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_AndGuard_NullableUserClassMemberCall_Runs()
+    {
+        const string source = """
+            package i1545anduserclass
+            import System
+
+            class Widget {
+                prop On bool { get; init; }
+                func IsOn() bool -> On
+            }
+
+            func Enabled(o Widget?) bool -> o != nil && o.IsOn()
+
+            func Main() {
+                System.Console.WriteLine(Enabled(nil))
+                System.Console.WriteLine(Enabled(Widget() { On = true }))
+                System.Console.WriteLine(Enabled(Widget() { On = false }))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("False\nTrue\nFalse\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_OrGuard_GenericNullableSequence_Runs()
+    {
+        const string source = """
+            package i1545orsequence
+            import System
+            import System.Collections.Generic
+            import System.Linq
+
+            func CountIt(e IEnumerable[int32]) int32 -> e.Count()
+
+            func IsEmpty(e IEnumerable[int32]?) bool -> e == nil || CountIt(e) == 0
+
+            func Main() {
+                System.Console.WriteLine(IsEmpty(nil))
+                var l = List[int32]()
+                System.Console.WriteLine(IsEmpty(l))
+                l.Add(7)
+                System.Console.WriteLine(IsEmpty(l))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\nTrue\nFalse\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_OrGuard_StableMemberPath_Runs()
+    {
+        const string source = """
+            package i1545stablepath
+            import System
+
+            class Holder {
+                prop Field string? { get; init; }
+                func Blank() bool -> this.Field == nil || this.Field.Length == 0
+            }
+
+            func Main() {
+                System.Console.WriteLine(Holder() { Field = nil }.Blank())
+                System.Console.WriteLine(Holder() { Field = "" }.Blank())
+                System.Console.WriteLine(Holder() { Field = "abc" }.Blank())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\nTrue\nFalse\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_AndGuard_StableMemberPath_Runs()
+    {
+        const string source = """
+            package i1545stablepathand
+            import System
+
+            class Holder {
+                prop Field string? { get; init; }
+                func HasText() bool -> this.Field != nil && this.Field.Length > 0
+            }
+
+            func Main() {
+                System.Console.WriteLine(Holder() { Field = nil }.HasText())
+                System.Console.WriteLine(Holder() { Field = "" }.HasText())
+                System.Console.WriteLine(Holder() { Field = "abc" }.HasText())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("False\nFalse\nTrue\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_NilOnLeftOperand_Runs()
+    {
+        // Either operand order must be recognised: `nil == x` / `nil != x`.
+        const string source = """
+            package i1545operandorder
+            import System
+
+            func OrGuard(s string?) bool -> nil == s || s.Length == 0
+            func AndGuard(s string?) bool -> nil != s && s.Length > 0
+
+            func Main() {
+                System.Console.WriteLine(OrGuard(nil))
+                System.Console.WriteLine(OrGuard("abc"))
+                System.Console.WriteLine(AndGuard(nil))
+                System.Console.WriteLine(AndGuard("abc"))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\nFalse\nFalse\nTrue\n", output);
+    }
+
+    [Fact]
+    public void Negative_UnguardedMemberRead_ReportsGs0158()
+    {
+        // OUTSIDE the guarded operand, `.Length` on a nullable is still GS0158.
+        const string source = """
+            package i1545neg158
+
+            func Bad(x []?uint8) int32 -> x.Length
+            """;
+
+        var (exit, output) = CompileOnly(source);
+        Assert.NotEqual(0, exit);
+        Assert.Contains("GS0158", output);
+    }
+
+    [Fact]
+    public void Negative_NonNullableComparedToNil_ReportsGs0129()
+    {
+        // A non-nullable operand compared to nil must still report GS0129; the
+        // nil-guard leaf only fires for NullableTypeSymbol targets.
+        const string source = """
+            package i1545neg129
+
+            func Bad(x int32) bool -> x == nil || x > 8
+            """;
+
+        var (exit, output) = CompileOnly(source);
+        Assert.NotEqual(0, exit);
+        Assert.Contains("GS0129", output);
+    }
+
+    private static (int Exit, string Output) CompileOnly(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1545_neg_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            return (compileExit, stdoutWriter + stderrWriter.ToString());
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1545_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

gsc threaded type-test narrowing (`x is T`, issues #700/#712) into the right operand of `&&`/`||`, but did **not** thread nil-guard narrowing (`x == nil` / `x != nil`). So the canonical short-circuit null-guard idiom failed with GS0158 even though the receiver is provably non-nil where used:

```gsharp
func OrGuard(x []?uint8) bool  -> x == nil || x.Length < 8   // was GS0158
func AndGuard(x []?uint8) bool -> x != nil && x.Length >= 8  // was GS0158
```

## Fix

The leaf nil-guard classification is extracted into a shared static helper `SmartCastStability.TryClassifyNilGuardLeaf`, reused by **both** the if-condition classifier (`StatementBinder.TryClassifyNilGuard`) and the short-circuit operand classifier (`ExpressionBinder.ClassifyTypeTestNarrowing`), keeping the two consistent.

- `x != nil` ⇒ whenTrue non-nil narrowing (threaded into `&&`'s right operand).
- `x == nil` ⇒ whenFalse non-nil narrowing (threaded into `||`'s right operand).
- Covers either operand order, bare nullable locals/params, and stable immutable member paths, for any `NullableTypeSymbol` shape (nullable value type, reference, array `[]?T`, sequence, etc.).
- Non-nullable operands untouched (`int32 == nil` still GS0129); unguarded reads still GS0158.

The if-statement classifier keeps accepting mutable globals (guarded by its flow-based mutation invalidation); the expression classifier restricts bare variables to locals/params, matching the soundness rule the `x is T` short-circuit classifier already applies.

## Tests

Added `Issue1545ShortCircuitNilNarrowingEmitTests` (10 tests): nullable array `||`/`&&`, nullable string reference, nullable user-class member call, generic nullable sequence, stable member path (`||` and `&&`), nil-on-left operand order, plus GS0158/GS0129 negative controls. All compile, ilverify-clean, and run.

Full solution builds 0 warnings / 0 errors (StyleCop enforced). Core.Tests 0 failed; RefactoringBaselineTests (byte-identical IL gate) unchanged.

Fixes #1545

Refs #914
