### PR TITLE
Resolve bare-name static-sibling calls inside static method bodies (#1585)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -4072,6 +4072,33 @@ internal sealed class OverloadResolver
                 }
             }
 
+            // Issue #1585: implicit static-self dispatch inside a `shared`
+            // (static) method body of a user struct/class. The enclosing
+            // function has no `this` parameter but carries <c>StaticOwnerType</c>
+            // = the owning StructSymbol. An unqualified call (`Helper(args)` /
+            // `Helper[T](args)`) must resolve against the type's own static
+            // (`shared`) method group — mirroring both the qualified
+            // `Type.Helper(args)` path and the instance-body bare-call path
+            // (issue #1147), which already reach sibling statics. Routing
+            // through the shared static-call finalizer (`bindUserTypeStaticCall`)
+            // gives full private/overload/optional/variadic/generic fidelity and
+            // walks the same base-type chain as the qualified path. The method
+            // group is fetched through the canonical member-resolution layer
+            // (ADR-0112) so it holds under both reference resolvers.
+            if (getCurrentFunction()?.ThisParameter == null
+                && getCurrentFunction()?.StaticOwnerType is StructSymbol implicitStaticStruct
+                && bindUserTypeStaticCall != null)
+            {
+                var implicitStaticStructOverloads = TypeMemberModel.GetMethods(
+                    implicitStaticStruct,
+                    syntax.Identifier.Text,
+                    MemberQuery.Static(MemberKinds.Method));
+                if (!implicitStaticStructOverloads.IsDefaultOrEmpty)
+                {
+                    return bindUserTypeStaticCall(implicitStaticStruct, syntax);
+                }
+            }
+
             // Issue #1566: reaching here with a non-null symbol means the name
             // denotes only extension function(s) and the enclosing type had no
             // matching member — fall through to the free-function/extension

--- a/test/Compiler.Tests/Emit/Issue1585StaticBareCallEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1585StaticBareCallEmitTests.cs
@@ -1,0 +1,144 @@
+// <copyright file="Issue1585StaticBareCallEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1585 — an unqualified (bare-name) call from inside a static
+/// (<c>shared</c>) method body to a sibling static method of the same type
+/// failed to resolve (<c>GS0130</c>). This proves the fix end-to-end: a
+/// static→static bare call now binds, emits verifiable IL, and runs.
+/// </summary>
+public class Issue1585StaticBareCallEmitTests
+{
+    [Fact]
+    public void EndToEnd_StaticToStaticBareCall_NonGeneric_Runs()
+    {
+        const string source = """
+            package i1585barestatic
+            import System
+
+            class Widget {
+                shared {
+                    func Caller() int32 { return Helper() + 40 }
+                    private func Helper() int32 { return 2 }
+                }
+            }
+
+            func Main() { System.Console.WriteLine(Widget.Caller()) }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_StaticToStaticBareCall_GenericExplicitTypeArgs_Runs()
+    {
+        const string source = """
+            package i1585barestaticgen
+            import System
+
+            class Gadget {
+                shared {
+                    func Caller() int32 { return Echo[int32](7) }
+                    private func Echo[T](v T) T { return v }
+                }
+            }
+
+            func Main() { System.Console.WriteLine(Gadget.Caller()) }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("7\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1585_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1585StaticBareCallTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1585StaticBareCallTests.cs
@@ -1,0 +1,226 @@
+// <copyright file="Issue1585StaticBareCallTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1585: an unqualified (bare-name) call from inside a static
+/// (<c>shared</c>) method body to a sibling static method of the same type must
+/// resolve — just like the same call qualified with the type name, and just
+/// like a bare call to a static sibling from an instance method body. Before
+/// the fix static-method bodies were not searched against the enclosing type's
+/// own static method group, so such calls reported <c>GS0130</c>
+/// ("Function '…' doesn't exist.").
+/// Every scenario is asserted under BOTH the live-reflection
+/// (<see cref="ReferenceResolver.Default"/>) resolver and the
+/// <see cref="System.Reflection.MetadataLoadContext"/>-backed
+/// (<see cref="ReferenceResolver.WithReferences"/>) resolver, since the SDK
+/// build path uses the latter.
+/// </summary>
+public class Issue1585StaticBareCallTests
+{
+    // Non-generic static -> static bare call.
+    [Theory]
+    [MemberData(nameof(Resolvers))]
+    public void StaticToStatic_BareCall_NonGeneric_Resolves(bool withReferences)
+    {
+        var source = @"
+package p
+class M {
+    shared {
+        func Caller() int32 { return Helper() }
+        private func Helper() int32 { return 1 }
+    }
+}
+";
+        AssertNoErrors(source, withReferences);
+    }
+
+    // Generic static -> static bare call with explicit type arguments.
+    [Theory]
+    [MemberData(nameof(Resolvers))]
+    public void StaticToStatic_BareCall_GenericExplicitTypeArgs_Resolves(bool withReferences)
+    {
+        var source = @"
+package p
+class M {
+    shared {
+        func Caller[T class init()]() T { return Helper[T]() }
+        private func Helper[T class init()]() T { return T() }
+    }
+}
+";
+        AssertNoErrors(source, withReferences);
+    }
+
+    // Generic static -> static bare call with INFERRED type arguments.
+    [Theory]
+    [MemberData(nameof(Resolvers))]
+    public void StaticToStatic_BareCall_GenericInferredTypeArgs_Resolves(bool withReferences)
+    {
+        var source = @"
+package p
+class M {
+    shared {
+        func Caller(x int32) int32 { return Ident(x) }
+        private func Ident[T](v T) T { return v }
+    }
+}
+";
+        AssertNoErrors(source, withReferences);
+    }
+
+    // Overloaded static siblings — the correct overload is picked by arity.
+    [Theory]
+    [MemberData(nameof(Resolvers))]
+    public void StaticToStatic_BareCall_OverloadedSiblings_Resolve(bool withReferences)
+    {
+        var source = @"
+package p
+class M {
+    shared {
+        func Caller() int32 { return Add(1) + Add(1, 2) }
+        private func Add(a int32) int32 { return a }
+        private func Add(a int32, b int32) int32 { return a + b }
+    }
+}
+";
+        AssertNoErrors(source, withReferences);
+    }
+
+    // Default-parameter static sibling — the omitted trailing slot is filled.
+    [Theory]
+    [MemberData(nameof(Resolvers))]
+    public void StaticToStatic_BareCall_DefaultParameter_Resolves(bool withReferences)
+    {
+        var source = @"
+package p
+class M {
+    shared {
+        func Caller() int32 { return Add(1) }
+        private func Add(a int32, b int32 = 5) int32 { return a + b }
+    }
+}
+";
+        AssertNoErrors(source, withReferences);
+    }
+
+    // A user struct behaves the same as a class for static-self dispatch.
+    [Theory]
+    [MemberData(nameof(Resolvers))]
+    public void StaticToStatic_BareCall_OnStruct_Resolves(bool withReferences)
+    {
+        var source = @"
+package p
+struct S {
+    shared {
+        func Caller() int32 { return Helper() }
+        private func Helper() int32 { return 7 }
+    }
+}
+";
+        AssertNoErrors(source, withReferences);
+    }
+
+    // Control — the qualified `Type.Helper[T]()` static call still resolves.
+    [Theory]
+    [MemberData(nameof(Resolvers))]
+    public void QualifiedStaticCall_FromStaticCaller_StillResolves(bool withReferences)
+    {
+        var source = @"
+package p
+class M {
+    shared {
+        func Caller[T class init()]() T { return M.Helper[T]() }
+        private func Helper[T class init()]() T { return T() }
+    }
+}
+";
+        AssertNoErrors(source, withReferences);
+    }
+
+    // Control — a bare call to a static sibling from an INSTANCE body still
+    // resolves (the path that always worked; guards against a regression).
+    [Theory]
+    [MemberData(nameof(Resolvers))]
+    public void InstanceToStatic_BareCall_StillResolves(bool withReferences)
+    {
+        var source = @"
+package p
+class M {
+    func Caller[T class init()]() T { return Helper[T]() }
+    shared {
+        private func Helper[T class init()]() T { return T() }
+    }
+}
+";
+        AssertNoErrors(source, withReferences);
+    }
+
+    // Control — a genuinely undefined bare call from a static body still reports
+    // GS0130 (the fix must not swallow real "not found" diagnostics).
+    [Theory]
+    [MemberData(nameof(Resolvers))]
+    public void StaticBareCall_UndefinedName_StillReportsGs0130(bool withReferences)
+    {
+        var source = @"
+package p
+class M {
+    shared {
+        func Caller() int32 { return Nope() }
+    }
+}
+";
+        var diagnostics = Bind(source, withReferences);
+        Assert.Contains(diagnostics, d => d.IsError && d.Message.Contains("'Nope' doesn't exist"));
+    }
+
+    public static TheoryData<bool> Resolvers() => new() { false, true };
+
+    private static void AssertNoErrors(string source, bool withReferences)
+    {
+        var diagnostics = Bind(source, withReferences);
+        Assert.Empty(diagnostics.Where(d => d.IsError));
+    }
+
+    private static ImmutableArray<Diagnostic> Bind(string source, bool withReferences)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var globalScope = Binder.BindGlobalScope(
+            previous: null,
+            ImmutableArray.Create(tree),
+            CreateResolver(withReferences));
+        var program = Binder.BindProgram(globalScope, CreateResolver(withReferences));
+        return globalScope.Diagnostics.AddRange(program.Diagnostics);
+    }
+
+    private static ReferenceResolver CreateResolver(bool withReferences)
+    {
+        if (!withReferences)
+        {
+            return ReferenceResolver.Default();
+        }
+
+        var paths = new[]
+        {
+            typeof(object).Assembly.Location,
+            typeof(System.Console).Assembly.Location,
+        }
+        .Where(p => !string.IsNullOrEmpty(p))
+        .Distinct(StringComparer.OrdinalIgnoreCase)
+        .ToArray();
+
+        return ReferenceResolver.WithReferences(paths);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes `GS0130: Function '…' doesn't exist.` for an unqualified (bare-name) call
from inside a static (`shared`) method body to a sibling static method of the
same type. The same call worked when qualified (`M.Helper()`) or when made from
an instance method body.

## Root cause

In `OverloadResolver`'s unqualified-call resolution, the implicit-`this` path
handled instance method bodies (combined instance+static group, #1147) and
there was a separate static-self path for interface `shared` helpers — but no
equivalent path for a static method body whose `StaticOwnerType` is a user
struct/class. With no `this` parameter, `GetEffectiveThisParameter()` is null,
so the enclosing type's own static methods were never searched and resolution
fell straight to the `GS0130` not-found path.

## Fix

- `OverloadResolver.cs`: added a static-self dispatch branch — when the current
  function has no `this` and its `StaticOwnerType` is a `StructSymbol`, look up
  the type's own static method group via `TypeMemberModel` (ADR-0112) and
  finalize through `BindUserTypeStaticCall`. Mirrors both the qualified
  `Type.Helper(args)` path and the instance-body bare-call path — full
  private/overload/optional/variadic/generic (explicit & inferred) fidelity,
  under both reference resolvers.

## Tests

- `Issue1585StaticBareCallTests` (Core.Tests): 9 scenarios × 2 resolvers
  (Default + WithReferences) — non-generic, explicit & inferred generic,
  overloads, default params, struct, plus controls (qualified still works,
  instance→static still works, undefined still `GS0130`).
- `Issue1585StaticBareCallEmitTests` (Compiler.Tests): 2 end-to-end emit/run
  tests (non-generic → 42, generic → 7).
- Full Core.Tests: 4945 passed, 1 skipped, 0 failed. RefactoringBaseline
  byte-identical gate unaffected.

## Out of scope

Bare calls to *inherited* static methods through a **user** base class remain
unchanged — the qualified `M.Helper()` and instance-body oracles fail there too,
so this fix matches existing instance-method semantics without over-reaching.

Fixes #1585

Refs #914
