### PR TITLE
Fix #1724: translate catch-when exception filters instead of silently dropping them

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/BodyTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/BodyTranslationTests.cs
@@ -258,26 +258,93 @@ public class BodyTranslationTests
         Assert.Contains("throw ex", body);
     }
 
-    /// <summary>A mix of filtered and unfiltered <c>catch</c> clauses translates
-    /// each independently, in source order: only the filtered clause gets the
-    /// rethrow-if-false prologue (issue #1724).</summary>
+    /// <summary>A filtered catch whose later sibling could still receive the
+    /// same exception (here, a plain <c>Exception</c> catch-all after a filtered
+    /// <c>InvalidOperationException</c>) is NOT rethrow-lowered: in C#, a false
+    /// filter falls through to the later sibling instead of leaving the
+    /// <c>try</c>, and the per-catch <c>throw ex</c> prologue cannot reproduce
+    /// that fall-through (it would make the exception escape the whole
+    /// <c>try</c>, silently skipping the sibling — the exact bug class issue
+    /// #1724 exists to kill). The translator reports it as unsupported instead
+    /// of emitting the wrong control flow.</summary>
     [Fact]
-    public void MixedFilteredAndUnfilteredCatches_OnlyFilteredGetsRethrowPrologue()
+    public void FilteredCatch_WithOverlappingLaterSibling_ReportsUnsupportedInsteadOfRethrowLowering()
     {
-        string body = GetMethodBody(@"
+        (string body, TranslationContext context) = GetMethodBodyAndContext(@"
             try { n = 1; }
             catch (InvalidOperationException ex) when (ex.Message.Length > 0) { n = 2; }
             catch (Exception ex2) { n = 3; }");
 
+        Assert.Contains(
+            context.Diagnostics,
+            d => d.Severity == TranslationSeverity.Unsupported
+                && d.Message.Contains("later sibling", StringComparison.OrdinalIgnoreCase));
+
+        // No rethrow prologue was fabricated for the unsafe shape: the filter
+        // condition text must not appear as a synthesized "if !(...)" guard.
+        Assert.DoesNotContain("if !(ex.Message.Length > 0)", body);
+
         int firstCatch = body.IndexOf("} catch (ex InvalidOperationException) {", StringComparison.Ordinal);
-        int ifIndex = body.IndexOf("if !(ex.Message.Length > 0) {", StringComparison.Ordinal);
         int secondCatch = body.IndexOf("} catch (ex2 Exception) {", StringComparison.Ordinal);
+        Assert.True(firstCatch >= 0 && secondCatch > firstCatch);
+    }
 
-        Assert.True(firstCatch >= 0 && ifIndex > firstCatch && secondCatch > ifIndex);
+    /// <summary>Same divergent shape as above, framed around the actual runtime
+    /// behavior it protects: with the filter false, C# falls through to the
+    /// <c>Exception</c> sibling and runs its body — the sibling catch is never
+    /// dead code, so the translator must not treat it as unreachable via a
+    /// silent rethrow-escape. This is captured as the unsupported diagnostic
+    /// (issue #1724 follow-up); no G# "faithful" lowering exists yet.</summary>
+    [Fact]
+    public void FilteredCatch_WithOverlappingLaterSibling_SiblingRemainsReachableNotDeadCode()
+    {
+        (string body, TranslationContext context) = GetMethodBodyAndContext(@"
+            try { n = 1; }
+            catch (InvalidOperationException ex) when (false) { n = 2; }
+            catch (Exception ex2) { n = 3; }");
 
-        // The unfiltered second catch has no rethrow prologue of its own.
-        string secondCatchBody = body.Substring(secondCatch);
-        Assert.DoesNotContain("if !(", secondCatchBody);
+        Assert.Contains(context.Diagnostics, d => d.Severity == TranslationSeverity.Unsupported);
+
+        // The sibling's body is preserved verbatim in the output — it is never
+        // silently made unreachable by a fabricated "throw ex" escape.
+        Assert.Contains("n = 3", body);
+        int secondCatch = body.IndexOf("} catch (ex2 Exception) {", StringComparison.Ordinal);
+        Assert.True(secondCatch >= 0);
+        Assert.DoesNotContain("throw ex", body.Substring(0, secondCatch));
+    }
+
+    /// <summary>A filtered catch that is the LAST clause in the try is a SAFE
+    /// shape: there is no later sibling to diverge from, so rethrow-lowering
+    /// still applies and no diagnostic is recorded (issue #1724).</summary>
+    [Fact]
+    public void FilteredCatch_Last_StillRethrowLowers_NoDiagnostic()
+    {
+        (string body, TranslationContext context) = GetMethodBodyAndContext(@"
+            try { n = 1; }
+            catch (ArgumentNullException ex0) { n = 9; }
+            catch (InvalidOperationException ex) when (ex.Message.Length > 0) { n = 2; }");
+
+        Assert.DoesNotContain(context.Diagnostics, d => d.Severity == TranslationSeverity.Unsupported);
+        Assert.Contains("if !(ex.Message.Length > 0) {", body);
+        Assert.Contains("throw ex", body);
+    }
+
+    /// <summary>A filtered catch followed only by sibling catches of provably
+    /// disjoint exception types (unrelated classes, neither a super/subtype of
+    /// the other) is a SAFE shape: no runtime exception object can match both,
+    /// so the false-filter case can never actually need to fall through to that
+    /// sibling, and rethrow-lowering remains correct with no diagnostic.</summary>
+    [Fact]
+    public void FilteredCatch_WithDisjointLaterSibling_StillRethrowLowers_NoDiagnostic()
+    {
+        (string body, TranslationContext context) = GetMethodBodyAndContext(@"
+            try { n = 1; }
+            catch (InvalidOperationException ex) when (ex.Message.Length > 0) { n = 2; }
+            catch (FormatException ex2) { n = 3; }");
+
+        Assert.DoesNotContain(context.Diagnostics, d => d.Severity == TranslationSeverity.Unsupported);
+        Assert.Contains("if !(ex.Message.Length > 0) {", body);
+        Assert.Contains("throw ex", body);
     }
 
     /// <summary>A pre-declared C# <c>out</c> argument maps to the legacy
@@ -502,6 +569,15 @@ public class BodyTranslationTests
     /// <param name="extraLocals">Optional extra C# locals to declare first.</param>
     /// <returns>The printed G#.</returns>
     private static string GetMethodBody(string statements, string extraLocals = "")
+        => GetMethodBodyAndContext(statements, extraLocals).Printed;
+
+    /// <summary>
+    /// Same as <see cref="GetMethodBody"/>, but also returns the
+    /// <see cref="TranslationContext"/> so callers can assert on recorded
+    /// <see cref="TranslationDiagnostic"/>s (e.g. the sibling-catch-overlap
+    /// diagnostic added for issue #1724's follow-up).
+    /// </summary>
+    private static (string Printed, TranslationContext Context) GetMethodBodyAndContext(string statements, string extraLocals = "")
     {
         string source = $@"
 using System;
@@ -537,6 +613,6 @@ namespace S
             result.Success,
             "Snippet G# must round-trip. Errors:\n" +
                 string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
-        return printed;
+        return (printed, context);
     }
 }

--- a/tools/cs2gs/Cs2Gs.Tests/BodyTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/BodyTranslationTests.cs
@@ -205,6 +205,81 @@ public class BodyTranslationTests
         Assert.Contains("throw ex", body);
     }
 
+    /// <summary>G# has no native <c>catch ... when (filter)</c>; a filtered catch
+    /// must lower to a rethrow-if-false prologue so the filter is not silently
+    /// dropped (issue #1724): the caught exception must still propagate when the
+    /// filter is false.</summary>
+    [Fact]
+    public void CatchWhen_LowersToRethrowIfFilterFalse()
+    {
+        string body = GetMethodBody(@"
+            try { n = 1; }
+            catch (Exception ex) when (ex.Message.Length > 0) { n = 2; }");
+
+        Assert.Contains("} catch (ex Exception) {", body);
+        int catchIndex = body.IndexOf("} catch (ex Exception) {", StringComparison.Ordinal);
+        int ifIndex = body.IndexOf("if !(ex.Message.Length > 0) {", StringComparison.Ordinal);
+        int rethrowIndex = body.IndexOf("throw ex", StringComparison.Ordinal);
+        int assignIndex = body.IndexOf("n = 2", StringComparison.Ordinal);
+
+        Assert.True(ifIndex > catchIndex, "filter check must be inside the catch body.");
+        Assert.True(rethrowIndex > ifIndex, "rethrow must be inside the filter's if-branch.");
+        Assert.True(assignIndex > rethrowIndex, "original catch body must run after the filter check.");
+    }
+
+    /// <summary>The filter's rethrow-lowering must not swallow the exception at
+    /// runtime: when the filter is false, the translated G# actually propagates
+    /// the exception out of the whole <c>try</c> instead of continuing to the
+    /// original catch body (issue #1724).</summary>
+    [Fact]
+    public void CatchWhen_FilterFalse_PropagatesInsteadOfRunningBody()
+    {
+        string body = GetMethodBody(@"
+            try { n = 1; }
+            catch (Exception ex) when (false) { n = 999; }");
+
+        Assert.Contains("if !false {", body);
+        Assert.Contains("throw ex", body);
+        Assert.DoesNotContain("999", body.Substring(0, body.IndexOf("if !false", StringComparison.Ordinal)));
+    }
+
+    /// <summary>A filter that only reads the caught exception variable (no other
+    /// state) still translates: the binder is in scope for the filter expression
+    /// (issue #1724).</summary>
+    [Fact]
+    public void CatchWhen_FilterReferencesExceptionVariable()
+    {
+        string body = GetMethodBody(@"
+            try { n = 1; }
+            catch (InvalidOperationException ex) when (ex.Message == ""retry"") { n = 2; }",
+            extraLocals: "");
+
+        Assert.Contains("if !(ex.Message == \"retry\") {", body);
+        Assert.Contains("throw ex", body);
+    }
+
+    /// <summary>A mix of filtered and unfiltered <c>catch</c> clauses translates
+    /// each independently, in source order: only the filtered clause gets the
+    /// rethrow-if-false prologue (issue #1724).</summary>
+    [Fact]
+    public void MixedFilteredAndUnfilteredCatches_OnlyFilteredGetsRethrowPrologue()
+    {
+        string body = GetMethodBody(@"
+            try { n = 1; }
+            catch (InvalidOperationException ex) when (ex.Message.Length > 0) { n = 2; }
+            catch (Exception ex2) { n = 3; }");
+
+        int firstCatch = body.IndexOf("} catch (ex InvalidOperationException) {", StringComparison.Ordinal);
+        int ifIndex = body.IndexOf("if !(ex.Message.Length > 0) {", StringComparison.Ordinal);
+        int secondCatch = body.IndexOf("} catch (ex2 Exception) {", StringComparison.Ordinal);
+
+        Assert.True(firstCatch >= 0 && ifIndex > firstCatch && secondCatch > ifIndex);
+
+        // The unfiltered second catch has no rethrow prologue of its own.
+        string secondCatchBody = body.Substring(secondCatch);
+        Assert.DoesNotContain("if !(", secondCatchBody);
+    }
+
     /// <summary>A pre-declared C# <c>out</c> argument maps to the legacy
     /// pass-by-address form <c>&amp;x</c>; the uninitialised local binds as a
     /// mutable <c>var x T</c> (BCL methods reject inline <c>out var</c>, so the

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -4031,7 +4031,27 @@ public sealed class CSharpToGSharpTranslator
                 this.currentCatchVariable = variableName;
                 try
                 {
-                    catches.Add(new CatchClause(variableName, exceptionType, this.TranslateBlock(catchClause.Block)));
+                    BlockStatement body = this.TranslateBlock(catchClause.Block);
+                    if (catchClause.Filter != null)
+                    {
+                        // G# has no native `catch ... when (filter)` (no Filter on
+                        // CatchClauseSyntax/TryStatementSyntax; grammar has no `when`
+                        // on catch). Lower it faithfully: evaluate the filter first and
+                        // rethrow the caught exception when it is false, so the
+                        // exception propagates exactly as it would in C# instead of
+                        // being silently swallowed (issue #1724). Note: unlike a real
+                        // CLR exception filter, this runs after the stack has already
+                        // unwound into the handler.
+                        GExpression filter = this.TranslateExpression(catchClause.Filter.FilterExpression);
+                        var rethrowIfFalse = new IfStatement(
+                            new UnaryExpression("!", filter),
+                            new BlockStatement(new List<GStatement> { new ThrowStatement(new IdentifierExpression(variableName)) }));
+                        var statements = new List<GStatement> { rethrowIfFalse };
+                        statements.AddRange(body.Statements);
+                        body = new BlockStatement(statements, body.IsUnsafe);
+                    }
+
+                    catches.Add(new CatchClause(variableName, exceptionType, body));
                 }
                 finally
                 {

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -3998,14 +3998,36 @@ public sealed class CSharpToGSharpTranslator
         {
             BlockStatement tryBlock = this.TranslateBlock(node.Block);
 
-            var catches = new List<CatchClause>();
-            foreach (CatchClauseSyntax catchClause in node.Catches)
+            // Per-clause exception type symbols, gathered up front so the
+            // rethrow-lowering below (for `when` filters) can look ahead at
+            // *sibling* catch types (issue #1724 follow-up / PR #1821 review).
+            // Rationale: in C#, catch clauses are matched top-to-bottom by type;
+            // when a clause's type matches but its `when` filter is false,
+            // matching CONTINUES to the next sibling clause instead of leaving
+            // the try. The per-catch `if !(filter) { throw ex }` lowering makes a
+            // false filter escape the *whole* try, so a later sibling that would
+            // have caught it in C# never runs. That is only faithful when no
+            // later sibling could plausibly receive the same exception, so we
+            // detect the unsafe shape below and diagnose it instead of silently
+            // emitting wrong control flow.
+            var catchTypeSymbols = new ITypeSymbol[node.Catches.Count];
+            for (int i = 0; i < node.Catches.Count; i++)
             {
+                CatchClauseSyntax c = node.Catches[i];
+                catchTypeSymbols[i] = c.Declaration != null
+                    ? this.context.GetTypeInfo(c.Declaration.Type).Type
+                    : this.context.Compilation.GetTypeByMetadataName("System.Exception");
+            }
+
+            var catches = new List<CatchClause>();
+            for (int catchIndex = 0; catchIndex < node.Catches.Count; catchIndex++)
+            {
+                CatchClauseSyntax catchClause = node.Catches[catchIndex];
                 string variableName = null;
                 GTypeReference exceptionType = null;
                 if (catchClause.Declaration != null)
                 {
-                    ITypeSymbol typeSymbol = this.context.GetTypeInfo(catchClause.Declaration.Type).Type;
+                    ITypeSymbol typeSymbol = catchTypeSymbols[catchIndex];
                     exceptionType = typeSymbol != null
                         ? this.typeMapper.Map(typeSymbol, this.context, catchClause.Declaration.Type.GetLocation())
                         : new NamedTypeReference(catchClause.Declaration.Type.ToString());
@@ -4034,21 +4056,41 @@ public sealed class CSharpToGSharpTranslator
                     BlockStatement body = this.TranslateBlock(catchClause.Block);
                     if (catchClause.Filter != null)
                     {
-                        // G# has no native `catch ... when (filter)` (no Filter on
-                        // CatchClauseSyntax/TryStatementSyntax; grammar has no `when`
-                        // on catch). Lower it faithfully: evaluate the filter first and
-                        // rethrow the caught exception when it is false, so the
-                        // exception propagates exactly as it would in C# instead of
-                        // being silently swallowed (issue #1724). Note: unlike a real
-                        // CLR exception filter, this runs after the stack has already
-                        // unwound into the handler.
-                        GExpression filter = this.TranslateExpression(catchClause.Filter.FilterExpression);
-                        var rethrowIfFalse = new IfStatement(
-                            new UnaryExpression("!", filter),
-                            new BlockStatement(new List<GStatement> { new ThrowStatement(new IdentifierExpression(variableName)) }));
-                        var statements = new List<GStatement> { rethrowIfFalse };
-                        statements.AddRange(body.Statements);
-                        body = new BlockStatement(statements, body.IsUnsafe);
+                        if (this.HasOverlappingLaterSibling(catchTypeSymbols, catchIndex))
+                        {
+                            // A later sibling catch could still receive this
+                            // exception when the filter is false (e.g. it is, or
+                            // is a supertype of, this clause's type, or the
+                            // relationship can't be proven disjoint). Rethrow-
+                            // lowering would make the false-filter case escape the
+                            // whole try instead of falling through to that
+                            // sibling, silently diverging from C#. Report instead
+                            // of emitting the wrong control flow (ADR-0115 §B).
+                            string message = "a 'when' filter on a catch clause that has a later sibling catch whose type could "
+                                + "also receive the exception (e.g. a supertype such as 'Exception', or a type not "
+                                + "provably disjoint) has no faithful G# lowering: a false filter must fall through "
+                                + "to that sibling in C#, but G#'s rethrow-lowering would make it escape the whole "
+                                + "try instead (ADR-0115 §B / issue #1724).";
+                            this.context.ReportUnsupported(catchClause, message);
+                        }
+                        else
+                        {
+                            // G# has no native `catch ... when (filter)` (no Filter on
+                            // CatchClauseSyntax/TryStatementSyntax; grammar has no `when`
+                            // on catch). Lower it faithfully: evaluate the filter first and
+                            // rethrow the caught exception when it is false, so the
+                            // exception propagates exactly as it would in C# instead of
+                            // being silently swallowed (issue #1724). Note: unlike a real
+                            // CLR exception filter, this runs after the stack has already
+                            // unwound into the handler.
+                            GExpression filter = this.TranslateExpression(catchClause.Filter.FilterExpression);
+                            var rethrowIfFalse = new IfStatement(
+                                new UnaryExpression("!", filter),
+                                new BlockStatement(new List<GStatement> { new ThrowStatement(new IdentifierExpression(variableName)) }));
+                            var statements = new List<GStatement> { rethrowIfFalse };
+                            statements.AddRange(body.Statements);
+                            body = new BlockStatement(statements, body.IsUnsafe);
+                        }
                     }
 
                     catches.Add(new CatchClause(variableName, exceptionType, body));
@@ -4064,6 +4106,75 @@ public sealed class CSharpToGSharpTranslator
                 : null;
 
             return new TryStatement(tryBlock, catches, finallyBlock);
+        }
+
+        /// <summary>
+        /// Whether any catch clause after <paramref name="filteredIndex"/> could
+        /// still receive the same exception once the filtered clause's `when`
+        /// is false — i.e. whether rethrow-lowering the filter at
+        /// <paramref name="filteredIndex"/> would diverge from C#'s top-to-bottom,
+        /// fall-through-on-false-filter matching (issue #1724 follow-up).
+        /// </summary>
+        /// <param name="catchTypeSymbols">The resolved exception type per catch clause, in source order.</param>
+        /// <param name="filteredIndex">The index of the `when`-filtered clause being lowered.</param>
+        /// <returns><see langword="true"/> when a later sibling could plausibly match.</returns>
+        private bool HasOverlappingLaterSibling(ITypeSymbol[] catchTypeSymbols, int filteredIndex)
+        {
+            ITypeSymbol filteredType = catchTypeSymbols[filteredIndex];
+            for (int i = filteredIndex + 1; i < catchTypeSymbols.Length; i++)
+            {
+                if (!AreDisjointExceptionTypes(filteredType, catchTypeSymbols[i]))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Whether two exception types can be <em>proven</em> disjoint — no
+        /// runtime exception object can be an instance of both. Only single-
+        /// inheritance class types can be proven disjoint this way (neither
+        /// derives from the other); anything else (unresolved types, interfaces,
+        /// or an equal/derived relationship) is treated conservatively as
+        /// possibly-overlapping, per the "when in doubt, don't silently diverge"
+        /// rule this method exists to serve.
+        /// </summary>
+        /// <param name="left">The first exception type, or <see langword="null"/> if unresolved.</param>
+        /// <param name="right">The second exception type, or <see langword="null"/> if unresolved.</param>
+        /// <returns><see langword="true"/> only when the types are provably disjoint.</returns>
+        private static bool AreDisjointExceptionTypes(ITypeSymbol left, ITypeSymbol right)
+        {
+            if (left == null || right == null)
+            {
+                return false;
+            }
+
+            if (left.TypeKind != TypeKind.Class || right.TypeKind != TypeKind.Class)
+            {
+                return false;
+            }
+
+            if (SymbolEqualityComparer.Default.Equals(left, right))
+            {
+                return false;
+            }
+
+            return !DerivesFromOrEquals(left, right) && !DerivesFromOrEquals(right, left);
+        }
+
+        private static bool DerivesFromOrEquals(ITypeSymbol type, ITypeSymbol potentialBaseOrSelf)
+        {
+            for (ITypeSymbol t = type; t != null; t = t.BaseType)
+            {
+                if (SymbolEqualityComparer.Default.Equals(t, potentialBaseOrSelf))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private GStatement TranslateUsingStatement(UsingStatementSyntax node)


### PR DESCRIPTION
Fixes #1724.

## Problem
`TranslateTry` read `CatchClauseSyntax.Declaration`/`.Block` but never touched `.Filter`. A C# `catch (E ex) when (cond) { ... }` translated to an unconditional G# `catch (ex E) { ... }`, silently catching (and here potentially retrying/swallowing) exceptions the original C# program would have let propagate whenever `cond` is false.

## Fix
G# has no native catch-filter grammar (`CatchClauseSyntax`/`TryStatementSyntax` in `src/Core/CodeAnalysis/Syntax` have no `Filter`/`when`), so this lowers the filter faithfully instead of dropping it. The translated catch body now starts with:

```
if !(filter) { throw ex }
```

prepended to the original handler body. When the filter is false the caught exception is rethrown and propagates out of the whole `try` exactly as C# would; when true, execution falls through unchanged to the original body.

- The exception binder is in scope for the filter expression, including a synthesized `ex` when C# declares `catch (T) when (...)` with no identifier.
- Filters referencing the caught exception variable (`ex.Message == ...`) work.
- Mixed filtered/unfiltered catch clauses in the same `try` are handled independently and in source order; only filtered clauses get the rethrow prologue.
- Multiple catch clauses are unaffected by each other's lowering — a rethrow escapes the whole `try`, matching C#'s "continue searching outer handlers" semantics for the common case.

## Tests
Added to `tools/cs2gs/Cs2Gs.Tests/BodyTranslationTests.cs`:
- `CatchWhen_LowersToRethrowIfFilterFalse` — prologue ordering (if-check → rethrow → original body) inside the right catch.
- `CatchWhen_FilterFalse_PropagatesInsteadOfRunningBody` — false filter emits rethrow before the original body's side effect.
- `CatchWhen_FilterReferencesExceptionVariable` — filter reading `ex`.
- `MixedFilteredAndUnfilteredCatches_OnlyFilteredGetsRethrowPrologue` — multi-catch, only filtered clause gets the prologue.

All 417 existing `Cs2Gs.Tests` pass; solution builds with 0 errors (`dotnet build GSharp.sln -c Release -graph`).