### PR TITLE
Fix #1609: track interpolation-hole delimiters per-kind, not shared depth

### DIFF
--- a/src/Core/CodeAnalysis/Syntax/Lexer.cs
+++ b/src/Core/CodeAnalysis/Syntax/Lexer.cs
@@ -929,7 +929,11 @@ public sealed class Lexer
 
     private bool ScanInterpolationHoleCore(int holeStart)
     {
-        var depth = 1; // the opening '{' of '${'
+        // Issue #1609: track open delimiters by kind instead of a single
+        // shared counter. A stray/mismatched ')' or ']' must not decrement
+        // past the hole's own '{' — that let a later legit '}' slip through
+        // unmatched and swallow the rest of the file into one token.
+        var openDelimiters = new Stack<char>();
         while (true)
         {
             var c = Current;
@@ -981,20 +985,39 @@ public sealed class Lexer
 
             if (c == '(' || c == '[' || c == '{')
             {
-                depth++;
+                openDelimiters.Push(c);
             }
-            else if (c == ')' || c == ']')
+            else if (c == ')')
             {
-                depth--;
+                if (openDelimiters.Count > 0 && openDelimiters.Peek() == '(')
+                {
+                    openDelimiters.Pop();
+                }
+
+                // else: stray/mismatched ')' — ignore, nothing open to close.
+            }
+            else if (c == ']')
+            {
+                if (openDelimiters.Count > 0 && openDelimiters.Peek() == '[')
+                {
+                    openDelimiters.Pop();
+                }
+
+                // else: stray/mismatched ']' — ignore, nothing open to close.
             }
             else if (c == '}')
             {
-                if (depth == 1)
+                if (openDelimiters.Count == 0)
                 {
-                    return true; // matching close; leave it for the caller
+                    return true; // matches the hole's own '{'; leave it for the caller
                 }
 
-                depth--;
+                if (openDelimiters.Peek() == '{')
+                {
+                    openDelimiters.Pop();
+                }
+
+                // else: stray/mismatched '}' closing a '(' or '[' — ignore.
             }
 
             position++;

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue1609InterpolationHoleBalanceTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue1609InterpolationHoleBalanceTests.cs
@@ -1,0 +1,94 @@
+// <copyright file="Issue1609InterpolationHoleBalanceTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Issue #1609: <c>ScanInterpolationHoleCore</c> used a single shared counter
+/// for <c>()[]{}</c> nesting inside a <c>${…}</c> interpolation hole. A stray
+/// or mismatched <c>)</c>/<c>]</c> decremented that counter with no floor, so
+/// it could drop below the level of the hole's own opening <c>{</c>; the
+/// following <c>}</c> would then fail to match, and the scanner ran to EOF,
+/// swallowing the rest of the file into one unterminated string token. The
+/// fix tracks open delimiters by kind (a stack) so only the matching close
+/// for the currently-open delimiter pops it; unmatched closes are ignored
+/// instead of corrupting the depth used to find the hole's terminating
+/// <c>}</c>.
+/// </summary>
+public class Issue1609InterpolationHoleBalanceTests
+{
+    [Fact]
+    public void StrayCloseParen_InHole_DoesNotSwallowRestOfFile()
+    {
+        // Exact issue #1609 repro.
+        var source = "let a = \"${ ) }\"\nlet b = 2\n";
+        var tokens = SyntaxTree.ParseTokens(source, out var diagnostics);
+
+        Assert.Empty(diagnostics);
+        Assert.Contains(tokens, t => t.Kind == SyntaxKind.InterpolatedStringToken);
+
+        // The `let b = 2` line must still lex as its own tokens, not be
+        // absorbed into the string token.
+        var identifiers = tokens.Where(t => t.Kind == SyntaxKind.IdentifierToken).Select(t => t.Text).ToArray();
+        Assert.Contains("b", identifiers);
+    }
+
+    [Fact]
+    public void StrayCloseBracket_InHole_DoesNotSwallowRestOfFile()
+    {
+        var source = "let a = \"${ ] }\"\nlet b = 2\n";
+        var tokens = SyntaxTree.ParseTokens(source, out var diagnostics);
+
+        Assert.Empty(diagnostics);
+        var identifiers = tokens.Where(t => t.Kind == SyntaxKind.IdentifierToken).Select(t => t.Text).ToArray();
+        Assert.Contains("b", identifiers);
+    }
+
+    [Fact]
+    public void MismatchedCloseBracket_InsideOpenParen_IsIgnoredAndHoleStillClosesCorrectly()
+    {
+        // A ']' that doesn't match the innermost '(' must be ignored rather
+        // than popping the '(' (or corrupting the tracking); the following
+        // ')' must still close the '(' and the final '}' must still close
+        // the hole normally.
+        var source = "let a = \"${ (1] + 2) }\"\nlet b = 2\n";
+        var tokens = SyntaxTree.ParseTokens(source, out var diagnostics);
+
+        Assert.Empty(diagnostics);
+        Assert.Contains(tokens, t => t.Kind == SyntaxKind.InterpolatedStringToken);
+        var identifiers = tokens.Where(t => t.Kind == SyntaxKind.IdentifierToken).Select(t => t.Text).ToArray();
+        Assert.Contains("b", identifiers);
+    }
+
+    [Fact]
+    public void BalancedNestedBrackets_OfAllKinds_CloseHoleCorrectly()
+    {
+        var source = "let a = \"${ f(g[h(1)], {2}) }\"\nlet b = 2\n";
+        var tokens = SyntaxTree.ParseTokens(source, out var diagnostics);
+
+        Assert.Empty(diagnostics);
+        Assert.Contains(tokens, t => t.Kind == SyntaxKind.InterpolatedStringToken);
+        var identifiers = tokens.Where(t => t.Kind == SyntaxKind.IdentifierToken).Select(t => t.Text).ToArray();
+        Assert.Contains("b", identifiers);
+    }
+
+    [Fact]
+    public void NestedInterpolationHole_WithStrayCloseParenInInnerString_StillClosesOuterHole()
+    {
+        // A nested "${...}" inside the hole (its own string literal with an
+        // interpolation) must be skipped wholesale by
+        // SkipInterpolationNestedLiteral; a stray ')' inside that nested hole
+        // must not corrupt the outer hole's own tracking.
+        var source = "let a = \"${ \"${ ) }\" }\"\nlet b = 2\n";
+        var tokens = SyntaxTree.ParseTokens(source, out var diagnostics);
+
+        Assert.Empty(diagnostics);
+        var identifiers = tokens.Where(t => t.Kind == SyntaxKind.IdentifierToken).Select(t => t.Text).ToArray();
+        Assert.Contains("b", identifiers);
+    }
+}


### PR DESCRIPTION
Fixes #1609

ScanInterpolationHoleCore in src/Core/CodeAnalysis/Syntax/Lexer.cs used a single shared counter for `()[]{}` nesting inside a `${…}` interpolation hole. A stray or mismatched `)`/`]` decremented it with no floor, dropping below the level of the hole's own opening `{`. The following `}` then failed to match, and the scanner ran to EOF, swallowing the rest of the file into one unterminated string token (one typo erased diagnostics/symbols for the whole file).

Fix: replaced the counter with a stack of open delimiters (per-kind). Only the matching close for the currently-open delimiter pops the stack; unmatched `)`, `]`, or `}` are ignored rather than corrupting the tracking. The hole terminates on the `}` that empties the stack (i.e. matches its opening `{`). This generalizes to all bracket kinds, nested interpolation holes, and string/char literals inside holes (all still exercised via existing recursive helpers).

Added `test/Core.Tests/CodeAnalysis/Syntax/Issue1609InterpolationHoleBalanceTests.cs` covering: the exact issue repro (stray `)`), stray `]`, a mismatched `]` inside an open `(` that's later balanced, balanced nested brackets of all three kinds, and a nested interpolation hole containing a stray `)`.

Verified: `dotnet build GSharp.sln -c Release -graph` — 0 errors. `dotnet test test/Core.Tests/Core.Tests.csproj -c Release` — full suite green (5079 passed, 1 skipped baseline regen test).