### PR TITLE
Fix #1642: recurse definite-assignment into try/select/scope/fixed bodies

### DIFF
--- a/src/Core/CodeAnalysis/Binding/RefKindDefiniteAssignmentAnalyzer.cs
+++ b/src/Core/CodeAnalysis/Binding/RefKindDefiniteAssignmentAnalyzer.cs
@@ -22,7 +22,11 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 ///     call site must be definitely assigned at that point.</item>
 /// </list>
 /// The analyzer builds a <see cref="ControlFlowGraph"/> for the function body
-/// and runs a forward "must be assigned" data-flow with intersect-meet over
+/// (and, recursively, for the body of every try/catch/finally, <c>select</c>
+/// case, <c>scope</c>, and <c>fixed</c> block it contains — issue #1642: the
+/// outer CFG treats those as single opaque statements, see
+/// <see cref="ControlFlowGraph"/>'s <c>BasicBlockBuilder</c>) and runs a
+/// forward "must be assigned" data-flow with intersect-meet over
 /// predecessors. Reads are checked before writes apply within a basic block,
 /// so a single statement that both writes and reads the same variable is
 /// classified using the set at the start of that statement.
@@ -32,16 +36,6 @@ internal static class RefKindDefiniteAssignmentAnalyzer
     public static void Analyze(BoundBlockStatement body, FunctionSymbol function, DiagnosticBag diagnostics)
     {
         if (body == null || function == null)
-        {
-            return;
-        }
-
-        ControlFlowGraph graph;
-        try
-        {
-            graph = ControlFlowGraph.Create(body);
-        }
-        catch
         {
             return;
         }
@@ -58,23 +52,69 @@ internal static class RefKindDefiniteAssignmentAnalyzer
 
         var outParams = function.Parameters.Where(p => p.RefKind == RefKind.Out).ToImmutableArray();
 
-        // Block entry sets.
+        // Best-effort `p = &v` / `var p = &v` alias tracking so `*p = expr`
+        // (BoundIndirectAssignmentExpression) can count as an assignment to
+        // `v`. Function-scoped and not part of the dataflow lattice — see
+        // TrackPointerAlias/TryResolvePointerTarget for the (deliberately
+        // narrow) semantics.
+        var pointerAliases = new Dictionary<VariableSymbol, VariableSymbol>();
+
+        try
+        {
+            AnalyzeRegion(body, initialAssigned, outParams, function, diagnostics, pointerAliases, isFunctionBody: true);
+        }
+        catch
+        {
+            // ponytail: fail-safe, not fail-open (issue #1642 secondary defect).
+            // ControlFlowGraph.Create is already called unguarded against this
+            // same lowered body a few lines above in Binder.cs
+            // (ControlFlowGraph.AllPathsReturn) for every non-void function, so
+            // this branch is realistically only reachable for void functions or
+            // a genuine bug in this analyzer's own recursion. Either way,
+            // silently returning (the previous behavior) would let a possibly-
+            // unassigned `out` parameter compile with no diagnostic at all.
+            // Report it instead of swallowing the failure; GS0239 (ref-read)
+            // checks are best-effort and are simply skipped on this rare path.
+            foreach (var op in outParams)
+            {
+                diagnostics.ReportOutParameterNotAssigned(function.Declaration?.Location ?? default(TextLocation), op.Name);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Runs the forward "must be assigned" fixpoint over the CFG of
+    /// <paramref name="regionBody"/> (wrapping it in a synthetic block first
+    /// if it isn't already one), seeded with <paramref name="initialAssigned"/>.
+    /// When <paramref name="isFunctionBody"/> is true, every path reaching the
+    /// region's end is an actual function exit and is checked against
+    /// <paramref name="outParams"/> (mirrors the original top-level check).
+    /// Otherwise, only paths ending in an internal <c>return</c>/<c>throw</c>
+    /// are exits (checked here, since they leave the function from a point
+    /// the outer CFG never sees — issue #1642); paths that fall off the end
+    /// of the region normally are merged (intersected) and returned so the
+    /// caller can keep propagating assignment state past the compound
+    /// statement. Returns null when the region never completes normally.
+    /// </summary>
+    private static HashSet<VariableSymbol> AnalyzeRegion(
+        BoundStatement regionBody,
+        HashSet<VariableSymbol> initialAssigned,
+        ImmutableArray<ParameterSymbol> outParams,
+        FunctionSymbol function,
+        DiagnosticBag diagnostics,
+        Dictionary<VariableSymbol, VariableSymbol> pointerAliases,
+        bool isFunctionBody = false)
+    {
+        var graph = ControlFlowGraph.Create(AsBlock(regionBody));
+
         var entryAssigned = new Dictionary<ControlFlowGraph.BasicBlock, HashSet<VariableSymbol>>();
         var exitAssigned = new Dictionary<ControlFlowGraph.BasicBlock, HashSet<VariableSymbol>>();
-
-        // Initialize: all blocks start with the universal set (intersection
-        // identity), except the start block which carries the initial
-        // assigned-on-entry parameter set.
         foreach (var b in graph.Blocks)
         {
             entryAssigned[b] = b.IsStart ? new HashSet<VariableSymbol>(initialAssigned) : null;
             exitAssigned[b] = null;
         }
 
-        // Worklist iteration. We don't report diagnostics during fixed-point
-        // computation — only on a final pass once entry sets have converged.
-        var worklist = new Queue<ControlFlowGraph.BasicBlock>();
-        worklist.Enqueue(graph.Start);
         var changed = true;
         var safety = 0;
         while (changed && safety++ < 10000)
@@ -87,7 +127,6 @@ internal static class RefKindDefiniteAssignmentAnalyzer
                     continue;
                 }
 
-                // Compute entry as intersection over predecessors' exits.
                 HashSet<VariableSymbol> entry;
                 if (block.IsStart)
                 {
@@ -104,34 +143,20 @@ internal static class RefKindDefiniteAssignmentAnalyzer
                             continue;
                         }
 
-                        if (entry == null)
-                        {
-                            entry = new HashSet<VariableSymbol>(predExit);
-                        }
-                        else
-                        {
-                            entry.IntersectWith(predExit);
-                        }
+                        entry = entry == null ? new HashSet<VariableSymbol>(predExit) : Intersect(entry, predExit);
                     }
 
-                    if (entry == null)
-                    {
-                        entry = new HashSet<VariableSymbol>(initialAssigned);
-                    }
+                    entry ??= new HashSet<VariableSymbol>(initialAssigned);
                 }
 
                 var prevEntry = entryAssigned[block];
-                if (prevEntry != null && SetsEqual(prevEntry, entry))
-                {
-                    // No change to entry — re-compute exit if necessary.
-                }
-                else
+                if (prevEntry == null || !SetsEqual(prevEntry, entry))
                 {
                     entryAssigned[block] = entry;
                     changed = true;
                 }
 
-                var exit = SimulateBlock(block, new HashSet<VariableSymbol>(entryAssigned[block]), null);
+                var exit = SimulateBlock(block, new HashSet<VariableSymbol>(entryAssigned[block]), outParams, function, null, pointerAliases);
                 var prevExit = exitAssigned[block];
                 if (prevExit == null || !SetsEqual(prevExit, exit))
                 {
@@ -141,36 +166,89 @@ internal static class RefKindDefiniteAssignmentAnalyzer
             }
         }
 
-        // Final reporting pass.
-        foreach (var block in graph.Blocks)
+        // Final reporting pass — only performed once the caller actually wants
+        // diagnostics (nested regions get re-analyzed without diagnostics
+        // while probing a parent's dataflow; see e.g. ProcessTryStatement).
+        if (diagnostics != null)
         {
-            if (block.IsStart || block.IsEnd)
+            foreach (var block in graph.Blocks)
             {
-                continue;
-            }
+                if (block.IsStart || block.IsEnd)
+                {
+                    continue;
+                }
 
-            var entry = entryAssigned[block] ?? new HashSet<VariableSymbol>(initialAssigned);
-            SimulateBlock(block, new HashSet<VariableSymbol>(entry), diagnostics);
+                var entry = entryAssigned[block] ?? new HashSet<VariableSymbol>(initialAssigned);
+                SimulateBlock(block, new HashSet<VariableSymbol>(entry), outParams, function, diagnostics, pointerAliases);
+            }
         }
 
-        // Item #4: at the function exit, check all out parameters are assigned.
-        // We report at the last statement of each predecessor of the end block.
-        if (!outParams.IsDefaultOrEmpty)
+        if (isFunctionBody)
         {
-            foreach (var endBranch in graph.End.Incoming)
+            if (diagnostics != null && !outParams.IsDefaultOrEmpty)
             {
-                var fromBlock = endBranch.From;
-                var exit = exitAssigned[fromBlock] ?? new HashSet<VariableSymbol>(initialAssigned);
-                foreach (var op in outParams)
+                foreach (var endBranch in graph.End.Incoming)
                 {
-                    if (!exit.Contains(op))
+                    var exit = exitAssigned[endBranch.From] ?? new HashSet<VariableSymbol>(initialAssigned);
+                    foreach (var op in outParams)
                     {
-                        var loc = GetReportLocation(fromBlock, function);
-                        diagnostics.ReportOutParameterNotAssigned(loc, op.Name);
+                        if (!exit.Contains(op))
+                        {
+                            diagnostics.ReportOutParameterNotAssigned(GetReportLocation(endBranch.From, function), op.Name);
+                        }
                     }
                 }
             }
+
+            return null;
         }
+
+        // Not the function body: classify each predecessor of this region's
+        // end as either an internal exit (return/throw — leaves the function
+        // right here, from a point the outer CFG can't see) or a normal
+        // fall-through (continues past the compound statement).
+        HashSet<VariableSymbol> normalExit = null;
+        var anyNormal = false;
+        foreach (var endBranch in graph.End.Incoming)
+        {
+            var fromBlock = endBranch.From;
+            var exit = exitAssigned[fromBlock] ?? new HashSet<VariableSymbol>(initialAssigned);
+            var lastStatement = fromBlock.Statements.LastOrDefault();
+            var isInternalExit = lastStatement != null
+                && (lastStatement.Kind == BoundNodeKind.ReturnStatement || lastStatement.Kind == BoundNodeKind.ThrowStatement);
+
+            if (isInternalExit)
+            {
+                if (diagnostics != null && !outParams.IsDefaultOrEmpty)
+                {
+                    foreach (var op in outParams)
+                    {
+                        if (!exit.Contains(op))
+                        {
+                            diagnostics.ReportOutParameterNotAssigned(GetReportLocation(fromBlock, function), op.Name);
+                        }
+                    }
+                }
+
+                continue;
+            }
+
+            anyNormal = true;
+            normalExit = normalExit == null ? new HashSet<VariableSymbol>(exit) : Intersect(normalExit, exit);
+        }
+
+        return anyNormal ? normalExit : null;
+    }
+
+    private static BoundBlockStatement AsBlock(BoundStatement statement)
+    {
+        if (statement is BoundBlockStatement block)
+        {
+            return block;
+        }
+
+        var statements = statement == null ? ImmutableArray<BoundStatement>.Empty : ImmutableArray.Create(statement);
+        return new BoundBlockStatement(statement?.Syntax, statements);
     }
 
     private static TextLocation GetReportLocation(ControlFlowGraph.BasicBlock block, FunctionSymbol function)
@@ -205,36 +283,52 @@ internal static class RefKindDefiniteAssignmentAnalyzer
         return true;
     }
 
+    private static HashSet<VariableSymbol> Intersect(HashSet<VariableSymbol> a, HashSet<VariableSymbol> b)
+    {
+        var result = new HashSet<VariableSymbol>(a);
+        result.IntersectWith(b);
+        return result;
+    }
+
     /// <summary>
     /// Walks a basic block linearly, updating <paramref name="assigned"/>
     /// in place. When <paramref name="diagnostics"/> is non-null, reports
-    /// GS0239 at every detected unassigned-before-ref read. Returns the
-    /// exit set.
+    /// GS0239/GS0238 at every detected violation (including ones nested
+    /// inside try/select/scope/fixed bodies). Returns the exit set.
     /// </summary>
     private static HashSet<VariableSymbol> SimulateBlock(
         ControlFlowGraph.BasicBlock block,
         HashSet<VariableSymbol> assigned,
-        DiagnosticBag diagnostics)
+        ImmutableArray<ParameterSymbol> outParams,
+        FunctionSymbol function,
+        DiagnosticBag diagnostics,
+        Dictionary<VariableSymbol, VariableSymbol> pointerAliases)
     {
         foreach (var statement in block.Statements)
         {
-            ProcessStatement(statement, assigned, diagnostics);
+            ProcessStatement(statement, assigned, outParams, function, diagnostics, pointerAliases);
         }
 
         return assigned;
     }
 
-    private static void ProcessStatement(BoundStatement statement, HashSet<VariableSymbol> assigned, DiagnosticBag diagnostics)
+    private static void ProcessStatement(
+        BoundStatement statement,
+        HashSet<VariableSymbol> assigned,
+        ImmutableArray<ParameterSymbol> outParams,
+        FunctionSymbol function,
+        DiagnosticBag diagnostics,
+        Dictionary<VariableSymbol, VariableSymbol> pointerAliases)
     {
         switch (statement)
         {
             case BoundExpressionStatement es:
-                ProcessExpression(es.Expression, assigned, diagnostics);
+                ProcessExpression(es.Expression, assigned, diagnostics, pointerAliases);
                 break;
             case BoundVariableDeclaration vd:
                 if (vd.Initializer != null)
                 {
-                    ProcessExpression(vd.Initializer, assigned, diagnostics);
+                    ProcessExpression(vd.Initializer, assigned, diagnostics, pointerAliases);
 
                     // Synthesised default expressions (BoundDefaultExpression)
                     // emitted for `var x T` without an explicit initializer
@@ -244,32 +338,318 @@ internal static class RefKindDefiniteAssignmentAnalyzer
                     {
                         assigned.Add(vd.Variable);
                     }
+
+                    TrackPointerAlias(vd.Variable, vd.Initializer, pointerAliases);
                 }
 
                 break;
             case BoundReturnStatement rs:
                 if (rs.Expression != null)
                 {
-                    ProcessExpression(rs.Expression, assigned, diagnostics);
+                    ProcessExpression(rs.Expression, assigned, diagnostics, pointerAliases);
                 }
 
                 break;
+            case BoundThrowStatement th:
+                ProcessExpression(th.Expression, assigned, diagnostics, pointerAliases);
+                break;
             case BoundConditionalGotoStatement cgs:
-                ProcessExpression(cgs.Condition, assigned, diagnostics);
+                ProcessExpression(cgs.Condition, assigned, diagnostics, pointerAliases);
                 break;
             case BoundLabelStatement:
             case BoundGotoStatement:
                 break;
+
+            // Issue #1642: the following compound statements are opaque to
+            // the outer ControlFlowGraph (treated as single fall-through
+            // statements — see ControlFlowGraph.BasicBlockBuilder), so their
+            // nested bodies must be recursively analyzed here or assignments
+            // inside them are invisible to this analyzer.
+            case BoundTryStatement tryStmt:
+                ProcessTryStatement(tryStmt, assigned, outParams, function, diagnostics, pointerAliases);
+                break;
+            case BoundSelectStatement selectStmt:
+                ProcessSelectStatement(selectStmt, assigned, outParams, function, diagnostics, pointerAliases);
+                break;
+            case BoundScopeStatement scopeStmt:
+            {
+                var exit = AnalyzeRegion(scopeStmt.Body, new HashSet<VariableSymbol>(assigned), outParams, function, diagnostics, pointerAliases);
+                if (exit != null)
+                {
+                    assigned.Clear();
+                    assigned.UnionWith(exit);
+                }
+
+                break;
+            }
+
+            case BoundFixedStatement fixedStmt:
+                ProcessFixedStatement(fixedStmt, assigned, outParams, function, diagnostics, pointerAliases);
+                break;
+            case BoundPatternSwitchStatement switchStmt:
+                ProcessPatternSwitchStatement(switchStmt, assigned, outParams, function, diagnostics, pointerAliases);
+                break;
             default:
-                // For other statements, walk top-level expressions if any.
-                // We deliberately avoid recursing into nested blocks (CFG
-                // already flattened them) but do walk child expressions of
-                // unmodeled statements via reflection-free best-effort.
+                // Other opaque statement kinds (go/channel-send/await-for-range/
+                // yield) fall through to the next statement at the CFG level
+                // too, but their bodies either don't run unconditionally
+                // (a loop body may run zero times) or don't affect the
+                // enclosing function's locals, so no-op here is correct.
                 break;
         }
     }
 
-    private static void ProcessExpression(BoundExpression expression, HashSet<VariableSymbol> assigned, DiagnosticBag diagnostics)
+    /// <summary>
+    /// try/catch/finally semantics (mirrors C# definite assignment):
+    /// <list type="bullet">
+    ///   <item>Each <c>catch</c> clause is analyzed as if entered at the very
+    ///     top of the try statement — an exception can occur before any
+    ///     try-body statement runs — so catch bodies never see try-body
+    ///     assignments.</item>
+    ///   <item>An assignment made only in the try body (with no matching
+    ///     unconditional assignment in every catch) is NOT guaranteed after
+    ///     the statement, because an exception could have skipped it.</item>
+    ///   <item>An assignment in <c>finally</c> IS guaranteed, because
+    ///     <c>finally</c> always runs before control can continue past the
+    ///     try statement.</item>
+    /// </list>
+    /// </summary>
+    private static void ProcessTryStatement(
+        BoundTryStatement tryStmt,
+        HashSet<VariableSymbol> assigned,
+        ImmutableArray<ParameterSymbol> outParams,
+        FunctionSymbol function,
+        DiagnosticBag diagnostics,
+        Dictionary<VariableSymbol, VariableSymbol> pointerAliases)
+    {
+        var preTry = new HashSet<VariableSymbol>(assigned);
+
+        var tryExit = AnalyzeRegion(tryStmt.TryBlock, preTry, outParams, function, diagnostics, pointerAliases);
+        var meet = tryExit;
+        var anyReachable = tryExit != null;
+
+        foreach (var clause in tryStmt.CatchClauses)
+        {
+            var catchEntry = new HashSet<VariableSymbol>(preTry);
+            if (clause.Variable != null)
+            {
+                catchEntry.Add(clause.Variable);
+            }
+
+            var catchExit = AnalyzeRegion(clause.Body, catchEntry, outParams, function, diagnostics, pointerAliases);
+            if (catchExit == null)
+            {
+                continue;
+            }
+
+            anyReachable = true;
+            meet = meet == null ? catchExit : Intersect(meet, catchExit);
+        }
+
+        // If neither the try body nor any catch can complete normally (every
+        // path always returns/throws), the code after this try statement is
+        // unreachable. Leave `assigned` untouched — ponytail: dead code, any
+        // choice here is equally "correct" since it can never execute.
+        if (anyReachable)
+        {
+            assigned.Clear();
+            assigned.UnionWith(meet);
+        }
+
+        if (tryStmt.FinallyBlock != null)
+        {
+            var finallyExit = AnalyzeRegion(tryStmt.FinallyBlock, new HashSet<VariableSymbol>(assigned), outParams, function, diagnostics, pointerAliases);
+            if (finallyExit != null)
+            {
+                assigned.Clear();
+                assigned.UnionWith(finallyExit);
+            }
+        }
+    }
+
+    /// <summary>
+    /// <c>select</c> always blocks until exactly one arm becomes ready and
+    /// runs its body (there is no "no arm matched" fallthrough, unlike a
+    /// pattern switch), so whatever is assigned on every arm that completes
+    /// normally is guaranteed to be assigned afterward.
+    /// </summary>
+    private static void ProcessSelectStatement(
+        BoundSelectStatement selectStmt,
+        HashSet<VariableSymbol> assigned,
+        ImmutableArray<ParameterSymbol> outParams,
+        FunctionSymbol function,
+        DiagnosticBag diagnostics,
+        Dictionary<VariableSymbol, VariableSymbol> pointerAliases)
+    {
+        HashSet<VariableSymbol> meet = null;
+        var any = false;
+
+        foreach (var c in selectStmt.Cases)
+        {
+            if (c.Channel != null)
+            {
+                ProcessExpression(c.Channel, assigned, diagnostics, pointerAliases);
+            }
+
+            if (c.Value != null)
+            {
+                ProcessExpression(c.Value, assigned, diagnostics, pointerAliases);
+            }
+
+            var caseEntry = new HashSet<VariableSymbol>(assigned);
+            if (c.Variable != null)
+            {
+                caseEntry.Add(c.Variable);
+            }
+
+            var caseExit = AnalyzeRegion(c.Body, caseEntry, outParams, function, diagnostics, pointerAliases);
+            if (caseExit == null)
+            {
+                continue;
+            }
+
+            any = true;
+            meet = meet == null ? caseExit : Intersect(meet, caseExit);
+        }
+
+        if (any)
+        {
+            assigned.Clear();
+            assigned.UnionWith(meet);
+        }
+    }
+
+    /// <summary>The <c>fixed</c> body always runs (no branching), so its
+    /// assignments flow through unconditionally once its synthetic pinned
+    /// and pointer locals are seeded as assigned.</summary>
+    private static void ProcessFixedStatement(
+        BoundFixedStatement fixedStmt,
+        HashSet<VariableSymbol> assigned,
+        ImmutableArray<ParameterSymbol> outParams,
+        FunctionSymbol function,
+        DiagnosticBag diagnostics,
+        Dictionary<VariableSymbol, VariableSymbol> pointerAliases)
+    {
+        ProcessExpression(fixedStmt.PinnedSource, assigned, diagnostics, pointerAliases);
+
+        var entry = new HashSet<VariableSymbol>(assigned)
+        {
+            fixedStmt.PinnedVariable,
+            fixedStmt.PointerVariable,
+        };
+        if (fixedStmt.SourceVariable != null)
+        {
+            entry.Add(fixedStmt.SourceVariable);
+        }
+
+        var exit = AnalyzeRegion(fixedStmt.Body, entry, outParams, function, diagnostics, pointerAliases);
+        if (exit != null)
+        {
+            assigned.Clear();
+            assigned.UnionWith(exit);
+        }
+    }
+
+    /// <summary>
+    /// A pattern switch, unlike <c>select</c>, can complete having matched no
+    /// arm at all when there's no exhaustive <c>default</c> — that "nothing
+    /// matched" path must also be in the meet (it contributes the untouched
+    /// incoming <paramref name="assigned"/> set).
+    /// </summary>
+    private static void ProcessPatternSwitchStatement(
+        BoundPatternSwitchStatement switchStmt,
+        HashSet<VariableSymbol> assigned,
+        ImmutableArray<ParameterSymbol> outParams,
+        FunctionSymbol function,
+        DiagnosticBag diagnostics,
+        Dictionary<VariableSymbol, VariableSymbol> pointerAliases)
+    {
+        ProcessExpression(switchStmt.Discriminant, assigned, diagnostics, pointerAliases);
+
+        HashSet<VariableSymbol> meet = null;
+        var any = false;
+        var hasDefault = false;
+
+        foreach (var arm in switchStmt.Arms)
+        {
+            if (arm.IsDefault)
+            {
+                hasDefault = true;
+            }
+
+            if (arm.Guard != null)
+            {
+                ProcessExpression(arm.Guard, assigned, diagnostics, pointerAliases);
+            }
+
+            var armExit = AnalyzeRegion(arm.Body, new HashSet<VariableSymbol>(assigned), outParams, function, diagnostics, pointerAliases);
+            if (armExit == null)
+            {
+                continue;
+            }
+
+            any = true;
+            meet = meet == null ? armExit : Intersect(meet, armExit);
+        }
+
+        if (!hasDefault)
+        {
+            meet = meet == null ? new HashSet<VariableSymbol>(assigned) : Intersect(meet, assigned);
+            any = true;
+        }
+
+        if (any)
+        {
+            assigned.Clear();
+            assigned.UnionWith(meet);
+        }
+    }
+
+    /// <summary>
+    /// Best-effort `pointerVar = &amp;localVar` alias tracking for
+    /// <see cref="BoundIndirectAssignmentExpression"/> (issue #1642): records
+    /// (or drops, on reassignment to something else) which local variable a
+    /// pointer variable's address-of assignment targets. Intentionally
+    /// narrow — no aliasing through arithmetic, field access, or indirection
+    /// chains — and not merged across CFG joins (best-effort, shared per
+    /// function rather than tracked per-path); this only needs to catch the
+    /// common straight-line `var p = &amp;v; *p = expr` pattern.
+    /// </summary>
+    private static void TrackPointerAlias(VariableSymbol pointerVar, BoundExpression rhs, Dictionary<VariableSymbol, VariableSymbol> pointerAliases)
+    {
+        if (pointerVar == null)
+        {
+            return;
+        }
+
+        if (rhs is BoundAddressOfExpression addr && addr.Operand is BoundVariableExpression bve)
+        {
+            pointerAliases[pointerVar] = bve.Variable;
+        }
+        else
+        {
+            pointerAliases.Remove(pointerVar);
+        }
+    }
+
+    private static bool TryResolvePointerTarget(BoundExpression pointerExpr, Dictionary<VariableSymbol, VariableSymbol> pointerAliases, out VariableSymbol target)
+    {
+        if (pointerExpr is BoundAddressOfExpression addr && addr.Operand is BoundVariableExpression bve)
+        {
+            target = bve.Variable;
+            return true;
+        }
+
+        if (pointerExpr is BoundVariableExpression pve && pointerAliases.TryGetValue(pve.Variable, out target))
+        {
+            return true;
+        }
+
+        target = null;
+        return false;
+    }
+
+    private static void ProcessExpression(BoundExpression expression, HashSet<VariableSymbol> assigned, DiagnosticBag diagnostics, Dictionary<VariableSymbol, VariableSymbol> pointerAliases)
     {
         if (expression == null)
         {
@@ -304,30 +684,40 @@ internal static class RefKindDefiniteAssignmentAnalyzer
                     }
                     else
                     {
-                        ProcessExpression(arg, assigned, diagnostics);
+                        ProcessExpression(arg, assigned, diagnostics, pointerAliases);
                     }
                 }
 
                 break;
             case BoundAssignmentExpression assign:
-                ProcessExpression(assign.Expression, assigned, diagnostics);
+                ProcessExpression(assign.Expression, assigned, diagnostics, pointerAliases);
                 assigned.Add(assign.Variable);
+                TrackPointerAlias(assign.Variable, assign.Expression, pointerAliases);
+                break;
+            case BoundIndirectAssignmentExpression indirect:
+                ProcessExpression(indirect.Value, assigned, diagnostics, pointerAliases);
+                ProcessExpression(indirect.Pointer, assigned, diagnostics, pointerAliases);
+                if (TryResolvePointerTarget(indirect.Pointer, pointerAliases, out var indirectTarget))
+                {
+                    assigned.Add(indirectTarget);
+                }
+
                 break;
             case BoundBinaryExpression bin:
-                ProcessExpression(bin.Left, assigned, diagnostics);
-                ProcessExpression(bin.Right, assigned, diagnostics);
+                ProcessExpression(bin.Left, assigned, diagnostics, pointerAliases);
+                ProcessExpression(bin.Right, assigned, diagnostics, pointerAliases);
                 break;
             case BoundUnaryExpression un:
-                ProcessExpression(un.Operand, assigned, diagnostics);
+                ProcessExpression(un.Operand, assigned, diagnostics, pointerAliases);
                 break;
             case BoundAddressOfExpression aof:
-                ProcessExpression(aof.Operand, assigned, diagnostics);
+                ProcessExpression(aof.Operand, assigned, diagnostics, pointerAliases);
                 break;
             case BoundDereferenceExpression deref:
-                ProcessExpression(deref.Operand, assigned, diagnostics);
+                ProcessExpression(deref.Operand, assigned, diagnostics, pointerAliases);
                 break;
             case BoundConversionExpression conv:
-                ProcessExpression(conv.Expression, assigned, diagnostics);
+                ProcessExpression(conv.Expression, assigned, diagnostics, pointerAliases);
                 break;
             default:
                 break;

--- a/test/Core.Tests/CodeAnalysis/Binding/RefKindDefiniteAssignmentTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/RefKindDefiniteAssignmentTests.cs
@@ -144,4 +144,169 @@ func caller() {
         var result = Compile(Source);
         Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0239");
     }
+
+    // Issue #1642 — the definite-assignment CFG previously treated
+    // try/select/scope/fixed bodies as opaque, so assignments inside them
+    // were invisible and produced false GS0238/GS0239 errors on valid code.
+
+    [Fact]
+    public void OutParameterAssignedInTryAndFinally_NoDiagnostic()
+    {
+        // Exact repro from issue #1642.
+        const string Source = @"package TryDA1
+
+func ok(out a int32) {
+    try { a = 1 } finally { }
+}
+";
+        var result = Compile(Source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0238");
+    }
+
+    [Fact]
+    public void OutParameterAssignedOnlyInFinally_NoDiagnostic()
+    {
+        // `finally` always runs, so an assignment made only there is
+        // guaranteed regardless of what happens in the try body.
+        const string Source = @"package TryDA2
+
+func ok(out a int32) {
+    try { } finally { a = 1 }
+}
+";
+        var result = Compile(Source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0238");
+    }
+
+    [Fact]
+    public void OutParameterAssignedInTryBodyOnly_CatchDoesNotAssign_ReportsGS0238()
+    {
+        // An exception could skip the try-body assignment, and the catch
+        // clause (which can complete normally without assigning `a`)
+        // doesn't guarantee it either — must still be rejected.
+        const string Source = @"package TryDA3
+
+import System
+
+func bad(out a int32) {
+    try {
+        a = 1
+    } catch (e Exception) {
+    }
+}
+";
+        var result = Compile(Source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0238");
+    }
+
+    [Fact]
+    public void OutParameterAssignedInTryAndEveryCatch_NoDiagnostic()
+    {
+        const string Source = @"package TryDA4
+
+import System
+
+func ok(out a int32) {
+    try {
+        a = 1
+    } catch (e Exception) {
+        a = 2
+    }
+}
+";
+        var result = Compile(Source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0238");
+    }
+
+    [Fact]
+    public void OutParameterAssignedInScopeBody_NoDiagnostic()
+    {
+        const string Source = @"package ScopeDA1
+
+func ok(out a int32) {
+    scope {
+        a = 1
+    }
+}
+";
+        var result = Compile(Source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0238");
+    }
+
+    [Fact]
+    public void OutParameterAssignedInFixedBody_NoDiagnostic()
+    {
+        const string Source = @"package FixedDA1
+
+unsafe func ok(out a int32, arr []int32) {
+    fixed p *int32 = arr {
+        a = 1
+    }
+}
+";
+        var result = Compile(Source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0238");
+    }
+
+    [Fact]
+    public void OutParameterAssignedInEveryExhaustiveSelectArm_NoDiagnostic()
+    {
+        // `select` always blocks until exactly one arm runs its body, so an
+        // assignment made on every arm is guaranteed afterward.
+        const string Source = @"package SelectDA1
+
+func ok(out a int32) {
+    let ch = make(chan int32, 1)
+    ch <- 1
+    select {
+    case let v = <-ch {
+        a = v
+    }
+    default {
+        a = 0
+    }
+    }
+}
+";
+        var result = Compile(Source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0238");
+    }
+
+    [Fact]
+    public void IndirectAssignmentThroughPointer_CountsAsAssignment()
+    {
+        // `*p = expr` (BoundIndirectAssignmentExpression) through a pointer
+        // known to alias the out parameter must count as an assignment.
+        const string Source = @"package IndirectDA1
+
+unsafe func ok(out a int32) {
+    var p *int32 = &a
+    *p = 5
+}
+";
+        var result = Compile(Source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0238");
+    }
+
+    [Fact]
+    public void ReturnInsideTryWithoutAssigningOutParameter_ReportsGS0238()
+    {
+        // A `return` nested inside a try body still leaves the function; the
+        // out parameter must be assigned before it, same as a top-level return.
+        const string Source = @"package TryDA5
+
+func bad(out a int32, cond bool) {
+    try {
+        if cond {
+            return
+        }
+
+        a = 1
+    } finally {
+    }
+}
+";
+        var result = Compile(Source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0238");
+    }
 }


### PR DESCRIPTION
## Root cause

`RefKindDefiniteAssignmentAnalyzer` (GS0238 out-parameter / GS0239 ref-read
checks) builds one `ControlFlowGraph` per function and walks each basic
block's statements. `ControlFlowGraph`'s `BasicBlockBuilder` deliberately
treats `try`/`catch`/`finally`, `select`, `scope`, and `fixed` as **single
opaque statements** (exception-flow modeling was deferred). The analyzer's
`ProcessStatement` had a `default: break;` for everything it didn't
explicitly model, so assignments made *inside* these bodies were completely
invisible — a function assigning an `out` parameter inside a `try`/`finally`
was rejected with a false GS0238.

## Fix

`ProcessStatement` now recursively re-runs the same CFG-based fixpoint
dataflow (`AnalyzeRegion`) on the nested body of every such compound
statement and folds the result back into the enclosing assigned-set:

- **try/catch/finally**: catch clauses are analyzed as if entered at the very
  top of the try (an exception can occur before any try-body statement
  runs), so they never see try-body assignments. An assignment made only in
  the try body is **not** guaranteed afterward unless every catch also
  assigns it (meet across try-body-normal-completion ∩ each
  catch-normal-completion). An assignment in `finally` **is** guaranteed,
  since `finally` always runs before control can continue past the `try`
  statement.
- **select**: always blocks until exactly one arm becomes ready and runs its
  body (no implicit "no arm matched" fallthrough), so the meet is taken
  across every arm that can complete normally.
- **scope/fixed**: the body always runs unconditionally, so its assignments
  flow straight through (`fixed` also seeds its synthetic pinned/pointer
  locals as assigned).
- **pattern switch** (bonus — same underlying bug, not explicitly listed in
  the issue but the same class of fix): meet across arms, plus the "no arm
  matched" fallthrough contributes the untouched incoming set when there's
  no exhaustive `default`.

A `return`/`throw` nested inside one of these bodies still leaves the
function from a point the outer CFG never modeled at all; those internal
exits are now checked against out-parameters directly inside the recursive
analysis instead of silently disappearing (this closes a related gap beyond
the literal repro, at no extra architectural cost since the recursion
already reuses the CFG/report machinery).

Also added `BoundIndirectAssignmentExpression` handling in
`ProcessExpression`, plus best-effort `p = &v` pointer-alias tracking, so
`*p = expr` counts as an assignment to `v` for the common
`var p = &v; *p = expr` pattern (intentionally narrow — no aliasing through
arithmetic/field-access/indirection chains, matching the existing
`&v`-argument convention already used for `ref`/`out` call sites in this
analyzer).

## Secondary defects (per issue)

- **Catch-swallow**: the blanket `catch { return; }` around
  `ControlFlowGraph.Create` silently disabled the *entire* analysis on any
  internal exception, which could let a genuinely-unassigned `out` parameter
  compile with zero diagnostics. Replaced with a narrower try/catch around
  the top-level `AnalyzeRegion` call that **fails safe**: on an internal
  error it now reports GS0238 for every `out` parameter instead of silently
  accepting the function. (`ControlFlowGraph.Create` is already called
  unguarded against the same lowered body in `Binder.cs` via
  `ControlFlowGraph.AllPathsReturn` for every non-void function, so this is
  a narrow safety net for void functions / a bug in this analyzer's own
  recursion, not the common path.)
- **Dead worklist**: the `Queue<BasicBlock> worklist` was enqueued once and
  never dequeued — removed. The existing whole-graph fixpoint loop already
  did the real work; the queue contributed nothing.

## Tests

Added to `RefKindDefiniteAssignmentTests.cs`:
- `OutParameterAssignedInTryAndFinally_NoDiagnostic` — exact issue repro.
- `OutParameterAssignedOnlyInFinally_NoDiagnostic`
- `OutParameterAssignedInTryBodyOnly_CatchDoesNotAssign_ReportsGS0238` —
  negative test: must still reject.
- `OutParameterAssignedInTryAndEveryCatch_NoDiagnostic`
- `OutParameterAssignedInScopeBody_NoDiagnostic`
- `OutParameterAssignedInFixedBody_NoDiagnostic`
- `OutParameterAssignedInEveryExhaustiveSelectArm_NoDiagnostic`
- `IndirectAssignmentThroughPointer_CountsAsAssignment` — `*p = expr`.
- `ReturnInsideTryWithoutAssigningOutParameter_ReportsGS0238` — negative
  test for the internal-return gap.

Ran (all green):
- `dotnet test test/Core.Tests --filter RefKind|Select|Scope|Fixed|Exception|Try|Pointer|Switch` — 620 passed.
- Full `dotnet test test/Core.Tests` — 4994 passed, 1 skipped (unrelated baseline-regen test), 0 failed.
- Full `dotnet test test/Interpreter.Tests` — 339 passed.
- Full `dotnet test test/Compiler.Tests` — 2545 passed.
- `dotnet build GSharp.sln -c Release -graph` — succeeded, 0 warnings/errors.

Fixes #1642
