### PR TITLE
Fix #1629: dedupe diagnostics from generic constructor inference pre-bind

### DIFF
--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -2204,6 +2204,13 @@ internal sealed class OverloadResolver
             }
             else
             {
+                // Issue #1629: the pre-bind below is a throwaway probe used only
+                // to infer type arguments — the same argument syntax is bound
+                // again for real once the type arguments are known (loop after
+                // this generic block). Roll back any diagnostics it produced so
+                // they are reported exactly once, by the real bind.
+                var inferenceDiagMark = Diagnostics.Count;
+
                 // Pre-bind arguments and infer type arguments from them.
                 // Issue #343: when an argument is named, locate its parameter
                 // by name (so type inference still works with named args) and
@@ -2290,6 +2297,10 @@ internal sealed class OverloadResolver
                         }
                     }
                 }
+
+                // Issue #1629: discard the pre-bind's speculative diagnostics —
+                // the arguments are bound again for real below.
+                Diagnostics.TruncateTo(inferenceDiagMark);
 
                 foreach (var tp in tps)
                 {
@@ -3120,6 +3131,13 @@ internal sealed class OverloadResolver
             // (first) explicit constructor's parameter list. The open-definition
             // constructor parameter types reference the class type parameters,
             // so binding each argument and unifying drives inference.
+            //
+            // Issue #1629: this is a throwaway probe — BindExplicitConstructorCallExpression
+            // re-binds the same argument syntax for real once the closed type is
+            // known. Roll back any diagnostics the probe produced so they are
+            // reported exactly once, by the real bind.
+            var inferenceDiagMark = Diagnostics.Count;
+
             var ctorOverloads = classType.EffectiveExplicitConstructors;
             var ctorParams = ctorOverloads.IsDefaultOrEmpty
                 ? ImmutableArray<ParameterSymbol>.Empty
@@ -3131,6 +3149,8 @@ internal sealed class OverloadResolver
                 var preBound = bindExpression(argSyntax);
                 inferTypeArguments(ctorParams[i].Type, preBound.Type, substitution);
             }
+
+            Diagnostics.TruncateTo(inferenceDiagMark);
 
             foreach (var tp in tps)
             {

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1629GenericCtorInferenceDoubleBindTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1629GenericCtorInferenceDoubleBindTests.cs
@@ -1,0 +1,132 @@
+// <copyright file="Issue1629GenericCtorInferenceDoubleBindTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1629: generic constructor type-argument inference pre-bound every
+/// argument to drive inference, then bound the same arguments again for the
+/// real call. Because <see cref="DiagnosticBag"/> is append-only, any
+/// diagnostic inside an argument (e.g. an undefined variable) was reported
+/// twice. The fix rolls back the pre-bind's diagnostics via
+/// <see cref="DiagnosticBag.TruncateTo"/> so only the real bind's diagnostics
+/// remain. These tests cover both the primary-constructor inference path
+/// (<c>Box(x)</c>) and the explicit <c>init(...)</c> inference path
+/// (<c>Box(x)</c> where the class declares an explicit constructor), plus a
+/// nested-generic-construction case that would previously multiply
+/// diagnostics further.
+/// </summary>
+public class Issue1629GenericCtorInferenceDoubleBindTests
+{
+    [Fact]
+    public void PrimaryCtor_GenericInference_UndefinedArgument_ReportsDiagnosticExactlyOnce()
+    {
+        var source = """
+            package p
+            class Box[T](value T) { }
+            func Use() {
+                let b = Box(undefinedVar)
+            }
+            """;
+
+        var diagnostics = Diagnose(source);
+
+        Assert.Single(diagnostics);
+    }
+
+    [Fact]
+    public void ExplicitInitCtor_GenericInference_UndefinedArgument_ReportsDiagnosticExactlyOnce()
+    {
+        var source = """
+            package p
+            class Box[T] {
+                let value T
+                init(v T) { value = v }
+            }
+            func Use() {
+                let b = Box(undefinedVar)
+            }
+            """;
+
+        var diagnostics = Diagnose(source);
+
+        Assert.Single(diagnostics);
+    }
+
+    [Fact]
+    public void PrimaryCtor_NestedGenericInference_UndefinedArgument_ReportsDiagnosticExactlyOnce()
+    {
+        // Nested generic construction: without the fix, each level re-binds its
+        // own arguments twice, so the innermost undefined-variable diagnostic
+        // would multiply with nesting depth.
+        var source = """
+            package p
+            class Box[T](value T) { }
+            func Use() {
+                let b = Box(Box(Box(undefinedVar)))
+            }
+            """;
+
+        var diagnostics = Diagnose(source);
+
+        Assert.Single(diagnostics);
+    }
+
+    [Fact]
+    public void PrimaryCtor_GenericInference_ValidArgument_StillCompilesCleanly()
+    {
+        var source = """
+            package p
+            class Box[T](value T) { }
+            func Use() int32 {
+                let b = Box(5)
+                return b.value
+            }
+            """;
+
+        var diagnostics = Diagnose(source);
+
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void ExplicitInitCtor_GenericInference_ValidArgument_StillCompilesCleanly()
+    {
+        var source = """
+            package p
+            class Box[T] {
+                let value T
+                init(v T) { value = v }
+                func Get() T { return value }
+            }
+            func Use() int32 {
+                let b = Box(5)
+                return b.Get()
+            }
+            """;
+
+        var diagnostics = Diagnose(source);
+
+        Assert.Empty(diagnostics);
+    }
+
+    private static ImmutableArray<Diagnostic> Diagnose(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return result.Diagnostics;
+    }
+}


### PR DESCRIPTION
Fixes #1629

Generic constructor type-argument inference pre-bound every argument to drive inference, then bound the same argument syntax again for the real call. `DiagnosticBag` is append-only with no dedupe, so any diagnostic inside an argument (e.g. an undefined variable) was reported twice; nested generic constructions multiplied the duplication with depth.

**Fix**: mark `Diagnostics.Count` before the inference pre-bind and `Diagnostics.TruncateTo` it after, at both sites:
- `BindConstructorCallExpression` (primary-constructor inference)
- `TryCloseGenericExplicitConstructorType` (explicit `init(...)` inference)

Mirrors the existing rollback pattern already used elsewhere in the binder (`ExpressionBinder.*`) for speculative binds. The redundant re-bind itself is left in place (correctness-first, matches issue's fallback suggestion) — only the pre-bind's diagnostics are discarded.

**Tests**: added `Issue1629GenericCtorInferenceDoubleBindTests` covering primary-ctor and explicit-init-ctor inference paths, a nested generic construction, and positive (clean-compile) cases.

**Verification**: full `dotnet build GSharp.sln -c Release -graph` (0 errors); full `Core.Tests` suite (5109 passed, 0 failed).