### PR TITLE
Fix #1747: ilverify tool crash no longer silently passes stage 3

### DIFF
--- a/tools/cs2gs/Cs2Gs.Pipeline/IlVerifyRunner.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/IlVerifyRunner.cs
@@ -20,7 +20,7 @@ namespace Cs2Gs.Pipeline;
 /// verifier's reference set. All process I/O is local — it only shells out to
 /// <c>dotnet</c>; there is no network egress and no keys.
 /// </summary>
-public sealed class IlVerifyRunner
+public class IlVerifyRunner
 {
     /// <summary>
     /// The environment variable that, when set to <c>1</c>, bypasses IL
@@ -141,7 +141,7 @@ public sealed class IlVerifyRunner
     /// <param name="assemblyPath">The absolute path of the .dll to verify.</param>
     /// <param name="additionalReferences">The app's extra references, or null.</param>
     /// <returns>The verification result (skipped/passed/failed + parsed errors).</returns>
-    public IlVerifyResult Verify(string assemblyPath, IReadOnlyList<string> additionalReferences = null)
+    public virtual IlVerifyResult Verify(string assemblyPath, IReadOnlyList<string> additionalReferences = null)
     {
         if (!IsEnabled)
         {
@@ -175,12 +175,7 @@ public sealed class IlVerifyRunner
 
         IReadOnlyList<IlVerifyError> errors = FilterIgnored(ParseErrors(output));
 
-        if (exit == 0 || errors.Count == 0)
-        {
-            return IlVerifyResult.Passed(output, errors);
-        }
-
-        return IlVerifyResult.Failed(exit, output, errors);
+        return IlVerifyResult.FromRun(exit, output, errors);
     }
 
     /// <summary>
@@ -425,4 +420,21 @@ public sealed class IlVerifyResult
     /// <returns>A failing <see cref="IlVerifyResult"/>.</returns>
     public static IlVerifyResult Failed(int exitCode, string output, IReadOnlyList<IlVerifyError> errors) =>
         new IlVerifyResult(IlVerifyStatus.Failed, exitCode, output, errors);
+
+    /// <summary>
+    /// Decides pass/fail from a completed ilverify run (#1747): exit 0 is the
+    /// only signal ilverify gives for "verified clean" — the <c>-g</c> ignore
+    /// flags plus <see cref="IlVerifyRunner.FilterIgnored"/> already strip known
+    /// false positives before this runs, so a zero exit is trusted as-is. Any
+    /// non-zero exit is a failure, whether or not error lines parsed: a
+    /// tool crash / offline restore / a future ilverify output-format change
+    /// must never be silently swallowed as a pass just because
+    /// <see cref="IlVerifyRunner.ParseErrors"/> found nothing to report.
+    /// </summary>
+    /// <param name="exitCode">The ilverify process exit code.</param>
+    /// <param name="output">The tool's combined stdout+stderr.</param>
+    /// <param name="errors">The parsed, false-positive-filtered errors.</param>
+    /// <returns>A passing or failing <see cref="IlVerifyResult"/>.</returns>
+    public static IlVerifyResult FromRun(int exitCode, string output, IReadOnlyList<IlVerifyError> errors) =>
+        exitCode == 0 ? Passed(output, errors) : Failed(exitCode, output, errors);
 }

--- a/tools/cs2gs/Cs2Gs.Tests/IlVerifyStageTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/IlVerifyStageTests.cs
@@ -134,6 +134,92 @@ public class IlVerifyStageTests
     }
 
     /// <summary>
+    /// #1747 regression: exit 0 is always Passed, regardless of stray parsed
+    /// error lines (the <c>-g</c> ignore flags + <see cref="IlVerifyRunner.FilterIgnored"/>
+    /// already handle known false positives upstream of this decision).
+    /// </summary>
+    [Fact]
+    public void FromRun_ExitZero_IsPassed()
+    {
+        IlVerifyResult result = IlVerifyResult.FromRun(0, "All Classes and Methods Verified.", Array.Empty<IlVerifyError>());
+        Assert.Equal(IlVerifyStatus.Passed, result.Status);
+        Assert.True(result.Succeeded);
+    }
+
+    /// <summary>
+    /// #1747 regression: exit non-zero with real parsed error lines is Failed
+    /// (unchanged behavior).
+    /// </summary>
+    [Fact]
+    public void FromRun_NonZeroExitWithErrors_IsFailed()
+    {
+        var errors = new[] { new IlVerifyError("StackUnexpected", "P::Main(string[])", SampleErrorLine) };
+        IlVerifyResult result = IlVerifyResult.FromRun(1, SampleErrorLine, errors);
+        Assert.Equal(IlVerifyStatus.Failed, result.Status);
+        Assert.False(result.Succeeded);
+    }
+
+    /// <summary>
+    /// #1747: this is the bug's core case — ilverify crashes (or its output
+    /// format no longer matches <see cref="IlVerifyRunner.ParseErrors"/>) and
+    /// exits non-zero with zero parseable error lines. Before the fix this
+    /// silently returned Passed, permanently defeating the gate; it must now
+    /// return Failed so <see cref="IlVerifyStage"/>'s synthetic-artifact
+    /// fallback is reachable.
+    /// </summary>
+    [Fact]
+    public void FromRun_NonZeroExitWithNoParseableErrors_IsFailed_NotSilentlyPassed()
+    {
+        IlVerifyResult result = IlVerifyResult.FromRun(134, "Segmentation fault (core dumped)", Array.Empty<IlVerifyError>());
+        Assert.Equal(IlVerifyStatus.Failed, result.Status);
+        Assert.False(result.Succeeded);
+        Assert.Equal(134, result.ExitCode);
+    }
+
+    /// <summary>
+    /// #1747: when <see cref="IlVerifyRunner.Verify"/> reports a tool-crash
+    /// Failed result (non-zero exit, no parseable errors), the stage must not
+    /// pass silently — it hits the synthetic-artifact fallback in
+    /// <c>IlVerifyStage</c> (ExecuteAsync's <c>artifacts.Count == 0</c> branch)
+    /// and reports <see cref="StageOutcome"/> failed with one synthetic
+    /// <c>ilverify-failure</c> artifact.
+    /// </summary>
+    [Fact]
+    public async Task ExecuteAsync_ToolCrash_FailsStage_WithSyntheticArtifact()
+    {
+        string outRoot = NewOutputRoot("ilverify-tool-crash");
+        var runner = new CrashingIlVerifyRunner();
+        var stage = new IlVerifyStage(runner);
+
+        string fakeAssembly = Path.Combine(outRoot, "App.dll");
+        File.WriteAllBytes(fakeAssembly, Array.Empty<byte>());
+
+        var app = new CorpusApp("corpus/Fake", "/fake/Fake.csproj", TargetKind.Exe);
+        var options = new PipelineOptions { GscPath = "/fake/gsc.dll", OutputRoot = outRoot };
+        var context = new StageExecutionContext(
+            app,
+            options,
+            new GscInvoker(options.GscPath),
+            outRoot,
+            new TriageBuilder("run_1", "2026-06-21T20:00:00Z", "0.2.0+abc", "corpus/Fake"))
+        {
+            EmittedAssemblyPath = fakeAssembly,
+        };
+
+        StageOutcome outcome = await stage.ExecuteAsync(context);
+
+        Assert.Equal(StageStatus.Failed, outcome.Status);
+        TriageArtifact artifact = Assert.Single(outcome.Artifacts);
+        Assert.Equal("ilverify-failure", artifact.Category);
+    }
+
+    private sealed class CrashingIlVerifyRunner : IlVerifyRunner
+    {
+        public override IlVerifyResult Verify(string assemblyPath, IReadOnlyList<string> additionalReferences = null) =>
+            IlVerifyResult.FromRun(134, "Segmentation fault (core dumped)", Array.Empty<IlVerifyError>());
+    }
+
+    /// <summary>
     /// Running the pipeline over <c>corpus/L1-Console</c> passes stage 3
     /// (<c>ilverify</c>) cleanly with zero artifacts: all three stages green and
     /// the stage list now has three entries. Gated on the compiler artifact and


### PR DESCRIPTION
IlVerifyRunner.Verify treated `exit != 0 && errors.Count == 0` as Passed, which made the IlVerifyStage synthetic-failure fallback for tool crashes (IlVerifyStage.cs ~88-96) unreachable dead code. An offline CI run, a never-restored dotnet tool manifest, a corrupted manifest, or a future ilverify output-format change would all exit non-zero with zero parseable `[IL]: Error` lines — and stage 3 would silently green.

Fix: exit code 0 is the only signal ilverify gives for a clean verify (the `-g` ignore flags plus `FilterIgnored` already strip known false positives before this decision runs), so a non-zero exit is now always a failure, whether or not error lines parsed. Added `IlVerifyResult.FromRun(exitCode, output, errors)` implementing that single rule and reused the existing `Failed` status — no new `ToolError` status needed, keeping the change minimal. `IlVerifyRunner.Verify` is now virtual so tests can inject a canned tool-crash result without a real ilverify process or new process-invocation seam.

Tests added (Cs2Gs.Tests/IlVerifyStageTests.cs):
- `FromRun_ExitZero_IsPassed`
- `FromRun_NonZeroExitWithErrors_IsFailed` (regression, unchanged behavior)
- `FromRun_NonZeroExitWithNoParseableErrors_IsFailed_NotSilentlyPassed` (the bug's core case)
- `ExecuteAsync_ToolCrash_FailsStage_WithSyntheticArtifact` — drives `IlVerifyStage` with a fake runner returning a tool-crash `Failed` result and asserts the stage now reports `StageOutcome.Failed` with the synthetic `ilverify-failure` artifact.

Verified: `dotnet build tools/cs2gs/Cs2Gs.Pipeline/Cs2Gs.Pipeline.csproj -c Release` (0 errors), and `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release` — 422/423 passed; the 1 failure (`ReportTests.Cli_ReportVerb_RegeneratesBothArtifacts`, missing `cs2gs.dll` because only the Pipeline project was built, not the whole solution) is pre-existing and unrelated to this change.

Fixes #1747.