### PR TITLE
Fix embedded NUL silently truncating source (#1608)

### DIFF
--- a/src/Core/CodeAnalysis/Syntax/Lexer.cs
+++ b/src/Core/CodeAnalysis/Syntax/Lexer.cs
@@ -75,7 +75,19 @@ public sealed class Lexer
         switch (Current)
         {
             case '\0':
-                kind = SyntaxKind.EndOfFileToken;
+                if (position >= end)
+                {
+                    kind = SyntaxKind.EndOfFileToken;
+                }
+                else
+                {
+                    // Embedded NUL mid-file: distinct from true end-of-file (position >= end).
+                    // Report and skip so the rest of the file still lexes (issue #1608).
+                    var location = new TextLocation(this.text, new TextSpan(position, 1));
+                    Diagnostics.ReportBadCharacter(location, Current);
+                    position++;
+                }
+
                 break;
             case '+':
                 position++;

--- a/test/Core.Tests/CodeAnalysis/Syntax/LexerTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/LexerTests.cs
@@ -5,6 +5,7 @@
 using System.Collections.Immutable;
 using System.Linq;
 using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Syntax;
@@ -446,5 +447,36 @@ public class LexerTests
         Assert.Equal(2, fragments.Length);
         Assert.False(fragments[0].IsExpression);
         Assert.Equal("hello\n", fragments[0].Text);
+    }
+
+    [Fact]
+    public void EmbeddedNul_ReportsDiagnostic_AndDoesNotTruncateFile()
+    {
+        // Issue #1608: an embedded NUL used to be indistinguishable from EOF,
+        // silently dropping everything after it.
+        var tree = SyntaxTree.Parse("let a = 1\n\0let b = 2\n");
+
+        Assert.Contains(tree.Diagnostics, d => d.Message.Contains("Bad character", System.StringComparison.OrdinalIgnoreCase));
+        Assert.Equal(2, tree.Root.Members.Length);
+    }
+
+    [Fact]
+    public void NormalInput_StillLexesToSingleTrailingEndOfFileToken()
+    {
+        var sourceText = SourceText.From("let a = 1");
+        var syntaxTree = SyntaxTree.Parse(sourceText);
+        var lexer = new Lexer(syntaxTree);
+        var tokens = new System.Collections.Generic.List<SyntaxToken>();
+        SyntaxToken token;
+        do
+        {
+            token = lexer.Lex();
+            tokens.Add(token);
+        }
+        while (token.Kind != SyntaxKind.EndOfFileToken);
+
+        Assert.Empty(lexer.Diagnostics);
+        Assert.Equal(SyntaxKind.EndOfFileToken, tokens[^1].Kind);
+        Assert.Single(tokens, t => t.Kind == SyntaxKind.EndOfFileToken);
     }
 }


### PR DESCRIPTION
Fixes #1608

Root cause: `Lex()` treated any `\0` char value as end-of-file, so a literal U+0000 embedded in source was indistinguishable from true EOF. This silently dropped everything after the NUL with zero diagnostics.

Fix: EOF is now only emitted when `position >= end` (true end of input). An embedded NUL mid-file is instead reported through the existing bad-character diagnostic path (`Diagnostics.ReportBadCharacter`) and skipped, so lexing/parsing continues normally past it.

Added tests:
- embedded-NUL source reports a diagnostic and still parses both members instead of truncating.
- normal input still lexes to exactly one trailing `EndOfFileToken`.

Verified: `dotnet build GSharp.sln -c Release -graph` succeeds; `dotnet test test/Core.Tests/Core.Tests.csproj -c Release` — 5046 passed, 1 skipped (unrelated baseline-regen test), 0 failed.