### PR TITLE
Fix empty-body if/while/for condition mis-parsed as struct literal (#1575)

### DIFF
--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -7071,6 +7071,8 @@ public class Parser
                 // Issue #522: an indexer is a fresh inner expression context.
                 var savedSuppress = suppressTrailingObjectInitializer;
                 suppressTrailingObjectInitializer = 0;
+                var savedStructLiteral = suppressStructLiteral;
+                suppressStructLiteral = 0;
                 ExpressionSyntax index;
                 try
                 {
@@ -7079,6 +7081,7 @@ public class Parser
                 finally
                 {
                     suppressTrailingObjectInitializer = savedSuppress;
+                    suppressStructLiteral = savedStructLiteral;
                 }
 
                 var closeBracket = MatchToken(SyntaxKind.CloseSquareBracketToken);
@@ -8012,7 +8015,7 @@ public class Parser
         }
         else if (Current.Kind == SyntaxKind.IdentifierToken
             && Peek(1).Kind == SyntaxKind.OpenBraceToken
-            && suppressStructLiteral == 0
+            && (suppressStructLiteral == 0 || StructLiteralAllowedInSuppressedHeader(1))
             && IsStructLiteralFollowingBrace(2))
         {
             current = ParseStructLiteralExpression();
@@ -8563,6 +8566,8 @@ public class Parser
         // where trailing object/collection initializers are again allowed.
         var savedSuppress = suppressTrailingObjectInitializer;
         suppressTrailingObjectInitializer = 0;
+        var savedStructLiteral = suppressStructLiteral;
+        suppressStructLiteral = 0;
         try
         {
             // Indexed entry `[key] = value`.
@@ -8592,6 +8597,7 @@ public class Parser
         finally
         {
             suppressTrailingObjectInitializer = savedSuppress;
+            suppressStructLiteral = savedStructLiteral;
         }
     }
 
@@ -8781,6 +8787,8 @@ public class Parser
             ExpressionSyntax value;
             var savedSuppress = suppressTrailingObjectInitializer;
             suppressTrailingObjectInitializer = 0;
+            var savedStructLiteral = suppressStructLiteral;
+            suppressStructLiteral = 0;
             try
             {
                 value = ParseExpression();
@@ -8788,6 +8796,7 @@ public class Parser
             finally
             {
                 suppressTrailingObjectInitializer = savedSuppress;
+                suppressStructLiteral = savedStructLiteral;
             }
 
             nodesAndSeparators.Add(new PropertyInitializerSyntax(syntaxTree, propertyId, equals, value));
@@ -8807,17 +8816,24 @@ public class Parser
 
     // Parses an expression in a body-header context (the condition of an `if`,
     // the collection of a `for-range`, etc.) — trailing `Call() { ... }`
-    // object initializers are suppressed so the following `{` is recognised
-    // as the body of the surrounding statement.
+    // object initializers AND bare `Ident { }` struct literals are suppressed so
+    // the following `{` is recognised as the body of the surrounding statement.
+    // Suppressing the bare struct-literal form matters for an empty body: an
+    // `if disposing { }` condition would otherwise commit `disposing { }` as an
+    // empty struct literal (GS0157), because the struct-literal lookahead accepts
+    // `{}` (a non-empty body already backtracks). Mirrors the if-expression
+    // (#669), `if let`, and `fixed` headers, which suppress both forms.
     private ExpressionSyntax ParseExpressionInBodyHeader()
     {
         suppressTrailingObjectInitializer++;
+        suppressStructLiteral++;
         try
         {
             return ParseExpression();
         }
         finally
         {
+            suppressStructLiteral--;
             suppressTrailingObjectInitializer--;
         }
     }
@@ -9081,6 +9097,12 @@ public class Parser
         var savedSuppress = suppressTrailingObjectInitializer;
         suppressTrailingObjectInitializer = 0;
 
+        // A call argument is likewise a fresh context for the bare `Ident { }`
+        // struct-literal form, so `Foo(Pt{X: 1})` is recognised even inside a
+        // body-header condition (#1575).
+        var savedStructLiteral = suppressStructLiteral;
+        suppressStructLiteral = 0;
+
         // Issue #1038: an argument list is a fresh context, so a standalone
         // range argument (`f(1..3)`) is recognised even inside an index bound.
         var savedRange = suppressRangeOperator;
@@ -9092,6 +9114,7 @@ public class Parser
         finally
         {
             suppressTrailingObjectInitializer = savedSuppress;
+            suppressStructLiteral = savedStructLiteral;
             suppressRangeOperator = savedRange;
         }
     }
@@ -9633,6 +9656,26 @@ public class Parser
         return false;
     }
 
+    // In a body-header controlling expression (`if`/`while`/`for` clauses, a
+    // `for-in` collection, …) bare struct literals are suppressed so a trailing
+    // `{` opens the statement body (issue #1575). A NON-empty struct literal
+    // (`Pt{X: 1}`) is unambiguous — `{ Ident : … }` cannot open a body — so it is
+    // still admitted (`if Pt{X: 1} == p { }`). Only an EMPTY `Ident{}` collides
+    // with an empty body: it is a struct literal solely when a real body `{`
+    // follows it (`for v in Numbers{} { … }`); otherwise the identifier is the
+    // controlling expression and the `{}` is the empty body (`if disposing { }`),
+    // which previously mis-parsed as an empty struct literal (GS0157).
+    // <paramref name="braceOffset"/> is the offset of the opening `{`.
+    private bool StructLiteralAllowedInSuppressedHeader(int braceOffset)
+    {
+        if (Peek(braceOffset + 1).Kind != SyntaxKind.CloseBraceToken)
+        {
+            return true;
+        }
+
+        return Peek(braceOffset + 2).Kind == SyntaxKind.OpenBraceToken;
+    }
+
     private ExpressionSyntax ParseStructLiteralExpression()
     {
         var typeIdentifier = MatchToken(SyntaxKind.IdentifierToken);
@@ -9708,6 +9751,12 @@ public class Parser
         var savedSuppress = suppressTrailingObjectInitializer;
         suppressTrailingObjectInitializer = 0;
 
+        // A parenthesised expression is likewise a fresh context for the bare
+        // `Ident { }` struct-literal form, so `(Pt{X: 1})` is recognised even
+        // inside a body-header condition (`if p == (Pt{X: 1}) { }`, #1575).
+        var savedStructLiteral = suppressStructLiteral;
+        suppressStructLiteral = 0;
+
         // Issue #1038: a parenthesised expression is a fresh context, so a
         // parenthesised range (`a[(1..3)]`) is recognised as a standalone
         // `System.Range` value even inside an index bound.
@@ -9720,6 +9769,7 @@ public class Parser
         finally
         {
             suppressTrailingObjectInitializer = savedSuppress;
+            suppressStructLiteral = savedStructLiteral;
             suppressRangeOperator = savedRange;
         }
 

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue1575EmptyBodyConditionParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue1575EmptyBodyConditionParserTests.cs
@@ -1,0 +1,163 @@
+// <copyright file="Issue1575EmptyBodyConditionParserTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Issue #1575: an <c>if</c> / <c>while</c> / <c>for</c> statement whose
+/// controlling expression is a bare identifier (or any composite-literal-shaped
+/// expression) immediately followed by an EMPTY body <c>{ }</c> must parse the
+/// identifier as the condition and let <c>{ }</c> open the (empty) body — it
+/// must NOT be mis-parsed as an empty struct literal (<c>Ident{}</c>), which
+/// previously surfaced a spurious <c>GS0157</c>.
+/// <para>
+/// A non-empty body already backtracked correctly; only the empty <c>{ }</c>
+/// slipped through because the struct-literal lookahead accepts <c>{}</c>. The
+/// body-header context now suppresses the bare struct-literal form (as it
+/// already did the trailing <c>Call() { … }</c> form), while the fresh inner
+/// contexts (parentheses, argument lists, indexers, collection/object-literal
+/// element values) still admit a struct literal so <c>(Pt{X: 1})</c> and
+/// <c>Foo(Pt{X: 1})</c> keep working inside a condition.
+/// </para>
+/// </summary>
+public class Issue1575EmptyBodyConditionParserTests
+{
+    private static IEnumerable<SyntaxNode> Descendants(SyntaxNode node)
+    {
+        foreach (var child in node.GetChildren())
+        {
+            yield return child;
+            foreach (var d in Descendants(child))
+            {
+                yield return d;
+            }
+        }
+    }
+
+    [Fact]
+    public void If_With_BareIdentifier_Condition_And_EmptyBody_Parses_As_Condition()
+    {
+        const string source = @"
+package p
+class C { func F(disposing bool) { if disposing { } var x = 1 } }
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var ifStatement = Descendants(tree.Root).OfType<IfStatementSyntax>().Single();
+
+        // The condition must be a plain name reference, not a struct literal.
+        Assert.Empty(Descendants(ifStatement.Condition).OfType<StructLiteralExpressionSyntax>());
+        Assert.IsNotType<StructLiteralExpressionSyntax>(ifStatement.Condition);
+    }
+
+    [Fact]
+    public void While_With_BareIdentifier_Condition_And_EmptyBody_Parses_As_Condition()
+    {
+        const string source = @"
+package p
+class C { func F(disposing bool) { while disposing { } var x = 1 } }
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var whileStatement = Descendants(tree.Root).OfType<WhileStatementSyntax>().Single();
+        Assert.Empty(Descendants(whileStatement.Condition).OfType<StructLiteralExpressionSyntax>());
+    }
+
+    [Fact]
+    public void ParenthesizedStructLiteral_In_Condition_Still_Parses()
+    {
+        // Regression guard: a struct literal inside parentheses is a fresh inner
+        // context, so it is still recognised even in a body-header condition.
+        const string source = @"
+package p
+data struct Pt { let X int32 }
+class C { func F(p Pt) { if p == (Pt{X: 1}) { } var x = 1 } }
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var structLiteral = Descendants(tree.Root).OfType<StructLiteralExpressionSyntax>().Single();
+        Assert.Equal("Pt", structLiteral.TypeIdentifier.Text);
+    }
+
+    [Fact]
+    public void StructLiteral_As_CallArgument_In_Condition_Still_Parses()
+    {
+        const string source = @"
+package p
+data struct Pt { let X int32 }
+class C {
+ func Check(p Pt) bool { return p.X > 0 }
+ func F() { if Check(Pt{X: 1}) { } var x = 1 } }
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var structLiteral = Descendants(tree.Root).OfType<StructLiteralExpressionSyntax>().Single();
+        Assert.Equal("Pt", structLiteral.TypeIdentifier.Text);
+    }
+
+    [Fact]
+    public void BareStructLiteral_In_Expression_Position_Still_Parses()
+    {
+        // The suppression must apply ONLY in statement-header controlling
+        // expressions; ordinary expression position still parses a struct literal.
+        const string source = @"
+package p
+data struct Pt { let X int32 }
+class C { func F() { var p = Pt{X: 1} } }
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var structLiteral = Descendants(tree.Root).OfType<StructLiteralExpressionSyntax>().Single();
+        Assert.Equal("Pt", structLiteral.TypeIdentifier.Text);
+    }
+
+    [Fact]
+    public void EmptyStructLiteral_As_ForIn_Collection_Followed_By_Body_Still_Parses()
+    {
+        // Regression guard for the inverse case: an EMPTY struct literal that IS
+        // a `for-in` collection is followed by a real body `{`, so it must remain
+        // a struct literal (`for v in Numbers{} { .. }`), not be split into an
+        // identifier collection with an empty body.
+        const string source = @"
+package p
+class Numbers { func GetEnumerator() NumberEnum { return NumberEnum() } }
+class NumberEnum { func MoveNext() bool { return false }
+ func Current() int32 { return 0 } }
+class C { func F() { for v in Numbers{} { var x = v } } }
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var structLiteral = Descendants(tree.Root).OfType<StructLiteralExpressionSyntax>().Single();
+        Assert.Equal("Numbers", structLiteral.TypeIdentifier.Text);
+    }
+
+    [Fact]
+    public void NonEmptyStructLiteral_At_Start_Of_Condition_Still_Parses()
+    {
+        // A non-empty struct literal is unambiguous even as the head of a
+        // condition (`{ Ident : .. }` cannot open a body), so `if Pt{X: 1} == p`
+        // keeps parsing `Pt{X: 1}` as a struct literal.
+        const string source = @"
+package p
+data struct Pt { let X int32 }
+class C { func F(p Pt) { if Pt{X: 1} == p { } var x = 1 } }
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var structLiteral = Descendants(tree.Root).OfType<StructLiteralExpressionSyntax>().Single();
+        Assert.Equal("Pt", structLiteral.TypeIdentifier.Text);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a parser bug where a bare-identifier controlling expression with an
empty body was mis-parsed as an empty struct literal.

`if disposing { }`, `while disposing { }`, and `for v in coll { }` (empty
bodies) reported `GS0157` because the trailing `{ }` was consumed as a
struct literal `disposing{}` rather than the empty statement body.

## Root cause

`ParseExpressionInBodyHeader` incremented only `suppressTrailingObjectInitializer`,
not `suppressStructLiteral`, leaving the bare `Ident{}` struct-literal form
active. Non-empty bodies happened to backtrack correctly, which hid the bug.

## Fix

Suppress bare struct literals in body-header controlling expressions, with a
precise disambiguation rule that preserves the cases where a struct literal
is genuinely intended:

- a **non-empty** struct literal (`Pt{X:1}`) is always allowed — `{Ident:`
  cannot open a statement body;
- an **empty** `Ident{}` is a struct literal only when immediately followed
  by a body `{` (`for v in Numbers{} { .. }`); otherwise the identifier is
  the condition and `{ }` is the empty body.

`suppressStructLiteral` is also reset at the five fresh-inner-context sites
(parenthesized expression, arguments, indexer, collection element, object
initializer value) so struct literals nested inside a header condition still
parse.

## Tests

New `Issue1575EmptyBodyConditionParserTests` (7 cases) covering empty-body
if/while, the non-empty struct-literal condition, the empty-struct-literal
for-in collection, and ordinary expression-position struct literals. Full
Core.Tests suite green (4913 passed, 1 skipped) — including the `ForIn.gs`
baseline that constrains the empty-collection case.

Fixes #1575

Refs #914
