### PR TITLE
Fix #1620: structurally key FunctionTypeSymbol cache on nested type-parameter identity

### DIFF
--- a/src/Core/CodeAnalysis/Symbols/FunctionTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/FunctionTypeSymbol.cs
@@ -238,7 +238,151 @@ public sealed class FunctionTypeSymbol : TypeSymbol
                 builder.Append(")->");
                 AppendIdentityKey(builder, fn.ReturnType);
                 break;
+
+            // Issue #1620: a composite type (List[T], []T, T?, (T, int32), ...)
+            // that structurally carries a type parameter must NOT fall through
+            // to the name-based default below — two distinct generic
+            // declarations reusing the same letter (`T`) for unrelated
+            // TypeParameterSymbol instances would render the identical name
+            // ("List<T>") and alias in the process-wide cache. Recurse
+            // structurally so every nested type parameter contributes its own
+            // `!tp<N>` identity id instead.
+            case not null when TypeSymbol.ContainsTypeParameter(type):
+                AppendStructuralKey(builder, type);
+                break;
             default:
+                builder.Append(type?.Name ?? "void");
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Issue #1620: builds a shape-plus-identity key for a composite type that
+    /// structurally contains a <see cref="TypeParameterSymbol"/>. Each
+    /// composite kind contributes a stable shape tag (its generic definition
+    /// identity for user/imported generics, or a fixed marker for built-in
+    /// wrappers) followed by its recursively-keyed components, so the overall
+    /// key is unique per distinct combination of shape and nested type
+    /// parameter identities while still collapsing structurally identical
+    /// signatures.
+    /// </summary>
+    private static void AppendStructuralKey(System.Text.StringBuilder builder, TypeSymbol type)
+    {
+        switch (type)
+        {
+            case NullableTypeSymbol n:
+                builder.Append("!nullable(");
+                AppendIdentityKey(builder, n.UnderlyingType);
+                builder.Append(')');
+                break;
+            case SliceTypeSymbol s:
+                builder.Append("!slice(");
+                AppendIdentityKey(builder, s.ElementType);
+                builder.Append(')');
+                break;
+            case ArrayTypeSymbol a:
+                builder.Append("!array(");
+                AppendIdentityKey(builder, a.ElementType);
+                builder.Append(')');
+                break;
+            case SequenceTypeSymbol seq:
+                builder.Append("!seq(");
+                AppendIdentityKey(builder, seq.ElementType);
+                builder.Append(')');
+                break;
+            case AsyncSequenceTypeSymbol aseq:
+                builder.Append("!aseq(");
+                AppendIdentityKey(builder, aseq.ElementType);
+                builder.Append(')');
+                break;
+            case MapTypeSymbol m:
+                builder.Append("!map(");
+                AppendIdentityKey(builder, m.KeyType);
+                builder.Append(',');
+                AppendIdentityKey(builder, m.ValueType);
+                builder.Append(')');
+                break;
+            case TupleTypeSymbol tup:
+                builder.Append("!tuple(");
+                for (var i = 0; i < tup.ElementTypes.Length; i++)
+                {
+                    if (i > 0)
+                    {
+                        builder.Append(',');
+                    }
+
+                    AppendIdentityKey(builder, tup.ElementTypes[i]);
+                }
+
+                builder.Append(')');
+                break;
+            case ByRefTypeSymbol br:
+                builder.Append("!byref(");
+                AppendIdentityKey(builder, br.PointeeType);
+                builder.Append(')');
+                break;
+            case StructSymbol st when !st.TypeArguments.IsDefaultOrEmpty:
+                builder.Append("!struct:").Append(st.Definition?.Name ?? st.Name).Append('(');
+                for (var i = 0; i < st.TypeArguments.Length; i++)
+                {
+                    if (i > 0)
+                    {
+                        builder.Append(',');
+                    }
+
+                    AppendIdentityKey(builder, st.TypeArguments[i]);
+                }
+
+                builder.Append(')');
+                break;
+            case InterfaceSymbol iface when !iface.TypeArguments.IsDefaultOrEmpty:
+                builder.Append("!iface:").Append(iface.Definition?.Name ?? iface.Name).Append('(');
+                for (var i = 0; i < iface.TypeArguments.Length; i++)
+                {
+                    if (i > 0)
+                    {
+                        builder.Append(',');
+                    }
+
+                    AppendIdentityKey(builder, iface.TypeArguments[i]);
+                }
+
+                builder.Append(')');
+                break;
+            case DelegateTypeSymbol del:
+                builder.Append("!delegate(");
+                for (var i = 0; i < del.Parameters.Length; i++)
+                {
+                    if (i > 0)
+                    {
+                        builder.Append(',');
+                    }
+
+                    AppendIdentityKey(builder, del.Parameters[i].Type);
+                }
+
+                builder.Append(")->");
+                AppendIdentityKey(builder, del.ReturnType);
+                break;
+            case ImportedTypeSymbol it when !it.TypeArguments.IsDefaultOrEmpty:
+                builder.Append("!imported:").Append(it.OpenDefinition?.FullName ?? it.Name).Append('(');
+                for (var i = 0; i < it.TypeArguments.Length; i++)
+                {
+                    if (i > 0)
+                    {
+                        builder.Append(',');
+                    }
+
+                    AppendIdentityKey(builder, it.TypeArguments[i]);
+                }
+
+                builder.Append(')');
+                break;
+            default:
+                // TypeSymbol.ContainsTypeParameter only descends into the
+                // composite kinds handled above (see AnyTypeParameter), so
+                // this default is unreachable in practice; keep the
+                // name-based fallback for safety.
                 builder.Append(type?.Name ?? "void");
                 break;
         }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1620FunctionTypeCacheNestedTypeParamTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1620FunctionTypeCacheNestedTypeParamTests.cs
@@ -1,0 +1,169 @@
+// <copyright file="Issue1620FunctionTypeCacheNestedTypeParamTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1620: the process-wide <see cref="FunctionTypeSymbol"/> cache keyed a
+/// composite parameter type (<c>List[T]</c>, <c>[]T</c>, <c>T?</c>, tuples) by
+/// its display NAME whenever the type parameter was nested rather than a
+/// direct slot. Two distinct generic declarations that both spell their type
+/// parameter <c>T</c> and both take a function-typed parameter shaped
+/// <c>(List[T]) -&gt; int32</c> produced the SAME name ("(List&lt;T&gt;) -&gt; int32")
+/// and therefore aliased in the cache: whichever declaration bound SECOND
+/// reused the FIRST declaration's <see cref="TypeParameterSymbol"/> instance,
+/// so substitution / lambda-parameter inference at its call sites silently
+/// failed (GS0304 / GS0158). Each test below uses a UNIQUE package name
+/// because the cache is not cleared between tests (see
+/// <see cref="Issue1537GenericNestedInGenericBinderTests"/>).
+/// </summary>
+public class Issue1620FunctionTypeCacheNestedTypeParamTests
+{
+    [Fact]
+    public void TwoGenericFunctions_SameLetterListOfT_FirstDeclarationOrder_BothBind()
+    {
+        AssertBothOrdersBind(package: "Issue1620ListOrderA", declareApplyAFirst: true);
+    }
+
+    [Fact]
+    public void TwoGenericFunctions_SameLetterListOfT_SecondDeclarationOrder_BothBind()
+    {
+        // Swapping declaration order is the crux of the repro: before the fix
+        // whichever of applyA/applyB was declared SECOND lost its own
+        // TypeParameterSymbol identity to the cache alias.
+        AssertBothOrdersBind(package: "Issue1620ListOrderB", declareApplyAFirst: false);
+    }
+
+    [Fact]
+    public void TwoGenericFunctions_SameLetterNestedListOfListOfT_BothBind()
+    {
+        var source = """
+            package Issue1620NestedListList
+            import System.Collections.Generic
+
+            func applyA[T](xs List[List[T]], f (List[List[T]]) -> int32) int32 {
+                return f(xs)
+            }
+            func applyB[T](xs List[List[T]], f (List[List[T]]) -> int32) int32 {
+                return f(xs)
+            }
+            func Main() {
+                var la = List[List[int32]]()
+                var ra = applyA(la, (l) -> l.Count)
+                var lb = List[List[string]]()
+                var rb = applyB(lb, (l) -> l.Count)
+            }
+            """;
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void TwoGenericFunctions_SameLetterTupleOfT_BothBind()
+    {
+        var source = """
+            package Issue1620TupleT
+
+            func applyA[T](x T, f ((T, int32)) -> int32) int32 {
+                return f((x, 1))
+            }
+            func applyB[T](x T, f ((T, int32)) -> int32) int32 {
+                return f((x, 2))
+            }
+            func Main() {
+                var ra = applyA(1, (t) -> t.Item2)
+                var rb = applyB("s", (t) -> t.Item2)
+            }
+            """;
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void TwoGenericFunctions_SameLetterNullableT_BothBind()
+    {
+        var source = """
+            package Issue1620NullableT
+
+            func applyA[T](x T, f (T?) -> int32) int32 {
+                return f(x)
+            }
+            func applyB[T](x T, f (T?) -> int32) int32 {
+                return f(x)
+            }
+            func Main() {
+                var ra = applyA(1, (x) -> 1)
+                var rb = applyB("s", (x) -> 2)
+            }
+            """;
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    [Fact]
+    public void TwoGenericFunctions_SameLetterArrayOfT_BothBind()
+    {
+        var source = """
+            package Issue1620ArrayT
+            import Gsharp.Extensions.Go
+
+            func applyA[T](xs []T, f ([]T) -> int32) int32 {
+                return f(xs)
+            }
+            func applyB[T](xs []T, f ([]T) -> int32) int32 {
+                return f(xs)
+            }
+            func Main() {
+                var ra = applyA([]int32{1, 2}, (s) -> len(s))
+                var rb = applyB([]string{"a", "b", "c"}, (s) -> len(s))
+            }
+            """;
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    private static void AssertBothOrdersBind(string package, bool declareApplyAFirst)
+    {
+        var applyA = """
+            func applyA[T](xs List[T], f (List[T]) -> int32) int32 {
+                return f(xs)
+            }
+            """;
+        var applyB = """
+            func applyB[T](xs List[T], f (List[T]) -> int32) int32 {
+                return f(xs)
+            }
+            """;
+        var first = declareApplyAFirst ? applyA : applyB;
+        var second = declareApplyAFirst ? applyB : applyA;
+
+        var source = $$"""
+            package {{package}}
+            import System.Collections.Generic
+
+            {{first}}
+            {{second}}
+            func Main() {
+                var la = List[int32]{1, 2, 3}
+                var ra = applyA(la, (l) -> l.Count)
+                var lb = List[string]{"a", "b"}
+                var rb = applyB(lb, (l) -> l.Count)
+            }
+            """;
+
+        Assert.Empty(GetDiagnostics(source));
+    }
+
+    private static IReadOnlyList<Diagnostic> GetDiagnostics(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return result.Diagnostics;
+    }
+}


### PR DESCRIPTION
## Root cause

`FunctionTypeSymbol.AppendIdentityKey` only routed a *direct* `TypeParameterSymbol` slot through the process-wide cache's identity scheme (`!tp<N>`, keyed off the symbol instance via a `ConditionalWeakTable`). Any composite type that carried a type parameter *nested* inside it — `List[T]`, `[]T`, `T?`, tuples, and nested combinations like `List[List[T]]` — fell through to the name-based `default` branch, keyed only by `type.Name` (e.g. `List<T>`).

Two distinct generic declarations that both spell their type parameter `T` and both take a function-typed parameter shaped `(List[T]) -> int32` therefore produced the identical cache key (`(List<T>)->int32`). The cache aliased them: whichever declaration bound *second* got back the *first* declaration's `FunctionTypeSymbol`, carrying the first declaration's `TypeParameterSymbol` instance. Substitution and lambda-parameter inference at the second declaration's call sites then compared against a foreign type-parameter symbol and silently failed, surfacing as GS0304 (cannot infer lambda parameter type) and GS0158 (cannot find member) — with the failure moving to whichever function was declared second.

## Fix

Added `AppendStructuralKey`, invoked whenever `TypeSymbol.ContainsTypeParameter(type)` is true (checked right before the name-based default). It recurses through every composite kind that can structurally carry a type parameter, mirroring the existing canonical `TypeSymbol.AnyTypeParameter` walker:

- `NullableTypeSymbol`, `SliceTypeSymbol`, `ArrayTypeSymbol`, `SequenceTypeSymbol`, `AsyncSequenceTypeSymbol`, `ByRefTypeSymbol` (single-element wrappers)
- `MapTypeSymbol` (key + value)
- `TupleTypeSymbol` (all elements)
- `StructSymbol` / `InterfaceSymbol` with type arguments, keyed off their `Definition` identity (so two unrelated generic types don't collide) plus recursively-keyed type arguments
- `DelegateTypeSymbol` (parameters + return)
- `ImportedTypeSymbol` with type arguments, keyed off its open CLR `OpenDefinition` (generalizes beyond `List` to any BCL generic, e.g. `Dictionary[K, V]`)

Each nested `TypeParameterSymbol` still contributes its own `!tp<N>` id via the existing scheme, so two same-lettered declarations now get distinct cache keys, while a fully concrete composite (no type parameter) still falls through to the cheap name-based default and keeps sharing cache entries.

## Tests

Added `Issue1620FunctionTypeCacheNestedTypeParamTests` (`test/Core.Tests/CodeAnalysis/Binding/`):
- `List[T]` in a function-typed parameter, both declaration orders (the exact repro from the issue)
- Nested `List[List[T]]`
- Tuple `(T, int32)`
- Nullable `T?`
- Array `[]T`

Each test uses a unique package name since the `FunctionTypeSymbol` cache is process-wide and not cleared between tests.

Verified: all 6 new tests fail with the exact original errors (GS0304/GS0158) when the fix is reverted, and pass once it's applied. Full `Core.Tests` suite (4988 tests) stays green.

Fixes #1620
