### PR TITLE
Fix #1700: invalid IL for await + ?. on value-type Nullable<T> receiver

### DIFF
--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
@@ -1214,11 +1214,11 @@ internal sealed partial class MethodBodyEmitter
         // branch with no matching value on the not-null branch).
         if (ReferenceEquals(nc.Type, Symbols.TypeSymbol.Void))
         {
-            this.EmitExpression(nc.Receiver);
-            this.EmitStoreVariable(nc.Capture);
-            this.EmitLoadVariable(nc.Capture);
             var endVoid = this.il.DefineLabel();
-            this.il.Branch(ILOpCode.Brfalse, endVoid);
+            var nonNullVoid = this.il.DefineLabel();
+            this.EmitNullConditionalReceiverProbe(nc, nonNullVoid);
+            this.il.Branch(ILOpCode.Br, endVoid);
+            this.il.MarkLabel(nonNullVoid);
             this.EmitExpression(nc.WhenNotNull);
             this.il.MarkLabel(endVoid);
             return;
@@ -1229,12 +1229,9 @@ internal sealed partial class MethodBodyEmitter
         // null on the stack and skip the access; otherwise evaluate the
         // access sub-tree, which references the capture local in place
         // of the original receiver.
-        this.EmitExpression(nc.Receiver);
-        this.EmitStoreVariable(nc.Capture);
-        this.EmitLoadVariable(nc.Capture);
         var end = this.il.DefineLabel();
         var nonNull = this.il.DefineLabel();
-        this.il.Branch(ILOpCode.Brtrue, nonNull);
+        this.EmitNullConditionalReceiverProbe(nc, nonNull);
 
         if (nc.ResultSlot != null)
         {
@@ -1335,6 +1332,73 @@ internal sealed partial class MethodBodyEmitter
         this.il.MarkLabel(nonNull);
         this.EmitExpression(nc.WhenNotNull);
         this.il.MarkLabel(end);
+    }
+
+    // Issue #1700: evaluates a null-conditional access's receiver and
+    // branches to <paramref name="nonNullTarget"/> when it has a value,
+    // otherwise falls through (the caller supplies the nil-path code
+    // immediately after this call). On the has-value path, `nc.Capture` is
+    // populated so the (unchanged) `WhenNotNull` sub-tree — bound against
+    // `nc.Capture` as its receiver — sees the same value it always has.
+    //
+    // A value-type `Nullable<T>` receiver (BCL, user struct/enum, or a
+    // struct-constrained open type parameter) cannot reuse `nc.Capture`'s
+    // slot for the raw receiver value: that slot is declared as the
+    // unwrapped `T` (so member-access binding resolves `Add`/etc. against
+    // `T`, not `Nullable<T>`), but the receiver expression pushes the real
+    // `Nullable<T>` wrapper. Storing that wrapper into the `T`-typed capture
+    // slot, then `brtrue`-ing the reloaded `T` struct, is invalid IL
+    // (ilverify StackUnexpected) — this is the actual root cause, reachable
+    // with or without an `await` inside the access. Route the wrapper
+    // through the pre-allocated `Nullable<T>`-typed scratch slot
+    // (`receiverSpillSlots[nc.Receiver]`, planned in
+    // `MethodBodyPlanner.CollectLocalsAndLabels`) instead: probe `HasValue`
+    // via `box; brtrue` (ECMA-335 §I.8.2.4 — boxing `Nullable<T>` yields
+    // `null` when empty, a boxed `T` otherwise, giving a legally
+    // branchable object reference), and only unwrap into `nc.Capture` once
+    // the has-value path is confirmed.
+    private void EmitNullConditionalReceiverProbe(BoundNullConditionalAccessExpression nc, LabelHandle nonNullTarget)
+    {
+        if (nc.Receiver.Type is NullableTypeSymbol receiverNullable
+            && NullableLifting.IsAnyValueTypeNullable(receiverNullable))
+        {
+            var wrapperSlot = this.receiverSpillSlots[nc.Receiver];
+            this.EmitExpression(nc.Receiver);
+            this.il.StoreLocal(wrapperSlot);
+            this.il.LoadLocal(wrapperSlot);
+            this.il.OpCode(ILOpCode.Box);
+            this.il.Token(this.outer.GetElementTypeToken(receiverNullable));
+            var nilFallthrough = this.il.DefineLabel();
+            this.il.Branch(ILOpCode.Brfalse, nilFallthrough);
+
+            this.il.LoadLocalAddress(wrapperSlot);
+            if (NullableLifting.IsUserValueTypeNullable(receiverNullable))
+            {
+                this.il.OpCode(ILOpCode.Call);
+                this.il.Token(this.outer.GetNullableGetValueMemberRefForUserValueType(receiverNullable));
+            }
+            else
+            {
+                var innerClr = receiverNullable.UnderlyingType.ClrType
+                    ?? throw new InvalidOperationException(
+                        $"Value-type Nullable<{receiverNullable.UnderlyingType.Name}> null-conditional receiver has no CLR underlying type.");
+                this.il.OpCode(ILOpCode.Call);
+                this.il.Token(this.outer.wellKnown.GetNullableGetValueOrDefaultReference(innerClr));
+            }
+
+            this.EmitStoreVariable(nc.Capture);
+            this.il.Branch(ILOpCode.Br, nonNullTarget);
+            this.il.MarkLabel(nilFallthrough);
+            return;
+        }
+
+        // Reference-typed (or non-nullable-collapse) receiver: `nc.Capture`
+        // shares the CLR representation of `nc.Receiver`, so a direct
+        // store/reload/brtrue is valid IL.
+        this.EmitExpression(nc.Receiver);
+        this.EmitStoreVariable(nc.Capture);
+        this.EmitLoadVariable(nc.Capture);
+        this.il.Branch(ILOpCode.Brtrue, nonNullTarget);
     }
 
     private void EmitTupleLiteral(BoundTupleLiteralExpression tuple)

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
@@ -963,7 +963,7 @@ internal sealed partial class MethodBodyEmitter
 
         if (!crossesRegion)
         {
-            this.EmitExpression(conditional);
+            this.EmitConditionalGotoProbe(conditional);
             this.il.Branch(jumpIfTrue ? ILOpCode.Brtrue : ILOpCode.Brfalse, targetHandle);
             return;
         }
@@ -972,10 +972,36 @@ internal sealed partial class MethodBodyEmitter
         // `leave` is not conditional, so emit the inverse branch over a
         // `leave` to the target.
         var skipLabel = this.il.DefineLabel();
-        this.EmitExpression(conditional);
+        this.EmitConditionalGotoProbe(conditional);
         this.il.Branch(jumpIfTrue ? ILOpCode.Brfalse : ILOpCode.Brtrue, skipLabel);
         this.il.Branch(ILOpCode.Leave, targetHandle);
         this.il.MarkLabel(skipLabel);
+    }
+
+    // Issue #1700: a BoundConditionalGotoStatement whose condition is a
+    // value-type `Nullable<T>` (e.g. the null-conditional-access spiller's
+    // receiver capture for a struct/enum `T?`) cannot use `brtrue`/`brfalse`
+    // directly on the loaded struct — that is invalid IL (ilverify
+    // StackUnexpected: a Nullable<T> value has no valid truthy
+    // interpretation). Mirror the `??`/`!!` null-probe shapes elsewhere in
+    // this emitter: `box Nullable<T>` yields `null` when `HasValue == false`
+    // and a boxed `T` otherwise (ECMA-335 §I.8.2.4), giving an object
+    // reference that `brtrue`/`brfalse` can legally test. This covers BCL
+    // value types, user-declared struct/enum underlyings (null ClrType during
+    // emit — GetElementTypeToken already closes the TypeSpec over the emitted
+    // TypeDef for those), and struct-constrained open type parameters
+    // uniformly, since no reload of the boxed value is needed here (the
+    // non-null branch re-reads the original capture/local, not this probe).
+    private void EmitConditionalGotoProbe(BoundExpression conditional)
+    {
+        this.EmitExpression(conditional);
+
+        if (conditional.Type is NullableTypeSymbol nullable
+            && (NullableLifting.IsValueTypeNullable(nullable) || NullableLifting.IsUserValueTypeNullable(nullable)))
+        {
+            this.il.OpCode(ILOpCode.Box);
+            this.il.Token(this.outer.GetElementTypeToken(nullable));
+        }
     }
 
     // Issue #420 (P3-4): debug-only check used by EmitFieldAssignment to

--- a/src/Core/CodeAnalysis/Emit/MethodBodyPlanner.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyPlanner.cs
@@ -387,6 +387,28 @@ internal sealed class MethodBodyPlanner
                 locals[nc.ResultSlot] = localTypes.Count;
                 localTypes.Add(nc.ResultSlot.Type);
             }
+
+            // Issue #1700: a value-type `Nullable<T>` receiver (e.g. a
+            // struct/enum `T?`) cannot share `nc.Capture`'s slot — that slot
+            // is declared as the unwrapped `T` (so member-access binding
+            // resolves against `T`, not `Nullable<T>`), but the receiver
+            // expression pushes the real `Nullable<T>` wrapper. Storing that
+            // wrapper into the `T`-typed capture slot, then `brtrue`-ing the
+            // reloaded `T` struct, is invalid IL (ilverify StackUnexpected)
+            // regardless of whether an `await` is involved — this is the
+            // root cause, not just the await-spilled shape. Pre-allocate a
+            // second, `Nullable<T>`-typed scratch slot (keyed by nc.Receiver,
+            // mirroring the `!!`/`??` value-type spill slots) so the emitter
+            // can store the real wrapper, probe `HasValue` off its address,
+            // and only then unwrap into `nc.Capture` on the non-nil path.
+            if (nc.Receiver.Type is NullableTypeSymbol receiverNullable
+                && NullableLifting.IsAnyValueTypeNullable(receiverNullable)
+                && !receiverSpillSlots.ContainsKey(nc.Receiver))
+            {
+                var wrapperSlot = localTypes.Count;
+                localTypes.Add(nc.Receiver.Type);
+                receiverSpillSlots[nc.Receiver] = wrapperSlot;
+            }
         }
 
         foreach (var append in this.CollectAppends(body))

--- a/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
@@ -1506,10 +1506,36 @@ public static class SpillSequenceSpiller
         /// </summary>
         private BoundSpillSequenceExpression SpillNullConditionalAccess(BoundNullConditionalAccessExpression nc)
         {
+            // Issue #1700: a value-type `Nullable<T>` receiver (BCL, user
+            // struct/enum) needs the statement-based (declare + goto/label)
+            // rebuild below UNCONDITIONALLY — even when neither the receiver
+            // nor WhenNotNull contains an await. `nc.Capture` is declared as
+            // the unwrapped `T` (so member-access binding resolves against
+            // `T`), so it can never directly hold the real `Nullable<T>`
+            // receiver value; and since this whole method reachable via
+            // SpillExpression only runs inside an async method body,
+            // MoveNextBodyRewriter's hoisting walk may promote `nc.Capture`
+            // to a state-machine field regardless of whether *this specific*
+            // access spans a suspension point — and it only redirects
+            // bound-tree-visible reads/writes (BoundVariableExpression /
+            // BoundAssignmentExpression / BoundVariableDeclaration nodes),
+            // never the emitter's direct EmitStoreVariable/EmitLoadVariable
+            // calls. Leaving the node's own capture-write to
+            // EmitNullConditionalAccess (as the Trivial passthrough would)
+            // risks a silent dead store into an unused fallback local while
+            // every real read resolves to a never-written hoisted field —
+            // wrong runtime value with still-valid IL (ilverify cannot see
+            // this). Building the write as a genuine
+            // BoundAssignmentExpression here (mirroring the existing
+            // reference-type Leg-1/2/3 patterns below) keeps it visible to
+            // the hoisting walk regardless of leg.
+            var isValueTypeNullableReceiver = nc.Receiver.Type is NullableTypeSymbol ncReceiverNullable
+                && NullableLifting.IsAnyValueTypeNullable(ncReceiverNullable);
+
             var receiverHasAwait = HasAwait(nc.Receiver);
             var whenNotNullHasAwait = HasAwait(nc.WhenNotNull);
 
-            if (!receiverHasAwait && !whenNotNullHasAwait)
+            if (!isValueTypeNullableReceiver && !receiverHasAwait && !whenNotNullHasAwait)
             {
                 return Trivial(nc);
             }
@@ -1526,9 +1552,10 @@ public static class SpillSequenceSpiller
                 receiver = spilledReceiver.Value;
             }
 
-            if (!whenNotNullHasAwait)
+            if (!isValueTypeNullableReceiver && !whenNotNullHasAwait)
             {
-                // Only the receiver needed spilling — WhenNotNull is still
+                // Reference-type (or non-nullable-collapse) receiver, only
+                // the receiver needed spilling — WhenNotNull is still
                 // await-free. EmitNullConditionalAccess writes/reads
                 // nc.Capture via direct EmitStoreVariable/EmitLoadVariable
                 // calls, not through bound-tree Assignment/Variable nodes —
@@ -1545,6 +1572,8 @@ public static class SpillSequenceSpiller
                 // harmless no-op dead store into the (unused) plain-local
                 // fallback slot, while every real read still consistently
                 // resolves to the (already correctly written) hoisted field.
+                // `nc.Capture` shares the CLR representation of `receiver`
+                // for reference types, so this workaround remains sound.
                 sideEffects.Add(new BoundVariableDeclaration(null, (LocalVariableSymbol)nc.Capture, receiver));
                 locals.Add((LocalVariableSymbol)nc.Capture);
                 var captureRef = new BoundVariableExpression(null, nc.Capture);
@@ -1552,19 +1581,54 @@ public static class SpillSequenceSpiller
                 return new BoundSpillSequenceExpression(null, locals.ToImmutable(), sideEffects.ToImmutable(), rebuiltNc);
             }
 
-            // WhenNotNull has an await: it must run only on the non-nil path,
-            // so the nil check needs explicit if/else control flow. Since this
+            // Either WhenNotNull has an await (must run only on the non-nil
+            // path, needing explicit if/else control flow) or the receiver
+            // is a value-type Nullable<T> (needing the wrapper-local +
+            // guard + `!!` unwrap shape regardless of await). Since this
             // path replaces the BoundNullConditionalAccessExpression node
-            // entirely, nc.Capture is no longer discoverable by the emitter's
-            // CollectNullConditionalCaptures walk (which only finds the local
-            // through a surviving node of that kind) — it must be registered
-            // as a spill local explicitly here or its slot never gets planned.
-            // It is declared (not just assigned) with the real receiver value
-            // as its initializer so FlushSideEffects never falls back to its
-            // int32-literal-0 default — which is the wrong CLR type for a
-            // reference/struct-typed capture and would fail IL verification.
-            locals.Add((LocalVariableSymbol)nc.Capture);
-            sideEffects.Add(new BoundVariableDeclaration(null, (LocalVariableSymbol)nc.Capture, receiver));
+            // entirely, nc.Capture is no longer discoverable by the
+            // emitter's CollectNullConditionalCaptures walk (which only
+            // finds the local through a surviving node of that kind) — it
+            // must be registered as a spill local explicitly here or its
+            // slot never gets planned.
+            //
+            // Issue #1700: a value-type `Nullable<T>` receiver cannot reuse
+            // `nc.Capture` (declared as unwrapped `T`) to hold the raw
+            // receiver, nor can a `T`-typed variable read be branched on
+            // directly (both are the same StackUnexpected mismatch as the
+            // reference-type Leg-1 case above). Route it through its own
+            // `Nullable<T>`-typed wrapper local instead: declare
+            // `wrapper := receiver`, guard on `wrapper` (its Nullable<T>
+            // type makes EmitConditionalGotoProbe take the box-probe path),
+            // then unwrap `wrapper` into `nc.Capture` via `!!`
+            // (NullAssertion) only once the guard confirms HasValue — `!!`'s
+            // emit path already has full, pre-existing support for user
+            // struct/enum and BCL value-type Nullable<T> operands
+            // (NullableValueTypeUnwrapCollector auto-slots any such node it
+            // finds in the tree), so no new emitter plumbing is needed here.
+            LocalVariableSymbol wrapperLocal = null;
+            BoundExpression guardCondition;
+            if (isValueTypeNullableReceiver)
+            {
+                wrapperLocal = MakeSpillTemp(receiver.Type);
+                locals.Add(wrapperLocal);
+                sideEffects.Add(new BoundVariableDeclaration(null, wrapperLocal, receiver));
+
+                locals.Add((LocalVariableSymbol)nc.Capture);
+                sideEffects.Add(new BoundVariableDeclaration(null, (LocalVariableSymbol)nc.Capture, new BoundDefaultExpression(null, nc.Capture.Type)));
+                guardCondition = new BoundVariableExpression(null, wrapperLocal);
+            }
+            else
+            {
+                // It is declared (not just assigned) with the real receiver
+                // value as its initializer so FlushSideEffects never falls
+                // back to its int32-literal-0 default — which is the wrong
+                // CLR type for a reference-typed capture and would fail IL
+                // verification.
+                locals.Add((LocalVariableSymbol)nc.Capture);
+                sideEffects.Add(new BoundVariableDeclaration(null, (LocalVariableSymbol)nc.Capture, receiver));
+                guardCondition = new BoundVariableExpression(null, nc.Capture);
+            }
 
             var isVoid = ReferenceEquals(nc.Type, TypeSymbol.Void);
             var resultLocal = isVoid ? null : MakeSpillTemp(nc.Type);
@@ -1572,8 +1636,8 @@ public static class SpillSequenceSpiller
             var nonNullLabel = MakeLabel();
             var endLabel = MakeLabel();
 
-            // if (capture) goto nonNull   (brtrue — reference/Nullable non-nil check)
-            sideEffects.Add(new BoundConditionalGotoStatement(null, nonNullLabel, new BoundVariableExpression(null, nc.Capture), jumpIfTrue: true));
+            // if (capture/wrapper) goto nonNull   (brtrue — reference/Nullable non-nil check)
+            sideEffects.Add(new BoundConditionalGotoStatement(null, nonNullLabel, guardCondition, jumpIfTrue: true));
 
             // nil branch
             if (!isVoid)
@@ -1585,6 +1649,14 @@ public static class SpillSequenceSpiller
 
             // non-null branch
             sideEffects.Add(new BoundLabelStatement(null, nonNullLabel));
+
+            if (isValueTypeNullableReceiver)
+            {
+                var unwrapOp = BoundUnaryOperator.Bind(SyntaxKind.BangBangToken, wrapperLocal.Type);
+                var unwrap = new BoundUnaryExpression(null, unwrapOp, new BoundVariableExpression(null, wrapperLocal));
+                sideEffects.Add(new BoundExpressionStatement(null, new BoundAssignmentExpression(null, nc.Capture, unwrap)));
+            }
+
             var spilledWhenNotNull = SpillExpression(nc.WhenNotNull);
             locals.AddRange(spilledWhenNotNull.Locals);
             sideEffects.AddRange(spilledWhenNotNull.SideEffects);

--- a/src/Core/CodeAnalysis/Symbols/NullableLifting.cs
+++ b/src/Core/CodeAnalysis/Symbols/NullableLifting.cs
@@ -161,6 +161,24 @@ public static class NullableLifting
     }
 
     /// <summary>
+    /// Issue #1700: unifies <see cref="IsValueTypeNullable"/> (BCL / open
+    /// struct-constrained type-parameter underlyings, which carry a runtime
+    /// <c>ClrType</c>) and <see cref="IsUserValueTypeNullable"/> (same-
+    /// compilation user struct/enum underlyings, which do not) into a single
+    /// predicate for emit-side code that must treat every value-type
+    /// <c>Nullable&lt;T&gt;</c> receiver the same way — e.g. the null-
+    /// conditional-access receiver probe, which cannot use <c>brtrue</c>
+    /// directly on a <c>Nullable&lt;T&gt;</c> struct value (ilverify
+    /// <c>StackUnexpected</c>) regardless of which kind of <c>T</c> it wraps.
+    /// </summary>
+    /// <param name="nullable">The wrapper to test.</param>
+    /// <returns><see langword="true"/> for any value-type <c>Nullable&lt;T&gt;</c>, BCL or user-declared.</returns>
+    internal static bool IsAnyValueTypeNullable(NullableTypeSymbol nullable)
+    {
+        return IsValueTypeNullable(nullable) || IsUserValueTypeNullable(nullable);
+    }
+
+    /// <summary>
     /// Returns <see langword="true"/> when <paramref name="type"/> is a
     /// constructed <c>System.Nullable&lt;T&gt;</c> (i.e. closed-generic over the
     /// open <c>System.Nullable`1</c> definition). The open definition itself

--- a/test/Compiler.Tests/Emit/Issue1619SpillCompositeAwaitEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1619SpillCompositeAwaitEmitTests.cs
@@ -563,23 +563,19 @@ public class Issue1619SpillCompositeAwaitEmitTests
     }
 
     [Fact]
-    public void Await_In_NullConditional_Access_On_ValueType_Nullable_Emits_Invalid_IL_KnownLimitation()
+    public void Await_In_NullConditional_Access_On_ValueType_Nullable_Runs_And_Verifies()
     {
-        // Watch-item: T? for a value type (struct) receiver, with an await
-        // inside the null-conditional invocation's argument. Unlike the
-        // reference-type case above (Await_In_NullConditional_Access_...),
-        // gsc currently emits INVALID IL for this shape: the spiller's
-        // rebuilt receiver ends up boxed as System.Nullable`1<Pt> where the
-        // emitter expects the unwrapped Pt value, caught here by ilverify's
-        // StackUnexpected error. This is a pre-existing, separate defect in
-        // how nullable *value types* are represented across the
-        // null-conditional spill path - unrelated to the
-        // SpillConditionalAddress double-eval fixed above - and is out of
-        // scope for issue #1619 / this fix. This test pins the current
-        // (broken) behavior so a future fix has a regression test to flip
-        // green, and so this gap doesn't silently regress further.
+        // Issue #1700: T? for a value type (struct) receiver, with an await
+        // inside the null-conditional invocation's argument. The receiver
+        // probe (EmitNullConditionalReceiverProbe) now spills the value-type
+        // Nullable<T> receiver to its own scratch slot and boxes it (rather
+        // than storing it into nc.Capture, which is declared as the
+        // unwrapped T and previously produced a StackUnexpected verifier
+        // error), matching the `??`/`!!` null-probe shapes elsewhere in the
+        // emitter, so this now emits valid IL and runs both the has-value
+        // and nil receiver shapes correctly.
         var source = """
-            package P1619O
+            package P1700A
 
             import System.Threading.Tasks
 
@@ -597,14 +593,60 @@ public class Issue1619SpillCompositeAwaitEmitTests
             }
 
             public var nonNilResult = -1
+            public var nilResult = -1
             let c = C()
             let p = Pt{X: 10}
             let r1 = c.AddToPoint(p, Task.FromResult(5)).Result
             nonNilResult = r1 ?? -100
+            let r2 = c.AddToPoint(nil, Task.FromResult(5)).Result
+            nilResult = r2 ?? -100
             """;
 
-        var ex = Assert.Throws<Xunit.Sdk.XunitException>(() => CompileAndInvokeEntry(source));
-        Assert.Contains("StackUnexpected", ex.Message);
+        var assembly = CompileAndInvokeEntry(source);
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+
+        Assert.Equal(15, ReadInt(program, "nonNilResult"));
+        Assert.Equal(-100, ReadInt(program, "nilResult"));
+    }
+
+    [Fact]
+    public void Await_In_NullConditional_Receiver_On_Bcl_ValueType_Nullable_Runs_And_Verifies()
+    {
+        // Issue #1700 sibling shape: the await sits in the *receiver*
+        // expression (SpillNullConditionalAccess's receiverHasAwait branch,
+        // rebuilding the node with the possibly-spilled receiver expression
+        // unchanged) rather than in the invocation argument (the
+        // receiverHasAwait == false, whenNotNullHasAwait == true branch
+        // exercised above). Uses a BCL value type (int32?) to prove the fix
+        // generalizes beyond user-declared structs. Both branches funnel
+        // through the same EmitNullConditionalReceiverProbe fix.
+        var source = """
+            package P1700C
+
+            import System.Threading.Tasks
+
+            class C2 {
+                init() {}
+
+                async func Cmp(t Task[int32?]) int32? {
+                    return (await t)?.CompareTo(5)
+                }
+            }
+
+            public var nonNilResult = -100
+            public var nilResult = -100
+            let c = C2()
+            let r1 = c.Cmp(Task.FromResult[int32?](10)).Result
+            nonNilResult = r1 ?? -100
+            let r2 = c.Cmp(Task.FromResult[int32?](nil)).Result
+            nilResult = r2 ?? -100
+            """;
+
+        var assembly = CompileAndInvokeEntry(source);
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+
+        Assert.Equal(1, ReadInt(program, "nonNilResult"));
+        Assert.Equal(-100, ReadInt(program, "nilResult"));
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #1700

Null-conditional access (`?.`) on a value-type `Nullable<T>` receiver (BCL, user struct/enum) emitted invalid IL — `ilverify` reported `StackUnexpected` (a boxed/real `Nullable<T>` on the stack where the unwrapped `T` was expected). Confirmed reachable with or without `await` (this is a receiver-shape bug in `EmitNullConditionalAccess`, not an async-spilling bug — the issue's async framing undersold the scope).

**Root cause:** `BoundNullConditionalAccessExpression.Capture` is declared as the unwrapped underlying type `T` (needed so the `WhenNotNull` member access binds against `T`), but a value-type `Nullable<T>` receiver pushes the real `Nullable<T>` wrapper at emit time. Storing that wrapper directly into the `T`-typed capture slot and then `brtrue`-ing the reloaded `T` struct is invalid IL.

**Fix:**
- `EmitNullConditionalAccess`: extracted `EmitNullConditionalReceiverProbe`. For value-type `Nullable<T>` receivers, spills the receiver into its own `Nullable<T>`-typed scratch slot (planned in `MethodBodyPlanner`), probes `HasValue` via `box`+`brtrue` (ECMA-335 §I.8.2.4), and unwraps into `nc.Capture` via `get_Value`/`GetValueOrDefault` (BCL) or `GetNullableGetValueMemberRefForUserValueType` (user struct/enum) only once `HasValue` is confirmed.
- `SpillSequenceSpiller.SpillNullConditionalAccess`: for value-type `Nullable<T>` receivers, always rebuilds via the statement-based (wrapper-local declare + goto/label + `!!` unwrap into `nc.Capture`) shape, even when neither side has an `await`. Required because this function only runs inside async method bodies, where `MoveNextBodyRewriter`'s hoisting walk may promote `nc.Capture` to a state-machine field regardless of whether this specific access spans a suspension point — and hoisting only redirects bound-tree-visible writes, never the emitter's direct `EmitStoreVariable` calls. The `!!` unwrap reuses existing, tested emit support with no new plumbing.
- `NullableLifting.IsAnyValueTypeNullable`: new helper (BCL or user struct/enum) used by both call sites.

**Tests:** Flipped the pinned `Await_In_NullConditional_Access_On_ValueType_Nullable_Emits_Invalid_IL_KnownLimitation` to `..._Runs_And_Verifies` (asserts correct runtime result + ilverify-clean). Added coverage for await-in-argument, await-in-receiver (BCL `int32?`), and has-value/nil cases. All 309 targeted nullable/null-conditional/spill emit tests and 77 await emit tests pass; full solution builds with 0 errors.

**Deferred (separate, pre-existing bug, out of scope):** awaiting `Task[T?]` where `T` is a user-declared value type mis-types the hoisted `TaskAwaiter<Nullable<T>>` field as `object` (ilverify `StackUnexpected` on `GetResult`), independent of null-conditional access — reproduces with a plain `let x = await someTaskOfUserStructNullable`, no `?.` involved.
