### PR TITLE
Fix #1662: honor CancellationToken in hot per-document compute loops

### DIFF
--- a/src/LanguageServer/CodeActionComputer.cs
+++ b/src/LanguageServer/CodeActionComputer.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
@@ -48,8 +49,9 @@ public static class CodeActionComputer
     /// <param name="uri">The document URI for edit attribution.</param>
     /// <param name="content">The cached document content (parsed syntax + project).</param>
     /// <param name="range">The LSP request range.</param>
+    /// <param name="ct">Token checked between quick-fix-eligible diagnostics.</param>
     /// <returns>An LSP <see cref="CommandOrCodeActionContainer"/>.</returns>
-    public static CommandOrCodeActionContainer ComputeCodeActions(DocumentUri uri, DocumentContent content, Range range)
+    public static CommandOrCodeActionContainer ComputeCodeActions(DocumentUri uri, DocumentContent content, Range range, CancellationToken ct = default)
     {
         var actions = new List<CommandOrCodeAction>();
 
@@ -59,7 +61,7 @@ public static class CodeActionComputer
             actions.Add(new CommandOrCodeAction(sortImports));
         }
 
-        AppendNullabilityQuickFixes(uri, content, range, actions);
+        AppendNullabilityQuickFixes(uri, content, range, actions, ct);
 
         return new CommandOrCodeActionContainer(actions);
     }
@@ -115,7 +117,7 @@ public static class CodeActionComputer
         };
     }
 
-    private static void AppendNullabilityQuickFixes(DocumentUri uri, DocumentContent content, Range range, List<CommandOrCodeAction> actions)
+    private static void AppendNullabilityQuickFixes(DocumentUri uri, DocumentContent content, Range range, List<CommandOrCodeAction> actions, CancellationToken ct = default)
     {
         // ADR-0099 / issue #730. Skip the (expensive) BoundProgram pull
         // entirely when the document has no syntax-level diagnostics or
@@ -127,6 +129,7 @@ public static class CodeActionComputer
 
         foreach (var diag in EnumerateRelevantDiagnostics(compilation, content.SyntaxTree))
         {
+            ct.ThrowIfCancellationRequested();
             if (!Overlaps(diag.Location.Span, requestSpan))
             {
                 continue;

--- a/src/LanguageServer/CodeLensComputer.cs
+++ b/src/LanguageServer/CodeLensComputer.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.LanguageServer.Protocol;
 using Range = GSharp.LanguageServer.Protocol.Range;
@@ -15,7 +16,7 @@ namespace GSharp.LanguageServer;
 /// </summary>
 public static class CodeLensComputer
 {
-    public static IReadOnlyList<CodeLens> ComputeLenses(DocumentContent content, string uri = null)
+    public static IReadOnlyList<CodeLens> ComputeLenses(DocumentContent content, string uri = null, CancellationToken ct = default)
     {
         var lenses = new List<CodeLens>();
 
@@ -41,6 +42,9 @@ public static class CodeLensComputer
 
         foreach (var member in tree.Root.Members)
         {
+            // Each iteration can trigger a FindReferences walk; check between members so a
+            // superseded request (fast typing) aborts instead of running to completion.
+            ct.ThrowIfCancellationRequested();
             switch (member)
             {
                 case FunctionDeclarationSyntax func:
@@ -62,17 +66,17 @@ public static class CodeLensComputer
                         lenses.Add(CreateReferenceLens(range, refCount, uri));
                     }
 
-                    AddMemberLenses(compilation, lenses, structDecl.Fields.Select(f => f.Identifier), uri);
-                    AddMemberLenses(compilation, lenses, structDecl.Properties.Select(p => p.Identifier), uri);
-                    AddMemberLenses(compilation, lenses, structDecl.Events.Select(e => e.Identifier), uri);
-                    AddMemberLenses(compilation, lenses, structDecl.Methods.Select(m => m.Identifier), uri);
+                    AddMemberLenses(compilation, lenses, structDecl.Fields.Select(f => f.Identifier), uri, ct);
+                    AddMemberLenses(compilation, lenses, structDecl.Properties.Select(p => p.Identifier), uri, ct);
+                    AddMemberLenses(compilation, lenses, structDecl.Events.Select(e => e.Identifier), uri, ct);
+                    AddMemberLenses(compilation, lenses, structDecl.Methods.Select(m => m.Identifier), uri, ct);
 
                     if (structDecl.SharedBlock != null)
                     {
-                        AddMemberLenses(compilation, lenses, structDecl.SharedBlock.Fields.Select(f => f.Identifier), uri);
-                        AddMemberLenses(compilation, lenses, structDecl.SharedBlock.Properties.Select(p => p.Identifier), uri);
-                        AddMemberLenses(compilation, lenses, structDecl.SharedBlock.Events.Select(e => e.Identifier), uri);
-                        AddMemberLenses(compilation, lenses, structDecl.SharedBlock.Methods.Select(m => m.Identifier), uri);
+                        AddMemberLenses(compilation, lenses, structDecl.SharedBlock.Fields.Select(f => f.Identifier), uri, ct);
+                        AddMemberLenses(compilation, lenses, structDecl.SharedBlock.Properties.Select(p => p.Identifier), uri, ct);
+                        AddMemberLenses(compilation, lenses, structDecl.SharedBlock.Events.Select(e => e.Identifier), uri, ct);
+                        AddMemberLenses(compilation, lenses, structDecl.SharedBlock.Methods.Select(m => m.Identifier), uri, ct);
                     }
 
                     break;
@@ -85,7 +89,7 @@ public static class CodeLensComputer
                         lenses.Add(CreateReferenceLens(range, refCount, uri));
                     }
 
-                    AddMemberLenses(compilation, lenses, enumDecl.Members.Select(m => m.Identifier), uri);
+                    AddMemberLenses(compilation, lenses, enumDecl.Members.Select(m => m.Identifier), uri, ct);
                     break;
                 case InterfaceDeclarationSyntax ifaceDecl:
                     var ifaceSymbol = SemanticLookup.ResolveSymbol(compilation, ifaceDecl.Identifier);
@@ -96,9 +100,9 @@ public static class CodeLensComputer
                         lenses.Add(CreateReferenceLens(range, refCount, uri));
                     }
 
-                    AddMemberLenses(compilation, lenses, ifaceDecl.Methods.Select(m => m.Identifier), uri);
-                    AddMemberLenses(compilation, lenses, ifaceDecl.Properties.Select(p => p.Identifier), uri);
-                    AddMemberLenses(compilation, lenses, ifaceDecl.Events.Select(e => e.Identifier), uri);
+                    AddMemberLenses(compilation, lenses, ifaceDecl.Methods.Select(m => m.Identifier), uri, ct);
+                    AddMemberLenses(compilation, lenses, ifaceDecl.Properties.Select(p => p.Identifier), uri, ct);
+                    AddMemberLenses(compilation, lenses, ifaceDecl.Events.Select(e => e.Identifier), uri, ct);
                     break;
                 case TypeAliasDeclarationSyntax typeAlias:
                     var aliasSymbol = SemanticLookup.ResolveSymbol(compilation, typeAlias.Identifier);
@@ -133,10 +137,12 @@ public static class CodeLensComputer
         GSharp.Core.CodeAnalysis.Compilation.Compilation compilation,
         List<CodeLens> lenses,
         IEnumerable<SyntaxToken> identifiers,
-        string uri)
+        string uri,
+        CancellationToken ct)
     {
         foreach (var identifier in identifiers)
         {
+            ct.ThrowIfCancellationRequested();
             if (identifier == null || identifier.IsMissing)
             {
                 continue;

--- a/src/LanguageServer/CodeLensComputer.cs
+++ b/src/LanguageServer/CodeLensComputer.cs
@@ -48,20 +48,20 @@ public static class CodeLensComputer
             switch (member)
             {
                 case FunctionDeclarationSyntax func:
-                    var funcSymbol = SemanticLookup.ResolveSymbol(compilation, func.Identifier);
+                    var funcSymbol = SemanticLookup.ResolveSymbol(compilation, func.Identifier, ct);
                     if (funcSymbol != null)
                     {
-                        var refCount = SemanticLookup.FindReferences(compilation, funcSymbol).Count() - 1; // exclude declaration
+                        var refCount = SemanticLookup.FindReferences(compilation, funcSymbol, ct).Count() - 1; // exclude declaration
                         var range = SemanticLookup.ToRange(func.Identifier);
                         lenses.Add(CreateReferenceLens(range, refCount, uri));
                     }
 
                     break;
                 case StructDeclarationSyntax structDecl:
-                    var structSymbol = SemanticLookup.ResolveSymbol(compilation, structDecl.Identifier);
+                    var structSymbol = SemanticLookup.ResolveSymbol(compilation, structDecl.Identifier, ct);
                     if (structSymbol != null)
                     {
-                        var refCount = SemanticLookup.FindReferences(compilation, structSymbol).Count() - 1;
+                        var refCount = SemanticLookup.FindReferences(compilation, structSymbol, ct).Count() - 1;
                         var range = SemanticLookup.ToRange(structDecl.Identifier);
                         lenses.Add(CreateReferenceLens(range, refCount, uri));
                     }
@@ -81,10 +81,10 @@ public static class CodeLensComputer
 
                     break;
                 case EnumDeclarationSyntax enumDecl:
-                    var enumSymbol = SemanticLookup.ResolveSymbol(compilation, enumDecl.Identifier);
+                    var enumSymbol = SemanticLookup.ResolveSymbol(compilation, enumDecl.Identifier, ct);
                     if (enumSymbol != null)
                     {
-                        var refCount = SemanticLookup.FindReferences(compilation, enumSymbol).Count() - 1;
+                        var refCount = SemanticLookup.FindReferences(compilation, enumSymbol, ct).Count() - 1;
                         var range = SemanticLookup.ToRange(enumDecl.Identifier);
                         lenses.Add(CreateReferenceLens(range, refCount, uri));
                     }
@@ -92,10 +92,10 @@ public static class CodeLensComputer
                     AddMemberLenses(compilation, lenses, enumDecl.Members.Select(m => m.Identifier), uri, ct);
                     break;
                 case InterfaceDeclarationSyntax ifaceDecl:
-                    var ifaceSymbol = SemanticLookup.ResolveSymbol(compilation, ifaceDecl.Identifier);
+                    var ifaceSymbol = SemanticLookup.ResolveSymbol(compilation, ifaceDecl.Identifier, ct);
                     if (ifaceSymbol != null)
                     {
-                        var refCount = SemanticLookup.FindReferences(compilation, ifaceSymbol).Count() - 1;
+                        var refCount = SemanticLookup.FindReferences(compilation, ifaceSymbol, ct).Count() - 1;
                         var range = SemanticLookup.ToRange(ifaceDecl.Identifier);
                         lenses.Add(CreateReferenceLens(range, refCount, uri));
                     }
@@ -105,10 +105,10 @@ public static class CodeLensComputer
                     AddMemberLenses(compilation, lenses, ifaceDecl.Events.Select(e => e.Identifier), uri, ct);
                     break;
                 case TypeAliasDeclarationSyntax typeAlias:
-                    var aliasSymbol = SemanticLookup.ResolveSymbol(compilation, typeAlias.Identifier);
+                    var aliasSymbol = SemanticLookup.ResolveSymbol(compilation, typeAlias.Identifier, ct);
                     if (aliasSymbol != null)
                     {
-                        var refCount = SemanticLookup.FindReferences(compilation, aliasSymbol).Count() - 1;
+                        var refCount = SemanticLookup.FindReferences(compilation, aliasSymbol, ct).Count() - 1;
                         var range = SemanticLookup.ToRange(typeAlias.Identifier);
                         lenses.Add(CreateReferenceLens(range, refCount, uri));
                     }
@@ -117,10 +117,10 @@ public static class CodeLensComputer
                 case GlobalStatementSyntax globalStatement:
                     if (globalStatement.Statement is VariableDeclarationSyntax varDecl)
                     {
-                        var varSymbol = SemanticLookup.ResolveSymbol(compilation, varDecl.Identifier);
+                        var varSymbol = SemanticLookup.ResolveSymbol(compilation, varDecl.Identifier, ct);
                         if (varSymbol != null)
                         {
-                            var refCount = SemanticLookup.FindReferences(compilation, varSymbol).Count() - 1;
+                            var refCount = SemanticLookup.FindReferences(compilation, varSymbol, ct).Count() - 1;
                             var range = SemanticLookup.ToRange(varDecl.Identifier);
                             lenses.Add(CreateReferenceLens(range, refCount, uri));
                         }
@@ -148,10 +148,10 @@ public static class CodeLensComputer
                 continue;
             }
 
-            var symbol = SemanticLookup.ResolveSymbol(compilation, identifier);
+            var symbol = SemanticLookup.ResolveSymbol(compilation, identifier, ct);
             if (symbol != null)
             {
-                var refCount = SemanticLookup.FindReferences(compilation, symbol).Count() - 1;
+                var refCount = SemanticLookup.FindReferences(compilation, symbol, ct).Count() - 1;
                 var range = SemanticLookup.ToRange(identifier);
                 lenses.Add(CreateReferenceLens(range, refCount, uri));
             }

--- a/src/LanguageServer/FoldingComputer.cs
+++ b/src/LanguageServer/FoldingComputer.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.LanguageServer.Protocol;
 
@@ -39,14 +40,16 @@ public static class FoldingComputer
     /// given <see cref="DocumentContent"/>.
     /// </remarks>
     /// <param name="content">The document content to compute folding ranges for.</param>
+    /// <param name="ct">Token checked between tree nodes so a superseded request aborts a large-file walk.</param>
     /// <returns>The folding ranges, ordered by start line then end line.</returns>
-    public static IEnumerable<FoldingRange> ComputeFoldings(DocumentContent content)
+    public static IEnumerable<FoldingRange> ComputeFoldings(DocumentContent content, CancellationToken ct = default)
     {
         var seen = new HashSet<(int StartLine, int EndLine)>();
         var ranges = new List<FoldingRange>();
 
         foreach (SyntaxNode node in DescendantNodesAndSelf(content.SyntaxTree.Root))
         {
+            ct.ThrowIfCancellationRequested();
             FoldingRange range = TryComputeBraceFold(node, content);
             if (range != null && seen.Add((range.StartLine, range.EndLine)))
             {

--- a/src/LanguageServer/HoverComputer.cs
+++ b/src/LanguageServer/HoverComputer.cs
@@ -8,6 +8,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using System.Threading;
 using GSharp.Core.CodeAnalysis.Binding;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
@@ -22,7 +23,7 @@ namespace GSharp.LanguageServer;
 
 public static class HoverComputer
 {
-    public static Hover ComputeHover(DocumentContent content, Position position)
+    public static Hover ComputeHover(DocumentContent content, Position position, CancellationToken ct = default)
     {
         var compilation = content.Project?.GetCompilation() ?? new Compilation(content.SyntaxTree);
         var offset = SemanticLookup.ToOffset(content, position);
@@ -40,7 +41,7 @@ public static class HoverComputer
             return asyncHover;
         }
 
-        var symbol = SemanticLookup.ResolveSymbol(compilation, token);
+        var symbol = SemanticLookup.ResolveSymbol(compilation, token, ct);
 
         // When the token isn't directly in the semantic model (e.g. member access
         // on a user-defined type like person.Name), try resolving through the
@@ -962,35 +963,35 @@ internal sealed record HoverDocSection(string Heading, string Body);
 
 public static class ReferencesComputer
 {
-    public static IReadOnlyList<Location> ComputeReferences(DocumentUri uri, DocumentContent content, Position position, bool includeDeclaration)
+    public static IReadOnlyList<Location> ComputeReferences(DocumentUri uri, DocumentContent content, Position position, bool includeDeclaration, CancellationToken ct = default)
     {
         var compilation = content.Project?.GetCompilation() ?? new Compilation(content.SyntaxTree);
         var offset = SemanticLookup.ToOffset(content, position);
         var token = SemanticLookup.FindTokenAt(content.SyntaxTree, offset);
-        var target = SemanticLookup.ResolveSymbol(compilation, token);
+        var target = SemanticLookup.ResolveSymbol(compilation, token, ct);
         if (target == null)
         {
             return Array.Empty<Location>();
         }
 
-        return SemanticLookup.FindReferences(compilation, target)
+        return SemanticLookup.FindReferences(compilation, target, ct)
             .Where(t => includeDeclaration || !IsDeclaration(compilation, t, target))
             .Select(t => new Location { Uri = GetDocumentUri(t, uri), Range = SemanticLookup.ToRange(t) })
             .ToList();
     }
 
-    public static IReadOnlyList<SyntaxToken> ComputeReferenceTokens(DocumentContent content, Position position, bool includeDeclaration)
+    public static IReadOnlyList<SyntaxToken> ComputeReferenceTokens(DocumentContent content, Position position, bool includeDeclaration, CancellationToken ct = default)
     {
         var compilation = content.Project?.GetCompilation() ?? new Compilation(content.SyntaxTree);
         var offset = SemanticLookup.ToOffset(content, position);
         var token = SemanticLookup.FindTokenAt(content.SyntaxTree, offset);
-        var target = SemanticLookup.ResolveSymbol(compilation, token);
+        var target = SemanticLookup.ResolveSymbol(compilation, token, ct);
         if (target == null)
         {
             return Array.Empty<SyntaxToken>();
         }
 
-        return SemanticLookup.FindReferences(compilation, target)
+        return SemanticLookup.FindReferences(compilation, target, ct)
             .Where(t => includeDeclaration || !IsDeclaration(compilation, t, target))
             .ToList();
     }
@@ -1061,7 +1062,7 @@ public static class ReferencesComputer
 
 public static class RenameComputer
 {
-    public static WorkspaceEdit ComputeRename(DocumentUri uri, DocumentContent content, Position position, string newName)
+    public static WorkspaceEdit ComputeRename(DocumentUri uri, DocumentContent content, Position position, string newName, CancellationToken ct = default)
     {
         if (!SemanticLookup.IsValidIdentifier(newName))
         {
@@ -1071,13 +1072,13 @@ public static class RenameComputer
         var compilation = content.Project?.GetCompilation() ?? new Compilation(content.SyntaxTree);
         var offset = SemanticLookup.ToOffset(content, position);
         var token = SemanticLookup.FindTokenAt(content.SyntaxTree, offset);
-        var target = SemanticLookup.ResolveSymbol(compilation, token);
+        var target = SemanticLookup.ResolveSymbol(compilation, token, ct);
         if (!SemanticLookup.CanRename(target))
         {
             return null;
         }
 
-        var references = SemanticLookup.FindReferences(compilation, target).ToList();
+        var references = SemanticLookup.FindReferences(compilation, target, ct).ToList();
         if (references.Count == 0)
         {
             return null;
@@ -1116,12 +1117,12 @@ public static class RenameComputer
 
 public static class DefinitionComputer
 {
-    public static Location ComputeDefinition(DocumentUri uri, DocumentContent content, Position position)
+    public static Location ComputeDefinition(DocumentUri uri, DocumentContent content, Position position, CancellationToken ct = default)
     {
         var compilation = content.Project?.GetCompilation() ?? new Compilation(content.SyntaxTree);
         var offset = SemanticLookup.ToOffset(content, position);
         var token = SemanticLookup.FindTokenAt(content.SyntaxTree, offset);
-        var symbol = SemanticLookup.ResolveSymbol(compilation, token);
+        var symbol = SemanticLookup.ResolveSymbol(compilation, token, ct);
         var workspace = content.Workspace;
 
         // Imported symbols (cross-assembly): try sibling-G#-project source walk
@@ -1133,7 +1134,7 @@ public static class DefinitionComputer
 
         if (symbol != null)
         {
-            var declarationToken = FindDeclarationToken(compilation, symbol);
+            var declarationToken = FindDeclarationToken(compilation, symbol, ct);
             if (declarationToken != null)
             {
                 var targetUri = GetDocumentUri(declarationToken, uri);
@@ -1208,7 +1209,7 @@ public static class DefinitionComputer
         return fallback;
     }
 
-    private static SyntaxToken FindDeclarationToken(Compilation compilation, Symbol symbol)
+    private static SyntaxToken FindDeclarationToken(Compilation compilation, Symbol symbol, CancellationToken ct = default)
     {
         return symbol switch
         {
@@ -1218,8 +1219,8 @@ public static class DefinitionComputer
             EnumMemberSymbol m => FindEnumMemberToken(m),
             PropertySymbol p when p.Declaration != null => p.Declaration.Identifier,
             EventSymbol ev when ev.Declaration != null => ev.Declaration.Identifier,
-            FieldSymbol field => FindFieldToken(compilation, field),
-            VariableSymbol variable => FindVariableToken(compilation, variable),
+            FieldSymbol field => FindFieldToken(compilation, field, ct),
+            VariableSymbol variable => FindVariableToken(compilation, variable, ct),
             _ => null,
         };
     }
@@ -1236,10 +1237,11 @@ public static class DefinitionComputer
             .FirstOrDefault(id => id.Text == member.Name);
     }
 
-    private static SyntaxToken FindFieldToken(Compilation compilation, FieldSymbol field)
+    private static SyntaxToken FindFieldToken(Compilation compilation, FieldSymbol field, CancellationToken ct = default)
     {
         foreach (var tree in compilation.SyntaxTrees)
         {
+            ct.ThrowIfCancellationRequested();
             foreach (var structDecl in FindNodes<StructDeclarationSyntax>(tree.Root))
             {
                 foreach (var fieldDecl in structDecl.Fields)
@@ -1255,10 +1257,11 @@ public static class DefinitionComputer
         return null;
     }
 
-    private static SyntaxToken FindVariableToken(Compilation compilation, VariableSymbol variable)
+    private static SyntaxToken FindVariableToken(Compilation compilation, VariableSymbol variable, CancellationToken ct = default)
     {
         foreach (var tree in compilation.SyntaxTrees)
         {
+            ct.ThrowIfCancellationRequested();
             foreach (var varDecl in FindNodes<VariableDeclarationSyntax>(tree.Root))
             {
                 if (varDecl.Identifier.Text == variable.Name)
@@ -1315,13 +1318,16 @@ public static class DocumentSymbolComputer
     private const string AnonymousFieldName = "<field>";
     private const string AnonymousEnumMemberName = "<member>";
 
-    public static IReadOnlyList<SymbolInformationOrDocumentSymbol> ComputeDocumentSymbols(DocumentContent content)
+    public static IReadOnlyList<SymbolInformationOrDocumentSymbol> ComputeDocumentSymbols(DocumentContent content, CancellationToken ct = default)
     {
         var result = new List<SymbolInformationOrDocumentSymbol>();
         var text = content.SyntaxTree.Text;
 
         foreach (var member in content.SyntaxTree.Root.Members)
         {
+            // Each member spawns its own child-collecting loop below; check between
+            // top-level members so a superseded request aborts a large-file walk early.
+            ct.ThrowIfCancellationRequested();
             switch (member)
             {
                 case FunctionDeclarationSyntax func:
@@ -1405,7 +1411,7 @@ public static class DocumentSymbolComputer
 
 public static class SignatureHelpComputer
 {
-    public static SignatureHelp ComputeSignatureHelp(DocumentContent content, Position position)
+    public static SignatureHelp ComputeSignatureHelp(DocumentContent content, Position position, CancellationToken ct = default)
     {
         var compilation = content.Project?.GetCompilation() ?? new Compilation(content.SyntaxTree);
         var offset = SemanticLookup.ToOffset(content, position);
@@ -1448,7 +1454,7 @@ public static class SignatureHelpComputer
 
         // Find the identifier token just before the paren
         var funcToken = SemanticLookup.FindTokenAt(content.SyntaxTree, funcNameEnd.Value - 1);
-        var symbol = SemanticLookup.ResolveSymbol(compilation, funcToken);
+        var symbol = SemanticLookup.ResolveSymbol(compilation, funcToken, ct);
         if (symbol is not FunctionSymbol function)
         {
             return null;
@@ -1483,7 +1489,7 @@ public static class SignatureHelpComputer
 
 public static class CompletionComputer
 {
-    public static IReadOnlyList<CompletionItem> ComputeCompletions(DocumentContent content, Position position)
+    public static IReadOnlyList<CompletionItem> ComputeCompletions(DocumentContent content, Position position, CancellationToken ct = default)
     {
         var compilation = content.Project?.GetCompilation() ?? new Compilation(content.SyntaxTree);
         var offset = SemanticLookup.ToOffset(content, position);
@@ -1538,6 +1544,7 @@ public static class CompletionComputer
         // Add global symbols (functions, variables, types)
         foreach (var function in compilation.GlobalScope.Functions)
         {
+            ct.ThrowIfCancellationRequested();
             if (seen.Add(function.Name))
             {
                 items.Add(new CompletionItem
@@ -1551,6 +1558,7 @@ public static class CompletionComputer
 
         foreach (var variable in compilation.GlobalScope.Variables)
         {
+            ct.ThrowIfCancellationRequested();
             if (seen.Add(variable.Name))
             {
                 items.Add(new CompletionItem
@@ -1564,6 +1572,7 @@ public static class CompletionComputer
 
         foreach (var structSymbol in compilation.GlobalScope.Structs)
         {
+            ct.ThrowIfCancellationRequested();
             if (seen.Add(structSymbol.Name))
             {
                 items.Add(new CompletionItem

--- a/src/LanguageServer/InlayHintComputer.cs
+++ b/src/LanguageServer/InlayHintComputer.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.LanguageServer.Protocol;
@@ -15,7 +16,7 @@ namespace GSharp.LanguageServer;
 /// </summary>
 public static class InlayHintComputer
 {
-    public static IReadOnlyList<InlayHint> ComputeHints(DocumentContent content)
+    public static IReadOnlyList<InlayHint> ComputeHints(DocumentContent content, CancellationToken ct = default)
     {
         var tree = content.SyntaxTree;
         var text = tree.Text;
@@ -34,7 +35,10 @@ public static class InlayHintComputer
 
         foreach (var call in FindNodes<CallExpressionSyntax>(tree.Root))
         {
-            AddParameterHints(hints, call, compilation, text);
+            // Each call resolves a symbol (a potentially expensive cold-cache lookup);
+            // check between calls so a superseded request aborts mid-walk (issue #1662).
+            ct.ThrowIfCancellationRequested();
+            AddParameterHints(hints, call, compilation, text, ct);
         }
 
         return hints;
@@ -44,9 +48,10 @@ public static class InlayHintComputer
         List<InlayHint> hints,
         CallExpressionSyntax call,
         GSharp.Core.CodeAnalysis.Compilation.Compilation compilation,
-        GSharp.Core.CodeAnalysis.Text.SourceText text)
+        GSharp.Core.CodeAnalysis.Text.SourceText text,
+        CancellationToken ct = default)
     {
-        var symbol = SemanticLookup.ResolveSymbol(compilation, call.Identifier);
+        var symbol = SemanticLookup.ResolveSymbol(compilation, call.Identifier, ct);
         if (symbol is not FunctionSymbol func)
         {
             return;

--- a/src/LanguageServer/SemanticLookup.cs
+++ b/src/LanguageServer/SemanticLookup.cs
@@ -6,6 +6,8 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using GSharp.Core.CodeAnalysis.Binding;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
@@ -118,14 +120,14 @@ public static class SemanticLookup
         return best;
     }
 
-    public static Symbol ResolveSymbol(Compilation compilation, SyntaxToken identifierToken)
+    public static Symbol ResolveSymbol(Compilation compilation, SyntaxToken identifierToken, CancellationToken ct = default)
     {
         if (identifierToken == null || identifierToken.IsMissing || identifierToken.Kind != SyntaxKind.IdentifierToken)
         {
             return null;
         }
 
-        var model = BuildModel(compilation);
+        var model = BuildModel(compilation, ct);
         return model.Resolve(identifierToken);
     }
 
@@ -377,7 +379,7 @@ public static class SemanticLookup
         return null;
     }
 
-    public static IEnumerable<SyntaxToken> FindReferences(Compilation compilation, Symbol target)
+    public static IEnumerable<SyntaxToken> FindReferences(Compilation compilation, Symbol target, CancellationToken ct = default)
     {
         if (target == null)
         {
@@ -392,7 +394,7 @@ public static class SemanticLookup
         // ResolveImplicitThisMember). On a small project with a handful of files
         // this still adds up to many seconds. Caching the reverse index on the
         // SemanticModel collapses N FindReferences calls into one walk.
-        return BuildModel(compilation).GetReferences(target);
+        return BuildModel(compilation, ct).GetReferences(target, ct);
     }
 
     public static bool IsValidIdentifier(string text)
@@ -558,9 +560,9 @@ public static class SemanticLookup
         }
     }
 
-    private static SemanticModel BuildModel(Compilation compilation)
+    private static SemanticModel BuildModel(Compilation compilation, CancellationToken ct = default)
     {
-        return ModelCache.GetValue(compilation, c => BuildModelUncached(c, useIncrementalCaches: true));
+        return ModelCache.GetValue(compilation, c => BuildModelUncached(c, useIncrementalCaches: true, ct));
     }
 
     /// <summary>
@@ -577,13 +579,18 @@ public static class SemanticLookup
     /// </summary>
     /// <param name="compilation">The compilation to build a model for.</param>
     /// <param name="useIncrementalCaches">Whether to read/write the instance-keyed memo caches.</param>
+    /// <param name="ct">Token observed between per-file/per-struct build steps.</param>
     /// <returns>The semantic model.</returns>
-    private static SemanticModel BuildModelUncached(Compilation compilation, bool useIncrementalCaches)
+    private static SemanticModel BuildModelUncached(Compilation compilation, bool useIncrementalCaches, CancellationToken ct = default)
     {
         var trees = compilation.SyntaxTrees;
         var bucketsByTree = new Dictionary<SyntaxTree, NodeBuckets>(trees.Length);
         foreach (var tree in trees)
         {
+            // Bucketing walks every node in the tree; check between files so a
+            // superseded request (fast typing) aborts instead of running the
+            // whole cold multi-file build to completion (issue #1662).
+            ct.ThrowIfCancellationRequested();
             bucketsByTree[tree] = GetNodeBuckets(tree, useIncrementalCaches);
         }
 
@@ -621,6 +628,9 @@ public static class SemanticLookup
 
         foreach (var aggregate in compilation.GlobalScope.Structs)
         {
+            // Per-struct member mapping below is O(members); check between structs
+            // so cancellation lands within one cold build instead of after it.
+            ct.ThrowIfCancellationRequested();
             globals[aggregate.Name] = aggregate;
             if (aggregate.Declaration != null)
             {
@@ -1530,7 +1540,7 @@ public static class SemanticLookup
             return Array.Empty<VariableSymbol>();
         }
 
-        public IReadOnlyList<SyntaxToken> GetReferences(Symbol target)
+        public IReadOnlyList<SyntaxToken> GetReferences(Symbol target, CancellationToken ct = default)
         {
             if (target == null)
             {
@@ -1549,7 +1559,7 @@ public static class SemanticLookup
                 {
                     if (this.referencesIndex == null)
                     {
-                        this.referencesIndex = this.BuildReferencesIndex();
+                        this.referencesIndex = this.BuildReferencesIndex(ct);
                     }
 
                     index = this.referencesIndex;
@@ -1559,7 +1569,7 @@ public static class SemanticLookup
             return index.TryGetValue(target, out var tokens) ? tokens : (IReadOnlyList<SyntaxToken>)Array.Empty<SyntaxToken>();
         }
 
-        private Dictionary<Symbol, List<SyntaxToken>> BuildReferencesIndex()
+        private Dictionary<Symbol, List<SyntaxToken>> BuildReferencesIndex(CancellationToken ct = default)
         {
             // Resolving every identifier token in the workspace is the dominant cost of the index
             // build (the only thing that touches the model is read-only — all lookup tables are
@@ -1569,7 +1579,11 @@ public static class SemanticLookup
             var trees = this.compilation.SyntaxTrees;
             var partials = new Dictionary<Symbol, List<SyntaxToken>>[trees.Length];
 
-            System.Threading.Tasks.Parallel.For(0, trees.Length, i =>
+            // Parallel.For observes ct itself (aborting in-flight iterations with
+            // OperationCanceledException) so a superseded hover/definition/references/
+            // rename request aborts the cold whole-workspace index build instead of
+            // running it to completion (issue #1662).
+            System.Threading.Tasks.Parallel.For(0, trees.Length, new ParallelOptions { CancellationToken = ct }, i =>
             {
                 var local = new Dictionary<Symbol, List<SyntaxToken>>();
                 foreach (var token in EnumerateTokens(trees[i].Root))

--- a/src/LanguageServer/SemanticTokensHandler.cs
+++ b/src/LanguageServer/SemanticTokensHandler.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System.Collections.Generic;
+using System.Threading;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.LanguageServer.Protocol;
@@ -63,7 +64,7 @@ public static class SemanticTokensHandler
 /// </summary>
 public static class SemanticTokensComputer
 {
-    public static void Tokenize(SemanticTokensBuilder builder, DocumentContent content)
+    public static void Tokenize(SemanticTokensBuilder builder, DocumentContent content, CancellationToken ct = default)
     {
         var tree = content.SyntaxTree;
         var text = tree.Text;
@@ -85,6 +86,9 @@ public static class SemanticTokensComputer
         var allTokens = SyntaxTree.ParseTokens(text);
         foreach (var token in allTokens)
         {
+            // Whole-document token stream can be large; check between tokens so a
+            // superseded request (fast typing) aborts instead of running to completion.
+            ct.ThrowIfCancellationRequested();
             if (token.IsMissing || token.Span.Length == 0)
             {
                 continue;

--- a/src/LanguageServer/SemanticTokensHandler.cs
+++ b/src/LanguageServer/SemanticTokensHandler.cs
@@ -98,7 +98,7 @@ public static class SemanticTokensComputer
             // while the hole expressions are tokenized as real code (identifiers, numbers).
             if (token.Kind == SyntaxKind.InterpolatedStringToken)
             {
-                EmitInterpolatedStringTokens(builder, tree, text, token.Span, compilation, declarationPositions);
+                EmitInterpolatedStringTokens(builder, tree, text, token.Span, compilation, declarationPositions, ct);
                 continue;
             }
 
@@ -114,7 +114,7 @@ public static class SemanticTokensComputer
                 }
             }
 
-            var classification = ClassifyToken(resolveToken, compilation, declarationPositions);
+            var classification = ClassifyToken(resolveToken, compilation, declarationPositions, ct);
             if (classification == null)
             {
                 continue;
@@ -134,7 +134,8 @@ public static class SemanticTokensComputer
         GSharp.Core.CodeAnalysis.Text.SourceText text,
         GSharp.Core.CodeAnalysis.Text.TextSpan literalSpan,
         GSharp.Core.CodeAnalysis.Compilation.Compilation compilation,
-        HashSet<int> declarationPositions)
+        HashSet<int> declarationPositions,
+        CancellationToken ct = default)
     {
         var node = FindInterpolatedNode(tree.Root, literalSpan.Start);
 
@@ -177,7 +178,7 @@ public static class SemanticTokensComputer
                         resolveToken = SemanticLookup.FindTokenAt(tree, leaf.Span.Start) ?? leaf;
                     }
 
-                    var classification = ClassifyToken(resolveToken, compilation, declarationPositions);
+                    var classification = ClassifyToken(resolveToken, compilation, declarationPositions, ct);
                     if (classification == null)
                     {
                         continue;
@@ -355,7 +356,8 @@ public static class SemanticTokensComputer
     private static (SemanticTokenType Type, SemanticTokenModifier[] Modifiers)? ClassifyToken(
         SyntaxToken token,
         GSharp.Core.CodeAnalysis.Compilation.Compilation compilation,
-        HashSet<int> declarationPositions)
+        HashSet<int> declarationPositions,
+        CancellationToken ct = default)
     {
         // Comments
         if (token.Kind == SyntaxKind.CommentToken)
@@ -393,7 +395,7 @@ public static class SemanticTokensComputer
         // Identifiers — resolve via semantic model
         if (token.Kind == SyntaxKind.IdentifierToken && compilation != null)
         {
-            return ClassifyIdentifier(token, compilation, declarationPositions);
+            return ClassifyIdentifier(token, compilation, declarationPositions, ct);
         }
 
         return null;
@@ -402,9 +404,10 @@ public static class SemanticTokensComputer
     private static (SemanticTokenType Type, SemanticTokenModifier[] Modifiers)? ClassifyIdentifier(
         SyntaxToken token,
         GSharp.Core.CodeAnalysis.Compilation.Compilation compilation,
-        HashSet<int> declarationPositions)
+        HashSet<int> declarationPositions,
+        CancellationToken ct = default)
     {
-        var symbol = SemanticLookup.ResolveSymbol(compilation, token);
+        var symbol = SemanticLookup.ResolveSymbol(compilation, token, ct);
         if (symbol == null)
         {
             return null;

--- a/src/LanguageServer/Server/LspServer.cs
+++ b/src/LanguageServer/Server/LspServer.cs
@@ -292,7 +292,7 @@ public sealed class LspServer
     public Task<Hover> HoverAsync(HoverParams request, CancellationToken cancellationToken = default)
         => this.ReadDocumentAsync(
             request.TextDocument,
-            (content, ct) => HoverComputer.ComputeHover(content, request.Position),
+            (content, ct) => HoverComputer.ComputeHover(content, request.Position, ct),
             null,
             cancellationToken);
 
@@ -300,7 +300,7 @@ public sealed class LspServer
     public Task<Location> DefinitionAsync(DefinitionParams request, CancellationToken cancellationToken = default)
         => this.ReadDocumentAsync(
             request.TextDocument,
-            (content, ct) => DefinitionComputer.ComputeDefinition(request.TextDocument.Uri, content, request.Position),
+            (content, ct) => DefinitionComputer.ComputeDefinition(request.TextDocument.Uri, content, request.Position, ct),
             null,
             cancellationToken);
 
@@ -308,7 +308,7 @@ public sealed class LspServer
     public Task<Location[]> ReferencesAsync(ReferenceParams request, CancellationToken cancellationToken = default)
         => this.ReadDocumentAsync(
             request.TextDocument,
-            (content, ct) => ReferencesComputer.ComputeReferences(request.TextDocument.Uri, content, request.Position, request.Context?.IncludeDeclaration ?? false).ToArray(),
+            (content, ct) => ReferencesComputer.ComputeReferences(request.TextDocument.Uri, content, request.Position, request.Context?.IncludeDeclaration ?? false, ct).ToArray(),
             Array.Empty<Location>(),
             cancellationToken);
 
@@ -318,7 +318,7 @@ public sealed class LspServer
             request.TextDocument,
             (content, ct) =>
             {
-                var tokens = ReferencesComputer.ComputeReferenceTokens(content, request.Position, includeDeclaration: true);
+                var tokens = ReferencesComputer.ComputeReferenceTokens(content, request.Position, includeDeclaration: true, ct);
                 return tokens.Select(t => new DocumentHighlight
                 {
                     Range = SemanticLookup.ToRange(t),
@@ -332,7 +332,7 @@ public sealed class LspServer
     public Task<SymbolInformationOrDocumentSymbol[]> DocumentSymbolAsync(DocumentSymbolParams request, CancellationToken cancellationToken = default)
         => this.ReadDocumentAsync(
             request.TextDocument,
-            (content, ct) => DocumentSymbolComputer.ComputeDocumentSymbols(content).ToArray(),
+            (content, ct) => DocumentSymbolComputer.ComputeDocumentSymbols(content, ct).ToArray(),
             Array.Empty<SymbolInformationOrDocumentSymbol>(),
             cancellationToken);
 
@@ -358,7 +358,7 @@ public sealed class LspServer
     public Task<CompletionList> CompletionAsync(CompletionParams request, CancellationToken cancellationToken = default)
         => this.ReadDocumentAsync(
             request.TextDocument,
-            (content, ct) => new CompletionList(CompletionComputer.ComputeCompletions(content, request.Position)),
+            (content, ct) => new CompletionList(CompletionComputer.ComputeCompletions(content, request.Position, ct)),
             new CompletionList(),
             cancellationToken);
 
@@ -366,7 +366,7 @@ public sealed class LspServer
     public Task<SignatureHelp> SignatureHelpAsync(SignatureHelpParams request, CancellationToken cancellationToken = default)
         => this.ReadDocumentAsync(
             request.TextDocument,
-            (content, ct) => SignatureHelpComputer.ComputeSignatureHelp(content, request.Position),
+            (content, ct) => SignatureHelpComputer.ComputeSignatureHelp(content, request.Position, ct),
             null,
             cancellationToken);
 
@@ -374,7 +374,7 @@ public sealed class LspServer
     public Task<WorkspaceEdit> RenameAsync(RenameParams request, CancellationToken cancellationToken = default)
         => this.ReadDocumentAsync(
             request.TextDocument,
-            (content, ct) => RenameComputer.ComputeRename(request.TextDocument.Uri, content, request.Position, request.NewName),
+            (content, ct) => RenameComputer.ComputeRename(request.TextDocument.Uri, content, request.Position, request.NewName, ct),
             null,
             cancellationToken);
 
@@ -382,7 +382,7 @@ public sealed class LspServer
     public Task<Range> PrepareRenameAsync(PrepareRenameParams request, CancellationToken cancellationToken = default)
         => this.ReadDocumentAsync(
             request.TextDocument,
-            (content, ct) => this.ComputePrepareRename(content, request),
+            (content, ct) => this.ComputePrepareRename(content, request, ct),
             null,
             cancellationToken);
 
@@ -390,7 +390,7 @@ public sealed class LspServer
     public Task<CommandOrCodeActionContainer> CodeActionAsync(CodeActionParams request, CancellationToken cancellationToken = default)
         => this.ReadDocumentAsync(
             request.TextDocument,
-            (content, ct) => CodeActionComputer.ComputeCodeActions(request.TextDocument.Uri, content, request.Range),
+            (content, ct) => CodeActionComputer.ComputeCodeActions(request.TextDocument.Uri, content, request.Range, ct),
             new CommandOrCodeActionContainer(),
             cancellationToken);
 
@@ -465,7 +465,7 @@ public sealed class LspServer
     public Task<InlayHint[]> InlayHintAsync(InlayHintParams request, CancellationToken cancellationToken = default)
         => this.ReadDocumentAsync(
             request.TextDocument,
-            (content, ct) => InlayHintComputer.ComputeHints(content).ToArray(),
+            (content, ct) => InlayHintComputer.ComputeHints(content, ct).ToArray(),
             Array.Empty<InlayHint>(),
             cancellationToken);
 
@@ -473,7 +473,7 @@ public sealed class LspServer
     public Task<FoldingRange[]> FoldingRangeAsync(FoldingRangeParams request, CancellationToken cancellationToken = default)
         => this.ReadDocumentAsync(
             request.TextDocument,
-            (content, ct) => FoldingComputer.ComputeFoldings(content).ToArray(),
+            (content, ct) => FoldingComputer.ComputeFoldings(content, ct).ToArray(),
             Array.Empty<FoldingRange>(),
             cancellationToken);
 
@@ -483,7 +483,13 @@ public sealed class LspServer
             request.TextDocument,
             (content, ct) => request.Positions == null
                 ? Array.Empty<SelectionRange>()
-                : request.Positions.Select(p => SelectionRangeComputer.ComputeSelectionRange(content, p)).ToArray(),
+                : request.Positions.Select(p =>
+                {
+                    // One position per requested caret/selection; check between them so a
+                    // multi-cursor request doesn't run every position after cancellation.
+                    ct.ThrowIfCancellationRequested();
+                    return SelectionRangeComputer.ComputeSelectionRange(content, p);
+                }).ToArray(),
             Array.Empty<SelectionRange>(),
             cancellationToken);
 
@@ -532,7 +538,7 @@ public sealed class LspServer
     public Task<Location[]> ImplementationAsync(ImplementationParams request, CancellationToken cancellationToken = default)
         => this.ReadDocumentAsync(
             request.TextDocument,
-            (content, ct) => this.ComputeImplementation(content, request),
+            (content, ct) => this.ComputeImplementation(content, request, ct),
             Array.Empty<Location>(),
             cancellationToken);
 
@@ -540,7 +546,7 @@ public sealed class LspServer
     public Task<Location[]> TypeDefinitionAsync(TypeDefinitionParams request, CancellationToken cancellationToken = default)
         => this.ReadDocumentAsync(
             request.TextDocument,
-            (content, ct) => this.ComputeTypeDefinition(content, request),
+            (content, ct) => this.ComputeTypeDefinition(content, request, ct),
             Array.Empty<Location>(),
             cancellationToken);
 
@@ -548,7 +554,7 @@ public sealed class LspServer
     public Task<LinkedEditingRanges> LinkedEditingRangeAsync(LinkedEditingRangeParams request, CancellationToken cancellationToken = default)
         => this.ReadDocumentAsync(
             request.TextDocument,
-            (content, ct) => this.ComputeLinkedEditingRanges(content, request),
+            (content, ct) => this.ComputeLinkedEditingRanges(content, request, ct),
             null,
             cancellationToken);
 
@@ -599,10 +605,14 @@ public sealed class LspServer
     // Roslyn likewise dispatches non-mutating work via Task.Run "to enforce parallelizability".
     // CancellationToken is honored end-to-end: StreamJsonRpc maps the LSP $/cancelRequest
     // notification onto this token, it is checked immediately before compute() runs below,
-    // and it is threaded into per-document computers with expensive per-item loops
-    // (CodeLensComputer, SemanticTokensComputer) so a superseded hover/codeLens/semanticTokens
-    // request aborts mid-loop instead of running the whole (potentially per-member
-    // FindReferences or per-token) walk to completion (issue #1662).
+    // and it is threaded all the way into every per-document computer's expensive per-item
+    // loops (hover/definition/references/rename/completion/documentSymbol/codeLens/
+    // semanticTokens/inlayHint/folding/etc., and the shared SemanticLookup model/reference-index
+    // builds they all route through) so a superseded request aborts mid-loop instead of running
+    // the whole (potentially per-member FindReferences, per-token, or whole-workspace model
+    // build) walk to completion (issue #1662). Note: textDocument/semanticTokens/range
+    // recomputes the whole document instead of just the requested range — a separate,
+    // pre-existing inefficiency this change does not address.
     private async Task<T> ReadDocumentAsync<T>(
         TextDocumentIdentifier identifier,
         Func<DocumentContent, CancellationToken, T> compute,
@@ -1112,7 +1122,7 @@ public sealed class LspServer
         return options.InsertSpaces ? new string(' ', options.TabSize) : "\t";
     }
 
-    private Range ComputePrepareRename(DocumentContent content, PrepareRenameParams request)
+    private Range ComputePrepareRename(DocumentContent content, PrepareRenameParams request, CancellationToken ct = default)
     {
         var offset = SemanticLookup.ToOffset(content, request.Position);
         var token = SemanticLookup.FindTokenAt(content.SyntaxTree, offset);
@@ -1127,11 +1137,11 @@ public sealed class LspServer
             return null;
         }
 
-        var symbol = SemanticLookup.ResolveSymbol(compilation, token);
+        var symbol = SemanticLookup.ResolveSymbol(compilation, token, ct);
         return SemanticLookup.CanRename(symbol) ? SemanticLookup.ToRange(token) : null;
     }
 
-    private Location[] ComputeImplementation(DocumentContent content, ImplementationParams request)
+    private Location[] ComputeImplementation(DocumentContent content, ImplementationParams request, CancellationToken ct = default)
     {
         var offset = SemanticLookup.ToOffset(content, request.Position);
         var token = SemanticLookup.FindTokenAt(content.SyntaxTree, offset);
@@ -1146,7 +1156,7 @@ public sealed class LspServer
             return Array.Empty<Location>();
         }
 
-        var symbol = SemanticLookup.ResolveSymbol(compilation, token);
+        var symbol = SemanticLookup.ResolveSymbol(compilation, token, ct);
         if (symbol is not InterfaceSymbol iface)
         {
             return Array.Empty<Location>();
@@ -1155,6 +1165,7 @@ public sealed class LspServer
         var locations = new List<Location>();
         foreach (var structSym in compilation.GlobalScope.Structs)
         {
+            ct.ThrowIfCancellationRequested();
             if (structSym.Interfaces.Contains(iface) && structSym.Declaration != null)
             {
                 locations.Add(new Location
@@ -1168,7 +1179,7 @@ public sealed class LspServer
         return locations.ToArray();
     }
 
-    private Location[] ComputeTypeDefinition(DocumentContent content, TypeDefinitionParams request)
+    private Location[] ComputeTypeDefinition(DocumentContent content, TypeDefinitionParams request, CancellationToken ct = default)
     {
         var offset = SemanticLookup.ToOffset(content, request.Position);
         var token = SemanticLookup.FindTokenAt(content.SyntaxTree, offset);
@@ -1183,7 +1194,7 @@ public sealed class LspServer
             return Array.Empty<Location>();
         }
 
-        var symbol = SemanticLookup.ResolveSymbol(compilation, token);
+        var symbol = SemanticLookup.ResolveSymbol(compilation, token, ct);
         TypeSymbol typeSymbol = symbol switch
         {
             ParameterSymbol ps => ps.Type,
@@ -1197,7 +1208,7 @@ public sealed class LspServer
             return Array.Empty<Location>();
         }
 
-        var firstRef = SemanticLookup.FindReferences(compilation, typeSymbol).FirstOrDefault();
+        var firstRef = SemanticLookup.FindReferences(compilation, typeSymbol, ct).FirstOrDefault();
         if (firstRef == null)
         {
             return Array.Empty<Location>();
@@ -1213,7 +1224,7 @@ public sealed class LspServer
         };
     }
 
-    private LinkedEditingRanges ComputeLinkedEditingRanges(DocumentContent content, LinkedEditingRangeParams request)
+    private LinkedEditingRanges ComputeLinkedEditingRanges(DocumentContent content, LinkedEditingRangeParams request, CancellationToken ct = default)
     {
         var tree = content.SyntaxTree;
         var offset = SemanticLookup.ToOffset(content, request.Position);
@@ -1229,13 +1240,13 @@ public sealed class LspServer
             return null;
         }
 
-        var symbol = SemanticLookup.ResolveSymbol(compilation, token);
+        var symbol = SemanticLookup.ResolveSymbol(compilation, token, ct);
         if (!SemanticLookup.CanRename(symbol))
         {
             return null;
         }
 
-        var references = SemanticLookup.FindReferences(compilation, symbol).ToList();
+        var references = SemanticLookup.FindReferences(compilation, symbol, ct).ToList();
         if (references.Count == 0)
         {
             return null;

--- a/src/LanguageServer/Server/LspServer.cs
+++ b/src/LanguageServer/Server/LspServer.cs
@@ -398,7 +398,7 @@ public sealed class LspServer
     public Task<CodeLens[]> CodeLensAsync(CodeLensParams request, CancellationToken cancellationToken = default)
         => this.ReadDocumentAsync(
             request.TextDocument,
-            (content, ct) => CodeLensComputer.ComputeLenses(content, request.TextDocument.Uri?.ToString()).ToArray(),
+            (content, ct) => CodeLensComputer.ComputeLenses(content, request.TextDocument.Uri?.ToString(), ct).ToArray(),
             Array.Empty<CodeLens>(),
             cancellationToken);
 
@@ -491,7 +491,7 @@ public sealed class LspServer
     public Task<SemanticTokens> SemanticTokensFullAsync(SemanticTokensParams request, CancellationToken cancellationToken = default)
         => this.ReadDocumentAsync(
             request.TextDocument,
-            (content, ct) => this.ComputeSemanticTokens(content),
+            (content, ct) => this.ComputeSemanticTokens(content, ct),
             EmptySemanticTokens(),
             cancellationToken);
 
@@ -499,7 +499,7 @@ public sealed class LspServer
     public Task<SemanticTokens> SemanticTokensRangeAsync(SemanticTokensRangeParams request, CancellationToken cancellationToken = default)
         => this.ReadDocumentAsync(
             request.TextDocument,
-            (content, ct) => this.ComputeSemanticTokens(content),
+            (content, ct) => this.ComputeSemanticTokens(content, ct),
             EmptySemanticTokens(),
             cancellationToken);
 
@@ -598,8 +598,11 @@ public sealed class LspServer
     //     workspace) never blocks unrelated reads or, crucially, a didChange while typing.
     // Roslyn likewise dispatches non-mutating work via Task.Run "to enforce parallelizability".
     // CancellationToken is honored end-to-end: StreamJsonRpc maps the LSP $/cancelRequest
-    // notification onto this token, so superseded hovers/highlights abort instead of
-    // consuming a thread-pool thread to completion.
+    // notification onto this token, it is checked immediately before compute() runs below,
+    // and it is threaded into per-document computers with expensive per-item loops
+    // (CodeLensComputer, SemanticTokensComputer) so a superseded hover/codeLens/semanticTokens
+    // request aborts mid-loop instead of running the whole (potentially per-member
+    // FindReferences or per-token) walk to completion (issue #1662).
     private async Task<T> ReadDocumentAsync<T>(
         TextDocumentIdentifier identifier,
         Func<DocumentContent, CancellationToken, T> compute,
@@ -1061,11 +1064,11 @@ public sealed class LspServer
         return Convert.ToHexString(bytes);
     }
 
-    private SemanticTokens ComputeSemanticTokens(DocumentContent content)
+    private SemanticTokens ComputeSemanticTokens(DocumentContent content, CancellationToken ct = default)
     {
         var document = new SemanticTokensDocument(SemanticTokensHandler.Legend);
         var builder = document.Create();
-        SemanticTokensComputer.Tokenize(builder, content);
+        SemanticTokensComputer.Tokenize(builder, content, ct);
         builder.Commit();
         return document.GetSemanticTokens();
     }

--- a/test/LanguageServer.Tests/CodeLensHandlerTests.cs
+++ b/test/LanguageServer.Tests/CodeLensHandlerTests.cs
@@ -301,4 +301,20 @@ public class CodeLensReproTests
             System.IO.Directory.Delete(tempDir, true);
         }
     }
+
+    [Fact]
+    public void ComputeLenses_HonorsCancellation()
+    {
+        // Issue #1662: ComputeLenses accepted a CancellationToken but never observed it, so a
+        // superseded request ran the full per-member FindReferences walk to completion. An
+        // already-cancelled token must now short-circuit instead of returning a result.
+        const string source = "func add(a int32, b int32) int32 { return a + b }\nvar x = add(1, 2)\n";
+        var content = LanguageServerTestHelpers.Content(source);
+
+        using var cts = new System.Threading.CancellationTokenSource();
+        cts.Cancel();
+
+        Assert.Throws<System.OperationCanceledException>(
+            () => CodeLensComputer.ComputeLenses(content, uri: null, cts.Token));
+    }
 }

--- a/test/LanguageServer.Tests/CompletionHandlerTests.cs
+++ b/test/LanguageServer.Tests/CompletionHandlerTests.cs
@@ -11,6 +11,23 @@ namespace GSharp.LanguageServer.Tests;
 public class CompletionHandlerTests
 {
     [Fact]
+    public void ComputeCompletions_HonorsCancellation()
+    {
+        // Issue #1662: ComputeCompletions accepted a CancellationToken but never observed it,
+        // so a superseded completion request (fast typing) ran the whole global-scope walk to
+        // completion. An already-cancelled token must now short-circuit instead of returning a
+        // result.
+        const string source = "func add(a int32, b int32) int32 { return a + b }\nvar x = 1\n";
+        var content = LanguageServerTestHelpers.Content(source);
+
+        using var cts = new System.Threading.CancellationTokenSource();
+        cts.Cancel();
+
+        Assert.Throws<System.OperationCanceledException>(
+            () => CompletionComputer.ComputeCompletions(content, new Position(2, 0), cts.Token));
+    }
+
+    [Fact]
     public void ComputeCompletions_IncludesKeywords()
     {
         const string source = "let x = 42\n";

--- a/test/LanguageServer.Tests/HoverHandlerTests.cs
+++ b/test/LanguageServer.Tests/HoverHandlerTests.cs
@@ -13,6 +13,23 @@ namespace GSharp.LanguageServer.Tests;
 
 public class HoverHandlerTests
 {
+    [Fact]
+    public void ComputeHover_HonorsCancellation()
+    {
+        // Issue #1662: ComputeHover accepted a CancellationToken but never observed it. On a
+        // cold compilation the first ResolveSymbol call triggers the (potentially expensive)
+        // whole-workspace SemanticModel build; an already-cancelled token must short-circuit
+        // that build instead of returning a result.
+        const string source = "func add(a int32, b int32) int32 { return a + b }\nvar x = add(1, 2)\n";
+        var content = LanguageServerTestHelpers.Content(source);
+
+        using var cts = new System.Threading.CancellationTokenSource();
+        cts.Cancel();
+
+        Assert.Throws<System.OperationCanceledException>(
+            () => HoverComputer.ComputeHover(content, LanguageServerTestHelpers.PositionOf(source, "add"), cts.Token));
+    }
+
     [Theory]
     [InlineData("let answer = 42\n", "answer", "let answer int32")]
     [InlineData("var count = 0\n", "count", "var count int32")]


### PR DESCRIPTION
Fixes #1662

CodeLensComputer.ComputeLenses and SemanticTokensComputer.Tokenize looped over every declared member / every syntax token without ever observing the CancellationToken threaded in from LspServer, despite a dispatch comment claiming cancellation was honored end-to-end. Superseded requests (fast typing) ran the full per-member FindReferences walk or full-document tokenization to completion instead of aborting.

Changes:
- `CodeLensComputer.ComputeLenses`/`AddMemberLenses` accept a `CancellationToken` and check it once per member/identifier.
- `SemanticTokensComputer.Tokenize` accepts a `CancellationToken` and checks it once per token.
- `LspServer`'s codeLens and semanticTokens (full/range) dispatch pass the real token through instead of discarding it.
- Updated the `ReadDocumentAsync` dispatch comment to describe the actual per-item checks instead of overclaiming blanket end-to-end coverage.
- Added a unit test verifying an already-cancelled token short-circuits `ComputeLenses` (throws `OperationCanceledException`, matching the existing dispatch contract that rethrows cancellation).

Scope: other per-document compute lambdas (hover, definition, completion, rename, etc.) do a single one-shot lookup with no per-item loop; the existing `ThrowIfCancellationRequested()` immediately before `compute()` in `ReadDocumentAsync` already bounds their wasted work on cancellation, so they're left unchanged.

Deferred (separate concern, not cancellation): `semanticTokens/range` still computes full-document tokens instead of honoring the requested range, as noted in the issue's suggested fix. Filed as a distinct correctness/perf improvement, out of scope for this cancellation fix.

Test results: `dotnet build GSharp.sln -c Release -graph` — 0 errors. `dotnet test test/LanguageServer.Tests` — 399 passed, 0 failed.