### PR TITLE
Fix #1605: parse interpolation holes without padded full-file re-lex

### DIFF
--- a/src/Core/CodeAnalysis/Syntax/Lexer.cs
+++ b/src/Core/CodeAnalysis/Syntax/Lexer.cs
@@ -17,6 +17,7 @@ public sealed class Lexer
 {
     private readonly SyntaxTree syntaxTree;
     private readonly SourceText text;
+    private readonly int end;
 
     private int position;
 
@@ -29,9 +30,27 @@ public sealed class Lexer
     /// </summary>
     /// <param name="syntaxTree">The source syntax tree that contains the text document to lex from.</param>
     public Lexer(SyntaxTree syntaxTree)
+        : this(syntaxTree, 0, syntaxTree.Text.Length)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Lexer"/> class that lexes only the
+    /// <paramref name="start"/>-<paramref name="end"/> window of <paramref name="syntaxTree"/>'s
+    /// text, treating <paramref name="end"/> as a virtual end-of-file. Used to re-lex an
+    /// interpolated-string hole's expression text directly out of the outer source so the
+    /// resulting tokens carry true absolute positions without copying/padding the file
+    /// prefix (issue #1605).
+    /// </summary>
+    /// <param name="syntaxTree">The source syntax tree that contains the text document to lex from.</param>
+    /// <param name="start">The absolute position to start lexing from.</param>
+    /// <param name="end">The absolute position, exclusive, at which the lexer reports end-of-file.</param>
+    public Lexer(SyntaxTree syntaxTree, int start, int end)
     {
         this.syntaxTree = syntaxTree;
         this.text = syntaxTree.Text;
+        this.end = end;
+        this.position = start;
     }
 
     /// <summary>
@@ -477,7 +496,7 @@ public sealed class Lexer
     {
         var index = position + offset;
 
-        if (index >= text.Length)
+        if (index >= end)
         {
             return '\0';
         }

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -82,11 +82,26 @@ public class Parser
     /// </summary>
     /// <param name="syntaxTree">The source syntax tree object.</param>
     public Parser(SyntaxTree syntaxTree)
+        : this(syntaxTree, 0, syntaxTree.Text.Length)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Parser"/> class that parses only the
+    /// <paramref name="start"/>-<paramref name="end"/> window of <paramref name="syntaxTree"/>'s
+    /// text. Used to re-parse an interpolated-string hole's expression directly out of the
+    /// outer source so resulting nodes carry true absolute positions without copying/padding
+    /// the file prefix (issue #1605).
+    /// </summary>
+    /// <param name="syntaxTree">The source syntax tree object.</param>
+    /// <param name="start">The absolute position to start parsing from.</param>
+    /// <param name="end">The absolute position, exclusive, at which parsing stops.</param>
+    public Parser(SyntaxTree syntaxTree, int start, int end)
     {
         var tokens = new List<SyntaxToken>();
         var docTokens = ImmutableArray.CreateBuilder<SyntaxToken>();
 
-        var lexer = new Lexer(syntaxTree);
+        var lexer = new Lexer(syntaxTree, start, end);
         SyntaxToken token;
         do
         {
@@ -9938,17 +9953,16 @@ public class Parser
                 }
             }
 
-            // ADR-0055 §C: parse the captured expression with span remapping so
-            // every inner token, node, and diagnostic carries its true absolute
-            // position in the outer file. The hole's expression clause begins at
-            // fragment.Position; we re-create a source text in which everything
-            // before that offset is blanked to spaces (newlines preserved, so
-            // line/column also match) and the expression text sits at its real
-            // offset. Inner spans are therefore absolute outer-file spans.
-            var innerText = SourceText.From(BuildHolePaddedText(syntaxTree.Text, fragment.Position, exprText), syntaxTree.Text.FileName);
-            var innerTree = SyntaxTree.Parse(innerText);
-            Diagnostics.AddRange(innerTree.Diagnostics);
-            var innerExpression = ExtractFirstExpression(innerTree);
+            // ADR-0055 §C / issue #1605: parse the captured expression directly out of
+            // the outer syntax tree's own text, bounded to [fragment.Position,
+            // fragment.Position + exprText.Length). Every inner token/node is built
+            // against the SAME outer SyntaxTree, so its Position is already the true
+            // absolute offset in the outer file — no padded-copy allocation or re-lex
+            // of the file prefix is needed (that was O(fileSize) per hole).
+            var innerParser = new Parser(syntaxTree, fragment.Position, fragment.Position + exprText.Length);
+            var innerRoot = innerParser.ParseCompilationUnit();
+            Diagnostics.AddRange(innerParser.Diagnostics);
+            var innerExpression = ExtractFirstExpression(innerRoot);
             if (innerExpression == null)
             {
                 // Fall back to a synthetic missing-name node anchored on the
@@ -9962,25 +9976,6 @@ public class Parser
         }
 
         return new InterpolatedStringExpressionSyntax(syntaxTree, token, segments.ToImmutable());
-    }
-
-    // ADR-0055 §C: builds the source text used to parse a hole expression with
-    // correct absolute positions. The returned text equals the outer text up to
-    // <paramref name="holeOffset"/> — but with every non-newline character
-    // blanked to a space so the prefix produces no tokens — followed by the
-    // expression source itself. The expression's first character thus lands at
-    // its true outer offset, and preserved newlines keep line/column accurate.
-    private static string BuildHolePaddedText(SourceText outerText, int holeOffset, string exprText)
-    {
-        var builder = new System.Text.StringBuilder(holeOffset + exprText.Length);
-        for (var i = 0; i < holeOffset; i++)
-        {
-            var c = outerText[i];
-            builder.Append(c == '\r' || c == '\n' ? c : ' ');
-        }
-
-        builder.Append(exprText);
-        return builder.ToString();
     }
 
     // ADR-0055 delimiter-aware hole splitter. Finds the first top-level `,`
@@ -10054,9 +10049,9 @@ public class Parser
         }
     }
 
-    private static ExpressionSyntax ExtractFirstExpression(SyntaxTree innerTree)
+    private static ExpressionSyntax ExtractFirstExpression(CompilationUnitSyntax innerRoot)
     {
-        foreach (var member in innerTree.Root.Members)
+        foreach (var member in innerRoot.Members)
         {
             if (member is GlobalStatementSyntax gs && gs.Statement is ExpressionStatementSyntax es)
             {

--- a/test/Core.Tests/CodeAnalysis/Binding/InterpolatedStringTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/InterpolatedStringTests.cs
@@ -425,6 +425,61 @@ public class InterpolatedStringTests
         Assert.Equal("undefinedThing".Length, diagnostic.Location.Span.Length);
     }
 
+    [Fact]
+    public void Hole_Diagnostic_On_Later_Line_Reports_True_Line_Number()
+    {
+        // Issue #1605: the hole is now re-lexed directly out of the outer text
+        // (no padded-copy re-parse), so the line/column must still come out
+        // right for a hole many lines into the file.
+        var source = string.Concat(System.Linq.Enumerable.Repeat("let a = 1\n", 20))
+            + "let msg = \"val=${undefinedThing}\"\n";
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var vars = new System.Collections.Generic.Dictionary<VariableSymbol, object>();
+        var result = compilation.Evaluate(vars);
+
+        var expectedStart = source.IndexOf("undefinedThing", System.StringComparison.Ordinal);
+        var diagnostic = Assert.Single(result.Diagnostics, d => d.Location.Span.Start == expectedStart);
+        Assert.Equal(20, diagnostic.Location.StartLine);
+    }
+
+    [Fact]
+    public void Many_Interpolation_Holes_Parse_Near_Linear_Time()
+    {
+        // Issue #1605: each hole used to re-lex/re-parse a padded copy of the
+        // whole file prefix seen so far (O(fileSize) per hole => O(n^2)
+        // total). Doubling the hole count should now roughly double the
+        // parse time, not quadruple it.
+        static string BuildSource(int holeCount)
+        {
+            var sb = new System.Text.StringBuilder();
+            for (var i = 0; i < holeCount; i++)
+            {
+                sb.Append("let v").Append(i).Append(" = \"prefix ${").Append(i).Append("} suffix\"\n");
+            }
+
+            return sb.ToString();
+        }
+
+        static long TimeParse(string source)
+        {
+            // Warm up JIT once before timing.
+            SyntaxTree.Parse(SourceText.From(source));
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            SyntaxTree.Parse(SourceText.From(source));
+            sw.Stop();
+            return sw.ElapsedTicks;
+        }
+
+        var small = TimeParse(BuildSource(500));
+        var large = TimeParse(BuildSource(4000)); // 8x the holes/text
+
+        // Quadratic behavior would show ~64x growth; near-linear should stay
+        // well under that. Generous bound to avoid flakiness on shared CI
+        // hardware while still catching a regression back to O(n^2).
+        Assert.True(large < small * 30, $"expected near-linear scaling, got small={small} large={large} ratio={(double)large / small}");
+    }
+
     private static (ImmutableArray<GSharp.Core.CodeAnalysis.Diagnostic> Diagnostics, System.Collections.Generic.Dictionary<VariableSymbol, object> Variables) Evaluate(string source)
     {
         var tree = SyntaxTree.Parse(SourceText.From(source));


### PR DESCRIPTION
Fixes #1605

Each `${...}` interpolation hole re-lexed and re-parsed a StringBuilder-padded copy of the entire file prefix up to the hole (via `BuildHolePaddedText` + `SyntaxTree.Parse`), then discarded everything but the expression. That's O(fileSize) of work per hole, so files with many interpolation holes parsed in O(n^2) — matching the issue's measured 4x-time-per-2x-size blowup.

## Fix

Added windowed `Lexer(syntaxTree, start, end)` / `Parser(syntaxTree, start, end)` constructors that lex/parse a `[start, end)` slice directly out of the *same* outer `SyntaxTree`/`SourceText`, treating `end` as a virtual EOF (`Peek` returns `'\0'` once past `end`).

Since a hole's expression text is captured as a verbatim substring of the outer source (`Lexer.ReadString` does `this.text.ToString(exprStart, ...)`, no unescaping), lexing that same window directly means every resulting token/node already carries its true absolute position and belongs to the outer `SyntaxTree` — no padded-copy allocation, no separate `SourceText`, no post-hoc offset remapping needed. `BuildHolePaddedText` is removed entirely.

## Tests

- `Hole_Diagnostic_Span_Maps_To_True_Source_Location` (pre-existing) still passes — proves absolute positions are preserved.
- Added `Hole_Diagnostic_On_Later_Line_Reports_True_Line_Number` — proves line numbers stay correct for a hole many lines into the file.
- Added `Many_Interpolation_Holes_Parse_Near_Linear_Time` — parses 500 vs. 4000 holes and asserts the time ratio stays well under quadratic growth.

## Validation

- `dotnet build GSharp.sln -c Release -graph` — succeeded, 0 warnings/errors.
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release` — 5041 passed, 1 skipped (pre-existing `RegenerateBaseline`, unrelated).
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Release --filter "FullyQualifiedName~Interpolat" -- xUnit.MaxParallelThreads=2` — 4 passed.
