### PR TITLE
Fix #1672: use $(TargetRefPath) instead of hardcoded obj/ path in Pack target

### DIFF
--- a/src/Sdk/Gsharp.NET.Sdk/build/Gsharp.NET.Core.Sdk.targets
+++ b/src/Sdk/Gsharp.NET.Sdk/build/Gsharp.NET.Core.Sdk.targets
@@ -148,7 +148,12 @@
   <Target Name="_GsharpGetRefAssemblyForPack"
           Condition=" '$(ProduceReferenceAssembly)' == 'true' ">
     <ItemGroup>
-      <TfmSpecificPackageFile Include="$(ProjectDir)obj/$(Configuration)/$(TargetFramework)/ref/$(TargetName)$(TargetExt)"
+      <!-- Issue #1672: use the SDK-computed $(TargetRefPath) instead of
+           reconstructing the obj/ layout by string concatenation, so pack
+           still works with customized BaseIntermediateOutputPath/
+           IntermediateOutputPath (see build/gsharp.build.props), UseArtifactsOutput,
+           or a non-default MSBuildProjectExtensionsPath. -->
+      <TfmSpecificPackageFile Include="$(TargetRefPath)"
                               PackagePath="ref/$(TargetFramework)/" />
     </ItemGroup>
   </Target>


### PR DESCRIPTION
Fixes #1672

_GsharpGetRefAssemblyForPack in src/Sdk/Gsharp.NET.Sdk/build/Gsharp.NET.Core.Sdk.targets hardcoded the reference-assembly path via `$(ProjectDir)obj/$(Configuration)/$(TargetFramework)/ref/$(TargetName)$(TargetExt)`. This breaks when BaseIntermediateOutputPath/IntermediateOutputPath is customized (this repo's own build/gsharp.build.props:60 does exactly that), UseArtifactsOutput=true is set, or a non-default MSBuildProjectExtensionsPath is used — dotnet pack then references a nonexistent file.

Fix: use `$(TargetRefPath)`, the MSBuild-provided full path to the ref assembly, same idea as CoreCompile's own `@(IntermediateRefAssembly)` usage a few lines above. PackagePath unchanged.

Verification:
- `dotnet build GSharp.sln -c Release -graph` — succeeds, 0 warnings/errors, Gsharp.NET.Sdk nupkg produced.
- Built a scratch consumer .gsproj (Gsharp.Templates' gsharp-lib content) against the freshly-built Gsharp.NET.Sdk package, with `BaseIntermediateOutputPath` customized to `customobj/` (reproducing this repo's non-default layout). `dotnet pack` succeeded and the resulting .nupkg contains `ref/net10.0/Verify.dll` (confirmed via `unzip -l`).
- Confirmed the old hardcoded path (`obj/Release/net10.0/ref/`) never existed under the customized layout — the actual ref assembly lived at `customobj/Release/net10.0/ref/Verify.dll`, which only `$(TargetRefPath)` resolves correctly.