### PR TITLE
Fix #1659: Test Explorer now waits for dotnet test and parses TRX results

### DIFF
--- a/src/vscode-gsharp/src/features/processKill.ts
+++ b/src/vscode-gsharp/src/features/processKill.ts
@@ -1,0 +1,69 @@
+// Kills the whole `dotnet test` process tree, not just the immediate `dotnet` process.
+//
+// `child.kill()` alone only terminates the `dotnet` launcher. On Windows, the actual
+// `testhost.exe` (and any attached debuggee) is a separate process that survives,
+// keeps the TRX/results directory open, and leaves the run un-cancelled. On POSIX,
+// `dotnet` typically execs into the same process so a plain kill works, but a plain
+// kill would still miss any child processes `dotnet` forked instead of exec'd into
+// (e.g. when a debugger is attached), so the whole process group is targeted instead.
+import * as cp from 'child_process';
+
+export interface KillCommand {
+  command: string;
+  args: string[];
+}
+
+/** Pure selection logic: which OS-level command kills an entire process tree by pid.
+ * Kept separate from `killProcessTree` so it can be unit-tested without spawning a
+ * real process. */
+export function getKillCommand(
+  pid: number,
+  platform: NodeJS.Platform = process.platform,
+): KillCommand {
+  if (platform === 'win32') {
+    return { command: 'taskkill', args: ['/pid', String(pid), '/T', '/F'] };
+  }
+
+  // POSIX: killing the negative pid targets the whole process group. This requires
+  // the child to have been spawned with `detached: true` (see runTestProcess /
+  // runDebugProcess), which makes it its own process group leader.
+  return { command: 'kill', args: ['-TERM', `-${pid}`] };
+}
+
+/**
+ * Terminates `child` and everything it spawned. On Windows this shells out to
+ * `taskkill /T /F`. On POSIX it sends SIGTERM to the process group, then escalates to
+ * SIGKILL after a short grace period if the group hasn't exited.
+ */
+export function killProcessTree(
+  child: cp.ChildProcess,
+  platform: NodeJS.Platform = process.platform,
+): void {
+  const pid = child.pid;
+  if (!pid) {
+    return;
+  }
+
+  if (platform === 'win32') {
+    const { command, args } = getKillCommand(pid, platform);
+    cp.execFile(command, args, () => {
+      // Best effort: the process may have already exited.
+    });
+    return;
+  }
+
+  try {
+    process.kill(-pid, 'SIGTERM');
+  } catch {
+    // Process group already gone.
+  }
+
+  const killTimer = setTimeout(() => {
+    try {
+      process.kill(-pid, 'SIGKILL');
+    } catch {
+      // Already exited after SIGTERM.
+    }
+  }, 2000);
+  killTimer.unref();
+}

--- a/src/vscode-gsharp/src/features/testing.ts
+++ b/src/vscode-gsharp/src/features/testing.ts
@@ -1,8 +1,11 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
+import * as os from 'os';
+import * as fs from 'fs';
 import * as cp from 'child_process';
 import { LanguageClient } from 'vscode-languageclient/node';
 import { Logger } from '../utils/logger';
+import { classifyOutcome, matchTrxResult, parseTrx, TrxTestResult } from './trx';
 
 interface TestItem {
   id: string;
@@ -401,30 +404,65 @@ async function runProject(
     forEachLeaf(item, (leaf) => leaves.push(leaf));
   }
 
-  const args = ['test', projectFile, '--logger', 'trx'];
+  // A dedicated, unique results directory + fixed file name gives a deterministic
+  // path to the TRX file `dotnet test` writes, regardless of project name or
+  // concurrent runs of other projects/tests.
+  const resultsDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'gsharp-test-'));
+  const trxFileName = 'result.trx';
+  const trxPath = path.join(resultsDirectory, trxFileName);
+
+  const args = [
+    'test',
+    projectFile,
+    '--logger',
+    `trx;LogFileName=${trxFileName}`,
+    '--results-directory',
+    resultsDirectory,
+  ];
   if (filterExpression) {
     args.push('--filter', filterExpression);
   }
 
   const projectUri = vscode.Uri.file(projectFile);
-  if (debug) {
-    await debugTests(projectUri, args, leaves, run, logger, token);
-    return;
+
+  try {
+    const exitCode = debug
+      ? await runDebugProcess(projectUri, args, run, logger, token)
+      : await runTestProcess(projectUri, args, run, token);
+
+    reportTrxResults(leaves, trxPath, exitCode, token, run);
+  } finally {
+    fs.rmSync(resultsDirectory, { recursive: true, force: true });
   }
+}
 
-  const task = new vscode.Task(
-    { type: 'gsharp', task: 'test', project: projectFile },
-    vscode.TaskScope.Workspace,
-    'test',
-    'gsharp',
-    new vscode.ShellExecution('dotnet', args),
-  );
+/**
+ * Runs `dotnet test` as a plain child process and awaits its actual exit (as opposed
+ * to `vscode.tasks.executeTask`, which resolves once the task *starts*). Cancelling
+ * the test run kills the process.
+ */
+async function runTestProcess(
+  projectUri: vscode.Uri,
+  args: string[],
+  run: vscode.TestRun,
+  token: vscode.CancellationToken,
+): Promise<number> {
+  const child = cp.spawn('dotnet', args, { cwd: path.dirname(projectUri.fsPath) });
 
-  await vscode.tasks.executeTask(task);
+  const handleOutput = (data: Buffer) => {
+    run.appendOutput(data.toString().replace(/\r?\n/g, '\r\n'));
+  };
+  child.stdout.on('data', handleOutput);
+  child.stderr.on('data', handleOutput);
 
-  // Mark all as passed (actual result parsing from TRX would be added here).
-  for (const leaf of leaves) {
-    run.passed(leaf);
+  const cancellation = token.onCancellationRequested(() => child.kill());
+  try {
+    return await new Promise<number>((resolve) => {
+      child.on('error', () => resolve(1));
+      child.on('close', (code) => resolve(code ?? 0));
+    });
+  } finally {
+    cancellation.dispose();
   }
 }
 
@@ -432,14 +470,13 @@ async function runProject(
  * Runs `dotnet test` with VSTEST_HOST_DEBUG enabled so the test host pauses and
  * prints its process id, then attaches the CoreCLR debugger to that process.
  */
-async function debugTests(
+async function runDebugProcess(
   projectUri: vscode.Uri,
   args: string[],
-  items: vscode.TestItem[],
   run: vscode.TestRun,
   logger: Logger,
   token: vscode.CancellationToken,
-) {
+): Promise<number> {
   const folder = vscode.workspace.getWorkspaceFolder(projectUri);
   const child = cp.spawn('dotnet', args, {
     cwd: path.dirname(projectUri.fsPath),
@@ -469,23 +506,93 @@ async function debugTests(
     child.kill();
   });
 
-  const exitCode = await new Promise<number>((resolve) => {
-    child.on('error', (err) => {
-      logger.error('Failed to launch dotnet test for debugging', err);
-      resolve(1);
+  try {
+    return await new Promise<number>((resolve) => {
+      child.on('error', (err) => {
+        logger.error('Failed to launch dotnet test for debugging', err);
+        resolve(1);
+      });
+      child.on('close', (code) => resolve(code ?? 0));
     });
-    child.on('close', (code) => resolve(code ?? 0));
-  });
+  } finally {
+    cancellation.dispose();
+  }
+}
 
-  cancellation.dispose();
+/**
+ * Reads and parses the TRX file `dotnet test` produced and reports per-test outcomes.
+ * Never marks a test as passed just because the process exited cleanly: a missing or
+ * unparseable TRX file (e.g. the run crashed before writing it, or was cancelled) is
+ * reported as an error/skip on every requested test instead of a false pass.
+ */
+function reportTrxResults(
+  leaves: vscode.TestItem[],
+  trxPath: string,
+  exitCode: number,
+  token: vscode.CancellationToken,
+  run: vscode.TestRun,
+) {
+  let trxResults: TrxTestResult[] = [];
+  let trxError: string | undefined;
 
-  for (const item of items) {
+  if (!fs.existsSync(trxPath)) {
+    trxError = token.isCancellationRequested
+      ? 'Test run was cancelled before results were produced.'
+      : `No TRX results file was produced (dotnet test exited with code ${exitCode}).`;
+  } else {
+    try {
+      trxResults = parseTrx(fs.readFileSync(trxPath, 'utf8'));
+      if (trxResults.length === 0) {
+        trxError = 'The TRX results file did not contain any test results.';
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      trxError = `Failed to parse TRX results file: ${message}`;
+    }
+  }
+
+  for (const leaf of leaves) {
     if (token.isCancellationRequested) {
-      run.skipped(item);
-    } else if (exitCode === 0) {
-      run.passed(item);
-    } else {
-      run.errored(item, new vscode.TestMessage(`Test host exited with code ${exitCode}.`));
+      run.skipped(leaf);
+      continue;
+    }
+
+    if (trxError) {
+      run.errored(leaf, new vscode.TestMessage(trxError));
+      continue;
+    }
+
+    const key = testFilters.get(leaf.id) ?? leaf.label;
+    const result = matchTrxResult(key, trxResults);
+    if (!result) {
+      run.errored(
+        leaf,
+        new vscode.TestMessage(`No matching result found in TRX output for '${key}'.`),
+      );
+      continue;
+    }
+
+    const outcome = classifyOutcome(result.outcome);
+    switch (outcome) {
+      case 'passed':
+        run.passed(leaf);
+        break;
+      case 'failed': {
+        const text = result.stackTrace
+          ? `${result.message ?? 'Test failed'}\n${result.stackTrace}`
+          : (result.message ?? `Test failed: ${key}`);
+        run.failed(leaf, new vscode.TestMessage(text));
+        break;
+      }
+      case 'skipped':
+        run.skipped(leaf);
+        break;
+      default:
+        run.errored(
+          leaf,
+          new vscode.TestMessage(result.message ?? `Test outcome: ${result.outcome}`),
+        );
+        break;
     }
   }
 }

--- a/src/vscode-gsharp/src/features/testing.ts
+++ b/src/vscode-gsharp/src/features/testing.ts
@@ -5,7 +5,8 @@ import * as fs from 'fs';
 import * as cp from 'child_process';
 import { LanguageClient } from 'vscode-languageclient/node';
 import { Logger } from '../utils/logger';
-import { classifyOutcome, matchTrxResult, parseTrx, TrxTestResult } from './trx';
+import { aggregateTrxResults, matchTrxResults, parseTrx, TrxTestResult } from './trx';
+import { killProcessTree } from './processKill';
 
 interface TestItem {
   id: string;
@@ -296,6 +297,9 @@ async function runTests(
     forEachLeaf(item, (leaf) => run.started(leaf));
   }
 
+  // `run.end()` must happen no matter how this exits (early return, thrown error while
+  // building the run itself, etc.) — otherwise the Test Explorer UI stays "running"
+  // forever because VS Code never learns the run finished.
   try {
     // Group the selection by the owning project so each `dotnet test` invocation runs
     // against the correct `.gsproj`. A multi-project workspace (e.g. several test
@@ -307,7 +311,6 @@ async function runTests(
           run.errored(leaf, new vscode.TestMessage('No .gsproj file found.')),
         );
       }
-      run.end();
       return;
     }
 
@@ -323,9 +326,9 @@ async function runTests(
     for (const item of items) {
       forEachLeaf(item, (leaf) => run.errored(leaf, new vscode.TestMessage(message)));
     }
+  } finally {
+    run.end();
   }
-
-  run.end();
 }
 
 /**
@@ -432,7 +435,27 @@ async function runProject(
 
     reportTrxResults(leaves, trxPath, exitCode, token, run);
   } finally {
-    fs.rmSync(resultsDirectory, { recursive: true, force: true });
+    removeResultsDirectory(resultsDirectory);
+  }
+}
+
+/**
+ * Best-effort cleanup of the temporary results directory. If the test host process
+ * wasn't fully torn down (see `killProcessTree`) the TRX file or directory can still
+ * be locked for a moment after the child process is reported closed; retrying a few
+ * times with a short delay avoids `fs.rmSync` throwing and aborting the run instead of
+ * merely leaving a stray temp directory behind.
+ */
+function removeResultsDirectory(dir: string, retriesLeft = 5): void {
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    const retryable = code === 'EBUSY' || code === 'ENOTEMPTY' || code === 'EPERM';
+    if (retryable && retriesLeft > 0) {
+      setTimeout(() => removeResultsDirectory(dir, retriesLeft - 1), 200).unref();
+    }
+    // Otherwise give up silently: a leftover temp directory is not fatal.
   }
 }
 
@@ -447,7 +470,7 @@ async function runTestProcess(
   run: vscode.TestRun,
   token: vscode.CancellationToken,
 ): Promise<number> {
-  const child = cp.spawn('dotnet', args, { cwd: path.dirname(projectUri.fsPath) });
+  const child = spawnDotnet(args, path.dirname(projectUri.fsPath));
 
   const handleOutput = (data: Buffer) => {
     run.appendOutput(data.toString().replace(/\r?\n/g, '\r\n'));
@@ -455,7 +478,7 @@ async function runTestProcess(
   child.stdout.on('data', handleOutput);
   child.stderr.on('data', handleOutput);
 
-  const cancellation = token.onCancellationRequested(() => child.kill());
+  const cancellation = token.onCancellationRequested(() => killProcessTree(child));
   try {
     return await new Promise<number>((resolve) => {
       child.on('error', () => resolve(1));
@@ -464,6 +487,21 @@ async function runTestProcess(
   } finally {
     cancellation.dispose();
   }
+}
+
+/**
+ * Spawns `dotnet` for a test run. On POSIX the child is detached into its own process
+ * group so `killProcessTree` can terminate every process it spawns (e.g. `testhost`)
+ * via the group, not just the `dotnet` launcher itself. Windows has no equivalent of
+ * process groups here; `killProcessTree` instead uses `taskkill /T` to walk the actual
+ * process tree by pid.
+ */
+function spawnDotnet(args: string[], cwd: string, env?: NodeJS.ProcessEnv): cp.ChildProcessWithoutNullStreams {
+  return cp.spawn('dotnet', args, {
+    cwd,
+    env,
+    detached: process.platform !== 'win32',
+  });
 }
 
 /**
@@ -478,9 +516,9 @@ async function runDebugProcess(
   token: vscode.CancellationToken,
 ): Promise<number> {
   const folder = vscode.workspace.getWorkspaceFolder(projectUri);
-  const child = cp.spawn('dotnet', args, {
-    cwd: path.dirname(projectUri.fsPath),
-    env: { ...process.env, VSTEST_HOST_DEBUG: '1' },
+  const child = spawnDotnet(args, path.dirname(projectUri.fsPath), {
+    ...process.env,
+    VSTEST_HOST_DEBUG: '1',
   });
 
   let attached = false;
@@ -503,7 +541,7 @@ async function runDebugProcess(
   child.stderr.on('data', handleOutput);
 
   const cancellation = token.onCancellationRequested(() => {
-    child.kill();
+    killProcessTree(child);
   });
 
   try {
@@ -563,8 +601,9 @@ function reportTrxResults(
     }
 
     const key = testFilters.get(leaf.id) ?? leaf.label;
-    const result = matchTrxResult(key, trxResults);
-    if (!result) {
+    const matches = matchTrxResults(key, trxResults);
+    const aggregated = aggregateTrxResults(matches);
+    if (!aggregated) {
       run.errored(
         leaf,
         new vscode.TestMessage(`No matching result found in TRX output for '${key}'.`),
@@ -572,25 +611,20 @@ function reportTrxResults(
       continue;
     }
 
-    const outcome = classifyOutcome(result.outcome);
-    switch (outcome) {
+    switch (aggregated.outcome) {
       case 'passed':
         run.passed(leaf);
         break;
-      case 'failed': {
-        const text = result.stackTrace
-          ? `${result.message ?? 'Test failed'}\n${result.stackTrace}`
-          : (result.message ?? `Test failed: ${key}`);
-        run.failed(leaf, new vscode.TestMessage(text));
+      case 'failed':
+        run.failed(leaf, new vscode.TestMessage(aggregated.message ?? `Test failed: ${key}`));
         break;
-      }
       case 'skipped':
         run.skipped(leaf);
         break;
       default:
         run.errored(
           leaf,
-          new vscode.TestMessage(result.message ?? `Test outcome: ${result.outcome}`),
+          new vscode.TestMessage(aggregated.message ?? `Test outcome: ${aggregated.outcome}`),
         );
         break;
     }

--- a/src/vscode-gsharp/src/features/trx.ts
+++ b/src/vscode-gsharp/src/features/trx.ts
@@ -1,0 +1,112 @@
+// Minimal, dependency-free parser for the TRX (`--logger trx`) format produced by
+// `dotnet test`. Only the handful of fields the Test Explorer needs are extracted;
+// the full TRX schema is much larger but not relevant here.
+
+export interface TrxTestResult {
+  testName: string;
+  outcome: string;
+  message?: string;
+  stackTrace?: string;
+}
+
+export type RunOutcome = 'passed' | 'failed' | 'skipped' | 'errored';
+
+/**
+ * Parses the `<UnitTestResult>` entries out of a TRX document's `<Results>` section.
+ * Returns an empty array (never throws) for malformed input, so callers can treat "no
+ * results" and "unparseable file" the same way: don't silently mark anything as passed.
+ */
+export function parseTrx(xml: string): TrxTestResult[] {
+  const results: TrxTestResult[] = [];
+  const resultTagPattern = /<UnitTestResult\b([^>]*?)(?:\/>|>([\s\S]*?)<\/UnitTestResult>)/g;
+
+  let match: RegExpExecArray | null;
+  while ((match = resultTagPattern.exec(xml)) !== null) {
+    const [, attrs, body] = match;
+    const testName = getAttribute(attrs, 'testName');
+    const outcome = getAttribute(attrs, 'outcome');
+    if (!testName || !outcome) {
+      continue;
+    }
+
+    const result: TrxTestResult = { testName, outcome };
+    if (body) {
+      const message = extractTag(body, 'Message');
+      const stackTrace = extractTag(body, 'StackTrace');
+      if (message) {
+        result.message = message;
+      }
+      if (stackTrace) {
+        result.stackTrace = stackTrace;
+      }
+    }
+
+    results.push(result);
+  }
+
+  return results;
+}
+
+function getAttribute(attrs: string, name: string): string | undefined {
+  const match = new RegExp(`${name}="([^"]*)"`).exec(attrs);
+  return match ? decodeXmlEntities(match[1]) : undefined;
+}
+
+function extractTag(xml: string, tag: string): string | undefined {
+  const match = new RegExp(`<${tag}>([\\s\\S]*?)<\\/${tag}>`).exec(xml);
+  return match ? decodeXmlEntities(match[1].trim()) : undefined;
+}
+
+function decodeXmlEntities(value: string): string {
+  return value
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, '&');
+}
+
+/**
+ * Finds the TRX result for a given test key (either a fully-qualified name or the
+ * server-provided filter token). TRX `testName` values aren't guaranteed to match the
+ * key exactly (e.g. the key may be a partial FQN used with `FullyQualifiedName~`), so
+ * an exact match is tried first, then a suffix/substring match in either direction.
+ */
+export function matchTrxResult(
+  key: string,
+  results: readonly TrxTestResult[],
+): TrxTestResult | undefined {
+  const exact = results.find((r) => r.testName === key);
+  if (exact) {
+    return exact;
+  }
+
+  return results.find(
+    (r) =>
+      r.testName.endsWith(`.${key}`) ||
+      key.endsWith(`.${r.testName}`) ||
+      r.testName.includes(key) ||
+      key.includes(r.testName),
+  );
+}
+
+/**
+ * Maps a raw TRX `outcome` attribute to the coarse-grained bucket the Test Explorer
+ * reports through. Unrecognized outcomes (e.g. "Error", "Timeout", "Aborted") are
+ * treated as errors rather than silently passing.
+ */
+export function classifyOutcome(outcome: string): RunOutcome {
+  switch (outcome) {
+    case 'Passed':
+      return 'passed';
+    case 'Failed':
+      return 'failed';
+    case 'NotExecuted':
+    case 'Skipped':
+    case 'Inconclusive':
+    case 'Disconnected':
+      return 'skipped';
+    default:
+      return 'errored';
+  }
+}

--- a/src/vscode-gsharp/src/features/trx.ts
+++ b/src/vscode-gsharp/src/features/trx.ts
@@ -67,27 +67,48 @@ function decodeXmlEntities(value: string): string {
 }
 
 /**
- * Finds the TRX result for a given test key (either a fully-qualified name or the
- * server-provided filter token). TRX `testName` values aren't guaranteed to match the
- * key exactly (e.g. the key may be a partial FQN used with `FullyQualifiedName~`), so
- * an exact match is tried first, then a suffix/substring match in either direction.
+ * Strips the `(arg=value, ...)` parameter list MSTest `[DataRow]`/xUnit `[Theory]`
+ * append to a TRX `testName`, leaving the base (non-parameterized) test name so a
+ * single TestItem leaf can be matched against every data-driven row it produced.
  */
-export function matchTrxResult(
+function baseTestName(testName: string): string {
+  const parenIndex = testName.indexOf('(');
+  return parenIndex === -1 ? testName : testName.slice(0, parenIndex);
+}
+
+/**
+ * Finds every TRX result for a given test key (either a fully-qualified name or the
+ * server-provided filter token). A single TestItem leaf can map to *multiple* TRX rows
+ * when the test is parameterized (`[DataRow]`/`[Theory]`), so this returns all matches
+ * rather than just the first — callers must aggregate them (see `aggregateTrxResults`)
+ * instead of only looking at one row, or a single failing data row can be hidden behind
+ * an earlier passing one.
+ *
+ * TRX `testName` values aren't guaranteed to match the key exactly (e.g. the key may be
+ * a partial FQN used with `FullyQualifiedName~`), so an exact match (ignoring any
+ * parameter list) is tried first, then a qualified suffix match in either direction
+ * (`Namespace.Class.Add` matches key `Add`, and vice versa). Plain substring matching is
+ * intentionally not used: it would let a short name like `Add` spuriously match an
+ * unrelated test like `ReadAddress`.
+ */
+export function matchTrxResults(
   key: string,
   results: readonly TrxTestResult[],
-): TrxTestResult | undefined {
-  const exact = results.find((r) => r.testName === key);
-  if (exact) {
+): TrxTestResult[] {
+  const keyBase = baseTestName(key);
+
+  const exact = results.filter((r) => {
+    const base = baseTestName(r.testName);
+    return r.testName === key || base === key || base === keyBase;
+  });
+  if (exact.length > 0) {
     return exact;
   }
 
-  return results.find(
-    (r) =>
-      r.testName.endsWith(`.${key}`) ||
-      key.endsWith(`.${r.testName}`) ||
-      r.testName.includes(key) ||
-      key.includes(r.testName),
-  );
+  return results.filter((r) => {
+    const base = baseTestName(r.testName);
+    return base.endsWith(`.${keyBase}`) || keyBase.endsWith(`.${base}`);
+  });
 }
 
 /**
@@ -109,4 +130,67 @@ export function classifyOutcome(outcome: string): RunOutcome {
     default:
       return 'errored';
   }
+}
+
+/** The outcome and combined message for a TestItem leaf after aggregating every TRX
+ * row that matched it (see `matchTrxResults`). */
+export interface AggregatedTrxResult {
+  outcome: RunOutcome;
+  message?: string;
+}
+
+const OUTCOME_PRECEDENCE: RunOutcome[] = ['errored', 'failed', 'passed', 'skipped'];
+
+/**
+ * Combines every TRX row matched for a single TestItem leaf into one outcome, using
+ * "any failure wins" precedence: if any row errored the leaf is reported as errored,
+ * else if any row failed the leaf is failed, else if any row passed the leaf is
+ * passed, and only if every row was skipped/not-executed is the leaf skipped. This
+ * is what prevents a parameterized test ([DataRow]/[Theory]) with a mix of passing
+ * and failing data rows from being reported as passed just because the first row
+ * happened to pass. Failure/error messages from every non-passing row are
+ * concatenated so no failing data row is silently dropped from the report.
+ */
+export function aggregateTrxResults(
+  results: readonly TrxTestResult[],
+): AggregatedTrxResult | undefined {
+  if (results.length === 0) {
+    return undefined;
+  }
+
+  const byOutcome = new Map<RunOutcome, TrxTestResult[]>();
+  for (const result of results) {
+    const outcome = classifyOutcome(result.outcome);
+    const bucket = byOutcome.get(outcome);
+    if (bucket) {
+      bucket.push(result);
+    } else {
+      byOutcome.set(outcome, [result]);
+    }
+  }
+
+  for (const outcome of OUTCOME_PRECEDENCE) {
+    const bucket = byOutcome.get(outcome);
+    if (!bucket) {
+      continue;
+    }
+    if (outcome === 'passed' || outcome === 'skipped') {
+      return { outcome };
+    }
+    return { outcome, message: formatFailureMessages(bucket) };
+  }
+
+  // Unreachable: every classifyOutcome() result is one of OUTCOME_PRECEDENCE.
+  return { outcome: 'skipped' };
+}
+
+function formatFailureMessages(rows: readonly TrxTestResult[]): string {
+  return rows
+    .map((row) => {
+      const text = row.stackTrace
+        ? `${row.message ?? 'Test failed'}\n${row.stackTrace}`
+        : (row.message ?? `Test failed: ${row.testName}`);
+      return rows.length > 1 ? `[${row.testName}] ${text}` : text;
+    })
+    .join('\n\n');
 }

--- a/src/vscode-gsharp/src/test/processKill.test.ts
+++ b/src/vscode-gsharp/src/test/processKill.test.ts
@@ -1,0 +1,15 @@
+import { getKillCommand } from '../features/processKill';
+
+describe('getKillCommand', () => {
+  it('uses taskkill /T /F on Windows to walk the whole process tree by pid', () => {
+    expect(getKillCommand(1234, 'win32')).toEqual({
+      command: 'taskkill',
+      args: ['/pid', '1234', '/T', '/F'],
+    });
+  });
+
+  it('targets the negative pid (process group) on POSIX platforms', () => {
+    expect(getKillCommand(4321, 'darwin')).toEqual({ command: 'kill', args: ['-TERM', '-4321'] });
+    expect(getKillCommand(4321, 'linux')).toEqual({ command: 'kill', args: ['-TERM', '-4321'] });
+  });
+});

--- a/src/vscode-gsharp/src/test/trx.test.ts
+++ b/src/vscode-gsharp/src/test/trx.test.ts
@@ -1,0 +1,87 @@
+import { classifyOutcome, matchTrxResult, parseTrx } from '../features/trx';
+
+const sampleTrx = `<?xml version="1.0" encoding="UTF-8"?>
+<TestRun id="abc" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
+  <Results>
+    <UnitTestResult executionId="1" testId="1" testName="MyApp.Tests.MathTests.Add_ReturnsSum" outcome="Passed" />
+    <UnitTestResult executionId="2" testId="2" testName="MyApp.Tests.MathTests.Divide_ByZero_Throws" outcome="Failed">
+      <Output>
+        <ErrorInfo>
+          <Message>Assert.Throws() Failure: expected DivideByZeroException, got none</Message>
+          <StackTrace>   at MyApp.Tests.MathTests.Divide_ByZero_Throws() in /src/MathTests.cs:line 42</StackTrace>
+        </ErrorInfo>
+      </Output>
+    </UnitTestResult>
+    <UnitTestResult executionId="3" testId="3" testName="MyApp.Tests.MathTests.Skip_NotRun" outcome="NotExecuted" />
+  </Results>
+</TestRun>`;
+
+describe('parseTrx', () => {
+  it('extracts test name, outcome, message and stack trace for every result', () => {
+    const results = parseTrx(sampleTrx);
+    expect(results).toHaveLength(3);
+
+    expect(results[0]).toEqual({
+      testName: 'MyApp.Tests.MathTests.Add_ReturnsSum',
+      outcome: 'Passed',
+    });
+
+    expect(results[1].testName).toBe('MyApp.Tests.MathTests.Divide_ByZero_Throws');
+    expect(results[1].outcome).toBe('Failed');
+    expect(results[1].message).toContain('Assert.Throws() Failure');
+    expect(results[1].stackTrace).toContain('MathTests.cs:line 42');
+
+    expect(results[2]).toEqual({
+      testName: 'MyApp.Tests.MathTests.Skip_NotRun',
+      outcome: 'NotExecuted',
+    });
+  });
+
+  it('returns an empty array for malformed or non-TRX input', () => {
+    expect(parseTrx('not xml at all')).toEqual([]);
+    expect(parseTrx('')).toEqual([]);
+  });
+
+  it('decodes XML entities in attributes and text content', () => {
+    const xml = `<Results><UnitTestResult testName="A&amp;B.Test" outcome="Failed"><Output><ErrorInfo><Message>expected &lt;1&gt; but got &quot;2&quot;</Message></ErrorInfo></Output></UnitTestResult></Results>`;
+    const [result] = parseTrx(xml);
+    expect(result.testName).toBe('A&B.Test');
+    expect(result.message).toBe('expected <1> but got "2"');
+  });
+});
+
+describe('classifyOutcome', () => {
+  it('maps known TRX outcomes to run buckets', () => {
+    expect(classifyOutcome('Passed')).toBe('passed');
+    expect(classifyOutcome('Failed')).toBe('failed');
+    expect(classifyOutcome('NotExecuted')).toBe('skipped');
+    expect(classifyOutcome('Skipped')).toBe('skipped');
+    expect(classifyOutcome('Inconclusive')).toBe('skipped');
+  });
+
+  it('treats unrecognized outcomes as errors rather than passes', () => {
+    expect(classifyOutcome('Error')).toBe('errored');
+    expect(classifyOutcome('Timeout')).toBe('errored');
+    expect(classifyOutcome('Aborted')).toBe('errored');
+    expect(classifyOutcome('SomeFutureOutcome')).toBe('errored');
+  });
+});
+
+describe('matchTrxResult', () => {
+  const results = parseTrx(sampleTrx);
+
+  it('matches on an exact fully-qualified test name', () => {
+    const match = matchTrxResult('MyApp.Tests.MathTests.Add_ReturnsSum', results);
+    expect(match?.outcome).toBe('Passed');
+  });
+
+  it('matches a partial filter token against the fully-qualified TRX name', () => {
+    const match = matchTrxResult('Divide_ByZero_Throws', results);
+    expect(match?.outcome).toBe('Failed');
+  });
+
+  it('returns undefined when a requested test has no corresponding TRX entry', () => {
+    const match = matchTrxResult('MyApp.Tests.MathTests.Never_Ran', results);
+    expect(match).toBeUndefined();
+  });
+});

--- a/src/vscode-gsharp/src/test/trx.test.ts
+++ b/src/vscode-gsharp/src/test/trx.test.ts
@@ -1,4 +1,10 @@
-import { classifyOutcome, matchTrxResult, parseTrx } from '../features/trx';
+import {
+  aggregateTrxResults,
+  classifyOutcome,
+  matchTrxResults,
+  parseTrx,
+  TrxTestResult,
+} from '../features/trx';
 
 const sampleTrx = `<?xml version="1.0" encoding="UTF-8"?>
 <TestRun id="abc" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
@@ -71,17 +77,91 @@ describe('matchTrxResult', () => {
   const results = parseTrx(sampleTrx);
 
   it('matches on an exact fully-qualified test name', () => {
-    const match = matchTrxResult('MyApp.Tests.MathTests.Add_ReturnsSum', results);
+    const [match] = matchTrxResults('MyApp.Tests.MathTests.Add_ReturnsSum', results);
     expect(match?.outcome).toBe('Passed');
   });
 
   it('matches a partial filter token against the fully-qualified TRX name', () => {
-    const match = matchTrxResult('Divide_ByZero_Throws', results);
+    const [match] = matchTrxResults('Divide_ByZero_Throws', results);
     expect(match?.outcome).toBe('Failed');
   });
 
-  it('returns undefined when a requested test has no corresponding TRX entry', () => {
-    const match = matchTrxResult('MyApp.Tests.MathTests.Never_Ran', results);
-    expect(match).toBeUndefined();
+  it('returns no matches when a requested test has no corresponding TRX entry', () => {
+    expect(matchTrxResults('MyApp.Tests.MathTests.Never_Ran', results)).toEqual([]);
+  });
+
+  it('does not match a short name as a substring of an unrelated qualified name', () => {
+    const xml = `<Results>
+      <UnitTestResult testName="MyApp.Tests.AddressTests.ReadAddress" outcome="Passed" />
+    </Results>`;
+    const rows = parseTrx(xml);
+    expect(matchTrxResults('Add', rows)).toEqual([]);
+  });
+
+  it('matches a qualified suffix even when the leaf key is short', () => {
+    const xml = `<Results>
+      <UnitTestResult testName="MyApp.Tests.MathTests.Add" outcome="Passed" />
+    </Results>`;
+    const rows = parseTrx(xml);
+    const matches = matchTrxResults('Add', rows);
+    expect(matches).toHaveLength(1);
+    expect(matches[0].testName).toBe('MyApp.Tests.MathTests.Add');
+  });
+
+  it('matches every parameterized data row against its base (non-parameterized) name', () => {
+    const xml = `<Results>
+      <UnitTestResult testName="MyApp.Tests.MathTests.Add(a: 1,b: 2)" outcome="Passed" />
+      <UnitTestResult testName="MyApp.Tests.MathTests.Add(a: 2,b: 2)" outcome="Failed" />
+      <UnitTestResult testName="MyApp.Tests.MathTests.Add(a: 3,b: 2)" outcome="Passed" />
+    </Results>`;
+    const rows = parseTrx(xml);
+
+    const matches = matchTrxResults('MyApp.Tests.MathTests.Add', rows);
+    expect(matches).toHaveLength(3);
+
+    // A short, non-qualified key should also reach every parameterized row via the
+    // qualified-suffix match on the base name.
+    expect(matchTrxResults('Add', rows)).toHaveLength(3);
+  });
+});
+
+describe('aggregateTrxResults', () => {
+  function row(outcome: string, message?: string): TrxTestResult {
+    return { testName: 'MyApp.Tests.MathTests.Add', outcome, message };
+  }
+
+  it('returns undefined when there are no matching rows', () => {
+    expect(aggregateTrxResults([])).toBeUndefined();
+  });
+
+  it('reports passed when every data row passed', () => {
+    expect(aggregateTrxResults([row('Passed'), row('Passed')])).toEqual({ outcome: 'passed' });
+  });
+
+  it('reports failed if any data row failed, even when an earlier row passed', () => {
+    // Regression test for the "any-fail-wins" bug: naive first-match logic (e.g.
+    // Array.prototype.find) would return the first (Passed) row here and hide the
+    // real failure in the second row.
+    const aggregated = aggregateTrxResults([row('Passed'), row('Failed', 'boom')]);
+    expect(aggregated?.outcome).toBe('failed');
+    expect(aggregated?.message).toContain('boom');
+  });
+
+  it('reports passed when a row passed and another was merely not executed', () => {
+    expect(aggregateTrxResults([row('Passed'), row('NotExecuted')])).toEqual({
+      outcome: 'passed',
+    });
+  });
+
+  it('reports errored when any row errored, even alongside a failed row', () => {
+    const aggregated = aggregateTrxResults([row('Failed', 'assertion failed'), row('Error', 'boom')]);
+    expect(aggregated?.outcome).toBe('errored');
+    expect(aggregated?.message).toContain('boom');
+  });
+
+  it('reports skipped only when every row was skipped/not executed', () => {
+    expect(aggregateTrxResults([row('NotExecuted'), row('Skipped')])).toEqual({
+      outcome: 'skipped',
+    });
   });
 });


### PR DESCRIPTION
Fixes #1659

## Problem
Both the Run and Debug test profiles marked every selected test as passed unconditionally:
- The **Run** profile used `vscode.tasks.executeTask`, which resolves once the task *starts*, not when `dotnet test` finishes.
- The **Debug** profile did wait for process exit, but only mapped the process exit code to pass/error for *every* test — it never read the requested `--logger trx` output either.

Result: failing tests showed green instantly, `--logger trx` output was ignored, and cancelling a run didn't stop the underlying process for the Run profile.

## Fix
- Added a dependency-free TRX parser/matcher (`src/features/trx.ts`) that extracts `UnitTestResult` entries (test name, outcome, failure message, stack trace) and matches a test key (filter token or label) against them.
- Both profiles now run `dotnet test` as a child process with `--results-directory <unique temp dir> --logger trx;LogFileName=result.trx`, giving a deterministic TRX path per run.
- Both profiles await the actual process exit before reporting anything.
- Real per-test outcomes are reported via `run.passed` / `run.failed` (with failure message + stack trace) / `run.skipped` / `run.errored`. Tests requested but missing from the TRX file are errored, never silently passed. A missing/unparseable TRX file errors out every test instead of false-passing.
- The run's `CancellationToken` now kills the child process for both profiles (previously only the Debug profile did), and the temp results directory is cleaned up afterward.
- Removed the unused `vscode.Task`/`ShellExecution` path in favor of the same `child_process` approach already used by the Debug profile, since it already had all the pieces needed (process lifetime, output capture, cancellation).

## Tests
Added `src/test/trx.test.ts` (Jest, matches existing unit test style) covering:
- Parsing passed/failed/skipped TRX results, including failure message + stack trace extraction.
- XML entity decoding.
- Empty/malformed input handling (no false results).
- Outcome classification, including unrecognized outcomes mapping to "errored" (not "passed").
- Test matching, including the case where a requested test has no TRX entry.

## Validation
- `npm ci`
- `npm run compile` — clean
- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors
- `npm run test:unit` — 45/45 passing