### PR TITLE
Memoize HasAwait queries in async lowering

### DIFF
--- a/src/Core/CodeAnalysis/Lowering/Async/AsyncBoundTreeQueries.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AsyncBoundTreeQueries.cs
@@ -2,6 +2,7 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using System.Collections.Generic;
 using GSharp.Core.CodeAnalysis.Binding;
 using GSharp.Core.CodeAnalysis.Syntax;
 
@@ -23,20 +24,44 @@ namespace GSharp.Core.CodeAnalysis.Lowering.Async;
 public static class AsyncBoundTreeQueries
 {
     /// <summary>
+    /// Creates a fresh, reference-keyed memo for <see cref="HasAwait(BoundStatement, Dictionary{BoundNode, bool})"/>
+    /// and <see cref="HasAwait(BoundExpression, Dictionary{BoundNode, bool})"/>. Callers that query the
+    /// same bound tree (or overlapping subtrees) many times during one lowering pass — e.g.
+    /// <c>SpillSequenceSpiller</c>'s per-recursion-level probes — should create one memo per pass and
+    /// pass it to every call so each node's "contains await" result is computed once and reused (issue
+    /// #1625). <see cref="BoundNode"/> does not override <c>Equals</c>/<c>GetHashCode</c>, so the default
+    /// dictionary comparer already keys by reference identity; rewriting a subtree produces new node
+    /// instances, so a stale entry can never be observed for a node that was actually mutated.
+    /// </summary>
+    /// <returns>A new, empty memo dictionary.</returns>
+    public static Dictionary<BoundNode, bool> CreateHasAwaitMemo() => new();
+
+    /// <summary>
     /// Returns <see langword="true"/> when the given bound statement subtree
     /// contains at least one <see cref="BoundAwaitExpression"/>.
     /// </summary>
     /// <param name="statement">The bound statement to inspect.</param>
     /// <returns>Whether the subtree contains an <c>await</c>.</returns>
-    public static bool HasAwait(BoundStatement statement)
+    public static bool HasAwait(BoundStatement statement) => HasAwait(statement, memo: null);
+
+    /// <summary>
+    /// Returns <see langword="true"/> when the given bound statement subtree
+    /// contains at least one <see cref="BoundAwaitExpression"/>, consulting and
+    /// populating <paramref name="memo"/> (see <see cref="CreateHasAwaitMemo"/>)
+    /// so repeated/nested queries over the same nodes are O(1) after the first visit.
+    /// </summary>
+    /// <param name="statement">The bound statement to inspect.</param>
+    /// <param name="memo">An optional reference-keyed cache shared across calls in one lowering pass.</param>
+    /// <returns>Whether the subtree contains an <c>await</c>.</returns>
+    public static bool HasAwait(BoundStatement statement, Dictionary<BoundNode, bool> memo)
     {
         if (statement == null)
         {
             return false;
         }
 
-        var probe = new AwaitDetector();
-        probe.Visit(statement);
+        var probe = new AwaitDetector(memo);
+        probe.VisitStatement(statement);
         return probe.Found;
     }
 
@@ -46,15 +71,26 @@ public static class AsyncBoundTreeQueries
     /// </summary>
     /// <param name="expression">The bound expression to inspect.</param>
     /// <returns>Whether the subtree contains an <c>await</c>.</returns>
-    public static bool HasAwait(BoundExpression expression)
+    public static bool HasAwait(BoundExpression expression) => HasAwait(expression, memo: null);
+
+    /// <summary>
+    /// Returns <see langword="true"/> when the given bound expression subtree
+    /// contains at least one <see cref="BoundAwaitExpression"/>, consulting and
+    /// populating <paramref name="memo"/> (see <see cref="CreateHasAwaitMemo"/>)
+    /// so repeated/nested queries over the same nodes are O(1) after the first visit.
+    /// </summary>
+    /// <param name="expression">The bound expression to inspect.</param>
+    /// <param name="memo">An optional reference-keyed cache shared across calls in one lowering pass.</param>
+    /// <returns>Whether the subtree contains an <c>await</c>.</returns>
+    public static bool HasAwait(BoundExpression expression, Dictionary<BoundNode, bool> memo)
     {
         if (expression == null)
         {
             return false;
         }
 
-        var probe = new AwaitDetector();
-        probe.Visit(expression);
+        var probe = new AwaitDetector(memo);
+        probe.VisitExpression(expression);
         return probe.Found;
     }
 
@@ -81,9 +117,65 @@ public static class AsyncBoundTreeQueries
         return probe.Syntax;
     }
 
+    /// <summary>
+    /// Walks a subtree looking for an await, optionally memoizing per-node
+    /// results (reference-keyed) so overlapping queries over the same tree
+    /// reuse work instead of re-walking already-visited subtrees (issue #1625).
+    /// <see cref="VisitStatement"/> and <see cref="VisitExpression"/> are the
+    /// sole dispatch entry points every recursive descent in
+    /// <see cref="BoundTreeWalker"/> funnels through, so overriding them here
+    /// is sufficient to intercept — and memoize — every node in the walk.
+    /// </summary>
     private sealed class AwaitDetector : BoundTreeWalker
     {
+        private readonly Dictionary<BoundNode, bool> memo;
+
+        public AwaitDetector(Dictionary<BoundNode, bool> memo)
+        {
+            this.memo = memo;
+        }
+
         public bool Found { get; private set; }
+
+        public override void VisitStatement(BoundStatement node)
+        {
+            if (node == null)
+            {
+                return;
+            }
+
+            if (memo != null && memo.TryGetValue(node, out var cached))
+            {
+                Found = Found || cached;
+                return;
+            }
+
+            var outerFound = Found;
+            Found = false;
+            base.VisitStatement(node);
+            memo?.Add(node, Found);
+            Found = Found || outerFound;
+        }
+
+        public override void VisitExpression(BoundExpression node)
+        {
+            if (node == null)
+            {
+                return;
+            }
+
+            if (memo != null && memo.TryGetValue(node, out var cached))
+            {
+                Found = Found || cached;
+                return;
+            }
+
+            var outerFound = Found;
+            Found = false;
+            base.VisitExpression(node);
+            memo?.Add(node, Found);
+            Found = Found || outerFound;
+        }
 
         protected override void VisitAwaitExpression(BoundAwaitExpression node)
         {

--- a/src/Core/CodeAnalysis/Lowering/Async/AsyncExceptionHandlerRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AsyncExceptionHandlerRewriter.cs
@@ -117,6 +117,14 @@ public static class AsyncExceptionHandlerRewriter
 
     private sealed class Rewriter : BoundTreeRewriter
     {
+        // Reference-keyed "does this subtree contain an await" cache shared by every
+        // HasAwait probe this Rewriter instance makes, so repeated queries over the
+        // same nested try/catch/finally subtrees are O(1) after the first visit
+        // (issue #1625). Safe for the whole pass: rewriting always produces new node
+        // instances (see BoundTreeRewriter), so a memoized entry is never observed
+        // for a node that was actually mutated.
+        private readonly Dictionary<BoundNode, bool> awaitMemo = AsyncBoundTreeQueries.CreateHasAwaitMemo();
+
         private int localOrdinal;
 
         /// <summary>
@@ -149,14 +157,14 @@ public static class AsyncExceptionHandlerRewriter
             bool anyCatchHasAwait = false;
             foreach (var clause in rewrittenClauses)
             {
-                if (AsyncBoundTreeQueries.HasAwait(clause.Body))
+                if (HasAwait(clause.Body))
                 {
                     anyCatchHasAwait = true;
                     break;
                 }
             }
 
-            bool finallyHasAwait = rewrittenFinally != null && AsyncBoundTreeQueries.HasAwait(rewrittenFinally);
+            bool finallyHasAwait = rewrittenFinally != null && HasAwait(rewrittenFinally);
 
             // The finally must be lifted out of the protected region in either
             // of two cases:
@@ -167,7 +175,7 @@ public static class AsyncExceptionHandlerRewriter
             //      finally on every yield, which is semantically wrong (the
             //      finally should run only when the try completes normally,
             //      exceptionally, or via early exit — not on async suspension).
-            bool tryBodyHasAwait = AsyncBoundTreeQueries.HasAwait(rewrittenTry);
+            bool tryBodyHasAwait = HasAwait(rewrittenTry);
             bool needsFinallyLift = rewrittenFinally != null && (finallyHasAwait || tryBodyHasAwait);
 
             if (!anyCatchHasAwait && !needsFinallyLift)
@@ -225,6 +233,8 @@ public static class AsyncExceptionHandlerRewriter
             return new BoundBlockStatement(null, statements.ToImmutable());
         }
 
+        private bool HasAwait(BoundStatement statement) => AsyncBoundTreeQueries.HasAwait(statement, awaitMemo);
+
         private void RewriteCatchWithAwait(
             ImmutableArray<BoundStatement>.Builder statements,
             BoundStatement tryBody,
@@ -247,7 +257,7 @@ public static class AsyncExceptionHandlerRewriter
 
             foreach (var clause in catchClauses)
             {
-                if (AsyncBoundTreeQueries.HasAwait(clause.Body))
+                if (HasAwait(clause.Body))
                 {
                     // Per-clause capture local of nullable-of-original-type.
                     // A reference-type nullable shares the CLR representation,
@@ -388,7 +398,7 @@ public static class AsyncExceptionHandlerRewriter
 
             foreach (var clause in catchClauses)
             {
-                if (AsyncBoundTreeQueries.HasAwait(clause.Body))
+                if (HasAwait(clause.Body))
                 {
                     // Per-clause capture local of nullable-of-original-type.
                     var captureType = NullableTypeSymbol.Get(clause.ExceptionType);

--- a/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
@@ -82,6 +82,14 @@ public static class SpillSequenceSpiller
 
     private sealed class Spiller
     {
+        // Reference-keyed "does this subtree contain an await" cache shared by every
+        // HasAwait probe this Spiller instance makes. RewriteStatementToList/SpillExpression
+        // re-query the same child nodes at every recursion level; without this memo that
+        // was an O(n^2) re-walk of the tree for an async body with n nodes (issue #1625).
+        // Safe across the whole pass because rewriting always produces new node instances
+        // (see BoundTreeRewriter) — a memoized entry is never observed for a mutated node.
+        private readonly Dictionary<BoundNode, bool> awaitMemo = AsyncBoundTreeQueries.CreateHasAwaitMemo();
+
         private int spillOrdinal;
 
         public BoundBlockStatement RewriteBlock(BoundBlockStatement block)
@@ -185,7 +193,7 @@ public static class SpillSequenceSpiller
 
         private bool RewriteVariableDeclaration(BoundVariableDeclaration decl, ImmutableArray<BoundStatement>.Builder builder)
         {
-            if (decl.Initializer == null || !AsyncBoundTreeQueries.HasAwait(decl.Initializer))
+            if (decl.Initializer == null || !HasAwait(decl.Initializer))
             {
                 builder.Add(decl);
                 return false;
@@ -199,7 +207,7 @@ public static class SpillSequenceSpiller
 
         private bool RewriteExpressionStatement(BoundExpressionStatement exprStmt, ImmutableArray<BoundStatement>.Builder builder)
         {
-            if (!AsyncBoundTreeQueries.HasAwait(exprStmt.Expression))
+            if (!HasAwait(exprStmt.Expression))
             {
                 builder.Add(exprStmt);
                 return false;
@@ -231,7 +239,7 @@ public static class SpillSequenceSpiller
 
         private bool RewriteReturnStatement(BoundReturnStatement ret, ImmutableArray<BoundStatement>.Builder builder)
         {
-            if (ret.Expression == null || !AsyncBoundTreeQueries.HasAwait(ret.Expression))
+            if (ret.Expression == null || !HasAwait(ret.Expression))
             {
                 builder.Add(ret);
                 return false;
@@ -254,7 +262,7 @@ public static class SpillSequenceSpiller
             BoundExpression condition = ifStmt.Condition;
             var conditionChanged = false;
 
-            if (AsyncBoundTreeQueries.HasAwait(condition))
+            if (HasAwait(condition))
             {
                 var spilledCond = SpillExpression(condition);
                 FlushSideEffects(spilledCond, builder);
@@ -313,7 +321,7 @@ public static class SpillSequenceSpiller
         /// </remarks>
         private bool RewriteConditionalGotoStatement(BoundConditionalGotoStatement gotoStmt, ImmutableArray<BoundStatement>.Builder builder)
         {
-            if (!AsyncBoundTreeQueries.HasAwait(gotoStmt.Condition))
+            if (!HasAwait(gotoStmt.Condition))
             {
                 builder.Add(gotoStmt);
                 return false;
@@ -681,7 +689,7 @@ public static class SpillSequenceSpiller
             BoundSpillSequenceExpression innerSpill = null;
             BoundExpression innerExpr = awaitExpr.Expression;
 
-            if (AsyncBoundTreeQueries.HasAwait(awaitExpr.Expression))
+            if (HasAwait(awaitExpr.Expression))
             {
                 innerSpill = SpillExpression(awaitExpr.Expression);
                 innerExpr = innerSpill.Value;
@@ -724,8 +732,8 @@ public static class SpillSequenceSpiller
                 return SpillLogicalOr(binary);
             }
 
-            var leftHasAwait = AsyncBoundTreeQueries.HasAwait(binary.Left);
-            var rightHasAwait = AsyncBoundTreeQueries.HasAwait(binary.Right);
+            var leftHasAwait = HasAwait(binary.Left);
+            var rightHasAwait = HasAwait(binary.Right);
 
             if (!leftHasAwait && !rightHasAwait)
             {
@@ -794,7 +802,7 @@ public static class SpillSequenceSpiller
 
             // Spill the left side.
             BoundExpression left = binary.Left;
-            if (AsyncBoundTreeQueries.HasAwait(binary.Left))
+            if (HasAwait(binary.Left))
             {
                 var spilledLeft = SpillExpression(binary.Left);
                 locals.AddRange(spilledLeft.Locals);
@@ -843,7 +851,7 @@ public static class SpillSequenceSpiller
             var sideEffects = ImmutableArray.CreateBuilder<BoundStatement>();
 
             BoundExpression left = binary.Left;
-            if (AsyncBoundTreeQueries.HasAwait(binary.Left))
+            if (HasAwait(binary.Left))
             {
                 var spilledLeft = SpillExpression(binary.Left);
                 locals.AddRange(spilledLeft.Locals);
@@ -953,14 +961,14 @@ public static class SpillSequenceSpiller
             var argsHaveAwait = false;
             foreach (var arg in call.Arguments)
             {
-                if (AsyncBoundTreeQueries.HasAwait(arg))
+                if (HasAwait(arg))
                 {
                     argsHaveAwait = true;
                     break;
                 }
             }
 
-            if (AsyncBoundTreeQueries.HasAwait(receiver))
+            if (HasAwait(receiver))
             {
                 var spilledReceiver = SpillExpression(receiver);
                 locals.AddRange(spilledReceiver.Locals);
@@ -1002,14 +1010,14 @@ public static class SpillSequenceSpiller
             var argsHaveAwait = false;
             foreach (var arg in call.Arguments)
             {
-                if (AsyncBoundTreeQueries.HasAwait(arg))
+                if (HasAwait(arg))
                 {
                     argsHaveAwait = true;
                     break;
                 }
             }
 
-            if (AsyncBoundTreeQueries.HasAwait(receiver))
+            if (HasAwait(receiver))
             {
                 var spilledReceiver = SpillExpression(receiver);
                 locals.AddRange(spilledReceiver.Locals);
@@ -1051,14 +1059,14 @@ public static class SpillSequenceSpiller
             var argsHaveAwait = false;
             foreach (var arg in call.Arguments)
             {
-                if (AsyncBoundTreeQueries.HasAwait(arg))
+                if (HasAwait(arg))
                 {
                     argsHaveAwait = true;
                     break;
                 }
             }
 
-            if (AsyncBoundTreeQueries.HasAwait(receiver))
+            if (HasAwait(receiver))
             {
                 var spilledReceiver = SpillExpression(receiver);
                 locals.AddRange(spilledReceiver.Locals);
@@ -1100,14 +1108,14 @@ public static class SpillSequenceSpiller
             var argsHaveAwait = false;
             foreach (var arg in call.Arguments)
             {
-                if (AsyncBoundTreeQueries.HasAwait(arg))
+                if (HasAwait(arg))
                 {
                     argsHaveAwait = true;
                     break;
                 }
             }
 
-            if (AsyncBoundTreeQueries.HasAwait(receiver))
+            if (HasAwait(receiver))
             {
                 var spilledReceiver = SpillExpression(receiver);
                 locals.AddRange(spilledReceiver.Locals);
@@ -1142,7 +1150,7 @@ public static class SpillSequenceSpiller
 
         private BoundSpillSequenceExpression SpillConversion(BoundConversionExpression conv)
         {
-            if (!AsyncBoundTreeQueries.HasAwait(conv.Expression))
+            if (!HasAwait(conv.Expression))
             {
                 return Trivial(conv);
             }
@@ -1158,7 +1166,7 @@ public static class SpillSequenceSpiller
 
         private BoundSpillSequenceExpression SpillAssignment(BoundAssignmentExpression assign)
         {
-            if (!AsyncBoundTreeQueries.HasAwait(assign.Expression))
+            if (!HasAwait(assign.Expression))
             {
                 return Trivial(assign);
             }
@@ -1176,7 +1184,7 @@ public static class SpillSequenceSpiller
         {
             // Receiver is a VariableSymbol — already a stable local read, no spilling needed.
             // Only the RHS Value can contain an await.
-            if (!AsyncBoundTreeQueries.HasAwait(assign.Value))
+            if (!HasAwait(assign.Value))
             {
                 return Trivial(assign);
             }
@@ -1199,8 +1207,8 @@ public static class SpillSequenceSpiller
         {
             // Target is a VariableSymbol — already a stable local read.
             // Index and Value can each contain an await.
-            var indexHasAwait = AsyncBoundTreeQueries.HasAwait(assign.Index);
-            var valueHasAwait = AsyncBoundTreeQueries.HasAwait(assign.Value);
+            var indexHasAwait = HasAwait(assign.Index);
+            var valueHasAwait = HasAwait(assign.Value);
 
             if (!indexHasAwait && !valueHasAwait)
             {
@@ -1255,7 +1263,7 @@ public static class SpillSequenceSpiller
 
         private BoundSpillSequenceExpression SpillUnary(BoundUnaryExpression unary)
         {
-            if (!AsyncBoundTreeQueries.HasAwait(unary.Operand))
+            if (!HasAwait(unary.Operand))
             {
                 return Trivial(unary);
             }
@@ -1281,9 +1289,9 @@ public static class SpillSequenceSpiller
         /// </summary>
         private BoundSpillSequenceExpression SpillConditional(BoundConditionalExpression conditional)
         {
-            var conditionHasAwait = AsyncBoundTreeQueries.HasAwait(conditional.Condition);
-            var trueHasAwait = AsyncBoundTreeQueries.HasAwait(conditional.WhenTrue);
-            var falseHasAwait = AsyncBoundTreeQueries.HasAwait(conditional.WhenFalse);
+            var conditionHasAwait = HasAwait(conditional.Condition);
+            var trueHasAwait = HasAwait(conditional.WhenTrue);
+            var falseHasAwait = HasAwait(conditional.WhenFalse);
 
             if (!conditionHasAwait && !trueHasAwait && !falseHasAwait)
             {
@@ -1360,19 +1368,19 @@ public static class SpillSequenceSpiller
         /// </summary>
         private BoundSpillSequenceExpression SpillSwitch(BoundSwitchExpression switchExpr)
         {
-            var discriminantHasAwait = AsyncBoundTreeQueries.HasAwait(switchExpr.Discriminant);
+            var discriminantHasAwait = HasAwait(switchExpr.Discriminant);
             BoundExpression firstGuardAwaitSyntaxHolder = null;
             var anyGuardHasAwait = false;
             var anyResultHasAwait = false;
             foreach (var arm in switchExpr.Arms)
             {
-                if (arm.Guard != null && AsyncBoundTreeQueries.HasAwait(arm.Guard))
+                if (arm.Guard != null && HasAwait(arm.Guard))
                 {
                     anyGuardHasAwait = true;
                     firstGuardAwaitSyntaxHolder ??= arm.Guard;
                 }
 
-                if (AsyncBoundTreeQueries.HasAwait(arm.Result))
+                if (HasAwait(arm.Result))
                 {
                     anyResultHasAwait = true;
                 }
@@ -1498,8 +1506,8 @@ public static class SpillSequenceSpiller
         /// </summary>
         private BoundSpillSequenceExpression SpillNullConditionalAccess(BoundNullConditionalAccessExpression nc)
         {
-            var receiverHasAwait = AsyncBoundTreeQueries.HasAwait(nc.Receiver);
-            var whenNotNullHasAwait = AsyncBoundTreeQueries.HasAwait(nc.WhenNotNull);
+            var receiverHasAwait = HasAwait(nc.Receiver);
+            var whenNotNullHasAwait = HasAwait(nc.WhenNotNull);
 
             if (!receiverHasAwait && !whenNotNullHasAwait)
             {
@@ -1653,9 +1661,9 @@ public static class SpillSequenceSpiller
         /// </summary>
         private BoundSpillSequenceExpression SpillConditionalAddress(BoundConditionalAddressExpression condAddr)
         {
-            var conditionHasAwait = AsyncBoundTreeQueries.HasAwait(condAddr.Condition);
-            var trueHasAwait = AsyncBoundTreeQueries.HasAwait(condAddr.WhenTrueOperand);
-            var falseHasAwait = AsyncBoundTreeQueries.HasAwait(condAddr.WhenFalseOperand);
+            var conditionHasAwait = HasAwait(condAddr.Condition);
+            var trueHasAwait = HasAwait(condAddr.WhenTrueOperand);
+            var falseHasAwait = HasAwait(condAddr.WhenFalseOperand);
 
             if (!conditionHasAwait && !trueHasAwait && !falseHasAwait)
             {
@@ -2063,7 +2071,7 @@ public static class SpillSequenceSpiller
             BoundExpression operand,
             Func<BoundExpression, BoundExpression> rebuild)
         {
-            if (!AsyncBoundTreeQueries.HasAwait(operand))
+            if (!HasAwait(operand))
             {
                 return Trivial(original);
             }
@@ -2086,8 +2094,8 @@ public static class SpillSequenceSpiller
             BoundExpression b,
             Func<BoundExpression, BoundExpression, BoundExpression> rebuild)
         {
-            var aHasAwait = AsyncBoundTreeQueries.HasAwait(a);
-            var bHasAwait = AsyncBoundTreeQueries.HasAwait(b);
+            var aHasAwait = HasAwait(a);
+            var bHasAwait = HasAwait(b);
 
             if (!aHasAwait && !bHasAwait)
             {
@@ -2141,13 +2149,17 @@ public static class SpillSequenceSpiller
             var sideEffects = ImmutableArray.CreateBuilder<BoundStatement>();
             var args = ImmutableArray.CreateBuilder<BoundExpression>(arguments.Length);
 
-            // First pass: determine which args have await.
+            // First pass: determine which args have await. Cache the per-argument
+            // result in a set so the main loop below reuses it instead of
+            // re-walking each argument's subtree a second time (issue #1625).
             var awaitIndices = new List<int>();
+            var argsWithAwait = new HashSet<int>();
             for (var i = 0; i < arguments.Length; i++)
             {
-                if (AsyncBoundTreeQueries.HasAwait(arguments[i]))
+                if (HasAwait(arguments[i]))
                 {
                     awaitIndices.Add(i);
+                    argsWithAwait.Add(i);
                 }
             }
 
@@ -2169,7 +2181,7 @@ public static class SpillSequenceSpiller
             {
                 var arg = arguments[i];
 
-                if (AsyncBoundTreeQueries.HasAwait(arg))
+                if (argsWithAwait.Contains(i))
                 {
                     // Spill this argument's await.
                     var spilledArg = SpillExpression(arg);
@@ -2296,5 +2308,9 @@ public static class SpillSequenceSpiller
             // The actual value will be overwritten before use.
             return new BoundLiteralExpression(null, 0);
         }
+
+        private bool HasAwait(BoundStatement statement) => AsyncBoundTreeQueries.HasAwait(statement, awaitMemo);
+
+        private bool HasAwait(BoundExpression expression) => AsyncBoundTreeQueries.HasAwait(expression, awaitMemo);
     }
 }


### PR DESCRIPTION
Fixes #1625

## Problem
`AsyncBoundTreeQueries.HasAwait` allocated a fresh `AwaitDetector` and walked the **whole** subtree on every call. `SpillSequenceSpiller`'s `SpillExpression`/`RewriteStatementToList` call `HasAwait` on children at every recursion level, and `SpillArgumentList` walked each argument once in a pre-pass and again per-argument in the main loop. For an async body with n nodes this was O(n²) node visits during lowering.

## Fix
- `AsyncBoundTreeQueries.HasAwait` gained an optional reference-keyed `Dictionary<BoundNode, bool>` memo parameter (plus a `CreateHasAwaitMemo()` factory). The private `AwaitDetector` walker now overrides `VisitStatement`/`VisitExpression` — the sole recursive dispatch entry points in `BoundTreeWalker` — to consult/populate the memo before/after descending, so every node's "contains await" result is computed once and reused, including by nested/overlapping queries.
- `SpillSequenceSpiller.Spiller` and `AsyncExceptionHandlerRewriter.Rewriter` each create one memo per top-level `Rewrite()` call (stored as an instance field) and expose a private `HasAwait` wrapper so every call site within that pass shares the cache.
- `SpillArgumentList`'s pre-pass `HasAwait` result per argument is now reused in the main loop instead of being recomputed a second time.

## Why this is safe
`BoundNode` does not override `Equals`/`GetHashCode`, so a plain `Dictionary<BoundNode, bool>` already keys by reference identity — no custom comparer needed. Every rewrite in this pipeline (`BoundTreeRewriter`-based) returns a **new** node instance when anything changes; it never mutates a node in place. So a memoized entry can never be stale: if a subtree changes, lowering is working with a different node reference, not the one cached. The memo is scoped to one `Spiller`/`Rewriter` instance (i.e., one top-level `Rewrite()` call for one method body), so there's no cross-body leakage or lifetime concerns either.

Public behavior (the true/false result of every `HasAwait` call) is unchanged — this is a pure performance fix.

## Testing
- `dotnet build GSharp.sln -c Release -graph` — succeeds, 0 warnings/errors.
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release --filter "FullyQualifiedName~Async|FullyQualifiedName~Iterator"` — 326/326 passed.
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Release --filter "FullyQualifiedName~Async"` (narrowed emit tests, `-- xUnit.MaxParallelThreads=2`) — 106/106 passed.

Nothing deferred — the memo covers every `HasAwait` call site in both `SpillSequenceSpiller` and `AsyncExceptionHandlerRewriter`, and the `SpillArgumentList` double-walk is eliminated.