### PR TITLE
Fix constructed-generic cache keys to use reference equality

### DIFF
--- a/src/Core/CodeAnalysis/Symbols/DelegateTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/DelegateTypeSymbol.cs
@@ -30,7 +30,7 @@ namespace GSharp.Core.CodeAnalysis.Symbols;
 /// </remarks>
 public sealed class DelegateTypeSymbol : TypeSymbol
 {
-    private static readonly ConcurrentDictionary<(DelegateTypeSymbol Definition, string ArgsKey), DelegateTypeSymbol> ConstructedCache = new();
+    private static readonly ConcurrentDictionary<(DelegateTypeSymbol Definition, TypeArgsKey ArgsKey), DelegateTypeSymbol> ConstructedCache = new();
 
     private FunctionTypeSymbol equivalentFunctionType;
 
@@ -177,16 +177,7 @@ public sealed class DelegateTypeSymbol : TypeSymbol
         return ConstructedCache.GetOrAdd((definition, key), _ => CreateConstructed(definition, typeArguments));
     }
 
-    private static string BuildArgsKey(ImmutableArray<TypeSymbol> typeArguments)
-    {
-        var parts = new string[typeArguments.Length];
-        for (var i = 0; i < typeArguments.Length; i++)
-        {
-            parts[i] = System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(typeArguments[i]).ToString(System.Globalization.CultureInfo.InvariantCulture);
-        }
-
-        return string.Join(",", parts);
-    }
+    private static TypeArgsKey BuildArgsKey(ImmutableArray<TypeSymbol> typeArguments) => new(typeArguments);
 
     private static DelegateTypeSymbol CreateConstructed(DelegateTypeSymbol definition, ImmutableArray<TypeSymbol> typeArguments)
     {

--- a/src/Core/CodeAnalysis/Symbols/InterfaceSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/InterfaceSymbol.cs
@@ -18,7 +18,7 @@ namespace GSharp.Core.CodeAnalysis.Symbols;
 /// </summary>
 public sealed class InterfaceSymbol : TypeSymbol
 {
-    private static readonly ConcurrentDictionary<(InterfaceSymbol Def, string Args), InterfaceSymbol> ConstructedCache = new();
+    private static readonly ConcurrentDictionary<(InterfaceSymbol Def, TypeArgsKey Args), InterfaceSymbol> ConstructedCache = new();
 
     private ImmutableArray<FunctionSymbol> methods;
     private ImmutableArray<FunctionSymbol> staticMethods = ImmutableArray<FunctionSymbol>.Empty;
@@ -576,16 +576,7 @@ public sealed class InterfaceSymbol : TypeSymbol
         TryResolveMembers();
     }
 
-    private static string BuildArgsKey(ImmutableArray<TypeSymbol> typeArguments)
-    {
-        var parts = new string[typeArguments.Length];
-        for (var i = 0; i < typeArguments.Length; i++)
-        {
-            parts[i] = System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(typeArguments[i]).ToString();
-        }
-
-        return string.Join(",", parts);
-    }
+    private static TypeArgsKey BuildArgsKey(ImmutableArray<TypeSymbol> typeArguments) => new(typeArguments);
 
     private static InterfaceSymbol CreateConstructed(InterfaceSymbol definition, ImmutableArray<TypeSymbol> typeArguments)
     {

--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -18,14 +18,14 @@ namespace GSharp.Core.CodeAnalysis.Symbols;
 /// </summary>
 public sealed class StructSymbol : TypeSymbol
 {
-    private static readonly ConcurrentDictionary<(StructSymbol Def, string ArgsKey), StructSymbol> ConstructedCache = new();
+    private static readonly ConcurrentDictionary<(StructSymbol Def, TypeArgsKey ArgsKey), StructSymbol> ConstructedCache = new();
 
     // Issue #1521: identity cache for constructed references to types nested
     // inside a generic enclosing type (`Box[int32].Tag`), keyed by the nested
     // definition and the flattened enclosing type-argument vector so two
     // references to the same construction share one symbol (preserving
     // reference equality and TypeSpec caching in the emitter).
-    private static readonly ConcurrentDictionary<(StructSymbol Def, string ArgsKey), StructSymbol> ConstructedNestedCache = new();
+    private static readonly ConcurrentDictionary<(StructSymbol Def, TypeArgsKey ArgsKey), StructSymbol> ConstructedNestedCache = new();
 
     // Issue #1537: identity cache for constructed references to a GENERIC type
     // nested inside a generic enclosing type (`Outer[int32].Middle[string]`),
@@ -33,7 +33,7 @@ public sealed class StructSymbol : TypeSymbol
     // vector, and the nested type's own type-argument vector. Distinct from
     // ConstructedNestedCache (which keys only the enclosing args for a nested
     // type with no own parameters) so the two representations never collide.
-    private static readonly ConcurrentDictionary<(StructSymbol Def, string EnclosingKey, string OwnKey), StructSymbol> ConstructedNestedGenericCache = new();
+    private static readonly ConcurrentDictionary<(StructSymbol Def, TypeArgsKey EnclosingKey, TypeArgsKey OwnKey), StructSymbol> ConstructedNestedGenericCache = new();
 
     // Issue #1341: backing stores for the generically-erased member tables whose
     // reads are forwarded to Definition on a constructed instance. On a
@@ -1503,16 +1503,7 @@ public sealed class StructSymbol : TypeSymbol
         return changed ? builder.MoveToImmutable() : default;
     }
 
-    private static string BuildArgsKey(ImmutableArray<TypeSymbol> typeArguments)
-    {
-        var parts = new string[typeArguments.Length];
-        for (var i = 0; i < typeArguments.Length; i++)
-        {
-            parts[i] = System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(typeArguments[i]).ToString();
-        }
-
-        return string.Join(",", parts);
-    }
+    private static TypeArgsKey BuildArgsKey(ImmutableArray<TypeSymbol> typeArguments) => new(typeArguments);
 
     private static TypeSymbol EnclosingTypeOf(TypeSymbol type) => type switch
     {

--- a/src/Core/CodeAnalysis/Symbols/TypeArgsKey.cs
+++ b/src/Core/CodeAnalysis/Symbols/TypeArgsKey.cs
@@ -1,0 +1,58 @@
+// <copyright file="TypeArgsKey.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
+
+namespace GSharp.Core.CodeAnalysis.Symbols;
+
+/// <summary>
+/// Issue #1621: dictionary key for constructed-generic caches (<see cref="StructSymbol"/>,
+/// <see cref="InterfaceSymbol"/>, <see cref="DelegateTypeSymbol"/>) that compares a vector of
+/// type arguments by REFERENCE identity, not by a stringified <see cref="RuntimeHelpers.GetHashCode"/>.
+/// TypeSymbols are reference-identity throughout the codebase, so a hash-only key risks silently
+/// aliasing two distinct constructions whose type arguments' identity hashes collide (the hash is
+/// at most 31 bits and is not guaranteed unique). <see cref="Equals(TypeArgsKey)"/> performs the
+/// real, correct-by-construction comparison; <see cref="GetHashCode"/> is only a bucketing hint.
+/// </summary>
+internal readonly struct TypeArgsKey : System.IEquatable<TypeArgsKey>
+{
+    private readonly ImmutableArray<TypeSymbol> args;
+
+    public TypeArgsKey(ImmutableArray<TypeSymbol> args)
+    {
+        this.args = args.IsDefault ? ImmutableArray<TypeSymbol>.Empty : args;
+    }
+
+    public bool Equals(TypeArgsKey other)
+    {
+        if (this.args.Length != other.args.Length)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < this.args.Length; i++)
+        {
+            if (!ReferenceEquals(this.args[i], other.args[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public override bool Equals(object obj) => obj is TypeArgsKey other && this.Equals(other);
+
+    public override int GetHashCode()
+    {
+        var hash = 17;
+        for (var i = 0; i < this.args.Length; i++)
+        {
+            hash = unchecked((hash * 31) + RuntimeHelpers.GetHashCode(this.args[i]));
+        }
+
+        return hash;
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Symbols/Issue1621ConstructedGenericCacheKeyTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/Issue1621ConstructedGenericCacheKeyTests.cs
@@ -1,0 +1,71 @@
+// <copyright file="Issue1621ConstructedGenericCacheKeyTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Symbols;
+
+/// <summary>
+/// Issue #1621 regression coverage: constructed-generic caches (<see cref="StructSymbol"/>,
+/// <see cref="InterfaceSymbol"/>, <see cref="DelegateTypeSymbol"/>) used to key on a stringified
+/// <c>RuntimeHelpers.GetHashCode</c> per type argument. That hash is at most 31 bits and is NOT an
+/// identity — two distinct, live <see cref="TypeSymbol"/> instances can collide, which would make
+/// <c>Construct(def, [B])</c> silently return a cached instantiation for a different argument
+/// <c>A</c>. The fix (<see cref="TypeArgsKey"/>) compares type-argument vectors by REFERENCE
+/// identity per element instead, so the cache can never conflate two distinct arguments regardless
+/// of what their identity hashes happen to be.
+/// </summary>
+public class Issue1621ConstructedGenericCacheKeyTests
+{
+    private const string Source = @"package P
+
+class Box[T] {
+    var field T
+}
+";
+
+    [Fact]
+    public void TypeArgsKey_Equals_IsReferenceIdentityPerElement_NotHashBased()
+    {
+        var keyInt = new TypeArgsKey(ImmutableArray.Create<TypeSymbol>(TypeSymbol.Int32));
+        var keyBool = new TypeArgsKey(ImmutableArray.Create<TypeSymbol>(TypeSymbol.Bool));
+        var keyIntAgain = new TypeArgsKey(ImmutableArray.Create<TypeSymbol>(TypeSymbol.Int32));
+
+        // Distinct type arguments must never compare equal, no matter what their
+        // RuntimeHelpers.GetHashCode values happen to be.
+        Assert.False(keyInt.Equals(keyBool));
+
+        // The same argument reference, wrapped independently, must still compare equal.
+        Assert.True(keyInt.Equals(keyIntAgain));
+    }
+
+    [Fact]
+    public void Construct_WithDistinctTypeArguments_NeverAliasesDistinctInstantiations()
+    {
+        var box = GetStruct("Box");
+
+        var boxInt = StructSymbol.Construct(box, ImmutableArray.Create<TypeSymbol>(TypeSymbol.Int32));
+        var boxBool = StructSymbol.Construct(box, ImmutableArray.Create<TypeSymbol>(TypeSymbol.Bool));
+        var boxIntAgain = StructSymbol.Construct(box, ImmutableArray.Create<TypeSymbol>(TypeSymbol.Int32));
+
+        Assert.NotSame(boxInt, boxBool);
+        Assert.Same(boxInt, boxIntAgain);
+    }
+
+    private static StructSymbol GetStruct(string name)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(Source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.Empty(result.Diagnostics);
+        return (StructSymbol)compilation.GlobalScope.Structs.Single(s => s.Name == name);
+    }
+}


### PR DESCRIPTION
Fixes #1621

## Problem
`StructSymbol`, `InterfaceSymbol`, and `DelegateTypeSymbol` each cache their `Construct`/`ConstructNested`/`ConstructNestedGeneric` results in a `ConcurrentDictionary` keyed on a string built from `RuntimeHelpers.GetHashCode()` per type argument (`BuildArgsKey`). That hash is at most 31 bits and is an identity **hash**, not an identity. Two distinct, live `TypeSymbol` instances can collide, so `Construct(def, [B])` could silently return a cached instantiation built for a different argument `A` — a hash-collision-triggered miscompile that is undiagnosable and non-reproducible.

## Fix
Added `src/Core/CodeAnalysis/Symbols/TypeArgsKey.cs`: a small internal readonly struct wrapping `ImmutableArray<TypeSymbol>` whose `Equals` compares elements by **reference** (TypeSymbols are reference-identity throughout this codebase), while `GetHashCode` still combines each element's identity hash purely as a dictionary bucketing hint. This mirrors the existing correct pattern already used by `MethodSpecSymbolKey`/`CtorRefSymbolKey` in `src/Core/CodeAnalysis/Emit/MetadataTokenCache.cs`.

Replaced the three `BuildArgsKey` string-hash helpers and their cache dictionary key types in:
- `StructSymbol.cs` (`ConstructedCache`, `ConstructedNestedCache`, `ConstructedNestedGenericCache`)
- `InterfaceSymbol.cs` (`ConstructedCache`)
- `DelegateTypeSymbol.cs` (`ConstructedCache`)

Grepped the whole repo for `RuntimeHelpers.GetHashCode` and `BuildArgsKey`; the only other hits are the already-correct `MetadataTokenCache` key structs, which needed no change.

## Testing
- `dotnet build GSharp.sln -c Release -graph` — succeeded, 0 warnings/errors.
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release --filter "FullyQualifiedName~Symbols"` — 198/198 passed.
- Added `test/Core.Tests/CodeAnalysis/Symbols/Issue1621ConstructedGenericCacheKeyTests.cs`: asserts `TypeArgsKey` equality is reference-based (distinct type arguments never compare equal; the same reference always does), and that `StructSymbol.Construct` with distinct type arguments never aliases distinct instantiations.

Nothing deferred.