### PR TITLE
Fix #1677: reduce Lexer allocations for identifiers and whitespace

### DIFF
--- a/src/Core/CodeAnalysis/Syntax/Lexer.cs
+++ b/src/Core/CodeAnalysis/Syntax/Lexer.cs
@@ -2,6 +2,8 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Text;
@@ -24,15 +26,32 @@ public sealed class Lexer
     // when the parser parses the hole's expression text.
     private const int MaxInterpolationNestingDepth = 32;
 
+    // Issue #1677: uniform-run whitespace text (all-space or all-tab indentation, single
+    // newlines, etc.) is shared process-wide instead of re-substringed per token, since it
+    // is immutable and identical across files/lexers. Kept small and static (not tied to any
+    // one lexer instance) because whitespace runs are a closed, tiny alphabet.
+    private static readonly ConcurrentDictionary<(char Ch, int Length), string> WhitespaceRunCache = new();
+
     private readonly SyntaxTree syntaxTree;
     private readonly SourceText text;
     private readonly int end;
+
+    // Issue #1677: lexer-local identifier intern table so repeated identifiers (e.g. `foo`
+    // used 1000 times in a file) share one string instance for their .Text instead of each
+    // occurrence allocating its own substring. Scoped per-Lexer (per-parse), so it never
+    // leaks across compilations.
+    private readonly Dictionary<string, string> internedIdentifiers = new(StringComparer.Ordinal);
 
     private int position;
 
     private int start;
     private SyntaxKind kind;
     private object value;
+
+    // Issue #1677: set by ReadIdentifierOrKeyword when it determines the token is a plain
+    // identifier (not a keyword). Lex() reuses this interned string instead of substringing
+    // the same range a second time.
+    private string internedIdentifierText;
 
     // Issue #1602: current interpolation-hole nesting depth. See
     // MaxInterpolationNestingDepth above.
@@ -88,6 +107,7 @@ public sealed class Lexer
         start = position;
         kind = SyntaxKind.BadToken;
         value = null;
+        internedIdentifierText = null;
 
         switch (Current)
         {
@@ -515,10 +535,43 @@ public sealed class Lexer
         var text = SyntaxFacts.GetText(kind);
         if (text == null)
         {
-            text = this.text.ToString(start, length);
+            text = kind == SyntaxKind.IdentifierToken && internedIdentifierText != null
+                ? internedIdentifierText
+                : GetTrivialText(start, length);
         }
 
         return new SyntaxToken(syntaxTree, kind, start, text, value);
+    }
+
+    // Issue #1677: whitespace runs (indentation, single newlines, blank lines) are a tiny,
+    // closed alphabet of immutable strings, so a uniform run (all same char) is looked up
+    // in a shared cache instead of substringed fresh every time. Non-uniform whitespace and
+    // every other trivial-text kind (comments, numbers, strings) fall back to the substring:
+    // their exact text is observed by consumers (for example FormattingEngine reads
+    // WhitespaceToken/CommentToken .Text verbatim to preserve user line breaks and comment
+    // content), so it cannot be replaced by a placeholder.
+    private string GetTrivialText(int start, int length)
+    {
+        if (kind == SyntaxKind.WhitespaceToken && length > 0)
+        {
+            var ch = text[start];
+            var uniform = true;
+            for (var i = start + 1; i < start + length; i++)
+            {
+                if (text[i] != ch)
+                {
+                    uniform = false;
+                    break;
+                }
+            }
+
+            if (uniform)
+            {
+                return WhitespaceRunCache.GetOrAdd((ch, length), _ => this.text.ToString(start, length));
+            }
+        }
+
+        return this.text.ToString(start, length);
     }
 
     private char Peek(int offset)
@@ -1728,5 +1781,18 @@ public sealed class Lexer
         var length = position - start;
         var text = this.text.ToString(start, length);
         kind = SyntaxFacts.GetKeywordKind(text);
+
+        if (kind == SyntaxKind.IdentifierToken)
+        {
+            // Issue #1677: intern so repeated identifiers share one string, and stash it so
+            // Lex() below doesn't substring the same source range a second time.
+            if (!internedIdentifiers.TryGetValue(text, out var interned))
+            {
+                interned = text;
+                internedIdentifiers.Add(text, text);
+            }
+
+            internedIdentifierText = interned;
+        }
     }
 }

--- a/src/Core/CodeAnalysis/Syntax/Lexer.cs
+++ b/src/Core/CodeAnalysis/Syntax/Lexer.cs
@@ -29,7 +29,11 @@ public sealed class Lexer
     // Issue #1677: uniform-run whitespace text (all-space or all-tab indentation, single
     // newlines, etc.) is shared process-wide instead of re-substringed per token, since it
     // is immutable and identical across files/lexers. Kept small and static (not tied to any
-    // one lexer instance) because whitespace runs are a closed, tiny alphabet.
+    // one lexer instance) because whitespace runs are a closed, tiny alphabet. Runs longer
+    // than WhitespaceRunCacheMaxLength bypass the cache so the static table stays bounded
+    // (a few whitespace chars x lengths 1..MaxLength) in a long-lived language-server process;
+    // long uniform runs are rare and the per-occurrence win is dominated by short indent runs.
+    private const int WhitespaceRunCacheMaxLength = 64;
     private static readonly ConcurrentDictionary<(char Ch, int Length), string> WhitespaceRunCache = new();
 
     private readonly SyntaxTree syntaxTree;
@@ -552,7 +556,7 @@ public sealed class Lexer
     // content), so it cannot be replaced by a placeholder.
     private string GetTrivialText(int start, int length)
     {
-        if (kind == SyntaxKind.WhitespaceToken && length > 0)
+        if (kind == SyntaxKind.WhitespaceToken && length > 0 && length <= WhitespaceRunCacheMaxLength)
         {
             var ch = text[start];
             var uniform = true;

--- a/test/Core.Tests/CodeAnalysis/Syntax/LexerTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/LexerTests.cs
@@ -479,4 +479,63 @@ public class LexerTests
         Assert.Equal(SyntaxKind.EndOfFileToken, tokens[^1].Kind);
         Assert.Single(tokens, t => t.Kind == SyntaxKind.EndOfFileToken);
     }
+
+    [Fact]
+    public void RepeatedIdentifiers_ShareSameTextInstance()
+    {
+        // Issue #1677: repeated identifiers must be interned (same reference) but still
+        // compare equal by value, and every occurrence must keep its own correct Span/Start.
+        var tokens = SyntaxTree.ParseTokens("foo foo foo bar foo")
+            .Where(t => t.Kind == SyntaxKind.IdentifierToken)
+            .ToImmutableArray();
+
+        Assert.Equal(5, tokens.Length);
+        var fooTokens = tokens.Where(t => t.Text == "foo").ToImmutableArray();
+        Assert.Equal(4, fooTokens.Length);
+        Assert.Same(fooTokens[0].Text, fooTokens[1].Text);
+        Assert.Same(fooTokens[0].Text, fooTokens[2].Text);
+        Assert.Same(fooTokens[0].Text, fooTokens[3].Text);
+        Assert.NotSame(fooTokens[0].Text, tokens.First(t => t.Text == "bar").Text);
+
+        // Spans still reflect each occurrence's own position despite sharing text.
+        Assert.Equal(0, tokens[0].Span.Start);
+        Assert.Equal(4, tokens[1].Span.Start);
+        Assert.Equal(8, tokens[2].Span.Start);
+        Assert.Equal(12, tokens[3].Span.Start);
+        Assert.Equal(16, tokens[4].Span.Start);
+    }
+
+    [Theory]
+    [InlineData("a  b")]
+    [InlineData("a\tb")]
+    [InlineData("a\nb")]
+    [InlineData("a \t\t b")]
+    public void Whitespace_TextAndSpan_AreExact(string source)
+    {
+        // Issue #1677: whitespace text may be served from a shared cache for uniform runs,
+        // but must still be value-identical to (and long enough to reconstruct) the source.
+        var tokens = SyntaxTree.ParseTokens(source);
+        var reconstructed = new System.Text.StringBuilder();
+        foreach (var token in tokens.Where(t => t.Kind != SyntaxKind.EndOfFileToken))
+        {
+            Assert.Equal(token.Span.Length, token.Text.Length);
+            reconstructed.Append(token.Text);
+        }
+
+        Assert.Equal(source, reconstructed.ToString());
+    }
+
+    [Fact]
+    public void UniformWhitespaceRuns_OfSameLength_ShareTextInstance()
+    {
+        // Issue #1677: same-length, same-character whitespace runs (e.g. matching indentation)
+        // are served from a shared cache instead of a fresh substring per occurrence.
+        var tokens = SyntaxTree.ParseTokens("a   b   c")
+            .Where(t => t.Kind == SyntaxKind.WhitespaceToken)
+            .ToImmutableArray();
+
+        Assert.Equal(2, tokens.Length);
+        Assert.Equal("   ", tokens[0].Text);
+        Assert.Same(tokens[0].Text, tokens[1].Text);
+    }
 }


### PR DESCRIPTION
Fixes #1677

## Change
- Intern identifier text in a lexer-local `Dictionary<string,string>`. Repeated identifiers (`foo` x1000) now share one string, and the identifier substring computed by `ReadIdentifierOrKeyword` (for the keyword check) is reused for `.Text` instead of being substringed again at the end of `Lex()`.
- Cache uniform-char whitespace runs (all-space indentation, single newlines, etc.) in a small shared static `ConcurrentDictionary<(char,int),string>` so repeat runs share one string instance instead of a fresh substring per token.

## Deliberately NOT changed (correctness)
`SyntaxKind.WhitespaceToken`/`CommentToken` exact `.Text` is left substringed (not replaced by a singleton/placeholder) because `FormattingEngine` (`src/LanguageServer/FormattingEngine.cs`) calls `SyntaxTree.ParseTokens` directly and reads:
- `WhitespaceToken.Text.Contains('\n')` to detect user line breaks, and
- `CommentToken.Text` verbatim to re-emit the comment.

A shared placeholder would silently corrupt formatting output for these consumers, so the whitespace optimization only dedupes *value-identical* runs (safe) rather than replacing text with a sentinel. Comments/numbers/strings are unaffected — no safe win identified there without changing observable behavior.

## Tests
Added to `test/Core.Tests/CodeAnalysis/Syntax/LexerTests.cs`:
- `RepeatedIdentifiers_ShareSameTextInstance` — same identifier occurrences share `.Text` reference, still equal by value, correct per-occurrence `Span.Start`.
- `Whitespace_TextAndSpan_AreExact` — whitespace token text still reconstructs the exact source.
- `UniformWhitespaceRuns_OfSameLength_ShareTextInstance` — same-length/char whitespace runs share one string instance.

## Validation
- `dotnet build GSharp.sln -c Release -graph` — 0 errors/warnings.
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release` — 5109 passed, 1 skipped (pre-existing baseline regen test).
- `dotnet test test/LanguageServer.Tests/LanguageServer.Tests.csproj -c Release` — 398 passed (covers `FormattingEngine` round-trip).