### PR TITLE
Fix #1612: select 32->64 conv opcode from source signedness in unchecked path

### DIFF
--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
@@ -717,21 +717,28 @@ internal sealed partial class MethodBodyEmitter
 
             op = ILOpCode.Conv_u4;
         }
-        else if (to.IsSameAs(typeof(long)))
+        else if (to.IsSameAs(typeof(long)) || to.IsSameAs(typeof(ulong))
+            || to.IsSameAs(typeof(nint)) || to.IsSameAs(typeof(nuint)))
         {
-            op = ILOpCode.Conv_i8;
-        }
-        else if (to.IsSameAs(typeof(ulong)))
-        {
-            op = ILOpCode.Conv_u8;
-        }
-        else if (to.IsSameAs(typeof(nint)))
-        {
-            op = ILOpCode.Conv_i;
-        }
-        else if (to.IsSameAs(typeof(nuint)))
-        {
-            op = ILOpCode.Conv_u;
+            // ECMA-335: widening to a 64-bit/native-int slot must
+            // sign-extend or zero-extend based on the SOURCE's
+            // signedness, not the target's. `uint32 -> int64` needs
+            // `conv.u8` (zero-extend); `int32 -> uint64` needs
+            // `conv.i8` (sign-extend). Float sources have no signedness
+            // distinction, so those keep the target-based opcode.
+            var fromFloat = from.IsSameAs(typeof(float)) || from.IsSameAs(typeof(double));
+            var useUnsigned = fromFloat
+                ? (to.IsSameAs(typeof(ulong)) || to.IsSameAs(typeof(nuint)))
+                : IsUnsignedClrType(from);
+
+            if (to.IsSameAs(typeof(long)) || to.IsSameAs(typeof(ulong)))
+            {
+                op = useUnsigned ? ILOpCode.Conv_u8 : ILOpCode.Conv_i8;
+            }
+            else
+            {
+                op = useUnsigned ? ILOpCode.Conv_u : ILOpCode.Conv_i;
+            }
         }
         else if (to.IsSameAs(typeof(float)))
         {

--- a/test/Compiler.Tests/Emit/ConversionEmitTests.cs
+++ b/test/Compiler.Tests/Emit/ConversionEmitTests.cs
@@ -119,6 +119,104 @@ public class ConversionEmitTests
         Assert.Equal("Blue", result2.ToString());
     }
 
+    [Fact]
+    public void UInt32_To_Int64_Widens_As_Unsigned_Not_Sign_Extended()
+    {
+        // Issue #1612: `uint32 -> int64` must zero-extend (conv.u8), not
+        // sign-extend (conv.i8). 0xFFFFFFFF as uint32 is 4294967295, and
+        // that value must survive the widen unchanged.
+        var source = """
+            package P
+
+            func ToInt64(value uint32) int64 {
+                return int64(value)
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var toInt64 = program.GetMethod(
+            "ToInt64",
+            BindingFlags.Public | BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(toInt64);
+
+        var result = toInt64!.Invoke(null, new object[] { 0xFFFFFFFFu });
+        Assert.Equal(4294967295L, result);
+    }
+
+    [Fact]
+    public void Int32_To_UInt64_Widens_As_Signed_Sign_Extended()
+    {
+        // Issue #1612: `int32 -> uint64` must sign-extend (conv.i8), not
+        // zero-extend (conv.u8). -1 as int32 must become
+        // 0xFFFFFFFFFFFFFFFF, not 0x00000000FFFFFFFF.
+        var source = """
+            package P
+
+            func ToUInt64(value int32) uint64 {
+                return uint64(value)
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var toUInt64 = program.GetMethod(
+            "ToUInt64",
+            BindingFlags.Public | BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(toUInt64);
+
+        var result = toUInt64!.Invoke(null, new object[] { -1 });
+        Assert.Equal(0xFFFFFFFFFFFFFFFFUL, result);
+    }
+
+    [Fact]
+    public void UInt32_To_NInt_Widens_As_Unsigned_Not_Sign_Extended()
+    {
+        // Issue #1612 same defect on the native-int target: `uint32 ->
+        // nint` must zero-extend.
+        var source = """
+            package P
+
+            func ToNInt(value uint32) nint {
+                return nint(value)
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var toNInt = program.GetMethod(
+            "ToNInt",
+            BindingFlags.Public | BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(toNInt);
+
+        var result = toNInt!.Invoke(null, new object[] { 0xFFFFFFFFu });
+        Assert.Equal(unchecked((nint)4294967295L), result);
+    }
+
+    [Fact]
+    public void Int32_To_NUInt_Widens_As_Signed_Sign_Extended()
+    {
+        // Issue #1612 same defect on the native-uint target: `int32 ->
+        // nuint` must sign-extend.
+        var source = """
+            package P
+
+            func ToNUInt(value int32) nuint {
+                return nuint(value)
+            }
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var toNUInt = program.GetMethod(
+            "ToNUInt",
+            BindingFlags.Public | BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(toNUInt);
+
+        var result = toNUInt!.Invoke(null, new object[] { -1 });
+        Assert.Equal(unchecked((nuint)0xFFFFFFFFFFFFFFFFUL), result);
+    }
+
     private static Assembly CompileToAssembly(string source)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_conv_emit_").FullName;


### PR DESCRIPTION
## Root cause
`TryEmitNumericConversion` (unchecked path) picked the `conv.*` opcode for `long`/`ulong`/`nint`/`nuint` targets purely from the *target* type. Per ECMA-335, widening a 32-bit-or-smaller value into a 64-bit or native-int stack slot must sign- or zero-extend based on the source's signedness, not the target's.

This made:
- `uint32 -> int64` emit `conv.i8` (sign-extend): `0xFFFFFFFF` became `-1` instead of `4294967295`.
- `int32 -> uint64` emit `conv.u8` (zero-extend): `-1` became `0x00000000FFFFFFFF` instead of all-ones.
- Same defect for `nint`/`nuint` targets.

`TryEmitCheckedNumericConversion` already got this right by consulting `IsUnsignedClrType(from)`; only the common unchecked path was broken.

## Fix
For `long`/`ulong`/`nint`/`nuint` targets, select `conv.u8`/`conv.u` when the source is unsigned (or `char`) and `conv.i8`/`conv.i` when the source is signed, mirroring the checked path's logic. Float sources keep target-based selection (floats have no signedness distinction).

## Tests
Added 4 regression tests to `test/Compiler.Tests/Emit/ConversionEmitTests.cs`:
- `UInt32_To_Int64_Widens_As_Unsigned_Not_Sign_Extended`
- `Int32_To_UInt64_Widens_As_Signed_Sign_Extended`
- `UInt32_To_NInt_Widens_As_Unsigned_Not_Sign_Extended`
- `Int32_To_NUInt_Widens_As_Signed_Sign_Extended`

Ran narrowly: `dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Release --no-build --filter "FullyQualifiedName~ConversionEmitTests" -- xUnit.MaxParallelThreads=2` -> 47/47 passed (all existing + 4 new).

Full solution build: `dotnet build GSharp.sln -c Release -graph` -> succeeded, 0 warnings, 0 errors.

Fixes #1612
