### PR TITLE
Fix #1624: identity-correct cache keying for tuples and function pointers

### DIFF
--- a/src/Core/CodeAnalysis/Symbols/FunctionPointerTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/FunctionPointerTypeSymbol.cs
@@ -68,10 +68,12 @@ public sealed class FunctionPointerTypeSymbol : TypeSymbol
     /// <returns>A cached <see cref="FunctionPointerTypeSymbol"/>.</returns>
     public static FunctionPointerTypeSymbol Get(CallingConvention callingConvention, ImmutableArray<TypeSymbol> parameterTypes, TypeSymbol returnType)
     {
-        var displayName = BuildDisplayName(callingConvention, parameterTypes, returnType ?? TypeSymbol.Void);
+        returnType ??= TypeSymbol.Void;
+        var displayName = BuildDisplayName(callingConvention, parameterTypes, returnType);
+        var key = BuildIdentityKey("u", callingConvention.ToString(), parameterTypes, returnType);
         return Cache.GetOrAdd(
-            displayName,
-            _ => new FunctionPointerTypeSymbol(displayName, isManaged: false, callingConvention, parameterTypes, returnType ?? TypeSymbol.Void));
+            key,
+            _ => new FunctionPointerTypeSymbol(displayName, isManaged: false, callingConvention, parameterTypes, returnType));
     }
 
     /// <summary>
@@ -85,10 +87,45 @@ public sealed class FunctionPointerTypeSymbol : TypeSymbol
     /// <returns>A cached managed <see cref="FunctionPointerTypeSymbol"/>.</returns>
     public static FunctionPointerTypeSymbol GetManaged(ImmutableArray<TypeSymbol> parameterTypes, TypeSymbol returnType)
     {
-        var displayName = BuildManagedDisplayName(parameterTypes, returnType ?? TypeSymbol.Void);
+        returnType ??= TypeSymbol.Void;
+        var displayName = BuildManagedDisplayName(parameterTypes, returnType);
+        var key = BuildIdentityKey("m", null, parameterTypes, returnType);
         return Cache.GetOrAdd(
-            displayName,
-            _ => new FunctionPointerTypeSymbol(displayName, isManaged: true, CallingConvention.Winapi, parameterTypes, returnType ?? TypeSymbol.Void));
+            key,
+            _ => new FunctionPointerTypeSymbol(displayName, isManaged: true, CallingConvention.Winapi, parameterTypes, returnType));
+    }
+
+    /// <summary>
+    /// Issue #1624: builds an identity-correct cache key using
+    /// <see cref="FunctionTypeSymbol.AppendIdentityKey"/> — the same builder
+    /// <see cref="FunctionTypeSymbol"/> and <see cref="TupleTypeSymbol"/> use —
+    /// so two distinct types that merely share a display name (e.g. a
+    /// same-named parameter type loaded from different compilations) never
+    /// alias in this process-wide cache.
+    /// </summary>
+    private static string BuildIdentityKey(string kindTag, string callingConventionTag, ImmutableArray<TypeSymbol> parameterTypes, TypeSymbol returnType)
+    {
+        var sb = new System.Text.StringBuilder();
+        sb.Append('!').Append(kindTag);
+        if (callingConventionTag != null)
+        {
+            sb.Append('[').Append(callingConventionTag).Append(']');
+        }
+
+        sb.Append('(');
+        for (var i = 0; i < parameterTypes.Length; i++)
+        {
+            if (i > 0)
+            {
+                sb.Append(',');
+            }
+
+            FunctionTypeSymbol.AppendIdentityKey(sb, parameterTypes[i]);
+        }
+
+        sb.Append(")->");
+        FunctionTypeSymbol.AppendIdentityKey(sb, returnType);
+        return sb.ToString();
     }
 
     private static string BuildManagedDisplayName(ImmutableArray<TypeSymbol> parameterTypes, TypeSymbol returnType)

--- a/src/Core/CodeAnalysis/Symbols/FunctionTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/FunctionTypeSymbol.cs
@@ -30,6 +30,24 @@ public sealed class FunctionTypeSymbol : TypeSymbol
     // still sharing within one.
     private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<TypeSymbol, object> UserTypeIds = new System.Runtime.CompilerServices.ConditionalWeakTable<TypeSymbol, object>();
 
+    // Issue #1624 regression: a plain imported CLR reference type (e.g. a
+    // `Holder` class from a project reference, loaded through a
+    // MetadataLoadContext) has a non-null ClrType, so it skipped the
+    // ContainsSameCompilationUserType branch above and fell to the
+    // name-only default below ("Holder"). Two *different* test
+    // compilations each load their own MetadataLoadContext and get a
+    // distinct System.Type instance for "Holder" — but the name-only key
+    // aliased them, so a tuple cached by the first compilation (holding a
+    // ClrType from its now-disposed context) was handed back to the
+    // second, breaking emit. Key any type with a live ClrType by that
+    // Type object's identity instead: stable process-wide singletons
+    // (int32, string, ...) keep one id forever (still fully shared), while
+    // distinct MetadataLoadContext Type instances across compilations get
+    // distinct ids (no aliasing), and repeated lookups of the *same*
+    // System.Type within one compilation collapse to the same id (still
+    // interned).
+    private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<System.Type, object> ClrTypeIds = new System.Runtime.CompilerServices.ConditionalWeakTable<System.Type, object>();
+
     private static long typeParameterIdSeed;
 
     private FunctionTypeSymbol(string name, ImmutableArray<TypeSymbol> parameterTypes, ImmutableArray<bool> isVariadic, TypeSymbol returnType)
@@ -248,6 +266,21 @@ public sealed class FunctionTypeSymbol : TypeSymbol
                 AppendIdentityKey(builder, fn.ReturnType);
                 break;
 
+            // Issue #1518/#1624 regression: NullableTypeSymbol's ClrType is
+            // the bare *underlying* CLR type (see NullableTypeSymbol ctor),
+            // not Nullable<T> — so `int32?` and `int32` share the same
+            // System.Type. Falling through to the ClrType-identity default
+            // below would collapse their keys and alias a `Func<..,int32?>`
+            // with a `Func<..,int32>` in the process-wide cache. Always key
+            // nullable slots structurally (by their own tag plus the
+            // recursively-keyed underlying type) regardless of whether they
+            // carry a type parameter.
+            case NullableTypeSymbol nt:
+                builder.Append("!nullable(");
+                AppendIdentityKey(builder, nt.UnderlyingType);
+                builder.Append(')');
+                break;
+
             // Issue #1620: a composite type (List[T], []T, T?, (T, int32), ...)
             // that structurally carries a type parameter must NOT fall through
             // to the name-based default below — two distinct generic
@@ -260,7 +293,7 @@ public sealed class FunctionTypeSymbol : TypeSymbol
                 AppendStructuralKey(builder, type);
                 break;
             default:
-                builder.Append(type?.Name ?? "void");
+                AppendNameOrClrIdentityKey(builder, type);
                 break;
         }
     }
@@ -392,8 +425,38 @@ public sealed class FunctionTypeSymbol : TypeSymbol
                 // composite kinds handled above (see AnyTypeParameter), so
                 // this default is unreachable in practice; keep the
                 // name-based fallback for safety.
-                builder.Append(type?.Name ?? "void");
+                AppendNameOrClrIdentityKey(builder, type);
                 break;
+        }
+    }
+
+    /// <summary>
+    /// Issue #1624 regression fix: appends the identity-key fragment for a
+    /// type that is neither a type parameter, a function type, nor a
+    /// same-compilation user type without CLR backing. Such a type either has
+    /// no ClrType (the true singleton built-ins like <c>void</c>/<c>error</c>,
+    /// safely shared by name) or carries a live <see cref="System.Type"/> —
+    /// a built-in primitive (a genuine process-wide singleton) or an
+    /// <see cref="ImportedTypeSymbol"/> projected from a
+    /// <see cref="System.Reflection.MetadataLoadContext"/> (a distinct
+    /// <see cref="System.Type"/> instance per compilation even when the
+    /// simple name matches, e.g. two test compilations that each define a
+    /// "Holder" class). Keying by the CLR <see cref="System.Type"/> object's
+    /// identity keeps every true singleton shared while never aliasing two
+    /// same-named types loaded by different compilations.
+    /// </summary>
+    /// <param name="builder">The key builder to append to.</param>
+    /// <param name="type">The type whose fallback key fragment to append.</param>
+    private static void AppendNameOrClrIdentityKey(System.Text.StringBuilder builder, TypeSymbol type)
+    {
+        if (type?.ClrType is System.Type clrType)
+        {
+            var id = (long)ClrTypeIds.GetValue(clrType, _ => NextTypeParameterId());
+            builder.Append("!clr").Append(id);
+        }
+        else
+        {
+            builder.Append(type?.Name ?? "void");
         }
     }
 

--- a/src/Core/CodeAnalysis/Symbols/FunctionTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/FunctionTypeSymbol.cs
@@ -281,6 +281,24 @@ public sealed class FunctionTypeSymbol : TypeSymbol
                 builder.Append(')');
                 break;
 
+            // #1777 follow-up: SliceTypeSymbol/ArrayTypeSymbol both build their
+            // ClrType as `elementType.ClrType.MakeArrayType()` — a fixed-length
+            // array's Length is symbol-only metadata that never reaches the CLR
+            // shape, so `[]int32`, `[3]int32`, and `[5]int32` all resolve to the
+            // identical `typeof(int[])` instance. PinnedTypeSymbol copies its
+            // underlying type's ClrType verbatim, and NullabilityAnnotatedTypeSymbol
+            // copies both Name and ClrType from its BaseType. None of these carry a
+            // type parameter or same-compilation user type, so all four would
+            // otherwise fall through to the ClrType/name fallback below and alias
+            // distinct shapes in the process-wide Tuple/FunctionPointer caches —
+            // the same failure mode as #1624. Always key them structurally.
+            case SliceTypeSymbol:
+            case ArrayTypeSymbol:
+            case PinnedTypeSymbol:
+            case NullabilityAnnotatedTypeSymbol:
+                AppendStructuralKey(builder, type);
+                break;
+
             // Issue #1620: a composite type (List[T], []T, T?, (T, int32), ...)
             // that structurally carries a type parameter must NOT fall through
             // to the name-based default below — two distinct generic
@@ -323,8 +341,31 @@ public sealed class FunctionTypeSymbol : TypeSymbol
                 builder.Append(')');
                 break;
             case ArrayTypeSymbol a:
-                builder.Append("!array(");
+                // Length must be part of the key: it is symbol-only metadata
+                // absent from the shared `elementType[]` ClrType, so `[3]int32`
+                // and `[5]int32` (and `[]int32`, via the distinct `!slice` tag
+                // above) would otherwise collide.
+                builder.Append("!array(").Append(a.Length).Append(',');
                 AppendIdentityKey(builder, a.ElementType);
+                builder.Append(')');
+                break;
+            case PinnedTypeSymbol p:
+                builder.Append("!pinned(");
+                AppendIdentityKey(builder, p.UnderlyingType);
+                builder.Append(')');
+                break;
+            case NullabilityAnnotatedTypeSymbol na:
+                // Include NullableFlags so two annotations of the same base
+                // type with different inner-position nullability (e.g. key
+                // vs. value nullable in Dictionary<K,V>) also key distinctly,
+                // not just annotated-vs-bare.
+                builder.Append("!nann(");
+                for (var i = 0; i < na.NullableFlags.Length; i++)
+                {
+                    builder.Append(na.NullableFlags[i]).Append(',');
+                }
+
+                AppendIdentityKey(builder, na.BaseType);
                 builder.Append(')');
                 break;
             case SequenceTypeSymbol seq:

--- a/src/Core/CodeAnalysis/Symbols/FunctionTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/FunctionTypeSymbol.cs
@@ -201,7 +201,16 @@ public sealed class FunctionTypeSymbol : TypeSymbol
         return returnType == null || returnType == TypeSymbol.Void;
     }
 
-    private static void AppendIdentityKey(System.Text.StringBuilder builder, TypeSymbol type)
+    /// <summary>
+    /// Appends an identity-correct cache-key fragment for <paramref name="type"/>.
+    /// Issue #1624: shared by <see cref="TupleTypeSymbol"/> and
+    /// <see cref="FunctionPointerTypeSymbol"/> so every structural cache in the
+    /// symbol table keys on symbol identity (not display name), preventing
+    /// same-named types from different compilations from aliasing.
+    /// </summary>
+    /// <param name="builder">The key builder to append to.</param>
+    /// <param name="type">The type whose identity-key fragment to append.</param>
+    internal static void AppendIdentityKey(System.Text.StringBuilder builder, TypeSymbol type)
     {
         // Issue #1457: any slot that references a same-compilation user type
         // (directly or nested, e.g. `Item`, `List[Item]`, `(Item, int)`) must be

--- a/src/Core/CodeAnalysis/Symbols/TupleTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/TupleTypeSymbol.cs
@@ -46,24 +46,27 @@ public sealed class TupleTypeSymbol : TypeSymbol
             throw new ArgumentException("Tuples must have at least two element types.", nameof(elementTypes));
         }
 
-        var key = BuildName(elementTypes);
-
-        // Issue #649: The cache is keyed by name alone (e.g. "(Holder, string)").
-        // Across compilations in the same process (common in tests), different
-        // TypeSymbol instances with the same name may appear (loaded from
-        // different MetadataLoadContext instances). Validate that the cached
-        // entry's element types still match by reference; if not, replace it.
-        if (Cache.TryGetValue(key, out var existing))
+        // Issue #1624: key on element-type *identity* (via FunctionTypeSymbol's
+        // shared identity-key builder), not the display name. A name-based key
+        // (e.g. "(Holder, string)") can alias two distinct same-named types
+        // from different compilations; the previous fix (#649) validated
+        // identity on lookup but then racily overwrote the cache entry on a
+        // mismatch, so concurrent callers could still observe two distinct
+        // instances for the same elements. GetOrAdd is atomic, so no overwrite
+        // is needed once the key itself is identity-correct.
+        var keyBuilder = new StringBuilder();
+        for (var i = 0; i < elementTypes.Length; i++)
         {
-            if (existing.ElementTypes.SequenceEqual(elementTypes))
+            if (i > 0)
             {
-                return existing;
+                keyBuilder.Append(',');
             }
+
+            FunctionTypeSymbol.AppendIdentityKey(keyBuilder, elementTypes[i]);
         }
 
-        var result = new TupleTypeSymbol(elementTypes);
-        Cache[key] = result;
-        return result;
+        var key = keyBuilder.ToString();
+        return Cache.GetOrAdd(key, _ => new TupleTypeSymbol(elementTypes));
     }
 
     private static string BuildName(ImmutableArray<TypeSymbol> elementTypes)

--- a/test/Core.Tests/CodeAnalysis/Symbols/Issue1624SymbolCacheKeyingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/Issue1624SymbolCacheKeyingTests.cs
@@ -99,4 +99,82 @@ public class Issue1624SymbolCacheKeyingTests
         var type = module.DefineType("Holder", TypeAttributes.Public | TypeAttributes.Class);
         return type.CreateType();
     }
+
+    /// <summary>
+    /// #1777 follow-up regression: <see cref="SliceTypeSymbol"/> and
+    /// <see cref="ArrayTypeSymbol"/> both build their <c>ClrType</c> as
+    /// <c>elementType.ClrType.MakeArrayType()</c> (the fixed length is
+    /// symbol-only metadata, absent from the CLR shape), so
+    /// <c>[]int32</c>, <c>[3]int32</c>, and <c>[5]int32</c> all share the
+    /// identical <c>typeof(int[])</c> instance. Neither carries a type
+    /// parameter or same-compilation user type, so the ClrType-identity
+    /// fallback introduced by #1777 would alias all three as tuple
+    /// elements -- the same failure mode as #1624.
+    /// </summary>
+    [Fact]
+    public void TupleTypeSymbol_Get_WithSliceVsFixedArrayElements_NeverAliases()
+    {
+        var slice = SliceTypeSymbol.Get(TypeSymbol.Int32);
+        var array3 = ArrayTypeSymbol.Get(TypeSymbol.Int32, 3);
+        var array5 = ArrayTypeSymbol.Get(TypeSymbol.Int32, 5);
+        var array3Again = ArrayTypeSymbol.Get(TypeSymbol.Int32, 3);
+
+        var tupleSlice = TupleTypeSymbol.Get(ImmutableArray.Create<TypeSymbol>(slice, TypeSymbol.String));
+        var tupleArray3 = TupleTypeSymbol.Get(ImmutableArray.Create<TypeSymbol>(array3, TypeSymbol.String));
+        var tupleArray5 = TupleTypeSymbol.Get(ImmutableArray.Create<TypeSymbol>(array5, TypeSymbol.String));
+        var tupleArray3Again = TupleTypeSymbol.Get(ImmutableArray.Create<TypeSymbol>(array3Again, TypeSymbol.String));
+
+        Assert.NotSame(tupleSlice, tupleArray3);
+        Assert.NotSame(tupleArray3, tupleArray5);
+        Assert.NotSame(tupleSlice, tupleArray5);
+
+        // Positive interning check: the same shape used twice still resolves
+        // to the same cached symbol -- the fix must not over-fragment.
+        Assert.Same(tupleArray3, tupleArray3Again);
+    }
+
+    /// <summary>
+    /// #1777 follow-up regression: <see cref="PinnedTypeSymbol"/> copies its
+    /// underlying type's <c>ClrType</c> verbatim, so a pinned wrapper and its
+    /// bare underlying type would alias as tuple elements under the
+    /// ClrType-identity fallback.
+    /// </summary>
+    [Fact]
+    public void TupleTypeSymbol_Get_WithPinnedVsUnpinnedUnderlying_NeverAliases()
+    {
+        var pinned = new PinnedTypeSymbol(TypeSymbol.String);
+
+        var tuplePinned = TupleTypeSymbol.Get(ImmutableArray.Create<TypeSymbol>(pinned, TypeSymbol.Int32));
+        var tupleBare = TupleTypeSymbol.Get(ImmutableArray.Create<TypeSymbol>(TypeSymbol.String, TypeSymbol.Int32));
+
+        Assert.NotSame(tuplePinned, tupleBare);
+    }
+
+    /// <summary>
+    /// #1777 follow-up regression: <see cref="NullabilityAnnotatedTypeSymbol"/>
+    /// inherits both <c>Name</c> and <c>ClrType</c> from its <c>BaseType</c>
+    /// unchanged, so an annotated element (e.g. carrying a nullable inner
+    /// generic argument byte) would alias its bare base type as a tuple
+    /// element -- and two annotated wrappers of the same base with different
+    /// nullability flags (key vs. value nullable) would alias each other too.
+    /// </summary>
+    [Fact]
+    public void TupleTypeSymbol_Get_WithNullabilityAnnotatedVsBareElements_NeverAliases()
+    {
+        var annotatedA = new NullabilityAnnotatedTypeSymbol(TypeSymbol.String, ImmutableArray.Create<byte>(1, 2));
+        var annotatedB = new NullabilityAnnotatedTypeSymbol(TypeSymbol.String, ImmutableArray.Create<byte>(1, 1));
+        var annotatedAAgain = new NullabilityAnnotatedTypeSymbol(TypeSymbol.String, ImmutableArray.Create<byte>(1, 2));
+
+        var tupleAnnotatedA = TupleTypeSymbol.Get(ImmutableArray.Create<TypeSymbol>(annotatedA, TypeSymbol.Int32));
+        var tupleAnnotatedB = TupleTypeSymbol.Get(ImmutableArray.Create<TypeSymbol>(annotatedB, TypeSymbol.Int32));
+        var tupleBare = TupleTypeSymbol.Get(ImmutableArray.Create<TypeSymbol>(TypeSymbol.String, TypeSymbol.Int32));
+        var tupleAnnotatedAAgain = TupleTypeSymbol.Get(ImmutableArray.Create<TypeSymbol>(annotatedAAgain, TypeSymbol.Int32));
+
+        Assert.NotSame(tupleAnnotatedA, tupleBare);
+        Assert.NotSame(tupleAnnotatedA, tupleAnnotatedB);
+
+        // Positive interning check: same shape (same base + same flags) still
+        // resolves to the same cached symbol.
+        Assert.Same(tupleAnnotatedA, tupleAnnotatedAAgain);
+    }
 }

--- a/test/Core.Tests/CodeAnalysis/Symbols/Issue1624SymbolCacheKeyingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/Issue1624SymbolCacheKeyingTests.cs
@@ -1,0 +1,64 @@
+// <copyright file="Issue1624SymbolCacheKeyingTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Runtime.InteropServices;
+using GSharp.Core.CodeAnalysis.Symbols;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Symbols;
+
+/// <summary>
+/// Issue #1624 regression coverage: <see cref="TupleTypeSymbol"/> and
+/// <see cref="FunctionPointerTypeSymbol"/> used to key their process-wide
+/// caches by display name alone (or, for tuples, validated identity on
+/// lookup but then raced a plain-write replace on mismatch). Two distinct
+/// <see cref="TypeParameterSymbol"/> instances that share a name (as happens
+/// across separate compilations reusing a letter like <c>T</c>) must never
+/// alias to the same cached tuple / function-pointer instance.
+/// </summary>
+public class Issue1624SymbolCacheKeyingTests
+{
+    [Fact]
+    public void TupleTypeSymbol_Get_WithDistinctSameNamedElementTypes_NeverAliases()
+    {
+        var t1 = new TypeParameterSymbol("T", 0, TypeParameterConstraint.Any, TypeParameterVariance.None);
+        var t2 = new TypeParameterSymbol("T", 0, TypeParameterConstraint.Any, TypeParameterVariance.None);
+
+        var tupleA = TupleTypeSymbol.Get(ImmutableArray.Create<TypeSymbol>(t1, TypeSymbol.String));
+        var tupleB = TupleTypeSymbol.Get(ImmutableArray.Create<TypeSymbol>(t2, TypeSymbol.String));
+        var tupleAAgain = TupleTypeSymbol.Get(ImmutableArray.Create<TypeSymbol>(t1, TypeSymbol.String));
+
+        Assert.NotSame(tupleA, tupleB);
+        Assert.Same(tupleA, tupleAAgain);
+    }
+
+    [Fact]
+    public void FunctionPointerTypeSymbol_GetUnmanaged_WithDistinctSameNamedParameterTypes_NeverAliases()
+    {
+        var t1 = new TypeParameterSymbol("T", 0, TypeParameterConstraint.Any, TypeParameterVariance.None);
+        var t2 = new TypeParameterSymbol("T", 0, TypeParameterConstraint.Any, TypeParameterVariance.None);
+
+        var fpA = FunctionPointerTypeSymbol.Get(CallingConvention.Cdecl, ImmutableArray.Create<TypeSymbol>(t1), TypeSymbol.Void);
+        var fpB = FunctionPointerTypeSymbol.Get(CallingConvention.Cdecl, ImmutableArray.Create<TypeSymbol>(t2), TypeSymbol.Void);
+        var fpAAgain = FunctionPointerTypeSymbol.Get(CallingConvention.Cdecl, ImmutableArray.Create<TypeSymbol>(t1), TypeSymbol.Void);
+
+        Assert.NotSame(fpA, fpB);
+        Assert.Same(fpA, fpAAgain);
+    }
+
+    [Fact]
+    public void FunctionPointerTypeSymbol_GetManaged_WithDistinctSameNamedParameterTypes_NeverAliases()
+    {
+        var t1 = new TypeParameterSymbol("T", 0, TypeParameterConstraint.Any, TypeParameterVariance.None);
+        var t2 = new TypeParameterSymbol("T", 0, TypeParameterConstraint.Any, TypeParameterVariance.None);
+
+        var fpA = FunctionPointerTypeSymbol.GetManaged(ImmutableArray.Create<TypeSymbol>(t1), TypeSymbol.Void);
+        var fpB = FunctionPointerTypeSymbol.GetManaged(ImmutableArray.Create<TypeSymbol>(t2), TypeSymbol.Void);
+        var fpAAgain = FunctionPointerTypeSymbol.GetManaged(ImmutableArray.Create<TypeSymbol>(t1), TypeSymbol.Void);
+
+        Assert.NotSame(fpA, fpB);
+        Assert.Same(fpA, fpAAgain);
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Symbols/Issue1624SymbolCacheKeyingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/Issue1624SymbolCacheKeyingTests.cs
@@ -3,6 +3,8 @@
 // </copyright>
 
 using System.Collections.Immutable;
+using System.Reflection;
+using System.Reflection.Emit;
 using System.Runtime.InteropServices;
 using GSharp.Core.CodeAnalysis.Symbols;
 using Xunit;
@@ -60,5 +62,41 @@ public class Issue1624SymbolCacheKeyingTests
 
         Assert.NotSame(fpA, fpB);
         Assert.Same(fpA, fpAAgain);
+    }
+
+    /// <summary>
+    /// Regression for the fix-up in this same PR: the original #1624 patch
+    /// keyed a plain imported CLR reference-type element (one with a
+    /// non-null <c>ClrType</c>, e.g. a class from a project reference) by
+    /// name alone, so two *distinct* same-named CLR types (as happens across
+    /// separate compilations, each loading their own copy of a same-named
+    /// class) aliased to a single cached <see cref="TupleTypeSymbol"/> —
+    /// which broke <c>Tuple2_OneClrRefType_ReturnsAndDestructures</c> and
+    /// <c>Tuple_AsParameterType</c> in Compiler.Tests. This builds two
+    /// dynamic assemblies that each define an unrelated "Holder" class (same
+    /// simple name, different <see cref="System.Type"/> identity) and
+    /// asserts they never alias, while confirming the same CLR type used
+    /// twice still interns to one shared instance.
+    /// </summary>
+    [Fact]
+    public void TupleTypeSymbol_Get_WithDistinctSameNamedClrRefTypeElements_NeverAliases()
+    {
+        var holderA = ImportedTypeSymbol.Get(DefineHolderType("HolderAsm.A"));
+        var holderB = ImportedTypeSymbol.Get(DefineHolderType("HolderAsm.B"));
+
+        var tupleA = TupleTypeSymbol.Get(ImmutableArray.Create<TypeSymbol>(holderA, TypeSymbol.String));
+        var tupleB = TupleTypeSymbol.Get(ImmutableArray.Create<TypeSymbol>(holderB, TypeSymbol.String));
+        var tupleAAgain = TupleTypeSymbol.Get(ImmutableArray.Create<TypeSymbol>(holderA, TypeSymbol.String));
+
+        Assert.NotSame(tupleA, tupleB);
+        Assert.Same(tupleA, tupleAAgain);
+    }
+
+    private static System.Type DefineHolderType(string assemblyName)
+    {
+        var asm = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName(assemblyName), AssemblyBuilderAccess.Run);
+        var module = asm.DefineDynamicModule(assemblyName);
+        var type = module.DefineType("Holder", TypeAttributes.Public | TypeAttributes.Class);
+        return type.CreateType();
     }
 }


### PR DESCRIPTION
Fixes #1624

TupleTypeSymbol and FunctionPointerTypeSymbol cached instances by display name (e.g. `(Holder, string)`), so two distinct same-named types from different compilations could alias. Tuple's earlier #649 patch validated element identity on lookup but then did a non-atomic check-then-write replace on mismatch, so concurrent Get calls could still return two distinct instances for identical elements.

Fix: both now build their cache key with FunctionTypeSymbol's existing identity-key builder (`AppendIdentityKey`, exposed `internal` — originally added for issue #1457) instead of the display name, and use `ConcurrentDictionary.GetOrAdd` atomically instead of the racy replace.

Scope: touched only TupleTypeSymbol.cs, FunctionPointerTypeSymbol.cs, and (accessibility-only) FunctionTypeSymbol.cs. No eviction/Dispose/ClearCache changes (left for #1622).

Tests: added `Issue1624SymbolCacheKeyingTests` — two distinct `TypeParameterSymbol` instances sharing the name `T` never alias in the tuple cache or either function-pointer cache (managed/unmanaged).

Full `dotnet build GSharp.sln -c Release -graph`: 0 errors. `dotnet test test/Core.Tests/Core.Tests.csproj -c Release`: 5077 passed, 1 skipped (pre-existing baseline-regen skip), 0 failed.