### PR TITLE
Fix #1785: type async awaiter field as TaskAwaiter<Nullable<T>> for nullable user-struct Task results

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs
@@ -447,13 +447,22 @@ internal sealed partial class ExpressionBinder
         return new BoundAwaitExpression(null, operand, element, TryGetAwaiterTypeSymbol(operand.Type));
     }
 
+    // Issue #1785: `Task[T?]` for a same-compilation user value type
+    // (struct/enum) wraps T in a NullableTypeSymbol, whose ClrType is null
+    // just like the bare struct/enum case. Symbol-based detection (not
+    // ClrType.IsValueType, which is null for in-flight user types) is
+    // required to recognize it below.
+    private static bool IsAwaiterTypeArgumentCandidate(TypeSymbol a) =>
+        a is StructSymbol or InterfaceSymbol or EnumSymbol
+        || (a is NullableTypeSymbol nt && nt.UnderlyingType is StructSymbol or InterfaceSymbol or EnumSymbol);
+
     private static TypeSymbol TryGetAwaiterTypeSymbol(TypeSymbol awaitableType)
     {
         if (awaitableType is not ImportedTypeSymbol importedAwaitable
             || importedAwaitable.OpenDefinition == null
             || importedAwaitable.TypeArguments.IsDefaultOrEmpty
             || importedAwaitable.HasTypeParameterArgument
-            || !importedAwaitable.TypeArguments.Any(static a => a is StructSymbol or InterfaceSymbol or EnumSymbol))
+            || !importedAwaitable.TypeArguments.Any(IsAwaiterTypeArgumentCandidate))
         {
             return null;
         }

--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -726,7 +726,20 @@ internal sealed class LambdaBinder
         var clr = element.ClrType;
         if (clr == null)
         {
-            if (element is StructSymbol or InterfaceSymbol or EnumSymbol
+            // Issue #1785: a nullable same-compilation user type
+            // (`UserStruct?`/`UserEnum?`/`UserClass?`) also has a null ClrType
+            // (its NullableTypeSymbol wraps the struct/enum/class's null
+            // ClrType), so it must widen to `Task<T?>` the same way a bare
+            // user struct/enum/class does below. Symbol-based detection (not
+            // ClrType.IsValueType, which is null for in-flight user types) is
+            // required. Reference-type nullables (`UserClass?`) are included
+            // too — their CLR shape is identical to the bare class, but the
+            // wrapping NullableTypeSymbol still reports a null ClrType and
+            // previously fell through unwrapped, leaving the async function's
+            // observable return type as the bare element instead of
+            // `Task<T?>` (e.g. "Cannot find member Result" at the call site).
+            if ((element is StructSymbol or InterfaceSymbol or EnumSymbol
+                || (element is NullableTypeSymbol nullableUserVt && nullableUserVt.UnderlyingType is StructSymbol or InterfaceSymbol or EnumSymbol))
                 && Scope.References.TryResolveType("System.Threading.Tasks.Task`1", out var symbolicTaskOpen))
             {
                 // Issue #502 / #320: a user-defined async result type has no CLR

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -10172,8 +10172,16 @@ internal sealed class ReflectionMetadataEmitter
         }
     }
 
+    // Issue #1785: `async func f(...) T?` for a same-compilation user value
+    // type (struct/enum) has a ResultTypeSymbol that is a NullableTypeSymbol
+    // wrapping the struct/enum, not the bare struct/enum symbol itself.
+    // Recognize that shape too — symbol-based (NullableLifting), not
+    // ClrType.IsValueType, which is null for in-flight user types — so the
+    // kickoff method's real Task<T?> return type is closed over the emitted
+    // Nullable<UserT> instead of falling back to the erased Task<object>.
     private static bool IsAsyncUserDefinedResultType(TypeSymbol type)
-        => type is StructSymbol or InterfaceSymbol or EnumSymbol;
+        => type is StructSymbol or InterfaceSymbol or EnumSymbol
+        || (type is NullableTypeSymbol nullableUserVt && nullableUserVt.UnderlyingType is StructSymbol or InterfaceSymbol or EnumSymbol);
 
     /// <summary>
     /// ADR-0122 §9 / issue #1035: builds a standalone method signature for a

--- a/src/Core/CodeAnalysis/Lowering/Async/AsyncStateMachineTypeBuilder.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AsyncStateMachineTypeBuilder.cs
@@ -115,7 +115,8 @@ public static class AsyncStateMachineTypeBuilder
         sm.StateField = stateField;
 
         var builderFieldType = TypeSymbol.FromClrType(builderInfo.BuilderType);
-        if (kickoff.Type is StructSymbol or InterfaceSymbol or EnumSymbol
+        if ((kickoff.Type is StructSymbol or InterfaceSymbol or EnumSymbol
+                || (kickoff.Type is NullableTypeSymbol nullableUserVt3 && nullableUserVt3.UnderlyingType is StructSymbol or InterfaceSymbol or EnumSymbol))
             && builderInfo.BuilderType is { IsConstructedGenericType: true } builderClrType)
         {
             builderFieldType = ImportedTypeSymbol.GetConstructed(
@@ -230,7 +231,15 @@ public static class AsyncStateMachineTypeBuilder
             inner = kickoff.Type?.ClrType;
             if (inner == null)
             {
-                if (kickoff.Type is StructSymbol or InterfaceSymbol or EnumSymbol)
+                // Issue #1785: a nullable same-compilation user value type
+                // (`UserStruct?`/`UserEnum?`) reaches here too — the
+                // `IsValueType: true` probe above uses `nullable.UnderlyingType.ClrType`,
+                // which is null for a user struct/enum, so it fails to match
+                // and falls through. Erase to `object` the same way the bare
+                // struct/enum case does, using symbol-based detection instead
+                // of the null ClrType.
+                if (kickoff.Type is StructSymbol or InterfaceSymbol or EnumSymbol
+                    || (kickoff.Type is NullableTypeSymbol nullableUserVt2 && nullableUserVt2.UnderlyingType is StructSymbol or InterfaceSymbol or EnumSymbol))
                 {
                     inner = references.MapClrTypeToReferences(typeof(object));
                 }

--- a/test/Compiler.Tests/Emit/Issue1785AsyncNullableUserStructAwaiterEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1785AsyncNullableUserStructAwaiterEmitTests.cs
@@ -1,0 +1,212 @@
+// <copyright file="Issue1785AsyncNullableUserStructAwaiterEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1785: awaiting a <c>Task[T?]</c> where <c>T</c> is a same-
+/// compilation user value type (struct/enum) mistyped the hoisted awaiter
+/// field. <c>TryGetAwaiterTypeSymbol</c> only recognized a bare
+/// <c>StructSymbol</c>/<c>InterfaceSymbol</c>/<c>EnumSymbol</c> type argument,
+/// so a <c>NullableTypeSymbol</c> wrapping a user struct/enum fell through to
+/// <see langword="null"/>, and the awaiter field/local ended up typed
+/// <c>TaskAwaiter&lt;object&gt;</c> instead of the correct
+/// <c>TaskAwaiter&lt;Nullable&lt;T&gt;&gt;</c>. The same narrow predicate
+/// recurred in three other places that also need to agree on the widened
+/// <c>Task&lt;T?&gt;</c> shape: <c>LambdaBinder.WrapAsTask</c> (the async
+/// function's own declared/observable return type), <c>ReflectionMetadataEmitter
+/// .IsAsyncUserDefinedResultType</c> (the kickoff method's real emitted
+/// <c>Task&lt;T&gt;</c> return type), and <c>AsyncStateMachineTypeBuilder</c>'s
+/// <c>ResolveAsyncReturnClrType</c>/<c>Build</c> (the async method builder's
+/// erasure placeholder and the state machine's <c>&lt;&gt;t__builder</c> field
+/// type). All four now use symbol-based detection (a
+/// <c>NullableTypeSymbol</c> whose <c>UnderlyingType</c> is a
+/// <c>StructSymbol</c>/<c>InterfaceSymbol</c>/<c>EnumSymbol</c>) instead of
+/// <c>ClrType.IsValueType</c>, which is <see langword="null"/> for an
+/// in-flight (same-compilation) user type and therefore can't distinguish the
+/// nullable-wrapped case from an ordinary BCL/erased type.
+/// </summary>
+public class Issue1785AsyncNullableUserStructAwaiterEmitTests
+{
+    [Fact]
+    public void Await_Task_Of_NullableUserStruct_Returns_Value()
+    {
+        const string source = """
+            package i1785struct
+            import System
+            import System.Threading.Tasks
+
+            struct Point1785(X int32) { }
+
+            async func inner() Point1785 {
+                return Point1785(42)
+            }
+
+            async func getVal() Point1785? {
+                let v = await inner()
+                return v
+            }
+
+            let opt = getVal().Result
+            let p = opt ?? Point1785(0)
+            Console.WriteLine(p.X)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void Await_Task_Of_NullableUserEnum_Returns_Value()
+    {
+        const string source = """
+            package i1785enum
+            import System
+            import System.Threading.Tasks
+
+            enum Color1785 { Red, Green, Blue }
+
+            async func inner() Color1785 {
+                return Color1785.Green
+            }
+
+            async func getVal() Color1785? {
+                let v = await inner()
+                return v
+            }
+
+            let opt = getVal().Result
+            let r = opt ?? Color1785.Red
+            Console.WriteLine(r)
+            """;
+
+        // G# has no user-defined enum ToString override here, so
+        // Console.WriteLine prints the underlying int32 value (Green = 1).
+        var output = CompileAndRun(source);
+        Assert.Equal("1\n", output);
+    }
+
+    [Fact]
+    public void Await_Task_Of_NullableUserClass_Still_Works()
+    {
+        // Regression guard: a nullable REFERENCE type (`UserClass?`) has the
+        // same CLR shape as the bare class (no `Nullable<T>` wrapper), but its
+        // NullableTypeSymbol also reports a null ClrType during compilation.
+        // The fix must not force reference-type nullables down the
+        // value-type-nullable path; they still need the widened detection so
+        // `WrapAsTask` produces `Task[UserClass?]` instead of falling through
+        // unwrapped.
+        const string source = """
+            package i1785class
+            import System
+            import System.Threading.Tasks
+
+            class Box1785(X int32) { }
+
+            async func inner() Box1785 {
+                return Box1785(42)
+            }
+
+            async func getVal() Box1785? {
+                let v = await inner()
+                return v
+            }
+
+            let opt = getVal().Result
+            let b = opt ?? Box1785(0)
+            Console.WriteLine(b.X)
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1785_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1785.

## Root cause

Awaiting a `Task<T?>` where `T` is a same-compilation user value type (struct or enum) mistyped the hoisted awaiter field as `TaskAwaiter<object>` instead of `TaskAwaiter<Nullable<T>>`. `TryGetAwaiterTypeSymbol` (`ExpressionBinder.Async.cs`) only recognized a bare `StructSymbol`/`InterfaceSymbol`/`EnumSymbol` type argument — a `NullableTypeSymbol` wrapping one of those (whose `ClrType` is also `null` during compilation, exactly like the bare type) fell through unrecognized, so the awaiter mechanism silently degraded to the erased/reflection-resolved shape.

The same narrow predicate recurred in three more locations that all need to agree on the widened `Task<T?>` shape:
- `LambdaBinder.WrapAsTask` — the async function's own declared/observable return type (`Task<T?>` vs. falling through unwrapped, producing "Cannot find member Result" compile errors).
- `ReflectionMetadataEmitter.IsAsyncUserDefinedResultType` — the kickoff method's real emitted `Task<T>` return type (`TryCreateSymbolicAsyncTaskType`).
- `AsyncStateMachineTypeBuilder.ResolveAsyncReturnClrType` / `Build` — the async method builder's erasure placeholder and the state machine's `<>t__builder` field type.

## Fix

All four now use symbol-based detection (`NullableTypeSymbol.UnderlyingType is StructSymbol or InterfaceSymbol or EnumSymbol`) instead of `ClrType.IsValueType`, which is `null` for in-flight user types and can't distinguish the nullable-wrapped case from an ordinary BCL/erased type argument.

**Generalization**: this covers ANY same-compilation user value type (any struct, any enum) wrapped in `Nullable`, in any async awaiter position — not just the struct from the issue repro. It also fixes the identical gap for nullable-wrapped user **classes** (`Task<UserClass?>`), which hit the same four locations (a reference-type nullable shares the bare class's CLR shape but its `NullableTypeSymbol` also reports a null `ClrType` during compilation) — previously `async func f() UserClass?` also failed to widen to `Task[UserClass?]`.

## Tests

Added `test/Compiler.Tests/Emit/Issue1785AsyncNullableUserStructAwaiterEmitTests.cs` with 3 end-to-end emit tests (ilverify-clean + correct runtime value):
- `Await_Task_Of_NullableUserStruct_Returns_Value`
- `Await_Task_Of_NullableUserEnum_Returns_Value`
- `Await_Task_Of_NullableUserClass_Still_Works` (reference-type regression guard)

Run narrowly per repo guidance:
```
dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Release --filter "FullyQualifiedName~Issue1785AsyncNullableUserStructAwaiterEmitTests" -- xUnit.MaxParallelThreads=2
```
→ 3/3 passed.

`dotnet build GSharp.sln -c Release -graph` → 0 errors, 0 warnings.
`dotnet test test/Core.Tests/Core.Tests.csproj -c Release` → 5248 passed, 0 failed, 1 skipped (RegenerateBaseline, expected).

No `samples/*.gs` added and no new SyntaxKind/BoundNodeKind, so the IL baseline (`RefactoringBaselineTests.cs`) did not need regeneration.

## Out of scope (separate pre-existing bug found, not fixed here)

While building an end-to-end repro I found an unrelated, pre-existing bug: awaiting `Task[UserStruct]` (non-nullable, any struct) and assigning the awaited result directly to a local (`let v = await t`) produces invalid IL (`ilverify` `StackUnexpected`: "found ref UserStruct expected value UserStruct") — confirmed via git-stash A/B testing that it reproduces identically on unpatched `main`. This is unrelated to nullability/awaiter typing and is out of scope per the issue; the tests here route around it via an inner non-nullable async helper + widening return, which is itself a legitimate code shape and exercises the #1785 fix end-to-end. Will file a follow-up issue separately.