### PR TITLE
Fix #1607: bound unbounded parser lookahead scans

### DIFF
--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -37,6 +37,15 @@ public class Parser
     // enough.
     private const int UncheckedRecursionDepth = 64;
 
+    // Issue #1607: shared bound for speculative "does this look like X"
+    // token-lookahead scans (matching-bracket / matching-brace searches).
+    // A well-formed construct always resolves within a few dozen tokens;
+    // this cap only fires on malformed/unbalanced input, turning an O(n)
+    // scan-to-EOF (which is O(n^2) in aggregate since these run per
+    // position) into an O(1) bailout. Mirrors the existing maxScan used by
+    // LooksLikeLambdaStart / LooksLikeArrowFunctionTypeClauseStart.
+    private const int LookaheadMaxScan = 4096;
+
     private readonly SyntaxTree syntaxTree;
 
     // ADR-0078 / issue #725: when a single source-level declaration desugars
@@ -5979,7 +5988,8 @@ public class Parser
         var depth = 0;
         var bracketDepth = 0;
         var braceDepth = 0;
-        for (var i = parenOffset; i < tokens.Length; i++)
+        var scanBound = Math.Min(tokens.Length, parenOffset + LookaheadMaxScan);
+        for (var i = parenOffset; i < scanBound; i++)
         {
             var t = Peek(i);
             switch (t.Kind)
@@ -8192,7 +8202,7 @@ public class Parser
     {
         offset = 0;
         var depth = 0;
-        for (var i = 1; ; i++)
+        for (var i = 1; i <= LookaheadMaxScan; i++)
         {
             var kind = Peek(i).Kind;
             if (kind == SyntaxKind.EndOfFileToken)
@@ -8219,6 +8229,8 @@ public class Parser
                 }
             }
         }
+
+        return false;
     }
 
     private ExpressionSyntax ParseNameOrCallExpression()
@@ -8780,7 +8792,7 @@ public class Parser
         }
 
         var depth = 0;
-        for (var i = 1; ; i++)
+        for (var i = 1; i <= LookaheadMaxScan; i++)
         {
             var kind = Peek(i).Kind;
             if (kind == SyntaxKind.EndOfFileToken)
@@ -8813,6 +8825,8 @@ public class Parser
                 return true;
             }
         }
+
+        return false;
     }
 
     private static bool IsLiteralStartToken(SyntaxKind kind)
@@ -9360,7 +9374,8 @@ public class Parser
         }
 
         var depth = 0;
-        for (var i = openParenOffset; ; i++)
+        var scanBound = openParenOffset + LookaheadMaxScan;
+        for (var i = openParenOffset; i <= scanBound; i++)
         {
             var kind = Peek(i).Kind;
             if (kind == SyntaxKind.EndOfFileToken)
@@ -9386,6 +9401,8 @@ public class Parser
                 }
             }
         }
+
+        return false;
     }
 
     private SeparatedSyntaxList<ExpressionSyntax> ParseArguments()
@@ -9841,6 +9858,11 @@ public class Parser
             var j = i + 1;
             while (true)
             {
+                if (j > LookaheadMaxScan)
+                {
+                    return false;
+                }
+
                 var k = Peek(j).Kind;
                 if (k == SyntaxKind.EndOfFileToken)
                 {
@@ -9883,6 +9905,11 @@ public class Parser
             var braceDepth = 0;
             while (true)
             {
+                if (j > LookaheadMaxScan)
+                {
+                    return false;
+                }
+
                 var k = Peek(j).Kind;
                 if (k == SyntaxKind.EndOfFileToken)
                 {

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue1607UnboundedLookaheadPerfParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue1607UnboundedLookaheadPerfParserTests.cs
@@ -1,0 +1,126 @@
+// <copyright file="Issue1607UnboundedLookaheadPerfParserTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Diagnostics;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Issue #1607: several speculative "does this look like X" token-lookahead
+/// scans (<c>TryFindMatchingCloseBracketFollowedByEquals</c>,
+/// <c>LooksLikeYieldTupleLiteral</c>, <c>LooksLikeCollectionInitializerBrace</c>,
+/// <c>LooksLikeReceiverMethodDeclaration</c>, <c>LooksLikeIfExpression</c>) had
+/// no scan bound and ran to EOF on malformed/unbalanced input. Since each is
+/// invoked per statement/position, an unbalanced construct repeated many
+/// times made parsing O(N^2). All five are now capped at the same
+/// <c>LookaheadMaxScan</c> bound already used by <c>LooksLikeLambdaStart</c>,
+/// so a malformed lookahead bails out quickly instead of scanning to EOF.
+/// </summary>
+public class Issue1607UnboundedLookaheadPerfParserTests
+{
+    [Fact]
+    public void Many_Unbalanced_Index_Assignments_Parse_Quickly()
+    {
+        // Each `a[` opens TryFindMatchingCloseBracketFollowedByEquals with no
+        // matching `]` anywhere in the file. Before the fix, each occurrence
+        // rescanned the remaining tokens to EOF -> O(N^2). The index content is
+        // a literal (not another unclosed `ident[`) so each statement's index
+        // expression terminates on its own instead of chaining into the next
+        // statement's unclosed bracket (a separate, pre-existing recursion
+        // concern unrelated to this lookahead-bound fix).
+        const int statementCount = 3000;
+        var source = "package p\nfunc F() {\n" +
+            string.Join("\n", Enumerable.Range(0, statementCount).Select(i => $"a{i}[{i}")) +
+            "\n}";
+
+        // Warm up JIT once, then take the best (minimum) of several runs.
+        // Minimum excludes cold-JIT and GC/scheduler spikes that make a
+        // single wall-clock sample flaky on shared CI hardware; the 2000ms
+        // bound still has ~1000x headroom over the linear parse while
+        // catching a regression back to the quadratic scan-to-EOF.
+        SyntaxTree.Parse(source);
+        var bestMs = long.MaxValue;
+        SyntaxTree tree = null;
+        for (var run = 0; run < 3; run++)
+        {
+            var stopwatch = Stopwatch.StartNew();
+            tree = SyntaxTree.Parse(source);
+            stopwatch.Stop();
+            if (stopwatch.ElapsedMilliseconds < bestMs)
+            {
+                bestMs = stopwatch.ElapsedMilliseconds;
+            }
+        }
+
+        Assert.NotEmpty(tree.Diagnostics);
+        Assert.True(bestMs < 2000, $"Parsing {statementCount} unbalanced '[' statements took {bestMs}ms, expected < 2000ms (quadratic before issue #1607 fix).");
+    }
+
+    [Fact]
+    public void Many_Unclosed_If_Blocks_Parse_Quickly()
+    {
+        // Each nested `if` inside a block expression invokes LooksLikeIfExpression,
+        // which used to walk to EOF when the `{` never closes.
+        const int nestCount = 3000;
+        var source = "package p\nlet x = {\n" +
+            string.Join("\n", Enumerable.Range(0, nestCount).Select(i => "if true {")) +
+            "\n}";
+
+        // Warm up JIT once, then take the best (minimum) of several runs to
+        // avoid cold-JIT / GC-spike flakiness on shared CI hardware.
+        SyntaxTree.Parse(source);
+        var bestMs = long.MaxValue;
+        for (var run = 0; run < 3; run++)
+        {
+            var stopwatch = Stopwatch.StartNew();
+            SyntaxTree.Parse(source);
+            stopwatch.Stop();
+            if (stopwatch.ElapsedMilliseconds < bestMs)
+            {
+                bestMs = stopwatch.ElapsedMilliseconds;
+            }
+        }
+
+        Assert.True(bestMs < 2000, $"Parsing {nestCount} unclosed 'if' blocks took {bestMs}ms, expected < 2000ms (quadratic before issue #1607 fix).");
+    }
+
+    [Fact]
+    public void Valid_Index_Assignment_Still_Parses()
+    {
+        const string source = "package p\nfunc F() {\n a[0] = 1\n}";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+    }
+
+    [Fact]
+    public void Valid_Yield_Tuple_Literal_Still_Parses()
+    {
+        const string source = """
+            package p
+            class C {
+                shared {
+                    func F() sequence[(int32, int32)] {
+                        yield (1, 2)
+                    }
+                }
+            }
+            """;
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+    }
+
+    [Fact]
+    public void Valid_If_Expression_Chain_Still_Parses()
+    {
+        const string source = """
+            package P
+            let x = if true { 1 } else { 2 }
+            """;
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+    }
+}


### PR DESCRIPTION
Fixes #1607

## Summary
Five speculative "does this look like X" token-lookahead scans in `Parser.cs` had no scan bound and ran to EOF on malformed/unbalanced input, making parsing O(N^2) since each scan is invoked per-position:

- `TryFindMatchingCloseBracketFollowedByEquals`
- `LooksLikeYieldTupleLiteral`
- `LooksLikeCollectionInitializerBrace`
- `LooksLikeReceiverMethodDeclaration`
- `LooksLikeIfExpression`

## Fix
Added a shared `LookaheadMaxScan = 4096` constant (mirroring the existing `maxScan` cap already used by `LooksLikeLambdaStart` / `LooksLikeArrowFunctionTypeClauseStart`) and applied it to all five scans. Each already tracks nested-delimiter depth and returns as soon as the depth returns to zero for well-formed input — the bound only changes behavior when depth never returns to zero (malformed/unbalanced input), causing a fast bailout instead of an O(n) scan-to-EOF.

## Testing
- `dotnet build GSharp.sln -c Release -graph` — succeeds, 0 warnings/errors.
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release` — full suite green (5049 passed, 1 skipped baseline regen).
- Added `Issue1607UnboundedLookaheadPerfParserTests` with pathological malformed-input inputs (thousands of unbalanced `[`/`if` constructs) asserting fast termination, plus valid-construct regression coverage for index-assignment, yield-tuple-literal, and if-expression parsing.