### PR TITLE
Fix #1667: BuildTask.Cancel() now stops child gsc process

### DIFF
--- a/src/Sdk/Gsharp.NET.Sdk/BuildTask.cs
+++ b/src/Sdk/Gsharp.NET.Sdk/BuildTask.cs
@@ -224,6 +224,26 @@ public class BuildTask : Microsoft.Build.Utilities.Task, ICancelableTask
         };
 
         using var proc = Process.Start(psi);
+
+        // Issue #1667: Cancel() only requests cancellation via cts; without
+        // this registration the child gsc process is never signaled and
+        // WaitForExit() below blocks until gsc finishes on its own, making
+        // MSBuild's cancel a no-op and risking orphaned compiler processes.
+        using var cancelRegistration = this.cts.Token.Register(() =>
+        {
+            try
+            {
+                // netstandard2.0 (this task's TFM) lacks Process.Kill(bool);
+                // gsc.dll doesn't spawn grandchildren, so killing it directly
+                // is sufficient to stop the compile.
+                proc.Kill();
+            }
+            catch (InvalidOperationException)
+            {
+                // Process already exited.
+            }
+        });
+
         string lastStdoutLine = null;
         string lastStderrLine = null;
         proc.OutputDataReceived += (_, e) =>
@@ -259,6 +279,13 @@ public class BuildTask : Microsoft.Build.Utilities.Task, ICancelableTask
         proc.BeginOutputReadLine();
         proc.BeginErrorReadLine();
         proc.WaitForExit();
+
+        if (this.cts.IsCancellationRequested)
+        {
+            // Build was cancelled: gsc was killed above, report failure
+            // without logging a spurious "gsc exited with code N" error.
+            return false;
+        }
 
         // Issue #519 + 6.2 SilentEmitFailure invariant (boundary ring): when
         // gsc exits non-zero but no structured diagnostic was logged, anchor


### PR DESCRIPTION
Fixes #1667

Cancel() set a CancellationTokenSource but Execute() never read it: proc.WaitForExit() blocked until gsc.dll finished on its own, making MSBuild build-cancel a no-op and risking orphaned compiler processes.

Fix: register a cts.Token callback that kills the gsc process on cancel, and return false promptly when cancellation was requested (before the GS9998 silent-failure check runs, so no spurious error is logged).

Note: Process.Kill(entireProcessTree: true) isn't available on netstandard2.0 (this task's TFM); used plain Kill() since gsc.dll doesn't spawn grandchild processes.

Tested: dotnet build GSharp.sln -c Release -graph succeeds; existing Sdk.Tests (38 tests) pass. No harness exists to instantiate BuildTask directly (requires IBuildEngine) per BuildTaskSilentFailureTests.cs comments, so cancellation was verified via code inspection of the WaitForExit/Kill/return-false path.