### PR TITLE
Fix #1721: make GSharpPrinter operator-precedence aware

### DIFF
--- a/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
@@ -23,6 +23,11 @@ public static class GSharpPrinter
 {
     private const string IndentUnit = "    ";
 
+    // Unary operators (`+ - ! ^ * & <-`) bind at precedence 6 in G#'s
+    // grammar — higher than every binary operator — per
+    // SyntaxFacts.GetUnaryOperatorPrecedence.
+    private const int UnaryPrecedence = 6;
+
     /// <summary>
     /// Prints a compilation unit to canonical G# source text.
     /// </summary>
@@ -344,7 +349,65 @@ public static class GSharpPrinter
     private static string RenderCharLiteralBody(string value) =>
         RenderEscapedLiteralBody(value, '\'', escapeDollar: false);
 
-    private static string RenderExpression(GExpression expression, int indent)
+    // Issue #1721: G# uses Go-style operator precedence (mirrored from
+    // SyntaxFacts.GetBinaryOperatorPrecedence in src/Core/CodeAnalysis/Syntax),
+    // which differs from C#'s: `<< >> & &^` are MULTIPLICATIVE (level 5, same
+    // as `* / %`), `| ^` are ADDITIVE (level 4, same as `+ -`), and ALL
+    // comparisons (`== != < <= > >=`) plus `is`/`as` share level 3. C# instead
+    // ranks shifts below additive, bitwise `& ^ |` below equality, and
+    // relational above equality. Because the translator preserves the
+    // original C# expression tree shape (which encodes C# precedence via
+    // nesting, not via G# tokens), printing that tree flat under G#'s table
+    // silently re-associates it. `??` is handled outside this table (parsed
+    // separately, right-associative, binding just below `||`) — see the
+    // level-0 fallback comment on GetBinaryOperatorPrecedence.
+    private static int GetBinaryPrecedence(string op) => op switch
+    {
+        "*" or "/" or "%" or "<<" or ">>" or "&" or "&^" => 5,
+        "+" or "-" or "|" or "^" => 4,
+        "==" or "!=" or "<" or "<=" or ">" or ">=" or "is" or "as" => 3,
+        "&&" => 2,
+        "||" => 1,
+        "??" => 0,
+        _ => throw new ArgumentException($"Unknown binary operator: {op}"),
+    };
+
+    /// <summary>
+    /// Renders an expression, parenthesizing it if its own G# operator
+    /// precedence is lower than <paramref name="minPrecedence"/> (the
+    /// precedence required by the surrounding context to reproduce the
+    /// original tree shape when re-parsed).
+    /// </summary>
+    private static string RenderExpression(GExpression expression, int indent, int minPrecedence)
+    {
+        if (expression is BinaryExpression outerBinary)
+        {
+            var precedence = GetBinaryPrecedence(outerBinary.Operator);
+
+            // `??` is right-associative: its left operand must strictly
+            // out-bind it (else a nested `??` on the left would silently
+            // re-associate), while its right operand may sit at the same
+            // level (a nested `??` on the right reproduces the natural
+            // right-associative chain). Every other G# binary operator is
+            // left-associative: the left operand may sit at the same level,
+            // but the right operand must strictly out-bind it.
+            var isRightAssociative = outerBinary.Operator == "??";
+            var leftMin = isRightAssociative ? precedence + 1 : precedence;
+            var rightMin = isRightAssociative ? precedence : precedence + 1;
+
+            var leftText = RenderExpression(outerBinary.Left, indent, leftMin);
+            var rightText = RenderExpression(outerBinary.Right, indent, rightMin);
+            var rendered = $"{leftText} {outerBinary.Operator} {rightText}";
+            return precedence < minPrecedence ? $"({rendered})" : rendered;
+        }
+
+        return RenderExpressionCore(expression, indent);
+    }
+
+    private static string RenderExpression(GExpression expression, int indent) =>
+        RenderExpression(expression, indent, 0);
+
+    private static string RenderExpressionCore(GExpression expression, int indent)
     {
         switch (expression)
         {
@@ -400,19 +463,35 @@ public static class GSharpPrinter
                 var tupleElements = string.Join(", ", tuple.Elements.Select(e => RenderExpression(e, indent)));
                 return $"({tupleElements})";
 
-            case BinaryExpression binary:
-                return $"{RenderExpression(binary.Left, indent)} {binary.Operator} {RenderExpression(binary.Right, indent)}";
-
             case UnaryExpression unary:
-                return $"{unary.Operator}{RenderExpression(unary.Operand, indent)}";
+                {
+                    // Unary operators bind at precedence 6 — higher than every
+                    // binary operator — so a binary-expression operand (e.g. a
+                    // stray `BinaryExpression` reaching here without an explicit
+                    // `ParenthesizedExpression` wrapper) must be parenthesized.
+                    var operandText = RenderExpression(unary.Operand, indent, UnaryPrecedence);
+
+                    // Issue #1721: nested same-character prefix operators
+                    // silently coalesce into a different token if printed with
+                    // no separating space — `!!flag` (double logical negation)
+                    // lexes as the single BangBangToken (postfix non-null
+                    // assertion), and `- -x` lexes as `--x` (predecrement),
+                    // changing the parsed program. A space between the operator
+                    // and an operand that starts with the same character keeps
+                    // the tokens distinct and is always semantically safe.
+                    var separator = operandText.Length > 0 && operandText[0] == unary.Operator[unary.Operator.Length - 1]
+                        ? " "
+                        : string.Empty;
+                    return $"{unary.Operator}{separator}{operandText}";
+                }
 
             case NonNullAssertionExpression nonNull:
-                return $"{RenderExpression(nonNull.Operand, indent)}!!";
+                return $"{RenderExpression(nonNull.Operand, indent, UnaryPrecedence)}!!";
 
             case IncrementDecrementExpression incDec:
                 return incDec.IsPrefix
-                    ? $"{incDec.Operator}{RenderExpression(incDec.Operand, indent)}"
-                    : $"{RenderExpression(incDec.Operand, indent)}{incDec.Operator}";
+                    ? $"{incDec.Operator}{RenderExpression(incDec.Operand, indent, UnaryPrecedence)}"
+                    : $"{RenderExpression(incDec.Operand, indent, UnaryPrecedence)}{incDec.Operator}";
 
             case StackAllocExpression stackAlloc:
                 {
@@ -434,7 +513,9 @@ public static class GSharpPrinter
                 return RenderLambda(lambda, indent);
 
             case AwaitExpression await:
-                return $"await {RenderExpression(await.Operand, indent)}";
+                // `await` binds at the same precedence slot as unary operators
+                // (Parser.cs: `ParseBinaryExpression(6)` for the await operand).
+                return $"await {RenderExpression(await.Operand, indent, UnaryPrecedence)}";
 
             case SwitchExpression switchExpression:
                 return RenderSwitchExpression(switchExpression, indent);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1721PrinterPrecedenceTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1721PrinterPrecedenceTests.cs
@@ -1,0 +1,263 @@
+// <copyright file="Issue1721PrinterPrecedenceTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Translation tests for issue #1721: <see cref="GSharpPrinter"/> printed
+/// binary/unary expressions completely flat, with no awareness of G#'s
+/// Go-style operator precedence (mirrored from
+/// <c>SyntaxFacts.GetBinaryOperatorPrecedence</c> in
+/// <c>src/Core/CodeAnalysis/Syntax</c>). C#'s precedence differs from G#'s in
+/// exactly the ways exercised below, so a flat reprint of a C#-precedence
+/// expression tree silently re-associates under G#'s rules and reparses to a
+/// different value:
+///
+/// <list type="bullet">
+/// <item>C#: multiplicative &gt; additive &gt; shift &gt; relational &gt;
+/// equality &gt; <c>&amp;</c> &gt; <c>^</c> &gt; <c>|</c>.</item>
+/// <item>G# (Go-style): <c>* / % &lt;&lt; &gt;&gt; &amp; &amp;^</c> share the
+/// multiplicative level; <c>+ - | ^</c> share the additive level; ALL of
+/// <c>== != &lt; &lt;= &gt; &gt;=</c> (plus <c>is</c>/<c>as</c>) share a single
+/// comparison level below that.</item>
+/// </list>
+///
+/// The fix makes <c>GSharpPrinter.RenderExpression</c> precedence-aware: it
+/// threads the precedence required by the surrounding context through the
+/// recursive descent and parenthesizes a child whenever its own G#-table
+/// precedence would let it bind differently than the original (C#-shaped)
+/// tree intends. It also inserts a separating space between adjacent unary
+/// operators that would otherwise lex as a single (different) token, e.g.
+/// <c>!!</c> (postfix non-null assertion) or <c>--</c> (predecrement).
+/// </summary>
+public class Issue1721PrinterPrecedenceTests
+{
+    // --- Shift vs. additive: G# puts `<<`/`>>` at the MULTIPLICATIVE level
+    // (same as `*`), strictly above additive `+`/`-`, whereas C# puts shifts
+    // BELOW additive. A flat reprint of `1 << 2 + 3` re-associates it.
+    [Fact]
+    public void ShiftOverAdditiveRightOperand_IsParenthesized()
+    {
+        string g = Render(@"
+namespace N { public class C { public static int F() => 1 << 2 + 3; } }");
+
+        Assert.Contains("1 << (2 + 3)", g, StringComparison.Ordinal);
+        AssertEvaluatesTo(1 << 2 + 3, ExtractArrowBody(g));
+    }
+
+    [Fact]
+    public void AdditiveOverShiftLeftOperand_IsParenthesized()
+    {
+        // C#: `+` binds tighter than `<<`, so this is `(1 + 2) << 3`. G#
+        // ranks `<<` at the SAME level as `+`'s sibling multiplicative tier —
+        // strictly above additive — so the left operand must be parenthesized
+        // or it silently re-associates as `1 + (2 << 3)`.
+        string g = Render(@"
+namespace N { public class C { public static int F() => 1 + 2 << 3; } }");
+
+        Assert.Contains("(1 + 2) << 3", g, StringComparison.Ordinal);
+        AssertEvaluatesTo(1 + 2 << 3, ExtractArrowBody(g));
+    }
+
+    // --- Bitwise-and vs. additive: G# puts `&` at the MULTIPLICATIVE level
+    // (same as `*`), whereas C# puts `&` far below additive (below equality).
+    [Fact]
+    public void BitwiseAndOverAdditiveRightOperand_IsParenthesized()
+    {
+        int a = 6, b = 3, c = 5;
+        string g = Render(@"
+namespace N { public class C { public static int F(int a, int b, int c) => a & b + c; } }");
+
+        Assert.Contains("a & (b + c)", g, StringComparison.Ordinal);
+        AssertEvaluatesTo(a & (b + c), "a", a, "b", b, "c", c, ExtractArrowBody(g));
+    }
+
+    // --- Bitwise-or vs. bitwise-xor: G# puts `|` and `^` at the SAME
+    // (additive) level, left-associative, whereas C# ranks `^` strictly
+    // above `|`. `x | y ^ z` is `x | (y ^ z)` in C# but re-associates to
+    // `(x | y) ^ z` if printed flat under G#'s table.
+    [Fact]
+    public void BitwiseOrOverXorRightOperand_IsParenthesized()
+    {
+        int x = 0b1010, y = 0b0110, z = 0b0011;
+        string g = Render(@"
+namespace N { public class C { public static int F(int x, int y, int z) => x | y ^ z; } }");
+
+        Assert.Contains("x | (y ^ z)", g, StringComparison.Ordinal);
+        AssertEvaluatesTo(x | (y ^ z), "x", x, "y", y, "z", z, ExtractArrowBody(g));
+    }
+
+    // --- Equality vs. bitwise-and: G# ranks ALL comparisons (`==` included)
+    // and `&` at DIFFERENT levels than C# does. C#'s `==` binds tighter than
+    // `&`, so `a == b & c` is `(a == b) & c`; G# also ranks `==` (comparison,
+    // level 3) below `&` (multiplicative, level 5), so the left operand of
+    // `&` must be parenthesized or it silently re-associates to
+    // `a == (b & c)`.
+    [Fact]
+    public void EqualityOverBitwiseAndLeftOperand_IsParenthesized()
+    {
+        string g = Render(@"
+namespace N { public class C { public static bool F(int a, int b, bool c) => a == b & c; } }");
+
+        Assert.Contains("(a == b) & c", g, StringComparison.Ordinal);
+    }
+
+    // --- Equality vs. relational: C# ranks relational (`<`) strictly ABOVE
+    // equality (`==`), but G# puts them at the SAME (comparison) level. Flat
+    // printing `a == b < c` (C# = `a == (b < c)`) re-associates to
+    // `(a == b) < c` under G#'s rules.
+    [Fact]
+    public void EqualityOverRelationalRightOperand_IsParenthesized()
+    {
+        string g = Render(@"
+namespace N { public class C { public static bool F(bool a, int b, int c) => a == (b < c); } }");
+
+        Assert.Contains("a == (b < c)", g, StringComparison.Ordinal);
+    }
+
+    // --- Nested same-precedence, left-associative: no extra parens needed;
+    // flat reprint already reproduces `(a - b) - c` under both C#'s and G#'s
+    // (both left-associative, same tier) rules.
+    [Fact]
+    public void NestedSamePrecedenceLeftAssociative_NoParensNeeded()
+    {
+        int a = 10, b = 3, c = 2;
+        string g = Render(@"
+namespace N { public class C { public static int F(int a, int b, int c) => a - b - c; } }");
+
+        Assert.Contains("a - b - c", g, StringComparison.Ordinal);
+        Assert.DoesNotContain("(a - b)", g, StringComparison.Ordinal);
+        AssertEvaluatesTo(a - b - c, "a", a, "b", b, "c", c, ExtractArrowBody(g));
+    }
+
+    // --- Nested same-precedence, RIGHT operand: re-association changes the
+    // value even though the operator is the same on both sides, so the right
+    // operand must be parenthesized whenever it is itself the same (or a
+    // same-tier) operator.
+    [Fact]
+    public void NestedSamePrecedenceRightOperand_IsParenthesized()
+    {
+        int a = 10, b = 3, c = 2;
+        string g = Render(@"
+namespace N { public class C { public static int F(int a, int b, int c) => a - (b - c); } }");
+
+        Assert.Contains("a - (b - c)", g, StringComparison.Ordinal);
+        AssertEvaluatesTo(a - (b - c), "a", a, "b", b, "c", c, ExtractArrowBody(g));
+    }
+
+    // --- Unary vs. binary: a nested unary `!!flag` (double logical negation)
+    // must not coalesce into the postfix `!!` (non-null assertion) token, and
+    // `- -x` must not coalesce into a predecrement `--x`.
+    [Fact]
+    public void DoubleLogicalNegation_InsertsSeparatingSpace()
+    {
+        string g = Render(@"
+namespace N { public class C { public static bool F(bool flag) => !!flag; } }");
+
+        Assert.Contains("! !flag", g, StringComparison.Ordinal);
+        Assert.DoesNotContain("!!flag", g, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DoubleUnaryMinus_InsertsSeparatingSpace()
+    {
+        string g = Render(@"
+namespace N { public class C { public static int F(int x) => - -x; } }");
+
+        Assert.Contains("- -x", g, StringComparison.Ordinal);
+        Assert.DoesNotContain("--x", g, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Translates the supplied C# source with the full cs2gs pipeline and
+    /// returns the printed G# source, after confirming it round-trips (parses
+    /// with no error diagnostics) with the real G# parser.
+    /// </summary>
+    private static string Render(string csharp)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Source.cs", csharp) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        string printed = GSharpPrinter.Print(unit);
+
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+
+    /// <summary>
+    /// Extracts the expression-bodied arrow tail (<c>-&gt; &lt;expr&gt;</c>)
+    /// of the (single) free function <c>F</c> emitted by <see cref="Render"/>.
+    /// </summary>
+    private static string ExtractArrowBody(string printed)
+    {
+        Match match = Regex.Match(printed, @"func F\([^)]*\)[^\r\n{]* -> (?<body>[^\r\n]+)");
+        Assert.True(match.Success, "Expected an arrow-bodied `F` in printed G#:\n" + printed);
+        return match.Groups["body"].Value.Trim();
+    }
+
+    /// <summary>
+    /// Evaluates the printed arrow-body expression with the real G#
+    /// interpreter (no free variables) and asserts it equals
+    /// <paramref name="expected"/> — the same expression, evaluated directly
+    /// by the C# compiler in the calling test — proving the printed G# text
+    /// re-parses to a tree that preserves the original C# value.
+    /// </summary>
+    private static void AssertEvaluatesTo(int expected, string gsharpExpression)
+    {
+        EvaluationResult result = Evaluate(gsharpExpression);
+        AssertNoRealDiagnostics(result);
+        Assert.Equal(expected, Convert.ToInt64(result.Value));
+    }
+
+    /// <summary>
+    /// Same as <see cref="AssertEvaluatesTo(int, string)"/> but binds the
+    /// function's parameters to concrete values via `let` bindings ahead of
+    /// the expression. <paramref name="expected"/> is computed by the calling
+    /// test using C#'s own operators over the same values, so the two
+    /// languages' results are compared independently.
+    /// </summary>
+    private static void AssertEvaluatesTo(int expected, string name1, int value1, string name2, int value2, string name3, int value3, string gsharpExpression)
+    {
+        string script = $"let {name1} = {value1}\nlet {name2} = {value2}\nlet {name3} = {value3}\n{gsharpExpression}";
+        EvaluationResult result = Evaluate(script);
+        AssertNoRealDiagnostics(result);
+        Assert.Equal(expected, Convert.ToInt64(result.Value));
+    }
+
+    private static EvaluationResult Evaluate(string gsharpSource)
+    {
+        var tree = SyntaxTree.Parse(gsharpSource);
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+
+    private static void AssertNoRealDiagnostics(EvaluationResult result)
+    {
+        Assert.DoesNotContain(result.Diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+    }
+}


### PR DESCRIPTION
Fixes #1721

## Problem
`GSharpPrinter.RenderExpression` printed binary/unary expressions completely flat (no operator-precedence awareness). The translator preserves the C# expression tree shape (which encodes C#'s precedence via nesting, not via G# tokens), so a flat reprint silently re-associates under G#'s Go-style precedence rules — producing semantically different G# that parses and evaluates to a different value than the original C#.

## Fix
Made the printer precedence-aware with the standard child-vs-parent-precedence parenthesization algorithm:
- `RenderExpression` now threads a `minPrecedence` through the recursive descent.
- A `BinaryExpression` child is parenthesized whenever its own G#-table precedence is too low for its position: for left-associative operators (everything except `??`), the left operand needs precedence `>=` the parent's, the right operand needs precedence `>` the parent's (strict, since equal-precedence on the right would silently re-associate). For `??` (right-associative), it's the mirror image.
- Unary/postfix (`UnaryExpression`, `NonNullAssertionExpression`, `IncrementDecrementExpression`, `AwaitExpression`) operands require precedence `>=` 6 (the unary tier), so a stray low-precedence `BinaryExpression` operand gets parenthesized too.
- Added a separating-space guard for adjacent same-character unary operators that would otherwise coalesce into a different token: `!!flag` (double logical negation) vs. the postfix `!!` non-null-assertion token, and `- -x` vs. predecrement `--x`.
- Extra parentheses are always safe; the algorithm never tries to minimize them — correctness first.

## G#'s real precedence table
Mirrored from `SyntaxFacts.GetBinaryOperatorPrecedence`/`GetUnaryOperatorPrecedence` in `src/Core/CodeAnalysis/Syntax/SyntaxFacts.cs`, confirmed against the parser (`Parser.cs`, incl. how `is`/`as` and `??` are special-cased):

| Level | Operators |
|---|---|
| 6 (unary) | `+ - ! ^ * & <-` (prefix) |
| 5 | `* / % << >> & &^` |
| 4 | `+ - \| ^` |
| 3 | `== != < <= > >= is as` |
| 2 | `&&` |
| 1 | `\|\|` |
| 0 | `??` (right-associative, parsed separately, binds just below `\|\|`) |

## C#→Go precedence differences this now handles
- Shift (`<< >>`) is **multiplicative** in G# (same tier as `*`), but sits **below additive** in C#.
- `&` and `&^` are **multiplicative** in G#, but `&` sits **far below equality** in C#.
- `|` and `^` share the **same (additive) tier** in G#, but C# ranks `^` strictly above `|`.
- `== != < <= > >=` (plus `is`/`as`) are all **one comparison tier** in G#, but C# splits them into separate relational (`< <= > >=`, higher) and equality (`== !=`, lower) tiers.
- Nested same-precedence operators on the right (e.g. `a - (b - c)`) need parens to avoid re-associating even though the operator repeats.
- Adjacent same-character unary operators (`!!`, `--`) need a separating space to avoid re-lexing as a different token.

## Tests
Added `tools/cs2gs/Cs2Gs.Tests/Issue1721PrinterPrecedenceTests.cs`, translating real C# expressions through the full cs2gs pipeline and asserting the printed G# contains the required parens, round-trips through the real G# parser, and (for the arithmetic cases) evaluates to the same value the equivalent C# expression evaluates to via the real G# interpreter. Covers: shift-vs-additive (both directions), bitwise-and-vs-additive, bitwise-or-vs-xor, equality-vs-bitwise-and, equality-vs-relational, nested same-precedence left- and right-operand, and the two unary-collision cases.

Verified the new tests fail against the pre-fix printer (7/10 fail) and all pass with the fix (10/10).

## Verification
- `dotnet build GSharp.sln -c Release -graph` → 0 errors.
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release` → 390/390 passed (380 pre-existing + 10 new).