### PR TITLE
Emit valid IL for user value-type nullables (struct? / enum?) (#1572)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -597,8 +597,15 @@ internal sealed partial class ExpressionBinder
         // needs the storage `Nullable<T>` unwrapped on load. Reference-type
         // nullables narrow to a reference underlying and share the CLR shape, so
         // they fall through to the bare narrowed read.
+        //
+        // Issue #1572: a user-declared value-type underlying (value-kind struct
+        // or enum) diverges from its `Nullable<T>` storage exactly like a
+        // primitive value-type nullable, but has a null ClrType so
+        // `IsValueTypeNullable` misses it — include the symbol-aware predicate so
+        // the narrowed read is wrapped in the `!!` unwrap.
         if (declaredType is NullableTypeSymbol nullable
-            && NullableLifting.IsValueTypeNullable(nullable)
+            && (NullableLifting.IsValueTypeNullable(nullable)
+                || NullableLifting.IsUserValueTypeNullable(nullable))
             && narrowedType is not NullableTypeSymbol)
         {
             var op = BoundUnaryOperator.Bind(SyntaxKind.BangBangToken, declaredType);

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -4823,12 +4823,20 @@ internal sealed class OverloadResolver
             }
             else if (argument.Type != expectedType
                 && expectedType is NullableTypeSymbol ntConv
-                && ntConv.UnderlyingType?.ClrType is { IsValueType: true })
+                && (ntConv.UnderlyingType?.ClrType is { IsValueType: true }
+                    || NullableLifting.IsUserValueTypeNullable(ntConv)))
             {
                 // Issue #533: conversions to a value-type Nullable<T> parameter
                 // need explicit lowering:
                 // - nil → Nullable<T> becomes BoundDefaultExpression (initobj)
                 // - T → Nullable<T> becomes BoundConversionExpression (newobj ctor)
+                //
+                // Issue #1572: a user-declared value-type underlying (struct? /
+                // enum?) has a null ClrType, so the primitive probe above misses
+                // it and the argument would otherwise pass through unlifted (a
+                // bare `UserT` where `Nullable<UserT>` is expected). Include the
+                // symbol-aware predicate so the `UserT → UserT?` argument lift is
+                // lowered to a `newobj Nullable<UserT>::.ctor` here too.
                 var argLoc = i < parameterSyntax.Length ? parameterSyntax[i].Location : syntax.Identifier.Location;
                 boundArguments[i] = conversions.BindConversion(argLoc, argument, expectedType);
             }

--- a/src/Core/CodeAnalysis/Binding/SmartCastStability.cs
+++ b/src/Core/CodeAnalysis/Binding/SmartCastStability.cs
@@ -220,7 +220,12 @@ internal static class SmartCastStability
         // so narrowing is an IL no-op and is safe. The short-circuit
         // (`&&`/`||`) caller passes `referenceNullableOnly: true` to stay on the
         // safe side; the statement classifier keeps its pre-existing behaviour.
-        if (referenceNullableOnly && NullableLifting.IsValueTypeNullable(nullable))
+        // Issue #1572: a user-declared value-type nullable (struct? / enum?)
+        // has the same storage-vs-narrowed-type divergence, but a null ClrType,
+        // so include the symbol-aware predicate here too.
+        if (referenceNullableOnly
+            && (NullableLifting.IsValueTypeNullable(nullable)
+                || NullableLifting.IsUserValueTypeNullable(nullable)))
         {
             target = null;
             return false;

--- a/src/Core/CodeAnalysis/Emit/MetadataTokenCache.cs
+++ b/src/Core/CodeAnalysis/Emit/MetadataTokenCache.cs
@@ -169,6 +169,18 @@ internal sealed class MetadataTokenCache
         = new Dictionary<StructSymbol, MemberReferenceHandle>();
 
     /// <summary>
+    /// Gets the cache mapping a user-defined value-type underlying
+    /// (<see cref="EnumSymbol"/> or value-kind <see cref="StructSymbol"/>) to the
+    /// <see cref="MemberReferenceHandle"/> for
+    /// <c>System.Nullable`1&lt;T&gt;::get_Value()</c> (issue #1572). The parent
+    /// TypeSpec closes <c>Nullable&lt;&gt;</c> over the type's emitted
+    /// TypeDef/TypeSpec, so one MemberRef per underlying serves every
+    /// <c>(v!!)</c> unwrap and narrowing-read site.
+    /// </summary>
+    public Dictionary<TypeSymbol, MemberReferenceHandle> NullableUserValueTypeGetValueMemberRefs { get; }
+        = new Dictionary<TypeSymbol, MemberReferenceHandle>();
+
+    /// <summary>
     /// Gets the cache mapping a <see cref="FieldInfo"/> to its
     /// <see cref="MemberReferenceHandle"/>.
     /// </summary>

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
@@ -181,18 +181,19 @@ internal sealed partial class MethodBodyEmitter
                 + "ldloca/initobj/ldloc. Reaching EmitConversion indicates a missing lowering path.");
         }
 
-        // Issue #1298: value-type `E → E?` lift where E is a user-declared
-        // enum. The enum has no runtime CLR type, so the BCL-backed ctor path
-        // below (which closes `Nullable<>` over a real `Type`) cannot fire;
-        // instead emit `newobj Nullable<E>::.ctor(!0)` against a TypeSpec
-        // parent that closes `Nullable<>` over the enum's emitted TypeDef.
-        // Mirrors the open-type-parameter branch in the value-type lift below.
-        if (to is NullableTypeSymbol toUserEnumNullableLift
-            && toUserEnumNullableLift.UnderlyingType is EnumSymbol
-            && from == toUserEnumNullableLift.UnderlyingType)
+        // Issue #1298 / #1572: value-type `T → T?` lift where T is a
+        // user-declared value type (enum or value-kind struct). The type has no
+        // runtime CLR type, so the BCL-backed ctor path below (which closes
+        // `Nullable<>` over a real `Type`) cannot fire; instead emit
+        // `newobj Nullable<T>::.ctor(!0)` against a TypeSpec parent that closes
+        // `Nullable<>` over the type's emitted TypeDef/TypeSpec. Mirrors the
+        // open-type-parameter branch in the value-type lift below.
+        if (to is NullableTypeSymbol toUserVtNullableLift
+            && NullableLifting.IsUserValueTypeNullable(toUserVtNullableLift)
+            && from == toUserVtNullableLift.UnderlyingType)
         {
             this.il.OpCode(ILOpCode.Newobj);
-            this.il.Token(this.outer.GetNullableCtorMemberRefForUserEnum(toUserEnumNullableLift));
+            this.il.Token(this.outer.GetNullableCtorMemberRefForUserValueType(toUserVtNullableLift));
             return;
         }
 

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
@@ -44,6 +44,32 @@ internal sealed partial class MethodBodyEmitter
         // dependency on stack tracking inside the operand.
         if (u.Op.Kind == BoundUnaryOperatorKind.NullAssertion)
         {
+            // Issue #1572: a value-type `Nullable<T>` operand where T is a
+            // user-declared value type (value-kind struct or enum) emitted in
+            // this compilation. Its underlying has no runtime CLR type, so the
+            // BCL-backed `get_Value` reference below cannot be built; spill the
+            // struct to the pre-allocated `Nullable<T>` slot, take its address,
+            // and call `Nullable<T>::get_Value()` off a TypeSpec MemberRef that
+            // closes `Nullable<>` over the emitted TypeDef/TypeSpec. Mirrors the
+            // primitive value-type arm below (issue #504).
+            if (u.Operand.Type is NullableTypeSymbol userVtNullable
+                && NullableLifting.IsUserValueTypeNullable(userVtNullable))
+            {
+                if (!this.receiverSpillSlots.TryGetValue(u, out var userVtSlot))
+                {
+                    throw new InvalidOperationException(
+                        "No scratch slot pre-allocated for user value-type Nullable<T> '!!' operand — "
+                        + "check NullableValueTypeUnwrapCollector and the prepass in CollectLocalsAndLabels.");
+                }
+
+                this.EmitExpression(u.Operand);
+                this.il.StoreLocal(userVtSlot);
+                this.il.LoadLocalAddress(userVtSlot);
+                this.il.OpCode(ILOpCode.Call);
+                this.il.Token(this.outer.GetNullableGetValueMemberRefForUserValueType(userVtNullable));
+                return;
+            }
+
             // Issue #504: a value-type `Nullable<T>` operand cannot use
             // `dup; brtrue` (the `Nullable<T>` struct on the stack has no
             // valid `brtrue` interpretation — it produces invalid IL).

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -9527,6 +9527,51 @@ internal sealed class ReflectionMetadataEmitter
     }
 
     /// <summary>
+    /// Issue #1572: gets a MemberRef for <c>System.Nullable`1&lt;T&gt;::get_Value()</c>
+    /// where <c>T</c> is a user-declared value type emitted in this assembly
+    /// (a value-kind <see cref="StructSymbol"/> or an <see cref="EnumSymbol"/>).
+    /// The type has no runtime CLR type, so the BCL-backed
+    /// <see cref="WellKnownReferences.GetNullableGetValueReference"/> path cannot
+    /// build it; instead the parent TypeSpec closes <c>Nullable&lt;&gt;</c> over
+    /// the type's emitted TypeDef/TypeSpec and the getter returns <c>!0</c>.
+    /// Used by the <c>(v!!)</c> unwrap and value-type narrowing-read emit.
+    /// </summary>
+    /// <param name="nullableOfUserVt">A <c>Nullable&lt;T&gt;</c> over a user value type (enum or value struct).</param>
+    /// <returns>The <c>get_Value()</c> MemberRef.</returns>
+    internal MemberReferenceHandle GetNullableGetValueMemberRefForUserValueType(NullableTypeSymbol nullableOfUserVt)
+    {
+        if (nullableOfUserVt == null || !NullableLifting.IsUserValueTypeNullable(nullableOfUserVt))
+        {
+            throw new InvalidOperationException(
+                "GetNullableGetValueMemberRefForUserValueType requires Nullable<user enum or value struct>.");
+        }
+
+        var underlying = nullableOfUserVt.UnderlyingType;
+        if (this.cache.NullableUserValueTypeGetValueMemberRefs.TryGetValue(underlying, out var cached))
+        {
+            return cached;
+        }
+
+        var parentBlob = new BlobBuilder();
+        this.EncodeTypeSymbol(new BlobEncoder(parentBlob).TypeSpecificationSignature(), nullableOfUserVt);
+        var parent = this.emitCtx.Metadata.AddTypeSpecification(this.emitCtx.Metadata.GetOrAddBlob(parentBlob));
+
+        var sigBlob = new BlobBuilder();
+        new BlobEncoder(sigBlob).MethodSignature(isInstanceMethod: true)
+            .Parameters(
+                parameterCount: 0,
+                returnType: r => r.Type().GenericTypeParameter(0),
+                parameters: _ => { });
+
+        var handle = this.emitCtx.Metadata.AddMemberReference(
+            parent: parent,
+            name: this.emitCtx.Metadata.GetOrAddString("get_Value"),
+            signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
+        this.cache.NullableUserValueTypeGetValueMemberRefs[underlying] = handle;
+        return handle;
+    }
+
+    /// <summary>
     /// Phase 4 emit parity: get a MemberRef for a CLR field on a possibly
     /// generic declaring type (e.g. <c>KeyValuePair&lt;K, V&gt;.Key</c>).
     /// </summary>
@@ -10556,8 +10601,13 @@ internal sealed class ReflectionMetadataEmitter
         // ClrType-based branch below misses it; recognise the symbolic form so
         // default-init (`ldloca; initobj; ldloc`) and boxing decisions treat it
         // as a value type.
-        if (type is NullableTypeSymbol nullableEnum
-            && nullableEnum.UnderlyingType is EnumSymbol)
+        //
+        // Issue #1572: the same applies to `S?` over a user-declared value-type
+        // struct (`!IsClass`). Both underlyings have a null ClrType during emit,
+        // so without this arm `EmitDefault` takes the `ldnull` reference path
+        // for a `Nullable<UserStruct>` nil-default — producing invalid IL.
+        if (type is NullableTypeSymbol nullableUserVt
+            && NullableLifting.IsUserValueTypeNullable(nullableUserVt))
         {
             return true;
         }

--- a/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
+++ b/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
@@ -1219,7 +1219,14 @@ internal sealed class SlotPlanner
                 if (node.Operand.Type is NullableTypeSymbol n)
                 {
                     needsSlot = n.UnderlyingType?.ClrType is { IsValueType: true }
-                        || (n.UnderlyingType is TypeParameterSymbol tp && !tp.HasValueTypeConstraint);
+                        || (n.UnderlyingType is TypeParameterSymbol tp && !tp.HasValueTypeConstraint)
+
+                        // Issue #1572: a user-declared value-type underlying
+                        // (value-kind struct or enum) has a null ClrType during
+                        // emit, so the ClrType probe above misses it. The `(v!!)`
+                        // emit arm spills to a `Nullable<T>` slot and calls
+                        // get_Value off its address, so it needs the same slot.
+                        || NullableLifting.IsUserValueTypeNullable(n);
                 }
                 else if (node.Operand.Type is TypeParameterSymbol bare && !bare.HasValueTypeConstraint)
                 {

--- a/src/Core/CodeAnalysis/Symbols/NullableLifting.cs
+++ b/src/Core/CodeAnalysis/Symbols/NullableLifting.cs
@@ -140,6 +140,27 @@ public static class NullableLifting
     }
 
     /// <summary>
+    /// Issue #1572: returns <see langword="true"/> when <paramref name="nullable"/>
+    /// wraps a <em>user-declared</em> value type emitted in the current
+    /// compilation — a value-kind <see cref="StructSymbol"/> (i.e.
+    /// <c>!IsClass</c>) or an <see cref="EnumSymbol"/>. Such underlyings have a
+    /// null CLR <see cref="Type"/> during emit, so the
+    /// <see cref="IsValueTypeNullable"/> ClrType probe misclassifies them as
+    /// reference nullables. Emit and slot-planning code that must close
+    /// <c>System.Nullable`1</c> over the emitted TypeDef/TypeSpec (rather than a
+    /// host <c>Type</c>) uses this symbol-aware predicate to detect them. Both
+    /// the slot collectors and the corresponding emit arms call it so the two
+    /// sides stay in exact agreement.
+    /// </summary>
+    /// <param name="nullable">The wrapper to test.</param>
+    /// <returns><see langword="true"/> for a user value-type <c>Nullable&lt;T&gt;</c>.</returns>
+    internal static bool IsUserValueTypeNullable(NullableTypeSymbol nullable)
+    {
+        return nullable?.UnderlyingType is EnumSymbol
+            || (nullable?.UnderlyingType is StructSymbol s && !s.IsClass);
+    }
+
+    /// <summary>
     /// Returns <see langword="true"/> when <paramref name="type"/> is a
     /// constructed <c>System.Nullable&lt;T&gt;</c> (i.e. closed-generic over the
     /// open <c>System.Nullable`1</c> definition). The open definition itself

--- a/test/Compiler.Tests/Emit/Issue1572UserValueTypeNullableEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1572UserValueTypeNullableEmitTests.cs
@@ -1,0 +1,415 @@
+// <copyright file="Issue1572UserValueTypeNullableEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1572: user-declared value-type nullables (<c>struct?</c> / <c>enum?</c>)
+/// must emit verifiable IL for the nil-default, lift, <c>(v!!)</c> unwrap, and
+/// <c>(v!!).Member</c> operations, plus the <c>if v != nil { ... }</c> narrowing
+/// (issue #1547) that reuses the same unwrap machinery. In-flight user value
+/// types have a null CLR <see cref="Type"/> during emit, so the detector must be
+/// symbol-aware (<c>StructSymbol</c> with <c>!IsClass</c>, or <c>EnumSymbol</c>)
+/// and the emitter must close <c>System.Nullable`1</c> over the emitted
+/// TypeDef/TypeSpec rather than a host <c>Type</c>.
+///
+/// Each test compiles via <c>gsc</c>, IL-verifies the produced PE, then executes
+/// it under <c>dotnet exec</c> and asserts on captured stdout. Every user
+/// struct/enum/package is given a UNIQUE name because the in-process
+/// name-keyed <c>FunctionTypeSymbol</c> cache is not cleared between tests.
+/// </summary>
+public class Issue1572UserValueTypeNullableEmitTests
+{
+    [Fact]
+    public void StructNilDefault_EmitsVerifiableInitobj()
+    {
+        var source = """
+            package NilDefaultPkg
+
+            import System
+
+            struct PtA { var x int32 }
+
+            func MakeNil() PtA? { return nil }
+
+            let v = MakeNil()
+            Console.WriteLine(v == nil)
+            """;
+
+        Assert.Equal("True\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void StructLift_EmitsNewobjNullableCtor()
+    {
+        var source = """
+            package LiftPkg
+
+            import System
+
+            struct PtB { var x int32 }
+
+            func Lift() PtB? {
+                let p = PtB{x: 7}
+                return p
+            }
+
+            let v = Lift()
+            Console.WriteLine((v!!).x)
+            """;
+
+        Assert.Equal("7\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void StructBang_UnwrapsViaGetValue()
+    {
+        var source = """
+            package BangPkg
+
+            import System
+
+            struct PtC { var x int32 }
+
+            func Unwrap(v PtC?) PtC { return v!! }
+
+            let p = PtC{x: 42}
+            let r = Unwrap(p)
+            Console.WriteLine(r.x)
+            """;
+
+        Assert.Equal("42\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void StructBangMember_ReadsFieldOffUnwrappedValue()
+    {
+        var source = """
+            package BangMemberPkg
+
+            import System
+
+            struct PtD { var x int32 }
+
+            func GetX(v PtD?) int32 { return (v!!).x }
+
+            let p = PtD{x: 99}
+            Console.WriteLine(GetX(p))
+            """;
+
+        Assert.Equal("99\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EnumBang_UnwrapsViaGetValue()
+    {
+        var source = """
+            package EnumBangPkg
+
+            import System
+
+            enum ColorA { Red, Green, Blue }
+
+            func Unwrap(v ColorA?) ColorA { return v!! }
+
+            let c ColorA? = ColorA.Green
+            let r = Unwrap(c)
+            Console.WriteLine(r == ColorA.Green)
+            """;
+
+        Assert.Equal("True\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EnumNilDefault_EmitsVerifiableInitobj()
+    {
+        var source = """
+            package EnumNilPkg
+
+            import System
+
+            enum ColorB { Red, Green }
+
+            func MakeNil() ColorB? { return nil }
+
+            let v = MakeNil()
+            Console.WriteLine(v == nil)
+            """;
+
+        Assert.Equal("True\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void StructNarrowing_IfNotNil_ReadsUnwrappedValue()
+    {
+        var source = """
+            package NarrowStructPkg
+
+            import System
+
+            struct PtE { var x int32 }
+
+            func Describe(v PtE?) int32 {
+                if v != nil {
+                    return v.x
+                }
+                return -1
+            }
+
+            let p = PtE{x: 5}
+            let none PtE? = nil
+            Console.WriteLine(Describe(p))
+            Console.WriteLine(Describe(none))
+            """;
+
+        Assert.Equal("5\n-1\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EnumNarrowing_IfNotNil_ReadsUnwrappedValue()
+    {
+        var source = """
+            package NarrowEnumPkg
+
+            import System
+
+            enum ColorC { Red, Green, Blue }
+
+            func Pick(v ColorC?) ColorC {
+                if v != nil {
+                    return v
+                }
+                return ColorC.Red
+            }
+
+            let c ColorC? = ColorC.Blue
+            let none ColorC? = nil
+            Console.WriteLine(Pick(c) == ColorC.Blue)
+            Console.WriteLine(Pick(none) == ColorC.Red)
+            """;
+
+        Assert.Equal("True\nTrue\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void MultiFieldStruct_LiftUnwrapAndMemberAllVerify()
+    {
+        var source = """
+            package MultiFieldPkg
+
+            import System
+
+            struct Rec {
+                var a int32
+                var b string
+                var c bool
+            }
+
+            func Lift() Rec? {
+                let r = Rec{a: 1, b: "hi", c: true}
+                return r
+            }
+
+            func GetB(v Rec?) string { return (v!!).b }
+
+            let lifted = Lift()
+            Console.WriteLine((lifted!!).a)
+            Console.WriteLine(GetB(lifted))
+            """;
+
+        Assert.Equal("1\nhi\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void StructWithReferenceField_UnwrapReadsReferenceMember()
+    {
+        var source = """
+            package RefFieldPkg
+
+            import System
+
+            struct Named {
+                var name string
+                var count int32
+            }
+
+            func GetName(v Named?) string { return (v!!).name }
+
+            let n = Named{name: "widget", count: 3}
+            Console.WriteLine(GetName(n))
+            """;
+
+        Assert.Equal("widget\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EmptyStruct_NilDefaultAndUnwrapVerify()
+    {
+        var source = """
+            package EmptyStructPkg
+
+            import System
+
+            struct Unit {}
+
+            func MakeNil() Unit? { return nil }
+            func Unwrap(v Unit?) Unit { return v!! }
+
+            let some Unit? = Unit{}
+            let unwrapped = Unwrap(some)
+            Console.WriteLine(MakeNil() == nil)
+            """;
+
+        Assert.Equal("True\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void ArgumentLift_NonNullableStructPassedToNullableParameter()
+    {
+        var source = """
+            package ArgLiftPkg
+
+            import System
+
+            struct PtF { var x int32 }
+
+            func Take(v PtF?) int32 { return (v!!).x }
+
+            let p = PtF{x: 21}
+            Console.WriteLine(Take(p))
+            """;
+
+        Assert.Equal("21\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void NullableStructField_UnwrapReadsNestedMember()
+    {
+        var source = """
+            package NestedFieldPkg
+
+            import System
+
+            struct Inner { var v int32 }
+
+            struct Outer {
+                var opt Inner?
+            }
+
+            func Read(o Outer) int32 { return (o.opt!!).v }
+
+            let o = Outer{opt: Inner{v: 8}}
+            Console.WriteLine(Read(o))
+            """;
+
+        Assert.Equal("8\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var (exitCode, stdout, stderr) = CompileAndRunRaw(source);
+        Assert.True(
+            exitCode == 0,
+            $"exited {exitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout;
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) CompileAndRunRaw(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1572_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+            };
+
+            foreach (var bcl in BclReferences.Value)
+            {
+                args.Add("/r:" + bcl);
+            }
+
+            args.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            return (proc.ExitCode, stdout.Replace("\r\n", "\n"), stderr.Replace("\r\n", "\n"));
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static readonly Lazy<IReadOnlyList<string>> BclReferences = new(() =>
+    {
+        var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location);
+        if (string.IsNullOrEmpty(runtimeDir) || !Directory.Exists(runtimeDir))
+        {
+            return Array.Empty<string>();
+        }
+
+        return Directory.EnumerateFiles(runtimeDir, "*.dll", SearchOption.TopDirectoryOnly)
+            .Where(p =>
+            {
+                var name = Path.GetFileName(p);
+                return name.StartsWith("System.", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "mscorlib.dll", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "netstandard.dll", StringComparison.OrdinalIgnoreCase);
+            })
+            .ToList();
+    });
+}


### PR DESCRIPTION
## Summary

Same-compilation **user** value-type nullables (`struct?` / `enum?`) emitted **invalid IL** for the nil-default, lift, `(v!!)` unwrap, and `(v!!).Member` operations. This PR makes all of them (plus the #1547 `if v != nil` narrowing) emit verifiable IL, generalized to **any** user value type.

Fixes #1572
Refs #914
Refs #1298

## Root cause

In-flight user value types (`StructSymbol` with `!IsClass`, `EnumSymbol`) have a **null CLR `Type`** during emit. The value-type-nullable detectors probed `UnderlyingType.ClrType is { IsValueType: true }`, which is null for these, so `struct?` / `enum?` were misclassified as **reference** nullables and the emitter took reference-type IL paths (`ldnull` for nil-default, no-op for lift, `dup; brtrue` for `!!`) — all invalid against a `Nullable<UserT>` struct on the stack.

## Approach — targeted, symbol-aware (lower-risk)

I did **not** broaden the global `NullableLifting.IsValueTypeNullable` (many emit arms assume it implies a non-null host `ClrType`). Instead I added a shared symbol-aware predicate and dedicated user-value-type arms placed **before** the reference fallbacks, mirroring the proven #1298 strategy of closing `System.Nullable` over the emitted **TypeDef/TypeSpec** rather than a host `Type`. Detection (slot planning) and emit call the same predicate so they stay in exact agreement.

## Files changed

- **`Symbols/NullableLifting.cs`** — new `IsUserValueTypeNullable(NullableTypeSymbol)` shared predicate (value-kind struct or enum underlying).
- **`Emit/ReflectionMetadataEmitter.cs`** — recognise `Nullable<user value struct>` in `IsValueTypeSymbol` (drives nil-default `initobj` slot path); new `GetNullableGetValueMemberRefForUserValueType` (TypeSpec `get_Value()` MemberRef) for the `(v!!)` unwrap. (The lift ctor helper `GetNullableCtorMemberRefForUserValueType` and `GetElementTypeToken` TypeSpec support already existed from #1475.)
- **`Emit/MetadataTokenCache.cs`** — cache for the new `get_Value` MemberRefs.
- **`Emit/MethodBodyEmitter.Conversions.cs`** — generalise the #1298 enum lift arm to any user value type (`newobj Nullable<T>::.ctor`).
- **`Emit/MethodBodyEmitter.Operators.cs`** — new `(v!!)` unwrap arm for user value-type operands: spill to slot, `ldloca`, `call Nullable<T>::get_Value()`.
- **`Emit/SlotPlanner.cs`** — unwrap collector pre-allocates the `Nullable<T>` scratch slot for user value-type `!!` operands.
- **`Binding/ExpressionBinder.cs` + `Binding/SmartCastStability.cs`** — narrowed read of a user value-type nullable is wrapped in the `!!` unwrap (#1547 interaction).
- **`Binding/OverloadResolver.cs`** — lower `UserT -> UserT?` call arguments to the `newobj` lift (previously gated on `ClrType.IsValueType`, null here, so the argument passed through unlifted).
- **`test/Compiler.Tests/Emit/Issue1572UserValueTypeNullableEmitTests.cs`** — new regression suite (13 tests, unique type/package names per test), each ilverify-clean + runtime-asserted.

## Validation — all repros + generalization cases ilverify cleanly

- Issue matrix repro (`StructNil`, `StructLift`, `StructBang`, `EnumBang`, `BangMember`): **ilverify 0 errors** (was 5).
- Generalization: multi-field struct, struct with a reference-typed field, empty struct, argument-position lift, nullable **struct field** unwrap (`(o.opt!!).v`), nullable enum field unwrap, and `if v != nil { ... }` narrowing over both a user `struct?` and a user `enum?` — all **ilverify-clean** and **runtime-correct** (executed under `dotnet exec`).
- `dotnet build GSharp.sln -c Release -graph` → **0 warnings / 0 errors**.
- `dotnet test Core.Tests -c Release` → **4906 passed, 1 skipped** (RegenerateBaseline; byte-identical refactoring baseline unchanged).
- New `Issue1572` Emit suite → **13 passed**; related `Issue1298` / `Issue1547` / `Issue1475` → **16 passed**; `~Nullable` → **248 passed**; `~SmartCast|~Narrow` → **65 passed**. No regressions.

## Scope note (not deferred #1572 work)

Null-coalesce `??` over a user value-type nullable remains behind its own pre-existing "not yet supported" emit guard (it needs distinct `get_HasValue` / `GetValueOrDefault` helpers and result-type handling, and is not part of the #1572 matrix). It still fails as a clean compile-time error — never invalid IL — so there is no regression. Every operation listed in the issue is fully implemented; no work was deferred.
