### PR TITLE
Fix #1626: validate arity/named args in interface static-self dispatch (no ICE)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -589,6 +589,75 @@ internal sealed class OverloadResolver
     /// supplied the wrapper returns it unchanged so legacy single-overload
     /// callsites keep their existing diagnostics (wrong arity, etc.).
     /// </summary>
+    /// <summary>
+    /// Issue #1626: finalizes an implicit static-self dispatch (a bare
+    /// <c>Helper(args)</c> call resolved inside a static interface/struct
+    /// helper body) once <see cref="SelectInstanceOverloadOrReport"/> has
+    /// picked <paramref name="method"/>. That selector returns a lone
+    /// candidate with NO applicability check, so this helper — mirroring the
+    /// arity/named-argument handling every other static-call finalizer
+    /// performs — validates argument count and reorders named arguments
+    /// before converting, instead of indexing <c>method.Parameters</c>
+    /// positionally and risking an out-of-range crash (too many args) or an
+    /// invalid short <see cref="BoundCallExpression"/> (too few args).
+    /// </summary>
+    /// <remarks>
+    /// ponytail: this is only reached when <see cref="bindUserTypeStaticCall"/>
+    /// is <see langword="null"/> (e.g. an <see cref="OverloadResolver"/> built
+    /// directly, without the production callback wiring). The real binder
+    /// always supplies <c>bindUserTypeStaticCall</c>, which gives full
+    /// optional/variadic/generic fidelity via <c>BindUserTypeStaticCall</c>;
+    /// this fallback only needs to be crash-safe, not feature-complete.
+    /// </remarks>
+    private BoundExpression BindImplicitStaticSelfCallFallback(
+        FunctionSymbol method,
+        CallExpressionSyntax syntax,
+        ImmutableArray<BoundExpression> boundArguments,
+        ImmutableArray<string> argumentNames)
+    {
+        var parameterCount = method.Parameters.Length;
+        if (boundArguments.Length != parameterCount)
+        {
+            Diagnostics.ReportWrongArgumentCount(syntax.Location, method.Name, parameterCount, boundArguments.Length);
+            return new BoundErrorExpression(null);
+        }
+
+        ExpressionSyntax[] permutedSyntax;
+        ImmutableArray<BoundExpression> permutedArguments;
+        if (!argumentNames.IsDefault)
+        {
+            if (!TryReorderUserCallArguments(
+                    syntax.Arguments,
+                    boundArguments,
+                    parameterCount,
+                    p => method.Parameters[p].Name,
+                    method.Name,
+                    out permutedSyntax,
+                    out permutedArguments))
+            {
+                return new BoundErrorExpression(null);
+            }
+        }
+        else
+        {
+            permutedSyntax = new ExpressionSyntax[syntax.Arguments.Count];
+            for (var i = 0; i < syntax.Arguments.Count; i++)
+            {
+                permutedSyntax[i] = syntax.Arguments[i];
+            }
+
+            permutedArguments = boundArguments;
+        }
+
+        var convertedArgs = ImmutableArray.CreateBuilder<BoundExpression>(parameterCount);
+        for (var ai = 0; ai < parameterCount; ai++)
+        {
+            convertedArgs.Add(conversions.BindConversion(permutedSyntax[ai].Location, permutedArguments[ai], method.Parameters[ai].Type));
+        }
+
+        return new BoundCallExpression(null, method, convertedArgs.MoveToImmutable());
+    }
+
     public FunctionSymbol SelectInstanceOverloadOrReport(
         ImmutableArray<FunctionSymbol> overloads,
         ImmutableArray<BoundExpression> arguments,
@@ -3979,13 +4048,7 @@ internal sealed class OverloadResolver
                             return bindUserTypeStaticCall(implicitReceiverStruct, syntax);
                         }
 
-                        var convertedSelfStaticArgs = ImmutableArray.CreateBuilder<BoundExpression>(syntax.Arguments.Count);
-                        for (var ai = 0; ai < syntax.Arguments.Count; ai++)
-                        {
-                            convertedSelfStaticArgs.Add(conversions.BindConversion(syntax.Arguments[ai].Location, boundArguments[ai], implicitMethod.Parameters[ai].Type));
-                        }
-
-                        return new BoundCallExpression(null, implicitMethod, convertedSelfStaticArgs.MoveToImmutable());
+                        return BindImplicitStaticSelfCallFallback(implicitMethod, syntax, boundArguments.ToImmutable(), argumentNames);
                     }
 
                     var implicitReceiver = new BoundVariableExpression(null, effThis);
@@ -4062,13 +4125,17 @@ internal sealed class OverloadResolver
                         return new BoundErrorExpression(null);
                     }
 
-                    var convertedStaticArgs = ImmutableArray.CreateBuilder<BoundExpression>(syntax.Arguments.Count);
-                    for (var ai = 0; ai < syntax.Arguments.Count; ai++)
-                    {
-                        convertedStaticArgs.Add(conversions.BindConversion(syntax.Arguments[ai].Location, boundArguments[ai], implicitStaticMethod.Parameters[ai].Type));
-                    }
-
-                    return new BoundCallExpression(null, implicitStaticMethod, convertedStaticArgs.MoveToImmutable());
+                    // Issue #1626: `implicitStaticMethod` may be a private static
+                    // helper (only visible from inside the interface body, via
+                    // `GetStaticPrivateMethods` above) that the shared
+                    // `bindUserTypeStaticCall` finalizer cannot see — its own
+                    // member lookup only walks the public `StaticMethods`
+                    // bucket. Finalize directly here instead, but through the
+                    // same arity/named-argument-safe helper the struct
+                    // static-self path (above) falls back to, so a lone
+                    // candidate can no longer be indexed past its parameter
+                    // list.
+                    return BindImplicitStaticSelfCallFallback(implicitStaticMethod, syntax, boundArguments.ToImmutable(), argumentNames);
                 }
             }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1626InterfaceStaticSelfArityTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1626InterfaceStaticSelfArityTests.cs
@@ -1,0 +1,104 @@
+// <copyright file="Issue1626InterfaceStaticSelfArityTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1626: an unqualified (bare-name) call inside a static-virtual /
+/// private-static interface helper body to a sibling static method with a
+/// SINGLE overload skipped arity/named-argument validation entirely —
+/// <see cref="OverloadResolver.SelectInstanceOverloadOrReport"/> returns a
+/// lone candidate unchecked, and the interface static-self dispatch path then
+/// indexed the callee's parameter list positionally. Too many arguments threw
+/// an unhandled <see cref="System.IndexOutOfRangeException"/> (compiler
+/// crash); too few silently built an invalid, under-sized
+/// <see cref="BoundCallExpression"/>. Both must now report the standard
+/// "wrong number of arguments" diagnostic instead.
+/// </summary>
+public class Issue1626InterfaceStaticSelfArityTests
+{
+    [Fact]
+    public void StaticSelfCall_TooManyArguments_ReportsDiagnostic_NoCrash()
+    {
+        var source = @"
+package p
+interface ICalc {
+    shared {
+        func Caller() int32 { return Helper(1, 2) }
+        private func Helper(x int32) int32 { return x }
+    }
+}
+";
+        var diagnostics = Bind(source);
+        Assert.Contains(diagnostics, d => d.IsError);
+    }
+
+    [Fact]
+    public void StaticSelfCall_TooFewArguments_ReportsDiagnostic_NoCrash()
+    {
+        var source = @"
+package p
+interface ICalc {
+    shared {
+        func Caller() int32 { return Helper() }
+        private func Helper(x int32) int32 { return x }
+    }
+}
+";
+        var diagnostics = Bind(source);
+        Assert.Contains(diagnostics, d => d.IsError);
+    }
+
+    [Fact]
+    public void StaticSelfCall_NamedArgumentsOutOfOrder_BindsCorrectly()
+    {
+        var source = @"
+package p
+interface ICalc {
+    shared {
+        func Caller() int32 { return Helper(b: 2, a: 1) }
+        private func Helper(a int32, b int32) int32 { return a - b }
+    }
+}
+";
+        var diagnostics = Bind(source);
+        Assert.Empty(diagnostics.Where(d => d.IsError));
+    }
+
+    [Fact]
+    public void StaticSelfCall_CorrectArity_StillResolves()
+    {
+        var source = @"
+package p
+interface ICalc {
+    shared {
+        func Caller() int32 { return Helper(1) }
+        private func Helper(x int32) int32 { return x }
+    }
+}
+";
+        var diagnostics = Bind(source);
+        Assert.Empty(diagnostics.Where(d => d.IsError));
+    }
+
+    private static ImmutableArray<Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var globalScope = Binder.BindGlobalScope(
+            previous: null,
+            ImmutableArray.Create(tree),
+            ReferenceResolver.Default());
+        var program = Binder.BindProgram(globalScope, ReferenceResolver.Default());
+        return globalScope.Diagnostics.AddRange(program.Diagnostics);
+    }
+}


### PR DESCRIPTION
## Root cause

`SelectInstanceOverloadOrReport` short-circuits when a name resolves to a single overload: it returns that candidate with **no applicability/arity check at all** (`overloads.Length <= 1` path). Every other single-candidate call-finalization path re-validates arity before use (`BindUserInstanceCall`, `BindUserTypeStaticCall`) — except the ADR-0089/0090 **interface static-self dispatch** path (an unqualified sibling call from inside a static-virtual/private-static interface helper body). That path took the lone candidate and indexed its parameter list positionally:

```csharp
for (var ai = 0; ai < syntax.Arguments.Count; ai++)
{
    convertedStaticArgs.Add(conversions.BindConversion(..., implicitStaticMethod.Parameters[ai].Type));
}
```

Too many call-site arguments → `IndexOutOfRangeException` (unhandled compiler crash / ICE). Too few → an under-sized `BoundCallExpression` with fewer bound arguments than declared parameters (invalid downstream).

There was also a latent, structurally-identical copy on the struct static-self path, reachable only when the `bindUserTypeStaticCall` callback isn't wired in (e.g. an `OverloadResolver` built directly, without production wiring).

## Fix

Added a shared `BindImplicitStaticSelfCallFallback` helper that validates argument count and reorders named arguments before converting — mirroring the arity/named-argument handling every other static-call finalizer performs. Both the interface path and the latent struct-path copy now call this helper instead of hand-rolling their own unchecked conversion loop.

I initially tried routing the interface path through the existing shared static-call finalizer (`bindUserTypeStaticCall`, already used by the sibling struct static-self path), which is the leaner option the issue suggested. That's not safe here: `bindUserTypeStaticCall`'s own static-method lookup only walks an interface's **public** `StaticMethods` bucket — it has no visibility into `private static` helpers, which are kept in a separate `GetStaticPrivateMethods` bucket specifically so only in-interface callers can see them (ADR-0090). Routing a private-static sibling call through `bindUserTypeStaticCall` would silently fail to find it, breaking a working feature. So the new shared helper is used directly instead, using the already-correctly-selected candidate (which does include the private bucket).

## Tests

Added `Issue1626InterfaceStaticSelfArityTests` (`test/Core.Tests/CodeAnalysis/Binding/`):
- too-many-arguments → proper diagnostic, no crash (confirmed this reproduces the original `IndexOutOfRangeException` on pre-fix code)
- too-few-arguments → proper diagnostic, no crash (confirmed this reproduces silently-invalid binding on pre-fix code)
- named arguments out of declaration order → binds correctly
- correct arity → still resolves (control)

Ran targeted suites: `Issue1626InterfaceStaticSelfArityTests` (4/4), plus `StaticVirtualInterfaceTests`, `Issue1585StaticBareCallTests`, `Issue1268StaticVirtualGenericInterfaceTests`, `Issue1030InterfaceStaticMembersTests`, `InterfaceTests` (84/84 total), plus emit tests `Issue1585StaticBareCallEmitTests`, `PrivateInterfaceHelpersEmitTests`, `StaticVirtualInterfaceMembersEmitTests` (11/11). Full solution builds clean (`dotnet build GSharp.sln -c Release -graph`).

Fixes #1626