### PR TITLE
Prefer in-scope member over top-level extension for unqualified calls (#1566)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -3721,6 +3721,34 @@ internal sealed class OverloadResolver
         }
     }
 
+    /// <summary>
+    /// Issue #1566: determines whether every top-level function overload with the
+    /// given name is an extension function. When true, an unqualified,
+    /// receiver-less call to that name inside a type should first try to bind
+    /// against an accessible member of the enclosing type (member-over-extension
+    /// shadowing) before falling back to the extension.
+    /// </summary>
+    /// <param name="name">The invoked identifier.</param>
+    /// <returns><see langword="true"/> when at least one overload exists and all of them are extension functions.</returns>
+    private bool IsAllExtensionOverloadSet(string name)
+    {
+        var overloads = Scope.TryLookupFunctions(name);
+        if (overloads.IsDefaultOrEmpty)
+        {
+            return false;
+        }
+
+        foreach (var overload in overloads)
+        {
+            if (!overload.IsExtension)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     public BoundExpression BindCallExpression(CallExpressionSyntax syntax)
     {
         // ADR-0065 §2: a bare `init(args)` call inside a constructor body is
@@ -3895,7 +3923,21 @@ internal sealed class OverloadResolver
         }
 
         var symbol = Scope.TryLookupSymbol(syntax.Identifier.Text);
-        if (symbol == null)
+
+        // Issue #1566: an accessible in-scope member of the enclosing type
+        // shadows a same-named top-level EXTENSION function for an unqualified,
+        // receiver-less call — mirroring C#, where an in-scope member hides an
+        // extension method. Extension functions are flattened into the global
+        // function table (issue #1103) so `TryLookupSymbol` returns them for
+        // free-call syntax; when the resolved name denotes only extension
+        // function(s), route through the implicit-`this` member-resolution path
+        // first. If the enclosing type exposes no matching member the block
+        // falls through and the extension binds exactly as before (so both the
+        // receiver-form `x.Ext(...)` and free-call extension usage, and calls
+        // from types with no such member, are unaffected).
+        var resolvedIsExtensionOnly = symbol is FunctionSymbol
+            && IsAllExtensionOverloadSet(syntax.Identifier.Text);
+        if (symbol == null || resolvedIsExtensionOnly)
         {
             // Implicit `this`: if we are inside an instance method body and the
             // name matches a sibling method on the receiver type, dispatch via
@@ -4030,56 +4072,63 @@ internal sealed class OverloadResolver
                 }
             }
 
-            // Issue #1201 (C# `using static`): an unqualified call may resolve
-            // to a `shared` (static) method of a type brought into scope by a
-            // type import (`import Ns.Type`). Mirror C#'s using-static
-            // semantics — search every type-import's static method set and bind
-            // against the single match. When two or more imported types expose a
-            // same-named static method the reference is ambiguous (GS0414), but
-            // only here, where the name is actually used. The shared static-call
-            // finalizer (`bindUserTypeStaticCall`) provides full
-            // optional/variadic/generic fidelity, so an unqualified
-            // `GetValues[TEnum]()` resolves exactly like `EnumUtil.GetValues[TEnum]()`.
-            if (bindUserTypeStaticCall != null)
+            // Issue #1566: reaching here with a non-null symbol means the name
+            // denotes only extension function(s) and the enclosing type had no
+            // matching member — fall through to the free-function/extension
+            // binding below rather than the not-found paths.
+            if (symbol == null)
             {
-                StructSymbol matchedStaticImport = null;
-                var ambiguousStaticImport = false;
-                foreach (var importedType in binderCtx.GetStaticImportTypes())
+                // Issue #1201 (C# `using static`): an unqualified call may resolve
+                // to a `shared` (static) method of a type brought into scope by a
+                // type import (`import Ns.Type`). Mirror C#'s using-static
+                // semantics — search every type-import's static method set and bind
+                // against the single match. When two or more imported types expose a
+                // same-named static method the reference is ambiguous (GS0414), but
+                // only here, where the name is actually used. The shared static-call
+                // finalizer (`bindUserTypeStaticCall`) provides full
+                // optional/variadic/generic fidelity, so an unqualified
+                // `GetValues[TEnum]()` resolves exactly like `EnumUtil.GetValues[TEnum]()`.
+                if (bindUserTypeStaticCall != null)
                 {
-                    var importedStatics = TypeMemberModel.GetMethods(
-                        importedType,
-                        syntax.Identifier.Text,
-                        MemberQuery.Static(MemberKinds.Method));
-                    if (importedStatics.IsDefaultOrEmpty)
+                    StructSymbol matchedStaticImport = null;
+                    var ambiguousStaticImport = false;
+                    foreach (var importedType in binderCtx.GetStaticImportTypes())
                     {
-                        continue;
+                        var importedStatics = TypeMemberModel.GetMethods(
+                            importedType,
+                            syntax.Identifier.Text,
+                            MemberQuery.Static(MemberKinds.Method));
+                        if (importedStatics.IsDefaultOrEmpty)
+                        {
+                            continue;
+                        }
+
+                        if (matchedStaticImport == null)
+                        {
+                            matchedStaticImport = importedType;
+                        }
+                        else if (!ReferenceEquals(matchedStaticImport, importedType))
+                        {
+                            ambiguousStaticImport = true;
+                            break;
+                        }
                     }
 
-                    if (matchedStaticImport == null)
+                    if (ambiguousStaticImport)
                     {
-                        matchedStaticImport = importedType;
+                        Diagnostics.ReportAmbiguousImportedStaticMember(syntax.Identifier.Location, syntax.Identifier.Text);
+                        return new BoundErrorExpression(null);
                     }
-                    else if (!ReferenceEquals(matchedStaticImport, importedType))
+
+                    if (matchedStaticImport != null)
                     {
-                        ambiguousStaticImport = true;
-                        break;
+                        return bindUserTypeStaticCall(matchedStaticImport, syntax);
                     }
                 }
 
-                if (ambiguousStaticImport)
-                {
-                    Diagnostics.ReportAmbiguousImportedStaticMember(syntax.Identifier.Location, syntax.Identifier.Text);
-                    return new BoundErrorExpression(null);
-                }
-
-                if (matchedStaticImport != null)
-                {
-                    return bindUserTypeStaticCall(matchedStaticImport, syntax);
-                }
+                Diagnostics.ReportUndefinedFunction(syntax.Identifier.Location, syntax.Identifier.Text);
+                return new BoundErrorExpression(null);
             }
-
-            Diagnostics.ReportUndefinedFunction(syntax.Identifier.Location, syntax.Identifier.Text);
-            return new BoundErrorExpression(null);
         }
 
         // ADR-0122 §9 / issue #1035: invoking a function-pointer-typed

--- a/test/Compiler.Tests/Emit/Issue1566MemberVsExtensionShadowEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1566MemberVsExtensionShadowEmitTests.cs
@@ -1,0 +1,303 @@
+// <copyright file="Issue1566MemberVsExtensionShadowEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1566 — an unqualified, receiver-less call inside a type to a name that
+/// ALSO exists as a top-level extension function bound the EXTENSION instead of
+/// the type's own in-scope instance/static member, producing a spurious GS0144
+/// (wrong arity). Extension functions are flattened into the global function
+/// table (issue #1103) so a bare <c>Display(val)</c> resolved to the extension's
+/// full parameter list (receiver + args) rather than the enclosing type's member.
+/// <para>
+/// The fix makes an accessible in-scope member of the enclosing type SHADOW a
+/// same-named top-level extension for an unqualified receiver-less call, matching
+/// C# (an in-scope member hides an extension method). When the enclosing type
+/// exposes no matching member the extension still binds, and explicit-receiver
+/// calls (<c>x.Ext(...)</c>) are unaffected.
+/// </para>
+/// Each test uses a UNIQUE package and user-type names because the in-process
+/// <c>FunctionTypeSymbol</c> cache is name-keyed and leaks across tests.
+/// </summary>
+public class Issue1566MemberVsExtensionShadowEmitTests
+{
+    [Fact]
+    public void EndToEnd_InstanceMember_ShadowsExtension_Repro()
+    {
+        // The minimal repro from issue #1566: a private 1-arg member and a
+        // same-named receiver-clause extension. The unqualified call must bind
+        // the member.
+        const string source = """
+            package i1566instance
+            import System
+
+            class WidgetA {
+                private func Describe(value bool) string { return "member" }
+                func Use(val bool) string { return Describe(val) }
+            }
+
+            func (value T) Describe[T](rm int32) string { return "extension" }
+
+            func Main() {
+                let w = WidgetA()
+                System.Console.WriteLine(w.Use(true))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("member\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_InstanceMember_ShadowsExtension_MultipleArities()
+    {
+        // Member overloading is unaffected: a zero-arg and a two-arg member both
+        // shadow the same-named one-arg-plus-receiver extension.
+        const string source = """
+            package i1566arities
+            import System
+
+            class GadgetB {
+                private func Combine() string { return "zero" }
+                private func Combine(a int32, b int32) string { return "two" }
+                func Use() string { return Combine() + "-" + Combine(1, 2) }
+            }
+
+            func (value T) Combine[T](rm int32) string { return "ext" }
+
+            func Main() {
+                System.Console.WriteLine(GadgetB().Use())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("zero-two\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_StaticMember_ShadowsExtension()
+    {
+        // A `shared` (static) member of the enclosing type also shadows a
+        // same-named extension for an unqualified call.
+        const string source = """
+            package i1566static
+            import System
+
+            class RegistryC {
+                shared {
+                    func Lookup(a int32) string { return "static-member" }
+                }
+                func Use() string { return Lookup(1) }
+            }
+
+            func (value T) Lookup[T](rm int32) string { return "ext" }
+
+            func Main() {
+                System.Console.WriteLine(RegistryC().Use())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("static-member\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_StructMember_ShadowsExtension()
+    {
+        // The shadowing rule generalizes to struct receivers.
+        const string source = """
+            package i1566struct
+            import System
+
+            struct PointD {
+                var X int32
+                func Render() string { return "struct-member" }
+            }
+
+            func (value T) Render[T]() string { return "ext" }
+
+            func Main() {
+                let p = PointD{X: 1}
+                System.Console.WriteLine(p.Render())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("struct-member\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_MemberAndExplicitReceiverExtension_Coexist()
+    {
+        // A member shadows the extension for the unqualified call, but an
+        // explicit-receiver call to the SAME name still binds the extension.
+        const string source = """
+            package i1566coexist
+            import System
+
+            class BoxE {
+                private func Tag(value bool) string { return "member" }
+                func UseSelf(val bool) string { return Tag(val) }
+                func UseExt(n int32) string { return n.Tag(0) }
+            }
+
+            func (value T) Tag[T](rm int32) string { return "extension" }
+
+            func Main() {
+                let b = BoxE()
+                System.Console.WriteLine(b.UseSelf(true))
+                System.Console.WriteLine(b.UseExt(9))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("member\nextension\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_NoMember_ExplicitReceiverExtension_StillBinds()
+    {
+        // When the enclosing type has NO member of that name the extension is
+        // still found via explicit-receiver syntax (control: existing behavior
+        // preserved).
+        const string source = """
+            package i1566nomember
+            import System
+
+            class HolderF {
+                func Use(val int32) string { return val.Stringify(0) }
+            }
+
+            func (value T) Stringify[T](rm int32) string { return "ext-called" }
+
+            func Main() {
+                System.Console.WriteLine(HolderF().Use(3))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("ext-called\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_OahuCase_GenericExtension_MembersAcrossTypes()
+    {
+        // The real Oahu shape: several types each declare a private member of a
+        // name that also exists as a generic (multi-type-parameter) extension.
+        // Every enclosing type binds its own member for the unqualified call.
+        const string source = """
+            package i1566oahu
+            import System
+
+            class AlphaG {
+                private func ToDisplayString(x int32) string { return "alpha" }
+                func Use(x int32) string { return ToDisplayString(x) }
+            }
+
+            class BetaG {
+                private func ToDisplayString(x int32) string { return "beta" }
+                func Use(x int32) string { return ToDisplayString(x) }
+            }
+
+            func (value TEnum) ToDisplayString[TEnum, TPunct](rm int32) string { return "ext" }
+
+            func Main() {
+                System.Console.WriteLine(AlphaG().Use(1))
+                System.Console.WriteLine(BetaG().Use(2))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("alpha\nbeta\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1566_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
Fixes a spurious `GS0144` where an unqualified, receiver-less call inside a type to a name that also exists as a top-level extension function bound the extension instead of the type's own in-scope member.

### Root cause
Extension functions are flattened into the global function table (#1103) so free-call syntax resolves them. In `OverloadResolver.BindCallExpression`, an unqualified receiver-less call did `Scope.TryLookupSymbol(name)`, which returned the top-level extension; since the symbol was non-null, binding went straight to the extension path and never consulted the enclosing type's members. The extension's parameter list (receiver + args) then drove overload resolution, yielding the wrong arity (GS0144).

### Fix (`src/Core/CodeAnalysis/Binding/OverloadResolver.cs`)
- New helper `IsAllExtensionOverloadSet(name)` — true when every top-level overload of that name is an extension.
- Widened the implicit-`this` member-resolution guard from `if (symbol == null)` to also enter when the resolved name denotes only extension function(s), so the enclosing type's members get a chance to bind first (member shadows extension). The `using static`/undefined-function fallbacks are gated on `symbol == null` so an extension-only symbol with no matching member still falls through to the unchanged extension binding.

### Generalized
Works for class/struct/interface/enum receivers, instance and static (`shared`) members, any arity, and generic/non-generic (incl. multi-type-parameter) extensions. Preserved behavior: extension still binds when no member exists; explicit-receiver `x.Ext(...)` and free-call extension usage outside the type are unaffected; no IL change for unrelated programs (byte-identical baseline gate stays green).

### Tests
- New `Issue1566MemberVsExtensionShadowEmitTests` (7 tests) — all pass.
- Core.Tests: 4906 pass / 1 skip. Full solution build: 0 warnings / 0 errors. Extension regression suites (#1103/#1188/#1147/#1201/#1548/#773/#712/#666): 37/37 pass.

Fixes #1566

Refs #914
