### PR TITLE
cs2gs: fix value-position assignments silently discarding the write

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue1723ValuePositionAssignmentTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1723ValuePositionAssignmentTranslationTests.cs
@@ -1,0 +1,346 @@
+// <copyright file="Issue1723ValuePositionAssignmentTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Regression tests for issue #1723: a C# assignment used in VALUE position
+/// (<c>while ((line = r.ReadLine()) != null)</c>, <c>a = b += c</c>,
+/// <c>M(x = 5)</c>, <c>if ((x = f()) > 0)</c>, <c>return (x = M());</c>) was
+/// translated as if the assignment were statement-only, or by returning just
+/// the RHS — silently dropping the write. G# models assignment as a
+/// statement, not a value-yielding expression, so the fix hoists the
+/// assignment into a preceding (or, for loop conditions, per-iteration
+/// body-prologue) assignment statement and substitutes the assigned target's
+/// read for the original assignment expression, preserving evaluation order,
+/// evaluation COUNT, and the write itself. Every snippet must round-trip
+/// through the real G# parser.
+/// </summary>
+public class Issue1723ValuePositionAssignmentTranslationTests
+{
+    /// <summary>
+    /// The canonical idiom: <c>while ((line = r.ReadLine()) != null)</c>. The
+    /// assignment must be hoisted into the loop body (so <c>ReadLine</c> is
+    /// called exactly once per iteration) and the loop must break when the
+    /// hoisted <c>line</c> is nil, instead of comparing the call's return value
+    /// directly and losing the assignment to <c>line</c>.
+    /// </summary>
+    [Fact]
+    public void WhileConditionAssignment_HoistsReadLineIntoBodyAndBreaksOnNil()
+    {
+        string printed = TranslateUnit(@"
+using System.IO;
+
+namespace Demo
+{
+    public sealed class C
+    {
+        public void ReadAll(TextReader r)
+        {
+            string line;
+            while ((line = r.ReadLine()) != null)
+            {
+                System.Console.WriteLine(line);
+            }
+        }
+    }
+}");
+
+        Assert.Contains("while true {", printed);
+
+        // The assignment is hoisted as its own statement — `ReadLine` appears
+        // exactly once, and `line` is actually assigned (not just read).
+        Assert.Equal(1, CountOccurrences(printed, "r.ReadLine()"));
+        Assert.Contains("line = r.ReadLine()", printed);
+
+        // The condition becomes a negated break guard over the hoisted read.
+        Assert.Contains("!((line) != nil)", printed);
+        Assert.Contains("break", printed);
+
+        Assert.Contains("Console.WriteLine(line)", printed);
+    }
+
+    /// <summary>
+    /// <c>if ((x = f()) > 0)</c>: the assignment is hoisted immediately before
+    /// the <c>if</c> (evaluated exactly once, matching C#'s single evaluation of
+    /// an if-condition), and the condition reads the now-current <c>x</c>.
+    /// </summary>
+    [Fact]
+    public void IfConditionAssignment_HoistsBeforeIfAndReadsAssignedTarget()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public sealed class C
+    {
+        public static int F() => 5;
+
+        public void M()
+        {
+            int x = 0;
+            if ((x = F()) > 0)
+            {
+                System.Console.WriteLine(x);
+            }
+        }
+    }
+}");
+
+        Assert.Equal(1, CountOccurrences(printed, "= C.F()"));
+        Assert.Contains("x = C.F()", printed);
+        Assert.Contains("if (x) > 0 {", printed);
+        Assert.Contains("Console.WriteLine(x)", printed);
+    }
+
+    /// <summary>
+    /// A bare assignment used directly as an <c>if</c> condition:
+    /// <c>if (x = F())</c> (C# only allows this for a <c>bool</c>-typed target).
+    /// </summary>
+    [Fact]
+    public void IfConditionBareAssignment_HoistsAndReadsAssignedTarget()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public sealed class C
+    {
+        public static bool F() => true;
+
+        public void M()
+        {
+            bool x = false;
+            if (x = F())
+            {
+                System.Console.WriteLine(x);
+            }
+        }
+    }
+}");
+
+        Assert.Equal(1, CountOccurrences(printed, "= C.F()"));
+        Assert.Contains("x = C.F()", printed);
+        Assert.Contains("if x {", printed);
+    }
+
+    /// <summary>
+    /// Chained assignment through a COMPOUND operator link, <c>a = b += c</c>:
+    /// C# evaluates <c>b += c</c> first (mutating <c>b</c>, yielding its new
+    /// value) and then assigns that value to <c>a</c>. The compound link must
+    /// not be dropped (the historical bug turned this into plain <c>a = c</c>).
+    /// </summary>
+    [Fact]
+    public void ChainedAssignmentThroughCompoundOperator_PreservesBothWrites()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public sealed class C
+    {
+        public void M()
+        {
+            int a = 0;
+            int b = 1;
+            int c = 2;
+            a = b += c;
+            System.Console.WriteLine(a);
+            System.Console.WriteLine(b);
+        }
+    }
+}");
+
+        // Both the compound mutation of `b` and the final assignment to `a`
+        // must appear as separate statements, in this order.
+        int bMutation = printed.IndexOf("b += c", StringComparison.Ordinal);
+        int aAssignment = printed.IndexOf("a = b", StringComparison.Ordinal);
+        Assert.True(bMutation >= 0, "Expected `b += c` mutation in:\n" + printed);
+        Assert.True(aAssignment >= 0, "Expected `a = b` assignment in:\n" + printed);
+        Assert.True(bMutation < aAssignment, "`b += c` must run before `a = b`:\n" + printed);
+    }
+
+    /// <summary>
+    /// Assignment as a call argument, <c>M(x = 5)</c>: the argument's write
+    /// must land in <c>x</c> AND the call must observe the assigned value.
+    /// </summary>
+    [Fact]
+    public void AssignmentAsCallArgument_HoistsBeforeCallAndPassesAssignedValue()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public sealed class C
+    {
+        public static void Consume(int value)
+        {
+        }
+
+        public void M()
+        {
+            int x = 0;
+            Consume(x = 5);
+            System.Console.WriteLine(x);
+        }
+    }
+}");
+
+        Assert.Contains("x = 5", printed);
+        Assert.Contains("Consume(x)", printed);
+        Assert.Contains("Console.WriteLine(x)", printed);
+    }
+
+    /// <summary>
+    /// <c>return (x = M());</c>: the assignment is hoisted into a preceding
+    /// statement and the return value reads the now-assigned <c>x</c>.
+    /// </summary>
+    [Fact]
+    public void ReturnValueAssignment_HoistsBeforeReturnAndReadsAssignedTarget()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public sealed class C
+    {
+        public static int F() => 7;
+
+        public int M()
+        {
+            int x = 0;
+            return (x = F());
+        }
+    }
+}");
+
+        Assert.Equal(1, CountOccurrences(printed, "= C.F()"));
+        Assert.Contains("x = C.F()", printed);
+        Assert.Contains("return (x)", printed);
+    }
+
+    /// <summary>
+    /// A <c>for</c> loop whose condition carries a value-position assignment,
+    /// <c>for (...; (c = Next()) != -1; ...)</c>, must call <c>Next()</c>
+    /// exactly once per iteration (evaluated as part of the loop test) and use
+    /// the hoisted read to decide whether to continue.
+    /// </summary>
+    [Fact]
+    public void ForConditionAssignment_HoistsIntoBodyPrologue()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public sealed class Source
+    {
+        private int calls;
+
+        public int Next()
+        {
+            this.calls++;
+            return this.calls > 3 ? -1 : this.calls;
+        }
+    }
+
+    public sealed class C
+    {
+        public void M(Source s)
+        {
+            int c;
+            for (int i = 0; (c = s.Next()) != -1; i++)
+            {
+                System.Console.WriteLine(c);
+            }
+        }
+    }
+}");
+
+        Assert.Contains("while true {", printed);
+        Assert.Contains("c = s.Next()", printed);
+        Assert.Contains("!((c) != -1)", printed);
+        Assert.Contains("break", printed);
+        Assert.Contains("Console.WriteLine(c)", printed);
+    }
+
+    /// <summary>
+    /// An assignment hidden inside the short-circuited operand of <c>&amp;&amp;</c>
+    /// (<c>a() &amp;&amp; (x = f()) > 0</c>): hoisting it unconditionally would evaluate
+    /// <c>f()</c> even when <c>a()</c> is <c>false</c>, changing C#'s evaluation
+    /// COUNT. This is the one form the fix cannot lower faithfully, so it must be
+    /// surfaced as an <see cref="TranslationSeverity.Unsupported"/> diagnostic
+    /// instead of silently dropping the write.
+    /// </summary>
+    [Fact]
+    public void AssignmentInsideShortCircuitedAnd_ReportsUnsupportedInsteadOfSilentlyDropping()
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[]
+        {
+            ("Snippet.cs", @"
+namespace Demo
+{
+    public sealed class C
+    {
+        public static bool A() => true;
+
+        public static int F() => 5;
+
+        public void M()
+        {
+            int x = 0;
+            if (A() && (x = F()) > 0)
+            {
+                System.Console.WriteLine(x);
+            }
+        }
+    }
+}"),
+        });
+        Assert.True(project.BoundWithoutErrors);
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        _ = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        Assert.Contains(
+            context.Diagnostics,
+            d => d.Severity == TranslationSeverity.Unsupported && d.Message.Contains("short-circuited"));
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        int count = 0;
+        for (int index = haystack.IndexOf(needle, StringComparison.Ordinal);
+            index >= 0;
+            index = haystack.IndexOf(needle, index + needle.Length, StringComparison.Ordinal))
+        {
+            count++;
+        }
+
+        return count;
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1723ValuePositionAssignmentTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1723ValuePositionAssignmentTranslationTests.cs
@@ -310,6 +310,219 @@ namespace Demo
             d => d.Severity == TranslationSeverity.Unsupported && d.Message.Contains("short-circuited"));
     }
 
+    /// <summary>
+    /// A <c>do</c>/<c>while</c> loop whose condition carries a value-position
+    /// assignment must hoist the assignment + break-guard to the TAIL of the
+    /// body, not the top: C# evaluates the body BEFORE the condition on every
+    /// iteration (including the first), so hoisting at the top would apply the
+    /// assignment's write before the first body run, silently reordering an
+    /// observable side effect (issue #1723, do-while regression).
+    /// </summary>
+    [Fact]
+    public void DoWhileConditionAssignment_HoistsToBodyTailNotTop()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public sealed class C
+    {
+        public void M()
+        {
+            int i = 0;
+            do
+            {
+                System.Console.WriteLine(i);
+            } while ((i = i + 1) < 3);
+        }
+    }
+}");
+
+        int writeLine = printed.IndexOf("Console.WriteLine(i)", StringComparison.Ordinal);
+        int assign = printed.IndexOf("i = i + 1", StringComparison.Ordinal);
+        Assert.True(writeLine >= 0, "Expected `Console.WriteLine(i)` in:\n" + printed);
+        Assert.True(assign >= 0, "Expected hoisted `i = i + 1` in:\n" + printed);
+        Assert.True(writeLine < assign, "Body must run before the hoisted condition assignment:\n" + printed);
+    }
+
+    /// <summary>
+    /// A <c>while</c> loop whose hoisted condition-assignment body contains a
+    /// <c>continue</c>: the hoisted assignment lives at the TOP of the body (as
+    /// the loop's real condition check), so <c>continue</c> jumps back to it and
+    /// it re-runs every iteration — it must never go stale.
+    /// </summary>
+    [Fact]
+    public void WhileConditionAssignmentWithContinue_ReevaluatesHoistedAssignmentEachIteration()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public sealed class Source
+    {
+        private int calls;
+
+        public int Next()
+        {
+            this.calls++;
+            return this.calls > 5 ? -1 : this.calls;
+        }
+    }
+
+    public sealed class C
+    {
+        public void M(Source s)
+        {
+            int c;
+            while ((c = s.Next()) != -1)
+            {
+                if (c % 2 == 0)
+                {
+                    continue;
+                }
+
+                System.Console.WriteLine(c);
+            }
+        }
+    }
+}");
+
+        Assert.Contains("while true {", printed);
+        Assert.Contains("c = s.Next()", printed);
+        Assert.Contains("continue", printed);
+
+        // The hoisted assignment must be the first statement in the loop body
+        // (before the `continue`'s enclosing `if`), so `continue` re-triggers it.
+        int hoist = printed.IndexOf("c = s.Next()", StringComparison.Ordinal);
+        int continueIdx = printed.IndexOf("continue", StringComparison.Ordinal);
+        Assert.True(hoist >= 0 && continueIdx >= 0 && hoist < continueIdx, printed);
+    }
+
+    /// <summary>
+    /// An assignment hidden in the RHS of <c>??</c> (<c>a ?? (x = f())</c>): the
+    /// RHS only runs when <c>a</c> is null, so hoisting the assignment
+    /// unconditionally would run it even when <c>a</c> is non-null, changing C#'s
+    /// evaluation count. Must be surfaced as <see cref="TranslationSeverity.Unsupported"/>,
+    /// not silently hoisted (issue #1723 follow-up).
+    /// </summary>
+    [Fact]
+    public void AssignmentInsideCoalesceRight_ReportsUnsupportedInsteadOfSilentlyDropping()
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[]
+        {
+            ("Snippet.cs", @"
+namespace Demo
+{
+    public sealed class C
+    {
+        public void M(string s)
+        {
+            int x = 0;
+            int y = s?.Length ?? (x = 42);
+            System.Console.WriteLine(y);
+        }
+    }
+}"),
+        });
+        Assert.True(project.BoundWithoutErrors);
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        _ = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        Assert.Contains(
+            context.Diagnostics,
+            d => d.Severity == TranslationSeverity.Unsupported);
+    }
+
+    /// <summary>
+    /// An assignment inside the "when not null" side of a <c>?.</c> chain
+    /// (<c>obj?.M(x = 5)</c>): the call/argument only evaluates when <c>obj</c>
+    /// is non-null, so hoisting unconditionally would run it even when <c>obj</c>
+    /// is null. Must be surfaced as <see cref="TranslationSeverity.Unsupported"/>.
+    /// </summary>
+    [Fact]
+    public void AssignmentInsideConditionalAccessWhenNotNull_ReportsUnsupportedInsteadOfSilentlyDropping()
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[]
+        {
+            ("Snippet.cs", @"
+namespace Demo
+{
+    public sealed class Obj
+    {
+        public int M(int value) => value;
+    }
+
+    public sealed class C
+    {
+        public void M(Obj obj)
+        {
+            int x = 0;
+            int? y = obj?.M(x = 5);
+            System.Console.WriteLine(y);
+        }
+    }
+}"),
+        });
+        Assert.True(project.BoundWithoutErrors);
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        _ = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        Assert.Contains(
+            context.Diagnostics,
+            d => d.Severity == TranslationSeverity.Unsupported);
+    }
+
+    /// <summary>
+    /// Multiple independent embedded assignments in one expression must hoist
+    /// (and thus evaluate) in left-to-right source order: <c>if ((a=f())&gt;(b=g()))</c>
+    /// and <c>M(x=1, y=2)</c>.
+    /// </summary>
+    [Fact]
+    public void MultipleEmbeddedAssignments_PreserveLeftToRightOrder()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public sealed class C
+    {
+        public static int F() => 1;
+
+        public static int G() => 2;
+
+        public static void Consume(int x, int y)
+        {
+        }
+
+        public void M()
+        {
+            int a = 0;
+            int b = 0;
+            if ((a = F()) > (b = G()))
+            {
+                System.Console.WriteLine(a);
+            }
+
+            int p = 0;
+            int q = 0;
+            Consume(p = 1, q = 2);
+            System.Console.WriteLine(p);
+            System.Console.WriteLine(q);
+        }
+    }
+}");
+
+        int aAssign = printed.IndexOf("a = C.F()", StringComparison.Ordinal);
+        int bAssign = printed.IndexOf("b = C.G()", StringComparison.Ordinal);
+        Assert.True(aAssign >= 0 && bAssign >= 0 && aAssign < bAssign, printed);
+
+        int pAssign = printed.IndexOf("p = 1", StringComparison.Ordinal);
+        int qAssign = printed.IndexOf("q = 2", StringComparison.Ordinal);
+        Assert.True(pAssign >= 0 && qAssign >= 0 && pAssign < qAssign, printed);
+        Assert.Contains("Consume(p, q)", printed);
+    }
+
     private static int CountOccurrences(string haystack, string needle)
     {
         int count = 0;

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1723ValuePositionAssignmentTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1723ValuePositionAssignmentTranslationTests.cs
@@ -394,6 +394,53 @@ namespace Demo
     }
 
     /// <summary>
+    /// A <c>continue</c> inside a <c>switch</c> STATEMENT case still targets
+    /// the enclosing <c>do</c>/<c>while</c> loop — unlike <c>break</c>, C#'s
+    /// <c>switch</c> does not re-target <c>continue</c>. So this must be
+    /// flagged Unsupported the same as an un-nested continue (issue #1723).
+    /// </summary>
+    [Fact]
+    public void DoWhileConditionAssignmentWithContinueInsideSwitch_ReportsUnsupportedInsteadOfSilentlyDroppingHoist()
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[]
+        {
+            ("Snippet.cs", @"
+namespace Demo
+{
+    public sealed class C
+    {
+        public void M()
+        {
+            int i = 0;
+            int x = 0;
+            do
+            {
+                switch (i % 2)
+                {
+                    case 0:
+                        i = i + 1;
+                        continue;
+                    default:
+                        x = x + i;
+                        break;
+                }
+            } while ((i = i + 1) < 10);
+        }
+    }
+}"),
+        });
+        Assert.True(project.BoundWithoutErrors);
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        _ = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        Assert.Contains(
+            context.Diagnostics,
+            d => d.Severity == TranslationSeverity.Unsupported && d.Message.Contains("short-circuited"));
+    }
+
+    /// <summary>
     /// Regression guard: a <c>continue</c> inside a NESTED inner loop targets
     /// the inner loop, not the outer <c>do</c>/<c>while</c> — it never reaches
     /// this do-while's ADR-0070 continueLabel, so the outer tail-hoist is safe

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1723ValuePositionAssignmentTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1723ValuePositionAssignmentTranslationTests.cs
@@ -345,6 +345,97 @@ namespace Demo
     }
 
     /// <summary>
+    /// A <c>do</c>/<c>while</c> whose condition carries a value-position
+    /// assignment AND whose body has a <c>continue</c> targeting this loop: the
+    /// tail-hoisted assignment/break-guard sits AFTER the `continue`'s jump
+    /// target (ADR-0070's continueLabel is placed right after the whole bound
+    /// body), so `continue` would skip it — re-using a stale condition value
+    /// instead of re-evaluating it. This has no side-effect-preserving G#
+    /// lowering yet, so it must be flagged Unsupported instead of silently
+    /// mistranslated (issue #1723, do-while + continue regression).
+    /// </summary>
+    [Fact]
+    public void DoWhileConditionAssignmentWithOwnContinue_ReportsUnsupportedInsteadOfSilentlyDroppingHoist()
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[]
+        {
+            ("Snippet.cs", @"
+namespace Demo
+{
+    public sealed class C
+    {
+        public void M()
+        {
+            int i = 0;
+            int x = 0;
+            do
+            {
+                if (i % 2 == 0)
+                {
+                    i = i + 1;
+                    continue;
+                }
+
+                x = x + i;
+            } while ((i = i + 1) < 10);
+        }
+    }
+}"),
+        });
+        Assert.True(project.BoundWithoutErrors);
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        _ = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        Assert.Contains(
+            context.Diagnostics,
+            d => d.Severity == TranslationSeverity.Unsupported && d.Message.Contains("short-circuited"));
+    }
+
+    /// <summary>
+    /// Regression guard: a <c>continue</c> inside a NESTED inner loop targets
+    /// the inner loop, not the outer <c>do</c>/<c>while</c> — it never reaches
+    /// this do-while's ADR-0070 continueLabel, so the outer tail-hoist is safe
+    /// and must still lower normally (no diagnostic), instead of being
+    /// over-flagged as unsupported (issue #1723).
+    /// </summary>
+    [Fact]
+    public void DoWhileConditionAssignmentWithNestedLoopContinue_StillLowersNormally()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public sealed class C
+    {
+        public void M()
+        {
+            int i = 0;
+            do
+            {
+                for (int j = 0; j < 3; j++)
+                {
+                    if (j == 1)
+                    {
+                        continue;
+                    }
+
+                    System.Console.WriteLine(j);
+                }
+            } while ((i = i + 1) < 3);
+        }
+    }
+}");
+
+        Assert.Contains("i = i + 1", printed);
+        Assert.Contains("continue", printed);
+
+        int writeLine = printed.IndexOf("Console.WriteLine(j)", StringComparison.Ordinal);
+        int assign = printed.IndexOf("i = i + 1", StringComparison.Ordinal);
+        Assert.True(writeLine >= 0 && assign >= 0 && writeLine < assign, printed);
+    }
+
+    /// <summary>
     /// A <c>while</c> loop whose hoisted condition-assignment body contains a
     /// <c>continue</c>: the hoisted assignment lives at the TOP of the body (as
     /// the loop's real condition check), so <c>continue</c> jumps back to it and

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -4409,17 +4409,21 @@ public sealed class CSharpToGSharpTranslator
             return safe;
         }
 
-        // True when `node` is reached only through the (not-always-evaluated)
-        // right operand of a `&&`/`||` inside `root`, or through either branch of
-        // a `?:` inside `root`. Hoisting such an assignment out in front of `root`
-        // would evaluate/mutate it unconditionally, changing C# semantics.
+        // True when `node` is reached only through a not-always-evaluated operand
+        // inside `root`: the right operand of a `&&`/`||`, either branch of a
+        // `?:`, the right operand of `??`, or the "when not null" side of a
+        // `?.`/`?[...]` conditional-access chain (including any member/element
+        // access further chained off it). Hoisting such an assignment out in
+        // front of `root` would evaluate/mutate it unconditionally, changing C#
+        // semantics.
         private static bool IsInShortCircuitOrConditionalBranch(SyntaxNode node, ExpressionSyntax root)
         {
             for (SyntaxNode current = node; current != null && current != root; current = current.Parent)
             {
                 SyntaxNode parent = current.Parent;
                 if (parent is BinaryExpressionSyntax binary &&
-                    (binary.IsKind(SyntaxKind.LogicalAndExpression) || binary.IsKind(SyntaxKind.LogicalOrExpression)) &&
+                    (binary.IsKind(SyntaxKind.LogicalAndExpression) || binary.IsKind(SyntaxKind.LogicalOrExpression) ||
+                     binary.IsKind(SyntaxKind.CoalesceExpression)) &&
                     current == binary.Right)
                 {
                     return true;
@@ -4427,6 +4431,12 @@ public sealed class CSharpToGSharpTranslator
 
                 if (parent is ConditionalExpressionSyntax conditional &&
                     (current == conditional.WhenTrue || current == conditional.WhenFalse))
+                {
+                    return true;
+                }
+
+                if (parent is ConditionalAccessExpressionSyntax conditionalAccess &&
+                    current == conditionalAccess.WhenNotNull)
                 {
                     return true;
                 }
@@ -4706,8 +4716,24 @@ public sealed class CSharpToGSharpTranslator
             }
 
             BlockStatement originalBody = this.TranslateStatementAsBlock(bodyStatement);
-            var bodyStatements = new List<GStatement>(hoisted);
-            bodyStatements.AddRange(originalBody.Statements);
+            var bodyStatements = new List<GStatement>();
+            if (isDoWhile)
+            {
+                // C# `do { body } while (cond)` evaluates `cond` AFTER the body runs,
+                // so the hoisted assignment/break-guard must trail the body (not lead
+                // it), or the first body iteration would observe a write that hasn't
+                // happened yet (issue #1723). `continue` naturally still re-runs the
+                // hoist since it sits at the tail, mirroring where the real condition
+                // check happens.
+                bodyStatements.AddRange(originalBody.Statements);
+                bodyStatements.AddRange(hoisted);
+            }
+            else
+            {
+                bodyStatements.AddRange(hoisted);
+                bodyStatements.AddRange(originalBody.Statements);
+            }
+
             var body = new BlockStatement(bodyStatements);
 
             result = isDoWhile

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -4766,7 +4766,7 @@ public sealed class CSharpToGSharpTranslator
         {
             bool DescendGuard(SyntaxNode node) =>
                 node is not (ForStatementSyntax or ForEachStatementSyntax or ForEachVariableStatementSyntax or
-                    WhileStatementSyntax or DoStatementSyntax or SwitchStatementSyntax or
+                    WhileStatementSyntax or DoStatementSyntax or
                     AnonymousFunctionExpressionSyntax or LocalFunctionStatementSyntax);
 
             return body.DescendantNodesAndSelf(descendIntoChildren: DescendGuard).OfType<ContinueStatementSyntax>().Any();

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -4710,8 +4710,24 @@ public sealed class CSharpToGSharpTranslator
         {
             result = null;
 
-            if (!this.TryBuildHoistedLoopCondition(condition, out GExpression loopCondition, out List<GStatement> hoisted))
+            if (!this.TryBuildHoistedLoopCondition(condition, out GExpression loopCondition, out List<GStatement> hoisted, out bool hoistsAssignment))
             {
+                return false;
+            }
+
+            if (isDoWhile && hoistsAssignment && BodyContainsOwnLoopContinue(bodyStatement))
+            {
+                // The tail-appended hoist runs where C# evaluates `cond` — AFTER the
+                // body. But G# `do`/`while` lowers `continue` to a goto that lands
+                // right after the whole body (ADR-0070's continueLabel), which is
+                // now past the hoisted tail too. A `continue` targeting this loop
+                // would therefore skip the hoisted assignment/break-guard, silently
+                // re-using a stale value instead of re-evaluating it (issue #1723).
+                // Plain `while` is unaffected: its hoist leads the body, so
+                // `continue` re-enters it on the next iteration.
+                this.context.ReportUnsupported(
+                    condition,
+                    "assignment inside a short-circuited '&&'/'||' operand or a conditional ('?:') branch has no side-effect-preserving G# lowering yet (issue #1723).");
                 return false;
             }
 
@@ -4722,9 +4738,7 @@ public sealed class CSharpToGSharpTranslator
                 // C# `do { body } while (cond)` evaluates `cond` AFTER the body runs,
                 // so the hoisted assignment/break-guard must trail the body (not lead
                 // it), or the first body iteration would observe a write that hasn't
-                // happened yet (issue #1723). `continue` naturally still re-runs the
-                // hoist since it sits at the tail, mirroring where the real condition
-                // check happens.
+                // happened yet (issue #1723).
                 bodyStatements.AddRange(originalBody.Statements);
                 bodyStatements.AddRange(hoisted);
             }
@@ -4742,6 +4756,22 @@ public sealed class CSharpToGSharpTranslator
             return true;
         }
 
+        // True when `body` has a `continue` that targets THIS loop. Descent stops
+        // at any nested loop/switch (its own `continue`/`break` seam) and at
+        // nested lambdas/local functions (their own statement seam), so a
+        // `continue` inside an inner `for`/`foreach`/`while`/`do`/`switch` does
+        // NOT count — it never reaches this loop's do-while tail hoist (issue
+        // #1723).
+        private static bool BodyContainsOwnLoopContinue(StatementSyntax body)
+        {
+            bool DescendGuard(SyntaxNode node) =>
+                node is not (ForStatementSyntax or ForEachStatementSyntax or ForEachVariableStatementSyntax or
+                    WhileStatementSyntax or DoStatementSyntax or SwitchStatementSyntax or
+                    AnonymousFunctionExpressionSyntax or LocalFunctionStatementSyntax);
+
+            return body.DescendantNodesAndSelf(descendIntoChildren: DescendGuard).OfType<ContinueStatementSyntax>().Any();
+        }
+
         /// <summary>
         /// Splits <paramref name="condition"/> into its top-level `&amp;&amp;` clauses and,
         /// if any clause needs hoisting (an `is`-pattern requiring a scrutinee
@@ -4755,10 +4785,12 @@ public sealed class CSharpToGSharpTranslator
         private bool TryBuildHoistedLoopCondition(
             ExpressionSyntax condition,
             out GExpression loopCondition,
-            out List<GStatement> hoisted)
+            out List<GStatement> hoisted,
+            out bool hoistsAssignment)
         {
             loopCondition = null;
             hoisted = null;
+            hoistsAssignment = false;
 
             var clauses = new List<ExpressionSyntax>();
             FlattenAndClauses(condition, clauses);
@@ -4776,6 +4808,15 @@ public sealed class CSharpToGSharpTranslator
             if (firstHoist < 0)
             {
                 return false;
+            }
+
+            for (int i = firstHoist; i < clauses.Count; i++)
+            {
+                if (ClauseContainsAssignment(clauses[i]))
+                {
+                    hoistsAssignment = true;
+                    break;
+                }
             }
 
             // The leading side-effect-free clauses remain the real loop condition.
@@ -5521,7 +5562,7 @@ public sealed class CSharpToGSharpTranslator
                 condition = LiteralExpression.Bool(true);
                 conditionPrologue = new List<GStatement>();
             }
-            else if (this.TryBuildHoistedLoopCondition(forStatement.Condition, out GExpression hoistedCondition, out List<GStatement> hoisted))
+            else if (this.TryBuildHoistedLoopCondition(forStatement.Condition, out GExpression hoistedCondition, out List<GStatement> hoisted, out _))
             {
                 condition = hoistedCondition;
                 conditionPrologue = hoisted;

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -389,6 +389,16 @@ public sealed class CSharpToGSharpTranslator
         private readonly HashSet<SyntaxNode> suppressedPostfix =
             new HashSet<SyntaxNode>();
 
+        // C# assignment-expressions used in VALUE position (`while ((line =
+        // r.ReadLine()) != null)`, `M(x = 5)`, `if ((x = f()) > 0)`) that the
+        // surrounding statement/condition seam has hoisted into a preceding
+        // assignment statement (G# assignment is a statement, not a
+        // value-yielding expression; spec §Statements). While a node is in this
+        // set, `TranslateExpression` renders it as a bare read of its already-
+        // written target rather than dropping the write (issue #1723).
+        private readonly HashSet<SyntaxNode> suppressedAssignments =
+            new HashSet<SyntaxNode>();
+
         // Static-field initializers lifted out of a `static` constructor body
         // (`static T() { Field = value; }`). G# has no static constructor, so a
         // simple static ctor is folded into the corresponding `shared { }` field
@@ -3202,13 +3212,45 @@ public sealed class CSharpToGSharpTranslator
                     return this.TranslateFixedStatement(fixedStatement);
 
                 case ReturnStatementSyntax ret:
-                    return new[]
+                {
+                    if (ret.Expression == null)
                     {
-                        (GStatement)new ReturnStatement(
-                            ret.Expression == null
-                                ? null
-                                : this.TranslateValueWithNullForgiveness(ret.Expression)),
-                    };
+                        return new[] { (GStatement)new ReturnStatement(null) };
+                    }
+
+                    // `return (x = M());` — a value-position assignment in the
+                    // return expression is hoisted into a preceding assignment
+                    // statement; it runs once, exactly where C# would evaluate it
+                    // (issue #1723).
+                    var returnPrologue = new List<GStatement>();
+                    List<AssignmentExpressionSyntax> returnEmbedded =
+                        this.CollectEmbeddedAssignments(ret.Expression, includeSelf: true);
+                    foreach (AssignmentExpressionSyntax node in returnEmbedded)
+                    {
+                        returnPrologue.AddRange(this.FlattenChainedAssignment(node));
+                    }
+
+                    foreach (AssignmentExpressionSyntax node in returnEmbedded)
+                    {
+                        this.suppressedAssignments.Add(node);
+                    }
+
+                    GExpression returnValue;
+                    try
+                    {
+                        returnValue = this.TranslateValueWithNullForgiveness(ret.Expression);
+                    }
+                    finally
+                    {
+                        foreach (AssignmentExpressionSyntax node in returnEmbedded)
+                        {
+                            this.suppressedAssignments.Remove(node);
+                        }
+                    }
+
+                    returnPrologue.Add(new ReturnStatement(returnValue));
+                    return returnPrologue;
+                }
 
                 case IfStatementSyntax ifStatement:
                     return this.TranslateIfStatements(ifStatement).ToArray();
@@ -3296,11 +3338,43 @@ public sealed class CSharpToGSharpTranslator
 
             foreach (VariableDeclaratorSyntax declarator in declaration.Variables)
             {
-                GExpression initializer = declarator.Initializer == null
-                    ? null
-                    : this.CoerceConstantToUnsigned(
-                        declarator.Initializer.Value,
-                        this.TranslateExpression(declarator.Initializer.Value));
+                GExpression initializer;
+                if (declarator.Initializer == null)
+                {
+                    initializer = null;
+                }
+                else
+                {
+                    // `int y = (x = 5) + 1;` — a value-position assignment nested in
+                    // the initializer is hoisted into a preceding assignment
+                    // statement; it runs once, exactly where C# would evaluate it
+                    // (issue #1723).
+                    List<AssignmentExpressionSyntax> initializerEmbedded =
+                        this.CollectEmbeddedAssignments(declarator.Initializer.Value, includeSelf: true);
+                    foreach (AssignmentExpressionSyntax node in initializerEmbedded)
+                    {
+                        results.AddRange(this.FlattenChainedAssignment(node));
+                    }
+
+                    foreach (AssignmentExpressionSyntax node in initializerEmbedded)
+                    {
+                        this.suppressedAssignments.Add(node);
+                    }
+
+                    try
+                    {
+                        initializer = this.CoerceConstantToUnsigned(
+                            declarator.Initializer.Value,
+                            this.TranslateExpression(declarator.Initializer.Value));
+                    }
+                    finally
+                    {
+                        foreach (AssignmentExpressionSyntax node in initializerEmbedded)
+                        {
+                            this.suppressedAssignments.Remove(node);
+                        }
+                    }
+                }
 
                 BindingKind binding;
                 if (isConst)
@@ -4126,18 +4200,35 @@ public sealed class CSharpToGSharpTranslator
                 {
                     return this.LowerTupleAssignment(leftTuple, rightTuple);
                 }
-
-                if (assignment.Right is AssignmentExpressionSyntax)
-                {
-                    // `a = b = c` → `b = c` then `a = b`. G# assignment is a
-                    // statement, so the chain is flattened innermost-first.
-                    return this.FlattenChainedAssignment(assignment);
-                }
             }
 
-            return this.WithHoistedPostfix(
+            // `a = b = c`, `a = b += c`, `a += b = c`, … — any assignment whose
+            // RHS is itself an assignment (any operator, optionally parenthesized)
+            // has no single-statement G# form; flatten innermost-first so every
+            // link's write is preserved (issue #1723).
+            if (expression is AssignmentExpressionSyntax outerAssignment &&
+                Unwrap(outerAssignment.Right) is AssignmentExpressionSyntax)
+            {
+                return this.FlattenChainedAssignment(outerAssignment);
+            }
+
+            return this.WithHoistedAssignments(
                 expression,
-                () => new[] { this.TranslateExpressionStatement(expression) });
+                includeSelf: false,
+                () => this.WithHoistedPostfix(
+                    expression,
+                    () => new[] { this.TranslateExpressionStatement(expression) }).ToList());
+        }
+
+        // Strips parentheses so chain/assignment detection is parenthesis-transparent.
+        private static ExpressionSyntax Unwrap(ExpressionSyntax expression)
+        {
+            while (expression is ParenthesizedExpressionSyntax paren)
+            {
+                expression = paren.Expression;
+            }
+
+            return expression;
         }
 
         /// <summary>
@@ -4185,6 +4276,165 @@ public sealed class CSharpToGSharpTranslator
             return statements;
         }
 
+        /// <summary>
+        /// Translates an expression that may embed VALUE-POSITION assignments
+        /// (`M(x = 5)`, `while ((line = r.ReadLine()) != null)`, `if ((x = f()) >
+        /// 0)`), hoisting each into a preceding assignment statement. G# models
+        /// assignment as a statement, not a value-yielding expression, so a
+        /// naive translation drops the write and keeps only the read (issue
+        /// #1723). <paramref name="includeSelf"/> controls whether
+        /// <paramref name="expression"/> ITSELF counts as a hoist candidate when
+        /// it is an assignment: statement-position callers (where the whole
+        /// expression already IS the statement, e.g. `a += 5;`) pass <c>false</c>
+        /// so only assignments NESTED inside it (e.g. `a += (b = c);`) are
+        /// hoisted; condition callers (`if`/`while`/`for`, where the whole
+        /// condition can itself be a bare assignment, e.g. `if (x = f())`) pass
+        /// <c>true</c>.
+        /// </summary>
+        private IEnumerable<GStatement> WithHoistedAssignments(
+            ExpressionSyntax expression,
+            bool includeSelf,
+            Func<List<GStatement>> buildMain)
+        {
+            List<AssignmentExpressionSyntax> embedded = this.CollectEmbeddedAssignments(expression, includeSelf);
+            if (embedded.Count == 0)
+            {
+                return buildMain();
+            }
+
+            var hoisted = new List<GStatement>();
+            foreach (AssignmentExpressionSyntax node in embedded)
+            {
+                hoisted.AddRange(this.FlattenChainedAssignment(node));
+            }
+
+            foreach (AssignmentExpressionSyntax node in embedded)
+            {
+                this.suppressedAssignments.Add(node);
+            }
+
+            List<GStatement> main;
+            try
+            {
+                main = buildMain();
+            }
+            finally
+            {
+                foreach (AssignmentExpressionSyntax node in embedded)
+                {
+                    this.suppressedAssignments.Remove(node);
+                }
+            }
+
+            hoisted.AddRange(main);
+            return hoisted;
+        }
+
+        /// <summary>
+        /// Translates <paramref name="expression"/> (typically a condition:
+        /// `if`/`while`/`for`), hoisting any embedded value-position assignment
+        /// into <paramref name="prologue"/> as a preceding assignment statement
+        /// and returning the condition with each hoisted assignment read as its
+        /// already-written target (issue #1723). The whole expression counts as
+        /// a hoist candidate (a bare `if (x = f())` condition IS the assignment).
+        /// </summary>
+        private GExpression TranslateConditionWithHoist(ExpressionSyntax expression, List<GStatement> prologue)
+        {
+            List<AssignmentExpressionSyntax> embedded = this.CollectEmbeddedAssignments(expression, includeSelf: true);
+            if (embedded.Count == 0)
+            {
+                return this.TranslateExpression(expression);
+            }
+
+            foreach (AssignmentExpressionSyntax node in embedded)
+            {
+                prologue.AddRange(this.FlattenChainedAssignment(node));
+            }
+
+            foreach (AssignmentExpressionSyntax node in embedded)
+            {
+                this.suppressedAssignments.Add(node);
+            }
+
+            try
+            {
+                return this.TranslateExpression(expression);
+            }
+            finally
+            {
+                foreach (AssignmentExpressionSyntax node in embedded)
+                {
+                    this.suppressedAssignments.Remove(node);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Finds the outermost value-position assignment nodes in
+        /// <paramref name="expression"/> (in evaluation/document order),
+        /// excluding ones inside a nested lambda/local function (their own
+        /// statement seam) and — for chained links (`a = b = c`) — excluding the
+        /// inner links of a chain already captured by the outer node (see
+        /// <see cref="FlattenChainedAssignment"/>). An assignment hidden inside the
+        /// short-circuited operand of `&amp;&amp;`/`||` or a `?:` branch would change
+        /// evaluation COUNT/order if hoisted, so it is flagged unsupported instead
+        /// (issue #1723).
+        /// </summary>
+        private List<AssignmentExpressionSyntax> CollectEmbeddedAssignments(ExpressionSyntax expression, bool includeSelf)
+        {
+            bool DescendGuard(SyntaxNode node) =>
+                node is not (AnonymousFunctionExpressionSyntax or LocalFunctionStatementSyntax or AssignmentExpressionSyntax);
+
+            IEnumerable<AssignmentExpressionSyntax> Scan(ExpressionSyntax root) =>
+                root.DescendantNodesAndSelf(descendIntoChildren: DescendGuard).OfType<AssignmentExpressionSyntax>();
+
+            IEnumerable<AssignmentExpressionSyntax> candidates = includeSelf || expression is not AssignmentExpressionSyntax rootAssignment
+                ? Scan(expression)
+                : Scan(rootAssignment.Left).Concat(Scan(rootAssignment.Right));
+
+            var safe = new List<AssignmentExpressionSyntax>();
+            foreach (AssignmentExpressionSyntax candidate in candidates)
+            {
+                if (IsInShortCircuitOrConditionalBranch(candidate, expression))
+                {
+                    this.context.ReportUnsupported(
+                        candidate,
+                        "assignment inside a short-circuited '&&'/'||' operand or a conditional ('?:') branch has no side-effect-preserving G# lowering yet (issue #1723).");
+                    continue;
+                }
+
+                safe.Add(candidate);
+            }
+
+            return safe;
+        }
+
+        // True when `node` is reached only through the (not-always-evaluated)
+        // right operand of a `&&`/`||` inside `root`, or through either branch of
+        // a `?:` inside `root`. Hoisting such an assignment out in front of `root`
+        // would evaluate/mutate it unconditionally, changing C# semantics.
+        private static bool IsInShortCircuitOrConditionalBranch(SyntaxNode node, ExpressionSyntax root)
+        {
+            for (SyntaxNode current = node; current != null && current != root; current = current.Parent)
+            {
+                SyntaxNode parent = current.Parent;
+                if (parent is BinaryExpressionSyntax binary &&
+                    (binary.IsKind(SyntaxKind.LogicalAndExpression) || binary.IsKind(SyntaxKind.LogicalOrExpression)) &&
+                    current == binary.Right)
+                {
+                    return true;
+                }
+
+                if (parent is ConditionalExpressionSyntax conditional &&
+                    (current == conditional.WhenTrue || current == conditional.WhenFalse))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         private static List<PostfixUnaryExpressionSyntax> CollectEmbeddedPostfix(ExpressionSyntax expression)
         {
             // Collect `i++` / `i--` nodes nested inside `expression` (in document
@@ -4199,11 +4449,26 @@ public sealed class CSharpToGSharpTranslator
 
         private IEnumerable<GStatement> FlattenChainedAssignment(AssignmentExpressionSyntax assignment)
         {
+            // Follows the chain through ANY assignment operator (`=`, `+=`, …), not
+            // just `=`: `a = b += c` is `a = (b += c)`, so the `+=` link must also be
+            // captured or its mutation of `b` is silently dropped (issue #1723). The
+            // walk is parenthesis-transparent (`a = (b = c)`) since a link's RHS may
+            // be a parenthesized nested assignment.
             var lefts = new List<(GExpression Target, string Op)>();
             ExpressionSyntax current = assignment;
-            while (current is AssignmentExpressionSyntax link &&
-                link.IsKind(SyntaxKind.SimpleAssignmentExpression))
+            while (true)
             {
+                ExpressionSyntax unwrapped = current;
+                while (unwrapped is ParenthesizedExpressionSyntax paren)
+                {
+                    unwrapped = paren.Expression;
+                }
+
+                if (unwrapped is not AssignmentExpressionSyntax link)
+                {
+                    break;
+                }
+
                 lefts.Add((this.TranslateExpression(link.Left), link.OperatorToken.Text));
                 current = link.Right;
             }
@@ -4435,6 +4700,40 @@ public sealed class CSharpToGSharpTranslator
         {
             result = null;
 
+            if (!this.TryBuildHoistedLoopCondition(condition, out GExpression loopCondition, out List<GStatement> hoisted))
+            {
+                return false;
+            }
+
+            BlockStatement originalBody = this.TranslateStatementAsBlock(bodyStatement);
+            var bodyStatements = new List<GStatement>(hoisted);
+            bodyStatements.AddRange(originalBody.Statements);
+            var body = new BlockStatement(bodyStatements);
+
+            result = isDoWhile
+                ? new GStatement[] { new DoWhileStatement(body, GuardBlockCondition(loopCondition)) }
+                : new GStatement[] { new WhileStatement(GuardBlockCondition(loopCondition), body) };
+            return true;
+        }
+
+        /// <summary>
+        /// Splits <paramref name="condition"/> into its top-level `&amp;&amp;` clauses and,
+        /// if any clause needs hoisting (an `is`-pattern requiring a scrutinee
+        /// local, or a value-position assignment), returns the leading
+        /// side-effect-free clauses as <paramref name="loopCondition"/> and the
+        /// rest as body-prologue <paramref name="hoisted"/> statements (a scrutinee
+        /// local / hoisted assignment plus `if !test { break }` guards) — shared by
+        /// `while`, `do`/`while`, and `for` loop translation (issue #914, #1723).
+        /// Returns <c>false</c> (no hoisting needed) when every clause is plain.
+        /// </summary>
+        private bool TryBuildHoistedLoopCondition(
+            ExpressionSyntax condition,
+            out GExpression loopCondition,
+            out List<GStatement> hoisted)
+        {
+            loopCondition = null;
+            hoisted = null;
+
             var clauses = new List<ExpressionSyntax>();
             FlattenAndClauses(condition, clauses);
 
@@ -4454,33 +4753,27 @@ public sealed class CSharpToGSharpTranslator
             }
 
             // The leading side-effect-free clauses remain the real loop condition.
-            GExpression loopCondition = null;
+            GExpression combined = null;
             for (int i = 0; i < firstHoist; i++)
             {
                 GExpression clause = this.TranslateExpression(clauses[i]);
-                loopCondition = loopCondition == null
+                combined = combined == null
                     ? clause
-                    : new BinaryExpression(loopCondition, "&&", clause);
+                    : new BinaryExpression(combined, "&&", clause);
             }
 
-            loopCondition ??= LiteralExpression.Bool(true);
+            combined ??= LiteralExpression.Bool(true);
 
             // The remaining clauses hoist to the top of the loop body as a single
-            // scrutinee evaluation plus `if !test { break }` guards.
-            var hoisted = new List<GStatement>();
+            // scrutinee evaluation / assignment plus `if !test { break }` guards.
+            var prologue = new List<GStatement>();
             for (int i = firstHoist; i < clauses.Count; i++)
             {
-                this.HoistLoopConditionClause(clauses[i], hoisted);
+                this.HoistLoopConditionClause(clauses[i], prologue);
             }
 
-            BlockStatement originalBody = this.TranslateStatementAsBlock(bodyStatement);
-            var bodyStatements = new List<GStatement>(hoisted);
-            bodyStatements.AddRange(originalBody.Statements);
-            var body = new BlockStatement(bodyStatements);
-
-            result = isDoWhile
-                ? new GStatement[] { new DoWhileStatement(body, GuardBlockCondition(loopCondition)) }
-                : new GStatement[] { new WhileStatement(GuardBlockCondition(loopCondition), body) };
+            loopCondition = combined;
+            hoisted = prologue;
             return true;
         }
 
@@ -4508,14 +4801,28 @@ public sealed class CSharpToGSharpTranslator
         // A loop-condition clause needs hoisting when it is an `is`-pattern whose
         // lowering would duplicate a side-effecting scrutinee (an `and`/`or`
         // combinator re-emits the receiver), declare an `out var` more than once
-        // (GS0102), or bind a pattern variable the G# loop body cannot see (GS0125).
+        // (GS0102), or bind a pattern variable the G# loop body cannot see
+        // (GS0125); or when it contains a value-position assignment (`(line =
+        // r.ReadLine()) != null`) — G# assignment is a statement, so the write
+        // must be hoisted into the loop body, run once per iteration (issue
+        // #1723).
         private bool ClauseRequiresConditionHoist(ExpressionSyntax clause)
         {
-            return clause is IsPatternExpressionSyntax isPattern &&
+            return (clause is IsPatternExpressionSyntax isPattern &&
                 (PatternIntroducesBinding(isPattern.Pattern) ||
                  PatternDuplicatesScrutinee(isPattern.Pattern) ||
-                 ExpressionDeclaresOutVar(isPattern.Expression));
+                 ExpressionDeclaresOutVar(isPattern.Expression))) ||
+                ClauseContainsAssignment(clause);
         }
+
+        // Cheap presence check used only to decide whether a clause needs the
+        // hoist path at all; the short-circuit/`?:` safety analysis and the
+        // actual hoisting happen once, in HoistLoopConditionClause.
+        private static bool ClauseContainsAssignment(ExpressionSyntax clause) =>
+            clause.DescendantNodesAndSelf(descendIntoChildren: node =>
+                    node is not (AnonymousFunctionExpressionSyntax or LocalFunctionStatementSyntax))
+                .OfType<AssignmentExpressionSyntax>()
+                .Any();
 
         private static bool PatternIntroducesBinding(PatternSyntax pattern) =>
             pattern.DescendantNodesAndSelf().OfType<SingleVariableDesignationSyntax>().Any();
@@ -4527,14 +4834,46 @@ public sealed class CSharpToGSharpTranslator
             expression.DescendantNodesAndSelf().OfType<DeclarationExpressionSyntax>().Any();
 
         // Emits the hoisted statements for a single loop-condition clause: a pure
-        // clause becomes a negated `break` guard; an `is`-pattern clause evaluates
+        // clause becomes a negated `break` guard; a clause carrying a
+        // value-position assignment (`(line = r.ReadLine()) != null`) hoists the
+        // assignment(s) as preceding statement(s) — re-run every iteration, exactly
+        // where C# would re-evaluate them — then becomes a negated `break` guard
+        // over the now-hoisted read (issue #1723); an `is`-pattern clause evaluates
         // its scrutinee once into a local and turns the pattern's must-hold tests
         // into `break` guards (issue #914).
         private void HoistLoopConditionClause(ExpressionSyntax clause, List<GStatement> into)
         {
             if (clause is not IsPatternExpressionSyntax isPattern)
             {
-                into.Add(BreakIf(Negate(this.TranslateExpression(clause))));
+                List<AssignmentExpressionSyntax> embedded = this.CollectEmbeddedAssignments(clause, includeSelf: true);
+                if (embedded.Count == 0)
+                {
+                    into.Add(BreakIf(Negate(this.TranslateExpression(clause))));
+                    return;
+                }
+
+                foreach (AssignmentExpressionSyntax node in embedded)
+                {
+                    into.AddRange(this.FlattenChainedAssignment(node));
+                }
+
+                foreach (AssignmentExpressionSyntax node in embedded)
+                {
+                    this.suppressedAssignments.Add(node);
+                }
+
+                try
+                {
+                    into.Add(BreakIf(Negate(this.TranslateExpression(clause))));
+                }
+                finally
+                {
+                    foreach (AssignmentExpressionSyntax node in embedded)
+                    {
+                        this.suppressedAssignments.Remove(node);
+                    }
+                }
+
                 return;
             }
 
@@ -5017,8 +5356,13 @@ public sealed class CSharpToGSharpTranslator
             // Translate the condition first so any `x is T t` declaration pattern
             // registers its Kotlin-style smart-cast binding before the guarded
             // block is translated; the binding is scoped to the then-block only.
+            // A value-position assignment in the condition (`if ((x = f()) > 0)`,
+            // `if (x = f())`) is hoisted into a preceding assignment statement — it
+            // runs once, exactly where C# would evaluate it (issue #1723).
             var bindingsBefore = new HashSet<ISymbol>(this.patternBindings.Keys, SymbolEqualityComparer.Default);
-            GExpression condition = GuardBlockCondition(this.TranslateExpression(ifStatement.Condition));
+            var conditionPrologue = new List<GStatement>();
+            GExpression condition = GuardBlockCondition(
+                this.TranslateConditionWithHoist(ifStatement.Condition, conditionPrologue));
 
             BlockStatement then = this.TranslateStatementAsBlock(ifStatement.Statement);
 
@@ -5043,7 +5387,14 @@ public sealed class CSharpToGSharpTranslator
                 }
             }
 
-            return new IfStatement(condition, then, elseBranch);
+            GStatement result = new IfStatement(condition, then, elseBranch);
+            if (conditionPrologue.Count > 0)
+            {
+                conditionPrologue.Add(result);
+                result = new BlockStatement(conditionPrologue);
+            }
+
+            return result;
         }
 
         private GStatement TranslateForStatement(ForStatementSyntax forStatement)
@@ -5054,10 +5405,15 @@ public sealed class CSharpToGSharpTranslator
             // a C-style `for` with multiple declarators/initializers or multiple
             // incrementors cannot be represented directly. Lower those to a block
             // + `while` so every init runs once up front and every incrementor runs
-            // at the end of each iteration (issue #914).
+            // at the end of each iteration (issue #914). A condition needing clause
+            // hoisting (a value-position assignment, e.g. `for (…; (c = Next()) !=
+            // -1; …)`, or an is-pattern requiring a scrutinee local) has the same
+            // problem — G#'s single-expression `for` condition has nowhere to place
+            // the hoisted statement — so it takes the same lowering (issue #1723).
             if (declaratorCount > 1 ||
                 forStatement.Initializers.Count > 1 ||
-                forStatement.Incrementors.Count > 1)
+                forStatement.Incrementors.Count > 1 ||
+                this.ForConditionRequiresHoist(forStatement.Condition))
             {
                 return this.LowerForToWhile(forStatement);
             }
@@ -5088,12 +5444,28 @@ public sealed class CSharpToGSharpTranslator
                 this.TranslateStatementAsBlock(forStatement.Statement));
         }
 
+        private bool ForConditionRequiresHoist(ExpressionSyntax condition)
+        {
+            if (condition == null)
+            {
+                return false;
+            }
+
+            var clauses = new List<ExpressionSyntax>();
+            FlattenAndClauses(condition, clauses);
+            return clauses.Any(this.ClauseRequiresConditionHoist);
+        }
+
         /// <summary>
         /// Lowers a C-style <c>for</c> that has more than one initializer/declarator
         /// or more than one incrementor — neither of which fits G#'s single-init,
         /// single-incrementor <c>for</c> — into an equivalent block + <c>while</c>:
         /// all inits run once before the loop, the body runs each iteration, then
-        /// every incrementor runs at the end of the body (issue #914).
+        /// every incrementor runs at the end of the body (issue #914). A condition
+        /// needing clause hoisting places its prologue (hoisted assignment /
+        /// scrutinee local plus `if !test { break }` guards) at the TOP of the body,
+        /// re-run every iteration exactly where C# would re-test the condition
+        /// (issue #1723).
         /// </summary>
         /// <remarks>
         /// Fidelity caveat: in C# the incrementors also run when the body executes a
@@ -5116,19 +5488,33 @@ public sealed class CSharpToGSharpTranslator
                 outer.AddRange(this.TranslateExpressionStatements(init));
             }
 
-            GExpression condition = forStatement.Condition == null
-                ? LiteralExpression.Bool(true)
-                : GuardBlockCondition(this.TranslateExpression(forStatement.Condition));
+            GExpression condition;
+            List<GStatement> conditionPrologue;
+            if (forStatement.Condition == null)
+            {
+                condition = LiteralExpression.Bool(true);
+                conditionPrologue = new List<GStatement>();
+            }
+            else if (this.TryBuildHoistedLoopCondition(forStatement.Condition, out GExpression hoistedCondition, out List<GStatement> hoisted))
+            {
+                condition = hoistedCondition;
+                conditionPrologue = hoisted;
+            }
+            else
+            {
+                condition = this.TranslateExpression(forStatement.Condition);
+                conditionPrologue = new List<GStatement>();
+            }
 
-            var bodyStatements = new List<GStatement>(
-                this.TranslateStatementAsBlock(forStatement.Statement).Statements);
+            var bodyStatements = new List<GStatement>(conditionPrologue);
+            bodyStatements.AddRange(this.TranslateStatementAsBlock(forStatement.Statement).Statements);
 
             foreach (ExpressionSyntax inc in forStatement.Incrementors)
             {
                 bodyStatements.AddRange(this.TranslateExpressionStatements(inc));
             }
 
-            outer.Add(new WhileStatement(condition, new BlockStatement(bodyStatements)));
+            outer.Add(new WhileStatement(GuardBlockCondition(condition), new BlockStatement(bodyStatements)));
 
             return new BlockStatement(outer);
         }
@@ -5662,11 +6048,24 @@ public sealed class CSharpToGSharpTranslator
                     return new IdentifierExpression(aliasQualified.Name.Identifier.Text);
 
                 case AssignmentExpressionSyntax nestedAssignment:
-                    // An assignment used in value position (`a = b = c`, or an
-                    // assignment lambda body that reached here). G# models
-                    // assignment as a statement; the in-expression form has no
-                    // canonical value, so emit the assigned value and let the
-                    // enclosing statement seam re-materialise the write.
+                    // An assignment used in value position (`a = b = c`, `M(x =
+                    // 5)`, `while ((line = r.ReadLine()) != null)`). G# models
+                    // assignment as a statement, not a value-yielding expression.
+                    // The enclosing statement/condition seam (WithHoistedAssignments
+                    // / TranslateConditionWithHoist / HoistLoopConditionClause)
+                    // hoists the write into a preceding assignment statement and
+                    // marks this node suppressed; reading it here means the write
+                    // already happened, so the expression's value is just the
+                    // (now up-to-date) target (issue #1723).
+                    if (this.suppressedAssignments.Contains(nestedAssignment))
+                    {
+                        return this.TranslateExpression(nestedAssignment.Left);
+                    }
+
+                    // No enclosing seam claimed this node (e.g. it lives inside a
+                    // short-circuited `&&`/`||` operand or a `?:` branch, already
+                    // flagged unsupported at the point of detection): fall back to
+                    // the RHS value so translation still completes.
                     return this.TranslateExpression(nestedAssignment.Right);
 
                 case ThrowExpressionSyntax throwExpression:


### PR DESCRIPTION
Fixes #1723

## Root cause

cs2gs translated a C# assignment used in *value position* — `while ((line = r.ReadLine()) != null)`, `a = b += c`, `M(x = 5)`, `if ((x = f()) > 0)`, `return (x = M());` — as if it only existed at statement level, or by returning just the RHS. G# models assignment as a statement, not a value-yielding expression, and the only seams that re-materialized the write were the narrow `a = b = c` chain paths; every other route through `TranslateExpression` dropped the write silently.

## Fix

Each value-position assignment is now hoisted into a preceding assignment statement, and the original assignment-expression node is replaced by a read of its already-written target:

- **`while`/`do-while` condition** (`while ((line = r.ReadLine()) != null)`): the assignment is hoisted into the loop body prologue (reusing/extending the issue #914 loop-condition-hoist machinery), so it re-runs exactly once per iteration, followed by a negated `break` guard.
- **`for` condition** (`for (...; (c = Next()) != -1; ...)`): the same clause-hoist logic is now also applied to `for` loops — when the condition needs hoisting, the loop is lowered to `while(true)` with the hoisted assignment + break guard at the top of the body (matching where C# would re-test the condition) and the incrementor at the end.
- **`if` condition** (`if ((x = f()) > 0)`, `if (x = f())`): the assignment is hoisted into a statement immediately before the `if` — evaluated exactly once, matching C#.
- **Chained/compound assignment** (`a = b += c`): `FlattenChainedAssignment` now follows *any* assignment operator (not just `=`) and is parenthesis-transparent, so the `+=` link's mutation of `b` is preserved instead of silently vanishing.
- **Call argument / general nested expression** (`M(x = 5)`, `return (x = M());`, local-declaration initializers): the write is hoisted into a preceding statement at the relevant statement seam (expression-statement, `return`, local declaration), and the surrounding expression reads the target's post-write value.

Evaluation order and count are preserved throughout: side-effecting sub-expressions (e.g. `r.ReadLine()`) are evaluated exactly as many times as in the original C#.

**Known limitation (by design):** an assignment hidden inside the short-circuited operand of `&&`/`||`, or a `?:` branch, cannot be hoisted without changing the number of times it's evaluated. This one case is now reported as an `Unsupported` diagnostic instead of being silently dropped.

## Files changed

- `tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs`
- `tools/cs2gs/Cs2Gs.Tests/Issue1723ValuePositionAssignmentTranslationTests.cs` (new — 8 tests covering every form above plus the short-circuit diagnostic)

## Test results

- `dotnet build GSharp.sln -c Release -graph`: 0 errors, 0 warnings
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release`: 388/388 passed (380 pre-existing + 8 new), 0 failed