### PR TITLE
cs2gs: map nullable value-type .Value/.HasValue to G# smart-cast forms

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/OahuFoundationTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuFoundationTranslationTests.cs
@@ -77,6 +77,41 @@ namespace Demo
     }
 
     /// <summary>
+    /// Issue #914: a C# nullable *value* type (`T?` = `System.Nullable&lt;T&gt;`)
+    /// exposes `.Value` / `.HasValue`, but G# models `T?` directly and has no
+    /// `Nullable&lt;T&gt;` member surface (it relies on Kotlin-style smart-casts).
+    /// So `x.Value` maps to the non-null assertion `x!!` (faithful to C#'s
+    /// throw-if-null semantics) and `x.HasValue` maps to the null test
+    /// `x != nil`. A user type with a member literally named `Value` is left
+    /// untouched (the rewrite is gated on the receiver being `Nullable&lt;T&gt;`).
+    /// </summary>
+    [Fact]
+    public void NullableValueTypeValueAndHasValue_MapToAssertionAndNilTest()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class NullVX
+    {
+        public int Unwrap(int? x) => x.Value;
+        public bool Present(int? x) => x.HasValue;
+    }
+
+    public class BoxVX
+    {
+        public int Value => 7;
+        public int Read(BoxVX b) => b.Value;
+    }
+}");
+
+        Assert.Contains("x!!", printed);
+        Assert.Contains("x != nil", printed);
+        // The user `BoxVX.Value` member access is NOT a Nullable<T> receiver and
+        // must remain a plain member access, never rewritten to `!!`.
+        Assert.Contains("b.Value", printed);
+    }
+
+    /// <summary>
     /// ADR-0115 §B: `x is null` / `x is not null` map to G# `== nil` / `!= nil`,
     /// and a type-test with a binder (`x is T t`) becomes a smart-cast `is T`
     /// test that drops the binder (the receiver is narrowed inside the block).

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -6513,6 +6513,31 @@ public sealed class CSharpToGSharpTranslator
             // type to the non-null `Ac4DsiV1`, which gsc's extension-method lookup
             // does not match against the `Ac4DsiV1?` `this` slot (GS0159). Keep the
             // declared-nullable receiver so the extension resolves.
+            // A C# nullable *value* type (`T?` lowering to `System.Nullable<T>`)
+            // exposes `.Value` and `.HasValue`, but G# models a value-type `T?`
+            // directly (no `Nullable<T>` member surface) and relies on Kotlin-style
+            // smart-casts, so those members do not exist on the G# side. Rewrite
+            // them to the idiomatic G# equivalents (#914):
+            //   * `x.Value`    -> `x!!`      (assert non-null, matching C#'s throw-
+            //                                 if-null semantics; harmless once the
+            //                                 local is already smart-cast-narrowed).
+            //   * `x.HasValue` -> `x != nil` (a plain null test on the raw receiver).
+            // Guard on the receiver's *declared* type being `System.Nullable<T>` so
+            // a user type with a member literally named `Value`/`HasValue` is
+            // unaffected. Nullable *reference* types (`string?`) have a non-
+            // `Nullable<T>` receiver type and are likewise left alone.
+            if (this.context.GetTypeInfo(member.Expression).Type is { } receiverType
+                && receiverType.OriginalDefinition?.SpecialType == SpecialType.System_Nullable_T)
+            {
+                switch (member.Name.Identifier.Text)
+                {
+                    case "Value":
+                        return new NonNullAssertionExpression(this.TranslateExpression(member.Expression));
+                    case "HasValue":
+                        return new BinaryExpression(this.TranslateExpression(member.Expression), "!=", LiteralExpression.Null());
+                }
+            }
+
             GExpression target = this.MemberBindsToNullableThisExtension(member)
                 ? this.TranslateExpression(member.Expression)
                 : this.TranslateReceiverWithNullForgiveness(member.Expression);


### PR DESCRIPTION
## Summary

Translates C# nullable **value type** members `.Value` / `.HasValue` into their
idiomatic G# equivalents, closing a batch of `GS0158` errors in the
Oahu.Foundation migration (#914).

A C# `T?` (value type) lowers to `System.Nullable<T>` and exposes `.Value` /
`.HasValue`. G# has no `Nullable<T>` member surface — it models `T?` directly
and relies on Kotlin-style smart-casts — so emitting those members verbatim
fails to bind. This rewrite, in `TranslateMemberAccess`:

- `x.Value` → `x!!` — asserts non-null, faithful to C#'s throw-if-null
  semantics, and harmless once the local is already smart-cast-narrowed
  (verified `x!!` compiles both guarded and unguarded).
- `x.HasValue` → `x != nil` — a plain null test on the raw receiver.

The rewrite is gated on the receiver's declared type being `System.Nullable<T>`,
so a user type with a member literally named `Value`/`HasValue`, and nullable
**reference** types (`string?`), are left untouched.

### Context (design)

This is the cs2gs follow-up to #1590, which was closed as by-design: G#'s
smart-cast intentionally narrows `T?`→`T` after a null-guard, so `x.Value` on a
narrowed local reporting `GS0158` is correct compiler behavior — the fix belongs
in cs2gs, not gsc.

## Tests

- New translation test `NullableValueTypeValueAndHasValue_MapToAssertionAndNilTest`
  covering `x.Value`→`x!!`, `x.HasValue`→`x != nil`, and a negative case
  asserting a user `Value` member is not rewritten.
- Full cs2gs suite: 362 passed, 0 failed.

Refs #914
