### PR TITLE
cs2gs: nullable function type for delegate params defaulted to null

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/OahuFoundationTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuFoundationTranslationTests.cs
@@ -325,6 +325,33 @@ namespace Demo
     }
 
     /// <summary>
+    /// A C# delegate parameter with an explicit <c>= null</c> default (e.g.
+    /// <c>Action&lt;T&gt; report = null</c>) is nullable by construction: a
+    /// non-nullable G# function type cannot carry a <c>nil</c> default (gsc GS0265),
+    /// so the parameter must render as the nullable arrow form
+    /// <c>((T) -&gt; void)? = nil</c> now that nullable function types exist (#1399).
+    /// </summary>
+    [Fact]
+    public void DelegateParameterWithNullDefault_RendersNullableArrow()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    using System;
+    public static class Notifier
+    {
+        public static void Run(int count, Action<int> report = null, Func<bool> cancel = null)
+        {
+            report?.Invoke(count);
+        }
+    }
+}");
+
+        Assert.Contains("report ((int32) -> void)? = nil", printed);
+        Assert.Contains("cancel (() -> bool)? = nil", printed);
+    }
+
+    /// <summary>
     /// ADR-0115 §B.12: a suffix-less integer literal whose C# type is wider or
     /// unsigned than int32 (`0xD800000000000000` is `ulong`) is emitted with the
     /// matching G# suffix so the lexer does not reject it.

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -4959,6 +4959,11 @@ public sealed class CSharpToGSharpTranslator
                     new PointerTypeReference(pointer.ElementType) { IsNullable = true },
                 TupleTypeReference tuple =>
                     new TupleTypeReference(tuple.ElementTypes) { IsNullable = true },
+                ArrowTypeReference arrow =>
+                    new ArrowTypeReference(arrow.ParameterTypes, arrow.ReturnTypes, arrow.IsAsync)
+                    {
+                        IsNullable = true,
+                    },
                 _ => reference,
             };
         }
@@ -5345,6 +5350,20 @@ public sealed class CSharpToGSharpTranslator
                 || declared.NullableAnnotation == NullableAnnotation.Annotated)
             {
                 return false;
+            }
+
+            // A function-type (delegate) parameter with an explicit `= null`
+            // default is nullable by construction: a non-nullable function type
+            // cannot carry a `nil` default at all (gsc GS0265 at the declaration
+            // itself), so it must render `((…) -> R)?`. This is scoped to delegate
+            // types because promoting arbitrary reference parameters cascades
+            // nullable-mismatch errors (GS0156) at pass-through call sites that
+            // would each need their own flow-driven promotion.
+            if (symbol is IParameterSymbol { HasExplicitDefaultValue: true } defaulted
+                && defaulted.ExplicitDefaultValue is null
+                && defaulted.Type.TypeKind == TypeKind.Delegate)
+            {
+                return true;
             }
 
             return this.IsUsedAsNullable(symbol, this.GetNullabilityScope(symbol));


### PR DESCRIPTION
cs2gs: render nullable function type for delegate params defaulted to null

A C# delegate parameter with an explicit `= null` default (e.g.
`Action<ProgressMessage> report = null`) is nullable by construction: the call
site may omit it, so it must accept `nil`. A non-nullable G# function type
cannot carry a `nil` default at all — gsc rejects it at the declaration with
GS0265 ("'nil' is not a valid default for value-type parameter of type
'(...) -> void'").

Now that nullable function types exist (#1399), promote such a parameter to the
nullable arrow form `((...) -> R)? = nil`. The promotion is scoped to delegate
types (TypeKind.Delegate): promoting arbitrary reference parameters with null
defaults cascades nullable-mismatch errors at pass-through call sites that would
each need their own flow-driven promotion.

Also fixes `MakeNullable`, which silently dropped nullability for
`ArrowTypeReference` (it only handled named/array/pointer/tuple), so the arrow
`?` is now actually applied.

Clears the GS0265 diagnostics in the Oahu.Foundation migration (e.g. FileEx.Copy
`report`/`cancel` params).

Refs #914
