### PR TITLE
Fix #1622: clear all process-wide type-symbol caches on ReferenceResolver.Dispose

### DIFF
--- a/src/Core/CodeAnalysis/Symbols/ArrayTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ArrayTypeSymbol.cs
@@ -52,4 +52,12 @@ public sealed class ArrayTypeSymbol : TypeSymbol
 
         return Cache.GetOrAdd((elementType, length), key => new ArrayTypeSymbol(key.Element, key.Length));
     }
+
+    /// <summary>
+    /// Removes all entries from the static type cache. Called by
+    /// <see cref="ReferenceResolver.Dispose"/> to release stale
+    /// <see cref="Type"/> objects backed by a disposed metadata load context
+    /// that would otherwise pin the context's memory indefinitely.
+    /// </summary>
+    internal static void ClearCache() => Cache.Clear();
 }

--- a/src/Core/CodeAnalysis/Symbols/AsyncSequenceTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/AsyncSequenceTypeSymbol.cs
@@ -44,6 +44,14 @@ public sealed class AsyncSequenceTypeSymbol : TypeSymbol
         return Cache.GetOrAdd(elementType, et => new AsyncSequenceTypeSymbol(et));
     }
 
+    /// <summary>
+    /// Removes all entries from the static type cache. Called by
+    /// <see cref="ReferenceResolver.Dispose"/> to release stale
+    /// <see cref="Type"/> objects backed by a disposed metadata load context
+    /// that would otherwise pin the context's memory indefinitely.
+    /// </summary>
+    internal static void ClearCache() => Cache.Clear();
+
     private static Type MakeClrType(TypeSymbol elementType)
     {
         if (elementType.ClrType == null)

--- a/src/Core/CodeAnalysis/Symbols/ByRefTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ByRefTypeSymbol.cs
@@ -40,4 +40,12 @@ public sealed class ByRefTypeSymbol : TypeSymbol
 
         return Cache.GetOrAdd(pointeeType, pt => new ByRefTypeSymbol(pt));
     }
+
+    /// <summary>
+    /// Removes all entries from the static type cache. Called by
+    /// <see cref="ReferenceResolver.Dispose"/> to release stale
+    /// <see cref="Type"/> objects backed by a disposed metadata load context
+    /// that would otherwise pin the context's memory indefinitely.
+    /// </summary>
+    internal static void ClearCache() => Cache.Clear();
 }

--- a/src/Core/CodeAnalysis/Symbols/ChannelTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ChannelTypeSymbol.cs
@@ -45,6 +45,14 @@ public sealed class ChannelTypeSymbol : TypeSymbol
         return Cache.GetOrAdd(elementType, e => new ChannelTypeSymbol(e));
     }
 
+    /// <summary>
+    /// Removes all entries from the static type cache. Called by
+    /// <see cref="ReferenceResolver.Dispose"/> to release stale
+    /// <see cref="Type"/> objects backed by a disposed metadata load context
+    /// that would otherwise pin the context's memory indefinitely.
+    /// </summary>
+    internal static void ClearCache() => Cache.Clear();
+
     private static Type MakeClrType(TypeSymbol elementType)
     {
         if (elementType.ClrType == null)

--- a/src/Core/CodeAnalysis/Symbols/DelegateTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/DelegateTypeSymbol.cs
@@ -177,6 +177,15 @@ public sealed class DelegateTypeSymbol : TypeSymbol
         return ConstructedCache.GetOrAdd((definition, key), _ => CreateConstructed(definition, typeArguments));
     }
 
+    /// <summary>
+    /// Removes all entries from the static constructed-delegate cache.
+    /// Called by <see cref="ReferenceResolver.Dispose"/> to release stale
+    /// <see cref="Type"/> objects and definition/argument symbols backed by
+    /// a disposed metadata load context that would otherwise pin the
+    /// context's memory indefinitely.
+    /// </summary>
+    internal static void ClearCache() => ConstructedCache.Clear();
+
     private static TypeArgsKey BuildArgsKey(ImmutableArray<TypeSymbol> typeArguments) => new(typeArguments);
 
     private static DelegateTypeSymbol CreateConstructed(DelegateTypeSymbol definition, ImmutableArray<TypeSymbol> typeArguments)

--- a/src/Core/CodeAnalysis/Symbols/FunctionPointerTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/FunctionPointerTypeSymbol.cs
@@ -96,6 +96,14 @@ public sealed class FunctionPointerTypeSymbol : TypeSymbol
     }
 
     /// <summary>
+    /// Removes all entries from the static type cache. Called by
+    /// <see cref="ReferenceResolver.Dispose"/> to release stale
+    /// <see cref="Type"/> objects backed by a disposed metadata load context
+    /// that would otherwise pin the context's memory indefinitely.
+    /// </summary>
+    internal static void ClearCache() => Cache.Clear();
+
+    /// <summary>
     /// Issue #1624: builds an identity-correct cache key using
     /// <see cref="FunctionTypeSymbol.AppendIdentityKey"/> — the same builder
     /// <see cref="FunctionTypeSymbol"/> and <see cref="TupleTypeSymbol"/> use —

--- a/src/Core/CodeAnalysis/Symbols/InterfaceSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/InterfaceSymbol.cs
@@ -576,6 +576,15 @@ public sealed class InterfaceSymbol : TypeSymbol
         TryResolveMembers();
     }
 
+    /// <summary>
+    /// Removes all entries from the static constructed-interface cache.
+    /// Called by <see cref="ReferenceResolver.Dispose"/> to release stale
+    /// <see cref="Type"/> objects and definition/argument symbols backed by
+    /// a disposed metadata load context that would otherwise pin the
+    /// context's memory indefinitely.
+    /// </summary>
+    internal static void ClearCache() => ConstructedCache.Clear();
+
     private static TypeArgsKey BuildArgsKey(ImmutableArray<TypeSymbol> typeArguments) => new(typeArguments);
 
     private static InterfaceSymbol CreateConstructed(InterfaceSymbol definition, ImmutableArray<TypeSymbol> typeArguments)

--- a/src/Core/CodeAnalysis/Symbols/MapTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/MapTypeSymbol.cs
@@ -58,6 +58,14 @@ public sealed class MapTypeSymbol : TypeSymbol
         return Cache.GetOrAdd((keyType, valueType), k => new MapTypeSymbol(k.Item1, k.Item2));
     }
 
+    /// <summary>
+    /// Removes all entries from the static type cache. Called by
+    /// <see cref="ReferenceResolver.Dispose"/> to release stale
+    /// <see cref="Type"/> objects backed by a disposed metadata load context
+    /// that would otherwise pin the context's memory indefinitely.
+    /// </summary>
+    internal static void ClearCache() => Cache.Clear();
+
     private static Type MakeClrType(TypeSymbol keyType, TypeSymbol valueType)
     {
         if (keyType.ClrType == null || valueType.ClrType == null)

--- a/src/Core/CodeAnalysis/Symbols/NullableTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/NullableTypeSymbol.cs
@@ -57,6 +57,14 @@ public sealed class NullableTypeSymbol : TypeSymbol
         => NullableLifting.GetEffectiveClrType(typeSymbol);
 
     /// <summary>
+    /// Removes all entries from the static type cache. Called by
+    /// <see cref="ReferenceResolver.Dispose"/> to release stale
+    /// <see cref="Type"/> objects backed by a disposed metadata load context
+    /// that would otherwise pin the context's memory indefinitely.
+    /// </summary>
+    internal static void ClearCache() => Cache.Clear();
+
+    /// <summary>
     /// Issue #1212: a nullable array/slice must render with the <c>?</c> bound to
     /// the array itself (<c>[]?T</c> / <c>[N]?T</c>) so its display name is distinct
     /// from an array of nullable elements (<c>[]T?</c> = <c>Slice(Nullable(T))</c>).

--- a/src/Core/CodeAnalysis/Symbols/PointerTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/PointerTypeSymbol.cs
@@ -49,4 +49,12 @@ public sealed class PointerTypeSymbol : TypeSymbol
 
         return Cache.GetOrAdd(pointeeType, pt => new PointerTypeSymbol(pt));
     }
+
+    /// <summary>
+    /// Removes all entries from the static type cache. Called by
+    /// <see cref="ReferenceResolver.Dispose"/> to release stale
+    /// <see cref="Type"/> objects backed by a disposed metadata load context
+    /// that would otherwise pin the context's memory indefinitely.
+    /// </summary>
+    internal static void ClearCache() => Cache.Clear();
 }

--- a/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
+++ b/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
@@ -173,6 +173,27 @@ public sealed class ReferenceResolver : IDisposable
         // context across compilations in the same process (issue #908). Clear
         // it for the same reason.
         FunctionTypeSymbol.ClearCache();
+
+        // Every other interning cache in this namespace is process-wide and
+        // keyed (directly or via a constructed-generic definition) by symbols
+        // that ultimately point back at this context's Type objects or at
+        // Declaration syntax trees. Left uncleared they pin that memory for
+        // the lifetime of the process even though no live compilation can
+        // reach them anymore (#1622).
+        NullableTypeSymbol.ClearCache();
+        SliceTypeSymbol.ClearCache();
+        MapTypeSymbol.ClearCache();
+        PointerTypeSymbol.ClearCache();
+        ByRefTypeSymbol.ClearCache();
+        ArrayTypeSymbol.ClearCache();
+        SequenceTypeSymbol.ClearCache();
+        AsyncSequenceTypeSymbol.ClearCache();
+        ChannelTypeSymbol.ClearCache();
+        TupleTypeSymbol.ClearCache();
+        FunctionPointerTypeSymbol.ClearCache();
+        StructSymbol.ClearCache();
+        InterfaceSymbol.ClearCache();
+        DelegateTypeSymbol.ClearCache();
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Symbols/SequenceTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/SequenceTypeSymbol.cs
@@ -39,6 +39,14 @@ public sealed class SequenceTypeSymbol : TypeSymbol
         return Cache.GetOrAdd(elementType, et => new SequenceTypeSymbol(et));
     }
 
+    /// <summary>
+    /// Removes all entries from the static type cache. Called by
+    /// <see cref="ReferenceResolver.Dispose"/> to release stale
+    /// <see cref="Type"/> objects backed by a disposed metadata load context
+    /// that would otherwise pin the context's memory indefinitely.
+    /// </summary>
+    internal static void ClearCache() => Cache.Clear();
+
     private static Type MakeClrType(TypeSymbol elementType)
     {
         if (elementType.ClrType == null)

--- a/src/Core/CodeAnalysis/Symbols/SliceTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/SliceTypeSymbol.cs
@@ -49,4 +49,12 @@ public sealed class SliceTypeSymbol : TypeSymbol
 
         return Cache.GetOrAdd(elementType, e => new SliceTypeSymbol(e));
     }
+
+    /// <summary>
+    /// Removes all entries from the static type cache. Called by
+    /// <see cref="ReferenceResolver.Dispose"/> to release stale
+    /// <see cref="Type"/> objects backed by a disposed metadata load context
+    /// that would otherwise pin the context's memory indefinitely.
+    /// </summary>
+    internal static void ClearCache() => Cache.Clear();
 }

--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -1503,6 +1503,20 @@ public sealed class StructSymbol : TypeSymbol
         return changed ? builder.MoveToImmutable() : default;
     }
 
+    /// <summary>
+    /// Removes all entries from the static constructed-struct caches.
+    /// Called by <see cref="ReferenceResolver.Dispose"/> to release stale
+    /// <see cref="Type"/> objects and definition/argument symbols backed by
+    /// a disposed metadata load context that would otherwise pin the
+    /// context's memory indefinitely.
+    /// </summary>
+    internal static void ClearCache()
+    {
+        ConstructedCache.Clear();
+        ConstructedNestedCache.Clear();
+        ConstructedNestedGenericCache.Clear();
+    }
+
     private static TypeArgsKey BuildArgsKey(ImmutableArray<TypeSymbol> typeArguments) => new(typeArguments);
 
     private static TypeSymbol EnclosingTypeOf(TypeSymbol type) => type switch

--- a/src/Core/CodeAnalysis/Symbols/TupleTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/TupleTypeSymbol.cs
@@ -69,6 +69,14 @@ public sealed class TupleTypeSymbol : TypeSymbol
         return Cache.GetOrAdd(key, _ => new TupleTypeSymbol(elementTypes));
     }
 
+    /// <summary>
+    /// Removes all entries from the static type cache. Called by
+    /// <see cref="ReferenceResolver.Dispose"/> to release stale
+    /// <see cref="Type"/> objects backed by a disposed metadata load context
+    /// that would otherwise pin the context's memory indefinitely.
+    /// </summary>
+    internal static void ClearCache() => Cache.Clear();
+
     private static string BuildName(ImmutableArray<TypeSymbol> elementTypes)
     {
         var sb = new StringBuilder("(");

--- a/test/Core.Tests/CodeAnalysis/Symbols/Issue1622ClearCacheOnDisposeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/Issue1622ClearCacheOnDisposeTests.cs
@@ -1,0 +1,219 @@
+// <copyright file="Issue1622ClearCacheOnDisposeTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Symbols;
+
+/// <summary>
+/// Issue #1622 regression coverage: <see cref="ReferenceResolver.Dispose"/> only
+/// cleared <see cref="ImportedTypeSymbol"/> and <see cref="FunctionTypeSymbol"/>'s
+/// process-wide interning caches, leaving every other type-symbol cache
+/// (<see cref="NullableTypeSymbol"/>, <see cref="SliceTypeSymbol"/>,
+/// <see cref="MapTypeSymbol"/>, <see cref="PointerTypeSymbol"/>,
+/// <see cref="ByRefTypeSymbol"/>, <see cref="ArrayTypeSymbol"/>,
+/// <see cref="SequenceTypeSymbol"/>, <see cref="AsyncSequenceTypeSymbol"/>,
+/// <see cref="ChannelTypeSymbol"/>, <see cref="TupleTypeSymbol"/>,
+/// <see cref="FunctionPointerTypeSymbol"/>, <see cref="StructSymbol"/>,
+/// <see cref="InterfaceSymbol"/>, <see cref="DelegateTypeSymbol"/>) to leak
+/// entries — and the disposed <c>MetadataLoadContext</c> object graph they
+/// pin — for the process lifetime. Each test below populates a cache with an
+/// entry keyed on a stable singleton (e.g. <see cref="TypeSymbol.Int32"/>),
+/// clears the cache, and asserts a fresh lookup produces a NEW instance
+/// instead of the one cached before the clear.
+/// </summary>
+public class Issue1622ClearCacheOnDisposeTests
+{
+    [Fact]
+    public void ArrayTypeSymbol_ClearCache_EvictsEntries()
+    {
+        var before = ArrayTypeSymbol.Get(TypeSymbol.Int32, 4);
+        ArrayTypeSymbol.ClearCache();
+        var after = ArrayTypeSymbol.Get(TypeSymbol.Int32, 4);
+        Assert.NotSame(before, after);
+    }
+
+    [Fact]
+    public void AsyncSequenceTypeSymbol_ClearCache_EvictsEntries()
+    {
+        var before = AsyncSequenceTypeSymbol.Get(TypeSymbol.Int32);
+        AsyncSequenceTypeSymbol.ClearCache();
+        var after = AsyncSequenceTypeSymbol.Get(TypeSymbol.Int32);
+        Assert.NotSame(before, after);
+    }
+
+    [Fact]
+    public void ByRefTypeSymbol_ClearCache_EvictsEntries()
+    {
+        var before = ByRefTypeSymbol.Get(TypeSymbol.Int32);
+        ByRefTypeSymbol.ClearCache();
+        var after = ByRefTypeSymbol.Get(TypeSymbol.Int32);
+        Assert.NotSame(before, after);
+    }
+
+    [Fact]
+    public void ChannelTypeSymbol_ClearCache_EvictsEntries()
+    {
+        var before = ChannelTypeSymbol.Get(TypeSymbol.Int32);
+        ChannelTypeSymbol.ClearCache();
+        var after = ChannelTypeSymbol.Get(TypeSymbol.Int32);
+        Assert.NotSame(before, after);
+    }
+
+    [Fact]
+    public void MapTypeSymbol_ClearCache_EvictsEntries()
+    {
+        var before = MapTypeSymbol.Get(TypeSymbol.Int32, TypeSymbol.String);
+        MapTypeSymbol.ClearCache();
+        var after = MapTypeSymbol.Get(TypeSymbol.Int32, TypeSymbol.String);
+        Assert.NotSame(before, after);
+    }
+
+    [Fact]
+    public void NullableTypeSymbol_ClearCache_EvictsEntries()
+    {
+        var before = NullableTypeSymbol.Get(TypeSymbol.Int32);
+        NullableTypeSymbol.ClearCache();
+        var after = NullableTypeSymbol.Get(TypeSymbol.Int32);
+        Assert.NotSame(before, after);
+    }
+
+    [Fact]
+    public void PointerTypeSymbol_ClearCache_EvictsEntries()
+    {
+        var before = PointerTypeSymbol.Get(TypeSymbol.Int32);
+        PointerTypeSymbol.ClearCache();
+        var after = PointerTypeSymbol.Get(TypeSymbol.Int32);
+        Assert.NotSame(before, after);
+    }
+
+    [Fact]
+    public void SequenceTypeSymbol_ClearCache_EvictsEntries()
+    {
+        var before = SequenceTypeSymbol.Get(TypeSymbol.Int32);
+        SequenceTypeSymbol.ClearCache();
+        var after = SequenceTypeSymbol.Get(TypeSymbol.Int32);
+        Assert.NotSame(before, after);
+    }
+
+    [Fact]
+    public void SliceTypeSymbol_ClearCache_EvictsEntries()
+    {
+        var before = SliceTypeSymbol.Get(TypeSymbol.Int32);
+        SliceTypeSymbol.ClearCache();
+        var after = SliceTypeSymbol.Get(TypeSymbol.Int32);
+        Assert.NotSame(before, after);
+    }
+
+    [Fact]
+    public void TupleTypeSymbol_ClearCache_EvictsEntries()
+    {
+        var elements = ImmutableArray.Create(TypeSymbol.Int32, TypeSymbol.String);
+        var before = TupleTypeSymbol.Get(elements);
+        TupleTypeSymbol.ClearCache();
+        var after = TupleTypeSymbol.Get(elements);
+        Assert.NotSame(before, after);
+    }
+
+    [Fact]
+    public void FunctionPointerTypeSymbol_ClearCache_EvictsEntries()
+    {
+        var parameters = ImmutableArray.Create(TypeSymbol.Int32);
+        var before = FunctionPointerTypeSymbol.GetManaged(parameters, TypeSymbol.Bool);
+        FunctionPointerTypeSymbol.ClearCache();
+        var after = FunctionPointerTypeSymbol.GetManaged(parameters, TypeSymbol.Bool);
+        Assert.NotSame(before, after);
+    }
+
+    [Fact]
+    public void StructSymbol_ClearCache_EvictsConstructedCaches()
+    {
+        var box = GetStruct("Box");
+        var before = StructSymbol.Construct(box, ImmutableArray.Create<TypeSymbol>(TypeSymbol.Int32));
+
+        StructSymbol.ClearCache();
+
+        var after = StructSymbol.Construct(box, ImmutableArray.Create<TypeSymbol>(TypeSymbol.Int32));
+        Assert.NotSame(before, after);
+    }
+
+    [Fact]
+    public void InterfaceSymbol_ClearCache_EvictsConstructedCache()
+    {
+        var definition = new InterfaceSymbol("IBox", Accessibility.Public, declaration: null, packageName: "P");
+        definition.SetTypeParameters(ImmutableArray.Create(
+            new TypeParameterSymbol("T", 0, TypeParameterConstraint.Any, TypeParameterVariance.None)));
+
+        var typeArguments = ImmutableArray.Create<TypeSymbol>(TypeSymbol.Int32);
+        var before = InterfaceSymbol.Construct(definition, typeArguments);
+
+        InterfaceSymbol.ClearCache();
+
+        var after = InterfaceSymbol.Construct(definition, typeArguments);
+        Assert.NotSame(before, after);
+    }
+
+    [Fact]
+    public void DelegateTypeSymbol_ClearCache_EvictsConstructedCache()
+    {
+        var typeParameter = new TypeParameterSymbol("T", 0, TypeParameterConstraint.Any, TypeParameterVariance.None);
+        var definition = new DelegateTypeSymbol(
+            "D",
+            "P",
+            Accessibility.Public,
+            ImmutableArray<ParameterSymbol>.Empty,
+            returnType: typeParameter,
+            declaration: null);
+        definition.SetTypeParameters(ImmutableArray.Create(typeParameter));
+
+        var typeArguments = ImmutableArray.Create<TypeSymbol>(TypeSymbol.Int32);
+        var before = DelegateTypeSymbol.Construct(definition, typeArguments);
+
+        DelegateTypeSymbol.ClearCache();
+
+        var after = DelegateTypeSymbol.Construct(definition, typeArguments);
+        Assert.NotSame(before, after);
+    }
+
+    [Fact]
+    public void Dispose_ClearsEveryTypeSymbolCache()
+    {
+        // Populate a representative sample of the caches Dispose is
+        // responsible for evicting.
+        var arrayBefore = ArrayTypeSymbol.Get(TypeSymbol.Bool, 2);
+        var nullableBefore = NullableTypeSymbol.Get(TypeSymbol.Bool);
+        var sliceBefore = SliceTypeSymbol.Get(TypeSymbol.Bool);
+
+        var corePath = typeof(ReferenceResolver).Assembly.Location;
+        var resolver = ReferenceResolver.WithReferences(new[] { corePath });
+        resolver.Dispose();
+
+        Assert.NotSame(arrayBefore, ArrayTypeSymbol.Get(TypeSymbol.Bool, 2));
+        Assert.NotSame(nullableBefore, NullableTypeSymbol.Get(TypeSymbol.Bool));
+        Assert.NotSame(sliceBefore, SliceTypeSymbol.Get(TypeSymbol.Bool));
+    }
+
+    private const string StructSource = @"package P
+
+class Box[T] {
+    var field T
+}
+";
+
+    private static StructSymbol GetStruct(string name)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(StructSource));
+        var compilation = new Compilation(tree);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+        Assert.Empty(result.Diagnostics);
+        return (StructSymbol)compilation.GlobalScope.Structs.Single(s => s.Name == name);
+    }
+}


### PR DESCRIPTION
Fixes #1622

## Problem
`ReferenceResolver.Dispose` only cleared `ImportedTypeSymbol` and `FunctionTypeSymbol`'s static caches. ~14 other static `ConcurrentDictionary` interning caches in `src/Core/CodeAnalysis/Symbols` were never cleared: `NullableTypeSymbol`, `SliceTypeSymbol`, `MapTypeSymbol`, `PointerTypeSymbol`, `ByRefTypeSymbol`, `ArrayTypeSymbol`, `SequenceTypeSymbol`, `AsyncSequenceTypeSymbol`, `ChannelTypeSymbol`, `TupleTypeSymbol`, `FunctionPointerTypeSymbol`, `StructSymbol` (3 caches), `InterfaceSymbol`, `DelegateTypeSymbol`. Their entries pin the disposed `MetadataLoadContext` object graph (and, for the constructed-generic caches, generic definitions + `Declaration` syntax trees) for the process lifetime — a real leak in long-lived hosts like the language server.

## Fix
Added `internal static void ClearCache()` to every remaining cache-holding type symbol, matching the exact shape of the two that already existed (`Cache.Clear()`, or all three dictionaries for `StructSymbol`). Wired all of them into `ReferenceResolver.Dispose`.

Mirrors the existing invariant already relied on by `ImportedTypeSymbol`/`FunctionTypeSymbol`: these are process-wide caches, cleared under a single-live-compilation-at-dispose assumption — each compilation rebuilds its entries organically, so the only cost is a cold cache on the next compilation in the same process. No refcounting/generation-guard existed before, so none was introduced.

## Testing
- Added `test/Core.Tests/CodeAnalysis/Symbols/Issue1622ClearCacheOnDisposeTests.cs`: one test per new `ClearCache()` (populate → clear → re-lookup returns a new instance), plus an end-to-end test that calls `ReferenceResolver.Dispose()` via `ReferenceResolver.WithReferences` and asserts several caches were evicted.
- `dotnet build GSharp.sln -c Release -graph`: 0 errors.
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release --filter "FullyQualifiedName~Cache|FullyQualifiedName~Dispose|FullyQualifiedName~ReferenceResolver|FullyQualifiedName~Symbol"`: 287 passed.
- Full `dotnet test test/Core.Tests/Core.Tests.csproj -c Release`: 5142 passed, 0 failed, 1 skipped (pre-existing baseline-regen skip).