### PR TITLE
Fix #1644: BoundTreeRewriter clones silently drop set-after-construction properties

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -607,7 +607,14 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundCallExpression(null, node.Function, builder.MoveToImmutable(), node.ReturnType, node.IsConditionalElided);
+        // Issue #1644: preserve the set-after-construction generic-owner properties
+        // (#1209 / #1433) so the emitter still parents the call at the construction's
+        // TypeSpec instead of a bare open-generic MethodDef.
+        return new BoundCallExpression(null, node.Function, builder.MoveToImmutable(), node.ReturnType, node.IsConditionalElided)
+        {
+            StaticGenericOwnerType = node.StaticGenericOwnerType,
+            StaticGenericInterfaceOwnerType = node.StaticGenericInterfaceOwnerType,
+        };
     }
 
     /// <summary>
@@ -1926,7 +1933,10 @@ public abstract class BoundTreeRewriter
     /// <returns>The rewritten node.</returns>
     protected virtual BoundExpression RewriteFieldAccessExpression(BoundFieldAccessExpression node)
     {
-        // ADR-0053: static field access has no receiver (null).
+        // ADR-0053: static field access has no receiver (null). This also covers
+        // the interface static-field read form (ADR-0089 / #1030, InterfaceType
+        // != null), which likewise has a null Receiver — nothing to rewrite, so
+        // returning the original node here can never drop InterfaceType (issue #1644).
         if (node.Receiver == null)
         {
             return node;
@@ -1953,7 +1963,20 @@ public abstract class BoundTreeRewriter
             return BoundFieldAssignmentExpression.WithExpressionReceiver(null, receiverExpr, node.StructType, node.Field, value);
         }
 
-        return value == node.Value ? node : new BoundFieldAssignmentExpression(null, node.Receiver, node.StructType, node.Field, value);
+        if (value == node.Value)
+        {
+            return node;
+        }
+
+        // Issue #1644 / ADR-0089 #1030: an interface static field write is built
+        // with (syntax, field, interfaceType, value) — Receiver/StructType are
+        // both null and InterfaceType carries the owning (possibly constructed)
+        // interface. Reconstruct via that constructor instead of the
+        // variable-receiver one, or the emitter/interpreter lose the interface
+        // static routing and mis-codegen/crash.
+        return node.InterfaceType != null
+            ? new BoundFieldAssignmentExpression(null, node.Field, node.InterfaceType, value)
+            : new BoundFieldAssignmentExpression(null, node.Receiver, node.StructType, node.Field, value);
     }
 
     /// <summary>Rewrites a property read (ADR-0051).</summary>

--- a/test/Compiler.Tests/Emit/Issue1644BoundTreeRewriterClonePreservationEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1644BoundTreeRewriterClonePreservationEmitTests.cs
@@ -1,0 +1,182 @@
+// <copyright file="Issue1644BoundTreeRewriterClonePreservationEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1644 — <see cref="GSharp.Core.CodeAnalysis.Binding.BoundTreeRewriter"/>
+/// clone paths dropped properties the binder sets after construction (or via
+/// an alternate constructor). Both instances are exercised end-to-end through
+/// the async state-machine lowering pipeline, since <c>MoveNextBodyRewriter</c>
+/// hoists locals used across an <c>await</c> into state-machine fields, which
+/// forces <c>BoundTreeRewriter</c> to clone the enclosing call/assignment node:
+/// <list type="bullet">
+///   <item>a static call dispatched on a constructed generic user type
+///     (<c>Box[int32].Make(n)</c>, #1209) previously lost
+///     <c>StaticGenericOwnerType</c> on clone, mis-parenting the emitted call
+///     at a bare open-generic MethodDef instead of the construction's
+///     TypeSpec;</item>
+///   <item>an interface static field write (<c>ICounter.Count = ...</c>,
+///     ADR-0089 / #1030) previously lost <c>InterfaceType</c> on clone,
+///     because the rewriter rebuilt it via the variable-receiver constructor
+///     instead of the interface-static constructor.</item>
+/// </list>
+/// Every user type is uniquely named so the process-wide
+/// <c>FunctionTypeSymbol</c> cache cannot alias across tests.
+/// </summary>
+public class Issue1644BoundTreeRewriterClonePreservationEmitTests
+{
+    [Fact]
+    public void EndToEnd_AsyncGenericStaticCall_SurvivesLocalHoistAcrossAwait_Runs()
+    {
+        var source = """
+            package Probe1644a
+            import System
+            import System.Threading.Tasks
+
+            class BoxA1644[T]() {
+                var Value T
+                shared {
+                    func Make(v T) BoxA1644[T] {
+                        var b = BoxA1644[T]()
+                        b.Value = v
+                        return b
+                    }
+                }
+            }
+
+            async func MakeAsync(n int32) int32 {
+                await Task.Delay(1)
+                let b = BoxA1644[int32].Make(n)
+                return b.Value
+            }
+
+            func Main() {
+                let result = MakeAsync(7).Result
+                Console.WriteLine(result)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("7\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_AsyncInterfaceStaticFieldWrite_SurvivesLocalHoistAcrossAwait_Runs()
+    {
+        var source = """
+            package Probe1644b
+            import System
+            import System.Threading.Tasks
+
+            interface ICounterB1644 {
+                shared {
+                    var Count int32
+                }
+            }
+
+            async func BumpAsync(n int32) {
+                await Task.Delay(1)
+                ICounterB1644.Count = ICounterB1644.Count + n
+            }
+
+            func Main() {
+                BumpAsync(5).Wait()
+                BumpAsync(3).Wait()
+                Console.WriteLine(ICounterB1644.Count)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("8\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1644_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath, ignoredErrorCodes: IlVerifier.KnownIssues.StaticVirtualInterface);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/BoundTreeRewriterClonePreservationTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/BoundTreeRewriterClonePreservationTests.cs
@@ -1,0 +1,96 @@
+// <copyright file="BoundTreeRewriterClonePreservationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Regression tests for issue #1644: <see cref="BoundTreeRewriter"/> clone
+/// paths must not silently drop properties the binder sets after
+/// construction (or via an alternate constructor) when they rebuild a node
+/// whose children changed. Each test forces a clone via a rewriter subclass
+/// that always constructs a fresh leaf node, then asserts the rebuilt parent
+/// still carries the extra state.
+/// </summary>
+public class BoundTreeRewriterClonePreservationTests
+{
+    /// <summary>A no-op rewriter that always replaces literal expressions with an equivalent new instance, forcing every ancestor to clone.</summary>
+    private sealed class ForceCloneRewriter : BoundTreeRewriter
+    {
+        public new BoundExpression RewriteExpression(BoundExpression node) => base.RewriteExpression(node);
+
+        protected override BoundExpression RewriteLiteralExpression(BoundLiteralExpression node)
+        {
+            return new BoundLiteralExpression(node.Syntax, node.Value);
+        }
+    }
+
+    [Fact]
+    public void RewriteCallExpression_PreservesStaticGenericOwnerType()
+    {
+        // Arrange: Box[int32].Make() — static call parented at a constructed generic struct's TypeSpec (#1209).
+        var function = new FunctionSymbol("Make", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Int32);
+        var owner = new StructSymbol("Box", ImmutableArray<FieldSymbol>.Empty, Accessibility.Public, declaration: null, packageName: "main");
+        var arg = new BoundLiteralExpression(null, 1);
+        var call = new BoundCallExpression(null, function, ImmutableArray.Create<BoundExpression>(arg), returnType: null)
+        {
+            StaticGenericOwnerType = owner,
+        };
+
+        // Act
+        var result = (BoundCallExpression)new ForceCloneRewriter().RewriteExpression(call);
+
+        // Assert: a clone actually happened (argument was rebuilt) and the owner type survived.
+        Assert.NotSame(call, result);
+        Assert.Same(owner, result.StaticGenericOwnerType);
+        Assert.Null(result.StaticGenericInterfaceOwnerType);
+    }
+
+    [Fact]
+    public void RewriteCallExpression_PreservesStaticGenericInterfaceOwnerType()
+    {
+        // Arrange: IBox[int32].Create() — static call parented at a constructed generic interface's TypeSpec (#1433).
+        var function = new FunctionSymbol("Create", ImmutableArray<ParameterSymbol>.Empty, TypeSymbol.Int32);
+        var owner = new InterfaceSymbol("IBox", Accessibility.Public, declaration: null, packageName: "main");
+        var arg = new BoundLiteralExpression(null, 1);
+        var call = new BoundCallExpression(null, function, ImmutableArray.Create<BoundExpression>(arg), returnType: null)
+        {
+            StaticGenericInterfaceOwnerType = owner,
+        };
+
+        // Act
+        var result = (BoundCallExpression)new ForceCloneRewriter().RewriteExpression(call);
+
+        // Assert
+        Assert.NotSame(call, result);
+        Assert.Same(owner, result.StaticGenericInterfaceOwnerType);
+        Assert.Null(result.StaticGenericOwnerType);
+    }
+
+    [Fact]
+    public void RewriteFieldAssignmentExpression_PreservesInterfaceStaticField()
+    {
+        // Arrange: an interface static field write (ADR-0089 / #1030) — built via
+        // the (syntax, field, interfaceType, value) constructor: Receiver and
+        // StructType are both null, InterfaceType carries the owning interface.
+        var interfaceType = new InterfaceSymbol("IBox", Accessibility.Public, declaration: null, packageName: "main");
+        var field = new FieldSymbol("Count", TypeSymbol.Int32, Accessibility.Public, isStatic: true);
+        var value = new BoundLiteralExpression(null, 42);
+        var assignment = new BoundFieldAssignmentExpression(null, field, interfaceType, value);
+
+        // Act
+        var result = (BoundFieldAssignmentExpression)new ForceCloneRewriter().RewriteExpression(assignment);
+
+        // Assert: clone happened (value rebuilt) and the interface-static routing survived.
+        Assert.NotSame(assignment, result);
+        Assert.Same(interfaceType, result.InterfaceType);
+        Assert.Null(result.Receiver);
+        Assert.Null(result.StructType);
+        Assert.Null(result.ReceiverExpression);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1644. `BoundTreeRewriter` clone methods rebuild bound nodes when a child changed, but two clone paths dropped state that the binder sets after construction (or via an alternate constructor), and neither the emitter nor the interpreter can recover it once lost.

## Root causes fixed

1. **`RewriteCallExpression`** rebuilt `BoundCallExpression` on argument change but dropped `StaticGenericOwnerType` and `StaticGenericInterfaceOwnerType` (`BoundCallExpression.cs`), which `ExpressionBinder.Access.cs` sets *after* construction for a static call dispatched on a constructed generic struct/interface (#1209 / #1433). The emitter keys `TypeSpec` parenting off these properties (`MethodBodyEmitter.Expressions.cs`). Losing them during lowering (e.g. `MoveNextBodyRewriter` hoisting a captured local used as an argument into a state-machine field) parented the emitted call at a bare open-generic `MethodDef` instead of the construction's `TypeSpec`, producing invalid/incorrect IL.

2. **`RewriteFieldAssignmentExpression`** rebuilt an interface static field write — originally built via the `(syntax, field, interfaceType, value)` constructor (`Receiver == null`, `StructType == null`, `InterfaceType` set; ADR-0089 / #1030) — using the variable-receiver constructor, silently dropping `InterfaceType`. The emitter and interpreter both branch on `InterfaceType` (`MethodBodyEmitter.MemberAccess.cs`, `Evaluator.cs`), so this produced wrong codegen or a crash whenever the assigned value changed during lowering.

## Audit of the rest of `BoundTreeRewriter`

Checked every bound-node class with a property that has an `internal set` (set-after-construction) or with multiple constructors selecting different internal state, cross-referenced against its `Rewrite*` clone path:

- `RewriteFieldAccessExpression` (explicitly called out in the issue): short-circuits and returns the original node whenever `Receiver == null`, which is also true for the interface-static field *read* form — so it never clones and can't drop `InterfaceType`. Added a comment documenting why this is safe.
- `BoundMethodGroupExpression`, `BoundClrMethodGroupExpression` (resolved vs. unresolved overload state), `BoundConstructorCallExpression` (`SelectedConstructor`), `BoundReturnStatement` (`IsRef`), `BoundVariableExpression`/`BoundPropertyAccessExpression`/`BoundFieldAccessExpression` (`NarrowedType`), `BoundClrIndexAssignmentExpression`/`BoundFieldAssignmentExpression` (expression-receiver alternate constructor), `BoundArrayCreationExpression` (`LengthExpression` alternate constructor) — all already thread their extra state through correctly on clone.

No other instances of this bug class were found. No work was deferred.

## Tests added

- `test/Core.Tests/CodeAnalysis/Binding/BoundTreeRewriterClonePreservationTests.cs`: unit tests that force a clone via a rewriter subclass (always rebuilds literal leaves) and assert `StaticGenericOwnerType`, `StaticGenericInterfaceOwnerType`, and interface-static field `InterfaceType` all survive.
- `test/Compiler.Tests/Emit/Issue1644BoundTreeRewriterClonePreservationEmitTests.cs`: end-to-end emit tests that hoist a local across an `await` (forcing `MoveNextBodyRewriter` to clone the enclosing call/assignment) and verify a generic-static-call and an interface-static field write still produce valid IL (`ilverify`) and correct runtime output.

All new tests were verified to **fail** against the pre-fix rewriter (one of them via a real `ilverify` `StackUnexpected` error) and **pass** after the fix.

## Validation

- `dotnet build GSharp.sln -c Release -graph` — 0 errors, 0 warnings.
- New tests: 5/5 passed.
- Regression slice (`Issue1644*`, `Issue1433InterfaceStaticMemberCallEmitTests`, `Issue1030InterfaceStaticMembersEmitTests`, `Issue1030InterfaceStaticMembersInterpreterTests`, `Issue1209GenericTypeExprTests`, `MoveNextBodyRewriterTests`, `AsyncStateMachineRewriterTests`): 49/49 passed.

No golden coverage-matrix update needed (no new `SyntaxKind`/`BoundNodeKind`).
