### PR TITLE
Fix #1671: SourceLink, deterministic CI build, symbols for all shipped packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,10 @@ jobs:
         uses: actions/upload-artifact@v5
         with:
           name: nuget-packages
-          path: out/bin/Release/nupkgs/*.nupkg
+          # Include .snupkg symbol packages alongside .nupkg so they survive
+          # to the publish job (dotnet nuget push / gh release upload need
+          # them co-located in ./nupkgs to pick them up).
+          path: out/bin/Release/nupkgs/*
 
   e2e:
     runs-on: ubuntu-latest
@@ -225,7 +228,7 @@ jobs:
         run: |
           gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" \
             || gh release create "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --generate-notes --title "$GITHUB_REF_NAME"
-          gh release upload "$GITHUB_REF_NAME" ./nupkgs/*.nupkg ./vsix/*.vsix --repo "$GITHUB_REPOSITORY" --clobber
+          gh release upload "$GITHUB_REF_NAME" ./nupkgs/*.nupkg ./nupkgs/*.snupkg ./vsix/*.vsix --repo "$GITHUB_REPOSITORY" --clobber
 
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v5

--- a/build/gsharp.build.props
+++ b/build/gsharp.build.props
@@ -75,6 +75,20 @@
     <DocumentationFile Condition="'$(IsTestProject)' != 'true'">$(OutputPath)/$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
 
+  <!-- Shipping hygiene (issue #1671): SourceLink + deterministic CI build +
+       symbols for every packable project. Applies to all non-test projects
+       so future packages inherit it automatically. -->
+  <PropertyGroup Condition="'$(IsTestProject)' != 'true'">
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols Condition="'$(IncludeSymbols)' == ''">true</IncludeSymbols>
+    <SymbolPackageFormat Condition="'$(SymbolPackageFormat)' == ''">snupkg</SymbolPackageFormat>
+    <ContinuousIntegrationBuild Condition="'$(TF_BUILD)' == 'true' or '$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(IsTestProject)' != 'true'">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
   <!-- Versioning Support -->
   <ItemGroup>
     <PackageReference Include="@(NerdBankGitVersioningPackageReference)" />

--- a/build/gsharp.build.props
+++ b/build/gsharp.build.props
@@ -86,7 +86,9 @@
     <ContinuousIntegrationBuild Condition="'$(TF_BUILD)' == 'true' or '$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
   </PropertyGroup>
   <ItemGroup Condition="'$(IsTestProject)' != 'true'">
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+    <!-- Skip for content-only packages (e.g. Gsharp.Templates, IncludeBuildOutput=false):
+         SourceLink embeds build/debug info that such packages never produce. -->
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" Condition="'$(IncludeBuildOutput)' != 'false'" />
   </ItemGroup>
 
   <!-- Versioning Support -->

--- a/src/Sdk/Gsharp.Templates/Gsharp.Templates.csproj
+++ b/src/Sdk/Gsharp.Templates/Gsharp.Templates.csproj
@@ -5,6 +5,9 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <NoWarn>$(NoWarn);NU5128;NU5100</NoWarn>
     <IncludeBuildOutput>false</IncludeBuildOutput>
+    <!-- No compiled output means no PDB to symbol-package (issue #1671's central
+         IncludeSymbols=true would otherwise produce an empty, invalid .snupkg). -->
+    <IncludeSymbols>false</IncludeSymbols>
 
     <PackageType>Template</PackageType>
     <PackageId>Gsharp.Templates</PackageId>


### PR DESCRIPTION
Fixes #1671

Adds standard NuGet packaging hygiene centrally so every current and future packable project inherits it (no per-csproj edits needed):

- `Microsoft.SourceLink.GitHub` + `PublishRepositoryUrl`/`EmbedUntrackedSources` in `build/gsharp.build.props` (imported by root `Directory.Build.props`), scoped to non-test projects.
- `ContinuousIntegrationBuild` gated on `$(TF_BUILD)`/`$(GITHUB_ACTIONS)` so local builds are unaffected.
- `IncludeSymbols=true` + `SymbolPackageFormat=snupkg` centrally, which now also covers `gsi` (Gsharp.Repl) — previously only the custom Gsharp.NET.Sdk's `Sdk.props` set these, and that only applies to consumer `.gsproj` projects, not `Repl.csproj` itself.
- `Gsharp.Templates` opts out of `IncludeSymbols` since it's content-only (`IncludeBuildOutput=false`, no compiled output/PDB) — leaving it on produced an empty/invalid `.snupkg` (NU5017).

Verified:
- `dotnet build GSharp.sln -c Release -graph` succeeds locally (no CI env vars) and with `GITHUB_ACTIONS=true`/`GITHUB_ENV` set (simulating Actions).
- Inspected produced `Gsharp.Repl` (`gsi`) `.nupkg`/`.snupkg`: PDBs now shipped in `.snupkg`, nuspec has `<repository type="Git" ...>`.
- `sourcelink test` (dotnet-sourcelink tool) passes on `gsi.pdb`; under simulated CI, embedded source paths normalize to deterministic `/_/...` form instead of local absolute paths.
- `Microsoft.SourceLink.GitHub` restores cleanly from nuget.org (repo's existing NuGet.config already includes it).