### PR TITLE
Fix #1661: wire up watched-file sync, fix FindOwningProject prefix bug

### DIFF
--- a/src/LanguageServer/Server/LspServer.cs
+++ b/src/LanguageServer/Server/LspServer.cs
@@ -1332,13 +1332,34 @@ public sealed class LspServer
         var fileDir = Path.GetDirectoryName(Path.GetFullPath(filePath));
         foreach (var project in this.workspaceState.Projects)
         {
-            if (fileDir != null && fileDir.StartsWith(project.ProjectDirectory, StringComparison.OrdinalIgnoreCase))
+            if (fileDir != null && IsWithinDirectory(fileDir, project.ProjectDirectory))
             {
                 return project;
             }
         }
 
         return this.workspaceState.GetOrCreateImplicitProject();
+    }
+
+    // A plain StartsWith check would let "/repo/Lib2" match project directory "/repo/Lib".
+    // Require the prefix match to land on a path-separator boundary (or be an exact match)
+    // so sibling directories that merely share a name prefix are never confused for one
+    // another. Comparison is ordinal-ignore-case, matching ProjectDirectory's own case
+    // handling, and accepts both '/' and '\' as separators for cross-platform paths.
+    private static bool IsWithinDirectory(string candidateDir, string projectDirectory)
+    {
+        if (string.Equals(candidateDir, projectDirectory, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (!candidateDir.StartsWith(projectDirectory, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var boundaryChar = candidateDir[projectDirectory.Length];
+        return boundaryChar == Path.DirectorySeparatorChar || boundaryChar == Path.AltDirectorySeparatorChar;
     }
 
     private static GSharp.Core.CodeAnalysis.Compilation.Compilation TryGetCompilation(DocumentContent content)

--- a/src/vscode-gsharp/src/server/serverManager.ts
+++ b/src/vscode-gsharp/src/server/serverManager.ts
@@ -186,12 +186,23 @@ export class ServerManager {
       const traceChannel = vscode.window.createOutputChannel('GSharp LSP Trace');
       this.context.subscriptions.push(traceChannel);
 
+      // Watch .gs and .gsproj files so the server's workspace model (owning-project
+      // lookup, symbol/diagnostic caches) stays in sync with creates/deletes/renames
+      // and project-reference edits. vscode-languageclient registers this watcher
+      // client-side (LanguageClient.hookFileEvents), independent of dynamicRegistration,
+      // so it works even though GSharpLanguageClient strips dynamicRegistration below.
+      const fileWatcher = vscode.workspace.createFileSystemWatcher('**/*.{gs,gsproj}');
+      this.context.subscriptions.push(fileWatcher);
+
       const clientOptions: LanguageClientOptions = {
         documentSelector: [{ scheme: 'file', language: 'gsharp' }],
         traceOutputChannel: traceChannel,
         diagnosticPullOptions: {
           onChange: true,
           onSave: true,
+        },
+        synchronize: {
+          fileEvents: fileWatcher,
         },
         // ServerManager owns the restart policy (see handleServerStopped), so suppress
         // the LanguageClient's own crash toasts and "crashed N times" cascade and route

--- a/test/LanguageServer.Tests/FindOwningProjectTests.cs
+++ b/test/LanguageServer.Tests/FindOwningProjectTests.cs
@@ -1,0 +1,102 @@
+// <copyright file="FindOwningProjectTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Reflection;
+using GSharp.LanguageServer.Server;
+using Xunit;
+
+namespace GSharp.LanguageServer.Tests;
+
+// Fixes #1661 (bonus bug): FindOwningProject used a plain StartsWith prefix check, so a
+// project at "/repo/Lib" would incorrectly claim files under the unrelated sibling
+// directory "/repo/Lib2". These tests exercise the private FindOwningProject method via
+// reflection since it has no public seam of its own.
+public class FindOwningProjectTests
+{
+    private static ProjectState InvokeFindOwningProject(LspServer server, string filePath)
+    {
+        var method = typeof(LspServer).GetMethod("FindOwningProject", BindingFlags.NonPublic | BindingFlags.Instance);
+        return (ProjectState)method.Invoke(server, new object[] { filePath });
+    }
+
+    [Fact]
+    public void FindOwningProject_DoesNotMatchSiblingDirectoryWithSharedPrefix()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "gsharp-fop-" + Guid.NewGuid().ToString("N"));
+        var libDir = Path.Combine(root, "Lib");
+        var lib2Dir = Path.Combine(root, "Lib2");
+        Directory.CreateDirectory(libDir);
+        Directory.CreateDirectory(lib2Dir);
+
+        try
+        {
+            var workspaceState = new WorkspaceState();
+            workspaceState.AddProject(Path.Combine(libDir, "Lib.gsproj"));
+
+            var server = new LspServer(new DocumentContentService(), workspaceState);
+
+            var found = InvokeFindOwningProject(server, Path.Combine(lib2Dir, "foo.gs"));
+
+            // Lib2 must not be claimed by the Lib project. With only one project registered,
+            // GetOrCreateImplicitProject falls back to null (see WorkspaceState.projects.IsEmpty
+            // guard), so the fix surfaces as a null result rather than the unrelated Lib project.
+            Assert.Null(found);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void FindOwningProject_MatchesFileDirectlyUnderProjectDirectory()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "gsharp-fop-" + Guid.NewGuid().ToString("N"));
+        var libDir = Path.Combine(root, "Lib");
+        Directory.CreateDirectory(libDir);
+
+        try
+        {
+            var workspaceState = new WorkspaceState();
+            var project = workspaceState.AddProject(Path.Combine(libDir, "Lib.gsproj"));
+
+            var server = new LspServer(new DocumentContentService(), workspaceState);
+
+            var found = InvokeFindOwningProject(server, Path.Combine(libDir, "foo.gs"));
+
+            Assert.Same(project, found);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void FindOwningProject_MatchesFileInSubdirectoryOfProjectDirectory()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "gsharp-fop-" + Guid.NewGuid().ToString("N"));
+        var libDir = Path.Combine(root, "Lib");
+        var subDir = Path.Combine(libDir, "sub");
+        Directory.CreateDirectory(subDir);
+
+        try
+        {
+            var workspaceState = new WorkspaceState();
+            var project = workspaceState.AddProject(Path.Combine(libDir, "Lib.gsproj"));
+
+            var server = new LspServer(new DocumentContentService(), workspaceState);
+
+            var found = InvokeFindOwningProject(server, Path.Combine(subDir, "foo.gs"));
+
+            Assert.Same(project, found);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1661

## Problem
The LSP client sent no `workspace/didChangeWatchedFiles` notifications, so the server's `.gs`/`.gsproj` file-change handlers (`DidChangeWatchedFilesAsync`, `HandleProjectFileChange`, `HandleSourceFileChange`, `FindOwningProject`) were dead code. Creating/deleting/renaming `.gs` files and editing `.gsproj` project references never reached the server until restart.

## Fix
**Client (`src/vscode-gsharp/src/server/serverManager.ts`)**: added `synchronize.fileEvents` with a `vscode.workspace.createFileSystemWatcher('**/*.{gs,gsproj}')` to the language client options. Verified in `vscode-languageclient`'s source (`node_modules/vscode-languageclient/lib/common/client.js`, `hookFileEvents`) that this watcher is registered directly via `registerRaw` on the `DidChangeWatchedFilesNotification` feature -- independent of `dynamicRegistration` -- so it works correctly even though `GSharpLanguageClient` still strips `dynamicRegistration` for other capabilities. The watcher is disposed via `context.subscriptions`.

**Server (`src/LanguageServer/Server/LspServer.cs`)**: fixed the bonus bug in `FindOwningProject`, which used `fileDir.StartsWith(project.ProjectDirectory, ...)`. This let a project at `/repo/Lib` incorrectly claim files under the unrelated sibling directory `/repo/Lib2`. Added a generalized `IsWithinDirectory` helper that requires either an exact match or a path-separator boundary (`/` or `\`) immediately after the prefix, using the same `OrdinalIgnoreCase` comparison `ProjectDirectory` already uses. This fixes any sibling directory that shares a name prefix, not just the `Lib`/`Lib2` example.

## Verification
- `dotnet build GSharp.sln -c Release -graph` -> Build succeeded, 0 warnings, 0 errors.
- `dotnet test test/LanguageServer.Tests/LanguageServer.Tests.csproj -c Release --filter "FullyQualifiedName~FindOwningProject|FullyQualifiedName~LspServer|FullyQualifiedName~LanguageServer" --no-build` -> 398 passed, 0 failed (includes 3 new `FindOwningProjectTests`).
- `npm ci && npm run compile && npm run lint && npm run test:unit` in `src/vscode-gsharp` -> compiles clean, lint clean, 56 tests passed.
- Traced `vscode-languageclient`'s `hookFileEvents`/`registerRaw` implementation to confirm the `fileEvents` watcher notification path is registered independent of dynamic-registration capability negotiation, so it reaches `DidChangeWatchedFilesAsync` on the server as designed.

## Tests added
- `test/LanguageServer.Tests/FindOwningProjectTests.cs`: sibling-prefix false positive (`/repo/Lib` vs `/repo/Lib2`), exact directory match, and subdirectory match, using real temp directories and reflection to invoke the private `FindOwningProject` method.

## Deferred
Nothing. TS client wiring is not independently unit-testable per the issue's own note, but extension compile/lint/unit-test all pass, and the `vscode-languageclient` source trace above documents why the notification path is expected to work in the running extension.
