### PR TITLE
Fix #1631: user-overload resolution uses C#-faithful better-member ranking

### DIFF
--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -1177,21 +1177,14 @@ internal sealed class OverloadResolver
     /// </summary>
     private static int CompareUserConversions(OverloadResolution.ImplicitConversionKind ka, TypeSymbol paramA, bool tailA, OverloadResolution.ImplicitConversionKind kb, TypeSymbol paramB, bool tailB, TypeSymbol source)
     {
-        // Issue #1631 (B1): a normal-form (fixed-parameter) slot is always
-        // strictly better than an expanded-form (variadic tail) slot on the
-        // SAME argument, independent of each side's own conversion kind —
-        // C#'s "non-expanded form preferred over expanded form" rule
-        // (§7.5.3.2). Without this, a variadic candidate's tail argument
-        // (classified against the params element type) can out-rank a
-        // non-variadic sibling's real widening conversion and wrongly
-        // dominate it. When both sides are tail slots (two variadic
-        // candidates), fall through to the normal kind comparison so genuine
-        // element-type betterness still decides.
-        if (tailA != tailB)
-        {
-            return tailA ? 1 : -1;
-        }
-
+        // Issue #1631 (B1'): per C# §7.5.3.2, "non-expanded form preferred
+        // over expanded form" is a LATE tie-break applied only when per-arg
+        // betterness is otherwise tied across every argument — it is not a
+        // per-arg override. Per-arg comparison must rank purely on each
+        // side's own conversion kind (e.g. an exact element-type match on a
+        // variadic tail slot legitimately beats a widening conversion on a
+        // normal-form slot). Phase 2c (prefer non-variadic) applies the
+        // actual tie-break once all per-arg comparisons agree.
         if (ka != kb)
         {
             return ((int)ka).CompareTo((int)kb);

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -959,14 +959,40 @@ internal sealed class OverloadResolver
             // parameter type.
             var kinds = new OverloadResolution.ImplicitConversionKind[boundArguments.Count];
             var paramTypes = new TypeSymbol[boundArguments.Count];
+            var isTailSlot = new bool[boundArguments.Count];
+            var elementType = isVariadic && cand.Parameters[cand.Parameters.Length - 1].Type is SliceTypeSymbol variadicSlice
+                ? variadicSlice.ElementType
+                : null;
             for (var i = 0; i < boundArguments.Count; i++)
             {
                 var slot = MapArgumentIndexToParameterSlot(cand, argumentNames, i, parameterOffset, paramLen);
-                if (slot < 0 || slot >= paramCountForScore)
+                if (slot < 0)
                 {
-                    // Out of the fixed-parameter range (defaulted or variadic
-                    // tail) — neutral: contributes no per-argument preference.
+                    // Unmapped (shouldn't happen for an applicable candidate) —
+                    // neutral: contributes no per-argument preference.
                     kinds[i] = OverloadResolution.ImplicitConversionKind.Identity;
+                    continue;
+                }
+
+                if (slot >= paramCountForScore)
+                {
+                    // Issue #1631 (B1): variadic params-array tail argument.
+                    // Classify against the params ELEMENT type (so a genuine
+                    // widening in the tail is still visible) but flag the
+                    // slot as expanded-form. IsUserCandidateAtLeastAsGoodAs
+                    // below ranks an expanded-form slot strictly worse than a
+                    // normal-form slot on the SAME argument regardless of
+                    // conversion kind — C#'s "non-expanded form is preferred
+                    // over expanded form" rule (§7.5.3.2) — so a variadic
+                    // sibling can never dominate an applicable non-variadic
+                    // one purely because its tail was compared favourably.
+                    // Between two variadic candidates (both expanded), the
+                    // element-type kind still decides genuine betterness.
+                    isTailSlot[i] = true;
+                    var tailArgType = boundArguments[i]?.Type;
+                    kinds[i] = elementType == null
+                        ? OverloadResolution.ImplicitConversionKind.Identity
+                        : ClassifyUserArgumentConversionKind(tailArgType, elementType);
                     continue;
                 }
 
@@ -987,7 +1013,7 @@ internal sealed class OverloadResolver
                     : ClassifyUserArgumentConversionKind(argType, paramType);
             }
 
-            data.Add(new UserCandidateRankData(cand, kinds, paramTypes, defaultsUsed, isVariadic));
+            data.Add(new UserCandidateRankData(cand, kinds, paramTypes, isTailSlot, defaultsUsed, isVariadic));
         }
 
         // Phase 2a: pairwise domination. A candidate survives when no other
@@ -1026,7 +1052,12 @@ internal sealed class OverloadResolver
             }
         }
 
-        var pool = survivors.Count > 0 ? survivors : data;
+        // Domination is a strict partial order over a finite non-empty set
+        // (applicable.Count > 1 here), so a maximal element always survives —
+        // survivors is never empty; the old "fall back to data" branch was
+        // dead code.
+        System.Diagnostics.Debug.Assert(survivors.Count > 0, "pairwise domination must leave at least one survivor");
+        var pool = survivors;
 
         // Phase 2b: prefer the fewest defaulted parameters (an exact-arity
         // overload beats one that relies on defaults).
@@ -1079,11 +1110,12 @@ internal sealed class OverloadResolver
     /// </summary>
     private readonly struct UserCandidateRankData
     {
-        public UserCandidateRankData(FunctionSymbol candidate, OverloadResolution.ImplicitConversionKind[] kinds, TypeSymbol[] paramTypes, int defaultsUsed, bool isVariadic)
+        public UserCandidateRankData(FunctionSymbol candidate, OverloadResolution.ImplicitConversionKind[] kinds, TypeSymbol[] paramTypes, bool[] isTailSlot, int defaultsUsed, bool isVariadic)
         {
             Candidate = candidate;
             Kinds = kinds;
             ParamTypes = paramTypes;
+            IsTailSlot = isTailSlot;
             DefaultsUsed = defaultsUsed;
             IsVariadic = isVariadic;
         }
@@ -1093,6 +1125,13 @@ internal sealed class OverloadResolver
         public OverloadResolution.ImplicitConversionKind[] Kinds { get; }
 
         public TypeSymbol[] ParamTypes { get; }
+
+        /// <summary>
+        /// Gets per-argument flags set when the argument at that index bound
+        /// to this candidate's variadic params-array tail (as opposed to a
+        /// normal fixed parameter slot) (issue #1631, B1).
+        /// </summary>
+        public bool[] IsTailSlot { get; }
 
         public int DefaultsUsed { get; }
 
@@ -1111,7 +1150,7 @@ internal sealed class OverloadResolver
         var hasStrictlyBetter = false;
         for (var i = 0; i < a.Kinds.Length; i++)
         {
-            var cmp = CompareUserConversions(a.Kinds[i], a.ParamTypes[i], b.Kinds[i], b.ParamTypes[i], argTypes[i]);
+            var cmp = CompareUserConversions(a.Kinds[i], a.ParamTypes[i], a.IsTailSlot[i], b.Kinds[i], b.ParamTypes[i], b.IsTailSlot[i], argTypes[i]);
             if (cmp > 0)
             {
                 return false;
@@ -1136,8 +1175,23 @@ internal sealed class OverloadResolver
     /// helper rather than reimplementing the numeric/signed-vs-unsigned
     /// lattice a second time.
     /// </summary>
-    private static int CompareUserConversions(OverloadResolution.ImplicitConversionKind ka, TypeSymbol paramA, OverloadResolution.ImplicitConversionKind kb, TypeSymbol paramB, TypeSymbol source)
+    private static int CompareUserConversions(OverloadResolution.ImplicitConversionKind ka, TypeSymbol paramA, bool tailA, OverloadResolution.ImplicitConversionKind kb, TypeSymbol paramB, bool tailB, TypeSymbol source)
     {
+        // Issue #1631 (B1): a normal-form (fixed-parameter) slot is always
+        // strictly better than an expanded-form (variadic tail) slot on the
+        // SAME argument, independent of each side's own conversion kind —
+        // C#'s "non-expanded form preferred over expanded form" rule
+        // (§7.5.3.2). Without this, a variadic candidate's tail argument
+        // (classified against the params element type) can out-rank a
+        // non-variadic sibling's real widening conversion and wrongly
+        // dominate it. When both sides are tail slots (two variadic
+        // candidates), fall through to the normal kind comparison so genuine
+        // element-type betterness still decides.
+        if (tailA != tailB)
+        {
+            return tailA ? 1 : -1;
+        }
+
         if (ka != kb)
         {
             return ((int)ka).CompareTo((int)kb);
@@ -1185,6 +1239,12 @@ internal sealed class OverloadResolver
             return OverloadResolution.ImplicitConversionKind.NullableWrap;
         }
 
+        // ponytail: widening-then-wrap (e.g. int32 -> int64?) is not caught by
+        // the identity-underlying check above (argType != nullableParam.UnderlyingType)
+        // and falls through to the Reference bucket below instead of a rank
+        // between NumericWidening and Reference. No ImplicitConversionKind slot
+        // exists for it today; add one (and a matching CompareNumericTargets
+        // path against nullableParam.UnderlyingType) if a real ambiguity shows up.
         var argClr = argType.ClrType;
         var paramClr = paramType.ClrType;
         if (argClr != null && paramClr != null
@@ -1195,6 +1255,13 @@ internal sealed class OverloadResolver
             return OverloadResolution.ImplicitConversionKind.NumericWidening;
         }
 
+        // ponytail: object vs. an implemented interface (e.g. f(object) vs.
+        // f(IInterface) for a class arg) both fold into Reference here, so
+        // they tie and report GS0266 where C# would prefer the interface.
+        // Pre-existing ceiling (parity with the old linear score), not a
+        // #1631 regression. Upgrade path: split Reference into sub-kinds
+        // (exact-interface-satisfaction vs. base-class/object upcast) sharing
+        // more of Conversion.Classify's structure, if this surfaces in practice.
         return OverloadResolution.ImplicitConversionKind.Reference;
     }
 

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -914,12 +914,20 @@ internal sealed class OverloadResolver
             return applicable[0];
         }
 
-        // Phase 2: prefer candidates with the fewest defaulted parameters (an
-        // exact-arity overload beats one that relies on defaults). Also prefer
-        // a non-variadic candidate over a variadic one when both apply.
-        var bestScore = int.MaxValue;
-        FunctionSymbol best = null;
-        var tie = false;
+        // Phase 2 (issue #1631): rank by C# §7.5.3.2 "better function member"
+        // pairwise domination over per-argument conversion kind, reusing the
+        // SAME OverloadResolution.ImplicitConversionKind ranking (and numeric "better conversion
+        // target" tie-break) the CLR-reflection resolver
+        // (OverloadResolution.RankApplicable/CompareConversions) uses for
+        // imported-method overloads. This replaces the previous ad-hoc linear
+        // score, under which any two candidates that both needed an implicit
+        // conversion tied at score 0 (e.g. F(int64) / F(float64) called with an
+        // int32 constant) and reported a spurious GS0266 — even though one
+        // conversion is strictly "better" per C#. Only after the per-argument
+        // pairwise pass survivors are narrowed do the arity tie-breakers
+        // (fewest defaulted parameters, then non-variadic, then non-generic)
+        // run, matching the CLR path's phase ordering.
+        var data = new List<UserCandidateRankData>(applicable.Count);
         foreach (var cand in applicable)
         {
             var parameterOffset = cand.ExplicitReceiverParameter == null ? 0 : 1;
@@ -932,76 +940,262 @@ internal sealed class OverloadResolver
                 defaultsUsed = 0;
             }
 
-            // Apply a small penalty to variadic candidates (per ADR §6.6).
-            var score = defaultsUsed + (isVariadic ? 1 : 0);
-
             // For generic candidates, compute the inferred method-type
             // substitution so delegate parameter return types can be closed
-            // when scoring the value-return discard penalty below.
+            // when classifying the value-return discard case below.
             Dictionary<TypeParameterSymbol, TypeSymbol> candSubstitution = null;
             if (cand.IsGeneric)
             {
                 TryInferCandidateSubstitution(cand, boundArguments, argumentCount, out candSubstitution);
             }
 
-            // Score argument-type compatibility: +1 per exact-type match.
-            // Issue #1628: boundArguments[i] is source order, not parameter
-            // order — under named arguments the source-order index does not
-            // necessarily line up with the parameter it binds to (e.g. a
-            // named arg reorders a permutation-overload's parameters). Map
-            // each argument to its ACTUAL target slot (the same name→slot
-            // mapping IsApplicableUserCallable already validated) before
-            // scoring, so a named call still gets correct exact-match
-            // tie-breaking instead of being scored against the wrong param.
+            // Classify each supplied argument's conversion to its ACTUAL
+            // target slot. Issue #1628: boundArguments[i] is source order,
+            // not parameter order — under named arguments the source-order
+            // index does not necessarily line up with the parameter it binds
+            // to (e.g. a named arg reorders a permutation-overload's
+            // parameters). Map each argument to its real slot before
+            // classifying, so a named call still ranks against the correct
+            // parameter type.
+            var kinds = new OverloadResolution.ImplicitConversionKind[boundArguments.Count];
+            var paramTypes = new TypeSymbol[boundArguments.Count];
             for (var i = 0; i < boundArguments.Count; i++)
             {
                 var slot = MapArgumentIndexToParameterSlot(cand, argumentNames, i, parameterOffset, paramLen);
                 if (slot < 0 || slot >= paramCountForScore)
                 {
+                    // Out of the fixed-parameter range (defaulted or variadic
+                    // tail) — neutral: contributes no per-argument preference.
+                    kinds[i] = OverloadResolution.ImplicitConversionKind.Identity;
                     continue;
                 }
 
                 var argType = boundArguments[i]?.Type;
                 var paramType = cand.Parameters[slot + parameterOffset].Type;
-                if (argType != null && paramType != null && argType == paramType)
-                {
-                    score -= 10;
-                }
+                paramTypes[i] = paramType;
 
                 // Issue #1531 control: a value-returning delegate/method-group
                 // argument that maps onto a `(...)->void` delegate parameter
-                // discards its result. Penalize that mapping so a sibling
-                // `(...)->TResult` overload (whose delegate return closes to the
-                // argument's actual return type) is preferred — matching C#'s
-                // "better conversion from a method group" rule — instead of
-                // tying and reporting a spurious GS0266. Scoped strictly to the
-                // value-return-to-void-delegate shape, so it never disturbs the
-                // concrete-over-generic or defaulted-parameter preferences.
-                if (IsValueReturnDiscardedToVoidDelegate(argType, paramType, candSubstitution))
+                // discards its result. Classify it as C#'s worst-ranked
+                // "lambda to void delegate" conversion so a sibling
+                // `(...)->TResult` overload (whose delegate return closes to
+                // the argument's actual return type) is preferred — matching
+                // C#'s "better conversion from a method group" rule — instead
+                // of tying and reporting a spurious GS0266.
+                kinds[i] = IsValueReturnDiscardedToVoidDelegate(argType, paramType, candSubstitution)
+                    ? OverloadResolution.ImplicitConversionKind.LambdaToVoidDelegate
+                    : ClassifyUserArgumentConversionKind(argType, paramType);
+            }
+
+            data.Add(new UserCandidateRankData(cand, kinds, paramTypes, defaultsUsed, isVariadic));
+        }
+
+        // Phase 2a: pairwise domination. A candidate survives when no other
+        // candidate is "at least as good on every argument, and strictly
+        // better on at least one" (C# §7.5.3.2). Two candidates whose
+        // per-argument conversions are pairwise incomparable both survive —
+        // exactly the non-generic-vs-generic tie the previous strict-
+        // dominance-over-all-others requirement rejected.
+        var argTypes = new TypeSymbol[boundArguments.Count];
+        for (var i = 0; i < boundArguments.Count; i++)
+        {
+            argTypes[i] = boundArguments[i]?.Type;
+        }
+
+        var survivors = new List<UserCandidateRankData>(data.Count);
+        foreach (var c in data)
+        {
+            var dominated = false;
+            foreach (var o in data)
+            {
+                if (ReferenceEquals(c.Candidate, o.Candidate))
                 {
-                    score += 1;
+                    continue;
+                }
+
+                if (IsUserCandidateAtLeastAsGoodAs(o, c, argTypes))
+                {
+                    dominated = true;
+                    break;
                 }
             }
 
-            if (score < bestScore)
+            if (!dominated)
             {
-                bestScore = score;
-                best = cand;
-                tie = false;
-            }
-            else if (score == bestScore)
-            {
-                tie = true;
+                survivors.Add(c);
             }
         }
 
-        if (tie)
+        var pool = survivors.Count > 0 ? survivors : data;
+
+        // Phase 2b: prefer the fewest defaulted parameters (an exact-arity
+        // overload beats one that relies on defaults).
+        if (pool.Count > 1)
         {
-            ambiguous = true;
-            return null;
+            var minDefaults = pool.Min(w => w.DefaultsUsed);
+            var fewestDefaults = pool.Where(w => w.DefaultsUsed == minDefaults).ToList();
+            if (fewestDefaults.Count > 0 && fewestDefaults.Count < pool.Count)
+            {
+                pool = fewestDefaults;
+            }
         }
 
-        return best;
+        // Phase 2c: prefer a non-variadic candidate over a variadic one (per
+        // ADR §6.6 — the normal-form / non-expanded-params preference).
+        if (pool.Count > 1)
+        {
+            var nonVariadic = pool.Where(w => !w.IsVariadic).ToList();
+            if (nonVariadic.Count > 0 && nonVariadic.Count < pool.Count)
+            {
+                pool = nonVariadic;
+            }
+        }
+
+        // Phase 2d: prefer a non-generic candidate over a generic one when
+        // otherwise tied (C# §7.5.3.2's non-generic-over-generic tie-break).
+        if (pool.Count > 1)
+        {
+            var nonGeneric = pool.Where(w => !w.Candidate.IsGeneric).ToList();
+            if (nonGeneric.Count > 0 && nonGeneric.Count < pool.Count)
+            {
+                pool = nonGeneric;
+            }
+        }
+
+        if (pool.Count == 1)
+        {
+            return pool[0].Candidate;
+        }
+
+        ambiguous = true;
+        return null;
+    }
+
+    /// <summary>
+    /// Per-candidate data accumulated during Phase 2 user-overload ranking
+    /// (issue #1631): the per-argument conversion classification plus the
+    /// arity axes (defaulted-parameter count, variadic-ness) used by the
+    /// tie-breakers that run after pairwise domination.
+    /// </summary>
+    private readonly struct UserCandidateRankData
+    {
+        public UserCandidateRankData(FunctionSymbol candidate, OverloadResolution.ImplicitConversionKind[] kinds, TypeSymbol[] paramTypes, int defaultsUsed, bool isVariadic)
+        {
+            Candidate = candidate;
+            Kinds = kinds;
+            ParamTypes = paramTypes;
+            DefaultsUsed = defaultsUsed;
+            IsVariadic = isVariadic;
+        }
+
+        public FunctionSymbol Candidate { get; }
+
+        public OverloadResolution.ImplicitConversionKind[] Kinds { get; }
+
+        public TypeSymbol[] ParamTypes { get; }
+
+        public int DefaultsUsed { get; }
+
+        public bool IsVariadic { get; }
+    }
+
+    /// <summary>
+    /// Issue #1631: C# §7.5.3.2 "better function member" pairwise comparison —
+    /// mirrors <c>OverloadResolution.IsAtLeastAsGoodAs</c> for user-symbolic
+    /// candidates. Returns <see langword="true"/> when <paramref name="a"/> is
+    /// not worse than <paramref name="b"/> on any argument and strictly better
+    /// on at least one.
+    /// </summary>
+    private static bool IsUserCandidateAtLeastAsGoodAs(UserCandidateRankData a, UserCandidateRankData b, TypeSymbol[] argTypes)
+    {
+        var hasStrictlyBetter = false;
+        for (var i = 0; i < a.Kinds.Length; i++)
+        {
+            var cmp = CompareUserConversions(a.Kinds[i], a.ParamTypes[i], b.Kinds[i], b.ParamTypes[i], argTypes[i]);
+            if (cmp > 0)
+            {
+                return false;
+            }
+
+            if (cmp < 0)
+            {
+                hasStrictlyBetter = true;
+            }
+        }
+
+        return hasStrictlyBetter;
+    }
+
+    /// <summary>
+    /// Issue #1631: compares two candidate conversions for the SAME argument,
+    /// mirroring <c>OverloadResolution.CompareConversions</c>. Different
+    /// <see cref="OverloadResolution.ImplicitConversionKind"/>s rank by their declared ordinal
+    /// (lower is better); same-kind numeric widenings tie-break via the
+    /// shared <see cref="OverloadResolution.CompareNumericTargets"/> "better
+    /// conversion target" rule (C# §7.5.3.4), reusing the exact CLR-path
+    /// helper rather than reimplementing the numeric/signed-vs-unsigned
+    /// lattice a second time.
+    /// </summary>
+    private static int CompareUserConversions(OverloadResolution.ImplicitConversionKind ka, TypeSymbol paramA, OverloadResolution.ImplicitConversionKind kb, TypeSymbol paramB, TypeSymbol source)
+    {
+        if (ka != kb)
+        {
+            return ((int)ka).CompareTo((int)kb);
+        }
+
+        if (ka == OverloadResolution.ImplicitConversionKind.NumericWidening)
+        {
+            return OverloadResolution.CompareNumericTargets(paramA?.ClrType, paramB?.ClrType, source?.ClrType);
+        }
+
+        return 0;
+    }
+
+    /// <summary>
+    /// Issue #1631: classifies the implicit conversion from a user-symbolic
+    /// argument type to a user-symbolic parameter type using the SAME
+    /// <see cref="OverloadResolution.ImplicitConversionKind"/> ranking the CLR-reflection
+    /// resolver (<see cref="OverloadResolution.ClassifyImplicit"/>) uses for
+    /// imported-method overloads, so both resolvers agree on which conversion
+    /// is "better". Bounded to the conversion shapes the user-symbolic
+    /// <see cref="Conversion"/> classifier actually distinguishes: identity,
+    /// nullable-wrap (<c>T -&gt; T?</c>), and numeric widening (via the
+    /// shared <see cref="NumericWideningLattice"/>). Every other implicit
+    /// conversion (reference upcast, interface satisfaction, boxing,
+    /// user-defined <c>op_Implicit</c>, …) folds into
+    /// <see cref="OverloadResolution.ImplicitConversionKind.Reference"/> — the user-symbolic type
+    /// model does not carry enough structure to rank those sub-kinds
+    /// separately, but they still rank strictly better than the numeric/
+    /// delegate special cases ranked worse below.
+    /// </summary>
+    private static OverloadResolution.ImplicitConversionKind ClassifyUserArgumentConversionKind(TypeSymbol argType, TypeSymbol paramType)
+    {
+        if (argType == null || paramType == null)
+        {
+            return OverloadResolution.ImplicitConversionKind.None;
+        }
+
+        if (argType == paramType)
+        {
+            return OverloadResolution.ImplicitConversionKind.Identity;
+        }
+
+        if (paramType is NullableTypeSymbol nullableParam && argType == nullableParam.UnderlyingType)
+        {
+            return OverloadResolution.ImplicitConversionKind.NullableWrap;
+        }
+
+        var argClr = argType.ClrType;
+        var paramClr = paramType.ClrType;
+        if (argClr != null && paramClr != null
+            && NumericWideningLattice.IsNumericPrimitive(argClr.FullName)
+            && NumericWideningLattice.IsNumericPrimitive(paramClr.FullName)
+            && NumericWideningLattice.IsWidening(argClr, paramClr))
+        {
+            return OverloadResolution.ImplicitConversionKind.NumericWidening;
+        }
+
+        return OverloadResolution.ImplicitConversionKind.Reference;
     }
 
     /// <summary>

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1631UserOverloadBetterMemberTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1631UserOverloadBetterMemberTests.cs
@@ -136,14 +136,16 @@ func Issue1631VarUse() int32 -> Issue1631VarF(1, 2)
     }
 
     [Fact]
-    public void VariadicTailWidening_PrefersNormalFormOverExpanded()
+    public void VariadicElementIdentity_BeatsNormalFormWidening()
     {
-        // B1 regression: the variadic candidate's tail argument used to be
-        // forced to Identity (the best possible rank) regardless of its real
-        // conversion, letting it wrongly dominate an applicable non-variadic
-        // sibling that has to widen. Here arg1 (int32) widens to int64 on the
-        // normal-form overload but matches the params element type (int32)
-        // exactly on the variadic overload; C# still prefers the normal form.
+        // B1' regression: per C# §7.5.3.2, "prefer non-expanded form" is a
+        // LATE tie-break applied only when per-arg betterness is otherwise
+        // tied — it must not override a genuine per-arg conversion-kind
+        // difference. Here arg2 (int32) widens to int64 on the normal-form
+        // overload but matches the params element type (int32) exactly on
+        // the variadic overload, so per-arg betterness picks the variadic
+        // form (matching Roslyn: F(1, 2) with F(int,long) and
+        // F(int, params int[]) binds the params overload).
         const string source = @"
 package p
 func Issue1631VarWF(x int32, y int64) int32 -> 1
@@ -158,8 +160,31 @@ func Issue1631VarWUse() int32 -> Issue1631VarWF(1, 2)
         var selected = FindCall(compilation, "Issue1631VarWF");
         Assert.NotNull(selected);
         Assert.Equal(2, selected.Parameters.Length);
+        Assert.True(selected.Parameters[1].IsVariadic);
+    }
+
+    [Fact]
+    public void BothFormsIdenticalPerArg_PrefersNormalFormAsTieBreak()
+    {
+        // Locks in the true §7.5.3.2 tie-break: when every argument is
+        // Identity on BOTH the normal-form and variadic candidates (no
+        // widening anywhere to decide the arg comparisons), Phase 2c's
+        // "prefer non-variadic" rule is what picks the normal form.
+        const string source = @"
+package p
+func Issue1631VarTieF(x int32, y int32) int32 -> 1
+func Issue1631VarTieF(x int32, rest ...int32) int32 -> 2
+func Issue1631VarTieUse() int32 -> Issue1631VarTieF(1, 2)
+";
+        var compilation = Compile(source);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
+        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+
+        var selected = FindCall(compilation, "Issue1631VarTieF");
+        Assert.NotNull(selected);
+        Assert.Equal(2, selected.Parameters.Length);
         Assert.False(selected.Parameters[1].IsVariadic);
-        Assert.Equal(TypeSymbol.Int64, selected.Parameters[1].Type);
     }
 
     [Fact]

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1631UserOverloadBetterMemberTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1631UserOverloadBetterMemberTests.cs
@@ -136,6 +136,120 @@ func Issue1631VarUse() int32 -> Issue1631VarF(1, 2)
     }
 
     [Fact]
+    public void VariadicTailWidening_PrefersNormalFormOverExpanded()
+    {
+        // B1 regression: the variadic candidate's tail argument used to be
+        // forced to Identity (the best possible rank) regardless of its real
+        // conversion, letting it wrongly dominate an applicable non-variadic
+        // sibling that has to widen. Here arg1 (int32) widens to int64 on the
+        // normal-form overload but matches the params element type (int32)
+        // exactly on the variadic overload; C# still prefers the normal form.
+        const string source = @"
+package p
+func Issue1631VarWF(x int32, y int64) int32 -> 1
+func Issue1631VarWF(x int32, rest ...int32) int32 -> 2
+func Issue1631VarWUse() int32 -> Issue1631VarWF(1, 2)
+";
+        var compilation = Compile(source);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
+        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+
+        var selected = FindCall(compilation, "Issue1631VarWF");
+        Assert.NotNull(selected);
+        Assert.Equal(2, selected.Parameters.Length);
+        Assert.False(selected.Parameters[1].IsVariadic);
+        Assert.Equal(TypeSymbol.Int64, selected.Parameters[1].Type);
+    }
+
+    [Fact]
+    public void Variadic_SelectedWhenSoleApplicable()
+    {
+        // A variadic overload must still win when it is the only candidate
+        // whose arity accepts the call (a sibling with fewer fixed params
+        // that cannot take 3 arguments is not applicable at all).
+        const string source = @"
+package p
+func Issue1631VarSoleF(x int32, y int32) int32 -> 1
+func Issue1631VarSoleF(x int32, rest ...int32) int32 -> 2
+func Issue1631VarSoleUse() int32 -> Issue1631VarSoleF(1, 2, 3)
+";
+        var compilation = Compile(source);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
+        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+
+        var selected = FindCall(compilation, "Issue1631VarSoleF");
+        Assert.NotNull(selected);
+        Assert.True(selected.Parameters[selected.Parameters.Length - 1].IsVariadic);
+    }
+
+    [Fact]
+    public void TwoVariadic_ElementTypeBettemessStillDecides()
+    {
+        // Between two variadic candidates (both expanded form), the params
+        // element-type conversion kind must still decide genuine betterness.
+        const string source = @"
+package p
+func Issue1631VarVsVarF(x int32, rest ...int32) int32 -> 1
+func Issue1631VarVsVarF(x int32, rest ...int64) int32 -> 2
+func Issue1631VarVsVarUse() int32 -> Issue1631VarVsVarF(1, 2)
+";
+        var compilation = Compile(source);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
+        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+
+        var selected = FindCall(compilation, "Issue1631VarVsVarF");
+        Assert.NotNull(selected);
+        var tail = selected.Parameters[selected.Parameters.Length - 1];
+        Assert.True(tail.IsVariadic);
+        Assert.Equal(TypeSymbol.Int32, ((SliceTypeSymbol)tail.Type).ElementType);
+    }
+
+    [Fact]
+    public void NamedArgument_DominationUsesMappedSlot()
+    {
+        // S1: named arguments reorder the source-order -> parameter-slot
+        // mapping (#1628). Domination must rank each argument against its
+        // REAL slot, not its source position: here `b` (an int32 constant)
+        // binds against an int32 parameter on overload 1 (identity) and an
+        // int64 parameter on overload 2 (widening), while `a` ties on both —
+        // overload 1 must win even though it is named second at the call site.
+        const string source = @"
+package p
+func Issue1631NamedF(a int32, b int32) int32 -> 1
+func Issue1631NamedF(a int32, b int64) int32 -> 2
+func Issue1631NamedUse() int32 -> Issue1631NamedF(b: 2, a: 1)
+";
+        var compilation = Compile(source);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
+        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+
+        var selected = FindCall(compilation, "Issue1631NamedF");
+        Assert.NotNull(selected);
+        Assert.Equal(TypeSymbol.Int32, selected.Parameters[1].Type);
+    }
+
+    [Fact]
+    public void PerArgumentPairwiseTie_ReportsAmbiguity()
+    {
+        // S2: each candidate is strictly better on a DIFFERENT argument, so
+        // neither dominates the other under §7.5.3.2 pairwise comparison —
+        // a genuine GS0266 must be reported.
+        const string source = @"
+package p
+func Issue1631PairF(a int32, b int64) int32 -> 1
+func Issue1631PairF(a int64, b int32) int32 -> 2
+func Issue1631PairUse(x int32, y int32) int32 -> Issue1631PairF(x, y)
+";
+        var compilation = Compile(source);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0266");
+    }
+
+    [Fact]
     public void IdentityStillBeatsWidening()
     {
         // Control: an exact-type match still wins over any widening

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1631UserOverloadBetterMemberTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1631UserOverloadBetterMemberTests.cs
@@ -1,0 +1,201 @@
+// <copyright file="Issue1631UserOverloadBetterMemberTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1631: user-declared (non-imported) overload resolution now follows
+/// the C#-faithful "better function member" pairwise domination rules
+/// (§7.5.3.2), reusing the same <c>ImplicitConversionKind</c> ranking and
+/// numeric "better conversion target" tie-break the CLR-reflection resolver
+/// (<c>OverloadResolution</c>) applies to imported-method overloads — instead
+/// of the previous ad-hoc linear score under which two candidates that both
+/// needed an implicit conversion tied at score 0 regardless of which
+/// conversion C# actually prefers.
+/// </summary>
+public class Issue1631UserOverloadBetterMemberTests
+{
+    [Fact]
+    public void NumericWidening_PrefersLongOverFloat_FromIntArgument()
+    {
+        // Repro from the issue: F(int64) / F(float64) called with an int32
+        // constant. int32 -> int64 and int32 -> float64 are both implicit
+        // widenings, but int64 is the "smaller"/closer numeric target
+        // (int64 -> float64 is implicit, float64 -> int64 is not), so C#
+        // picks F(int64). The previous ad-hoc score tied both at 0 and
+        // reported a spurious GS0266.
+        const string source = @"
+package p
+func Issue1631NwF(x int64) int32 -> 1
+func Issue1631NwF(x float64) int32 -> 2
+func Issue1631NwUse() int32 -> Issue1631NwF(5)
+";
+        var compilation = Compile(source);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
+        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+
+        var selected = FindCall(compilation, "Issue1631NwF");
+        Assert.NotNull(selected);
+        Assert.Equal(TypeSymbol.Int64, selected.Parameters[0].Type);
+    }
+
+    [Fact]
+    public void NumericWidening_PrefersIntOverDouble_WideningChain()
+    {
+        // From an int16 argument: int16 -> int32 and int32 -> float64 are
+        // both implicit, so int32 is the better ("closer") target than
+        // float64.
+        const string source = @"
+package p
+func Issue1631ChF(x int32) int32 -> 1
+func Issue1631ChF(x float64) int32 -> 2
+func Issue1631ChUse(n int16) int32 -> Issue1631ChF(n)
+";
+        var compilation = Compile(source);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
+        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+
+        var selected = FindCall(compilation, "Issue1631ChF");
+        Assert.NotNull(selected);
+        Assert.Equal(TypeSymbol.Int32, selected.Parameters[0].Type);
+    }
+
+    [Fact]
+    public void GenuineAmbiguity_NeitherNumericTargetDominates_ReportsGS0266()
+    {
+        // From an int32 argument, neither float32 -> decimal nor
+        // decimal -> float32 is implicit, and neither appears in the signed-
+        // vs-unsigned table, so the two widenings genuinely tie and a real
+        // GS0266 must still be reported (not silently resolved).
+        const string source = @"
+package p
+func Issue1631AmbF(x float32) int32 -> 1
+func Issue1631AmbF(x decimal) int32 -> 2
+func Issue1631AmbUse(n int32) int32 -> Issue1631AmbF(n)
+";
+        var compilation = Compile(source);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0266");
+    }
+
+    [Fact]
+    public void NonGenericOverGeneric_TieBreak()
+    {
+        // A non-generic overload beats a generic one when both apply
+        // identically (C# §7.5.3.2: "If MP is a non-generic method and MQ is
+        // a generic method, then MP is better than MQ.").
+        const string source = @"
+package p
+func Issue1631GenF[T](x T) int32 -> 1
+func Issue1631GenF(x string) int32 -> 2
+func Issue1631GenUse(s string) int32 -> Issue1631GenF(s)
+";
+        var compilation = Compile(source);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
+        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+
+        var selected = FindCall(compilation, "Issue1631GenF");
+        Assert.NotNull(selected);
+        Assert.False(selected.IsGeneric);
+    }
+
+    [Fact]
+    public void ParamsExpanded_PrefersNormalFormOverVariadic()
+    {
+        // A non-variadic (normal-form) overload beats a variadic (expanded
+        // params) overload when both apply to the same call, matching C#'s
+        // preference for the normal form over the expanded form.
+        const string source = @"
+package p
+func Issue1631VarF(x int32, y int32) int32 -> 1
+func Issue1631VarF(x int32, rest ...int32) int32 -> 2
+func Issue1631VarUse() int32 -> Issue1631VarF(1, 2)
+";
+        var compilation = Compile(source);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0266");
+        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+
+        var selected = FindCall(compilation, "Issue1631VarF");
+        Assert.NotNull(selected);
+        Assert.Equal(2, selected.Parameters.Length);
+        Assert.False(selected.Parameters[selected.Parameters.Length - 1].IsVariadic);
+    }
+
+    [Fact]
+    public void IdentityStillBeatsWidening()
+    {
+        // Control: an exact-type match still wins over any widening
+        // candidate, exactly as before this fix.
+        const string source = @"
+package p
+func Issue1631IdF(x int32) int32 -> 1
+func Issue1631IdF(x int64) int32 -> 2
+func Issue1631IdUse(n int32) int32 -> Issue1631IdF(n)
+";
+        var compilation = Compile(source);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+
+        var selected = FindCall(compilation, "Issue1631IdF");
+        Assert.NotNull(selected);
+        Assert.Equal(TypeSymbol.Int32, selected.Parameters[0].Type);
+    }
+
+    private static Compilation Compile(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        return new Compilation(tree) { IsLibrary = true };
+    }
+
+    private static FunctionSymbol FindCall(Compilation compilation, string callName)
+    {
+        var collector = new CallCollector(callName);
+        foreach (var body in compilation.BoundProgram.Functions.Values)
+        {
+            collector.Visit(body);
+        }
+
+        return collector.Collected.FirstOrDefault();
+    }
+
+    private sealed class CallCollector : GSharp.Core.CodeAnalysis.Binding.BoundTreeWalker
+    {
+        private readonly string callName;
+
+        public CallCollector(string callName)
+        {
+            this.callName = callName;
+        }
+
+        public List<FunctionSymbol> Collected { get; } = new();
+
+        public override void VisitExpression(GSharp.Core.CodeAnalysis.Binding.BoundExpression node)
+        {
+            switch (node)
+            {
+                case GSharp.Core.CodeAnalysis.Binding.BoundCallExpression call when call.Function.Name == callName:
+                    Collected.Add(call.Function);
+                    break;
+                case GSharp.Core.CodeAnalysis.Binding.BoundUserInstanceCallExpression instanceCall when instanceCall.Method.Name == callName:
+                    Collected.Add(instanceCall.Method);
+                    break;
+            }
+
+            base.VisitExpression(node);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1631

## Problem
`OverloadResolver.SelectBestUserOverloadCore` (user-declared / non-imported overload resolution) ranked candidates with an ad-hoc linear score (exact-type-match bonus, variadic penalty, delegate-discard penalty). Any two candidates that both needed an implicit conversion tied at score 0 regardless of which conversion C# actually prefers, so `func F(x int64)` / `func F(x float64)` called with an `int32` constant reported a spurious `GS0266` ambiguity, while the byte-identical overload pair on an imported CLR method resolved correctly via the CLR-reflection path's `CompareNumericTargets`.

## Fix
Replaced the linear score with C# §7.5.3.2 "better function member" pairwise domination, mirroring `OverloadResolution` (the CLR-reflection resolver):

- Each argument's conversion is classified into the same `ImplicitConversionKind` ranking both resolvers now share (`Identity`, `NumericWidening`, `NullableWrap`, a `Reference` fallback bucket, and the existing `LambdaToVoidDelegate` special case for value-returning delegates discarded to void delegates).
- Same-kind numeric widenings tie-break via the existing `OverloadResolution.CompareNumericTargets` helper — reused directly, not reimplemented — for the §7.5.3.4 "better conversion target" + signed-over-unsigned rules.
- A candidate survives when no other candidate is at-least-as-good on every argument and strictly better on at least one. This correctly lets pairwise-incomparable candidates both survive, instead of the old code's implicit requirement of dominance over every other candidate.
- After domination, arity tie-breakers run in C# order: fewest defaulted parameters, then non-variadic over variadic (normal form over expanded params form), then non-generic over generic.

## Not implemented (scoped out)
Full "more specific parameter type" structural tie-break (the CLR path's `IsAtLeastAsSpecific`) is not ported — the user-symbolic `TypeSymbol` model has no equivalent structural-assignability probe without duplicating a chunk of `Conversion.Classify`. The per-argument conversion-kind domination above already resolves the common real-world cases (numeric widening, generic-vs-non-generic, params-vs-normal-form) and is a strict improvement over the previous "every implicit conversion ties at 0" behavior.

Boxing/Reference/user-defined-implicit conversions fold into a single `Reference` rank bucket since the user-symbolic `Conversion` classifier doesn't expose those sub-kinds the way `OverloadResolution.ClassifyImplicit` does for CLR types.

## Tests
Added `Issue1631UserOverloadBetterMemberTests`: the issue's `int64`/`float64` repro, a widening chain (`int16` to `int32` vs `int16` to `float64`), a genuine ambiguity that must still report `GS0266` (`float32` vs `decimal`, neither dominates), non-generic-over-generic, params-expanded vs normal form, and an identity-still-wins control.

**Regression checks**: `dotnet build GSharp.sln -c Release -graph` (0 errors); full `test/Core.Tests` suite: 5121 passed, 0 failed, 1 skipped (pre-existing baseline-regen skip).
