### PR TITLE
Fix #1712: interpreter relational/equality operators mishandle NaN

### DIFF
--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -2583,9 +2583,9 @@ public sealed class Evaluator
         switch (b.Op.Kind)
         {
             case BoundBinaryOperatorKind.Equals:
-                return Equals(left, right);
+                return NumericEquals(left, right);
             case BoundBinaryOperatorKind.NotEquals:
-                return !Equals(left, right);
+                return !NumericEquals(left, right);
             case BoundBinaryOperatorKind.LogicalAnd:
                 return (bool)left && (bool)right;
             case BoundBinaryOperatorKind.LogicalOr:
@@ -2664,13 +2664,27 @@ public sealed class Evaluator
             case BoundBinaryOperatorKind.ShiftRight:
                 return NarrowToResultType(NumericShr(left, (int)right), resultType);
             case BoundBinaryOperatorKind.Less:
-                return NumericCompare(left, right) < 0;
             case BoundBinaryOperatorKind.LessOrEquals:
-                return NumericCompare(left, right) <= 0;
             case BoundBinaryOperatorKind.Greater:
-                return NumericCompare(left, right) > 0;
             case BoundBinaryOperatorKind.GreaterOrEquals:
-                return NumericCompare(left, right) >= 0;
+                // Issue #1712: double/float.CompareTo (used by NumericCompare)
+                // sorts NaN as less than every value, but IEEE 754 says every
+                // ordered comparison against NaN is false. Guard here the same
+                // way the relational-pattern path already does (~line 3416)
+                // so operator and pattern semantics can't drift.
+                if (IsNaN(left) || IsNaN(right))
+                {
+                    return false;
+                }
+
+                var numCmp = NumericCompare(left, right);
+                return b.Op.Kind switch
+                {
+                    BoundBinaryOperatorKind.Less => numCmp < 0,
+                    BoundBinaryOperatorKind.LessOrEquals => numCmp <= 0,
+                    BoundBinaryOperatorKind.Greater => numCmp > 0,
+                    _ => numCmp >= 0,
+                };
             default:
                 throw new EvaluatorException($"Unexpected binary operator {b.Op}", b);
         }
@@ -3391,9 +3405,9 @@ public sealed class Evaluator
         switch (op)
         {
             case BoundBinaryOperatorKind.Equals:
-                return object.Equals(left, right);
+                return NumericEquals(left, right);
             case BoundBinaryOperatorKind.NotEquals:
-                return !object.Equals(left, right);
+                return !NumericEquals(left, right);
             case BoundBinaryOperatorKind.Less:
             case BoundBinaryOperatorKind.LessOrEquals:
             case BoundBinaryOperatorKind.Greater:
@@ -3430,6 +3444,19 @@ public sealed class Evaluator
                 throw new InvalidOperationException($"Unexpected relational pattern operator {op}.");
         }
     }
+
+    // Issue #1712: object.Equals(double, double) treats NaN as equal to
+    // itself (a documented .NET oddity so NaN can be used as a dictionary
+    // key / sort key), but IEEE-754 and the emitter's `ceq` opcode say
+    // NaN == NaN is false (and != is true). Route float/double equality
+    // through the native operators so NaN stays unordered/unequal
+    // everywhere; every other type keeps its normal Equals semantics.
+    private static bool NumericEquals(object l, object r) => (l, r) switch
+    {
+        (float lf, float rf) => lf == rf,
+        (double ld, double rd) => ld == rd,
+        _ => Equals(l, r),
+    };
 
     private static bool IsNaN(object value) => value switch
     {

--- a/test/Interpreter.Tests/Issue1712NaNBinaryOperatorInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue1712NaNBinaryOperatorInterpreterTests.cs
@@ -1,0 +1,142 @@
+// <copyright file="Issue1712NaNBinaryOperatorInterpreterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #1712: the tree-walking evaluator's binary relational operators
+/// (<c>&lt;</c>, <c>&lt;=</c>, <c>&gt;</c>, <c>&gt;=</c>) routed through
+/// <c>NumericCompare</c>, which uses <c>IComparable.CompareTo</c>.
+/// <c>double</c>/<c>float</c>.CompareTo sorts <c>NaN</c> as lower than every
+/// value, so <c>NaN &lt; x</c> wrongly returned <c>true</c> and
+/// <c>NaN &gt;= x</c> wrongly returned <c>false</c>. Per IEEE-754 (and the
+/// emitter's unordered opcodes, #421), every ordered comparison involving
+/// <c>NaN</c> must be <c>false</c>. #1653 already fixed the identical defect
+/// on the relational-pattern path; these tests pin down parity on the
+/// binary-operator path for both <c>float32</c> and <c>float64</c>.
+/// </summary>
+public class Issue1712NaNBinaryOperatorInterpreterTests
+{
+    [Fact]
+    public void Double_NaN_AllOrderedComparisons_AreFalse()
+    {
+        var output = RunSubmission(
+            """
+            let nan = 0.0 / 0.0
+            let one = 1.0
+            Console.WriteLine(nan < one)
+            Console.WriteLine(one < nan)
+            Console.WriteLine(nan <= one)
+            Console.WriteLine(one <= nan)
+            Console.WriteLine(nan > one)
+            Console.WriteLine(one > nan)
+            Console.WriteLine(nan >= one)
+            Console.WriteLine(one >= nan)
+            """);
+        Assert.DoesNotContain("error GS", output);
+        Assert.Equal(
+            "False\nFalse\nFalse\nFalse\nFalse\nFalse\nFalse\nFalse\n",
+            output.Replace("\r\n", "\n"));
+    }
+
+    [Fact]
+    public void Float32_NaN_AllOrderedComparisons_AreFalse()
+    {
+        var output = RunSubmission(
+            """
+            let nan = float32(0.0 / 0.0)
+            let one = float32(1.0)
+            Console.WriteLine(nan < one)
+            Console.WriteLine(one < nan)
+            Console.WriteLine(nan <= one)
+            Console.WriteLine(one <= nan)
+            Console.WriteLine(nan > one)
+            Console.WriteLine(one > nan)
+            Console.WriteLine(nan >= one)
+            Console.WriteLine(one >= nan)
+            """);
+        Assert.DoesNotContain("error GS", output);
+        Assert.Equal(
+            "False\nFalse\nFalse\nFalse\nFalse\nFalse\nFalse\nFalse\n",
+            output.Replace("\r\n", "\n"));
+    }
+
+    [Fact]
+    public void Double_NaN_Equality_AlreadyCorrect()
+    {
+        // Regression guard: NaN == NaN is false, NaN != NaN is true — these
+        // don't go through NumericCompare and were already correct.
+        var output = RunSubmission(
+            """
+            let nan = 0.0 / 0.0
+            Console.WriteLine(nan == nan)
+            Console.WriteLine(nan != nan)
+            """);
+        Assert.DoesNotContain("error GS", output);
+        Assert.Equal("False\nTrue\n", output.Replace("\r\n", "\n"));
+    }
+
+    [Fact]
+    public void Double_NormalOrdering_StillWorks()
+    {
+        // Non-NaN comparisons must be unaffected by the guard.
+        var output = RunSubmission(
+            """
+            let a = 1.5
+            let b = 2.5
+            Console.WriteLine(a < b)
+            Console.WriteLine(b < a)
+            Console.WriteLine(a <= a)
+            Console.WriteLine(b >= a)
+            Console.WriteLine(a > b)
+            Console.WriteLine(b > a)
+            """);
+        Assert.DoesNotContain("error GS", output);
+        Assert.Equal(
+            "True\nFalse\nTrue\nTrue\nFalse\nTrue\n",
+            output.Replace("\r\n", "\n"));
+    }
+
+    [Fact]
+    public void Int_And_Decimal_Ordering_Unaffected()
+    {
+        // Non-floating-point relational comparisons must not be affected by
+        // the NaN guard (IsNaN returns false for non-float/double operands).
+        var output = RunSubmission(
+            """
+            let i1 = 3
+            let i2 = 5
+            let d1 = 3.0m
+            let d2 = 5.0m
+            Console.WriteLine(i1 < i2)
+            Console.WriteLine(i2 <= i1)
+            Console.WriteLine(d1 < d2)
+            Console.WriteLine(d2 >= d1)
+            """);
+        Assert.DoesNotContain("error GS", output);
+        Assert.Equal("True\nFalse\nTrue\nTrue\n", output.Replace("\r\n", "\n"));
+    }
+
+    private static string RunSubmission(string text)
+    {
+        using var outWriter = new StringWriter();
+        var prevOut = Console.Out;
+        Console.SetOut(outWriter);
+        try
+        {
+            var repl = new GSharpRepl();
+            repl.EvaluateSubmission(text);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+        }
+
+        return outWriter.ToString();
+    }
+}


### PR DESCRIPTION
Fixes #1712

`NumericCompare` uses `IComparable.CompareTo`, which sorts `NaN` as the lowest value, so the interpreter's binary `<`, `<=`, `>`, `>=` disagreed with IEEE-754 and the compiled emitter's unordered opcodes (#421): `NaN < x` wrongly returned `true`, `NaN >= x` wrongly returned `false`.

**Fix**: guard `EvaluateNumericBinary`'s relational arms with the same `IsNaN` check #1653 already added to the relational-pattern path.

**Also found and fixed**: binary `==`/`!=` and the relational-pattern `==`/`!=` used `object.Equals`, which treats `NaN` as equal to itself (a documented .NET oddity) instead of the IEEE-754 answer (`NaN == NaN` is `false`, `NaN != NaN` is `true`). Added `NumericEquals` to route float/double equality through the native `==` operator, matching the compiled path's `ceq` opcode.

Verified the compiled/emitted path is unaffected (already correct, uses native `clt`/`cgt`/`ceq` — confirmed by existing `Issue1616`/`Issue1617` emit tests still passing).

**Tests added**: `Issue1712NaNBinaryOperatorInterpreterTests` — all four relational ops for `double` and `float32` NaN operands (both operand orders), NaN equality/inequality, and regressions for normal float/int/decimal ordering.

**Results**:
- `dotnet build GSharp.sln -c Release -graph` — 0 errors
- `Interpreter.Tests` (full suite): 386/386 passed
- `Core.Tests --filter FullyQualifiedName~Evaluat`: 126/126 passed
- `Compiler.Tests --filter FullyQualifiedName~NaN`: 21/21 passed (compiled path parity confirmed)