### PR TITLE
Fix #1650: guard locals frame push/pop against exception unwind

### DIFF
--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -72,6 +72,21 @@ public sealed class Evaluator
         return EvaluateFunctionBody(program.Statement);
     }
 
+    /// <summary>
+    /// Issue #1650: pushes a locals frame for a user-function call (plain
+    /// call, closure/indirect call, instance/base call, property or event
+    /// accessor, constrained static call, constructor body, etc.) and
+    /// returns a guard that pops it on <see cref="IDisposable.Dispose"/>.
+    /// Use with a <c>using</c> statement/declaration so the frame is always
+    /// popped — including when the callee throws and a caller-level
+    /// try/catch handles the exception. Without this guard, an unwound
+    /// exception used to leave the callee's dead frame on the stack,
+    /// corrupting every subsequent local-variable read/write in the caller.
+    /// </summary>
+    /// <param name="frame">The frame to push (parameters, 'this', captured locals).</param>
+    /// <returns>A disposable guard that pops <paramref name="frame"/> exactly once.</returns>
+    private FrameScope PushFrame(Dictionary<VariableSymbol, object> frame) => new(locals, frame);
+
     private object EvaluateStatement(BoundBlockStatement body)
     {
         var labelToIndex = new Dictionary<BoundLabel, int>();
@@ -1221,9 +1236,10 @@ public sealed class Evaluator
                         [init.Property.SetterSymbol.ThisParameter] = sv,
                         [init.Property.SetterSymbol.Parameters[0]] = value,
                     };
-                    locals.Push(frame);
-                    EvaluateFunctionBody(setterBody);
-                    locals.Pop();
+                    using (PushFrame(frame))
+                    {
+                        EvaluateFunctionBody(setterBody);
+                    }
                 }
 
                 continue;
@@ -1340,10 +1356,10 @@ public sealed class Evaluator
             frame[closure.Function.Parameters[i]] = EvaluateExpression(node.Arguments[i]);
         }
 
-        this.locals.Push(frame);
-        var result = EvaluateFunctionBody(closure.Body);
-        this.locals.Pop();
-        return result;
+        using (PushFrame(frame))
+        {
+            return EvaluateFunctionBody(closure.Body);
+        }
     }
 
     private object LookupVariable(VariableSymbol v)
@@ -1414,18 +1430,13 @@ public sealed class Evaluator
                         frame[primaryParams[i]] = sv.Fields[primaryParams[i].Name];
                     }
 
-                    locals.Push(frame);
-                    try
+                    using (PushFrame(frame))
                     {
                         var baseParams = gsBase.PrimaryConstructorParameters;
                         for (var i = 0; i < baseParams.Length && i < baseInitOnStruct.Arguments.Length; i++)
                         {
                             sv.Fields[baseParams[i].Name] = EvaluateExpression(baseInitOnStruct.Arguments[i]);
                         }
-                    }
-                    finally
-                    {
-                        locals.Pop();
                     }
                 }
 
@@ -1444,8 +1455,7 @@ public sealed class Evaluator
                 frame2[ctorFunction.Parameters[i]] = EvaluateExpression(node.Arguments[i]);
             }
 
-            locals.Push(frame2);
-            try
+            using (PushFrame(frame2))
             {
                 // Forward the GSharp base initializer. CLR base initializers are
                 // routed through reflection by AllocateClrBacking (issue #319) so
@@ -1464,10 +1474,6 @@ public sealed class Evaluator
 
                 var body = program.Functions[ctorFunction];
                 EvaluateFunctionBody(body);
-            }
-            finally
-            {
-                locals.Pop();
             }
 
             return sv;
@@ -1493,8 +1499,7 @@ public sealed class Evaluator
                 frame[parameters[i]] = sv.Fields[parameters[i].Name];
             }
 
-            locals.Push(frame);
-            try
+            using (PushFrame(frame))
             {
                 if (baseInit != null && baseInit.GSharpBaseType is StructSymbol gsharpBase)
                 {
@@ -1509,10 +1514,6 @@ public sealed class Evaluator
                 // ultimately derives from a CLR type) so inherited CLR instance
                 // state — such as Exception.Message — is set per the emit path.
                 AllocateClrBacking(sv, node.StructType, baseInit);
-            }
-            finally
-            {
-                locals.Pop();
             }
         }
 
@@ -1871,9 +1872,10 @@ public sealed class Evaluator
                     frame[methodSymbol.Parameters[0]] = handlerValue;
                 }
 
-                locals.Push(frame);
-                EvaluateFunctionBody(body);
-                locals.Pop();
+                using (PushFrame(frame))
+                {
+                    EvaluateFunctionBody(body);
+                }
             }
 
             return null;
@@ -2055,10 +2057,10 @@ public sealed class Evaluator
             {
                 // Issue #263: computed static property getter — no 'this' parameter.
                 var frame = new Dictionary<Symbols.VariableSymbol, object>();
-                locals.Push(frame);
-                var result = EvaluateFunctionBody(staticGetterBody);
-                locals.Pop();
-                return result;
+                using (PushFrame(frame))
+                {
+                    return EvaluateFunctionBody(staticGetterBody);
+                }
             }
 
             return DefaultValue(node.Property.Type);
@@ -2113,10 +2115,10 @@ public sealed class Evaluator
             {
                 [property.GetterSymbol.ThisParameter] = receiverValue,
             };
-            locals.Push(frame);
-            var result = EvaluateFunctionBody(getterBody);
-            locals.Pop();
-            return result;
+            using (PushFrame(frame))
+            {
+                return EvaluateFunctionBody(getterBody);
+            }
         }
 
         return DefaultValue(property.Type);
@@ -2139,9 +2141,10 @@ public sealed class Evaluator
                 {
                     [node.Property.SetterSymbol.Parameters[0]] = value,
                 };
-                locals.Push(frame);
-                EvaluateFunctionBody(staticSetterBody);
-                locals.Pop();
+                using (PushFrame(frame))
+                {
+                    EvaluateFunctionBody(staticSetterBody);
+                }
             }
 
             return value;
@@ -2187,9 +2190,11 @@ public sealed class Evaluator
                 [node.Property.SetterSymbol.ThisParameter] = receiverValue,
                 [node.Property.SetterSymbol.Parameters[0]] = value,
             };
-            locals.Push(frame);
-            EvaluateFunctionBody(setterBody);
-            locals.Pop();
+            using (PushFrame(frame))
+            {
+                EvaluateFunctionBody(setterBody);
+            }
+
             return value;
         }
 
@@ -2743,52 +2748,49 @@ public sealed class Evaluator
                 }
             }
 
-            this.locals.Push(locals);
-
-            var statement = program.Functions[node.Function];
-
-            if (IsIteratorFunction(node.Function, statement))
+            using (PushFrame(locals))
             {
-                var iteratorResult = EvaluateIteratorFunction(node.Function, statement);
-                this.locals.Pop();
-                return iteratorResult;
-            }
+                var statement = program.Functions[node.Function];
 
-            var result = EvaluateFunctionBody(statement);
-
-            // ADR-0060 item #7: write the final parameter slot value back to
-            // the caller's lvalue for every 'ref'/'out' parameter.
-            if (userRefSlots != null)
-            {
-                foreach (var (parameter, operand) in userRefSlots)
+                if (IsIteratorFunction(node.Function, statement))
                 {
-                    var finalValue = locals.TryGetValue(parameter, out var v) ? v : null;
-                    switch (operand)
+                    return EvaluateIteratorFunction(node.Function, statement);
+                }
+
+                var result = EvaluateFunctionBody(statement);
+
+                // ADR-0060 item #7: write the final parameter slot value back to
+                // the caller's lvalue for every 'ref'/'out' parameter.
+                if (userRefSlots != null)
+                {
+                    foreach (var (parameter, operand) in userRefSlots)
                     {
-                        case BoundVariableExpression bve:
-                            Assign(bve.Variable, finalValue);
-                            break;
-                        case BoundFieldAccessExpression fa:
-                            WriteBackField(fa, finalValue);
-                            break;
-                        case BoundPropertyAccessExpression pa:
-                            WriteBackProperty(pa, finalValue);
-                            break;
-                        case BoundIndexExpression idx:
-                            WriteBackIndex(idx, finalValue);
-                            break;
+                        var finalValue = locals.TryGetValue(parameter, out var v) ? v : null;
+                        switch (operand)
+                        {
+                            case BoundVariableExpression bve:
+                                Assign(bve.Variable, finalValue);
+                                break;
+                            case BoundFieldAccessExpression fa:
+                                WriteBackField(fa, finalValue);
+                                break;
+                            case BoundPropertyAccessExpression pa:
+                                WriteBackProperty(pa, finalValue);
+                                break;
+                            case BoundIndexExpression idx:
+                                WriteBackIndex(idx, finalValue);
+                                break;
+                        }
                     }
                 }
+
+                if (node.Function.IsAsync)
+                {
+                    return WrapAsyncResult(node.Function.Type, result);
+                }
+
+                return result;
             }
-
-            this.locals.Pop();
-
-            if (node.Function.IsAsync)
-            {
-                return WrapAsyncResult(node.Function.Type, result);
-            }
-
-            return result;
         }
     }
 
@@ -3591,12 +3593,11 @@ public sealed class Evaluator
             frame.Add(parameter, value);
         }
 
-        locals.Push(frame);
-        var statement = program.Functions[method];
-        var result = EvaluateFunctionBody(statement);
-        locals.Pop();
-
-        return result;
+        using (PushFrame(frame))
+        {
+            var statement = program.Functions[method];
+            return EvaluateFunctionBody(statement);
+        }
     }
 
     /// <summary>
@@ -3628,12 +3629,11 @@ public sealed class Evaluator
             frame.Add(parameter, value);
         }
 
-        locals.Push(frame);
-        var statement = program.Functions[method];
-        var result = EvaluateFunctionBody(statement);
-        locals.Pop();
-
-        return result;
+        using (PushFrame(frame))
+        {
+            var statement = program.Functions[method];
+            return EvaluateFunctionBody(statement);
+        }
     }
 
     /// <summary>
@@ -3692,12 +3692,11 @@ public sealed class Evaluator
             frame.Add(parameter, value);
         }
 
-        locals.Push(frame);
-        var statement = program.Functions[method];
-        var result = EvaluateFunctionBody(statement);
-        locals.Pop();
-
-        return result;
+        using (PushFrame(frame))
+        {
+            var statement = program.Functions[method];
+            return EvaluateFunctionBody(statement);
+        }
     }
 
     /// <summary>
@@ -3828,10 +3827,10 @@ public sealed class Evaluator
             frame2[target.Parameters[i]] = evaluatedArgs[i];
         }
 
-        locals.Push(frame2);
-        var result = EvaluateFunctionBody(statement);
-        locals.Pop();
-        return result;
+        using (PushFrame(frame2))
+        {
+            return EvaluateFunctionBody(statement);
+        }
     }
 
     private object EvaluateConversionExpression(BoundConversionExpression node)
@@ -4575,8 +4574,7 @@ public sealed class Evaluator
             chainFrame[targetCtor.Function.Parameters[i]] = argValues[i];
         }
 
-        locals.Push(chainFrame);
-        try
+        using (PushFrame(chainFrame))
         {
             if (targetCtor.BaseInitializer is BaseConstructorInitializer chainBaseInit
                 && chainBaseInit.GSharpBaseType is StructSymbol chainGsBase)
@@ -4591,12 +4589,35 @@ public sealed class Evaluator
             var body = program.Functions[targetCtor.Function];
             EvaluateFunctionBody(body);
         }
-        finally
-        {
-            locals.Pop();
-        }
 
         return null;
+    }
+
+    /// <summary>
+    /// Disposable guard returned by <see cref="PushFrame(Dictionary{VariableSymbol, object})"/>
+    /// that pops the associated locals frame when disposed, guaranteeing the
+    /// pop runs on both normal and exceptional (unwind) control flow.
+    /// </summary>
+    private readonly struct FrameScope : IDisposable
+    {
+        private readonly Stack<Dictionary<VariableSymbol, object>> stack;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FrameScope"/> struct,
+        /// pushing <paramref name="frame"/> onto <paramref name="stack"/>.
+        /// </summary>
+        /// <param name="stack">The locals stack to push onto and later pop from.</param>
+        /// <param name="frame">The frame to push.</param>
+        public FrameScope(Stack<Dictionary<VariableSymbol, object>> stack, Dictionary<VariableSymbol, object> frame)
+        {
+            this.stack = stack;
+            this.stack.Push(frame);
+        }
+
+        /// <summary>
+        /// Pops the frame pushed by the constructor.
+        /// </summary>
+        public void Dispose() => stack.Pop();
     }
 
     private sealed class YieldFinder : Binding.BoundTreeRewriter

--- a/test/Interpreter.Tests/Issue1650LocalsFrameLeakInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue1650LocalsFrameLeakInterpreterTests.cs
@@ -1,0 +1,221 @@
+// <copyright file="Issue1650LocalsFrameLeakInterpreterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #1650 — the tree-walking evaluator used to leave a callee's locals
+/// frame on <c>Evaluator.locals</c> when the callee threw and a caller-level
+/// try/catch handled the exception (every call path pushed the frame without
+/// a try/finally guard). The dangling frame then shadowed the caller's real
+/// frame for every subsequent local-variable read/write, corrupting
+/// evaluator state for the rest of the run. These tests exercise every call
+/// path that pushes a locals frame — plain call, property getter/setter,
+/// instance call, closure/indirect call, and nested calls — to confirm the
+/// frame is always popped, even on exception unwind.
+/// </summary>
+public class Issue1650LocalsFrameLeakInterpreterTests
+{
+    [Fact]
+    public void PlainCall_CaughtException_CallerLocalStillResolves()
+    {
+        // Exact repro from issue #1650.
+        var source = """
+            func boom() {
+                throw Exception("boom")
+            }
+            func run() string {
+                let name = "orig"
+                try {
+                    boom()
+                } catch (e Exception) {
+                }
+                return name
+            }
+            Console.WriteLine(run())
+            """;
+        var output = RunSubmission(source);
+        Assert.DoesNotContain("error GS", output);
+        Assert.Contains("orig", output);
+    }
+
+    [Fact]
+    public void NoThrow_PlainCall_StillWorks()
+    {
+        // Normal (no-exception) path must behave identically to before.
+        var source = """
+            func helper(x int32) int32 {
+                return x + 1
+            }
+            func run() int32 {
+                let a = 10
+                let b = helper(a)
+                return a + b
+            }
+            Console.WriteLine(run())
+            """;
+        var output = RunSubmission(source);
+        Assert.DoesNotContain("error GS", output);
+        Assert.Contains("21", output);
+    }
+
+    [Fact]
+    public void PropertyGetter_CaughtException_CallerLocalStillResolves()
+    {
+        var source = """
+            class Boom {
+                prop Value int32 {
+                    get {
+                        throw Exception("getter-boom")
+                    }
+                }
+            }
+            func run() string {
+                let name = "orig"
+                let b = Boom{}
+                try {
+                    var x = b.Value
+                } catch (e Exception) {
+                }
+                return name
+            }
+            Console.WriteLine(run())
+            """;
+        var output = RunSubmission(source);
+        Assert.DoesNotContain("error GS", output);
+        Assert.Contains("orig", output);
+    }
+
+    [Fact]
+    public void PropertySetter_CaughtException_CallerLocalStillResolves()
+    {
+        var source = """
+            class Boom {
+                prop raw int32
+                prop Value int32 {
+                    get {
+                        return this.raw
+                    }
+                    set(v) {
+                        throw Exception("setter-boom")
+                    }
+                }
+            }
+            func run() string {
+                let name = "orig"
+                let b = Boom{}
+                try {
+                    b.Value = 5
+                } catch (e Exception) {
+                }
+                return name
+            }
+            Console.WriteLine(run())
+            """;
+        var output = RunSubmission(source);
+        Assert.DoesNotContain("error GS", output);
+        Assert.Contains("orig", output);
+    }
+
+    [Fact]
+    public void InstanceCall_CaughtException_CallerLocalStillResolves()
+    {
+        var source = """
+            class Boom {
+                func Detonate() {
+                    throw Exception("instance-boom")
+                }
+            }
+            func run() string {
+                let name = "orig"
+                let b = Boom{}
+                try {
+                    b.Detonate()
+                } catch (e Exception) {
+                }
+                return name
+            }
+            Console.WriteLine(run())
+            """;
+        var output = RunSubmission(source);
+        Assert.DoesNotContain("error GS", output);
+        Assert.Contains("orig", output);
+    }
+
+    [Fact]
+    public void ClosureCall_CaughtException_CallerLocalStillResolves()
+    {
+        var source = """
+            func run() string {
+                let name = "orig"
+                let boom = func() {
+                    throw Exception("closure-boom")
+                }
+                try {
+                    boom()
+                } catch (e Exception) {
+                }
+                return name
+            }
+            Console.WriteLine(run())
+            """;
+        var output = RunSubmission(source);
+        Assert.DoesNotContain("error GS", output);
+        Assert.Contains("orig", output);
+    }
+
+    [Fact]
+    public void NestedCalls_ThrowCaughtTwoFramesUp_StackDepthRestored()
+    {
+        // The inner-most call throws; the exception is caught two call
+        // frames up. Once caught, both the inner and middle frames must be
+        // gone — a leaked frame at either depth would shadow the caller's
+        // "name" local with a dead frame's dictionary, and any read through
+        // it would either return a stale/wrong value or throw the
+        // 'key was not present' error the bug report describes.
+        var source = """
+            func innermost() {
+                throw Exception("nested-boom")
+            }
+            func middle() {
+                innermost()
+            }
+            func run() string {
+                let name = "orig"
+                try {
+                    middle()
+                } catch (e Exception) {
+                }
+                let after = "after"
+                return name + "-" + after
+            }
+            Console.WriteLine(run())
+            """;
+        var output = RunSubmission(source);
+        Assert.DoesNotContain("error GS", output);
+        Assert.Contains("orig-after", output);
+    }
+
+    private static string RunSubmission(string text)
+    {
+        using var outWriter = new StringWriter();
+        var prevOut = Console.Out;
+        Console.SetOut(outWriter);
+        try
+        {
+            var repl = new GSharpRepl();
+            repl.EvaluateSubmission(text);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+        }
+
+        return outWriter.ToString();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1650.

Every user-function call path in `Evaluator` pushed a locals frame with `locals.Push(...)` and popped it with `locals.Pop()` after evaluating the callee body, but **without a try/finally**. When the callee threw and a caller-level `try`/`catch` handled the exception, the callee's frame was left on the locals stack, silently shadowing the caller's real frame for every subsequent local-variable read/write — corrupting evaluator state for the rest of the run (repro from the issue: a caught exception followed by reading a local produces `GS9999: The given key '...' was not present in the dictionary`, or silently stale values).

## Fix

Introduced `Evaluator.PushFrame(frame)`, which returns a `FrameScope` `IDisposable` guard that pops the frame in `Dispose()`. Every call site that pushes a locals frame now does `using (PushFrame(frame)) { ... }`, guaranteeing the pop always runs — including on exception unwind — with no chance for a future call path to forget it.

Converted call paths (every `locals.Push`/`locals.Pop` site in `Evaluator.cs`):
- Plain user-function call (`EvaluateCallExpression`)
- Closure / indirect call (`EvaluateIndirectCallExpression`)
- Instance call (`EvaluateUserInstanceCallExpression`)
- Base-interface call (`EvaluateBaseInterfaceCallExpression`)
- Base-class call (`EvaluateBaseClassCallExpression`)
- Constrained static-virtual interface call
- Static and instance computed-property getters
- Static and instance computed-property setters
- Event add/remove accessor bodies
- Composite-literal computed-property setter
- Constructor bodies (explicit ctor, synthesized-primary-ctor base-init, primary-ctor base-init) — previously already guarded with a manual `try`/`finally`; converted to the same guard for consistency
- Convenience-initializer (`init(...)` chaining) — same as above

I also checked the other push/pop interpreter state stacks (`scopeFrames` for `scope`/`go`, `iteratorSinks` for iterator functions) — both already use `try`/`finally` correctly, so no change was needed there.

## Tests

Added `test/Interpreter.Tests/Issue1650LocalsFrameLeakInterpreterTests.cs`:
- Exact repro from the issue (caught exception, then a local read returns `"orig"` instead of crashing)
- Normal (no-throw) path unchanged
- Property getter throw, caught, caller local still resolves
- Property setter throw, caught, caller local still resolves
- Instance-method call throw, caught, caller local still resolves
- Closure/indirect call throw, caught, caller local still resolves
- Nested calls (inner throw caught two frames up) — verifies stack depth is fully restored, not just the immediate frame

## Validation

- `dotnet build GSharp.sln -c Release`: 0 errors, 0 warnings (StyleCop clean)
- `dotnet test test/Interpreter.Tests/Interpreter.Tests.csproj -c Release`: 346/346 passed (full suite, no regressions)
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release --filter FullyQualifiedName~Evaluator`: 3/3 passed