### PR TITLE
Fix #1649: interpreter typed catch clauses now match real exception type

### DIFF
--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -536,7 +536,12 @@ public sealed class Evaluator
         catch (Exception ex) when (TryFindCatchHandler(node, ex, out _))
         {
             TryFindCatchHandler(node, ex, out var handler);
-            Assign(handler.Variable, ex);
+
+            // Issue #1649: bind the handler variable to the REAL exception object,
+            // not the EvaluatorException wrapper that EvaluateExpression attaches
+            // for node context. Without this, `e is T`, typeof(e), and rethrow all
+            // observe the wrapper instead of the exception the user actually threw.
+            Assign(handler.Variable, UnwrapRuntimeException(ex));
             EvaluateStatement((BoundBlockStatement)handler.Body);
         }
         finally
@@ -608,9 +613,37 @@ public sealed class Evaluator
         throw new Exception(value?.ToString());
     }
 
+    /// <summary>
+    /// Issue #1649: EvaluateExpression wraps every non-EvaluatorException in an
+    /// EvaluatorException to attach node context (for GS9999 reporting when
+    /// nothing catches it). That wrapping must not leak into typed catch
+    /// matching or handler-variable binding, so unwrap repeatedly down to the
+    /// innermost real exception. TargetInvocationException (thrown by
+    /// reflection-based CLR calls) gets the same treatment.
+    /// </summary>
+    private static Exception UnwrapRuntimeException(Exception ex)
+    {
+        while (true)
+        {
+            if (ex is EvaluatorException { InnerException: { } inner })
+            {
+                ex = inner;
+                continue;
+            }
+
+            if (ex is TargetInvocationException { InnerException: { } tieInner })
+            {
+                ex = tieInner;
+                continue;
+            }
+
+            return ex;
+        }
+    }
+
     private static bool TryFindCatchHandler(BoundTryStatement node, Exception ex, out BoundCatchClause matched)
     {
-        var actualType = ex.GetType();
+        var actualType = UnwrapRuntimeException(ex).GetType();
         foreach (var clause in node.CatchClauses)
         {
             var clrName = clause.ExceptionType?.ClrType?.FullName;

--- a/test/Core.Tests/CodeAnalysis/Binding/ExceptionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/ExceptionTests.cs
@@ -88,6 +88,145 @@ trace
         Assert.NotEmpty(diagnostics);
     }
 
+    // Issue #1649: typed catch clauses must match the REAL exception type, not
+    // the EvaluatorException wrapper EvaluateExpression attaches at each
+    // expression boundary for node-context reporting.
+
+    [Fact]
+    public void TryCatch_TypedCatchMatchesThrownClrExceptionType()
+    {
+        var source = @"
+import System
+var caught = ""before""
+try {
+    var n = Int32.Parse(""not a number"")
+} catch (e FormatException) {
+    caught = ""caught""
+}
+caught
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("caught", result.Value);
+    }
+
+    [Fact]
+    public void TryCatch_TypedCatchDoesNotMatchUnrelatedType()
+    {
+        // FormatException should not be caught by a clause typed to a sibling
+        // exception type — confirms the matcher isn't just falling back to
+        // "catch everything".
+        var source = @"
+import System
+var caught = ""before""
+try {
+    var n = Int32.Parse(""not a number"")
+} catch (e IndexOutOfRangeException) {
+    caught = ""wrong""
+} catch (e FormatException) {
+    caught = ""right""
+}
+caught
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("right", result.Value);
+    }
+
+    [Fact]
+    public void TryCatch_BaseTypeCatchMatchesDerivedThrow()
+    {
+        // FormatException derives from SystemException/Exception; a catch
+        // typed to the CLR base Exception type still needs to match.
+        var source = @"
+import System
+var caught = ""before""
+try {
+    var n = Int32.Parse(""not a number"")
+} catch (e Exception) {
+    caught = ""caught""
+}
+caught
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("caught", result.Value);
+    }
+
+    [Fact]
+    public void TryCatch_HandlerVariableBindsRealExceptionObject()
+    {
+        // The handler variable must be the real FormatException, not the
+        // EvaluatorException wrapper — so .Message reads the original text.
+        var source = @"
+import System
+var msg = """"
+try {
+    var n = Int32.Parse(""not-a-number"")
+} catch (e FormatException) {
+    msg = e.Message
+}
+msg
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Contains("not-a-number", (string)result.Value, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TryCatch_IsExpressionObservesRealExceptionType()
+    {
+        var source = @"
+import System
+var isFormat = false
+try {
+    var n = Int32.Parse(""bad"")
+} catch (e Exception) {
+    isFormat = e is FormatException
+}
+isFormat
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(true, result.Value);
+    }
+
+    [Fact]
+    public void TryCatch_RethrowPropagatesOriginalTypeToOuterTypedCatch()
+    {
+        var source = @"
+import System
+var caught = ""none""
+try {
+    try {
+        var n = Int32.Parse(""bad"")
+    } catch (e FormatException) {
+        throw e
+    }
+} catch (e FormatException) {
+    caught = ""outer-typed""
+}
+caught
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("outer-typed", result.Value);
+    }
+
+    [Fact]
+    public void Uncaught_TypedException_StillReportsNodeContext()
+    {
+        // Nothing catches this — it must still surface as a diagnosed runtime
+        // error (GS9999) via the EvaluatorException node-context wrapping.
+        var source = @"
+import System
+var n = Int32.Parse(""still-bad"")
+n
+";
+        var result = Evaluate(source);
+        Assert.NotEmpty(result.Diagnostics);
+    }
+
     private static EvaluationResult Evaluate(string source)
     {
         var tree = SyntaxTree.Parse(SourceText.From(source));


### PR DESCRIPTION
Fixes #1649

## Bug
Evaluator.cs wrapped every non-EvaluatorException in an EvaluatorException at each expression boundary (for GS9999 node-context reporting). That wrapper leaked into `TryFindCatchHandler`'s type matching and into the handler-variable binding, so typed catch clauses like `catch (e FormatException)` never matched — only `catch (e Exception)` worked, since the wrapper's base chain is just `Exception`. The handler variable was also bound to the wrapper object, so `e is T`, `typeof(e)`, and rethrow all observed the wrong type.

## Fix
Added `UnwrapRuntimeException`, which repeatedly unwraps `EvaluatorException.InnerException` and `TargetInvocationException.InnerException` down to the real exception. Applied it in two places:
- `TryFindCatchHandler`: matches the catch clause's declared CLR type against the unwrapped exception's real type.
- `EvaluateTryStatement`: binds the handler variable to the unwrapped real exception object (not the wrapper).

Uncaught exceptions are untouched — they still surface as EvaluatorException with node context for GS9999 diagnostics.

## Tests
Added to `test/Core.Tests/CodeAnalysis/Binding/ExceptionTests.cs` (interpreter path via `Compilation.Evaluate`):
- typed catch matches thrown CLR exception type (`FormatException`)
- typed catch doesn't match an unrelated sibling type (falls through to the right clause)
- base-type catch (`Exception`) still matches a derived throw
- handler variable binds the real exception object (asserted via `.Message`)
- `e is T` observes the real type
- rethrow inside a catch propagates the original type to an outer typed catch
- uncaught typed exception still reports a diagnostic (GS9999 path preserved)

## Validation
- `dotnet build GSharp.sln -c Release -graph`: 0 errors, 0 warnings.
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release --filter "FullyQualifiedName~Exception|FullyQualifiedName~Try|FullyQualifiedName~Catch|FullyQualifiedName~Async" -- xUnit.MaxParallelThreads=2": 422 passed, 0 failed.

No work deferred.