### PR TITLE
Fix #1655: resolve duplicate diagnostic ID collisions

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -250,6 +250,8 @@ ADR-0056 §1/§2 makes spans indexable: a `Span[T]` / `ReadOnlySpan[T]` indexer 
 |----|----------|-------------|-----------------|
 | GS0226 | Error | Cannot assign through a read-only span element (`ReadOnlySpan[T]` is read-only). | `var s ReadOnlySpan[int32] = arr` then `s[0] = 1` — a `ReadOnlySpan[T]` indexer is `ref readonly T`; use `Span[T]` to write. |
 
+Issue #1655: the ref-kind-on-async/iterator ban was previously misfiled under this ID; it now ships as **GS0422** — see [Reassigned diagnostics (GS0419–GS0424)](#reassigned-diagnostics-gs0419gs0424).
+
 ### Nested-type resolution diagnostics (GS0268)
 
 | ID | Severity | Description | Example trigger |

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -250,6 +250,25 @@ ADR-0056 §1/§2 makes spans indexable: a `Span[T]` / `ReadOnlySpan[T]` indexer 
 |----|----------|-------------|-----------------|
 | GS0226 | Error | Cannot assign through a read-only span element (`ReadOnlySpan[T]` is read-only). | `var s ReadOnlySpan[int32] = arr` then `s[0] = 1` — a `ReadOnlySpan[T]` indexer is `ref readonly T`; use `Span[T]` to write. |
 
+### Nested-type resolution diagnostics (GS0268)
+
+| ID | Severity | Description | Example trigger |
+|----|----------|-------------|-----------------|
+| GS0268 | Error | Type does not contain a nested type of the requested name. | `Outer.Missing` when `Outer` exists but declares no nested type named `Missing` (issue #526). |
+
+### Reassigned diagnostics (GS0419–GS0424)
+
+Issue #1655: the IDs below used to collide with earlier, unrelated diagnostics (GS0189, GS0190, GS0226, GS0241, GS0268 respectively). Each collision has been resolved by keeping the earliest-established meaning on the original ID and moving the newer, unrelated meaning to a fresh ID.
+
+| ID | Severity | Description | Example trigger |
+|----|----------|-------------|-----------------|
+| GS0419 | Error | Property cannot be an auto-property in a `data struct`; use a computed property with an explicit body instead. | `data struct P { var X int32; prop Y int32 }` — `Y` has no explicit getter/setter body (ADR-0051). Previously misfiled under GS0189. |
+| GS0420 | Error | The argument to `nameof` must be a name reference: an identifier, member access, or type. | `nameof(123)` or `nameof(Console.WriteLine("hi"))`. Previously misfiled under GS0190. |
+| GS0421 | Error | Member is marked `open` but the enclosing class is not open. | `class C { open func M() {} }` where `C` is not declared `open` (ADR-0051). Previously misfiled under GS0190. |
+| GS0422 | Error | A ref-kind parameter (`ref`/`out`/`in`) cannot appear on an `async`, `sequence`, or `async sequence` function. | `async func f(ref x int32) { }` — the state-machine rewriter cannot hoist a managed pointer into a field (ADR-0060 §10). Previously misfiled under GS0226. |
+| GS0423 | Error | Type does not implement a usable `GetEnumerator()` method and cannot be iterated with `for ... in`. | `for x in 42 { }` where `42`'s type has no usable `GetEnumerator()`. Previously misfiled under GS0268. |
+| GS0424 | Error | A ref-kind modifier (`ref`/`out`/`in`) is not legal on a primary-constructor parameter. | `class Vec(ref x int32) { }` — primary-constructor parameters materialize fields, and the CLR cannot store a managed pointer in a field (ADR-0060 / ADR-0029). Previously misfiled under GS0241. |
+
 ### Pointer / by-ref diagnostics (GS9001–GS9006)
 
 | ID | Severity | Description | Example trigger |
@@ -305,7 +324,7 @@ ADR-0059 / Issue #255: `type Name = delegate func(...)` declares a real CLR `Mul
 
 ## Ref-kind parameter diagnostics (GS0235–GS0243)
 
-ADR-0060 introduces explicit `ref`, `out`, and `in` parameter passing modes at both call sites and method-definition sites. The ADR (§8) originally enumerated diagnostics GS0230–GS0238, but those codes were already in use by ADR-0029 / ADR-0030 / ADR-0056 / ADR-0059; the ADR-0060 diagnostics ship at the next free range, GS0235–GS0243, with a 1:1 mapping (GS0230→GS0235, GS0231→GS0236, …, GS0238→GS0243). The async/iterator ban (§10) reuses the existing GS0226 family.
+ADR-0060 introduces explicit `ref`, `out`, and `in` parameter passing modes at both call sites and method-definition sites. The ADR (§8) originally enumerated diagnostics GS0230–GS0238, but those codes were already in use by ADR-0029 / ADR-0030 / ADR-0056 / ADR-0059; the ADR-0060 diagnostics ship at the next free range, GS0235–GS0243, with a 1:1 mapping (GS0230→GS0235, GS0231→GS0236, …, GS0238→GS0243). The async/iterator ban (§10) is reported as **GS0422** and the primary-constructor ban (ADR-0060 + ADR-0029) as **GS0424** — see [Reassigned diagnostics (GS0419–GS0424)](#reassigned-diagnostics-gs0419gs0424).
 
 | Code | Severity | Message |
 |------|----------|---------|

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -1492,7 +1492,7 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
     /// <param name="propertyName">The property name.</param>
     public void ReportAutoPropertyInDataStruct(TextLocation location, string propertyName)
     {
-        Report(location, "GS0189", $"Property '{propertyName}' cannot be an auto-property in a data struct; use a computed property with an explicit body instead.");
+        Report(location, "GS0419", $"Property '{propertyName}' cannot be an auto-property in a data struct; use a computed property with an explicit body instead.");
     }
 
     /// <summary>ADR-0051: reports an <c>open</c> member declared on a class that is not itself <c>open</c>.</summary>
@@ -1500,7 +1500,7 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
     /// <param name="memberName">The member name.</param>
     public void ReportOpenMemberInNonOpenClass(TextLocation location, string memberName)
     {
-        Report(location, "GS0190", $"Member '{memberName}' is marked 'open' but the enclosing class is not open.");
+        Report(location, "GS0421", $"Member '{memberName}' is marked 'open' but the enclosing class is not open.");
     }
 
     /// <summary>GS9001: Cannot take address of a non-lvalue expression.</summary>
@@ -1769,7 +1769,7 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
     /// <param name="location">The text location of the argument.</param>
     public void ReportNameOfRequiresNameReference(TextLocation location)
     {
-        Report(location, "GS0190", "The argument to 'nameof' must be a name reference: an identifier, member access, or type.");
+        Report(location, "GS0420", "The argument to 'nameof' must be a name reference: an identifier, member access, or type.");
     }
 
     /// <summary>
@@ -2323,7 +2323,7 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
     /// <param name="parameterName">The parameter name.</param>
     public void ReportRefKindOnPrimaryCtorParameter(TextLocation location, string parameterName)
     {
-        Report(location, "GS0241", $"'ref'/'out'/'in' is not a legal modifier on the primary-constructor parameter '{parameterName}'; primary-ctor parameters materialize fields, and the CLR cannot store a managed pointer in a field. Move the constructor to an 'init(...)' body if a by-reference parameter is required.");
+        Report(location, "GS0424", $"'ref'/'out'/'in' is not a legal modifier on the primary-constructor parameter '{parameterName}'; primary-ctor parameters materialize fields, and the CLR cannot store a managed pointer in a field. Move the constructor to an 'init(...)' body if a by-reference parameter is required.");
     }
 
     /// <summary>
@@ -2356,15 +2356,14 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
     /// <summary>
     /// ADR-0060 §10: reports a ref-kind parameter on an <c>async</c>, <c>sequence</c>, or
     /// <c>async sequence</c> function. The state-machine rewriter cannot hoist a managed
-    /// pointer into a field, so the parameter is rejected. (Same GS0226 family as the
-    /// existing async/iterator restrictions.)
+    /// pointer into a field, so the parameter is rejected.
     /// </summary>
     /// <param name="location">The parameter location.</param>
     /// <param name="parameterName">The parameter name.</param>
     /// <param name="functionKind">"async", "sequence", or "async sequence".</param>
     public void ReportRefKindOnAsyncOrIterator(TextLocation location, string parameterName, string functionKind)
     {
-        Report(location, "GS0226", $"Ref-kind parameter '{parameterName}' cannot appear on a {functionKind} function.");
+        Report(location, "GS0422", $"Ref-kind parameter '{parameterName}' cannot appear on a {functionKind} function.");
     }
 
     /// <summary>
@@ -2662,7 +2661,7 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
     public void ReportTypeNotIterable(TextLocation location, TypeSymbol type)
     {
         var message = $"Type '{type.Name}' does not implement a usable 'GetEnumerator()' method and cannot be iterated with 'for ... in'.";
-        Report(location, "GS0268", message);
+        Report(location, "GS0423", message);
     }
 
     /// <summary>

--- a/test/Compiler.Tests/Emit/Issue1433InterfaceStaticMemberCallEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1433InterfaceStaticMemberCallEmitTests.cs
@@ -15,7 +15,7 @@ namespace GSharp.Compiler.Tests.Emit;
 /// user-defined <c>interface</c>. Before the fix the binder produced no
 /// resolution for <c>IName.Method(args)</c> (and interface static property
 /// reads / method groups), leaking a <see cref="GSharp.Core.CodeAnalysis.Binding.BoundErrorExpression"/>
-/// into emit which crashed with a misleading <c>GS0268</c> ("for-in loop")
+/// into emit which crashed with a misleading <c>GS0423</c> ("for-in loop")
 /// internal compiler error. These tests cover the generalized fix: interface
 /// static method calls (used + discarded), a static method group, a static
 /// property read, and a constructed generic interface static method call,

--- a/test/Core.Tests/CodeAnalysis/Binding/RefKindParameterSitesTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/RefKindParameterSitesTests.cs
@@ -113,7 +113,7 @@ class Vec(ref x int32) { }
 0
 ";
         var result = Evaluate(source);
-        Assert.Contains(result.Diagnostics, d => d.Id == "GS0241");
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0424");
     }
 
     // ----------------------------------------------------------------------

--- a/test/Core.Tests/CodeAnalysis/Binding/TypeOfNameOfTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/TypeOfNameOfTests.cs
@@ -107,7 +107,7 @@ var n = nameof(Console.WriteLine)
         var tree = SyntaxTree.Parse(SourceText.From("var n = nameof(123)\n"));
         var compilation = new Compilation(tree);
         var diagnostics = compilation.GlobalScope.Diagnostics;
-        Assert.Contains(diagnostics, d => d.Id == "GS0190");
+        Assert.Contains(diagnostics, d => d.Id == "GS0420");
     }
 
     [Fact]
@@ -119,7 +119,7 @@ var n = nameof(Console.WriteLine(""hi""))
 "));
         var compilation = new Compilation(tree);
         var diagnostics = compilation.GlobalScope.Diagnostics;
-        Assert.Contains(diagnostics, d => d.Id == "GS0190");
+        Assert.Contains(diagnostics, d => d.Id == "GS0420");
     }
 
     [Fact]

--- a/test/Core.Tests/CodeAnalysis/DiagnosticIdUniquenessTests.cs
+++ b/test/Core.Tests/CodeAnalysis/DiagnosticIdUniquenessTests.cs
@@ -1,0 +1,122 @@
+// <copyright file="DiagnosticIdUniquenessTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis;
+
+/// <summary>
+/// Issue #1655: a <c>GS####</c> diagnostic ID is a stable public contract —
+/// it appears in <c>/nowarn</c> and <c>/warnaserror</c> flags, IDE quick-info,
+/// and documentation. Two unrelated diagnostics sharing one ID silently break
+/// that contract (suppressing one silently suppresses the other). This test
+/// scans every <c>Report(location, "GS####", message)</c> call site under
+/// <c>src/</c> and fails if any ID is used for more than one distinct message
+/// shape, so a future collision fails CI instead of shipping.
+/// </summary>
+public class DiagnosticIdUniquenessTests
+{
+    // Interpolation holes ("{name}", "{0}", nested braces) vary call to call;
+    // normalize them to a single placeholder so two reports of the *same*
+    // diagnostic with different interpolated values are not flagged as a
+    // collision, while two genuinely different message templates still are.
+    private static readonly Regex InterpolationHole = new(@"\{[^{}]*\}", RegexOptions.Compiled);
+
+    // Matches `Report(<args>, "GSxxxx", <message>)` — the DiagnosticBag helper
+    // form, where <message> is a (possibly interpolated) C# string literal.
+    private static readonly Regex ReportCall = new(
+        @"\bReport\([^;]*?""(GS\d{4})""\s*,\s*(\$?""(?:[^""\\]|\\.)*"")",
+        RegexOptions.Compiled | RegexOptions.Singleline);
+
+    // Matches `new Diagnostic(<args>, "GSxxxx", <severity>, <message>)` — the
+    // low-level form used outside DiagnosticBag (e.g. AsyncEmitPrecheck),
+    // where <message> is typically an identifier/expression rather than a
+    // literal. The expression text itself is the "shape" being compared.
+    private static readonly Regex NewDiagnosticCall = new(
+        @"new\s+Diagnostic\([^;]*?""(GS\d{4})""\s*,\s*DiagnosticSeverity\.\w+\s*,\s*([^,;()]+?)\s*\)",
+        RegexOptions.Compiled | RegexOptions.Singleline);
+
+    [Fact]
+    public void Every_DiagnosticId_Maps_To_Exactly_One_Message_Shape()
+    {
+        var repoRoot = FindRepoRoot();
+        var srcRoot = Path.Combine(repoRoot, "src");
+        Assert.True(Directory.Exists(srcRoot), $"src directory not found: {srcRoot}");
+
+        // id -> set of (normalized message template -> example "file:line" site)
+        var idToTemplates = new Dictionary<string, Dictionary<string, string>>();
+
+        foreach (var file in Directory.EnumerateFiles(srcRoot, "*.cs", SearchOption.AllDirectories))
+        {
+            var text = File.ReadAllText(file);
+            RecordMatches(ReportCall, text, file, repoRoot, idToTemplates);
+            RecordMatches(NewDiagnosticCall, text, file, repoRoot, idToTemplates);
+        }
+
+        Assert.NotEmpty(idToTemplates);
+
+        var collisions = idToTemplates
+            .Where(kv => kv.Value.Count > 1)
+            .OrderBy(kv => kv.Key, StringComparer.Ordinal)
+            .Select(kv => $"{kv.Key} is used for {kv.Value.Count} distinct messages:\n" +
+                          string.Join("\n", kv.Value.Select(t => $"    {t.Value}: {t.Key}")))
+            .ToArray();
+
+        Assert.True(
+            collisions.Length == 0,
+            "Duplicate diagnostic IDs found (each GS#### must map to exactly one message shape):\n\n" +
+            string.Join("\n\n", collisions));
+    }
+
+    private static void RecordMatches(
+        Regex pattern,
+        string text,
+        string file,
+        string repoRoot,
+        Dictionary<string, Dictionary<string, string>> idToTemplates)
+    {
+        foreach (Match match in pattern.Matches(text))
+        {
+            var id = match.Groups[1].Value;
+            var rawMessage = match.Groups[2].Value;
+            var template = InterpolationHole.Replace(rawMessage, "{}");
+            var line = text[..match.Index].Count(c => c == '\n') + 1;
+            var site = $"{Path.GetRelativePath(repoRoot, file)}:{line}";
+
+            if (!idToTemplates.TryGetValue(id, out var templates))
+            {
+                templates = new Dictionary<string, string>();
+                idToTemplates[id] = templates;
+            }
+
+            // Keep the first site seen for each distinct template so the
+            // failure message can point at both call sites of a collision.
+            if (!templates.ContainsKey(template))
+            {
+                templates[template] = site;
+            }
+        }
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = Path.GetDirectoryName(typeof(DiagnosticIdUniquenessTests).Assembly.Location);
+        while (!string.IsNullOrEmpty(dir))
+        {
+            if (File.Exists(Path.Combine(dir, ".config", "dotnet-tools.json")))
+            {
+                return dir;
+            }
+
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        return Environment.CurrentDirectory;
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/DiagnosticIdUniquenessTests.cs
+++ b/test/Core.Tests/CodeAnalysis/DiagnosticIdUniquenessTests.cs
@@ -6,7 +6,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis;
@@ -16,32 +18,18 @@ namespace GSharp.Core.Tests.CodeAnalysis;
 /// it appears in <c>/nowarn</c> and <c>/warnaserror</c> flags, IDE quick-info,
 /// and documentation. Two unrelated diagnostics sharing one ID silently break
 /// that contract (suppressing one silently suppresses the other). This test
-/// scans every <c>Report(location, "GS####", message)</c> call site under
-/// <c>src/</c> and fails if any ID is used for more than one distinct message
-/// shape, so a future collision fails CI instead of shipping.
+/// parses every file under <c>src/</c> with Roslyn and finds every
+/// <c>Report(..., "GS####", ...)</c> / <c>new Diagnostic(..., "GS####", ...)</c>
+/// call site, regardless of whether the message argument is a string literal,
+/// an interpolated string, or a local variable/expression. The "shape" for a
+/// given ID is the name of its enclosing method — this repo's convention is
+/// one <c>ReportXxx</c> wrapper method per diagnostic ID — so an ID used from
+/// two distinct methods (a real collision) is caught even when the message
+/// argument text itself gives no clue (the variable-message form regex alone
+/// would miss).
 /// </summary>
 public class DiagnosticIdUniquenessTests
 {
-    // Interpolation holes ("{name}", "{0}", nested braces) vary call to call;
-    // normalize them to a single placeholder so two reports of the *same*
-    // diagnostic with different interpolated values are not flagged as a
-    // collision, while two genuinely different message templates still are.
-    private static readonly Regex InterpolationHole = new(@"\{[^{}]*\}", RegexOptions.Compiled);
-
-    // Matches `Report(<args>, "GSxxxx", <message>)` — the DiagnosticBag helper
-    // form, where <message> is a (possibly interpolated) C# string literal.
-    private static readonly Regex ReportCall = new(
-        @"\bReport\([^;]*?""(GS\d{4})""\s*,\s*(\$?""(?:[^""\\]|\\.)*"")",
-        RegexOptions.Compiled | RegexOptions.Singleline);
-
-    // Matches `new Diagnostic(<args>, "GSxxxx", <severity>, <message>)` — the
-    // low-level form used outside DiagnosticBag (e.g. AsyncEmitPrecheck),
-    // where <message> is typically an identifier/expression rather than a
-    // literal. The expression text itself is the "shape" being compared.
-    private static readonly Regex NewDiagnosticCall = new(
-        @"new\s+Diagnostic\([^;]*?""(GS\d{4})""\s*,\s*DiagnosticSeverity\.\w+\s*,\s*([^,;()]+?)\s*\)",
-        RegexOptions.Compiled | RegexOptions.Singleline);
-
     [Fact]
     public void Every_DiagnosticId_Maps_To_Exactly_One_Message_Shape()
     {
@@ -49,22 +37,42 @@ public class DiagnosticIdUniquenessTests
         var srcRoot = Path.Combine(repoRoot, "src");
         Assert.True(Directory.Exists(srcRoot), $"src directory not found: {srcRoot}");
 
-        // id -> set of (normalized message template -> example "file:line" site)
-        var idToTemplates = new Dictionary<string, Dictionary<string, string>>();
+        // id -> set of (enclosing-method shape -> example "file:line" site)
+        var idToShapes = new Dictionary<string, Dictionary<string, string>>();
 
         foreach (var file in Directory.EnumerateFiles(srcRoot, "*.cs", SearchOption.AllDirectories))
         {
             var text = File.ReadAllText(file);
-            RecordMatches(ReportCall, text, file, repoRoot, idToTemplates);
-            RecordMatches(NewDiagnosticCall, text, file, repoRoot, idToTemplates);
+            var tree = CSharpSyntaxTree.ParseText(text, path: file);
+            var root = tree.GetCompilationUnitRoot();
+
+            foreach (var invocation in root.DescendantNodes().OfType<InvocationExpressionSyntax>())
+            {
+                if (GetSimpleName(invocation.Expression) != "Report")
+                {
+                    continue;
+                }
+
+                RecordCallSite(invocation.ArgumentList, invocation, file, repoRoot, text, idToShapes);
+            }
+
+            foreach (var creation in root.DescendantNodes().OfType<ObjectCreationExpressionSyntax>())
+            {
+                if (GetSimpleName(creation.Type) != "Diagnostic" || creation.ArgumentList == null)
+                {
+                    continue;
+                }
+
+                RecordCallSite(creation.ArgumentList, creation, file, repoRoot, text, idToShapes);
+            }
         }
 
-        Assert.NotEmpty(idToTemplates);
+        Assert.NotEmpty(idToShapes);
 
-        var collisions = idToTemplates
+        var collisions = idToShapes
             .Where(kv => kv.Value.Count > 1)
             .OrderBy(kv => kv.Key, StringComparer.Ordinal)
-            .Select(kv => $"{kv.Key} is used for {kv.Value.Count} distinct messages:\n" +
+            .Select(kv => $"{kv.Key} is used from {kv.Value.Count} distinct enclosing methods:\n" +
                           string.Join("\n", kv.Value.Select(t => $"    {t.Value}: {t.Key}")))
             .ToArray();
 
@@ -74,34 +82,83 @@ public class DiagnosticIdUniquenessTests
             string.Join("\n\n", collisions));
     }
 
-    private static void RecordMatches(
-        Regex pattern,
-        string text,
+    private static void RecordCallSite(
+        ArgumentListSyntax argumentList,
+        SyntaxNode callNode,
         string file,
         string repoRoot,
-        Dictionary<string, Dictionary<string, string>> idToTemplates)
+        string text,
+        Dictionary<string, Dictionary<string, string>> idToShapes)
     {
-        foreach (Match match in pattern.Matches(text))
+        // Find the "GSxxxx" string literal argument, wherever it falls in the
+        // argument list (Report and Diagnostic's ctor put it in different
+        // positions).
+        var idLiteral = argumentList.Arguments
+            .Select(a => a.Expression)
+            .OfType<LiteralExpressionSyntax>()
+            .FirstOrDefault(l => l.IsKind(SyntaxKind.StringLiteralExpression) && IsGsId(l.Token.ValueText));
+
+        if (idLiteral == null)
         {
-            var id = match.Groups[1].Value;
-            var rawMessage = match.Groups[2].Value;
-            var template = InterpolationHole.Replace(rawMessage, "{}");
-            var line = text[..match.Index].Count(c => c == '\n') + 1;
-            var site = $"{Path.GetRelativePath(repoRoot, file)}:{line}";
+            return;
+        }
 
-            if (!idToTemplates.TryGetValue(id, out var templates))
-            {
-                templates = new Dictionary<string, string>();
-                idToTemplates[id] = templates;
-            }
+        var id = idLiteral.Token.ValueText;
+        var shape = GetEnclosingMemberName(callNode);
+        var line = text[..callNode.SpanStart].Count(c => c == '\n') + 1;
+        var site = $"{Path.GetRelativePath(repoRoot, file)}:{line}";
 
-            // Keep the first site seen for each distinct template so the
-            // failure message can point at both call sites of a collision.
-            if (!templates.ContainsKey(template))
+        if (!idToShapes.TryGetValue(id, out var shapes))
+        {
+            shapes = new Dictionary<string, string>();
+            idToShapes[id] = shapes;
+        }
+
+        // Keep the first site seen for each distinct shape so the failure
+        // message can point at both call sites of a collision.
+        if (!shapes.ContainsKey(shape))
+        {
+            shapes[shape] = site;
+        }
+    }
+
+    private static bool IsGsId(string value) =>
+        value.Length == 6 && value.StartsWith("GS", StringComparison.Ordinal) && value[2..].All(char.IsDigit);
+
+    // Resolves the simple name of a possibly-qualified expression
+    // (e.g. `this.Report`, `Diagnostics.Report` -> "Report").
+    private static string GetSimpleName(SyntaxNode expression) => expression switch
+    {
+        MemberAccessExpressionSyntax member => member.Name.Identifier.ValueText,
+        IdentifierNameSyntax identifier => identifier.Identifier.ValueText,
+        GenericNameSyntax generic => generic.Identifier.ValueText,
+        _ => string.Empty,
+    };
+
+    // The "shape" for a diagnostic ID: the name of its nearest enclosing
+    // method/local-function/constructor/property accessor. This is what
+    // actually distinguishes two unrelated diagnostics sharing an ID, since
+    // this repo's convention is one ReportXxx wrapper method per ID -
+    // regardless of whether the message is a literal, interpolated string,
+    // or a local variable.
+    private static string GetEnclosingMemberName(SyntaxNode node)
+    {
+        for (var current = node.Parent; current != null; current = current.Parent)
+        {
+            switch (current)
             {
-                templates[template] = site;
+                case MethodDeclarationSyntax method:
+                    return method.Identifier.ValueText;
+                case LocalFunctionStatementSyntax localFunction:
+                    return localFunction.Identifier.ValueText;
+                case ConstructorDeclarationSyntax ctor:
+                    return ctor.Identifier.ValueText;
+                case AccessorDeclarationSyntax accessor:
+                    return $"{(accessor.Parent?.Parent as PropertyDeclarationSyntax)?.Identifier.ValueText}.{accessor.Keyword.ValueText}";
             }
         }
+
+        return "<top-level>";
     }
 
     private static string FindRepoRoot()

--- a/test/Core.Tests/CodeAnalysis/Syntax/PropertyParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/PropertyParserTests.cs
@@ -95,9 +95,9 @@ public class PropertyParserTests
     }
 
     [Fact]
-    public void AutoPropertyInDataStruct_ParsesButBinderReportsGS0189()
+    public void AutoPropertyInDataStruct_ParsesButBinderReportsGS0419()
     {
-        // The parser accepts prop in data struct; the binder reports GS0189.
+        // The parser accepts prop in data struct; the binder reports GS0419.
         const string source = "package P\ndata struct P {\n  var X int32\n  prop Y int32\n}\n";
         var tree = SyntaxTree.Parse(source);
 

--- a/test/Core.Tests/Core.Tests.csproj
+++ b/test/Core.Tests/Core.Tests.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="FsCheck.Xunit" Version="3.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Interpreter.Tests/PropertyInterpreterTests.cs
+++ b/test/Interpreter.Tests/PropertyInterpreterTests.cs
@@ -107,11 +107,11 @@ public class PropertyInterpreterTests
     }
 
     [Fact]
-    public void AutoPropertyInDataStruct_ReportsGS0189()
+    public void AutoPropertyInDataStruct_ReportsGS0419()
     {
         var source = "data struct P {\n  var X int32\n  prop Y int32\n}\n";
         var output = RunSubmission(source);
-        Assert.Contains("GS0189", output);
+        Assert.Contains("GS0419", output);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #1655

## Problem
Five `GS####` diagnostic IDs were each reused for 2-3 unrelated diagnostics. Because diagnostic IDs are the stable public contract (`/nowarn`, `/warnaserror`, docs, IDE quick-info), a suppression targeting one meaning silently suppresses the unrelated one too.

## Fix
For each collision, kept the earliest-established meaning (verified via `git log -L` first-commit date) on the original ID and moved every newer meaning to a fresh ID above the current max (`GS0418`):

| ID | Kept meaning (original) | Moved meaning(s) to new ID |
|----|--------------------------|------------------------------|
| GS0189 | `async func(...)` implicit `Task` wrap (ADR-0043, #150, 2026-05-26) | Auto-property in a `data struct` -> GS0419 (#245, 2026-05-28) |
| GS0190 | Async state machine unavailable (`AsyncEmitPrecheck`, #152, 2026-05-26 09:09) | `nameof` argument must be a name reference -> GS0420 (#156, 2026-05-26 13:43); `open` member on non-open class -> GS0421 (#245, 2026-05-28) |
| GS0226 | Read-only span element assignment (#383, 2026-06-01) | Ref-kind parameter on async/iterator function -> GS0422 (#489, 2026-06-05) |
| GS0241 | Ref-kind modifier on a variadic parameter (#489) | Ref-kind modifier on a primary-constructor parameter -> GS0424 (#489, same commit, kept file order) |
| GS0268 | No such nested type (#552, 2026-06-07 08:17) | Type not iterable in `for ... in` -> GS0423 (#565, 2026-06-07 14:53) |

Note: GS0241 was not in the original issue list. The guard test (and a manual scan of `Report(...)` calls in `DiagnosticBag.cs`) surfaced it as a 5th real collision: same PR, two genuinely different rules sharing one ID. Fixed the same way.

## Changes
1. `src/Core/CodeAnalysis/DiagnosticBag.cs` - reassigned the 6 moved `Report(...)` call sites to the new IDs.
2. `docs/diagnostics.md` - added a new "Reassigned diagnostics (GS0419-GS0424)" section, added the previously-undocumented GS0268 entry (nested-type meaning), and corrected the stale "async/iterator ban reuses GS0226" note in the ADR-0060 section.
3. Updated tests that asserted on the moved diagnostics: `TypeOfNameOfTests`, `RefKindParameterSitesTests`, `PropertyParserTests`, `PropertyInterpreterTests`, plus a comment in `Issue1433InterfaceStaticMemberCallEmitTests`.
4. Added `test/Core.Tests/CodeAnalysis/DiagnosticIdUniquenessTests.cs` - a guard test that scans every `Report(...)` / `new Diagnostic(...)` call site under `src/` and fails if any `GS####` ID maps to more than one distinct message template (interpolation holes normalized to `{}`). Run against the fixed tree it passes with no further collisions found.

## Validation
- `dotnet build GSharp.sln -c Release -graph` - succeeded, 0 warnings/errors.
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release` (full suite) - 5071 passed, 1 skipped (pre-existing baseline-regen skip), 0 failed.
- `dotnet test test/Interpreter.Tests/Interpreter.Tests.csproj --filter PropertyInterpreterTests` - 15 passed.
