### PR TITLE
Fix #1628: Phase-2 overload scoring maps named args to correct parameter slot

### DIFF
--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -945,10 +945,24 @@ internal sealed class OverloadResolver
             }
 
             // Score argument-type compatibility: +1 per exact-type match.
-            for (var i = 0; i < paramCountForScore && i < boundArguments.Count; i++)
+            // Issue #1628: boundArguments[i] is source order, not parameter
+            // order — under named arguments the source-order index does not
+            // necessarily line up with the parameter it binds to (e.g. a
+            // named arg reorders a permutation-overload's parameters). Map
+            // each argument to its ACTUAL target slot (the same name→slot
+            // mapping IsApplicableUserCallable already validated) before
+            // scoring, so a named call still gets correct exact-match
+            // tie-breaking instead of being scored against the wrong param.
+            for (var i = 0; i < boundArguments.Count; i++)
             {
+                var slot = MapArgumentIndexToParameterSlot(cand, argumentNames, i, parameterOffset, paramLen);
+                if (slot < 0 || slot >= paramCountForScore)
+                {
+                    continue;
+                }
+
                 var argType = boundArguments[i]?.Type;
-                var paramType = cand.Parameters[i + parameterOffset].Type;
+                var paramType = cand.Parameters[slot + parameterOffset].Type;
                 if (argType != null && paramType != null && argType == paramType)
                 {
                     score -= 10;
@@ -1322,6 +1336,42 @@ internal sealed class OverloadResolver
     /// ADR-0063: returns true when the supplied argument count + names could
     /// reach the parameter list of the candidate.
     /// </summary>
+    /// <summary>
+    /// Issue #1628: maps a source-order argument index to the parameter slot
+    /// (0-based, excluding <paramref name="parameterOffset"/>) it actually
+    /// binds to on <paramref name="candidate"/>. A named argument binds to
+    /// whichever parameter shares its name — not necessarily its source
+    /// position — while an unnamed argument binds positionally. Mirrors the
+    /// name→slot resolution <see cref="IsApplicableUserCallable"/> already
+    /// validates and <c>TryReorderUserCallArguments</c> already performs, so
+    /// Phase-2 exact-match scoring ranks the candidate against the parameter
+    /// it will really receive the argument on. Returns -1 if the name (already
+    /// validated applicable) is not found, which should not happen in practice.
+    /// </summary>
+    private static int MapArgumentIndexToParameterSlot(
+        FunctionSymbol candidate,
+        ImmutableArray<string> argumentNames,
+        int argumentIndex,
+        int parameterOffset,
+        int paramLen)
+    {
+        var name = argumentNames.IsDefault || argumentIndex >= argumentNames.Length ? null : argumentNames[argumentIndex];
+        if (name == null)
+        {
+            return argumentIndex;
+        }
+
+        for (var p = 0; p < paramLen; p++)
+        {
+            if (candidate.Parameters[p + parameterOffset].Name == name)
+            {
+                return p;
+            }
+        }
+
+        return -1;
+    }
+
     private static bool IsApplicableUserCallable(FunctionSymbol candidate, int argumentCount, ImmutableArray<string> argumentNames)
     {
         var parameterOffset = candidate.ExplicitReceiverParameter == null ? 0 : 1;

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1628NamedArgumentPermutationOverloadTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1628NamedArgumentPermutationOverloadTests.cs
@@ -1,0 +1,61 @@
+// <copyright file="Issue1628NamedArgumentPermutationOverloadTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1628: Phase-2 exact-match scoring in
+/// <c>OverloadResolver.SelectBestUserOverloadCore</c> used to map
+/// <c>boundArguments[i]</c> (source order) onto <c>cand.Parameters[i]</c>
+/// (declaration order) even when the call used named arguments, so an
+/// argument named for parameter <c>c</c> could be scored against a
+/// different candidate's parameter that merely sits at the SAME source
+/// index. Between two overloads whose parameters are a permutation of each
+/// other, this let the wrong overload win by accidental positional type
+/// coincidence, with no diagnostic. The fix maps each argument to its real
+/// name-resolved parameter slot before scoring.
+/// </summary>
+public class Issue1628NamedArgumentPermutationOverloadTests
+{
+    [Fact]
+    public void NamedArgs_PermutationOverloads_SelectsNameCorrectCandidate()
+    {
+        // F_Right(a int32, b string, c bool) is the only candidate that is an
+        // EXACT type match for every argument once named args are resolved to
+        // their real parameter (b -> string, c -> bool).
+        //
+        // F_Wrong(a int32, b bool, c string) only looks better under the OLD
+        // buggy positional scoring: boundArguments[1] (c: true, a bool value)
+        // happens to sit at F_Wrong's declaration slot 1 (also bool), and
+        // boundArguments[2] (b: "s", a string value) happens to sit at slot 2
+        // (also string) -- an accidental positional coincidence that used to
+        // out-score the real match.
+        const string source = @"
+package p
+func F(a int32, b string, c bool) int32 { return 100 }
+func F(a int32, b bool, c string) int32 { return 200 }
+
+let x = F(1, c: true, b: ""s"")
+x
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(100, result.Value);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
Fixes #1628

## Problem
`OverloadResolver.SelectBestUserOverloadCore` Phase-2 exact-match scoring mapped `boundArguments[i]` (source order) onto `cand.Parameters[i + parameterOffset]` (declaration order) unconditionally, even for named-argument calls. The sibling convertibility filter (~line 800) already treats this mapping as unreliable under named arguments and skips itself; scoring did not.

Between two overloads whose parameters are a permutation of each other, a named argument could be scored against the wrong candidate's parameter purely because it shared the same source index — silently selecting the wrong overload (or a spurious tie), with no diagnostic.

## Fix
Added `MapArgumentIndexToParameterSlot`, mirroring the name→slot resolution already validated by `IsApplicableUserCallable` and performed by `TryReorderUserCallArguments`. Phase-2 scoring now resolves each argument to its real target parameter (by name when named, positionally otherwise) before comparing types. Handles mixed positional+named calls, any permutation, and the extension/receiver `parameterOffset` case. Positional-only calls are unaffected (mapping is the identity).

## Testing
- `dotnet build GSharp.sln -c Release -graph` — succeeds.
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release --filter "FullyQualifiedName~Overload|FullyQualifiedName~NamedArgument|FullyQualifiedName~Issue1154|FullyQualifiedName~Issue1319|FullyQualifiedName~Issue1147|FullyQualifiedName~Issue1552|FullyQualifiedName~Issue1531|FullyQualifiedName~Issue1628"` — 214 passed.
- Added `Issue1628NamedArgumentPermutationOverloadTests`: two overloads with permuted parameters, called with named args that reorder them; verified the test fails (wrong overload picked, conversion errors) on the pre-fix code and passes after the fix.

Nothing deferred.