### PR TITLE
Fix pull-diagnostics stale-tree race off the write gate (#1657)

### DIFF
--- a/src/LanguageServer/CodeLensComputer.cs
+++ b/src/LanguageServer/CodeLensComputer.cs
@@ -32,10 +32,11 @@ public static class CodeLensComputer
 
         // SemanticLookup.ResolveSymbol matches identifier tokens by reference equality, so the
         // tree we iterate must be the exact instance the project compilation was built from.
-        // Diagnostic pulls reparse the file via ProjectState.UpdateFile, which replaces the tree
-        // held by the project after DocumentContent was cached — leaving content.SyntaxTree stale
-        // relative to the cached compilation. Prefer the project's current tree for this file so
-        // member-identifier lookups (which have no name-based fallback in SemanticModel) succeed.
+        // ProjectState.UpdateFile only ever runs under the write gate (didOpen/didChange/didSave;
+        // see issue #1657), so content.SyntaxTree and the project's cached tree stay in sync in
+        // practice. Still prefer the project's current tree defensively so member-identifier
+        // lookups (which have no name-based fallback in SemanticModel) keep working even if a
+        // future caller races the two.
         var tree = ResolveProjectTree(content, uri) ?? content.SyntaxTree;
 
         foreach (var member in tree.Root.Members)

--- a/src/LanguageServer/DocumentSyncHandler.cs
+++ b/src/LanguageServer/DocumentSyncHandler.cs
@@ -37,21 +37,11 @@ public static class DocumentSyncHandler
 
     public static DiagnosticComputationResult ComputeDiagnostics(string text, bool skipBinding, ProjectState project, string filePath, WorkspaceState workspace)
     {
-        var newLines = new List<int>();
-        int nextNewLine = text.IndexOf('\n');
-        while (nextNewLine >= 0)
-        {
-            newLines.Add(nextNewLine);
-            nextNewLine = text.IndexOf('\n', nextNewLine + 1);
-        }
-
-        var diagnostics = new List<Diagnostic>();
-
-        // When the file belongs to a project, bind it as part of the project-level compilation
-        // for cross-file awareness, but make sure that compilation reflects the in-memory editor
-        // text. The project keeps its own SyntaxTree per file; we sync this file's tree with the
-        // current text and then filter diagnostics by that exact tree so squiggles for the edited
-        // file are reported (and diagnostics for other files in the project are excluded).
+        // Mutating path: only safe to call while holding the write gate (didOpen/didChange/
+        // didSave). UpdateFile overwrites the project's shared per-file SyntaxTree with no lock
+        // of its own; calling it off-gate lets a stale snapshot clobber a newer concurrently
+        // written tree (issue #1657). Non-mutating requests must use
+        // <see cref="ComputeDiagnosticsForSnapshot"/> instead.
         Compilation compilation;
         SyntaxTree syntaxTree;
         bool useProject = project != null && !string.IsNullOrEmpty(filePath) && project.ContainsFile(filePath);
@@ -65,6 +55,47 @@ public static class DocumentSyncHandler
             syntaxTree = SyntaxTree.Parse(text);
             compilation = new Compilation(syntaxTree);
         }
+
+        return BuildResult(syntaxTree, compilation, useProject, skipBinding, project, workspace);
+    }
+
+    /// <summary>
+    /// Read-only counterpart to <see cref="ComputeDiagnostics(string, bool, ProjectState, string, WorkspaceState)"/>
+    /// for non-mutating requests (e.g. the textDocument/diagnostic pull handler) that run off the
+    /// write gate. Binds against the caller-supplied <paramref name="syntaxTree"/> snapshot
+    /// exactly as-is: it never calls <see cref="ProjectState.UpdateFile"/> and never mutates
+    /// <paramref name="project"/>'s cached trees or compilation, so a diagnostics pull for a
+    /// stale snapshot can never overwrite a newer tree written by a concurrent didChange
+    /// (issue #1657). The returned diagnostics always reflect exactly the requested snapshot text.
+    /// </summary>
+    /// <param name="syntaxTree">The already-parsed snapshot tree to bind and report diagnostics for.</param>
+    /// <param name="skipBinding">When <see langword="true"/>, skips the (potentially expensive) binding pass and reports only syntax diagnostics.</param>
+    /// <param name="project">The project owning <paramref name="filePath"/>, or <see langword="null"/> if the file is not part of a project.</param>
+    /// <param name="filePath">Absolute path to the <c>.gs</c> file the snapshot belongs to.</param>
+    /// <param name="workspace">The current workspace state, used to resolve cross-file symbols during binding.</param>
+    /// <returns>The computed diagnostics and binding metadata for <paramref name="syntaxTree"/>.</returns>
+    public static DiagnosticComputationResult ComputeDiagnosticsForSnapshot(SyntaxTree syntaxTree, bool skipBinding, ProjectState project, string filePath, WorkspaceState workspace)
+    {
+        bool useProject = project != null && !string.IsNullOrEmpty(filePath) && project.ContainsFile(filePath);
+        Compilation compilation = useProject
+            ? project.GetCompilationForSnapshot(filePath, syntaxTree)
+            : new Compilation(syntaxTree);
+
+        return BuildResult(syntaxTree, compilation, useProject, skipBinding, project, workspace);
+    }
+
+    private static DiagnosticComputationResult BuildResult(SyntaxTree syntaxTree, Compilation compilation, bool useProject, bool skipBinding, ProjectState project, WorkspaceState workspace)
+    {
+        var text = syntaxTree.Text.ToString();
+        var newLines = new List<int>();
+        int nextNewLine = text.IndexOf('\n');
+        while (nextNewLine >= 0)
+        {
+            newLines.Add(nextNewLine);
+            nextNewLine = text.IndexOf('\n', nextNewLine + 1);
+        }
+
+        var diagnostics = new List<Diagnostic>();
 
         foreach (var d in syntaxTree.Diagnostics)
         {

--- a/src/LanguageServer/ProjectState.cs
+++ b/src/LanguageServer/ProjectState.cs
@@ -280,6 +280,62 @@ public class ProjectState
     }
 
     /// <summary>
+    /// Builds a <see cref="Compilation"/> against a caller-supplied <paramref name="snapshotTree"/>
+    /// for <paramref name="filePath"/> WITHOUT mutating this project's cached trees, cached
+    /// compilation, or dirty flag. This is the read-only counterpart to
+    /// <see cref="UpdateFile"/> + <see cref="GetCompilation"/>: non-mutating LSP requests (e.g.
+    /// the textDocument/diagnostic pull handler) that run off the write gate must never call
+    /// <see cref="UpdateFile"/>, because a request holding a stale (pre-edit) snapshot could
+    /// otherwise race a concurrent didChange and overwrite a newer tree with the stale one
+    /// (issue #1657). When <paramref name="snapshotTree"/> is reference-equal to the tree
+    /// already cached for <paramref name="filePath"/> — the overwhelmingly common case, since
+    /// <see cref="UpdateFile"/> keeps the two in sync on every didOpen/didChange under the gate
+    /// — this reuses the normal cached <see cref="GetCompilation"/> path. Otherwise (a pull
+    /// racing a not-yet-applied or already-superseded edit) it builds a throwaway compilation
+    /// from the current tree set with this file's tree swapped for the snapshot, so the returned
+    /// diagnostics always reflect exactly the requested text without disturbing project state.
+    /// </summary>
+    /// <param name="filePath">Absolute path to the <c>.gs</c> file the snapshot belongs to.</param>
+    /// <param name="snapshotTree">The already-parsed snapshot tree to bind.</param>
+    /// <returns>A <see cref="Compilation"/> reflecting exactly <paramref name="snapshotTree"/>.</returns>
+    public Compilation GetCompilationForSnapshot(string filePath, SyntaxTree snapshotTree)
+    {
+        var key = NormalizePath(filePath);
+        lock (compilationLock)
+        {
+            if (syntaxTrees.TryGetValue(key, out var current) && ReferenceEquals(current, snapshotTree))
+            {
+                return GetCompilation();
+            }
+
+            RefreshReferencesFromSourceFile_NoLock();
+            var resolver = GetOrBuildResolver_NoLock();
+            var trees = syntaxTrees.Values.ToArray();
+            bool replaced = false;
+            for (int i = 0; i < trees.Length; i++)
+            {
+                if (string.Equals(NormalizePath(trees[i].Text?.FileName), key, StringComparison.Ordinal))
+                {
+                    trees[i] = snapshotTree;
+                    replaced = true;
+                    break;
+                }
+            }
+
+            if (!replaced)
+            {
+                trees = trees.Append(snapshotTree).ToArray();
+            }
+
+            var snapshotCompilation = resolver != null
+                ? new Compilation(resolver, trees)
+                : new Compilation(trees);
+            snapshotCompilation.BodyCache = bodyCache;
+            return snapshotCompilation;
+        }
+    }
+
+    /// <summary>
     /// ADR-0105 (Phase 2): attempts to construct the next <see cref="Compilation"/>
     /// incrementally when the only change since <see cref="compilation"/> is a
     /// body-only edit to a single file. On success returns a new compilation

--- a/src/LanguageServer/Server/LspServer.cs
+++ b/src/LanguageServer/Server/LspServer.cs
@@ -189,9 +189,12 @@ public sealed class LspServer
             return new FullDocumentDiagnosticReport { Items = Array.Empty<Diagnostic>() };
         }
 
-        // Snapshot the current text and owning project under the gate, then run the (potentially
-        // expensive) full binding pass off the gate so interactive requests are not blocked.
-        string text = null;
+        // Snapshot the current SyntaxTree and owning project under the gate, then run the
+        // (potentially expensive) full binding pass off the gate so interactive requests are not
+        // blocked. Binding runs against the captured tree via ComputeDiagnosticsForSnapshot, which
+        // never calls ProjectState.UpdateFile — a stale snapshot pull racing a concurrent
+        // didChange can therefore never clobber a newer tree written under the gate (issue #1657).
+        SyntaxTree syntaxTree = null;
         string filePath = null;
         ProjectState project = null;
         await this.gate.WaitAsync(cancellationToken).ConfigureAwait(false);
@@ -201,7 +204,7 @@ public sealed class LspServer
             project = !string.IsNullOrEmpty(filePath) ? this.workspaceState.GetProjectForFile(filePath) : null;
             if (this.documentContentService.TryGet(uri.ToString(), out var content))
             {
-                text = content.SyntaxTree.Text.ToString();
+                syntaxTree = content.SyntaxTree;
             }
         }
         finally
@@ -209,7 +212,7 @@ public sealed class LspServer
             this.gate.Release();
         }
 
-        if (text == null)
+        if (syntaxTree == null)
         {
             return new FullDocumentDiagnosticReport { Items = Array.Empty<Diagnostic>() };
         }
@@ -219,7 +222,7 @@ public sealed class LspServer
         DiagnosticComputationResult result;
         try
         {
-            result = DocumentSyncHandler.ComputeDiagnostics(text, skipBinding: false, project, filePath, this.workspaceState);
+            result = DocumentSyncHandler.ComputeDiagnosticsForSnapshot(syntaxTree, skipBinding: false, project, filePath, this.workspaceState);
         }
         catch (OperationCanceledException)
         {

--- a/test/LanguageServer.Tests/DocumentSyncHandlerTests.cs
+++ b/test/LanguageServer.Tests/DocumentSyncHandlerTests.cs
@@ -77,4 +77,45 @@ public class DocumentSyncHandlerTests
             catch (IOException) { }
         }
     }
+
+    [Fact]
+    public void ComputeDiagnosticsForSnapshot_DoesNotOverwriteNewerProjectTreeOrInvalidateNewerCompilation()
+    {
+        // Regression for issue #1657: a read-only request (e.g. textDocument/diagnostic pull)
+        // captures a SyntaxTree snapshot under the write gate and then binds off-gate. If a
+        // didChange lands on the gate between the snapshot capture and the off-gate bind, the
+        // pull must never clobber the project's newer tree with its own stale snapshot, and the
+        // diagnostics it returns must still reflect exactly the snapshot it was given.
+        const string staleText = "func F() int32 {\n}\n";
+        const string newerText = "func F() int32 {\n    return 1\n}\n";
+        const string filePath = "/test/file1.gs";
+
+        var project = new ProjectState("/test/project.gsproj");
+        var staleTree = project.UpdateFile(filePath, staleText);
+
+        // Cache a compilation for the current (stale) tree, mirroring the project's state at the
+        // moment the pull captured its snapshot.
+        project.GetCompilation();
+
+        // Simulate a concurrent didChange landing on the gate after the pull's snapshot was
+        // captured: this both replaces the project's tree and invalidates its cached compilation.
+        var newerTree = project.UpdateFile(filePath, newerText);
+
+        // The pull binds against the pre-edit snapshot it captured earlier under the gate.
+        var snapshotResult = DocumentSyncHandler.ComputeDiagnosticsForSnapshot(staleTree, skipBinding: false, project, filePath, workspace: null);
+
+        // The returned diagnostics must reflect exactly the stale snapshot text (the missing
+        // return statement), not the project's current, already-fixed text.
+        Assert.Contains(snapshotResult.Diagnostics, d => d.Message.Contains("Not all code paths", System.StringComparison.Ordinal));
+
+        // The project's own tree must still be the newer one written by UpdateFile: the pull must
+        // never have clobbered it with the stale snapshot it was bound against.
+        var currentCompilation = project.GetCompilation();
+        Assert.Contains(currentCompilation.SyntaxTrees, t => ReferenceEquals(t, newerTree));
+        Assert.DoesNotContain(currentCompilation.SyntaxTrees, t => ReferenceEquals(t, staleTree));
+
+        // Rebinding the project's current (fixed) tree must show no missing-return diagnostic,
+        // proving the newer compilation was neither corrupted nor left bound to stale content.
+        Assert.DoesNotContain(currentCompilation.GlobalScope.Diagnostics, d => d.Message.Contains("Not all code paths", System.StringComparison.Ordinal));
+    }
 }


### PR DESCRIPTION
## Problem

`textDocument/diagnostic` (pull diagnostics) reparsed the requested text and called `ProjectState.UpdateFile` off the write gate. `UpdateFile` overwrites the project's shared per-file `SyntaxTree` with no locking of its own beyond the project's internal lock, so a diagnostics pull holding a stale (pre-edit) snapshot could race a concurrent `didChange` and clobber the newer tree with the stale one — silencing or corrupting diagnostics for the edit that just landed.

## Fix

- `ProjectState.GetCompilationForSnapshot(filePath, snapshotTree)`: builds a `Compilation` bound to a caller-supplied snapshot tree without touching the project's cached trees, cached compilation, or dirty flag. Reuses the normal cached `GetCompilation()` path when the snapshot is reference-equal to the project's current tree (the common case); otherwise builds a throwaway compilation with this file's tree swapped for the snapshot.
- `DocumentSyncHandler.ComputeDiagnosticsForSnapshot(...)`: read-only counterpart to `ComputeDiagnostics` for non-mutating requests. Binds against the caller-supplied `SyntaxTree` as-is and never calls `ProjectState.UpdateFile`.
- `LspServer`'s diagnostic pull handler now captures the `SyntaxTree` (not raw text) under the gate and calls `ComputeDiagnosticsForSnapshot` off-gate, removing the only off-gate `UpdateFile` call site.
- `CodeLensComputer`'s stale comment updated to reflect that `UpdateFile` is now exclusively a gated (didOpen/didChange/didSave) operation.
- Added the StyleCop-required `<param>`/`<returns>` doc tags on `ComputeDiagnosticsForSnapshot` (this was the build-breaking gap left behind).

## Handler audit

Audited every other read-only LSP handler for the same off-gate mutation anti-pattern: hover, definition, references, documentHighlight, documentSymbol, workspace/symbol, completion, signatureHelp, rename, prepareRename, codeAction, codeLens, inlayHint, foldingRange, selectionRange, semanticTokens (full/range), formatting (full/range/onType), implementation, typeDefinition, linkedEditingRange, discoverTests.

All of these route through `ReadDocumentAsync` / `ReadWorkspaceAsync` / `ReadTestSnapshotAsync`, which snapshot `DocumentContent` (or document lists / test sources) under the gate and compute off-gate purely from that snapshot. None of them call `ProjectState.UpdateFile`. **No further changes were needed for these handlers** — the pull-diagnostics path was the only one with the anti-pattern.

## Testing

Added `ComputeDiagnosticsForSnapshot_DoesNotOverwriteNewerProjectTreeOrInvalidateNewerCompilation` to `DocumentSyncHandlerTests`, which:
1. Captures a stale tree snapshot, then simulates a concurrent `didChange` (newer tree + invalidated compilation).
2. Calls `ComputeDiagnosticsForSnapshot` against the stale snapshot and asserts the returned diagnostics reflect exactly the stale text.
3. Asserts the project's own current tree/compilation still reflect the newer edit and were not clobbered by the stale snapshot pull.

- `dotnet build GSharp.sln -c Release -graph`: 0 errors, 0 warnings.
- `dotnet test test/LanguageServer.Tests/LanguageServer.Tests.csproj -c Release`: 377/377 passed (full LanguageServer.Tests suite).

Fixes #1657