### PR TITLE
Fix #1819: recover symbolic generic parameter type for same-compilation struct/enum call arguments

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -691,6 +691,37 @@ internal sealed class ConversionClassifier
                             ?? TryRecoverReceiverTypeParameterSlot(method, paramIndex, receiverType);
                     }
 
+                    // Issue #1819: the argument may already be bound to a
+                    // CONCRETE same-compilation user type (struct/enum,
+                    // possibly `Nullable<T>`-wrapped) rather than a bare
+                    // `TypeParameterSymbol` — e.g. `Task.FromResult(Pt(42))`
+                    // where `Pt` is a same-compilation struct. The closed CLR
+                    // method still erases the generic slot to `object`
+                    // (same-compilation user types have no CLR backing yet),
+                    // but the call is re-instantiated at emit over the REAL
+                    // symbolic type argument recovered from
+                    // `symbolicMethodTypeArgs` (see
+                    // `BoundImportedCallExpression.TypeArgumentSymbols` and its
+                    // consumer `GetMethodEntityHandle`), which produces a
+                    // MethodSpec closed over the real value/enum type — e.g.
+                    // `Task<Pt>::FromResult<Pt>(!!0)`. Left unrecovered, the
+                    // erased `object` target below classifies the argument as
+                    // a boxing conversion and inserts a `box Pt` ahead of a
+                    // call whose actual (symbolically re-closed) signature
+                    // expects the raw value on the stack — an ilverify
+                    // StackUnexpected ("found ref 'Pt' expected value 'Pt'")
+                    // at the call site, and the identical class of bug for
+                    // any consumer of the awaited/returned result (a local,
+                    // a field, a member-access receiver, or a `??` operand)
+                    // since the erroneous `box` already corrupted the value
+                    // flowing out of the call/await before it ever reaches
+                    // those consumers.
+                    if (substituted == null
+                        && TypeSymbol.IsSameCompilationUserTypeTopLevel(argument.Type))
+                    {
+                        substituted = TrySubstituteParameterTypeFromMethodTypeArgs(method, paramIndex, symbolicMethodTypeArgs);
+                    }
+
                     var targetType = substituted ?? TypeSymbol.FromClrType(parameterType);
                     if (argument.Type != targetType
                         && Conversion.Classify(argument.Type, targetType).Exists

--- a/test/Compiler.Tests/Emit/Issue1819AsyncStructResultEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1819AsyncStructResultEmitTests.cs
@@ -1,0 +1,257 @@
+// <copyright file="Issue1819AsyncStructResultEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1819 — awaiting a <c>Task&lt;UserValueType&gt;</c> (a same-compilation
+/// user struct or enum, non-nullable OR nullable) whose CLR type is still
+/// <see langword="null"/> at bind time forced the closed-over-object CLR
+/// signature of the generic BCL method that produced the task (for example
+/// <c>Task.FromResult&lt;T&gt;(T)</c>) to be used for ARGUMENT conversion,
+/// classifying the concrete struct/enum argument as an implicit
+/// value-to-object boxing conversion and inserting a spurious <c>box</c>.
+/// Meanwhile the call is actually re-instantiated at emit over the REAL
+/// symbolic type argument (e.g. <c>Task&lt;Pt&gt;::FromResult&lt;Pt&gt;</c>), whose
+/// MethodSpec expects the raw (unboxed) value on the stack — producing an
+/// ilverify <c>StackUnexpected</c> ("found ref 'X' expected value 'X'") at the
+/// call site. Every downstream consumer of the produced <c>Task&lt;X&gt;</c> (an
+/// awaited local, a field, a member-access receiver, a <c>??</c> operand)
+/// inherits the same corrupted value, since the bug already occurs before the
+/// <c>Task&lt;X&gt;</c> is even constructed.
+/// <para>
+/// The fix teaches <c>ConversionClassifier.BindClrParameterConversions</c> to
+/// recover the real symbolic parameter type (via
+/// <c>TrySubstituteParameterTypeFromMethodTypeArgs</c>) whenever the argument's
+/// OWN bound type is already a concrete same-compilation user type
+/// (<c>TypeSymbol.IsSameCompilationUserTypeTopLevel</c> — struct, enum,
+/// interface, delegate; unwraps <c>Nullable&lt;T&gt;</c>), not just when the
+/// argument is a bare <see cref="GSharp.Core.CodeAnalysis.Symbols.TypeParameterSymbol"/>
+/// or a function literal (the pre-existing #1512/#1540 recoveries). This
+/// keeps the argument an identity conversion (<c>Pt -&gt; Pt</c>, no <c>box</c>),
+/// matching what the emitter's <c>GetMethodEntityHandle</c> actually
+/// instantiates.
+/// </para>
+/// Every facet failed ilverify on current main and passes after the fix. Each
+/// uses a UNIQUE package/type name because the in-process
+/// <c>FunctionTypeSymbol</c> cache is name-keyed.
+/// </summary>
+public class Issue1819AsyncStructResultEmitTests
+{
+    [Fact]
+    public void EndToEnd_AwaitTaskUserStruct_LocalThenFieldAccess_Runs()
+    {
+        // The exact issue #1819 repro shape: `let v = await t; return v.X`.
+        const string source = """
+            package i1819structlocal
+            import System
+            import System.Threading.Tasks
+
+            struct Pt1819A(X int32) { }
+
+            async func getVal() int32 {
+                let t = Task.FromResult(Pt1819A(42))
+                let v = await t
+                return v.X
+            }
+
+            func Main() { System.Console.WriteLine(getVal().Result) }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_AwaitTaskUserStruct_FieldAssignment_Runs()
+    {
+        // Generalization: the awaited struct result is stored directly into a
+        // FIELD (hoisted across the await) rather than a plain local, then
+        // read back via field access — exercises the `TryGetHoistedField`
+        // result-target path alongside the argument-conversion fix.
+        const string source = """
+            package i1819structfield
+            import System
+            import System.Threading.Tasks
+
+            struct Pt1819B(X int32, Y int32) { }
+
+            async func getSum() int32 {
+                var acc = 0
+                let v = await Task.FromResult(Pt1819B(10, 32))
+                acc = v.X + v.Y
+                let v2 = await Task.FromResult(Pt1819B(1, 1))
+                acc = acc + v2.X
+                return acc
+            }
+
+            func Main() { System.Console.WriteLine(getSum().Result) }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("43\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_AwaitTaskUserEnum_UsedDirectlyInBinaryExpression_Runs()
+    {
+        // Generalization: a same-compilation user ENUM (not a struct), and the
+        // awaited result is consumed directly in a binary expression without
+        // ever being assigned to an intermediate local.
+        const string source = """
+            package i1819enumbinary
+            import System
+            import System.Threading.Tasks
+
+            enum Shade1819 { Dim, Mid, Bright }
+
+            async func isBright() bool {
+                let t = Task.FromResult(Shade1819.Bright)
+                return await t == Shade1819.Bright
+            }
+
+            func Main() { System.Console.WriteLine(isBright().Result) }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("True\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_AwaitTaskNullableUserStruct_NullCoalesce_Runs()
+    {
+        // Generalization: a NULLABLE same-compilation user struct
+        // (`Task<Pt?>`), with the awaited result immediately consumed as the
+        // left operand of `??`.
+        const string source = """
+            package i1819nullablecoalesce
+            import System
+            import System.Threading.Tasks
+
+            struct Pt1819C(X int32) { }
+
+            async func getValOrDefault() int32 {
+                let t = Task.FromResult[Pt1819C?](Pt1819C(7))
+                let v = (await t) ?? Pt1819C(0)
+                return v.X
+            }
+
+            func Main() { System.Console.WriteLine(getValOrDefault().Result) }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("7\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_AwaitTaskUserStruct_MemberAccessReceiver_Runs()
+    {
+        // Generalization: the awaited struct result is used directly as the
+        // RECEIVER of a member access (no intermediate local at all).
+        const string source = """
+            package i1819memberaccess
+            import System
+            import System.Threading.Tasks
+
+            struct Pt1819D(X int32) { }
+
+            async func getX() int32 {
+                return (await Task.FromResult(Pt1819D(99))).X
+            }
+
+            func Main() { System.Console.WriteLine(getX().Result) }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("99\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1819_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
## Root cause

Awaiting `Task<UserStruct>` (or a same-compilation user enum) whose CLR type is still `null` at bind time made argument conversion for the generic call that produced the task (e.g. `Task.FromResult<T>(T)`) use the CLOSED, erased-to-`object` CLR parameter type. That classified the concrete struct/enum argument as an implicit boxing conversion, inserting a spurious `box`.

The emitter, however, re-instantiates the call over the REAL symbolic type argument at emit time (e.g. `Task<Pt>::FromResult<Pt>`), whose MethodSpec expects the raw (unboxed) value on the stack. That mismatch — `box` emitted, but the actual token's signature wants a value — is exactly the ilverify `StackUnexpected` (`found ref 'Pt' expected value 'Pt'`) reported in #1819. Every downstream consumer of the resulting `Task<X>` (an awaited local, a field, a member-access receiver, a `??` operand) inherits the same corruption, since it happens before the task is even constructed — matching the issue's observation that the bug surfaces "as soon as the awaited struct value is captured into a local (or even used later via a null-coalescing operator / field access)".

## Fix

`ConversionClassifier.BindClrParameterConversions` already recovers the real symbolic parameter type (via `TrySubstituteParameterTypeFromMethodTypeArgs`) for a couple of specific argument shapes — a bare open `TypeParameterSymbol`, or a function-literal argument (the #1512/#1540 fixes). It generalizes this to ANY argument whose OWN bound type is already a concrete same-compilation user type (`TypeSymbol.IsSameCompilationUserTypeTopLevel` — struct, enum, interface, or delegate; unwraps `Nullable<T>`), which is exactly the #1819 shape (`Pt(42)` passed to `Task.FromResult<T>`). Recovering the symbolic parameter type keeps the argument an identity conversion (`Pt -> Pt`, no `box`), matching what `GetMethodEntityHandle` actually instantiates at emit.

This is a fix to the shared argument-conversion pipeline used by every generic-method call site (static calls, instance calls, extension calls, constructors), so it covers the await path generally, not just `Task.FromResult`.

## Tests

Added `Issue1819AsyncStructResultEmitTests` (compile + ilverify + runtime-output assertions, following the `Issue1502DelegateUserTypeArgEmitTests` pattern) covering:
- The exact repro: `let v = await t; return v.X` for a non-nullable user struct.
- A hoisted result target (assignment across two awaits into a field-backed local, plus arithmetic on the field).
- A same-compilation user enum consumed directly in a binary expression, with no intermediate local.
- A nullable user struct (`Task<Pt?>`) consumed via `??`.
- An awaited struct result used directly as a member-access receiver.

All 5 new tests pass (compile, ilverify-clean, correct runtime output). Ran a wider regression slice narrowly (async/await emit tests + the #1512/#1540/#1471/#1325/#903/#765 conversion-recovery tests in both Compiler.Tests and Core.Tests) — 101 tests total, 0 failures.

Fixes #1819.