### PR TITLE
Fix #1614: evaluate field-assignment receiver once, spill value to temp for result

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundTreeWalker.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeWalker.cs
@@ -726,6 +726,16 @@ public abstract class BoundTreeWalker
 
     protected virtual void VisitFieldAssignmentExpression(BoundFieldAssignmentExpression node)
     {
+        // Issue #1614: an expression-based receiver (issue #567, closure
+        // boxing) is an arbitrary BoundExpression subtree — visit it so
+        // pre-pass collectors (e.g. AssignmentValueSpillCollector,
+        // ReceiverSpillCollector) see any nested spill-worthy nodes inside
+        // it, not just the top-level field assignment node.
+        if (node.ReceiverExpression != null)
+        {
+            VisitExpression(node.ReceiverExpression);
+        }
+
         VisitExpression(node.Value);
     }
 

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
@@ -567,15 +567,34 @@ internal sealed partial class MethodBodyEmitter
                 ? drefRecv.Operand
                 : null;
 
+            // Issue #1614: the receiver is an arbitrary expression (e.g. a
+            // method-call result) and may have side effects, so it must be
+            // evaluated exactly once. Previously the receiver was emitted a
+            // second time after the store to re-read the field for the
+            // expression result — re-running any side effect and, worse,
+            // reading the field off a freshly re-evaluated (possibly
+            // different) object. Mirror the property-assignment fix (issue
+            // #418 P1-2): dup the assigned value into a pre-planned temp
+            // before the `stfld` and load the temp back as the result —
+            // no second receiver evaluation, no re-read.
+            if (!this.receiverSpillSlots.TryGetValue(fas, out var valueSlot))
+            {
+                throw new InvalidOperationException(
+                    $"No slot populated for {fas.Kind} on field '{fas.Field.Name}' — "
+                    + "walker pre-pass missed this child? "
+                    + "Check AssignmentValueSpillCollector and its ancestor walker.");
+            }
+
             this.EmitExpression(addressReceiver ?? fas.ReceiverExpression);
             this.EmitExpression(fas.Value);
+            this.il.OpCode(ILOpCode.Dup);
+            this.il.StoreLocal(valueSlot);
             this.il.OpCode(ILOpCode.Stfld);
             this.il.Token(fieldHandle);
 
-            // Leave the assigned value on the stack as the expression result.
-            this.EmitExpression(addressReceiver ?? fas.ReceiverExpression);
-            this.il.OpCode(ILOpCode.Ldfld);
-            this.il.Token(fieldHandle);
+            // Expression result: the value we just stored — no second
+            // receiver evaluation, no second field read.
+            this.il.LoadLocal(valueSlot);
             return;
         }
 

--- a/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
+++ b/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
@@ -1153,6 +1153,29 @@ internal sealed class SlotPlanner
             base.VisitClrPropertyAssignmentExpression(node);
         }
 
+        // Issue #1614: a field assignment through an expression-based
+        // receiver (issue #567: closure-boxing lowers `variable.Field = v`
+        // to `boxLocal.Value.Field = v`; ADR-0112 chained assignment binds
+        // `a.B.C = v` the same way) is the only field-assignment shape whose
+        // receiver is an arbitrary, potentially side-effecting expression.
+        // The emitter used to evaluate it twice — once for `stfld`, once
+        // more afterwards to `ldfld` the just-stored value back out as the
+        // expression result — invoking any receiver side effect (e.g. a
+        // factory call) twice. Mirror the property-assignment fix (issue
+        // #418 P1-2): pre-allocate a value-typed temp so the emitter can
+        // `dup; stloc tmp; stfld; ldloc tmp` instead of re-evaluating the
+        // receiver. The simple-variable-receiver overloads below are
+        // unaffected — reloading a variable has no side effects.
+        protected override void VisitFieldAssignmentExpression(BoundFieldAssignmentExpression node)
+        {
+            if (node.ReceiverExpression != null)
+            {
+                this.sink.Add(node);
+            }
+
+            base.VisitFieldAssignmentExpression(node);
+        }
+
         // ADR-0060 / issue #491: assignments to ref-kind parameters or to
         // ref-aliasing locals lower to `<addr>; value; dup; stloc tmp; stind`.
         // To preserve the assignment-as-expression result semantics without

--- a/test/Compiler.Tests/Emit/Issue1614FieldAssignmentReceiverOnceEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1614FieldAssignmentReceiverOnceEmitTests.cs
@@ -1,0 +1,168 @@
+// <copyright file="Issue1614FieldAssignmentReceiverOnceEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1614: <c>EmitFieldAssignment</c>'s expression-receiver arm (the
+/// shape produced by <c>BoundFieldAssignmentExpression.WithExpressionReceiver</c>
+/// for <c>getObj().Field = v</c> / chained member assignment) emitted the
+/// receiver TWICE — once for the <c>stfld</c>, once more afterwards to
+/// <c>ldfld</c> the field back out as the expression result. When the
+/// receiver is a side-effecting call, that call ran twice, and the second
+/// run could even hand back a different object than the one written to.
+/// Compound assignment (<c>getObj().Field += v</c>) routed through the same
+/// node with the receiver already evaluated once for the read side, so the
+/// bug tripled the call count.
+///
+/// The fix spills the assigned value into a pre-planned temp local (mirrors
+/// the property-assignment fix for issue #418 P1-2): <c>receiver; value;
+/// dup; stloc tmp; stfld; ldloc tmp</c>. The receiver is evaluated exactly
+/// once for the simple-assignment shape, and the redundant post-store
+/// evaluation is eliminated from the compound-assignment shape too.
+/// </summary>
+public class Issue1614FieldAssignmentReceiverOnceEmitTests
+{
+    [Fact]
+    public void CallReceiverFieldAssignment_EvaluatesReceiverExactlyOnce()
+    {
+        var source = """
+            package P
+            import System
+
+            class Box {
+                var Count int32
+            }
+
+            public var calls = 0
+            let shared = Box()
+
+            func GetBox() Box {
+                calls = calls + 1
+                return shared
+            }
+
+            public var assignResult = GetBox().Count = 5
+            public var finalCount = shared.Count
+            public var callCount = calls
+            """;
+
+        var (assignResult, finalCount, callCount) = RunAndGetThreeIntResults(
+            source, "assignResult", "finalCount", "callCount");
+
+        Assert.Equal(5, assignResult);
+        Assert.Equal(5, finalCount);
+        Assert.Equal(1, callCount);
+    }
+
+    [Fact]
+    public void CallReceiverFieldCompoundAssignment_DoesNotTripleEvaluateReceiver()
+    {
+        var source = """
+            package P
+            import System
+
+            class Box {
+                var Count int32
+            }
+
+            public var calls = 0
+            let shared = Box()
+
+            func GetBox() Box {
+                calls = calls + 1
+                return shared
+            }
+
+            shared.Count = 10
+            GetBox().Count += 5
+            public var finalCount = shared.Count
+            public var callCount = calls
+            """;
+
+        var (finalCount, callCount) = RunAndGetTwoIntResults(source, "finalCount", "callCount");
+
+        // Compound assignment reads the current field value through the
+        // receiver once and writes through it once (two evaluations,
+        // matching the accepted property-compound-assignment behavior).
+        // Pre-fix this was three evaluations (read + write + spurious
+        // reload for the discarded statement-position result).
+        Assert.Equal(15, finalCount);
+        Assert.Equal(2, callCount);
+    }
+
+    private static (int First, int Second) RunAndGetTwoIntResults(string source, string firstField, string secondField)
+    {
+        var assembly = CompileToAssembly(source);
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var entry = program.GetMethod(
+            "<Main>$",
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+        var first = program.GetField(firstField, BindingFlags.Public | BindingFlags.Static);
+        var second = program.GetField(secondField, BindingFlags.Public | BindingFlags.Static);
+
+        entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+        return ((int)first!.GetValue(null)!, (int)second!.GetValue(null)!);
+    }
+
+    private static (int First, int Second, int Third) RunAndGetThreeIntResults(
+        string source, string firstField, string secondField, string thirdField)
+    {
+        var assembly = CompileToAssembly(source);
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var entry = program.GetMethod(
+            "<Main>$",
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+        var first = program.GetField(firstField, BindingFlags.Public | BindingFlags.Static);
+        var second = program.GetField(secondField, BindingFlags.Public | BindingFlags.Static);
+        var third = program.GetField(thirdField, BindingFlags.Public | BindingFlags.Static);
+
+        entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+        return ((int)first!.GetValue(null)!, (int)second!.GetValue(null)!, (int)third!.GetValue(null)!);
+    }
+
+    private static Assembly CompileToAssembly(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1614_emit_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+        var bytes = File.ReadAllBytes(outPath);
+        return Assembly.Load(bytes);
+    }
+}


### PR DESCRIPTION
Fixes #1614

## Root cause

`EmitFieldAssignment`'s expression-receiver arm (`BoundFieldAssignmentExpression.WithExpressionReceiver`,
used for arbitrary receivers like `getObj().Field = v` and closure-boxed field writes, e.g.
`boxLocal.Value.Field = v`) emitted the receiver expression **twice**: once to compute the target for
`stfld`, and once more afterwards to `ldfld` the field back out as the expression result. A
side-effecting receiver (a factory call, an incrementing counter, etc.) ran twice, and the second
`ldfld` could even read the field off a freshly re-evaluated (and possibly different) object.

The compound-assignment path (`getObj().Field += v`) routes through the same node with the receiver
already evaluated once for the read side (`leftRead = new BoundFieldAccessExpression(...boundReceiver...)`),
so the bug tripled the call count for that shape.

## Fix

Mirrors the property-assignment fix from issue #418 (P1-2): a pre-planned value-typed temp local is
populated via `dup; stloc tmp` right before `stfld`, and the expression result loads that temp instead
of re-reading the field through a re-evaluated receiver.

- `SlotPlanner.AssignmentValueSpillCollector` now also visits `BoundFieldAssignmentExpression` nodes
  that have an expression receiver, adding them to the same slot-collecting pre-pass used for property
  assignments.
- `BoundTreeWalker.VisitFieldAssignmentExpression` now visits `ReceiverExpression` (previously only
  `Value` was visited) — this closes a latent gap where nested spill-worthy nodes inside the receiver
  subtree were invisible to every pre-pass collector.
- `MethodBodyEmitter.EmitFieldAssignment`'s expression-receiver arm now emits the receiver once, dups
  the assigned value into the temp, `stfld`s, and loads the temp back as the result — no second
  receiver evaluation, no re-read.

The variable-receiver overloads further down (`fas.Receiver`) are untouched — they carry a pre-existing
documented invariant (Debug.Assert) that reloading a plain variable has no side effects, so they were
never part of this bug.

## Compound-assignment path

Verified and covered by a test: `getObj().Field += v` now evaluates the receiver exactly **twice**
(once to read the current value, once to write it back) instead of the pre-fix **three** times. Fully
collapsing compound assignment to a single receiver evaluation would require capturing the receiver
into its own temp and is a larger change shared with property compound-assignment (which has the same
two-evaluation shape today); that's out of scope for this fix and is not part of the reported bug.

## Tests

Added `test/Compiler.Tests/Emit/Issue1614FieldAssignmentReceiverOnceEmitTests.cs`:
- `CallReceiverFieldAssignment_EvaluatesReceiverExactlyOnce`: `GetBox().Count = 5` — asserts the
  receiver call counter is `1`, the assignment expression result is `5`, and the field on the shared
  object is `5`.
- `CallReceiverFieldCompoundAssignment_DoesNotTripleEvaluateReceiver`: `GetBox().Count += 5` — asserts
  the receiver call counter is `2` (not the pre-fix `3`) and the field lands at the correct value.

Ran targeted (`--filter FullyQualifiedName~Issue1614...`), then broader
(`--filter FullyQualifiedName~FieldAssignment|PropertyAssignment|Issue418|Issue567|Issue1446|Issue507`,
47 tests), then the full `Emit.Issue*` suite (1914 tests) with `-- xUnit.MaxParallelThreads=2` — all
green, no regressions. Full-solution build (`dotnet build GSharp.sln -c Release -graph`) succeeds.

## Deferred work

None. The compound-assignment two-evaluation behavior described above is an existing, accepted
property-assignment-parity shape, not deferred work from this bug's scope.