### PR TITLE
Fix inherited-member resolution for metadata (BCL) base classes (#1582)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -3366,19 +3366,22 @@ internal sealed partial class ExpressionBinder
                         }
                     }
 
-                    // Issue #296: a GSharp class inheriting an imported CLR base
-                    // exposes the base's instance properties/fields. Fall back to
-                    // CLR member lookup on the imported base type.
-                    if (structSym.ImportedBaseType?.ClrType is System.Type inheritedBaseClr)
+                    // Issue #296 / #1582: a GSharp class inheriting an imported
+                    // CLR base (directly or through user classes) exposes the
+                    // base's instance properties/fields — including inherited
+                    // `protected` / `protected internal` members. Resolve the
+                    // inherited CLR base type by walking the user base chain,
+                    // then reflect the member (reflection walks the CLR chain).
+                    if (GetInheritedClrBaseType(structSym) is System.Type inheritedBaseClr)
                     {
                         var memberName = ne.IdentifierToken.Text;
-                        var clrProp = ClrTypeUtilities.SafeGetProperty(inheritedBaseClr, memberName, BindingFlags.Public | BindingFlags.Instance);
-                        if (clrProp != null && clrProp.GetIndexParameters().Length == 0 && clrProp.CanRead)
+                        var clrProp = ClrTypeUtilities.SafeGetInheritedInstanceProperty(inheritedBaseClr, memberName);
+                        if (clrProp != null && clrProp.CanRead)
                         {
                             return new BoundClrPropertyAccessExpression(null, receiver, clrProp, TypeSymbol.FromClrType(clrProp.PropertyType));
                         }
 
-                        var clrFld = ClrTypeUtilities.SafeGetField(inheritedBaseClr, memberName, BindingFlags.Public | BindingFlags.Instance);
+                        var clrFld = ClrTypeUtilities.SafeGetInheritedInstanceField(inheritedBaseClr, memberName);
                         if (clrFld != null)
                         {
                             return new BoundClrPropertyAccessExpression(null, receiver, clrFld, TypeSymbol.FromClrType(clrFld.FieldType));

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -424,16 +424,13 @@ internal sealed partial class ExpressionBinder
                 return new BoundPropertyAssignmentExpression(initSyntax, receiverExpr, structSymbol, prop, converted);
             }
 
-            // Issue #319 parity: fall through to imported base CLR members.
-            if (structSymbol.ImportedBaseType?.ClrType is Type inheritedBaseClr)
+            // Issue #319 / #1582 parity: fall through to imported base CLR
+            // members reachable through the user base chain, including inherited
+            // protected members.
+            if (GetInheritedClrBaseType(structSymbol) is Type inheritedBaseClr)
             {
-                MemberInfo inhMember = ClrTypeUtilities.SafeGetProperty(inheritedBaseClr, propertyName, BindingFlags.Public | BindingFlags.Instance);
-                if (inhMember is PropertyInfo inhIdxProp && inhIdxProp.GetIndexParameters().Length != 0)
-                {
-                    inhMember = null;
-                }
-
-                inhMember ??= ClrTypeUtilities.SafeGetField(inheritedBaseClr, propertyName, BindingFlags.Public | BindingFlags.Instance);
+                MemberInfo inhMember = ClrTypeUtilities.SafeGetInheritedInstanceProperty(inheritedBaseClr, propertyName);
+                inhMember ??= ClrTypeUtilities.SafeGetInheritedInstanceField(inheritedBaseClr, propertyName);
                 if (inhMember != null)
                 {
                     if (!TryGetWritableClrMember(inhMember, out _, out var inhTargetSymbol, out _))
@@ -709,20 +706,16 @@ internal sealed partial class ExpressionBinder
                 return new BoundPropertyAssignmentExpression(null, propReceiver, structSymbol, prop, propConverted);
             }
 
-            // Issue #319: a GSharp class inheriting an imported CLR base exposes
-            // the base's settable instance properties/fields. Fall back to CLR
-            // member lookup on the imported base type so `e.HResult = 42` style
-            // writes work the same as the read fallback further down.
-            if (structSymbol.ImportedBaseType?.ClrType is System.Type inheritedBaseClr)
+            // Issue #319 / #1582: a GSharp class inheriting an imported CLR base
+            // exposes the base's settable instance properties/fields — including
+            // inherited `protected` / `protected internal` members. Resolve the
+            // inherited CLR base type by walking the user base chain so `e.HResult
+            // = 42` and protected-field writes work the same as the read fallback.
+            if (GetInheritedClrBaseType(structSymbol) is System.Type inheritedBaseClr)
             {
                 var memberName = syntax.FieldIdentifier.Text;
-                MemberInfo clrMember = ClrTypeUtilities.SafeGetProperty(inheritedBaseClr, memberName, BindingFlags.Public | BindingFlags.Instance);
-                if (clrMember is PropertyInfo idxProp && idxProp.GetIndexParameters().Length != 0)
-                {
-                    clrMember = null;
-                }
-
-                clrMember ??= ClrTypeUtilities.SafeGetField(inheritedBaseClr, memberName, BindingFlags.Public | BindingFlags.Instance);
+                MemberInfo clrMember = ClrTypeUtilities.SafeGetInheritedInstanceProperty(inheritedBaseClr, memberName);
+                clrMember ??= ClrTypeUtilities.SafeGetInheritedInstanceField(inheritedBaseClr, memberName);
                 if (clrMember != null)
                 {
                     if (!TryGetWritableClrMember(clrMember, out var inhTargetType, out var inhTargetSymbol, out var inhWritable))
@@ -1147,11 +1140,12 @@ internal sealed partial class ExpressionBinder
             return new BoundPropertyAssignmentExpression(null, boundReceiver, structSym, prop, converted);
         }
 
-        // Inherited CLR base member fallback.
-        if (structSym.ImportedBaseType?.ClrType is System.Type inheritedBaseClr)
+        // Inherited CLR base member fallback (issue #1582: resolve through the
+        // user base chain and include inherited protected members).
+        if (GetInheritedClrBaseType(structSym) is System.Type inheritedBaseClr)
         {
             return TryBindChainedClrCompoundAssignment(
-                boundReceiver, inheritedBaseClr, memberName, memberNameSyntax, syntax, isAdd);
+                boundReceiver, inheritedBaseClr, memberName, memberNameSyntax, syntax, isAdd, includeInherited: true);
         }
 
         return null;
@@ -1167,17 +1161,30 @@ internal sealed partial class ExpressionBinder
         string memberName,
         NameExpressionSyntax memberNameSyntax,
         EventSubscriptionExpressionSyntax syntax,
-        bool isAdd)
+        bool isAdd,
+        bool includeInherited = false)
     {
         var baseOpSyntaxKind = isAdd ? SyntaxKind.PlusToken : SyntaxKind.MinusToken;
 
-        MemberInfo instanceMember = ClrTypeUtilities.SafeGetPropertyIncludingInterfaces(clrReceiverType, memberName, BindingFlags.Public | BindingFlags.Instance);
-        if (instanceMember is PropertyInfo propInfo && propInfo.GetIndexParameters().Length != 0)
+        MemberInfo instanceMember;
+        if (includeInherited)
         {
-            instanceMember = null;
+            // Issue #1582: the receiver is a derived G# type reaching into its
+            // metadata base — surface inherited protected/public members.
+            instanceMember = ClrTypeUtilities.SafeGetInheritedInstanceProperty(clrReceiverType, memberName);
+            instanceMember ??= ClrTypeUtilities.SafeGetInheritedInstanceField(clrReceiverType, memberName);
+        }
+        else
+        {
+            instanceMember = ClrTypeUtilities.SafeGetPropertyIncludingInterfaces(clrReceiverType, memberName, BindingFlags.Public | BindingFlags.Instance);
+            if (instanceMember is PropertyInfo propInfo && propInfo.GetIndexParameters().Length != 0)
+            {
+                instanceMember = null;
+            }
+
+            instanceMember ??= ClrTypeUtilities.SafeGetFieldIncludingInterfaces(clrReceiverType, memberName, BindingFlags.Public | BindingFlags.Instance);
         }
 
-        instanceMember ??= ClrTypeUtilities.SafeGetFieldIncludingInterfaces(clrReceiverType, memberName, BindingFlags.Public | BindingFlags.Instance);
         if (instanceMember == null)
         {
             return null;
@@ -1604,16 +1611,12 @@ internal sealed partial class ExpressionBinder
                 return new BoundPropertyAssignmentExpression(null, receiver, structSym, prop, propConverted);
             }
 
-            // Inherited CLR base member fallback.
-            if (structSym.ImportedBaseType?.ClrType is System.Type inheritedBaseClr)
+            // Inherited CLR base member fallback (issue #1582: walk the user
+            // base chain and include inherited protected members).
+            if (GetInheritedClrBaseType(structSym) is System.Type inheritedBaseClr)
             {
-                MemberInfo clrMember = ClrTypeUtilities.SafeGetProperty(inheritedBaseClr, fieldName, BindingFlags.Public | BindingFlags.Instance);
-                if (clrMember is PropertyInfo idxProp && idxProp.GetIndexParameters().Length != 0)
-                {
-                    clrMember = null;
-                }
-
-                clrMember ??= ClrTypeUtilities.SafeGetField(inheritedBaseClr, fieldName, BindingFlags.Public | BindingFlags.Instance);
+                MemberInfo clrMember = ClrTypeUtilities.SafeGetInheritedInstanceProperty(inheritedBaseClr, fieldName);
+                clrMember ??= ClrTypeUtilities.SafeGetInheritedInstanceField(inheritedBaseClr, fieldName);
                 if (clrMember != null)
                 {
                     if (!TryGetWritableClrMember(clrMember, out var inhTargetType, out var inhTargetSymbol, out var inhWritable))

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -432,6 +432,18 @@ internal sealed partial class ExpressionBinder
                 return importedStaticMember;
             }
 
+            // Issue #1582: a bare identifier inside an instance method of a G#
+            // class that derives from a metadata base may name an inherited CLR
+            // instance property/field (e.g. `return Message` in a class deriving
+            // from System.Exception). Unqualified inherited METHODS already
+            // resolve via the method-group path above; this mirrors that for
+            // properties/fields so bare and `this.`-qualified access behave
+            // identically for a metadata base, matching a user-defined base.
+            if (TryBindInheritedClrInstanceMemberByBareName(syntax.IdentifierToken.Text, out var inheritedClrMember))
+            {
+                return inheritedClrMember;
+            }
+
             // Not a method group: surface the suppressed diagnostics.
             if (scope.TryLookupSymbol(name) is null)
             {
@@ -1310,6 +1322,80 @@ internal sealed partial class ExpressionBinder
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Issue #1582: resolves the CLR/metadata base type that a user-defined G#
+    /// class (transitively) derives from, so inherited CLR members can be
+    /// surfaced on instances of the derived type. Walks the user
+    /// <see cref="StructSymbol.BaseClass"/> chain and returns the first
+    /// <see cref="StructSymbol.ImportedBaseType"/>'s CLR type encountered — the
+    /// point where the user inheritance chain meets metadata. From there,
+    /// reflection walks the remainder of the CLR base chain, so this covers a
+    /// direct metadata base (<c>class A : Exception</c>) as well as a metadata
+    /// base reached through one or more user classes (<c>class B : A</c> where
+    /// <c>A : Exception</c>). Returns <see langword="null"/> when the class
+    /// derives only from other user classes / <c>System.Object</c>.
+    /// </summary>
+    /// <param name="structSymbol">The user class to resolve the inherited CLR base for.</param>
+    /// <returns>The inherited CLR base type, or <see langword="null"/> when there is none.</returns>
+    private static Type GetInheritedClrBaseType(StructSymbol structSymbol)
+    {
+        for (var c = structSymbol; c != null; c = c.BaseClass)
+        {
+            if (c.ImportedBaseType?.ClrType is Type clr)
+            {
+                return clr;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Issue #1582: tries to bind a bare (unqualified) identifier inside an
+    /// instance method to an inherited CLR instance property/field of the
+    /// enclosing G# class's metadata base. The bound node reads through the
+    /// effective <c>this</c> receiver, so it behaves identically to the
+    /// <c>this.</c>-qualified access resolved in
+    /// <c>ExpressionBinder.Access.cs</c>. Runs only after the name failed to
+    /// resolve as a local/parameter/implicit member or a method group.
+    /// </summary>
+    /// <param name="name">The bare identifier text.</param>
+    /// <param name="bound">The bound member access on success.</param>
+    /// <returns><see langword="true"/> when an inherited CLR member was bound.</returns>
+    private bool TryBindInheritedClrInstanceMemberByBareName(string name, out BoundExpression bound)
+    {
+        bound = null;
+
+        var effThis = GetEffectiveThisParameter();
+        if (effThis?.Type is not StructSymbol thisStruct)
+        {
+            return false;
+        }
+
+        if (GetInheritedClrBaseType(thisStruct) is not Type clrBase)
+        {
+            return false;
+        }
+
+        var receiver = new BoundVariableExpression(null, effThis);
+
+        var clrProp = ClrTypeUtilities.SafeGetInheritedInstanceProperty(clrBase, name);
+        if (clrProp != null && clrProp.CanRead)
+        {
+            bound = new BoundClrPropertyAccessExpression(null, receiver, clrProp, TypeSymbol.FromClrType(clrProp.PropertyType));
+            return true;
+        }
+
+        var clrFld = ClrTypeUtilities.SafeGetInheritedInstanceField(clrBase, name);
+        if (clrFld != null)
+        {
+            bound = new BoundClrPropertyAccessExpression(null, receiver, clrFld, TypeSymbol.FromClrType(clrFld.FieldType));
+            return true;
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
@@ -837,9 +837,14 @@ internal sealed partial class MethodBodyEmitter
         switch (access.Member)
         {
             case PropertyInfo property:
+                // Issue #1582: an inherited property from a metadata base may
+                // expose only a `protected` / `protected internal` getter. Try
+                // the public accessor first (unchanged IL for existing samples),
+                // then fall back to the non-public getter for inherited members.
                 var getter = ReflectionMetadataEmitter.GetTypeBuilderSafePropertyAccessor(property, wantSetter: false)
+                    ?? ReflectionMetadataEmitter.GetTypeBuilderSafePropertyAccessor(property, wantSetter: false, nonPublic: true)
                     ?? throw new InvalidOperationException(
-                        $"Property '{property.DeclaringType?.FullName}.{property.Name}' has no public getter.");
+                        $"Property '{property.DeclaringType?.FullName}.{property.Name}' has no accessible getter.");
                 // Issue #671: when the receiver is a symbolic constructed
                 // generic (e.g. List[MyGs] with a user-defined type arg),
                 // route the getter through the receiver-aware overload so
@@ -924,7 +929,11 @@ internal sealed partial class MethodBodyEmitter
         switch (assn.Member)
         {
             case PropertyInfo property:
+                // Issue #1582: fall back to a non-public setter for an inherited
+                // metadata-base property (public accessor tried first so existing
+                // sample IL is unchanged).
                 var setter = ReflectionMetadataEmitter.GetTypeBuilderSafePropertyAccessor(property, wantSetter: true)
+                    ?? ReflectionMetadataEmitter.GetTypeBuilderSafePropertyAccessor(property, wantSetter: true, nonPublic: true)
                     ?? throw new InvalidOperationException(
                         $"Property '{property.DeclaringType?.FullName}.{property.Name}' has no public setter.");
                 this.il.OpCode(isStatic || receiverIsValueType ? ILOpCode.Call : ILOpCode.Callvirt);

--- a/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
+++ b/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
@@ -485,6 +485,72 @@ public static class ClrTypeUtilities
         => SafeGetMember(type, name, flags, (t, f) => t.GetField(name, f), SafeGetFields);
 
     /// <summary>
+    /// Issue #1582: looks up an instance FIELD named <paramref name="name"/>
+    /// inherited from <paramref name="type"/> (a CLR/metadata base class),
+    /// walking the CLR base chain and including non-public members whose
+    /// accessibility is visible to a derived type — <c>public</c>,
+    /// <c>protected</c> (Family), or <c>protected internal</c>
+    /// (FamilyOrAssembly). Private and (cross-assembly) internal fields are
+    /// excluded, mirroring the accessibility rule used for inherited CLR
+    /// methods in <c>CollectBaseClrMethodCandidates</c>. Reflection's
+    /// <see cref="Type.GetField(string, BindingFlags)"/> already surfaces
+    /// inherited (non-<c>DeclaredOnly</c>) members, so a single tolerant probe
+    /// covers the whole chain.
+    /// </summary>
+    /// <param name="type">The CLR base type to search (its base chain is walked by reflection).</param>
+    /// <param name="name">The field name.</param>
+    /// <returns>The matching visible inherited field, or <c>null</c> when none is found.</returns>
+    public static FieldInfo SafeGetInheritedInstanceField(Type type, string name)
+    {
+        if (type is null)
+        {
+            return null;
+        }
+
+        var field = SafeGetField(type, name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        if (field != null && (field.IsPublic || field.IsFamily || field.IsFamilyOrAssembly))
+        {
+            return field;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Issue #1582: looks up a non-indexer instance PROPERTY named
+    /// <paramref name="name"/> inherited from <paramref name="type"/> (a
+    /// CLR/metadata base class), walking the CLR base chain and including
+    /// members with a non-public accessor whose accessibility is visible to a
+    /// derived type (<c>public</c>, <c>protected</c>, or
+    /// <c>protected internal</c>). See
+    /// <see cref="SafeGetInheritedInstanceField"/> for the accessibility rule.
+    /// </summary>
+    /// <param name="type">The CLR base type to search (its base chain is walked by reflection).</param>
+    /// <param name="name">The property name.</param>
+    /// <returns>The matching visible inherited property, or <c>null</c> when none is found.</returns>
+    public static PropertyInfo SafeGetInheritedInstanceProperty(Type type, string name)
+    {
+        if (type is null)
+        {
+            return null;
+        }
+
+        var property = SafeGetProperty(type, name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        if (property == null || property.GetIndexParameters().Length != 0)
+        {
+            return null;
+        }
+
+        var accessor = property.GetGetMethod(nonPublic: true) ?? property.GetSetMethod(nonPublic: true);
+        if (accessor != null && (accessor.IsPublic || accessor.IsFamily || accessor.IsFamilyOrAssembly))
+        {
+            return property;
+        }
+
+        return null;
+    }
+
+    /// <summary>
     /// Looks up a single event by name tolerantly (issue #338). See
     /// <see cref="SafeGetProperty"/> for the tolerance contract.
     /// </summary>

--- a/test/Compiler.Tests/Emit/Issue1582MetadataBaseInheritedMemberEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1582MetadataBaseInheritedMemberEmitTests.cs
@@ -1,0 +1,135 @@
+// <copyright file="Issue1582MetadataBaseInheritedMemberEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1582 — end-to-end proof that a G# class deriving from a metadata
+/// (BCL) base class emits verifiable IL for inherited-member access and runs
+/// correctly. A class deriving from <see cref="System.Exception"/> reads the
+/// inherited public property <c>Message</c> by BARE name (Defect A) and
+/// round-trips the inherited public property <c>HResult</c> through a
+/// <c>this.</c>-qualified write + read (member-access emit parity). Uses a
+/// UNIQUE package AND user-type name because the in-process
+/// <c>FunctionTypeSymbol</c> cache is name-keyed.
+/// </summary>
+public class Issue1582MetadataBaseInheritedMemberEmitTests
+{
+    [Fact]
+    public void EndToEnd_InheritedMetadataBaseMembers_BareAndQualified_Run()
+    {
+        const string source = """
+            package i1582metabase
+            import System
+
+            class Boom : Exception {
+                func Roundtrip() int32 {
+                    this.HResult = 42
+                    return this.HResult
+                }
+
+                func Describe() bool {
+                    return Message != ""
+                }
+            }
+
+            func Main() {
+                let b = Boom()
+                System.Console.WriteLine(b.Roundtrip())
+                System.Console.WriteLine(b.Describe())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\nTrue\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1582_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1582MetadataBaseInheritedMemberTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1582MetadataBaseInheritedMemberTests.cs
@@ -1,0 +1,181 @@
+// <copyright file="Issue1582MetadataBaseInheritedMemberTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1582: when a G# class derives from a metadata (BCL / referenced
+/// assembly) base class, inherited members — methods, properties, AND fields,
+/// of any accessibility visible to the derived type — must resolve identically
+/// to a user-defined base, both unqualified (bare name) and <c>this.</c>
+/// qualified. Two historic defects are covered:
+/// <list type="bullet">
+///   <item>Defect A: unqualified simple-name lookup skipped the metadata base
+///   chain for properties/fields (inherited methods already resolved).</item>
+///   <item>Defect B: qualified member lookup did not find inherited
+///   <c>protected</c> fields of a metadata base (inherited properties did).</item>
+/// </list>
+/// Every scenario is asserted under BOTH the live-reflection
+/// (<see cref="ReferenceResolver.Default"/>) resolver and the
+/// <see cref="System.Reflection.MetadataLoadContext"/>-backed
+/// (<see cref="ReferenceResolver.WithReferences"/>) resolver, since the SDK
+/// build path uses the latter.
+/// </summary>
+public class Issue1582MetadataBaseInheritedMemberTests
+{
+    // Defect A — unqualified inherited PROPERTY from a metadata base.
+    [Theory]
+    [MemberData(nameof(Resolvers))]
+    public void Unqualified_InheritedProperty_FromMetadataBase_Resolves(bool withReferences)
+    {
+        var source = @"
+package p
+import System
+class A : Exception { func F() string { return Message } }
+";
+        AssertNoErrors(source, withReferences);
+    }
+
+    // Defect A — unqualified inherited protected FIELD from a metadata base.
+    [Theory]
+    [MemberData(nameof(Resolvers))]
+    public void Unqualified_InheritedField_FromMetadataBase_Resolves(bool withReferences)
+    {
+        var source = @"
+package p
+import System.Security.Cryptography
+open class A : HashAlgorithm {
+    func Initialize() { }
+    protected func HashCore(a []uint8, s int32, c int32) { }
+    protected func HashFinal() []uint8 { return HashValue }
+}
+";
+        AssertNoErrors(source, withReferences);
+    }
+
+    // Defect B — qualified inherited protected FIELD from a metadata base
+    // (read AND write).
+    [Theory]
+    [MemberData(nameof(Resolvers))]
+    public void Qualified_InheritedField_FromMetadataBase_Resolves(bool withReferences)
+    {
+        var source = @"
+package p
+import System.Security.Cryptography
+open class A : HashAlgorithm {
+    func Initialize() { }
+    protected func HashCore(a []uint8, s int32, c int32) { }
+    protected func HashFinal() []uint8 {
+        this.HashValue = []uint8{}
+        return this.HashValue
+    }
+}
+";
+        AssertNoErrors(source, withReferences);
+    }
+
+    // Regression — unqualified inherited METHOD from a metadata base still
+    // resolves (this path always worked; guards against a regression).
+    [Theory]
+    [MemberData(nameof(Resolvers))]
+    public void Unqualified_InheritedMethod_FromMetadataBase_Resolves(bool withReferences)
+    {
+        var source = @"
+package p
+import System
+class A : Exception { func F() string? { return ToString() } }
+";
+        AssertNoErrors(source, withReferences);
+    }
+
+    // Generalization — a metadata base reached THROUGH a user class exposes the
+    // inherited property both bare and qualified (full base-chain walk).
+    [Theory]
+    [MemberData(nameof(Resolvers))]
+    public void Inherited_MetadataBase_ThroughUserClass_Resolves(bool withReferences)
+    {
+        var source = @"
+package p
+import System
+open class Base : Exception { }
+class Derived : Base {
+    func F() string { return Message }
+    func G() string { return this.Message }
+}
+";
+        AssertNoErrors(source, withReferences);
+    }
+
+    // Control — a USER-defined base works for unqualified/qualified property AND
+    // field, confirming the metadata-base behavior now matches it.
+    [Theory]
+    [MemberData(nameof(Resolvers))]
+    public void UserDefinedBase_AllMemberKinds_Resolve(bool withReferences)
+    {
+        var source = @"
+package p
+open class Base {
+    protected let value int32
+    prop Tag string { get set }
+}
+class Derived : Base {
+    func ReadFieldBare() int32 { return value }
+    func ReadFieldQualified() int32 { return this.value }
+    func ReadPropBare() string { return Tag }
+    func ReadPropQualified() string { return this.Tag }
+}
+";
+        AssertNoErrors(source, withReferences);
+    }
+
+    public static TheoryData<bool> Resolvers() => new() { false, true };
+
+    private static void AssertNoErrors(string source, bool withReferences)
+    {
+        var diagnostics = Bind(source, withReferences);
+        Assert.Empty(diagnostics.Where(d => d.IsError));
+    }
+
+    private static ImmutableArray<Diagnostic> Bind(string source, bool withReferences)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var globalScope = Binder.BindGlobalScope(
+            previous: null,
+            ImmutableArray.Create(tree),
+            CreateResolver(withReferences));
+        var program = Binder.BindProgram(globalScope, CreateResolver(withReferences));
+        return globalScope.Diagnostics.AddRange(program.Diagnostics);
+    }
+
+    private static ReferenceResolver CreateResolver(bool withReferences)
+    {
+        if (!withReferences)
+        {
+            return ReferenceResolver.Default();
+        }
+
+        var paths = new[]
+        {
+            typeof(object).Assembly.Location,
+            typeof(System.Exception).Assembly.Location,
+            typeof(System.Security.Cryptography.HashAlgorithm).Assembly.Location,
+            typeof(System.Console).Assembly.Location,
+        }
+        .Where(p => !string.IsNullOrEmpty(p))
+        .Distinct(StringComparer.OrdinalIgnoreCase)
+        .ToArray();
+
+        return ReferenceResolver.WithReferences(paths);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes inherited-member resolution when a G# type derives from a **metadata
(BCL / referenced-assembly) base class**. A user-defined base worked in every
case; only metadata base classes were broken.

## Defects fixed

**A — unqualified property/field lookup skipped the metadata base chain.**
Implicit-`this` bare-name seeding only walked the user `StructSymbol.BaseClass`
chain, so inherited CLR properties/fields were never exposed as bare names
(`return Message` on an `Exception` subtype → `GS0125`). Inherited *methods*
resolved through a separate method-group path, which masked the gap.

**B — qualified lookup missed inherited protected fields from a metadata base.**
The imported-base fallbacks used `BindingFlags.Public | Instance` and probed
only the immediate `ImportedBaseType`, so protected/protected-internal fields
(e.g. `HashAlgorithm.HashValue`) and members reached through a user base were
missed (`this.HashValue` → `GS0158`). Public inherited properties worked only
because reflection walks the chain for public members.

## Changes

- `ClrTypeUtilities.cs` — `SafeGetInheritedInstanceField` /
  `SafeGetInheritedInstanceProperty` (Public|NonPublic, derived-visible
  accessibility: public/Family/FamilyOrAssembly).
- `ExpressionBinder.cs` — `GetInheritedClrBaseType` (walks the user base chain
  to the metadata base) and `TryBindInheritedClrInstanceMemberByBareName`
  (Defect A bare-name fallback).
- `ExpressionBinder.Access.cs` — qualified read fallback uses the chain +
  inherited helpers.
- `ExpressionBinder.Assignments.cs` — write + compound-assignment fallbacks
  updated (`includeInherited`).
- `MethodBodyEmitter.MemberAccess.cs` — property get/set emit falls back to a
  non-public accessor only when no public one exists (existing IL unchanged).

Holds for both resolvers (`ReferenceResolver.Default()` live reflection and
`.WithReferences()` MetadataLoadContext).

## Tests

- `Issue1582MetadataBaseInheritedMemberTests` (Core.Tests): 12 passing
  (6 scenarios × Default + WithReferences) — unqualified/qualified property,
  field, method regression, metadata-base-through-user-class chain, and a
  user-defined-base control.
- `Issue1582MetadataBaseInheritedMemberEmitTests` (Compiler.Tests): 1 passing
  end-to-end (ilverify + run).
- Full Core.Tests: 4925 passed, 1 skipped, 0 failed. RefactoringBaseline
  byte-identical gate unaffected.

Fixes #1582

Refs #914
