### PR TITLE
Fix bare-name write/compound-write to inherited metadata-base members (#1584)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -35,9 +35,26 @@ internal sealed partial class ExpressionBinder
         // `A : T?`) binds context-free, picks `T` from the non-nil arm, and then
         // rejects the `nil` arm with GS0155 — even though the identical RHS bound
         // through `let a T? = ...` (which does receive the target type) compiles.
-        var variable = BindVariableReference(name, syntax.IdentifierToken.Location);
+        var variable = BindVariableReference(name, syntax.IdentifierToken.Location, suppressNotAVariable: false, suppressUndefinedVariable: true);
         if (variable == null)
         {
+            // Issue #1584: a bare write to an inherited CLR instance
+            // property/field of a metadata base resolves to `this.member =
+            // value`, mirroring the qualified path and the bare-name READ
+            // fallback in BindNameExpression.
+            if (TryBindInheritedClrInstanceMemberWriteByBareName(name, syntax.Expression, syntax.EqualsToken.Location, out var inheritedWrite))
+            {
+                return inheritedWrite;
+            }
+
+            // Surface the diagnostic suppressed above (GS0125) only when the
+            // name is genuinely unresolved; a non-variable symbol already
+            // reported its own diagnostic.
+            if (scope.TryLookupSymbol(name) is null)
+            {
+                Diagnostics.ReportUndefinedVariable(syntax.IdentifierToken.Location, name);
+            }
+
             return BindExpression(syntax.Expression);
         }
 
@@ -855,12 +872,38 @@ internal sealed partial class ExpressionBinder
 
         // Not an event: fall back to compound assignment semantics.
         // Reconstruct `name = name +/- rhs` as the parser used to do.
-        var boundRhs = BindExpression(syntax.Value);
-        var variable = BindVariableReference(name, bareName.IdentifierToken.Location);
+        var variable = BindVariableReference(name, bareName.IdentifierToken.Location, suppressNotAVariable: false, suppressUndefinedVariable: true);
         if (variable == null)
         {
-            return boundRhs;
+            // Issue #1584: a bare compound-write to an inherited CLR instance
+            // property/field of a metadata base resolves to `this.member op=
+            // value`, mirroring the qualified compound path and the bare-name
+            // simple-write fallback.
+            var effThis = GetEffectiveThisParameter();
+            if (effThis?.Type is StructSymbol thisStruct
+                && GetInheritedClrBaseType(thisStruct) is System.Type inheritedBaseClr)
+            {
+                var inheritedReceiver = new BoundVariableExpression(null, effThis);
+                var inheritedCompound = TryBindChainedClrCompoundAssignment(
+                    inheritedReceiver, inheritedBaseClr, name, bareName, syntax, isAdd, includeInherited: true);
+                if (inheritedCompound != null)
+                {
+                    return inheritedCompound;
+                }
+            }
+
+            // Surface the diagnostic suppressed above (GS0125) only when the
+            // name is genuinely unresolved; a non-variable symbol already
+            // reported its own diagnostic.
+            if (scope.TryLookupSymbol(name) is null)
+            {
+                Diagnostics.ReportUndefinedVariable(bareName.IdentifierToken.Location, name);
+            }
+
+            return BindExpression(syntax.Value);
         }
+
+        var boundRhs = BindExpression(syntax.Value);
 
         // Synthesize the binary expression: variable op rhs.
         var leftExpr = BindNameExpressionCore(bareName);

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -1368,6 +1368,44 @@ internal sealed partial class ExpressionBinder
     {
         bound = null;
 
+        if (!TryResolveInheritedClrInstanceMemberByBareName(name, out var receiver, out var member))
+        {
+            return false;
+        }
+
+        switch (member)
+        {
+            case PropertyInfo clrProp when clrProp.CanRead:
+                bound = new BoundClrPropertyAccessExpression(null, receiver, clrProp, TypeSymbol.FromClrType(clrProp.PropertyType));
+                return true;
+            case FieldInfo clrFld:
+                bound = new BoundClrPropertyAccessExpression(null, receiver, clrFld, TypeSymbol.FromClrType(clrFld.FieldType));
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    /// <summary>
+    /// Issue #1584: resolves a bare (unqualified) identifier inside an instance
+    /// method to an inherited CLR instance property/field of the enclosing G#
+    /// class's metadata base, returning the effective <c>this</c> receiver and
+    /// the resolved <see cref="MemberInfo"/>. Shared by the bare-name READ
+    /// fallback (<see cref="TryBindInheritedClrInstanceMemberByBareName"/>) and
+    /// the bare-name WRITE / COMPOUND-WRITE fallbacks in
+    /// <c>ExpressionBinder.Assignments.cs</c> so all three behave identically to
+    /// the <c>this.</c>-qualified paths. A property is preferred over a field of
+    /// the same name (mirroring the qualified member-lookup order).
+    /// </summary>
+    /// <param name="name">The bare identifier text.</param>
+    /// <param name="receiver">The effective <c>this</c> receiver on success.</param>
+    /// <param name="member">The resolved inherited CLR member on success.</param>
+    /// <returns><see langword="true"/> when an inherited CLR member was resolved.</returns>
+    private bool TryResolveInheritedClrInstanceMemberByBareName(string name, out BoundExpression receiver, out MemberInfo member)
+    {
+        receiver = null;
+        member = null;
+
         var effThis = GetEffectiveThisParameter();
         if (effThis?.Type is not StructSymbol thisStruct)
         {
@@ -1379,23 +1417,59 @@ internal sealed partial class ExpressionBinder
             return false;
         }
 
-        var receiver = new BoundVariableExpression(null, effThis);
-
-        var clrProp = ClrTypeUtilities.SafeGetInheritedInstanceProperty(clrBase, name);
-        if (clrProp != null && clrProp.CanRead)
+        member = ClrTypeUtilities.SafeGetInheritedInstanceProperty(clrBase, name);
+        member ??= ClrTypeUtilities.SafeGetInheritedInstanceField(clrBase, name);
+        if (member == null)
         {
-            bound = new BoundClrPropertyAccessExpression(null, receiver, clrProp, TypeSymbol.FromClrType(clrProp.PropertyType));
+            return false;
+        }
+
+        receiver = new BoundVariableExpression(null, effThis);
+        return true;
+    }
+
+    /// <summary>
+    /// Issue #1584: tries to bind a bare (unqualified) simple write
+    /// <c>member = value</c> inside an instance method to an inherited CLR
+    /// instance property/field of the enclosing G# class's metadata base,
+    /// producing a <see cref="BoundClrPropertyAssignmentExpression"/> through the
+    /// effective <c>this</c> receiver — identical to the <c>this.member =
+    /// value</c> qualified path in <see cref="BindMemberFieldAssignmentExpression"/>.
+    /// A resolved-but-unsettable member (get-only property / readonly field)
+    /// reports <c>cannot assign</c> rather than GS0125, matching the qualified
+    /// path. Runs only after the bare name failed to resolve as a
+    /// local/parameter/implicit member.
+    /// </summary>
+    /// <param name="name">The bare identifier text.</param>
+    /// <param name="valueSyntax">The RHS value syntax.</param>
+    /// <param name="assignLocation">The location of the assignment operator, for diagnostics.</param>
+    /// <param name="bound">The bound assignment (or an error expression) on success.</param>
+    /// <returns><see langword="true"/> when an inherited CLR member was resolved.</returns>
+    private bool TryBindInheritedClrInstanceMemberWriteByBareName(
+        string name,
+        ExpressionSyntax valueSyntax,
+        TextLocation assignLocation,
+        out BoundExpression bound)
+    {
+        bound = null;
+
+        if (!TryResolveInheritedClrInstanceMemberByBareName(name, out var receiver, out var member))
+        {
+            return false;
+        }
+
+        if (!TryGetWritableClrMember(member, out _, out var targetSymbol, out _))
+        {
+            Diagnostics.ReportCannotAssign(assignLocation, name);
+            _ = BindExpression(valueSyntax);
+            bound = new BoundErrorExpression(null);
             return true;
         }
 
-        var clrFld = ClrTypeUtilities.SafeGetInheritedInstanceField(clrBase, name);
-        if (clrFld != null)
-        {
-            bound = new BoundClrPropertyAccessExpression(null, receiver, clrFld, TypeSymbol.FromClrType(clrFld.FieldType));
-            return true;
-        }
-
-        return false;
+        var value = BindAssignmentRhs(valueSyntax, targetSymbol);
+        var converted = conversions.BindConversion(valueSyntax.Location, value, targetSymbol);
+        bound = new BoundClrPropertyAssignmentExpression(null, receiver, member, converted, targetSymbol);
+        return true;
     }
 
     /// <summary>

--- a/test/Compiler.Tests/Emit/Issue1584InheritedMemberBareWriteEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1584InheritedMemberBareWriteEmitTests.cs
@@ -1,0 +1,130 @@
+// <copyright file="Issue1584InheritedMemberBareWriteEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1584 (follow-up to #1582): a bare (unqualified) WRITE and
+/// COMPOUND-WRITE to an inherited CLR instance member of a metadata base must
+/// not only bind, but emit verifiable IL that round-trips at runtime. This
+/// end-to-end test derives from <see cref="System.Exception"/>, sets and
+/// compound-updates the inherited <c>HResult</c> property through bare names,
+/// then reads it back. Uses a UNIQUE package/type name because the in-process
+/// <c>FunctionTypeSymbol</c> cache is name-keyed.
+/// </summary>
+public class Issue1584InheritedMemberBareWriteEmitTests
+{
+    [Fact]
+    public void EndToEnd_BareWriteAndCompound_InheritedMember_Runs()
+    {
+        const string source = """
+            package i1584barewrite
+            import System
+
+            open class BareWriter : Exception {
+                func SetAndGet() int32 {
+                    HResult = 100
+                    HResult += 23
+                    return HResult
+                }
+            }
+
+            func Main() {
+                let w = BareWriter()
+                System.Console.WriteLine(w.SetAndGet())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("123\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1584_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1584InheritedMemberBareWriteTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1584InheritedMemberBareWriteTests.cs
@@ -1,0 +1,252 @@
+// <copyright file="Issue1584InheritedMemberBareWriteTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1584 (follow-up to #1582): a bare (unqualified) WRITE or
+/// COMPOUND-WRITE to an inherited CLR instance member (field or property) of a
+/// metadata (BCL / referenced-assembly) base class must resolve identically to
+/// the <c>this.</c>-qualified path and to a user-defined base — instead of
+/// failing with <c>GS0125: Variable '…' doesn't exist</c>. #1582 fixed the READ
+/// path and the qualified WRITE path but left the bare-name write /
+/// compound-write target resolution unaware of the inherited-CLR base chain.
+/// Every scenario is asserted under BOTH the live-reflection
+/// (<see cref="ReferenceResolver.Default"/>) resolver and the
+/// <see cref="System.Reflection.MetadataLoadContext"/>-backed
+/// (<see cref="ReferenceResolver.WithReferences"/>) resolver.
+/// </summary>
+public class Issue1584InheritedMemberBareWriteTests
+{
+    // Bare WRITE to an inherited protected FIELD of a metadata base.
+    [Theory]
+    [MemberData(nameof(Resolvers))]
+    public void BareWrite_InheritedField_FromMetadataBase_Resolves(bool withReferences)
+    {
+        var source = @"
+package p
+import System.Security.Cryptography
+open class A : HashAlgorithm {
+    func Initialize() { }
+    protected func HashCore(a []uint8, s int32, c int32) { }
+    protected func HashFinal() []uint8 {
+        HashValue = []uint8{}
+        return []uint8{}
+    }
+}
+";
+        AssertNoErrors(source, withReferences);
+    }
+
+    // Bare COMPOUND-WRITE to an inherited protected FIELD of a metadata base.
+    [Theory]
+    [MemberData(nameof(Resolvers))]
+    public void BareCompoundWrite_InheritedField_FromMetadataBase_Resolves(bool withReferences)
+    {
+        var source = @"
+package p
+import System.Security.Cryptography
+open class A : HashAlgorithm {
+    func Initialize() { }
+    protected func HashCore(a []uint8, s int32, c int32) { }
+    protected func HashFinal() []uint8 {
+        HashSizeValue += 1
+        return []uint8{}
+    }
+}
+";
+        AssertNoErrors(source, withReferences);
+    }
+
+    // Bare WRITE to an inherited PROPERTY of a metadata base.
+    [Theory]
+    [MemberData(nameof(Resolvers))]
+    public void BareWrite_InheritedProperty_FromMetadataBase_Resolves(bool withReferences)
+    {
+        var source = @"
+package p
+import System
+open class A : Exception {
+    func F() { HResult = 5 }
+}
+";
+        AssertNoErrors(source, withReferences);
+    }
+
+    // Bare COMPOUND-WRITE to an inherited PROPERTY of a metadata base.
+    [Theory]
+    [MemberData(nameof(Resolvers))]
+    public void BareCompoundWrite_InheritedProperty_FromMetadataBase_Resolves(bool withReferences)
+    {
+        var source = @"
+package p
+import System
+open class A : Exception {
+    func F() { HResult += 5 }
+}
+";
+        AssertNoErrors(source, withReferences);
+    }
+
+    // Negative — a bare write to a get-only inherited property reports
+    // "cannot assign" (GS0127), NOT GS0125 "doesn't exist".
+    [Theory]
+    [MemberData(nameof(Resolvers))]
+    public void BareWrite_InheritedGetOnlyProperty_ReportsCannotAssign(bool withReferences)
+    {
+        var source = @"
+package p
+import System
+open class A : Exception {
+    func F() { Message = ""x"" }
+}
+";
+        var diagnostics = Bind(source, withReferences);
+        var errors = diagnostics.Where(d => d.IsError).ToArray();
+        Assert.NotEmpty(errors);
+        Assert.All(errors, d => Assert.DoesNotContain("doesn't exist", d.Message));
+        Assert.Contains(errors, d => d.Message.Contains("read-only") || d.Message.Contains("cannot be assigned"));
+    }
+
+    // Negative — a bare compound-write to a get-only inherited property reports
+    // "cannot assign" (GS0127), NOT GS0125 "doesn't exist".
+    [Theory]
+    [MemberData(nameof(Resolvers))]
+    public void BareCompoundWrite_InheritedGetOnlyProperty_ReportsCannotAssign(bool withReferences)
+    {
+        var source = @"
+package p
+import System
+open class A : Exception {
+    func F() { StackTrace += ""x"" }
+}
+";
+        var diagnostics = Bind(source, withReferences);
+        var errors = diagnostics.Where(d => d.IsError).ToArray();
+        Assert.NotEmpty(errors);
+        Assert.All(errors, d => Assert.DoesNotContain("doesn't exist", d.Message));
+        Assert.Contains(errors, d => d.Message.Contains("read-only") || d.Message.Contains("cannot be assigned"));
+    }
+
+    // Regression — a genuinely undefined bare write still reports GS0125.
+    [Theory]
+    [MemberData(nameof(Resolvers))]
+    public void BareWrite_UndefinedName_StillReportsDoesNotExist(bool withReferences)
+    {
+        var source = @"
+package p
+import System
+open class A : Exception {
+    func F() { Nonexistent = 5 }
+}
+";
+        var diagnostics = Bind(source, withReferences);
+        Assert.Contains(diagnostics.Where(d => d.IsError), d => d.Message.Contains("doesn't exist"));
+    }
+
+    // Control — the qualified WRITE (fixed by #1582) still resolves.
+    [Theory]
+    [MemberData(nameof(Resolvers))]
+    public void QualifiedWrite_InheritedMember_StillResolves(bool withReferences)
+    {
+        var source = @"
+package p
+import System.Security.Cryptography
+open class A : HashAlgorithm {
+    func Initialize() { }
+    protected func HashCore(a []uint8, s int32, c int32) { }
+    protected func HashFinal() []uint8 {
+        this.HashValue = []uint8{}
+        return this.HashValue
+    }
+}
+";
+        AssertNoErrors(source, withReferences);
+    }
+
+    // Control — the bare READ (fixed by #1582) still resolves.
+    [Theory]
+    [MemberData(nameof(Resolvers))]
+    public void BareRead_InheritedMember_StillResolves(bool withReferences)
+    {
+        var source = @"
+package p
+import System
+class A : Exception { func F() string { return Message } }
+";
+        AssertNoErrors(source, withReferences);
+    }
+
+    // Control — a USER-defined base bare write / compound-write to inherited
+    // field AND property resolves, confirming metadata-base parity.
+    [Theory]
+    [MemberData(nameof(Resolvers))]
+    public void UserDefinedBase_BareWriteAndCompound_Resolve(bool withReferences)
+    {
+        var source = @"
+package p
+open class Base {
+    protected var value int32
+    prop Tag int32 { get set }
+}
+class Derived : Base {
+    func WriteFieldBare() { value = 1 }
+    func CompoundFieldBare() { value += 1 }
+    func WritePropBare() { Tag = 1 }
+    func CompoundPropBare() { Tag += 1 }
+}
+";
+        AssertNoErrors(source, withReferences);
+    }
+
+    public static TheoryData<bool> Resolvers() => new() { false, true };
+
+    private static void AssertNoErrors(string source, bool withReferences)
+    {
+        var diagnostics = Bind(source, withReferences);
+        Assert.Empty(diagnostics.Where(d => d.IsError));
+    }
+
+    private static ImmutableArray<Diagnostic> Bind(string source, bool withReferences)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var globalScope = Binder.BindGlobalScope(
+            previous: null,
+            ImmutableArray.Create(tree),
+            CreateResolver(withReferences));
+        var program = Binder.BindProgram(globalScope, CreateResolver(withReferences));
+        return globalScope.Diagnostics.AddRange(program.Diagnostics);
+    }
+
+    private static ReferenceResolver CreateResolver(bool withReferences)
+    {
+        if (!withReferences)
+        {
+            return ReferenceResolver.Default();
+        }
+
+        var paths = new[]
+        {
+            typeof(object).Assembly.Location,
+            typeof(System.Exception).Assembly.Location,
+            typeof(System.Security.Cryptography.HashAlgorithm).Assembly.Location,
+            typeof(System.Console).Assembly.Location,
+        }
+        .Where(p => !string.IsNullOrEmpty(p))
+        .Distinct(StringComparer.OrdinalIgnoreCase)
+        .ToArray();
+
+        return ReferenceResolver.WithReferences(paths);
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #1582 / #1583. That fix resolved inherited members from a metadata
(BCL) base class for the READ path and QUALIFIED writes, but the **unqualified
(bare-name) WRITE and COMPOUND-WRITE** paths were not extended, so assigning to
an inherited CLR member by bare name still failed with `GS0125`.

## Root cause

Bare-name assignment targets resolve via `BindVariableReference`, which walks
locals/params/implicit members and the *user* `StructSymbol` base chain only —
never the inherited-CLR base chain. An inherited CLR field/property produced a
null target and fell through to `GS0125`. The bare compound-write path
(`BindBareEventOrCompoundAssignment`) had the identical gap.

## Changes

- `ExpressionBinder.cs`: extracted a shared
  `TryResolveInheritedClrInstanceMemberByBareName` (reused by the existing READ
  fallback) and added `TryBindInheritedClrInstanceMemberWriteByBareName`
  (builds `this.member = value`; reports the correct "cannot assign" (GS0127)
  for get-only/readonly members via `TryGetWritableClrMember`, not GS0125).
- `ExpressionBinder.Assignments.cs`: `BindAssignmentExpression` and
  `BindBareEventOrCompoundAssignment` now consult the inherited-CLR fallback
  (compound reuses `TryBindChainedClrCompoundAssignment(includeInherited: true)`),
  suppressing then re-reporting `GS0125` only when the name is truly unresolved.

Generalized — no type/member special-casing; walks the full base chain; holds
under both `ReferenceResolver.Default()` and `.WithReferences()`.

## Tests

- `Issue1584InheritedMemberBareWriteTests` (Core.Tests, parameterized over both
  resolvers): bare write/compound-write × field/property, get-only "cannot
  assign" negative, undefined-name still `GS0125`, plus user-defined-base and
  qualified-write/bare-read regression controls.
- One `Compiler.Tests` emit round-trip test (ilverify + runtime → `123`).
- Full Core.Tests: 4947 passed, 1 skipped, 0 failed. RefactoringBaseline
  byte-identical gate unaffected.

Fixes #1584

Refs #914
