### PR TITLE
gsc: fix GS9999 crash and non-resolution for value-type-constrained generic + inline out var (Enum.TryParse)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -2789,13 +2789,15 @@ internal sealed partial class ExpressionBinder
     /// <param name="resolvedMethod">The chosen imported method (constructed if generic).</param>
     /// <param name="parameterMapping">The source-argument → parameter-position mapping; default for positional calls.</param>
     /// <param name="receiverType">The receiver's static type (for symbolic by-ref-parameter recovery); may be <see langword="null"/>.</param>
+    /// <param name="typeArgSymbols">The explicit type-argument symbols (issue #1599, for recovering a placeholder-closed out-parameter pointee); default when absent.</param>
     /// <returns>The argument vector with inline out-var placeholders rebound.</returns>
     private ImmutableArray<BoundExpression> RebindInlineOutVarArguments(
         CallExpressionSyntax ce,
         ImmutableArray<BoundExpression> arguments,
         System.Reflection.MethodInfo resolvedMethod,
         ImmutableArray<int> parameterMapping,
-        TypeSymbol receiverType = null)
+        TypeSymbol receiverType = null,
+        ImmutableArray<TypeSymbol> typeArgSymbols = default)
     {
         ImmutableArray<BoundExpression>.Builder rebuilt = null;
         System.Reflection.ParameterInfo[] parameters = null;
@@ -2824,6 +2826,7 @@ internal sealed partial class ExpressionBinder
             // Recover the symbolic pointee type from the receiver's symbolic
             // type arguments (mirroring `ResolveInstanceReturnTypeFromReceiver`).
             var pointeeType = ResolveInstanceParameterPointeeTypeFromReceiver(receiverType, resolvedMethod, paramIndex)
+                ?? ResolveMethodGenericParameterPointeeType(resolvedMethod, paramIndex, typeArgSymbols)
                 ?? TypeSymbol.FromClrType(pointeeClr);
             var syntheticParameter = new ParameterSymbol(
                 parameters[paramIndex].Name ?? "value",
@@ -2836,6 +2839,37 @@ internal sealed partial class ExpressionBinder
         }
 
         return rebuilt != null ? rebuilt.ToImmutable() : arguments;
+    }
+
+    /// <summary>
+    /// Issue #1599: recovers the pointee type of an <c>out</c>/<c>ref</c> parameter that
+    /// is typed by one of the resolved generic method's own type parameters (e.g. the
+    /// <c>out TEnum</c> of <c>Enum.TryParse&lt;TEnum&gt;(string, out TEnum)</c>) from the
+    /// explicit type-argument symbols. When the method was closed over a value-type
+    /// placeholder (or an <see cref="object"/> erasure) — as happens for a
+    /// same-compilation user value type under a <c>where T : struct</c> constraint — the
+    /// closed CLR parameter carries the placeholder, which must not leak into an inline
+    /// <c>out var</c> local. Returns <see langword="null"/> when no recovery applies so
+    /// the caller falls back to the CLR pointee type.
+    /// </summary>
+    /// <param name="resolvedMethod">The closed generic method selected by overload resolution.</param>
+    /// <param name="parameterIndex">The zero-based parameter position of the out/ref argument.</param>
+    /// <param name="typeArgSymbols">The explicit type-argument symbols, or default.</param>
+    /// <returns>The recovered pointee type symbol, or <see langword="null"/>.</returns>
+    private static TypeSymbol ResolveMethodGenericParameterPointeeType(
+        System.Reflection.MethodInfo resolvedMethod,
+        int parameterIndex,
+        ImmutableArray<TypeSymbol> typeArgSymbols)
+    {
+        if (!typeArgSymbols.IsDefaultOrEmpty
+            && OverloadResolution.TryGetGenericMethodParameterPosition(resolvedMethod, parameterIndex, out var position)
+            && position >= 0
+            && position < typeArgSymbols.Length)
+        {
+            return typeArgSymbols[position];
+        }
+
+        return null;
     }
 
     private BoundExpression BindAccessorCall(BoundExpression receiver, ImportedClassSymbol classSymbol, CallExpressionSyntax ce)
@@ -2970,7 +3004,7 @@ internal sealed partial class ExpressionBinder
                 // would never exist for the rest of the body. Static calls have
                 // no receiver, so pass null; the mapping aligns source args to
                 // parameters for out-parameters in any position.
-                arguments = RebindInlineOutVarArguments(ce, arguments, staticFn.Method, staticMapping, receiver?.Type);
+                arguments = RebindInlineOutVarArguments(ce, arguments, staticFn.Method, staticMapping, receiver?.Type, typeArgSymbols);
 
                 // Issue #1330: when the receiver is a generic type constructed
                 // over an in-scope generic type parameter (`Comparer[TResult]`),
@@ -3434,7 +3468,7 @@ internal sealed partial class ExpressionBinder
                             // any inline `out var`/`out let`/`out _` placeholders
                             // against the resolved by-ref parameter so the new
                             // local is declared with the inferred pointee type.
-                            arguments = RebindInlineOutVarArguments(ce, arguments, resolution.Best, resolution.ParameterMapping, receiver?.Type);
+                            arguments = RebindInlineOutVarArguments(ce, arguments, resolution.Best, resolution.ParameterMapping, receiver?.Type, typeArgSymbols);
 
                             // Issue #1512: for a genuine INSTANCE method the receiver
                             // is `this`, not a formal parameter — `GetParameters()`

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
@@ -778,6 +778,51 @@ internal static class OverloadResolution
     }
 
     /// <summary>
+    /// Issue #1599: determines whether the parameter at <paramref name="parameterIndex"/>
+    /// of a closed generic method's open definition is typed by exactly one of the
+    /// method's own type parameters — including through a by-ref (<c>out</c>/<c>ref</c>)
+    /// wrapper, e.g. the <c>out TEnum</c> parameter of
+    /// <c>bool TryParse&lt;TEnum&gt;(string, out TEnum)</c>. When it does, the caller can
+    /// recover the real parameter (pointee) type from the explicit type-argument symbol
+    /// at the reported position, which is necessary when the method was closed over a
+    /// value-type placeholder (or an <see cref="object"/> erasure) because the type
+    /// argument is a same-compilation user value type with no reference-context CLR type.
+    /// This is the parameter analogue of
+    /// <see cref="TryGetGenericMethodParameterReturnPosition(MethodInfo, out int)"/> and
+    /// is what lets an inline <c>out var</c> declaration recover the correct pointee type
+    /// instead of leaking the placeholder.
+    /// </summary>
+    /// <param name="closed">The closed generic method.</param>
+    /// <param name="parameterIndex">The zero-based parameter position to inspect.</param>
+    /// <param name="position">The method type-parameter position of the parameter, when matched.</param>
+    /// <returns><see langword="true"/> when the parameter (pointee) is a bare method type parameter.</returns>
+    public static bool TryGetGenericMethodParameterPosition(MethodInfo closed, int parameterIndex, out int position)
+    {
+        position = -1;
+        if (closed == null || !closed.IsGenericMethod || parameterIndex < 0)
+        {
+            return false;
+        }
+
+        var open = closed.IsGenericMethodDefinition ? closed : closed.GetGenericMethodDefinition();
+        var parameters = open.GetParameters();
+        if (parameterIndex >= parameters.Length)
+        {
+            return false;
+        }
+
+        var paramType = parameters[parameterIndex].ParameterType;
+        var pointee = paramType != null && paramType.IsByRef ? paramType.GetElementType() : paramType;
+        if (pointee != null && pointee.IsGenericParameter && pointee.DeclaringMethod != null)
+        {
+            position = pointee.GenericParameterPosition;
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Compares two candidate conversion targets for the same source type per
     /// C# §7.5.3.4 "Better conversion target". Returns a negative value when
     /// <paramref name="t1"/> is the better target, a positive value when

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -3955,9 +3955,98 @@ public sealed class Evaluator
         var args = new object[node.Arguments.Length];
         var refSlots = BuildRefSlots(node.Arguments, node.ArgumentRefKinds, args);
 
+        // Issue #1599: a generic BCL method closed over a same-compilation user
+        // value type (e.g. `Enum.TryParse[Color]`) was closed over a value-type
+        // placeholder during overload resolution because the user type has no
+        // reference-context CLR type. Such a method cannot be reflection-invoked
+        // (the placeholder parameter rejects the interpreter's boxed value), so
+        // emulate the ones the interpreter can service directly. `Enum.TryParse`
+        // maps a member name (or a numeric string) to the enum's underlying
+        // integer value — exactly the interpreter's representation of a user enum.
+        if (TryEmulateSameCompilationEnumTryParse(node, args, out var emulatedResult))
+        {
+            WriteBackRefSlots(refSlots, args);
+            return emulatedResult;
+        }
+
         var result = node.Function.Method.Invoke(null, args);
         WriteBackRefSlots(refSlots, args);
         return result;
+    }
+
+    /// <summary>
+    /// Issue #1599: emulates <c>Enum.TryParse&lt;TEnum&gt;(string, out TEnum)</c> and its
+    /// <c>(string, bool ignoreCase, out TEnum)</c> overload when <c>TEnum</c> is a
+    /// same-compilation user enum. The closed BCL method carries a value-type
+    /// placeholder for the erased user enum and therefore cannot be reflection-invoked;
+    /// the interpreter represents user-enum values as their underlying <see cref="int"/>,
+    /// so the parse can be serviced against the enum symbol's members. Writes the parsed
+    /// value into the <c>out</c> argument slot and reports success via
+    /// <paramref name="parseResult"/>.
+    /// </summary>
+    /// <param name="node">The imported call being evaluated.</param>
+    /// <param name="args">The evaluated argument slots (mutated for the out parameter).</param>
+    /// <param name="parseResult">The boolean parse outcome, when emulated.</param>
+    /// <returns><see langword="true"/> when the call was emulated; otherwise <see langword="false"/>.</returns>
+    private static bool TryEmulateSameCompilationEnumTryParse(BoundImportedCallExpression node, object[] args, out object parseResult)
+    {
+        parseResult = null;
+        var method = node.Function?.Method;
+        if (method == null
+            || !method.IsGenericMethod
+            || !string.Equals(method.Name, "TryParse", System.StringComparison.Ordinal)
+            || method.DeclaringType?.IsSameAs(typeof(System.Enum)) != true
+            || node.TypeArgumentSymbols.IsDefaultOrEmpty
+            || node.TypeArgumentSymbols[0] is not Symbols.EnumSymbol enumSymbol
+            || enumSymbol.ClrType != null)
+        {
+            return false;
+        }
+
+        // The out parameter is the final by-ref slot.
+        var outIndex = -1;
+        for (var i = 0; i < node.ArgumentRefKinds.Length; i++)
+        {
+            if (node.ArgumentRefKinds[i] == RefKind.Out)
+            {
+                outIndex = i;
+            }
+        }
+
+        if (outIndex < 0 || args.Length == 0)
+        {
+            return false;
+        }
+
+        var value = args[0] as string;
+        var ignoreCase = outIndex >= 2 && args[1] is bool ic && ic;
+        var comparison = ignoreCase ? System.StringComparison.OrdinalIgnoreCase : System.StringComparison.Ordinal;
+
+        var success = false;
+        var parsed = 0;
+        if (!string.IsNullOrEmpty(value))
+        {
+            foreach (var member in enumSymbol.Members)
+            {
+                if (string.Equals(member.Name, value, comparison))
+                {
+                    parsed = member.Value;
+                    success = true;
+                    break;
+                }
+            }
+
+            // .NET also accepts a numeric string for any underlying value.
+            if (!success && int.TryParse(value, out var numeric))
+            {
+                parsed = numeric;
+                success = true;
+            }
+        }
+
+        args[outIndex] = parsed;
+        parseResult = success;
+        return true;
     }
 
     private object EvaluateImportedInstanceCallExpression(BoundImportedInstanceCallExpression node)
@@ -4135,8 +4224,15 @@ public sealed class Evaluator
 
             if (rk != RefKind.None && arg is BoundAddressOfExpression addrOf)
             {
-                // Evaluate the operand to get current value.
-                args[i] = EvaluateExpression(addrOf.Operand);
+                // ADR-0039 / issue #1599: `out` never reads the incoming value,
+                // and for an inline `out var n` declaration the synthesized local
+                // is not yet present in the interpreter's locals map (it is only
+                // created by the write-back below). Evaluating the operand here
+                // would throw a KeyNotFoundException, so pass the pointee type's
+                // default for `out` and only read the current value for `ref`.
+                args[i] = rk == RefKind.Out
+                    ? DefaultValue(addrOf.Operand.Type)
+                    : EvaluateExpression(addrOf.Operand);
                 if (rk == RefKind.Ref || rk == RefKind.Out)
                 {
                     refSlots ??= [];

--- a/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
@@ -216,6 +216,24 @@ public sealed class ImportedClassSymbol : Symbol
                 continue;
             }
 
+            // Issue #1599: a pre-declared `out r` (or `ref`) whose pointee is a
+            // same-compilation user value type (a user enum or non-class struct)
+            // has no reference-context CLR type, so its by-ref erasure cannot
+            // match a value-type-constrained generic by-ref parameter such as the
+            // `out TEnum` of `Enum.TryParse[Color](string, out r)` (the parameter
+            // is closed over an `object`/placeholder erasure). Feed the same
+            // "matches any by-ref parameter" sentinel used for inline `out var`
+            // so the value-type-constrained generic overload stays applicable;
+            // the recovered explicit type-argument symbols drive the constraint
+            // check and emit. Without this the call collapses to GS0159.
+            if (arguments[i] is BoundAddressOfExpression { Operand.Type: var byRefPointee }
+                && byRefPointee is EnumSymbol or StructSymbol { IsClass: false }
+                && byRefPointee.ClrType == null)
+            {
+                argTypes[i] = OverloadResolution.InlineOutVarArgumentType;
+                continue;
+            }
+
             // Issue #530: use effective CLR type so nullable value types
             // (e.g. int32?) are matched as Nullable<T> in overload resolution.
             // Issue #533: allow null (nil literal) through; overload resolution

--- a/test/Compiler.Tests/Emit/Issue1599EnumTryParseOutVarEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1599EnumTryParseOutVarEmitTests.cs
@@ -1,0 +1,204 @@
+// <copyright file="Issue1599EnumTryParseOutVarEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1599: a generic BCL method whose type parameter carries a value-type
+/// (<c>where T : struct</c>) constraint — canonically
+/// <c>Enum.TryParse&lt;TEnum&gt;(string, out TEnum)</c> and its
+/// <c>(string, bool, out TEnum)</c> overload — invoked with a SAME-COMPILATION
+/// user enum both crashed the compiler with an internal <c>GS9999</c>
+/// (<see cref="System.Collections.Generic.KeyNotFoundException"/>) on the inline
+/// <c>out var</c> form and failed to resolve at all (<c>GS0159</c>) with a
+/// pre-declared receiver.
+/// <para>
+/// Root cause: overload resolution closes the method over a value-type
+/// placeholder (because the user enum has no reference-context CLR type), and
+/// that placeholder leaked into the inline <c>out var</c> local's type. The fix
+/// recovers the out-parameter pointee from the explicit type-argument symbols
+/// (generalizing to any value-type-constrained generic + <c>out var</c>) and
+/// makes a pre-declared by-ref argument over a same-compilation user value type
+/// match the value-type-constrained generic parameter.
+/// </para>
+/// <para>
+/// These are end-to-end emit + execution tests: they compile via <c>gsc</c> and
+/// run the produced assembly, asserting the parse succeeds and the recovered
+/// value is the correct enum member (observed via <c>ToString()</c>, which for a
+/// real emitted enum yields the member name). Each test uses a UNIQUE enum name
+/// so the name-keyed FunctionTypeSymbol cache does not bleed across the shared
+/// in-process test host.
+/// </para>
+/// </summary>
+public class Issue1599EnumTryParseOutVarEmitTests
+{
+    [Fact]
+    public void InlineOutVar_UserEnum_ResolvesBindsAndRuns_NoGS9999()
+    {
+        // Exact shape of the minimal repro from the issue.
+        const string source = """
+            package Probe
+            import System
+
+            enum Palette1599A { Crimson, Emerald }
+
+            var ok = Enum.TryParse[Palette1599A]("Emerald", out var result)
+            Console.WriteLine(ok)
+            Console.WriteLine(result.ToString())
+            """;
+
+        Assert.Equal("True\nEmerald\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void InlineOutVar_UserEnum_ParseFailure_ReturnsFalse()
+    {
+        const string source = """
+            package Probe
+            import System
+
+            enum Palette1599B { Crimson, Emerald }
+
+            var ok = Enum.TryParse[Palette1599B]("Nope", out var result)
+            Console.WriteLine(ok)
+            """;
+
+        Assert.Equal("False\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void InlineOutVar_IgnoreCaseOverload_Resolves()
+    {
+        // The three-argument `(string, bool ignoreCase, out TEnum)` overload.
+        const string source = """
+            package Probe
+            import System
+
+            enum Palette1599C { Crimson, Emerald }
+
+            var ok = Enum.TryParse[Palette1599C]("emerald", true, out var result)
+            Console.WriteLine(ok)
+            Console.WriteLine(result.ToString())
+            """;
+
+        Assert.Equal("True\nEmerald\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void PreDeclaredReceiver_UserEnum_Resolves_NoGS0159()
+    {
+        // The pre-declared-receiver variant that previously failed with GS0159.
+        const string source = """
+            package Probe
+            import System
+
+            enum Palette1599D { Crimson, Emerald }
+
+            var r Palette1599D = Palette1599D.Crimson
+            var ok = Enum.TryParse[Palette1599D]("Emerald", out r)
+            Console.WriteLine(ok)
+            Console.WriteLine(r.ToString())
+            """;
+
+        Assert.Equal("True\nEmerald\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void BclEnum_TryParse_StillWorks_Regression()
+    {
+        // Control: a value-type constraint over a real BCL enum keeps working
+        // (it is closed over the real CLR type, not the placeholder).
+        const string source = """
+            package Probe
+            import System
+
+            var ok = Enum.TryParse[DayOfWeek]("Friday", out var d)
+            Console.WriteLine(ok)
+            Console.WriteLine(d.ToString())
+            """;
+
+        Assert.Equal("True\nFriday\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1599_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath, null, Array.Empty<string>());
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+                // ignored
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1599EnumTryParseOutVarTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1599EnumTryParseOutVarTests.cs
@@ -1,0 +1,124 @@
+// <copyright file="Issue1599EnumTryParseOutVarTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1599: <c>Enum.TryParse&lt;TEnum&gt;(string, out TEnum)</c> (a generic
+/// BCL method whose type parameter has a value-type/<c>struct</c> constraint)
+/// invoked over a SAME-COMPILATION user enum must resolve and bind — both with
+/// an inline <c>out var</c> declaration and with a pre-declared receiver.
+/// <para>
+/// Before the fix the inline <c>out var</c> form crashed the compiler with an
+/// internal <c>GS9999</c> because the value-type placeholder used to close the
+/// method leaked into the synthesized local's type, and the pre-declared form
+/// failed with <c>GS0159</c> because the by-ref user-enum argument could not
+/// match the value-type-constrained by-ref parameter.
+/// </para>
+/// </summary>
+public class Issue1599EnumTryParseOutVarTests
+{
+    [Fact]
+    public void InlineOutVar_EnumTryParse_ResolvesAndBinds_NoDiagnostics()
+    {
+        // Exact repro from the issue: inline `out var` over a user enum.
+        const string source = @"
+package p
+import System
+
+enum Color { Red, Green }
+
+var ok = Enum.TryParse[Color](""Red"", out var result)
+";
+        var diagnostics = Bind(source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS9999");
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0159");
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void InlineOutVar_ResultLocal_IsTypedAsTheEnum()
+    {
+        // The synthesized local must carry the enum type, not the placeholder
+        // (which is what leaked and caused GS9999).
+        const string source = @"
+package p
+import System
+
+enum Color { Red, Green }
+
+var ok = Enum.TryParse[Color](""Red"", out var result)
+var reuse Color = result
+";
+        var diagnostics = Bind(source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS9999");
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void InlineOutVar_IgnoreCaseOverload_ResolvesAndBinds()
+    {
+        const string source = @"
+package p
+import System
+
+enum Color { Red, Green }
+
+var ok = Enum.TryParse[Color](""red"", true, out var result)
+";
+        var diagnostics = Bind(source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS9999");
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0159");
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void PreDeclaredReceiver_EnumTryParse_Resolves_NoGS0159()
+    {
+        const string source = @"
+package p
+import System
+
+enum Color { Red, Green }
+
+var r Color = Color.Red
+var ok = Enum.TryParse[Color](""Green"", out r)
+";
+        var diagnostics = Bind(source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0159");
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void BclEnum_InlineOutVar_StillResolves_Regression()
+    {
+        // Control: a real BCL enum (with a CLR type) keeps resolving through
+        // the ordinary path, not the placeholder recovery.
+        const string source = @"
+package p
+import System
+
+var ok = Enum.TryParse[DayOfWeek](""Monday"", out var d)
+";
+        var diagnostics = Bind(source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS9999");
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0159");
+        Assert.Empty(diagnostics);
+    }
+
+    private static IReadOnlyList<Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new GSharp.Core.CodeAnalysis.Compilation.Compilation(tree);
+        using var peStream = new System.IO.MemoryStream();
+        return compilation.Emit(peStream).Diagnostics.ToList();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a `gsc` internal crash (GS9999) and non-resolution (GS0159) when a generic method with a value-type-constrained type parameter (e.g. `System.Enum.TryParse<TEnum>(string, out TEnum)`) is invoked — most visibly with an inline `out var`.

## Root cause

`Enum.TryParse<TEnum>(string, out TEnum)` carries a `where TEnum : struct` constraint. When the type argument is a same-compilation user value type (e.g. a user `enum Color`, whose reference-context `ClrType` is null), overload resolution closes the method over a `UserValueTypeConstraintPlaceholder` struct (live `MakeGenericMethod` rejects `object`). Two failures resulted:

1. **GS9999 crash** — `RebindInlineOutVarArguments` read the placeholder-closed `out TEnum` parameter as the inline `out var` local's type; the placeholder leaked into a symbol-keyed dictionary → unhandled `KeyNotFoundException`.
2. **GS0159** — a pre-declared by-ref receiver (`out r`) over a user value type had no CLR type and matched no branch in `ImportedClassSymbol.TryLookupFunction`.

## Fix (generalized, not Enum-specific)

- **`OverloadResolution.cs`** — new `TryGetGenericMethodParameterPosition` (parameter analogue of the return-position helper): reports when an out/ref parameter is typed by a bare method type parameter.
- **`ExpressionBinder.Calls.cs`** — `RebindInlineOutVarArguments` recovers the out-var pointee from the explicit type-argument symbols instead of the leaked placeholder, for any value-type-constrained generic + inline `out var`.
- **`ImportedClassSymbol.cs`** — feeds the existing "matches-any-by-ref" sentinel for a pre-declared by-ref arg over any same-compilation user value type (`EnumSymbol` / non-class `StructSymbol`).
- **`Evaluator.cs`** — `out` args no longer evaluate the not-yet-declared operand local (also fixes non-generic `Int32.TryParse(..., out var n)`); plus an interpreter emulation of same-compilation `Enum.TryParse` overloads that cannot be reflection-invoked (closed over the placeholder). Only this last piece is Enum-specific and unavoidable.

## Testing

- `dotnet build GSharp.sln -c Release -graph` = 0 errors.
- Core.Tests: 4971 passed / 1 skipped. Interpreter.Tests: 339 passed.
- Targeted Compiler.Tests (Overload|Generic|OutVar|Enum): 567 passed; (ByRef|RefKind|Struct|Dim|TryParse): 353 passed.
- New regression tests: Core 5/5, Emit 5/5 (with IL verification, unique enum names).

Fixes #1599

Refs #914
