### PR TITLE
Fix float/double literal overflow diagnostic being dead code

### DIFF
--- a/src/Core/CodeAnalysis/Syntax/Lexer.cs
+++ b/src/Core/CodeAnalysis/Syntax/Lexer.cs
@@ -1536,7 +1536,17 @@ public sealed class Lexer
         {
             if (targetType == TypeSymbol.Float32)
             {
-                return float.Parse(digitBody, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture);
+                var f = float.Parse(digitBody, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture);
+
+                // G# has no float-infinity literal syntax, so any non-finite
+                // result here means the literal overflowed (net10.0's
+                // float.Parse returns ±Infinity instead of throwing).
+                if (float.IsInfinity(f))
+                {
+                    throw new System.OverflowException();
+                }
+
+                return f;
             }
 
             if (targetType == TypeSymbol.Decimal)
@@ -1545,7 +1555,13 @@ public sealed class Lexer
             }
 
             // Float64 default.
-            return double.Parse(digitBody, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture);
+            var d = double.Parse(digitBody, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture);
+            if (double.IsInfinity(d))
+            {
+                throw new System.OverflowException();
+            }
+
+            return d;
         }
         catch (System.Exception)
         {

--- a/test/Core.Tests/CodeAnalysis/Syntax/LexerTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/LexerTests.cs
@@ -260,6 +260,22 @@ public class LexerTests
         Assert.Equal(expectedValue, token.Value);
     }
 
+    // .NET Core 3.0+ float/double.Parse returns ±Infinity for out-of-range
+    // text instead of throwing. G# has no infinity literal syntax, so any
+    // non-finite parse result is a genuine overflow (issue #1606) and must
+    // report GS0004 rather than silently producing Infinity.
+    [Theory]
+    [InlineData("1e999")]
+    [InlineData("1e999d")]
+    [InlineData("1e40f")]
+    public void Lexes_FloatLiteral_Overflow_Reports(string text)
+    {
+        var tokens = SyntaxTree.ParseTokens(text, out var diagnostics);
+        var token = Assert.Single(tokens);
+        Assert.Contains(diagnostics, d => d.Id == "GS0004");
+        Assert.False(double.IsInfinity(System.Convert.ToDouble(token.Value)));
+    }
+
     [Theory]
     [InlineData("1.5M")]
     [InlineData("1.5m")]


### PR DESCRIPTION
Fixes #1606

.NET Core 3.0+ changed float.Parse/double.Parse to return ±Infinity for out-of-range text instead of throwing, so the catch block guarding ReportOverflow in Lexer.ParseFloatLiteral never fired. `1e999` silently lexed to Infinity with 0 diagnostics.

Fix: after parsing, check float.IsInfinity/double.IsInfinity. G# has no infinity literal syntax, so any non-finite parse result from a numeric literal is overflow; throw and route through the existing ReportOverflow (GS0004) path. Decimal path unchanged (still throws on overflow).

Added Lexer tests: 1e999, 1e999d, 1e40f now report GS0004; existing float/double literal tests confirm normal values still parse fine.