### PR TITLE
Compound assignment falls back to user-defined and CLR operators (#1554)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -788,27 +788,30 @@ internal sealed partial class ExpressionBinder
     }
 
     /// <summary>
-    /// Handles a bare `identifier += expr` / `identifier -= expr` that the parser
-    /// emitted as an <see cref="EventSubscriptionExpressionSyntax"/> with a
-    /// <see cref="NameExpressionSyntax"/> LHS. Resolves as:
-    /// 1. An event subscription on the implicit <c>this</c> if the name matches an event.
-    /// 2. A compound assignment fallback (<c>x += 1</c>) otherwise.
-    /// </summary>
-    /// <summary>
     /// Issue #1246: binds the underlying binary operation of a compound
     /// assignment (<c>lhs op= rhs</c> ⇒ <c>lhs op rhs</c>) so that the right
     /// operand participates in the SAME implicit numeric widening and constant-
     /// integer-literal adaptation that the binary operator <c>lhs op rhs</c>
     /// applies (via <see cref="BindBinaryOperatorWithNumericAdaptation"/>).
-    /// Returns the bound binary expression, or <see langword="null"/> when no
-    /// operator binds even after adaptation (the caller reports GS0129). The
+    /// Issue #1554: when no built-in operator binds, falls back to the SAME
+    /// user-defined (<c>operator</c> methods) and CLR (<c>op_*</c>) resolution
+    /// that the equivalent binary expression uses, so that <c>x += y</c> binds
+    /// whenever <c>x = x + y</c> does (e.g. <c>TimeSpan += TimeSpan</c>,
+    /// <c>DateTime += TimeSpan</c>, or a user <c>operator +</c>). Returns the
+    /// bound expression, or <see langword="null"/> when no operator binds even
+    /// after adaptation and both fallbacks (the caller reports GS0129). The
     /// caller is responsible for converting the result back to the LHS type for
     /// the store, which preserves the C#-style guardrail that a compound
     /// assignment whose result does not implicitly convert back to the LHS type
     /// (e.g. <c>uint8 += int32</c>) is still rejected — exactly as
     /// <c>lhs = lhs op rhs</c> is.
     /// </summary>
-    private BoundBinaryExpression TryBindCompoundBinaryOperation(
+    /// <param name="baseOperatorKind">The base binary operator token kind.</param>
+    /// <param name="leftRead">The bound read of the compound-assignment target.</param>
+    /// <param name="boundRhs">The bound right-hand-side operand.</param>
+    /// <param name="rhsLocation">The source location used for operand diagnostics.</param>
+    /// <returns>The bound binary/user/CLR operator, or <see langword="null"/>.</returns>
+    private BoundExpression TryBindCompoundBinaryOperation(
         SyntaxKind baseOperatorKind,
         BoundExpression leftRead,
         BoundExpression boundRhs,
@@ -817,7 +820,14 @@ internal sealed partial class ExpressionBinder
         var left = leftRead;
         var right = boundRhs;
         var op = BindBinaryOperatorWithNumericAdaptation(baseOperatorKind, ref left, ref right, rhsLocation, rhsLocation);
-        return op == null ? null : new BoundBinaryExpression(null, left, op, right);
+        if (op != null)
+        {
+            return new BoundBinaryExpression(null, left, op, right);
+        }
+
+        // Issue #1554: fall back to user-defined / CLR operator resolution,
+        // exactly as the equivalent binary expression `lhs op rhs` does.
+        return TryBindBinaryWithUserAndClrFallback(baseOperatorKind, ref left, ref right, rhsLocation, rhsLocation, out _);
     }
 
     private BoundExpression BindBareEventOrCompoundAssignment(NameExpressionSyntax bareName, EventSubscriptionExpressionSyntax syntax)

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
@@ -1314,68 +1314,21 @@ internal sealed partial class ExpressionBinder
 
         if (boundOperator == null)
         {
-            // Stream D: try user-defined `func (a T) operator <op>(b U) R` on
-            // either operand's user type. Same-package operators are bound as
-            // methods on the struct (Phase 6.4); the receiver is at
-            // Parameters[0] (so binary ops have Parameters.Length == 2).
-            var userOpName = OperatorNames.TryGetBinaryName(syntax.OperatorToken.Kind);
-            if (userOpName != null)
+            // Streams D + C: user-defined `operator` methods then CLR `op_*`
+            // methods, shared with the compound-assignment path (issue #1554).
+            var fallback = TryBindBinaryWithUserAndClrFallback(
+                syntax.OperatorToken.Kind,
+                ref boundLeft,
+                ref boundRight,
+                syntax.Left.Location,
+                syntax.Right.Location,
+                out var ambiguous);
+            if (fallback != null)
             {
-                FunctionSymbol userOp = null;
-                bool leftIsStructReceiver = false;
-                bool rightIsStructReceiver = false;
-                if (boundLeft.Type is StructSymbol leftStruct && TypeMemberModel.TryGetMethodIncludingInherited(leftStruct, userOpName, out var leftOp))
-                {
-                    userOp = leftOp;
-                    leftIsStructReceiver = true;
-                }
-                else if (boundRight.Type is StructSymbol rightStruct && TypeMemberModel.TryGetMethodIncludingInherited(rightStruct, userOpName, out var rightOp))
-                {
-                    userOp = rightOp;
-                    rightIsStructReceiver = true;
-                }
-                else if (boundLeft.Type != null && scope.TryLookupExtensionFunction(boundLeft.Type, userOpName, out var leftExt))
-                {
-                    userOp = leftExt;
-                }
-                else if (boundRight.Type != null && scope.TryLookupExtensionFunction(boundRight.Type, userOpName, out var rightExt))
-                {
-                    userOp = rightExt;
-                }
-
-                if (userOp != null && userOp.Parameters.Length == 2)
-                {
-                    var convertedLeft = conversions.BindConversion(syntax.Left.Location, boundLeft, userOp.Parameters[0].Type);
-                    var convertedRight = conversions.BindConversion(syntax.Right.Location, boundRight, userOp.Parameters[1].Type);
-                    if (leftIsStructReceiver)
-                    {
-                        return new BoundUserInstanceCallExpression(null, convertedLeft, userOp, ImmutableArray.Create(convertedRight));
-                    }
-
-                    if (rightIsStructReceiver)
-                    {
-                        return new BoundUserInstanceCallExpression(null, convertedRight, userOp, ImmutableArray.Create(convertedLeft));
-                    }
-
-                    return new BoundCallExpression(null, userOp, ImmutableArray.Create(convertedLeft, convertedRight));
-                }
+                return fallback;
             }
 
-            // Stream C: fall back to a public-static `op_*` method on either
-            // operand's CLR type (TimeSpan + TimeSpan, BigInteger * int, ...).
-            var ambiguous = false;
-            if ((boundLeft.Type?.ClrType != null || boundRight.Type?.ClrType != null)
-                && ClrOperatorResolution.TryResolveBinary(syntax.OperatorToken.Kind, boundLeft.Type, boundRight.Type, out var clrMethod, out ambiguous))
-            {
-                return new BoundClrBinaryOperatorExpression(
-                    null,
-                    syntax.OperatorToken.Kind,
-                    boundLeft,
-                    boundRight,
-                    clrMethod,
-                    TypeSymbol.FromClrType(clrMethod.ReturnType));
-            }
-            else if (ambiguous)
+            if (ambiguous)
             {
                 Diagnostics.ReportAmbiguousOverload(syntax.OperatorToken.Location, syntax.OperatorToken.Text, candidateCount: 2);
                 return new BoundErrorExpression(null);
@@ -1414,6 +1367,96 @@ internal sealed partial class ExpressionBinder
         }
 
         return new BoundBinaryExpression(null, boundLeft, boundOperator, boundRight);
+    }
+
+    /// <summary>
+    /// Issue #1554: shared fallback that resolves a binary operator via the
+    /// user-defined operator path (Stream D) and then the CLR <c>op_*</c> path
+    /// (Stream C), in that order, for both the plain binary expression
+    /// (<c>lhs op rhs</c>) and the compound-assignment (<c>lhs op= rhs</c>)
+    /// paths. It is invoked only after the built-in numeric operator has failed
+    /// to bind, so that a compound assignment falls back to exactly the same
+    /// user/BCL operator resolution that the equivalent binary expression uses.
+    /// </summary>
+    /// <param name="opKind">The base binary operator token kind.</param>
+    /// <param name="left">The bound left operand (adapted by the built-in attempt).</param>
+    /// <param name="right">The bound right operand (adapted by the built-in attempt).</param>
+    /// <param name="leftLocation">The source location of the left operand.</param>
+    /// <param name="rightLocation">The source location of the right operand.</param>
+    /// <param name="ambiguous">Set to <see langword="true"/> when CLR operator resolution found multiple equally-applicable candidates.</param>
+    /// <returns>The bound user/CLR operator call, or <see langword="null"/> when neither resolves.</returns>
+    private BoundExpression TryBindBinaryWithUserAndClrFallback(
+        SyntaxKind opKind,
+        ref BoundExpression left,
+        ref BoundExpression right,
+        TextLocation leftLocation,
+        TextLocation rightLocation,
+        out bool ambiguous)
+    {
+        ambiguous = false;
+
+        // Stream D: try user-defined `func (a T) operator <op>(b U) R` on
+        // either operand's user type. Same-package operators are bound as
+        // methods on the struct (Phase 6.4); the receiver is at
+        // Parameters[0] (so binary ops have Parameters.Length == 2).
+        var userOpName = OperatorNames.TryGetBinaryName(opKind);
+        if (userOpName != null)
+        {
+            FunctionSymbol userOp = null;
+            bool leftIsStructReceiver = false;
+            bool rightIsStructReceiver = false;
+            if (left.Type is StructSymbol leftStruct && TypeMemberModel.TryGetMethodIncludingInherited(leftStruct, userOpName, out var leftOp))
+            {
+                userOp = leftOp;
+                leftIsStructReceiver = true;
+            }
+            else if (right.Type is StructSymbol rightStruct && TypeMemberModel.TryGetMethodIncludingInherited(rightStruct, userOpName, out var rightOp))
+            {
+                userOp = rightOp;
+                rightIsStructReceiver = true;
+            }
+            else if (left.Type != null && scope.TryLookupExtensionFunction(left.Type, userOpName, out var leftExt))
+            {
+                userOp = leftExt;
+            }
+            else if (right.Type != null && scope.TryLookupExtensionFunction(right.Type, userOpName, out var rightExt))
+            {
+                userOp = rightExt;
+            }
+
+            if (userOp != null && userOp.Parameters.Length == 2)
+            {
+                var convertedLeft = conversions.BindConversion(leftLocation, left, userOp.Parameters[0].Type);
+                var convertedRight = conversions.BindConversion(rightLocation, right, userOp.Parameters[1].Type);
+                if (leftIsStructReceiver)
+                {
+                    return new BoundUserInstanceCallExpression(null, convertedLeft, userOp, ImmutableArray.Create(convertedRight));
+                }
+
+                if (rightIsStructReceiver)
+                {
+                    return new BoundUserInstanceCallExpression(null, convertedRight, userOp, ImmutableArray.Create(convertedLeft));
+                }
+
+                return new BoundCallExpression(null, userOp, ImmutableArray.Create(convertedLeft, convertedRight));
+            }
+        }
+
+        // Stream C: fall back to a public-static `op_*` method on either
+        // operand's CLR type (TimeSpan + TimeSpan, BigInteger * int, ...).
+        if ((left.Type?.ClrType != null || right.Type?.ClrType != null)
+            && ClrOperatorResolution.TryResolveBinary(opKind, left.Type, right.Type, out var clrMethod, out ambiguous))
+        {
+            return new BoundClrBinaryOperatorExpression(
+                null,
+                opKind,
+                left,
+                right,
+                clrMethod,
+                TypeSymbol.FromClrType(clrMethod.ReturnType));
+        }
+
+        return null;
     }
 
     /// <summary>

--- a/test/Compiler.Tests/Emit/Issue1554CompoundAssignOperatorEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1554CompoundAssignOperatorEmitTests.cs
@@ -1,0 +1,389 @@
+// <copyright file="Issue1554CompoundAssignOperatorEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1554 — compound assignment <c>x op= y</c> only resolved the BUILT-IN
+/// binary operator; it did NOT fall back to USER-DEFINED
+/// (<c>func (a T) operator +(b U) R</c>) or CLR (<c>op_*</c>, e.g.
+/// <c>TimeSpan.op_Addition</c>) operator resolution the way the equivalent
+/// binary expression <c>x = x op y</c> does. So <c>x += y</c> reported GS0129 for
+/// any type whose operator is user-defined or a BCL operator, even though
+/// <c>x + y</c> bound fine.
+/// <para>
+/// The fix routes <see cref="M:GSharp.Binding.ExpressionBinder.TryBindCompoundBinaryOperation"/>
+/// through the same user/CLR operator fallback the binary path uses (a shared
+/// helper), so every compound-assignment target kind (local, instance field,
+/// static field, chained member) works uniformly for user and BCL operators.
+/// </para>
+/// Each test uses a UNIQUE package/type name because the in-process
+/// <c>FunctionTypeSymbol</c> cache is name-keyed for user types.
+/// </summary>
+public class Issue1554CompoundAssignOperatorEmitTests
+{
+    [Fact]
+    public void EndToEnd_TimeSpanPlusEquals_Local_Runs()
+    {
+        const string source = """
+            package i1554tsadd
+            import System
+            func Main() {
+              var x = TimeSpan.FromSeconds(int64(1))
+              x += TimeSpan.FromSeconds(int64(2))
+              Console.WriteLine(x.TotalSeconds)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("3\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_TimeSpanMinusEquals_Local_Runs()
+    {
+        const string source = """
+            package i1554tssub
+            import System
+            func Main() {
+              var x = TimeSpan.FromSeconds(int64(5))
+              x -= TimeSpan.FromSeconds(int64(2))
+              Console.WriteLine(x.TotalSeconds)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("3\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_DateTimePlusEqualsTimeSpan_Local_Runs()
+    {
+        const string source = """
+            package i1554dtadd
+            import System
+            func Main() {
+              var d = DateTime(2020, 1, 1, 0, 0, 0)
+              d += TimeSpan.FromDays(float64(5))
+              Console.WriteLine(d.Day)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("6\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_UserOperatorPlusEquals_Local_Runs()
+    {
+        const string source = """
+            package i1554vecadd
+            import System
+            class VecA {
+              var X int32
+              var Y int32
+            }
+            func (a VecA) operator +(b VecA) VecA {
+              return VecA{X: a.X + b.X, Y: a.Y + b.Y}
+            }
+            func Main() {
+              var p = VecA{X: 1, Y: 2}
+              p += VecA{X: 3, Y: 4}
+              Console.WriteLine(p.X)
+              Console.WriteLine(p.Y)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("4\n6\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_UserOperatorStarEquals_Local_Runs()
+    {
+        const string source = """
+            package i1554moneymul
+            import System
+            struct MoneyM {
+              var Cents int32
+            }
+            func (a MoneyM) operator *(b MoneyM) MoneyM {
+              return MoneyM{Cents: a.Cents * b.Cents}
+            }
+            func Main() {
+              var m = MoneyM{Cents: 3}
+              m *= MoneyM{Cents: 4}
+              Console.WriteLine(m.Cents)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("12\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_UserOperatorPlusEquals_InstanceField_Runs()
+    {
+        const string source = """
+            package i1554ifield
+            import System
+            class VecB {
+              var X int32
+              var Y int32
+            }
+            func (a VecB) operator +(b VecB) VecB {
+              return VecB{X: a.X + b.X, Y: a.Y + b.Y}
+            }
+            class HolderB { var V VecB }
+            func Main() {
+              var h = HolderB{}
+              h.V = VecB{X: 1, Y: 2}
+              h.V += VecB{X: 3, Y: 4}
+              Console.WriteLine(h.V.X)
+              Console.WriteLine(h.V.Y)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("4\n6\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_UserOperatorPlusEquals_StaticField_Runs()
+    {
+        const string source = """
+            package i1554sfield
+            import System
+            struct MoneyS {
+              var Cents int32
+            }
+            func (a MoneyS) operator +(b MoneyS) MoneyS {
+              return MoneyS{Cents: a.Cents + b.Cents}
+            }
+            class BankS {
+              shared {
+                var Total MoneyS
+              }
+            }
+            func Main() {
+              BankS.Total = MoneyS{Cents: 3}
+              BankS.Total += MoneyS{Cents: 4}
+              Console.WriteLine(BankS.Total.Cents)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("7\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_UserOperatorPlusEquals_ChainedMember_Runs()
+    {
+        const string source = """
+            package i1554chain
+            import System
+            struct VecC {
+              var X int32
+            }
+            func (a VecC) operator +(b VecC) VecC {
+              return VecC{X: a.X + b.X}
+            }
+            class InnerC { var V VecC }
+            class OuterC { var In InnerC }
+            func Main() {
+              var o = OuterC{In: InnerC{V: VecC{X: 1}}}
+              o.In.V += VecC{X: 10}
+              Console.WriteLine(o.In.V.X)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("11\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_Int32PlusEquals_Local_StillRuns()
+    {
+        const string source = """
+            package i1554i32
+            import System
+            func Main() {
+              var i int32 = 10
+              i += 5
+              Console.WriteLine(i)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("15\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_DecimalPlusEquals_Local_StillRuns()
+    {
+        const string source = """
+            package i1554dec
+            import System
+            func Main() {
+              var d decimal = decimal(10)
+              d += decimal(5)
+              Console.WriteLine(d)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("15\n", output);
+    }
+
+    [Fact]
+    public void CompileOnly_Uint8PlusEqualsInt32_StillRejected()
+    {
+        const string source = """
+            package i1554u8reject
+            import System
+            func Main() {
+              var b uint8 = uint8(1)
+              var i int32 = 5
+              b += i
+              Console.WriteLine(b)
+            }
+            """;
+
+        var (exit, output) = CompileOnly(source);
+        Assert.NotEqual(0, exit);
+        Assert.True(
+            output.Contains("GS0129") || output.Contains("GS0156"),
+            $"expected a compound-assignment rejection diagnostic, got:\n{output}");
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1554_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static (int Exit, string Output) CompileOnly(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1554_neg_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            return (compileExit, stdoutWriter + stderrWriter.ToString());
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
Compound assignment `x op= y` only resolved the built-in binary operator and reported GS0129 for any type whose operator is user-defined or a BCL `op_*` method, even though the binary form `x op y` bound fine (`TimeSpan += TimeSpan`, `DateTime += TimeSpan`, user `operator +` `+=`).

## Root cause
`TryBindCompoundBinaryOperation` (`ExpressionBinder.Assignments.cs`) called only the built-in numeric path and returned null on failure. The binary path `BindBinaryExpression` already fell back — after the built-in attempt — to Stream D (user-defined `operator` methods) then Stream C (CLR `op_*`), but the compound path had neither fallback.

## Fix
- Extracted the inline Stream D + Stream C fallback into a shared helper `TryBindBinaryWithUserAndClrFallback` in `ExpressionBinder.Operators.cs`; `BindBinaryExpression` now calls it (plain-binary behavior preserved exactly, including ambiguity reporting).
- `TryBindCompoundBinaryOperation` widened to `BoundExpression` and now uses the shared fallback when the built-in operator is null. The existing convert-back-to-LHS guardrail (e.g. `uint8 += int32` still rejected) is preserved.
- All compound-assignment target kinds funnel through the compound binder: bare local, instance/chained member, chained CLR member, user-type static field/prop, interface static field, and indexer compound.

## Verification
- `dotnet build GSharp.sln -c Release -graph`: 0 warnings, 0 errors.
- 3 repros compile, run (`3` / `6` / `4`,`6`), ilverify clean.
- Core.Tests: 4895 passed, 1 skipped, 0 failed.
- Compiler.Tests targeted (Issue1554|Compound|Operator|Assign|Issue1246|Issue1014): 222 passed; new Issue1554 suite: 11 passed.

Fixes #1554

Refs #914
