### PR TITLE
cs2gs: qualify generic-owner static self-references with type arguments

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/StaticMemberQualificationTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/StaticMemberQualificationTranslationTests.cs
@@ -71,6 +71,42 @@ namespace Corpus.StaticMember
         Assert.Contains("Holder.Tab", rendered, StringComparison.Ordinal);
     }
 
+    private const string GenericSiblingSource = @"
+namespace Corpus.StaticMember
+{
+    public static class Box
+    {
+        public static int Helper() => 0;
+    }
+
+    public class Box<T>
+    {
+        private static int Tab = 5;
+
+        public static int Read()
+        {
+            return Tab;
+        }
+
+        public static string Mkr() => Read().ToString();
+    }
+}
+";
+
+    [Fact]
+    public void StaticMemberReferenced_FromGenericSibling_IsQualifiedWithTypeArguments()
+    {
+        // A generic owner (`Box<T>`) that lives beside a non-generic type of the
+        // same simple name (`static class Box`) must be qualified with its type
+        // arguments (`Box[T].Tab` / `Box[T].Read()`), not the bare arity-0 name —
+        // otherwise gsc binds the wrong (non-generic) type and reports GS0158.
+        string rendered = TranslateAndPrint(GenericSiblingSource);
+
+        Assert.Contains("Box[T].Tab", rendered, StringComparison.Ordinal);
+        Assert.Contains("Box[T].Read()", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("Box.Tab", rendered, StringComparison.Ordinal);
+    }
+
     private static string TranslateAndPrint(string source)
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -6327,11 +6327,28 @@ public sealed class CSharpToGSharpTranslator
                 !SymbolEqualityComparer.Default.Equals(owner.OriginalDefinition, this.entryType?.OriginalDefinition))
             {
                 return new MemberAccessExpression(
-                    new IdentifierExpression(owner.Name),
+                    this.StaticQualifierReceiver(owner, identifier.GetLocation()),
                     SanitizeIdentifier(identifier.Identifier.Text));
             }
 
             return new IdentifierExpression(SanitizeIdentifier(identifier.Identifier.Text));
+        }
+
+        // Builds the receiver expression used to qualify a bare sibling static
+        // member reference through its owning type. For a non-generic owner this is
+        // a plain identifier (`Owner`); for a GENERIC owner it must carry the type
+        // arguments (`Owner[T]`) so it does not collide with a sibling non-generic
+        // type of the same simple name (e.g. `static class TreeDecomposition` beside
+        // `class TreeDecomposition<T>`), which would otherwise bind the arity-0 type
+        // and report GS0158 for members that live only on the generic type.
+        private GExpression StaticQualifierReceiver(INamedTypeSymbol owner, Location location)
+        {
+            if (owner.IsGenericType)
+            {
+                return new TypeExpression(this.typeMapper.Map(owner, this.context, location));
+            }
+
+            return new IdentifierExpression(owner.Name);
         }
 
         private GExpression TranslateLiteral(LiteralExpressionSyntax literal)
@@ -6722,7 +6739,7 @@ public sealed class CSharpToGSharpTranslator
                 // (ADR-0134): gsc brings it into scope through `import Owner`,
                 // so it is left unqualified above.
                 target = new MemberAccessExpression(
-                    new IdentifierExpression(owner.Name),
+                    this.StaticQualifierReceiver(owner, bareName.GetLocation()),
                     staticMethod.Name);
             }
             else


### PR DESCRIPTION
## Problem

A C# self-reference to a static member from inside a generic type is unqualified
(`primitveTypes.IsPrimitiveType(...)`, `Mkr()`, `Snamval(...)` inside
`TreeDecomposition<T>`). cs2gs qualifies such bare sibling static references through
the owning type (ADR-0115 §B.18), but used the bare arity-0 name:
`TreeDecomposition.primitveTypes`.

When a non-generic type of the same simple name also exists — e.g. Oahu's
`public static class TreeDecomposition` beside `internal class TreeDecomposition<T>` —
the arity-0 name binds the wrong type, and gsc reports GS0158 "Cannot find member"
for every member that lives only on the generic type (`primitveTypes`, `default_`,
`Mkr`, `Snamval` → ~8 cascading errors).

## Fix

Qualify a **generic** owner with its type arguments (`TreeDecomposition[T].X`) by
rendering a `TypeExpression` of the mapped constructed type (the same form used for
constructed-generic static receivers). Non-generic owners keep the plain identifier
qualifier, so existing behavior is unchanged.

Applied to both self-qualification paths (static field/property refs and static
method calls). New helper `StaticQualifierReceiver`.

## Validation

- New regression test `StaticMemberReferenced_FromGenericSibling_IsQualifiedWithTypeArguments`.
- All 350 cs2gs translation tests pass.
- Oahu.Foundation migration: 106 -> 96 diagnostics (TreeDecomposition member-not-found
  cascade cleared).

Refs #914
