### PR TITLE
Fix #1611: resolve generic backing-field tokens in field-like event accessors

### DIFF
--- a/src/Core/CodeAnalysis/Emit/MemberDefEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MemberDefEmitter.cs
@@ -641,57 +641,7 @@ internal sealed class MemberDefEmitter
                 && this.cache.StructFieldDefs.TryGetValue(ev.BackingField, out var backingHandle))
             {
                 // Issue #256: thread-safe CAS loop using Interlocked.CompareExchange<T>.
-                var il = new InstructionEncoder(new BlobBuilder(), new ControlFlowBuilder());
-                var eventTypeHandle = this.GetEventTypeHandle(ev.Type);
-
-                // ldsfld backingField; stloc.0
-                il.OpCode(ILOpCode.Ldsfld);
-                il.Token(backingHandle);
-                il.OpCode(ILOpCode.Stloc_0);
-
-                // loop_start:
-                var loopStart = il.DefineLabel();
-                il.MarkLabel(loopStart);
-
-                // ldloc.0; stloc.1
-                il.OpCode(ILOpCode.Ldloc_0);
-                il.OpCode(ILOpCode.Stloc_1);
-
-                // ldloc.1; ldarg.0; call Delegate.Combine; castclass T; stloc.2
-                il.OpCode(ILOpCode.Ldloc_1);
-                il.LoadArgument(0);
-                il.OpCode(ILOpCode.Call);
-                il.Token(this.wellKnown.GetDelegateCombineRef());
-                il.OpCode(ILOpCode.Castclass);
-                il.Token(eventTypeHandle);
-                il.OpCode(ILOpCode.Stloc_2);
-
-                // ldsflda backingField; ldloc.2; ldloc.1
-                il.OpCode(ILOpCode.Ldsflda);
-                il.Token(backingHandle);
-                il.OpCode(ILOpCode.Ldloc_2);
-                il.OpCode(ILOpCode.Ldloc_1);
-
-                // call Interlocked.CompareExchange<T>; stloc.0
-                il.OpCode(ILOpCode.Call);
-                il.Token(this.GetInterlockedCompareExchangeSpec(ev.Type));
-                il.OpCode(ILOpCode.Stloc_0);
-
-                // ldloc.0; ldloc.1; bne.un.s loop_start
-                il.OpCode(ILOpCode.Ldloc_0);
-                il.OpCode(ILOpCode.Ldloc_1);
-                il.Branch(ILOpCode.Bne_un_s, loopStart);
-
-                il.OpCode(ILOpCode.Ret);
-
-                var localsSigBlob = new BlobBuilder();
-                var localsEncoder = new BlobEncoder(localsSigBlob).LocalVariableSignature(3);
-                this.encodeTypeSymbol(localsEncoder.AddVariable().Type(), ev.Type);
-                this.encodeTypeSymbol(localsEncoder.AddVariable().Type(), ev.Type);
-                this.encodeTypeSymbol(localsEncoder.AddVariable().Type(), ev.Type);
-                var localsSignature = this.emitCtx.Metadata.AddStandaloneSignature(this.emitCtx.Metadata.GetOrAddBlob(localsSigBlob));
-
-                bodyOffset = this.emitCtx.MethodBodyStream.AddMethodBody(il, maxStack: MaxStackTracker.ComputeMaxStack(il), localVariablesSignature: localsSignature);
+                bodyOffset = this.EmitEventCasLoopBody(structSym, ev, backingHandle, isStatic: true, isAdd: true);
             }
             else if (ev.AddMethodSymbol != null && this.emitCtx.Program.Functions.TryGetValue(ev.AddMethodSymbol, out var addBody))
             {
@@ -742,57 +692,7 @@ internal sealed class MemberDefEmitter
                 && this.cache.StructFieldDefs.TryGetValue(ev.BackingField, out var backingHandle))
             {
                 // Issue #256: thread-safe CAS loop using Interlocked.CompareExchange<T>.
-                var il = new InstructionEncoder(new BlobBuilder(), new ControlFlowBuilder());
-                var eventTypeHandle = this.GetEventTypeHandle(ev.Type);
-
-                // ldsfld backingField; stloc.0
-                il.OpCode(ILOpCode.Ldsfld);
-                il.Token(backingHandle);
-                il.OpCode(ILOpCode.Stloc_0);
-
-                // loop_start:
-                var loopStart = il.DefineLabel();
-                il.MarkLabel(loopStart);
-
-                // ldloc.0; stloc.1
-                il.OpCode(ILOpCode.Ldloc_0);
-                il.OpCode(ILOpCode.Stloc_1);
-
-                // ldloc.1; ldarg.0; call Delegate.Remove; castclass T; stloc.2
-                il.OpCode(ILOpCode.Ldloc_1);
-                il.LoadArgument(0);
-                il.OpCode(ILOpCode.Call);
-                il.Token(this.wellKnown.GetDelegateRemoveRef());
-                il.OpCode(ILOpCode.Castclass);
-                il.Token(eventTypeHandle);
-                il.OpCode(ILOpCode.Stloc_2);
-
-                // ldsflda backingField; ldloc.2; ldloc.1
-                il.OpCode(ILOpCode.Ldsflda);
-                il.Token(backingHandle);
-                il.OpCode(ILOpCode.Ldloc_2);
-                il.OpCode(ILOpCode.Ldloc_1);
-
-                // call Interlocked.CompareExchange<T>; stloc.0
-                il.OpCode(ILOpCode.Call);
-                il.Token(this.GetInterlockedCompareExchangeSpec(ev.Type));
-                il.OpCode(ILOpCode.Stloc_0);
-
-                // ldloc.0; ldloc.1; bne.un.s loop_start
-                il.OpCode(ILOpCode.Ldloc_0);
-                il.OpCode(ILOpCode.Ldloc_1);
-                il.Branch(ILOpCode.Bne_un_s, loopStart);
-
-                il.OpCode(ILOpCode.Ret);
-
-                var localsSigBlob = new BlobBuilder();
-                var localsEncoder = new BlobEncoder(localsSigBlob).LocalVariableSignature(3);
-                this.encodeTypeSymbol(localsEncoder.AddVariable().Type(), ev.Type);
-                this.encodeTypeSymbol(localsEncoder.AddVariable().Type(), ev.Type);
-                this.encodeTypeSymbol(localsEncoder.AddVariable().Type(), ev.Type);
-                var localsSignature = this.emitCtx.Metadata.AddStandaloneSignature(this.emitCtx.Metadata.GetOrAddBlob(localsSigBlob));
-
-                bodyOffset = this.emitCtx.MethodBodyStream.AddMethodBody(il, maxStack: MaxStackTracker.ComputeMaxStack(il), localVariablesSignature: localsSignature);
+                bodyOffset = this.EmitEventCasLoopBody(structSym, ev, backingHandle, isStatic: true, isAdd: false);
             }
             else if (ev.RemoveMethodSymbol != null && this.emitCtx.Program.Functions.TryGetValue(ev.RemoveMethodSymbol, out var removeBody))
             {
@@ -1033,6 +933,90 @@ internal sealed class MemberDefEmitter
     }
 
     /// <summary>
+    /// Issue #1611: emits the thread-safe CAS-loop body shared by the instance/static
+    /// add/remove event accessors. Resolves the backing-field token through
+    /// <see cref="resolveFieldToken"/> when the owning type is a generic type (mirrors
+    /// the property fix for issue #989) so the emitted tokens are valid self-TypeSpec
+    /// MemberRefs instead of bare FieldDefs on a generic type.
+    /// </summary>
+    /// <param name="structSym">The struct/class declaring the event.</param>
+    /// <param name="ev">The field-like event being emitted.</param>
+    /// <param name="backingHandle">The FieldDef handle for the backing field.</param>
+    /// <param name="isStatic">Whether the accessor is static (ldsfld/ldsflda vs ldfld/ldflda, no `this`).</param>
+    /// <param name="isAdd">Whether this is the add accessor (Delegate.Combine) or remove (Delegate.Remove).</param>
+    private int EmitEventCasLoopBody(StructSymbol structSym, EventSymbol ev, FieldDefinitionHandle backingHandle, bool isStatic, bool isAdd)
+    {
+        var backingToken = ReflectionMetadataEmitter.IsUserGenericTypeReference(structSym)
+            ? this.resolveFieldToken(structSym, ev.BackingField)
+            : (EntityHandle)backingHandle;
+
+        var il = new InstructionEncoder(new BlobBuilder(), new ControlFlowBuilder());
+        var eventTypeHandle = this.GetEventTypeHandle(ev.Type);
+
+        // Static accessors have no `this`; the value parameter is argument 0 instead of 1.
+        var valueArgIndex = isStatic ? 0 : 1;
+
+        // load backingField; stloc.0
+        if (!isStatic)
+        {
+            il.LoadArgument(0);
+        }
+
+        il.OpCode(isStatic ? ILOpCode.Ldsfld : ILOpCode.Ldfld);
+        il.Token(backingToken);
+        il.OpCode(ILOpCode.Stloc_0);
+
+        // loop_start:
+        var loopStart = il.DefineLabel();
+        il.MarkLabel(loopStart);
+
+        // ldloc.0; stloc.1
+        il.OpCode(ILOpCode.Ldloc_0);
+        il.OpCode(ILOpCode.Stloc_1);
+
+        // ldloc.1; ldarg value; call Delegate.Combine/Remove; castclass T; stloc.2
+        il.OpCode(ILOpCode.Ldloc_1);
+        il.LoadArgument(valueArgIndex);
+        il.OpCode(ILOpCode.Call);
+        il.Token(isAdd ? this.wellKnown.GetDelegateCombineRef() : this.wellKnown.GetDelegateRemoveRef());
+        il.OpCode(ILOpCode.Castclass);
+        il.Token(eventTypeHandle);
+        il.OpCode(ILOpCode.Stloc_2);
+
+        // load backingField address; ldloc.2; ldloc.1
+        if (!isStatic)
+        {
+            il.LoadArgument(0);
+        }
+
+        il.OpCode(isStatic ? ILOpCode.Ldsflda : ILOpCode.Ldflda);
+        il.Token(backingToken);
+        il.OpCode(ILOpCode.Ldloc_2);
+        il.OpCode(ILOpCode.Ldloc_1);
+
+        // call Interlocked.CompareExchange<T>; stloc.0
+        il.OpCode(ILOpCode.Call);
+        il.Token(this.GetInterlockedCompareExchangeSpec(ev.Type));
+        il.OpCode(ILOpCode.Stloc_0);
+
+        // ldloc.0; ldloc.1; bne.un.s loop_start
+        il.OpCode(ILOpCode.Ldloc_0);
+        il.OpCode(ILOpCode.Ldloc_1);
+        il.Branch(ILOpCode.Bne_un_s, loopStart);
+
+        il.OpCode(ILOpCode.Ret);
+
+        var localsSigBlob = new BlobBuilder();
+        var localsEncoder = new BlobEncoder(localsSigBlob).LocalVariableSignature(3);
+        this.encodeTypeSymbol(localsEncoder.AddVariable().Type(), ev.Type);
+        this.encodeTypeSymbol(localsEncoder.AddVariable().Type(), ev.Type);
+        this.encodeTypeSymbol(localsEncoder.AddVariable().Type(), ev.Type);
+        var localsSignature = this.emitCtx.Metadata.AddStandaloneSignature(this.emitCtx.Metadata.GetOrAddBlob(localsSigBlob));
+
+        return this.emitCtx.MethodBodyStream.AddMethodBody(il, maxStack: MaxStackTracker.ComputeMaxStack(il), localVariablesSignature: localsSignature);
+    }
+
+    /// <summary>
     /// ADR-0052: emits the add_X accessor MethodDef for an event.
     /// </summary>
     private MethodDefinitionHandle EmitEventAddAccessor(StructSymbol structSym, EventSymbol ev)
@@ -1044,59 +1028,7 @@ internal sealed class MemberDefEmitter
                 && this.cache.StructFieldDefs.TryGetValue(ev.BackingField, out var backingHandle))
             {
                 // Issue #256: thread-safe CAS loop using Interlocked.CompareExchange<T>.
-                var il = new InstructionEncoder(new BlobBuilder(), new ControlFlowBuilder());
-                var eventTypeHandle = this.GetEventTypeHandle(ev.Type);
-
-                // ldarg.0; ldfld backingField; stloc.0
-                il.LoadArgument(0);
-                il.OpCode(ILOpCode.Ldfld);
-                il.Token(backingHandle);
-                il.OpCode(ILOpCode.Stloc_0);
-
-                // loop_start:
-                var loopStart = il.DefineLabel();
-                il.MarkLabel(loopStart);
-
-                // ldloc.0; stloc.1
-                il.OpCode(ILOpCode.Ldloc_0);
-                il.OpCode(ILOpCode.Stloc_1);
-
-                // ldloc.1; ldarg.1; call Delegate.Combine; castclass T; stloc.2
-                il.OpCode(ILOpCode.Ldloc_1);
-                il.LoadArgument(1);
-                il.OpCode(ILOpCode.Call);
-                il.Token(this.wellKnown.GetDelegateCombineRef());
-                il.OpCode(ILOpCode.Castclass);
-                il.Token(eventTypeHandle);
-                il.OpCode(ILOpCode.Stloc_2);
-
-                // ldarg.0; ldflda backingField; ldloc.2; ldloc.1
-                il.LoadArgument(0);
-                il.OpCode(ILOpCode.Ldflda);
-                il.Token(backingHandle);
-                il.OpCode(ILOpCode.Ldloc_2);
-                il.OpCode(ILOpCode.Ldloc_1);
-
-                // call Interlocked.CompareExchange<T>; stloc.0
-                il.OpCode(ILOpCode.Call);
-                il.Token(this.GetInterlockedCompareExchangeSpec(ev.Type));
-                il.OpCode(ILOpCode.Stloc_0);
-
-                // ldloc.0; ldloc.1; bne.un.s loop_start
-                il.OpCode(ILOpCode.Ldloc_0);
-                il.OpCode(ILOpCode.Ldloc_1);
-                il.Branch(ILOpCode.Bne_un_s, loopStart);
-
-                il.OpCode(ILOpCode.Ret);
-
-                var localsSigBlob = new BlobBuilder();
-                var localsEncoder = new BlobEncoder(localsSigBlob).LocalVariableSignature(3);
-                this.encodeTypeSymbol(localsEncoder.AddVariable().Type(), ev.Type);
-                this.encodeTypeSymbol(localsEncoder.AddVariable().Type(), ev.Type);
-                this.encodeTypeSymbol(localsEncoder.AddVariable().Type(), ev.Type);
-                var localsSignature = this.emitCtx.Metadata.AddStandaloneSignature(this.emitCtx.Metadata.GetOrAddBlob(localsSigBlob));
-
-                bodyOffset = this.emitCtx.MethodBodyStream.AddMethodBody(il, maxStack: MaxStackTracker.ComputeMaxStack(il), localVariablesSignature: localsSignature);
+                bodyOffset = this.EmitEventCasLoopBody(structSym, ev, backingHandle, isStatic: false, isAdd: true);
             }
             else if (ev.AddMethodSymbol != null && this.emitCtx.Program.Functions.TryGetValue(ev.AddMethodSymbol, out var addBody))
             {
@@ -1161,59 +1093,7 @@ internal sealed class MemberDefEmitter
                 && this.cache.StructFieldDefs.TryGetValue(ev.BackingField, out var backingHandle))
             {
                 // Issue #256: thread-safe CAS loop using Interlocked.CompareExchange<T>.
-                var il = new InstructionEncoder(new BlobBuilder(), new ControlFlowBuilder());
-                var eventTypeHandle = this.GetEventTypeHandle(ev.Type);
-
-                // ldarg.0; ldfld backingField; stloc.0
-                il.LoadArgument(0);
-                il.OpCode(ILOpCode.Ldfld);
-                il.Token(backingHandle);
-                il.OpCode(ILOpCode.Stloc_0);
-
-                // loop_start:
-                var loopStart = il.DefineLabel();
-                il.MarkLabel(loopStart);
-
-                // ldloc.0; stloc.1
-                il.OpCode(ILOpCode.Ldloc_0);
-                il.OpCode(ILOpCode.Stloc_1);
-
-                // ldloc.1; ldarg.1; call Delegate.Remove; castclass T; stloc.2
-                il.OpCode(ILOpCode.Ldloc_1);
-                il.LoadArgument(1);
-                il.OpCode(ILOpCode.Call);
-                il.Token(this.wellKnown.GetDelegateRemoveRef());
-                il.OpCode(ILOpCode.Castclass);
-                il.Token(eventTypeHandle);
-                il.OpCode(ILOpCode.Stloc_2);
-
-                // ldarg.0; ldflda backingField; ldloc.2; ldloc.1
-                il.LoadArgument(0);
-                il.OpCode(ILOpCode.Ldflda);
-                il.Token(backingHandle);
-                il.OpCode(ILOpCode.Ldloc_2);
-                il.OpCode(ILOpCode.Ldloc_1);
-
-                // call Interlocked.CompareExchange<T>; stloc.0
-                il.OpCode(ILOpCode.Call);
-                il.Token(this.GetInterlockedCompareExchangeSpec(ev.Type));
-                il.OpCode(ILOpCode.Stloc_0);
-
-                // ldloc.0; ldloc.1; bne.un.s loop_start
-                il.OpCode(ILOpCode.Ldloc_0);
-                il.OpCode(ILOpCode.Ldloc_1);
-                il.Branch(ILOpCode.Bne_un_s, loopStart);
-
-                il.OpCode(ILOpCode.Ret);
-
-                var localsSigBlob = new BlobBuilder();
-                var localsEncoder = new BlobEncoder(localsSigBlob).LocalVariableSignature(3);
-                this.encodeTypeSymbol(localsEncoder.AddVariable().Type(), ev.Type);
-                this.encodeTypeSymbol(localsEncoder.AddVariable().Type(), ev.Type);
-                this.encodeTypeSymbol(localsEncoder.AddVariable().Type(), ev.Type);
-                var localsSignature = this.emitCtx.Metadata.AddStandaloneSignature(this.emitCtx.Metadata.GetOrAddBlob(localsSigBlob));
-
-                bodyOffset = this.emitCtx.MethodBodyStream.AddMethodBody(il, maxStack: MaxStackTracker.ComputeMaxStack(il), localVariablesSignature: localsSignature);
+                bodyOffset = this.EmitEventCasLoopBody(structSym, ev, backingHandle, isStatic: false, isAdd: false);
             }
             else if (ev.RemoveMethodSymbol != null && this.emitCtx.Program.Functions.TryGetValue(ev.RemoveMethodSymbol, out var removeBody))
             {

--- a/test/Compiler.Tests/Emit/Issue1611GenericFieldLikeEventEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1611GenericFieldLikeEventEmitTests.cs
@@ -1,0 +1,140 @@
+// <copyright file="Issue1611GenericFieldLikeEventEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1611 regression tests: field-like event add/remove accessors on a
+/// generic type previously loaded their backing field with a bare FieldDef
+/// token even though the accessor body runs on a constructed (self-)generic
+/// receiver. ECMA-335 requires such member refs to go through the self-TypeSpec,
+/// exactly like the auto-property fix for issue #989. Invoking add/remove on a
+/// constructed generic instance used to throw <c>InvalidOperationException</c>
+/// at runtime ("containing type is not fully instantiated").
+/// </summary>
+public class Issue1611GenericFieldLikeEventEmitTests
+{
+    [Fact]
+    public void GenericFieldLikeEvent_InstanceAddRemove_RunsWithoutCrash()
+    {
+        var source = """
+            package Gh1611Instance
+            import System
+
+            class Holder1611A[T] {
+                public event Changed func()
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var openType = assembly.GetTypes().Single(t => t.Name == "Holder1611A`1");
+        var closedType = openType.MakeGenericType(typeof(int));
+        var instance = Activator.CreateInstance(closedType)!;
+        var ev = closedType.GetEvent("Changed")!;
+
+        bool invoked = false;
+        Action handler = () => invoked = true;
+
+        // Invoking add_Changed on a constructed generic instance is exactly
+        // where the bare-FieldDef token used to crash with
+        // InvalidOperationException ("containing type is not fully instantiated").
+        ev.AddEventHandler(instance, handler);
+
+        var backingField = closedType.GetField("Changed", BindingFlags.NonPublic | BindingFlags.Instance);
+        var del = backingField!.GetValue(instance) as Delegate;
+        Assert.NotNull(del);
+        del!.DynamicInvoke();
+        Assert.True(invoked);
+
+        invoked = false;
+        ev.RemoveEventHandler(instance, handler);
+        del = backingField.GetValue(instance) as Delegate;
+        Assert.Null(del);
+        Assert.False(invoked);
+    }
+
+    [Fact]
+    public void GenericFieldLikeEvent_StaticAddRemove_RunsWithoutCrash()
+    {
+        var source = """
+            package Gh1611Static
+            import System
+
+            class Holder1611B[T] {
+                shared {
+                    public event Changed func()
+                }
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var openType = assembly.GetTypes().Single(t => t.Name == "Holder1611B`1");
+        var closedType = openType.MakeGenericType(typeof(int));
+        var ev = closedType.GetEvent("Changed")!;
+
+        bool invoked = false;
+        Action handler = () => invoked = true;
+
+        // Static add/remove on a constructed generic type: same bare-FieldDef
+        // (ldsfld/ldsflda) crash as the instance case above.
+        ev.AddMethod!.Invoke(null, new object[] { handler });
+
+        var backingField = closedType.GetField("Changed", BindingFlags.NonPublic | BindingFlags.Static);
+        var del = backingField!.GetValue(null) as Delegate;
+        Assert.NotNull(del);
+        del!.DynamicInvoke();
+        Assert.True(invoked);
+
+        invoked = false;
+        ev.RemoveMethod!.Invoke(null, new object[] { handler });
+        del = backingField.GetValue(null) as Delegate;
+        Assert.Null(del);
+        Assert.False(invoked);
+    }
+
+    private static Assembly CompileToAssembly(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1611_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+        IlVerifier.Verify(outPath);
+
+        var bytes = File.ReadAllBytes(outPath);
+        return Assembly.Load(bytes);
+    }
+}


### PR DESCRIPTION
## Root cause
Field-like event add/remove accessors (instance and static) loaded their backing field with a bare `FieldDef` token even when the owning type is generic. Per ECMA-335, a member ref used inside a generic type's own method body must go through a self-TypeSpec, or the verifier/runtime rejects the receiver type on the stack (`InvalidOperationException: containing type is not fully instantiated`, ilverify `StackUnexpected`).

This is the same class of bug fixed for auto-properties in #989 (`MemberDefEmitter.EmitPropertyGetter`/`EmitPropertySetter` and their static counterparts already do `IsUserGenericTypeReference(structSym) ? resolveFieldToken(...) : backingHandle`). The four event CAS-loop accessor bodies (instance add, instance remove, static add, static remove) never received that fix — hence the drift called out in #1611.

## Fix
- `MemberDefEmitter.cs`: added `EmitEventCasLoopBody(structSym, ev, backingHandle, isStatic, isAdd)`, a single parameterized helper that emits the CAS-loop IL for all four accessor variants, resolving the backing-field token through `resolveFieldToken` whenever the owning type is generic (mirrors the property fix).
- Replaced the four near-duplicate CAS-loop bodies in `EmitEventAddAccessor`, `EmitEventRemoveAccessor`, `EmitStaticEventAddAccessor`, and `EmitStaticEventRemoveAccessor` with calls to the new helper, so this class of drift can't recur independently in each site.

## Test
Added `test/Compiler.Tests/Emit/Issue1611GenericFieldLikeEventEmitTests.cs`:
- `GenericFieldLikeEvent_InstanceAddRemove_RunsWithoutCrash`: compiles a generic class with a field-like instance event, IL-verifies the assembly, constructs `Holder1611A<int>`, and exercises add/remove through reflection — the same path that used to crash.
- `GenericFieldLikeEvent_StaticAddRemove_RunsWithoutCrash`: same but for a static field-like event in a `shared` block.

Verified both tests fail against the pre-fix code (ilverify `StackUnexpected` for instance; null backing field for static) and pass with the fix. Full targeted run (`Issue1611GenericFieldLikeEventEmitTests` + existing `EventEmitTests` + `Issue989*`) is green (35/35).

Fixes #1611