### PR TITLE
Fix #1603: emit diagnostic instead of crashing on `using let (a,b)` deconstruction

### DIFF
--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -4292,6 +4292,23 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
     }
 
     /// <summary>
+    /// Issue #1603: GS0417 — a <c>using</c> or <c>await using</c> statement's
+    /// declaration was a tuple or named deconstruction (<c>let (a, b) = …</c>
+    /// or <c>let { … } = …</c>) rather than a single variable declaration.
+    /// <c>using</c> disposes exactly one bound value, so deconstruction is not
+    /// supported there; report a diagnostic instead of crashing the parser.
+    /// </summary>
+    /// <param name="location">The text location of the offending declaration.</param>
+    public void ReportUsingRequiresSingleVariableDeclaration(TextLocation location)
+    {
+        Report(
+            location,
+            "GS0417",
+            "A 'using' statement requires a single variable declaration ('let'/'var'/'const name = …'); tuple or named deconstruction is not supported here (issue #1603).",
+            DiagnosticSeverity.Error);
+    }
+
+    /// <summary>
     /// Issue #987: GS0386 — an attempt to construct (instantiate) an abstract
     /// class. A class is abstract when it declares (or inherits without
     /// overriding) an abstract method — a no-body <c>open func F() R;</c>. Like

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -6230,8 +6230,18 @@ public class Parser
             MatchToken(SyntaxKind.LetKeyword);
         }
 
-        var decl = (VariableDeclarationSyntax)ParseVariableDeclaration();
-        return new UsingStatementSyntax(syntaxTree, keyword, decl);
+        var decl = ParseVariableDeclaration();
+        if (decl is not VariableDeclarationSyntax variableDecl)
+        {
+            // Issue #1603: `let (a, b) = …` / `let { … } = …` deconstructions
+            // aren't a single variable declaration, so `using` can't wrap
+            // them. Report and recover with the deconstruction statement
+            // itself (no disposal), instead of an InvalidCastException.
+            Diagnostics.ReportUsingRequiresSingleVariableDeclaration(decl.Location);
+            return decl;
+        }
+
+        return new UsingStatementSyntax(syntaxTree, keyword, variableDecl);
     }
 
     private StatementSyntax ParseAwaitUsingStatement()
@@ -6245,8 +6255,14 @@ public class Parser
             MatchToken(SyntaxKind.LetKeyword);
         }
 
-        var decl = (VariableDeclarationSyntax)ParseVariableDeclaration();
-        return new AwaitUsingStatementSyntax(syntaxTree, awaitKeyword, usingKeyword, decl);
+        var decl = ParseVariableDeclaration();
+        if (decl is not VariableDeclarationSyntax variableDecl)
+        {
+            Diagnostics.ReportUsingRequiresSingleVariableDeclaration(decl.Location);
+            return decl;
+        }
+
+        return new AwaitUsingStatementSyntax(syntaxTree, awaitKeyword, usingKeyword, variableDecl);
     }
 
     private StatementSyntax ParseGoStatement()

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue1603UsingDeconstructionParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue1603UsingDeconstructionParserTests.cs
@@ -1,0 +1,69 @@
+// <copyright file="Issue1603UsingDeconstructionParserTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Issue #1603: <c>using let (a, b) = …</c> (tuple deconstruction) and
+/// <c>using let { … } = …</c> (named deconstruction) are not a single
+/// variable declaration, so <c>using</c> cannot wrap them. Parsing must
+/// report <c>GS0417</c> and recover instead of throwing an
+/// <see cref="System.InvalidCastException"/> from the previous unconditional
+/// cast to <see cref="VariableDeclarationSyntax"/>. Same for
+/// <c>await using</c>.
+/// </summary>
+public class Issue1603UsingDeconstructionParserTests
+{
+    [Fact]
+    public void Using_TupleDeconstruction_Reports_GS0417_Instead_Of_Throwing()
+    {
+        const string source = @"
+package p
+class C { func F() { using let (a, b) = G() } func G() (int32, int32) { return (1, 2) } }
+";
+        var tree = SyntaxTree.Parse(source);
+
+        Assert.Contains(tree.Diagnostics, d => d.Id == "GS0417");
+    }
+
+    [Fact]
+    public void AwaitUsing_TupleDeconstruction_Reports_GS0417_Instead_Of_Throwing()
+    {
+        const string source = @"
+package p
+class C { async func F() { await using let (a, b) = G() } func G() (int32, int32) { return (1, 2) } }
+";
+        var tree = SyntaxTree.Parse(source);
+
+        Assert.Contains(tree.Diagnostics, d => d.Id == "GS0417");
+    }
+
+    [Fact]
+    public void Using_NamedDeconstruction_Reports_GS0417_Instead_Of_Throwing()
+    {
+        const string source = @"
+package p
+data struct Pt { let X int32 let Y int32 }
+class C { func F(p Pt) { using let { X, Y } = p } }
+";
+        var tree = SyntaxTree.Parse(source);
+
+        Assert.Contains(tree.Diagnostics, d => d.Id == "GS0417");
+    }
+
+    [Fact]
+    public void Using_SingleVariableDeclaration_Still_Parses_Without_GS0417()
+    {
+        const string source = @"
+package p
+class C { func F() { using let a = G() } func G() int32 { return 1 } }
+";
+        var tree = SyntaxTree.Parse(source);
+
+        Assert.DoesNotContain(tree.Diagnostics, d => d.Id == "GS0417");
+    }
+}


### PR DESCRIPTION
## Root cause
`ParseUsingStatement` / `ParseAwaitUsingStatement` (src/Core/CodeAnalysis/Syntax/Parser.cs) unconditionally cast the result of `ParseVariableDeclaration()` to `VariableDeclarationSyntax`. That method also returns `TupleDeconstructionStatementSyntax` for `let (a, b) = e` and `NamedDeconstructionStatementSyntax` for `let { .. } = e` — neither derives from `VariableDeclarationSyntax`. So a plausible user statement such as:

```
func f() {
    using let (a, b) = g()
}
```

threw an unhandled `InvalidCastException` during parsing instead of producing a diagnostic.

## Fix
Pattern-match the parsed declaration in both `ParseUsingStatement` and `ParseAwaitUsingStatement`. When it is not a `VariableDeclarationSyntax` (i.e. it's a tuple or named deconstruction), report a new diagnostic `GS0417` ('using' statement requires a single variable declaration) and recover by returning the deconstruction statement itself (no disposal semantics attached), instead of crashing. Applies uniformly to `using` and `await using`, and to both deconstruction forms (tuple and named).

Added `ReportUsingRequiresSingleVariableDeclaration` to `DiagnosticBag.cs` (GS0417), mirroring the existing diagnostic conventions in that file.

## Tests
Added `test/Core.Tests/CodeAnalysis/Syntax/Issue1603UsingDeconstructionParserTests.cs`:
- `using let (a, b) = ..` reports GS0417 (was: crash)
- `await using let (a, b) = ..` reports GS0417 (was: crash)
- `using let { X, Y } = ..` (named deconstruction) reports GS0417 (was: crash)
- `using let a = ..` (plain declaration) does NOT report GS0417 (no regression)

Ran:
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release --filter "FullyQualifiedName~Issue1603UsingDeconstructionParserTests"` → 4/4 passed
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release --filter "FullyQualifiedName~Syntax"` → 806/806 passed (no regressions)
- `dotnet build GSharp.sln -c Release -graph` → succeeded, 0 warnings, 0 errors

Fixes #1603