### PR TITLE
Fix #1688: evaluate compound-assignment receiver exactly once (field + property)

### DIFF
--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.MemberAccess.cs
@@ -479,8 +479,11 @@ internal sealed partial class MethodBodyEmitter
         {
             // address is on the stack
         }
-        else
+        else if (!this.TryEmitCachedReceiver(fa.Receiver, needAddress: false))
         {
+            // Issue #1688: TryEmitCachedReceiver returns false when this
+            // receiver isn't the shared receiver of a compound assignment
+            // (no planned slot) — fall back to a plain evaluation.
             this.EmitExpression(fa.Receiver);
         }
 
@@ -585,7 +588,15 @@ internal sealed partial class MethodBodyEmitter
                     + "Check AssignmentValueSpillCollector and its ancestor walker.");
             }
 
-            this.EmitExpression(addressReceiver ?? fas.ReceiverExpression);
+            // Issue #1688: this receiver is a plain value push for `stfld`
+            // (not an address), so needAddress: false — TryEmitCachedReceiver
+            // falls back to a normal EmitExpression when no compound-reuse
+            // slot was planned (the common #1614 simple-assignment case).
+            if (!this.TryEmitCachedReceiver(addressReceiver ?? fas.ReceiverExpression, needAddress: false))
+            {
+                this.EmitExpression(addressReceiver ?? fas.ReceiverExpression);
+            }
+
             this.EmitExpression(fas.Value);
             this.il.OpCode(ILOpCode.Dup);
             this.il.StoreLocal(valueSlot);
@@ -1181,21 +1192,69 @@ internal sealed partial class MethodBodyEmitter
             // addressable storage. Spill it to a pre-declared local and
             // pass `ldloca` as `this`; this is valid for ordinary structs
             // and by-ref-like `ref struct` values, which cannot be boxed.
-            this.EmitExpression(receiver);
-            if (!this.receiverSpillSlots.TryGetValue(receiver, out var slot))
+            // Issue #1688: if this exact receiver instance is ALSO the
+            // shared receiver of a compound member assignment, it was (or
+            // will be) cached once via TryEmitCachedReceiver — reuse that
+            // cache instead of re-evaluating the receiver a second time.
+            if (this.TryEmitCachedReceiver(receiver, needAddress: true))
             {
-                throw new InvalidOperationException(
-                    $"No slot populated for {receiver.Kind} receiver of type '{receiver.Type}' — "
-                    + "walker pre-pass missed this child? "
-                    + "Check ReceiverSpillCollector and its ancestor walker.");
+                return;
             }
 
-            this.il.StoreLocal(slot);
-            this.il.LoadLocalAddress(slot);
+            throw new InvalidOperationException(
+                $"No slot populated for {receiver.Kind} receiver of type '{receiver.Type}' — "
+                + "walker pre-pass missed this child? "
+                + "Check ReceiverSpillCollector and its ancestor walker.");
+        }
+
+        // Issue #1688: a reference-type receiver shared between the read and
+        // write side of a compound member assignment (`getObj().F += x` /
+        // `getObj().P += x`) must be evaluated exactly once. Route through
+        // the cache before falling back to a plain re-emit.
+        if (this.TryEmitCachedReceiver(receiver, needAddress: false))
+        {
             return;
         }
 
         this.EmitExpression(receiver);
+    }
+
+    /// <summary>
+    /// Issue #1688: when <paramref name="receiver"/> was flagged by
+    /// <c>SlotPlanner.ReceiverSpillCollector.AddIfCompoundReused</c> — i.e. it
+    /// is the shared receiver of a compound field/property assignment
+    /// (<c>getObj().F += x</c> / <c>getObj().P += x</c>) — evaluates it
+    /// exactly once into its planned slot and loads from the slot on every
+    /// subsequent encounter of the SAME node instance, instead of re-running
+    /// the (potentially side-effecting) receiver expression for each of the
+    /// read and write sides.
+    /// </summary>
+    /// <param name="receiver">The receiver expression to emit or reuse from cache.</param>
+    /// <param name="needAddress">Whether the caller needs the receiver's address (value-type <c>this</c>) rather than its value.</param>
+    /// <returns><see langword="true"/> when the receiver was handled via the cache (planned slot found); <see langword="false"/> when no slot was planned and the caller should fall back to its own emission.</returns>
+    private bool TryEmitCachedReceiver(BoundExpression receiver, bool needAddress)
+    {
+        if (!this.receiverSpillSlots.TryGetValue(receiver, out var slot))
+        {
+            return false;
+        }
+
+        if (this.spilledCompoundReceivers.Add(receiver))
+        {
+            this.EmitExpression(receiver);
+            this.il.StoreLocal(slot);
+        }
+
+        if (needAddress)
+        {
+            this.il.LoadLocalAddress(slot);
+        }
+        else
+        {
+            this.il.LoadLocal(slot);
+        }
+
+        return true;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
@@ -65,6 +65,17 @@ internal sealed partial class MethodBodyEmitter
     private readonly Dictionary<BoundExpression, int> receiverSpillSlots;
     private readonly Dictionary<BoundStackAllocExpression, int> stackAllocResultSlots;
     private readonly HashSet<BoundStackAllocExpression> materializedStackAllocs = new HashSet<BoundStackAllocExpression>();
+
+    // Issue #1688: tracks which planned receiverSpillSlots entries have
+    // already been evaluated-and-cached during this method's emission. A
+    // compound member assignment (`getObj().F += x` / `getObj().P += x`)
+    // reuses the SAME receiver BoundExpression instance for both the read
+    // (embedded in the compound RHS) and the write (the assignment's own
+    // target) — see TryEmitCachedReceiver. The first encounter evaluates the
+    // receiver and stores it; every later encounter of the identical node
+    // instance loads the cached value/address instead of re-running the
+    // (potentially side-effecting) receiver expression.
+    private readonly HashSet<BoundExpression> spilledCompoundReceivers = new HashSet<BoundExpression>();
     private readonly Dictionary<BoundBinaryExpression, int> nullableCoalesceSpillSlots;
     private readonly Dictionary<BoundExpression, int> indexAssignmentValueSlots;
     private readonly Dictionary<BoundGoStatement, BoundScopeStatement> goEnclosingScopes;

--- a/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
+++ b/src/Core/CodeAnalysis/Emit/SlotPlanner.cs
@@ -990,9 +990,27 @@ internal sealed class SlotPlanner
             if (node.Receiver != null)
             {
                 this.AddIfNeeded(node.Receiver);
+                this.AddIfCompoundReused(node.Receiver, node.Value);
             }
 
             base.VisitClrPropertyAssignmentExpression(node);
+        }
+
+        // Issue #1688: a field assignment through an expression-based receiver
+        // (issue #567 / ADR-0112) whose Value re-reads the SAME receiver node —
+        // the shape TryBindChainedCompoundAssignment produces for
+        // `getObj().Field += x` (the compound RHS embeds a
+        // BoundFieldAccessExpression over the identical receiver instance) —
+        // must spill the receiver to a temp and evaluate it exactly once
+        // instead of once for the read and once more for the write.
+        protected override void VisitFieldAssignmentExpression(BoundFieldAssignmentExpression node)
+        {
+            if (node.ReceiverExpression != null)
+            {
+                this.AddIfCompoundReused(node.ReceiverExpression, node.Value);
+            }
+
+            base.VisitFieldAssignmentExpression(node);
         }
 
         // Issue #418 (P1-5): G# computed/auto properties also need the spill
@@ -1013,6 +1031,7 @@ internal sealed class SlotPlanner
             if (node.Receiver != null)
             {
                 this.AddIfNeeded(node.Receiver);
+                this.AddIfCompoundReused(node.Receiver, node.Value);
             }
 
             base.VisitPropertyAssignmentExpression(node);
@@ -1078,6 +1097,83 @@ internal sealed class SlotPlanner
             if (this.needsRvalueReceiverSpill(receiver, this.function, this.locals))
             {
                 this.sink.Add(receiver);
+            }
+        }
+
+        // Issue #1688: a compound member assignment (`getObj().F += x` /
+        // `getObj().P += x`) binds the receiver ONCE (TryBindChainedCompoundAssignment
+        // / TryBindChainedClrCompoundAssignment reuse the same BoundExpression
+        // instance for the read side embedded in `value` and the write side on
+        // the assignment node itself). A trivial receiver (a local, parameter,
+        // global, or `this` — all represented as BoundVariableExpression) has no
+        // side effect and no observable identity to preserve, so re-emitting it
+        // is harmless and needs no temp. Any other receiver shape (a call, an
+        // indexer, a chained member access, etc.) must be spilled to a temp and
+        // evaluated exactly once — otherwise a side-effecting or non-idempotent
+        // receiver expression runs twice and the read/write can target two
+        // different instances.
+        private void AddIfCompoundReused(BoundExpression receiver, BoundExpression value)
+        {
+            if (receiver is BoundVariableExpression)
+            {
+                return;
+            }
+
+            var found = ReceiverReuseWalker.ContainsReceiverReference(value, receiver);
+            if (found)
+            {
+                this.sink.Add(receiver);
+            }
+        }
+    }
+
+    // Issue #1688: walks a compound-assignment's bound RHS (the lowered
+    // `<field/property access> OP rhs` expression) looking for a field/property
+    // read whose receiver is the SAME BoundExpression instance as the outer
+    // assignment's receiver — the shape the compound-assignment binder helpers
+    // produce. Used by ReceiverSpillCollector.AddIfCompoundReused to decide
+    // whether the receiver needs a once-only spill.
+    private sealed class ReceiverReuseWalker : BoundTreeWalker
+    {
+        private readonly BoundExpression target;
+
+        private ReceiverReuseWalker(BoundExpression target)
+        {
+            this.target = target;
+        }
+
+        private bool Found { get; set; }
+
+        public static bool ContainsReceiverReference(BoundExpression tree, BoundExpression target)
+        {
+            var walker = new ReceiverReuseWalker(target);
+            walker.Visit(tree);
+            return walker.Found;
+        }
+
+        protected override void VisitFieldAccessExpression(BoundFieldAccessExpression node)
+        {
+            this.CheckReceiver(node.Receiver);
+            base.VisitFieldAccessExpression(node);
+        }
+
+        protected override void VisitPropertyAccessExpression(BoundPropertyAccessExpression node)
+        {
+            this.CheckReceiver(node.Receiver);
+            base.VisitPropertyAccessExpression(node);
+        }
+
+        protected override void VisitClrPropertyAccessExpression(BoundClrPropertyAccessExpression node)
+        {
+            this.CheckReceiver(node.Receiver);
+            base.VisitClrPropertyAccessExpression(node);
+        }
+
+        private void CheckReceiver(BoundExpression receiver)
+        {
+            if (receiver != null && ReferenceEquals(receiver, this.target))
+            {
+                this.Found = true;
             }
         }
     }

--- a/src/Core/CodeAnalysis/Lowering/SideEffectSpiller.cs
+++ b/src/Core/CodeAnalysis/Lowering/SideEffectSpiller.cs
@@ -200,15 +200,33 @@ internal sealed class SideEffectSpiller : BoundTreeRewriter
         var rewritten = (BoundPropertyAssignmentExpression)base.RewritePropertyAssignmentExpression(node);
 
         var spillReceiver = SideEffectAnalyzer.HasObservableSideEffect(rewritten.Receiver);
-        var spillValue = SideEffectAnalyzer.HasObservableSideEffect(rewritten.Value);
+        var value = rewritten.Value;
+        var statements = ImmutableArray.CreateBuilder<BoundStatement>();
+
+        var receiver = rewritten.Receiver;
+        if (spillReceiver)
+        {
+            receiver = this.MaybeSpill(rewritten.Receiver, true, "recv", statements);
+
+            // Issue #1688: a compound assignment (`getObj().P += x`) lowers
+            // to `assign(receiver, get(receiver) OP rhs)` — the SAME
+            // receiver node appears both as the assignment's own receiver
+            // and nested inside `value` as the read side. Spilling only
+            // the copy above and leaving the nested read pointing at the
+            // original (still side-effecting) receiver expression would
+            // evaluate it a second time. Substitute every occurrence of
+            // the shared receiver inside `value` with the freshly spilled
+            // temp so both sides observe exactly one evaluation.
+            value = ReceiverSubstitutionRewriter.Replace(value, rewritten.Receiver, receiver);
+        }
+
+        var spillValue = SideEffectAnalyzer.HasObservableSideEffect(value);
         if (!spillReceiver && !spillValue)
         {
             return rewritten;
         }
 
-        var statements = ImmutableArray.CreateBuilder<BoundStatement>();
-        var receiver = this.MaybeSpill(rewritten.Receiver, spillReceiver, "recv", statements);
-        var value = this.MaybeSpill(rewritten.Value, spillValue, "val", statements);
+        value = this.MaybeSpill(value, spillValue, "val", statements);
 
         var assignment = new BoundPropertyAssignmentExpression(
             rewritten.Syntax,
@@ -227,17 +245,26 @@ internal sealed class SideEffectSpiller : BoundTreeRewriter
 
         var spillReceiver = rewritten.Receiver != null
             && SideEffectAnalyzer.HasObservableSideEffect(rewritten.Receiver);
-        var spillValue = SideEffectAnalyzer.HasObservableSideEffect(rewritten.Value);
+        var value = rewritten.Value;
+        var statements = ImmutableArray.CreateBuilder<BoundStatement>();
+
+        var receiver = rewritten.Receiver;
+        if (spillReceiver)
+        {
+            receiver = this.MaybeSpill(rewritten.Receiver, true, "recv", statements);
+
+            // Issue #1688: same double-eval hazard as the user-property
+            // path above, for CLR properties (`obj.ClrProp += x`).
+            value = ReceiverSubstitutionRewriter.Replace(value, rewritten.Receiver, receiver);
+        }
+
+        var spillValue = SideEffectAnalyzer.HasObservableSideEffect(value);
         if (!spillReceiver && !spillValue)
         {
             return rewritten;
         }
 
-        var statements = ImmutableArray.CreateBuilder<BoundStatement>();
-        var receiver = rewritten.Receiver == null
-            ? null
-            : this.MaybeSpill(rewritten.Receiver, spillReceiver, "recv", statements);
-        var value = this.MaybeSpill(rewritten.Value, spillValue, "val", statements);
+        value = this.MaybeSpill(value, spillValue, "val", statements);
 
         var assignment = new BoundClrPropertyAssignmentExpression(
             rewritten.Syntax,
@@ -279,5 +306,41 @@ internal sealed class SideEffectSpiller : BoundTreeRewriter
             type: expression.Type);
         statements.Add(new BoundVariableDeclaration(expression.Syntax, local, expression));
         return new BoundVariableExpression(expression.Syntax, local);
+    }
+
+    /// <summary>
+    /// Issue #1688: rewrites a bound expression tree, replacing every
+    /// reference-equal occurrence of a shared receiver node with a
+    /// replacement expression (typically a read of the temp local it was
+    /// just spilled into). Used to keep the nested read embedded in a
+    /// compound assignment's <c>value</c> in sync with the receiver copy
+    /// the assignment itself was rewritten to use.
+    /// </summary>
+    private sealed class ReceiverSubstitutionRewriter : BoundTreeRewriter
+    {
+        private readonly BoundExpression target;
+        private readonly BoundExpression replacement;
+
+        private ReceiverSubstitutionRewriter(BoundExpression target, BoundExpression replacement)
+        {
+            this.target = target;
+            this.replacement = replacement;
+        }
+
+        public static BoundExpression Replace(BoundExpression tree, BoundExpression target, BoundExpression replacement)
+        {
+            var rewriter = new ReceiverSubstitutionRewriter(target, replacement);
+            return rewriter.RewriteExpression(tree);
+        }
+
+        // Intercepting the single generic dispatch point (rather than each
+        // Rewrite*AccessExpression override) means every parent-node
+        // reconstruction still goes through the normal Rewrite* overrides,
+        // which already know how to preserve NarrowedType / InterfaceType /
+        // StaticContainerType — no risk of silently dropping a field here.
+        protected override BoundExpression RewriteExpression(BoundExpression node)
+        {
+            return ReferenceEquals(node, this.target) ? this.replacement : base.RewriteExpression(node);
+        }
     }
 }

--- a/test/Compiler.Tests/Emit/Issue1614FieldAssignmentReceiverOnceEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1614FieldAssignmentReceiverOnceEmitTests.cs
@@ -89,13 +89,114 @@ public class Issue1614FieldAssignmentReceiverOnceEmitTests
 
         var (finalCount, callCount) = RunAndGetTwoIntResults(source, "finalCount", "callCount");
 
-        // Compound assignment reads the current field value through the
-        // receiver once and writes through it once (two evaluations,
-        // matching the accepted property-compound-assignment behavior).
-        // Pre-fix this was three evaluations (read + write + spurious
-        // reload for the discarded statement-position result).
+        // Issue #1688: the compound-assignment receiver is spilled to a
+        // temp and evaluated exactly ONCE, then reused for both the read
+        // (current field value) and the write. Pre-#1688 this was two
+        // evaluations (read + write); pre-#1614 it was three (plus a
+        // spurious reload for the discarded statement-position result).
         Assert.Equal(15, finalCount);
-        Assert.Equal(2, callCount);
+        Assert.Equal(1, callCount);
+    }
+
+    [Fact]
+    public void CallReceiverFieldCompoundAssignment_WritesBackToTheSameObjectItRead()
+    {
+        // The receiver is a call that mutates shared state and returns a
+        // fresh object each invocation; the compound write must land on the
+        // SAME instance the compound read observed (recorded via a global
+        // set inside GetBox), not a second freshly-constructed instance.
+        var source = """
+            package P1688A
+            import System
+
+            class Box {
+                var Count int32
+            }
+
+            public var calls = 0
+            public var lastBox = Box()
+
+            func GetBox() Box {
+                calls = calls + 1
+                var b = Box()
+                b.Count = 10
+                lastBox = b
+                return b
+            }
+
+            GetBox().Count += 5
+            public var finalCount = lastBox.Count
+            public var callCount = calls
+            """;
+
+        var (finalCount, callCount) = RunAndGetTwoIntResults(source, "finalCount", "callCount");
+
+        Assert.Equal(15, finalCount);
+        Assert.Equal(1, callCount);
+    }
+
+    [Fact]
+    public void CallReceiverPropertyCompoundAssignment_EvaluatesReceiverExactlyOnce()
+    {
+        var source = """
+            package P1688B
+            import System
+
+            class Box {
+                var backing int32
+                prop Count int32 { get { return backing } set { backing = value } }
+            }
+
+            public var calls = 0
+            let shared = Box()
+
+            func GetBox() Box {
+                calls = calls + 1
+                return shared
+            }
+
+            shared.Count = 10
+            GetBox().Count += 5
+            public var finalCount = shared.Count
+            public var callCount = calls
+            """;
+
+        var (finalCount, callCount) = RunAndGetTwoIntResults(source, "finalCount", "callCount");
+
+        Assert.Equal(15, finalCount);
+        Assert.Equal(1, callCount);
+    }
+
+    [Fact]
+    public void LocalReceiverFieldCompoundAssignment_NeedsNoSpillAndStillWorks()
+    {
+        // Trivial (local-variable) receivers have no side effect to
+        // preserve; the fix must not force a temp for them, and the
+        // compound assignment must still produce the correct result.
+        var source = """
+            package P1688C
+            import System
+
+            class Box {
+                var Count int32
+            }
+
+            let shared = Box()
+            shared.Count = 10
+            shared.Count += 5
+            public var finalCount = shared.Count
+            """;
+
+        var assembly = CompileToAssembly(source);
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var entry = program.GetMethod(
+            "<Main>$",
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+        var finalCountField = program.GetField("finalCount", BindingFlags.Public | BindingFlags.Static);
+
+        entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+
+        Assert.Equal(15, (int)finalCountField!.GetValue(null)!);
     }
 
     private static (int First, int Second) RunAndGetTwoIntResults(string source, string firstField, string secondField)


### PR DESCRIPTION
Fixes #1688

Follow-up to #1614/#1686/#418: this closes the COMPOUND-assignment path (`getObj().F += x` and `getObj().P += x`), which was explicitly out of scope for #1614 (fields only) and pre-existing for properties.

## Root cause (two different places)

- **Field**: `TryBindChainedCompoundAssignment` binds the receiver once but embeds the SAME `BoundExpression` instance both as the assignment's own receiver and inside the compound RHS's nested field read. The emitter re-emitted the receiver at each site independently, causing two evaluations.
- **Property**: the double-eval actually happens earlier, in `SideEffectSpiller` (issue #452), which already spills a side-effecting property-assignment receiver into a temp, but only rewrites the assignment's own receiver copy, not the reference-equal receiver embedded in the nested compound read inside `value`. That nested read kept calling the original (still side-effecting) receiver expression a second time.

## Fix

- **Field** (`SlotPlanner.cs` / `MethodBodyEmitter.MemberAccess.cs`): `ReceiverSpillCollector` now detects (`AddIfCompoundReused`) when a `BoundFieldAssignmentExpression`'s receiver is reused inside its compound RHS and plans a spill slot for it (skipped for trivial local/param/`this` receivers, no side effect, no needless temp). `TryEmitCachedReceiver` evaluates the receiver once into that slot and reuses it (value or address, as needed) for both the read and the write.
- **Property/CLR-property** (`SideEffectSpiller.cs`): added `ReceiverSubstitutionRewriter`, which replaces every reference-equal occurrence of the spilled receiver inside `value` with the same spilled-temp read, so the nested compound read and the outer assignment observe the identical (already-evaluated) receiver. Applied in both `RewritePropertyAssignmentExpression` and `RewriteClrPropertyAssignmentExpression`.

Value-type receivers: unchanged from #1614/#418, a value-type rvalue receiver still gets its address taken via the existing addressable-spill slot, now unified with the same `TryEmitCachedReceiver` cache so a receiver that is BOTH a value-type-needs-address AND a compound-reused receiver only evaluates once.

## Tests (`test/Compiler.Tests/Emit/Issue1614FieldAssignmentReceiverOnceEmitTests.cs`)

- Flipped `CallReceiverFieldCompoundAssignment_DoesNotTripleEvaluateReceiver`'s pinned `callCount` from 2 to 1.
- Added `CallReceiverFieldCompoundAssignment_WritesBackToTheSameObjectItRead` (field, call receiver mutating shared state).
- Added `CallReceiverPropertyCompoundAssignment_EvaluatesReceiverExactlyOnce` (computed property, call receiver), was failing (`callCount == 2`) before the `SideEffectSpiller` fix, passes now.
- Added `LocalReceiverFieldCompoundAssignment_NeedsNoSpillAndStillWorks` (trivial receiver, no spill needed).

## Validation

- `dotnet build GSharp.sln -c Release -graph`, 0 errors.
- Narrow filter `FullyQualifiedName~Issue1614|FullyQualifiedName~CompoundAssign|FullyQualifiedName~ReceiverOnce|FullyQualifiedName~Issue1688`: 36 passed.
- `Core.Tests` `PropertyAssignmentSpillEmitTests` / `ClrMemberAccessTests` / `SideEffectSpiller`-related tests: 35 passed.
- `Sample_EmittedPE_Matches_Baseline`: 137 passed, no `samples/*.gs` IL baseline changed, no regen needed.
