### PR TITLE
Fix concurrent writes corrupting shared interpreter frame/object state

### DIFF
--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -85,10 +86,17 @@ public sealed class Evaluator
     {
         this.program = program;
         globals = variables;
-        Locals.Push(new Dictionary<VariableSymbol, object>());
+        Locals.Push(new ConcurrentDictionary<VariableSymbol, object>());
     }
 
-    private Stack<Dictionary<VariableSymbol, object>> Locals => executionState.Value.Locals;
+    // Issue #1718: a frame dictionary is shared by reference with every
+    // goroutine spawned while it is on the locals stack (see
+    // CloneExecutionStateForGoroutine), so a captured enclosing-scope
+    // variable can be assigned from the spawning thread and a goroutine at
+    // the same time. Plain Dictionary<,> is not thread-safe under
+    // concurrent writes (can corrupt buckets/throw on resize); every frame
+    // is a ConcurrentDictionary so those racing reads/writes are safe.
+    private Stack<ConcurrentDictionary<VariableSymbol, object>> Locals => executionState.Value.Locals;
 
     private Stack<ScopeFrame> ScopeFrames => executionState.Value.ScopeFrames;
 
@@ -232,7 +240,7 @@ public sealed class Evaluator
     /// </summary>
     /// <param name="frame">The frame to push (parameters, 'this', captured locals).</param>
     /// <returns>A disposable guard that pops <paramref name="frame"/> exactly once.</returns>
-    private FrameScope PushFrame(Dictionary<VariableSymbol, object> frame) => new(Locals, frame);
+    private FrameScope PushFrame(ConcurrentDictionary<VariableSymbol, object> frame) => new(Locals, frame);
 
     private static Dictionary<BoundLabel, int> GetLabelToIndex(BoundBlockStatement body) =>
         LabelIndexCache.GetValue(body, static b =>
@@ -540,7 +548,7 @@ public sealed class Evaluator
         var current = executionState.Value;
         return new ExecutionState
         {
-            Locals = new Stack<Dictionary<VariableSymbol, object>>(current.Locals.Reverse()),
+            Locals = new Stack<ConcurrentDictionary<VariableSymbol, object>>(current.Locals.Reverse()),
         };
     }
 
@@ -1452,7 +1460,7 @@ public sealed class Evaluator
                 else if (init.Property.SetterSymbol != null && program.Functions.TryGetValue(init.Property.SetterSymbol, out var setterBody))
                 {
                     var value = EvaluateExpression(init.Value);
-                    var frame = new Dictionary<Symbols.VariableSymbol, object>
+                    var frame = new ConcurrentDictionary<Symbols.VariableSymbol, object>
                     {
                         [init.Property.SetterSymbol.ThisParameter] = sv,
                         [init.Property.SetterSymbol.Parameters[0]] = value,
@@ -1566,7 +1574,7 @@ public sealed class Evaluator
         }
 
         var closure = (ClosureValue)targetValue;
-        var frame = new Dictionary<VariableSymbol, object>();
+        var frame = new ConcurrentDictionary<VariableSymbol, object>();
         foreach (var kv in closure.CapturedLocals)
         {
             frame[kv.Key] = kv.Value;
@@ -1645,7 +1653,7 @@ public sealed class Evaluator
                 if (baseInitOnStruct != null
                     && baseInitOnStruct.GSharpBaseType is StructSymbol gsBase)
                 {
-                    var frame = new Dictionary<VariableSymbol, object>();
+                    var frame = new ConcurrentDictionary<VariableSymbol, object>();
                     for (var i = 0; i < primaryParams.Length; i++)
                     {
                         frame[primaryParams[i]] = sv.Fields[primaryParams[i].Name];
@@ -1666,7 +1674,7 @@ public sealed class Evaluator
             }
 
             var ctorFunction = explicitCtor.Function;
-            var frame2 = new Dictionary<VariableSymbol, object>
+            var frame2 = new ConcurrentDictionary<VariableSymbol, object>
             {
                 [ctorFunction.ThisParameter] = sv,
             };
@@ -1714,7 +1722,7 @@ public sealed class Evaluator
         if (baseInit != null || node.StructType.ImportedBaseType != null
             || HasClrAncestor(node.StructType))
         {
-            var frame = new Dictionary<VariableSymbol, object>();
+            var frame = new ConcurrentDictionary<VariableSymbol, object>();
             for (var i = 0; i < parameters.Length; i++)
             {
                 frame[parameters[i]] = sv.Fields[parameters[i].Name];
@@ -2082,7 +2090,7 @@ public sealed class Evaluator
             var methodSymbol = node.IsAdd ? node.Event.AddMethodSymbol : node.Event.RemoveMethodSymbol;
             if (methodSymbol != null && program.Functions.TryGetValue(methodSymbol, out var body))
             {
-                var frame = new Dictionary<Symbols.VariableSymbol, object>();
+                var frame = new ConcurrentDictionary<Symbols.VariableSymbol, object>();
                 if (methodSymbol.ThisParameter != null)
                 {
                     frame[methodSymbol.ThisParameter] = receiverValue;
@@ -2277,7 +2285,7 @@ public sealed class Evaluator
             else if (node.Property.GetterSymbol != null && program.Functions.TryGetValue(node.Property.GetterSymbol, out var staticGetterBody))
             {
                 // Issue #263: computed static property getter — no 'this' parameter.
-                var frame = new Dictionary<Symbols.VariableSymbol, object>();
+                var frame = new ConcurrentDictionary<Symbols.VariableSymbol, object>();
                 using (PushFrame(frame))
                 {
                     return EvaluateFunctionBody(staticGetterBody);
@@ -2332,7 +2340,7 @@ public sealed class Evaluator
         // Computed property: execute the bound getter body.
         if (property.GetterSymbol != null && program.Functions.TryGetValue(property.GetterSymbol, out var getterBody))
         {
-            var frame = new Dictionary<Symbols.VariableSymbol, object>
+            var frame = new ConcurrentDictionary<Symbols.VariableSymbol, object>
             {
                 [property.GetterSymbol.ThisParameter] = receiverValue,
             };
@@ -2358,7 +2366,7 @@ public sealed class Evaluator
             }
             else if (node.Property.SetterSymbol != null && program.Functions.TryGetValue(node.Property.SetterSymbol, out var staticSetterBody))
             {
-                var frame = new Dictionary<Symbols.VariableSymbol, object>
+                var frame = new ConcurrentDictionary<Symbols.VariableSymbol, object>
                 {
                     [node.Property.SetterSymbol.Parameters[0]] = value,
                 };
@@ -2406,7 +2414,7 @@ public sealed class Evaluator
         if (node.Property.SetterSymbol != null && program.Functions.TryGetValue(node.Property.SetterSymbol, out var setterBody))
         {
             var receiverValue = EvaluateExpression(node.Receiver);
-            var frame = new Dictionary<Symbols.VariableSymbol, object>
+            var frame = new ConcurrentDictionary<Symbols.VariableSymbol, object>
             {
                 [node.Property.SetterSymbol.ThisParameter] = receiverValue,
                 [node.Property.SetterSymbol.Parameters[0]] = value,
@@ -2968,7 +2976,7 @@ public sealed class Evaluator
         }
         else
         {
-            var locals = new Dictionary<VariableSymbol, object>();
+            var locals = new ConcurrentDictionary<VariableSymbol, object>();
 
             // ADR-0060 item #7: identify ref-kind parameters so we can
             // write the post-body value back into the caller's lvalue.
@@ -2995,7 +3003,7 @@ public sealed class Evaluator
                 else
                 {
                     var value = EvaluateExpression(arg);
-                    locals.Add(parameter, value);
+                    locals[parameter] = value;
                 }
             }
 
@@ -3221,7 +3229,7 @@ public sealed class Evaluator
         {
             foreach (var binding in bindings)
             {
-                frame.Remove(binding.Key);
+                frame.TryRemove(binding.Key, out _);
             }
         }
     }
@@ -3875,7 +3883,7 @@ public sealed class Evaluator
             }
         }
 
-        var frame = new Dictionary<VariableSymbol, object>
+        var frame = new ConcurrentDictionary<VariableSymbol, object>
         {
             [method.ThisParameter] = receiverValue,
         };
@@ -3885,7 +3893,7 @@ public sealed class Evaluator
         {
             var parameter = method.Parameters[i + parameterOffset];
             var value = EvaluateExpression(node.Arguments[i]);
-            frame.Add(parameter, value);
+            frame[parameter] = value;
         }
 
         using (PushFrame(frame))
@@ -3911,7 +3919,7 @@ public sealed class Evaluator
         var receiverValue = EvaluateExpression(node.Receiver);
         var method = node.Method;
 
-        var frame = new Dictionary<VariableSymbol, object>
+        var frame = new ConcurrentDictionary<VariableSymbol, object>
         {
             [method.ThisParameter] = receiverValue,
         };
@@ -3921,7 +3929,7 @@ public sealed class Evaluator
         {
             var parameter = method.Parameters[i + parameterOffset];
             var value = EvaluateExpression(node.Arguments[i]);
-            frame.Add(parameter, value);
+            frame[parameter] = value;
         }
 
         using (PushFrame(frame))
@@ -3974,7 +3982,7 @@ public sealed class Evaluator
 
         var method = node.Method;
 
-        var frame = new Dictionary<VariableSymbol, object>
+        var frame = new ConcurrentDictionary<VariableSymbol, object>
         {
             [method.ThisParameter] = receiverValue,
         };
@@ -3984,7 +3992,7 @@ public sealed class Evaluator
         {
             var parameter = method.Parameters[i + parameterOffset];
             var value = EvaluateExpression(node.Arguments[i]);
-            frame.Add(parameter, value);
+            frame[parameter] = value;
         }
 
         using (PushFrame(frame))
@@ -4116,7 +4124,7 @@ public sealed class Evaluator
                 $"Static-virtual interface call '{node.InterfaceMethod.Name}' has no runtime body (no implementer found and no default).");
         }
 
-        var frame2 = new Dictionary<VariableSymbol, object>();
+        var frame2 = new ConcurrentDictionary<VariableSymbol, object>();
         for (var i = 0; i < node.Arguments.Length; i++)
         {
             frame2[target.Parameters[i]] = evaluatedArgs[i];
@@ -4679,7 +4687,7 @@ public sealed class Evaluator
         }
         finally
         {
-            locals.Remove(node.Capture);
+            locals.TryRemove(node.Capture, out _);
         }
     }
 
@@ -4859,7 +4867,7 @@ public sealed class Evaluator
             return null;
         }
 
-        var chainFrame = new Dictionary<VariableSymbol, object>
+        var chainFrame = new ConcurrentDictionary<VariableSymbol, object>
         {
             [thisParam] = receiver,
         };
@@ -4889,13 +4897,13 @@ public sealed class Evaluator
     }
 
     /// <summary>
-    /// Disposable guard returned by <see cref="PushFrame(Dictionary{VariableSymbol, object})"/>
+    /// Disposable guard returned by <see cref="PushFrame(ConcurrentDictionary{VariableSymbol, object})"/>
     /// that pops the associated locals frame when disposed, guaranteeing the
     /// pop runs on both normal and exceptional (unwind) control flow.
     /// </summary>
     private readonly struct FrameScope : IDisposable
     {
-        private readonly Stack<Dictionary<VariableSymbol, object>> stack;
+        private readonly Stack<ConcurrentDictionary<VariableSymbol, object>> stack;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FrameScope"/> struct,
@@ -4903,7 +4911,7 @@ public sealed class Evaluator
         /// </summary>
         /// <param name="stack">The locals stack to push onto and later pop from.</param>
         /// <param name="frame">The frame to push.</param>
-        public FrameScope(Stack<Dictionary<VariableSymbol, object>> stack, Dictionary<VariableSymbol, object> frame)
+        public FrameScope(Stack<ConcurrentDictionary<VariableSymbol, object>> stack, ConcurrentDictionary<VariableSymbol, object> frame)
         {
             this.stack = stack;
             this.stack.Push(frame);
@@ -4991,7 +4999,7 @@ public sealed class Evaluator
     /// </summary>
     private sealed class ExecutionState
     {
-        public Stack<Dictionary<VariableSymbol, object>> Locals { get; set; } = new();
+        public Stack<ConcurrentDictionary<VariableSymbol, object>> Locals { get; set; } = new();
 
         public Stack<ScopeFrame> ScopeFrames { get; set; } = new();
 

--- a/src/Core/CodeAnalysis/StructValue.cs
+++ b/src/Core/CodeAnalysis/StructValue.cs
@@ -2,7 +2,7 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Globalization;
 using System.Text;
 using GSharp.Core.CodeAnalysis.Symbols;
@@ -22,10 +22,10 @@ public sealed class StructValue
     public StructValue(StructSymbol structType)
     {
         StructType = structType;
-        Fields = new Dictionary<string, object>();
+        Fields = new ConcurrentDictionary<string, object>();
     }
 
-    private StructValue(StructSymbol structType, Dictionary<string, object> fields)
+    private StructValue(StructSymbol structType, ConcurrentDictionary<string, object> fields)
     {
         StructType = structType;
         Fields = fields;
@@ -34,8 +34,18 @@ public sealed class StructValue
     /// <summary>Gets the struct type.</summary>
     public StructSymbol StructType { get; }
 
+    // Issue #1718: class-typed StructValue instances (Evaluator.Assign skips
+    // Copy() for IsClass structs) are shared by reference, including the
+    // heap "box" cells CaptureBoxingRewriter synthesizes for a mutable
+    // variable captured by a function literal (isClass: true). Any number
+    // of goroutines that received the same class instance/box (as an
+    // argument, a captured variable, or a field) can write distinct fields
+    // on it at the same time, so this dictionary needs the same
+    // concurrent-write safety as an interpreter locals frame. Plain
+    // Dictionary&lt;,&gt; is not thread-safe under concurrent writes.
+
     /// <summary>Gets the mutable field dictionary backing this instance.</summary>
-    public Dictionary<string, object> Fields { get; }
+    public ConcurrentDictionary<string, object> Fields { get; }
 
     /// <summary>
     /// Gets or sets the CLR backing instance for a GSharp class that inherits an
@@ -52,7 +62,7 @@ public sealed class StructValue
     /// <returns>A new instance with the same fields.</returns>
     public StructValue Copy()
     {
-        var copy = new Dictionary<string, object>(Fields.Count);
+        var copy = new ConcurrentDictionary<string, object>();
         foreach (var kvp in Fields)
         {
             copy[kvp.Key] = kvp.Value is StructValue inner ? inner.Copy() : kvp.Value;

--- a/test/Interpreter.Tests/Issue1718FrameConcurrencyInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue1718FrameConcurrencyInterpreterTests.cs
@@ -1,0 +1,214 @@
+// <copyright file="Issue1718FrameConcurrencyInterpreterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Text;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #1718 — a goroutine that captures an enclosing-scope local (a
+/// mutable variable a function literal closes over, lowered by
+/// <c>CaptureBoxingRewriter</c> into a heap "box" cell, or a class
+/// instance passed to multiple goroutines) shares that storage BY
+/// REFERENCE with the spawning thread and every other goroutine that
+/// captured/received it — that is the whole point of Go-style by-reference
+/// closure capture (see <c>Issue1651GoroutineIsolationInterpreterTests
+/// .Goroutine_SeesCapturedEnclosingVariable_ClosureVisibilityPreserved</c>).
+/// Before this fix, both the interpreter's locals-frame dictionaries
+/// (<c>Dictionary&lt;VariableSymbol, object&gt;</c>) and a class/box
+/// instance's field dictionary (<c>StructValue.Fields</c>,
+/// <c>Dictionary&lt;string, object&gt;</c>) were plain, non-thread-safe
+/// <c>Dictionary&lt;,&gt;</c> instances. Concurrent writes from two or more
+/// threads to the SAME shared instance can corrupt its internal
+/// buckets/entries array (torn state, lost writes, or an
+/// <c>InvalidOperationException</c> mid-resize) — a crash class that is
+/// harsher than Go's own "this is a user data race" semantics.
+///
+/// The fix swaps every frame dictionary and <see cref="StructValue.Fields"/>
+/// for a <see cref="System.Collections.Concurrent.ConcurrentDictionary{TKey, TValue}"/>,
+/// which tolerates concurrent readers/writers without corrupting its
+/// internal state (individual key writes still race per Go's own memory
+/// model — this only removes the crash/corruption class, not the
+/// requirement that user code synchronize logically-ordered updates).
+///
+/// These tests deliberately avoid wall-clock sleeps: correctness is
+/// synchronized through <c>scope</c> (which awaits every <c>go</c> task
+/// spawned inside it before returning) and, for the crash-detection test,
+/// by running many full evaluations concurrently via <c>Parallel.For</c>
+/// and joining on it.
+/// </summary>
+public class Issue1718FrameConcurrencyInterpreterTests
+{
+    [Fact]
+    public void ManyGoroutines_WriteDistinctFieldsOnSharedClassInstance_AllWritesSurvive()
+    {
+        // A single class instance ("box") is handed to N goroutines, each of
+        // which writes to a DIFFERENT field of the SAME shared
+        // StructValue.Fields dictionary at the same time — directly
+        // exercising concurrent-write safety of that dictionary. Every
+        // field already exists (composite-literal initialized them before
+        // the object was shared), so a pre-fix plain Dictionary<,> could
+        // still corrupt/lose entries under concurrent set-on-existing-key
+        // pressure; post-fix, every field must deterministically hold the
+        // value only its own goroutine ever wrote.
+        const int fieldCount = 24;
+        var sb = new StringBuilder();
+        sb.AppendLine("class Box {");
+        for (var i = 0; i < fieldCount; i++)
+        {
+            sb.AppendLine($"    var F{i} int32");
+        }
+
+        sb.AppendLine("}");
+        sb.AppendLine();
+        for (var i = 0; i < fieldCount; i++)
+        {
+            sb.AppendLine($"func setF{i}(b Box) int32 {{\n    b.F{i} = {i + 1}\n    return 0\n}}");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("func run() int32 {");
+        sb.Append("    var b = Box{");
+        for (var i = 0; i < fieldCount; i++)
+        {
+            sb.Append($"F{i}: 0");
+            if (i < fieldCount - 1)
+            {
+                sb.Append(", ");
+            }
+        }
+
+        sb.AppendLine("}");
+        sb.AppendLine("    scope {");
+        for (var i = 0; i < fieldCount; i++)
+        {
+            sb.AppendLine($"        go setF{i}(b)");
+        }
+
+        sb.AppendLine("    }");
+        sb.Append("    return ");
+        for (var i = 0; i < fieldCount; i++)
+        {
+            sb.Append($"b.F{i}");
+            if (i < fieldCount - 1)
+            {
+                sb.Append(" + ");
+            }
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("}");
+        sb.AppendLine();
+        sb.AppendLine("run()");
+
+        var expectedSum = 0;
+        for (var i = 0; i < fieldCount; i++)
+        {
+            expectedSum += i + 1;
+        }
+
+        var result = Evaluate(sb.ToString());
+        AssertNoRealDiagnostics(result);
+        Assert.Equal(expectedSum, result.Value);
+    }
+
+    [Fact]
+    public void ManyConcurrentRuns_GoroutineAndSpawnerBothWriteCapturedVariable_NeverCorruptsOrCrashes()
+    {
+        // Direct repro of the issue's literal scenario: a function literal
+        // captures a mutable enclosing local (boxed by CaptureBoxingRewriter
+        // into a shared heap cell). Fifty goroutines invoke that SAME
+        // closure, and the spawning thread writes the SAME captured
+        // variable too, all inside one `scope` block. The individual
+        // `counter = counter + 1` read-modify-write is intentionally left
+        // unsynchronized (same as an unsynchronized Go `counter++` across
+        // goroutines is a data race by design) — this test's contract is
+        // "no crash / no corrupted dictionary", not "exact arithmetic",
+        // matching Go's own memory model for a racy counter. Running many
+        // evaluations concurrently maximizes the chance any residual
+        // Dictionary<,> corruption bug would surface as an exception.
+        var source = """
+            func run() int32 {
+                var counter = 0
+                let bump = func() int32 {
+                    counter = counter + 1
+                    return 0
+                }
+
+                scope {
+                    for var i = 0; i < 50; i++ {
+                        go bump()
+                    }
+
+                    counter = counter + 1
+                }
+
+                return counter
+            }
+
+            run()
+            """;
+
+        const int iterations = 300;
+        var exceptions = new System.Collections.Concurrent.ConcurrentBag<System.Exception>();
+        var outOfRangeResults = new System.Collections.Concurrent.ConcurrentBag<int>();
+        System.Threading.Tasks.Parallel.For(
+            0,
+            iterations,
+            new System.Threading.Tasks.ParallelOptions { MaxDegreeOfParallelism = 32 },
+            i =>
+            {
+                try
+                {
+                    var result = Evaluate(source);
+                    AssertNoRealDiagnostics(result);
+                    var value = (int)result.Value;
+
+                    // 51 concurrent increments starting from 0: a torn/lost
+                    // update can only ever under-count (never invent a
+                    // value outside [1, 51], and never throw). Anything
+                    // outside that range indicates real corruption, not
+                    // just a benign lost update.
+                    if (value < 1 || value > 51)
+                    {
+                        outOfRangeResults.Add(value);
+                    }
+                }
+                catch (System.Exception ex)
+                {
+                    exceptions.Add(ex);
+                }
+            });
+
+        Assert.Empty(exceptions);
+        Assert.Empty(outOfRangeResults);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        // ADR-0082 / issue #722: `go` is gated behind this import.
+        var fullSource = "import Gsharp.Extensions.Go\n" + source;
+        var tree = SyntaxTree.Parse(SourceText.From(fullSource));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+
+    /// <summary>
+    /// See <see cref="Issue1651GoroutineIsolationInterpreterTests.AssertNoRealDiagnostics"/>:
+    /// some fixtures place a `let`/`var` declaration ahead of the functions
+    /// that use it for readability, which GS0286 (ADR-0066 D5) flags as a
+    /// warning, not an error.
+    /// </summary>
+    private static void AssertNoRealDiagnostics(EvaluationResult result)
+    {
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id != "GS0286");
+    }
+}


### PR DESCRIPTION
Fixes #1718

## Root cause
The tree-walking interpreter shares two kinds of storage by reference across a goroutine and the thread/goroutine that spawned it, by design, to preserve Go-style by-reference closure/aliasing semantics:

- **Locals frame dictionaries** (`Dictionary<VariableSymbol, object>`): `CloneExecutionStateForGoroutine` clones the locals stack with the *same* frame dictionary instances so a goroutine's closure still observes writes to captured enclosing variables.
- **`StructValue.Fields`** (`Dictionary<string, object>`): backs every class instance, and also backs the heap "box" cells `CaptureBoxingRewriter` synthesizes for a mutable local captured by a function literal. Class-typed `StructValue` instances are never copied on assignment (`Evaluator.Assign` explicitly skips `Copy()` for `IsClass` types), so a box/class instance handed to multiple goroutines is the same shared object.

Both are plain, non-thread-safe `Dictionary<,>`. Concurrent writes to the same shared frame or object from two or more threads can corrupt its internal buckets/entries array — torn state, lost writes, or an `InvalidOperationException` mid-resize — which is harsher than Go's own "this is a user data race" semantics for the equivalent unsynchronized access.

## Fix
Replaced every frame dictionary and `StructValue.Fields` with `ConcurrentDictionary<,>`, which tolerates concurrent readers/writers without corrupting its internal state. This is the right primitive here (over a per-frame lock or a copy-on-capture clone) because:
- A per-frame lock would work but adds lock overhead on every single-threaded read/write (the overwhelming common case) for a hazard that's rare per the issue.
- Copy-on-capture would be **wrong**: G# goroutines that capture an enclosing local must observe/write the *same* shared variable (Go's memory model for closures), so cloning would silently break correct programs that rely on that aliasing (already covered by an existing regression test, `Issue1651...Goroutine_SeesCapturedEnclosingVariable_ClosureVisibilityPreserved`).
- `ConcurrentDictionary<,>` is a drop-in replacement for every call site here (indexer get/set, `TryGetValue`, `ContainsKey`); only a few `.Add`/`.Remove` calls needed switching to `ConcurrentDictionary`'s indexer/`TryRemove` equivalents, which are semantically identical for these use sites (all touched keys are already known-unique or already known-present).

Globals, struct/interface static fields, the iterator-function cache, and the shared `Random` instance were already guarded by an explicit lock (`globalsLock`) from the prior #1651 fix and are unchanged.

## Files changed
- `src/Core/CodeAnalysis/Evaluator.cs` — `Locals` stack element type, `PushFrame`/`FrameScope`, `ExecutionState.Locals`, and every frame-dictionary literal (constructor frame, function/method/constructor calls, event accessors, pattern-binding merge, base-class/base-interface calls) now use `ConcurrentDictionary<VariableSymbol, object>`.
- `src/Core/CodeAnalysis/StructValue.cs` — `Fields` is now `ConcurrentDictionary<string, object>`, covering class instances and captured-variable box cells; `Copy()` updated accordingly.
- `test/Interpreter.Tests/Issue1718FrameConcurrencyInterpreterTests.cs` — new tests:
  - `ManyGoroutines_WriteDistinctFieldsOnSharedClassInstance_AllWritesSurvive`: 24 goroutines each write a distinct field on one shared class instance inside a `scope` (joined without sleeps); asserts every field deterministically holds its expected value.
  - `ManyConcurrentRuns_GoroutineAndSpawnerBothWriteCapturedVariable_NeverCorruptsOrCrashes`: the issue's literal repro (goroutines + spawner both writing a function-literal-captured mutable variable) run 300 times concurrently via `Parallel.For`; asserts no exception and no out-of-range result (a lost update is an acceptable data race outcome; a crash or an impossible value is not).

## Verification
- `dotnet build GSharp.sln -c Release -graph` — 0 warnings, 0 errors.
- `dotnet test test/Interpreter.Tests/Interpreter.Tests.csproj -c Release` — 388/388 passed (includes the 2 new tests, run narrowly first via `--filter`).
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release` — 5157 passed, 1 skipped (pre-existing `RegenerateBaseline`), 0 failed.

No deferrals: every interpreter frame/scope/environment structure holding variables shared across goroutines (locals frames and struct/class field storage) was audited and converted; globals/statics were already safe from #1651.