### PR TITLE
cs2gs: brace-delimit interpolation holes before identifier chars

### DIFF
--- a/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
@@ -670,8 +670,9 @@ public static class GSharpPrinter
     {
         var sb = new StringBuilder();
         sb.Append('"');
-        foreach (var part in interpolated.Parts)
+        for (var i = 0; i < interpolated.Parts.Count; i++)
         {
+            var part = interpolated.Parts[i];
             if (!part.IsHole)
             {
                 sb.Append(RenderInterpolationText(part.Text));
@@ -680,7 +681,8 @@ public static class GSharpPrinter
 
             var canUseShorthand = part.Expression is IdentifierExpression
                 && string.IsNullOrEmpty(part.Alignment)
-                && string.IsNullOrEmpty(part.Format);
+                && string.IsNullOrEmpty(part.Format)
+                && !NextLiteralContinuesIdentifier(interpolated.Parts, i);
 
             if (canUseShorthand)
             {
@@ -708,6 +710,23 @@ public static class GSharpPrinter
 
         sb.Append('"');
         return sb.ToString();
+    }
+
+    private static bool NextLiteralContinuesIdentifier(IReadOnlyList<InterpolationPart> parts, int holeIndex)
+    {
+        if (holeIndex + 1 >= parts.Count)
+        {
+            return false;
+        }
+
+        var next = parts[holeIndex + 1];
+        if (next.IsHole || string.IsNullOrEmpty(next.Text))
+        {
+            return false;
+        }
+
+        var first = next.Text[0];
+        return char.IsLetterOrDigit(first) || first == '_';
     }
 
     private static string RenderStatement(GStatement statement, int indent)

--- a/tools/cs2gs/Cs2Gs.Tests/BodyTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/BodyTranslationTests.cs
@@ -322,6 +322,21 @@ public class BodyTranslationTests
         Assert.Contains("\"$n items at $$$n each\"", body);
     }
 
+    /// <summary>An identifier hole immediately followed by literal text that begins
+    /// with an identifier-continuation character (letter/digit/underscore) must use
+    /// the braced <c>${ident}</c> form so the trailing characters are not absorbed
+    /// into the interpolated variable name (regression: <c>$"{thrdid}_{ticks}"</c>).</summary>
+    [Fact]
+    public void StringInterpolation_BracesHoleWhenFollowedByIdentifierChar()
+    {
+        string body = GetMethodBody(
+            "var s = $\"{n}_more{n}x{n}.{n} end{n}\";",
+            extraLocals: "var more = 0; var x = 0;");
+
+        // `_`, `x`, follow the hole -> braced; `.`, ` `, and end-of-string do not -> shorthand.
+        Assert.Contains("\"${n}_more${n}x$n.$n end$n\"", body);
+    }
+
     /// <summary>local <c>var</c> never reassigned becomes <c>let</c>; a reassigned
     /// local becomes <c>var</c>; <c>const</c> stays <c>const</c> (ADR-0115 §B.3,
     /// data-flow driven).</summary>


### PR DESCRIPTION
cs2gs: brace-delimit interpolation holes before identifier chars

An identifier hole rendered with the `$ident` shorthand greedily absorbs any
following literal text that begins with an identifier-continuation character
(letter, digit, or underscore). So C# `$"{thrdid}_{ticks}"` printed as
`"$thrdid_$ticks"`, which G# reads as the (undefined) variable `thrdid_`
(GS0125), and `$"{c}yyyy_MM_dd..."` became `"$cyyyy_MM_dd..."`.

Suppress the shorthand and use the braced `${ident}` form whenever the next
literal part starts with a letter, digit, or `_`. Punctuation (`.`, space,
etc.) and end-of-string still use the compact `$ident` form.

Clears 2 GS0125 diagnostics in the Oahu.Foundation migration.

Refs #914
