### PR TITLE
Emit valid IL for '??' over user value-type nullables (struct? / enum?) (#1578)

### DIFF
--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
@@ -353,11 +353,68 @@ internal sealed partial class MethodBodyEmitter
                 return;
             }
 
-            // Defensive: any other value-typed LHS (raw struct or enum)
-            // remains unsupported by `??`. Today the encoder rejects
-            // nullable user-defined structs/enums, so this branch is
-            // unreachable from valid source, but fail loudly rather
-            // than silently producing PEVerify-rejected IL.
+            // Issue #1578: NullCoalesce over a user value-type nullable LHS —
+            // `Nullable<UserT>` where UserT is a user-declared value-kind
+            // struct or enum emitted in this compilation (#1572). The
+            // underlying has no runtime CLR type, so neither the primitive
+            // `Nullable<T>` spill arm at the top (which probes via the
+            // BCL-backed `get_HasValue`) nor the bottom `dup; brtrue` shape is
+            // usable. Mirror the sibling value-type spill (#831 / #1516) with a
+            // box-probe over the emitted `Nullable<UserT>` TypeSpec: spill the
+            // LHS to the pre-allocated `Nullable<UserT>` slot, box it (boxing a
+            // `Nullable<T>` yields `null` when `!HasValue`, else a boxed `T` —
+            // ECMA-335), and `brfalse` to the fallback on the empty case. On
+            // the non-null branch, reproduce the operator's result type: reload
+            // the wrapper when the result is itself `Nullable<UserT>`, else
+            // unwrap to `UserT` via the TypeSpec `get_Value` MemberRef (#1572).
+            if (b.Left.Type is NullableTypeSymbol userVtNullable
+                && NullableLifting.IsUserValueTypeNullable(userVtNullable))
+            {
+                if (!this.nullableCoalesceSpillSlots.TryGetValue(b, out var userVtSlot))
+                {
+                    throw new InvalidOperationException(
+                        "No scratch slot pre-allocated for user value-type Nullable<T> '??' LHS — "
+                        + "check NullableValueTypeCoalesceCollector and the prepass in CollectLocalsAndLabels.");
+                }
+
+                var userVtBoxToken = this.outer.GetElementTypeToken(userVtNullable);
+                var fallback = this.il.DefineLabel();
+                var end = this.il.DefineLabel();
+
+                this.EmitExpression(b.Left);
+                this.il.StoreLocal(userVtSlot);
+                this.il.LoadLocal(userVtSlot);
+                this.il.OpCode(ILOpCode.Box);
+                this.il.Token(userVtBoxToken);
+                this.il.Branch(ILOpCode.Brfalse, fallback);
+
+                if (b.Type is NullableTypeSymbol)
+                {
+                    // Result is `Nullable<UserT>` — reload the present wrapper.
+                    this.il.LoadLocal(userVtSlot);
+                }
+                else
+                {
+                    // Result is the underlying `UserT` — unwrap via get_Value.
+                    this.il.LoadLocalAddress(userVtSlot);
+                    this.il.OpCode(ILOpCode.Call);
+                    this.il.Token(this.outer.GetNullableGetValueMemberRefForUserValueType(userVtNullable));
+                }
+
+                this.il.Branch(ILOpCode.Br, end);
+
+                this.il.MarkLabel(fallback);
+                this.EmitExpression(b.Right);
+                this.il.MarkLabel(end);
+                return;
+            }
+
+            // Defensive: any other value-typed LHS remains unsupported by
+            // `??`. All known value-type shapes are handled above (primitive
+            // `Nullable<T>` #519, open struct-constrained `T?` #831, bare
+            // reference type-parameter #1516, user value-type nullable #1578);
+            // fail loudly rather than silently producing PEVerify-rejected IL
+            // for any unanticipated value-type stack shape.
             var leftType = b.Left.Type;
             if (ReflectionMetadataEmitter.IsValueTypeSymbol(leftType))
             {

--- a/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
+++ b/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
@@ -1286,7 +1286,16 @@ internal sealed class SlotPlanner
                 if (node.Left.Type is NullableTypeSymbol n)
                 {
                     needsSlot = n.UnderlyingType?.ClrType is { IsValueType: true }
-                        || (n.UnderlyingType is TypeParameterSymbol tp && !tp.HasValueTypeConstraint);
+                        || (n.UnderlyingType is TypeParameterSymbol tp && !tp.HasValueTypeConstraint)
+
+                        // Issue #1578: a user-declared value-type underlying
+                        // (value-kind struct or enum) has a null ClrType during
+                        // emit, so the ClrType probe above misses it. The `??`
+                        // emit arm spills the `Nullable<UserT>` LHS to this slot
+                        // and box-probes / calls get_Value off its address, so
+                        // it needs the same pre-allocated slot. Keep this in
+                        // exact agreement with the emitter's user value-type arm.
+                        || NullableLifting.IsUserValueTypeNullable(n);
                 }
                 else if (IsReferenceTypeParameterCoalesceProbe(node, out _))
                 {

--- a/test/Compiler.Tests/Emit/Issue1578UserValueTypeNullableCoalesceEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1578UserValueTypeNullableCoalesceEmitTests.cs
@@ -1,0 +1,357 @@
+// <copyright file="Issue1578UserValueTypeNullableCoalesceEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1578: null-coalesce <c>??</c> over a user-declared value-type nullable
+/// (<c>struct?</c> / <c>enum?</c>) must emit verifiable IL. The primitive
+/// <c>Nullable&lt;T&gt;</c> <c>??</c> path (issue #519) probes via the BCL-backed
+/// <c>get_HasValue</c>, but user value types have a null CLR <see cref="Type"/>
+/// during emit, so #1572's TypeSpec machinery is required. The emitter spills the
+/// <c>Nullable&lt;UserT&gt;</c> LHS to a pre-allocated slot, box-probes it over the
+/// emitted <c>Nullable&lt;UserT&gt;</c> TypeSpec (<c>box; brfalse</c> — boxing a
+/// <c>Nullable&lt;T&gt;</c> yields <c>null</c> when empty, ECMA-335), and on the
+/// non-null branch either reloads the wrapper (result is <c>Nullable&lt;UserT&gt;</c>)
+/// or unwraps to <c>UserT</c> via the TypeSpec <c>get_Value</c> MemberRef (#1572).
+///
+/// Each test compiles via <c>gsc</c>, IL-verifies the produced PE, then executes
+/// it under <c>dotnet exec</c> and asserts on captured stdout. Every user
+/// struct/enum/package is given a UNIQUE name because the in-process name-keyed
+/// <c>FunctionTypeSymbol</c> cache is not cleared between tests.
+/// </summary>
+public class Issue1578UserValueTypeNullableCoalesceEmitTests
+{
+    [Fact]
+    public void StructCoalesce_NilOperandTakesFallback()
+    {
+        var source = """
+            package CoalStructNilPkg
+
+            import System
+
+            struct CsnPt { var x int32 }
+
+            func Coalesce(v CsnPt?) CsnPt {
+                let fb = CsnPt{x: -1}
+                return v ?? fb
+            }
+
+            let none CsnPt? = nil
+            Console.WriteLine(Coalesce(none).x)
+            """;
+
+        Assert.Equal("-1\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void StructCoalesce_PresentOperandTakesValue()
+    {
+        var source = """
+            package CoalStructPresentPkg
+
+            import System
+
+            struct CspPt { var x int32 }
+
+            func Coalesce(v CspPt?) CspPt {
+                let fb = CspPt{x: -1}
+                return v ?? fb
+            }
+
+            let some CspPt? = CspPt{x: 9}
+            Console.WriteLine(Coalesce(some).x)
+            """;
+
+        Assert.Equal("9\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EnumCoalesce_NilAndPresentOperands()
+    {
+        var source = """
+            package CoalEnumPkg
+
+            import System
+
+            enum CeColor { Red, Green, Blue }
+
+            func Coalesce(v CeColor?) CeColor { return v ?? CeColor.Red }
+
+            let none CeColor? = nil
+            let some CeColor? = CeColor.Blue
+            Console.WriteLine(Coalesce(none) == CeColor.Red)
+            Console.WriteLine(Coalesce(some) == CeColor.Blue)
+            """;
+
+        Assert.Equal("True\nTrue\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void MultiFieldStructCoalesce_NilAndPresent()
+    {
+        var source = """
+            package CoalMultiPkg
+
+            import System
+
+            struct CmRec {
+                var a int32
+                var b string
+                var c bool
+            }
+
+            func Coalesce(v CmRec?) CmRec {
+                return v ?? CmRec{a: 1, b: "fb", c: false}
+            }
+
+            let none CmRec? = nil
+            let some CmRec? = CmRec{a: 2, b: "present", c: true}
+            Console.WriteLine(Coalesce(none).b)
+            Console.WriteLine(Coalesce(some).b)
+            """;
+
+        Assert.Equal("fb\npresent\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void StructWithReferenceFieldCoalesce_ReadsReferenceMember()
+    {
+        var source = """
+            package CoalRefFieldPkg
+
+            import System
+
+            struct CrfNamed {
+                var name string
+                var count int32
+            }
+
+            func Coalesce(v CrfNamed?) CrfNamed {
+                return v ?? CrfNamed{name: "fallback", count: 0}
+            }
+
+            let none CrfNamed? = nil
+            Console.WriteLine(Coalesce(none).name)
+            """;
+
+        Assert.Equal("fallback\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void EmptyStructCoalesce_NilTakesFallback()
+    {
+        var source = """
+            package CoalEmptyPkg
+
+            import System
+
+            struct CeUnit {}
+
+            func Coalesce(v CeUnit?) CeUnit { return v ?? CeUnit{} }
+
+            let none CeUnit? = nil
+            Console.WriteLine(Coalesce(none).ToString())
+            """;
+
+        Assert.Equal("CoalEmptyPkg.CeUnit\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void StructCoalesceChain_ThreeOperands()
+    {
+        var source = """
+            package CoalChainPkg
+
+            import System
+
+            struct CcPt { var x int32 }
+
+            func Chain(v CcPt?, w CcPt?) CcPt {
+                return v ?? w ?? CcPt{x: -99}
+            }
+
+            let none CcPt? = nil
+            let w CcPt? = CcPt{x: 5}
+            Console.WriteLine(Chain(none, none).x)
+            Console.WriteLine(Chain(none, w).x)
+            """;
+
+        Assert.Equal("-99\n5\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void StructCoalesceMemberAccessOnResult()
+    {
+        var source = """
+            package CoalMemberPkg
+
+            import System
+
+            struct CmemPt { var x int32 }
+
+            func GetX(v CmemPt?) int32 {
+                let fb = CmemPt{x: 42}
+                return (v ?? fb).x
+            }
+
+            let none CmemPt? = nil
+            let some CmemPt? = CmemPt{x: 9}
+            Console.WriteLine(GetX(none))
+            Console.WriteLine(GetX(some))
+            """;
+
+        Assert.Equal("42\n9\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void StructCoalesce_NullableResultBranchReloadsWrapper()
+    {
+        var source = """
+            package CoalNullableRhsPkg
+
+            import System
+
+            struct CnrPt { var x int32 }
+
+            func Coalesce(v CnrPt?, w CnrPt?) CnrPt {
+                let fb = CnrPt{x: -5}
+                return (v ?? w) ?? fb
+            }
+
+            let none CnrPt? = nil
+            let w CnrPt? = CnrPt{x: 7}
+            Console.WriteLine(Coalesce(none, none).x)
+            Console.WriteLine(Coalesce(none, w).x)
+            """;
+
+        Assert.Equal("-5\n7\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void PrimitiveCoalesce_StillEmitsVerifiableIl()
+    {
+        var source = """
+            package CoalPrimPkg
+
+            import System
+
+            func Coalesce(v int32?) int32 { return v ?? -1 }
+
+            let none int32? = nil
+            let some int32? = 8
+            Console.WriteLine(Coalesce(none))
+            Console.WriteLine(Coalesce(some))
+            """;
+
+        Assert.Equal("-1\n8\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var (exitCode, stdout, stderr) = CompileAndRunRaw(source);
+        Assert.True(
+            exitCode == 0,
+            $"exited {exitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout;
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) CompileAndRunRaw(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1578_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+            };
+
+            foreach (var bcl in BclReferences.Value)
+            {
+                args.Add("/r:" + bcl);
+            }
+
+            args.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            return (proc.ExitCode, stdout.Replace("\r\n", "\n"), stderr.Replace("\r\n", "\n"));
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static readonly Lazy<IReadOnlyList<string>> BclReferences = new(() =>
+    {
+        var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location);
+        if (string.IsNullOrEmpty(runtimeDir) || !Directory.Exists(runtimeDir))
+        {
+            return Array.Empty<string>();
+        }
+
+        return Directory.EnumerateFiles(runtimeDir, "*.dll", SearchOption.TopDirectoryOnly)
+            .Where(p =>
+            {
+                var name = Path.GetFileName(p);
+                return name.StartsWith("System.", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "mscorlib.dll", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "netstandard.dll", StringComparison.OrdinalIgnoreCase);
+            })
+            .ToList();
+    });
+}


### PR DESCRIPTION
Fixes #1578
Refs #914
Refs #1572

## Root cause

Null-coalesce `??` over a user-declared value-type nullable (`struct?` / `enum?`) failed to compile with a `GS9998 NotSupportedException` from the emitter. The final defensive branch in the `NullCoalesce` emit (in `MethodBodyEmitter.Operators.cs`) threw for "any other value-typed LHS (raw struct or enum)", carrying a now-stale comment: *"the encoder rejects nullable user-defined structs/enums, so this branch is unreachable from valid source."* #1572 (PR #1576) taught the encoder to emit nullable user-defined `struct?`/`enum?`, so this branch became **reachable** from valid source — `??` was the one operation still unimplemented for user value-type nullables (after nil-default, lift, `(v!!)`, `(v!!).Member`, and `if v != nil` narrowing).

The primitive `Nullable<T>` `??` path (#519) probes via the BCL-backed `get_HasValue`, but user value types have a null CLR `Type` during emit, so that path misses them and the bottom `dup; brtrue` shape is invalid IL for a struct stack value.

## Fix

Emit layer + SlotPlanner + shared predicate:

- **`src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs`** — replaced the stale defensive `throw` with a real emit arm for user value-type nullable `??` LHS, mirroring the sibling #831/#1516 box-probe. It spills the `Nullable<UserT>` LHS to the pre-allocated slot, `box`es it over the emitted `Nullable<UserT>` TypeSpec (boxing a `Nullable<T>` yields `null` when `!HasValue`, else a boxed `T` — ECMA-335), and `brfalse`s to the fallback. On the non-null branch it reloads the wrapper when the result is itself `Nullable<UserT>`, else unwraps to `UserT` via #1572's TypeSpec `get_Value` MemberRef (`GetNullableGetValueMemberRefForUserValueType`). Both branches leave the operator's result type on the stack so the merge verifies. The stale "unreachable from valid source" comment was rewritten.
- **`src/Core/CodeAnalysis/Emit/SlotPlanner.cs`** — extended `NullableValueTypeCoalesceCollector` to pre-allocate the `Nullable<UserT>` scratch slot for user value-type `??` LHS using the same `NullableLifting.IsUserValueTypeNullable` predicate as the emitter, keeping SlotPlanner detection and the emitter arm in exact agreement (avoids the "No scratch slot pre-allocated" exception).
- **`test/Compiler.Tests/Emit/Issue1578UserValueTypeNullableCoalesceEmitTests.cs`** — new Emit regression suite (10 tests, each with unique struct/enum/package names) covering `struct?`/`enum?` `??` (nil and present operands), multi-field struct, struct with a reference-typed field, empty struct, `??` chain, member-access on the result, the `Nullable<UserT>`-result reload branch, and primitive `??` non-regression — all ilverify-clean with runtime assertions.

## Validation

- Repro (`CoalesceStruct`, `CoalesceEnum`) and generalization cases (multi-field struct, struct with reference field, empty struct, `??` chain, `(v ?? fallback).Member`, `(v ?? w) ?? fb` nullable-result branch, primitive `int32?`) all compile, **ilverify cleanly (0 errors)**, and produce correct runtime output (e.g. `CoalesceStruct(nil).x` → `-1`, `CoalesceStruct(Pt{x:9}).x` → `9`).
- Full solution build green: `dotnet build GSharp.sln -c Release -graph` (0 warnings / 0 errors).
- `dotnet test test/Core.Tests` → **4906 passed, 1 skipped** (RegenerateBaseline, expected). The byte-identical RefactoringBaseline test still passes (no IL change for existing samples).
- New Emit suite: `--filter FullyQualifiedName~Issue1578` → **10 passed**.

No work was deferred. The only case not covered is enums with explicit backing type/values, which the G# language grammar does not support (`enum Name int64 { A = 1 }` is a parse error); every enum shape the language accepts is handled and tested.