### PR TITLE
Fix #1665: gsc ParseIdList splits on ';' as well as ','

### DIFF
--- a/src/Compiler/Program.cs
+++ b/src/Compiler/Program.cs
@@ -713,8 +713,10 @@ public class Program
     }
 
     /// <summary>
-    /// Parses a comma-separated list of diagnostic IDs. Accepts both canonical
-    /// form (<c>GS0001</c>) and bare numeric form (<c>0001</c> or <c>1</c>).
+    /// Parses a comma- or semicolon-separated list of diagnostic IDs. Accepts both canonical
+    /// form (<c>GS0001</c>) and bare numeric form (<c>0001</c> or <c>1</c>). Semicolon is
+    /// supported because MSBuild-forwarded properties such as NoWarn/WarningsAsErrors are
+    /// conventionally semicolon-delimited (e.g. <c>$(NoWarn);GS0012</c>).
     /// </summary>
     private static IEnumerable<string> ParseIdList(string value)
     {
@@ -723,7 +725,7 @@ public class Program
             yield break;
         }
 
-        foreach (var raw in value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        foreach (var raw in value.Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
         {
             if (raw.StartsWith("GS", StringComparison.OrdinalIgnoreCase))
             {

--- a/test/Compiler.Tests/ProgramTests.cs
+++ b/test/Compiler.Tests/ProgramTests.cs
@@ -387,6 +387,101 @@ public class ProgramTests
     }
 
     [Fact]
+    public void Main_NowarnFlag_AcceptsSemicolonDelimitedList()
+    {
+        // Issue #1665: MSBuild forwards NoWarn as a semicolon-delimited list
+        // (e.g. "/nowarn:;NU5131;GS0001,GS0002") since $(NoWarn) conventionally
+        // starts with an empty/leading separator (see Sdk.props: "$(NoWarn);NU5131").
+        // gsc must split on ';' as well as ',' or the IDs after the first ';' are
+        // never recognised.
+        var sample = Path.Combine(Path.GetTempPath(), $"gs_test_{System.Guid.NewGuid():N}.gs");
+        File.WriteAllText(sample, "package P\n");
+        var tempDir = Directory.CreateTempSubdirectory("gsc_nowarn_semi_").FullName;
+        var outPath = Path.Combine(tempDir, "P.dll");
+        using var outWriter = new StringWriter();
+        using var errWriter = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(outWriter);
+        Console.SetError(errWriter);
+        try
+        {
+            var exit = Program.Main(new[] { "/out:" + outPath, "/target:library", "/nowarn:;NU5131;GS0001,GS0002", sample });
+            Assert.Equal(0, exit);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+            try { File.Delete(sample); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Main_UnderReferencedClosure_SemicolonNoWarnSuppressesGs9100()
+    {
+        // Issue #1665: reproduces the exact SDK-forwarded shape (leading empty
+        // token + semicolon separators) and confirms the previously-broken
+        // suppression now works end to end.
+        var refDir = Directory.CreateTempSubdirectory("gsc_ref1665n_").FullName;
+        var libPath = BuildLibraryWithMissingDependency(refDir);
+
+        var sample = Path.Combine(Path.GetTempPath(), $"gs_test_{System.Guid.NewGuid():N}.gs");
+        File.WriteAllText(sample, "package P\n\nfunc Main() {\n}\n");
+        var tempDir = Directory.CreateTempSubdirectory("gsc_outn1665_").FullName;
+        var outPath = Path.Combine(tempDir, "P.dll");
+
+        using var outWriter = new StringWriter();
+        var prevOut = Console.Out;
+        Console.SetOut(outWriter);
+        try
+        {
+            var exit = Program.Main(new[] { "/out:" + outPath, "/target:library", "/nowarn:;NU5131;GS9100", "/r:" + libPath, sample });
+            Assert.Equal(0, exit);
+            Assert.DoesNotContain("GS9100", outWriter.ToString());
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+            try { Directory.Delete(refDir, recursive: true); } catch { }
+            try { File.Delete(sample); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Main_SemicolonWarnAsErrorPromotesRealWarningToError()
+    {
+        // Issue #1665: the WarningsAsErrors counterpart of the NoWarn tests —
+        // a semicolon-delimited /warnaserror+ value (as MSBuild forwards it,
+        // e.g. "$(WarningsAsErrors);GS0166") must promote the targeted
+        // warning to an error and fail the build. GS0166 (ADR-0066 D6: TLS +
+        // explicit Main coexistence) is a real warning emitted through the
+        // normal diagnostics pipeline, unlike the advisory GS9100.
+        var sample = Path.Combine(Path.GetTempPath(), $"gs_test_{System.Guid.NewGuid():N}.gs");
+        File.WriteAllText(sample, "package P\nimport System\n\nConsole.WriteLine(\"tls\")\n\nfunc Main() {\n}\n");
+        var tempDir = Directory.CreateTempSubdirectory("gsc_wae1665_").FullName;
+        var outPath = Path.Combine(tempDir, "P.dll");
+
+        using var outWriter = new StringWriter();
+        var prevOut = Console.Out;
+        Console.SetOut(outWriter);
+        try
+        {
+            var exit = Program.Main(new[] { "/out:" + outPath, "/target:exe", "/warnaserror+:;GS0166", sample });
+            Assert.NotEqual(0, exit);
+            Assert.Contains("error GS0166", outWriter.ToString());
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+            try { File.Delete(sample); } catch { }
+        }
+    }
+
+    [Fact]
     public void Diagnostic_HasStableId_AndSeverity()
     {
         // Verify that a compile error produces a diagnostic with a stable GS#### ID and Error severity.


### PR DESCRIPTION
## Problem

MSBuild forwards `NoWarn`/`WarningsAsErrors` as **semicolon**-delimited lists by convention, and the SDK itself guarantees a semicolon in every consumer build (`Sdk.props`: `<NoWarn>$(NoWarn);NU5131</NoWarn>`). `BuildTask` forwards these properties verbatim to gsc (`/nowarn:{NoWarn}`, `/warnaserror+:{WarningsAsErrors}`), but gsc's `ParseIdList` (src/Compiler/Program.cs) only split on `,`.

A consumer setting `<NoWarn>$(NoWarn);GS0012</NoWarn>` sends gsc `/nowarn:;NU5131;GS0012`. Splitting only on `,` yields a single token `;NU5131;GS0012` which never matches `GS0012`, so the suppression (or promotion, for `WarningsAsErrors`) silently did nothing.

Fixes #1665.

## Fix

`ParseIdList` now splits on both `,` and `;` (still with `RemoveEmptyEntries` + `TrimEntries`), which also correctly drops the leading empty token produced by MSBuild's `;NU5131` pattern.

This single change fixes every consumer that routes through `ParseIdList`:
- `/nowarn`
- `/warnaserror` (bare value form)
- `/warnaserror+`
- `/warnaserror-`

Diagnostic ID case handling (`GS####` normalization / bare-numeric expansion) already existed in `ParseIdList` and required no changes.

### Audit for the same bug class

`ParseIdList` is the only `.Split(...)` call site in gsc's command-line parser (`src/Compiler/Program.cs`) and in the SDK's `BuildTask.cs`. No other MSBuild-forwarded delimited-list switch (e.g. defines, additional files, references) exists in gsc today, so there are no other instances of this bug class to fix.

## Tests

Added to `test/Compiler.Tests/ProgramTests.cs`:
- `Main_NowarnFlag_AcceptsSemicolonDelimitedList` — `/nowarn:;NU5131;GS0001,GS0002` parses and compiles without crashing (mixed `,`/`;`, leading empty token).
- `Main_UnderReferencedClosure_SemicolonNoWarnSuppressesGs9100` — end-to-end: `/nowarn:;NU5131;GS9100` actually suppresses the GS9100 warning (previously broken).
- `Main_SemicolonWarnAsErrorPromotesRealWarningToError` — end-to-end: `/warnaserror+:;GS0166` promotes a real pipeline warning (GS0166) to an error and fails the build (previously broken).

## Validation

- `dotnet build GSharp.sln -c Release -graph` → 0 errors, 0 warnings.
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Release` → 2556 passed, 0 failed.
- `dotnet test test/Sdk.Tests/Sdk.Tests.csproj -c Release` → 38 passed, 0 failed.

No work was deferred.