### PR TITLE
Fix invalid IL from nullable value-type if-guard narrowing (#1547)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -680,12 +680,20 @@ internal sealed partial class ExpressionBinder
                     // Issue #208: apply any [MemberNotNull] narrowing so that
                     // chained access like `_name.Length` after a [MemberNotNull]
                     // call is accepted without a nil-guard.
-                    receiver = new BoundFieldAccessExpression(
-                        null,
-                        new BoundVariableExpression(null, implicitField.Receiver),
-                        implicitField.StructType,
-                        implicitField.Field,
-                        TryGetNarrowedType(implicitField));
+                    receiver = BuildNarrowedRead(
+                        new BoundFieldAccessExpression(
+                            null,
+                            new BoundVariableExpression(null, implicitField.Receiver),
+                            implicitField.StructType,
+                            implicitField.Field),
+                        implicitField.Field.Type,
+                        TryGetNarrowedType(implicitField),
+                        nt => new BoundFieldAccessExpression(
+                            null,
+                            new BoundVariableExpression(null, implicitField.Receiver),
+                            implicitField.StructType,
+                            implicitField.Field,
+                            nt));
                 }
                 else if (variable is ImplicitStaticFieldVariableSymbol implicitStaticField)
                 {
@@ -759,7 +767,11 @@ internal sealed partial class ExpressionBinder
                 }
                 else
                 {
-                    receiver = new BoundVariableExpression(null, variable, TryGetNarrowedType(variable));
+                    receiver = BuildNarrowedRead(
+                        new BoundVariableExpression(null, variable),
+                        variable.Type,
+                        TryGetNarrowedType(variable),
+                        narrowed => new BoundVariableExpression(null, variable, narrowed));
                 }
             }
             else if (scope.TryLookupImport(name, out var matchedImport)

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -470,12 +470,20 @@ internal sealed partial class ExpressionBinder
             // `field.Member` accesses after a [MemberNotNull] helper call are
             // accepted without a nil-guard.
             var narrowedFieldType = TryGetNarrowedType(implicitField);
-            return new BoundFieldAccessExpression(
-                null,
-                new BoundVariableExpression(null, implicitField.Receiver),
-                implicitField.StructType,
-                implicitField.Field,
-                narrowedFieldType);
+            return BuildNarrowedRead(
+                new BoundFieldAccessExpression(
+                    null,
+                    new BoundVariableExpression(null, implicitField.Receiver),
+                    implicitField.StructType,
+                    implicitField.Field),
+                implicitField.Field.Type,
+                narrowedFieldType,
+                nt => new BoundFieldAccessExpression(
+                    null,
+                    new BoundVariableExpression(null, implicitField.Receiver),
+                    implicitField.StructType,
+                    implicitField.Field,
+                    nt));
         }
 
         // Issue #261: bare static field name inside a shared method body.
@@ -539,7 +547,65 @@ internal sealed partial class ExpressionBinder
                 implicitProp.Property);
         }
 
-        return new BoundVariableExpression(null, variable, TryGetNarrowedType(variable));
+        return BuildNarrowedRead(
+            new BoundVariableExpression(null, variable),
+            variable.Type,
+            TryGetNarrowedType(variable),
+            narrowed => new BoundVariableExpression(null, variable, narrowed));
+    }
+
+    /// <summary>
+    /// Issue #1547: builds a smart-cast-narrowed read from a bare (declared-type)
+    /// read and its narrowed static type.
+    /// <para>
+    /// For a nullable <em>value</em> type (e.g. <c>int32?</c> =
+    /// <c>System.Nullable&lt;int32&gt;</c>) narrowed to its underlying type, the
+    /// storage slot/field holds a <c>Nullable&lt;T&gt;</c> while the narrowed
+    /// static type is the bare <c>T</c>. A plain narrowed load would leave a
+    /// <c>Nullable&lt;T&gt;</c> on the stack where <c>T</c> is expected, which
+    /// fails ilverify. Instead we wrap the bare read in a synthesized <c>!!</c>
+    /// (<see cref="BoundUnaryOperatorKind.NullAssertion"/>), reusing the proven
+    /// value-type unwrap emit path (spill → <c>Nullable&lt;T&gt;::get_Value</c>).
+    /// The nil-guard already proved the value non-nil, so the assertion can never
+    /// throw at runtime.
+    /// </para>
+    /// <para>
+    /// For a nullable <em>reference</em> type the narrowed type and its storage
+    /// share the CLR representation, so narrowing is a metadata no-op and the
+    /// bare narrowed read is produced unchanged (wrapping in <c>!!</c> would add a
+    /// pointless runtime null-check).
+    /// </para>
+    /// </summary>
+    /// <param name="bareRead">A read of the declared (un-narrowed) type.</param>
+    /// <param name="declaredType">The variable/member's declared type.</param>
+    /// <param name="narrowedType">The narrowed static type, or <c>null</c>.</param>
+    /// <param name="makeNarrowedNode">Factory building the narrowed read node for
+    /// the reference-nullable (metadata no-op) case.</param>
+    /// <returns>The narrowed read (possibly a value-type unwrap).</returns>
+    private static BoundExpression BuildNarrowedRead(
+        BoundExpression bareRead,
+        TypeSymbol declaredType,
+        TypeSymbol narrowedType,
+        Func<TypeSymbol, BoundExpression> makeNarrowedNode)
+    {
+        if (narrowedType == null)
+        {
+            return bareRead;
+        }
+
+        // A value-type `Nullable<T>` narrowed to its (value-type) underlying `T`
+        // needs the storage `Nullable<T>` unwrapped on load. Reference-type
+        // nullables narrow to a reference underlying and share the CLR shape, so
+        // they fall through to the bare narrowed read.
+        if (declaredType is NullableTypeSymbol nullable
+            && NullableLifting.IsValueTypeNullable(nullable)
+            && narrowedType is not NullableTypeSymbol)
+        {
+            var op = BoundUnaryOperator.Bind(SyntaxKind.BangBangToken, declaredType);
+            return new BoundUnaryExpression(null, op, bareRead);
+        }
+
+        return makeNarrowedNode(narrowedType);
     }
 
     private TypeSymbol TryGetNarrowedType(VariableSymbol variable)
@@ -612,7 +678,11 @@ internal sealed partial class ExpressionBinder
                     var narrowed = TryGetNarrowedType(path);
                     return narrowed == null
                         ? node
-                        : new BoundFieldAccessExpression(null, fa.Receiver, fa.StructType, fa.Field, narrowed);
+                        : BuildNarrowedRead(
+                            new BoundFieldAccessExpression(null, fa.Receiver, fa.StructType, fa.Field),
+                            fa.Field.Type,
+                            narrowed,
+                            nt => new BoundFieldAccessExpression(null, fa.Receiver, fa.StructType, fa.Field, nt));
                 }
 
             case BoundPropertyAccessExpression pa when pa.NarrowedType == null:
@@ -625,7 +695,11 @@ internal sealed partial class ExpressionBinder
                     var narrowed = TryGetNarrowedType(path);
                     return narrowed == null
                         ? node
-                        : new BoundPropertyAccessExpression(null, pa.Receiver, pa.StructType, pa.Property, narrowed);
+                        : BuildNarrowedRead(
+                            new BoundPropertyAccessExpression(null, pa.Receiver, pa.StructType, pa.Property),
+                            pa.Property.Type,
+                            narrowed,
+                            nt => new BoundPropertyAccessExpression(null, pa.Receiver, pa.StructType, pa.Property, nt));
                 }
 
             default:

--- a/test/Compiler.Tests/Emit/Issue1547StatementNilGuardValueNarrowingEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1547StatementNilGuardValueNarrowingEmitTests.cs
@@ -1,0 +1,336 @@
+// <copyright file="Issue1547StatementNilGuardValueNarrowingEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1547 — narrowing a nullable VALUE type via an if-statement nil-guard
+/// (<c>if v != nil { ... }</c>) previously emitted invalid IL. The if-statement
+/// classifier (<c>StatementBinder.TryClassifyNilGuard</c>) accepts value-type
+/// nullables (<c>int32?</c> = the CLR struct <c>System.Nullable&lt;int32&gt;</c>)
+/// and narrows a read of <c>v</c> inside the block to the underlying <c>int32</c>.
+/// But the storage slot holds a <c>Nullable&lt;int32&gt;</c>, so a bare narrowed
+/// load left a <c>Nullable&lt;T&gt;</c> on the stack where <c>T</c> was expected,
+/// failing ilverify with <c>[StackUnexpected] found Nullable`1&lt;int32&gt;,
+/// expected Int32</c>.
+/// <para>
+/// The fix (<c>ExpressionBinder.BuildNarrowedRead</c>) wraps a narrowed
+/// value-type-nullable read in a synthesized <c>!!</c>
+/// (<c>BoundUnaryOperatorKind.NullAssertion</c>), reusing the proven value-type
+/// unwrap emit path (spill → <c>Nullable&lt;T&gt;::get_Value</c>). The nil-guard
+/// already proved the value non-nil, so the assertion never throws. Reference
+/// nullables keep a bare narrowed read (a metadata no-op).
+/// </para>
+/// Every facet below fails ilverify on current main and passes after the fix.
+/// Each uses a UNIQUE package/type name because the in-process
+/// <c>FunctionTypeSymbol</c> cache is name-keyed for user types.
+/// </summary>
+public class Issue1547StatementNilGuardValueNarrowingEmitTests
+{
+    [Fact]
+    public void EndToEnd_Int32_ComparisonInGuard_Runs()
+    {
+        // The canonical issue #1547 repro: `if v != nil { return v > 0 }`.
+        const string source = """
+            package i1547int32cmp
+            import System
+
+            func StmtNarrow(v int32?) bool {
+                if v != nil { return v > 0 }
+                return false
+            }
+
+            func Main() {
+                Console.WriteLine(StmtNarrow(5))
+                Console.WriteLine(StmtNarrow(-1))
+                Console.WriteLine(StmtNarrow(nil))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\nFalse\nFalse\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_Int64_LetAssignArithmeticMultipleReads_Runs()
+    {
+        // `let x int64 = v` plus arithmetic over multiple narrowed reads.
+        const string source = """
+            package i1547int64arith
+            import System
+
+            func Sum(v int64?) int64 {
+                if v != nil {
+                    let x int64 = v
+                    return x + v + int64(1)
+                }
+                return int64(0)
+            }
+
+            func Main() {
+                Console.WriteLine(Sum(int64(10)))
+                Console.WriteLine(Sum(nil))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("21\n0\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_PlainReturnOfNarrowedValue_Runs()
+    {
+        // A bare `return v` (the narrowed value flowing straight through the
+        // return conversion) must also unwrap.
+        const string source = """
+            package i1547plainret
+            import System
+
+            func Unwrap(v int32?) int32 {
+                if v != nil { return v }
+                return -1
+            }
+
+            func Main() {
+                Console.WriteLine(Unwrap(42))
+                Console.WriteLine(Unwrap(nil))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n-1\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_PassNarrowedValueAsNonNullableArg_Runs()
+    {
+        // The narrowed value passed as a non-nullable `int32` argument.
+        const string source = """
+            package i1547passarg
+            import System
+
+            func Twice(n int32) int32 -> n * 2
+
+            func Apply(v int32?) int32 {
+                if v != nil { return Twice(v) }
+                return 0
+            }
+
+            func Main() {
+                Console.WriteLine(Apply(6))
+                Console.WriteLine(Apply(nil))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("12\n0\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_BoolCharDouble_UnderlyingTypes_Run()
+    {
+        // Generalize across several underlying value types and use sites.
+        const string source = """
+            package i1547mixed
+            import System
+
+            func UseBool(v bool?) bool {
+                if v != nil { return v }
+                return false
+            }
+
+            func UseChar(v char?) char {
+                if v != nil { return v }
+                return 'z'
+            }
+
+            func UseDouble(v float64?) float64 {
+                if v != nil {
+                    var total float64 = 0.0
+                    total = total + v
+                    total = total + v
+                    return total
+                }
+                return 0.0
+            }
+
+            func Main() {
+                Console.WriteLine(UseBool(true))
+                Console.WriteLine(UseChar('A'))
+                Console.WriteLine(UseDouble(2.5))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\nA\n5\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_NestedGuardBlocks_Run()
+    {
+        // Nested guarded blocks with multiple narrowed reads.
+        const string source = """
+            package i1547nested
+            import System
+
+            func Nested(v int32?) int32 {
+                if v != nil {
+                    if v > 0 {
+                        return v + 100
+                    }
+                    return v
+                }
+                return -1
+            }
+
+            func Main() {
+                Console.WriteLine(Nested(5))
+                Console.WriteLine(Nested(-3))
+                Console.WriteLine(Nested(nil))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("105\n-3\n-1\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_ImportedValueTypeNullable_PassedAsArg_Runs()
+    {
+        // An imported/BCL value type (System.TimeSpan) narrowed and passed as a
+        // non-nullable argument — the unwrap is not int32-specific.
+        const string source = """
+            package i1547timespan
+            import System
+
+            func IsZero(t System.TimeSpan) bool -> t == System.TimeSpan.Zero
+
+            func Check(v System.TimeSpan?) bool {
+                if v != nil { return IsZero(v) }
+                return false
+            }
+
+            func Main() {
+                Console.WriteLine(Check(System.TimeSpan.Zero))
+                Console.WriteLine(Check(System.TimeSpan.FromSeconds(1.0)))
+                Console.WriteLine(Check(nil))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\nFalse\nFalse\n", output);
+    }
+
+    [Fact]
+    public void Control_ReferenceNullable_StatementGuard_StillNarrows()
+    {
+        // Reference-type nullable narrowing is a metadata no-op and must keep
+        // working (the fix must NOT wrap reference nullables in `!!`).
+        const string source = """
+            package i1547refguard
+            import System
+
+            func Len(s string?) int32 {
+                if s != nil { return s.Length }
+                return -1
+            }
+
+            func Main() {
+                Console.WriteLine(Len("abc"))
+                Console.WriteLine(Len(nil))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("3\n-1\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1547_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1547
Refs #914

## Root cause

G# has Kotlin-style smart-cast narrowing: after `if v != nil { ... }`, a read of `v` (declared `int32?`) inside the block is given a **narrowed static type** = the underlying `int32`. Narrowing is represented by constructing the variable read with a narrowed `Type`.

For a nullable **reference** type the CLR representation of `T?` and `T` is identical, so a bare narrowed read is a metadata no-op and emits fine. But for a nullable **value** type (`int32?` = the CLR struct `System.Nullable<int32>`), the storage slot holds a `Nullable<T>` while the narrowed read's static type is the bare `T`. The emitter loaded the slot **without unwrapping**, leaving a `Nullable<T>` on the stack where `T` was expected:

```
[StackUnexpected] found Int32, expected Nullable`1<int32>
```

The shared nil-guard leaf classifier has a `referenceNullableOnly` flag. The short-circuit `&&`/`||` path (#1545 / PR #1546) passes `true` and correctly declines value-type nullables; the if-**statement** path (`StatementBinder.TryClassifyNilGuard`) passes `false` and accepts them — narrowing the static type without the emitter unwrapping the storage → the bug.

## Fix — direction 1 ("make it work"), reusing the existing `!!` machinery

Rather than disable value-type statement narrowing (the fallback, which would create an asymmetry with reference narrowing and force users onto `v!!` / lifted operators), the narrowing is made to actually work.

The compiler already has a proven, ilverify-clean value-type nullable unwrap: the postfix `!!` (`BoundUnaryOperatorKind.NullAssertion`), which spills the `Nullable<T>` to a scratch slot and calls `Nullable<T>::get_Value()`. A new `ExpressionBinder.BuildNarrowedRead` helper wraps a narrowed value-type-nullable read in a synthesized `!!` node (whose result type is the underlying `T`, so downstream type-checking is unchanged). The nil-guard already proved the value non-nil, so the assertion can never throw. `SlotPlanner`'s existing `NullableValueTypeUnwrapCollector` walks the final bound tree and auto-allocates the scratch slot for the synthesized node, and the existing `EmitUnary` path emits the unwrap. Reference nullables keep their bare narrowed read (no pointless runtime null-check).

The unwrap is applied **uniformly** at every narrowed-read construction site so the fix is general, not just the single primary site.

## Files changed

- **`src/Core/CodeAnalysis/Binding/ExpressionBinder.cs`** — added the `BuildNarrowedRead` helper; routed the bare-variable read, the two `ApplyMemberNarrowing` field/property stable-path reads, and the `[MemberNotNull]` implicit-field read through it.
- **`src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs`** — routed the two member-access receiver narrowed-read sites (local-variable receiver and `[MemberNotNull]` implicit-field receiver) through the same helper.
- **`test/Compiler.Tests/Emit/Issue1547StatementNilGuardValueNarrowingEmitTests.cs`** — new Emit regression suite (8 facts) asserting ilverify-clean output and correct runtime results.

## Generalization — verified

The fix works for any value-type underlying and any use site the value-type-nullable machinery supports. Confirmed ilverify-clean and runtime-correct:

- **Underlying types:** `int8/16/32/64`, `uint32/uint64`, `nint`, `bool`, `char`, `float32/64`, and an imported BCL value type (`System.TimeSpan`).
- **Use sites:** `return v`, `v > 0`, `let x int64 = v`, passing `v` as a non-nullable `int32` argument, arithmetic (`x + v + 1`), multiple reads of the same narrowed var, and nested guarded blocks.
- The canonical repro compiles and passes ilverify cleanly (0 errors) and runs correctly.

## Not a regression / no deferred work

- Reference-nullable narrowing stays a metadata no-op (not wrapped in `!!`) — a `Control_ReferenceNullable_StatementGuard_StillNarrows` test guards this.
- The #1545 short-circuit `&&`/`||` restriction and its tests still pass, as do the smart-cast/narrowing and `!!` suites.
- `Conversion.cs` untouched; no new `SyntaxKind` / `BoundNodeKind` added (the existing `NullAssertion` is reused), so no coverage-matrix updates needed.
- Full solution build is 0 warnings / 0 errors; **Core.Tests: 4906 passed, 1 skipped** (`RegenerateBaseline`, expected), 0 failed — the byte-identical `RefactoringBaselineTests` baseline is unchanged, so no baseline regeneration was required.
- New Emit test: `--filter "FullyQualifiedName~Issue1547"` → 8 passed.

### Scope note (pre-existing, orthogonal limitation)

Same-compilation **user `struct?` / `enum?`** value-type nullables are broadly unsupported on `main` today — the `nil → Nullable<UserT>` default lowering, the value → `Nullable<UserT>` lift, and explicit `(v!!)` all emit invalid IL for these types (they are detected via CLR `Type`, which is null for types still being emitted). Likewise, member access on a narrowed value (`v.Member`) hits a pre-existing slot-collision bug that also affects explicit `(v!!).Member`. These gaps are independent of narrowing (they reproduce without any `if`-guard) and are out of scope for #1547; this change does not regress them, and its `!!`-reuse strategy will pick them up automatically once that separate value-type-nullable emit support lands. All narrowing cases the value-type-nullable machinery currently supports are fully fixed here — no work was deferred within #1547's scope.
