### PR TITLE
Fix #1634: eliminate mutable static overload-resolution hooks (thread/reentrancy correctness)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -857,41 +857,35 @@ internal sealed partial class ExpressionBinder
         bool ctorIsExpanded = false;
         if (argsAllTyped)
         {
-            // Issue #658: when any argument is a user-defined G# class, set up
-            // the supplementary interface check so ClassifyImplicit recognises
-            // the user-class → CLR-interface implicit reference conversion.
-            if (hasUserClassArg)
-            {
-                OverloadResolution.SupplementaryInterfaceCheck = (source, target) =>
-                    IsUserClassAssignableToInterface(boundArguments, argTypes, source, target);
-            }
+            // Issue #658 / #1634: when any argument is a user-defined G# class,
+            // pass a supplementary interface check into Resolve so
+            // ClassifyImplicit recognises the user-class → CLR-interface
+            // implicit reference conversion. Threaded as a call-local
+            // parameter (not a shared static) so concurrent/nested binds never
+            // observe another call's closure.
+            Func<Type, Type, bool> supplementaryInterfaceCheck = hasUserClassArg
+                ? (source, target) => IsUserClassAssignableToInterface(boundArguments, argTypes, source, target)
+                : null;
 
-            OverloadResolution.ConstantNarrowingArgumentCheck = MakeConstantNarrowingArgumentCheck(boundArguments);
-            try
+            var resolution = OverloadResolution.Resolve(
+                ctors,
+                argTypes,
+                interpolatedStringArgs: ComputeInterpolatedStringArgFlags(syntax.Arguments, boundArguments.Count),
+                argumentNames: argumentNames.IsDefault ? null : (IReadOnlyList<string>)argumentNames,
+                supplementaryInterfaceCheck: supplementaryInterfaceCheck,
+                constantNarrowingArgumentCheck: MakeConstantNarrowingArgumentCheck(boundArguments));
+            switch (resolution.Outcome)
             {
-                var resolution = OverloadResolution.Resolve(ctors, argTypes, interpolatedStringArgs: ComputeInterpolatedStringArgFlags(syntax.Arguments, boundArguments.Count), argumentNames: argumentNames.IsDefault ? null : (IReadOnlyList<string>)argumentNames);
-                switch (resolution.Outcome)
-                {
-                    case OverloadResolution.ResolutionOutcome.Resolved:
-                        bestCtor = resolution.Best;
-                        ctorMapping = resolution.ParameterMapping;
-                        ctorIsExpanded = resolution.IsExpanded;
-                        break;
-                    case OverloadResolution.ResolutionOutcome.Ambiguous:
-                        Diagnostics.ReportAmbiguousOverload(syntax.Location, clrType.Name, resolution.Ambiguous.Length, resolution.Ambiguous.Select(OverloadResolution.FormatMethodSignature));
-                        return false;
-                    default:
-                        break;
-                }
-            }
-            finally
-            {
-                if (hasUserClassArg)
-                {
-                    OverloadResolution.SupplementaryInterfaceCheck = null;
-                }
-
-                OverloadResolution.ConstantNarrowingArgumentCheck = null;
+                case OverloadResolution.ResolutionOutcome.Resolved:
+                    bestCtor = resolution.Best;
+                    ctorMapping = resolution.ParameterMapping;
+                    ctorIsExpanded = resolution.IsExpanded;
+                    break;
+                case OverloadResolution.ResolutionOutcome.Ambiguous:
+                    Diagnostics.ReportAmbiguousOverload(syntax.Location, clrType.Name, resolution.Ambiguous.Length, resolution.Ambiguous.Select(OverloadResolution.FormatMethodSignature));
+                    return false;
+                default:
+                    break;
             }
         }
 
@@ -3450,76 +3444,71 @@ internal sealed partial class ExpressionBinder
 
             if (argsAllTyped)
             {
-                // Issue #658: set up supplementary interface check for user-class args.
-                if (hasUserClassArg)
-                {
-                    OverloadResolution.SupplementaryInterfaceCheck = (source, target) =>
-                        IsUserClassAssignableToInterfaceFromArgs(arguments, argTypes, source, target);
-                }
+                // Issue #658 / #1634: supplementary interface check for user-class
+                // args, threaded as a call-local parameter into Resolve instead of
+                // a shared static so nested/concurrent binds can't clobber it.
+                Func<Type, Type, bool> supplementaryInterfaceCheck = hasUserClassArg
+                    ? (source, target) => IsUserClassAssignableToInterfaceFromArgs(arguments, argTypes, source, target)
+                    : null;
 
-                try
+                var resolution = OverloadResolution.Resolve(
+                    candidates,
+                    argTypes,
+                    explicitTypeArgs,
+                    scope.References.MapClrTypeToReferences,
+                    ComputeInterpolatedStringArgFlags(ce.Arguments, arguments.Length),
+                    argumentNames.IsDefault ? null : (IReadOnlyList<string>)argumentNames,
+                    supplementaryInterfaceCheck: supplementaryInterfaceCheck,
+                    constantNarrowingArgumentCheck: MakeConstantNarrowingArgumentCheck(arguments));
+                switch (resolution.Outcome)
                 {
-                    OverloadResolution.ConstantNarrowingArgumentCheck = MakeConstantNarrowingArgumentCheck(arguments);
-                    var resolution = OverloadResolution.Resolve(candidates, argTypes, explicitTypeArgs, scope.References.MapClrTypeToReferences, ComputeInterpolatedStringArgFlags(ce.Arguments, arguments.Length), argumentNames.IsDefault ? null : (IReadOnlyList<string>)argumentNames);
-                    switch (resolution.Outcome)
-                    {
-                        case OverloadResolution.ResolutionOutcome.Resolved:
-                            // Issue #977: now that the overload is chosen, re-bind
-                            // any inline `out var`/`out let`/`out _` placeholders
-                            // against the resolved by-ref parameter so the new
-                            // local is declared with the inferred pointee type.
-                            arguments = RebindInlineOutVarArguments(ce, arguments, resolution.Best, resolution.ParameterMapping, receiver?.Type, typeArgSymbols);
+                    case OverloadResolution.ResolutionOutcome.Resolved:
+                        // Issue #977: now that the overload is chosen, re-bind
+                        // any inline `out var`/`out let`/`out _` placeholders
+                        // against the resolved by-ref parameter so the new
+                        // local is declared with the inferred pointee type.
+                        arguments = RebindInlineOutVarArguments(ce, arguments, resolution.Best, resolution.ParameterMapping, receiver?.Type, typeArgSymbols);
 
-                            // Issue #1512: for a genuine INSTANCE method the receiver
-                            // is `this`, not a formal parameter — `GetParameters()`
-                            // excludes it. The method-type-argument inference vector
-                            // must therefore align with the method's parameters and
-                            // must NOT carry the receiver as slot 0 (unlike the
-                            // extension-method path, where the receiver IS param 0).
-                            // Including it shifted every real argument by one slot, so
-                            // a method type parameter inferable only from a lambda
-                            // argument (e.g. `TResult` of
-                            // `Task.ContinueWith<TResult>(Func<Task,TResult>)`) was
-                            // never unified and the call collapsed to `<object>`. The
-                            // receiver still drives return-type Var substitution via
-                            // `ResolveCallReturnTypeFromSymbolicTypeArgs` below.
-                            var instSymbolicArgs = MemberLookup.BuildSymbolicArgTypeVector(null, ImmutableArray.CreateRange(arguments.Select(a => a?.Type)));
-                            var instSymbolicTypeArgs = MemberLookup.BuildSymbolicMethodTypeArgs(resolution.Best, typeArgSymbols, instSymbolicArgs);
-                            var instTypeArgSymbolsForCall = !instSymbolicTypeArgs.IsDefault ? instSymbolicTypeArgs : typeArgSymbols;
-                            var returnType = ResolveImportedGenericReturnType(resolution.Best, typeArgSymbols)
-                                ?? MemberLookup.ResolveCallReturnTypeFromSymbolicTypeArgs(resolution.Best, instSymbolicTypeArgs, effectiveReceiverType)
-                                ?? ResolveInstanceReturnTypeFromReceiver(effectiveReceiverType, resolution.Best)
-                                ?? MapClrMethodReturnType(resolution.Best);
-                            var instParameters = resolution.Best.GetParameters();
-                            var instMapping = resolution.ParameterMapping;
-                            var instExpandedArgs = resolution.IsExpanded
-                                ? overloads.ExpandParamsArguments(arguments, instParameters, ce, parameterMapping: instMapping)
-                                : arguments;
-                            var instDownstreamMapping = resolution.IsExpanded ? default : instMapping;
-                            var instRebound = RebindFormattableInterpolationArguments(instExpandedArgs, ce.Arguments, instParameters, instDownstreamMapping);
-                            var instHandlerArgs = ApplyInterpolatedStringHandlers(instParameters, instRebound, receiver, ce.Location, instDownstreamMapping, out var instHandlerPrelude, out var instUpdatedReceiver);
-                            var instDelegateArgs = RebindFunctionLiteralDelegateArguments(instHandlerArgs, instParameters, instDownstreamMapping, resolution.Best, instTypeArgSymbolsForCall, effectiveReceiverType);
-                            var instConvertedArgs = conversions.BindClrParameterConversions(instDelegateArgs, instParameters, ce, instDownstreamMapping, method: resolution.Best, receiverType: receiver?.Type, symbolicMethodTypeArgs: instTypeArgSymbolsForCall);
-                            var instArguments = OverloadResolver.BuildOrderedCallArguments(instConvertedArgs, instDownstreamMapping, instParameters);
-                            var instRefKinds = ComputeArgumentRefKinds(instParameters);
-                            overloads.ValidateRefArguments(instArguments, instRefKinds, methodName, ce.Location);
-                            BoundExpression instCall = ConversionClassifier.AutoDereferenceRefReturn(new BoundImportedInstanceCallExpression(null, instUpdatedReceiver ?? receiver, resolution.Best, returnType, instArguments, instRefKinds, instTypeArgSymbolsForCall));
-                            return WrapWithHandlerPrelude(instCall, instHandlerPrelude, ce);
-                        case OverloadResolution.ResolutionOutcome.Ambiguous:
-                            Diagnostics.ReportAmbiguousOverload(ce.Location, methodName, resolution.Ambiguous.Length, resolution.Ambiguous.Select(OverloadResolution.FormatMethodSignature));
-                            return new BoundErrorExpression(null);
-                        default:
-                            break;
-                    }
-                }
-                finally
-                {
-                    if (hasUserClassArg)
-                    {
-                        OverloadResolution.SupplementaryInterfaceCheck = null;
-                    }
-
-                    OverloadResolution.ConstantNarrowingArgumentCheck = null;
+                        // Issue #1512: for a genuine INSTANCE method the receiver
+                        // is `this`, not a formal parameter — `GetParameters()`
+                        // excludes it. The method-type-argument inference vector
+                        // must therefore align with the method's parameters and
+                        // must NOT carry the receiver as slot 0 (unlike the
+                        // extension-method path, where the receiver IS param 0).
+                        // Including it shifted every real argument by one slot, so
+                        // a method type parameter inferable only from a lambda
+                        // argument (e.g. `TResult` of
+                        // `Task.ContinueWith<TResult>(Func<Task,TResult>)`) was
+                        // never unified and the call collapsed to `<object>`. The
+                        // receiver still drives return-type Var substitution via
+                        // `ResolveCallReturnTypeFromSymbolicTypeArgs` below.
+                        var instSymbolicArgs = MemberLookup.BuildSymbolicArgTypeVector(null, ImmutableArray.CreateRange(arguments.Select(a => a?.Type)));
+                        var instSymbolicTypeArgs = MemberLookup.BuildSymbolicMethodTypeArgs(resolution.Best, typeArgSymbols, instSymbolicArgs);
+                        var instTypeArgSymbolsForCall = !instSymbolicTypeArgs.IsDefault ? instSymbolicTypeArgs : typeArgSymbols;
+                        var returnType = ResolveImportedGenericReturnType(resolution.Best, typeArgSymbols)
+                            ?? MemberLookup.ResolveCallReturnTypeFromSymbolicTypeArgs(resolution.Best, instSymbolicTypeArgs, effectiveReceiverType)
+                            ?? ResolveInstanceReturnTypeFromReceiver(effectiveReceiverType, resolution.Best)
+                            ?? MapClrMethodReturnType(resolution.Best);
+                        var instParameters = resolution.Best.GetParameters();
+                        var instMapping = resolution.ParameterMapping;
+                        var instExpandedArgs = resolution.IsExpanded
+                            ? overloads.ExpandParamsArguments(arguments, instParameters, ce, parameterMapping: instMapping)
+                            : arguments;
+                        var instDownstreamMapping = resolution.IsExpanded ? default : instMapping;
+                        var instRebound = RebindFormattableInterpolationArguments(instExpandedArgs, ce.Arguments, instParameters, instDownstreamMapping);
+                        var instHandlerArgs = ApplyInterpolatedStringHandlers(instParameters, instRebound, receiver, ce.Location, instDownstreamMapping, out var instHandlerPrelude, out var instUpdatedReceiver);
+                        var instDelegateArgs = RebindFunctionLiteralDelegateArguments(instHandlerArgs, instParameters, instDownstreamMapping, resolution.Best, instTypeArgSymbolsForCall, effectiveReceiverType);
+                        var instConvertedArgs = conversions.BindClrParameterConversions(instDelegateArgs, instParameters, ce, instDownstreamMapping, method: resolution.Best, receiverType: receiver?.Type, symbolicMethodTypeArgs: instTypeArgSymbolsForCall);
+                        var instArguments = OverloadResolver.BuildOrderedCallArguments(instConvertedArgs, instDownstreamMapping, instParameters);
+                        var instRefKinds = ComputeArgumentRefKinds(instParameters);
+                        overloads.ValidateRefArguments(instArguments, instRefKinds, methodName, ce.Location);
+                        BoundExpression instCall = ConversionClassifier.AutoDereferenceRefReturn(new BoundImportedInstanceCallExpression(null, instUpdatedReceiver ?? receiver, resolution.Best, returnType, instArguments, instRefKinds, instTypeArgSymbolsForCall));
+                        return WrapWithHandlerPrelude(instCall, instHandlerPrelude, ce);
+                    case OverloadResolution.ResolutionOutcome.Ambiguous:
+                        Diagnostics.ReportAmbiguousOverload(ce.Location, methodName, resolution.Ambiguous.Length, resolution.Ambiguous.Select(OverloadResolution.FormatMethodSignature));
+                        return new BoundErrorExpression(null);
+                    default:
+                        break;
                 }
             }
         }
@@ -4115,28 +4104,21 @@ internal sealed partial class ExpressionBinder
             argTypes[i] = t;
         }
 
-        // Issue #658: set up supplementary interface check for user-class args.
-        if (hasUserClassArg)
-        {
-            OverloadResolution.SupplementaryInterfaceCheck = (source, target) =>
-                IsUserClassAssignableToInterfaceFromArgs(arguments, argTypes, source, target);
-        }
+        // Issue #658 / #1634: supplementary interface check for user-class args,
+        // threaded as a call-local parameter into Resolve instead of a shared
+        // static so nested/concurrent binds can't clobber it.
+        Func<Type, Type, bool> supplementaryInterfaceCheck = hasUserClassArg
+            ? (source, target) => IsUserClassAssignableToInterfaceFromArgs(arguments, argTypes, source, target)
+            : null;
 
-        OverloadResolution.Result<MethodInfo> resolution;
-        try
-        {
-            OverloadResolution.ConstantNarrowingArgumentCheck = MakeConstantNarrowingArgumentCheck(arguments);
-            resolution = OverloadResolution.Resolve(candidates, argTypes, explicitTypeArgs, scope.References.MapClrTypeToReferences, argumentNames: argumentNames.IsDefault ? null : (IReadOnlyList<string>)argumentNames);
-        }
-        finally
-        {
-            if (hasUserClassArg)
-            {
-                OverloadResolution.SupplementaryInterfaceCheck = null;
-            }
-
-            OverloadResolution.ConstantNarrowingArgumentCheck = null;
-        }
+        var resolution = OverloadResolution.Resolve(
+            candidates,
+            argTypes,
+            explicitTypeArgs,
+            scope.References.MapClrTypeToReferences,
+            argumentNames: argumentNames.IsDefault ? null : (IReadOnlyList<string>)argumentNames,
+            supplementaryInterfaceCheck: supplementaryInterfaceCheck,
+            constantNarrowingArgumentCheck: MakeConstantNarrowingArgumentCheck(arguments));
 
         switch (resolution.Outcome)
         {
@@ -4375,31 +4357,24 @@ internal sealed partial class ExpressionBinder
         // when the call site supplied explicit type arguments (e.g.
         // services.AddSingleton[IService, Service]()), those are used to close
         // the generic method instead of inference.
-        // Issue #658: set up supplementary interface check for user-class args.
-        if (hasUserClassArg)
-        {
-            OverloadResolution.SupplementaryInterfaceCheck = (source, target) =>
-                IsUserClassAssignableToInterfaceFromArgs(arguments, argTypes, source, target);
-        }
+        // Issue #658 / #1634: supplementary interface check for user-class args,
+        // threaded as a call-local parameter into Resolve instead of a shared
+        // static so nested/concurrent binds can't clobber it.
+        Func<Type, Type, bool> supplementaryInterfaceCheck = hasUserClassArg
+            ? (source, target) => IsUserClassAssignableToInterfaceFromArgs(arguments, argTypes, source, target)
+            : null;
 
-        OverloadResolution.Result<MethodInfo> resolution;
-        try
-        {
-            // Issue #1311: imported extension calls dispatch as
-            // `Class.Method(this receiver, args…)`, so argTypes slot 0 is the
-            // receiver and user argument `i` lives at slot `i + 1`.
-            OverloadResolution.ConstantNarrowingArgumentCheck = MakeConstantNarrowingArgumentCheck(arguments, argumentOffset: 1);
-            resolution = OverloadResolution.Resolve(candidates, argTypes, explicitTypeArgs, scope.References.MapClrTypeToReferences, argumentNames: extensionArgumentNames);
-        }
-        finally
-        {
-            if (hasUserClassArg)
-            {
-                OverloadResolution.SupplementaryInterfaceCheck = null;
-            }
-
-            OverloadResolution.ConstantNarrowingArgumentCheck = null;
-        }
+        // Issue #1311: imported extension calls dispatch as
+        // `Class.Method(this receiver, args…)`, so argTypes slot 0 is the
+        // receiver and user argument `i` lives at slot `i + 1`.
+        var resolution = OverloadResolution.Resolve(
+            candidates,
+            argTypes,
+            explicitTypeArgs,
+            scope.References.MapClrTypeToReferences,
+            argumentNames: extensionArgumentNames,
+            supplementaryInterfaceCheck: supplementaryInterfaceCheck,
+            constantNarrowingArgumentCheck: MakeConstantNarrowingArgumentCheck(arguments, argumentOffset: 1));
 
         switch (resolution.Outcome)
         {
@@ -4727,8 +4702,9 @@ internal sealed partial class ExpressionBinder
     /// Issue #658: determines whether a user-defined G# class argument (identified
     /// by its surrogate CLR type in <paramref name="argTypes"/>) implements the
     /// specified CLR <paramref name="target"/> interface. Used as the
-    /// <see cref="OverloadResolution.SupplementaryInterfaceCheck"/> callback during
-    /// overload resolution for calls that include user-class arguments.
+    /// <c>supplementaryInterfaceCheck</c> argument to
+    /// <see cref="OverloadResolution.Resolve{T}"/> during overload resolution for
+    /// calls that include user-class arguments.
     /// </summary>
     private static bool IsUserClassAssignableToInterface(
         ImmutableArray<BoundExpression>.Builder boundArguments,

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
@@ -274,7 +274,7 @@ internal sealed partial class ExpressionBinder
 
     /// <summary>
     /// ADR-0055 Tier 4 (#369): builds the per-argument flags consumed by
-    /// <see cref="OverloadResolution.Resolve{T}(System.Collections.Generic.IEnumerable{T}, System.Collections.Generic.IReadOnlyList{System.Type}, System.Collections.Generic.IReadOnlyList{System.Type}, System.Func{System.Type, System.Type}, System.Collections.Generic.IReadOnlyList{bool}, System.Collections.Generic.IReadOnlyList{string}, System.Func{System.Reflection.MethodInfo, System.Collections.Immutable.ImmutableArray{GSharp.Core.CodeAnalysis.Symbols.TypeSymbol}})"/>,
+    /// <see cref="OverloadResolution.Resolve{T}"/>,
     /// marking each positional argument whose syntax is an interpolated-string
     /// literal. These arguments may convert to an
     /// <c>IFormattable</c>/<c>FormattableString</c> parameter in addition to

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
@@ -231,40 +231,19 @@ internal static class OverloadResolution
     public static readonly Type DefaultLiteralArgumentType = typeof(DefaultLiteralArgumentMarker);
 #pragma warning restore SA1201
 
-    /// <summary>
-    /// Issue #658: per-call supplementary interface check for user-defined G#
-    /// classes whose CLR type does not exist at bind time. When set (non-null),
-    /// <see cref="ClassifyImplicit"/> invokes this callback as a final
-    /// reference-conversion check before falling through to
-    /// <see cref="UserDefinedImplicitConversionLookup"/>. The binder sets this
-    /// before calling <see cref="Resolve{T}"/> for calls that include user-
-    /// class arguments and clears it immediately after.
-    /// </summary>
-    [ThreadStatic]
-#pragma warning disable SA1401 // Field should be private
-#pragma warning disable SA1201 // Elements should appear in the correct order
-    internal static Func<Type, Type, bool> SupplementaryInterfaceCheck;
-#pragma warning restore SA1201
-#pragma warning restore SA1401
-
-    /// <summary>
-    /// Issue #1311: per-call constant-narrowing applicability hook for imported/
-    /// BCL candidates. When set (non-null), <see cref="EvaluateCandidate{T}"/>
-    /// invokes it for an argument whose natural type has no implicit conversion
-    /// to the parameter type. The callback receives the source argument index
-    /// and the CLR parameter type and returns <see langword="true"/> when the
-    /// argument is a constant integer expression whose value fits that
-    /// (possibly narrower / cross-sign) integer parameter — i.e. C# §10.2.11
-    /// implicit constant expression conversion. The binder sets this from the
-    /// bound arguments before calling <see cref="Resolve{T}"/> and clears it
-    /// immediately after. Modelled on <see cref="SupplementaryInterfaceCheck"/>.
-    /// </summary>
-    [ThreadStatic]
-#pragma warning disable SA1401 // Field should be private
-#pragma warning disable SA1201 // Elements should appear in the correct order
-    internal static Func<int, Type, bool> ConstantNarrowingArgumentCheck;
-#pragma warning restore SA1201
-#pragma warning restore SA1401
+    // Issue #658 / #1311 / #1634: the supplementary-interface and constant-
+    // narrowing checks used to live here as mutable (later [ThreadStatic])
+    // fields, set immediately before and nulled immediately after each
+    // `Resolve<T>` call. That "install/clear around the call" pattern is not
+    // reentrant: nested resolution performed *inside* the hook window (e.g.
+    // `RebindInlineOutVarArguments`, lambda re-binding, or any other bind that
+    // itself resolves an overload before the outer `finally` runs) clears the
+    // outer call's hook out from under it, and — because binding also runs
+    // concurrently across language-server request threads via `Task.Run` —
+    // a `[ThreadStatic]` field only protects against *cross-thread* races, not
+    // this same-thread reentrancy hazard. Both checks are now threaded through
+    // `Resolve<T>` as ordinary parameters instead, so each call carries its own
+    // context and there is no shared mutable state to race or clobber.
 
     /// <summary>
     /// Classifies the implicit conversion from <paramref name="source"/> to
@@ -274,8 +253,16 @@ internal static class OverloadResolution
     /// </summary>
     /// <param name="target">The target parameter type.</param>
     /// <param name="source">The argument type.</param>
+    /// <param name="supplementaryInterfaceCheck">
+    /// Issue #658 / #1634: optional per-call callback recognising a user-
+    /// defined G# class → CLR-interface implicit reference conversion that the
+    /// built-in checks below cannot see (the class's CLR type is a surrogate at
+    /// bind time). Passed down from the <see cref="Resolve{T}"/> call that is
+    /// evaluating this argument; <see langword="null"/> when the call has no
+    /// user-class arguments.
+    /// </param>
     /// <returns>The conversion classification.</returns>
-    public static ImplicitConversionKind ClassifyImplicit(Type target, Type source)
+    public static ImplicitConversionKind ClassifyImplicit(Type target, Type source, Func<Type, Type, bool> supplementaryInterfaceCheck = null)
     {
         if (target is null)
         {
@@ -462,8 +449,7 @@ internal static class OverloadResolution
         // whose CLR type is a surrogate (e.g. System.Object), the built-in checks
         // above won't recognise that the user class implements the target interface.
         // This callback lets the binder inject that knowledge.
-        var sic = SupplementaryInterfaceCheck;
-        if (sic != null && target.IsInterface && sic(source, target))
+        if (supplementaryInterfaceCheck != null && target.IsInterface && supplementaryInterfaceCheck(source, target))
         {
             return ImplicitConversionKind.Reference;
         }
@@ -598,7 +584,20 @@ internal static class OverloadResolution
     /// <see langword="null"/>, the constraint check relies solely on the CLR
     /// type arguments (prior behaviour).
     /// </param>
-    public static Result<T> Resolve<T>(IEnumerable<T> candidates, IReadOnlyList<Type> argTypes, IReadOnlyList<Type> explicitTypeArgs = null, Func<Type, Type> projectTypeArgument = null, IReadOnlyList<bool> interpolatedStringArgs = null, IReadOnlyList<string> argumentNames = null, Func<MethodInfo, ImmutableArray<TypeSymbol>> recoverTypeArgSymbols = null)
+    /// <param name="supplementaryInterfaceCheck">
+    /// Issue #658 / #1634: optional per-call user-class → CLR-interface
+    /// applicability hook forwarded to <see cref="ClassifyImplicit"/> while
+    /// evaluating this call's candidates. Threaded as a parameter (rather than
+    /// a shared mutable static) so concurrent and nested resolutions never
+    /// observe another call's hook.
+    /// </param>
+    /// <param name="constantNarrowingArgumentCheck">
+    /// Issue #1311 / #1634: optional per-call constant-narrowing applicability
+    /// hook forwarded to <see cref="EvaluateCandidate{T}"/> while evaluating
+    /// this call's candidates. Threaded as a parameter for the same reentrancy/
+    /// concurrency reason as <paramref name="supplementaryInterfaceCheck"/>.
+    /// </param>
+    public static Result<T> Resolve<T>(IEnumerable<T> candidates, IReadOnlyList<Type> argTypes, IReadOnlyList<Type> explicitTypeArgs = null, Func<Type, Type> projectTypeArgument = null, IReadOnlyList<bool> interpolatedStringArgs = null, IReadOnlyList<string> argumentNames = null, Func<MethodInfo, ImmutableArray<TypeSymbol>> recoverTypeArgSymbols = null, Func<Type, Type, bool> supplementaryInterfaceCheck = null, Func<int, Type, bool> constantNarrowingArgumentCheck = null)
         where T : MethodBase
     {
         var applicable = new List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[] Mapping, bool IsExpanded)>();
@@ -622,7 +621,7 @@ internal static class OverloadResolution
             // rest.
             try
             {
-                EvaluateCandidate(rawCandidate, argTypes, explicitTypeArgs, projectTypeArgument, applicable, interpolatedStringArgs, argumentNames, recoverTypeArgSymbols);
+                EvaluateCandidate(rawCandidate, argTypes, explicitTypeArgs, projectTypeArgument, applicable, interpolatedStringArgs, argumentNames, recoverTypeArgSymbols, supplementaryInterfaceCheck, constantNarrowingArgumentCheck);
             }
             catch (Exception ex) when (IsMetadataLoadFailure(ex))
             {
@@ -641,7 +640,7 @@ internal static class OverloadResolution
             {
                 try
                 {
-                    EvaluateExpandedParamsCandidate(rawCandidate, argTypes, explicitTypeArgs, projectTypeArgument, applicable, argumentNames, recoverTypeArgSymbols);
+                    EvaluateExpandedParamsCandidate(rawCandidate, argTypes, explicitTypeArgs, projectTypeArgument, applicable, argumentNames, recoverTypeArgSymbols, supplementaryInterfaceCheck, constantNarrowingArgumentCheck);
                 }
                 catch (Exception ex) when (IsMetadataLoadFailure(ex))
                 {
@@ -1705,11 +1704,11 @@ internal static class OverloadResolution
     /// <summary>
     /// Evaluates a single candidate for applicability against the supplied
     /// argument types, appending it to <paramref name="applicable"/> when it
-    /// applies. Factored out of <see cref="Resolve{T}(IEnumerable{T}, IReadOnlyList{Type}, IReadOnlyList{Type}, Func{Type, Type}, IReadOnlyList{bool}, IReadOnlyList{string}, Func{MethodInfo, ImmutableArray{TypeSymbol}})"/>
+    /// applies. Factored out of <see cref="Resolve{T}"/>
     /// so the per-candidate work can be guarded against reflection load
     /// failures (issue #321) without disturbing the surrounding control flow.
     /// </summary>
-    private static void EvaluateCandidate<T>(T rawCandidate, IReadOnlyList<Type> argTypes, IReadOnlyList<Type> explicitTypeArgs, Func<Type, Type> projectTypeArgument, List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[] Mapping, bool IsExpanded)> applicable, IReadOnlyList<bool> interpolatedStringArgs = null, IReadOnlyList<string> argumentNames = null, Func<MethodInfo, ImmutableArray<TypeSymbol>> recoverTypeArgSymbols = null)
+    private static void EvaluateCandidate<T>(T rawCandidate, IReadOnlyList<Type> argTypes, IReadOnlyList<Type> explicitTypeArgs, Func<Type, Type> projectTypeArgument, List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[] Mapping, bool IsExpanded)> applicable, IReadOnlyList<bool> interpolatedStringArgs = null, IReadOnlyList<string> argumentNames = null, Func<MethodInfo, ImmutableArray<TypeSymbol>> recoverTypeArgSymbols = null, Func<Type, Type, bool> supplementaryInterfaceCheck = null, Func<int, Type, bool> constantNarrowingArgumentCheck = null)
         where T : MethodBase
     {
         {
@@ -1888,7 +1887,7 @@ internal static class OverloadResolution
                 paramTypes[i] = paramTypeRewrite != null
                     ? paramTypeRewrite(parameters[paramIndex].ParameterType)
                     : parameters[paramIndex].ParameterType;
-                var conv = ClassifyImplicit(paramTypes[i], argTypes[i]);
+                var conv = ClassifyImplicit(paramTypes[i], argTypes[i], supplementaryInterfaceCheck);
                 if (conv == ImplicitConversionKind.None)
                 {
                     // ADR-0055 Tier 4 (#369): an interpolated-string argument
@@ -1905,8 +1904,8 @@ internal static class OverloadResolution
                     {
                         conv = ImplicitConversionKind.InterpolatedStringToFormattable;
                     }
-                    else if (ConstantNarrowingArgumentCheck != null
-                        && ConstantNarrowingArgumentCheck(i, paramTypes[i]))
+                    else if (constantNarrowingArgumentCheck != null
+                        && constantNarrowingArgumentCheck(i, paramTypes[i]))
                     {
                         // Issue #1311: a constant integer argument that fits a
                         // narrower / cross-sign integer parameter is implicitly
@@ -1947,7 +1946,7 @@ internal static class OverloadResolution
     /// applicability check in <see cref="EvaluateCandidate"/> but rewrites the
     /// trailing parameter type to the element type for ranking purposes.
     /// </summary>
-    private static void EvaluateExpandedParamsCandidate<T>(T rawCandidate, IReadOnlyList<Type> argTypes, IReadOnlyList<Type> explicitTypeArgs, Func<Type, Type> projectTypeArgument, List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[] Mapping, bool IsExpanded)> applicable, IReadOnlyList<string> argumentNames = null, Func<MethodInfo, ImmutableArray<TypeSymbol>> recoverTypeArgSymbols = null)
+    private static void EvaluateExpandedParamsCandidate<T>(T rawCandidate, IReadOnlyList<Type> argTypes, IReadOnlyList<Type> explicitTypeArgs, Func<Type, Type> projectTypeArgument, List<(T Method, ImplicitConversionKind[] Conversions, Type[] ParamTypes, int[] Mapping, bool IsExpanded)> applicable, IReadOnlyList<string> argumentNames = null, Func<MethodInfo, ImmutableArray<TypeSymbol>> recoverTypeArgSymbols = null, Func<Type, Type, bool> supplementaryInterfaceCheck = null, Func<int, Type, bool> constantNarrowingArgumentCheck = null)
         where T : MethodBase
     {
         T candidate = rawCandidate;
@@ -2126,7 +2125,7 @@ internal static class OverloadResolution
             }
 
             paramTypes[i] = target;
-            var conv = ClassifyImplicit(target, argTypes[i]);
+            var conv = ClassifyImplicit(target, argTypes[i], supplementaryInterfaceCheck);
             if (conv == ImplicitConversionKind.None)
             {
                 return;

--- a/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
@@ -293,32 +293,29 @@ public sealed class ImportedClassSymbol : Symbol
             argTypes[i] = t;
         }
 
-        // Issue #658: set up supplementary interface check for user-class args.
-        if (hasUserClassArg)
-        {
-            OverloadResolution.SupplementaryInterfaceCheck = (source, target) =>
-                IsUserClassAssignableToInterface(arguments, argTypes, source, target);
-        }
+        // Issue #658 / #1634: supplementary interface check for user-class args,
+        // threaded as a call-local parameter into Resolve instead of a shared
+        // static so nested/concurrent binds can't clobber it.
+        Func<Type, Type, bool> supplementaryInterfaceCheck = hasUserClassArg
+            ? (source, target) => IsUserClassAssignableToInterface(arguments, argTypes, source, target)
+            : null;
 
-        OverloadResolution.Result<MethodInfo> result;
-        try
-        {
-            // Issue #1325: recover the symbolic type-argument vector per candidate
-            // so the generic-constraint check can see through the `object`
-            // erasure of same-compilation user value types (a user struct must
-            // satisfy `where T : struct`, e.g. MemoryMarshal.Cast/AsBytes).
-            var symbolicArgVector = MemberLookup.BuildSymbolicArgTypeVector(
-                receiverType: null,
-                ImmutableArray.CreateRange(arguments.Select(a => a?.Type)));
-            result = OverloadResolution.Resolve(nameMatches, argTypes, explicitTypeArgs, projectTypeArgument, ComputeInterpolatedStringArgFlags(callExpression, arguments.Length), argumentNames, closed => MemberLookup.BuildSymbolicMethodTypeArgs(closed, typeArgSymbols, symbolicArgVector));
-        }
-        finally
-        {
-            if (hasUserClassArg)
-            {
-                OverloadResolution.SupplementaryInterfaceCheck = null;
-            }
-        }
+        // Issue #1325: recover the symbolic type-argument vector per candidate
+        // so the generic-constraint check can see through the `object`
+        // erasure of same-compilation user value types (a user struct must
+        // satisfy `where T : struct`, e.g. MemoryMarshal.Cast/AsBytes).
+        var symbolicArgVector = MemberLookup.BuildSymbolicArgTypeVector(
+            receiverType: null,
+            ImmutableArray.CreateRange(arguments.Select(a => a?.Type)));
+        var result = OverloadResolution.Resolve(
+            nameMatches,
+            argTypes,
+            explicitTypeArgs,
+            projectTypeArgument,
+            ComputeInterpolatedStringArgFlags(callExpression, arguments.Length),
+            argumentNames,
+            closed => MemberLookup.BuildSymbolicMethodTypeArgs(closed, typeArgSymbols, symbolicArgVector),
+            supplementaryInterfaceCheck: supplementaryInterfaceCheck);
 
         switch (result.Outcome)
         {
@@ -343,9 +340,6 @@ public sealed class ImportedClassSymbol : Symbol
                 // the type-erased `IEnumerable<object>`.
                 if (returnOverride == null)
                 {
-                    var symbolicArgVector = MemberLookup.BuildSymbolicArgTypeVector(
-                        receiverType: null,
-                        ImmutableArray.CreateRange(arguments.Select(a => a?.Type)));
                     var symbolicMethodTypeArgs = MemberLookup.BuildSymbolicMethodTypeArgs(result.Best, typeArgSymbols, symbolicArgVector);
                     returnOverride = MemberLookup.ResolveCallReturnTypeFromSymbolicTypeArgs(result.Best, symbolicMethodTypeArgs, receiverType: null);
                 }

--- a/test/Core.Tests/CodeAnalysis/Binding/OverloadResolutionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/OverloadResolutionTests.cs
@@ -728,6 +728,109 @@ public class OverloadResolutionTests
         Assert.Equal(OverloadResolution.ResolutionOutcome.Ambiguous, result.Outcome);
     }
 
+    // ----- Issue #1634: supplementaryInterfaceCheck / constantNarrowingArgumentCheck
+    // must be per-call parameters, not shared mutable state, so that concurrent
+    // and nested (reentrant) `Resolve<T>` calls never observe each other's hook. -----
+
+    [Fact]
+    public async System.Threading.Tasks.Task Resolve_SupplementaryInterfaceCheck_IsIsolatedAcrossConcurrentCalls()
+    {
+        // Two disjoint interface targets, both applicable only through a
+        // per-call supplementaryInterfaceCheck (the `object`-typed argument
+        // stands in for a user-class surrogate CLR type, mirroring issue
+        // #658). Hammer Resolve<T> from many threads at once, each thread
+        // consistently requesting ONE of the two targets: if the hooks were
+        // still shared static state, some iterations would race and resolve
+        // to the wrong candidate (or throw NullReferenceException from a
+        // hook nulled out mid-flight by another thread).
+        var takeIA = typeof(EqualLike).GetMethod(nameof(EqualLike.Take_IA), BindingFlags.Public | BindingFlags.Static);
+        var takeIB = typeof(EqualLike).GetMethod(nameof(EqualLike.Take_IB), BindingFlags.Public | BindingFlags.Static);
+        var candidates = new[] { takeIA, takeIB };
+
+        void RunFor(Type wantInterface, string expectedName, int iterations, List<Exception> errors)
+        {
+            for (var i = 0; i < iterations; i++)
+            {
+                try
+                {
+                    var result = OverloadResolution.Resolve(
+                        candidates,
+                        new[] { typeof(object) },
+                        supplementaryInterfaceCheck: (source, target) => target == wantInterface);
+                    if (result.Outcome != OverloadResolution.ResolutionOutcome.Resolved
+                        || result.Best.Name != expectedName)
+                    {
+                        lock (errors)
+                        {
+                            errors.Add(new Exception($"Expected {expectedName} for {wantInterface}, got {result.Outcome}/{result.Best?.Name}"));
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    lock (errors)
+                    {
+                        errors.Add(ex);
+                    }
+                }
+            }
+        }
+
+        var errors = new List<Exception>();
+        const int iterations = 500;
+        var taskA = System.Threading.Tasks.Task.Run(() => RunFor(typeof(EqualLike.IA), nameof(EqualLike.Take_IA), iterations, errors));
+        var taskB = System.Threading.Tasks.Task.Run(() => RunFor(typeof(EqualLike.IB), nameof(EqualLike.Take_IB), iterations, errors));
+        await System.Threading.Tasks.Task.WhenAll(taskA, taskB);
+
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void Resolve_SupplementaryInterfaceCheck_SurvivesNestedResolveInsideHookCallback()
+    {
+        // Reentrancy guard: a supplementaryInterfaceCheck callback that itself
+        // triggers a nested Resolve<T> call (mirroring RebindInlineOutVarArguments
+        // / lambda re-binding running "inside the hook window" per issue #1634)
+        // must not corrupt the outer call's own hook. With hooks threaded as
+        // parameters instead of mutable statics, the outer closure is captured
+        // by value and is unaffected by whatever the nested call does.
+        var takeIA = typeof(EqualLike).GetMethod(nameof(EqualLike.Take_IA), BindingFlags.Public | BindingFlags.Static);
+        var takeIB = typeof(EqualLike).GetMethod(nameof(EqualLike.Take_IB), BindingFlags.Public | BindingFlags.Static);
+        var candidates = new[] { takeIA, takeIB };
+
+        var nestedCallCount = 0;
+        var outerResult = OverloadResolution.Resolve(
+            candidates,
+            new[] { typeof(object) },
+            supplementaryInterfaceCheck: (source, target) =>
+            {
+                if (target == typeof(EqualLike.IA))
+                {
+                    // Nested resolution, run from *inside* the outer hook,
+                    // using a DIFFERENT hook that targets IB. Under the old
+                    // "install -> Resolve -> finally null" static-field
+                    // pattern this would null the outer's field once the
+                    // nested call's finally ran, and any subsequent
+                    // ClassifyImplicit probe of the outer call would silently
+                    // stop recognising IA.
+                    nestedCallCount++;
+                    var nested = OverloadResolution.Resolve(
+                        candidates,
+                        new[] { typeof(object) },
+                        supplementaryInterfaceCheck: (nestedSource, nestedTarget) => nestedTarget == typeof(EqualLike.IB));
+                    Assert.Equal(OverloadResolution.ResolutionOutcome.Resolved, nested.Outcome);
+                    Assert.Equal(nameof(EqualLike.Take_IB), nested.Best.Name);
+                    return true;
+                }
+
+                return false;
+            });
+
+        Assert.True(nestedCallCount > 0);
+        Assert.Equal(OverloadResolution.ResolutionOutcome.Resolved, outerResult.Outcome);
+        Assert.Equal(nameof(EqualLike.Take_IA), outerResult.Best.Name);
+    }
+
     private static IEnumerable<MethodInfo> ThreeWayCandidates()
     {
         yield return typeof(ThreeWayClass).GetMethod(nameof(ThreeWayClass.Choose), BindingFlags.Public | BindingFlags.Static);


### PR DESCRIPTION
## Root cause

`OverloadResolution.SupplementaryInterfaceCheck` and `OverloadResolution.ConstantNarrowingArgumentCheck` were process-wide `[ThreadStatic]` fields, set to a closure over one specific call's `boundArguments`/`argTypes` and installed/cleared with a `set → try → finally-null` pattern around each of 5 `OverloadResolution.Resolve` call sites (4 in `ExpressionBinder.Calls.cs`, 1 in `ImportedClassSymbol.cs`).

`[ThreadStatic]` only protects against **cross-thread** races (relevant because the language server dispatches request handling via `Task.Run`, and `HoverComputer` calls `Binder.TryInferExpressionType` which runs the same binding paths concurrently). It does **not** fix **same-thread reentrancy**: at `ExpressionBinder.Calls.cs`, `RebindInlineOutVarArguments` and lambda re-binding run *inside* the hook window (after `Resolve` returns but before the outer `finally`). If that nested code path resolves another overload, its own `finally` nulls the shared field out from under the still-in-progress outer call.

## Fix

Eliminated both mutable static fields entirely. `SupplementaryInterfaceCheck` and `ConstantNarrowingArgumentCheck` are now threaded as ordinary optional parameters through `OverloadResolution.Resolve<T>` and its internal helpers (`EvaluateCandidate<T>`, `EvaluateExpandedParamsCandidate<T>`, `ClassifyImplicit`). Each of the 5 call sites now builds a call-local closure and passes it directly into `Resolve`, so every concurrent or nested resolution carries its own context — no shared mutable state left to race or clobber.

## Validation

- `dotnet build GSharp.sln -c Release -graph`: 0 warnings, 0 errors.
- Full `Core.Tests` suite: 5029 passed, 1 skipped, 0 failed.
- Targeted `Compiler.Tests` emit suites covering the affected code paths (issues #658, #977, #1311): all pass.
- Added two new tests to `OverloadResolutionTests.cs`:
  - `Resolve_SupplementaryInterfaceCheck_IsIsolatedAcrossConcurrentCalls`: two threads concurrently resolving against different interface targets 500 times each, asserting no cross-contamination.
  - `Resolve_SupplementaryInterfaceCheck_SurvivesNestedResolveInsideHookCallback`: a hook callback that itself triggers a nested `Resolve` call with a different hook, proving the outer call's context is unaffected — this would fail under the old static-field null-reset pattern.

Nothing deferred.