### PR TITLE
cs2gs: construct primitive-keyword types via qualified CLR name

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/OahuFoundationTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuFoundationTranslationTests.cs
@@ -414,6 +414,28 @@ namespace Demo
     }
 
 
+    /// <summary>
+    /// A C# `new` of a primitive type keyword (e.g. `new string(char, int)`) must be
+    /// emitted with the qualified CLR type name (`System.String(' ', n)`), because the
+    /// G# alias `string` is a language keyword and is not callable as a constructor —
+    /// emitting `string(...)` yields GS0130 ("Function 'string' doesn't exist").
+    /// </summary>
+    [Fact]
+    public void NewStringFromCharCount_EmitsQualifiedClrConstructor()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class PadX
+    {
+        public string Pad(int n) => new string(' ', n);
+    }
+}");
+
+        Assert.Contains("System.String(' ', n)", printed);
+        Assert.DoesNotContain("string(' '", printed);
+    }
+
     private static string TranslateUnit(string source)
     {
         (string printed, RoundTripResult result) = TranslateAndValidate(source);

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -7194,13 +7194,32 @@ public sealed class CSharpToGSharpTranslator
 
         /// <summary>
         /// Maps a constructed type's G# name to a callable construction callee.
-        /// The G# alias <c>object</c> is a keyword, not a function, so constructing
-        /// a <see cref="object"/> (<c>new object()</c> / target-typed <c>new()</c>)
-        /// must spell the qualified type name <c>System.Object</c> instead (OD-T3,
-        /// otherwise GS0130 "Function 'object' doesn't exist").
+        /// A G# primitive type keyword (<c>object</c>, <c>string</c>, <c>decimal</c>,
+        /// …) is a language keyword, not a function, so constructing one
+        /// (<c>new object()</c>, <c>new string(' ', n)</c>, target-typed <c>new()</c>)
+        /// must spell the qualified CLR type name instead (e.g. <c>System.Object</c>,
+        /// <c>System.String</c>) — otherwise gsc reports GS0130 ("Function 'string'
+        /// doesn't exist"). Non-keyword type names are returned unchanged.
         /// </summary>
-        private static string ConstructionCalleeName(string typeName) =>
-            typeName == "object" ? "System.Object" : typeName;
+        private static string ConstructionCalleeName(string typeName) => typeName switch
+        {
+            "object" => "System.Object",
+            "string" => "System.String",
+            "bool" => "System.Boolean",
+            "char" => "System.Char",
+            "decimal" => "System.Decimal",
+            "int8" => "System.SByte",
+            "uint8" => "System.Byte",
+            "int16" => "System.Int16",
+            "uint16" => "System.UInt16",
+            "int32" => "System.Int32",
+            "uint32" => "System.UInt32",
+            "int64" => "System.Int64",
+            "uint64" => "System.UInt64",
+            "float32" => "System.Single",
+            "float64" => "System.Double",
+            _ => typeName,
+        };
 
         /// <summary>
         /// Builds the canonical G# struct literal <c>T{Field: value, ...}</c> from a


### PR DESCRIPTION
## Problem

A C# `new` of a primitive type whose G# spelling is a language keyword —
`new string(' ', n)`, `new decimal(...)`, etc. — was emitted as a call on the
lowercase keyword: `string(' ', n)`. gsc rejects that with GS0130
("Function 'string' doesn't exist") because a type keyword is not callable as a
constructor. Seen in Oahu.Foundation's `Indent.BuildString`
(`new string(' ', (int)offset + indent)`).

## Fix

The construction path already special-cased `object -> System.Object` for exactly
this reason. Generalize `ConstructionCalleeName` to map every G# primitive keyword
alias (`string`, `bool`, `char`, `decimal`, and the sized integer / floating
keywords) to its qualified CLR type name, so `new string(...)` emits
`System.String(' ', n)` and binds. Non-keyword type names are unchanged.

## Validation

- New test `NewStringFromCharCount_EmitsQualifiedClrConstructor`.
- All 351 cs2gs translation tests pass.
- Oahu.Foundation migration: Indent GS0130 cleared (93 -> 92 diagnostics).

Refs #914
