### PR TITLE
Fix spurious GS0266 for nullable reference argument overloads (#1552)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -606,13 +606,20 @@ internal sealed class OverloadResolver
         // selection so generic candidates are filtered for applicability against
         // either the explicit type arguments or, in their absence, type inference.
         var explicitTypeArgCount = ce.TypeArgumentList?.Arguments.Count ?? 0;
-        var selected = SelectBestInstanceOverload(overloads, arguments.Length, argumentNames, arguments, out var ambiguous, explicitTypeArgCount);
+        var selected = SelectBestInstanceOverload(overloads, arguments.Length, argumentNames, arguments, out var ambiguous, out var nullSafetyFailure, explicitTypeArgCount);
         if (selected != null)
         {
             return selected;
         }
 
-        if (ambiguous)
+        if (nullSafetyFailure != null)
+        {
+            var argLoc = nullSafetyFailure.Index < ce.Arguments.Count
+                ? ce.Arguments[nullSafetyFailure.Index].Location
+                : ce.Identifier.Location;
+            Diagnostics.ReportWrongArgumentType(argLoc, nullSafetyFailure.ParamName, nullSafetyFailure.ParamType, nullSafetyFailure.ArgType);
+        }
+        else if (ambiguous)
         {
             Diagnostics.ReportAmbiguousOverloadResolution(ce.Identifier.Location, methodName);
         }
@@ -677,9 +684,10 @@ internal sealed class OverloadResolver
         ImmutableArray<string> argumentNames,
         ImmutableArray<BoundExpression>.Builder boundArguments,
         out bool ambiguous,
+        out NullSafetyArgumentMismatch nullSafetyFailure,
         int explicitTypeArgCount = 0)
     {
-        return SelectBestUserOverloadCore(candidates, argumentCount, argumentNames, boundArguments, out ambiguous, explicitTypeArgCount);
+        return SelectBestUserOverloadCore(candidates, argumentCount, argumentNames, boundArguments, out ambiguous, out nullSafetyFailure, explicitTypeArgCount);
     }
 
     /// <summary>
@@ -694,9 +702,11 @@ internal sealed class OverloadResolver
         ImmutableArray<string> argumentNames,
         ImmutableArray<BoundExpression> boundArguments,
         out bool ambiguous,
+        out NullSafetyArgumentMismatch nullSafetyFailure,
         int explicitTypeArgCount = 0)
     {
         ambiguous = false;
+        nullSafetyFailure = null;
         if (candidates.Length == 0)
         {
             return null;
@@ -709,7 +719,7 @@ internal sealed class OverloadResolver
 
         var builder = ImmutableArray.CreateBuilder<BoundExpression>(boundArguments.Length);
         builder.AddRange(boundArguments);
-        return SelectBestUserOverloadCore(candidates, argumentCount, argumentNames, builder, out ambiguous, explicitTypeArgCount);
+        return SelectBestUserOverloadCore(candidates, argumentCount, argumentNames, builder, out ambiguous, out nullSafetyFailure, explicitTypeArgCount);
     }
 
     private FunctionSymbol SelectBestUserOverloadCore(
@@ -718,9 +728,11 @@ internal sealed class OverloadResolver
         ImmutableArray<string> argumentNames,
         ImmutableArray<BoundExpression>.Builder boundArguments,
         out bool ambiguous,
+        out NullSafetyArgumentMismatch nullSafetyFailure,
         int explicitTypeArgCount = 0)
     {
         ambiguous = false;
+        nullSafetyFailure = null;
 
         // Phase 1: applicability.
         var applicable = new List<FunctionSymbol>();
@@ -803,6 +815,23 @@ internal sealed class OverloadResolver
             if (convertible.Count > 0)
             {
                 applicable = convertible;
+            }
+            else
+            {
+                // Issue #1552: every arity-applicable candidate was filtered
+                // out. When the reason is the Kotlin-model null-safety gate — a
+                // nullable REFERENCE argument `S?` reaching a non-nullable,
+                // non-`object` reference parameter — surface the SAME GS0154
+                // the single-candidate path emits, rather than falling through
+                // to a spurious GS0266 ambiguity or a generic
+                // no-applicable-overload. This preserves null safety: the user
+                // is prompted to write `!!` (or narrow) exactly as the
+                // single-overload call already requires.
+                nullSafetyFailure = TryFindNullSafetyArgumentMismatch(applicable, argumentCount, boundArguments);
+                if (nullSafetyFailure != null)
+                {
+                    return null;
+                }
             }
         }
 
@@ -970,6 +999,22 @@ internal sealed class OverloadResolver
                 continue;
             }
 
+            // Issue #1552: Kotlin-model null-safety gate. A nullable REFERENCE
+            // argument `S?` does NOT satisfy a non-nullable REFERENCE parameter
+            // unless the parameter is null-tolerant (`object`/`object?` or any
+            // nullable target). This overrides the #521 reference-upcast leak in
+            // Conversion.Classify (a NullableTypeSymbol exposes its underlying
+            // ClrType, so an IMPORTED `S? -> S` is otherwise mis-classified as
+            // implicit) WITHOUT changing global conversion semantics — we only
+            // treat such a candidate as non-applicable here. Value-type nullables
+            // (`int32?`, user `struct?`, `enum?`) and nullable type-parameter
+            // underlyings are never reference-like, so the gate leaves them
+            // untouched.
+            if (IsNullableReferenceGateRejected(argType, paramType))
+            {
+                return false;
+            }
+
             var conversion = Conversion.Classify(argType, paramType);
             if (conversion.Exists && (conversion.IsImplicit || conversion.IsIdentity))
             {
@@ -1040,6 +1085,175 @@ internal sealed class OverloadResolver
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// Issue #1552: the Kotlin-model null-safety gate used by overload
+    /// applicability. Returns <see langword="true"/> when a nullable REFERENCE
+    /// argument <paramref name="argType"/> (<c>S?</c>) must NOT be accepted by
+    /// the (non-nullable, non-<c>object</c>) reference parameter
+    /// <paramref name="paramType"/>. Passing a nullable reference where a
+    /// non-nullable reference is required is an error in G# (the user must write
+    /// <c>!!</c> or rely on smart-cast narrowing); this mirrors that rule during
+    /// overload resolution so the ambiguity/leak paths cannot silently drop the
+    /// <c>?</c>. The gate deliberately fires ONLY for reference-like nullable
+    /// underlyings, so value-type nullables and nullable type-parameter
+    /// underlyings are unaffected.
+    /// </summary>
+    private static bool IsNullableReferenceGateRejected(TypeSymbol argType, TypeSymbol paramType)
+    {
+        if (argType is not NullableTypeSymbol argNullable)
+        {
+            return false;
+        }
+
+        // Only a REFERENCE-like nullable underlying is subject to the gate.
+        if (!IsReferenceLikeType(argNullable.UnderlyingType))
+        {
+            return false;
+        }
+
+        // A null-tolerant parameter (`object`/`object?` or any nullable target)
+        // accepts null, so the gate does not fire.
+        if (IsNullTolerantParameter(paramType))
+        {
+            return false;
+        }
+
+        // Only reference parameters are gated; a nullable-reference argument to
+        // a value-type parameter is already non-convertible via Conversion.
+        return IsReferenceLikeType(paramType);
+    }
+
+    /// <summary>
+    /// Issue #1552: a parameter is null-tolerant when it accepts a null
+    /// reference: the top type <c>object</c>/<c>object?</c> or any nullable
+    /// target (<c>T?</c>).
+    /// </summary>
+    private static bool IsNullTolerantParameter(TypeSymbol paramType)
+    {
+        if (paramType is NullableTypeSymbol)
+        {
+            return true;
+        }
+
+        if (paramType == TypeSymbol.Object)
+        {
+            return true;
+        }
+
+        return paramType?.ClrType?.IsSameAs(typeof(object)) == true;
+    }
+
+    /// <summary>
+    /// Issue #1552: the reference-like notion used by the null-safety gate,
+    /// mirroring <c>Conversion.IsReferenceLikeTarget</c>. A type is reference-
+    /// like when it is a user interface, a user <c>class</c> (StructSymbol with
+    /// IsClass), the built-in <c>string</c>, or an imported/CLR-backed type
+    /// whose backing is a class/interface. User classes/interfaces carry a null
+    /// ClrType during binding and are matched by their symbol kind.
+    /// </summary>
+    private static bool IsReferenceLikeType(TypeSymbol type)
+    {
+        if (type is InterfaceSymbol)
+        {
+            return true;
+        }
+
+        if (type is StructSymbol { IsClass: true })
+        {
+            return true;
+        }
+
+        if (type == TypeSymbol.String)
+        {
+            return true;
+        }
+
+        if (type?.ClrType is { } clrBacking)
+        {
+            return !clrBacking.IsValueType && !clrBacking.IsPointer && !clrBacking.IsByRef;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Issue #1552: when every arity-applicable candidate was filtered out by
+    /// the convertibility pass, locate the first supplied argument whose
+    /// nullable-reference type is rejected by the null-safety gate against at
+    /// least one candidate's parameter at that position. Returns the mismatch so
+    /// the caller can emit the same GS0154 the single-candidate path produces
+    /// (pointing at the argument), or <see langword="null"/> when the empty set
+    /// is not attributable to the null-safety gate.
+    /// </summary>
+    private static NullSafetyArgumentMismatch TryFindNullSafetyArgumentMismatch(
+        List<FunctionSymbol> candidates,
+        int argumentCount,
+        ImmutableArray<BoundExpression>.Builder boundArguments)
+    {
+        var count = Math.Min(argumentCount, boundArguments.Count);
+        for (var i = 0; i < count; i++)
+        {
+            var argType = boundArguments[i]?.Type;
+            if (argType is not NullableTypeSymbol argNullable || !IsReferenceLikeType(argNullable.UnderlyingType))
+            {
+                continue;
+            }
+
+            foreach (var candidate in candidates)
+            {
+                if (candidate.IsGeneric)
+                {
+                    continue;
+                }
+
+                var parameterOffset = candidate.ExplicitReceiverParameter == null ? 0 : 1;
+                var paramIndex = i + parameterOffset;
+                if (paramIndex < 0 || paramIndex >= candidate.Parameters.Length)
+                {
+                    continue;
+                }
+
+                var parameter = candidate.Parameters[paramIndex];
+                if (parameter.RefKind != RefKind.None || parameter.IsVariadic)
+                {
+                    continue;
+                }
+
+                if (IsNullableReferenceGateRejected(argType, parameter.Type))
+                {
+                    return new NullSafetyArgumentMismatch(i, argType, parameter.Type, parameter.Name);
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Issue #1552: describes a null-safety overload-resolution failure — a
+    /// nullable-reference argument at <see cref="Index"/> that no applicable
+    /// overload can accept without dropping the <c>?</c>. Carries the argument
+    /// and parameter types so the call site can emit GS0154 at the argument.
+    /// </summary>
+    internal sealed class NullSafetyArgumentMismatch
+    {
+        public NullSafetyArgumentMismatch(int index, TypeSymbol argType, TypeSymbol paramType, string paramName)
+        {
+            Index = index;
+            ArgType = argType;
+            ParamType = paramType;
+            ParamName = paramName;
+        }
+
+        public int Index { get; }
+
+        public TypeSymbol ArgType { get; }
+
+        public TypeSymbol ParamType { get; }
+
+        public string ParamName { get; }
     }
 
     /// <summary>
@@ -2431,11 +2645,19 @@ internal sealed class OverloadResolver
                 syntax.Arguments.Count,
                 argumentNames,
                 boundArgumentsBuilder.ToImmutable(),
-                out var ambiguous);
+                out var ambiguous,
+                out var nullSafetyFailure);
 
             if (selectedFn == null)
             {
-                if (ambiguous)
+                if (nullSafetyFailure != null)
+                {
+                    var argLoc = nullSafetyFailure.Index < syntax.Arguments.Count
+                        ? syntax.Arguments[nullSafetyFailure.Index].Location
+                        : syntax.Identifier.Location;
+                    Diagnostics.ReportWrongArgumentType(argLoc, nullSafetyFailure.ParamName, nullSafetyFailure.ParamType, nullSafetyFailure.ArgType);
+                }
+                else if (ambiguous)
                 {
                     Diagnostics.ReportAmbiguousOverloadResolution(syntax.Identifier.Location, classType.Name);
                 }
@@ -2927,11 +3149,19 @@ internal sealed class OverloadResolver
                 syntax.Arguments.Count,
                 argumentNames,
                 boundArgsBuilder.ToImmutable(),
-                out var ambiguous);
+                out var ambiguous,
+                out var nullSafetyFailure);
 
             if (selectedFn == null)
             {
-                if (ambiguous)
+                if (nullSafetyFailure != null)
+                {
+                    var argLoc = nullSafetyFailure.Index < syntax.Arguments.Count
+                        ? syntax.Arguments[nullSafetyFailure.Index].Location
+                        : syntax.Identifier.Location;
+                    Diagnostics.ReportWrongArgumentType(argLoc, nullSafetyFailure.ParamName, nullSafetyFailure.ParamType, nullSafetyFailure.ArgType);
+                }
+                else if (ambiguous)
                 {
                     Diagnostics.ReportAmbiguousOverloadResolution(syntax.Identifier.Location, "init");
                 }
@@ -4076,10 +4306,17 @@ internal sealed class OverloadResolver
         var overloadSet = Scope.TryLookupFunctions(syntax.Identifier.Text);
         if (overloadSet.Length > 1)
         {
-            var selected = SelectBestUserOverload(overloadSet, syntax.Arguments.Count, argumentNames, boundArguments, out var overloadAmbiguous, syntax.TypeArgumentList?.Arguments.Count ?? 0);
+            var selected = SelectBestUserOverload(overloadSet, syntax.Arguments.Count, argumentNames, boundArguments, out var overloadAmbiguous, out var nullSafetyFailure, syntax.TypeArgumentList?.Arguments.Count ?? 0);
             if (selected == null)
             {
-                if (overloadAmbiguous)
+                if (nullSafetyFailure != null)
+                {
+                    var argLoc = nullSafetyFailure.Index < syntax.Arguments.Count
+                        ? syntax.Arguments[nullSafetyFailure.Index].Location
+                        : syntax.Identifier.Location;
+                    Diagnostics.ReportWrongArgumentType(argLoc, nullSafetyFailure.ParamName, nullSafetyFailure.ParamType, nullSafetyFailure.ArgType);
+                }
+                else if (overloadAmbiguous)
                 {
                     Diagnostics.ReportAmbiguousOverloadResolution(syntax.Identifier.Location, syntax.Identifier.Text);
                 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1552NullableArgOverloadTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1552NullableArgOverloadTests.cs
@@ -1,0 +1,327 @@
+// <copyright file="Issue1552NullableArgOverloadTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1552. When a nullable REFERENCE argument <c>S?</c> is passed to an
+/// overload SET, overload resolution must do the null-safe thing rather than
+/// report a spurious GS0266 ambiguity (which ignored the <c>?</c> wrapper):
+///
+/// <list type="bullet">
+/// <item>If a null-tolerant overload exists (a parameter typed <c>object</c>/
+/// <c>object?</c> or itself nullable), it is selected — a nullable reference is
+/// a valid value there.</item>
+/// <item>If EVERY surviving overload wants a non-nullable, non-<c>object</c>
+/// reference parameter, the call reports the SAME GS0154 the single-candidate
+/// path already emits, prompting the user to write <c>!!</c> (or narrow).</item>
+/// </list>
+///
+/// Crucially this PRESERVES G#'s Kotlin-model null safety: <c>T? -&gt; T</c>
+/// (reference) is NOT made implicit anywhere. The abandoned PR #1553 silenced
+/// GS0154/GS0155 by making that conversion implicit language-wide; this fix does
+/// not — the null-safety diagnostic is retained, only re-routed away from the
+/// spurious ambiguity. Every user type below uses an <c>Issue1552</c>-unique
+/// name because the in-process FunctionTypeSymbol cache is not cleared between
+/// tests.
+/// </summary>
+public class Issue1552NullableArgOverloadTests
+{
+    [Fact]
+    public void AOverload_NullableImportedType_SelectsObjectOverload_NoDiagnostics()
+    {
+        // Repro (a): imported base/derived (object / System.Type). A nullable
+        // `Type?` argument must cleanly select F(object) — object is null-
+        // tolerant — with NO GS0266 and no error.
+        const string source = @"
+package p
+import System
+func Issue1552AF(caller object) int32 -> 1
+func Issue1552AF(caller Type) int32 -> 2
+func Issue1552AUseNull(t Type?) int32 -> Issue1552AF(t)
+";
+        var compilation = Compile(source);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
+        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+
+        var selected = FindCall(compilation, "Issue1552AF");
+        Assert.NotNull(selected);
+        Assert.Equal(TypeSymbol.Object, selected.Parameters[0].Type);
+    }
+
+    [Fact]
+    public void AOverload_NonNullableImportedType_StillSelectsDerivedOverload()
+    {
+        // Control: a NON-nullable `Type` argument still selects F(Type) — the
+        // gate never fires for a non-nullable argument.
+        const string source = @"
+package p
+import System
+func Issue1552NnF(caller object) int32 -> 1
+func Issue1552NnF(caller Type) int32 -> 2
+func Issue1552NnUse(t Type) int32 -> Issue1552NnF(t)
+";
+        var compilation = Compile(source);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+
+        var selected = FindCall(compilation, "Issue1552NnF");
+        Assert.NotNull(selected);
+        Assert.NotEqual(TypeSymbol.Object, selected.Parameters[0].Type);
+        Assert.Equal(typeof(System.Type), selected.Parameters[0].Type.ClrType);
+    }
+
+    [Fact]
+    public void CUser_NullableUserDerived_ReportsGS0154_NotGS0266()
+    {
+        // Repro (c): only non-nullable-reference overloads (no object overload).
+        // A nullable `Issue1552CDog?` argument must report GS0154 (the same
+        // null-safety diagnostic the single-candidate path emits) — NOT GS0266,
+        // NOT a generic no-applicable-overload.
+        const string source = @"
+package p
+open class Issue1552CAnimal {}
+class Issue1552CDog : Issue1552CAnimal {}
+func Issue1552CG(a Issue1552CAnimal) int32 -> 1
+func Issue1552CG(d Issue1552CDog) int32 -> 2
+func Issue1552CUse(d Issue1552CDog?) int32 -> Issue1552CG(d)
+";
+        var compilation = Compile(source);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
+        var gs0154 = Assert.Single(result.Diagnostics, d => d.Id == "GS0154");
+        Assert.Contains("Issue1552CAnimal", gs0154.Message);
+        Assert.Contains("Issue1552CDog?", gs0154.Message);
+    }
+
+    [Fact]
+    public void CUser_SingleCandidate_AlsoReportsGS0154_Analog()
+    {
+        // The single-candidate analog of repro (c) already reports GS0154 today;
+        // the overload case above must MATCH it (same diagnostic id).
+        const string source = @"
+package p
+open class Issue1552SAnimal {}
+class Issue1552SDog : Issue1552SAnimal {}
+func Issue1552SSink(a Issue1552SAnimal) int32 -> 1
+func Issue1552SUse(d Issue1552SDog?) int32 -> Issue1552SSink(d)
+";
+        var compilation = Compile(source);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0154");
+    }
+
+    [Fact]
+    public void CUser_BangEscape_Compiles_SelectsDerivedOverload()
+    {
+        // The `!!` escape hatch narrows `Dog?` to `Dog`, so the gate never fires
+        // and the derived overload G(Dog) is selected.
+        const string source = @"
+package p
+open class Issue1552BAnimal {}
+class Issue1552BDog : Issue1552BAnimal {}
+func Issue1552BG(a Issue1552BAnimal) int32 -> 1
+func Issue1552BG(d Issue1552BDog) int32 -> 2
+func Issue1552BUse(d Issue1552BDog?) int32 -> Issue1552BG(d!!)
+";
+        var compilation = Compile(source);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+
+        var selected = FindCall(compilation, "Issue1552BG");
+        Assert.NotNull(selected);
+        Assert.Equal("Issue1552BDog", selected.Parameters[0].Type.Name);
+    }
+
+    [Fact]
+    public void NonNullableUserArg_StillSelectsDerivedOverload()
+    {
+        // Control: a non-nullable `Dog{}` argument still selects G(Dog).
+        const string source = @"
+package p
+open class Issue1552NAnimal {}
+class Issue1552NDog : Issue1552NAnimal {}
+func Issue1552NG(a Issue1552NAnimal) int32 -> 1
+func Issue1552NG(d Issue1552NDog) int32 -> 2
+func Issue1552NUse() int32 -> Issue1552NG(Issue1552NDog{})
+";
+        var compilation = Compile(source);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+
+        var selected = FindCall(compilation, "Issue1552NG");
+        Assert.NotNull(selected);
+        Assert.Equal("Issue1552NDog", selected.Parameters[0].Type.Name);
+    }
+
+    [Fact]
+    public void NullableParameterOverload_StillApplies_ForNullableRefArg()
+    {
+        // A null-tolerant nullable-parameter overload accepts the nullable-ref
+        // argument (S? -> S? / base-S?). No GS0154, no GS0266.
+        const string source = @"
+package p
+open class Issue1552PAnimal {}
+class Issue1552PDog : Issue1552PAnimal {}
+func Issue1552PG(a Issue1552PAnimal?) int32 -> 1
+func Issue1552PG(s string) int32 -> 2
+func Issue1552PUse(d Issue1552PDog?) int32 -> Issue1552PG(d)
+";
+        var compilation = Compile(source);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
+        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+
+        var selected = FindCall(compilation, "Issue1552PG");
+        Assert.NotNull(selected);
+        Assert.IsType<NullableTypeSymbol>(selected.Parameters[0].Type);
+    }
+
+    [Fact]
+    public void ValueTypeNullable_Unaffected_ByGate()
+    {
+        // The gate must NOT touch value-type nullables. `int32?` still lifts /
+        // widens through the normal conversion lattice; here it selects the
+        // lifted-widening `int64?` overload with no null-safety GS0154.
+        const string source = @"
+package p
+func Issue1552VG(a int64?) int32 -> 1
+func Issue1552VG(a string) int32 -> 2
+func Issue1552VUse(n int32?) int32 -> Issue1552VG(n)
+";
+        var compilation = Compile(source);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0154");
+        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+
+        var selected = FindCall(compilation, "Issue1552VG");
+        Assert.NotNull(selected);
+        Assert.IsType<NullableTypeSymbol>(selected.Parameters[0].Type);
+    }
+
+    [Fact]
+    public void GenuineAmbiguity_StillReportsGS0266()
+    {
+        // Two unrelated interfaces both satisfied by the argument genuinely tie.
+        // The nullable-reference gate does not fire (both params are null-
+        // tolerant only via nullable form? no — they are non-nullable
+        // interfaces, but the argument is non-nullable `Both`), so this remains
+        // a real ambiguity => GS0266.
+        const string source = @"
+package p
+interface Issue1552IA {}
+interface Issue1552IB {}
+class Issue1552Both : Issue1552IA, Issue1552IB {}
+func Issue1552AmbTake(x Issue1552IA) int32 -> 1
+func Issue1552AmbTake(x Issue1552IB) int32 -> 2
+func Issue1552AmbUse(b Issue1552Both) int32 -> Issue1552AmbTake(b)
+";
+        var compilation = Compile(source);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0266");
+    }
+
+    [Fact]
+    public void DeeperChain_GrandbaseBaseDerived_NullableDerived_ReportsGS0154()
+    {
+        // Generality: any base/derived depth. A `Derived?` argument against
+        // overloads on Grandbase and Base (no object overload) reports GS0154.
+        const string source = @"
+package p
+open class Issue1552DGrand {}
+open class Issue1552DBase : Issue1552DGrand {}
+class Issue1552DDerived : Issue1552DBase {}
+func Issue1552DG(a Issue1552DGrand) int32 -> 1
+func Issue1552DG(b Issue1552DBase) int32 -> 2
+func Issue1552DUse(d Issue1552DDerived?) int32 -> Issue1552DG(d)
+";
+        var compilation = Compile(source);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
+        var gs0154 = Assert.Single(result.Diagnostics, d => d.Id == "GS0154");
+        Assert.Contains("Issue1552DDerived?", gs0154.Message);
+    }
+
+    [Fact]
+    public void DeeperChain_NullableDerived_ToObject_SelectsObject()
+    {
+        // Generality: with a null-tolerant object overload present, a deep-chain
+        // nullable IMPORTED argument (ArgumentException : ... : Exception)
+        // selects object cleanly (imported reference types have a live ClrType,
+        // so S? -> object is a genuine implicit box/upcast). The non-object
+        // Exception overload is dropped by the null-safety gate.
+        const string source = @"
+package p
+import System
+func Issue1552OG(a object) int32 -> 1
+func Issue1552OG(b Exception) int32 -> 2
+func Issue1552OUse(d ArgumentException?) int32 -> Issue1552OG(d)
+";
+        var compilation = Compile(source);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
+        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+
+        var selected = FindCall(compilation, "Issue1552OG");
+        Assert.NotNull(selected);
+        Assert.Equal(TypeSymbol.Object, selected.Parameters[0].Type);
+    }
+
+    private static Compilation Compile(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        return new Compilation(tree) { IsLibrary = true };
+    }
+
+    private static FunctionSymbol FindCall(Compilation compilation, string callName)
+    {
+        var collector = new CallCollector(callName);
+        foreach (var body in compilation.BoundProgram.Functions.Values)
+        {
+            collector.Visit(body);
+        }
+
+        return collector.Collected.FirstOrDefault();
+    }
+
+    private sealed class CallCollector : BoundTreeWalker
+    {
+        private readonly string callName;
+
+        public CallCollector(string callName)
+        {
+            this.callName = callName;
+        }
+
+        public List<FunctionSymbol> Collected { get; } = new();
+
+        public override void VisitExpression(BoundExpression node)
+        {
+            switch (node)
+            {
+                case BoundCallExpression call when call.Function.Name == callName:
+                    Collected.Add(call.Function);
+                    break;
+                case BoundUserInstanceCallExpression instanceCall when instanceCall.Method.Name == callName:
+                    Collected.Add(instanceCall.Method);
+                    break;
+            }
+
+            base.VisitExpression(node);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1552. Refs #914.

When a nullable **reference** argument `S?` is passed to an **overload set**, overload resolution wrongly reported **GS0266 (ambiguous)** — the betterness/applicability logic ignored the `?` wrapper. This fix makes overload resolution do the null-safe thing instead.

### Approach (null-safety **preserving**)

This deliberately does **not** repeat the abandoned PR #1553, which made `S? -> S` (nullable → non-nullable reference) an implicit conversion language-wide in `Conversion.Classify`. That removed G#'s Kotlin-model null-safety guard (silencing GS0154/GS0155). **We do not make `T? -> T` (reference) implicit anywhere.** `Conversion.cs` is untouched; the `Issue1255` null-safety tests stay green.

Instead, a precise null-safety **gate** is added to overload applicability in `OverloadResolver.cs`:

- A nullable **reference** argument `S?` does **not** satisfy a non-nullable, non-`object` **reference** parameter — *unless* the parameter is null-tolerant (`object`/`object?` or itself nullable `T?`). This is applied in `IsConvertibilityApplicable`, so it **overrides the #521 reference-upcast leak** in `Conversion.Classify` (a `NullableTypeSymbol` exposes its underlying `ClrType`, so an imported `S? -> S` was otherwise mis-classified as implicit) **without** changing global conversion semantics.
- When every arity-applicable candidate is dropped **solely** by this gate, the call reports the **same GS0154** the single-candidate path already emits (pointed at the argument), rather than a spurious **GS0266** or a generic no-applicable-overload — prompting the user to write `!!` (or narrow via smart-cast).

The gate fires only for **reference-like** nullable underlyings (user `class`, interface, `string`, imported reference types, and user types with a null `ClrType` during binding). It never fires for value-type nullables (`int32?`, user `struct?`, `enum?`) or nullable type-parameter underlyings. It is per-argument, so it generalizes to any base/derived depth, any arity, and any argument position, across BCL/imported and user-declared reference types and interfaces.

### Behavior

| Case | Before | After |
| --- | --- | --- |
| `F(object)/F(Type)` with `Type?` arg | GS0266 | selects `F(object)` (clean) |
| `F(object)/F(Type)` with `Type` arg | selects `F(Type)` | selects `F(Type)` (unchanged) |
| `G(Animal)/G(Dog)` with `Dog?` arg | GS0266 | **GS0154** (matches single-candidate `Sink(Animal)`) |
| `G(Dog)` via `G(d!!)` | — | selects `G(Dog)` |
| value-type nullable (`int32?`) overloads | unchanged | unchanged (gate inert) |
| two unrelated interfaces genuinely tie | GS0266 | GS0266 (unchanged) |

### cs2gs

No change needed. `TranslateArgument` already applies `ReceiverNeedsNullForgiveness`, a **flow-analysis-gated** (`NullableFlowState.NotNull`) pass that emits `!!` for exactly the clearly-correct, runtime-safe subset (a declared-nullable reference argument C# has proven non-null). With this gsc fix, the object-overload Foundation cases (`Logging.Log(object)/Log(Type)`, etc.) now resolve to the `object` overload with no `!!` at all. The residual case — a genuinely-maybe-null field flowing into an overload set with **only** non-nullable-reference params where C# did **not** prove non-null — is consciously **deferred**: auto-emitting `!!` there would assert non-null where C# permitted null, changing runtime semantics, which is the unsafe hack to avoid.

### Tests

- New `test/Core.Tests/CodeAnalysis/Binding/Issue1552NullableArgOverloadTests.cs` (11 tests, `Issue1552`-unique type names): object-overload selection (imported), GS0154 for user-type-only overloads + single-candidate parity, `!!` escape, non-nullable control, nullable-param overload still applies, value-type-nullable unaffected, genuine GS0266 ambiguity, deeper base chain.
- Full Core.Tests: **4906 passed, 0 failed** (includes `RefactoringBaselineTests` — no IL/baseline change).
- Targeted Compiler.Tests (`Issue1552|Issue1255|Overload|Issue1154`): **73 passed**.
- Cs2Gs.Tests: **354 passed**.
