### PR TITLE
Fix #1664: move push-mode didSave bind off the write gate, eliminate double parse

### DIFF
--- a/src/LanguageServer/Server/LspServer.cs
+++ b/src/LanguageServer/Server/LspServer.cs
@@ -3,6 +3,7 @@
 // out of StyleCop documentation/ordering rules; this is protocol plumbing, not product logic.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -36,6 +37,15 @@ public sealed class LspServer
     private readonly WorkspaceState workspaceState;
     private readonly ILogger logger;
     private readonly SemaphoreSlim gate = new SemaphoreSlim(1, 1);
+    private readonly ConcurrentDictionary<string, CancellationTokenSource> pushBindCts = new ConcurrentDictionary<string, CancellationTokenSource>();
+
+    // Test-only seams (issue #1664): letting tests observe/control the off-gate push-diagnostics
+    // bind deterministically, without sleeps or a real JsonRpc transport. Unused in production
+    // (rpc is null in these unit tests anyway, so publishing is otherwise unobservable).
+    internal Action<DocumentUri, DiagnosticComputationResult> TestOnParseResult;
+    internal Action<DocumentUri, DiagnosticComputationResult> TestOnBindResult;
+    internal Action<DocumentUri, IReadOnlyList<Diagnostic>> TestOnPublish;
+    internal Func<CancellationToken, Task> TestPushBindDelay;
     private readonly TaskCompletionSource<int> exitSource = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly object refreshLock = new object();
 
@@ -163,8 +173,10 @@ public sealed class LspServer
 
         return this.GuardAsync(() =>
         {
-            this.UpdateDocument(uri, text);
-            this.PublishDiagnosticsIfPushMode(uri, text, skipBinding: true);
+            // Issue #1664: UpdateDocument already parses text and computes skipBinding:true
+            // diagnostics; reuse that result instead of re-parsing the same text a second time.
+            var result = this.UpdateDocument(uri, text);
+            this.PublishDiagnosticsIfPushMode(uri, result);
             return 0;
         });
     }
@@ -181,8 +193,8 @@ public sealed class LspServer
 
         return this.GuardAsync(() =>
         {
-            this.UpdateDocument(uri, text);
-            this.PublishDiagnosticsIfPushMode(uri, text, skipBinding: true);
+            var result = this.UpdateDocument(uri, text);
+            this.PublishDiagnosticsIfPushMode(uri, result);
 
             // Inter-file edits can change diagnostics in other open documents; ask the
             // client to re-pull them. Debounced so a burst of keystrokes coalesces.
@@ -203,11 +215,17 @@ public sealed class LspServer
 
         return this.GuardAsync(() =>
         {
-            this.UpdateDocument(uri, text);
+            var result = this.UpdateDocument(uri, text);
 
-            // Pull clients already receive live binding diagnostics; only push clients need
-            // the full pipeline run here.
-            this.PublishDiagnosticsIfPushMode(uri, text, skipBinding: false);
+            // Pull clients already receive live binding diagnostics via textDocument/diagnostic;
+            // only push clients need the full (binding + DocumentationValidator) pipeline here.
+            // Issue #1664: that full bind used to run inline, under this gate — freezing every
+            // other request for the duration of a cold whole-project bind. Snapshot the just-
+            // parsed tree/project (brief, done above under the gate) and kick the bind off the
+            // gate on the thread pool instead, mirroring DocumentDiagnosticAsync. The fire-and-
+            // forget task below does not block GuardAsync's body, so the gate is released
+            // immediately.
+            this.SchedulePushDiagnosticsBind(uri, result);
             return 0;
         });
     }
@@ -228,6 +246,14 @@ public sealed class LspServer
             if (!string.IsNullOrEmpty(filePath))
             {
                 this.workspaceState.ClearOpenBuffer(filePath);
+            }
+
+            // Issue #1664: a still-running push-mode didSave bind for this file would otherwise
+            // publish diagnostics for a document the client no longer has open.
+            if (this.pushBindCts.TryRemove(uri.ToString(), out var cts))
+            {
+                cts.Cancel();
+                cts.Dispose();
             }
 
             return 0;
@@ -957,7 +983,7 @@ public sealed class LspServer
         return uri != null && this.documentContentService.TryGet(uri.ToString(), out content);
     }
 
-    private void UpdateDocument(DocumentUri uri, string text)
+    private DiagnosticComputationResult UpdateDocument(DocumentUri uri, string text)
     {
         var filePath = uri.GetFileSystemPath();
 
@@ -977,11 +1003,20 @@ public sealed class LspServer
 
         // Parse-only content (no binding) feeds the content service used by other features;
         // diagnostics are produced on demand by the textDocument/diagnostic pull handler.
+        // Issue #1664: this is the only parse of `text`; callers (didOpen/didChange push
+        // publish, didSave's off-gate bind) reuse this result instead of re-parsing it.
         var result = DocumentSyncHandler.ComputeDiagnostics(text, skipBinding: true, project, filePath, this.workspaceState);
         this.documentContentService.AddOrUpdate(uri.ToString(), result.Content);
+        this.TestOnParseResult?.Invoke(uri, result);
+        return result;
     }
 
-    private void PublishDiagnosticsIfPushMode(DocumentUri uri, string text, bool skipBinding)
+    /// <summary>
+    /// Publishes the already-computed (parse-only) diagnostics for push-mode clients. Used by
+    /// didOpen/didChange, where <see cref="UpdateDocument"/>'s skipBinding:true result is exactly
+    /// what push clients should see, so no recomputation is needed (issue #1664).
+    /// </summary>
+    private void PublishDiagnosticsIfPushMode(DocumentUri uri, DiagnosticComputationResult result)
     {
         // Clients advertising pull diagnostics request them via textDocument/diagnostic, so push
         // is suppressed to avoid double reporting. Older push-only clients still get notifications.
@@ -990,13 +1025,98 @@ public sealed class LspServer
             return;
         }
 
-        var filePath = uri.GetFileSystemPath();
-        var project = !string.IsNullOrEmpty(filePath) ? this.workspaceState.GetProjectForFile(filePath) : null;
-        var result = DocumentSyncHandler.ComputeDiagnostics(text, skipBinding, project, filePath, this.workspaceState);
-
+        this.TestOnPublish?.Invoke(uri, result.Diagnostics);
         this.rpc?.NotifyWithParameterObjectAsync(
             "textDocument/publishDiagnostics",
             new PublishDiagnosticsParams { Uri = uri, Diagnostics = result.Diagnostics });
+    }
+
+    /// <summary>
+    /// Schedules the full (binding + <c>DocumentationValidator</c>) diagnostics pass a push-mode
+    /// didSave needs, off the write gate. Mirrors <see cref="DocumentDiagnosticAsync"/>: the
+    /// already-parsed <paramref name="parseResult"/>'s <see cref="SyntaxTree"/> and owning
+    /// project were captured under the gate by <see cref="UpdateDocument"/> (brief, parse-only);
+    /// the (potentially ~seconds-long, cold-workspace) bind itself runs on the thread pool via
+    /// <see cref="DocumentSyncHandler.ComputeDiagnosticsForSnapshot"/>, which never calls
+    /// <see cref="ProjectState.UpdateFile"/> and so can never clobber a newer tree written by a
+    /// concurrent didChange/didSave (issue #1657).
+    ///
+    /// A per-file <see cref="CancellationTokenSource"/> supersedes stale binds: a newer edit to
+    /// the same file cancels any still-running bind for the file's previous text, and the
+    /// superseded bind's publish is skipped so it can never overwrite the newer diagnostics
+    /// (issue #1664).
+    /// </summary>
+    private void SchedulePushDiagnosticsBind(DocumentUri uri, DiagnosticComputationResult parseResult)
+    {
+        if (this.clientSupportsPullDiagnostics)
+        {
+            return;
+        }
+
+        var filePath = uri.GetFileSystemPath();
+        var project = parseResult.Content.Project;
+        var syntaxTree = parseResult.Content.SyntaxTree;
+        var key = uri.ToString();
+
+        var cts = new CancellationTokenSource();
+        this.pushBindCts.AddOrUpdate(
+            key,
+            cts,
+            (_, previous) =>
+            {
+                previous.Cancel();
+                previous.Dispose();
+                return cts;
+            });
+        var token = cts.Token;
+
+        _ = Task.Run(
+            async () =>
+            {
+                var delay = this.TestPushBindDelay;
+                if (delay != null)
+                {
+                    try
+                    {
+                        await delay(token).ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        return;
+                    }
+                }
+
+                DiagnosticComputationResult bound;
+                try
+                {
+                    token.ThrowIfCancellationRequested();
+                    bound = DocumentSyncHandler.ComputeDiagnosticsForSnapshot(syntaxTree, skipBinding: false, project, filePath, this.workspaceState);
+                }
+                catch (OperationCanceledException)
+                {
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    LogHandlerException(nameof(this.SchedulePushDiagnosticsBind), ex);
+                    return;
+                }
+
+                this.TestOnBindResult?.Invoke(uri, bound);
+
+                // A newer edit superseded this bind while it ran; its diagnostics are stale, so
+                // drop them instead of clobbering whatever the newer edit publishes.
+                if (token.IsCancellationRequested)
+                {
+                    return;
+                }
+
+                this.TestOnPublish?.Invoke(uri, bound.Diagnostics);
+                this.rpc?.NotifyWithParameterObjectAsync(
+                    "textDocument/publishDiagnostics",
+                    new PublishDiagnosticsParams { Uri = uri, Diagnostics = bound.Diagnostics });
+            },
+            token);
     }
 
     private void DetectClientDiagnosticCapabilities(JsonElement capabilities)

--- a/test/LanguageServer.Tests/Issue1664PushDiagnosticsOffGateTests.cs
+++ b/test/LanguageServer.Tests/Issue1664PushDiagnosticsOffGateTests.cs
@@ -1,0 +1,242 @@
+// <copyright file="Issue1664PushDiagnosticsOffGateTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.LanguageServer.Protocol;
+using GSharp.LanguageServer.Server;
+using Xunit;
+
+namespace GSharp.LanguageServer.Tests;
+
+/// <summary>
+/// Issue #1664: for push-diagnostics clients (no textDocument/diagnostic pull support —
+/// vim/neovim/emacs/older editors), didOpen/didChange/didSave used to (1) parse the same text
+/// twice (once in <c>UpdateDocument</c>, once again in the old push-publish path) and (2) run the
+/// full binding pass + <c>DocumentationValidator</c> inline, under the single write
+/// <c>gate</c> every other request must acquire — freezing the whole server for the duration of
+/// a full project bind on every didSave. These tests lock in the fix: the parse result is reused
+/// (no second parse), the didSave bind runs off the gate on the thread pool, a newer edit
+/// supersedes (and its publish is dropped for) any still-running older bind, and push clients
+/// still receive correct, full diagnostics once the bind completes.
+///
+/// None of these tests attach a real JsonRpc transport (server.rpc stays null, matching every
+/// other test in this suite), so they use the internal Test* hooks on <see cref="LspServer"/> —
+/// invoked at exactly the points production code would otherwise call into JsonRpc — to observe
+/// diagnostics and control bind timing deterministically, without sleeps.
+/// </summary>
+public class Issue1664PushDiagnosticsOffGateTests
+{
+    private const string BindingErrorSource = "func F() int32 {\n}\n";
+
+    [Fact]
+    public async Task DidSave_ReusesParsedTree_DoesNotReparseForOffGateBind()
+    {
+        // A standalone file (no .gsproj) takes the most literal double-parse path: without a
+        // project, ComputeDiagnostics always does `SyntaxTree.Parse(text)` fresh, with no
+        // ProjectState-level cache. If the off-gate bind reparsed instead of reusing
+        // UpdateDocument's tree, the two captured SyntaxTree instances below would differ.
+        var server = new LspServer(new DocumentContentService(), new WorkspaceState());
+        var uri = DocumentUri.From("file:///reparse-check.gs");
+
+        SyntaxTree parsedTree = null;
+        SyntaxTree boundTree = null;
+        server.TestOnParseResult = (_, result) => parsedTree = result.Content.SyntaxTree;
+        server.TestOnBindResult = (_, result) => boundTree = result.Content.SyntaxTree;
+
+        await server.DidOpenAsync(new DidOpenTextDocumentParams
+        {
+            TextDocument = new TextDocumentItem { Uri = uri, Text = BindingErrorSource },
+        });
+
+        await server.DidSaveAsync(new DidSaveTextDocumentParams
+        {
+            TextDocument = new TextDocumentIdentifier { Uri = uri },
+            Text = BindingErrorSource,
+        });
+
+        await WaitForAsync(() => boundTree != null);
+
+        Assert.NotNull(parsedTree);
+        Assert.Same(parsedTree, boundTree);
+    }
+
+    [Fact]
+    public async Task DidSave_PushMode_PublishesFullBindingDiagnostics()
+    {
+        var server = new LspServer(new DocumentContentService(), new WorkspaceState());
+        var uri = DocumentUri.From("file:///offgate-correctness.gs");
+
+        IReadOnlyList<Diagnostic> published = null;
+        server.TestOnPublish = (_, diagnostics) => published = diagnostics;
+
+        await server.DidOpenAsync(new DidOpenTextDocumentParams
+        {
+            TextDocument = new TextDocumentItem { Uri = uri, Text = BindingErrorSource },
+        });
+
+        // didOpen's push publish is parse-only (skipBinding:true) and must not include the
+        // binding-level "not all code paths return a value" diagnostic yet.
+        Assert.NotNull(published);
+        Assert.DoesNotContain(published, d => d.Message.Contains("Not all code paths", StringComparison.Ordinal));
+
+        await server.DidSaveAsync(new DidSaveTextDocumentParams
+        {
+            TextDocument = new TextDocumentIdentifier { Uri = uri },
+            Text = BindingErrorSource,
+        });
+
+        await WaitForAsync(() => published.Any(d => d.Message.Contains("Not all code paths", StringComparison.Ordinal)));
+    }
+
+    [Fact]
+    public async Task DidSave_FullBindRunsOffGate_ConcurrentGatedRequestIsNotBlocked()
+    {
+        var server = new LspServer(new DocumentContentService(), new WorkspaceState());
+        var uri = DocumentUri.From("file:///gate-free-check.gs");
+
+        // Stall the bind indefinitely (until released below) to simulate the ~17s cold
+        // full-project bind the issue describes. If it still ran under GuardAsync's gate,
+        // DidSaveAsync itself would not return until released, and the concurrent didChange
+        // below would hang waiting for the same gate.
+        var release = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        server.TestPushBindDelay = async ct =>
+        {
+            using var registration = ct.Register(() => release.TrySetCanceled(ct));
+#pragma warning disable VSTHRD003 // test-only: awaiting a TaskCompletionSource signaled by the test body, not started here.
+            await release.Task.ConfigureAwait(false);
+#pragma warning restore VSTHRD003
+        };
+
+        await server.DidOpenAsync(new DidOpenTextDocumentParams
+        {
+            TextDocument = new TextDocumentItem { Uri = uri, Text = BindingErrorSource },
+        });
+
+        var saveTask = server.DidSaveAsync(new DidSaveTextDocumentParams
+        {
+            TextDocument = new TextDocumentIdentifier { Uri = uri },
+            Text = BindingErrorSource,
+        });
+
+        // DidSaveAsync's GuardAsync body only parses and schedules the bind; it must complete
+        // promptly even though the bind it scheduled is stalled indefinitely.
+        var completed = await Task.WhenAny(saveTask, Task.Delay(TimeSpan.FromSeconds(5)));
+        Assert.Same(saveTask, completed);
+
+        // With the gate held for the whole bind (the bug), this would hang until `release`
+        // completes. With the fix, the gate was already released, so this proceeds immediately.
+        var changeTask = server.DidChangeAsync(new DidChangeTextDocumentParams
+        {
+            TextDocument = new VersionedTextDocumentIdentifier { Uri = uri },
+            ContentChanges = new List<TextDocumentContentChangeEvent> { new TextDocumentContentChangeEvent { Text = BindingErrorSource } },
+        });
+        var changeCompleted = await Task.WhenAny(changeTask, Task.Delay(TimeSpan.FromSeconds(5)));
+        Assert.Same(changeTask, changeCompleted);
+
+        release.TrySetResult(true);
+    }
+
+    [Fact]
+    public async Task NewerEdit_SupersedesOlderInFlightBind_NoStaleDiagnosticsClobber()
+    {
+        var server = new LspServer(new DocumentContentService(), new WorkspaceState());
+        var uri = DocumentUri.From("file:///supersede-check.gs");
+
+        const string firstText = "func F() int32 {\n}\n"; // binding error: missing return
+        const string secondText = "func F() int32 {\n  return 1\n}\n"; // no binding error
+
+        var firstBindGate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var firstBindStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var publishes = new List<(string Uri, IReadOnlyList<Diagnostic> Diagnostics)>();
+        var delayCallCount = 0;
+
+        server.TestPushBindDelay = async ct =>
+        {
+            var call = Interlocked.Increment(ref delayCallCount);
+            if (call == 1)
+            {
+                // Stall the FIRST bind (for firstText) until the second edit has had a chance to
+                // supersede it.
+                firstBindStarted.TrySetResult(true);
+                using var registration = ct.Register(() => firstBindGate.TrySetCanceled(ct));
+#pragma warning disable VSTHRD003 // test-only: awaiting a TaskCompletionSource signaled by the test body, not started here.
+                await firstBindGate.Task.ConfigureAwait(false);
+#pragma warning restore VSTHRD003
+            }
+
+            // The second bind (for secondText) proceeds immediately, no stall.
+        };
+        server.TestOnPublish = (u, diagnostics) =>
+        {
+            lock (publishes)
+            {
+                publishes.Add((u.ToString(), diagnostics));
+            }
+        };
+
+        await server.DidOpenAsync(new DidOpenTextDocumentParams
+        {
+            TextDocument = new TextDocumentItem { Uri = uri, Text = firstText },
+        });
+
+        var firstSave = server.DidSaveAsync(new DidSaveTextDocumentParams
+        {
+            TextDocument = new TextDocumentIdentifier { Uri = uri },
+            Text = firstText,
+        });
+        await firstSave;
+        await firstBindStarted.Task;
+
+        // Supersede: a newer save for the same file while the first bind is still stalled.
+        // This must cancel the first bind's token so its (stale) diagnostics for firstText are
+        // never published, even though it "completes" (via cancellation) after the second.
+        var secondSave = server.DidSaveAsync(new DidSaveTextDocumentParams
+        {
+            TextDocument = new TextDocumentIdentifier { Uri = uri },
+            Text = secondText,
+        });
+        await secondSave;
+
+        await WaitForAsync(() =>
+        {
+            lock (publishes)
+            {
+                return publishes.Any(p => p.Uri == uri.ToString()
+                    && !p.Diagnostics.Any(d => d.Message.Contains("Not all code paths", StringComparison.Ordinal)));
+            }
+        });
+
+        // Let the stalled first bind observe cancellation and (if it ever reaches the publish
+        // check) attempt to publish; it must not, because its token was cancelled.
+        firstBindGate.TrySetResult(true);
+        await Task.Delay(200);
+
+        lock (publishes)
+        {
+            var forThisFile = publishes.Where(p => p.Uri == uri.ToString()).ToList();
+            Assert.DoesNotContain(
+                forThisFile,
+                p => p.Diagnostics.Any(d => d.Message.Contains("Not all code paths", StringComparison.Ordinal)));
+        }
+    }
+
+    private static async Task WaitForAsync(Func<bool> condition, int timeoutMs = 10000)
+    {
+        var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+        while (!condition())
+        {
+            if (DateTime.UtcNow > deadline)
+            {
+                Assert.Fail("Timed out waiting for the condition to become true.");
+            }
+
+            await Task.Delay(25);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1664

## Problem
For push-diagnostics clients (no textDocument/diagnostic pull support), didOpen/didChange/didSave:
1. Parsed the same text twice per keystroke — `UpdateDocument` parses, then the old `PublishDiagnosticsIfPushMode` re-ran `DocumentSyncHandler.ComputeDiagnostics` on the same text.
2. On didSave, ran the full bind (`compilation.BoundProgram` + `DocumentationValidator.Validate`) inline, inside `GuardAsync`, holding the single write `gate` every other request must acquire — freezing the server for the duration of a full project bind.

## Fix
- `UpdateDocument` now returns its (parse-only, skipBinding:true) `DiagnosticComputationResult` instead of discarding it. didOpen/didChange push-publish reuse that result directly — no second parse.
- didSave's full bind now snapshots the already-parsed tree/project under the gate (brief), then runs the bind off the gate on the thread pool via `DocumentSyncHandler.ComputeDiagnosticsForSnapshot`, mirroring the existing `DocumentDiagnosticAsync` pull-diagnostics pattern. `GuardAsync`'s body returns immediately; the bind + publish happen afterward, off the gate.
- A per-file `CancellationTokenSource` supersedes stale binds: a newer edit to the same file cancels any still-running bind for its previous text, and a superseded bind's diagnostics are never published — a newer edit can never be clobbered by an older in-flight bind. `didClose` also cancels any pending bind for the closed document.

## Tests
Added `test/LanguageServer.Tests/Issue1664PushDiagnosticsOffGateTests.cs` using internal test-only hooks on `LspServer` (no real JsonRpc transport needed, matching the rest of the suite) to deterministically verify:
- The off-gate bind reuses the parsed `SyntaxTree` (no re-parse).
- Push clients still receive correct, full (binding + `DocumentationValidator`) diagnostics.
- The gate remains free for a concurrent request while a didSave bind is stalled.
- A newer edit supersedes an older in-flight bind; the stale bind's diagnostics are never published.

`dotnet build GSharp.sln -c Release -graph`: 0 errors.
`dotnet test test/LanguageServer.Tests/LanguageServer.Tests.csproj -c Release`: 409/409 passed.