### PR TITLE
Fix #1653: relational patterns hard-cast discriminant to int, throwing for non-int widths

### DIFF
--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -3158,17 +3158,48 @@ public sealed class Evaluator
             case BoundBinaryOperatorKind.NotEquals:
                 return !object.Equals(left, right);
             case BoundBinaryOperatorKind.Less:
-                return (int)left < (int)right;
             case BoundBinaryOperatorKind.LessOrEquals:
-                return (int)left <= (int)right;
             case BoundBinaryOperatorKind.Greater:
-                return (int)left > (int)right;
             case BoundBinaryOperatorKind.GreaterOrEquals:
-                return (int)left >= (int)right;
+                // Issue #1653: this used to hard-cast both operands to `int`,
+                // throwing InvalidCastException for any other discriminant
+                // width (double, long, uint, char, enum, ...). Route through
+                // the same width-aware NumericCompare the binary relational
+                // operators use (after unwrapping enum discriminants to their
+                // underlying numeric type, mirroring line ~2380) so a pattern
+                // comparison matches `<`/`<=`/`>`/`>=` operator semantics and
+                // the emitter's unsigned/NaN-aware opcodes (#421).
+                var relLeft = UnwrapEnumToUnderlying(left);
+                var relRight = UnwrapEnumToUnderlying(right);
+
+                // IEEE 754: every relational comparison against NaN is false.
+                // double/float.CompareTo instead sorts NaN as less than any
+                // other value, so NaN must be special-cased here to match the
+                // emitter's unordered handling rather than NumericCompare.
+                if (IsNaN(relLeft) || IsNaN(relRight))
+                {
+                    return false;
+                }
+
+                var cmp = NumericCompare(relLeft, relRight);
+                return op switch
+                {
+                    BoundBinaryOperatorKind.Less => cmp < 0,
+                    BoundBinaryOperatorKind.LessOrEquals => cmp <= 0,
+                    BoundBinaryOperatorKind.Greater => cmp > 0,
+                    _ => cmp >= 0,
+                };
             default:
                 throw new InvalidOperationException($"Unexpected relational pattern operator {op}.");
         }
     }
+
+    private static bool IsNaN(object value) => value switch
+    {
+        float f => float.IsNaN(f),
+        double d => double.IsNaN(d),
+        _ => false,
+    };
 
     private object EvaluateAwaitExpression(BoundAwaitExpression node)
     {

--- a/test/Interpreter.Tests/Issue1653RelationalPatternWidthInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue1653RelationalPatternWidthInterpreterTests.cs
@@ -1,0 +1,165 @@
+// <copyright file="Issue1653RelationalPatternWidthInterpreterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #1653 — the tree-walking evaluator's <c>EvaluateRelationalPattern</c>
+/// hard-cast both operands of a relational pattern (<c>&lt;</c>, <c>&lt;=</c>,
+/// <c>&gt;</c>, <c>&gt;=</c>) to <c>int</c>, throwing
+/// <see cref="InvalidCastException"/> for any other discriminant width
+/// (double, int64, uint32, char, enum, ...) even though the binder allows a
+/// relational pattern on any type with a relational operator
+/// (<c>PatternBinder.cs</c>) and the compiled emitter already handles every
+/// width with the correct unsigned/NaN-aware opcodes
+/// (<c>MethodBodyEmitter.Patterns.cs</c>, issue #421). These tests pin down
+/// interpreter/compiled parity across widths, an unsigned boundary value, an
+/// enum discriminant (compared by underlying value), and IEEE-754 NaN
+/// unordered semantics.
+/// </summary>
+public class Issue1653RelationalPatternWidthInterpreterTests
+{
+    [Fact]
+    public void RelationalPattern_Float64_Matches()
+    {
+        var output = RunSubmission(
+            """
+            let v = 7.5
+            let r = switch v { case > 5.0: "big" default: "small" }
+            Console.WriteLine(r)
+            """);
+        Assert.DoesNotContain("error GS", output);
+        Assert.Contains("big", output);
+    }
+
+    [Fact]
+    public void RelationalPattern_Int64_Matches()
+    {
+        var output = RunSubmission(
+            """
+            let v = 5000000000L
+            let r = switch v { case > 1000000000L: "big" default: "small" }
+            Console.WriteLine(r)
+            """);
+        Assert.DoesNotContain("error GS", output);
+        Assert.Contains("big", output);
+    }
+
+    [Fact]
+    public void RelationalPattern_UInt32_Boundary_UsesUnsignedComparison()
+    {
+        // 0xFFFFFFFFu is uint.MaxValue. Sign-interpreted it is -1 and would
+        // NOT satisfy `> 1u`; compared unsigned it does — matches the
+        // compiled emitter's Cgt_un opcode (issue #421).
+        var output = RunSubmission(
+            """
+            let v = 4294967295u
+            let r = switch v { case > 1u: "hi" default: "lo" }
+            Console.WriteLine(r)
+            """);
+        Assert.DoesNotContain("error GS", output);
+        Assert.Contains("hi", output);
+    }
+
+    [Fact]
+    public void RelationalPattern_Char_Matches()
+    {
+        var output = RunSubmission(
+            """
+            let c = 'z'
+            let r = switch c { case > 'a': "hi" default: "lo" }
+            Console.WriteLine(r)
+            """);
+        Assert.DoesNotContain("error GS", output);
+        Assert.Contains("hi", output);
+    }
+
+    [Fact]
+    public void RelationalPattern_NegativeVsUnsignedBoundary_Matches()
+    {
+        // A small unsigned value must still compare correctly below the
+        // unsigned boundary (regression guard against reintroducing a
+        // signed-cast shortcut for uint/ulong discriminants).
+        var output = RunSubmission(
+            """
+            let v = 3u
+            let r = switch v { case < 4294967295u: "lt" default: "ge" }
+            Console.WriteLine(r)
+            """);
+        Assert.DoesNotContain("error GS", output);
+        Assert.Contains("lt", output);
+    }
+
+    [Fact]
+    public void RelationalPattern_Enum_ComparesByUnderlyingValue()
+    {
+        var output = RunSubmission(
+            """
+            import System
+            let d = DayOfWeek.Wednesday
+            let r = switch d { case > DayOfWeek.Monday: "later" default: "earlier-or-same" }
+            Console.WriteLine(r)
+            """);
+        Assert.DoesNotContain("error GS", output);
+        Assert.Contains("later", output);
+    }
+
+    [Fact]
+    public void RelationalPattern_Float64_NaN_NeverMatchesAnyRelation()
+    {
+        // IEEE-754: every ordered relation involving NaN is false. Must
+        // agree with the compiled emitter's unordered handling (#421)
+        // rather than double.CompareTo's "NaN sorts lowest" semantics.
+        var output = RunSubmission(
+            """
+            let v = 0.0 / 0.0
+            let g = switch v { case > 0.0: "gt" default: "nope" }
+            let l = switch v { case < 0.0: "lt" default: "nope" }
+            let ge = switch v { case >= 0.0: "ge" default: "nope" }
+            let le = switch v { case <= 0.0: "le" default: "nope" }
+            Console.WriteLine(g)
+            Console.WriteLine(l)
+            Console.WriteLine(ge)
+            Console.WriteLine(le)
+            """);
+        Assert.DoesNotContain("error GS", output);
+        Assert.Contains("nope\nnope\nnope\nnope\n", output.Replace("\r\n", "\n"));
+    }
+
+    [Fact]
+    public void PropertyPatternGuard_RelationalSubPatternOnDouble_Matches()
+    {
+        var output = RunSubmission(
+            """
+            class Reading { var Name string var Value float64 }
+            let r = Reading{Name: "temp", Value: 98.6}
+            let x = switch r { case { Name: "temp", Value: > 90.0 }: "hot" default: "normal" }
+            Console.WriteLine(x)
+            """);
+        Assert.DoesNotContain("error GS", output);
+        Assert.Contains("hot", output);
+    }
+
+    private static string RunSubmission(string text)
+    {
+        using var outWriter = new StringWriter();
+        var prevOut = Console.Out;
+        Console.SetOut(outWriter);
+        try
+        {
+            var repl = new GSharpRepl();
+            repl.EvaluateSubmission(text);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+        }
+
+        return outWriter.ToString();
+    }
+}


### PR DESCRIPTION
## Root cause

`EvaluateRelationalPattern` in `src/Core/CodeAnalysis/Evaluator.cs` (~line 3117) hard-cast both operands of a relational pattern (`<`, `<=`, `>`, `>=`) directly to `int`:

```csharp
case BoundBinaryOperatorKind.Less:
    return (int)left < (int)right;
```

The binder (`PatternBinder.cs:334-345`) allows a relational pattern on **any** type with a relational operator, and the compiled emitter (`MethodBodyEmitter.Patterns.cs:337-385`, issue #421) already handles every numeric width with the correct unsigned/NaN-aware opcodes. So a boxed `double`/`int64`/`uint32`/`char`/enum discriminant compiled fine but threw `InvalidCastException` in the interpreter:

```
let v = 7.5
switch v { case > 5.0: "big" ... }
// GS9999: Unable to cast object of type 'System.Double' to type 'System.Int32'
```

Property-pattern guards with a relational sub-pattern on a non-int field hit the same path.

## Fix

`EvaluateRelationalPattern` now routes `Less`/`LessOrEquals`/`Greater`/`GreaterOrEquals` through the existing width-aware `NumericCompare` helper (the same helper the binary relational operators already use), after unwrapping enum discriminants to their underlying numeric type via `UnwrapEnumToUnderlying` — mirroring the binary-operator code path exactly so pattern comparisons match operator comparisons and the emitter.

`NumericCompare` is implemented with `CompareTo`, which sorts `NaN` as less than every other value — that disagrees with IEEE-754 (every ordered relation against NaN must be `false`) and with the emitter's unordered-opcode handling (#421). Added an explicit NaN check ahead of `NumericCompare` so `<`, `<=`, `>`, `>=` against a NaN discriminant are always `false` in the interpreter, matching compiled output.

Change is scoped to `EvaluateRelationalPattern` only; `NumericCompare` and `UnwrapEnumToUnderlying` are read but not modified.

## Tests

Added `test/Interpreter.Tests/Issue1653RelationalPatternWidthInterpreterTests.cs`:
- relational pattern on `double`
- relational pattern on `int64`
- `uint32` boundary value (`uint.MaxValue`), unsigned comparison
- small unsigned value vs. the `uint32` boundary (regression guard)
- `char` discriminant
- enum discriminant (`System.DayOfWeek`), compared by underlying value
- NaN discriminant across all four relational operators — must not match any
- property-pattern guard with a relational sub-pattern on a non-`int` field (`float64`)

## Validation

- `dotnet build GSharp.sln -c Release -graph` — build succeeded, 0 warnings, 0 errors
- `dotnet test test/Interpreter.Tests -c Release --no-build --filter FullyQualifiedName~Issue1653RelationalPatternWidthInterpreterTests` — 8/8 passed
- `dotnet test test/Interpreter.Tests -c Release --no-build` (full suite) — 354/354 passed
- `dotnet test test/Core.Tests -c Release --no-build --filter FullyQualifiedName~PatternEvaluationTests\|FullyQualifiedName~RelationalPatternEmitTests` — 24/24 passed

Fixes #1653
