### PR TITLE
cs2gs: annotate inferred locals as nullable when used as nullable (#1072)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue1072NullCheckedAsNullableTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1072NullCheckedAsNullableTranslationTests.cs
@@ -191,6 +191,34 @@ namespace Demo
         Assert.Contains("GetChild[T IBox]() T?", printed);
     }
 
+    [Fact]
+    public void NullComparedInferredLocal_RendersNullableType()
+    {
+        // A `var x = e` local with no explicit type whose initializer is a
+        // non-nullable reference but which is compared to `null` is really
+        // nullable: inference over the non-null initializer would pick the
+        // non-nullable type and the `!= nil` guard would fail with GS0129, so an
+        // explicit `T?` annotation must be emitted (issue #1072 inferred-local form).
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class Box { public string Name = string.Empty; }
+    public class C
+    {
+        private static Box Find() => new Box();
+        public string Run()
+        {
+            var found = Find();
+            if (found != null) { return found.Name; }
+            return string.Empty;
+        }
+    }
+}");
+
+        Assert.Contains("found Box? =", printed);
+        Assert.DoesNotContain("let found =", printed);
+    }
+
     private static string TranslateUnit(string source)
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -3385,6 +3385,20 @@ public sealed class CSharpToGSharpTranslator
                         }
                     }
                 }
+                else if (initializer != null &&
+                    this.context.GetDeclaredSymbol(declarator) is ILocalSymbol inferredLocal &&
+                    this.IsPromotedToNullableReference(inferredLocal))
+                {
+                    // Issue #1072 (inferred-type form): a `var x = e` local with no
+                    // explicit type whose initializer is a non-nullable reference but
+                    // which is compared to `nil` / assigned `nil` in scope is really
+                    // nullable. Type inference over the non-null initializer would
+                    // pick the non-nullable type, so the `== nil` / `!= nil` guard
+                    // fails (GS0129) or a later `= nil` fails (GS0156). Emit an
+                    // explicit `T?` annotation so the binding is nullable.
+                    type = MakeNullable(this.typeMapper.Map(
+                        inferredLocal.Type, this.context, declaration.Type.GetLocation()));
+                }
 
                 results.Add(new LocalDeclarationStatement(
                     binding,


### PR DESCRIPTION
## Problem

The issue #1072 nullable-promotion (mark a local as `T?` when it is null-checked
or null-assigned) only ran for locals declared with an **explicit** type. An
inferred `var x = e` local whose initializer is a non-nullable reference but which
is compared to `nil` / assigned `nil` in scope stayed non-nullable — inference over
the non-null initializer picks the non-nullable type, so the later `== nil` / `!= nil`
guard fails with GS0129 (or a `= nil` fails with GS0156).

Example (Oahu.Foundation TreeDecomposition):
```
let displName = attrs.FirstOfType[DisplayNameAttribute]()   // inferred non-null
if displName != nil { ... }                                 // GS0129
```

## Fix

Extend the local-declaration path: when a local has no explicit type but
`IsPromotedToNullableReference` (its declared reference type is non-nullable yet it
is used as nullable), emit an explicit `T?` annotation. Reuses the existing #1072
detection, so no new heuristics.

## Validation

- New test `NullComparedInferredLocal_RendersNullableType`.
- All 354 cs2gs translation tests pass.
- Oahu.Foundation migration: `displName` now `DisplayNameAttribute?`, GS0129 guard
  cleared (89 -> 88 diagnostics).

Refs #914
