### PR TITLE
Restrict empty-struct-literal-then-body allowance to for-in collections (#1580)

### DIFF
--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -48,6 +48,16 @@ public class Parser
     // literals — e.g. `for v in Numbers{} { body }` is valid.
     private int suppressStructLiteral;
 
+    // Within a body-header controlling expression, an EMPTY `Ident{}` that is
+    // immediately followed by a body `{` is genuinely ambiguous. In a for-in
+    // collection it is a struct-literal collection (`for v in Numbers{} { .. }`);
+    // in a boolean if/while condition a struct literal is never valid, so the
+    // identifier is the condition and `{}` is the empty body
+    // (`if disposing {} { .. }`). This flag is set only while parsing a for-in
+    // collection so the empty-then-body form is treated as a struct literal
+    // there and only there (#1575 follow-up).
+    private bool allowEmptyStructLiteralInHeader;
+
     // ADR-0122 §4 / issue #1034: tracks the unsafe-context nesting depth while
     // parsing. Inside an unsafe context (`unsafe func`/`unsafe {}`/unsafe
     // type), a single-identifier `p->member` is parsed as pointer member
@@ -5681,7 +5691,7 @@ public class Parser
             rangeKeyword = null;
         }
 
-        var collection = ParseExpressionInBodyHeader();
+        var collection = ParseExpressionInBodyHeader(allowEmptyStructLiteralCollection: true);
         var body = ParseStatement();
         return new ForRangeStatementSyntax(syntaxTree, keyword, firstIdentifier, commaToken, secondIdentifier, colonEqualsToken, rangeKeyword, inToken, collection, body);
     }
@@ -8823,16 +8833,19 @@ public class Parser
     // empty struct literal (GS0157), because the struct-literal lookahead accepts
     // `{}` (a non-empty body already backtracks). Mirrors the if-expression
     // (#669), `if let`, and `fixed` headers, which suppress both forms.
-    private ExpressionSyntax ParseExpressionInBodyHeader()
+    private ExpressionSyntax ParseExpressionInBodyHeader(bool allowEmptyStructLiteralCollection = false)
     {
         suppressTrailingObjectInitializer++;
         suppressStructLiteral++;
+        var savedAllowEmptyStructLiteral = allowEmptyStructLiteralInHeader;
+        allowEmptyStructLiteralInHeader = allowEmptyStructLiteralCollection;
         try
         {
             return ParseExpression();
         }
         finally
         {
+            allowEmptyStructLiteralInHeader = savedAllowEmptyStructLiteral;
             suppressStructLiteral--;
             suppressTrailingObjectInitializer--;
         }
@@ -9673,7 +9686,12 @@ public class Parser
             return true;
         }
 
-        return Peek(braceOffset + 2).Kind == SyntaxKind.OpenBraceToken;
+        // Empty `Ident{}`: only a for-in collection may treat an empty struct
+        // literal immediately followed by a body `{` as a struct literal.
+        // In boolean if/while conditions the identifier is the condition and
+        // `{}` is the empty body (`if disposing {} { .. }`).
+        return allowEmptyStructLiteralInHeader
+            && Peek(braceOffset + 2).Kind == SyntaxKind.OpenBraceToken;
     }
 
     private ExpressionSyntax ParseStructLiteralExpression()

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue1575EmptyBodyConditionParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue1575EmptyBodyConditionParserTests.cs
@@ -72,6 +72,38 @@ class C { func F(disposing bool) { while disposing { } var x = 1 } }
     }
 
     [Fact]
+    public void If_With_EmptyBody_Followed_By_Block_Parses_As_Condition()
+    {
+        // #1580 (follow-up): the empty-body `if` is immediately followed by a
+        // block statement. The identifier is still the condition and `{}` the
+        // empty body — the trailing block must NOT be consumed as the `if`
+        // condition's struct-literal body (`if (disposing{}) { .. }`).
+        const string source = @"
+package p
+class C { func F(disposing bool) { if disposing { } { var y = 2 } var x = 1 } }
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var ifStatement = Descendants(tree.Root).OfType<IfStatementSyntax>().Single();
+        Assert.Empty(Descendants(ifStatement.Condition).OfType<StructLiteralExpressionSyntax>());
+    }
+
+    [Fact]
+    public void While_With_EmptyBody_Followed_By_Block_Parses_As_Condition()
+    {
+        const string source = @"
+package p
+class C { func F(disposing bool) { while disposing { } { var y = 2 } var x = 1 } }
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var whileStatement = Descendants(tree.Root).OfType<WhileStatementSyntax>().Single();
+        Assert.Empty(Descendants(whileStatement.Condition).OfType<StructLiteralExpressionSyntax>());
+    }
+
+    [Fact]
     public void ParenthesizedStructLiteral_In_Condition_Still_Parses()
     {
         // Regression guard: a struct literal inside parentheses is a fresh inner


### PR DESCRIPTION
## Summary

Follow-up to #1575. Fixes a context-blind disambiguation that still
mis-parsed the common empty-body `if`/`while` shape when it is immediately
followed by a block statement.

```gsharp
func Dispose(disposing bool) {
    if disposing {
    }
    {
        // cleanup block
    }
}
```

This parsed as `if (disposing{}) { .. }` — `disposing` plus its empty body was
greedily consumed as a struct literal whose "body" was the following block —
yielding a spurious `GS0157: Cannot find type disposing`.

## Root cause

`#1575` allowed an EMPTY `Ident{}` immediately followed by a body `{` to parse
as a struct literal, to preserve the for-in collection form
`for v in Numbers{} { .. }`. That allowance was applied in ALL body-header
contexts, including boolean `if`/`while` conditions where a struct literal can
never be a valid controlling expression.

## Fix

The empty-struct-literal-then-body form is now honored only while parsing a
for-in collection (via a header flag set solely on that parse). In
if/while/do-while conditions an empty `Ident{}` is always the identifier
condition plus an empty body.

## Tests

Two new cases in `Issue1575EmptyBodyConditionParserTests`
(`If_With_EmptyBody_Followed_By_Block_Parses_As_Condition`,
`While_With_EmptyBody_Followed_By_Block_Parses_As_Condition`). Full Core.Tests
green (4915 passed, 1 skipped), including the `ForIn.gs` baseline that
constrains the empty-collection case. Verified against the real Oahu.Foundation
`ProcessList.Dispose` shape.

Fixes #1580

Refs #914
