### PR TITLE
Fix #1817: ProcessRunner external-cancel leak, drain-timeout unobserved fault, stage-4 timeout override

### DIFF
--- a/tools/cs2gs/Cs2Gs.Pipeline/ProcessRunner.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/ProcessRunner.cs
@@ -107,36 +107,70 @@ public static class ProcessRunner
         {
             await process.WaitForExitAsync(linkedCts.Token).ConfigureAwait(false);
         }
-        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
+        catch (OperationCanceledException)
         {
-            timedOut = true;
+            // Either token can fire here (timeout or an external caller
+            // cancellation); either way the child must be killed before we
+            // leave, or it leaks as an orphaned process (#1817 N1).
+            KillTree(process);
+            await DrainOrObserve(stdoutTask, stderrTask).ConfigureAwait(false);
+
+            if (timeoutCts.IsCancellationRequested)
+            {
+                timedOut = true;
+            }
+            else
+            {
+                throw;
+            }
         }
 
         if (timedOut)
         {
-            KillTree(process);
-
-            // The kill closes the child's ends of the pipes, which lets the
-            // pending reads drain and complete; bound the wait so a
-            // stuck grandchild can't re-introduce a hang.
-            await Task.WhenAny(Task.WhenAll(stdoutTask, stderrTask), Task.Delay(TimeSpan.FromSeconds(10)))
-                .ConfigureAwait(false);
-
+            // The kill (above) closes the child's ends of the pipes, which
+            // lets the pending reads drain and complete; DrainOrObserve
+            // already bounded that wait so a stuck grandchild can't
+            // re-introduce a hang.
             string timedOutStderr = SafeResult(stderrTask) +
                 $"{Environment.NewLine}[ProcessRunner] '{fileName}' timed out after {effectiveTimeout} and was killed.";
             return new ProcessRunResult(-1, SafeResult(stdoutTask), timedOutStderr, timedOut: true);
-        }
-
-        if (cancellationToken.IsCancellationRequested)
-        {
-            KillTree(process);
-            cancellationToken.ThrowIfCancellationRequested();
         }
 
         // The process has already exited, so these reads are bounded by the
         // pipes actually closing — this await cannot hang.
         string[] outputs = await Task.WhenAll(stdoutTask, stderrTask).ConfigureAwait(false);
         return new ProcessRunResult(process.ExitCode, outputs[0], outputs[1], timedOut: false);
+    }
+
+    /// <summary>
+    /// Bounds the wait for the stdout/stderr drain tasks to complete after a
+    /// kill, and observes their result/fault either way so that a stuck
+    /// grandchild's pipes (or the eventual <c>using var process</c> disposal
+    /// racing a still-pending read) never produce an unobserved task
+    /// exception once we walk away from the tasks (#1817 N2).
+    /// </summary>
+    private static async Task DrainOrObserve(Task<string> stdoutTask, Task<string> stderrTask)
+    {
+        await Task.WhenAny(Task.WhenAll(stdoutTask, stderrTask), Task.Delay(TimeSpan.FromSeconds(10)))
+            .ConfigureAwait(false);
+
+        // Attach a continuation to any still-pending task so its eventual
+        // fault (e.g. ObjectDisposedException once `process` is disposed) is
+        // observed instead of becoming an unhandled/unobserved task
+        // exception on the finalizer thread.
+        ObserveWhenDone(stdoutTask);
+        ObserveWhenDone(stderrTask);
+    }
+
+    private static void ObserveWhenDone(Task<string> task)
+    {
+        if (task.IsCompleted)
+        {
+            _ = task.Exception;
+            return;
+        }
+
+        _ = task.ContinueWith(t => _ = t.Exception, TaskScheduler.Default);
     }
 
     private static void KillTree(Process process)

--- a/tools/cs2gs/Cs2Gs.Pipeline/TestParityStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TestParityStage.cs
@@ -288,8 +288,22 @@ public sealed class TestParityStage : IMigrationStage
         // translated Console.ReadLine() would otherwise block on inherited
         // stdin. ProcessRunner bounds the run and never inherits stdin (#1748).
         ProcessRunResult result = ProcessRunner.Run(
-            "dotnet", new[] { assemblyPath }, workingDirectory, TimeSpan.FromSeconds(30));
+            "dotnet", new[] { assemblyPath }, workingDirectory, Stage4Timeout());
         return (result.ExitCode, result.Stdout, result.Stderr, result.TimedOut);
+    }
+
+    /// <summary>
+    /// The stage-4 program-under-test timeout, 30s by default. A legit slow
+    /// migrated program on a cold/constrained CI runner can false-positive
+    /// against a fixed 30s, so allow an override via
+    /// <c>CS2GS_STAGE4_TIMEOUT_SEC</c> (#1817 S1).
+    /// </summary>
+    private static TimeSpan Stage4Timeout()
+    {
+        string env = Environment.GetEnvironmentVariable("CS2GS_STAGE4_TIMEOUT_SEC");
+        return int.TryParse(env, out int seconds) && seconds > 0
+            ? TimeSpan.FromSeconds(seconds)
+            : TimeSpan.FromSeconds(30);
     }
 
     private static string EmittedGsRelative(StageExecutionContext context) =>

--- a/tools/cs2gs/Cs2Gs.Tests/ProcessRunnerTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/ProcessRunnerTests.cs
@@ -3,7 +3,9 @@
 // </copyright>
 
 using System;
+using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Cs2Gs.Pipeline;
 using Xunit;
@@ -115,5 +117,98 @@ public class ProcessRunnerTests
         Assert.False(result.TimedOut);
         Assert.Equal(0, result.ExitCode);
         Assert.Equal(string.Empty, result.Stdout);
+    }
+
+    /// <summary>
+    /// #1817 N1: canceling the caller-supplied token (not the timeout) used to
+    /// let <see cref="OperationCanceledException"/> propagate straight past
+    /// the timeout-only catch filter, skipping <c>KillTree</c> entirely and
+    /// leaking the still-running child. The child must be dead by the time
+    /// the exception reaches the caller.
+    /// </summary>
+    [Fact]
+    public async Task Run_ExternalCancellation_ThrowsAndKillsChild()
+    {
+        using var cts = new CancellationTokenSource();
+        const string marker = "gsharp-1817-external-cancel-probe";
+
+        Task<ProcessRunResult> runTask = ProcessRunner.RunAsync(
+            "/bin/sh",
+            new[] { "-c", $": {marker}; sleep 60" },
+            timeout: TimeSpan.FromSeconds(30),
+            cancellationToken: cts.Token);
+
+        // Let the child actually start before cancelling externally, so this
+        // exercises the external-token path rather than racing process start.
+        await Task.Delay(TimeSpan.FromMilliseconds(300));
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => runTask);
+
+        // KillTree runs before the exception is thrown, but reaping is
+        // async relative to our assertion; poll briefly instead of asserting
+        // instantaneously.
+        bool stillRunning = IsProcessRunning(marker);
+        for (int i = 0; i < 20 && stillRunning; i++)
+        {
+            await Task.Delay(100);
+            stillRunning = IsProcessRunning(marker);
+        }
+
+        Assert.False(stillRunning, "External cancellation must kill the child process tree, not leak it.");
+    }
+
+    /// <summary>
+    /// #1817 N2: once the drain-timeout window elapses, <c>using var
+    /// process</c> disposes the stdout/stderr <see cref="System.IO.StreamReader"/>s
+    /// while their read tasks may still be pending, faulting them with
+    /// <see cref="ObjectDisposedException"/>. Left unobserved, that becomes an
+    /// unobserved task exception once the task is garbage collected.
+    /// <see cref="ProcessRunner"/>'s private <c>ObserveWhenDone</c> helper
+    /// must attach a continuation that observes any such late fault.
+    /// </summary>
+    [Fact]
+    public void ObserveWhenDone_LateFaultAfterDrainWindow_IsObservedNotUnobserved()
+    {
+        var pending = new TaskCompletionSource<string>();
+        bool unobserved = false;
+        EventHandler<UnobservedTaskExceptionEventArgs> handler = (_, e) =>
+        {
+            unobserved = true;
+            e.SetObserved();
+        };
+
+        TaskScheduler.UnobservedTaskException += handler;
+        try
+        {
+            System.Reflection.MethodInfo observeWhenDone = typeof(ProcessRunner).GetMethod(
+                "ObserveWhenDone", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+            Assert.NotNull(observeWhenDone);
+            observeWhenDone.Invoke(null, new object[] { pending.Task });
+
+            // Simulate the drain-window expiring and `using var process`
+            // disposing the StreamReader out from under the still-pending read.
+            pending.SetException(new ObjectDisposedException("StreamReader"));
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+        }
+        finally
+        {
+            TaskScheduler.UnobservedTaskException -= handler;
+        }
+
+        Assert.False(unobserved, "A late read-task fault must be observed by ObserveWhenDone, not left to the finalizer.");
+    }
+
+    private static bool IsProcessRunning(string marker)
+    {
+        var psi = new ProcessStartInfo("pgrep") { RedirectStandardOutput = true, UseShellExecute = false };
+        psi.ArgumentList.Add("-f");
+        psi.ArgumentList.Add(marker);
+        using Process pgrep = Process.Start(psi);
+        pgrep.WaitForExit(2000);
+        return pgrep.ExitCode == 0;
     }
 }


### PR DESCRIPTION
Follow-up to #1748/#1816's shared `ProcessRunner`. Fixes two latent robustness bugs flagged in review (no current call site triggers them since none passes a `CancellationToken`, but the shared helper must be correct for future callers) plus one small hardening item.

**N1 — external-cancellation path leaked the child process.** `RunAsync` linked the caller token with an internal timeout token, but the catch was filtered to only handle the timeout case (`when (timeoutCts.IsCancellationRequested)`). An external cancel threw `OperationCanceledException` straight past that filter, so `using var process` disposed without ever calling `KillTree`, leaking the running child. Fixed by catching `OperationCanceledException` unconditionally, killing the process tree in both the timeout and external-cancel cases, then branching on which token actually fired (timeout: return the existing timed-out result; external: rethrow). Removed the now-unreachable dead cancellation check that used to sit after the timeout branch.

**N2 — drain-timeout could leave stdout/stderr read tasks with an unobserved fault.** When the 10s bounded drain expired, control left the method and `using var process` disposed the `StreamReader`s while the read tasks could still be pending, faulting them with `ObjectDisposedException` that nothing observed. Added a small `ObserveWhenDone`/`DrainOrObserve` helper that attaches a continuation to any still-pending read task so its eventual fault is observed instead of surfacing as an unobserved task exception.

**S1 — stage-4 timeout override.** The stage-4 program-under-test timeout was hardcoded at 30s. Added an env-var override, `CS2GS_STAGE4_TIMEOUT_SEC`, so a slow migrated program on a constrained CI runner doesn't false-positive; falls back to the existing 30s default when unset or not a valid positive integer.

**Tests.** Added to `ProcessRunnerTests`:
- `Run_ExternalCancellation_ThrowsAndKillsChild`: cancels the external token against a real `/bin/sh sleep 60` child and verifies (via `pgrep`) it's actually killed, not leaked.
- `ObserveWhenDone_LateFaultAfterDrainWindow_IsObservedNotUnobserved`: deterministically forces the private `ObserveWhenDone` helper's continuation to observe a late `ObjectDisposedException`, asserting no `TaskScheduler.UnobservedTaskException` fires after a forced GC — this pins down the N2 mechanism without depending on a flaky real OS grandchild-escaping-the-process-tree scenario.

**Verification.** Built `Cs2Gs.Pipeline` and `Cs2Gs.Tests` in Release (0 warnings/errors). Ran the full `Cs2Gs.Tests` project: 420/421 passed; the one failure (`Cli_ReportVerb_RegeneratesBothArtifacts`) is pre-existing and unrelated — it needs the separate `cs2gs` CLI executable built, which the narrow build for this change doesn't produce. All 6 `ProcessRunnerTests`, including the two new ones, pass.

Fixes #1817.