### PR TITLE
Fix #1636: gate is-test narrowing on genuine subtype relation

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -792,6 +792,18 @@ internal sealed partial class ExpressionBinder
                         return (null, null);
                     }
 
+                    // Issue #1636: mirror StatementBinder.IsStrictlyNarrower —
+                    // only install the narrowing when the candidate is
+                    // actually a subtype of the declared type (candidate
+                    // implicitly converts to declared). A supertype/interface/
+                    // unrelated candidate is a widening or unrelated test and
+                    // must not replace the declared type.
+                    var conversion = Conversion.Classify(targetType, declaredType);
+                    if (!conversion.Exists || !conversion.IsImplicit)
+                    {
+                        return (null, null);
+                    }
+
                     return (new Dictionary<AccessPath, TypeSymbol> { [targetPath] = targetType }, null);
                 }
 

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.cs
@@ -1839,13 +1839,23 @@ internal sealed class StatementBinder
             return true;
         }
 
-        // For any other shape, accept it as a narrowing as long as the
-        // declared and candidate types are distinct. The runtime `is`
-        // test has already proved that the value is of the candidate
-        // type, so binder-time soundness is satisfied regardless of
-        // whether the candidate is a strict subtype in the type
-        // hierarchy.
-        return true;
+        // Issue #1636: a candidate distinct from the declared type is only a
+        // genuine narrowing if it is actually a subtype of the declared type
+        // (candidate implicitly converts to declared — every candidate value
+        // is already usable as declared). `Conversion.Classify` already
+        // encodes the full class/interface/base-type lattice (class → base
+        // class, class → implemented interface, interface → base interface,
+        // struct → interface, etc.), so reuse it instead of re-deriving the
+        // subtype relation here.
+        //
+        // A supertype/interface/unrelated candidate (e.g. `Circle is
+        // IDrawable`, `string is object`) does NOT implicitly convert back to
+        // the (narrower) declared type — that's a widening or unrelated test,
+        // and replacing the declared type with it would hide members the
+        // declared type actually has (C# keeps the declared type in that
+        // case).
+        var conversion = Conversion.Classify(candidate, declared);
+        return conversion.Exists && conversion.IsImplicit;
     }
 
     private (Dictionary<AccessPath, TypeSymbol> NonNil, Dictionary<AccessPath, TypeSymbol> Nil) TryClassifyNilGuard(BoundExpression condition)

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1636TypeTestNarrowingSubtypeGateTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1636TypeTestNarrowingSubtypeGateTests.cs
@@ -1,0 +1,183 @@
+// <copyright file="Issue1636TypeTestNarrowingSubtypeGateTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1636 — <c>x is T</c> smart-cast narrowing must only replace the
+/// declared type when <c>T</c> is a genuine subtype (or nullable-strip) of
+/// the declared type. Supertype/interface/unrelated candidates are a
+/// widening or unrelated test and must keep the declared type, matching C#'s
+/// treatment of a bare <c>is</c> test.
+/// </summary>
+public class Issue1636TypeTestNarrowingSubtypeGateTests
+{
+    [Fact]
+    public void If_IsTestOnImplementedInterface_KeepsDeclaredClassMembers()
+    {
+        // `Circle` implements `IDrawable`. Testing `c is IDrawable` is a
+        // WIDENING (interface is a supertype) — `c` must remain usable as
+        // `Circle`, so `c.Radius` (a Circle-only member) must still resolve.
+        var result = Evaluate(@"
+interface IDrawable {
+    func Draw() int32;
+}
+class Circle(Radius int32) : IDrawable {
+    func Draw() int32 { return Radius }
+}
+func Run(c Circle) int32 {
+    if c is IDrawable {
+        return c.Radius
+    }
+    return 0
+}
+Run(Circle{Radius: 3})
+");
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void If_IsTestOnObject_KeepsStringMembers()
+    {
+        // `object` is a supertype of `string`; `s is object` must not hide
+        // `string.Length`.
+        var result = Evaluate(@"
+func Run(s string) int32 {
+    if s is object {
+        return s.Length
+    }
+    return 0
+}
+Run(""hello"")
+");
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void If_IsTestOnBaseClass_KeepsSubtypeMembers()
+    {
+        // Testing a `Dog`-typed value against its base class `Animal` is
+        // widening — `d.Bark()` (a Dog-only member) must remain usable.
+        var result = Evaluate(@"
+open class Animal {
+    var Name string
+}
+class Dog : Animal {
+    func Bark() string { return ""woof"" }
+}
+func Run(d Dog) string {
+    if d is Animal {
+        return d.Bark()
+    }
+    return """"
+}
+Run(Dog{Name: ""Rex""})
+");
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void If_IsTestOnSubclass_StillNarrows()
+    {
+        // Genuine narrowing must still work: `a is Dog` narrows `a` to
+        // `Dog`, so `Bark()` (Dog-only) becomes callable.
+        var result = Evaluate(@"
+open class Animal {
+    var Name string
+}
+class Dog : Animal {
+    func Bark() string { return ""woof"" }
+}
+func Run(a Animal) string {
+    if a is Dog {
+        return a.Bark()
+    }
+    return """"
+}
+Run(Dog{Name: ""Rex""})
+");
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void If_IsTestOnSubclass_DogOnlyMemberUnavailableBeforeTest()
+    {
+        // Before the narrowing test, `a` is still `Animal` — `Bark()` must
+        // NOT resolve outside the then-branch.
+        var result = Evaluate(@"
+open class Animal {
+    var Name string
+}
+class Dog : Animal {
+    func Bark() string { return ""woof"" }
+}
+func Run(a Animal) string {
+    return a.Bark()
+}
+Run(Dog{Name: ""Rex""})
+");
+
+        Assert.Contains(result.Diagnostics, d => d.Message.Contains("Bark"));
+    }
+
+    [Fact]
+    public void If_IsTestOnNullableUnderlyingType_StillNarrows()
+    {
+        // Nullable-strip (`string? is string`) remains a genuine narrowing.
+        var result = Evaluate(@"
+func Run(s string?) int32 {
+    if s is string {
+        return s.Length
+    }
+    return 0
+}
+Run(""hi"")
+");
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void If_IsTestOnUnrelatedInterface_KeepsDeclaredClassMembers()
+    {
+        // `Circle` does not implement `IComparable` — an unrelated type test
+        // must also keep the declared type (no narrowing installed at all).
+        var result = Evaluate(@"
+interface IComparableThing {
+    func CompareTo() int32;
+}
+class Circle(Radius int32) {
+    func Draw() int32 { return Radius }
+}
+func Run(c Circle) int32 {
+    if c is IComparableThing {
+        return 0
+    }
+    return c.Radius
+}
+Run(Circle{Radius: 3})
+");
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(syntaxTree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
Fixes #1636

`is T` type-test smart-cast narrowing accepted ANY type distinct from
the declared type as a "narrowing", including supertypes and
interfaces. The narrowed type replaced the receiver's type on reads
in the then-branch, so e.g. `c is IDrawable` on a `Circle` (or
`s is object` on a `string`) retyped the receiver to the wider type
and hid its original members ("unable to find member").

## Fix

Both narrowing classifiers (`StatementBinder.IsStrictlyNarrower` and
`ExpressionBinder.ClassifyTypeTestNarrowing`) now require the
candidate type to actually be a subtype of the declared type before
installing a narrowing frame. Subtyping is decided via the existing
`Conversion.Classify(candidate, declared)` lattice (candidate
implicitly converts to declared), which already encodes:

- class → base class
- class → implemented interface
- interface → base interface
- struct → implemented interface

so no new subtype logic was invented. A supertype/interface/unrelated
candidate no longer installs a narrowing frame — the declared type
(and its members) stays usable, matching C#'s treatment of a bare
`is` test. Nullable-strip (`string? is string`) and genuine narrowing
(`Animal is Dog`) are unaffected — those still gate `true`.

## Tests

Added `Issue1636TypeTestNarrowingSubtypeGateTests` covering:
- interface widening keeps class members (`Circle is IDrawable` → `c.Radius` resolves)
- `object` widening keeps `string` members (`s is object` → `s.Length` resolves)
- base-class widening keeps subclass members (`Dog is Animal` → `d.Bark()` resolves)
- subclass narrowing still works (`Animal is Dog` → `a.Bark()` resolves), and the
  Dog-only member is unavailable before the test (still diagnoses)
- nullable-strip narrowing still works (`string? is string` → `s.Length` resolves)
- unrelated-interface test keeps declared class members

## Validation

- `dotnet build GSharp.sln -c Release -graph` — 0 errors, 0 warnings
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release` — 5134 passed, 1 skipped (pre-existing baseline-regen skip), 0 failed
- Targeted narrowing/smart-cast filter and full `CodeAnalysis.Binding` filter (3200 tests) — all pass, no regressions