### PR TITLE
Fix #1679: memoize TypeIdentityComparer's AQN key per Type instance

### DIFF
--- a/src/Core/CodeAnalysis/Emit/TypeIdentityComparer.cs
+++ b/src/Core/CodeAnalysis/Emit/TypeIdentityComparer.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace GSharp.Core.CodeAnalysis.Emit;
 
@@ -28,6 +29,28 @@ namespace GSharp.Core.CodeAnalysis.Emit;
 internal sealed class TypeIdentityComparer : IEqualityComparer<Type>
 {
     public static readonly TypeIdentityComparer Instance = new TypeIdentityComparer();
+
+    /// <summary>
+    /// Issue #1679: process-wide memoization of <see cref="GetKey"/>, keyed by
+    /// the CLR <see cref="Type"/> instance. <c>TypeRefs</c>/<c>TypeSpecs</c>
+    /// (see <see cref="MetadataTokenCache"/>) are keyed by this comparer, so
+    /// every dictionary probe — including cache hits — used to rebuild the
+    /// type's assembly-qualified name from scratch; for a constructed generic
+    /// like <c>Dictionary&lt;string, List&lt;Foo&gt;&gt;</c> that string is
+    /// built recursively and is invoked many times per emitted method body
+    /// (casts, boxes, array creations, local signatures, member-ref parents).
+    /// A <see cref="ConditionalWeakTable{TKey, TValue}"/> keyed on the
+    /// <see cref="Type"/> itself lets repeated probes for the same Type
+    /// instance reuse the already-computed key without allocating a new
+    /// string, while still comparing/hashing distinct Type instances that
+    /// describe the same logical type by their (now-cached) AQN string. Being
+    /// weakly keyed, entries are collected automatically once the owning
+    /// <see cref="System.Reflection.MetadataLoadContext"/>'s Type instances
+    /// become unreachable, so — unlike the process-wide caches added for
+    /// #1622 — this table needs no explicit <c>ClearCache</c>/Dispose wiring
+    /// to avoid pinning a disposed context.
+    /// </summary>
+    private static readonly ConditionalWeakTable<Type, string> KeyCache = new();
 
     private TypeIdentityComparer()
     {
@@ -62,16 +85,17 @@ internal sealed class TypeIdentityComparer : IEqualityComparer<Type>
 
     private static string GetKey(Type type)
     {
-        // AssemblyQualifiedName encodes namespace, name (including nesting via
-        // '+'), generic arity, generic arguments, array/pointer/byref suffixes,
-        // and the full assembly identity. That makes it a faithful structural
-        // key: two Type instances that describe the same logical type from
-        // different MetadataLoadContext paths share the same string here.
-        // Fall back to FullName/Name when AssemblyQualifiedName is unavailable
-        // (e.g. generic type parameters), preferring the most specific
-        // identifier we can build.
-        return type.AssemblyQualifiedName
-            ?? type.FullName
-            ?? type.Name;
+        // AssemblyQualifiedName encodes namespace, name (including nesting
+        // via '+'), generic arity, generic arguments, array/pointer/byref
+        // suffixes, and the full assembly identity. That makes it a
+        // faithful structural key: two Type instances that describe the
+        // same logical type from different MetadataLoadContext paths
+        // share the same string here. Fall back to FullName/Name when
+        // AssemblyQualifiedName is unavailable (e.g. generic type
+        // parameters), preferring the most specific identifier we can
+        // build.
+        return KeyCache.GetValue(
+            type,
+            static t => t.AssemblyQualifiedName ?? t.FullName ?? t.Name);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue1679TypeIdentityAqnCacheTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue1679TypeIdentityAqnCacheTests.cs
@@ -1,0 +1,172 @@
+// <copyright file="Issue1679TypeIdentityAqnCacheTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using GSharp.Core.CodeAnalysis.Emit;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #1679: <see cref="TypeIdentityComparer"/> used to rebuild each
+/// <see cref="Type"/>'s assembly-qualified-name key from scratch on every
+/// <c>Equals</c>/<c>GetHashCode</c> call — including cache hits against the
+/// <c>TypeRefs</c>/<c>TypeSpecs</c> dictionaries it backs. The fix memoizes
+/// the key per <see cref="Type"/> instance in a
+/// <see cref="ConditionalWeakTable{TKey, TValue}"/>. These tests pin that the
+/// memoization is transparent to observers (identical Equals/GetHashCode
+/// results before and after caching kicks in) for the representative type
+/// shapes called out in the issue — generics, arrays, nested types, and
+/// types reached through distinct <c>MetadataLoadContext</c> instances — and
+/// that the cache is actually populated (not merely a no-op wrapper).
+/// </summary>
+public class Issue1679TypeIdentityAqnCacheTests
+{
+    private class OuterHolder
+    {
+        public class NestedType
+        {
+        }
+    }
+
+    private static readonly FieldInfo KeyCacheField = typeof(TypeIdentityComparer)
+        .GetField("KeyCache", BindingFlags.NonPublic | BindingFlags.Static);
+
+    [Fact]
+    public void GetHashCode_IsStable_AcrossRepeatedCallsOnSameInstance()
+    {
+        // First call populates the cache; subsequent calls must return the
+        // exact same hash (memoization must not change observable behavior).
+        var type = typeof(Dictionary<string, List<int>>);
+        var first = TypeIdentityComparer.Instance.GetHashCode(type);
+        var second = TypeIdentityComparer.Instance.GetHashCode(type);
+        var third = TypeIdentityComparer.Instance.GetHashCode(type);
+
+        Assert.Equal(first, second);
+        Assert.Equal(second, third);
+    }
+
+    [Fact]
+    public void Equals_And_GetHashCode_PreservedForConstructedGenerics()
+    {
+        var a = typeof(Dictionary<string, List<int>>);
+        var b = typeof(Dictionary<string, List<int>>);
+
+        Assert.True(TypeIdentityComparer.Instance.Equals(a, b));
+        Assert.Equal(
+            TypeIdentityComparer.Instance.GetHashCode(a),
+            TypeIdentityComparer.Instance.GetHashCode(b));
+
+        // A different generic argument must remain distinct.
+        var c = typeof(Dictionary<string, List<long>>);
+        Assert.False(TypeIdentityComparer.Instance.Equals(a, c));
+    }
+
+    [Fact]
+    public void Equals_And_GetHashCode_PreservedForArrays()
+    {
+        var a1 = typeof(int[]);
+        var a2 = typeof(int[]);
+        var jagged = typeof(int[][]);
+        var rank2 = typeof(int[,]);
+        var strings = typeof(string[]);
+
+        Assert.True(TypeIdentityComparer.Instance.Equals(a1, a2));
+        Assert.Equal(
+            TypeIdentityComparer.Instance.GetHashCode(a1),
+            TypeIdentityComparer.Instance.GetHashCode(a2));
+
+        Assert.False(TypeIdentityComparer.Instance.Equals(a1, jagged));
+        Assert.False(TypeIdentityComparer.Instance.Equals(a1, rank2));
+        Assert.False(TypeIdentityComparer.Instance.Equals(a1, strings));
+    }
+
+    [Fact]
+    public void Equals_And_GetHashCode_PreservedForNestedTypes()
+    {
+        var a = typeof(OuterHolder.NestedType);
+        var b = typeof(OuterHolder.NestedType);
+
+        Assert.True(TypeIdentityComparer.Instance.Equals(a, b));
+        Assert.Equal(
+            TypeIdentityComparer.Instance.GetHashCode(a),
+            TypeIdentityComparer.Instance.GetHashCode(b));
+
+        // Nested type must remain distinct from its declaring (outer) type.
+        Assert.False(TypeIdentityComparer.Instance.Equals(a, typeof(OuterHolder)));
+    }
+
+    [Fact]
+    public void Equals_And_GetHashCode_PreservedAcrossMetadataLoadContexts()
+    {
+        // Same repro as TypeRefDeduplicationTests, but covering constructed
+        // generics reached through two distinct MetadataLoadContext
+        // instances, to make sure memoizing the key per-Type-instance still
+        // lets structurally-identical (but reference-distinct) generic
+        // instantiations compare equal.
+        var coreAssemblies = Directory
+            .GetFiles(System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory(), "*.dll")
+            .ToList();
+
+        using var ctxA = new MetadataLoadContext(new PathAssemblyResolver(coreAssemblies));
+        using var ctxB = new MetadataLoadContext(new PathAssemblyResolver(coreAssemblies));
+
+        var listOfObjectA = ctxA.CoreAssembly!.GetType("System.Collections.Generic.List`1")
+            !.MakeGenericType(ctxA.CoreAssembly!.GetType("System.String")!);
+        var listOfObjectB = ctxB.CoreAssembly!.GetType("System.Collections.Generic.List`1")
+            !.MakeGenericType(ctxB.CoreAssembly!.GetType("System.String")!);
+
+        Assert.NotSame(listOfObjectA, listOfObjectB);
+        Assert.True(TypeIdentityComparer.Instance.Equals(listOfObjectA, listOfObjectB));
+        Assert.Equal(
+            TypeIdentityComparer.Instance.GetHashCode(listOfObjectA),
+            TypeIdentityComparer.Instance.GetHashCode(listOfObjectB));
+    }
+
+    [Fact]
+    public void KeyCache_IsPopulated_AfterFirstProbe()
+    {
+        // Confirms the memoization is real (not a dead field): after a single
+        // Equals/GetHashCode call for a fresh Type, the ConditionalWeakTable
+        // holds an entry for it.
+        Assert.NotNull(KeyCacheField);
+
+        var cache = KeyCacheField.GetValue(null);
+        Assert.NotNull(cache);
+
+        var tryGetValue = cache.GetType().GetMethod("TryGetValue");
+        Assert.NotNull(tryGetValue);
+
+        // Use a type unlikely to have been probed by any earlier test in this
+        // run, so we can observe the cache transition from empty to populated
+        // for this specific key.
+        var type = typeof(Issue1679TypeIdentityAqnCacheTests);
+
+        var argsBefore = new object[] { type, null };
+        var foundBefore = (bool)tryGetValue.Invoke(cache, argsBefore);
+
+        TypeIdentityComparer.Instance.GetHashCode(type);
+
+        var argsAfter = new object[] { type, null };
+        var foundAfter = (bool)tryGetValue.Invoke(cache, argsAfter);
+
+        Assert.False(foundBefore);
+        Assert.True(foundAfter);
+        Assert.Equal(type.AssemblyQualifiedName, (string)argsAfter[1]);
+    }
+
+    [Fact]
+    public void NullHandling_Unchanged()
+    {
+        Assert.True(TypeIdentityComparer.Instance.Equals(null, null));
+        Assert.False(TypeIdentityComparer.Instance.Equals(null, typeof(int)));
+        Assert.False(TypeIdentityComparer.Instance.Equals(typeof(int), null));
+        Assert.Throws<ArgumentNullException>(() => TypeIdentityComparer.Instance.GetHashCode(null));
+    }
+}


### PR DESCRIPTION
Fixes #1679

## Root cause
`TypeIdentityComparer.GetKey` rebuilt each `Type`'s `AssemblyQualifiedName` string from scratch on every `Equals`/`GetHashCode` call — including cache hits. `MetadataTokenCache.TypeRefs`/`TypeSpecs` are keyed by this comparer and back `GetTypeReference`/`GetTypeHandleForMember`, which the method-body emitters call for casts, boxes, array creations, local signatures, and member-ref parents — many times per emitted method. For a constructed generic like `Dictionary<string, List<Foo>>` the AQN is a multi-hundred-character string built recursively, so every dictionary probe (hit or miss) paid that formatting cost.

## Fix
Added a `ConditionalWeakTable<Type, string>` in `TypeIdentityComparer` that memoizes `GetKey`'s result per `Type` instance. This mirrors the existing weakly-keyed cache pattern already used in this codebase (`AssemblyDocumentationProvider.Cache`, `FunctionTypeSymbol.ClrTypeIds`). Because the table is weakly keyed, entries are collected automatically once the owning `MetadataLoadContext`'s `Type` instances become unreachable — so unlike the process-wide caches wired into `ReferenceResolver.Dispose` for #1622/#1678, this cache needs no explicit `ClearCache`/Dispose wiring; there's nothing to leak.

## Correctness
`Equals`/`GetHashCode` still compute the exact same key (`AssemblyQualifiedName ?? FullName ?? Name`) — memoization only avoids recomputing it for repeat probes of the *same* `Type` instance. Structural identity semantics are unchanged:
- Two distinct `Type` instances describing the same logical type (e.g. reached through different `MetadataLoadContext` paths) still compare equal and hash identically, because their independently-cached keys are the same string.
- Generics, arrays (including jagged/rank-2), and nested types all keep their existing distinguishing AQN, so they still compare unequal to non-matching shapes.

## Tests
Added `test/Core.Tests/CodeAnalysis/Emit/Issue1679TypeIdentityAqnCacheTests.cs`:
- Hash stability across repeated `GetHashCode` calls on the same `Type` instance.
- Equality/hashing preserved for constructed generics, arrays (incl. jagged/rank-2/element-type), and nested types.
- Equality/hashing preserved for constructed generics reached through two distinct `MetadataLoadContext` instances.
- Direct verification (via reflection on the private `ConditionalWeakTable`) that the cache is actually populated after the first probe, not a dead field.
- Null handling unchanged.

Existing `TypeRefDeduplicationTests.cs` (dedup across `MetadataLoadContext`s, end-to-end no-duplicate-`TypeRef`-rows) continues to pass unmodified.

## Files changed
- `src/Core/CodeAnalysis/Emit/TypeIdentityComparer.cs`
- `test/Core.Tests/CodeAnalysis/Emit/Issue1679TypeIdentityAqnCacheTests.cs` (new)

## Verification
- `dotnet build GSharp.sln -c Release -graph` — 0 errors.
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release` — 5220 passed, 0 failed, 1 skipped (pre-existing baseline-regen test).
