### PR TITLE
Rank nullable reference argument (S?) by underlying type in overload betterness (#1552)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -338,9 +338,12 @@ public sealed class Conversion
                 // non-null value reference-upcasts), so this is a representation-
                 // preserving no-op conversion — never boxing or wrapping. The
                 // value-type underlying case is handled by the lifted numeric
-                // rule above and intentionally excluded here. Note this never
-                // makes `T? → U` (non-nullable target, handled below) implicit,
-                // so the narrowing null-dropping conversion still errors.
+                // rule above and intentionally excluded here. Issue #1552 later
+                // made the sibling `T? → U` (non-nullable reference target) case
+                // implicit too — see the dedicated nullable-reference-source
+                // rule after this `to is NullableTypeSymbol` block — so a
+                // nullable reference argument narrows to its underlying/base as
+                // a representation-preserving reference conversion.
                 if (IsReferenceLikeTarget(fromNullable.UnderlyingType)
                     && IsReferenceLikeTarget(toNullable.UnderlyingType))
                 {
@@ -376,6 +379,36 @@ public sealed class Conversion
                 {
                     return Conversion.Implicit;
                 }
+            }
+        }
+
+        // Issue #1552: a nullable REFERENCE argument `S?` shares the CLR
+        // representation of its underlying reference type `S` (null stays null,
+        // a non-null value is the very same reference), so every implicit
+        // reference conversion available from the bare `S` — identity `S -> S`,
+        // an upcast `S -> Base`, or an interface implementation `S -> IFace` —
+        // is equally available from `S?`. Imported reference nullables already
+        // reach this through the #521 CLR-assignability rule below (their
+        // wrapper inherits the underlying's `ClrType`), but a user-declared
+        // class/interface/delegate underlying carries no `ClrType` during
+        // binding, so the #521 arm and the symbolic reference-upcast arms
+        // (which key on `from is StructSymbol`/`InterfaceSymbol`, not the
+        // nullable wrapper) never fire and `Dog? -> Dog`/`Dog? -> Animal`
+        // wrongly errored. Classify against the underlying reference symbol
+        // here so user and imported reference nullables narrow identically —
+        // matching the ranking the #1552 overload tie-break relies on. Scoped
+        // to reference-like underlyings and non-nullable targets: value-type
+        // `int32? -> int32` stays an explicit narrowing (handled elsewhere),
+        // and the `S? -> U?` nullable-target case is handled by the #1255 rule
+        // above.
+        if (from is NullableTypeSymbol fromNullableReference
+            && to is not NullableTypeSymbol
+            && IsReferenceLikeTarget(fromNullableReference.UnderlyingType))
+        {
+            var underlyingConversion = Classify(fromNullableReference.UnderlyingType, to);
+            if (underlyingConversion.Exists && (underlyingConversion.IsImplicit || underlyingConversion.IsIdentity))
+            {
+                return Conversion.Implicit;
             }
         }
 

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -822,6 +822,7 @@ internal sealed class OverloadResolver
         var bestScore = int.MaxValue;
         FunctionSymbol best = null;
         var tie = false;
+        var scored = new List<(FunctionSymbol Candidate, int Score)>(applicable.Count);
         foreach (var cand in applicable)
         {
             var parameterOffset = cand.ExplicitReceiverParameter == null ? 0 : 1;
@@ -881,15 +882,225 @@ internal sealed class OverloadResolver
             {
                 tie = true;
             }
+
+            scored.Add((cand, score));
         }
 
         if (tie)
         {
+            // Issue #1552: a plain score tie can still be broken by C#
+            // §7.5.3.2's "more specific parameter" rule when the tied
+            // candidates differ only in a reference parameter that is a base
+            // type (e.g. `object`) versus a more-derived type (e.g. `Type` or
+            // a user base/derived class). The exact-type score above already
+            // resolves this for a NON-nullable argument (the derived parameter
+            // scores an exact match), but a nullable REFERENCE argument `S?`
+            // never equals a non-nullable parameter, so both candidates tie
+            // and the call is wrongly reported ambiguous. Treat such a nullable
+            // reference argument as its underlying reference type `S` and pick
+            // the candidate whose parameters are uniquely the most specific.
+            var tiedBest = new List<FunctionSymbol>();
+            foreach (var (candidate, score) in scored)
+            {
+                if (score == bestScore)
+                {
+                    tiedBest.Add(candidate);
+                }
+            }
+
+            var moreSpecific = TryBreakTieByReferenceParameterSpecificity(tiedBest, argumentCount, boundArguments);
+            if (moreSpecific != null)
+            {
+                return moreSpecific;
+            }
+
             ambiguous = true;
             return null;
         }
 
         return best;
+    }
+
+    /// <summary>
+    /// Issue #1552: breaks a score tie among applicable user-function overloads
+    /// using C# §7.5.3.2's "more specific parameter" rule for reference types.
+    /// The tie-break engages only when at least one supplied argument is a
+    /// nullable REFERENCE type (<c>S?</c> over a class/interface/delegate or an
+    /// imported reference type). For the purpose of ranking, such an argument
+    /// behaves exactly like its underlying reference type <c>S</c>, so a
+    /// candidate whose parameter is the more-derived type (e.g. <c>Type</c> or
+    /// <c>Dog</c>) is preferred over one taking a base type (e.g. <c>object</c>
+    /// or <c>Animal</c>) — mirroring the selection already made for a non-null
+    /// <c>S</c> argument. A candidate wins only when, position by position, its
+    /// parameters are each at least as specific as every other tied candidate's
+    /// and strictly more specific in at least one position; a genuinely
+    /// non-orderable tie (e.g. two unrelated interfaces both implemented by the
+    /// argument) leaves the ambiguity intact. Value-type nullable arguments
+    /// (<c>int32?</c>) never engage this rule, preserving existing numeric and
+    /// lifted-operator ranking.
+    /// </summary>
+    /// <param name="tiedBest">The equally-scored candidate overloads.</param>
+    /// <param name="argumentCount">The number of supplied positional arguments.</param>
+    /// <param name="boundArguments">The bound argument expressions.</param>
+    /// <returns>The uniquely most-specific candidate, or <see langword="null"/> when the tie cannot be broken.</returns>
+    private static FunctionSymbol TryBreakTieByReferenceParameterSpecificity(
+        List<FunctionSymbol> tiedBest,
+        int argumentCount,
+        ImmutableArray<BoundExpression>.Builder boundArguments)
+    {
+        if (tiedBest.Count < 2)
+        {
+            return null;
+        }
+
+        var hasNullableReferenceArgument = false;
+        for (var i = 0; i < argumentCount && i < boundArguments.Count; i++)
+        {
+            if (boundArguments[i]?.Type is NullableTypeSymbol nullable
+                && IsReferenceTypeSymbol(nullable.UnderlyingType))
+            {
+                hasNullableReferenceArgument = true;
+                break;
+            }
+        }
+
+        if (!hasNullableReferenceArgument)
+        {
+            return null;
+        }
+
+        // A generic candidate carries unsubstituted method type parameters in
+        // its signature, so its parameter specificity is unreliable here.
+        foreach (var candidate in tiedBest)
+        {
+            if (candidate.IsGeneric || candidate.ExplicitReceiverParameter != null)
+            {
+                return null;
+            }
+        }
+
+        FunctionSymbol winner = null;
+        foreach (var candidate in tiedBest)
+        {
+            var dominatesAll = true;
+            foreach (var other in tiedBest)
+            {
+                if (ReferenceEquals(candidate, other))
+                {
+                    continue;
+                }
+
+                if (!IsStrictlyMoreSpecific(candidate, other, argumentCount))
+                {
+                    dominatesAll = false;
+                    break;
+                }
+            }
+
+            if (dominatesAll)
+            {
+                if (winner != null)
+                {
+                    return null;
+                }
+
+                winner = candidate;
+            }
+        }
+
+        return winner;
+    }
+
+    /// <summary>
+    /// Issue #1552: returns <see langword="true"/> when <paramref name="a"/> is
+    /// strictly more specific than <paramref name="b"/> across the supplied
+    /// positional parameters — each of <paramref name="a"/>'s parameters is at
+    /// least as specific (as derived) as <paramref name="b"/>'s, and at least
+    /// one is strictly more specific. Specificity at a position is decided by
+    /// the implicit reference conversion direction: the more-derived type (the
+    /// source of the one-way implicit conversion) is the more specific one.
+    /// </summary>
+    private static bool IsStrictlyMoreSpecific(FunctionSymbol a, FunctionSymbol b, int argumentCount)
+    {
+        var count = Math.Min(argumentCount, Math.Min(a.Parameters.Length, b.Parameters.Length));
+        var hasStrictlyMoreSpecific = false;
+        for (var i = 0; i < count; i++)
+        {
+            var cmp = CompareParameterSpecificity(a.Parameters[i].Type, b.Parameters[i].Type);
+            if (cmp > 0)
+            {
+                return false;
+            }
+
+            if (cmp < 0)
+            {
+                hasStrictlyMoreSpecific = true;
+            }
+        }
+
+        return hasStrictlyMoreSpecific;
+    }
+
+    /// <summary>
+    /// Issue #1552: compares two reference parameter types for specificity.
+    /// Returns a negative value when <paramref name="a"/> is more specific
+    /// (more derived) than <paramref name="b"/>, a positive value when
+    /// <paramref name="b"/> is more specific, and 0 when they are equal or not
+    /// orderable by a one-way implicit reference conversion (e.g. two unrelated
+    /// interfaces). Only reference types participate; value-type parameters are
+    /// treated as non-orderable so numeric ranking is never disturbed.
+    /// </summary>
+    private static int CompareParameterSpecificity(TypeSymbol a, TypeSymbol b)
+    {
+        if (a == null || b == null || a == b)
+        {
+            return 0;
+        }
+
+        if (!IsReferenceTypeSymbol(a) || !IsReferenceTypeSymbol(b))
+        {
+            return 0;
+        }
+
+        var aToB = Conversion.Classify(a, b);
+        var bToA = Conversion.Classify(b, a);
+        var aIntoB = aToB.Exists && aToB.IsImplicit && !aToB.IsIdentity;
+        var bIntoA = bToA.Exists && bToA.IsImplicit && !bToA.IsIdentity;
+
+        if (aIntoB && !bIntoA)
+        {
+            // a implicitly converts to b (a is more derived) → a is more specific.
+            return -1;
+        }
+
+        if (bIntoA && !aIntoB)
+        {
+            return 1;
+        }
+
+        return 0;
+    }
+
+    /// <summary>
+    /// Issue #1552: returns <see langword="true"/> when <paramref name="type"/>
+    /// is a reference type — a user class, interface, or delegate, or an
+    /// imported reference type — as opposed to a value type. Used to confine
+    /// the nullable-argument specificity tie-break to reference underlyings.
+    /// </summary>
+    private static bool IsReferenceTypeSymbol(TypeSymbol type)
+    {
+        switch (type)
+        {
+            case null:
+                return false;
+            case StructSymbol structSymbol:
+                return structSymbol.IsClass;
+            case InterfaceSymbol:
+            case DelegateTypeSymbol:
+                return true;
+        }
+
+        return type.ClrType is { IsValueType: false, IsPointer: false };
     }
 
     /// <summary>

--- a/test/Compiler.Tests/Emit/Issue1552NullableArgOverloadEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1552NullableArgOverloadEmitTests.cs
@@ -1,0 +1,357 @@
+// <copyright file="Issue1552NullableArgOverloadEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1552 — when an argument has a nullable REFERENCE type <c>S?</c> and
+/// two overloads differ only in a parameter that is a base type (<c>object</c>
+/// or a base class/interface) versus the more-derived <c>S</c>, overload
+/// resolution failed to pick the more-specific <c>S</c> overload and instead
+/// reported GS0266 (ambiguous). The non-nullable <c>S</c> argument already
+/// resolved correctly because the derived parameter scored an exact-type match;
+/// a nullable <c>S?</c> argument never equals a non-nullable parameter, so both
+/// candidates tied.
+/// <para>
+/// The fix has two coupled parts: (1) <c>Conversion.Classify</c> now narrows a
+/// nullable reference source <c>S?</c> to its underlying reference type for
+/// classification, so a user-declared <c>Dog? -&gt; Dog</c>/<c>Dog? -&gt; Animal</c>
+/// converts implicitly exactly as an imported <c>Type? -&gt; Type</c> already
+/// did; and (2) the user-function overload resolver breaks a score tie by C#
+/// §7.5.3.2's "more specific reference parameter" rule when the argument is a
+/// nullable reference type, so the most-derived applicable parameter wins.
+/// Genuinely non-orderable ties (two unrelated interfaces) stay ambiguous, and
+/// value-type nullables (<c>int32?</c>) are untouched.
+/// </para>
+/// Each test uses a UNIQUE package name and UNIQUE user-type names because the
+/// in-process <c>FunctionTypeSymbol</c> cache is name-keyed for user types.
+/// </summary>
+public class Issue1552NullableArgOverloadEmitTests
+{
+    [Fact]
+    public void EndToEnd_ImportedBase_NullableTypeArg_SelectsDerivedType()
+    {
+        const string source = """
+            package i1552imported
+            import System
+
+            func F(caller object) int32 -> 1
+            func F(caller Type) int32 -> 2
+
+            func UseNull(t Type?) int32 -> F(t)
+
+            func Main() { System.Console.WriteLine(UseNull(typeof(int32))) }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("2\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_ImportedBase_NonNullTypeArg_SelectsDerivedType_Regression()
+    {
+        const string source = """
+            package i1552importednn
+            import System
+
+            func F(caller object) int32 -> 1
+            func F(caller Type) int32 -> 2
+
+            func UseNN(t Type) int32 -> F(t)
+
+            func Main() { System.Console.WriteLine(UseNN(typeof(int32))) }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("2\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_UserBaseDerived_NullableArg_SelectsDerivedClass()
+    {
+        const string source = """
+            package i1552userclass
+            import System
+
+            open class Wolf1552 {}
+            class Husky1552 : Wolf1552 {}
+
+            func G(a Wolf1552) int32 -> 1
+            func G(d Husky1552) int32 -> 2
+
+            func Use(d Husky1552?) int32 -> G(d)
+
+            func Main() { System.Console.WriteLine(Use(Husky1552())) }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("2\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_UserBaseDerived_NonNullArg_SelectsDerivedClass_Regression()
+    {
+        const string source = """
+            package i1552userclassnn
+            import System
+
+            open class Cat1552 {}
+            class Lion1552 : Cat1552 {}
+
+            func G(a Cat1552) int32 -> 1
+            func G(d Lion1552) int32 -> 2
+
+            func Use(d Lion1552) int32 -> G(d)
+
+            func Main() { System.Console.WriteLine(Use(Lion1552())) }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("2\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_DeepHierarchy_NullableArg_SelectsMostDerived()
+    {
+        const string source = """
+            package i1552deep
+            import System
+
+            open class RootA1552 {}
+            open class MidB1552 : RootA1552 {}
+            class LeafC1552 : MidB1552 {}
+
+            func K(a RootA1552) int32 -> 1
+            func K(c LeafC1552) int32 -> 3
+
+            func Use(c LeafC1552?) int32 -> K(c)
+
+            func Main() { System.Console.WriteLine(Use(LeafC1552())) }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("3\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_DifferingParameterNotFirst_NullableArg_SelectsDerivedType()
+    {
+        const string source = """
+            package i1552position
+            import System
+
+            func H(n int32, c object) int32 -> 1
+            func H(n int32, c Type) int32 -> 2
+
+            func Use(t Type?) int32 -> H(3, t)
+
+            func Main() { System.Console.WriteLine(Use(typeof(int32))) }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("2\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_InterfaceVersusImplementingClass_NullableArg_SelectsClass()
+    {
+        const string source = """
+            package i1552iface
+            import System
+
+            interface IFoo1552 { func Foo() int32; }
+            class Bar1552 : IFoo1552 { func Foo() int32 -> 5 }
+
+            func P2(x IFoo1552) int32 -> 1
+            func P2(x Bar1552) int32 -> 2
+
+            func Use(b Bar1552?) int32 -> P2(b)
+
+            func Main() { System.Console.WriteLine(Use(Bar1552())) }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("2\n", output);
+    }
+
+    [Fact]
+    public void CompileOnly_TwoUnrelatedInterfaces_NullableArg_StaysAmbiguous()
+    {
+        const string source = """
+            package i1552ambiguous
+            import System
+
+            interface IA1552 { func A() int32; }
+            interface IB1552 { func B() int32; }
+            class Baz1552 : IA1552, IB1552 {
+              func A() int32 -> 1
+              func B() int32 -> 2
+            }
+
+            func M(x IA1552) int32 -> 1
+            func M(x IB1552) int32 -> 2
+
+            func Use(b Baz1552?) int32 -> M(b)
+
+            func Main() { System.Console.WriteLine(0) }
+            """;
+
+        var (exit, output) = CompileOnly(source);
+        Assert.NotEqual(0, exit);
+        Assert.Contains("GS0266", output);
+    }
+
+    [Fact]
+    public void CompileOnly_ValueTypeNullable_NarrowingStaysExplicitError()
+    {
+        // Regression guard: the #1552 nullable-source narrowing is scoped to
+        // REFERENCE underlyings, so a value-type `int32?` argument still does
+        // NOT implicitly convert to a non-nullable `int32` parameter. If this
+        // ever compiles the reference-only gate has leaked into value types.
+        const string source = """
+            package i1552value
+            import System
+
+            func Take(x int32) int32 -> x
+
+            func Use(v int32?) int32 -> Take(v)
+
+            func Main() { System.Console.WriteLine(0) }
+            """;
+
+        var (exit, output) = CompileOnly(source);
+        Assert.NotEqual(0, exit);
+        Assert.Contains("GS0154", output);
+    }
+
+    private static (int Exit, string Output) CompileOnly(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1552_neg_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            return (compileExit, stdoutWriter + stderrWriter.ToString());
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1552_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1255NullableToNullableRefUpcastConversionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1255NullableToNullableRefUpcastConversionTests.cs
@@ -21,9 +21,13 @@ namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 /// <c>T? → U?</c> with <c>GS0155</c> (<c>GS0154</c> in argument position).
 ///
 /// These tests assert the positive base-class and interface cases in both
-/// argument and let-target positions, that the narrowing <c>T? → U</c>
-/// (non-nullable target) still errors, that the #1121 <c>T → U?</c> control still
-/// binds, and that an unrelated <c>T? → U?</c> still fails.
+/// argument and let-target positions, that the #1121 <c>T → U?</c> control still
+/// binds, and that an unrelated <c>T? → U?</c> still fails. Issue #1552 later
+/// made the narrowing <c>T? → U</c> (non-nullable reference target) an implicit
+/// conversion as well — a nullable reference shares its underlying's CLR
+/// representation, so <c>Derived? → Base</c> binds exactly like the imported
+/// <c>Type? → Type</c> already did; see
+/// <see cref="NullableDerived_To_NonNullableBase_Binds"/>.
 /// </summary>
 public class Issue1255NullableToNullableRefUpcastConversionTests
 {
@@ -99,8 +103,15 @@ func F(x Impl?) { TakeBase(x) }
     }
 
     [Fact]
-    public void NullableDerived_To_NonNullableBase_StillReportsGS0155()
+    public void NullableDerived_To_NonNullableBase_Binds()
     {
+        // Issue #1552: a nullable reference `Derived?` shares the CLR
+        // representation of its underlying reference type, so narrowing it to a
+        // non-nullable base `Base` is a representation-preserving reference
+        // upcast — implicit exactly as the imported `Type? -> Type` already is.
+        // (Previously #1255 rejected this user-class case with GS0155, an
+        // inconsistency #1552 removed so a nullable reference argument selects
+        // and binds the more-derived overload.)
         var source = @"
 open class Base {}
 class Derived : Base {}
@@ -109,11 +120,7 @@ func TakeBase(p Base) {}
 
 func F(x Derived?) { TakeBase(x) }
 ";
-        var result = Evaluate(source);
-        Assert.NotEmpty(result.Diagnostics);
-        Assert.Contains(
-            result.Diagnostics,
-            d => d.Message.Contains("Cannot convert") || d.Message.Contains("requires a value of type"));
+        Assert.Empty(Evaluate(source).Diagnostics);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes the spurious GS0266 ambiguity when a nullable reference argument `S?` is passed to an overload set whose parameters differ by base (`object`/base class) vs derived (`S`). Betterness/specificity now sees through the `?` wrapper so a nullable reference argument ranks the most-derived applicable parameter exactly as its non-nullable underlying does.

## Root cause (two coupled gaps)
Top-level user-`func` calls resolve via `OverloadResolver.SelectBestUserOverloadCore` (symbolic), not the CLR `OverloadResolution.cs` path:
1. Ranking: the scorer awards an exact-type bonus only when `argType == paramType`. A nullable `Type?`/`Dog?` never equals a non-nullable param, so both candidates tied -> GS0266.
2. Applicability/conversion: `Conversion.Classify` accepted imported `Type? -> Type` (nullable inherits underlying `ClrType`, #521 rule) but rejected user `Dog? -> Dog`/`Dog? -> Animal` (user classes have null `ClrType` during binding) -> GS0154 after selection.

## Fix
- Added a C# §7.5.3.2 "more-specific reference parameter" tie-break that engages only when an argument is a nullable reference type, treating `S?` as underlying `S` and selecting the uniquely most-derived applicable parameter. Unrelated-interface ties stay ambiguous; `int32?` never engages it.
- Narrowed a nullable reference source to its underlying reference type when classifying against a non-nullable reference target, so user and imported reference nullables narrow identically. Value-type `int32? -> int32` stays explicit.

## Verification
- `dotnet build GSharp.sln -c Release -graph`: 0 warnings, 0 errors.
- Both repros compile, run, and pass ilverify; derived overload selected.
- Core.Tests: 4895 passed, 1 skipped, 0 failed.
- Compiler.Tests targeted (Issue1552|Overload|Issue377|Issue1311|Issue1150|Issue750): 82 passed; new Issue1552 suite: 9 passed; nullable regression sweep (Issue1121|1255|1545|1502|Nullable): 254 passed.

Fixes #1552

Refs #914
