### PR TITLE
Fix #1641: respect shadowing in field-initializer instance-member scan

### DIFF
--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -4193,27 +4193,208 @@ internal sealed class DeclarationBinder
         SyntaxNode node,
         HashSet<string> forbiddenNames,
         out string offendingName,
+        out TextLocation offendingLocation) =>
+        TryFindInstanceMemberReference(node, forbiddenNames, new HashSet<string>(StringComparer.Ordinal), out offendingName, out offendingLocation);
+
+    /// <summary>
+    /// Issue #1641: scoped/shadow-aware variant of the scan above. A name that
+    /// resolves to a locally-introduced binding (lambda/function-literal
+    /// parameter, local <c>let</c>/<c>var</c>, deconstruction binding, pattern
+    /// capture, catch/for-loop variable, ...) shadows the instance member of
+    /// the same name and must not be flagged. <paramref name="shadowedNames"/>
+    /// carries the names bound by enclosing scopes down into this call.
+    /// </summary>
+    private static bool TryFindInstanceMemberReference(
+        SyntaxNode node,
+        HashSet<string> forbiddenNames,
+        HashSet<string> shadowedNames,
+        out string offendingName,
         out TextLocation offendingLocation)
     {
-        if (node is NameExpressionSyntax nameExpr &&
-            forbiddenNames.Contains(nameExpr.IdentifierToken.Text))
+        switch (node)
         {
-            offendingName = nameExpr.IdentifierToken.Text;
-            offendingLocation = nameExpr.IdentifierToken.Location;
-            return true;
+            case NameExpressionSyntax nameExpr:
+                if (forbiddenNames.Contains(nameExpr.IdentifierToken.Text) &&
+                    !shadowedNames.Contains(nameExpr.IdentifierToken.Text))
+                {
+                    offendingName = nameExpr.IdentifierToken.Text;
+                    offendingLocation = nameExpr.IdentifierToken.Location;
+                    return true;
+                }
+
+                break;
+
+            // Lambda / function-literal parameters shadow only within the body.
+            case LambdaExpressionSyntax lambda:
+                return TryFindInstanceMemberReference(
+                    lambda.Body, forbiddenNames, WithShadowed(shadowedNames, lambda.Parameters.Select(p => p.Identifier.Text)), out offendingName, out offendingLocation);
+
+            case FunctionLiteralExpressionSyntax func:
+                return TryFindInstanceMemberReference(
+                    func.Body, forbiddenNames, WithShadowed(shadowedNames, func.Parameters.Select(p => p.Identifier.Text)), out offendingName, out offendingLocation);
+
+            // Catch and loop variables shadow only within their body; the
+            // scrutinee/collection/bounds are evaluated in the outer scope.
+            case CatchClauseSyntax catchClause when catchClause.Identifier != null:
+                return TryFindInstanceMemberReference(
+                    catchClause.Body, forbiddenNames, WithShadowed(shadowedNames, new[] { catchClause.Identifier.Text }), out offendingName, out offendingLocation);
+
+            case ForRangeStatementSyntax forRange:
+                if (TryFindInstanceMemberReference(forRange.Collection, forbiddenNames, shadowedNames, out offendingName, out offendingLocation))
+                {
+                    return true;
+                }
+
+                var forRangeNames = forRange.SecondIdentifier != null
+                    ? new[] { forRange.FirstIdentifier.Text, forRange.SecondIdentifier.Text }
+                    : new[] { forRange.FirstIdentifier.Text };
+                return TryFindInstanceMemberReference(forRange.Body, forbiddenNames, WithShadowed(shadowedNames, forRangeNames), out offendingName, out offendingLocation);
+
+            case ForEllipsisStatementSyntax forEllipsis:
+                if (TryFindInstanceMemberReference(forEllipsis.LowerBound, forbiddenNames, shadowedNames, out offendingName, out offendingLocation) ||
+                    TryFindInstanceMemberReference(forEllipsis.UpperBound, forbiddenNames, shadowedNames, out offendingName, out offendingLocation))
+                {
+                    return true;
+                }
+
+                return TryFindInstanceMemberReference(
+                    forEllipsis.Body, forbiddenNames, WithShadowed(shadowedNames, new[] { forEllipsis.Identifier.Text }), out offendingName, out offendingLocation);
+
+            case AwaitForRangeStatementSyntax awaitForRange:
+                if (TryFindInstanceMemberReference(awaitForRange.Stream, forbiddenNames, shadowedNames, out offendingName, out offendingLocation))
+                {
+                    return true;
+                }
+
+                return TryFindInstanceMemberReference(
+                    awaitForRange.Body, forbiddenNames, WithShadowed(shadowedNames, new[] { awaitForRange.Identifier.Text }), out offendingName, out offendingLocation);
+
+            // `if let` bindings are visible only in the then/else clauses, not
+            // to statements following the `if`.
+            case IfLetStatementSyntax ifLet:
+                var ifLetNames = new List<string>();
+                foreach (var binding in ifLet.Bindings)
+                {
+                    if (TryFindInstanceMemberReference(binding.Initializer, forbiddenNames, shadowedNames, out offendingName, out offendingLocation))
+                    {
+                        return true;
+                    }
+
+                    ifLetNames.Add(binding.Identifier.Text);
+                }
+
+                var ifLetShadowed = WithShadowed(shadowedNames, ifLetNames);
+                if (TryFindInstanceMemberReference(ifLet.ThenStatement, forbiddenNames, ifLetShadowed, out offendingName, out offendingLocation))
+                {
+                    return true;
+                }
+
+                return ifLet.ElseClause != null &&
+                    TryFindInstanceMemberReference(ifLet.ElseClause, forbiddenNames, shadowedNames, out offendingName, out offendingLocation);
         }
 
+        // Generic default: sequentially walk this node's children, growing a
+        // local shadow set as declaration-introducing children are seen so
+        // later siblings (e.g. a subsequent statement in the same block) see
+        // names bound by an earlier `let`/`var`, deconstruction, `guard let`,
+        // or pattern capture — matching how those bindings extend the
+        // enclosing scope.
+        var local = shadowedNames;
+        var cloned = false;
         foreach (var child in node.GetChildren())
         {
-            if (TryFindInstanceMemberReference(child, forbiddenNames, out offendingName, out offendingLocation))
+            if (TryFindInstanceMemberReference(child, forbiddenNames, local, out offendingName, out offendingLocation))
             {
                 return true;
+            }
+
+            var declared = GetSequentiallyDeclaredNames(child);
+            if (declared != null)
+            {
+                if (!cloned)
+                {
+                    local = new HashSet<string>(local, StringComparer.Ordinal);
+                    cloned = true;
+                }
+
+                foreach (var name in declared)
+                {
+                    local.Add(name);
+                }
             }
         }
 
         offendingName = null;
         offendingLocation = default;
         return false;
+    }
+
+    /// <summary>Returns a copy of <paramref name="shadowedNames"/> with <paramref name="newNames"/> added.</summary>
+    private static HashSet<string> WithShadowed(HashSet<string> shadowedNames, IEnumerable<string> newNames)
+    {
+        var result = new HashSet<string>(shadowedNames, StringComparer.Ordinal);
+        foreach (var name in newNames)
+        {
+            result.Add(name);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Names bound by <paramref name="node"/> that remain visible to its
+    /// following siblings within the enclosing node's child list — plain
+    /// local declarations (<c>let</c>/<c>var</c>, tuple/named deconstruction,
+    /// <c>guard let</c>) and pattern captures (e.g. <c>x is Foo y</c> or a
+    /// <c>match</c> arm pattern), which this scan conservatively treats as
+    /// shadowing for the rest of the initializer rather than modelling
+    /// precise flow-sensitive scoping. Returns <c>null</c> when the node
+    /// introduces no such bindings.
+    /// </summary>
+    private static IEnumerable<string> GetSequentiallyDeclaredNames(SyntaxNode node)
+    {
+        switch (node)
+        {
+            case VariableDeclarationSyntax variableDeclaration:
+                return new[] { variableDeclaration.Identifier.Text };
+
+            case TupleDeconstructionStatementSyntax tupleDeconstruction:
+                return tupleDeconstruction.Identifiers.Select(t => t.Text).ToArray();
+
+            case NamedDeconstructionStatementSyntax namedDeconstruction:
+                return namedDeconstruction.Fields.Select(f => f.LocalIdentifier.Text).ToArray();
+
+            case GuardLetStatementSyntax guardLet:
+                return guardLet.Bindings.Select(b => b.Identifier.Text).ToArray();
+
+            case PatternSyntax pattern:
+                var captures = new List<string>();
+                CollectPatternCaptureNames(pattern, captures);
+                return captures.Count > 0 ? captures : null;
+
+            default:
+                return null;
+        }
+    }
+
+    /// <summary>Recursively collects capture names (e.g. <c>y</c> in the type pattern <c>Foo y</c>, or <c>rest</c> in a slice pattern) from a pattern subtree.</summary>
+    private static void CollectPatternCaptureNames(SyntaxNode node, List<string> captures)
+    {
+        switch (node)
+        {
+            case TypePatternSyntax typePattern when typePattern.Identifier != null:
+                captures.Add(typePattern.Identifier.Text);
+                break;
+
+            case SlicePatternSyntax slicePattern when slicePattern.CaptureIdentifier != null:
+                captures.Add(slicePattern.CaptureIdentifier.Text);
+                break;
+        }
+
+        foreach (var child in node.GetChildren())
+        {
+            CollectPatternCaptureNames(child, captures);
+        }
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -4203,6 +4203,15 @@ internal sealed class DeclarationBinder
     /// capture, catch/for-loop variable, ...) shadows the instance member of
     /// the same name and must not be flagged. <paramref name="shadowedNames"/>
     /// carries the names bound by enclosing scopes down into this call.
+    /// Note: unlike C#, G#'s <c>is</c> operator (<see cref="IsExpressionSyntax"/>)
+    /// is a plain type test with no capture — <c>expr is T name</c> does not
+    /// exist. The only pattern captures reachable here come from
+    /// <c>switch</c>/<c>match</c> arm patterns (<see cref="TypePatternSyntax"/>,
+    /// <see cref="SlicePatternSyntax"/>), which the generic child walk already
+    /// scopes correctly: a capture is added to the shadow set only while
+    /// iterating the owning <see cref="SwitchCaseSyntax"/>/
+    /// <see cref="SwitchExpressionArmSyntax"/>'s own children (guard + body),
+    /// never leaking to sibling arms or the enclosing scope.
     /// </summary>
     private static bool TryFindInstanceMemberReference(
         SyntaxNode node,
@@ -4225,6 +4234,11 @@ internal sealed class DeclarationBinder
                 break;
 
             // Lambda / function-literal parameters shadow only within the body.
+            // Param default-value expressions (ADR-0063) and type clauses are
+            // intentionally not scanned: defaults are restricted by the binder
+            // to compile-time constants (numeric/bool/char/string/enum/nil),
+            // which can never resolve to an instance member, and type clauses
+            // carry no expressions either.
             case LambdaExpressionSyntax lambda:
                 return TryFindInstanceMemberReference(
                     lambda.Body, forbiddenNames, WithShadowed(shadowedNames, lambda.Parameters.Select(p => p.Identifier.Text)), out offendingName, out offendingLocation);

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -9809,7 +9809,12 @@ public class Parser
         // If the current token is `if` and this could be an if-expression
         // (value-producing), parse it as an expression statement wrapping
         // an IfExpressionSyntax. This handles nested `if` in block position.
-        if (Current.Kind == SyntaxKind.IfKeyword && LooksLikeIfExpression())
+        // `if let` (ADR-0071) is always a statement, never a value-producing
+        // if-expression, even when it ends in a plain `else { … }` — without
+        // this check `LooksLikeIfExpression` would misparse `if let x = y {
+        // … } else { … }` as an if-expression, since it only inspects the
+        // shape of the trailing else, not the `let` after `if`.
+        if (Current.Kind == SyntaxKind.IfKeyword && Peek(1).Kind != SyntaxKind.LetKeyword && LooksLikeIfExpression())
         {
             var ifExpr = ParseIfExpression();
             return new ExpressionStatementSyntax(syntaxTree, ifExpr);

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1641FieldInitializerShadowingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1641FieldInitializerShadowingTests.cs
@@ -1,0 +1,119 @@
+// <copyright file="Issue1641FieldInitializerShadowingTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1641: the instance field initializer scan
+/// (<c>DeclarationBinder.TryFindInstanceMemberReference</c>) must respect
+/// scoping/shadowing. A lambda parameter, nested lambda parameter, or local
+/// binding that shares a name with an instance member must not be treated as
+/// an illegal instance-member reference (GS0377) — only a name that
+/// genuinely resolves to the instance member, unshadowed, may be flagged.
+/// </summary>
+public class Issue1641FieldInitializerShadowingTests
+{
+    [Fact]
+    public void FieldInitializer_LambdaParamShadowsFieldName_NoGS0377()
+    {
+        const string source =
+            "package p\n" +
+            "class C {\n" +
+            "    let value int32 = 5\n" +
+            "    let Compare (int32) -> bool = (value int32) -> value > 0\n" +
+            "}\n";
+
+        var diagnostics = GetDiagnostics(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0377");
+    }
+
+    [Fact]
+    public void FieldInitializer_GenuineInstanceMemberReference_StillReportsGS0377()
+    {
+        const string source =
+            "package p\n" +
+            "class C {\n" +
+            "    let value int32 = 5\n" +
+            "    let Other int32 = value + 1\n" +
+            "}\n";
+
+        var diagnostics = GetDiagnostics(source);
+
+        Assert.Contains(diagnostics, d => d.Id == "GS0377");
+    }
+
+    [Fact]
+    public void FieldInitializer_NestedLambdaParamShadowsFieldName_NoGS0377()
+    {
+        const string source =
+            "package p\n" +
+            "class C {\n" +
+            "    let value int32 = 5\n" +
+            "    let F (int32) -> (int32) -> int32 = (x int32) -> (value int32) -> value + x\n" +
+            "}\n";
+
+        var diagnostics = GetDiagnostics(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0377");
+    }
+
+    [Fact]
+    public void FieldInitializer_LocalLetShadowsFieldName_NoGS0377()
+    {
+        // A field initializer can only be a bare expression (block
+        // expressions are only legal as a lambda/if-expression body), so the
+        // local `let` lives inside the lambda's block body.
+        const string source =
+            "package p\n" +
+            "class C {\n" +
+            "    let value int32 = 5\n" +
+            "    let F (int32) -> int32 = (x int32) -> {\n" +
+            "        let value int32 = 10\n" +
+            "        value\n" +
+            "    }\n" +
+            "}\n";
+
+        var diagnostics = GetDiagnostics(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0377");
+    }
+
+    [Fact]
+    public void FieldInitializer_ReferenceOutsideLambdaScope_StillReportsGS0377()
+    {
+        // The inner lambda parameter `value` only shadows the field inside
+        // its own body; the trailing `+ value` refers to the instance field
+        // and must still be rejected.
+        const string source =
+            "package p\n" +
+            "class C {\n" +
+            "    let value int32 = 5\n" +
+            "    let F (int32) -> int32 = (x int32) -> {\n" +
+            "        let g (int32) -> int32 = (value int32) -> value + 1\n" +
+            "        g(3) + value\n" +
+            "    }\n" +
+            "}\n";
+
+        var diagnostics = GetDiagnostics(source);
+
+        Assert.Contains(diagnostics, d => d.Id == "GS0377");
+    }
+
+    private static IEnumerable<Diagnostic> GetDiagnostics(string source)
+    {
+        var tree = SyntaxTree.Parse(source);
+        var compilation = new Compilation(tree);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        return result.Diagnostics.ToList();
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1641FieldInitializerShadowingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1641FieldInitializerShadowingTests.cs
@@ -109,6 +109,382 @@ public class Issue1641FieldInitializerShadowingTests
         Assert.Contains(diagnostics, d => d.Id == "GS0377");
     }
 
+    [Fact]
+    public void FieldInitializer_CatchVariableShadowsMemberName_NoGS0377()
+    {
+        const string source =
+            "package p\n" +
+            "class C {\n" +
+            "    let value int32 = 5\n" +
+            "    let F (int32) -> int32 = (x int32) -> {\n" +
+            "        try {\n" +
+            "            x\n" +
+            "        } catch (value Exception) {\n" +
+            "            value.Message.Length\n" +
+            "        }\n" +
+            "    }\n" +
+            "}\n";
+
+        var diagnostics = GetDiagnostics(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0377");
+    }
+
+    [Fact]
+    public void FieldInitializer_CatchClause_GenuineMemberReferenceInTryBlock_StillReportsGS0377()
+    {
+        const string source =
+            "package p\n" +
+            "class C {\n" +
+            "    let value int32 = 5\n" +
+            "    let F (int32) -> int32 = (x int32) -> {\n" +
+            "        try {\n" +
+            "            value\n" +
+            "        } catch (e Exception) {\n" +
+            "            x\n" +
+            "        }\n" +
+            "    }\n" +
+            "}\n";
+
+        var diagnostics = GetDiagnostics(source);
+
+        Assert.Contains(diagnostics, d => d.Id == "GS0377");
+    }
+
+    [Fact]
+    public void FieldInitializer_ForRangeVariableShadowsMemberName_NoGS0377()
+    {
+        const string source =
+            "package p\n" +
+            "class C {\n" +
+            "    let value int32 = 5\n" +
+            "    let F ([]int32) -> int32 = (xs []int32) -> {\n" +
+            "        var total int32 = 0\n" +
+            "        for value in xs {\n" +
+            "            total = total + value\n" +
+            "        }\n" +
+            "        total\n" +
+            "    }\n" +
+            "}\n";
+
+        var diagnostics = GetDiagnostics(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0377");
+    }
+
+    [Fact]
+    public void FieldInitializer_ForRangeBody_GenuineMemberReference_StillReportsGS0377()
+    {
+        const string source =
+            "package p\n" +
+            "class C {\n" +
+            "    let value int32 = 5\n" +
+            "    let F ([]int32) -> int32 = (xs []int32) -> {\n" +
+            "        var total int32 = 0\n" +
+            "        for v in xs {\n" +
+            "            total = total + value\n" +
+            "        }\n" +
+            "        total\n" +
+            "    }\n" +
+            "}\n";
+
+        var diagnostics = GetDiagnostics(source);
+
+        Assert.Contains(diagnostics, d => d.Id == "GS0377");
+    }
+
+    [Fact]
+    public void FieldInitializer_ForEllipsisVariableShadowsMemberName_NoGS0377()
+    {
+        const string source =
+            "package p\n" +
+            "class C {\n" +
+            "    let value int32 = 5\n" +
+            "    let F (int32) -> int32 = (x int32) -> {\n" +
+            "        var total int32 = 0\n" +
+            "        for value in 0 ... x {\n" +
+            "            total = total + value\n" +
+            "        }\n" +
+            "        total\n" +
+            "    }\n" +
+            "}\n";
+
+        var diagnostics = GetDiagnostics(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0377");
+    }
+
+    [Fact]
+    public void FieldInitializer_ForEllipsisBody_GenuineMemberReference_StillReportsGS0377()
+    {
+        const string source =
+            "package p\n" +
+            "class C {\n" +
+            "    let value int32 = 5\n" +
+            "    let F (int32) -> int32 = (x int32) -> {\n" +
+            "        var total int32 = 0\n" +
+            "        for i in 0 ... x {\n" +
+            "            total = total + value\n" +
+            "        }\n" +
+            "        total\n" +
+            "    }\n" +
+            "}\n";
+
+        var diagnostics = GetDiagnostics(source);
+
+        Assert.Contains(diagnostics, d => d.Id == "GS0377");
+    }
+
+    [Fact]
+    public void FieldInitializer_AwaitForRangeVariableShadowsMemberName_NoGS0377()
+    {
+        const string source =
+            "import System.Linq\n" +
+            "import GSharp.Core.Tests.CodeAnalysis.Binding\n" +
+            "package p\n" +
+            "class C {\n" +
+            "    let value int32 = 5\n" +
+            "    let F async () -> int32 = async () -> {\n" +
+            "        var total int32 = 0\n" +
+            "        await for value in AsyncStreamFixture.Counts() {\n" +
+            "            total = total + value\n" +
+            "        }\n" +
+            "        total\n" +
+            "    }\n" +
+            "}\n";
+
+        var diagnostics = GetDiagnostics(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0377");
+    }
+
+    [Fact]
+    public void FieldInitializer_AwaitForRangeBody_GenuineMemberReference_StillReportsGS0377()
+    {
+        const string source =
+            "import System.Linq\n" +
+            "import GSharp.Core.Tests.CodeAnalysis.Binding\n" +
+            "package p\n" +
+            "class C {\n" +
+            "    let value int32 = 5\n" +
+            "    let F async () -> int32 = async () -> {\n" +
+            "        var total int32 = 0\n" +
+            "        await for v in AsyncStreamFixture.Counts() {\n" +
+            "            total = total + value\n" +
+            "        }\n" +
+            "        total\n" +
+            "    }\n" +
+            "}\n";
+
+        var diagnostics = GetDiagnostics(source);
+
+        Assert.Contains(diagnostics, d => d.Id == "GS0377");
+    }
+
+    [Fact]
+    public void FieldInitializer_IfLetBindingShadowsMemberName_NoGS0377InThenBranch()
+    {
+        // `if let` is a statement (not an if-expression), so its branches
+        // use `return` rather than a trailing value.
+        const string source =
+            "package p\n" +
+            "class C {\n" +
+            "    let value string? = nil\n" +
+            "    let F (string?) -> int32 = (s string?) -> {\n" +
+            "        if let value = s {\n" +
+            "            return value.Length\n" +
+            "        }\n" +
+            "        return 0\n" +
+            "    }\n" +
+            "}\n";
+
+        var diagnostics = GetDiagnostics(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0377");
+    }
+
+    [Fact]
+    public void FieldInitializer_IfLetElseBranch_GenuineMemberReference_StillReportsGS0377()
+    {
+        // The `if let` binding is not visible in the else branch, so a
+        // reference to the member name there is a genuine, unshadowed
+        // instance-member access and must still be flagged.
+        const string source =
+            "package p\n" +
+            "class C {\n" +
+            "    let value int32 = 5\n" +
+            "    let text string? = nil\n" +
+            "    let F (string?) -> int32 = (s string?) -> {\n" +
+            "        if let value = s {\n" +
+            "            return 0\n" +
+            "        } else {\n" +
+            "            return value\n" +
+            "        }\n" +
+            "    }\n" +
+            "}\n";
+
+        var diagnostics = GetDiagnostics(source);
+
+        Assert.Contains(diagnostics, d => d.Id == "GS0377");
+    }
+
+    [Fact]
+    public void FieldInitializer_GuardLetBindingShadowsMemberName_NoGS0377()
+    {
+        const string source =
+            "package p\n" +
+            "class C {\n" +
+            "    let value string? = nil\n" +
+            "    let F (string?) -> int32 = (s string?) -> {\n" +
+            "        guard let value = s else {\n" +
+            "            return 0\n" +
+            "        }\n" +
+            "        return value.Length\n" +
+            "    }\n" +
+            "}\n";
+
+        var diagnostics = GetDiagnostics(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0377");
+    }
+
+    [Fact]
+    public void FieldInitializer_GuardLetTail_GenuineMemberReference_StillReportsGS0377()
+    {
+        const string source =
+            "package p\n" +
+            "class C {\n" +
+            "    let value int32 = 5\n" +
+            "    let text string? = nil\n" +
+            "    let F (string?) -> int32 = (s string?) -> {\n" +
+            "        guard let x = s else {\n" +
+            "            return 0\n" +
+            "        }\n" +
+            "        return value\n" +
+            "    }\n" +
+            "}\n";
+
+        var diagnostics = GetDiagnostics(source);
+
+        Assert.Contains(diagnostics, d => d.Id == "GS0377");
+    }
+
+    [Fact]
+    public void FieldInitializer_TupleDeconstructionShadowsMemberName_NoGS0377()
+    {
+        const string source =
+            "package p\n" +
+            "class C {\n" +
+            "    let value int32 = 5\n" +
+            "    let F ((int32, int32)) -> int32 = (p (int32, int32)) -> {\n" +
+            "        let (value, y) = p\n" +
+            "        value + y\n" +
+            "    }\n" +
+            "}\n";
+
+        var diagnostics = GetDiagnostics(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0377");
+    }
+
+    [Fact]
+    public void FieldInitializer_TupleDeconstructionTail_GenuineMemberReference_StillReportsGS0377()
+    {
+        const string source =
+            "package p\n" +
+            "class C {\n" +
+            "    let value int32 = 5\n" +
+            "    let F ((int32, int32)) -> int32 = (p (int32, int32)) -> {\n" +
+            "        let (a, b) = p\n" +
+            "        a + b + value\n" +
+            "    }\n" +
+            "}\n";
+
+        var diagnostics = GetDiagnostics(source);
+
+        Assert.Contains(diagnostics, d => d.Id == "GS0377");
+    }
+
+    [Fact]
+    public void FieldInitializer_NamedDeconstructionShadowsMemberName_NoGS0377()
+    {
+        const string source =
+            "package p\n" +
+            "class C {\n" +
+            "    let value int32 = 5\n" +
+            "    let F ((int32, int32)) -> int32 = (p (int32, int32)) -> {\n" +
+            "        let { Item1 = value } = p\n" +
+            "        value\n" +
+            "    }\n" +
+            "}\n";
+
+        var diagnostics = GetDiagnostics(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0377");
+    }
+
+    [Fact]
+    public void FieldInitializer_NamedDeconstructionTail_GenuineMemberReference_StillReportsGS0377()
+    {
+        const string source =
+            "package p\n" +
+            "class C {\n" +
+            "    let value int32 = 5\n" +
+            "    let F ((int32, int32)) -> int32 = (p (int32, int32)) -> {\n" +
+            "        let { Item1 = a } = p\n" +
+            "        a + value\n" +
+            "    }\n" +
+            "}\n";
+
+        var diagnostics = GetDiagnostics(source);
+
+        Assert.Contains(diagnostics, d => d.Id == "GS0377");
+    }
+
+    [Fact]
+    public void FieldInitializer_SwitchTypePatternCaptureShadowsMemberName_NoGS0377()
+    {
+        // A `switch` arm's type-pattern capture (e.g. `case value is int32:`)
+        // is the only capture-producing pattern form G# supports (there is no
+        // C#-style `expr is T name` capture at expression level); the capture
+        // is visible in the guard/result of its own arm only.
+        const string source =
+            "package p\n" +
+            "class C {\n" +
+            "    let value int32 = 5\n" +
+            "    let F (object) -> int32 = (o object) -> {\n" +
+            "        switch o {\n" +
+            "            case value is int32: value\n" +
+            "            default: 0\n" +
+            "        }\n" +
+            "    }\n" +
+            "}\n";
+
+        var diagnostics = GetDiagnostics(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0377");
+    }
+
+    [Fact]
+    public void FieldInitializer_SwitchArm_GenuineMemberReference_StillReportsGS0377()
+    {
+        const string source =
+            "package p\n" +
+            "class C {\n" +
+            "    let value int32 = 5\n" +
+            "    let F (object) -> int32 = (o object) -> {\n" +
+            "        switch o {\n" +
+            "            case x is int32: value\n" +
+            "            default: 0\n" +
+            "        }\n" +
+            "    }\n" +
+            "}\n";
+
+        var diagnostics = GetDiagnostics(source);
+
+        Assert.Contains(diagnostics, d => d.Id == "GS0377");
+    }
+
     private static IEnumerable<Diagnostic> GetDiagnostics(string source)
     {
         var tree = SyntaxTree.Parse(source);


### PR DESCRIPTION
Fixes #1641

## Problem
`DeclarationBinder.TryFindInstanceMemberReference` flagged any `NameExpressionSyntax` matching an instance-member/primary-ctor-param name as an illegal GS0377 reference, purely by text. A lambda parameter (or any locally-introduced binding) sharing a field's name was wrongly rejected even though it shadows the field, not references it.

## Fix
The scan now threads a shadowed-names set through the syntax walk:
- Lambda/function-literal parameters, catch-clause and for/foreach/for-range/for-ellipsis loop variables shadow only within their own body/sub-scope.
- `if let` bindings shadow only in the then/else clauses.
- Local `let`/`var`, tuple/named deconstruction, `guard let`, and pattern captures (e.g. `x is Foo y`) shadow for the rest of the enclosing block, matching how those bindings extend scope elsewhere in the binder.

Only a name that is *not* currently shadowed is reported as GS0377.

## Tests
Added `test/Core.Tests/CodeAnalysis/Binding/Issue1641FieldInitializerShadowingTests.cs`:
- lambda param shadowing a field name → no GS0377
- nested lambda param shadowing → no GS0377
- local `let` shadowing (inside a lambda block body, since bare block expressions aren't valid field initializers) → no GS0377
- genuine instance-member reference → still GS0377
- reference outside the shadowing scope in the same initializer → still GS0377

`dotnet build GSharp.sln -c Release -graph`: 0 errors. Full `Core.Tests` suite: 5120 passed, 0 failed.