### PR TITLE
Fix #1748: robust shared subprocess runner (concurrent pipe reads, timeouts, no stdin inherit, ArgumentList quoting)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Pipeline/GscInvoker.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/GscInvoker.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
 
 namespace Cs2Gs.Pipeline;
@@ -121,27 +120,26 @@ public sealed class GscInvoker
         TargetKind target,
         IReadOnlyList<string> references)
     {
-        var args = new StringBuilder();
-        args.Append('"').Append(this.GscPath).Append('"');
-        args.Append(target == TargetKind.Exe ? " /target:exe" : " /target:library");
-        args.Append(" /out:\"").Append(outputPath).Append('"');
+        var args = new List<string>
+        {
+            this.GscPath,
+            target == TargetKind.Exe ? "/target:exe" : "/target:library",
+            "/out:" + outputPath,
+        };
 
         if (references is not null)
         {
             foreach (string reference in references)
             {
-                args.Append(" /reference:\"").Append(reference).Append('"');
+                args.Add("/reference:" + reference);
             }
         }
 
-        foreach (string gs in gsFiles)
-        {
-            args.Append(" \"").Append(gs).Append('"');
-        }
+        args.AddRange(gsFiles);
 
-        (int exit, string output) = RunDotnet(args.ToString());
-        IReadOnlyList<GscDiagnostic> diagnostics = ParseDiagnostics(output);
-        return new GscResult(exit, output, diagnostics);
+        ProcessRunResult result = ProcessRunner.Run("dotnet", args);
+        IReadOnlyList<GscDiagnostic> diagnostics = ParseDiagnostics(result.Output);
+        return new GscResult(result.ExitCode, result.Output, diagnostics);
     }
 
     /// <summary>
@@ -175,23 +173,6 @@ public sealed class GscInvoker
         }
 
         return diagnostics;
-    }
-
-    private static (int Exit, string Output) RunDotnet(string arguments)
-    {
-        var psi = new ProcessStartInfo("dotnet", arguments)
-        {
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-        };
-
-        using var process = Process.Start(psi);
-        var output = new StringBuilder();
-        output.Append(process.StandardOutput.ReadToEnd());
-        output.Append(process.StandardError.ReadToEnd());
-        process.WaitForExit();
-        return (process.ExitCode, output.ToString());
     }
 }
 

--- a/tools/cs2gs/Cs2Gs.Pipeline/GsharpTestProjectRunner.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/GsharpTestProjectRunner.cs
@@ -4,10 +4,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Text;
 
 namespace Cs2Gs.Pipeline;
 
@@ -348,25 +346,12 @@ public sealed class GsharpTestProjectRunner
 
     private (int Exit, string Output) RunDotnet(IReadOnlyList<string> arguments, string workingDirectory)
     {
-        var psi = new ProcessStartInfo("dotnet")
-        {
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            CreateNoWindow = true,
-            WorkingDirectory = workingDirectory,
-        };
-        foreach (string arg in arguments)
-        {
-            psi.ArgumentList.Add(arg);
-        }
-
-        using var process = Process.Start(psi);
-        var output = new StringBuilder();
-        output.Append(process.StandardOutput.ReadToEnd());
-        output.Append(process.StandardError.ReadToEnd());
-        process.WaitForExit();
-        return (process.ExitCode, output.ToString());
+        // `dotnet test` builds a project before running it, so allow more
+        // headroom than the default; still bounded so a wedged run fails the
+        // batch instead of hanging it (#1748).
+        ProcessRunResult result = ProcessRunner.Run(
+            "dotnet", arguments, workingDirectory, TimeSpan.FromMinutes(10));
+        return (result.ExitCode, result.Output);
     }
 }
 

--- a/tools/cs2gs/Cs2Gs.Pipeline/IlVerifyRunner.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/IlVerifyRunner.cs
@@ -4,10 +4,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
 
 namespace Cs2Gs.Pipeline;
@@ -340,28 +338,10 @@ public sealed class IlVerifyRunner
 
     private (int Exit, string Output) RunDotnet(IReadOnlyList<string> arguments)
     {
-        var psi = new ProcessStartInfo("dotnet")
-        {
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            CreateNoWindow = true,
-
-            // The local tool manifest is discovered relative to the working
-            // directory; anchor at the repo root. All paths are passed absolute.
-            WorkingDirectory = this.RepoRoot,
-        };
-        foreach (string arg in arguments)
-        {
-            psi.ArgumentList.Add(arg);
-        }
-
-        using var process = Process.Start(psi);
-        var output = new StringBuilder();
-        output.Append(process.StandardOutput.ReadToEnd());
-        output.Append(process.StandardError.ReadToEnd());
-        process.WaitForExit();
-        return (process.ExitCode, output.ToString());
+        // The local tool manifest is discovered relative to the working
+        // directory; anchor at the repo root. All paths are passed absolute.
+        ProcessRunResult result = ProcessRunner.Run("dotnet", arguments, this.RepoRoot);
+        return (result.ExitCode, result.Output);
     }
 }
 

--- a/tools/cs2gs/Cs2Gs.Pipeline/ProcessRunner.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/ProcessRunner.cs
@@ -1,0 +1,196 @@
+// <copyright file="ProcessRunner.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Cs2Gs.Pipeline;
+
+/// <summary>
+/// The single shared subprocess launcher for every cs2gs pipeline stage
+/// (gsc, ilverify, `dotnet test`, and the migrated program under test). Fixes
+/// the deadlock/hang/quoting family in #1748 in one place instead of four:
+/// stdout and stderr are drained concurrently (never sequential
+/// <c>ReadToEnd</c>, which deadlocks once a child fills the pipe it isn't
+/// currently being read from), every run is bounded by a timeout that kills
+/// the whole process tree on expiry instead of hanging forever, stdin is
+/// always redirected and immediately closed so a child can never block
+/// waiting on console input it will never receive, and arguments are passed
+/// via <see cref="ProcessStartInfo.ArgumentList"/> so no call site hand-quotes
+/// a command line.
+/// </summary>
+public static class ProcessRunner
+{
+    /// <summary>The default timeout applied when a caller does not supply one.</summary>
+    public static readonly TimeSpan DefaultTimeout = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Runs <paramref name="fileName"/> to completion (or until <paramref name="timeout"/>
+    /// expires) and captures its stdout/stderr concurrently.
+    /// </summary>
+    /// <param name="fileName">The executable to launch (e.g. <c>dotnet</c>).</param>
+    /// <param name="arguments">The argument list, passed unquoted via <see cref="ProcessStartInfo.ArgumentList"/>.</param>
+    /// <param name="workingDirectory">The working directory, or <see langword="null"/> to inherit the current one.</param>
+    /// <param name="timeout">The maximum wall-clock time to wait before killing the process tree; defaults to <see cref="DefaultTimeout"/>.</param>
+    /// <returns>The exit code, captured output, and whether the run timed out.</returns>
+    public static ProcessRunResult Run(
+        string fileName,
+        IReadOnlyList<string> arguments,
+        string workingDirectory = null,
+        TimeSpan? timeout = null) =>
+        RunAsync(fileName, arguments, workingDirectory, timeout).GetAwaiter().GetResult();
+
+    /// <summary>The async form of <see cref="Run"/>; see its remarks for behavior.</summary>
+    /// <param name="fileName">The executable to launch (e.g. <c>dotnet</c>).</param>
+    /// <param name="arguments">The argument list, passed unquoted via <see cref="ProcessStartInfo.ArgumentList"/>.</param>
+    /// <param name="workingDirectory">The working directory, or <see langword="null"/> to inherit the current one.</param>
+    /// <param name="timeout">The maximum wall-clock time to wait before killing the process tree; defaults to <see cref="DefaultTimeout"/>.</param>
+    /// <param name="cancellationToken">A token that, when canceled, also kills the process tree early.</param>
+    /// <returns>The exit code, captured output, and whether the run timed out.</returns>
+    public static async Task<ProcessRunResult> RunAsync(
+        string fileName,
+        IReadOnlyList<string> arguments,
+        string workingDirectory = null,
+        TimeSpan? timeout = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(fileName))
+        {
+            throw new ArgumentException("File name must be supplied.", nameof(fileName));
+        }
+
+        TimeSpan effectiveTimeout = timeout ?? DefaultTimeout;
+        var psi = new ProcessStartInfo(fileName)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            RedirectStandardInput = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        if (!string.IsNullOrEmpty(workingDirectory))
+        {
+            psi.WorkingDirectory = workingDirectory;
+        }
+
+        foreach (string arg in arguments ?? Array.Empty<string>())
+        {
+            psi.ArgumentList.Add(arg);
+        }
+
+        using var process = new Process { StartInfo = psi };
+        if (!process.Start())
+        {
+            throw new InvalidOperationException($"Failed to start process '{fileName}'.");
+        }
+
+        // No call site needs the child to read from our console, and an
+        // inherited stdin lets a translated `Console.ReadLine()` (stage 4)
+        // block forever instead of failing fast (#1748). Close it up front.
+        process.StandardInput.Close();
+
+        // Read stdout and stderr concurrently. Sequential ReadToEnd on both
+        // pipes deadlocks the moment a child fills the OS pipe buffer on the
+        // stream we are not currently blocked reading (#1748).
+        Task<string> stdoutTask = process.StandardOutput.ReadToEndAsync();
+        Task<string> stderrTask = process.StandardError.ReadToEndAsync();
+
+        using var timeoutCts = new CancellationTokenSource(effectiveTimeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(timeoutCts.Token, cancellationToken);
+
+        bool timedOut = false;
+        try
+        {
+            await process.WaitForExitAsync(linkedCts.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
+        {
+            timedOut = true;
+        }
+
+        if (timedOut)
+        {
+            KillTree(process);
+
+            // The kill closes the child's ends of the pipes, which lets the
+            // pending reads drain and complete; bound the wait so a
+            // stuck grandchild can't re-introduce a hang.
+            await Task.WhenAny(Task.WhenAll(stdoutTask, stderrTask), Task.Delay(TimeSpan.FromSeconds(10)))
+                .ConfigureAwait(false);
+
+            string timedOutStderr = SafeResult(stderrTask) +
+                $"{Environment.NewLine}[ProcessRunner] '{fileName}' timed out after {effectiveTimeout} and was killed.";
+            return new ProcessRunResult(-1, SafeResult(stdoutTask), timedOutStderr, timedOut: true);
+        }
+
+        if (cancellationToken.IsCancellationRequested)
+        {
+            KillTree(process);
+            cancellationToken.ThrowIfCancellationRequested();
+        }
+
+        // The process has already exited, so these reads are bounded by the
+        // pipes actually closing — this await cannot hang.
+        string[] outputs = await Task.WhenAll(stdoutTask, stderrTask).ConfigureAwait(false);
+        return new ProcessRunResult(process.ExitCode, outputs[0], outputs[1], timedOut: false);
+    }
+
+    private static void KillTree(Process process)
+    {
+        try
+        {
+            process.Kill(entireProcessTree: true);
+        }
+        catch (InvalidOperationException)
+        {
+            // Already exited between the timeout firing and the kill call.
+        }
+        catch (System.ComponentModel.Win32Exception)
+        {
+            // The OS refused the kill (process already gone/zombie); nothing more to do.
+        }
+    }
+
+    private static string SafeResult(Task<string> task) =>
+        task.Status == TaskStatus.RanToCompletion ? task.Result : string.Empty;
+}
+
+/// <summary>
+/// The captured outcome of a <see cref="ProcessRunner.Run"/>/<see cref="ProcessRunner.RunAsync"/> invocation.
+/// </summary>
+public sealed class ProcessRunResult
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ProcessRunResult"/> class.
+    /// </summary>
+    /// <param name="exitCode">The process exit code, or <c>-1</c> when <paramref name="timedOut"/>.</param>
+    /// <param name="stdout">The captured standard output.</param>
+    /// <param name="stderr">The captured standard error (carries a trailing timeout note when <paramref name="timedOut"/>).</param>
+    /// <param name="timedOut">Whether the process was killed because it exceeded its timeout.</param>
+    public ProcessRunResult(int exitCode, string stdout, string stderr, bool timedOut)
+    {
+        this.ExitCode = exitCode;
+        this.Stdout = stdout ?? string.Empty;
+        this.Stderr = stderr ?? string.Empty;
+        this.TimedOut = timedOut;
+    }
+
+    /// <summary>Gets the process exit code, or <c>-1</c> when <see cref="TimedOut"/>.</summary>
+    public int ExitCode { get; }
+
+    /// <summary>Gets the captured standard output.</summary>
+    public string Stdout { get; }
+
+    /// <summary>Gets the captured standard error (carries a trailing timeout note when <see cref="TimedOut"/>).</summary>
+    public string Stderr { get; }
+
+    /// <summary>Gets a value indicating whether the process was killed for exceeding its timeout.</summary>
+    public bool TimedOut { get; }
+
+    /// <summary>Gets the combined stdout+stderr, matching the shape every existing call site consumed.</summary>
+    public string Output => this.Stdout + this.Stderr;
+}

--- a/tools/cs2gs/Cs2Gs.Pipeline/TestParityStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TestParityStage.cs
@@ -4,10 +4,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Cs2Gs.CodeModel.Ast;
@@ -105,15 +103,27 @@ public sealed class TestParityStage : IMigrationStage
 
     private StageOutcome RunStdoutParity(StageExecutionContext context)
     {
-        (int exit, string stdout, string stderr) = RunProgram(context.EmittedAssemblyPath, context.AppRunDir);
+        (int exit, string stdout, string stderr, bool timedOut) =
+            RunProgram(context.EmittedAssemblyPath, context.AppRunDir);
 
         string golden = File.ReadAllText(context.App.StdoutGolden);
         StdoutParityResult parity = StdoutParity.Compare(golden, stdout);
 
-        string note = $"stdout parity: exit={exit}; match={parity.IsMatch}." +
+        string note = $"stdout parity: exit={exit}; match={parity.IsMatch}; timedOut={timedOut}." +
             (parity.IsMatch ? string.Empty : " " + parity.Describe()) +
             (string.IsNullOrWhiteSpace(stderr) ? string.Empty : "\nstderr:\n" + stderr);
         this.Note(context, note);
+
+        if (timedOut)
+        {
+            // A codegen bug producing an infinite loop must surface as a named
+            // parity failure, not an unattended-CI hang (#1748).
+            StdoutParityResult timeoutDiff = StdoutParityResult.Mismatch(
+                0, "process to complete", "process timed out");
+            TriageArtifact timeoutArtifact = context.Triage.TestParityStdoutFailure(
+                timeoutDiff, EmittedGsRelative(context));
+            return StageOutcome.Failed(new[] { timeoutArtifact });
+        }
 
         if (parity.IsMatch && exit == 0)
         {
@@ -249,23 +259,15 @@ public sealed class TestParityStage : IMigrationStage
         return TranslatedProject.Ready(files);
     }
 
-    private static (int Exit, string Stdout, string Stderr) RunProgram(string assemblyPath, string workingDirectory)
+    private static (int Exit, string Stdout, string Stderr, bool TimedOut) RunProgram(string assemblyPath, string workingDirectory)
     {
-        var psi = new ProcessStartInfo("dotnet")
-        {
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            CreateNoWindow = true,
-            WorkingDirectory = workingDirectory,
-        };
-        psi.ArgumentList.Add(assemblyPath);
-
-        using var process = Process.Start(psi);
-        string stdout = process.StandardOutput.ReadToEnd();
-        string stderr = process.StandardError.ReadToEnd();
-        process.WaitForExit();
-        return (process.ExitCode, stdout, stderr);
+        // The migrated program under test is exactly the code stage 4 exists to
+        // scrutinize: a codegen bug can produce an infinite loop, and a
+        // translated Console.ReadLine() would otherwise block on inherited
+        // stdin. ProcessRunner bounds the run and never inherits stdin (#1748).
+        ProcessRunResult result = ProcessRunner.Run(
+            "dotnet", new[] { assemblyPath }, workingDirectory, TimeSpan.FromSeconds(30));
+        return (result.ExitCode, result.Stdout, result.Stderr, result.TimedOut);
     }
 
     private static string EmittedGsRelative(StageExecutionContext context) =>

--- a/tools/cs2gs/Cs2Gs.Tests/ProcessRunnerTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/ProcessRunnerTests.cs
@@ -1,0 +1,119 @@
+// <copyright file="ProcessRunnerTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Covers the #1748 subprocess-runner fixes directly against real child
+/// processes (CI is Linux-only per <c>.github/workflows/build.yml</c>, so
+/// <c>/bin/sh</c> is always available): concurrent stdout+stderr draining
+/// (no pipe-buffer deadlock), timeout-triggered kill of a wedged child, and
+/// <see cref="System.Diagnostics.ProcessStartInfo.ArgumentList"/>-based
+/// argument passing (no hand-rolled quoting).
+/// </summary>
+public class ProcessRunnerTests
+{
+    /// <summary>
+    /// Writing well past the OS pipe buffer (~64 KB) to BOTH stdout and stderr
+    /// before exiting used to deadlock every call site's sequential
+    /// <c>ReadToEnd()</c> pair. <see cref="ProcessRunner"/> drains both
+    /// concurrently, so this must complete comfortably within the test's own
+    /// generous timeout instead of hanging forever.
+    /// </summary>
+    [Fact]
+    public async Task Run_LargeStdoutAndStderr_DoesNotDeadlock()
+    {
+        // ~200 KB on each stream: several multiples of any plausible OS pipe
+        // buffer size, so a sequential ReadToEnd/ReadToEnd pair would wedge.
+        string script =
+            "yes stdout-line-01234567890123456789012345678901234567890 | head -c 200000 >&1; " +
+            "yes stderr-line-01234567890123456789012345678901234567890 | head -c 200000 >&2; " +
+            "exit 7";
+
+        Task<ProcessRunResult> runTask = ProcessRunner.RunAsync(
+            "/bin/sh",
+            new[] { "-c", script },
+            timeout: TimeSpan.FromSeconds(30));
+
+        // If ProcessRunner regresses to sequential ReadToEnd, this deadlocks;
+        // fail fast instead of hanging the test run indefinitely.
+        Task winner = await Task.WhenAny(runTask, Task.Delay(TimeSpan.FromSeconds(20)));
+        Assert.True(ReferenceEquals(winner, runTask), "ProcessRunner.Run deadlocked reading large stdout+stderr concurrently.");
+
+        ProcessRunResult result = await runTask;
+        Assert.False(result.TimedOut);
+        Assert.Equal(7, result.ExitCode);
+
+        // `head -c` byte-count boundaries can land mid-line depending on the
+        // platform's pipe/buffering behavior, so assert "comfortably past any
+        // OS pipe buffer" rather than an exact byte count.
+        Assert.True(result.Stdout.Length >= 190000, $"stdout too short: {result.Stdout.Length}");
+        Assert.True(result.Stderr.Length >= 190000, $"stderr too short: {result.Stderr.Length}");
+    }
+
+    /// <summary>
+    /// A child that never exits must be killed once it exceeds its timeout —
+    /// not left to hang the pipeline forever — and the result must clearly
+    /// report the timeout rather than silently returning partial/zero output.
+    /// </summary>
+    [Fact]
+    public void Run_ChildExceedsTimeout_IsKilledAndReportsTimeout()
+    {
+        ProcessRunResult result = ProcessRunner.Run(
+            "/bin/sh",
+            new[] { "-c", "sleep 60" },
+            timeout: TimeSpan.FromMilliseconds(300));
+
+        Assert.True(result.TimedOut);
+        Assert.Equal(-1, result.ExitCode);
+        Assert.Contains("timed out", result.Stderr, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Arguments containing spaces and embedded quotes must survive intact
+    /// via <see cref="System.Diagnostics.ProcessStartInfo.ArgumentList"/>
+    /// rather than a hand-rolled quoted command-line string, which is exactly
+    /// the class of bug <c>GscInvoker</c>'s old quoting had (#1748 item 4).
+    /// </summary>
+    [Fact]
+    public void Run_ArgumentsWithSpacesAndQuotes_PassThroughExactly()
+    {
+        string[] args = { "arg with spaces", "arg\"with\"quotes", "trailing\\backslash\\" };
+
+        // `sh -c '... "$@"' _ <args>`: $0 becomes the placeholder "_", and the
+        // real arguments land in "$@" exactly as ArgumentList delivered them.
+        var shArgs = new[] { "-c", "for a in \"$@\"; do printf '%s\\n' \"$a\"; done", "_" }
+            .Concat(args)
+            .ToArray();
+
+        ProcessRunResult result = ProcessRunner.Run("/bin/sh", shArgs, timeout: TimeSpan.FromSeconds(10));
+
+        Assert.False(result.TimedOut);
+        Assert.Equal(0, result.ExitCode);
+        string[] lines = result.Stdout.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal(args, lines);
+    }
+
+    /// <summary>
+    /// Stage 4 (and every other stage) must never let a child inherit our
+    /// console's stdin: <c>cat</c> with no input reads until EOF, so it only
+    /// exits immediately if stdin was redirected and closed rather than
+    /// inherited.
+    /// </summary>
+    [Fact]
+    public void Run_NeverInheritsStdin_ChildSeesImmediateEof()
+    {
+        ProcessRunResult result = ProcessRunner.Run("cat", Array.Empty<string>(), timeout: TimeSpan.FromSeconds(10));
+
+        Assert.False(result.TimedOut);
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal(string.Empty, result.Stdout);
+    }
+}


### PR DESCRIPTION
Fixes #1748.

Adds `ProcessRunner`, one shared subprocess launcher for the cs2gs pipeline, replacing four drifted copies of `ProcessStartInfo`/`ReadToEnd`/`WaitForExit` in `GscInvoker`, `GsharpTestProjectRunner`, `IlVerifyRunner`, and `TestParityStage`.

## What changed

- **No more pipe-buffer deadlock**: stdout and stderr are drained concurrently (`ReadToEndAsync` on both) instead of sequential `ReadToEnd`, which used to hang once a child filled the OS pipe buffer on the stream not currently being read (e.g. verbose ilverify output, nested MSBuild/NuGet stack traces on stderr).
- **Timeouts everywhere**: every run is bounded (default 5 min; 10 min for `dotnet test`, 30 s for the migrated program under test in stage 4). On expiry the whole process tree is killed (`Process.Kill(entireProcessTree: true)`) and the result reports `TimedOut=true` instead of hanging the batch forever.
- **Stage 4 no longer inherits stdin**: `ProcessRunner` always redirects stdin and closes it immediately, so a translated `Console.ReadLine()` in the program under test fails fast instead of blocking on (or stealing) the invoking terminal's stdin. `TestParityStage` now turns a timed-out run into a named `test-parity-failure` artifact rather than a silent hang.
- **No more hand-rolled quoting**: all call sites now build a plain `string[]`/`List<string>` passed via `ProcessStartInfo.ArgumentList`. This removes `GscInvoker`'s hand-rolled quoted command-line string, which broke on paths containing `"` or a trailing `\` before the closing quote.

## Call sites migrated

- `GscInvoker.RunDotnet` (gsc invocation)
- `GsharpTestProjectRunner.RunDotnet` (`dotnet test`)
- `IlVerifyRunner.RunDotnet` (`dotnet tool run ilverify`)
- `TestParityStage.RunProgram` (the migrated program under test)

All four now just call `ProcessRunner.Run`/`RunAsync` and map the result back to their existing `(exit, output)`-shaped return types, so exit codes and captured output consumed by triage/parity stages are unchanged.

## Tests

`Cs2Gs.Tests/ProcessRunnerTests.cs` exercises `ProcessRunner` against real child processes (CI is Linux-only):
- `Run_LargeStdoutAndStderr_DoesNotDeadlock`: ~200 KB written to both stdout and stderr before exit — several multiples of any plausible OS pipe buffer — completes instead of deadlocking (guarded by an outer `Task.WhenAny` so a regression fails fast instead of hanging the test run).
- `Run_ChildExceedsTimeout_IsKilledAndReportsTimeout`: a `sleep 60` child with a 300 ms timeout is killed and reported as timed out.
- `Run_ArgumentsWithSpacesAndQuotes_PassThroughExactly`: arguments containing spaces, embedded quotes, and a trailing backslash survive exactly via `ArgumentList`.
- `Run_NeverInheritsStdin_ChildSeesImmediateEof`: `cat` with no input reads immediate EOF, proving stdin is redirected/closed rather than inherited.

## Verification

- `dotnet build GSharp.sln -c Release -graph` → 0 errors, 0 warnings.
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release` → 413 passed, 0 failed.
