### PR TITLE
Fix templates staging target skipping version substitution on incremental builds

### DIFF
--- a/src/Sdk/Gsharp.Templates/Gsharp.Templates.csproj
+++ b/src/Sdk/Gsharp.Templates/Gsharp.Templates.csproj
@@ -68,7 +68,7 @@
   <Target Name="BuildGsharpTemplatesContent"
           BeforeTargets="AssignTargetPaths;_GetPackageFiles;GenerateNuspec;CoreCompile"
           Inputs="@(_TemplateSourceFile)"
-          Outputs="$(GsharpTemplatesIntermediateContent)/.stamp">
+          Outputs="$(GsharpTemplatesIntermediateContent)/.stamp-$(Version)">
     <!-- Clean stale staging so files removed from content/ are not packed. -->
     <RemoveDir Directories="$(GsharpTemplatesIntermediateContent)" />
     <MakeDir Directories="$(GsharpTemplatesIntermediateContent)" />
@@ -81,7 +81,7 @@
                       Token="__GSHARP_SDK_VERSION__"
                       Replacement="$(Version)" />
 
-    <WriteLinesToFile File="$(GsharpTemplatesIntermediateContent)/.stamp" Lines="$(Version)" Overwrite="true" />
+    <WriteLinesToFile File="$(GsharpTemplatesIntermediateContent)/.stamp-$(Version)" Lines="$(Version)" Overwrite="true" />
   </Target>
 
   <!-- Materialize substituted content as Content items that NuGet will pack under content/. -->
@@ -89,7 +89,7 @@
           DependsOnTargets="BuildGsharpTemplatesContent"
           BeforeTargets="_GetPackageFiles;GenerateNuspec">
     <ItemGroup>
-      <_PackagedTemplateFile Include="$(GsharpTemplatesIntermediateContent)/**/*" Exclude="$(GsharpTemplatesIntermediateContent)/.stamp" />
+      <_PackagedTemplateFile Include="$(GsharpTemplatesIntermediateContent)/**/*" Exclude="$(GsharpTemplatesIntermediateContent)/.stamp*" />
       <Content Include="@(_PackagedTemplateFile)"
                Pack="true"
                PackagePath="content/%(RecursiveDir)%(Filename)%(Extension)" />


### PR DESCRIPTION
Fixes #1673

BuildGsharpTemplatesContent's Inputs/Outputs incremental check was purely file-timestamp based, but the target's output content depends on $(Version) (Nerdbank.GitVersioning bumps this every commit). A commit that doesn't touch content/ left the stamp file up-to-date, so the target was skipped and templates were packed with a stale __GSHARP_SDK_VERSION__ substitution.

Fix: fold $(Version) into the stamp file name (`.stamp-$(Version)`). A version change means the expected output file doesn't exist, forcing MSBuild to re-run the target; an unchanged version still short-circuits it. Also widened the pack-exclude glob from `.stamp` to `.stamp*` since the stamp filename is now version-suffixed.

Verified: built Gsharp.Templates, confirmed stamp file `.stamp-0.2.476-gc3c3912fa2` and substituted content 0.2.476-gc3c3912fa2. Added a throwaway commit (bumping NBGV height to 0.2.477-gfd101db627) and rebuilt: target re-ran (no skip message), new stamp `.stamp-0.2.477-gfd101db627` created, template content substituted with the new version. Rebuilding again unchanged: target correctly skipped as up-to-date. Full solution build (`dotnet build GSharp.sln -c Release -graph`) succeeds with 0 warnings/errors.