### PR TITLE
Fix #1639: skip narrowing-invalidation walks when no narrowings are active

### DIFF
--- a/src/Core/CodeAnalysis/Binding/StatementBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.cs
@@ -459,13 +459,17 @@ internal sealed class StatementBinder
 
     private void InvalidateNarrowingsForAssignedVariables(SyntaxNode statementSyntax)
     {
-        if (binderCtx.NarrowedVariables.Count == 0)
+        // Issue #1639: `NarrowedVariables.Count == 0` never fires in practice —
+        // `BindBlockStatements` pushes a (usually empty) memberNotNullFrame for
+        // every block, so the list always has at least one entry once binding
+        // is inside any block. The real fast-path question is whether any
+        // active frame actually holds a narrowing; if none do, no walk of the
+        // statement's syntax subtree can possibly invalidate anything, so skip
+        // both walks (and their HashSet/List allocations) entirely.
+        if (!HasAnyActiveNarrowings())
         {
             return;
         }
-
-        var assignedNames = new HashSet<string>();
-        CollectAssignedNames(statementSyntax, assignedNames);
 
         // ADR-0069 addendum / issue #1180: member-path narrowings are far more
         // fragile than local narrowings. Any call could mutate a field reached
@@ -475,7 +479,13 @@ internal sealed class StatementBinder
         // drop EVERY member-bearing path when the statement contains a call or a
         // member-mutating assignment. Plain variable narrowings keep their
         // existing, more permissive invalidation (reassignment only).
-        var dropAllMemberPaths = StatementMayMutateMemberPaths(statementSyntax);
+        //
+        // Issue #1639: both the assigned-name collection and the member-mutation
+        // check used to walk the full statement syntax subtree separately. They
+        // gather independent facts from the same tree, so a single combined
+        // walk collects both in one pass instead of two.
+        var assignedNames = new HashSet<string>();
+        var dropAllMemberPaths = CollectAssignedNamesAndMemberMutation(statementSyntax, assignedNames);
 
         // Resolve the set of reassigned root variables so we can also drop any
         // member path rooted at one of them.
@@ -531,14 +541,42 @@ internal sealed class StatementBinder
     }
 
     /// <summary>
-    /// ADR-0069 addendum / issue #1180: returns whether <paramref name="node"/>
-    /// contains a construct that could change a value reached through a stable
-    /// member path — a call (whose callee could mutate a field), or a member /
-    /// index / indirect assignment. Such statements conservatively invalidate
-    /// all member-path smart casts.
+    /// Issue #1639: returns whether any currently active narrowing frame holds
+    /// at least one entry. Used as the fast-path guard before walking a
+    /// statement's syntax subtree for invalidation purposes — a block's
+    /// persistent <c>memberNotNullFrame</c> is pushed unconditionally (even
+    /// when empty), so testing <see cref="BinderContext.NarrowedVariables"/>
+    /// for emptiness alone never short-circuits. Frame counts are typically
+    /// shallow (bounded by nesting depth), so this scan is cheap relative to a
+    /// syntax subtree walk.
     /// </summary>
-    private static bool StatementMayMutateMemberPaths(SyntaxNode node)
+    private bool HasAnyActiveNarrowings()
     {
+        for (var i = binderCtx.NarrowedVariables.Count - 1; i >= 0; i--)
+        {
+            if (binderCtx.NarrowedVariables[i].Count > 0)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// ADR-0069 addendum / issue #1180 / issue #1639: combined single-pass walk
+    /// that collects both facts previously gathered by two separate full
+    /// subtree walks: (a) the set of plain-variable names reassigned anywhere
+    /// in <paramref name="node"/>, added to <paramref name="assigned"/>, and
+    /// (b) whether the subtree contains a construct that could change a value
+    /// reached through a stable member path — a call (whose callee could
+    /// mutate a field), or a member / index / indirect assignment — returned
+    /// as the method result. Such statements conservatively invalidate all
+    /// member-path smart casts.
+    /// </summary>
+    private static bool CollectAssignedNamesAndMemberMutation(SyntaxNode node, HashSet<string> assigned)
+    {
+        var mayMutateMemberPaths = false;
         switch (node)
         {
             case CallExpressionSyntax:
@@ -548,24 +586,8 @@ internal sealed class StatementBinder
             case CompoundIndexAssignmentExpressionSyntax:
             case IndirectAssignmentExpressionSyntax:
             case FieldAssignmentExpressionSyntax:
-                return true;
-        }
-
-        foreach (var child in node.GetChildren())
-        {
-            if (StatementMayMutateMemberPaths(child))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private static void CollectAssignedNames(SyntaxNode node, HashSet<string> assigned)
-    {
-        switch (node)
-        {
+                mayMutateMemberPaths = true;
+                break;
             case AssignmentExpressionSyntax a:
                 assigned.Add(a.IdentifierToken.Text);
                 break;
@@ -583,8 +605,10 @@ internal sealed class StatementBinder
 
         foreach (var child in node.GetChildren())
         {
-            CollectAssignedNames(child, assigned);
+            mayMutateMemberPaths |= CollectAssignedNamesAndMemberMutation(child, assigned);
         }
+
+        return mayMutateMemberPaths;
     }
 
     /// <summary>

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1639NarrowingInvalidationFastPathTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1639NarrowingInvalidationFastPathTests.cs
@@ -1,0 +1,185 @@
+// <copyright file="Issue1639NarrowingInvalidationFastPathTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1639 — <c>InvalidateNarrowingsForAssignedVariables</c> used to walk
+/// every statement's full syntax subtree twice (once via
+/// <c>CollectAssignedNames</c>, once via <c>StatementMayMutateMemberPaths</c>)
+/// even when zero narrowings were active, because
+/// <c>BinderContext.NarrowedVariables.Count == 0</c> never fires — a block
+/// pushes a (usually empty) persistent frame unconditionally. The fix adds a
+/// real "any frame non-empty" fast-path guard and merges the two walks into
+/// one. These tests pin the invariant: no active narrowing ⇒ the walk is
+/// skipped with no diagnostic change, and whenever a narrowing IS active,
+/// invalidation behaves exactly as before — including across nested blocks,
+/// loops, and branches, and for both plain-variable and member-path
+/// narrowings.
+/// </summary>
+public class Issue1639NarrowingInvalidationFastPathTests
+{
+    [Fact]
+    public void NoActiveNarrowing_PlainStatements_FastPathProducesNoDiagnostics()
+    {
+        // No `is`/nil-guard/assignment narrowing is ever established here, so
+        // every block's persistent frame stays empty for the whole function.
+        // This exercises the fast path (HasAnyActiveNarrowings == false) on a
+        // variety of statement shapes: plain assignment, a call, a loop, and a
+        // branch — none of which should trigger a syntax walk, and none of
+        // which should change binding results.
+        var result = Evaluate(@"
+class C {
+    func Helper() int32 { return 1 }
+    func F(n int32) int32 {
+        var total = 0
+        var i = 0
+        while i < n {
+            total = total + Helper()
+            i = i + 1
+        }
+        if total > 0 {
+            total = total + 1
+        }
+        return total
+    }
+}
+C{}.F(3)
+");
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void ActiveLocalNarrowing_InvalidatingAssignment_StillInvalidates()
+    {
+        // A narrowing is active (assignment smart cast on `x`); a subsequent
+        // possibly-null reassignment must still clear it, even with the new
+        // fast-path guard in place.
+        var result = Evaluate(@"
+class E { func M() int32 { return 1 } }
+class C {
+    func F(fresh E, maybe E?) int32 {
+        var x E? = nil
+        x = fresh
+        x = maybe
+        return x.M()
+    }
+}
+");
+
+        Assert.Contains(result.Diagnostics, d => d.Message.Contains("M", System.StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ActiveLocalNarrowing_NonInvalidatingStatement_NarrowingSurvives()
+    {
+        // Control for the above: with the same active narrowing, a statement
+        // that does NOT reassign `x` must leave the narrowing intact.
+        var result = Evaluate(@"
+class E { func M() int32 { return 1 } }
+class C {
+    func F(fresh E) int32 {
+        var x E? = nil
+        x = fresh
+        var unrelated = 1
+        return x.M() + unrelated
+    }
+}
+");
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void ActiveMemberPathNarrowing_InterveningMemberAssignment_StillInvalidates()
+    {
+        // Mirrors Issue1180's member-path invalidation coverage: an active
+        // member-path narrowing must still be dropped by an intervening
+        // member-mutating assignment, exercising the merged single-pass walk.
+        var result = Evaluate(@"
+open class Animal { var Name string }
+class Dog : Animal { func Bark() string { return ""woof"" } }
+class Box { var Other int32 = 0 let Pet Animal }
+func Run(b Box) string {
+    if b.Pet !is Dog { return """" }
+    b.Other = 1
+    return b.Pet.Bark()
+}
+Run(Box{Pet: Dog{Name: ""Rex""}})
+");
+
+        Assert.Contains(result.Diagnostics, d => d.Message.Contains("Bark", System.StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ActiveNarrowing_InvalidatedInsideNestedLoopAndBranch_DoesNotEscape()
+    {
+        // The narrowing on `x` is invalidated by a reassignment nested two
+        // levels deep (inside an if inside a while). The invalidation must
+        // still propagate to all active frames (per-block persistent frames
+        // up the stack), so the member access after the loop sees the
+        // original nullable type again.
+        var result = Evaluate(@"
+class E { func M() int32 { return 1 } }
+class C {
+    func F(fresh E, maybe E?, n int32) int32 {
+        var x E? = nil
+        x = fresh
+        var i = 0
+        while i < n {
+            if i == 0 {
+                x = maybe
+            }
+            i = i + 1
+        }
+        return x.M()
+    }
+}
+");
+
+        Assert.Contains(result.Diagnostics, d => d.Message.Contains("M", System.StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ActiveNarrowing_ReNarrowedInsideBranch_ReachesNestedBlock()
+    {
+        // Positive nested-block control: narrowing established, then
+        // re-affirmed inside a branch, must still reach a further-nested
+        // block without any diagnostic.
+        var result = Evaluate(@"
+class E { func M() int32 { return 1 } }
+class C {
+    func F(fresh E) int32 {
+        var x E? = nil
+        x = fresh
+        if true {
+            x = fresh
+            if true {
+                return x.M()
+            }
+        }
+        return 0
+    }
+}
+");
+
+        Assert.Empty(result.Diagnostics);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(syntaxTree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
Fixes #1639

## Root cause
`InvalidateNarrowingsForAssignedVariables`'s early-out (`binderCtx.NarrowedVariables.Count == 0`) never fired in practice: `BindBlockStatements` pushes a persistent `memberNotNullFrame` for every block, so the list always has at least one (usually empty) frame once binding is inside any block. As a result, every statement paid two full recursive syntax-subtree walks — `CollectAssignedNames` and `StatementMayMutateMemberPaths` — unconditionally, even when zero narrowings were active (the common case).

## Fix
- Added `HasAnyActiveNarrowings()`, which checks whether *any* active frame actually holds an entry (a cheap scan bounded by block-nesting depth) instead of just checking the frame-list count. `InvalidateNarrowingsForAssignedVariables` now returns immediately when this is false, skipping both walks and their `HashSet`/`List` allocations entirely.
- Merged `CollectAssignedNames` and `StatementMayMutateMemberPaths` into a single `CollectAssignedNamesAndMemberMutation` walk that gathers both facts (assigned variable names, and whether the subtree may mutate a member path) in one recursive pass over the statement's syntax subtree instead of two.
- When at least one narrowing is active, behavior is byte-identical to before: the same assigned-name set and the same `dropAllMemberPaths` result are computed, just in one walk instead of two.

## Files changed
- `src/Core/CodeAnalysis/Binding/StatementBinder.cs`
- `test/Core.Tests/CodeAnalysis/Binding/Issue1639NarrowingInvalidationFastPathTests.cs` (new)

## Tests added
- No-active-narrowing fast path produces no diagnostic change across plain assignment, call, loop, and branch statement shapes.
- Active local narrowing: invalidating reassignment still invalidates; non-invalidating statement leaves the narrowing intact.
- Active member-path narrowing: intervening member-mutating assignment still invalidates (mirrors issue #1180 coverage).
- Active narrowing invalidated inside a nested loop + branch still propagates correctly (does not escape); re-narrowing inside a branch still reaches a further-nested block.

## Verification
- `dotnet build GSharp.sln -c Release -graph` — 0 errors, 0 warnings.
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release` — 5178 passed, 0 failed, 1 skipped (pre-existing `RegenerateBaseline` skip, unrelated).
- Targeted `--filter FullyQualifiedName~Issue1639` — 6/6 passed.