### PR TITLE
Fix #1637: guard let else-block diagnostics reported exactly once

### DIFF
--- a/src/Core/CodeAnalysis/Binding/StatementBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.cs
@@ -1606,6 +1606,20 @@ internal sealed class StatementBinder
             persistentFrame[variable] = underlying;
             statements.Add(ifStmt);
         }
+
+        // If every arm's binding clause failed (all `continue`d above), the
+        // else block was never bound and its diagnostics -- including
+        // GS0297 -- would silently vanish. Bind it once here, purely for
+        // diagnostics; it isn't wired into any statement since there's no
+        // successful binding left to guard.
+        if (!hasBoundElseOnce)
+        {
+            var armElse = BindStatement(syntax.ElseStatement);
+            if (!EndsInUnconditionalExit(armElse))
+            {
+                Diagnostics.ReportGuardLetElseMustExit(syntax.ElseStatement.Location);
+            }
+        }
     }
 
     private static Dictionary<AccessPath, TypeSymbol> MergeNarrowingFrames(

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.cs
@@ -1555,16 +1555,14 @@ internal sealed class StatementBinder
         ImmutableArray<BoundStatement>.Builder statements,
         Dictionary<AccessPath, TypeSymbol> persistentFrame)
     {
-        // Bind the else block once up-front strictly to validate that it
-        // unconditionally exits the enclosing scope (GS0297). We then
-        // re-bind it for each binding arm because the ControlFlowGraph
-        // builder demands that each BoundStatement appear at most once
-        // in the tree (it keys block lookup by statement identity).
-        var probeElse = BindStatement(syntax.ElseStatement);
-        if (!EndsInUnconditionalExit(probeElse))
-        {
-            Diagnostics.ReportGuardLetElseMustExit(syntax.ElseStatement.Location);
-        }
+        // The else block must be re-bound once per binding arm because the
+        // ControlFlowGraph builder demands that each BoundStatement appear
+        // at most once in the tree (it keys block lookup by statement
+        // identity). Re-binding the same syntax repeatedly would otherwise
+        // report every diagnostic inside the else block once per arm
+        // (issue #1637), so only the first bind's diagnostics are kept;
+        // subsequent re-binds are truncated back to that point.
+        var hasBoundElseOnce = false;
 
         foreach (var binding in syntax.Bindings)
         {
@@ -1578,7 +1576,20 @@ internal sealed class StatementBinder
             // Bind a fresh copy of the else block for this arm so that the
             // ControlFlowGraph builder sees a unique BoundStatement
             // instance per arm.
+            var diagMark = Diagnostics.Count;
             var armElse = BindStatement(syntax.ElseStatement);
+            if (hasBoundElseOnce)
+            {
+                Diagnostics.TruncateTo(diagMark);
+            }
+            else
+            {
+                hasBoundElseOnce = true;
+                if (!EndsInUnconditionalExit(armElse))
+                {
+                    Diagnostics.ReportGuardLetElseMustExit(syntax.ElseStatement.Location);
+                }
+            }
 
             // Build `if <var> == nil { else }`.
             var read = new BoundVariableExpression(binding, variable);

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue708IfLetGuardLetBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue708IfLetGuardLetBindingTests.cs
@@ -220,6 +220,69 @@ Run(""hi"")
         Assert.Empty(result.Diagnostics);
     }
 
+    [Fact]
+    public void GuardLet_SingleBinding_ElseDiagnosticReportedExactlyOnce()
+    {
+        // Issue #1637: the else block used to be bound once as a
+        // validity probe and once more per binding arm, so a single
+        // binding produced the same diagnostic twice.
+        var result = Evaluate(@"
+func Run(s string?) int32 {
+    guard let v = s else {
+        var w = ""hi""
+        guard let n = w else {
+            return 0
+        }
+        return n.Length
+    }
+    return v.Length
+}
+Run(""hi"")
+");
+
+        Assert.Single(result.Diagnostics, d => d.Id == "GS0296");
+    }
+
+    [Fact]
+    public void GuardLet_MultipleBindings_ElseDiagnosticReportedExactlyOnce()
+    {
+        // Issue #1637: with N binding arms the else block used to be
+        // re-bound N+1 times, reporting every diagnostic inside it
+        // N+1 times instead of once.
+        var result = Evaluate(@"
+func Run(a string?, b string?) int32 {
+    guard let x = a, let y = b else {
+        var w = ""hi""
+        guard let n = w else {
+            return 0
+        }
+        return n.Length
+    }
+    return x.Length + y.Length
+}
+Run(""a"", ""b"")
+");
+
+        Assert.Single(result.Diagnostics, d => d.Id == "GS0296");
+    }
+
+    [Fact]
+    public void GuardLet_MultipleBindings_ElseWithoutExit_DiagnosesGS0297ExactlyOnce()
+    {
+        var result = Evaluate(@"
+func Run(a string?, b string?) {
+    guard let x = a, let y = b else {
+        var z = 1
+    }
+    var w = x
+    var q = y
+}
+Run(""a"", ""b"")
+");
+
+        Assert.Single(result.Diagnostics, d => d.Id == "GS0297");
+    }
+
     private static EvaluationResult Evaluate(string source)
     {
         var syntaxTree = SyntaxTree.Parse(SourceText.From(source));

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue708IfLetGuardLetBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue708IfLetGuardLetBindingTests.cs
@@ -283,6 +283,47 @@ Run(""a"", ""b"")
         Assert.Single(result.Diagnostics, d => d.Id == "GS0297");
     }
 
+    [Fact]
+    public void GuardLet_LaterArmBadInitializer_ArmDiagnosticSurvivesExactlyOnce()
+    {
+        // Arm 2's rhs is non-nullable (its own GS0296). Arm 1 succeeds and
+        // binds the else block; per #1637 the arm-2-specific diagnostic
+        // must still surface exactly once, not swallowed by the else's
+        // per-arm TruncateTo.
+        var result = Evaluate(@"
+func Run(a string?) int32 {
+    guard let x = a, let y = ""hi"" else {
+        return 0
+    }
+    return x.Length + y.Length
+}
+Run(""a"")
+");
+
+        Assert.Single(result.Diagnostics, d => d.Id == "GS0296");
+    }
+
+    [Fact]
+    public void GuardLet_AllArmsFail_ElseStillBoundOnceForDiagnostics()
+    {
+        // Issue #1637 follow-up: if every binding arm fails (non-nullable
+        // rhs on both), the arm loop never binds the else block. The
+        // fallback bind must still surface GS0297 and the else's own
+        // internal diagnostic exactly once.
+        var result = Evaluate(@"
+func Run() {
+    guard let x = ""a"", let y = ""b"" else {
+        var z = 1
+    }
+    var w = 1
+}
+Run()
+");
+
+        Assert.Equal(2, result.Diagnostics.Count(d => d.Id == "GS0296"));
+        Assert.Single(result.Diagnostics, d => d.Id == "GS0297");
+    }
+
     private static EvaluationResult Evaluate(string source)
     {
         var syntaxTree = SyntaxTree.Parse(SourceText.From(source));


### PR DESCRIPTION
Fixes #1637

`guard let`'s else-block was bound once as a discarded validity probe (GS0297 must-exit check) and then re-bound once per binding arm for ControlFlowGraph node identity. `DiagnosticBag` is append-only, so any diagnostic inside the else block was reported N+1 times for N binding arms.

Fix: drop the separate probe bind. Still rebind the else statement once per arm (required so each `BoundStatement` instance is unique for the CFG), but only keep the diagnostics from the first bind; `DiagnosticBag.TruncateTo` discards the duplicates from every subsequent rebind. The GS0297 must-exit check now runs against the first bind's result, so it still fires exactly once.

Tests added in `Issue708IfLetGuardLetBindingTests.cs`:
- single-binding guard let: diagnostic inside else reported exactly once
- multi-binding (N=2) guard let: diagnostic inside else reported exactly once
- multi-binding guard let with non-exiting else: GS0297 reported exactly once

Build: `dotnet build GSharp.sln -c Release -graph` — 0 errors/warnings.
Tests: targeted GuardLet/IfLet filter (23 passed) + full Binding filter (3198 passed).