### PR TITLE
cs2gs: pin TriageSerialization.Options.NewLine for cross-platform byte determinism

### DIFF
--- a/tools/cs2gs/Cs2Gs.Pipeline/TriageSerialization.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TriageSerialization.cs
@@ -18,12 +18,16 @@ public static class TriageSerialization
     /// <summary>
     /// Gets the shared serializer options: indented, camelCase via explicit
     /// <c>[JsonPropertyName]</c>, relaxed escaping so snippets stay readable, and
-    /// nulls preserved (the schema's source-map sub-fields are nullable).
+    /// nulls preserved (the schema's source-map sub-fields are nullable). <c>NewLine</c>
+    /// is pinned to <c>"\n"</c> so <c>summary.json</c>/<c>run.json</c>/triage artifacts are
+    /// byte-identical across platforms (ADR-0115 §F) — without this, .NET defaults
+    /// <c>NewLine</c> to <see cref="Environment.NewLine"/>, which is <c>\r\n</c> on Windows.
     /// </summary>
     public static JsonSerializerOptions Options { get; } = new JsonSerializerOptions
     {
         WriteIndented = true,
         Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+        NewLine = "\n",
     };
 
     /// <summary>

--- a/tools/cs2gs/Cs2Gs.Tests/TriageSerializationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/TriageSerializationTests.cs
@@ -1,0 +1,117 @@
+// <copyright file="TriageSerializationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Text.Json;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Tests that <see cref="TriageSerialization.Options"/> produces byte-identical
+/// output regardless of the host OS's <see cref="System.Environment.NewLine"/>
+/// (the determinism contract for <c>summary.json</c>/<c>run.json</c>/triage
+/// artifacts, ADR-0115 §F).
+/// </summary>
+public class TriageSerializationTests
+{
+    /// <summary>
+    /// <c>NewLine</c> is pinned to <c>"\n"</c>: the serialized output never
+    /// contains <c>"\r\n"</c>, even though .NET otherwise defaults
+    /// <c>JsonSerializerOptions.NewLine</c> to <see cref="System.Environment.NewLine"/>
+    /// (which is <c>"\r\n"</c> on Windows).
+    /// </summary>
+    [Fact]
+    public void Options_PinsNewLineToLineFeed()
+    {
+        Assert.Equal("\n", TriageSerialization.Options.NewLine);
+
+        string json = JsonSerializer.Serialize(SampleArtifact(), TriageSerialization.Options);
+
+        Assert.DoesNotContain("\r\n", json, System.StringComparison.Ordinal);
+        Assert.Contains("\n", json, System.StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Serializing the same model twice yields byte-identical output — the
+    /// baseline determinism guarantee that cross-OS diffing, golden files, and
+    /// content-hash dedup depend on.
+    /// </summary>
+    [Fact]
+    public void Serialization_IsByteIdentical_AcrossRepeatedRuns()
+    {
+        TriageArtifact artifact = SampleArtifact();
+
+        string first = JsonSerializer.Serialize(artifact, TriageSerialization.Options);
+        string second = JsonSerializer.Serialize(SampleArtifact(), TriageSerialization.Options);
+
+        Assert.Equal(first, second);
+    }
+
+    /// <summary>
+    /// A small fixed model serializes to an exact golden byte string, pinning
+    /// indentation, property order, and line endings all at once.
+    /// </summary>
+    [Fact]
+    public void Serialization_MatchesGoldenBytes_ForFixedModel()
+    {
+        var diagnostic = new TriageDiagnostic
+        {
+            Id = "GS0313",
+            Message = "unsupported construct",
+            Severity = "error",
+        };
+
+        string json = JsonSerializer.Serialize(diagnostic, TriageSerialization.Options);
+
+        const string expected =
+            "{\n" +
+            "  \"id\": \"GS0313\",\n" +
+            "  \"message\": \"unsupported construct\",\n" +
+            "  \"severity\": \"error\"\n" +
+            "}";
+
+        Assert.Equal(expected, json);
+    }
+
+    private static TriageArtifact SampleArtifact()
+    {
+        return new TriageArtifact
+        {
+            RunId = "2026-06-21T20-00-00Z_3f9c1a",
+            Timestamp = "2026-06-21T20:00:00Z",
+            GscVersion = "1.0.0",
+            CorpusAppId = "corpus/L2-Library",
+            Stage = "translate",
+            Category = "translation-unsupported",
+            Diagnostic = new TriageDiagnostic
+            {
+                Id = "GS0313",
+                Message = "unsupported construct",
+                Severity = "error",
+            },
+            SourceLocation = new TriageSourceLocation
+            {
+                GsFile = "L2-Library.gs",
+                GsLine = 10,
+                GsColumn = 5,
+                CsFile = "L2-Library.cs",
+                CsLine = 12,
+                CsColumn = 9,
+            },
+            OffendingCSharpConstruct = new TriageOffendingConstruct
+            {
+                Kind = "RecordDeclaration",
+                Snippet = "record Point(int X, int Y);",
+            },
+            SuggestedIssue = new TriageSuggestedIssue
+            {
+                Title = "Support record declarations",
+                Body = "cs2gs cannot translate this construct.",
+                Labels = { "Oats" },
+            },
+            Fingerprint = "sha256:deadbeef",
+        };
+    }
+}


### PR DESCRIPTION
Fixes #1755

## Root cause
`TriageSerialization.Options` (`tools/cs2gs/Cs2Gs.Pipeline/TriageSerialization.cs`) set `WriteIndented = true` without pinning `NewLine`. Since .NET 9, `JsonSerializerOptions.NewLine` defaults to `Environment.NewLine`, so a Windows-produced `summary.json`/`run.json`/triage artifact used `\r\n` while Linux/macOS produced `\n`. This one `Options` instance is shared by every JSON writer/reader in cs2gs (`MigrationPipeline`, `ReportModel`, `JsonSummaryWriter`, `BaselineTestsOracle`), so the single fix covers all affected artifacts.

## Fix
Added `NewLine = "\n"` to the shared `TriageSerialization.Options` factory, matching the pin `HtmlReportWriter` already uses for `report.html`.

## Determinism audit (per issue's checklist)
- **NewLine**: fixed (this PR).
- **WriteIndented / indentation**: already fixed (`WriteIndented = true`, default 2-space indent, unchanged).
- **Property order**: already fixed via explicit `[JsonPropertyOrder]` on every model (`RunResult`, `TriageArtifact`, `ReportModel`, etc.) — no reliance on declaration order.
- **Collection order**: already fixed — `ReportModel.Build`/`GroupGaps`/`MergeRetryHistory` sort apps, gaps, artifacts, fingerprints, and retry history with `StringComparer.Ordinal` before serialization.
- **Culture-invariant formatting**: already fixed — the run timestamp uses `CultureInfo.InvariantCulture`.
- **Path separators**: already fixed — artifact paths are stored with `/` and normalized to `Path.DirectorySeparatorChar` only when reading from disk, never re-embedded with an OS separator in the JSON.
- **Encoder/escaping**: already fixed — `JavaScriptEncoder.UnsafeRelaxedJsonEscaping` is a single pinned encoder shared everywhere.

No shared-options factory was needed beyond the existing `TriageSerialization.Options` — it was already the single source every writer/reader uses; it just needed the one missing setting.

## Tests
Added `tools/cs2gs/Cs2Gs.Tests/TriageSerializationTests.cs`:
- `Options_PinsNewLineToLineFeed`: asserts `Options.NewLine == "\n"` and that serialized output never contains `\r\n`.
- `Serialization_IsByteIdentical_AcrossRepeatedRuns`: serializes the same model twice, asserts byte-equal.
- `Serialization_MatchesGoldenBytes_ForFixedModel`: pins an exact golden JSON string for a small fixed model.

## Verification
- `dotnet build GSharp.sln -c Release -graph` → 0 errors, 0 warnings.
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release` → 383 passed, 0 failed, 0 skipped.