### PR TITLE
Fix #1615: make scope bodies real protected regions (leave + return rewrite)

### DIFF
--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Statements.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Statements.cs
@@ -429,7 +429,12 @@ internal sealed partial class MethodBodyEmitter
         var endLabel = this.il.DefineLabel();
 
         this.il.MarkLabel(tryStart);
-        this.EmitStatement(node.Body);
+
+        // Issue #1615: the scope body is a protected region just like a
+        // try block — `return`/`break`/`goto` out of it must emit `leave`,
+        // not a bare `ret`/`br`. EmitProtectedRegion pushes the body's label
+        // set so region-crossing gotos are translated to `leave`.
+        this.EmitProtectedRegion((BoundBlockStatement)node.Body);
         this.il.Branch(ILOpCode.Leave, endLabel);
 
         this.il.MarkLabel(finallyStart);

--- a/src/Core/CodeAnalysis/Lowering/Lowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/Lowerer.cs
@@ -99,6 +99,28 @@ public sealed class Lowerer : BoundTreeRewriter
 
     /// <inheritdoc/>
     /// <remarks>
+    /// Issue #1615: <c>scope { }</c> bodies are emitted as a protected
+    /// (try/finally) region so spawned tasks are always awaited — see
+    /// <c>MethodBodyEmitter.EmitScopeStatement</c>. A <c>return</c> lexically
+    /// inside a scope must therefore get the same store-to-temp +
+    /// goto-exit rewrite as a return inside a real try block, so counts
+    /// toward <see cref="tryNestingDepth"/> just like <see cref="RewriteTryStatement"/>.
+    /// </remarks>
+    protected override BoundStatement RewriteScopeStatement(BoundScopeStatement node)
+    {
+        this.tryNestingDepth++;
+        try
+        {
+            return base.RewriteScopeStatement(node);
+        }
+        finally
+        {
+            this.tryNestingDepth--;
+        }
+    }
+
+    /// <inheritdoc/>
+    /// <remarks>
     /// Issue #419 (P0-2): rewrites <c>return</c> statements that appear
     /// lexically inside a try / catch / finally region. The original
     /// <c>BoundReturnStatement</c> is replaced with a store to a synthetic

--- a/test/Compiler.Tests/Emit/Issue1615ScopeProtectedRegionEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1615ScopeProtectedRegionEmitTests.cs
@@ -1,0 +1,207 @@
+// <copyright file="Issue1615ScopeProtectedRegionEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1615 — <c>scope { }</c> bodies are emitted as a try/finally region
+/// (the finally awaits/disposes spawned tasks) but the body itself was
+/// emitted with plain <c>EmitStatement</c> instead of <c>EmitProtectedRegion</c>,
+/// and the lowerer never counted <c>BoundScopeStatement</c> toward
+/// <c>tryNestingDepth</c>. A <c>return</c>/<c>break</c>/<c>goto</c> out of a
+/// scope therefore emitted a bare <c>ret</c>/<c>br</c> from inside a
+/// protected region — invalid per ECMA-335 (ReturnFromTry / BranchOutOfTry)
+/// and an <see cref="InvalidProgramException"/> at JIT time. The fix emits
+/// the scope body via <c>EmitProtectedRegion</c> (region-crossing gotos
+/// become <c>leave</c>) and makes the lowerer rewrite <c>return</c> inside a
+/// scope into a store-to-temp + goto-exit, exactly like <c>return</c> inside
+/// a real <c>try</c>.
+/// </summary>
+public class Issue1615ScopeProtectedRegionEmitTests
+{
+    [Fact]
+    public void ReturnInsideScope_ReturnsValue_AndVerifies()
+    {
+        var source = """
+            package Probe1615a
+
+            func f() int32 {
+                scope {
+                    return 1
+                }
+            }
+
+            func Main() {
+                System.Console.WriteLine(f())
+            }
+            """;
+
+        var output = CompileAndRun(source, "1615a");
+        Assert.Equal("1\n", output);
+    }
+
+    [Fact]
+    public void BreakInsideScopeInsideLoop_BreaksLoop_AndVerifies()
+    {
+        var source = """
+            package Probe1615b
+
+            func f() int32 {
+                var i int32 = 0
+                for i < 10 {
+                    scope {
+                        if i == 3 {
+                            break
+                        }
+                    }
+                    i = i + 1
+                }
+                return i
+            }
+
+            func Main() {
+                System.Console.WriteLine(f())
+            }
+            """;
+
+        var output = CompileAndRun(source, "1615b");
+        Assert.Equal("3\n", output);
+    }
+
+    [Fact]
+    public void NestedScopeWithReturn_ReturnsValue_AndVerifies()
+    {
+        var source = """
+            package Probe1615c
+
+            func f() int32 {
+                scope {
+                    scope {
+                        return 42
+                    }
+                }
+            }
+
+            func Main() {
+                System.Console.WriteLine(f())
+            }
+            """;
+
+        var output = CompileAndRun(source, "1615c");
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void ScopeInsideTry_ReturnFromScope_RunsFinally_AndVerifies()
+    {
+        var source = """
+            package Probe1615d
+
+            func f() int32 {
+                try {
+                    scope {
+                        return 7
+                    }
+                } finally {
+                    System.Console.WriteLine("finally")
+                }
+            }
+
+            func Main() {
+                System.Console.WriteLine(f())
+            }
+            """;
+
+        var output = CompileAndRun(source, "1615d");
+        Assert.Equal("finally\n7\n", output);
+    }
+
+    private static string CompileAndRun(string source, string tag)
+    {
+        var tempDir = Directory.CreateTempSubdirectory($"gs_{tag}_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
## Root cause

`scope { }` bodies are wrapped in a try/finally (the finally awaits and disposes spawned `go` tasks), but two coordinated mechanisms that make try blocks safe for region-crossing control flow were missing for scopes:

1. Emit side: `EmitScopeStatement` emitted the body with plain `EmitStatement` instead of `EmitProtectedRegion`. `EmitProtectedRegion` pushes the block's label set onto `protectedRegionStack` so any `goto` (including ones synthesized for `break`/`continue`) targeting a label outside the region gets translated to `leave` instead of `br`. Without it, `break`/`continue`/`goto` out of a scope emitted a bare `br`, which ilverify rejects as `BranchOutOfTry`.
2. Lowering side: `Lowerer.RewriteTryStatement` increments `tryNestingDepth` so `RewriteReturnStatement` rewrites `return` into a store-to-temp + `goto` method-exit pair (the only legal way to leave a protected region per ECMA-335). `BoundScopeStatement` had no such override, so `return` inside a scope stayed a bare return, which then emitted an invalid `ret` inside the try, or, when the scope was the entire function body, tripped the `GS0100` "not all code paths return a value" diagnostic, because `ControlFlowGraph` treats `ScopeStatement` as an opaque fall-through node and never sees the return.

## Fix

Mirrors the existing try/finally machinery instead of inventing new logic:

- `MethodBodyEmitter.EmitScopeStatement` now emits the body via `EmitProtectedRegion`.
- `Lowerer` now overrides `RewriteScopeStatement` to increment `tryNestingDepth` around the body, exactly like `RewriteTryStatement`. This routes `return` inside a scope through the same store-to-temp + goto-exit rewrite, which also fixes the `GS0100` false positive since the rewritten return is hoisted to the method-exit epilogue.

Since both scope and try already share the finally-region emit shape, this generalizes for free to nested scopes, scope-inside-try, try-inside-scope, and loops around scopes, no special-casing needed.

## Tests

Added `test/Compiler.Tests/Emit/Issue1615ScopeProtectedRegionEmitTests.cs`, 4 end-to-end compile+ilverify+run cases:

- return from inside a scope that is the whole function body
- break out of a loop from inside a scope (`for { scope { if c { break } } }`)
- nested `scope { scope { return } }`
- scope nested inside a try/finally

Verified all 4 fail without the fix (`GS0100` or ilverify `BranchOutOfTry`/`InvalidProgramException`) and pass with it.

Ran targeted: `dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Release --filter "FullyQualifiedName~Issue1615|FullyQualifiedName~Scope|FullyQualifiedName~Try|FullyQualifiedName~419|FullyQualifiedName~Goto" -- xUnit.MaxParallelThreads=2` (37 passed) and `test/Core.Tests` scope/lowerer/try filters (190 passed). Full solution builds clean with `dotnet build GSharp.sln -c Release -graph`.

Fixes #1615
