### PR TITLE
Fix #1678: memoize CLR member enumeration to avoid re-scanning per call site

### DIFF
--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -42,6 +42,16 @@ internal sealed class MemberLookup
     private readonly BinderContext binderCtx;
 
     /// <summary>
+    /// Process-wide memoization backing <see cref="SafeGetMethodsIncludingSelfAndInterfaces"/>,
+    /// keyed on the CLR <see cref="Type"/> plus the probed method name.
+    /// Cleared via <see cref="ClearCache"/> (wired into
+    /// <see cref="ReferenceResolver.Dispose"/>) so entries keyed on a disposed
+    /// <c>MetadataLoadContext</c>'s <see cref="Type"/> instances do not pin
+    /// that context's memory for the process lifetime (#1622-style leak).
+    /// </summary>
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<(Type ClrType, string Name), IReadOnlyList<MethodInfo>> MethodsIncludingSelfAndInterfacesCache = new();
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="MemberLookup"/> class.
     /// </summary>
     /// <param name="binderCtx">The shared binder context that exposes the
@@ -133,34 +143,48 @@ internal sealed class MemberLookup
             return Array.Empty<MethodInfo>();
         }
 
-        var selfMethods = ClrTypeUtilities.SafeGetMethods(clrType, BindingFlags.Public | BindingFlags.Instance);
-        var result = new List<MethodInfo>();
-        foreach (var m in selfMethods)
+        // Issue #1678: this result is recomputed identically at every call
+        // site that probes the same (type, name) pair — e.g. the "does this
+        // type have an accessible Add?" collection-initializer check runs once
+        // per collection-literal expression against the same receiver type.
+        // ClrTypeUtilities.SafeGetMethods/SafeGetInterfaces are themselves
+        // memoized per Type now, but the name filter and the O(result ×
+        // candidates) IsMethodHiddenByExisting dedup below still re-ran on
+        // every call before this cache existed. Keyed on the CLR Type (not the
+        // GSharp symbol) so it is naturally invalidated by
+        // ClrTypeUtilities.ClearCache() clearing the caches it reads from.
+        return MethodsIncludingSelfAndInterfacesCache.GetOrAdd((clrType, name), key =>
         {
-            if (string.Equals(m.Name, name, StringComparison.Ordinal))
+            var (t, n) = key;
+            var selfMethods = ClrTypeUtilities.SafeGetMethods(t, BindingFlags.Public | BindingFlags.Instance);
+            var result = new List<MethodInfo>();
+            foreach (var m in selfMethods)
             {
-                result.Add(m);
-            }
-        }
-
-        // Walk transitive interfaces for DIMs not surfaced by the concrete type.
-        foreach (var iface in ClrTypeUtilities.SafeGetInterfaces(clrType))
-        {
-            foreach (var m in ClrTypeUtilities.SafeGetMethods(iface, BindingFlags.Public | BindingFlags.Instance))
-            {
-                if (!string.Equals(m.Name, name, StringComparison.Ordinal))
-                {
-                    continue;
-                }
-
-                if (!IsMethodHiddenByExisting(result, m))
+                if (string.Equals(m.Name, n, StringComparison.Ordinal))
                 {
                     result.Add(m);
                 }
             }
-        }
 
-        return result;
+            // Walk transitive interfaces for DIMs not surfaced by the concrete type.
+            foreach (var iface in ClrTypeUtilities.SafeGetInterfaces(t))
+            {
+                foreach (var m in ClrTypeUtilities.SafeGetMethods(iface, BindingFlags.Public | BindingFlags.Instance))
+                {
+                    if (!string.Equals(m.Name, n, StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+
+                    if (!IsMethodHiddenByExisting(result, m))
+                    {
+                        result.Add(m);
+                    }
+                }
+            }
+
+            return result;
+        });
     }
 
     /// <summary>
@@ -1995,6 +2019,13 @@ internal sealed class MemberLookup
 
         return false;
     }
+
+    /// <summary>
+    /// Removes every entry from the <see cref="MethodsIncludingSelfAndInterfacesCache"/>.
+    /// Called by <see cref="ReferenceResolver.Dispose"/> (#1678, mirroring #1622)
+    /// alongside <see cref="ClrTypeUtilities.ClearCache"/>.
+    /// </summary>
+    internal static void ClearCache() => MethodsIncludingSelfAndInterfacesCache.Clear();
 
     /// <summary>
     /// Returns the callable parameter slice of <paramref name="method"/> —

--- a/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
+++ b/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
@@ -20,6 +21,17 @@ namespace GSharp.Core.CodeAnalysis.Symbols;
 /// </summary>
 public static class ClrTypeUtilities
 {
+    /// <summary>
+    /// Issue #1678: process-wide memoization of <see cref="SafeGetInterfaces"/>,
+    /// keyed by the CLR <see cref="Type"/>. Every binder call site that walks a
+    /// receiver's transitive interfaces (member lookup, collection-initializer
+    /// <c>Add</c> probing, base-call candidate collection, etc.) re-enumerated
+    /// <see cref="Type.GetInterfaces"/> from scratch before this cache existed;
+    /// for BCL types with wide interface sets (<c>List&lt;T&gt;</c>) that cost
+    /// was paid once per call site instead of once per type.
+    /// </summary>
+    private static readonly ConcurrentDictionary<Type, Type[]> InterfacesCache = new();
+
     /// <summary>
     /// Resolves a named method without asking a constructed
     /// <see cref="TypeBuilder"/> generic instantiation to resolve members
@@ -416,7 +428,7 @@ public static class ClrTypeUtilities
     /// <param name="flags">The binding flags controlling visibility.</param>
     /// <returns>The properties whose signatures load cleanly.</returns>
     public static PropertyInfo[] SafeGetProperties(Type type, BindingFlags flags)
-        => SafeEnumerate(type, t => t.GetProperties(flags));
+        => SafeEnumerate(type, flags, t => t.GetProperties(flags));
 
     /// <summary>
     /// Enumerates a type's fields tolerantly (issue #338): fields whose type
@@ -426,7 +438,7 @@ public static class ClrTypeUtilities
     /// <param name="flags">The binding flags controlling visibility.</param>
     /// <returns>The fields whose signatures load cleanly.</returns>
     public static FieldInfo[] SafeGetFields(Type type, BindingFlags flags)
-        => SafeEnumerate(type, t => t.GetFields(flags));
+        => SafeEnumerate(type, flags, t => t.GetFields(flags));
 
     /// <summary>
     /// Enumerates a type's events tolerantly (issue #338): events whose handler
@@ -436,7 +448,7 @@ public static class ClrTypeUtilities
     /// <param name="flags">The binding flags controlling visibility.</param>
     /// <returns>The events whose signatures load cleanly.</returns>
     public static EventInfo[] SafeGetEvents(Type type, BindingFlags flags)
-        => SafeEnumerate(type, t => t.GetEvents(flags));
+        => SafeEnumerate(type, flags, t => t.GetEvents(flags));
 
     /// <summary>
     /// Enumerates a type's constructors tolerantly (issue #338): constructors
@@ -447,7 +459,7 @@ public static class ClrTypeUtilities
     /// <param name="flags">The binding flags controlling visibility.</param>
     /// <returns>The constructors whose signatures load cleanly.</returns>
     public static ConstructorInfo[] SafeGetConstructors(Type type, BindingFlags flags)
-        => SafeEnumerate(type, t => t.GetConstructors(flags));
+        => SafeEnumerate(type, flags, t => t.GetConstructors(flags));
 
     /// <summary>
     /// Enumerates a type's methods tolerantly (issue #338): methods whose
@@ -458,7 +470,7 @@ public static class ClrTypeUtilities
     /// <param name="flags">The binding flags controlling visibility.</param>
     /// <returns>The methods whose signatures load cleanly.</returns>
     public static MethodInfo[] SafeGetMethods(Type type, BindingFlags flags)
-        => SafeEnumerate(type, t => t.GetMethods(flags));
+        => SafeEnumerate(type, flags, t => t.GetMethods(flags));
 
     /// <summary>
     /// Looks up a single property by name tolerantly (issue #338). When the
@@ -749,14 +761,39 @@ public static class ClrTypeUtilities
             return Array.Empty<Type>();
         }
 
-        try
+        // Issue #1678: Type.GetInterfaces() walks the full transitive interface
+        // graph on every call; memoize it per Type so a receiver used at N call
+        // sites (or matched against N interface methods) pays that walk once.
+        return InterfacesCache.GetOrAdd(type, t =>
         {
-            return type.GetInterfaces();
-        }
-        catch (Exception ex) when (IsMetadataLoadFailure(ex))
-        {
-            return Array.Empty<Type>();
-        }
+            try
+            {
+                return t.GetInterfaces();
+            }
+            catch (Exception ex) when (IsMetadataLoadFailure(ex))
+            {
+                return Array.Empty<Type>();
+            }
+        });
+    }
+
+    /// <summary>
+    /// Removes every entry from the process-wide CLR member-enumeration caches
+    /// (<see cref="InterfacesCache"/> and the per-member-kind caches backing
+    /// <see cref="SafeEnumerate{TMember}"/>). Called by
+    /// <see cref="ReferenceResolver.Dispose"/> alongside the other
+    /// process-wide symbol caches (#1622) so entries keyed on a disposed
+    /// <see cref="System.Reflection.MetadataLoadContext"/>'s <see cref="Type"/>
+    /// instances do not pin that context's memory for the life of the process.
+    /// </summary>
+    internal static void ClearCache()
+    {
+        InterfacesCache.Clear();
+        MemberCache<MethodInfo>.Cache.Clear();
+        MemberCache<PropertyInfo>.Cache.Clear();
+        MemberCache<FieldInfo>.Cache.Clear();
+        MemberCache<EventInfo>.Cache.Clear();
+        MemberCache<ConstructorInfo>.Cache.Clear();
     }
 
     private static bool IsConstructedGenericWithTypeBuilderArgument(Type type)
@@ -848,7 +885,7 @@ public static class ClrTypeUtilities
         return true;
     }
 
-    private static TMember[] SafeEnumerate<TMember>(Type type, Func<Type, TMember[]> getAll)
+    private static TMember[] SafeEnumerate<TMember>(Type type, BindingFlags flags, Func<Type, TMember[]> getAll)
         where TMember : MemberInfo
     {
         if (type is null)
@@ -856,26 +893,33 @@ public static class ClrTypeUtilities
             return Array.Empty<TMember>();
         }
 
-        TMember[] all;
-        try
+        // Issue #1678: Type.GetMethods()/GetProperties()/etc. re-walk and
+        // re-validate every member on every call (expensive under a
+        // MetadataLoadContext); memoize per (Type, Flags, member kind) so a
+        // type used at N call sites pays this once instead of N times.
+        return MemberCache<TMember>.Cache.GetOrAdd((type, flags), key =>
         {
-            all = getAll(type);
-        }
-        catch (Exception ex) when (IsMetadataLoadFailure(ex))
-        {
-            return Array.Empty<TMember>();
-        }
-
-        var usable = new List<TMember>(all.Length);
-        foreach (var member in all)
-        {
-            if (CanLoadSignature(member))
+            TMember[] all;
+            try
             {
-                usable.Add(member);
+                all = getAll(key.Type);
             }
-        }
+            catch (Exception ex) when (IsMetadataLoadFailure(ex))
+            {
+                return Array.Empty<TMember>();
+            }
 
-        return usable.ToArray();
+            var usable = new List<TMember>(all.Length);
+            foreach (var member in all)
+            {
+                if (CanLoadSignature(member))
+                {
+                    usable.Add(member);
+                }
+            }
+
+            return usable.ToArray();
+        });
     }
 
     private static TMember SafeGetMember<TMember>(
@@ -955,5 +999,19 @@ public static class ClrTypeUtilities
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Per-member-kind cache backing <see cref="SafeEnumerate{TMember}"/>. A
+    /// distinct closed generic (<c>MemberCache&lt;MethodInfo&gt;</c> vs.
+    /// <c>MemberCache&lt;PropertyInfo&gt;</c>, etc.) gets its own static
+    /// dictionary, so a single <c>(Type, BindingFlags)</c> key cannot collide
+    /// across member kinds.
+    /// </summary>
+    /// <typeparam name="TMember">The <see cref="MemberInfo"/>-derived member kind cached.</typeparam>
+    private static class MemberCache<TMember>
+        where TMember : MemberInfo
+    {
+        internal static readonly ConcurrentDictionary<(Type Type, BindingFlags Flags), TMember[]> Cache = new();
     }
 }

--- a/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
+++ b/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
@@ -14,6 +14,7 @@ using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using System.Runtime.CompilerServices;
+using GSharp.Core.CodeAnalysis.Binding;
 
 namespace GSharp.Core.CodeAnalysis.Symbols;
 
@@ -194,6 +195,14 @@ public sealed class ReferenceResolver : IDisposable
         StructSymbol.ClearCache();
         InterfaceSymbol.ClearCache();
         DelegateTypeSymbol.ClearCache();
+
+        // Issue #1678: the binder's per-Type CLR member-enumeration
+        // memoization (ClrTypeUtilities.SafeGetMethods/SafeGetInterfaces/etc.
+        // and MemberLookup's higher-level (Type, name) method cache) is also
+        // process-wide and keyed on this context's Type objects. Clear it for
+        // the same reason as every cache above.
+        ClrTypeUtilities.ClearCache();
+        MemberLookup.ClearCache();
     }
 
     /// <summary>

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1678ClrMemberLookupMemoTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1678ClrMemberLookupMemoTests.cs
@@ -1,0 +1,160 @@
+// <copyright file="Issue1678ClrMemberLookupMemoTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1678 regression coverage: CLR member lookup (<see cref="ClrTypeUtilities.SafeGetMethods"/>,
+/// <see cref="ClrTypeUtilities.SafeGetInterfaces"/>, and
+/// <see cref="MemberLookup.SafeGetMethodsIncludingSelfAndInterfaces"/>) used to
+/// re-enumerate every method / every transitive interface method on every
+/// call, with no memoization, so a type used at N call sites paid N full
+/// reflection walks. These tests assert:
+/// <list type="bullet">
+/// <item>repeated lookups for the same (type, flags) / (type, name) return
+/// the identical cached instance instead of re-enumerating,</item>
+/// <item>the cached result is identical in content and order to what a fresh
+/// per-call-site enumeration would produce (no behavior change), and</item>
+/// <item>the caches are evicted on <see cref="ReferenceResolver.Dispose"/>
+/// (mirroring the #1622 process-wide cache eviction) so entries keyed on a
+/// disposed <c>MetadataLoadContext</c>'s <see cref="System.Type"/> instances
+/// do not pin that context's memory for the process lifetime.</item>
+/// </list>
+/// </summary>
+public class Issue1678ClrMemberLookupMemoTests
+{
+    [Fact]
+    public void SafeGetMethods_RepeatedCalls_ReturnSameCachedInstance()
+    {
+        ClrTypeUtilities.ClearCache();
+
+        var first = ClrTypeUtilities.SafeGetMethods(typeof(List<int>), BindingFlags.Public | BindingFlags.Instance);
+        var second = ClrTypeUtilities.SafeGetMethods(typeof(List<int>), BindingFlags.Public | BindingFlags.Instance);
+
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void SafeGetMethods_ClearCache_EvictsEntry()
+    {
+        ClrTypeUtilities.ClearCache();
+
+        var before = ClrTypeUtilities.SafeGetMethods(typeof(List<int>), BindingFlags.Public | BindingFlags.Instance);
+        ClrTypeUtilities.ClearCache();
+        var after = ClrTypeUtilities.SafeGetMethods(typeof(List<int>), BindingFlags.Public | BindingFlags.Instance);
+
+        Assert.NotSame(before, after);
+
+        // Content must remain identical — the cache changes identity, not results.
+        Assert.Equal(before.Select(m => m.ToString()), after.Select(m => m.ToString()));
+    }
+
+    [Fact]
+    public void SafeGetMethods_CachedResult_MatchesUncachedReflectionExactly()
+    {
+        ClrTypeUtilities.ClearCache();
+
+        var cached = ClrTypeUtilities.SafeGetMethods(typeof(List<int>), BindingFlags.Public | BindingFlags.Instance);
+        var direct = typeof(List<int>).GetMethods(BindingFlags.Public | BindingFlags.Instance);
+
+        // Same members, same order — SafeGetMethods only filters out members
+        // whose signature cannot load (never true here for a live runtime
+        // type), so the two sequences must match one-for-one.
+        Assert.Equal(direct.Select(m => m.ToString()), cached.Select(m => m.ToString()));
+    }
+
+    [Fact]
+    public void SafeGetInterfaces_RepeatedCalls_ReturnSameCachedInstance()
+    {
+        ClrTypeUtilities.ClearCache();
+
+        var first = ClrTypeUtilities.SafeGetInterfaces(typeof(List<int>));
+        var second = ClrTypeUtilities.SafeGetInterfaces(typeof(List<int>));
+
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void SafeGetInterfaces_ClearCache_EvictsEntry()
+    {
+        ClrTypeUtilities.ClearCache();
+
+        var before = ClrTypeUtilities.SafeGetInterfaces(typeof(List<int>));
+        ClrTypeUtilities.ClearCache();
+        var after = ClrTypeUtilities.SafeGetInterfaces(typeof(List<int>));
+
+        Assert.NotSame(before, after);
+        Assert.Equal(before.Select(t => t.FullName), after.Select(t => t.FullName));
+    }
+
+    [Fact]
+    public void SafeGetMethodsIncludingSelfAndInterfaces_RepeatedCalls_ReturnSameCachedInstance()
+    {
+        ClrTypeUtilities.ClearCache();
+        MemberLookup.ClearCache();
+
+        var first = MemberLookup.SafeGetMethodsIncludingSelfAndInterfaces(typeof(List<int>), "Add");
+        var second = MemberLookup.SafeGetMethodsIncludingSelfAndInterfaces(typeof(List<int>), "Add");
+
+        Assert.Same(first, second);
+        Assert.NotEmpty(first);
+    }
+
+    [Fact]
+    public void SafeGetMethodsIncludingSelfAndInterfaces_ClearCache_EvictsEntry()
+    {
+        ClrTypeUtilities.ClearCache();
+        MemberLookup.ClearCache();
+
+        var before = MemberLookup.SafeGetMethodsIncludingSelfAndInterfaces(typeof(List<int>), "Add");
+        MemberLookup.ClearCache();
+        var after = MemberLookup.SafeGetMethodsIncludingSelfAndInterfaces(typeof(List<int>), "Add");
+
+        Assert.NotSame(before, after);
+        Assert.Equal(before.Select(m => m.ToString()), after.Select(m => m.ToString()));
+    }
+
+    [Fact]
+    public void SafeGetMethodsIncludingSelfAndInterfaces_DifferentNames_AreCachedIndependently()
+    {
+        ClrTypeUtilities.ClearCache();
+        MemberLookup.ClearCache();
+
+        var add = MemberLookup.SafeGetMethodsIncludingSelfAndInterfaces(typeof(List<int>), "Add");
+        var clear = MemberLookup.SafeGetMethodsIncludingSelfAndInterfaces(typeof(List<int>), "Clear");
+
+        Assert.All(add, m => Assert.Equal("Add", m.Name));
+        Assert.All(clear, m => Assert.Equal("Clear", m.Name));
+    }
+
+    [Fact]
+    public void Dispose_ClearsClrMemberLookupCaches()
+    {
+        ClrTypeUtilities.ClearCache();
+        MemberLookup.ClearCache();
+
+        var methodsBefore = ClrTypeUtilities.SafeGetMethods(typeof(Dictionary<string, int>), BindingFlags.Public | BindingFlags.Instance);
+        var interfacesBefore = ClrTypeUtilities.SafeGetInterfaces(typeof(Dictionary<string, int>));
+        var includingBefore = MemberLookup.SafeGetMethodsIncludingSelfAndInterfaces(typeof(Dictionary<string, int>), "Add");
+
+        var corePath = typeof(ReferenceResolver).Assembly.Location;
+        var resolver = ReferenceResolver.WithReferences(new[] { corePath });
+        resolver.Dispose();
+
+        var methodsAfter = ClrTypeUtilities.SafeGetMethods(typeof(Dictionary<string, int>), BindingFlags.Public | BindingFlags.Instance);
+        var interfacesAfter = ClrTypeUtilities.SafeGetInterfaces(typeof(Dictionary<string, int>));
+        var includingAfter = MemberLookup.SafeGetMethodsIncludingSelfAndInterfaces(typeof(Dictionary<string, int>), "Add");
+
+        Assert.NotSame(methodsBefore, methodsAfter);
+        Assert.NotSame(interfacesBefore, interfacesAfter);
+        Assert.NotSame(includingBefore, includingAfter);
+    }
+}


### PR DESCRIPTION
Fixes #1678

## Root cause
Every binder call site that probed a CLR/imported type's members re-ran the full reflection enumeration from scratch, with no memoization:

- `ClrTypeUtilities.SafeGetMethods`/`SafeGetInterfaces`/`SafeGetProperties`/`SafeGetFields`/`SafeGetEvents`/`SafeGetConstructors` re-invoked `Type.GetMethods`/`GetInterfaces`/etc. and re-validated every returned member's signature on every call.
- `MemberLookup.SafeGetMethodsIncludingSelfAndInterfaces(clrType, name)` (the exact repro in the issue — used by the collection-initializer `hasAdd` probe and other call sites) re-ran the self-method scan, the transitive-interface walk, and its O(result × candidates) `IsMethodHiddenByExisting` dedup on every call, even for the same `(Type, name)` pair.

For a type with a wide method/interface surface (e.g. `List<T>`, hundreds of methods across ~10 interfaces) used at N call sites, this meant N full reflection walks instead of one. Under a `MetadataLoadContext` (where `GetMethods()` is notably slower than live runtime reflection), this cost compounds further.

## Fix
Added memoization at both layers, following the existing `ClearCache()` + `ReferenceResolver.Dispose` pattern established for #1622:

- **ClrTypeUtilities**: added a `ConcurrentDictionary<(Type, BindingFlags), TMember[]>` per member kind (methods/properties/fields/events/constructors, one dictionary per closed generic so kinds can't collide) backing the shared `SafeEnumerate<TMember>` helper, plus a `ConcurrentDictionary<Type, Type[]>` for `SafeGetInterfaces`. Since every higher-level walk (`SafeGetMethodsIncludingInterfaces`, `CollectBaseClrMethodCandidates`, `MemberLookup`'s self+interface walk, static-member probes, etc.) routes through these two primitives, caching here is the root-cause fix for all of them at once — not just the one method the repro hits.
- **MemberLookup**: added a `ConcurrentDictionary<(Type, string), IReadOnlyList<MethodInfo>>` caching the full `SafeGetMethodsIncludingSelfAndInterfaces` result (name filter + interface walk + hiding dedup) keyed on `(clrType, name)`.
- Added `ClrTypeUtilities.ClearCache()` and `MemberLookup.ClearCache()`, both wired into `ReferenceResolver.Dispose()` next to the existing `ImportedTypeSymbol.ClearCache()` etc. calls, so cache entries keyed on a disposed `MetadataLoadContext`'s `Type` objects are evicted and don't pin that context's memory across compilations in the same process.

## Cache design / lifetime
- Process-wide static caches (mirrors `ImportedTypeSymbol`/`FunctionTypeSymbol` etc.), since the underlying `Type` objects are already process-wide and stable for the lifetime of their originating `MetadataLoadContext`.
- Keyed purely on CLR `Type` (+ `BindingFlags` / method name where applicable) — never on a GSharp compilation or symbol — so results are shared safely across compilations that reference the same assemblies.
- Evicted via `ClearCache()` on `ReferenceResolver.Dispose()`, exactly like the #1622 caches, so no leak of disposed-MLC `Type` graphs across compilations.
- Verified identical output: new tests assert the memoized result is byte-for-byte/order-identical to an uncached direct reflection call.

## Files changed
- `src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs`
- `src/Core/CodeAnalysis/Binding/MemberLookup.cs`
- `src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs`
- `test/Core.Tests/CodeAnalysis/Binding/Issue1678ClrMemberLookupMemoTests.cs` (new)

## Test results
- `dotnet build GSharp.sln -c Release -graph`: **0 errors**.
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release`: **5207 passed, 0 failed, 1 skipped** (pre-existing unrelated skip).
- New targeted filter (Issue1678/Issue1622): **24 passed, 0 failed**, including a `Dispose_ClearsClrMemberLookupCaches` test proving the new caches are evicted on `ReferenceResolver.Dispose`, mirroring the #1622 regression test pattern.

No deferrals — memoization covers instance methods, static methods, interface methods, properties, fields, events, and constructors (every `SafeEnumerate`-backed helper), not just the single `Add`-probe method named in the repro.
