### PR TITLE
cs2gs: fix negated HasValue precedence and nullable delegate-field invoke

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/OahuFoundationTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuFoundationTranslationTests.cs
@@ -639,6 +639,60 @@ namespace Demo
         Assert.DoesNotContain("string(' '", printed);
     }
 
+    /// <summary>
+    /// Issue #914 (GS0128): C# `!x.HasValue` on a nullable value type must
+    /// parenthesize the mapped null test, otherwise `.HasValue` -> `x != nil`
+    /// composes under the prefix `!` as `!x != nil`, which G# parses as
+    /// `(!x) != nil` (GS0128, `!` undefined for the nullable type). The correct
+    /// form is `!(x != nil)`.
+    /// </summary>
+    [Fact]
+    public void NegatedHasValue_ParenthesizesNullTest()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class NegHasX
+    {
+        public bool Missing(System.DateTime? when) => !when.HasValue;
+    }
+}");
+
+        Assert.Contains("!(when != nil)", printed);
+        Assert.DoesNotContain("!when != nil", printed);
+    }
+
+    /// <summary>
+    /// Issue #914 (GS0131): directly invoking a nullable-reference delegate
+    /// *field* (`handler(args)` where `handler` is `((T) -&gt; R)?`) needs a `!!`
+    /// assertion on the callee — G# smart-casts only locals, never a field/
+    /// property chain, so the field stays nullable and "is not a function" even
+    /// inside an `if handler != nil` guard. cs2gs must emit `handler!!(args)`.
+    /// </summary>
+    [Fact]
+    public void NullableDelegateFieldInvocation_AssertsCalleeNonNull()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class DelInvX
+    {
+        private readonly System.Func<int, int>? handler;
+        public DelInvX(System.Func<int, int>? h) => this.handler = h;
+        public int Fire(int value)
+        {
+            if (this.handler != null)
+            {
+                return this.handler(value);
+            }
+            return 0;
+        }
+    }
+}");
+
+        Assert.Contains("this.handler!!(value)", printed);
+    }
+
     private static string TranslateUnit(string source)
     {
         (string printed, RoundTripResult result) = TranslateAndValidate(source);

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -6578,7 +6578,12 @@ public sealed class CSharpToGSharpTranslator
                     case "Value":
                         return new NonNullAssertionExpression(this.TranslateExpression(member.Expression));
                     case "HasValue":
-                        return new BinaryExpression(this.TranslateExpression(member.Expression), "!=", LiteralExpression.Null());
+                        // Parenthesize the null test so it composes correctly
+                        // under any surrounding operator. C# `!x.HasValue` would
+                        // otherwise translate to `!x != nil`, which G# parses as
+                        // `(!x) != nil` (GS0128); `!(x != nil)` is always correct.
+                        return new ParenthesizedExpression(
+                            new BinaryExpression(this.TranslateExpression(member.Expression), "!=", LiteralExpression.Null()));
                 }
             }
 
@@ -6893,6 +6898,21 @@ public sealed class CSharpToGSharpTranslator
             var arguments = invocation.ArgumentList.Arguments
                 .Select(a => this.TranslateArgument(a))
                 .ToList();
+
+            // Directly invoking a nullable-reference delegate field/property
+            // (`handler(args)` where `handler` is `((T) -> R)?`) needs a `!!`
+            // assertion on the callee: G# smart-casts only locals, never a
+            // field/property chain, so an unforgiven nullable delegate field is
+            // "not a function" (GS0131) even inside an `if handler != nil` guard.
+            // This is the invocation-callee analog of the receiver `!!` pass
+            // (#1594); locals are excluded by the shared helper. It fires for any
+            // nullable delegate field/property callee, not just this one shape.
+            if (this.context.GetSymbolInfo(invocation).Symbol is IMethodSymbol
+                    { MethodKind: MethodKind.DelegateInvoke }
+                && this.ReceiverIsNullableReferenceFieldOrProperty(invocation.Expression))
+            {
+                target = new NonNullAssertionExpression(target);
+            }
 
             return new InvocationExpression(target, arguments, typeArguments);
         }


### PR DESCRIPTION
## Summary

Two `cs2gs` translation fixes surfaced by the Oahu.Foundation migration (issue #914), both rooted in G#'s Kotlin-style null model (smart-casts narrow only locals, never property/field chains):

### GS0128 — negated `HasValue` precedence
The `.HasValue` → `x != nil` mapping emitted a bare binary expression, so C# `!when.HasValue` translated to `!when != nil`, which G# parses as `(!when) != nil` (`!` is undefined for the nullable type). The null test is now parenthesized so it composes correctly under any surrounding operator: `!(when != nil)`.

### GS0131 — nullable delegate-field invocation
Directly invoking a nullable-reference delegate field/property (`handler(args)` where `handler` is `((T) -> R)?`) needs a `!!` assertion on the callee. G# smart-casts only locals, never a field/property chain, so the field stays nullable and "is not a function" even inside an `if handler != nil` guard. cs2gs now emits `handler!!(args)` — the invocation-callee analog of the receiver `!!` pass (#1594), reusing the shared field/property predicate (which excludes locals, preserving smart-casting). Generalizes to any nullable delegate field/property callee.

## Testing
- Two new round-tripped translation tests in `OahuFoundationTranslationTests`.
- Full `cs2gs` suite: 371 passing.
- Oahu.Foundation compile gaps 57 → 56.

Refs #914
