### PR TITLE
Fix #1652: Evaluator.DefaultValue diverges from compiled zero-value for non-int32/bool primitives

### DIFF
--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -2203,14 +2203,13 @@ public sealed class Evaluator
 
     private static object DefaultValue(Symbols.TypeSymbol type)
     {
-        if (type == Symbols.TypeSymbol.Bool)
+        // Issue #504/#1652: NullableTypeSymbol.ClrType aliases the underlying
+        // type's ClrType (e.g. `int?` reports `typeof(int)`), so it must be
+        // special-cased ahead of the value-type fallback below — otherwise
+        // `default(int?)` would wrongly become boxed `0` instead of `nil`.
+        if (type is Symbols.NullableTypeSymbol)
         {
-            return false;
-        }
-
-        if (type == Symbols.TypeSymbol.Int32)
-        {
-            return 0;
+            return null;
         }
 
         if (type == Symbols.TypeSymbol.String)
@@ -2218,9 +2217,19 @@ public sealed class Evaluator
             return string.Empty;
         }
 
-        if (type is Symbols.EnumSymbol)
+        // Issue #1652: user-defined enums have no ClrType (they're not emitted
+        // to real CLR System.Enum types at interpret time) and their members
+        // are bound to raw `int` literals (see EnumMemberSymbol.Value / the
+        // BoundLiteralExpression produced in ExpressionBinder.Access.cs) — so
+        // a plain boxed `int 0` here already equals `Color.Zero`'s boxed int.
+        // Imported enums (real CLR System.Enum types) DO have a ClrType and
+        // are handled by the general value-type fallback below via
+        // Enum.ToObject (Activator.CreateInstance produces the real enum
+        // zero), matching the idiom already used for enum arithmetic results
+        // elsewhere in this file (see UnwrapEnumToUnderlying/NumericCoerce).
+        if (type is Symbols.EnumSymbol enumType)
         {
-            return 0;
+            return enumType.ClrType != null ? Enum.ToObject(enumType.ClrType, 0) : 0;
         }
 
         if (type is Symbols.StructSymbol s)
@@ -2232,6 +2241,18 @@ public sealed class Evaluator
             }
 
             return sv;
+        }
+
+        // Issue #1652: every other value type (bool, all sized/unsigned ints,
+        // float32/float64, decimal, char, nint/nuint, and user value structs
+        // that slipped through as plain ClrType) gets its real CLR default via
+        // Activator.CreateInstance, so the boxed runtime type always matches
+        // what the emitter would produce for a V-typed scratch local. Reference
+        // types (string handled above, classes, interfaces) and nullable T?
+        // correctly fall through to null.
+        if (type?.ClrType != null && type.ClrType.IsValueType)
+        {
+            return Activator.CreateInstance(type.ClrType);
         }
 
         return null;

--- a/test/Interpreter.Tests/Issue1652DefaultValueInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue1652DefaultValueInterpreterTests.cs
@@ -1,0 +1,243 @@
+// <copyright file="Issue1652DefaultValueInterpreterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #1652: <c>Evaluator.DefaultValue</c> only special-cased
+/// <c>bool</c>/<c>int32</c>/<c>string</c>/enum/struct and fell back to
+/// <c>null</c> for every other primitive (int64, the unsigned/sized integer
+/// family, float32/float64, decimal, char, nint/nuint) — diverging from the
+/// emitted IL, which always produces the CLR-correct zero for a value type
+/// (e.g. <c>0L</c> for int64, <c>0.0</c> for float64). These tests cover
+/// map-miss defaults, struct/class field defaults, auto-property defaults,
+/// and enum defaults for every affected primitive, proving interpreter/
+/// compiled parity (a `nil` default would either throw or misbehave in the
+/// arithmetic/comparison below, so a correct numeric result demonstrates the
+/// fix).
+/// </summary>
+public class Issue1652DefaultValueInterpreterTests
+{
+    [Theory]
+    [InlineData("int64", "5")]
+    [InlineData("uint64", "5")]
+    [InlineData("uint32", "5")]
+    [InlineData("int16", "5")]
+    [InlineData("uint16", "5")]
+    [InlineData("int8", "5")]
+    [InlineData("uint8", "5")]
+    [InlineData("nint", "5")]
+    [InlineData("nuint", "5")]
+    public void MapMiss_IntegerDefault_AddsAsTypedZero(string typeName, string expected)
+    {
+        // Repro from the issue: reading a missing map key must yield the
+        // CLR zero for the value type, not `nil` (which would blow up or
+        // silently no-op the `+`).
+        var source = $$"""
+            var m = map[string,{{typeName}}]{}
+            let v = m["missing"]
+            v + {{typeName}}(5)
+            """;
+        var output = RunSubmission(source);
+        Assert.DoesNotContain("error GS", output);
+        Assert.Contains(expected, output);
+    }
+
+    [Fact]
+    public void MapMiss_Float32Default_AddsAsZero()
+    {
+        var source = """
+            var m = map[string,float32]{}
+            let v = m["missing"]
+            v + float32(1.5)
+            """;
+        var output = RunSubmission(source);
+        Assert.DoesNotContain("error GS", output);
+        Assert.Contains("1.5", output);
+    }
+
+    [Fact]
+    public void MapMiss_Float64Default_AddsAsZero()
+    {
+        var source = """
+            var m = map[string,float64]{}
+            let v = m["missing"]
+            v + 1.5
+            """;
+        var output = RunSubmission(source);
+        Assert.DoesNotContain("error GS", output);
+        Assert.Contains("1.5", output);
+    }
+
+    [Fact]
+    public void MapMiss_CharDefault_IsNulChar()
+    {
+        // char's CLR default is '\0'; comparing against it must succeed
+        // (previously `nil` would fail the comparison / throw).
+        var source = """
+            var m = map[string,char]{}
+            let v = m["missing"]
+            v == char(0)
+            """;
+        var output = RunSubmission(source);
+        Assert.DoesNotContain("error GS", output);
+        Assert.Contains("True", output);
+    }
+
+    [Fact]
+    public void MapMiss_BoolDefault_IsFalse()
+    {
+        var source = """
+            var m = map[string,bool]{}
+            m["missing"]
+            """;
+        var output = RunSubmission(source);
+        Assert.DoesNotContain("error GS", output);
+        Assert.Contains("False", output);
+    }
+
+    [Fact]
+    public void StructField_Int64Default_AddsAsZero()
+    {
+        var source = """
+            struct Counter {
+                var Value int64
+            }
+            let c = Counter{}
+            c.Value + int64(7)
+            """;
+        var output = RunSubmission(source);
+        Assert.DoesNotContain("error GS", output);
+        Assert.Contains("7", output);
+    }
+
+    [Fact]
+    public void ClassField_Float64Default_AddsAsZero()
+    {
+        var source = """
+            class Sample {
+                var Amount float64
+            }
+            let s = Sample{}
+            s.Amount + 2.25
+            """;
+        var output = RunSubmission(source);
+        Assert.DoesNotContain("error GS", output);
+        Assert.Contains("2.25", output);
+    }
+
+    [Fact]
+    public void AutoProperty_UInt32Default_AddsAsZero()
+    {
+        var source = """
+            class Foo {
+                prop Count uint32
+            }
+            let f = Foo{}
+            f.Count + uint32(9)
+            """;
+        var output = RunSubmission(source);
+        Assert.DoesNotContain("error GS", output);
+        Assert.Contains("9", output);
+    }
+
+    [Fact]
+    public void AutoProperty_CharDefault_IsNulChar()
+    {
+        var source = """
+            class Foo {
+                prop Letter char
+            }
+            let f = Foo{}
+            f.Letter == char(0)
+            """;
+        var output = RunSubmission(source);
+        Assert.DoesNotContain("error GS", output);
+        Assert.Contains("True", output);
+    }
+
+    [Fact]
+    public void UserEnum_DefaultValue_EqualsZeroMember()
+    {
+        // User-defined enums have no ClrType at interpret time (their
+        // members are raw int literals — see EnumMemberSymbol.Value), so
+        // default(Color) must equal the boxed int backing Color.Red (the
+        // first, auto-numbered-0 member), not `nil`.
+        var source = """
+            package p
+            enum Color { Red, Green, Blue }
+            class Box {
+                var C Color
+            }
+            let b = Box{}
+            b.C == Color.Red
+            """;
+        var output = RunSubmission(source);
+        Assert.DoesNotContain("error GS", output);
+        Assert.Contains("True", output);
+    }
+
+    [Fact]
+    public void ImportedEnum_DefaultValue_IsZeroMember()
+    {
+        // Imported enums (real CLR System.Enum types, e.g. DayOfWeek) DO
+        // have a ClrType, so their default must be a properly-typed boxed
+        // enum zero via Enum.ToObject, not a raw int — printing the zero
+        // member's name ("Sunday"), and arithmetic off it produces the
+        // next real enum member ("Monday"), exactly as compiled code would.
+        var source = """
+            import System
+            struct Meeting {
+                var Day DayOfWeek
+            }
+            let m = Meeting{}
+            Console.WriteLine(m.Day)
+            Console.WriteLine(m.Day + int32(1))
+            """;
+        var output = RunSubmission(source);
+        Assert.DoesNotContain("error GS", output);
+        Assert.Contains("Sunday", output);
+        Assert.Contains("Monday", output);
+    }
+
+    [Fact]
+    public void NullableInt32Default_IsNilNotZero()
+    {
+        // Regression guard: NullableTypeSymbol.ClrType aliases the
+        // underlying type's ClrType, so the value-type fallback must not
+        // swallow it — default(int32?) is nil, not boxed 0.
+        var source = """
+            class Foo {
+                var Count int32?
+            }
+            let f = Foo{}
+            f.Count == nil
+            """;
+        var output = RunSubmission(source);
+        Assert.DoesNotContain("error GS", output);
+        Assert.Contains("True", output);
+    }
+
+    private static string RunSubmission(string text)
+    {
+        using var outWriter = new StringWriter();
+        var prevOut = Console.Out;
+        Console.SetOut(outWriter);
+        try
+        {
+            var repl = new GSharpRepl();
+            repl.EvaluateSubmission(text);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+        }
+
+        return outWriter.ToString();
+    }
+}


### PR DESCRIPTION
## Root cause

`Evaluator.DefaultValue(TypeSymbol type)` only special-cased `bool` (→ `false`), `int32` (→ `0`), `string` (→ `""`), `EnumSymbol` (→ raw `int 0`), and `StructSymbol` (recurse). Every other value type — `int64`, the sized/unsigned integer family (`int8`/`uint8`/`int16`/`uint16`/`uint32`/`uint64`/`nint`/`nuint`), `float32`/`float64`/`decimal`, and `char` — fell through to `null`.

This is consumed for map-miss reads, uninitialized field reads, and uninitialized auto-property reads. A `null` default for e.g. `int64` diverges from the emitter, which always lowers `default(V)` to the CLR-correct zero via a V-typed scratch local (see `MethodBodyPlanner.cs:416-418`). Repro from the issue:

```
var m = map[string,int64]{}
let v = m["missing"]
v + 5
```
Compiled: prints `5`. Interpreted (before this fix): throws/returns `nil`.

## Fix

- Added a general fallback: for any `TypeSymbol` whose `ClrType` is a value type, return `Activator.CreateInstance(type.ClrType)` — this produces the exact CLR default for every primitive (`0L`, `0UL`, `0.0f`, `0.0d`, `'\0'`, `(byte)0`, etc.), matching the emitter's V-typed scratch-local zero exactly, without needing a per-type switch.
- `NullableTypeSymbol` is special-cased *ahead* of that fallback: its `ClrType` aliases the underlying type's `ClrType` (e.g. `int32?` reports `typeof(int32)`), so without the guard the fallback would wrongly produce boxed `0` instead of `nil` for `default(int32?)`.
- User-defined enums (`EnumSymbol`) have no `ClrType` at interpret time — their members are bound to raw `int` literals (see `EnumMemberSymbol.Value` / `ExpressionBinder.Access.cs`), so their default stays a raw `int 0` to match that representation (a boxed `int 0` already equals another boxed `int 0` in comparisons).
- Imported enums (real CLR `System.Enum` types such as `System.DayOfWeek`) *do* have a `ClrType`, so they're handled by the general fallback with `Enum.ToObject` semantics via `Activator.CreateInstance`, producing a properly-typed enum zero (prints `"Sunday"`, and `default + 1` correctly produces `"Monday"`), matching the existing `Enum.ToObject` idiom already used for enum arithmetic elsewhere in `Evaluator.cs`.
- `StructSymbol` recursion is unchanged — each field now benefits from the corrected `DefaultValue`.
- Reference types, interfaces, and classes correctly keep falling through to `null`.

## Validation

- `dotnet build GSharp.sln -c Release -graph` → 0 warnings, 0 errors (StyleCop clean).
- Added `test/Interpreter.Tests/Issue1652DefaultValueInterpreterTests.cs` (20 new tests) covering map-miss defaults for `int64`/`uint64`/`uint32`/`int16`/`uint16`/`int8`/`uint8`/`nint`/`nuint`/`float32`/`float64`/`char`/`bool`, struct/class field defaults, auto-property defaults, user-enum default parity, imported-enum default parity, and a nullable-default regression guard.
- `dotnet test test/Interpreter.Tests --filter FullyQualifiedName~Issue1652DefaultValueInterpreterTests` → 20/20 passed.
- Full `dotnet test test/Interpreter.Tests` suite → 366/366 passed (no regressions).

Fixes #1652.
