### PR TITLE
De-flake interpolation parse scaling perf test

### DIFF
--- a/test/Core.Tests/CodeAnalysis/Binding/InterpolatedStringTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/InterpolatedStringTests.cs
@@ -465,10 +465,26 @@ public class InterpolatedStringTests
         {
             // Warm up JIT once before timing.
             SyntaxTree.Parse(SourceText.From(source));
-            var sw = System.Diagnostics.Stopwatch.StartNew();
-            SyntaxTree.Parse(SourceText.From(source));
-            sw.Stop();
-            return sw.ElapsedTicks;
+
+            // Take the best (minimum) of several runs. Minimum is the least
+            // noisy statistic for wall-clock microbenchmarks: it excludes GC
+            // pauses and scheduler preemption spikes that otherwise make a
+            // single-shot ratio flaky on shared CI hardware.
+            var best = long.MaxValue;
+            for (var i = 0; i < 7; i++)
+            {
+                var sw = System.Diagnostics.Stopwatch.StartNew();
+                SyntaxTree.Parse(SourceText.From(source));
+                sw.Stop();
+                if (sw.ElapsedTicks < best)
+                {
+                    best = sw.ElapsedTicks;
+                }
+            }
+
+            // Floor the denominator so an anomalously fast small sample can't
+            // blow up the ratio.
+            return System.Math.Max(best, 1);
         }
 
         var small = TimeParse(BuildSource(500));


### PR DESCRIPTION
The wall-clock perf test `Many_Interpolation_Holes_Parse_Near_Linear_Time` (added by #1605) intermittently fails on CI: it took a single Stopwatch sample per input size and asserted a ratio bound. A single sample is noisy on shared CI runners, and an anomalously fast small sample blows up the ratio, producing false failures unrelated to any regression (observed on an unrelated PR's build leg).

Fix: take the best (minimum) of several runs per size and floor the denominator. Minimum is the least-noisy statistic for wall-clock microbenchmarks — it excludes GC pauses and scheduler preemption — so the near-linear scaling guarantee stays intact without the flakiness.

Test-only change.