### PR TITLE
Fix #1722: escape cs2gs char literals to match G#'s lexer

### DIFF
--- a/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
@@ -274,89 +274,75 @@ public static class GSharpPrinter
         return string.IsNullOrEmpty(argument.Name) ? value : $"{argument.Name}: {value}";
     }
 
-    private static string RenderStringLiteralBody(string value)
+    // Shared escaper for double-quoted string/interpolation bodies and
+    // single-quoted char bodies. `quoteChar` is the delimiter that needs
+    // backslash-escaping for the given literal kind ('"' for strings and
+    // interpolations, '\'' for chars); `escapeDollar` doubles '$' so it can't
+    // be mistaken for an interpolation hole (only applies to string forms —
+    // char literals have no interpolation syntax). Matches exactly the
+    // escapes G#'s lexer accepts (Lexer.cs ReadCharLiteral / string scanning):
+    // \\, \", \', \n, \r, \t, and \uXXXX for other control/non-printable
+    // chars.
+    private static string RenderEscapedLiteralBody(string value, char quoteChar, bool escapeDollar)
     {
         var sb = new StringBuilder();
         foreach (var ch in value)
         {
-            switch (ch)
+            if (ch == '\\')
             {
-                case '\\':
-                    sb.Append("\\\\");
-                    break;
-                case '"':
-                    sb.Append("\\\"");
-                    break;
-                case '$':
-                    sb.Append("$$");
-                    break;
-                case '\n':
-                    sb.Append("\\n");
-                    break;
-                case '\r':
-                    sb.Append("\\r");
-                    break;
-                case '\t':
-                    sb.Append("\\t");
-                    break;
-                default:
-                    if (ch < ' ' || ch == '\u007F')
-                    {
-                        sb.Append("\\u").Append(((int)ch).ToString("X4", CultureInfo.InvariantCulture));
-                    }
-                    else
-                    {
-                        sb.Append(ch);
-                    }
+                sb.Append("\\\\");
+            }
+            else if (ch == quoteChar)
+            {
+                sb.Append('\\').Append(quoteChar);
+            }
+            else if (escapeDollar && ch == '$')
+            {
+                sb.Append("$$");
+            }
+            else
+            {
+                switch (ch)
+                {
+                    case '\n':
+                        sb.Append("\\n");
+                        break;
+                    case '\r':
+                        sb.Append("\\r");
+                        break;
+                    case '\t':
+                        sb.Append("\\t");
+                        break;
+                    default:
+                        if (ch < ' ' || ch == '\u007F')
+                        {
+                            sb.Append("\\u").Append(((int)ch).ToString("X4", CultureInfo.InvariantCulture));
+                        }
+                        else
+                        {
+                            sb.Append(ch);
+                        }
 
-                    break;
+                        break;
+                }
             }
         }
 
         return sb.ToString();
     }
 
-    private static string RenderInterpolationText(string value)
-    {
-        var sb = new StringBuilder();
-        foreach (var ch in value)
-        {
-            switch (ch)
-            {
-                case '\\':
-                    sb.Append("\\\\");
-                    break;
-                case '"':
-                    sb.Append("\\\"");
-                    break;
-                case '$':
-                    sb.Append("$$");
-                    break;
-                case '\n':
-                    sb.Append("\\n");
-                    break;
-                case '\r':
-                    sb.Append("\\r");
-                    break;
-                case '\t':
-                    sb.Append("\\t");
-                    break;
-                default:
-                    if (ch < ' ' || ch == '\u007F')
-                    {
-                        sb.Append("\\u").Append(((int)ch).ToString("X4", CultureInfo.InvariantCulture));
-                    }
-                    else
-                    {
-                        sb.Append(ch);
-                    }
+    private static string RenderStringLiteralBody(string value) =>
+        RenderEscapedLiteralBody(value, '"', escapeDollar: true);
 
-                    break;
-            }
-        }
+    private static string RenderInterpolationText(string value) =>
+        RenderEscapedLiteralBody(value, '"', escapeDollar: true);
 
-        return sb.ToString();
-    }
+    // Issue #1722: char literals must escape the closing quote, backslash,
+    // and control chars the same way strings do, or C#'s '\'' , '\\', '\n',
+    // etc. produce malformed/corrupted G# (empty literal, unterminated
+    // literal, or raw control bytes in the output file).
+    private static string RenderCharLiteralBody(string value) =>
+        RenderEscapedLiteralBody(value, '\'', escapeDollar: false);
 
     private static string RenderExpression(GExpression expression, int indent)
     {
@@ -560,7 +546,7 @@ public static class GSharpPrinter
             case LiteralKind.String:
                 return $"\"{RenderStringLiteralBody(literal.Value)}\"";
             case LiteralKind.Char:
-                return $"'{literal.Value}'";
+                return $"'{RenderCharLiteralBody(literal.Value)}'";
             default:
                 return literal.Value;
         }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1722CharLiteralEscapeTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1722CharLiteralEscapeTests.cs
@@ -1,0 +1,133 @@
+// <copyright file="Issue1722CharLiteralEscapeTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Translation tests for issue #1722: cs2gs printed char literals with zero
+/// escaping. C# <c>'\''</c>, <c>'\\'</c>, <c>'\n'</c>, and other control
+/// characters were emitted verbatim, producing malformed G# (empty-literal
+/// diagnostics, unterminated literals, or raw control bytes in the output
+/// file). <see cref="Cs2Gs.CodeModel.Printing.GSharpPrinter"/> now escapes
+/// char literals the same way it escapes string literals (minus dollar-sign
+/// doubling, which only applies to interpolation), matching exactly the
+/// escapes G#'s own lexer accepts (<c>Lexer.ReadCharLiteral</c>): <c>\\</c>,
+/// <c>\'</c>, <c>\n</c>, <c>\r</c>, <c>\t</c>, and <c>\uXXXX</c> for other
+/// control/non-printable chars.
+/// </summary>
+public class Issue1722CharLiteralEscapeTests
+{
+    [Theory]
+    [InlineData('\'', "SingleQuote")]
+    [InlineData('\\', "Backslash")]
+    [InlineData('\n', "Newline")]
+    [InlineData('\t', "Tab")]
+    [InlineData('\r', "CarriageReturn")]
+    [InlineData('\0', "Nul")]
+    [InlineData('A', "PrintableAscii")]
+    [InlineData('\u00e9', "LatinSupplement")]
+    [InlineData('\u3042', "Hiragana")]
+    public void CharLiteral_RoundTripsToSameValue(char value, string label)
+    {
+        _ = label;
+
+        string source = $@"
+namespace Demo
+{{
+    public class C
+    {{
+        public char F() => '{EscapeForCSharpSource(value)}';
+    }}
+}}";
+
+        string printed = TranslateUnit(source);
+
+        // The printed char literal must lex back to the exact same char value.
+        char reparsed = LexSingleCharLiteral(printed);
+        Assert.Equal(value, reparsed);
+    }
+
+    /// <summary>
+    /// Escapes a char for embedding in the *C#* source snippet under test
+    /// (independent of the G# printer under test).
+    /// </summary>
+    private static string EscapeForCSharpSource(char value) => value switch
+    {
+        '\'' => "\\'",
+        '\\' => "\\\\",
+        '\n' => "\\n",
+        '\t' => "\\t",
+        '\r' => "\\r",
+        '\0' => "\\0",
+        _ => value.ToString(),
+    };
+
+    /// <summary>
+    /// Finds the (single) char-literal token in the printed G# source and
+    /// returns the value the real G# lexer produces for it.
+    /// </summary>
+    private static char LexSingleCharLiteral(string gsharpSource)
+    {
+        SyntaxTree tree = SyntaxTree.Parse(gsharpSource);
+        return FindCharToken(tree);
+    }
+
+    private static char FindCharToken(SyntaxTree tree)
+    {
+        foreach (var token in EnumerateTokens(tree))
+        {
+            if (token.Kind == SyntaxKind.CharacterToken)
+            {
+                return (char)token.Value;
+            }
+        }
+
+        throw new InvalidOperationException(
+            "No char-literal token found in printed G# source:\n" + tree.Text.ToString());
+    }
+
+    private static System.Collections.Generic.IEnumerable<SyntaxToken> EnumerateTokens(SyntaxTree tree)
+    {
+        var lexer = new Lexer(tree);
+        while (true)
+        {
+            SyntaxToken token = lexer.Lex();
+            yield return token;
+            if (token.Kind == SyntaxKind.EndOfFileToken)
+            {
+                yield break;
+            }
+        }
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}


### PR DESCRIPTION
Fixes #1722

## Root cause
`GSharpPrinter.RenderLiteral` printed `LiteralKind.Char` values completely raw (`'{literal.Value}'`), with no escaping. C# `'\''`, `'\\'`, `'\n'`, `'\t'`, `'\r'`, `'\0'`, and other control characters were written verbatim into the G# output, producing:
- `'\''` → `'''` (empty-literal diagnostic + stray quote)
- `'\\'` → `'\'` (the escape swallows the closing quote → unterminated literal)
- `'\n'`/`'\0'` → a raw newline/NUL byte in the output file (unterminated literal / corrupted file)

String literals already had a correct escaper (`RenderStringLiteralBody`), but char literals shared none of it, and a byte-identical duplicate of that escaper (`RenderInterpolationText`, also called out in #1745) existed for interpolation text.

## Fix
Verified G#'s own char-literal lexer (`src/Core/CodeAnalysis/Syntax/Lexer.cs`, `ReadCharLiteral`) to confirm exactly which escapes it accepts: `\'`, `\"`, `\\`, `\0`, `\a`, `\b`, `\f`, `\n`, `\r`, `\t`, `\v`, `\xHH`, `\uHHHH`, `\UHHHHHHHH`.

Factored the three near-duplicate escapers into one shared `RenderEscapedLiteralBody(value, quoteChar, escapeDollar)` in `GSharpPrinter.cs`:
- `RenderStringLiteralBody` → `RenderEscapedLiteralBody(value, '"', escapeDollar: true)`
- `RenderInterpolationText` → `RenderEscapedLiteralBody(value, '"', escapeDollar: true)` (was a byte-identical copy of the string escaper — now shares the same body, addressing the duplication noted in #1745)
- new `RenderCharLiteralBody` → `RenderEscapedLiteralBody(value, '\'', escapeDollar: false)` (no dollar-doubling — char literals have no interpolation syntax)

The shared helper escapes backslash, the literal's own quote character, `\n`, `\r`, `\t`, and any other control/non-printable char (`< ' '` or DEL) as `\uXXXX` — exactly the subset the G# lexer parses back, so char literal *values* are preserved.

`RenderLiteral`'s `LiteralKind.Char` case now calls `RenderCharLiteralBody`.

## Tests
Added `tools/cs2gs/Cs2Gs.Tests/Issue1722CharLiteralEscapeTests.cs`: a theory over `'\''`, `'\\'`, `'\n'`, `'\t'`, `'\r'`, `'\0'`, a printable ASCII char, and two non-ASCII/unicode chars (Latin-1 supplement, Hiragana). Each case translates a C# snippet returning that char literal to G#, round-trips it through the real G# parser (existing `GSharpRoundTrip.Validate` harness), then re-lexes the emitted char literal with G#'s actual `Lexer` and asserts the produced value equals the original C# char — proving both parseability and value fidelity, not just "doesn't crash".

## Verification
- `dotnet build GSharp.sln -c Release -graph`: 0 errors, 0 warnings.
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release`: 380/380 passed (including the 9 new cases), 0 failed.

## Files changed
- `tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs`
- `tools/cs2gs/Cs2Gs.Tests/Issue1722CharLiteralEscapeTests.cs` (new)