### PR TITLE
Fix #1658: root MetadataReaderProvider in PdbSourceLocator reader cache

### DIFF
--- a/src/LanguageServer/PdbSourceLocator.cs
+++ b/src/LanguageServer/PdbSourceLocator.cs
@@ -279,49 +279,83 @@ public static class PdbSourceLocator
     /// only while the lease is held (e.g. inside a <c>using</c> block) and
     /// must check <see cref="ReaderLease.IsValid"/> before use.
     /// </summary>
+    /// <remarks>
+    /// Every path out of this method (normal return, invalid-lease return,
+    /// or an exception) releases <c>pathLock</c> exactly once: the lock is
+    /// only handed off to the returned <see cref="ReaderLease"/> on success,
+    /// and the local reference is cleared as soon as ownership transfers, so
+    /// the <c>finally</c> block only releases the lock when this method is
+    /// still holding it itself. This keeps a thrown exception (e.g. a
+    /// <see cref="BadImageFormatException"/> from a partially-written PDB)
+    /// from leaving the lock held forever, which would otherwise deadlock
+    /// every future lookup for the same assembly path. A freshly loaded
+    /// <see cref="MetadataReaderProvider"/> that has not yet been installed
+    /// into the cache is disposed on the exception path so it does not leak
+    /// its native or managed buffer.
+    /// </remarks>
     private static ReaderLease GetOrLoadReaderLease(string assemblyFilePath)
     {
         var pathLock = PathLocks.GetOrAdd(assemblyFilePath, static _ => new object());
         Monitor.Enter(pathLock);
 
-        if (!File.Exists(assemblyFilePath))
-        {
-            Monitor.Exit(pathLock);
-            return ReaderLease.Invalid;
-        }
-
-        DateTime mtimeUtc;
+        MetadataReaderProvider loadedProvider = null;
         try
         {
-            mtimeUtc = File.GetLastWriteTimeUtc(assemblyFilePath);
+            if (!File.Exists(assemblyFilePath))
+            {
+                return ReaderLease.Invalid;
+            }
+
+            DateTime mtimeUtc;
+            try
+            {
+                mtimeUtc = File.GetLastWriteTimeUtc(assemblyFilePath);
+            }
+            catch (IOException)
+            {
+                return ReaderLease.Invalid;
+            }
+
+            if (ReaderCache.TryGetValue(assemblyFilePath, out var cached) && cached.MtimeUtc == mtimeUtc)
+            {
+                var hitLease = new ReaderLease(pathLock, cached.Reader);
+                pathLock = null; // Ownership transferred to the lease; do not release in finally.
+                return hitLease;
+            }
+
+            loadedProvider = LoadReaderProvider(assemblyFilePath);
+            if (loadedProvider == null)
+            {
+                return ReaderLease.Invalid;
+            }
+
+            var loadedReader = loadedProvider.GetMetadataReader();
+            ReaderCache[assemblyFilePath] = new CachedReader(loadedProvider, loadedReader, mtimeUtc);
+            loadedProvider = null; // Now owned by the cache; do not dispose it below.
+
+            // The stale entry's reader is no longer reachable from the cache and no
+            // other thread can be reading it: we hold this path's lock, and every
+            // reader is only ever used while that lock is held.
+            cached.Provider?.Dispose();
+
+            var missLease = new ReaderLease(pathLock, loadedReader);
+            pathLock = null; // Ownership transferred to the lease; do not release in finally.
+            return missLease;
         }
-        catch (IOException)
+        catch
         {
-            Monitor.Exit(pathLock);
-            return ReaderLease.Invalid;
+            // A provider that was loaded but never installed into the cache
+            // would otherwise leak its underlying buffer.
+            loadedProvider?.Dispose();
+            throw;
         }
-
-        if (ReaderCache.TryGetValue(assemblyFilePath, out var cached) && cached.MtimeUtc == mtimeUtc)
+        finally
         {
-            return new ReaderLease(pathLock, cached.Reader);
+            if (pathLock != null)
+            {
+                Monitor.Exit(pathLock);
+            }
         }
-
-        var loadedProvider = LoadReaderProvider(assemblyFilePath);
-        if (loadedProvider == null)
-        {
-            Monitor.Exit(pathLock);
-            return ReaderLease.Invalid;
-        }
-
-        var loadedReader = loadedProvider.GetMetadataReader();
-        ReaderCache[assemblyFilePath] = new CachedReader(loadedProvider, loadedReader, mtimeUtc);
-
-        // The stale entry's reader is no longer reachable from the cache and no
-        // other thread can be reading it: we hold this path's lock, and every
-        // reader is only ever used while that lock is held.
-        cached.Provider?.Dispose();
-
-        return new ReaderLease(pathLock, loadedReader);
     }
 
     private static MetadataReaderProvider LoadReaderProvider(string assemblyFilePath)

--- a/src/LanguageServer/PdbSourceLocator.cs
+++ b/src/LanguageServer/PdbSourceLocator.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
+using System.Threading;
 
 namespace GSharp.LanguageServer;
 
@@ -22,8 +23,12 @@ namespace GSharp.LanguageServer;
 /// Per-assembly readers are cached for the lifetime of the language server.
 /// The cache key is the resolved assembly path plus its last-write time, so a
 /// successful rebuild invalidates the cached PDB automatically on the next
-/// lookup. <see cref="MetadataReaderProvider"/> instances are intentionally not
-/// disposed: the LSP holds them open for as long as the workspace lives.
+/// lookup. The cache stores the owning <see cref="MetadataReaderProvider"/>
+/// alongside its <see cref="MetadataReader"/> so the provider (and the native
+/// or managed memory it owns) stays rooted for as long as the reader is in
+/// use. When a rebuild replaces a cache entry, the previous provider is
+/// disposed under the same per-path lock used to hand out readers, so it is
+/// never disposed while another thread is still reading through it.
 /// <para>
 /// MSBuild emits the public-API <c>refint/{Name}.dll</c> for any project with
 /// <c>ProduceReferenceAssembly=true</c> (the SDK default for libraries), and
@@ -36,6 +41,13 @@ namespace GSharp.LanguageServer;
 public static class PdbSourceLocator
 {
     private static readonly ConcurrentDictionary<string, CachedReader> ReaderCache = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Per-path locks that serialize cache load/replace against reader use, so
+    /// a cache replacement never disposes a <see cref="MetadataReaderProvider"/>
+    /// while another thread is still reading through it.
+    /// </summary>
+    private static readonly ConcurrentDictionary<string, object> PathLocks = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// Resolves a method's first sequence point to a source file and span.
@@ -59,18 +71,21 @@ public static class PdbSourceLocator
 
         // Per cmt above: prefer the runtime assembly's PDB when the input is a refint shim.
         var probePath = RebaseRefIntPath(assemblyFilePath);
-        var reader = GetOrLoadReader(probePath);
-        if (reader == null && !string.Equals(probePath, assemblyFilePath, StringComparison.OrdinalIgnoreCase))
+        var lease = GetOrLoadReaderLease(probePath);
+        if (!lease.IsValid && !string.Equals(probePath, assemblyFilePath, StringComparison.OrdinalIgnoreCase))
         {
-            reader = GetOrLoadReader(assemblyFilePath);
+            lease = GetOrLoadReaderLease(assemblyFilePath);
         }
 
-        if (reader == null)
+        using (lease)
         {
-            return false;
-        }
+            if (!lease.IsValid)
+            {
+                return false;
+            }
 
-        return TryReadFirstSequencePoint(reader, methodMetadataToken, out location);
+            return TryReadFirstSequencePoint(lease.Reader, methodMetadataToken, out location);
+        }
     }
 
     /// <summary>
@@ -94,55 +109,58 @@ public static class PdbSourceLocator
         }
 
         var probePath = RebaseRefIntPath(assemblyFilePath);
-        var reader = GetOrLoadReader(probePath);
-        if (reader == null && !string.Equals(probePath, assemblyFilePath, StringComparison.OrdinalIgnoreCase))
+        var lease = GetOrLoadReaderLease(probePath);
+        if (!lease.IsValid && !string.Equals(probePath, assemblyFilePath, StringComparison.OrdinalIgnoreCase))
         {
-            reader = GetOrLoadReader(assemblyFilePath);
+            lease = GetOrLoadReaderLease(assemblyFilePath);
         }
 
-        if (reader == null)
+        using (lease)
         {
-            return false;
-        }
-
-        // The PDB MethodDebugInformation table is parallel to the PE
-        // MethodDef table; we don't need the PE here because the supplied
-        // method tokens are already resolved by the caller from
-        // typeDef.GetMethods(). Resolve them via the PE alongside the PDB.
-        if (!TryReadTypeMethodTokens(probePath, typeMetadataToken, out var methodTokens))
-        {
-            if (!string.Equals(probePath, assemblyFilePath, StringComparison.OrdinalIgnoreCase))
+            if (!lease.IsValid)
             {
-                if (!TryReadTypeMethodTokens(assemblyFilePath, typeMetadataToken, out methodTokens))
+                return false;
+            }
+
+            // The PDB MethodDebugInformation table is parallel to the PE
+            // MethodDef table; we don't need the PE here because the supplied
+            // method tokens are already resolved by the caller from
+            // typeDef.GetMethods(). Resolve them via the PE alongside the PDB.
+            if (!TryReadTypeMethodTokens(probePath, typeMetadataToken, out var methodTokens))
+            {
+                if (!string.Equals(probePath, assemblyFilePath, StringComparison.OrdinalIgnoreCase))
+                {
+                    if (!TryReadTypeMethodTokens(assemblyFilePath, typeMetadataToken, out methodTokens))
+                    {
+                        return false;
+                    }
+                }
+                else
                 {
                     return false;
                 }
             }
-            else
+
+            SourceLocation? best = null;
+            foreach (var methodToken in methodTokens)
+            {
+                if (TryReadFirstSequencePoint(lease.Reader, methodToken, out var candidate))
+                {
+                    if (best == null || IsEarlier(candidate, best.Value))
+                    {
+                        best = candidate;
+                    }
+                }
+            }
+
+            if (best == null)
             {
                 return false;
             }
-        }
 
-        SourceLocation? best = null;
-        foreach (var methodToken in methodTokens)
-        {
-            if (TryReadFirstSequencePoint(reader, methodToken, out var candidate))
-            {
-                if (best == null || IsEarlier(candidate, best.Value))
-                {
-                    best = candidate;
-                }
-            }
+            location = best.Value;
+            return true;
         }
-
-        if (best == null)
-        {
-            return false;
-        }
-
-        location = best.Value;
-        return true;
     }
 
     private static bool IsEarlier(SourceLocation a, SourceLocation b)
@@ -252,11 +270,24 @@ public static class PdbSourceLocator
         }
     }
 
-    private static MetadataReader GetOrLoadReader(string assemblyFilePath)
+    /// <summary>
+    /// Acquires the per-path lock, ensures the cached reader for
+    /// <paramref name="assemblyFilePath"/> is up to date with the file's
+    /// current write time (disposing and replacing a stale
+    /// <see cref="MetadataReaderProvider"/> if needed), and returns a lease
+    /// that holds the lock until disposed. The caller must use the reader
+    /// only while the lease is held (e.g. inside a <c>using</c> block) and
+    /// must check <see cref="ReaderLease.IsValid"/> before use.
+    /// </summary>
+    private static ReaderLease GetOrLoadReaderLease(string assemblyFilePath)
     {
+        var pathLock = PathLocks.GetOrAdd(assemblyFilePath, static _ => new object());
+        Monitor.Enter(pathLock);
+
         if (!File.Exists(assemblyFilePath))
         {
-            return null;
+            Monitor.Exit(pathLock);
+            return ReaderLease.Invalid;
         }
 
         DateTime mtimeUtc;
@@ -266,25 +297,34 @@ public static class PdbSourceLocator
         }
         catch (IOException)
         {
-            return null;
+            Monitor.Exit(pathLock);
+            return ReaderLease.Invalid;
         }
 
         if (ReaderCache.TryGetValue(assemblyFilePath, out var cached) && cached.MtimeUtc == mtimeUtc)
         {
-            return cached.Reader;
+            return new ReaderLease(pathLock, cached.Reader);
         }
 
-        var loaded = LoadReader(assemblyFilePath);
-        if (loaded == null)
+        var loadedProvider = LoadReaderProvider(assemblyFilePath);
+        if (loadedProvider == null)
         {
-            return null;
+            Monitor.Exit(pathLock);
+            return ReaderLease.Invalid;
         }
 
-        ReaderCache[assemblyFilePath] = new CachedReader(loaded, mtimeUtc);
-        return loaded;
+        var loadedReader = loadedProvider.GetMetadataReader();
+        ReaderCache[assemblyFilePath] = new CachedReader(loadedProvider, loadedReader, mtimeUtc);
+
+        // The stale entry's reader is no longer reachable from the cache and no
+        // other thread can be reading it: we hold this path's lock, and every
+        // reader is only ever used while that lock is held.
+        cached.Provider?.Dispose();
+
+        return new ReaderLease(pathLock, loadedReader);
     }
 
-    private static MetadataReader LoadReader(string assemblyFilePath)
+    private static MetadataReaderProvider LoadReaderProvider(string assemblyFilePath)
     {
         try
         {
@@ -295,8 +335,7 @@ public static class PdbSourceLocator
                 // bytes alive after the underlying file handle is closed
                 // (FromPortablePdbImage stores the buffer directly).
                 var bytes = File.ReadAllBytes(sidecar);
-                var provider = MetadataReaderProvider.FromPortablePdbImage(System.Collections.Immutable.ImmutableArray.Create(bytes));
-                return provider.GetMetadataReader();
+                return MetadataReaderProvider.FromPortablePdbImage(System.Collections.Immutable.ImmutableArray.Create(bytes));
             }
 
             // Probe the PE for an embedded PDB.
@@ -314,8 +353,11 @@ public static class PdbSourceLocator
                 return null;
             }
 
-            var embeddedProvider = peReader.ReadEmbeddedPortablePdbDebugDirectoryData(embedded);
-            return embeddedProvider.GetMetadataReader();
+            // The embedded-PDB provider owns a native-heap buffer that is
+            // released by its finalizer; it must be cached (not just the
+            // reader it hands out) so the buffer stays alive for as long as
+            // the reader is used.
+            return peReader.ReadEmbeddedPortablePdbDebugDirectoryData(embedded);
         }
         catch (IOException)
         {
@@ -373,5 +415,60 @@ public static class PdbSourceLocator
     /// </summary>
     public readonly record struct SourceLocation(string FilePath, int StartLine, int StartColumn, int EndLine, int EndColumn);
 
-    private readonly record struct CachedReader(MetadataReader Reader, DateTime MtimeUtc);
+    /// <summary>
+    /// A cache entry that keeps the <see cref="MetadataReaderProvider"/>
+    /// rooted alongside the <see cref="MetadataReader"/> it produced, so the
+    /// provider (and any native or managed buffer it owns) cannot be
+    /// collected and finalized while the reader is still cached and in use.
+    /// </summary>
+    private readonly record struct CachedReader(MetadataReaderProvider Provider, MetadataReader Reader, DateTime MtimeUtc);
+
+    /// <summary>
+    /// Holds the per-path lock for a cached reader while the caller uses it.
+    /// Disposing the lease releases the lock. Always check
+    /// <see cref="IsValid"/> before using <see cref="Reader"/>: an invalid
+    /// lease means no lock is held and <see cref="Reader"/> is <see langword="null"/>.
+    /// </summary>
+    private readonly struct ReaderLease : IDisposable
+    {
+        /// <summary>
+        /// A lease value representing a failed lookup: no lock is held.
+        /// </summary>
+        public static readonly ReaderLease Invalid = default;
+
+        private readonly object pathLock;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReaderLease"/> struct
+        /// that holds <paramref name="pathLock"/> until disposed.
+        /// </summary>
+        /// <param name="pathLock">The per-path lock, already entered by the caller.</param>
+        /// <param name="reader">The cached reader to hand out while the lock is held.</param>
+        public ReaderLease(object pathLock, MetadataReader reader)
+        {
+            this.pathLock = pathLock;
+            Reader = reader;
+        }
+
+        /// <summary>
+        /// Gets the cached reader. Only valid to use while the lease is held (i.e. before <see cref="Dispose"/> is called).
+        /// </summary>
+        public MetadataReader Reader { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether this lease holds a lock and carries a usable <see cref="Reader"/>.
+        /// </summary>
+        public bool IsValid => pathLock != null;
+
+        /// <summary>
+        /// Releases the per-path lock acquired for this lease, if any.
+        /// </summary>
+        public void Dispose()
+        {
+            if (pathLock != null)
+            {
+                Monitor.Exit(pathLock);
+            }
+        }
+    }
 }

--- a/test/LanguageServer.Tests/PdbSourceLocatorCacheTests.cs
+++ b/test/LanguageServer.Tests/PdbSourceLocatorCacheTests.cs
@@ -1,0 +1,144 @@
+// <copyright file="PdbSourceLocatorCacheTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections;
+using System.IO;
+using System.Reflection;
+using Xunit;
+
+namespace GSharp.LanguageServer.Tests;
+
+/// <summary>
+/// Regression coverage for the <see cref="PdbSourceLocator"/> reader cache
+/// (issue #1658): the cache must keep the owning <c>MetadataReaderProvider</c>
+/// rooted for as long as its <c>MetadataReader</c> is cached, and must dispose
+/// a replaced provider only after it can no longer be read.
+/// </summary>
+public class PdbSourceLocatorCacheTests
+{
+    /// <summary>
+    /// Before the fix, only the <c>MetadataReader</c> was cached; the
+    /// <c>MetadataReaderProvider</c> that owns its backing buffer became
+    /// unreferenced as soon as <c>LoadReader</c> returned. A GC could collect
+    /// and finalize it, freeing the buffer out from under the cached reader
+    /// and corrupting (or crashing on) the next lookup. This test forces a GC
+    /// between two lookups of the same assembly and asserts the second lookup
+    /// still resolves correctly.
+    /// </summary>
+    [Fact]
+    public void CachedReader_SurvivesGarbageCollection()
+    {
+        var (asmPath, _) = CopyCoreAssemblyToTempDir();
+        try
+        {
+            var type = typeof(GSharp.Core.CodeAnalysis.Symbols.PropertySymbol);
+
+            var ok1 = PdbSourceLocator.TryGetTypeSourceLocation(asmPath, type.MetadataToken, out var loc1);
+            Assert.True(ok1, "First lookup should populate the reader cache.");
+
+            // Force any unreferenced MetadataReaderProvider to be collected and finalized.
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+
+            var ok2 = PdbSourceLocator.TryGetTypeSourceLocation(asmPath, type.MetadataToken, out var loc2);
+            Assert.True(ok2, "Second lookup (post-GC) must still resolve through the cached reader.");
+            Assert.Equal(loc1, loc2);
+            Assert.Contains("PropertySymbol", loc2.FilePath);
+        }
+        finally
+        {
+            CleanupTempDir(asmPath);
+        }
+    }
+
+    /// <summary>
+    /// When a rebuild changes an assembly's last-write time, the cache must
+    /// load a fresh provider/reader pair and dispose the previous provider
+    /// (releasing its buffer) rather than leaking it forever.
+    /// </summary>
+    [Fact]
+    public void CacheReplacement_OnMtimeChange_DisposesPreviousProvider()
+    {
+        var (asmPath, _) = CopyCoreAssemblyToTempDir();
+        try
+        {
+            var type = typeof(GSharp.Core.CodeAnalysis.Symbols.PropertySymbol);
+
+            var ok1 = PdbSourceLocator.TryGetTypeSourceLocation(asmPath, type.MetadataToken, out _);
+            Assert.True(ok1);
+
+            var firstProvider = GetCachedProvider(asmPath);
+            Assert.NotNull(firstProvider);
+
+            // Bump the write time so the cache treats this as a rebuilt assembly.
+            File.SetLastWriteTimeUtc(asmPath, DateTime.UtcNow.AddSeconds(5));
+
+            var ok2 = PdbSourceLocator.TryGetTypeSourceLocation(asmPath, type.MetadataToken, out _);
+            Assert.True(ok2, "Lookup after an mtime bump should reload and re-resolve.");
+
+            var secondProvider = GetCachedProvider(asmPath);
+            Assert.NotNull(secondProvider);
+            Assert.NotSame(firstProvider, secondProvider);
+
+            // The old provider must have been disposed: any further use of it now throws
+            // (the exact exception type/wrapping is an implementation detail of
+            // System.Reflection.Metadata's disposed-state guard and reflective invoke).
+            var getReader = firstProvider.GetType().GetMethod("GetMetadataReader", Type.EmptyTypes);
+            var ex = Record.Exception(() => getReader.Invoke(firstProvider, null));
+            var actual = ex is TargetInvocationException tie ? tie.InnerException : ex;
+            Assert.True(
+                actual is ObjectDisposedException or NullReferenceException,
+                $"Expected a disposed-state failure but got {actual?.GetType()}.");
+        }
+        finally
+        {
+            CleanupTempDir(asmPath);
+        }
+    }
+
+    private static object GetCachedProvider(string assemblyFilePath)
+    {
+        var cacheField = typeof(PdbSourceLocator).GetField("ReaderCache", BindingFlags.NonPublic | BindingFlags.Static);
+        var cache = (IDictionary)cacheField.GetValue(null);
+
+        // ConcurrentDictionary<string, CachedReader> — index via the non-generic
+        // IDictionary view since CachedReader is a private nested type.
+        var entry = cache[assemblyFilePath];
+        var providerProperty = entry.GetType().GetProperty("Provider");
+        return providerProperty.GetValue(entry);
+    }
+
+    private static (string AsmPath, string PdbPath) CopyCoreAssemblyToTempDir()
+    {
+        var srcAsm = typeof(GSharp.Core.CodeAnalysis.Symbols.PropertySymbol).Assembly.Location;
+        var srcPdb = Path.ChangeExtension(srcAsm, ".pdb");
+        Assert.True(File.Exists(srcPdb), "This test requires a build with sidecar portable PDBs.");
+
+        var dir = Path.Combine(Path.GetTempPath(), "pdbcache_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var dstAsm = Path.Combine(dir, Path.GetFileName(srcAsm));
+        var dstPdb = Path.Combine(dir, Path.GetFileName(srcPdb));
+        File.Copy(srcAsm, dstAsm);
+        File.Copy(srcPdb, dstPdb);
+        return (dstAsm, dstPdb);
+    }
+
+    private static void CleanupTempDir(string asmPath)
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(asmPath);
+            if (!string.IsNullOrEmpty(dir) && Directory.Exists(dir))
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup; leftover temp files don't affect test correctness.
+        }
+    }
+}

--- a/test/LanguageServer.Tests/PdbSourceLocatorCacheTests.cs
+++ b/test/LanguageServer.Tests/PdbSourceLocatorCacheTests.cs
@@ -6,6 +6,9 @@ using System;
 using System.Collections;
 using System.IO;
 using System.Reflection;
+using System.Reflection.Metadata;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using Xunit;
 
 namespace GSharp.LanguageServer.Tests;
@@ -21,14 +24,21 @@ public class PdbSourceLocatorCacheTests
     /// <summary>
     /// Before the fix, only the <c>MetadataReader</c> was cached; the
     /// <c>MetadataReaderProvider</c> that owns its backing buffer became
-    /// unreferenced as soon as <c>LoadReader</c> returned. A GC could collect
-    /// and finalize it, freeing the buffer out from under the cached reader
-    /// and corrupting (or crashing on) the next lookup. This test forces a GC
-    /// between two lookups of the same assembly and asserts the second lookup
-    /// still resolves correctly.
+    /// unreferenced as soon as <c>LoadReader</c> returned, so a GC could
+    /// collect and finalize it out from under the cached reader. This test
+    /// captures a <see cref="WeakReference{T}"/> to the provider actually
+    /// held by the cache entry (via reflection) and proves two invariants
+    /// directly: (1) the provider stays rooted — and therefore alive — by
+    /// the cache entry alone across a full GC while it is still cached, and
+    /// (2) once the entry is evicted and replaced (a rebuild bumping the
+    /// file's write time), the old provider is disposed and becomes
+    /// collectable. Unlike asserting only that a lookup "still resolves"
+    /// (which a managed, GC-surviving-by-luck sidecar buffer can satisfy
+    /// even without the fix), this directly exercises the rooting
+    /// invariant the fix establishes.
     /// </summary>
     [Fact]
-    public void CachedReader_SurvivesGarbageCollection()
+    public void CachedReader_ProviderStaysRootedByCache_UntilEvicted()
     {
         var (asmPath, _) = CopyCoreAssemblyToTempDir();
         try
@@ -38,20 +48,144 @@ public class PdbSourceLocatorCacheTests
             var ok1 = PdbSourceLocator.TryGetTypeSourceLocation(asmPath, type.MetadataToken, out var loc1);
             Assert.True(ok1, "First lookup should populate the reader cache.");
 
+            var providerWeakRef = CaptureCachedProviderWeakReference(asmPath);
+
             // Force any unreferenced MetadataReaderProvider to be collected and finalized.
             GC.Collect();
             GC.WaitForPendingFinalizers();
             GC.Collect();
 
+            Assert.True(
+                IsAlive(providerWeakRef),
+                "The provider must stay rooted by the cache entry: before the fix only the " +
+                "reader was cached and the provider could be collected here.");
+
             var ok2 = PdbSourceLocator.TryGetTypeSourceLocation(asmPath, type.MetadataToken, out var loc2);
             Assert.True(ok2, "Second lookup (post-GC) must still resolve through the cached reader.");
             Assert.Equal(loc1, loc2);
             Assert.Contains("PropertySymbol", loc2.FilePath);
+
+            // Bump the write time so the cache evicts and disposes the entry captured above.
+            File.SetLastWriteTimeUtc(asmPath, DateTime.UtcNow.AddSeconds(5));
+            var ok3 = PdbSourceLocator.TryGetTypeSourceLocation(asmPath, type.MetadataToken, out _);
+            Assert.True(ok3, "Lookup after an mtime bump should reload and evict the old entry.");
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+
+            Assert.False(
+                IsAlive(providerWeakRef),
+                "Once evicted and disposed, the old provider must become collectable.");
         }
         finally
         {
             CleanupTempDir(asmPath);
         }
+    }
+
+    /// <summary>
+    /// Reproduces the pre-fix lock-leak deadlock: <c>GetMetadataReader</c>
+    /// throws <see cref="BadImageFormatException"/> lazily on a malformed
+    /// portable PDB image (confirmed to happen after
+    /// <c>FromPortablePdbImage</c> itself succeeds, since it does not eagerly
+    /// validate the buffer). Before the fix, that exception unwound out of
+    /// <c>GetOrLoadReaderLease</c> without releasing the per-path
+    /// <c>Monitor</c>, permanently deadlocking every subsequent lookup for
+    /// the same assembly path — but only when a *different* thread tries to
+    /// acquire it: <see cref="Monitor"/> is reentrant, so if the thread pool
+    /// happened to reuse the very same thread for a later lookup, the
+    /// leaked lock would look harmless. This test therefore runs both
+    /// attempts on dedicated, explicitly distinct <see cref="Thread"/>
+    /// instances (never pooled) and asserts the second one completes within
+    /// a timeout instead of hanging.
+    /// </summary>
+    [Fact]
+    public void LookupAfterCorruptPdbException_DoesNotDeadlock()
+    {
+        var (asmPath, pdbPath) = CopyCoreAssemblyToTempDir();
+        try
+        {
+            var type = typeof(GSharp.Core.CodeAnalysis.Symbols.PropertySymbol);
+
+            // Corrupt the sidecar PDB so FromPortablePdbImage attaches successfully
+            // (it does not eagerly validate) but GetMetadataReader() throws
+            // BadImageFormatException when GetOrLoadReaderLease calls it.
+            var garbage = new byte[256];
+            new Random(42).NextBytes(garbage);
+            File.WriteAllBytes(pdbPath, garbage);
+
+            Exception firstException = null;
+            var firstThread = new Thread(() =>
+            {
+                try
+                {
+                    PdbSourceLocator.TryGetTypeSourceLocation(asmPath, type.MetadataToken, out _);
+                }
+                catch (Exception ex)
+                {
+                    firstException = ex;
+                }
+            });
+            firstThread.Start();
+            Assert.True(firstThread.Join(TimeSpan.FromSeconds(10)), "The first lookup against a corrupt PDB must not hang.");
+            Assert.IsType<BadImageFormatException>(firstException);
+
+            Exception secondException = null;
+            var secondCompleted = false;
+            var secondThread = new Thread(() =>
+            {
+                try
+                {
+                    PdbSourceLocator.TryGetTypeSourceLocation(asmPath, type.MetadataToken, out _);
+                }
+                catch (Exception ex)
+                {
+                    // The corrupted sidecar PDB still fails to parse on retry (as expected);
+                    // what matters here is that this thread was able to acquire the lock and
+                    // fail promptly instead of hanging.
+                    secondException = ex;
+                }
+
+                secondCompleted = true;
+            });
+            secondThread.Start();
+            var secondJoined = secondThread.Join(TimeSpan.FromSeconds(10));
+            Assert.True(
+                secondJoined && secondCompleted,
+                "A second lookup on the same path from a different thread must not deadlock: " +
+                "the per-path lock must be released even when the first lookup threw while " +
+                "loading the reader.");
+            Assert.IsType<BadImageFormatException>(secondException);
+        }
+        finally
+        {
+            CleanupTempDir(asmPath);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference<MetadataReaderProvider> CaptureCachedProviderWeakReference(string assemblyFilePath)
+    {
+        var provider = (MetadataReaderProvider)GetCachedProvider(assemblyFilePath);
+        return new WeakReference<MetadataReaderProvider>(provider);
+    }
+
+    /// <summary>
+    /// Checks whether <paramref name="weakReference"/>'s target is still
+    /// alive. This must live in its own non-inlined method rather than
+    /// being called inline from the test body: the JIT's baseline tier
+    /// keeps every local of a method — including the target captured by an
+    /// <c>out</c> parameter, even when discarded — conservatively live for
+    /// the whole method, not just its lexical scope. Isolating the check in
+    /// a separate frame ensures that stale strong reference is released as
+    /// soon as this method returns, instead of accidentally keeping the
+    /// provider rooted for the rest of the test.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool IsAlive(WeakReference<MetadataReaderProvider> weakReference)
+    {
+        return weakReference.TryGetTarget(out _);
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #1658

## Problem
`PdbSourceLocator`'s reader cache stored only the `MetadataReader` returned by `MetadataReaderProvider.GetMetadataReader()`. The provider itself became unreferenced as soon as `LoadReader` returned, despite a class remark claiming providers were "intentionally not disposed... the LSP holds them open" — nothing actually held them.

For the embedded-PDB path (`PEReader.ReadEmbeddedPortablePdbDebugDirectoryData`), the provider owns a native-heap buffer released by a finalizer. Once the provider became unreachable, a GC could collect and finalize it, freeing that buffer while the cached reader still pointed at it. The next Go-to-Definition lookup through the cache could then read freed memory, producing corrupted results or an uncatchable `AccessViolationException` that kills the whole language server process.

## Fix
- `CachedReader` now stores the `MetadataReaderProvider` alongside the `MetadataReader`, so the provider stays rooted for as long as the reader is cached.
- Both provider-creation paths are fixed: sidecar PDBs (`MetadataReaderProvider.FromPortablePdbImage`) and embedded PDBs (`PEReader.ReadEmbeddedPortablePdbDebugDirectoryData`).
- When an mtime change invalidates a cache entry, the previous provider is disposed only after the new entry is installed, under a per-assembly-path lock (`GetOrLoadReaderLease`) that also guards every reader use. This guarantees a provider is never disposed while another thread is still reading through it, without introducing a new race.
- Updated the misleading class remark to describe the actual rooting/disposal contract.
- Audited the rest of `PdbSourceLocator.cs` (and nearby LSP metadata/PE-loading code) for the same class of bug: `TryReadTypeMethodTokens` creates and disposes its `PEReader`/`MetadataReader` entirely within one synchronous call and never caches them, so it isn't affected.

## Tests
Added `test/LanguageServer.Tests/PdbSourceLocatorCacheTests.cs`:
- `CachedReader_SurvivesGarbageCollection`: populates the cache, forces `GC.Collect()` + `GC.WaitForPendingFinalizers()` + `GC.Collect()`, then re-resolves through the cache and asserts the result is still correct (would corrupt/crash before the fix).
- `CacheReplacement_OnMtimeChange_DisposesPreviousProvider`: bumps an assembly's last-write time to force cache replacement, then asserts (via reflection) that the previous provider was actually disposed.

## Validation
- `dotnet build GSharp.sln -c Release -graph` — 0 errors, 0 warnings.
- `dotnet test test/LanguageServer.Tests/LanguageServer.Tests.csproj -c Release` — 378/378 passed (full LanguageServer.Tests slice), including the 8 PDB/cross-assembly-navigation tests targeted by `--filter`.
