### PR TITLE
Fix #1633: remove dead argument-builder copy in ValidateRefArguments

### DIFF
--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -2340,7 +2340,7 @@ internal sealed class OverloadResolver
         return false;
     }
 
-    public ImmutableArray<BoundExpression> ValidateRefArguments(
+    public void ValidateRefArguments(
         ImmutableArray<BoundExpression> arguments,
         ImmutableArray<RefKind> refKinds,
         string methodName,
@@ -2348,10 +2348,9 @@ internal sealed class OverloadResolver
     {
         if (refKinds.IsDefault || refKinds.Length == 0)
         {
-            return arguments;
+            return;
         }
 
-        var builder = arguments.ToBuilder();
         for (int i = 0; i < refKinds.Length && i < arguments.Length; i++)
         {
             var rk = refKinds[i];
@@ -2381,8 +2380,6 @@ internal sealed class OverloadResolver
 
             // For `in`: accept either &expr or plain value (emitter spills temp).
         }
-
-        return builder.ToImmutable();
     }
 
     private static bool IsByRefInterpolatedHandlerArgument(BoundExpression argument, RefKind expected)


### PR DESCRIPTION
Fixes #1633

`ValidateRefArguments` in `src/Core/CodeAnalysis/Binding/OverloadResolver.cs` allocated an `ImmutableArray<BoundExpression>` builder via `arguments.ToBuilder()`, copied all arguments into it, and returned `builder.ToImmutable()` — but the loop only calls `Diagnostics.Report*`; the builder is never written to. This performed two full array copies per by-ref call site for nothing.

All 5 call sites (in ExpressionBinder.Calls.cs) already discard the return value, confirming the method is validation-only.

Fix: changed `ValidateRefArguments` to `void` and removed the builder/copy entirely. No behavior change — same diagnostics, same control flow.

I also scanned the surrounding overload-resolution/argument-processing code (OverloadResolver.cs, ExpressionBinder.Calls.cs, OverloadResolution.cs) for the same dead-copy pattern. The only other `ToBuilder()` use (in `RebindInlineOutVarArguments`, ExpressionBinder.Calls.cs) does mutate its builder (`rebuilt[i] = rebound`) and is legitimate, so no further changes were needed.

Verified:
- `dotnet build GSharp.sln -c Release -graph`: 0 errors, 0 warnings.
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release`: 5204 passed, 0 failed.
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Release --filter "FullyQualifiedName~Ref|FullyQualifiedName~Overload"`: 293 passed, 0 failed.