### PR TITLE
Fix narrowed nullable value-type instance-call reading default value

### DIFF
--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
@@ -55,7 +55,7 @@ internal sealed partial class MethodBodyEmitter
             if (u.Operand.Type is NullableTypeSymbol userVtNullable
                 && NullableLifting.IsUserValueTypeNullable(userVtNullable))
             {
-                if (!this.receiverSpillSlots.TryGetValue(u, out var userVtSlot))
+                if (!this.receiverSpillSlots.TryGetValue(u.Operand, out var userVtSlot))
                 {
                     throw new InvalidOperationException(
                         "No scratch slot pre-allocated for user value-type Nullable<T> '!!' operand — "
@@ -81,7 +81,7 @@ internal sealed partial class MethodBodyEmitter
             if (u.Operand.Type is NullableTypeSymbol operandNullable
                 && operandNullable.UnderlyingType?.ClrType is { IsValueType: true } innerClr)
             {
-                if (!this.receiverSpillSlots.TryGetValue(u, out var unwrapSlot))
+                if (!this.receiverSpillSlots.TryGetValue(u.Operand, out var unwrapSlot))
                 {
                     throw new InvalidOperationException(
                         "No scratch slot pre-allocated for value-type Nullable<T> '!!' operand — "
@@ -112,7 +112,7 @@ internal sealed partial class MethodBodyEmitter
             // already collapsed to bare `T` after a null-check guard.
             if (TryGetOpenTypeParameter(u.Operand.Type, out var tpOperand))
             {
-                if (!this.receiverSpillSlots.TryGetValue(u, out var tpUnwrapSlot))
+                if (!this.receiverSpillSlots.TryGetValue(u.Operand, out var tpUnwrapSlot))
                 {
                     throw new InvalidOperationException(
                         "No scratch slot pre-allocated for class-constrained `T?` / open `T` '!!' operand — "

--- a/src/Core/CodeAnalysis/Emit/MethodBodyPlanner.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyPlanner.cs
@@ -566,20 +566,33 @@ internal sealed class MethodBodyPlanner
         // temp must be typed as `Nullable<T>` (not the unwrapped T). Reuse
         // receiverSpillSlots — the dictionary already aggregates several
         // distinct-by-node-identity scratch-slot kinds (receiver spills and
-        // assignment-value spills) and BoundUnaryExpression keys cannot
-        // collide with either. The slot is typed as the operand's
+        // assignment-value spills).
+        //
+        // Issue #1591: the slot is keyed by the unwrap's OPERAND node, NOT by
+        // the BoundUnaryExpression node itself. When the smart-cast-narrowed
+        // `!!` result is used as the receiver of a value-type instance call
+        // (`x.ToString()` after an `if x == nil` guard), the receiver-spill
+        // collector above independently keys an underlying-`T`-typed
+        // ldloca-address slot on the SAME BoundUnaryExpression node. Keying
+        // the unwrap on the unary node too made the two slots collapse into
+        // one (the receiver-address `T` slot won, being collected first), so
+        // the `get_Value` spill stored the `Nullable<T>` struct into a `T`
+        // slot and read a default-initialized value — silently printing the
+        // underlying type's default (0 / first enum member). Keying on the
+        // operand node keeps the `Nullable<T>` spill slot distinct from the
+        // receiver-address slot. The slot is typed as the operand's
         // NullableTypeSymbol, which `EncodeTypeSymbol` lowers to
         // `System.Nullable<T>` in the local-sig blob.
         foreach (var unwrap in this.CollectNullableValueTypeUnwraps(body))
         {
-            if (receiverSpillSlots.ContainsKey(unwrap))
+            if (receiverSpillSlots.ContainsKey(unwrap.Operand))
             {
                 continue;
             }
 
             var slot = localTypes.Count;
             localTypes.Add(unwrap.Operand.Type);
-            receiverSpillSlots[unwrap] = slot;
+            receiverSpillSlots[unwrap.Operand] = slot;
         }
 
         // Issue #519 / #752 / ADR-0084 L3: `??` whose LHS is a value-type

--- a/test/Compiler.Tests/Emit/Issue1591NarrowedNullableInstanceCallEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1591NarrowedNullableInstanceCallEmitTests.cs
@@ -1,0 +1,239 @@
+// <copyright file="Issue1591NarrowedNullableInstanceCallEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1591 — calling an INSTANCE METHOD on a nullable value-type local that
+/// has been smart-cast-narrowed by a null guard (<c>if x == nil { return }</c>)
+/// silently emitted IL that read the DEFAULT value of the underlying type
+/// instead of the actual stored value. No diagnostic was produced.
+/// <para>
+/// Root cause: smart-cast narrowing materializes the underlying <c>T</c> via the
+/// same <c>!!</c> unwrap lowering as postfix null-assertion. When the unwrapped
+/// value was then used as an instance-call receiver, the emitter needed the
+/// address of the unwrapped <c>T</c>. The <c>Nullable&lt;T&gt;</c> unwrap scratch
+/// slot and the bare-<c>T</c> receiver-address scratch slot were keyed on the
+/// SAME <c>BoundUnaryExpression</c> node in <c>receiverSpillSlots</c>, so one
+/// slot overwrote the other; the <c>get_Value</c> spill stored the
+/// <c>Nullable&lt;T&gt;</c> struct into a <c>T</c>-typed slot and the call read a
+/// default-initialized value (<c>0</c> for <c>int32?</c>, the first member for an
+/// <c>enum?</c>).
+/// </para>
+/// The fix keys the unwrap scratch slot on the unwrap's OPERAND node rather than
+/// the shared unary/receiver node, keeping the two slots distinct. Each test
+/// RUNS the program and asserts the CORRECT runtime output; each uses a UNIQUE
+/// package and user-type names because the in-process <c>FunctionTypeSymbol</c>
+/// cache is name-keyed and not cleared between in-process emit tests.
+/// </summary>
+public class Issue1591NarrowedNullableInstanceCallEmitTests
+{
+    [Fact]
+    public void EndToEnd_NarrowedInt32Nullable_ToStringReceiver_Runs()
+    {
+        const string source = """
+            package i1591int32tostring
+            import System
+
+            class C1591Int { func G(x int32?) string { if x == nil { return "none" } return x.ToString() } }
+
+            func Main() { System.Console.WriteLine(C1591Int().G(42)) }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_NarrowedInt32Nullable_NilGuardTakesNoneBranch_Runs()
+    {
+        const string source = """
+            package i1591int32none
+            import System
+
+            class C1591None { func G(x int32?) string { if x == nil { return "none" } return x.ToString() } }
+
+            func Main() { System.Console.WriteLine(C1591None().G(nil)) }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("none\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_NarrowedEnumNullable_ToStringReceiver_Runs()
+    {
+        const string source = """
+            package i1591enumtostring
+            import System
+
+            enum Hue1591 { Red, Green, Blue }
+
+            class C1591Enum { func G(x Hue1591?) string { if x == nil { return "none" } return x.ToString() } }
+
+            func Main() { System.Console.WriteLine(C1591Enum().G(Hue1591.Green)) }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("Green\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_NarrowedUserStructNullable_InstanceMethodReceiver_Runs()
+    {
+        const string source = """
+            package i1591structmethod
+            import System
+
+            struct Box1591 { var v int32
+              func Show() string { return v.ToString() } }
+
+            class C1591Struct { func G(x Box1591?) string { if x == nil { return "none" } return x.Show() } }
+
+            func Main() { System.Console.WriteLine(C1591Struct().G(Box1591{v: 7})) }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("7\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_NarrowedInt32Nullable_ChainedValueTypeMemberCall_Runs()
+    {
+        const string source = """
+            package i1591chained
+            import System
+
+            class C1591Chain { func G(x int32?) string { if x == nil { return "none" } return x.CompareTo(0).ToString() } }
+
+            func Main() { System.Console.WriteLine(C1591Chain().G(42)) }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("1\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_NarrowedInt32Nullable_OperatorUse_StaysCorrect_Runs()
+    {
+        // Control: operator use of the narrowed local was already correct on
+        // main; it must remain correct after the slot-keying fix.
+        const string source = """
+            package i1591operator
+            import System
+
+            class C1591Op { func G(x int32?) int32 { if x == nil { return -1 } return x + 1 } }
+
+            func Main() { System.Console.WriteLine(C1591Op().G(42)) }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("43\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_NarrowedInt32Nullable_BareReturn_StaysCorrect_Runs()
+    {
+        // Control: bare read of the narrowed local was already correct on main.
+        const string source = """
+            package i1591bare
+            import System
+
+            class C1591Bare { func G(x int32?) int32 { if x == nil { return -1 } return x } }
+
+            func Main() { System.Console.WriteLine(C1591Bare().G(42)) }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1591_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a **silent wrong-output** IL-emit bug (#1591): calling an instance method
on a nullable value-type local that has been smart-cast-narrowed by a null-guard
read the underlying type's **default** value instead of the actual stored value.

```gsharp
class C { func G(x int32?) string { if x == nil { return "none" } return x.ToString() } }
// C().G(42) printed "0"; now prints "42"
```

## Root cause

Smart-cast narrowing of a `T?` local materializes the underlying `T` through the
same `!!`/unwrap lowering as postfix null-assertion. When that unwrapped value is
used as a value-type **instance-call receiver**, two distinct scratch slots were
both keyed on the **same `BoundUnaryExpression` node** in `receiverSpillSlots`:

1. the receiver-address slot (typed underlying `T`), collected first, and
2. the `Nullable<T>` unwrap spill slot (needed for `stloc; ldloca; call get_Value`).

The unwrap collector's `ContainsKey` guard then skipped, so the `Nullable<T>`
struct was spilled into a `T`-typed slot and `get_Value` read a
default-initialized value (`0` / the first enum member).

## Fix

Key the unwrap scratch slot on the unwrap's **operand** node instead of the
shared unary node, keeping the two slots distinct. Applied consistently across
all three `!!` emit arms (primitive, user value type #1572, open type-param #831).

## Verification

- Runtime: `int32? x.ToString()` `0`→`42`; `enum? x.ToString()` `Red`→`Green`;
  user `struct? x.Show()` now correct; chained `x.CompareTo(0).ToString()`
  correct. Controls unchanged (`x + 1`→`43`, bare `x`→`42`).
- **RefactoringBaselineTests passed** — all existing sample IL byte-identical
  (only the previously-broken case, which had no valid baseline, changes).
- Core.Tests: 4966 passed, 1 skipped.
- New Emit tests: `Issue1591NarrowedNullableInstanceCallEmitTests` (7 tests,
  ilverify-clean).

Fixes #1591

Refs #914
