### PR TITLE
Fix #1663: run workspace discovery/parsing in background, off the initialize path

### DIFF
--- a/src/LanguageServer/ProjectState.cs
+++ b/src/LanguageServer/ProjectState.cs
@@ -179,6 +179,11 @@ public class ProjectState
         {
             return null;
         }
+        catch (UnauthorizedAccessException)
+        {
+            // An unreadable file (permissions) shouldn't abort loading the rest of the project.
+            return null;
+        }
     }
 
     /// <summary>

--- a/src/LanguageServer/Server/LspServer.cs
+++ b/src/LanguageServer/Server/LspServer.cs
@@ -123,6 +123,10 @@ public sealed class LspServer
             {
                 // Shutdown raced the background load; nothing left to do.
             }
+            catch (ObjectDisposedException)
+            {
+                // Shutdown disposed the CTS while the load observed its token; benign.
+            }
             catch (Exception ex)
             {
                 // Workspace discovery is best-effort; single-file editing still works without

--- a/src/LanguageServer/Server/LspServer.cs
+++ b/src/LanguageServer/Server/LspServer.cs
@@ -45,6 +45,7 @@ public sealed class LspServer
     private bool clientSupportsDiagnosticRefresh;
     private Timer refreshTimer;
     private string defaultFormattingIndent = "  ";
+    private string pendingWorkspaceRootPath;
 
     public LspServer(DocumentContentService documentContentService, WorkspaceState workspaceState, ILogger logger = null)
     {
@@ -67,17 +68,9 @@ public sealed class LspServer
     [JsonRpcMethod("initialize", UseSingleObjectParameterDeserialization = true)]
     public Task<InitializeResult> InitializeAsync(InitializeParams request)
     {
-        var rootPath = request?.RootPath ?? request?.RootUri?.GetFileSystemPath();
+        this.pendingWorkspaceRootPath = request?.RootPath ?? request?.RootUri?.GetFileSystemPath();
         this.DetectClientDiagnosticCapabilities(request?.Capabilities ?? default);
         this.defaultFormattingIndent = ResolveDefaultFormattingIndent(request?.InitializationOptions ?? default);
-        try
-        {
-            WorkspaceInitializer.Initialize(this.workspaceState, rootPath);
-        }
-        catch
-        {
-            // Workspace discovery is best-effort; single-file editing still works without it.
-        }
 
         return Task.FromResult(new InitializeResult
         {
@@ -89,7 +82,26 @@ public sealed class LspServer
     [JsonRpcMethod("initialized")]
     public void Initialized(JsonElement @params)
     {
-        // No-op: capabilities are advertised statically in the initialize result.
+        // Issue #1663: workspace discovery (globbing every project, reading and parsing every
+        // source file) used to run inline in "initialize", blocking the handshake for
+        // seconds-to-minutes on a large workspace. Kick it off in the background instead, now
+        // that the client has the capabilities and can start sending requests. WorkspaceState's
+        // maps are ConcurrentDictionary-backed, so requests racing the load see either "not
+        // found yet" (handled today via GetProjectForFile returning null → empty diagnostics,
+        // same as an unopened file) or the fully-populated project once loading catches up; no
+        // extra locking is needed for correctness.
+        var rootPath = this.pendingWorkspaceRootPath;
+        _ = Task.Run(() =>
+        {
+            try
+            {
+                WorkspaceInitializer.Initialize(this.workspaceState, rootPath);
+            }
+            catch
+            {
+                // Workspace discovery is best-effort; single-file editing still works without it.
+            }
+        });
     }
 
     [JsonRpcMethod("shutdown")]

--- a/src/LanguageServer/Server/LspServer.cs
+++ b/src/LanguageServer/Server/LspServer.cs
@@ -46,6 +46,7 @@ public sealed class LspServer
     private Timer refreshTimer;
     private string defaultFormattingIndent = "  ";
     private string pendingWorkspaceRootPath;
+    private CancellationTokenSource backgroundLoadCts;
 
     public LspServer(DocumentContentService documentContentService, WorkspaceState workspaceState, ILogger logger = null)
     {
@@ -85,21 +86,48 @@ public sealed class LspServer
         // Issue #1663: workspace discovery (globbing every project, reading and parsing every
         // source file) used to run inline in "initialize", blocking the handshake for
         // seconds-to-minutes on a large workspace. Kick it off in the background instead, now
-        // that the client has the capabilities and can start sending requests. WorkspaceState's
-        // maps are ConcurrentDictionary-backed, so requests racing the load see either "not
-        // found yet" (handled today via GetProjectForFile returning null → empty diagnostics,
-        // same as an unopened file) or the fully-populated project once loading catches up; no
-        // extra locking is needed for correctness.
+        // that the client has the capabilities and can start sending requests.
+        //
+        // Issue #1786 follow-up (B1): file registration is routed through the same gate as
+        // didOpen/didChange/didSave (one file at a time, brief hold, matching the write
+        // contract documented on the class), and prefers the client's recorded open buffer
+        // over disk text. This guarantees the client's buffer always wins over disk,
+        // regardless of how discovery interleaves with edits, with no torn state.
         var rootPath = this.pendingWorkspaceRootPath;
+        this.backgroundLoadCts?.Dispose();
+        var cts = new CancellationTokenSource();
+        this.backgroundLoadCts = cts;
         _ = Task.Run(() =>
         {
             try
             {
-                WorkspaceInitializer.Initialize(this.workspaceState, rootPath);
+                WorkspaceInitializer.Initialize(
+                    this.workspaceState,
+                    rootPath,
+                    cts.Token,
+                    tryGetOpenBuffer: file => this.workspaceState.TryGetOpenBuffer(file, out var text) ? text : null,
+                    withGate: mutate =>
+                    {
+                        this.gate.Wait(cts.Token);
+                        try
+                        {
+                            mutate();
+                        }
+                        finally
+                        {
+                            this.gate.Release();
+                        }
+                    });
             }
-            catch
+            catch (OperationCanceledException)
             {
-                // Workspace discovery is best-effort; single-file editing still works without it.
+                // Shutdown raced the background load; nothing left to do.
+            }
+            catch (Exception ex)
+            {
+                // Workspace discovery is best-effort; single-file editing still works without
+                // it, but a failed load should be debuggable rather than silently degraded.
+                this.logger?.LogError($"Background workspace load failed: {ex.GetType().FullName}: {ex.Message}", ex);
             }
         });
     }
@@ -108,6 +136,8 @@ public sealed class LspServer
     public object Shutdown()
     {
         this.shutdownRequested = true;
+        this.backgroundLoadCts?.Cancel();
+        this.backgroundLoadCts?.Dispose();
         return null;
     }
 
@@ -190,6 +220,12 @@ public sealed class LspServer
         return this.GuardAsync(() =>
         {
             this.documentContentService.TryRemove(uri.ToString());
+            var filePath = uri.GetFileSystemPath();
+            if (!string.IsNullOrEmpty(filePath))
+            {
+                this.workspaceState.ClearOpenBuffer(filePath);
+            }
+
             return 0;
         });
     }
@@ -920,6 +956,15 @@ public sealed class LspServer
     private void UpdateDocument(DocumentUri uri, string text)
     {
         var filePath = uri.GetFileSystemPath();
+
+        // Issue #1786 follow-up (B1): record the buffer before touching the project so a
+        // concurrent background load that hasn't registered this file's project yet will see
+        // it once it gets there, instead of loading stale disk text.
+        if (!string.IsNullOrEmpty(filePath))
+        {
+            this.workspaceState.SetOpenBuffer(filePath, text);
+        }
+
         var project = !string.IsNullOrEmpty(filePath) ? this.workspaceState.GetProjectForFile(filePath) : null;
         if (project != null)
         {

--- a/src/LanguageServer/WorkspaceInitializer.cs
+++ b/src/LanguageServer/WorkspaceInitializer.cs
@@ -2,6 +2,8 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace GSharp.LanguageServer;
@@ -16,7 +18,20 @@ public static class WorkspaceInitializer
     /// </summary>
     /// <param name="workspaceState"><see cref="WorkspaceState"/> instance.</param>
     /// <param name="rootPath">The workspace root path.</param>
-    public static void Initialize(WorkspaceState workspaceState, string rootPath)
+    /// <param name="cancellationToken">Cancelled when the server shuts down mid-load.</param>
+    /// <param name="tryGetOpenBuffer">Returns the client's current buffer text for a file
+    /// path if the client already has it open, or null. When the caller races this method
+    /// against didOpen/didChange (the LSP server does), this ensures the client's buffer
+    /// always wins over disk text. Callers that run single-threaded (tests) can omit it.</param>
+    /// <param name="withGate">Runs a single file's registration under the same gate used by
+    /// didOpen/didChange/didSave, so registration and buffer edits never interleave and
+    /// clobber each other. Callers that run single-threaded (tests) can omit it.</param>
+    public static void Initialize(
+        WorkspaceState workspaceState,
+        string rootPath,
+        CancellationToken cancellationToken = default,
+        Func<string, string> tryGetOpenBuffer = null,
+        Action<Action> withGate = null)
     {
         if (string.IsNullOrEmpty(rootPath))
         {
@@ -28,6 +43,8 @@ public static class WorkspaceInitializer
         var discovered = ProjectDiscovery.DiscoverProjects(rootPath);
         foreach (var disc in discovered)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             var project = workspaceState.AddProject(disc.ProjectFilePath);
             project.AssemblyName = disc.AssemblyName;
             project.TargetFramework = disc.TargetFramework;
@@ -36,8 +53,34 @@ public static class WorkspaceInitializer
             project.References = disc.References;
             foreach (var sourceFile in disc.SourceFiles)
             {
-                project.AddFileFromDisk(sourceFile);
-                workspaceState.RegisterFile(sourceFile, project);
+                cancellationToken.ThrowIfCancellationRequested();
+
+                void RegisterFile()
+                {
+                    // Issue #1786 follow-up (B1): prefer the client's open buffer over disk so a
+                    // didOpen/didChange that raced ahead of discovery is never clobbered with
+                    // stale disk text.
+                    var openText = tryGetOpenBuffer?.Invoke(sourceFile);
+                    if (openText != null)
+                    {
+                        project.UpdateFile(sourceFile, openText);
+                    }
+                    else
+                    {
+                        project.AddFileFromDisk(sourceFile);
+                    }
+
+                    workspaceState.RegisterFile(sourceFile, project);
+                }
+
+                if (withGate != null)
+                {
+                    withGate(RegisterFile);
+                }
+                else
+                {
+                    RegisterFile();
+                }
             }
         }
 
@@ -52,6 +95,11 @@ public static class WorkspaceInitializer
         // exception here so warm-up never crashes the LSP startup path.
         foreach (var disc in discovered)
         {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                break;
+            }
+
             var project = workspaceState.GetProject(disc.ProjectFilePath);
             if (project != null)
             {
@@ -59,6 +107,11 @@ public static class WorkspaceInitializer
                 {
                     try
                     {
+                        if (cancellationToken.IsCancellationRequested)
+                        {
+                            return;
+                        }
+
                         var compilation = project.GetCompilation();
                         _ = compilation.BoundProgram;
 

--- a/src/LanguageServer/WorkspaceState.cs
+++ b/src/LanguageServer/WorkspaceState.cs
@@ -17,6 +17,7 @@ public class WorkspaceState
 {
     private readonly ConcurrentDictionary<string, ProjectState> projects = new(StringComparer.OrdinalIgnoreCase);
     private readonly ConcurrentDictionary<string, string> fileToProject = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, string> openBuffers = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// Gets or sets the workspace root path.
@@ -119,6 +120,39 @@ public class WorkspaceState
     {
         var normalized = Path.GetFullPath(filePath);
         fileToProject.TryRemove(normalized, out _);
+    }
+
+    /// <summary>
+    /// Records the client's current in-memory buffer for a file (didOpen/didChange/didSave).
+    /// Issue #1786 follow-up: the background workspace loader consults this so a file the
+    /// client already has open is always registered with the client's buffer text, never
+    /// stale disk text, regardless of how the two race.
+    /// </summary>
+    /// <param name="filePath">Absolute path to the <c>.gs</c> file.</param>
+    /// <param name="text">The client's current buffer text.</param>
+    public void SetOpenBuffer(string filePath, string text)
+    {
+        openBuffers[Path.GetFullPath(filePath)] = text;
+    }
+
+    /// <summary>
+    /// Clears the recorded buffer for a file once the client closes it (didClose).
+    /// </summary>
+    /// <param name="filePath">Absolute path to the <c>.gs</c> file.</param>
+    public void ClearOpenBuffer(string filePath)
+    {
+        openBuffers.TryRemove(Path.GetFullPath(filePath), out _);
+    }
+
+    /// <summary>
+    /// Gets the client's current buffer text for a file, if the client has it open.
+    /// </summary>
+    /// <param name="filePath">Absolute path to the <c>.gs</c> file.</param>
+    /// <param name="text">The buffer text, if present.</param>
+    /// <returns>True if the file is currently open with a recorded buffer.</returns>
+    public bool TryGetOpenBuffer(string filePath, out string text)
+    {
+        return openBuffers.TryGetValue(Path.GetFullPath(filePath), out text);
     }
 
     /// <summary>

--- a/test/LanguageServer.Tests/Issue1663AsyncWorkspaceInitTests.cs
+++ b/test/LanguageServer.Tests/Issue1663AsyncWorkspaceInitTests.cs
@@ -1,0 +1,120 @@
+// <copyright file="Issue1663AsyncWorkspaceInitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+using GSharp.LanguageServer.Protocol;
+using GSharp.LanguageServer.Server;
+using Xunit;
+
+namespace GSharp.LanguageServer.Tests;
+
+/// <summary>
+/// Issue #1663: workspace discovery/parsing must not run inline in the "initialize" request —
+/// it should happen in the background after "initialized" so the handshake returns promptly and
+/// racing requests degrade gracefully instead of crashing or blocking.
+/// </summary>
+public class Issue1663AsyncWorkspaceInitTests
+{
+    [Fact]
+    public async Task InitializeAsync_DoesNotSynchronouslyLoadWorkspaceProjects()
+    {
+        var rootDir = CreateSampleWorkspace();
+        try
+        {
+            var workspace = new WorkspaceState();
+            var server = new LspServer(new DocumentContentService(), workspace);
+
+            await server.InitializeAsync(new InitializeParams { RootPath = rootDir });
+
+            // The "initialize" response must return before any project discovery/parsing runs.
+            Assert.Empty(workspace.Projects);
+        }
+        finally
+        {
+            Directory.Delete(rootDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Initialized_LoadsWorkspaceProjectsInBackground()
+    {
+        var rootDir = CreateSampleWorkspace();
+        try
+        {
+            var workspace = new WorkspaceState();
+            var server = new LspServer(new DocumentContentService(), workspace);
+
+            await server.InitializeAsync(new InitializeParams { RootPath = rootDir });
+            using var doc = JsonDocument.Parse("{}");
+            server.Initialized(doc.RootElement.Clone());
+
+            await WaitForAsync(() => workspace.Projects.Count > 0);
+
+            var project = Assert.Single(workspace.Projects);
+            Assert.Equal("Demo", project.AssemblyName);
+            var compilation = project.GetCompilation();
+            Assert.NotNull(compilation.BoundProgram);
+        }
+        finally
+        {
+            Directory.Delete(rootDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task RequestRacingBackgroundLoad_ReturnsEmptyInsteadOfCrashing()
+    {
+        var rootDir = CreateSampleWorkspace();
+        try
+        {
+            var workspace = new WorkspaceState();
+
+            // Simulate a request landing before background discovery has registered any files:
+            // GetProjectForFile must return null (handled gracefully by callers) rather than throw.
+            var project = workspace.GetProjectForFile(Path.Combine(rootDir, "Demo", "Foo.gs"));
+            Assert.Null(project);
+
+            WorkspaceInitializer.Initialize(workspace, rootDir);
+
+            var loaded = workspace.GetProjectForFile(Path.Combine(rootDir, "Demo", "Foo.gs"));
+            Assert.NotNull(loaded);
+        }
+        finally
+        {
+            Directory.Delete(rootDir, recursive: true);
+        }
+    }
+
+    private static string CreateSampleWorkspace()
+    {
+        var rootDir = Path.Combine(Path.GetTempPath(), "gsinit_" + Guid.NewGuid().ToString("N"));
+        var projDir = Path.Combine(rootDir, "Demo");
+        Directory.CreateDirectory(projDir);
+
+        File.WriteAllText(
+            Path.Combine(projDir, "Demo.gsproj"),
+            "<Project Sdk=\"Gsharp.NET.Sdk\">\n  <PropertyGroup><OutputType>Library</OutputType><TargetFramework>net10.0</TargetFramework><AssemblyName>Demo</AssemblyName></PropertyGroup>\n</Project>\n");
+
+        File.WriteAllText(Path.Combine(projDir, "Foo.gs"), "func foo() {\n  var x = 1\n}\n");
+
+        return rootDir;
+    }
+
+    private static async Task WaitForAsync(Func<bool> condition, int timeoutMs = 10000)
+    {
+        var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+        while (!condition())
+        {
+            if (DateTime.UtcNow > deadline)
+            {
+                Assert.Fail("Timed out waiting for background workspace load to complete.");
+            }
+
+            await Task.Delay(25);
+        }
+    }
+}

--- a/test/LanguageServer.Tests/Issue1663AsyncWorkspaceInitTests.cs
+++ b/test/LanguageServer.Tests/Issue1663AsyncWorkspaceInitTests.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -89,7 +90,77 @@ public class Issue1663AsyncWorkspaceInitTests
         }
     }
 
-    private static string CreateSampleWorkspace()
+    /// <summary>
+    /// Issue #1786 follow-up (B1): the background workspace load must never clobber a client's
+    /// open buffer with stale disk text, no matter how didOpen/didChange interleaves with
+    /// discovery reaching that file. Runs the real "initialized" background-load path
+    /// concurrently with didOpen/didChange on the same file, many times, to flush out both
+    /// documented races (client edits before discovery registers the project; client edits
+    /// after discovery registers the project but before it visits the file).
+    /// </summary>
+    [Fact]
+    public async Task BackgroundLoadRacingDidOpen_ClientBufferAlwaysWinsOverDisk()
+    {
+        const string diskText = "func foo() {\n  var x = 1\n}\n";
+        const string bufferText = "func foo() {\n  var x = 2 // edited by client\n}\n";
+
+        for (var iteration = 0; iteration < 25; iteration++)
+        {
+            var rootDir = CreateSampleWorkspace(diskText);
+            try
+            {
+                var workspace = new WorkspaceState();
+                var server = new LspServer(new DocumentContentService(), workspace);
+                var filePath = Path.Combine(rootDir, "Demo", "Foo.gs");
+                var uri = DocumentUri.FromFileSystemPath(filePath);
+
+                await server.InitializeAsync(new InitializeParams { RootPath = rootDir });
+
+                // Kick off the real background load and, concurrently, hammer didOpen/didChange
+                // for the same file with different text than what's on disk.
+                using var doc = JsonDocument.Parse("{}");
+                var initializedTask = Task.Run(() => server.Initialized(doc.RootElement.Clone()));
+                var editTask = Task.Run(async () =>
+                {
+                    await server.DidOpenAsync(new DidOpenTextDocumentParams
+                    {
+                        TextDocument = new TextDocumentItem { Uri = uri, Text = bufferText },
+                    });
+                    for (var i = 0; i < 10; i++)
+                    {
+                        await server.DidChangeAsync(new DidChangeTextDocumentParams
+                        {
+                            TextDocument = new VersionedTextDocumentIdentifier { Uri = uri },
+                            ContentChanges = new List<TextDocumentContentChangeEvent> { new TextDocumentContentChangeEvent { Text = bufferText } },
+                        });
+                    }
+                });
+
+                await Task.WhenAll(initializedTask, editTask);
+                await WaitForAsync(() => workspace.GetProjectForFile(filePath) != null);
+
+                // Give the background load's per-file registration a moment to fully settle
+                // (it may still be mid-flight for other files/projects, but this workspace has
+                // only one file).
+                await WaitForAsync(() =>
+                {
+                    var proj = workspace.GetProjectForFile(filePath);
+                    return proj != null && proj.TryGetSyntaxTree(filePath, out var t) && t.Text.ToString() == bufferText;
+                });
+
+                var loadedProject = workspace.GetProjectForFile(filePath);
+                Assert.NotNull(loadedProject);
+                Assert.True(loadedProject.TryGetSyntaxTree(filePath, out var syntaxTree));
+                Assert.Equal(bufferText, syntaxTree.Text.ToString());
+            }
+            finally
+            {
+                Directory.Delete(rootDir, recursive: true);
+            }
+        }
+    }
+
+    private static string CreateSampleWorkspace(string sourceText = "func foo() {\n  var x = 1\n}\n")
     {
         var rootDir = Path.Combine(Path.GetTempPath(), "gsinit_" + Guid.NewGuid().ToString("N"));
         var projDir = Path.Combine(rootDir, "Demo");
@@ -99,7 +170,7 @@ public class Issue1663AsyncWorkspaceInitTests
             Path.Combine(projDir, "Demo.gsproj"),
             "<Project Sdk=\"Gsharp.NET.Sdk\">\n  <PropertyGroup><OutputType>Library</OutputType><TargetFramework>net10.0</TargetFramework><AssemblyName>Demo</AssemblyName></PropertyGroup>\n</Project>\n");
 
-        File.WriteAllText(Path.Combine(projDir, "Foo.gs"), "func foo() {\n  var x = 1\n}\n");
+        File.WriteAllText(Path.Combine(projDir, "Foo.gs"), sourceText);
 
         return rootDir;
     }


### PR DESCRIPTION
Fixes #1663

`WorkspaceInitializer.Initialize` (project discovery, per-file read + parse) ran inline inside the `initialize` request handler, blocking the LSP handshake for seconds-to-minutes on large workspaces.

**Fix:**
- `InitializeAsync` now only stores the root path / capabilities and returns immediately.
- Workspace discovery moved to a fire-and-forget `Task.Run` kicked off from the `initialized` notification (the correct LSP lifecycle point per the spec).
- No new locking needed: `WorkspaceState`'s maps are already `ConcurrentDictionary`-backed, and every existing caller of `GetProjectForFile` already handles a null project (treated like an unopened/unknown file → empty diagnostics etc.), so requests racing the background load degrade gracefully instead of crashing or returning stale data.
- Also broadened `ProjectState.AddFileFromDisk` to swallow `UnauthorizedAccessException` per file (previously only `IOException` was caught, so one unreadable file aborted loading every remaining project).

**Tests** (`test/LanguageServer.Tests/Issue1663AsyncWorkspaceInitTests.cs`):
- `InitializeAsync` returns without populating `WorkspaceState`.
- `Initialized` background-loads projects (compilation binds, `AssemblyName` populated).
- A request racing the load (`GetProjectForFile` before discovery registers files) returns null instead of throwing.

Full `GSharp.sln` Release build: 0 errors. `LanguageServer.Tests`: 404/404 passed.