### PR TITLE
Fix #1680: index extension functions by name in BoundScope

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundScope.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundScope.cs
@@ -25,6 +25,18 @@ public sealed class BoundScope
     private ImmutableArray<string>.Builder typeAliasKeys;
     private ImmutableArray<FunctionSymbol>.Builder extensionFunctions;
 
+    // Issue #1680: name-keyed index over extensionFunctions. Extension lookup is a
+    // per-call-site hot path run for every member call that doesn't resolve as an
+    // instance member, so a flat per-scope list forced an O(callsites x extensions)
+    // scan (plus an O(E^2) inner pass in ReceiverConvertibilitySpecificity). Every
+    // extension is bucketed by name here as it's declared; lookups probe the bucket
+    // for the call-site name instead of the full list, then run the exact same
+    // receiver-matching (identity/CLR, generic-unification, subtype-convertibility)
+    // logic as before over the narrowed candidate set. This changes only how
+    // candidates are FOUND, never which one wins: same receiver-matching rules, same
+    // scope/shadowing order, so resolution and diagnostics are unchanged.
+    private ImmutableDictionary<string, ImmutableArray<FunctionSymbol>.Builder>.Builder extensionFunctionsByName;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="BoundScope"/> class.
     /// </summary>
@@ -261,17 +273,27 @@ public sealed class BoundScope
     public bool TryDeclareExtensionFunction(FunctionSymbol function)
     {
         extensionFunctions ??= ImmutableArray.CreateBuilder<FunctionSymbol>();
+        extensionFunctionsByName ??= ImmutableDictionary.CreateBuilder<string, ImmutableArray<FunctionSymbol>.Builder>();
 
-        foreach (var existing in extensionFunctions)
+        if (extensionFunctionsByName.TryGetValue(function.Name, out var bucket))
         {
-            if (FunctionSignaturesEqual(existing, function)
-                && ExtensionTypeParameterConstraintsEqual(existing, function))
+            foreach (var existing in bucket)
             {
-                return false;
+                if (FunctionSignaturesEqual(existing, function)
+                    && ExtensionTypeParameterConstraintsEqual(existing, function))
+                {
+                    return false;
+                }
             }
+        }
+        else
+        {
+            bucket = ImmutableArray.CreateBuilder<FunctionSymbol>();
+            extensionFunctionsByName.Add(function.Name, bucket);
         }
 
         extensionFunctions.Add(function);
+        bucket.Add(function);
         return true;
     }
 
@@ -310,11 +332,16 @@ public sealed class BoundScope
     public bool TryLookupExtensionFunction(TypeSymbol receiverType, string name, out FunctionSymbol function)
     {
         function = null;
-        if (extensionFunctions != null)
+
+        // Issue #1680: probe the name-keyed bucket instead of scanning every
+        // extension declared in this scope. A scope with no extensions named
+        // `name` is skipped in O(1) instead of an O(extensions) miss.
+        if (extensionFunctionsByName != null
+            && extensionFunctionsByName.TryGetValue(name, out var bucket))
         {
-            foreach (var ext in extensionFunctions)
+            foreach (var ext in bucket)
             {
-                if (ext.Name == name && ReceiverMatches(ext.ExtensionReceiverType, receiverType))
+                if (ReceiverMatches(ext.ExtensionReceiverType, receiverType))
                 {
                     function = ext;
                     return true;
@@ -342,13 +369,8 @@ public sealed class BoundScope
             // call-binding path if applicable).
             FunctionSymbol candidate = null;
             int candidateSpecificity = -1;
-            foreach (var ext in extensionFunctions)
+            foreach (var ext in bucket)
             {
-                if (ext.Name != name)
-                {
-                    continue;
-                }
-
                 if (ext.TypeParameters.IsDefaultOrEmpty)
                 {
                     continue;
@@ -392,13 +414,8 @@ public sealed class BoundScope
             // declaration order.
             FunctionSymbol subtypeCandidate = null;
             var subtypeSpecificity = -1;
-            foreach (var ext in extensionFunctions)
+            foreach (var ext in bucket)
             {
-                if (ext.Name != name)
-                {
-                    continue;
-                }
-
                 if (!ext.TypeParameters.IsDefaultOrEmpty
                     && ext.ExtensionReceiverType != null
                     && ReceiverMentionsAnyTypeParameter(ext.ExtensionReceiverType, ext.TypeParameters))
@@ -412,7 +429,7 @@ public sealed class BoundScope
                     continue;
                 }
 
-                var specificity = ReceiverConvertibilitySpecificity(extensionFunctions, ext.ExtensionReceiverType, name);
+                var specificity = ReceiverConvertibilitySpecificity(bucket, ext.ExtensionReceiverType);
                 if (subtypeCandidate == null || specificity > subtypeSpecificity)
                 {
                     subtypeCandidate = ext;
@@ -454,18 +471,17 @@ public sealed class BoundScope
         ImmutableArray<FunctionSymbol>.Builder builder = null;
         for (var s = this; s != null; s = s.Parent)
         {
-            if (s.extensionFunctions == null)
+            // Issue #1680: probe the name-keyed bucket instead of scanning every
+            // extension declared in this scope; scopes with no extension named
+            // `name` are skipped in O(1).
+            if (s.extensionFunctionsByName == null
+                || !s.extensionFunctionsByName.TryGetValue(name, out var bucket))
             {
                 continue;
             }
 
-            foreach (var ext in s.extensionFunctions)
+            foreach (var ext in bucket)
             {
-                if (ext.Name != name)
-                {
-                    continue;
-                }
-
                 var matches = ReceiverMatches(ext.ExtensionReceiverType, receiverType);
                 if (!matches
                     && !ext.TypeParameters.IsDefaultOrEmpty
@@ -1221,14 +1237,12 @@ public sealed class BoundScope
     /// singular deterministic lookup path (e.g. <c>string</c> beats
     /// <c>object</c> for a <c>string</c> receiver).
     /// </summary>
-    /// <param name="extensionFunctions">The same-scope extension candidates to rank against.</param>
+    /// <param name="extensionFunctions">The same-scope, same-name extension candidates to rank against.</param>
     /// <param name="declaredReceiverType">The candidate's declared receiver type.</param>
-    /// <param name="name">The extension method name being resolved.</param>
     /// <returns>The specificity score (higher is more specific).</returns>
     private static int ReceiverConvertibilitySpecificity(
         ImmutableArray<FunctionSymbol>.Builder extensionFunctions,
-        TypeSymbol declaredReceiverType,
-        string name)
+        TypeSymbol declaredReceiverType)
     {
         if (extensionFunctions == null || declaredReceiverType == null)
         {
@@ -1238,7 +1252,7 @@ public sealed class BoundScope
         var score = 0;
         foreach (var ext in extensionFunctions)
         {
-            if (ext.Name != name || ext.ExtensionReceiverType == null)
+            if (ext.ExtensionReceiverType == null)
             {
                 continue;
             }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1680ExtensionResolutionIndexTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1680ExtensionResolutionIndexTests.cs
@@ -1,0 +1,179 @@
+// <copyright file="Issue1680ExtensionResolutionIndexTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1680: <see cref="BoundScope"/> used to resolve every extension-function
+/// call site by scanning the FULL flat extension list of every scope in the
+/// chain (an O(callsites x extensions) full scan, plus an O(E^2) inner pass in
+/// the subtype-specificity ranking). The fix buckets declared extensions by
+/// name per scope so a call site probes only the candidates that share its
+/// method name, then runs the exact same receiver-matching logic (identity/CLR
+/// equality, generic-receiver unification, implicit-conversion subtyping) over
+/// that narrowed set. These tests pin down that the narrowed lookup still finds
+/// every extension shape the old full scan found: via a base class, via an
+/// implemented interface, via generic-receiver unification, and with the same
+/// scope-priority (innermost-first) order when two scopes both declare a
+/// same-named extension.
+/// </summary>
+public class Issue1680ExtensionResolutionIndexTests
+{
+    [Fact]
+    public void Extension_OnBaseClass_Dispatches_ViaDerivedReceiver()
+    {
+        // Issue #1548 subtype-convertibility pass: an extension declared on the
+        // BASE class must still be found for a call site whose static receiver
+        // type is the DERIVED class. Receiver-clause methods are reserved for
+        // types the extension's own package doesn't own (ADR-0079), so the
+        // types and the extension live in separate packages, like the
+        // pre-existing cross-package extension tests.
+        var typeTree = SyntaxTree.Parse(SourceText.From(@"
+package Zoo
+open class Animal { var Name string }
+class Dog : Animal { }
+"));
+        var extensionTree = SyntaxTree.Parse(SourceText.From(@"
+package ZooExtensions
+func (a Animal) Speak() string {
+    return ""...""
+}
+
+var d = Dog{Name: ""Rex""}
+d.Speak()
+"));
+        var result = Evaluate(typeTree, extensionTree);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("...", result.Value);
+    }
+
+    [Fact]
+    public void Extension_OnInterface_Dispatches_ViaImplementingReceiver()
+    {
+        // An extension declared on an INTERFACE must be found for a call site
+        // whose static receiver type is a class that implements it.
+        var typeTree = SyntaxTree.Parse(SourceText.From(@"
+package Greeting
+interface IGreeter {
+    func Hello() string;
+}
+class Person : IGreeter {
+    func Hello() string -> ""hi""
+}
+"));
+        var extensionTree = SyntaxTree.Parse(SourceText.From(@"
+package GreetingExtensions
+func (g IGreeter) Greet() string {
+    return g.Hello()
+}
+
+var p = Person{}
+p.Greet()
+"));
+        var result = Evaluate(typeTree, extensionTree);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("hi", result.Value);
+    }
+
+    [Fact]
+    public void Extension_GenericReceiver_Unifies_OnConcreteInstantiation()
+    {
+        // Issue #773 generic-receiver unification pass: the declared receiver
+        // carries the function's own type parameter, so it is never
+        // reference-equal to the concrete call-site receiver and must be found
+        // via unification, not identity.
+        const string source = @"
+package P
+import System
+import System.Collections.Generic
+
+func (self IEnumerable[T]) MyFirst[T any](fb T) T {
+    return fb
+}
+
+var arr = []int32{10, 20, 30}
+arr.MyFirst(99)
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(99, result.Value);
+    }
+
+    [Fact]
+    public void Extension_DeclaredInTwoScopes_InnerScopeWins()
+    {
+        // Scope-priority / shadowing: TryLookupExtensionFunction walks from
+        // `this` outward to Parent, returning the FIRST matching scope. The
+        // name-keyed index must preserve this order — a child scope's
+        // same-named extension must win over the parent's, exactly like the
+        // old full linear scan (which iterated the same scope chain).
+        var parent = new BoundScope(null, ReferenceResolver.Default());
+        var parentExtension = MakeExtension("Speak", TypeSymbol.Int32, TypeSymbol.String);
+        Assert.True(parent.TryDeclareExtensionFunction(parentExtension));
+
+        var child = new BoundScope(parent);
+        var childExtension = MakeExtension("Speak", TypeSymbol.Int32, TypeSymbol.String);
+        Assert.True(child.TryDeclareExtensionFunction(childExtension));
+
+        Assert.True(child.TryLookupExtensionFunction(TypeSymbol.Int32, "Speak", out var found));
+        Assert.Same(childExtension, found);
+
+        // Looked up directly from the parent scope, only the parent's
+        // extension is visible.
+        Assert.True(parent.TryLookupExtensionFunction(TypeSymbol.Int32, "Speak", out var foundFromParent));
+        Assert.Same(parentExtension, foundFromParent);
+    }
+
+    [Fact]
+    public void Extension_UnrelatedNameInSameScope_DoesNotMatch()
+    {
+        // The name-keyed bucket must not leak candidates across different
+        // names sharing a scope.
+        var scope = new BoundScope(null, ReferenceResolver.Default());
+        Assert.True(scope.TryDeclareExtensionFunction(MakeExtension("Foo", TypeSymbol.Int32, TypeSymbol.String)));
+        Assert.True(scope.TryDeclareExtensionFunction(MakeExtension("Bar", TypeSymbol.Int32, TypeSymbol.String)));
+
+        Assert.False(scope.TryLookupExtensionFunction(TypeSymbol.Int32, "Baz", out var found));
+        Assert.Null(found);
+
+        Assert.True(scope.TryLookupExtensionFunction(TypeSymbol.Int32, "Foo", out var foo));
+        Assert.Equal("Foo", foo.Name);
+    }
+
+    private static FunctionSymbol MakeExtension(string name, TypeSymbol receiverType, TypeSymbol returnType)
+    {
+        var function = new FunctionSymbol(
+            name,
+            ImmutableArray<ParameterSymbol>.Empty,
+            returnType,
+            declaration: null,
+            package: null,
+            accessibility: Accessibility.Public);
+        function.IsExtension = true;
+        function.ExtensionReceiverType = receiverType;
+        return function;
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
+        return Evaluate(syntaxTree);
+    }
+
+    private static EvaluationResult Evaluate(params SyntaxTree[] syntaxTrees)
+    {
+        var compilation = new Compilation(syntaxTrees);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
Fixes #1680

## Root cause
`BoundScope.TryLookupExtensionFunction` / `TryLookupExtensionFunctions` scanned the FULL flat per-scope extension list for every call site (O(callsites x extensions)), and the subtype-specificity ranking (`ReceiverConvertibilitySpecificity`) re-scanned that same flat list per candidate, adding an O(E^2) inner pass for a single lookup.

## Fix
Added a per-scope name-keyed index, `extensionFunctionsByName` (an `ImmutableDictionary<string, ImmutableArray<FunctionSymbol>.Builder>`), mirroring the existing name-bucketed `functions` dictionary already used for regular function overloads. It is populated in `TryDeclareExtensionFunction` alongside the existing flat `extensionFunctions` list (kept for `GetDeclaredExtensionFunctions()`).

Both lookup entry points now probe the name bucket instead of the full per-scope list:
- `TryLookupExtensionFunction` (used for user-defined operator overload extensions)
- `TryLookupExtensionFunctions` (used for member-call resolution, feeding the caller's overload resolution)

Once narrowed to the name bucket, every existing receiver-matching pass runs unchanged, in the same order, over that smaller set:
1. Identity / same-CLR-type exact match (`ReceiverMatches`)
2. Generic-receiver unification (issue #773/#775) — handles a declared receiver referencing the function's own type parameters (e.g. `func (self IEnumerable[T]) M[T any]()`), so generic extensions and interface/base receivers instantiated generically still unify correctly
3. Implicit-conversion (subtype) broadening (issue #1548) — handles base-class and interface receivers: a call-site receiver that is implicitly convertible to the declared receiver (derived-to-base, class-to-interface, boxing) still matches, with the most-specific candidate ranked via `ReceiverConvertibilitySpecificity` (now scored only over the same-name bucket instead of the whole scope)

Scope walk order (innermost scope first, falling back to `Parent`) is untouched, so scope-priority/shadowing behavior between scopes is identical. Nothing about WHICH overload wins changed — only how the candidate set is found.

## Files changed
- `src/Core/CodeAnalysis/Binding/BoundScope.cs` — added the name index and rewired both lookup methods and `ReceiverConvertibilitySpecificity` to use it.
- `test/Core.Tests/CodeAnalysis/Binding/Issue1680ExtensionResolutionIndexTests.cs` (new) — covers:
  - extension found via a base class (cross-package, subtype-convertibility pass)
  - extension found via an implemented interface (cross-package, subtype-convertibility pass)
  - generic-receiver unification on a concrete instantiation (issue #773 pattern)
  - scope-priority: a child scope's same-named extension shadows the parent's, and the parent scope alone still sees its own
  - unrelated names in the same scope don't leak into a bucket miss

## Test results
- `dotnet build GSharp.sln -c Release -graph`: **0 errors, 0 warnings**
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release`: **5177 passed, 0 failed, 1 skipped** (pre-existing `RegenerateBaseline` skip, unrelated)
- Targeted filter `FullyQualifiedName~Issue1680ExtensionResolutionIndexTests`: **5 passed, 0 failed**

No deferrals — all extension shapes named in the issue (generic, base/interface receivers, multi-scope, shadowing) are covered.