### PR TITLE
cs2gs: assert !! on nullable-reference field/property receivers

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/NullableFlowForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/NullableFlowForgivenessTranslationTests.cs
@@ -21,9 +21,11 @@ namespace Cs2Gs.Tests;
 /// receiver is a <em>declared</em>-nullable reference that Roslyn has
 /// flow-proven non-null is emitted with G#'s postfix non-null assertion
 /// (<c>recv!!.Member</c> / <c>recv!![i]</c>), re-establishing the fact the guard
-/// already proved. The negative tests pin the precision guards so a stray
-/// assertion is never emitted on an unguarded, static, or already-asserted
-/// receiver.
+/// already proved. For an unguarded declared-nullable field/property receiver
+/// the assertion is likewise emitted, since G# cannot narrow such chains and a
+/// bare access would be GS0158 (matching C#'s NRE-if-null runtime semantics).
+/// The negative tests pin the precision guards so a stray assertion is never
+/// emitted on a non-nullable, static, or already-asserted receiver.
 /// </summary>
 public class NullableFlowForgivenessTranslationTests
 {
@@ -71,7 +73,7 @@ namespace Demo
     }
 
     [Fact]
-    public void UnguardedNullableProperty_MemberAccess_DoesNotAssert()
+    public void UnguardedNullableProperty_MemberAccess_EmitsNonNullAssertion()
     {
         string printed = TranslateUnit(@"
 #nullable enable
@@ -88,9 +90,12 @@ namespace Demo
     }
 }");
 
-        // No guard means the flow state is MayBeNull, so no `!!` is emitted.
-        Assert.DoesNotContain("!!", printed);
-        Assert.Contains("o.Child.Value", printed);
+        // Even without a guard, the receiver `o.Child` is a declared-nullable
+        // PROPERTY. G# smart-casts only local variables, never property/field
+        // chains, so a bare `o.Child.Value` would be GS0158. The receiver rule
+        // emits `o.Child!!.Value`, faithfully preserving C#'s NRE-if-null
+        // semantics (C# itself only warns here, CS8602).
+        Assert.Contains("o.Child!!.Value", printed);
     }
 
     [Fact]

--- a/tools/cs2gs/Cs2Gs.Tests/OahuFoundationTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuFoundationTranslationTests.cs
@@ -112,6 +112,42 @@ namespace Demo
     }
 
     /// <summary>
+    /// Issue #914: G#'s smart-casts never narrow a property/field-access chain
+    /// (only locals), so a member/element access on a nullable-reference *field*
+    /// or *property* (declared `T?` or promoted to nullable per #1072) is rejected
+    /// (GS0158/GS0116) regardless of any preceding null-guard. cs2gs must assert
+    /// the receiver non-null (`field!!.Member`), which also matches C#'s
+    /// throw-on-null semantics for the same access. A field that stays non-null
+    /// (initialized, never null-checked/assigned) keeps a bare receiver.
+    /// </summary>
+    [Fact]
+    public void NullableReferenceFieldReceiver_GetsNonNullAssertion()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class ResFR { public bool Ok => true; }
+    public class NullFieldRecvX
+    {
+        private ResFR res;
+        private ResFR always = new ResFR();
+        public void Init() { res = new ResFR(); }
+        public bool Direct() => res.Ok;
+        public bool Guarded() => !(res is null) && res.Ok;
+        public bool Fixed() => always.Ok;
+    }
+}");
+
+        // The null-checked (`res is null`) field `res` is promoted to `ResFR?`, so
+        // every member-access receiver on it is asserted non-null.
+        Assert.Contains("res!!.Ok", printed);
+        Assert.DoesNotContain("res.Ok", printed);
+        // A field that is never null-checked/assigned-null stays non-null and
+        // keeps a bare receiver.
+        Assert.Contains("always.Ok", printed);
+    }
+
+    /// <summary>
     /// ADR-0115 §B: `x is null` / `x is not null` map to G# `== nil` / `!= nil`,
     /// and a type-test with a binder (`x is T t`) becomes a smart-cast `is T`
     /// test that drops the binder (the receiver is narrowed inside the block).

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -6586,12 +6586,62 @@ public sealed class CSharpToGSharpTranslator
         {
             GExpression translated = this.TranslateExpression(recv);
 
-            if (this.ReceiverNeedsNullForgiveness(recv))
+            if (this.ReceiverNeedsNullForgiveness(recv)
+                || this.ReceiverIsNullableReferenceFieldOrProperty(recv))
             {
                 return new NonNullAssertionExpression(translated);
             }
 
             return translated;
+        }
+
+        /// <summary>
+        /// True when a member-/element-access <paramref name="recv"/> receiver is a
+        /// nullable-reference <em>field</em> or <em>property</em> (declared <c>T?</c>
+        /// or promoted to nullable, issue #1072) and therefore always needs a G#
+        /// <c>!!</c> assertion — independent of Roslyn flow state.
+        /// </summary>
+        /// <remarks>
+        /// Unlike a local variable, G#'s Kotlin-style smart-casts never narrow a
+        /// property/field-access chain, so <c>field.Member</c> / <c>field[i]</c> on a
+        /// <c>T?</c> field is rejected (GS0158/GS0116) no matter what null-guard
+        /// precedes it. The Oahu corpus compiles nullable-<em>disabled</em>, so
+        /// Roslyn's flow analysis reports these receivers as oblivious (never
+        /// flow-state <c>NotNull</c>) and the flow-driven
+        /// <see cref="ReceiverNeedsNullForgiveness"/> pass leaves them bare.
+        /// Asserting <c>field!!.Member</c> both compiles and preserves C#'s
+        /// throw-on-null semantics for the same access (a null field would
+        /// <c>NullReferenceException</c> in C# too). Locals/parameters keep the
+        /// flow-proven path, since G# does smart-cast them; comparison operands and
+        /// <c>?.</c> receivers are routed elsewhere and never reach this pass.
+        /// </remarks>
+        private bool ReceiverIsNullableReferenceFieldOrProperty(ExpressionSyntax recv)
+        {
+            if (recv is PostfixUnaryExpressionSyntax { RawKind: (int)SyntaxKind.SuppressNullableWarningExpression }
+                or ThisExpressionSyntax
+                or BaseExpressionSyntax
+                or LiteralExpressionSyntax
+                or ConditionalAccessExpressionSyntax)
+            {
+                return false;
+            }
+
+            ISymbol symbol = this.context.GetSymbolInfo(recv).Symbol;
+
+            ITypeSymbol declared = symbol switch
+            {
+                IPropertySymbol property => property.Type,
+                IFieldSymbol field => field.Type,
+                _ => null,
+            };
+
+            if (declared is not { IsReferenceType: true })
+            {
+                return false;
+            }
+
+            return declared.NullableAnnotation == NullableAnnotation.Annotated
+                || this.IsPromotedToNullableReference(symbol);
         }
 
         // True when <paramref name="member"/> binds to an extension method whose


### PR DESCRIPTION
## Summary
G#'s Kotlin-style smart-casts narrow only **local variables**, never a property/field-access chain. A member/element access whose receiver is a declared-nullable (or #1072-promoted) reference **field** or **property** is therefore always `GS0158`/`GS0116` in G#, no matter what null-guard precedes it.

cs2gs now emits `receiver!!.Member` for such receivers so the translated G# compiles, while faithfully preserving C#'s throw-on-null semantics (a null field/property would `NullReferenceException` in C# too).

## Scope / precision
- Applies to field/property receivers only in the **receiver** path (`TranslateReceiverWithNullForgiveness`); the value path (proven-non-null-only) is unchanged.
- Locals and parameters keep the flow-proven path (G# does smart-cast them).
- Excludes `this` / `base` / literal / `?.` / already-`!` receivers.

## Impact
- Oahu.Foundation `64 -> 60` diagnostics (`handle!!.IsInvalid`, `logStreamWriter!!.BaseStream` now emitted).
- 363 cs2gs tests pass (new `NullableReferenceFieldReceiver_GetsNonNullAssertion`; updated the now-superseded `UnguardedNullableProperty_MemberAccess` negative test to expect the assertion).

Refs #914
