### PR TITLE
cs2gs: convert non-string operands in string concatenation

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/StringConcatenationTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/StringConcatenationTranslationTests.cs
@@ -1,0 +1,145 @@
+// <copyright file="StringConcatenationTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Translation tests for C# string concatenation (issue #914). C# `a + b`
+/// implicitly converts each non-<c>string</c> operand to a string via
+/// <c>String.Concat</c>/<c>ToString</c>, but G# has no implicit string
+/// conversion (spec: use interpolation or an explicit conversion), so a `+`
+/// whose operands are not both <c>string</c> is rejected with GS0129
+/// (<c>operator '+' is not defined for 'Indent' and 'string'</c>). The
+/// translator rewrites each non-<c>string</c> operand to an explicit
+/// <c>operand.ToString()</c> call so the concatenation type-checks while
+/// preserving C#'s displayed value.
+/// </summary>
+public class StringConcatenationTranslationTests
+{
+    [Fact]
+    public void UserObjectConcatenatedWithString_GetsToStringCall()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class Indent { public override string ToString() => ""i""; }
+    public class C
+    {
+        public string F(Indent ind, string s) => ind + s;
+    }
+}");
+
+        Assert.Contains("ind.ToString() + s", printed);
+    }
+
+    [Fact]
+    public void StringConcatenatedWithUserObject_GetsToStringCall()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class Indent { public override string ToString() => ""i""; }
+    public class C
+    {
+        public string F(Indent ind, string s) => s + ind;
+    }
+}");
+
+        Assert.Contains("s + ind.ToString()", printed);
+    }
+
+    [Fact]
+    public void PrimitiveConcatenatedWithString_GetsToStringCall()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public string F(int n) => ""n="" + n;
+    }
+}");
+
+        Assert.Contains("\"n=\" + n.ToString()", printed);
+    }
+
+    [Fact]
+    public void ChainedConcatenation_ConvertsOnlyNonStringOperands()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class Indent { public override string ToString() => ""i""; }
+    public class C
+    {
+        public string F(Indent ind, string m, string d) => ind + m + d;
+    }
+}");
+
+        // Left-associative: only the leading non-string `ind` needs conversion;
+        // the remaining `+ m + d` are string-to-string.
+        Assert.Contains("ind.ToString() + m + d", printed);
+    }
+
+    [Fact]
+    public void PureStringConcatenation_IsUnchanged()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public string F(string a, string b) => a + b;
+    }
+}");
+
+        Assert.Contains("a + b", printed);
+        Assert.DoesNotContain("ToString", printed);
+    }
+
+    [Fact]
+    public void NumericAddition_IsNotTreatedAsConcatenation()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public int F(int a, int b) => a + b;
+    }
+}");
+
+        Assert.Contains("a + b", printed);
+        Assert.DoesNotContain("ToString", printed);
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -3427,6 +3427,21 @@ public sealed class CSharpToGSharpTranslator
             string op = binary.OperatorToken.Text;
             GExpression right = this.TranslateExpression(binary.Right);
 
+            // C# string concatenation `a + b`: when the `+` operator binds to
+            // `string`, C# implicitly converts each non-string operand to a string
+            // (via `String.Concat`/`ToString`). G# has no implicit conversion, so a
+            // `+` whose operands are not both `string` is GS0129 (`operator '+' is
+            // not defined for 'Indent' and 'string'`). Rewrite each non-string
+            // operand to an explicit `operand.ToString()` so the concatenation
+            // type-checks, matching C#'s displayed value.
+            if (binary.IsKind(SyntaxKind.AddExpression)
+                && this.context.GetTypeInfo(binary).Type?.SpecialType == SpecialType.System_String)
+            {
+                left = this.CoerceConcatOperand(binary.Left, left);
+                right = this.CoerceConcatOperand(binary.Right, right);
+                return new BinaryExpression(left, op, right);
+            }
+
             // C# null-coalescing `a ?? b`: the left is a nullable numeric, the
             // right must match the left's *underlying* (non-nullable) numeric type
             // (a `??` is not a symmetric arithmetic promotion of both sides). Only
@@ -3501,6 +3516,35 @@ public sealed class CSharpToGSharpTranslator
             }
 
             return new BinaryExpression(left, op, right);
+        }
+
+        // For a string-concatenation `+` operand: if the operand's C# type is not
+        // already `string`, wrap the translated operand in an explicit
+        // `operand.ToString()` call so G# (which has no implicit string conversion)
+        // type-checks the concatenation. A string operand (including a nested
+        // string `+` sub-expression, whose type is also `string`) is returned
+        // unchanged, as is a bare `null` literal (`null.ToString()` would throw;
+        // C# renders it as the empty string, and a translated `nil` keeps that
+        // intent while remaining assignable to a `string` slot). The operand is
+        // parenthesized when needed so member access binds to the whole operand.
+        private GExpression CoerceConcatOperand(ExpressionSyntax operandSyntax, GExpression translated)
+        {
+            ITypeSymbol operandType = this.context.GetTypeInfo(operandSyntax).Type;
+            if (operandType?.SpecialType == SpecialType.System_String)
+            {
+                return translated;
+            }
+
+            if (IsNullOrSuppressedNull(operandSyntax))
+            {
+                return translated;
+            }
+
+            GExpression receiver = translated is BinaryExpression or IfExpression
+                ? new ParenthesizedExpression(translated)
+                : translated;
+
+            return new InvocationExpression(new MemberAccessExpression(receiver, "ToString"));
         }
 
         // For a compound numeric assignment `x OP= y` (`+= -= *= /= %= &= |= ^=`),


### PR DESCRIPTION
## Summary
C# `a + b` implicitly converts each non-`string` operand to a string (via `String.Concat`/`ToString`). G# has **no implicit string conversion** (spec: use interpolation or an explicit conversion), so a `+` whose operands are not both `string` is rejected with `GS0129` — e.g. `operator '+' is not defined for 'Indent' and 'string'`.

When a `+` binary expression binds to `string`, cs2gs now rewrites each non-`string` operand to an explicit `operand.ToString()` call so the concatenation type-checks while preserving C#'s displayed value.

## Precision
- Only fires when Roslyn types the whole `+` expression as `System.String` (real string concatenation), so numeric `+` is untouched.
- `string` operands — including nested string `+` sub-expressions (also typed `string`) — are left unchanged.
- A bare `null` literal operand is left as `nil` (C# renders it as `""`; `nil.ToString()` would throw).
- Operands are parenthesized when needed so `.ToString()` binds to the whole operand.

## Impact
- Oahu.Foundation `60 -> 58` diagnostics (e.g. `Indent + string` → `ind.ToString() + s`), no cascade.
- 369 cs2gs tests pass (6 new in `StringConcatenationTranslationTests`).

Refs #914
