### PR TITLE
Fix BoundBodyCache unbounded memory growth

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundBodyCache.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundBodyCache.cs
@@ -75,6 +75,12 @@ public sealed class BoundBodyCache
 {
     private readonly ConcurrentDictionary<BoundBodyCacheKey, Entry> entries = new();
 
+    // ponytail: only the latest body per member is ever reusable (an edit makes
+    // every prior bodyHash for that member unreachable — see TryReuse's
+    // ReferenceEquals gate), so tracking the current key per member and evicting
+    // its predecessor keeps the cache at O(members) instead of growing with every edit.
+    private readonly ConcurrentDictionary<string, BoundBodyCacheKey> latestKeyByMember = new();
+
     private long hits;
     private long misses;
     private long stores;
@@ -87,6 +93,9 @@ public sealed class BoundBodyCache
 
     /// <summary>Gets the number of bodies stored into the cache so far.</summary>
     public long Stores => Interlocked.Read(ref stores);
+
+    /// <summary>Gets the number of entries currently retained in the cache.</summary>
+    public int Count => entries.Count;
 
     /// <summary>
     /// Computes the stable, content-addressed key for a member body. Returns
@@ -187,6 +196,15 @@ public sealed class BoundBodyCache
 
         entries[key] = new Entry(member, loweredBody, diagnostics.IsDefault ? ImmutableArray<Diagnostic>.Empty : diagnostics);
         Interlocked.Increment(ref stores);
+
+        // Evict the previous body for this member (if any and if different):
+        // a superseded bodyHash can never hit again, so keeping it is a pure leak.
+        var priorKey = latestKeyByMember.GetOrAdd(key.StableMemberId, key);
+        if (!priorKey.Equals(key))
+        {
+            latestKeyByMember[key.StableMemberId] = key;
+            entries.TryRemove(priorKey, out _);
+        }
     }
 
     private static string ComputeContainingTypePath(FunctionSymbol member)

--- a/test/Core.Tests/CodeAnalysis/Binding/BoundBodyCacheTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/BoundBodyCacheTests.cs
@@ -287,6 +287,43 @@ public class BoundBodyCacheTests
         Assert.Equal(fromScratchPe, fromCachePe);
     }
 
+    /// <summary>
+    /// Issue #1645 — repeatedly editing one member's body must not leak stale
+    /// entries: only the current (memberId, bodyHash) stays cached, while a
+    /// lookup for that current body still hits.
+    /// </summary>
+    [Fact]
+    public void Store_Evicts_Stale_BodyHashes_For_Same_Member_On_Edit()
+    {
+        var cache = new BoundBodyCache();
+        BoundBodyCacheKey lastKey = default;
+        FunctionSymbol lastFunction = null;
+
+        for (var i = 0; i < 5; i++)
+        {
+            var source = $$"""
+                package P
+                func F(x int) int {
+                    return x + {{i}}
+                }
+                """;
+            var globalScope = BindGlobalScope(source);
+            var function = globalScope.Functions.Single(f => f.Name == "F");
+            var body = new BoundBlockStatement(function.Declaration.Body, ImmutableArray<BoundStatement>.Empty);
+
+            cache.Store(function, function.Declaration.Body, body, ImmutableArray<Diagnostic>.Empty);
+
+            lastFunction = function;
+            Assert.True(BoundBodyCache.TryCreateKey(function, function.Declaration.Body, out lastKey));
+        }
+
+        // Only the most recent edit's body survives — no unbounded growth.
+        Assert.Equal(1, cache.Count);
+
+        // The current (memberId, bodyHash) still hits.
+        Assert.True(cache.TryReuse(lastFunction, lastFunction.Declaration.Body, out _, out _));
+    }
+
     private static byte[] EmitToBytes(BoundProgram program)
     {
         using var stream = new MemoryStream();


### PR DESCRIPTION
Fixes #1645

BoundBodyCache had no eviction: every body edit produces a new (stableMemberId, bodyHash) key, and the entry for the previous hash was kept forever (unreachable — TryReuse's ReferenceEquals gate means a stale hash can never hit again). Over a long LSP session this leaked a lowered BoundBlockStatement + diagnostics + symbol graph per edit.

Fix: track the current key per stableMemberId; on Store, evict the prior key's entry when it differs from the new one. Bounds the cache to O(members) instead of O(edits). Current-body hit semantics unchanged (verified by existing tests).

Added a regression test (Store_Evicts_Stale_BodyHashes_For_Same_Member_On_Edit) simulating 5 edits to the same member: cache retains only 1 entry, and the current body still hits.