### PR TITLE
Fix #1790: generalize ContainsSameCompilationUserType to cover every wrapper kind

### DIFF
--- a/src/Core/CodeAnalysis/Symbols/TypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/TypeSymbol.cs
@@ -610,55 +610,32 @@ public class TypeSymbol : Symbol
         switch (type)
         {
             case null:
-                return false;
             case TypeParameterSymbol:
-                return false;
-            case NullableTypeSymbol n:
-                return ContainsSameCompilationUserType(n.UnderlyingType);
-            case SliceTypeSymbol s:
-                return ContainsSameCompilationUserType(s.ElementType);
-            case ArrayTypeSymbol a:
-                return ContainsSameCompilationUserType(a.ElementType);
-            case MapTypeSymbol m:
-                return ContainsSameCompilationUserType(m.KeyType) || ContainsSameCompilationUserType(m.ValueType);
-            case FunctionTypeSymbol fn:
-                foreach (var param in fn.ParameterTypes)
-                {
-                    if (ContainsSameCompilationUserType(param))
-                    {
-                        return true;
-                    }
-                }
-
-                return ContainsSameCompilationUserType(fn.ReturnType);
-            case TupleTypeSymbol tup:
-                foreach (var elem in tup.ElementTypes)
-                {
-                    if (ContainsSameCompilationUserType(elem))
-                    {
-                        return true;
-                    }
-                }
-
-                return false;
-            case ImportedTypeSymbol it when !it.TypeArguments.IsDefaultOrEmpty:
-                foreach (var arg in it.TypeArguments)
-                {
-                    if (ContainsSameCompilationUserType(arg))
-                    {
-                        return true;
-                    }
-                }
-
                 return false;
             case StructSymbol:
             case EnumSymbol:
             case InterfaceSymbol:
             case DelegateTypeSymbol:
                 return type.ClrType == null;
-            default:
-                return false;
         }
+
+        // Issue #1790: every other kind is a wrapper/constructed type — recurse
+        // through its immediate inner type(s) via the single canonical
+        // enumerator below instead of hand-copying a per-wrapper switch here.
+        // This is what previously let Sequence/AsyncSequence/Channel/ByRef/
+        // Pointer (whose CLR shape collapses to null when their element/
+        // pointee is a same-compilation user type) fall through to the
+        // "default: false" arm and alias across compilations (see
+        // <see cref="FunctionTypeSymbol.AppendIdentityKey"/>).
+        foreach (var inner in GetWrappedTypes(type))
+        {
+            if (ContainsSameCompilationUserType(inner))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>
@@ -695,6 +672,94 @@ public class TypeSymbol : Symbol
                 return type.ClrType == null;
             default:
                 return false;
+        }
+    }
+
+    /// <summary>
+    /// Issue #1790: the single canonical enumeration of a wrapper/constructed
+    /// <see cref="TypeSymbol"/>'s immediate inner type(s) — the element,
+    /// pointee, key/value, parameter/return, or type-argument slot(s) the
+    /// composite type structurally carries. Every generic/wrapper kind that
+    /// can carry another type is listed here exactly once so callers such as
+    /// <see cref="ContainsSameCompilationUserType"/> recurse uniformly rather
+    /// than each maintaining its own divergent switch (the class of bug that
+    /// let several wrapper kinds silently fall through as "no inner type").
+    /// Leaf kinds (primitives, same-compilation user types, type parameters)
+    /// are not wrappers and yield nothing here; their callers handle them
+    /// directly. Each yielded type is a strict substructure of
+    /// <paramref name="type"/> (types form a DAG built during binding, never
+    /// a cycle back to themselves), so recursive callers always terminate.
+    /// </summary>
+    /// <param name="type">The wrapper/constructed type to unwrap.</param>
+    /// <returns>The type's immediate inner type(s); empty for a leaf kind.</returns>
+    private static IEnumerable<TypeSymbol> GetWrappedTypes(TypeSymbol type)
+    {
+        switch (type)
+        {
+            case NullableTypeSymbol n:
+                yield return n.UnderlyingType;
+                break;
+            case SliceTypeSymbol s:
+                yield return s.ElementType;
+                break;
+            case ArrayTypeSymbol a:
+                yield return a.ElementType;
+                break;
+            case PinnedTypeSymbol p:
+                yield return p.UnderlyingType;
+                break;
+            case NullabilityAnnotatedTypeSymbol na:
+                yield return na.BaseType;
+                break;
+            case SequenceTypeSymbol seq:
+                yield return seq.ElementType;
+                break;
+            case AsyncSequenceTypeSymbol aseq:
+                yield return aseq.ElementType;
+                break;
+            case ChannelTypeSymbol ch:
+                yield return ch.ElementType;
+                break;
+            case ByRefTypeSymbol br:
+                yield return br.PointeeType;
+                break;
+            case PointerTypeSymbol ptr:
+                yield return ptr.PointeeType;
+                break;
+            case MapTypeSymbol m:
+                yield return m.KeyType;
+                yield return m.ValueType;
+                break;
+            case FunctionTypeSymbol fn:
+                foreach (var param in fn.ParameterTypes)
+                {
+                    yield return param;
+                }
+
+                yield return fn.ReturnType;
+                break;
+            case FunctionPointerTypeSymbol fp:
+                foreach (var param in fp.ParameterTypes)
+                {
+                    yield return param;
+                }
+
+                yield return fp.ReturnType;
+                break;
+            case TupleTypeSymbol tup:
+                foreach (var elem in tup.ElementTypes)
+                {
+                    yield return elem;
+                }
+
+                break;
+            case ImportedTypeSymbol it when !it.TypeArguments.IsDefaultOrEmpty:
+                foreach (var arg in it.TypeArguments)
+                {
+                    yield return arg;
+                }
+
+                break;
         }
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Symbols/Issue1790WrapperAliasingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/Issue1790WrapperAliasingTests.cs
@@ -1,0 +1,213 @@
+// <copyright file="Issue1790WrapperAliasingTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+#nullable enable
+
+using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis.Symbols;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Symbols;
+
+/// <summary>
+/// Issue #1790 regression coverage: <see cref="TypeSymbol.ContainsSameCompilationUserType"/>
+/// previously had arms for Nullable/Slice/Array/Map/Function/Tuple/imported-generic
+/// wrappers but was MISSING <see cref="SequenceTypeSymbol"/>,
+/// <see cref="AsyncSequenceTypeSymbol"/>, <see cref="ChannelTypeSymbol"/>,
+/// <see cref="ByRefTypeSymbol"/> and <see cref="PointerTypeSymbol"/>. Because
+/// these wrappers compute their <c>ClrType</c> via
+/// <c>MakeGenericType</c>/<c>MakeByRefType</c>/<c>MakePointerType</c> (which
+/// return <see langword="null"/> when the element/pointee is a
+/// same-compilation user type), the missing arms caused such a wrapper to be
+/// keyed by display name instead of by symbol identity
+/// (<see cref="FunctionTypeSymbol.AppendIdentityKey"/>) — aliasing two
+/// same-named user types from distinct compilations. These tests pin the
+/// predicate directly for every wrapper kind, and reproduce the end-to-end
+/// cross-compilation alias via <see cref="TupleTypeSymbol"/> (the same
+/// process-wide cache #1624/#1777 fixed for the other wrappers).
+/// </summary>
+public class Issue1790WrapperAliasingTests
+{
+    private static StructSymbol MakeUserStruct(string name) => new(
+        name,
+        ImmutableArray<FieldSymbol>.Empty,
+        Accessibility.Public,
+        declaration: null!,
+        packageName: "test");
+
+    // ---- ContainsSameCompilationUserType: true when wrapping a same-compilation user type ----
+
+    [Fact]
+    public void ContainsSameCompilationUserType_Sequence_OverUserType_ReturnsTrue()
+    {
+        var wrapper = SequenceTypeSymbol.Get(MakeUserStruct("UserFoo"));
+        Assert.True(TypeSymbol.ContainsSameCompilationUserType(wrapper));
+    }
+
+    [Fact]
+    public void ContainsSameCompilationUserType_AsyncSequence_OverUserType_ReturnsTrue()
+    {
+        var wrapper = AsyncSequenceTypeSymbol.Get(MakeUserStruct("UserFoo"));
+        Assert.True(TypeSymbol.ContainsSameCompilationUserType(wrapper));
+    }
+
+    [Fact]
+    public void ContainsSameCompilationUserType_Channel_OverUserType_ReturnsTrue()
+    {
+        var wrapper = ChannelTypeSymbol.Get(MakeUserStruct("UserFoo"));
+        Assert.True(TypeSymbol.ContainsSameCompilationUserType(wrapper));
+    }
+
+    [Fact]
+    public void ContainsSameCompilationUserType_ByRef_OverUserType_ReturnsTrue()
+    {
+        var wrapper = ByRefTypeSymbol.Get(MakeUserStruct("UserFoo"));
+        Assert.True(TypeSymbol.ContainsSameCompilationUserType(wrapper));
+    }
+
+    [Fact]
+    public void ContainsSameCompilationUserType_Pointer_OverUserType_ReturnsTrue()
+    {
+        var wrapper = PointerTypeSymbol.Get(MakeUserStruct("UserFoo"));
+        Assert.True(TypeSymbol.ContainsSameCompilationUserType(wrapper));
+    }
+
+    [Fact]
+    public void ContainsSameCompilationUserType_NestedSequenceOfChannelOfUserType_ReturnsTrue()
+    {
+        var wrapper = SequenceTypeSymbol.Get(ChannelTypeSymbol.Get(MakeUserStruct("UserFoo")));
+        Assert.True(TypeSymbol.ContainsSameCompilationUserType(wrapper));
+    }
+
+    // ---- ContainsSameCompilationUserType: false when wrapping a plain CLR type (no false positive) ----
+
+    [Fact]
+    public void ContainsSameCompilationUserType_Sequence_OverInt32_ReturnsFalse()
+    {
+        var wrapper = SequenceTypeSymbol.Get(TypeSymbol.Int32);
+        Assert.False(TypeSymbol.ContainsSameCompilationUserType(wrapper));
+    }
+
+    [Fact]
+    public void ContainsSameCompilationUserType_AsyncSequence_OverInt32_ReturnsFalse()
+    {
+        var wrapper = AsyncSequenceTypeSymbol.Get(TypeSymbol.Int32);
+        Assert.False(TypeSymbol.ContainsSameCompilationUserType(wrapper));
+    }
+
+    [Fact]
+    public void ContainsSameCompilationUserType_Channel_OverInt32_ReturnsFalse()
+    {
+        var wrapper = ChannelTypeSymbol.Get(TypeSymbol.Int32);
+        Assert.False(TypeSymbol.ContainsSameCompilationUserType(wrapper));
+    }
+
+    [Fact]
+    public void ContainsSameCompilationUserType_ByRef_OverInt32_ReturnsFalse()
+    {
+        var wrapper = ByRefTypeSymbol.Get(TypeSymbol.Int32);
+        Assert.False(TypeSymbol.ContainsSameCompilationUserType(wrapper));
+    }
+
+    [Fact]
+    public void ContainsSameCompilationUserType_Pointer_OverInt32_ReturnsFalse()
+    {
+        var wrapper = PointerTypeSymbol.Get(TypeSymbol.Int32);
+        Assert.False(TypeSymbol.ContainsSameCompilationUserType(wrapper));
+    }
+
+    [Fact]
+    public void ContainsSameCompilationUserType_NestedSequenceOfChannelOfInt32_ReturnsFalse()
+    {
+        var wrapper = SequenceTypeSymbol.Get(ChannelTypeSymbol.Get(TypeSymbol.Int32));
+        Assert.False(TypeSymbol.ContainsSameCompilationUserType(wrapper));
+    }
+
+    // ---- Other previously-missing wrapper kinds (Pinned, NullabilityAnnotated, FunctionPointer) ----
+
+    [Fact]
+    public void ContainsSameCompilationUserType_Pinned_OverUserType_ReturnsTrue()
+    {
+        var wrapper = new PinnedTypeSymbol(MakeUserStruct("UserFoo"));
+        Assert.True(TypeSymbol.ContainsSameCompilationUserType(wrapper));
+    }
+
+    [Fact]
+    public void ContainsSameCompilationUserType_NullabilityAnnotated_OverUserType_ReturnsTrue()
+    {
+        var wrapper = new NullabilityAnnotatedTypeSymbol(MakeUserStruct("UserFoo"), ImmutableArray.Create<byte>(1));
+        Assert.True(TypeSymbol.ContainsSameCompilationUserType(wrapper));
+    }
+
+    [Fact]
+    public void ContainsSameCompilationUserType_FunctionPointer_OverUserType_ReturnsTrue()
+    {
+        var wrapper = FunctionPointerTypeSymbol.GetManaged(
+            ImmutableArray.Create<TypeSymbol>(MakeUserStruct("UserFoo")),
+            TypeSymbol.Void);
+        Assert.True(TypeSymbol.ContainsSameCompilationUserType(wrapper));
+    }
+
+    // ---- End-to-end cross-compilation alias repro via the process-wide TupleTypeSymbol cache ----
+
+    [Theory]
+    [MemberData(nameof(WrapperFactories))]
+    public void TupleTypeSymbol_Get_WithDistinctSameNamedUserTypeWrapped_NeverAliases(
+        string _, System.Func<TypeSymbol, TypeSymbol> wrap)
+    {
+        // Two distinct StructSymbol instances sharing the same name simulate
+        // the same-named user type declared independently in two concurrent
+        // compilations (both have a null ClrType, like real same-compilation
+        // user types being compiled).
+        var userA = MakeUserStruct("UserFoo");
+        var userB = MakeUserStruct("UserFoo");
+
+        var wrapperA = wrap(userA);
+        var wrapperB = wrap(userB);
+        var wrapperAAgain = wrap(userA);
+
+        var tupleA = TupleTypeSymbol.Get(ImmutableArray.Create(wrapperA, TypeSymbol.String));
+        var tupleB = TupleTypeSymbol.Get(ImmutableArray.Create(wrapperB, TypeSymbol.String));
+        var tupleAAgain = TupleTypeSymbol.Get(ImmutableArray.Create(wrapperAAgain, TypeSymbol.String));
+
+        Assert.NotSame(tupleA, tupleB);
+
+        // Positive interning check within the same compilation: reusing the
+        // same underlying user-type instance still resolves to the same
+        // cached tuple.
+        Assert.Same(tupleA, tupleAAgain);
+    }
+
+    public static System.Collections.Generic.IEnumerable<object[]> WrapperFactories()
+    {
+        yield return new object[] { "Sequence", (System.Func<TypeSymbol, TypeSymbol>)(e => SequenceTypeSymbol.Get(e)) };
+        yield return new object[] { "AsyncSequence", (System.Func<TypeSymbol, TypeSymbol>)(e => AsyncSequenceTypeSymbol.Get(e)) };
+        yield return new object[] { "Channel", (System.Func<TypeSymbol, TypeSymbol>)(e => ChannelTypeSymbol.Get(e)) };
+        yield return new object[] { "ByRef", (System.Func<TypeSymbol, TypeSymbol>)(e => ByRefTypeSymbol.Get(e)) };
+        yield return new object[] { "Pointer", (System.Func<TypeSymbol, TypeSymbol>)(e => PointerTypeSymbol.Get(e)) };
+    }
+
+    /// <summary>
+    /// Secondary issue: <see cref="SequenceTypeSymbol"/> and
+    /// <see cref="AsyncSequenceTypeSymbol"/> share the display-name format
+    /// <c>sequence[{element.Name}]</c> (by design — ADR-0041's surface
+    /// syntax for both is <c>sequence[T]</c>). With the primary fix, a
+    /// same-compilation user element routes both through the per-instance
+    /// <c>!ut&lt;id&gt;</c> identity key rather than the shared name, so
+    /// <c>Sequence[UserFoo]</c> and <c>AsyncSequence[UserFoo]</c> (same
+    /// element instance) must still key distinctly.
+    /// </summary>
+    [Fact]
+    public void TupleTypeSymbol_Get_WithSequenceVsAsyncSequenceOfSameUserType_NeverAliases()
+    {
+        var user = MakeUserStruct("UserFoo");
+        var seq = SequenceTypeSymbol.Get(user);
+        var aseq = AsyncSequenceTypeSymbol.Get(user);
+
+        var tupleSeq = TupleTypeSymbol.Get(ImmutableArray.Create(seq, TypeSymbol.String));
+        var tupleAseq = TupleTypeSymbol.Get(ImmutableArray.Create(aseq, TypeSymbol.String));
+
+        Assert.NotSame(tupleSeq, tupleAseq);
+    }
+}


### PR DESCRIPTION
Fixes #1790

## Root cause
`ContainsSameCompilationUserType` (src/Core/CodeAnalysis/Symbols/TypeSymbol.cs) had arms for Nullable/Slice/Array/Map/Function/Tuple/imported-generic wrappers, but was missing `SequenceTypeSymbol`, `AsyncSequenceTypeSymbol`, `ChannelTypeSymbol`, `ByRefTypeSymbol`, and `PointerTypeSymbol`. These wrappers compute their `ClrType` via `MakeGenericType`/`MakeByRefType`/`MakePointerType`, which return `null` when the element/pointee is a same-compilation user type (a struct/class/enum/interface/delegate still being compiled has no CLR backing yet). With the arm missing, such a wrapper was not recognized as "contains a same-compilation user type", so `FunctionTypeSymbol.AppendIdentityKey` did not route it to the per-instance `!ut<id>` identity key and instead fell through to a display-name key — aliasing two distinct same-named user types declared in separate concurrent compilations (the same failure class #1624/#1777 fixed for the other wrappers).

## Fix — a single unifying abstraction
Rather than adding the five named wrappers as new hand-copied switch arms, I introduced one canonical enumerator, `GetWrappedTypes(TypeSymbol)`, that yields every wrapper/constructed kind's immediate inner type(s). `ContainsSameCompilationUserType` now recurses through it uniformly instead of maintaining its own divergent switch.

`GetWrappedTypes` covers every wrapper/constructed kind with an inner type:
- `NullableTypeSymbol` → UnderlyingType
- `SliceTypeSymbol` / `ArrayTypeSymbol` → ElementType
- `PinnedTypeSymbol` → UnderlyingType
- `NullabilityAnnotatedTypeSymbol` → BaseType
- `SequenceTypeSymbol` / `AsyncSequenceTypeSymbol` / `ChannelTypeSymbol` → ElementType
- `ByRefTypeSymbol` / `PointerTypeSymbol` → PointeeType
- `MapTypeSymbol` → KeyType, ValueType
- `FunctionTypeSymbol` / `FunctionPointerTypeSymbol` → ParameterTypes, ReturnType
- `TupleTypeSymbol` → ElementTypes
- `ImportedTypeSymbol` (constructed generic) → TypeArguments

This picked up `PinnedTypeSymbol`, `NullabilityAnnotatedTypeSymbol`, and `FunctionPointerTypeSymbol` too, which had the identical latent gap and were not named in the issue.

Leaf kinds (`StructSymbol`/`EnumSymbol`/`InterfaceSymbol`/`DelegateTypeSymbol`, checked by `ClrType == null`) and non-wrapper kinds (primitives, type parameters) are handled directly and are not part of the enumerator.

## Shared-`Name` follow-up
`SequenceTypeSymbol` and `AsyncSequenceTypeSymbol` intentionally share the `sequence[...]` display name (ADR-0041: both spell as `sequence[T]` at the surface-syntax level; only binding context distinguishes them), so I left `Name` unchanged. They already carry distinct `!seq`/`!aseq` structural-key tags in `FunctionTypeSymbol.AppendStructuralKey` for the type-parameter case. With this fix, a same-compilation user element now routes through the per-instance `!ut<id>` key instead of the shared name, so `Sequence[X]` and `AsyncSequence[X]` never alias even when `X` has no CLR backing — verified by a dedicated test.

## Termination / false-positive safety
- **Termination:** each yielded inner type is a strict substructure of its wrapper — types form a DAG built during binding, never a cycle back to themselves — so the recursion always terminates. No guard was needed (matches the existing unguarded recursion pattern used by the sibling `AnyTypeParameter`/`CollectReferencedTypeParameters` walkers).
- **No false positives:** a wrapper over a non-same-compilation type (e.g. `Sequence[int32]`) still returns `false`, verified for every wrapper kind.

## Files changed
- `src/Core/CodeAnalysis/Symbols/TypeSymbol.cs` — generalized `ContainsSameCompilationUserType` + new `GetWrappedTypes` helper.
- `test/Core.Tests/CodeAnalysis/Symbols/Issue1790WrapperAliasingTests.cs` — new regression tests.

## Tests
- `dotnet build GSharp.sln -c Release -graph` — 0 errors.
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release` — **5234 passed, 0 failed, 1 skipped** (pre-existing unrelated skip).
- New `Issue1790WrapperAliasingTests` (21 tests, all passing) cover, for every wrapper kind (Sequence, AsyncSequence, Channel, ByRef, Pointer, plus Pinned/NullabilityAnnotated/FunctionPointer and a nested `Sequence[Channel[UserType]]` combo):
  - `ContainsSameCompilationUserType` returns `true` when the inner type is a same-compilation user type.
  - `ContainsSameCompilationUserType` returns `false` when the inner type is a plain CLR type (no false positives).
  - An end-to-end cross-compilation alias repro via `TupleTypeSymbol.Get`: two distinct `StructSymbol` instances sharing the same name (simulating the same user type declared in two concurrent compilations) wrapped in each of Sequence/AsyncSequence/Channel/ByRef/Pointer produce **distinct** tuple symbols, while reusing the same instance within one compilation still interns to the same cached tuple.
  - `Sequence[X] != AsyncSequence[X]` for the same same-compilation-user element `X`.
- No existing Compiler.Tests target this specific cache-keying path (the #1624 regression tests live in Core.Tests), so no additional narrow Compiler.Tests filter was needed.

Zero deferrals — every wrapper kind identified during investigation is covered.