### PR TITLE
Fix #1643: flatten or-patterns in exhaustiveness analysis

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExhaustivenessAnalyzer.cs
+++ b/src/Core/CodeAnalysis/Binding/ExhaustivenessAnalyzer.cs
@@ -83,7 +83,15 @@ public static class ExhaustivenessAnalyzer
         }
 
         var patternArray = patterns.ToArray();
-        if (patternArray.Any(pattern => pattern == null || pattern is BoundDiscardPattern))
+        if (patternArray.Any(pattern => pattern == null))
+        {
+            return false;
+        }
+
+        // Issue #1643: an `or` disjunction (`Red or Green`) covers whatever its
+        // leaves cover, including a nested discard, so flatten before checking
+        // for a wildcard arm. `and` conjunctions narrow and are NOT flattened.
+        if (patternArray.Any(pattern => FlattenDisjunction(pattern).Any(leaf => leaf is BoundDiscardPattern)))
         {
             return false;
         }
@@ -94,12 +102,15 @@ public static class ExhaustivenessAnalyzer
             var coveredValues = new HashSet<int>();
             foreach (var pattern in patternArray)
             {
-                if (pattern is BoundConstantPattern constant
-                    && constant.Value is BoundLiteralExpression literal
-                    && literal.Type == enumSymbol
-                    && literal.Value is int value)
+                foreach (var leaf in FlattenDisjunction(pattern))
                 {
-                    coveredValues.Add(value);
+                    if (leaf is BoundConstantPattern constant
+                        && constant.Value is BoundLiteralExpression literal
+                        && literal.Type == enumSymbol
+                        && literal.Value is int value)
+                    {
+                        coveredValues.Add(value);
+                    }
                 }
             }
 
@@ -121,11 +132,14 @@ public static class ExhaustivenessAnalyzer
             var coveredTypes = new HashSet<StructSymbol>();
             foreach (var pattern in patternArray)
             {
-                if (pattern is BoundTypePattern typePattern
-                    && typePattern.TargetType is StructSymbol structSymbol
-                    && structSymbol.Interfaces.Any(i => SameInterface(i, sealedInterface)))
+                foreach (var leaf in FlattenDisjunction(pattern))
                 {
-                    coveredTypes.Add(structSymbol);
+                    if (leaf is BoundTypePattern typePattern
+                        && typePattern.TargetType is StructSymbol structSymbol
+                        && structSymbol.Interfaces.Any(i => SameInterface(i, sealedInterface)))
+                    {
+                        coveredTypes.Add(structSymbol);
+                    }
                 }
             }
 
@@ -151,11 +165,14 @@ public static class ExhaustivenessAnalyzer
             var coveredSubclasses = new HashSet<StructSymbol>();
             foreach (var pattern in patternArray)
             {
-                if (pattern is BoundTypePattern typePattern
-                    && typePattern.TargetType is StructSymbol structSymbol
-                    && IsSubclassOf(structSymbol, sealedBaseClass))
+                foreach (var leaf in FlattenDisjunction(pattern))
                 {
-                    coveredSubclasses.Add(structSymbol);
+                    if (leaf is BoundTypePattern typePattern
+                        && typePattern.TargetType is StructSymbol structSymbol
+                        && IsSubclassOf(structSymbol, sealedBaseClass))
+                    {
+                        coveredSubclasses.Add(structSymbol);
+                    }
                 }
             }
 
@@ -167,6 +184,33 @@ public static class ExhaustivenessAnalyzer
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Issue #1643: recursively flattens an `or` disjunction (<see cref="BoundBinaryPattern"/>
+    /// with <see cref="BoundBinaryPattern.IsConjunction"/> false) into its leaf patterns, so
+    /// each disjunct is matched individually against the covered-variant set. Any nesting
+    /// (<c>A or B or C</c>, <c>(A or B) or C</c>) is handled. An `and` conjunction narrows
+    /// rather than covers, so it is never flattened and is returned as a single opaque leaf.
+    /// </summary>
+    private static IEnumerable<BoundPattern> FlattenDisjunction(BoundPattern pattern)
+    {
+        if (pattern is BoundBinaryPattern { IsConjunction: false } disjunction)
+        {
+            foreach (var leaf in FlattenDisjunction(disjunction.Left))
+            {
+                yield return leaf;
+            }
+
+            foreach (var leaf in FlattenDisjunction(disjunction.Right))
+            {
+                yield return leaf;
+            }
+        }
+        else
+        {
+            yield return pattern;
+        }
     }
 
     private static bool IsSubclassOf(StructSymbol candidate, StructSymbol baseClass)

--- a/test/Core.Tests/CodeAnalysis/Binding/ExhaustivenessTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ExhaustivenessTests.cs
@@ -123,6 +123,97 @@ let label = switch value { case 1: ""one"" }
     }
 
     [Fact]
+    public void SwitchExpression_Enum_OrPattern_AllMembersCovered_HasNoDiagnostic()
+    {
+        // Issue #1643: `Red or Green` plus `Blue` covers every member.
+        var diagnostics = Bind(@"
+enum Color { Red, Green, Blue }
+let color = Color.Red
+let label = switch color { case Color.Red or Color.Green: ""warm"" case Color.Blue: ""cool"" }
+");
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void SwitchExpression_Enum_NestedOrPattern_SingleArm_HasNoDiagnostic()
+    {
+        // Issue #1643: `Red or Green or Blue` in one arm must flatten through
+        // arbitrary nesting.
+        var diagnostics = Bind(@"
+enum Color { Red, Green, Blue }
+let color = Color.Red
+let label = switch color { case Color.Red or Color.Green or Color.Blue: ""any"" }
+");
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void SwitchExpression_Enum_OrPattern_StillMissingMember_DiagnosesMissingName()
+    {
+        // Issue #1643: or-pattern flattening must not over-claim coverage — a
+        // genuinely non-exhaustive switch still reports the correct miss.
+        var diagnostics = Bind(@"
+enum Color { Red, Green, Blue }
+let color = Color.Red
+let label = switch color { case Color.Red or Color.Green: ""warm"" }
+");
+
+        Assert.Contains(diagnostics, d => d.Message == "Switch expression on enum 'Color' is not exhaustive: missing 'Blue'.");
+    }
+
+    [Fact]
+    public void SwitchExpression_Enum_AndPattern_DoesNotFalselyCoverConstants()
+    {
+        // Issue #1643: an `and` conjunction narrows and must not be flattened
+        // into covering its constituent constant.
+        var diagnostics = Bind(@"
+enum Color { Red, Green, Blue }
+let color = Color.Red
+let label = switch color { case Color.Red and Color.Red: ""red"" case Color.Green: ""green"" }
+");
+
+        Assert.Contains(diagnostics, d => d.Message == "Switch expression on enum 'Color' is not exhaustive: missing 'Red', 'Blue'.");
+    }
+
+    [Fact]
+    public void SwitchExpression_SealedInterface_OrPattern_AllImplementorsCovered_HasNoDiagnostic()
+    {
+        // Issue #1643: type patterns nested in an or-pattern must be flattened
+        // for sealed-interface discriminants too.
+        var diagnostics = Bind(@"
+sealed interface Expr { }
+class Add : Expr { }
+class Mul : Expr { }
+class Sub : Expr { }
+func Label(expr Expr) string {
+ return switch expr { case _ is Add or _ is Mul: ""addOrMul"" case x is Sub: ""sub"" }
+}
+");
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void SwitchExpression_SealedClass_OrPattern_AllSubclassesCovered_HasNoDiagnostic()
+    {
+        // Issue #1643: type patterns nested in an or-pattern must be flattened
+        // for sealed-class discriminants too.
+        var diagnostics = Bind(@"
+sealed class Shape { }
+class Circle : Shape { }
+class Square : Shape { }
+class Triangle : Shape { }
+func Area(s Shape) string {
+ return switch s { case _ is Circle or _ is Square: ""quad"" case t is Triangle: ""tri"" }
+}
+");
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
     public void SwitchStatement_Enum_MissingMember_DiagnosesStatementForm()
     {
         var diagnostics = Bind(@"


### PR DESCRIPTION
## Root cause
`ExhaustivenessAnalyzer.TryGetMissingVariants` only inspected top-level
`BoundConstantPattern`/`BoundTypePattern` nodes when building the
covered-variant set. Any arm using an `or`-pattern (`case Red or Green:`) is
bound as a `BoundBinaryPattern` (`IsConjunction == false`), so the analyzer
never decomposed it and treated the arm as covering nothing — leading to a
hard GS0177 error on provably exhaustive switches.

## Fix
Added one shared `FlattenDisjunction` helper that recursively decomposes a
`BoundBinaryPattern` disjunction into its leaf patterns (handles arbitrary
nesting: `A or B or C`, `(A or B) or C`). Used it in all three discriminant
loops:
- enum (constant-pattern matching)
- sealed interface (type-pattern matching)
- sealed class (type-pattern matching)

A disjunction containing a discard is now treated as a wildcard arm too.
`and` conjunctions (`IsConjunction == true`) and guarded patterns are
intentionally **not** flattened — they narrow rather than cover, so they
must not falsely mark a constant/type as handled.

## Tests added (test/Core.Tests/CodeAnalysis/Binding/ExhaustivenessTests.cs)
- `SwitchExpression_Enum_OrPattern_AllMembersCovered_HasNoDiagnostic` — the reported repro
- `SwitchExpression_Enum_NestedOrPattern_SingleArm_HasNoDiagnostic` — 3-way nested or in one arm
- `SwitchExpression_Enum_OrPattern_StillMissingMember_DiagnosesMissingName` — negative case, still reports correct missing member
- `SwitchExpression_Enum_AndPattern_DoesNotFalselyCoverConstants` — `and` must not over-claim coverage
- `SwitchExpression_SealedInterface_OrPattern_AllImplementorsCovered_HasNoDiagnostic`
- `SwitchExpression_SealedClass_OrPattern_AllSubclassesCovered_HasNoDiagnostic`

## Validation
- `dotnet build GSharp.sln -c Release -graph` — succeeded, 0 warnings/errors
- `dotnet test test/Core.Tests/Core.Tests.csproj --filter "FullyQualifiedName~ExhaustivenessTests|FullyQualifiedName~Issue1596SwitchExhaustiveReturnTests|FullyQualifiedName~SwitchExpressionTests"` — 59/59 passed
- `dotnet test test/Core.Tests/Core.Tests.csproj --filter "FullyQualifiedName~Pattern|FullyQualifiedName~Switch"` — 197/197 passed (no regressions)

Fixes #1643