### PR TITLE
Fix gsi arg handling: --help/--version, reject unrecognized args

### DIFF
--- a/src/Repl/Program.cs
+++ b/src/Repl/Program.cs
@@ -13,29 +13,52 @@ public static class Program
 {
     public static int Main(string[] args)
     {
-        if (args.Length > 0 && args[0].EndsWith(".gs", StringComparison.OrdinalIgnoreCase))
+        if (args.Length == 0)
         {
-            if (!File.Exists(args[0]))
-            {
-                Console.Error.WriteLine($"File not found: {args[0]}");
-                return 1;
-            }
-
-            var engine = new SessionEngine();
-            var cell = engine.Evaluate(File.ReadAllText(args[0]));
-            foreach (var d in cell.Diagnostics)
-            {
-                Console.Error.WriteLine($"{d.Id}: {d.Message}");
-            }
-
-            if (!cell.HasError && cell.Value is not null)
-            {
-                Console.WriteLine(cell.Value);
-            }
-
-            return cell.HasError ? 1 : 0;
+            return ReplHost.Run();
         }
 
-        return ReplHost.Run();
+        var arg = args[0];
+        switch (arg)
+        {
+            case "--help":
+            case "-h":
+            case "/?":
+                Console.WriteLine("Usage: gsi [file.gs] [--help] [--version]");
+                Console.WriteLine("  file.gs      Run the given G# script and exit.");
+                Console.WriteLine("  --help, -h   Show this help and exit.");
+                Console.WriteLine("  --version    Show the gsi version and exit.");
+                Console.WriteLine("  (no args)    Start the interactive REPL.");
+                return 0;
+            case "--version":
+                Console.WriteLine(ReplHost.GetVersion());
+                return 0;
+        }
+
+        if (!arg.EndsWith(".gs", StringComparison.OrdinalIgnoreCase))
+        {
+            Console.Error.WriteLine($"Unrecognized argument: {arg}");
+            return 1;
+        }
+
+        if (!File.Exists(arg))
+        {
+            Console.Error.WriteLine($"File not found: {arg}");
+            return 1;
+        }
+
+        var engine = new SessionEngine();
+        var cell = engine.Evaluate(File.ReadAllText(arg));
+        foreach (var d in cell.Diagnostics)
+        {
+            Console.Error.WriteLine($"{d.Id}: {d.Message}");
+        }
+
+        if (!cell.HasError && cell.Value is not null)
+        {
+            Console.WriteLine(cell.Value);
+        }
+
+        return cell.HasError ? 1 : 0;
     }
 }

--- a/src/Repl/Program.cs
+++ b/src/Repl/Program.cs
@@ -15,6 +15,12 @@ public static class Program
     {
         if (args.Length == 0)
         {
+            if (Console.IsInputRedirected)
+            {
+                Console.Error.WriteLine("gsi requires an interactive terminal");
+                return 1;
+            }
+
             return ReplHost.Run();
         }
 

--- a/src/Repl/ReplHost.cs
+++ b/src/Repl/ReplHost.cs
@@ -56,7 +56,7 @@ public static class ReplHost
     }
 
     /// <summary>Resolves the build version from the assembly's informational version (set by Nerdbank GitVersioning).</summary>
-    private static string GetVersion()
+    internal static string GetVersion()
     {
         var info = Assembly.GetExecutingAssembly()
             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;


### PR DESCRIPTION
Fixes #1674

gsi silently launched the TUI for --help, --version, and typoed/missing filenames, hijacking the terminal in non-interactive contexts.

- No args -> interactive REPL (unchanged intended case).
- --help/-h/-? -> usage, exit 0.
- --version -> assembly informational version (reuses ReplHost.GetVersion, now internal), exit 0.
- Any other non-.gs arg -> error to stderr, exit 1.
- .gs file -> runs as before.

Verified with built gsi.dll: --help, --version, and a nonexistent file all behave correctly (see commit).