### PR TITLE
Fix #1666: CoreCompile ignores property-only changes (stale assembly / version stamp)

### DIFF
--- a/src/Sdk/Gsharp.NET.Sdk.Bootstrap/build/Gsharp.NET.Sdk.Bootstrap.targets
+++ b/src/Sdk/Gsharp.NET.Sdk.Bootstrap/build/Gsharp.NET.Sdk.Bootstrap.targets
@@ -72,6 +72,8 @@
       <_GsharpCoreCompileInputsToHash Include="$(Optimize)" />
       <_GsharpCoreCompileInputsToHash Include="$(SourceLink)" />
       <_GsharpCoreCompileInputsToHash Include="$(EmbedAllSources)" />
+      <_GsharpCoreCompileInputsToHash Include="$(ProduceReferenceAssembly)" />
+      <_GsharpCoreCompileInputsToHash Include="$(GenerateDocumentationFile)" />
     </ItemGroup>
 
     <Hash ItemsToHash="@(_GsharpCoreCompileInputsToHash)">

--- a/src/Sdk/Gsharp.NET.Sdk.Bootstrap/build/Gsharp.NET.Sdk.Bootstrap.targets
+++ b/src/Sdk/Gsharp.NET.Sdk.Bootstrap/build/Gsharp.NET.Sdk.Bootstrap.targets
@@ -48,9 +48,56 @@
     <_ExplicitReference Include="$(FrameworkPathOverride)\mscorlib.dll" Condition=" '$(FrameworkPathOverride)' != '' " />
   </ItemGroup>
 
+  <!-- Issue #1666: same property-only-change hazard as
+       src/Sdk/Gsharp.NET.Sdk/build/Gsharp.NET.Core.Sdk.targets — mirror the
+       .NET SDK's CoreCompileInputs.cache idiom here too. Additionally list
+       $(GsharpCompilerFullPath) (gsc.dll) directly as a CoreCompile input:
+       rebuilding the in-tree compiler must retrigger Gsharp.Extensions so a
+       compiler bugfix is actually picked up rather than reusing the stale
+       assembly compiled with the old gsc. -->
+  <Target Name="_GsharpCreateCoreCompileInputsCache"
+          BeforeTargets="CoreCompile">
+    <PropertyGroup>
+      <_GsharpCoreCompileInputsCacheFile>$(IntermediateOutputPath)$(TargetName).CoreCompileInputs.cache</_GsharpCoreCompileInputsCacheFile>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_GsharpCoreCompileInputsToHash Include="$(Version)" />
+      <_GsharpCoreCompileInputsToHash Include="$(DebugType)" />
+      <_GsharpCoreCompileInputsToHash Include="$(Deterministic)" />
+      <_GsharpCoreCompileInputsToHash Include="$(NoWarn)" />
+      <_GsharpCoreCompileInputsToHash Include="$(TreatWarningsAsErrors)" />
+      <_GsharpCoreCompileInputsToHash Include="$(WarningsAsErrors)" />
+      <_GsharpCoreCompileInputsToHash Include="$(OutputType)" />
+      <_GsharpCoreCompileInputsToHash Include="$(Optimize)" />
+      <_GsharpCoreCompileInputsToHash Include="$(SourceLink)" />
+      <_GsharpCoreCompileInputsToHash Include="$(EmbedAllSources)" />
+    </ItemGroup>
+
+    <Hash ItemsToHash="@(_GsharpCoreCompileInputsToHash)">
+      <Output TaskParameter="HashResult" PropertyName="_GsharpCoreCompileInputsHash" />
+    </Hash>
+
+    <WriteLinesToFile Lines="$(_GsharpCoreCompileInputsHash)"
+                       File="$(_GsharpCoreCompileInputsCacheFile)"
+                       Overwrite="True"
+                       WriteOnlyWhenDifferent="True" />
+
+    <ItemGroup>
+      <FileWrites Include="$(_GsharpCoreCompileInputsCacheFile)" />
+    </ItemGroup>
+  </Target>
+
   <Target Name="CoreCompile"
-          Inputs="$(MSBuildAllProjects);@(Compile);@(ReferencePathWithRefAssemblies)"
-          Outputs="@(IntermediateAssembly)"
+          Inputs="$(MSBuildAllProjects);
+                  @(Compile);
+                  @(ReferencePathWithRefAssemblies);
+                  $(GsharpCompilerFullPath);
+                  $(IntermediateOutputPath)$(TargetName).CoreCompileInputs.cache"
+          Outputs="@(IntermediateAssembly);
+                   $(DocumentationFile);
+                   @(IntermediateRefAssembly);
+                   @(_DebugSymbolsIntermediatePath)"
           DependsOnTargets="$(CoreCompileDependsOn)">
 
     <Error Condition="!Exists('$(GsharpCompilerFullPath)')"

--- a/src/Sdk/Gsharp.NET.Sdk/build/Gsharp.NET.Core.Sdk.targets
+++ b/src/Sdk/Gsharp.NET.Sdk/build/Gsharp.NET.Core.Sdk.targets
@@ -31,8 +31,8 @@
        CoreCompile's own up-to-date check silently skips gsc and ships a
        stale assembly (e.g. with the previous build's version stamp). csc
        avoids this via the .NET SDK's CoreCompileInputs.cache idiom (see
-       Microsoft.NET.GenerateAssemblyInfo.targets /
-       CreateGeneratedAssemblyInfoInputsCacheFile): hash every
+       Microsoft.Managed.Core.targets / _GenerateCompileDependencyCache):
+       hash every
        compilation-affecting property BuildTask consumes into a cache file
        whose timestamp — via WriteOnlyWhenDifferent — only advances when the
        hash actually changes, then list that file as a CoreCompile input. -->
@@ -53,6 +53,8 @@
       <_GsharpCoreCompileInputsToHash Include="$(Optimize)" />
       <_GsharpCoreCompileInputsToHash Include="$(SourceLink)" />
       <_GsharpCoreCompileInputsToHash Include="$(EmbedAllSources)" />
+      <_GsharpCoreCompileInputsToHash Include="$(ProduceReferenceAssembly)" />
+      <_GsharpCoreCompileInputsToHash Include="$(GenerateDocumentationFile)" />
     </ItemGroup>
 
     <Hash ItemsToHash="@(_GsharpCoreCompileInputsToHash)">

--- a/src/Sdk/Gsharp.NET.Sdk/build/Gsharp.NET.Core.Sdk.targets
+++ b/src/Sdk/Gsharp.NET.Sdk/build/Gsharp.NET.Core.Sdk.targets
@@ -24,9 +24,60 @@
     <_ExplicitReference Include="$(FrameworkPathOverride)\mscorlib.dll" Condition=" '$(FrameworkPathOverride)' != '' " />
   </ItemGroup>
 
+  <!-- Issue #1666: property-only changes (e.g. `-p:Version=`, `-p:DebugType=`,
+       `-p:Deterministic=`, `-p:NoWarn=`, `-p:TreatWarningsAsErrors=`,
+       `-p:OutputType=`, ...) touch nothing on disk that $(MSBuildAllProjects),
+       @(Compile), or @(ReferencePathWithRefAssemblies) would catch, so
+       CoreCompile's own up-to-date check silently skips gsc and ships a
+       stale assembly (e.g. with the previous build's version stamp). csc
+       avoids this via the .NET SDK's CoreCompileInputs.cache idiom (see
+       Microsoft.NET.GenerateAssemblyInfo.targets /
+       CreateGeneratedAssemblyInfoInputsCacheFile): hash every
+       compilation-affecting property BuildTask consumes into a cache file
+       whose timestamp — via WriteOnlyWhenDifferent — only advances when the
+       hash actually changes, then list that file as a CoreCompile input. -->
+  <Target Name="_GsharpCreateCoreCompileInputsCache"
+          BeforeTargets="CoreCompile">
+    <PropertyGroup>
+      <_GsharpCoreCompileInputsCacheFile>$(IntermediateOutputPath)$(TargetName).CoreCompileInputs.cache</_GsharpCoreCompileInputsCacheFile>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_GsharpCoreCompileInputsToHash Include="$(Version)" />
+      <_GsharpCoreCompileInputsToHash Include="$(DebugType)" />
+      <_GsharpCoreCompileInputsToHash Include="$(Deterministic)" />
+      <_GsharpCoreCompileInputsToHash Include="$(NoWarn)" />
+      <_GsharpCoreCompileInputsToHash Include="$(TreatWarningsAsErrors)" />
+      <_GsharpCoreCompileInputsToHash Include="$(WarningsAsErrors)" />
+      <_GsharpCoreCompileInputsToHash Include="$(OutputType)" />
+      <_GsharpCoreCompileInputsToHash Include="$(Optimize)" />
+      <_GsharpCoreCompileInputsToHash Include="$(SourceLink)" />
+      <_GsharpCoreCompileInputsToHash Include="$(EmbedAllSources)" />
+    </ItemGroup>
+
+    <Hash ItemsToHash="@(_GsharpCoreCompileInputsToHash)">
+      <Output TaskParameter="HashResult" PropertyName="_GsharpCoreCompileInputsHash" />
+    </Hash>
+
+    <WriteLinesToFile Lines="$(_GsharpCoreCompileInputsHash)"
+                       File="$(_GsharpCoreCompileInputsCacheFile)"
+                       Overwrite="True"
+                       WriteOnlyWhenDifferent="True" />
+
+    <ItemGroup>
+      <FileWrites Include="$(_GsharpCoreCompileInputsCacheFile)" />
+    </ItemGroup>
+  </Target>
+
   <Target Name="CoreCompile"
-          Inputs="$(MSBuildAllProjects);@(Compile);@(ReferencePathWithRefAssemblies)"
-          Outputs="@(IntermediateAssembly)"
+          Inputs="$(MSBuildAllProjects);
+                  @(Compile);
+                  @(ReferencePathWithRefAssemblies);
+                  $(IntermediateOutputPath)$(TargetName).CoreCompileInputs.cache"
+          Outputs="@(IntermediateAssembly);
+                   $(DocumentationFile);
+                   @(IntermediateRefAssembly);
+                   @(_DebugSymbolsIntermediatePath)"
           DependsOnTargets="$(CoreCompileDependsOn)">
 
     <!-- When the SDK asks for a reference assembly (ProduceReferenceAssembly=true),


### PR DESCRIPTION
## Root cause

`CoreCompile` in both `Gsharp.NET.Core.Sdk.targets` and `Gsharp.NET.Sdk.Bootstrap.targets` declared:

```xml
Inputs="$(MSBuildAllProjects);@(Compile);@(ReferencePathWithRefAssemblies)"
Outputs="@(IntermediateAssembly)"
```

Unlike csc's `CoreCompile` (which, via the SDK's `GenerateAssemblyInfo`/`CoreCompileInputs.cache` machinery, regenerates an `AssemblyInfo.cs` file whenever version-affecting properties change, so the changed file shows up in `@(Compile)`), nothing on disk changes here when only **properties** change. That means a rebuild with `-p:Version=1.2.3` (or flipping `DebugType`, `Deterministic`, `TreatWarningsAsErrors`, `NoWarn`, or `OutputType` on the command line) after a prior build is silently treated as up-to-date by MSBuild, so `gsc` never re-runs and the previous build's stale assembly (with the old version stamp) ships unchanged. This is a real release-pipeline hazard: a CI job that re-invokes `dotnet build -p:Version=$NEW_VERSION` against a warm `obj/` directory would produce an assembly stamped with the *previous* version.

`Outputs` also only listed the runtime assembly, so losing the PDB, the `/refout:` reference assembly, or the XML doc file wouldn't retrigger a rebuild either.

## Fix

Mirrored the .NET SDK's own `CoreCompileInputs.cache` idiom (see `Microsoft.NET.GenerateAssemblyInfo.targets` / `CreateGeneratedAssemblyInfoInputsCacheFile`), applied to both `.targets` files:

1. A new `BeforeTargets="CoreCompile"` target hashes every compilation-affecting property the `BuildTask` consumes (`Version`, `DebugType`, `Deterministic`, `NoWarn`, `TreatWarningsAsErrors`, `WarningsAsErrors`, `OutputType`, `Optimize`, `SourceLink`, `EmbedAllSources`) using the `Hash` task, then writes the hash to `$(IntermediateOutputPath)$(TargetName).CoreCompileInputs.cache` via `WriteLinesToFile Overwrite="True" WriteOnlyWhenDifferent="True"`, so the cache file's timestamp only advances when the hash actually changes. That cache file is now part of `CoreCompile`'s `Inputs`.
2. `CoreCompile`'s `Outputs` now also include `$(DocumentationFile)`, `@(IntermediateRefAssembly)`, and `@(_DebugSymbolsIntermediatePath)` (all populated ahead of time by `Microsoft.Common.CurrentVersion.targets`), so losing the doc file, ref assembly, or PDB also retriggers a rebuild.
3. In the bootstrap variant, `$(GsharpCompilerFullPath)` (the in-tree `gsc.dll` path) is added directly to `Inputs`, so rebuilding the compiler retriggers `Gsharp.Extensions` recompilation with the fixed compiler.

## Validation

- `samples/HelloWorld`: built with `-p:Version=1.0.0`, then `-p:Version=2.0.0`. Diagnostic log shows `Building target "CoreCompile" completely.` on the second build, and the produced assembly's `InformationalVersion` actually updates (verified via `strings` on the output DLL).
- A third build with the same `Version=2.0.0` is skipped (`Skipping target "CoreCompile" because all output files are up-to-date`), confirming incrementality for the no-op case is preserved.
- Touched `out/bin/Debug/Compiler/gsc.dll` and rebuilt `Gsharp.NET.Sdk.csproj`: `Gsharp.Extensions.dll`'s mtime advances, confirming the bootstrap compiler-path input works.
- `test/Sdk.Tests` (38 XML-structural tests over these `.targets` files): all pass unchanged.
- `e2etests/sdk-e2e.sh` (pack SDK, pin sample's `global.json`, build, run): passes.

## Deferred

None.
