### PR TITLE
Fix #1604: cache SyntaxNode property list and span to remove quadratic parse of star chains

### DIFF
--- a/src/Core/CodeAnalysis/Syntax/SyntaxNode.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxNode.cs
@@ -23,7 +23,15 @@ public abstract class SyntaxNode
     // simple lazy cache is safe and turns Span from an O(subtree) walk into O(1)
     // amortized (each new wrapper node only re-scans its direct, already-cached
     // children). This is what kills the quadratic `*` chain parse (issue #1604).
-    private TextSpan? cachedSpan;
+    //
+    // ponytail: the LSP parses/analyzes in parallel, so first-read of .Span can
+    // race across threads. TextSpan? is a multi-field struct (bool + Start/Length)
+    // and a non-atomic write with no memory barrier can torn-read. Publish via the
+    // volatile flag below: write cachedSpan, then set spanComputed (release barrier)
+    // so readers that observe spanComputed==true (acquire barrier) see the full value.
+    // Racing threads may both compute -- fine, span is idempotent.
+    private TextSpan cachedSpan;
+    private volatile bool spanComputed;
 
     // ponytail: GetType().GetProperties() is uncached reflection, paid on every
     // GetChildren() call (i.e. every Span/Location access). One PropertyInfo[]
@@ -51,9 +59,9 @@ public abstract class SyntaxNode
     {
         get
         {
-            if (cachedSpan != null)
+            if (spanComputed)
             {
-                return cachedSpan.Value;
+                return cachedSpan;
             }
 
             // Compute the bounding span from min(start) and max(end) across all children, rather
@@ -85,6 +93,7 @@ public abstract class SyntaxNode
 
             var span = hasChild ? TextSpan.FromBounds(start, end) : new TextSpan(0, 0);
             cachedSpan = span;
+            spanComputed = true;
             return span;
         }
     }

--- a/src/Core/CodeAnalysis/Syntax/SyntaxNode.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxNode.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -16,6 +17,19 @@ namespace GSharp.Core.CodeAnalysis.Syntax;
 /// </summary>
 public abstract class SyntaxNode
 {
+    // ponytail: nodes are immutable once handed back to the caller -- the parser's
+    // few `{ get; set; }` properties (e.g. StructDeclarationSyntax.SharedBlock) are
+    // only ever assigned right after `new X(...)`, before anyone reads .Span. So a
+    // simple lazy cache is safe and turns Span from an O(subtree) walk into O(1)
+    // amortized (each new wrapper node only re-scans its direct, already-cached
+    // children). This is what kills the quadratic `*` chain parse (issue #1604).
+    private TextSpan? cachedSpan;
+
+    // ponytail: GetType().GetProperties() is uncached reflection, paid on every
+    // GetChildren() call (i.e. every Span/Location access). One PropertyInfo[]
+    // per concrete node type never changes, so cache it once per Type (issue #1604).
+    private static readonly ConcurrentDictionary<Type, PropertyInfo[]> PropertyCache = new();
+
     /// <summary>
     /// Initializes a new instance of the <see cref="SyntaxNode"/> class.
     /// </summary>
@@ -37,6 +51,11 @@ public abstract class SyntaxNode
     {
         get
         {
+            if (cachedSpan != null)
+            {
+                return cachedSpan.Value;
+            }
+
             // Compute the bounding span from min(start) and max(end) across all children, rather
             // than the first/last child in reflection order. The reflection-based enumeration in
             // GetChildren() returns properties in C# declaration order, which is not always the
@@ -64,7 +83,9 @@ public abstract class SyntaxNode
                 hasChild = true;
             }
 
-            return hasChild ? TextSpan.FromBounds(start, end) : new TextSpan(0, 0);
+            var span = hasChild ? TextSpan.FromBounds(start, end) : new TextSpan(0, 0);
+            cachedSpan = span;
+            return span;
         }
     }
 
@@ -84,7 +105,7 @@ public abstract class SyntaxNode
     /// <returns>An <see cref="IEnumerable{SyntaxNode}"/> with the children of this syntax node.</returns>
     public IEnumerable<SyntaxNode> GetChildren()
     {
-        var properties = GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance);
+        var properties = PropertyCache.GetOrAdd(GetType(), static t => t.GetProperties(BindingFlags.Public | BindingFlags.Instance));
 
         foreach (var property in properties)
         {

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue1604StarChainPerfParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue1604StarChainPerfParserTests.cs
@@ -1,0 +1,53 @@
+// <copyright file="Issue1604StarChainPerfParserTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Diagnostics;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Issue #1604: <c>SyntaxNode.Span</c> walked the whole subtree via uncached
+/// reflection on every access. The ADR-0122 leading-<c>*</c> newline check
+/// (<see cref="Parser"/>'s <c>IsCurrentOnNewLineAfter</c>) calls
+/// <c>node.Span</c> on the accumulated left operand at every <c>*</c> in a
+/// binary chain, so parsing <c>1 * 1 * ... * 1</c> re-walked an O(i) tree at
+/// each of N iterations: O(N^2) with a large reflection constant. A long
+/// <c>*</c> chain must parse in roughly the same time as an equivalent
+/// <c>+</c> chain, not 1000x+ slower.
+/// </summary>
+public class Issue1604StarChainPerfParserTests
+{
+    [Fact]
+    public void Long_Star_Chain_Parses_Quickly()
+    {
+        const int termCount = 4000;
+        var source = "package p\nfunc F() int32 { return " + string.Join(" * ", System.Linq.Enumerable.Repeat("1", termCount)) + " }";
+
+        var stopwatch = Stopwatch.StartNew();
+        var tree = SyntaxTree.Parse(source);
+        stopwatch.Stop();
+
+        Assert.Empty(tree.Diagnostics);
+
+        // Was ~3.6s for 4000 terms before the fix (quadratic); the fixed,
+        // amortized-O(1)-Span version parses in low tens of ms. Generous bound
+        // to avoid flakiness on slow CI machines while still catching a
+        // regression back to quadratic behavior.
+        Assert.True(stopwatch.ElapsedMilliseconds < 1000, $"Parsing {termCount} '*' terms took {stopwatch.ElapsedMilliseconds}ms, expected < 1000ms (was ~3660ms before issue #1604 fix).");
+    }
+
+    [Fact]
+    public void Span_Is_Cached_And_Stable_Across_Repeated_Access()
+    {
+        const string source = "package p\nfunc F() int32 { return 1 * 2 * 3 }";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var first = tree.Root.Span;
+        var second = tree.Root.Span;
+        Assert.Equal(first, second);
+    }
+}


### PR DESCRIPTION
## Root cause
`SyntaxNode.Span` recursively walks the whole subtree on every access, and `GetChildren()` calls `GetType().GetProperties()` (uncached reflection) plus `PropertyInfo.GetValue()` per node, per access.

The ADR-0122 leading-`*` newline check (`Parser.IsCurrentOnNewLineAfter`) calls `node.Span` on the accumulated left operand at every `*` token in the binary-expression loop. For an N-term `*` chain this re-walks an O(i) tree at each of N iterations -> O(N^2) parsing with a heavy reflection constant.

Measured before fix: `1 * 1 * ... * 1` (4000 terms) took ~3.66s vs ~2ms for an equivalent `+` chain (500->124ms, 1000->431ms, 2000->1106ms, 4000->3660ms -- quadratic).

## Fix
- Cache the per-`Type` `PropertyInfo[]` in a static `ConcurrentDictionary<Type, PropertyInfo[]>` inside `SyntaxNode.GetChildren()`. This removes the reflection cost for every Span/Location access across the whole tree, not just `*` chains.
- Cache the computed `TextSpan` per node instance. Nodes are immutable once handed back to callers -- the few post-construction `{ get; set; }` properties (e.g. `StructDeclarationSyntax.SharedBlock`) are always assigned immediately after `new X(...)`, before `.Span` is ever read, so lazy caching is safe. This turns each new binary node's Span computation into O(direct children) instead of O(subtree), since child spans are already cached from prior iterations.

Together these remove the quadratic blowup: each `*` iteration now does O(1) amortized work instead of O(i).

## Tests
Added `Issue1604StarChainPerfParserTests`:
- asserts a 4000-term `*` chain parses in well under 1s (was ~3.66s before the fix)
- asserts `Span` is stable across repeated access (basic caching correctness check)

Ran full `Syntax` test suite (804 tests, all passing) and a full solution build (`dotnet build GSharp.sln -c Release -graph`), both clean.

Fixes #1604
