### PR TITLE
gsc: bind assignment to a generic type's static field (G[T].field = v)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -2429,6 +2429,45 @@ internal sealed partial class ExpressionBinder
     }
 
     /// <summary>
+    /// Issue #1559: syntax-shape-agnostic dispatcher over the two
+    /// constructed-generic-type receiver resolvers. A qualified generic-type
+    /// receiver <c>G[T1..Tn]</c> reaches the binder as either an
+    /// <see cref="IndexExpressionSyntax"/> (single type argument that also reads
+    /// as an index — <c>Foo[T]</c>, <c>Box[int32]</c>) or a
+    /// <see cref="GenericNameExpressionSyntax"/> (arguments the parser could only
+    /// shape as types — <c>Box[int32?]</c>, <c>Pair[int32, string]</c>,
+    /// <c>Box[List[int32]]</c>). Both read (member access) and write (assignment
+    /// target) receiver resolution route through here so the WRITE path mirrors
+    /// the READ path (<see cref="BindAccessorExpression"/>) exactly rather than
+    /// duplicating shape-specific logic.
+    /// </summary>
+    /// <param name="receiver">The candidate constructed-generic-type receiver syntax.</param>
+    /// <param name="constructedStruct">The constructed generic class/struct on success.</param>
+    /// <param name="constructedInterface">The constructed generic interface on success.</param>
+    /// <param name="constructedImported">The constructed imported CLR generic type on success.</param>
+    /// <returns>Whether a constructed generic type receiver was resolved.</returns>
+    private bool TryResolveConstructedGenericTypeReceiver(
+        ExpressionSyntax receiver,
+        out StructSymbol constructedStruct,
+        out InterfaceSymbol constructedInterface,
+        out ImportedClassSymbol constructedImported)
+    {
+        constructedStruct = null;
+        constructedInterface = null;
+        constructedImported = null;
+
+        switch (receiver)
+        {
+            case IndexExpressionSyntax index when !index.IsNullConditional:
+                return TryResolveConstructedGenericTypeReceiver(index, out constructedStruct, out constructedInterface, out constructedImported);
+            case GenericNameExpressionSyntax generic:
+                return TryResolveConstructedGenericTypeReceiver(generic, out constructedStruct, out constructedInterface, out constructedImported);
+            default:
+                return false;
+        }
+    }
+
+    /// <summary>
     /// Closes an open imported CLR generic definition over the CLR types of the
     /// bound type arguments (e.g. <c>ArrayPool`1</c> + <c>byte</c> -&gt;
     /// <c>ArrayPool&lt;byte&gt;</c>) and surfaces it as an

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -1539,31 +1539,23 @@ internal sealed partial class ExpressionBinder
     /// </summary>
     private BoundExpression BindMemberFieldAssignmentExpression(MemberFieldAssignmentExpressionSyntax syntax)
     {
-        // ADR-0089 / issue #1030: `IBox[int32].Field = value` — a write to a
-        // constructed generic interface's static field. The receiver
-        // `IBox[int32]` is a type, not a value, so it is resolved to the
-        // constructed interface symbol rather than bound as an index expression.
-        if (syntax.Receiver is IndexExpressionSyntax ifaceIndex
-            && !ifaceIndex.IsNullConditional
-            && TryResolveConstructedGenericInterfaceReceiver(ifaceIndex, out var ctorIface))
+        // Issue #1559 (extends ADR-0089 / issue #1030 and issue #1209/#1323): a
+        // write to a static field/property through a constructed generic *type*
+        // receiver — `Foo[int32].x = v` (class/struct), `IBox[int32].Field = v`
+        // (interface), or an imported CLR generic. The receiver `Foo[int32]` is
+        // a TYPE, not a value, so it is resolved to the constructed type symbol
+        // (mirroring the READ path in BindAccessorExpression) rather than bound
+        // as an index expression — which would otherwise report GS0125
+        // "Variable 'Foo' doesn't exist". The parser shapes the receiver as an
+        // IndexExpression (single type-arg) or a GenericNameExpression (nullable
+        // / nested / multiple type-args); a single dispatcher covers both.
+        if (TryResolveConstructedGenericTypeReceiver(
+                syntax.Receiver,
+                out var ctorStruct,
+                out var ctorIface,
+                out var ctorImported))
         {
-            var ifaceFieldName = syntax.FieldIdentifier.Text;
-            var ownerDef = ctorIface.Definition ?? ctorIface;
-            var ifaceStaticField = ownerDef.GetStaticField(ifaceFieldName);
-            if (ifaceStaticField != null)
-            {
-                var ifaceValue = BindExpression(syntax.Value);
-                if (ifaceStaticField.IsReadOnly || ifaceStaticField.IsConst)
-                {
-                    Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, ifaceFieldName);
-                }
-
-                var ifaceConverted = conversions.BindConversion(syntax.Value.Location, ifaceValue, ifaceStaticField.Type);
-                return new BoundFieldAssignmentExpression(null, ifaceStaticField, ctorIface, ifaceConverted);
-            }
-
-            Diagnostics.ReportUnableToFindMember(syntax.FieldIdentifier.Location, ifaceFieldName);
-            return new BoundErrorExpression(null);
+            return BindConstructedGenericStaticFieldWrite(syntax, ctorStruct, ctorIface, ctorImported);
         }
 
         var receiver = BindExpression(syntax.Receiver);
@@ -1691,6 +1683,92 @@ internal sealed partial class ExpressionBinder
             _ = instTargetType;
             var instConverted = conversions.BindConversion(syntax.Value.Location, value, instTargetSymbol);
             return new BoundClrPropertyAssignmentExpression(null, receiver, instanceMember, instConverted, instTargetSymbol);
+        }
+
+        Diagnostics.ReportUnableToFindMember(syntax.FieldIdentifier.Location, fieldName);
+        return new BoundErrorExpression(null);
+    }
+
+    /// <summary>
+    /// Issue #1559: binds a write to a static field or property reached through
+    /// a constructed generic *type* receiver — <c>Foo[int32].x = v</c> (user
+    /// class/struct), <c>IBox[int32].Field = v</c> (user interface), or an
+    /// imported CLR generic. Exactly one of the constructed-type arguments is
+    /// non-null (the receiver resolver picks the owner kind). The struct/class
+    /// and interface paths carry the constructed symbol so the emitter parents
+    /// the field/property reference at the correct <c>TypeSpec</c> (ADR-0087 /
+    /// issue #1030 / issue #1209), giving each closed construction its own
+    /// static storage. Mirrors the READ path in
+    /// <see cref="BindUserTypeStaticMemberAccess"/> and the non-generic static
+    /// write in <see cref="BindFieldAssignmentExpression"/>.
+    /// </summary>
+    private BoundExpression BindConstructedGenericStaticFieldWrite(
+        MemberFieldAssignmentExpressionSyntax syntax,
+        StructSymbol constructedStruct,
+        InterfaceSymbol constructedInterface,
+        ImportedClassSymbol constructedImported)
+    {
+        var fieldName = syntax.FieldIdentifier.Text;
+        var value = BindExpression(syntax.Value);
+
+        // User class/struct → static field or static property write.
+        if (constructedStruct != null)
+        {
+            if (TypeMemberModel.TryGetStaticField(constructedStruct, fieldName, out var staticField))
+            {
+                if (staticField.IsReadOnly)
+                {
+                    Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, fieldName);
+                }
+
+                var staticConverted = conversions.BindConversion(syntax.Value.Location, value, staticField.Type);
+                return new BoundFieldAssignmentExpression(null, null, constructedStruct, staticField, staticConverted);
+            }
+
+            if (TypeMemberModel.TryGetStaticProperty(constructedStruct, fieldName, out var prop))
+            {
+                if (!prop.HasSetter)
+                {
+                    Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, fieldName);
+                    return new BoundErrorExpression(null);
+                }
+
+                var propConverted = conversions.BindConversion(syntax.Value.Location, value, prop.Type);
+                return new BoundPropertyAssignmentExpression(null, receiver: null, constructedStruct, prop, propConverted);
+            }
+
+            Diagnostics.ReportUnableToFindMember(syntax.FieldIdentifier.Location, fieldName);
+            return new BoundErrorExpression(null);
+        }
+
+        // User interface → static field write (per-construction storage).
+        if (constructedInterface != null)
+        {
+            var ownerDef = constructedInterface.Definition ?? constructedInterface;
+            var ifaceStaticField = ownerDef.GetStaticField(fieldName);
+            if (ifaceStaticField != null)
+            {
+                if (ifaceStaticField.IsReadOnly || ifaceStaticField.IsConst)
+                {
+                    Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, fieldName);
+                }
+
+                var ifaceConverted = conversions.BindConversion(syntax.Value.Location, value, ifaceStaticField.Type);
+                return new BoundFieldAssignmentExpression(null, ifaceStaticField, constructedInterface, ifaceConverted);
+            }
+
+            Diagnostics.ReportUnableToFindMember(syntax.FieldIdentifier.Location, fieldName);
+            return new BoundErrorExpression(null);
+        }
+
+        // Imported CLR generic → static field/property write via reflection on
+        // the closed construction (mirrors the non-generic imported-class write
+        // in BindFieldAssignmentExpression).
+        if (constructedImported.TryLookupMember(fieldName, ne: null, out var staticMember)
+            && TryGetWritableClrMember(staticMember, out _, out var staticTargetSymbol, out _))
+        {
+            var staticConverted = conversions.BindConversion(syntax.Value.Location, value, staticTargetSymbol);
+            return new BoundClrPropertyAssignmentExpression(null, receiver: null, staticMember, staticConverted, staticTargetSymbol);
         }
 
         Diagnostics.ReportUnableToFindMember(syntax.FieldIdentifier.Location, fieldName);

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs
@@ -110,14 +110,29 @@ internal sealed partial class ExpressionBinder
             Diagnostics.ReportUnableToFindMember(eventNameSyntax.Location, eventName);
             return new BoundErrorExpression(null);
         }
-        else if (accessor.LeftPart is IndexExpressionSyntax ifaceIndex
-            && !ifaceIndex.IsNullConditional
-            && TryResolveConstructedGenericInterfaceReceiver(ifaceIndex, out var ctorInterface))
+        else if ((accessor.LeftPart is IndexExpressionSyntax || accessor.LeftPart is GenericNameExpressionSyntax)
+            && TryResolveConstructedGenericTypeReceiver(
+                accessor.LeftPart,
+                out var ctorStruct,
+                out var ctorInterface,
+                out var ctorImported))
         {
-            // ADR-0089 / issue #1030: `IBox[int32].StaticField += rhs` —
-            // compound assignment to a constructed generic interface static
-            // field (per-construction storage).
-            if (TryBindInterfaceStaticCompoundAssignment(ctorInterface, eventNameSyntax, syntax, isAdd, out var ctorCompound))
+            // Issue #1559 (extends ADR-0089 / issue #1030): compound assignment
+            // to a static field/property through a constructed generic *type*
+            // receiver — `Foo[int32].x += rhs` (class/struct) or
+            // `IBox[int32].StaticField += rhs` (interface). The receiver is a
+            // TYPE, resolved to the constructed symbol (mirroring the READ /
+            // simple-write paths) rather than bound as element access, and the
+            // carried construction drives per-construction emit/storage.
+            _ = ctorImported;
+            if (ctorStruct != null
+                && TryBindUserTypeStaticCompoundAssignment(ctorStruct, eventNameSyntax, syntax, isAdd, out var ctorStructCompound))
+            {
+                return ctorStructCompound;
+            }
+
+            if (ctorInterface != null
+                && TryBindInterfaceStaticCompoundAssignment(ctorInterface, eventNameSyntax, syntax, isAdd, out var ctorCompound))
             {
                 return ctorCompound;
             }

--- a/test/Compiler.Tests/Emit/Issue1559GenericStaticFieldWriteEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1559GenericStaticFieldWriteEmitTests.cs
@@ -1,0 +1,410 @@
+// <copyright file="Issue1559GenericStaticFieldWriteEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1559 — assigning to a STATIC FIELD of a CONSTRUCTED GENERIC TYPE
+/// through a qualified receiver (<c>Type[T].staticField = value</c>) failed to
+/// bind: the assignment-target binder treated the type receiver as a variable
+/// and reported <c>GS0125 Variable 'Type' doesn't exist</c> (plus one GS0125 per
+/// type argument). READING the same field worked, and WRITING a NON-generic
+/// static field worked; only the constructed-generic type receiver on an
+/// assignment target was broken.
+/// <para>
+/// The fix routes the assignment-target binder (simple <c>=</c>, compound
+/// <c>+=</c>, and the <c>++</c>/<c>--</c> desugar) through the same
+/// constructed-generic-type receiver resolution the READ path uses, so
+/// <c>G[T1..Tn].staticMember = value</c> binds against the constructed TYPE and
+/// emits a store parented at the correct <c>TypeSpec</c>. Covers both parser
+/// receiver shapes (index-expression <c>Foo[T]</c> and generic-name
+/// <c>Foo[int32?]</c>/<c>Pair[A, B]</c>), static fields, static property setters,
+/// and multiple / nullable / nested type arguments.
+/// </para>
+/// Each test uses a UNIQUE package and type name because the in-process type /
+/// FunctionTypeSymbol caches are name-keyed; reused names cause cross-test
+/// contamination.
+/// </summary>
+public class Issue1559GenericStaticFieldWriteEmitTests
+{
+    [Fact]
+    public void EndToEnd_WriteThenRead_GenericStaticField_Runs()
+    {
+        // The minimal reproduction from issue #1559: write `7` into a generic
+        // static field through the constructed-type receiver, then read it back.
+        const string source = """
+            package i1559writeread
+            import System
+
+            class Foo[T]() {
+                func Set() {
+                    Foo[T].x = 7
+                }
+                func Get() int32 -> Foo[T].x
+                shared {
+                    var x int32 = 5
+                }
+            }
+
+            func Main() {
+                let f = Foo[int32]()
+                f.Set()
+                System.Console.WriteLine(f.Get())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("7\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_CompoundAssign_GenericStaticField_Runs()
+    {
+        // `Box[T].x += 10` — compound assignment reaches the assignment-target
+        // binder through the event-subscription fallback; it must resolve the
+        // constructed-type receiver rather than binding it as element access.
+        const string source = """
+            package i1559compound
+            import System
+
+            class Box[T]() {
+                func Bump() {
+                    Box[T].x += 10
+                }
+                func Get() int32 -> Box[T].x
+                shared {
+                    var x int32 = 1
+                }
+            }
+
+            func Main() {
+                let b = Box[int32]()
+                b.Bump()
+                b.Bump()
+                System.Console.WriteLine(b.Get())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("21\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_IncrementDecrement_GenericStaticField_Runs()
+    {
+        // `Cnt[T].n++` / `Cnt[T].n--` desugar to a member-field assignment whose
+        // receiver is the constructed-type reference.
+        const string source = """
+            package i1559incdec
+            import System
+
+            class Cnt[T]() {
+                func Up() {
+                    Cnt[T].n++
+                }
+                func Down() {
+                    Cnt[T].n--
+                }
+                func Get() int32 -> Cnt[T].n
+                shared {
+                    var n int32 = 10
+                }
+            }
+
+            func Main() {
+                let c = Cnt[int32]()
+                c.Up()
+                c.Up()
+                c.Up()
+                c.Down()
+                System.Console.WriteLine(c.Get())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("12\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_StaticPropertySetter_GenericType_Runs()
+    {
+        // Static PROPERTY setter through a constructed-type receiver:
+        // `Cell[T].P = 99` must dispatch through the property's setter.
+        const string source = """
+            package i1559propset
+            import System
+
+            class Cell[T]() {
+                func Set() {
+                    Cell[T].P = 99
+                }
+                func Get() int32 -> Cell[T].P
+                shared {
+                    var backing int32 = 0
+                    prop P int32 {
+                        get -> backing
+                        set { backing = value }
+                    }
+                }
+            }
+
+            func Main() {
+                let c = Cell[int32]()
+                c.Set()
+                System.Console.WriteLine(c.Get())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("99\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_StaticPropertyCompound_GenericType_Runs()
+    {
+        // Compound assignment on a static property (`Acc[T].P += 5`) round-trips
+        // through getter + setter on the construction.
+        const string source = """
+            package i1559propcompound
+            import System
+
+            class Acc[T]() {
+                func Add() {
+                    Acc[T].P += 5
+                }
+                func Get() int32 -> Acc[T].P
+                shared {
+                    var backing int32 = 100
+                    prop P int32 {
+                        get -> backing
+                        set { backing = value }
+                    }
+                }
+            }
+
+            func Main() {
+                let a = Acc[int32]()
+                a.Add()
+                a.Add()
+                System.Console.WriteLine(a.Get())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("110\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_MultipleTypeArguments_GenericStaticField_Runs()
+    {
+        // Multiple type arguments (`Pair[A, B]`) parse as a generic-name
+        // receiver, exercising the GenericNameExpression resolver branch.
+        const string source = """
+            package i1559multiarg
+            import System
+
+            class Pair[A, B]() {
+                func Set() {
+                    Pair[A, B].total = 42
+                }
+                func Get() int32 -> Pair[A, B].total
+                shared {
+                    var total int32 = 0
+                }
+            }
+
+            func Main() {
+                let p = Pair[int32, string]()
+                p.Set()
+                System.Console.WriteLine(p.Get())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_NullableTypeArgument_GenericStaticField_Runs()
+    {
+        // A nullable type argument (`Slot[int32?]`) cannot be shaped as an index
+        // expression, so the receiver arrives as a GenericNameExpression.
+        const string source = """
+            package i1559nullablearg
+            import System
+
+            class Slot[T]() {
+                func Set() {
+                    Slot[int32?].v = 5
+                }
+                func Get() int32 -> Slot[int32?].v
+                shared {
+                    var v int32 = 0
+                }
+            }
+
+            func Main() {
+                let s = Slot[bool]()
+                s.Set()
+                System.Console.WriteLine(s.Get())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("5\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_NestedGenericTypeArgument_GenericStaticField_Runs()
+    {
+        // A nested generic type argument (`Wrap[Inner[int32]]`) is a
+        // generic-name receiver whose sole argument is itself a construction.
+        const string source = """
+            package i1559nestedarg
+            import System
+
+            class Inner[T]() { }
+
+            class Wrap[T]() {
+                func Set() {
+                    Wrap[Inner[int32]].w = 33
+                }
+                func Get() int32 -> Wrap[Inner[int32]].w
+                shared {
+                    var w int32 = 0
+                }
+            }
+
+            func Main() {
+                let x = Wrap[bool]()
+                x.Set()
+                System.Console.WriteLine(x.Get())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("33\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_PerConstructionStorage_IndependentAcrossArgs_Runs()
+    {
+        // Writes through distinct constructions of the same open generic must
+        // target independent per-construction static storage.
+        const string source = """
+            package i1559perconstruction
+            import System
+
+            class Reg[T]() {
+                func Set(v int32) {
+                    Reg[T].slot = v
+                }
+                func Get() int32 -> Reg[T].slot
+                shared {
+                    var slot int32 = 0
+                }
+            }
+
+            func Main() {
+                let a = Reg[int32]()
+                let b = Reg[string]()
+                a.Set(11)
+                b.Set(22)
+                System.Console.WriteLine(a.Get())
+                System.Console.WriteLine(b.Get())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("11\n22\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1559_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Assigning to a static field of a **constructed generic type** via a qualified
receiver — `G[T].staticField = value` — failed to bind: the binder treated the type
receiver as a variable and reported `GS0125 Variable 'G' doesn't exist` (plus one per
type argument). Reading the same field (`G[T].staticField`) and writing a non-generic
static field (`G.staticField = value`) both worked, so the gap was specific to the
constructed-generic type receiver on an **assignment target**.

## Root cause

The READ path (`BindAccessorExpression`) resolves a `G[T]` receiver to the constructed
type via `TryResolveConstructedGenericTypeReceiver`, but the assignment-target (WRITE)
binder only special-cased constructed generic **interfaces**; a class/struct receiver
fell through to `BindExpression`, which bound `G[T]` as an indexer over a variable `G`
→ GS0125.

## Fix (generalized)

- `ExpressionBinder.Access.cs`: a syntax-shape-agnostic
  `TryResolveConstructedGenericTypeReceiver` dispatcher over the existing index-expression
  and generic-name resolvers, so READ and WRITE share one entry point.
- `ExpressionBinder.Assignments.cs`: `BindMemberFieldAssignmentExpression` routes any
  constructed-generic receiver through `BindConstructedGenericStaticFieldWrite` — user
  class/struct (static field **and** static property setter), user interface, and
  imported CLR generic — carrying the construction so the emitter parents the store at
  the correct per-construction `TypeSpec`.
- `ExpressionBinder.Async.cs`: the compound-assignment fallback resolves constructed
  struct/class **and** interface receivers.

Covers simple `=`, compound `+=`/`-=`, `++`/`--`, static property setters, both parser
receiver shapes (`G[T]` index and `G[int32?]` generic-name), and multiple / nullable /
nested type arguments with per-construction storage isolation.

## Validation

- New `Issue1559GenericStaticFieldWriteEmitTests.cs` (9 tests): write-then-read, compound
  `+=`, `++`/`--`, static property setter + compound, multiple type args, nullable type
  arg, nested generic type arg, per-construction storage — all pass.
- Full solution build `-c Release -graph`: 0 warnings, 0 errors.
- Core.Tests: 4895 passed, 1 skipped; RefactoringBaselineTests unaffected.

Fixes #1559

Refs #914
