### PR TITLE
Fix #1799: interpreter map thread-safety and deterministic interface-slot resolution

### DIFF
--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -77,6 +77,21 @@ public sealed class Evaluator
     // entries are reclaimed once the owning block is unreachable.
     private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<BoundBlockStatement, Dictionary<BoundLabel, int>> LabelIndexCache = new();
 
+    // Issue #1799: a G# map value is Go-style reference-shared — the SAME
+    // Dictionary<,> instance can be captured by multiple goroutine closures
+    // and read/written concurrently. Plain Dictionary<,> is not thread-safe
+    // under concurrent access (a write racing another write, or even a read
+    // racing a write, can corrupt its internal buckets/entries array mid-
+    // resize). The map's declared CLR type must stay Dictionary<,> (see
+    // EvaluateMapLiteralExpression), so — unlike frames/StructValue.Fields
+    // in #1718 — this can't be fixed by swapping the storage type. Instead,
+    // every interpreter-owned map access (index read, index write, delete,
+    // len) takes a lock keyed by the dictionary instance itself via this
+    // table, giving the same "no corruption under concurrent access"
+    // guarantee ConcurrentDictionary provides, scoped to the operations the
+    // interpreter itself performs.
+    private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<object, object> MapLocks = new();
+
     /// <summary>
     /// Initializes a new instance of the <see cref="Evaluator"/> class.
     /// </summary>
@@ -1249,6 +1264,23 @@ public sealed class Evaluator
     {
         var keyClr = node.MapType.KeyType.ClrType ?? typeof(object);
         var valClr = node.MapType.ValueType.ClrType ?? typeof(object);
+
+        // Issue #1799 (follow-up to #1718): map literals must stay backed
+        // by a real System.Collections.Generic.Dictionary<,> — MapTypeSymbol
+        // .ClrType (used both by the binder for CLR-reflection member access
+        // like `self.Count`/`.ContainsKey(...)` and by the compiled-emit
+        // backend's real IL for `m[k]`/`delete(m, k)`, see
+        // MethodBodyEmitter.EmitMapIndexRead/EmitMapDelete) is fixed at
+        // Dictionary<,>, and ConcurrentDictionary<,> doesn't even expose the
+        // same public surface (e.g. no public Remove(TKey), only
+        // TryRemove) — swapping the runtime type here would desync
+        // reflection-bound member access from the actual instance and break
+        // the compiled backend's method lookups. Thread-safety for the
+        // interpreter's own map read/write/delete paths below is instead
+        // provided by a lock keyed off the dictionary instance (see
+        // <see cref="GetMapLock"/>); insertion behavior, key equality, and
+        // iteration order (unspecified by G#, same as real Go maps) are
+        // unaffected.
         var dictType = typeof(System.Collections.Generic.Dictionary<,>).MakeGenericType(keyClr, valClr);
         var dict = (System.Collections.IDictionary)System.Activator.CreateInstance(dictType);
         foreach (var entry in node.Entries)
@@ -1261,13 +1293,21 @@ public sealed class Evaluator
         return dict;
     }
 
+    // Returns the shared lock guarding all interpreter-owned access to
+    // `dict` (see the <see cref="MapLocks"/> field doc for why maps need
+    // this instead of a ConcurrentDictionary swap).
+    private static object GetMapLock(object dict) => MapLocks.GetValue(dict, static _ => new object());
+
     private object EvaluateMapDeleteExpression(BoundMapDeleteExpression node)
     {
         var dict = (System.Collections.IDictionary)EvaluateExpression(node.Map);
         var key = EvaluateExpression(node.Key);
-        if (dict.Contains(key))
+        lock (GetMapLock(dict))
         {
-            dict.Remove(key);
+            if (dict.Contains(key))
+            {
+                dict.Remove(key);
+            }
         }
 
         return null;
@@ -1283,9 +1323,12 @@ public sealed class Evaluator
         if (node.Target.Type is MapTypeSymbol mapType && target is System.Collections.IDictionary dict)
         {
             var key = EvaluateExpression(node.Index);
-            if (dict.Contains(key))
+            lock (GetMapLock(dict))
             {
-                return dict[key];
+                if (dict.Contains(key))
+                {
+                    return dict[key];
+                }
             }
 
             return DefaultValue(mapType.ValueType);
@@ -1315,7 +1358,11 @@ public sealed class Evaluator
         {
             var key = EvaluateExpression(node.Index);
             var value = EvaluateExpression(node.Value);
-            dict[key] = value;
+            lock (GetMapLock(dict))
+            {
+                dict[key] = value;
+            }
+
             return value;
         }
 
@@ -1333,9 +1380,23 @@ public sealed class Evaluator
         {
             string s => s.Length,
             System.Array a => a.Length,
-            System.Collections.IDictionary d => d.Count,
+
+            // Issue #1799: `.Count` on a Dictionary<,> is a plain field read
+            // with no internal synchronization; take the same per-instance
+            // lock as every other interpreter-owned map access so `len(m)`
+            // can't observe (or crash on) a torn read during a concurrent
+            // `m[k] = v` write from another goroutine.
+            System.Collections.IDictionary d => EvaluateMapLen(d),
             _ => throw new EvaluatorException($"len: unsupported operand of CLR type '{v?.GetType()}'.", node),
         };
+    }
+
+    private static int EvaluateMapLen(System.Collections.IDictionary dict)
+    {
+        lock (GetMapLock(dict))
+        {
+            return dict.Count;
+        }
     }
 
     private static object EvaluateTypeOfExpression(BoundTypeOfExpression node)
@@ -4043,11 +4104,23 @@ public sealed class Evaluator
 
         // Strategy 2: walk locals for any in-scope StructValue
         // implementing the slot's interface.
+        //
+        // Issue #1799: frames became ConcurrentDictionary in #1718 (needed
+        // for goroutine-shared writes), so `foreach (var kv in frame)`
+        // enumerates in internal bucket-hash order instead of Dictionary's
+        // de-facto insertion order — when two in-scope locals both
+        // implement the slot's interface, first-match-wins could pick
+        // either one from run to run. Sort each frame's entries by variable
+        // name before scanning: names are unique within a single frame (a
+        // frame's keys are one call's parameters/captures, and a valid
+        // program cannot declare two same-named bindings in one scope), so
+        // ordinal-name order is a total, stable order that is the same on
+        // every run regardless of ConcurrentDictionary's bucket layout.
         if (resolvedImpl == null && slotIface != null)
         {
             foreach (var frame in Locals)
             {
-                foreach (var kv in frame)
+                foreach (var kv in frame.OrderBy(static kv => kv.Key.Name, StringComparer.Ordinal))
                 {
                     if (kv.Value is StructValue sv && sv.StructType != null)
                     {

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -1260,6 +1260,8 @@ public sealed class Evaluator
         return array;
     }
 
+    // concurrency: ALL interpreter-owned Dictionary access must go through
+    // GetMapLock — see MapLocks.
     private object EvaluateMapLiteralExpression(BoundMapLiteralExpression node)
     {
         var keyClr = node.MapType.KeyType.ClrType ?? typeof(object);
@@ -1297,6 +1299,58 @@ public sealed class Evaluator
     // `dict` (see the <see cref="MapLocks"/> field doc for why maps need
     // this instead of a ConcurrentDictionary swap).
     private static object GetMapLock(object dict) => MapLocks.GetValue(dict, static _ => new object());
+
+    // concurrency: ALL interpreter-owned Dictionary access must go through
+    // GetMapLock — see MapLocks. Issue #1799 follow-up: index get/set,
+    // delete, and len (above) aren't the only paths into a map's backing
+    // Dictionary<,> — `range m`, `m.Count`, `m.ContainsKey(k)`, `m.Keys`,
+    // `m.Values`, and any other dot-member access on a map value dispatch
+    // through the interpreter's generic CLR-reflection call/property paths
+    // (EvaluateImportedInstanceCallExpression / EvaluateClrPropertyAccessExpression),
+    // which never touched this lock. Both of those central dispatch points
+    // now call this single helper so every reflection-based access to an
+    // interpreter-owned map is serialized the same way, instead of scattering
+    // per-member special cases.
+    private static bool TryGetInterpreterMapLock(object receiver, out object lockObj)
+    {
+        if (receiver is System.Collections.IDictionary)
+        {
+            lockObj = GetMapLock(receiver);
+            return true;
+        }
+
+        lockObj = null;
+        return false;
+    }
+
+    // Issue #1799 follow-up: `GetEnumerator()`/`Keys`/`Values` normally
+    // return a live view over the dictionary's own storage — an enumerator
+    // that throws "Collection was modified" on a concurrent write, or a
+    // KeyCollection/ValueCollection backed by the same buckets. Neither can
+    // be made safe by locking just the call that *produces* them, since the
+    // caller keeps using the result (MoveNext/Current, further iteration)
+    // long after the lock is released. Instead, clone the dictionary while
+    // holding <see cref="GetMapLock"/> and hand back a view over the CLONE:
+    // the clone is only ever reachable by the calling goroutine, so no
+    // further locking is needed, no concurrent writer can invalidate it, and
+    // no deadlock is possible even if the loop body itself writes back to
+    // the original map.
+    private static System.Collections.IDictionary CloneMapSnapshot(System.Collections.IDictionary dict)
+    {
+        var clone = (System.Collections.IDictionary)System.Activator.CreateInstance(dict.GetType());
+        foreach (System.Collections.DictionaryEntry entry in dict)
+        {
+            clone[entry.Key] = entry.Value;
+        }
+
+        return clone;
+    }
+
+    // Member names whose result is a live view over the dictionary rather
+    // than a plain value snapshot — these need <see cref="CloneMapSnapshot"/>
+    // instead of a direct invoke/get against the real map.
+    private static bool IsMapViewMember(string name) =>
+        name is "GetEnumerator" or "Keys" or "Values";
 
     private object EvaluateMapDeleteExpression(BoundMapDeleteExpression node)
     {
@@ -1966,6 +2020,25 @@ public sealed class Evaluator
         // implement `IEnumerator<object>`. Route through the matching
         // closed-generic interface on the receiver's runtime type.
         var member = ResolvePropertyOrFieldForReceiver(node.Member, receiver);
+
+        // concurrency: see TryGetInterpreterMapLock — routes `m.Count`,
+        // `m.Keys`, `m.Values`, etc. through the same per-map lock as
+        // index/delete/len.
+        if (TryGetInterpreterMapLock(receiver, out var mapLock))
+        {
+            lock (mapLock)
+            {
+                var propReceiver = IsMapViewMember(member.Name)
+                    ? CloneMapSnapshot((System.Collections.IDictionary)receiver)
+                    : receiver;
+                return member switch
+                {
+                    System.Reflection.PropertyInfo p => p.GetValue(propReceiver),
+                    System.Reflection.FieldInfo f => f.GetValue(propReceiver),
+                    _ => throw new EvaluatorException($"Unsupported CLR member kind '{node.Member.MemberType}'.", node),
+                };
+            }
+        }
 
         return member switch
         {
@@ -4479,6 +4552,24 @@ public sealed class Evaluator
         var refSlots = BuildRefSlots(node.Arguments, node.ArgumentRefKinds, args);
 
         var method = ResolveMethodForReceiver(node.Method, receiver);
+
+        // concurrency: see TryGetInterpreterMapLock — routes `range m`'s
+        // `GetEnumerator()`/`MoveNext()`, `m.ContainsKey(k)`, `m.Remove(k)`,
+        // and any other reflection-dispatched method call whose receiver is
+        // an interpreter-owned map through the same per-map lock as
+        // index/delete/len.
+        if (TryGetInterpreterMapLock(receiver, out var mapLock))
+        {
+            lock (mapLock)
+            {
+                var invokeReceiver = IsMapViewMember(method.Name)
+                    ? CloneMapSnapshot((System.Collections.IDictionary)receiver)
+                    : receiver;
+                var lockedResult = method.Invoke(invokeReceiver, args);
+                WriteBackRefSlots(refSlots, args);
+                return lockedResult;
+            }
+        }
 
         var result = method.Invoke(receiver, args);
         WriteBackRefSlots(refSlots, args);

--- a/test/Interpreter.Tests/Issue1799MapAndInterfaceSlotConcurrencyInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue1799MapAndInterfaceSlotConcurrencyInterpreterTests.cs
@@ -166,6 +166,151 @@ public class Issue1799MapAndInterfaceSlotConcurrencyInterpreterTests
     }
 
     [Fact]
+    public void ManyConcurrentRuns_OneGoroutineRangesWhileOthersWrite_NeverThrowsCollectionModified()
+    {
+        // Opus review follow-up (blocking gap B1): the language sugar
+        // `for k, v in m` isn't currently wired for a native `map[K,V]`
+        // literal (only for imported CLR `Dictionary[K,V]`), but the
+        // underlying access it would lower to — `m.GetEnumerator()` /
+        // `MoveNext()` / `.Current.Key`/`.Value` — is directly reachable
+        // today and dispatches through the interpreter's generic
+        // CLR-reflection call path (EvaluateImportedInstanceCallExpression /
+        // EvaluateClrPropertyAccessExpression), a path the base #1799 fix
+        // never touched. One goroutine walks the shared map's enumerator in
+        // a hot loop while N others write distinct keys concurrently;
+        // without routing GetEnumerator() through GetMapLock (and returning
+        // an enumerator over a private clone) this reliably throws
+        // InvalidOperationException: "Collection was modified" or a
+        // NullReferenceException from a torn bucket read.
+        var source = """
+            func writer(m map[string,int32], key string, value int32) int32 {
+                for var i = 0; i < 20; i++ {
+                    m[key] = value
+                }
+
+                return 0
+            }
+
+            func rangeReader(m map[string,int32]) int32 {
+                var total = 0
+                for var i = 0; i < 20; i++ {
+                    var e = m.GetEnumerator()
+                    while e.MoveNext() {
+                        total = total + e.Current.Value
+                    }
+                }
+
+                return total
+            }
+
+            func run() int32 {
+                var m = map[string,int32]{}
+                scope {
+                    go rangeReader(m)
+                    for var i = 0; i < 16; i++ {
+                        go writer(m, "k" + i.ToString(), i)
+                    }
+                }
+
+                return 0
+            }
+
+            run()
+            """;
+
+        const int iterations = 200;
+        var exceptions = new System.Collections.Concurrent.ConcurrentBag<System.Exception>();
+        System.Threading.Tasks.Parallel.For(
+            0,
+            iterations,
+            new System.Threading.Tasks.ParallelOptions { MaxDegreeOfParallelism = 16 },
+            _ =>
+            {
+                try
+                {
+                    var result = Evaluate(source);
+                    AssertNoRealDiagnostics(result);
+                }
+                catch (System.Exception ex)
+                {
+                    exceptions.Add(ex);
+                }
+            });
+
+        Assert.Empty(exceptions);
+    }
+
+    [Fact]
+    public void ManyConcurrentRuns_LenAndContainsKeyAndKeysReadWhileWriting_NeverThrows()
+    {
+        // Same gap as above (B1) but for the other reflection-dispatched
+        // members named in the review: `len(m)` (Count), `m.ContainsKey(k)`,
+        // and `m.Keys` all resolve to real Dictionary<,> members via CLR
+        // reflection and must serialize on the same per-map lock as
+        // index/delete/range.
+        var source = """
+            func writer(m map[string,int32], key string, value int32) int32 {
+                for var i = 0; i < 20; i++ {
+                    m[key] = value
+                }
+
+                return 0
+            }
+
+            func reader(m map[string,int32]) int32 {
+                var total = 0
+                for var i = 0; i < 20; i++ {
+                    total = total + len(m)
+                    if m.ContainsKey("k0") {
+                        total = total + 1
+                    }
+
+                    for k in m.Keys {
+                        total = total + 1
+                    }
+                }
+
+                return total
+            }
+
+            func run() int32 {
+                var m = map[string,int32]{}
+                scope {
+                    go reader(m)
+                    for var i = 0; i < 16; i++ {
+                        go writer(m, "k" + i.ToString(), i)
+                    }
+                }
+
+                return 0
+            }
+
+            run()
+            """;
+
+        const int iterations = 200;
+        var exceptions = new System.Collections.Concurrent.ConcurrentBag<System.Exception>();
+        System.Threading.Tasks.Parallel.For(
+            0,
+            iterations,
+            new System.Threading.Tasks.ParallelOptions { MaxDegreeOfParallelism = 16 },
+            _ =>
+            {
+                try
+                {
+                    var result = Evaluate(source);
+                    AssertNoRealDiagnostics(result);
+                }
+                catch (System.Exception ex)
+                {
+                    exceptions.Add(ex);
+                }
+            });
+
+        Assert.Empty(exceptions);
+    }
+
+    [Fact]
     public void InterfaceSlotResolution_TwoInScopeImplementers_PicksSameOneEveryRun()
     {
         // "Strategy 2" of EvaluateConstrainedStaticCallExpression walks the

--- a/test/Interpreter.Tests/Issue1799MapAndInterfaceSlotConcurrencyInterpreterTests.cs
+++ b/test/Interpreter.Tests/Issue1799MapAndInterfaceSlotConcurrencyInterpreterTests.cs
@@ -1,0 +1,255 @@
+// <copyright file="Issue1799MapAndInterfaceSlotConcurrencyInterpreterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Issue #1799 — two residual thread-safety/determinism gaps left out of
+/// #1718's stated scope:
+///
+/// 1. <c>Evaluator.EvaluateMapLiteralExpression</c> backed a G# <c>map[K]V</c>
+/// with a plain, non-thread-safe <c>Dictionary&lt;,&gt;</c> even though a map
+/// value is Go-style reference-shared across goroutines exactly like the
+/// frame dictionaries and <see cref="StructValue.Fields"/> #1718 already
+/// fixed. Unlike those two, the map's runtime type can't simply become
+/// <c>ConcurrentDictionary&lt;,&gt;</c>: <c>MapTypeSymbol.ClrType</c> is
+/// <c>Dictionary&lt;,&gt;</c> and is load-bearing for both the binder's
+/// CLR-reflection member access (e.g. <c>self.Count</c> on a
+/// <c>map[K,V]</c>-typed receiver resolves a real
+/// <c>Dictionary&lt;,&gt;.Count</c> <c>PropertyInfo</c>) and the compiled
+/// emit backend's real IL for <c>m[k]</c>/<c>delete(m, k)</c> — and
+/// <c>ConcurrentDictionary&lt;,&gt;</c> doesn't even expose the same public
+/// surface (no public <c>Remove(TKey)</c>, only <c>TryRemove</c>), so
+/// swapping the object type would desync reflection-bound member access
+/// from the actual instance and break the compiled backend's method
+/// lookups. The fix instead keeps the map a real <c>Dictionary&lt;,&gt;</c>
+/// and has every interpreter-owned map access (index read, index write,
+/// delete, <c>len</c>) take a lock keyed off the dictionary instance, so
+/// concurrent goroutine reads/writes on the SAME shared map can no longer
+/// corrupt its internal buckets.
+///
+/// 2. <c>EvaluateConstrainedStaticCallExpression</c>'s "Strategy 2" locals
+/// scan (<c>foreach (var kv in frame)</c>) enumerates a frame that became a
+/// <c>ConcurrentDictionary</c> in #1718, so when two in-scope locals in the
+/// SAME frame both implement the slot's interface, first-match-wins used to
+/// depend on ConcurrentDictionary's internal bucket-hash order — which can
+/// differ from run to run. The fix sorts each frame's candidates by variable
+/// name (ordinal) before scanning, giving a stable, always-reproducible
+/// pick.
+/// </summary>
+public class Issue1799MapAndInterfaceSlotConcurrencyInterpreterTests
+{
+    [Fact]
+    public void ManyGoroutines_WriteDistinctKeysOnSharedMap_AllWritesSurvive()
+    {
+        // A single map literal is captured by N goroutines, each writing a
+        // DIFFERENT key on the SAME shared map at the same time — directly
+        // exercising concurrent-access safety of the map's backing
+        // dictionary (guarded by a per-instance lock). Mirrors
+        // Issue1718FrameConcurrencyInterpreterTests.ManyGoroutines_WriteDistinctFieldsOnSharedClassInstance_AllWritesSurvive
+        // but for a map value instead of a class instance.
+        const int keyCount = 24;
+        var sb = new System.Text.StringBuilder();
+        for (var i = 0; i < keyCount; i++)
+        {
+            sb.AppendLine($"func setK{i}(m map[string,int32]) int32 {{\n    m[\"k{i}\"] = {i + 1}\n    return 0\n}}");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("func run() int32 {");
+        sb.AppendLine("    var m = map[string,int32]{}");
+        sb.AppendLine("    scope {");
+        for (var i = 0; i < keyCount; i++)
+        {
+            sb.AppendLine($"        go setK{i}(m)");
+        }
+
+        sb.AppendLine("    }");
+        sb.Append("    return ");
+        for (var i = 0; i < keyCount; i++)
+        {
+            sb.Append($"m[\"k{i}\"]");
+            if (i < keyCount - 1)
+            {
+                sb.Append(" + ");
+            }
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("}");
+        sb.AppendLine();
+        sb.AppendLine("run()");
+
+        var expectedSum = 0;
+        for (var i = 0; i < keyCount; i++)
+        {
+            expectedSum += i + 1;
+        }
+
+        var result = Evaluate(sb.ToString());
+        AssertNoRealDiagnostics(result);
+        Assert.Equal(expectedSum, result.Value);
+    }
+
+    [Fact]
+    public void ManyConcurrentRuns_GoroutinesWritingSharedMap_NeverCorruptsOrCrashes()
+    {
+        // Same stress shape as
+        // Issue1718FrameConcurrencyInterpreterTests.ManyConcurrentRuns_GoroutineAndSpawnerBothWriteCapturedVariable_NeverCorruptsOrCrashes:
+        // run the whole evaluation many times concurrently to maximize the
+        // chance any residual plain-Dictionary corruption in the map
+        // literal would surface as a thrown exception or a corrupted key
+        // count.
+        var source = """
+            func bump(m map[string,int32]) int32 {
+                m["k"] = m["k"] + 1
+                return 0
+            }
+
+            func run() int32 {
+                var m = map[string,int32]{}
+                scope {
+                    for var i = 0; i < 50; i++ {
+                        go bump(m)
+                    }
+                }
+
+                return m["k"]
+            }
+
+            run()
+            """;
+
+        const int iterations = 300;
+        var exceptions = new System.Collections.Concurrent.ConcurrentBag<System.Exception>();
+        var outOfRangeResults = new System.Collections.Concurrent.ConcurrentBag<int>();
+        System.Threading.Tasks.Parallel.For(
+            0,
+            iterations,
+            new System.Threading.Tasks.ParallelOptions { MaxDegreeOfParallelism = 32 },
+            i =>
+            {
+                try
+                {
+                    var result = Evaluate(source);
+                    AssertNoRealDiagnostics(result);
+                    var value = (int)result.Value;
+
+                    // 50 concurrent racy `m["k"] = m["k"] + 1` increments
+                    // starting from the map's zero value (0): a lost update
+                    // can only ever under-count, never invent a value
+                    // outside [0, 50], and must never throw. Anything
+                    // outside that range (or an exception) indicates real
+                    // dictionary corruption, not just a benign lost update.
+                    if (value < 0 || value > 50)
+                    {
+                        outOfRangeResults.Add(value);
+                    }
+                }
+                catch (System.Exception ex)
+                {
+                    exceptions.Add(ex);
+                }
+            });
+
+        Assert.Empty(exceptions);
+        Assert.Empty(outOfRangeResults);
+    }
+
+    [Fact]
+    public void InterfaceSlotResolution_TwoInScopeImplementers_PicksSameOneEveryRun()
+    {
+        // "Strategy 2" of EvaluateConstrainedStaticCallExpression walks the
+        // current call frame for any in-scope StructValue implementing the
+        // slot's interface. Neither `a` nor `b` (T.Add's arguments) is
+        // T-typed, so Strategy 1's argument-sniff can't resolve the
+        // implementer and this call is forced onto Strategy 2 with TWO
+        // valid candidates in the SAME frame: `w` (Adder, declared type
+        // parameter T) and `other` (Adder2, a concrete, non-generic
+        // parameter) both implement IAdd. Ordinal name order picks "other"
+        // before "w" ('o' &lt; 'w'), so the resolved implementer — and
+        // therefore the result (12 = 3*4 from Adder2, never 7 = 3+4 from
+        // Adder) — must be identical on every run, regardless of
+        // ConcurrentDictionary's internal bucket-hash order for the frame.
+        var source = """
+            import System
+
+            sealed interface IAdd {
+                shared {
+                    func Add(a int32, b int32) int32;
+                }
+            }
+
+            class Adder : IAdd {
+                shared {
+                    func Add(a int32, b int32) int32 { return a + b }
+                }
+            }
+
+            class Adder2 : IAdd {
+                shared {
+                    func Add(a int32, b int32) int32 { return a * b }
+                }
+            }
+
+            func Compute[T IAdd](w T, other Adder2, a int32, b int32) int32 {
+                return T.Add(a, b)
+            }
+
+            Console.WriteLine(Compute(Adder{}, Adder2{}, 3, 4))
+            """;
+
+        for (var i = 0; i < 50; i++)
+        {
+            Assert.Equal("12\n", EvaluateToConsole(source));
+        }
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        // ADR-0082 / issue #722: `go` is gated behind this import.
+        var fullSource = "import Gsharp.Extensions.Go\n" + source;
+        var tree = SyntaxTree.Parse(SourceText.From(fullSource));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+
+    private static string EvaluateToConsole(string source)
+    {
+        var previousOut = System.Console.Out;
+        try
+        {
+            using var writer = new System.IO.StringWriter();
+            System.Console.SetOut(writer);
+            var tree = SyntaxTree.Parse(SourceText.From(source));
+            var compilation = new Compilation(tree);
+            var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+            AssertNoRealDiagnostics(result);
+            return writer.ToString();
+        }
+        finally
+        {
+            System.Console.SetOut(previousOut);
+        }
+    }
+
+    /// <summary>
+    /// See <see cref="Issue1651GoroutineIsolationInterpreterTests.AssertNoRealDiagnostics"/>:
+    /// some fixtures place a `let`/`var` declaration ahead of the functions
+    /// that use it for readability, which GS0286 (ADR-0066 D5) flags as a
+    /// warning, not an error.
+    /// </summary>
+    private static void AssertNoRealDiagnostics(EvaluationResult result)
+    {
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id != "GS0286");
+    }
+}


### PR DESCRIPTION
Fixes #1799

Follow-up to #1718, which switched interpreter frame dictionaries and `StructValue.Fields` to `ConcurrentDictionary` because Go closure semantics share those objects by reference across goroutines. This PR fixes the two residual gaps that were intentionally left out of #1718's scope.

## 1. Map literals were not goroutine-safe

`Evaluator.EvaluateMapLiteralExpression` backed a G# `map[K]V` with a plain, non-thread-safe `Dictionary<,>`, even though a map value is Go-style reference-shared across goroutines exactly like the frame dictionaries and `StructValue.Fields` #1718 already fixed.

Unlike those two, the map's runtime type can't simply become `ConcurrentDictionary<,>`: `MapTypeSymbol.ClrType` is fixed at `Dictionary<,>` and is load-bearing for both:
- the binder's CLR-reflection member access (e.g. `self.Count` on a `map[K,V]`-typed receiver resolves a real `Dictionary<,>.Count` `PropertyInfo`), and
- the compiled emit backend's real IL for `m[k]` / `delete(m, k)` (`MethodBodyEmitter.EmitMapIndexRead`/`EmitMapDelete` reflect directly against `mapType.ClrType`).

`ConcurrentDictionary<,>` also doesn't expose the same public surface (no public `Remove(TKey)`, only `TryRemove`), so swapping the object type would have broken `delete(m, k)` codegen and desynced reflection-bound member access from the actual runtime instance (verified directly — I tried the naive swap first and it broke `Issue751RichReceiverBinderTests.Map_Receiver_Dispatches_Via_DotSyntax` with a `TargetException`).

The fix instead keeps the map a real `Dictionary<,>` and has every interpreter-owned map access (index read, index write, delete, `len`) take a lock keyed off the dictionary instance (via a `ConditionalWeakTable`), giving the same "no corruption under concurrent access" guarantee `ConcurrentDictionary` provides, without touching `ClrType` or the compiled backend.

## 2. Nondeterministic interface-slot resolution

`EvaluateConstrainedStaticCallExpression`'s "Strategy 2" locals scan (`foreach (var kv in frame)`) enumerates a frame that became a `ConcurrentDictionary` in #1718, so when two in-scope locals in the same frame both implement the slot's interface, first-match-wins depended on `ConcurrentDictionary`'s internal bucket-hash order — which can differ from run to run.

Fixed by sorting each frame's candidates by variable name (ordinal) before scanning: names are unique within a single frame (one call's parameters/captures; a valid program can't declare two same-named bindings in one scope), so ordinal-name order is a total, stable order independent of `ConcurrentDictionary`'s bucket layout.

## Generalization

I scanned the rest of `Evaluator.cs` for the same two anti-pattern classes:
- **Other shared-across-goroutine mutable collections still using plain `Dictionary`/`List`**: `ClosureValue.CapturedLocals` is a plain `Dictionary` but is a documented "value-snapshot... captured at literal-evaluation time" — populated once by a single thread and never mutated afterward, so concurrent reads are safe without synchronization. `ScopeFrame.Tasks` (`List<Task>`) looked suspicious (goroutines could in theory register nested `go` tasks against the same scope frame), but `CloneExecutionStateForGoroutine` gives every goroutine a fresh, empty `ScopeFrames` stack, so a nested `go` inside a goroutine never resolves back to the spawner's enclosing scope frame — not reachable, no fix needed. Pattern-binding `bindings` dictionaries (switch/pattern match) are always thread-local (built and consumed within one call, never shared). No other genuine instances found.
- **Other `Dictionary` iterations whose bucket order is observable**: I found one more (`EvaluateConstructorChainingExpression`, ~line 4826) that also does `foreach (var kv in frame)` over a `ConcurrentDictionary`, but it's filtering for the unique `this` parameter in that frame (at most one match per frame by construction), so bucket order can't change the result — left as-is. All other struct/field iterations in `Evaluator.cs` iterate `StructSymbol.Fields` (an `ImmutableArray`, declaration-order, not the runtime dictionary), so they were never affected.

## Testing

- `dotnet build GSharp.sln -c Release -graph` — 0 errors.
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release` — 5204 passed, 0 failed, 1 skipped (pre-existing baseline-regen skip).
- `dotnet test test/Interpreter.Tests/Interpreter.Tests.csproj -c Release` — 391 passed, 0 failed.
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Release` — 2606 passed, 0 failed, 1 skipped (pre-existing), confirming the compiled emit backend is untouched.
- New file `test/Interpreter.Tests/Issue1799MapAndInterfaceSlotConcurrencyInterpreterTests.cs`:
  - `ManyGoroutines_WriteDistinctKeysOnSharedMap_AllWritesSurvive`: 24 goroutines each write a distinct key on one shared map; asserts every write survived.
  - `ManyConcurrentRuns_GoroutinesWritingSharedMap_NeverCorruptsOrCrashes`: 300 concurrent evaluations of 50 goroutines racily incrementing a shared map value; asserts no exceptions and no corrupted (out-of-range) results.
  - `InterfaceSlotResolution_TwoInScopeImplementers_PicksSameOneEveryRun`: two in-scope `StructValue`s in the same frame both implement the slot's interface; asserts the same implementer is picked across 50 runs.
  - I verified all three tests actually catch the pre-fix bugs by temporarily reverting the `Evaluator.cs` changes and confirming all three fail (map test: lost update / count mismatch; determinism test: wrong implementer picked).

Zero deferrals — both issue items and everything found during generalization were fixed or confirmed not reachable.
