### PR TITLE
cs2gs: declare address-taken locals as mutable (var)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/OahuFoundationTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuFoundationTranslationTests.cs
@@ -276,6 +276,55 @@ namespace Demo
     }
 
     /// <summary>
+    /// A local whose address is taken — passed by C# `ref`/`out` to an existing
+    /// variable, or via an unsafe `&local` address-of — must be declared mutable
+    /// (`var`), never immutable (`let`): gsc rejects taking the address of a `let`
+    /// with GS9005 ("Cannot take address of constant").
+    /// </summary>
+    [Fact]
+    public void LocalPassedByRef_IsDeclaredMutable()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class RefX
+    {
+        private static bool Fill(ref int slot) { slot = 1; return true; }
+        public int Run()
+        {
+            int captured = 0;
+            Fill(ref captured);
+            return captured;
+        }
+    }
+}");
+
+        Assert.Contains("var captured", printed);
+        Assert.DoesNotContain("let captured", printed);
+    }
+
+    [Fact]
+    public void LocalWhoseAddressIsTaken_IsDeclaredMutable()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public static unsafe class AddrX
+    {
+        private static bool Native(int* p) => *p == 0;
+        public static bool Run()
+        {
+            int slot = 0;
+            return Native(&slot);
+        }
+    }
+}");
+
+        Assert.Contains("var slot", printed);
+        Assert.DoesNotContain("let slot", printed);
+    }
+
+    /// <summary>
     /// ADR-0115 §B.12: a suffix-less integer literal whose C# type is wider or
     /// unsigned than int32 (`0xD800000000000000` is `ulong`) is emitted with the
     /// matching G# suffix so the lexer does not reject it.

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -5072,35 +5072,13 @@ public sealed class CSharpToGSharpTranslator
 
         private bool IsLocalReassigned(ILocalSymbol local)
         {
-            SyntaxNode scope = this.currentBodyScope;
-            if (scope == null)
-            {
-                return false;
-            }
-
-            foreach (SyntaxNode node in scope.DescendantNodes())
-            {
-                switch (node)
-                {
-                    case AssignmentExpressionSyntax assignment
-                        when this.BindsTo(assignment.Left, local):
-                        return true;
-
-                    case PostfixUnaryExpressionSyntax postfix
-                        when (postfix.IsKind(SyntaxKind.PostIncrementExpression)
-                                || postfix.IsKind(SyntaxKind.PostDecrementExpression))
-                            && this.BindsTo(postfix.Operand, local):
-                        return true;
-
-                    case PrefixUnaryExpressionSyntax prefix
-                        when (prefix.IsKind(SyntaxKind.PreIncrementExpression)
-                                || prefix.IsKind(SyntaxKind.PreDecrementExpression))
-                            && this.BindsTo(prefix.Operand, local):
-                        return true;
-                }
-            }
-
-            return false;
+            // A local is mutable in G# (`var`) when it is assigned, incremented,
+            // decremented, OR passed by `ref`/`out` (which cs2gs renders as an
+            // address-of `&arg`): taking the address of an immutable `let` is
+            // rejected by gsc with GS9005 ("Cannot take address of constant").
+            // Delegate to the general symbol walk, which already covers the
+            // `ref`/`out` argument case, so both paths stay consistent.
+            return this.IsSymbolReassigned(local, this.currentBodyScope);
         }
 
         private bool BindsTo(ExpressionSyntax expression, ISymbol target)
@@ -5143,6 +5121,11 @@ public sealed class CSharpToGSharpTranslator
                     case ArgumentSyntax argument
                         when !argument.RefOrOutKeyword.IsKind(SyntaxKind.None)
                             && this.BindsTo(argument.Expression, symbol):
+                        return true;
+
+                    case PrefixUnaryExpressionSyntax addressOf
+                        when addressOf.IsKind(SyntaxKind.AddressOfExpression)
+                            && this.BindsTo(addressOf.Operand, symbol):
                         return true;
                 }
             }


### PR DESCRIPTION
## Problem

A local whose address is taken must be mutable in G#, but cs2gs declared it
immutable (`let`) whenever it had an initializer and no plain reassignment. gsc
then rejects the address-of with GS9005 ("Cannot take address of constant").

Two forms are affected:
- A pre-declared variable passed by C# `ref`/`out` (`Fill(ref captured)`).
- An unsafe address-of (`Native(&slot)` / P/Invoke `ReadFile(..., &bytesRead, ...)`).

Seen in Oahu.Foundation: `TreeDecomposition` (`ref propInfos`) and `Win32FileIO`
(`&bytesRead`, `&bytesReadInBlock`).

## Fix

`IsLocalReassigned` (which chooses `let` vs `var` for a local declaration) only
detected assignment / `++` / `--`. It now delegates to the general
`IsSymbolReassigned` walk, which already promotes `ref`/`out` arguments — and this
change adds a case for unsafe `&local` **address-of** expressions. Both address-taking
forms now declare `var`. The two walkers are unified, removing the duplicated logic.

## Validation

- New tests `LocalPassedByRef_IsDeclaredMutable`, `LocalWhoseAddressIsTaken_IsDeclaredMutable`.
- All 353 cs2gs translation tests pass.
- Oahu.Foundation migration: all three GS9005 cleared (92 -> 89 diagnostics).

Refs #914
