### PR TITLE
Fix #1640: duplicate-member detection now covers methods

### DIFF
--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -1370,6 +1370,15 @@ internal sealed class DeclarationBinder
             existingNames.Add(f.Name);
         }
 
+        // Issue #1640: methods overload by signature, so a same-named method
+        // is not itself a duplicate — but a non-method member (property,
+        // event, or field) sharing a method's name IS a collision (CS0102).
+        // Method names are tracked separately from existingNames so the
+        // method-vs-method checks below (including instance-vs-shared/static
+        // overload, issue #1147) stay unaffected, while property/event/field
+        // checks can still see method names.
+        var methodNames = new HashSet<string>();
+
         // Phase 3.B.3 sub-step 2b: bind methods declared inside the class body.
         // Issue #938 / ADR-0079: in-body methods are the canonical declaration
         // site for owned `class` AND owned `struct`/`data struct` instance
@@ -1724,6 +1733,15 @@ internal sealed class DeclarationBinder
             }
 
             structSymbol.SetMethods(methodsBuilder.ToImmutable());
+
+            // Issue #1640: register instance method names so later
+            // property/event/field checks reject a name collision with a
+            // method, per the "fields + methods + other properties" contract
+            // the duplicate-check comments have always claimed.
+            foreach (var m in methodsBuilder)
+            {
+                methodNames.Add(m.Name);
+            }
         }
 
         // ADR-0051: bind property declarations.
@@ -1765,7 +1783,7 @@ internal sealed class DeclarationBinder
                 var propName = isIndexer ? "Item" : propSyntax.Identifier.Text;
 
                 // Check for duplicate names (fields + methods + other properties)
-                if (!existingNames.Add(propName))
+                if (methodNames.Contains(propName) || !existingNames.Add(propName))
                 {
                     Diagnostics.ReportSymbolAlreadyDeclared(propSyntax.Identifier.Location, propName);
                     continue;
@@ -1969,7 +1987,7 @@ internal sealed class DeclarationBinder
                 var eventName = eventSyntax.Identifier.Text;
 
                 // Check for duplicate names
-                if (!existingNames.Add(eventName))
+                if (methodNames.Contains(eventName) || !existingNames.Add(eventName))
                 {
                     Diagnostics.ReportSymbolAlreadyDeclared(eventSyntax.Identifier.Location, eventName);
                     continue;
@@ -2112,7 +2130,7 @@ internal sealed class DeclarationBinder
             foreach (var fieldSyntax in syntax.SharedBlock.Fields)
             {
                 var fieldName = fieldSyntax.Identifier.Text;
-                if (!existingNames.Add(fieldName))
+                if (methodNames.Contains(fieldName) || !existingNames.Add(fieldName))
                 {
                     Diagnostics.ReportSymbolAlreadyDeclared(fieldSyntax.Identifier.Location, fieldName);
                     continue;
@@ -2378,6 +2396,15 @@ internal sealed class DeclarationBinder
 
             structSymbol.SetStaticMethods(staticMethodsBuilder.ToImmutable());
 
+            // Issue #1640: register shared/static method names too, so a
+            // shared property/event/field colliding with a shared method name
+            // is still caught (methods vs methods remain overload-compatible;
+            // see the ADR-0063 signature check above).
+            foreach (var m in staticMethodsBuilder)
+            {
+                methodNames.Add(m.Name);
+            }
+
             // Static properties
             var staticPropertiesBuilder = ImmutableArray.CreateBuilder<PropertySymbol>();
             foreach (var propSyntax in syntax.SharedBlock.Properties)
@@ -2391,7 +2418,7 @@ internal sealed class DeclarationBinder
                 }
 
                 var propName = propSyntax.Identifier.Text;
-                if (!existingNames.Add(propName))
+                if (methodNames.Contains(propName) || !existingNames.Add(propName))
                 {
                     Diagnostics.ReportSymbolAlreadyDeclared(propSyntax.Identifier.Location, propName);
                     continue;
@@ -2526,7 +2553,7 @@ internal sealed class DeclarationBinder
             foreach (var eventSyntax in syntax.SharedBlock.Events)
             {
                 var eventName = eventSyntax.Identifier.Text;
-                if (!existingNames.Add(eventName))
+                if (methodNames.Contains(eventName) || !existingNames.Add(eventName))
                 {
                     Diagnostics.ReportSymbolAlreadyDeclared(eventSyntax.Identifier.Location, eventName);
                     continue;

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1640DuplicateMemberKindTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1640DuplicateMemberKindTests.cs
@@ -1,0 +1,149 @@
+// <copyright file="Issue1640DuplicateMemberKindTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1640: duplicate-member detection must reject a name collision
+/// across DIFFERENT member kinds (field/method/property/event), not just
+/// within the same kind. Legitimate method overloads (same name, different
+/// signature — including an instance/shared pair per issue #1147) must keep
+/// binding clean.
+/// </summary>
+public class Issue1640DuplicateMemberKindTests
+{
+    [Fact]
+    public void PropertyDuplicatingMethodName_IsReported()
+    {
+        var source = """
+            package p
+            class C {
+                func Foo() int32 { return 1 }
+                prop Foo int32 { get { return 1 } }
+            }
+            """;
+
+        Assert.Contains(Bind(source), d => d.Message.Contains("Foo"));
+    }
+
+    [Fact]
+    public void MethodDuplicatingPropertyName_IsReported()
+    {
+        var source = """
+            package p
+            class C {
+                prop Foo int32 { get { return 1 } }
+                func Foo() int32 { return 1 }
+            }
+            """;
+
+        Assert.Contains(Bind(source), d => d.Message.Contains("Foo"));
+    }
+
+    [Fact]
+    public void EventDuplicatingMethodName_IsReported()
+    {
+        var source = """
+            package p
+            class C {
+                func Foo() int32 { return 1 }
+                event Foo () -> void
+            }
+            """;
+
+        Assert.Contains(Bind(source), d => d.Message.Contains("Foo"));
+    }
+
+    [Fact]
+    public void SharedFieldDuplicatingInstanceMethodName_IsReported()
+    {
+        var source = """
+            package p
+            class C {
+                func Foo() int32 { return 1 }
+                shared {
+                    var Foo int32 = 0
+                }
+            }
+            """;
+
+        Assert.Contains(Bind(source), d => d.Message.Contains("Foo"));
+    }
+
+    [Fact]
+    public void SharedPropertyDuplicatingSharedMethodName_IsReported()
+    {
+        var source = """
+            package p
+            class C {
+                shared {
+                    func Foo() int32 { return 1 }
+                    prop Foo int32 { get { return 1 } }
+                }
+            }
+            """;
+
+        Assert.Contains(Bind(source), d => d.Message.Contains("Foo"));
+    }
+
+    [Fact]
+    public void InstanceAndSharedMethodOverload_SameName_BindsClean()
+    {
+        // Issue #1147: an instance method and a `shared` (static) method may
+        // legitimately share a name — this is an overload, not a duplicate.
+        var source = """
+            package p
+            class C {
+                func Foo(x int32) int32 { return x }
+                shared {
+                    func Foo(x string) int32 { return 0 }
+                }
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void DistinctMemberNames_BindClean()
+    {
+        var source = """
+            package p
+            class C {
+                var Field int32 = 0
+                prop Prop int32 { get { return 1 } }
+                func Method() int32 { return 1 }
+                event Evt () -> void
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    private static ImmutableArray<Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        if (tree.Diagnostics.Any())
+        {
+            return tree.Diagnostics;
+        }
+
+        var globalScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+        if (globalScope.Diagnostics.Any())
+        {
+            return globalScope.Diagnostics;
+        }
+
+        var program = Binder.BindProgram(globalScope);
+        return program.Diagnostics.ToImmutableArray();
+    }
+}


### PR DESCRIPTION
Fixes #1640

DeclarationBinder's duplicate-member check in `BindStructDeclarationBodyCore` seeded `existingNames` with field names only, despite comments claiming fields+methods+properties were all checked. A property, event, or shared field/property sharing a name with a method went undiagnosed.

Fix: track method names (instance + shared/static) in a separate `methodNames` set, and consult it from every property/event/field duplicate-name check site (instance properties, instance events, shared fields, shared properties, shared events). Method-declaration loops themselves are untouched — methods overload by signature, and an instance/shared method pair sharing a name is a legitimate overload (issue #1147), so `methodNames` is never checked there.

Tests added (`Issue1640DuplicateMemberKindTests`):
- property duplicating a method name → reported
- method duplicating a property name → reported
- event duplicating a method name → reported
- shared field duplicating an instance method name → reported
- shared property duplicating a shared method name → reported
- instance/shared method overload with same name → still binds clean
- distinct member names (field/prop/method/event) → still bind clean

Validation:
- `dotnet build GSharp.sln -c Release -graph`: 0 errors
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release --filter "FullyQualifiedName~Issue1640"`: 7/7 passed
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release --filter "FullyQualifiedName~CodeAnalysis.Binding"`: 3171/3171 passed
- Full `Core.Tests` suite: 5081 passed, 1 pre-existing skip, 0 failed
