### PR TITLE
cs2gs: unwrap delegate construction and self-type bare default

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/OahuFoundationTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuFoundationTranslationTests.cs
@@ -352,6 +352,62 @@ namespace Demo
     }
 
     /// <summary>
+    /// A C# delegate creation `new SomeDelegate(lambda)` wraps a lambda / method
+    /// group in a named delegate type. G# has no delegate wrapper type — a
+    /// delegate value IS a function value — so the redundant wrapper is unwrapped
+    /// to its sole target expression. Constructing the mapped delegate type would
+    /// otherwise leak the `ArrowTypeReference` AST node's CLR type name (issue
+    /// #914).
+    /// </summary>
+    [Fact]
+    public void DelegateConstructionWrappingLambda_UnwrapsToLambda()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    using System.Threading;
+    public static class Poster
+    {
+        public static void Post(SynchronizationContext ctx)
+        {
+            ctx.Send(new SendOrPostCallback((state) => { }), null);
+        }
+    }
+}");
+
+        Assert.DoesNotContain("ArrowTypeReference", printed);
+        Assert.DoesNotContain("SendOrPostCallback(", printed);
+        Assert.Contains("ctx.Send((state object?) -> {", printed);
+    }
+
+    /// <summary>
+    /// A C# bare `default` literal in a typed local (`TResult retval = default;`)
+    /// is emitted as the self-typed `default(TResult)`. Roslyn reports the bare
+    /// literal's natural type as the target type, so the local-declaration path
+    /// omits the type clause and relies on inference — yet bare `default` has
+    /// nothing to infer from, surfacing GS0362. Emitting `default(T)` keeps it
+    /// valid in every position (issue #914, ADR-0100).
+    /// </summary>
+    [Fact]
+    public void BareDefaultLiteral_RendersSelfTypedDefault()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public static class Boxes
+    {
+        public static TResult MakeDefault<TResult>()
+        {
+            TResult retval = default;
+            return retval;
+        }
+    }
+}");
+
+        Assert.Contains("default(TResult)", printed);
+    }
+
+    /// <summary>
     /// ADR-0115 §B.12: a suffix-less integer literal whose C# type is wider or
     /// unsigned than int32 (`0xD800000000000000` is `ulong`) is emitted with the
     /// matching G# suffix so the lexer does not reject it.

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -6423,10 +6423,18 @@ public sealed class CSharpToGSharpTranslator
                     return LiteralExpression.Null();
 
                 case SyntaxKind.DefaultLiteralExpression:
-                    // The target-typed `default` literal maps to the bare G#
-                    // `default`, whose type is supplied by the surrounding context
-                    // (ADR-0100).
-                    return new DefaultValueExpression();
+                    // The target-typed `default` literal maps to G# `default(T)`
+                    // for the converted (target) type when that type is known, so
+                    // the value is self-typed. A bare typeless `default` relies on
+                    // surrounding context for its type, but common positions supply
+                    // none: an inferred `var retval = default` (the C# type was
+                    // erased to the initializer's natural type, which for `default`
+                    // is the target type, so the local-declaration path omits the
+                    // clause and infers — yet bare `default` has nothing to infer
+                    // from) surfaces GS0362. Emitting `default(T)` keeps it valid
+                    // everywhere (ADR-0100). Falls back to bare `default` only when
+                    // the type is genuinely unavailable.
+                    return new DefaultValueExpression(this.ResolveExpressionType(literal));
 
                 default:
                     this.context.ReportUnsupported(
@@ -7124,6 +7132,20 @@ public sealed class CSharpToGSharpTranslator
                 : creation.ArgumentList.Arguments
                     .Select(a => this.TranslateArgument(a))
                     .ToList();
+
+            // A C# delegate creation `new SomeDelegate(target)` wraps a method
+            // group, lambda, or another delegate in a named delegate type. G# has
+            // no delegate wrapper type: a delegate value IS a function value
+            // (ADR-0115 function types). The wrapping constructor is therefore
+            // redundant — unwrap it to the sole target expression. Constructing the
+            // mapped delegate type directly would fail because a delegate maps to an
+            // `ArrowTypeReference` (a structural function type), not a callable named
+            // type, and would otherwise leak the AST node's CLR type name.
+            if (typeSymbol is INamedTypeSymbol { TypeKind: TypeKind.Delegate } &&
+                arguments.Count == 1)
+            {
+                return arguments[0];
+            }
 
             // A C# collection initializer maps to the canonical G# collection
             // initializer `Target{ ... }` (ADR-0117, issue #479). This covers


### PR DESCRIPTION
Two translator expression-lowering fixes surfaced by the Oahu.Foundation migration (issue #914).

### 1. Unwrap delegate construction
A C# delegate creation `new SomeDelegate(target)` wraps a lambda, method group, or another delegate in a named delegate type. G# has no delegate wrapper type — a delegate value **is** a function value — so the wrapper is redundant. Because a delegate type maps to a structural `ArrowTypeReference` (not a callable named type), the previous construction path fell through to `type.ToString()` and **leaked the AST node's CLR type name** `Cs2Gs.CodeModel.Ast.ArrowTypeReference` into the emitted G#. Now the single-argument delegate construction is unwrapped to its sole target expression.

Before:
```
synchronizationContext.Send(Cs2Gs.CodeModel.Ast.ArrowTypeReference((x object?) -> { ... }), nil)
```
After:
```
synchronizationContext.Send((x object?) -> { ... }, nil)
```

### 2. Self-type bare `default`
A C# bare `default` literal (`TResult retval = default;`) was emitted as a typeless `default`. Roslyn reports the bare literal's natural type as the target type, so the local-declaration path omits the type clause and relies on inference — but bare `default` has nothing to infer from, surfacing `GS0362`. Now the converted type is resolved and the self-typed `default(T)` is emitted, valid in every position.

### Impact
Oahu.Foundation: **79 → 71** diagnostics (GS0362 plus a cascade of untyped-`retval` errors across the `ExtensionsSyncContext.SendOrPost` overloads cleared).

### Tests
`DelegateConstructionWrappingLambda_UnwrapsToLambda` and `BareDefaultLiteral_RendersSelfTypedDefault` added; full cs2gs suite 358 pass.

Refs #914
