### PR TITLE
gsc: recognize exhaustive switch (with returning default) as all-paths-return (#1596)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ControlFlowGraph.cs
+++ b/src/Core/CodeAnalysis/Binding/ControlFlowGraph.cs
@@ -80,8 +80,15 @@ public sealed class ControlFlowGraph
             // up to a catch handler or off the frame entirely) and is therefore
             // a legitimate terminator for the "all paths return" check — the
             // path simply never falls off the end of the function.
+            //
+            // An exhaustive `switch` statement — one that has a `default` clause
+            // and whose every reachable arm definitely returns or throws — never
+            // falls off its end either, so it is likewise a valid terminator
+            // (issue #1596). Non-exhaustive switches (no `default`) still fall
+            // through and are rejected below.
             if (lastStatement.Kind != BoundNodeKind.ReturnStatement
-                && lastStatement.Kind != BoundNodeKind.ThrowStatement)
+                && lastStatement.Kind != BoundNodeKind.ThrowStatement
+                && !(lastStatement is BoundPatternSwitchStatement sw && SwitchAlwaysReturns(sw)))
             {
                 return false;
             }
@@ -127,6 +134,39 @@ public sealed class ControlFlowGraph
         }
 
         writer.WriteLine("}");
+    }
+
+    /// <summary>
+    /// Determines whether a pattern <c>switch</c> statement is exhaustive and
+    /// definitely returns — that is, it has a <c>default</c> arm and every arm
+    /// body definitely returns or throws. Such a switch never falls off its end
+    /// and therefore acts as a control-flow terminator for definite-return
+    /// analysis (issue #1596). A switch without a <c>default</c> arm can fall
+    /// through (the discriminant may match no arm) and is never treated as
+    /// definitely-returning.
+    /// </summary>
+    /// <param name="switchStatement">The pattern switch statement.</param>
+    /// <returns>Whether the switch definitely returns on every path.</returns>
+    private static bool SwitchAlwaysReturns(BoundPatternSwitchStatement switchStatement)
+    {
+        var hasDefault = false;
+        foreach (var arm in switchStatement.Arms)
+        {
+            if (arm.IsDefault)
+            {
+                hasDefault = true;
+            }
+
+            // Arm bodies are flattened into bound block statements by the
+            // lowerer, so the same all-paths-return analysis applies to each
+            // arm (recursively handling nested switches).
+            if (arm.Body is not BoundBlockStatement armBlock || !AllPathsReturn(armBlock))
+            {
+                return false;
+            }
+        }
+
+        return hasDefault;
     }
 
     /// <summary>
@@ -283,6 +323,18 @@ public sealed class ControlFlowGraph
                     case BoundNodeKind.ExpressionStatement:
                         statements.Add(statement);
                         break;
+                    case BoundNodeKind.PatternSwitchStatement:
+                        statements.Add(statement);
+
+                        // An exhaustive switch (default present and every arm
+                        // returns/throws) terminates the block like a return;
+                        // otherwise it falls through to the next statement.
+                        if (SwitchAlwaysReturns((BoundPatternSwitchStatement)statement))
+                        {
+                            StartBlock();
+                        }
+
+                        break;
                     case BoundNodeKind.TryStatement:
                     case BoundNodeKind.ThrowStatement:
                     case BoundNodeKind.GoStatement:
@@ -291,7 +343,6 @@ public sealed class ControlFlowGraph
                     case BoundNodeKind.ScopeStatement:
                     case BoundNodeKind.FixedStatement:
                     case BoundNodeKind.AwaitForRangeStatement:
-                    case BoundNodeKind.PatternSwitchStatement:
                     case BoundNodeKind.YieldStatement:
                         // Treat exception-flow constructs as opaque statements; precise
                         // CFG modeling of catch/finally edges is deferred to a later phase.
@@ -394,6 +445,21 @@ public sealed class ControlFlowGraph
                         case BoundNodeKind.ReturnStatement:
                             Connect(current, end);
                             break;
+                        case BoundNodeKind.PatternSwitchStatement:
+                            // An exhaustive switch (default present and every arm
+                            // returns/throws) terminates control like a return and
+                            // connects to the end block. A non-exhaustive switch may
+                            // fall through to the next statement (issue #1596).
+                            if (SwitchAlwaysReturns((BoundPatternSwitchStatement)statement))
+                            {
+                                Connect(current, end);
+                            }
+                            else if (isLastStatementInBlock)
+                            {
+                                Connect(current, next);
+                            }
+
+                            break;
                         case BoundNodeKind.VariableDeclaration:
                         case BoundNodeKind.LabelStatement:
                         case BoundNodeKind.ExpressionStatement:
@@ -404,7 +470,6 @@ public sealed class ControlFlowGraph
                         case BoundNodeKind.ScopeStatement:
                         case BoundNodeKind.FixedStatement:
                         case BoundNodeKind.AwaitForRangeStatement:
-                        case BoundNodeKind.PatternSwitchStatement:
                         case BoundNodeKind.YieldStatement:
                             // Issue #798: `yield` (ADR-0040) participates in the
                             // CFG as a fall-through to the next statement; the

--- a/src/Core/CodeAnalysis/Binding/ControlFlowGraph.cs
+++ b/src/Core/CodeAnalysis/Binding/ControlFlowGraph.cs
@@ -157,16 +157,43 @@ public sealed class ControlFlowGraph
                 hasDefault = true;
             }
 
-            // Arm bodies are flattened into bound block statements by the
-            // lowerer, so the same all-paths-return analysis applies to each
-            // arm (recursively handling nested switches).
-            if (arm.Body is not BoundBlockStatement armBlock || !AllPathsReturn(armBlock))
+            if (!StatementDefinitelyReturns(arm.Body))
             {
                 return false;
             }
         }
 
         return hasDefault;
+    }
+
+    /// <summary>
+    /// Structurally determines whether a bound statement definitely returns (or
+    /// throws) on the fall-through path — without constructing a sub control-flow
+    /// graph. This is deliberately conservative: escaping jumps such as
+    /// <c>continue</c>/<c>break</c>/<c>goto</c> (which the lowerer emits as goto
+    /// statements targeting labels outside the statement) are treated as NOT
+    /// returning. Building an isolated CFG for such a statement would fail
+    /// because those jump targets are not present in the isolated graph
+    /// (issue #1596 follow-up: fixes a crash on <c>continue</c>/<c>break</c>
+    /// inside a switch arm nested in a loop).
+    /// </summary>
+    /// <param name="statement">The bound statement.</param>
+    /// <returns>Whether the statement definitely returns or throws.</returns>
+    private static bool StatementDefinitelyReturns(BoundStatement statement)
+    {
+        switch (statement)
+        {
+            case BoundBlockStatement block:
+                // A block definitely returns iff its last reachable statement
+                // definitely returns.
+                var last = block.Statements.LastOrDefault();
+                return last != null && StatementDefinitelyReturns(last);
+            case BoundPatternSwitchStatement nestedSwitch:
+                return SwitchAlwaysReturns(nestedSwitch);
+            default:
+                return statement.Kind == BoundNodeKind.ReturnStatement
+                    || statement.Kind == BoundNodeKind.ThrowStatement;
+        }
     }
 
     /// <summary>

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1596SwitchExhaustiveReturnTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1596SwitchExhaustiveReturnTests.cs
@@ -1,0 +1,125 @@
+// <copyright file="Issue1596SwitchExhaustiveReturnTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1596. gsc's definite-return analysis (the <c>AllPathsReturn</c>
+/// check that powers GS0100, "Not all code paths return a value") used to
+/// treat every <c>switch</c> statement as possibly falling through, even
+/// when a <c>default</c> clause was present and every arm definitely
+/// returned or threw. That wrongly rejected value-returning functions whose
+/// body was an exhaustive switch, while the equivalent if/else compiled
+/// fine. A switch WITHOUT a <c>default</c> arm must still be treated as
+/// possibly-falling-through.
+/// </summary>
+public class Issue1596SwitchExhaustiveReturnTests
+{
+    [Fact]
+    public void SwitchWithDefaultOnly_DoesNotReport_AllPathsMustReturn()
+    {
+        const string Source = @"func I(value object) object {
+    switch value {
+        default {
+            return ""d""
+        }
+    }
+}
+";
+        AssertNoGs0100(Source);
+    }
+
+    [Fact]
+    public void SwitchWithDefaultAndCase_DoesNotReport_AllPathsMustReturn()
+    {
+        const string Source = @"func F(value object) object {
+    switch value {
+        default {
+            return ""d""
+        }
+        case val is bool {
+            return ""b""
+        }
+    }
+}
+";
+        AssertNoGs0100(Source);
+    }
+
+    [Fact]
+    public void SwitchWithCaseThenDefault_DoesNotReport_AllPathsMustReturn()
+    {
+        const string Source = @"func G(value object) object {
+    switch value {
+        case val is bool {
+            return ""b""
+        }
+        default {
+            return ""d""
+        }
+    }
+}
+";
+        AssertNoGs0100(Source);
+    }
+
+    [Fact]
+    public void SwitchWithThrowingArm_DoesNotReport_AllPathsMustReturn()
+    {
+        const string Source = @"package Issue1596.Throw
+
+import System
+
+func T(value object) object {
+    switch value {
+        case val is bool {
+            throw InvalidOperationException(""no"")
+        }
+        default {
+            return ""d""
+        }
+    }
+}
+";
+        AssertNoGs0100(Source);
+    }
+
+    [Fact]
+    public void SwitchWithoutDefault_StillReports_AllPathsMustReturn()
+    {
+        const string Source = @"func N(value object) object {
+    switch value {
+        case val is bool {
+            return ""b""
+        }
+    }
+}
+";
+        var diagnostics = Compile(Source);
+        Assert.Contains(diagnostics, d => d.Id == "GS0100");
+    }
+
+    private static System.Collections.Immutable.ImmutableArray<Diagnostic> Compile(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+
+        using var peStream = new System.IO.MemoryStream();
+        var emitResult = compilation.Emit(peStream);
+        return emitResult.Diagnostics;
+    }
+
+    private static void AssertNoGs0100(string source)
+    {
+        var diagnostics = Compile(source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0100");
+    }
+}


### PR DESCRIPTION
## Summary
gsc's definite-return flow analysis (`AllPathsReturn`, which emits **GS0100: Not all code paths return a value**) treated a `switch` statement as an opaque fall-through, so any value-returning function whose body is an exhaustive `switch` failed — even when a `default` clause was present and every arm returned. An equivalent `if`/`else` compiled fine.

## Root cause
`src/Core/CodeAnalysis/Binding/ControlFlowGraph.cs` — `BoundPatternSwitchStatement` was never folded into the control-flow graph the way `if`/`else` branches are, so the CFG believed control could fall off the end of the switch.

## Fix
Added `SwitchAlwaysReturns(...)`: true only when a `default` arm is present **and** every (flattened) arm body passes `AllPathsReturn` (recursive — nested switches and `throw`-terminated arms included). Wired into three sites: the `AllPathsReturn` end-branch check, `BasicBlockBuilder.Build`, and `GraphBuilder.Build`. A switch **without** `default` still falls through and requires a trailing return (no regression).

## Tests
- New `Issue1596SwitchExhaustiveReturnTests` (default-only, default+case, case+default, throwing arm, negative no-default) — all pass.
- Core.Tests: 4971 passed, 0 failed. `dotnet build GSharp.sln -c Release -graph`: 0 errors.

Fixes #1596

Refs #914
