### PR TITLE
Fix #1823: route remaining variadic pack sites through #1630 helper

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -2980,28 +2980,28 @@ internal sealed partial class ExpressionBinder
                 var substitutedSlice = substitution != null
                     ? (SliceTypeSymbol)Binder.SubstituteType(sliceType, substitution)
                     : sliceType;
-                var trailingCount = arguments.Length - fixedParamCount;
-                var passThrough = trailingCount == 1 && arguments[fixedParamCount].Type == substitutedSlice;
-                if (passThrough)
-                {
-                    permutedArgs = arguments;
-                }
-                else
-                {
-                    var packedTrailing = ImmutableArray.CreateBuilder<BoundExpression>(trailingCount);
-                    for (var i = fixedParamCount; i < arguments.Length; i++)
-                    {
-                        packedTrailing.Add(arguments[i]);
-                    }
+                var hasVariadicErrors = false;
 
-                    var newArgs = ImmutableArray.CreateBuilder<BoundExpression>(fixedParamCount + 1);
-                    for (var i = 0; i < fixedParamCount; i++)
-                    {
-                        newArgs.Add(arguments[i]);
-                    }
+                // Issue #1823: route through the #1630 canonical helper so
+                // trailing elements get the same per-element coercion applied
+                // at every other variadic pack site (previously packed raw,
+                // uncoerced elements here). Coerce against the SUBSTITUTED
+                // slice's element type since generic type arguments may have
+                // been inferred/substituted above.
+                permutedArgs = OverloadResolver.PackOrPassThroughVariadicArguments(
+                    conversions,
+                    Diagnostics,
+                    ce,
+                    arguments,
+                    fixedParamCount,
+                    substitutedSlice,
+                    variadicParam.Name,
+                    i => i < ce.Arguments.Count ? ce.Arguments[i].Location : ce.Identifier.Location,
+                    ref hasVariadicErrors);
 
-                    newArgs.Add(new BoundArrayCreationExpression(ce, substitutedSlice, packedTrailing.MoveToImmutable()));
-                    permutedArgs = newArgs.ToImmutable();
+                if (hasVariadicErrors)
+                {
+                    return new BoundErrorExpression(null);
                 }
             }
             else

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -3843,24 +3843,27 @@ internal sealed partial class ExpressionBinder
         if (fldIsVariadic)
         {
             var sliceType = (SliceTypeSymbol)functionType.ParameterTypes[functionType.ParameterTypes.Length - 1];
-            var trailing = arguments.Length - fldFixedCount;
-            var passThrough = trailing == 1 && arguments[fldFixedCount].Type == sliceType;
-            if (!passThrough)
+            var hasVariadicErrors = false;
+
+            // Issue #1823: route through the #1630 canonical helper so
+            // trailing elements get the same per-element coercion applied
+            // at every other variadic pack site (previously packed raw,
+            // uncoerced elements here).
+            permutedArgs = OverloadResolver.PackOrPassThroughVariadicArguments(
+                conversions,
+                Diagnostics,
+                ce,
+                arguments,
+                fldFixedCount,
+                sliceType,
+                methodName,
+                i => i < ce.Arguments.Count ? ce.Arguments[i].Location : ce.Location,
+                ref hasVariadicErrors);
+
+            if (hasVariadicErrors)
             {
-                var packed = ImmutableArray.CreateBuilder<BoundExpression>(trailing);
-                for (var i = fldFixedCount; i < arguments.Length; i++)
-                {
-                    packed.Add(arguments[i]);
-                }
-
-                var rebuilt = ImmutableArray.CreateBuilder<BoundExpression>(fldFixedCount + 1);
-                for (var i = 0; i < fldFixedCount; i++)
-                {
-                    rebuilt.Add(arguments[i]);
-                }
-
-                rebuilt.Add(new BoundArrayCreationExpression(ce, sliceType, packed.MoveToImmutable()));
-                permutedArgs = rebuilt.ToImmutable();
+                result = new BoundErrorExpression(null);
+                return true;
             }
         }
 
@@ -4271,24 +4274,26 @@ internal sealed partial class ExpressionBinder
         {
             var variadicParam = delegateSym.Parameters[delegateSym.Parameters.Length - 1];
             var sliceType = (SliceTypeSymbol)variadicParam.Type;
-            var trailingCount = arguments.Length - fixedParamCount;
-            var passThrough = trailingCount == 1 && arguments[fixedParamCount].Type == sliceType;
-            if (!passThrough)
+            var hasVariadicErrors = false;
+
+            // Issue #1823: route through the #1630 canonical helper so
+            // trailing elements get the same per-element coercion applied
+            // at every other variadic pack site (previously packed raw,
+            // uncoerced elements here).
+            permutedArgs = OverloadResolver.PackOrPassThroughVariadicArguments(
+                conversions,
+                Diagnostics,
+                ce,
+                arguments,
+                fixedParamCount,
+                sliceType,
+                variadicParam.Name,
+                i => i < ce.Arguments.Count ? ce.Arguments[i].Location : ce.Location,
+                ref hasVariadicErrors);
+
+            if (hasVariadicErrors)
             {
-                var packed = ImmutableArray.CreateBuilder<BoundExpression>(trailingCount);
-                for (var i = fixedParamCount; i < arguments.Length; i++)
-                {
-                    packed.Add(arguments[i]);
-                }
-
-                var rebuilt = ImmutableArray.CreateBuilder<BoundExpression>(fixedParamCount + 1);
-                for (var i = 0; i < fixedParamCount; i++)
-                {
-                    rebuilt.Add(arguments[i]);
-                }
-
-                rebuilt.Add(new BoundArrayCreationExpression(ce, sliceType, packed.MoveToImmutable()));
-                permutedArgs = rebuilt.ToImmutable();
+                return new BoundErrorExpression(null);
             }
         }
 

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -477,7 +477,9 @@ internal sealed class OverloadResolver
     /// conversion exists. This keeps overload applicability and final coercion in
     /// agreement with the non-variadic / array-literal element paths.
     /// </summary>
-    private BoundExpression CoerceVariadicElement(
+    internal static BoundExpression CoerceVariadicElement(
+        ConversionClassifier conversions,
+        DiagnosticBag diagnostics,
         BoundExpression argument,
         TypeSymbol elementType,
         TextLocation location,
@@ -515,7 +517,7 @@ internal sealed class OverloadResolver
             return udc;
         }
 
-        Diagnostics.ReportWrongArgumentType(location, parameterName, elementType, argType);
+        diagnostics.ReportWrongArgumentType(location, parameterName, elementType, argType);
         hasErrors = true;
         return argument;
     }
@@ -540,6 +542,8 @@ internal sealed class OverloadResolver
     /// duplicated by hand at each call site, and two copies had drifted to
     /// pack raw, uncoerced elements).
     /// </summary>
+    /// <param name="conversions">The conversion classifier used to bind per-element coercions; issue #1823 promotes this from an instance field to a parameter so <see cref="ExpressionBinder"/> call sites can share this helper.</param>
+    /// <param name="diagnostics">The diagnostic bag that receives GS0154 when an element has no valid conversion; issue #1823 promotes this from an instance property to a parameter for the same reason.</param>
     /// <param name="callSyntax">The syntax node attributed to the packed <see cref="BoundArrayCreationExpression"/> when packing is required.</param>
     /// <param name="boundArguments">The fully-bound, in-order argument list; length must be at least <paramref name="fixedCount"/>.</param>
     /// <param name="fixedCount">The number of leading fixed (non-variadic) parameters.</param>
@@ -548,7 +552,9 @@ internal sealed class OverloadResolver
     /// <param name="locationAt">Maps a trailing argument's index in <paramref name="boundArguments"/> to the source location used for its conversion diagnostics.</param>
     /// <param name="hasErrors">Set to <see langword="true"/> when any trailing element has no valid conversion to the slice's element type.</param>
     /// <returns>An argument list of length <paramref name="fixedCount"/> + 1 whose final element is either the pass-through argument or the packed array.</returns>
-    private ImmutableArray<BoundExpression> PackOrPassThroughVariadicArguments(
+    internal static ImmutableArray<BoundExpression> PackOrPassThroughVariadicArguments(
+        ConversionClassifier conversions,
+        DiagnosticBag diagnostics,
         SyntaxNode callSyntax,
         ImmutableArray<BoundExpression> boundArguments,
         int fixedCount,
@@ -577,6 +583,8 @@ internal sealed class OverloadResolver
         for (var i = fixedCount; i < boundArguments.Length; i++)
         {
             packed.Add(CoerceVariadicElement(
+                conversions,
+                diagnostics,
                 boundArguments[i],
                 elementType,
                 locationAt(i),
@@ -2757,6 +2765,8 @@ internal sealed class OverloadResolver
             // the canonical helper (applies #1493 element coercion when
             // packing).
             var packedArgs = PackOrPassThroughVariadicArguments(
+                conversions,
+                Diagnostics,
                 syntax,
                 boundArguments.ToImmutable(),
                 fixedPrimaryCount,
@@ -3200,6 +3210,8 @@ internal sealed class OverloadResolver
                 // canonical helper (applies #1493 element coercion).
                 var hasVariadicErrors = false;
                 var packedArgs = PackOrPassThroughVariadicArguments(
+                    conversions,
+                    Diagnostics,
                     syntax,
                     boundArguments.ToImmutable(),
                     fixedCtorParamCount,
@@ -4037,6 +4049,8 @@ internal sealed class OverloadResolver
             var sliceType = (SliceTypeSymbol)functionType.ParameterTypes[functionType.Arity - 1];
             var hasElementErrors = false;
             permutedArgs = PackOrPassThroughVariadicArguments(
+                conversions,
+                Diagnostics,
                 syntax,
                 boundArguments,
                 fixedCount,
@@ -4638,6 +4652,8 @@ internal sealed class OverloadResolver
                 var fnSliceType = (SliceTypeSymbol)fnType.ParameterTypes[fnType.Arity - 1];
                 var hasFnElementErrors = false;
                 fnPermutedArgs = PackOrPassThroughVariadicArguments(
+                    conversions,
+                    Diagnostics,
                     syntax,
                     fnPermutedArgs,
                     fnFixedCount,
@@ -4709,6 +4725,8 @@ internal sealed class OverloadResolver
                 var ndSliceType = (SliceTypeSymbol)ndVariadicParam.Type;
                 var hasNdElementErrors = false;
                 ndPermutedArgs = PackOrPassThroughVariadicArguments(
+                    conversions,
+                    Diagnostics,
                     syntax,
                     ndPermutedArgs,
                     ndFixedCount,
@@ -5346,6 +5364,8 @@ internal sealed class OverloadResolver
             // Issue #1630: pack/pass-through through the canonical helper
             // (applies #1493 element coercion when packing).
             var packedArgs = PackOrPassThroughVariadicArguments(
+                conversions,
+                Diagnostics,
                 syntax,
                 boundArguments.ToImmutable(),
                 fixedParamCount,
@@ -5884,6 +5904,8 @@ internal sealed class OverloadResolver
                 // #1493 element coercion).
                 var hasVariadicErrors = false;
                 permutedArguments = PackOrPassThroughVariadicArguments(
+                    conversions,
+                    Diagnostics,
                     ce,
                     permutedArguments,
                     fixedCallableParamCount,

--- a/test/Compiler.Tests/Emit/Issue1823VariadicRemainingSitesEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1823VariadicRemainingSitesEmitTests.cs
@@ -1,0 +1,183 @@
+// <copyright file="Issue1823VariadicRemainingSitesEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1823 — follow-up to #1630. That fix extracted
+/// <c>PackOrPassThroughVariadicArguments</c> in <c>OverloadResolver</c> and
+/// routed the 7 variadic pack sites there through it, but three sibling
+/// sites OUTSIDE <c>OverloadResolver</c> still packed raw, uncoerced trailing
+/// elements: a struct field of function type invoked directly
+/// (<c>TryBindUserStructDelegateFieldInvocation</c>), a named-CLR-delegate
+/// <c>.Invoke(args)</c> call (<c>BindNamedDelegateInvokeCall</c>), and a
+/// generic static method fallback with type-argument substitution
+/// (<c>BindUserTypeStaticCall</c>). Each case below packs an <c>int32</c>
+/// element into a variadic <c>...int64</c> slot — a widening conversion the
+/// #1493/#1630 per-element coercion is supposed to guarantee — and asserts
+/// the widened value is actually observed at runtime (not merely that the
+/// call compiles/verifies).
+/// </summary>
+public class Issue1823VariadicRemainingSitesEmitTests
+{
+    [Fact]
+    public void EndToEnd_StructFieldOfFunctionTypeDirectCall_CoercesElementsToInt64_Runs()
+    {
+        var source = """
+            package Probe1823a
+            import System
+
+            class Container1823a {
+                var callback (...int64) -> int64
+
+                init(cb (...int64) -> int64) {
+                    this.callback = cb
+                }
+            }
+
+            func Main() {
+                let cb (...int64) -> int64 = (xs) -> xs[0] + xs[1] + xs[2]
+                let c = Container1823a(cb)
+                Console.WriteLine(c.callback(1, 2, 3))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("6\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_NamedDelegateInvokeMemberCall_CoercesElementsToInt64_Runs()
+    {
+        var source = """
+            package Probe1823b
+            import System
+
+            type LongSumDelegate1823 = delegate func(xs ...int64) int64
+
+            func Main() {
+                var s LongSumDelegate1823 = (xs) -> xs[0] + xs[1] + xs[2]
+                Console.WriteLine(s.Invoke(1, 2, 3))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("6\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_GenericStaticMethodFallbackWithSubstitution_CoercesElementsToInt64_Runs()
+    {
+        var source = """
+            package Probe1823c
+            import System
+
+            class Utils1823c {
+                shared {
+                    func First[T any](xs ...T) T {
+                        return xs[0]
+                    }
+                }
+            }
+
+            func Main() {
+                var a int32 = 1
+                var b int32 = 2
+                var c int32 = 3
+                Console.WriteLine(Utils1823c.First[int64](a, b, c))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("1\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1823_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to #1630/#1822. That fix extracted `PackOrPassThroughVariadicArguments` (and its `CoerceVariadicElement` helper) in `OverloadResolver.cs` and routed the 7 variadic pack sites there through it, applying per-element coercion for the #1493 drift (raw uncoerced elements packed into a variadic array producing a wrong-typed array / IL `StackUnexpected`).

Three sibling call sites outside `OverloadResolver` still packed raw, uncoerced elements — same bug class:

- `ExpressionBinder.Calls.cs`: `TryBindUserStructDelegateFieldInvocation` (a struct field of function type invoked directly, e.g. `instance.callback(1, 2, 3)`)
- `ExpressionBinder.Calls.cs`: `BindNamedDelegateInvokeCall` (a named-CLR-delegate `.Invoke(args)` member call)
- `ExpressionBinder.Access.cs`: `BindUserTypeStaticCall` (a generic static method fallback with type-argument substitution — element type is derived from the SUBSTITUTED slice, not the open type parameter)

**Fix:** promoted `PackOrPassThroughVariadicArguments`/`CoerceVariadicElement` from `private` to `internal static`, threading the `ConversionClassifier` and `DiagnosticBag` in as parameters instead of reading instance state, so `ExpressionBinder` can call the same canonical helper. All three sites now route through it, preserving each site's existing pass-through-vs-pack decision. The 7 existing `OverloadResolver` callers are unchanged (just pass `conversions`/`Diagnostics` explicitly now). Grepped the binder for every remaining `passThrough`/raw-pack shape after the change — none left outside the shared helper.

**Tests:** added `Issue1823VariadicRemainingSitesEmitTests.cs` with one emit test per fixed path, each packing an `int32` element into a `...int64` variadic slot and asserting compile + ilverify-clean + correct runtime output. Verified all three reproduce the pre-fix `StackUnexpected` failure (via temporarily reverting the source changes) and pass post-fix.

**Verification:**
- `dotnet build GSharp.sln -c Release -graph` → 0 errors
- New tests: 3/3 pass
- `~Issue1823 | ~Issue1630 | ~Variadic` (Compiler.Tests): 38/38 pass
- `~Overload | ~Call` (Compiler.Tests, regression slice): 224/224 pass
- `~Variadic` (Core.Tests): 89/89 pass

Fixes #1823.