### PR TITLE
Fix #1613: use unsigned ldind opcodes for byte/bool/ushort/char pointees

### DIFF
--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
@@ -1430,13 +1430,25 @@ internal sealed partial class MethodBodyEmitter
         {
             this.il.OpCode(ILOpCode.Ldind_r8);
         }
-        else if (clrType.IsSameAs(typeof(short)) || clrType.IsSameAs(typeof(ushort)) || clrType.IsSameAs(typeof(char)))
+        else if (clrType.IsSameAs(typeof(short)))
         {
             this.il.OpCode(ILOpCode.Ldind_i2);
         }
-        else if (clrType.IsSameAs(typeof(byte)) || clrType.IsSameAs(typeof(sbyte)) || clrType.IsSameAs(typeof(bool)))
+        else if (clrType.IsSameAs(typeof(ushort)) || clrType.IsSameAs(typeof(char)))
+        {
+            // Issue #1613: ldind.i2 sign-extends to int32. ushort/char are
+            // unsigned pointees — mirror EmitLoadElement (issue #520) and use
+            // the unsigned form so values >= 0x8000 don't come back negative.
+            this.il.OpCode(ILOpCode.Ldind_u2);
+        }
+        else if (clrType.IsSameAs(typeof(sbyte)))
         {
             this.il.OpCode(ILOpCode.Ldind_i1);
+        }
+        else if (clrType.IsSameAs(typeof(byte)) || clrType.IsSameAs(typeof(bool)))
+        {
+            // Issue #1613: same fix for byte/bool — ldind.u1 zero-extends.
+            this.il.OpCode(ILOpCode.Ldind_u1);
         }
         else if (pointeeType is StructSymbol { IsClass: false } || (clrType != null && clrType.IsValueType))
         {

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue1613UnsignedLdindEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue1613UnsignedLdindEmitTests.cs
@@ -1,0 +1,129 @@
+// <copyright file="Issue1613UnsignedLdindEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #1613: <c>EmitLoadIndirect</c> used <c>ldind.i1</c>/<c>ldind.i2</c> for
+/// unsigned pointees (uint8/uint16/char/bool), sign-extending values with the
+/// high bit set. A ref/out param or ref-aliasing local dereference of such a
+/// value produced a negative int32 instead of the correct unsigned widening.
+/// Mirrors the already-correct <c>EmitLoadElement</c> fix from issue #520.
+/// </summary>
+public class Issue1613UnsignedLdindEmitTests
+{
+    [Fact]
+    public void RefUInt8Parameter_HighBitSet_ReadsAsUnsigned()
+    {
+        const string Source = @"package Issue1613RefUInt8
+import System
+
+func checkByte(ref b uint8) {
+    if b == 200 {
+        Console.WriteLine(""ok"")
+    } else {
+        Console.WriteLine(""bad"")
+    }
+}
+
+var v uint8 = 200
+checkByte(&v)
+";
+        var output = CompileAndRun(Source, "Issue1613RefUInt8");
+        Assert.Contains("ok", output);
+    }
+
+    [Fact]
+    public void RefUInt16Parameter_HighBitSet_ReadsAsUnsigned()
+    {
+        const string Source = @"package Issue1613RefUInt16
+import System
+
+func checkUShort(ref u uint16) {
+    if u == 40000 {
+        Console.WriteLine(""ok"")
+    } else {
+        Console.WriteLine(""bad"")
+    }
+}
+
+var v uint16 = 40000
+checkUShort(&v)
+";
+        var output = CompileAndRun(Source, "Issue1613RefUInt16");
+        Assert.Contains("ok", output);
+    }
+
+    [Fact]
+    public void OutUInt8Parameter_HighBitSet_FlowsBackAsUnsigned()
+    {
+        const string Source = @"package Issue1613OutUInt8
+import System
+
+func produce(out b uint8) {
+    b = 200
+}
+
+var r uint8 = 0
+produce(&r)
+Console.WriteLine(r)
+";
+        var output = CompileAndRun(Source, "Issue1613OutUInt8");
+        Assert.Contains("200", output);
+        Assert.DoesNotContain("-56", output);
+    }
+
+    private static string CompileAndRun(string source, string contextName)
+    {
+        using var peStream = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Emit(peStream);
+
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(contextName, isCollectible: true);
+        try
+        {
+            var asm = loadContext.LoadFromStream(peStream);
+            var programType = asm.GetTypes().FirstOrDefault(t => t.Name == "<Program>");
+            Assert.NotNull(programType);
+            var entry = programType!.GetMethod(
+                "<Main>$",
+                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(entry);
+
+            var stdout = Console.Out;
+            var captured = new StringWriter();
+            Console.SetOut(captured);
+            try
+            {
+                entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+            }
+            finally
+            {
+                Console.SetOut(stdout);
+            }
+
+            return captured.ToString();
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+}


### PR DESCRIPTION
## Root cause
`EmitLoadIndirect` (src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs) used `ldind.i1`/`ldind.i2` for byte/bool/ushort/char pointees. These opcodes sign-extend to int32 per ECMA-335, so reading an unsigned value with the high bit set (e.g. `uint8` 200, `uint16` 40000) through a pointer, `ref`/`out` parameter, or ref-aliasing local produced a negative int32 instead of the correct unsigned widening — `*p == 200` compared `-56 == 200` (always false), and the wrong value propagated through any further arithmetic/widening.

This mirrors issue #520, which already fixed the sibling `EmitLoadElement` (array element loads) to use `Ldelem_u1`/`Ldelem_u2` for the same set of types. `EmitLoadIndirect` had drifted from that fix.

## Fix
- `Ldind_u1` for `byte`/`bool`
- `Ldind_u2` for `ushort`/`char`
- kept `Ldind_i1` for `sbyte` and `Ldind_i2` for `int16` (these are genuinely signed)

## Store-side audit
Audited `EmitStoreIndirect` (`stind.i1`/`stind.i2`) for the same class of bug. ECMA-335 defines no unsigned `stind` variant — `stind.i1`/`stind.i2` are pure width-truncating stores with no sign-extension semantics, so there is no equivalent bug on the store side. No change made there.

## Tests
Added `test/Core.Tests/CodeAnalysis/Emit/Issue1613UnsignedLdindEmitTests.cs`:
- `ref uint8` param compared against 200 (>= 0x80) — reproduces the bug pre-fix (verified by reverting the fix locally and re-running: test fails with `bad` instead of `ok`)
- `ref uint16` param compared against 40000 (>= 0x8000) — same verification
- `out uint8` param round-trip, asserting the caller sees `200` not `-56`

Ran narrowly: `dotnet test test/Core.Tests/Core.Tests.csproj -c Release --filter "FullyQualifiedName~Issue1613UnsignedLdindEmitTests" -- xUnit.MaxParallelThreads=2` — 3/3 pass. Also re-ran `ByRefEmitTests`, `RefKindParameterEmitTests`, `RefLocalAliasingEmitTests` (25 tests) — no regressions. Full solution builds clean via `dotnet build GSharp.sln -c Release -graph`.

Fixes #1613