### PR TITLE
Fix #1627: reject imported nullable-reference S->S at classification source (null-safety)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -870,6 +870,27 @@ public sealed class Conversion
         // required), so the emitter treats this as a no-op. Restricted to
         // genuine reference types on both sides to avoid colliding with
         // the boxing / unboxing / value-type-to-interface rules above.
+        //
+        // Issue #1627: this arm only checks CLR-level assignability, and
+        // `NullableTypeSymbol` relays its underlying CLR type (see
+        // `NullableTypeSymbol.ClrType`), so an imported nullable-reference
+        // source `S?` and its non-nullable form `S` looked like two ordinary
+        // non-value-type CLR types — misclassifying `S? -> S` as an implicit
+        // no-op upcast (Kotlin-model null safety requires GS0154/GS0155 there
+        // instead; the caller must write `!!`). User-declared classes/
+        // interfaces carry a null ClrType during binding and were never
+        // affected by that leak. Guard this arm specifically (rather than
+        // rejecting earlier in the function) so it does not disturb any later
+        // EXPLICIT conversion arm — e.g. the #1532 `object?/object -> T`
+        // explicit unboxing cast — which must still see a genuine `S?` source
+        // and classify it on its own terms. Every `S? -> U?` (nullable
+        // target) case was already handled above and never reaches this arm.
+        if (from is NullableTypeSymbol fromNullableUpcastSrc
+            && IsReferenceLikeTarget(fromNullableUpcastSrc.UnderlyingType))
+        {
+            return Conversion.None;
+        }
+
         if (from?.ClrType != null && to?.ClrType != null
             && !from.ClrType.IsValueType && !to.ClrType.IsValueType
             && !from.ClrType.IsPointer && !to.ClrType.IsPointer

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -4466,7 +4466,18 @@ internal sealed partial class ExpressionBinder
             return ByRefTypeSymbol.Get(TypeSymbol.FromClrType(propertyType.GetElementType()!));
         }
 
-        return TypeSymbol.FromClrType(propertyType);
+        // Issue #1627 (surfaced regression fix): honour the indexer's
+        // `[NullableAttribute]`/`[NullableContextAttribute]` metadata (and
+        // the #1354 "unannotated imported reference type defaults to
+        // nullable" rule) the same way every other property/parameter read
+        // does via `ClrNullability`. Without this, a plain
+        // `TypeSymbol.FromClrType(propertyType)` erased a genuinely nullable
+        // indexer element (e.g. `JsonNode?` for `JsonNode.this[string]`) to
+        // its non-nullable form; the classification fix at
+        // `Conversion.Classify` now correctly rejects an incoming `S?` value
+        // against that spuriously non-nullable target instead of silently
+        // dropping the `?` via the #521 leak.
+        return ClrNullability.GetPropertyTypeSymbol(closedIndexer);
     }
 
     // Issue #1301: resolve the element type of a closed indexer against the

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -999,22 +999,15 @@ internal sealed class OverloadResolver
                 continue;
             }
 
-            // Issue #1552: Kotlin-model null-safety gate. A nullable REFERENCE
-            // argument `S?` does NOT satisfy a non-nullable REFERENCE parameter
-            // unless the parameter is null-tolerant (`object`/`object?` or any
-            // nullable target). This overrides the #521 reference-upcast leak in
-            // Conversion.Classify (a NullableTypeSymbol exposes its underlying
-            // ClrType, so an IMPORTED `S? -> S` is otherwise mis-classified as
-            // implicit) WITHOUT changing global conversion semantics — we only
-            // treat such a candidate as non-applicable here. Value-type nullables
-            // (`int32?`, user `struct?`, `enum?`) and nullable type-parameter
-            // underlyings are never reference-like, so the gate leaves them
-            // untouched.
-            if (IsNullableReferenceGateRejected(argType, paramType))
-            {
-                return false;
-            }
-
+            // Issue #1627: the #1552 point-fix gate that used to live here
+            // (calling IsNullableReferenceGateRejected before classification)
+            // has been removed. Conversion.Classify now rejects an imported
+            // nullable-REFERENCE argument `S?` against a non-null-tolerant
+            // reference parameter `S` at the classification source (see the
+            // `#1627` comment in Conversion.Classify), so the general
+            // convertibility check below already reports it as non-applicable
+            // — consistently, in every BindConversion position, not just this
+            // multi-candidate positional filter.
             var conversion = Conversion.Classify(argType, paramType);
             if (conversion.Exists && (conversion.IsImplicit || conversion.IsIdentity))
             {

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1627ImportedNullableRefSourceGateTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1627ImportedNullableRefSourceGateTests.cs
@@ -1,0 +1,134 @@
+// <copyright file="Issue1627ImportedNullableRefSourceGateTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1627: an imported/CLR-backed nullable reference <c>S?</c> was
+/// misclassified as implicitly convertible to its non-nullable form <c>S</c>
+/// because <c>NullableTypeSymbol</c> exposes the underlying CLR type, so the
+/// generic #521 reference-upcast arm in <c>Conversion.Classify</c> saw two
+/// ordinary non-value-type CLR types and let the <c>?</c> silently drop. The
+/// #1552 gate only patched the multi-candidate positional overload filter, so
+/// a single-overload call, a named-argument call, an assignment, and a return
+/// position all still leaked. This is fixed at the classification source, so
+/// every position now reports the same GS0154/GS0155 null-safety diagnostic
+/// user-declared classes already got. All allowed nullable-target conversions
+/// (<c>S? -&gt; S?</c>, <c>S? -&gt; U?</c> derived-to-base, and the <c>!!</c>
+/// escape hatch) must keep compiling. Every type below uses an
+/// <c>Issue1627</c>-unique name; imported types (<c>System.Exception</c> /
+/// <c>System.ArgumentException</c>) exercise the "live ClrType" leak path that
+/// user-declared classes never had.
+/// </summary>
+public class Issue1627ImportedNullableRefSourceGateTests
+{
+    [Fact]
+    public void SingleOverload_ImportedNullableArg_ReportsGS0154()
+    {
+        var source = @"
+package p
+import System
+func Issue1627ASink(a Exception) int32 -> 1
+func Issue1627AUse(e ArgumentException?) int32 -> Issue1627ASink(e)
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0154");
+    }
+
+    [Fact]
+    public void NamedArgument_ImportedNullableArg_ReportsGS0154()
+    {
+        var source = @"
+package p
+import System
+func Issue1627BSink(a Exception) int32 -> 1
+func Issue1627BUse(e ArgumentException?) int32 -> Issue1627BSink(a: e)
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0154");
+    }
+
+    [Fact]
+    public void Assignment_ImportedNullableSource_ReportsNullSafetyDiagnostic()
+    {
+        var source = @"
+package p
+import System
+func Issue1627CUse(e ArgumentException?) int32 {
+    var x Exception = e
+    return 1
+}
+";
+        var result = Evaluate(source);
+        Assert.NotEmpty(result.Diagnostics);
+        Assert.Contains(
+            result.Diagnostics,
+            d => d.Id == "GS0154" || d.Id == "GS0155" || d.Message.Contains("Cannot convert"));
+    }
+
+    [Fact]
+    public void ReturnPosition_ImportedNullableSource_ReportsNullSafetyDiagnostic()
+    {
+        var source = @"
+package p
+import System
+func Issue1627DGet(e ArgumentException?) Exception -> e
+";
+        var result = Evaluate(source);
+        Assert.NotEmpty(result.Diagnostics);
+        Assert.Contains(
+            result.Diagnostics,
+            d => d.Id == "GS0154" || d.Id == "GS0155" || d.Message.Contains("Cannot convert"));
+    }
+
+    [Fact]
+    public void NullableToNullable_SameType_StillCompiles()
+    {
+        var source = @"
+package p
+import System
+func Issue1627EGet(e ArgumentException?) Exception? -> e
+";
+        Assert.Empty(Evaluate(source).Diagnostics);
+    }
+
+    [Fact]
+    public void NullableToNullable_DerivedToBase_StillCompiles()
+    {
+        var source = @"
+package p
+import System
+func Issue1627FSink(a Exception?) int32 -> 1
+func Issue1627FUse(e ArgumentException?) int32 -> Issue1627FSink(e)
+";
+        Assert.Empty(Evaluate(source).Diagnostics);
+    }
+
+    [Fact]
+    public void BangEscape_ImportedNullableSource_StillCompiles()
+    {
+        var source = @"
+package p
+import System
+func Issue1627GSink(a Exception) int32 -> 1
+func Issue1627GUse(e ArgumentException?) int32 -> Issue1627GSink(e!!)
+";
+        Assert.Empty(Evaluate(source).Diagnostics);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree) { IsLibrary = true };
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
## Root cause

`NullableTypeSymbol` relays its underlying CLR type (`NullableTypeSymbol.cs:24`), so the generic #521 reference-upcast arm in `Conversion.Classify` (`Conversion.cs:873-880`) saw an imported `S?` and `S` as two ordinary non-value-type CLR types and misclassified `S? -> S` as an implicit no-op upcast. The #1552 point-fix only gated this inside the multi-candidate positional overload filter (`OverloadResolver.cs`, `applicable.Count > 1 && !HasNamedArguments`), so a single-overload call, a named-argument call, an assignment, and a return position all still silently dropped the `?` for imported/CLR-backed reference types. User-declared classes/interfaces have a null `ClrType` during binding and were never affected.

## Fix

- **`Conversion.Classify`** (source fix): guarded the #521 reference-upcast arm itself so a `NullableTypeSymbol` source over a reference-like underlying never reaches it — returns `Conversion.None` instead, forcing the binder to report GS0154/GS0155 in every `BindConversion` position (single-overload calls, named arguments, assignments, returns, initializers). All allowed nullable-target conversions (`S? -> S?`, `S? -> U?` derived-to-base upcast, `S? -> object`) are classified earlier in the function and are unaffected.
- **`OverloadResolver`**: deleted the now-redundant `IsNullableReferenceGateRejected` call inside `IsConvertibilityApplicable` — the general `Conversion.Classify` check that follows it now already rejects the leak on its own. `TryFindNullSafetyArgumentMismatch` (used to produce a friendly GS0154 when every arity-applicable overload gets filtered out) still calls `IsNullableReferenceGateRejected` and is unchanged.
- **Regression surfaced by the fix**: `MapErasedIndexerElementType` (`ExpressionBinder.Access.cs`) fell back to a raw `TypeSymbol.FromClrType` for CLR indexer element types outside the generic-substitution path, ignoring `NullableAttribute`/`NullableContextAttribute` metadata (and the #1354 unannotated-defaults-to-nullable rule). This spuriously typed genuinely nullable indexers (e.g. `System.Text.Json.Nodes.JsonNode.this[string]`) as non-nullable, so passing a real nullable value through them tripped the new gate. Routed the fallback through `ClrNullability.GetPropertyTypeSymbol` to match every other property/parameter nullability read.

## Tests

Added `Issue1627ImportedNullableRefSourceGateTests.cs` covering:
- single-overload call, named-argument call, assignment, and return position with an imported `S?` where `S` is required — all now report GS0154/GS0155.
- negative controls: `S? -> S?`, `S? -> U?` (derived-to-base nullable upcast), and the `!!` escape hatch all still compile.

Ran and passed:
- Targeted filters: Issue1627, Issue1552, Issue1255, Issue521, Issue1532, Issue663 (Core.Tests + Compiler.Tests).
- Full `Core.Tests`: 4992 passed, 1 skipped.
- Full `Compiler.Tests`: 2545 passed.

Fixes #1627
