### PR TITLE
Fix #1727: cs2gs reorders named/mixed call arguments into declaration order

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue1727NamedArgumentReorderTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1727NamedArgumentReorderTranslationTests.cs
@@ -135,6 +135,81 @@ namespace Demo
         Assert.NotNull(unit);
     }
 
+    /// <summary>
+    /// A named argument at a leading parameter's own position combined with a
+    /// <c>params</c> parameter used in EXPANDED form (C# 7.2+) makes several
+    /// arguments share the SAME <c>Parameter.Ordinal</c> (the params
+    /// parameter's). This must not crash the translator (previously an
+    /// unguarded <c>ToDictionary</c> threw on the duplicate key); since source
+    /// order already agrees with declaration order here, it is emitted
+    /// unchanged.
+    /// </summary>
+    [Fact]
+    public void NamedArgument_WithExpandedParams_DoesNotCrash_EmitsSourceOrder()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public void Foo(int x, params int[] rest) { }
+
+        public void Caller()
+        {
+            Foo(x: 0, 1, 2, 3);
+        }
+    }
+}");
+        Assert.Contains("Foo(0, 1, 2, 3)", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Skipping a MIDDLE optional parameter (not just a leading one) must
+    /// still dense-fill the gap from the parameter's own default.
+    /// </summary>
+    [Fact]
+    public void NamedArgument_SkipsMiddleOptionalParameter_FillsDefault()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public void Foo(int a = 1, int b = 2, int c = 3) { }
+
+        public void Caller()
+        {
+            Foo(a: 1, c: 5);
+        }
+    }
+}");
+        Assert.Contains("Foo(1, 2, 5)", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Sanity baseline: an all-positional call into a <c>params</c> parameter
+    /// (no named arguments at all) is untouched by the named-argument reorder
+    /// path and keeps its correct, unchanged output.
+    /// </summary>
+    [Fact]
+    public void AllPositionalArguments_WithParams_TranslateUnchanged()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public void Foo(int x, params int[] rest) { }
+
+        public void Caller()
+        {
+            Foo(1, 2, 3);
+        }
+    }
+}");
+        Assert.Contains("Foo(1, 2, 3)", printed, StringComparison.Ordinal);
+    }
+
     private static string TranslateUnit(string source)
     {
         (CompilationUnit unit, _) = Translate(source);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1727NamedArgumentReorderTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1727NamedArgumentReorderTranslationTests.cs
@@ -1,0 +1,163 @@
+// <copyright file="Issue1727NamedArgumentReorderTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #1727: <c>TranslateArgument</c> never read <c>ArgumentSyntax.NameColon</c>,
+/// and every call site emitted <c>invocation.ArgumentList.Arguments</c> in SYNTAX
+/// order. G# has no named-argument call syntax, so <c>Foo(b: 2, a: 1)</c> was
+/// silently emitted as <c>Foo(2, 1)</c> — the arguments swapped — and
+/// <c>Foo(c: 5)</c> against a method with leading optional parameters bound
+/// <c>5</c> to the FIRST parameter. The fix reorders named/mixed argument lists
+/// into parameter DECLARATION order using the semantic model
+/// (<c>IArgumentOperation.Parameter</c>), filling any skipped optional parameter
+/// with its default value, and refuses to reorder (reporting Unsupported instead)
+/// when doing so would change the observable evaluation order of a
+/// potentially side-effecting argument.
+/// </summary>
+public class Issue1727NamedArgumentReorderTranslationTests
+{
+    [Fact]
+    public void NamedArguments_OutOfDeclarationOrder_AreReorderedPositionally()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public void Foo(int a, int b) { }
+
+        public void Caller()
+        {
+            Foo(b: 2, a: 1);
+        }
+    }
+}");
+        Assert.Contains("Foo(1, 2)", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("Foo(2, 1)", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NamedArgument_SkipsLeadingOptionalParameters_FillsDefaults()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public void Foo(int a = 1, int b = 2, int c = 3) { }
+
+        public void Caller()
+        {
+            Foo(c: 5);
+        }
+    }
+}");
+        Assert.Contains("Foo(1, 2, 5)", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NamedArguments_AlreadyInDeclarationOrder_TranslateUnchanged()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public void Foo(int a, int b) { }
+
+        public void Caller()
+        {
+            Foo(a: 1, b: 2);
+        }
+    }
+}");
+        Assert.Contains("Foo(1, 2)", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MixedPositionalAndNamedArguments_ReorderCorrectly()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public void Foo(int a, int b, int c) { }
+
+        public void Caller()
+        {
+            Foo(1, c: 3, b: 2);
+        }
+    }
+}");
+        Assert.Contains("Foo(1, 2, 3)", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Reordering named arguments that carry a method call (a potential side
+    /// effect) relative to declaration order must not silently change C#'s
+    /// lexical evaluation order: the translator reports Unsupported rather than
+    /// emit a reordered call that could observably differ from the source.
+    /// </summary>
+    [Fact]
+    public void NamedArguments_ReorderingSideEffectingCalls_ReportsUnsupported()
+    {
+        (CompilationUnit unit, TranslationContext context) = Translate(@"
+namespace Demo
+{
+    public class C
+    {
+        public void Foo(int a, int b) { }
+
+        public int NextA() => 1;
+
+        public int NextB() => 2;
+
+        public void Caller()
+        {
+            Foo(b: NextB(), a: NextA());
+        }
+    }
+}");
+        Assert.Contains(context.Diagnostics, d => d.Severity == TranslationSeverity.Unsupported
+            && d.Message.Contains("issue #1727", StringComparison.OrdinalIgnoreCase));
+        Assert.NotNull(unit);
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        (CompilationUnit unit, _) = Translate(source);
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+
+    private static (CompilationUnit Unit, TranslationContext Context) Translate(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        return (unit, context);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -2257,9 +2257,7 @@ public sealed class CSharpToGSharpTranslator
                     // form `init(params) : base(args) { ... }` (sample
                     // ExplicitConstructor.gs; ADR-0115 §B.13). This is how a custom
                     // exception forwards its message to System.Exception's ctor.
-                    baseArguments = node.Initializer.ArgumentList.Arguments
-                        .Select(a => this.TranslateArgument(a))
-                        .ToList();
+                    baseArguments = this.TranslateArguments(node.Initializer.ArgumentList.Arguments);
                 }
                 else
                 {
@@ -2276,7 +2274,7 @@ public sealed class CSharpToGSharpTranslator
             {
                 var delegated = new ExpressionStatement(new InvocationExpression(
                     new IdentifierExpression("init"),
-                    node.Initializer.ArgumentList.Arguments.Select(a => this.TranslateArgument(a)).ToList()));
+                    this.TranslateArguments(node.Initializer.ArgumentList.Arguments)));
                 var statements = new List<GStatement> { delegated };
                 statements.AddRange(body.Statements);
                 body = new BlockStatement(statements);
@@ -7414,9 +7412,7 @@ public sealed class CSharpToGSharpTranslator
                     { MethodKind: MethodKind.DelegateInvoke }
                 && TryGetDelegateInvokeReceiver(invocation.Expression, out GExpression invokeTarget))
             {
-                var invokeArguments = invocation.ArgumentList.Arguments
-                    .Select(a => this.TranslateArgument(a))
-                    .ToList();
+                var invokeArguments = this.TranslateArguments(invocation.ArgumentList.Arguments);
                 return new InvocationExpression(invokeTarget, invokeArguments, null);
             }
 
@@ -7432,7 +7428,7 @@ public sealed class CSharpToGSharpTranslator
                 {
                     this.TranslateExpression(extMember.Expression),
                 };
-                extArgs.AddRange(invocation.ArgumentList.Arguments.Select(a => this.TranslateArgument(a)));
+                extArgs.AddRange(this.TranslateArguments(invocation.ArgumentList.Arguments));
                 IReadOnlyList<GTypeReference> extTypeArgs = extMember.Name is GenericNameSyntax extGeneric
                     ? this.MapTypeArguments(extGeneric)
                     : null;
@@ -7492,9 +7488,7 @@ public sealed class CSharpToGSharpTranslator
                 target = this.TranslateExpression(invocation.Expression);
             }
 
-            var arguments = invocation.ArgumentList.Arguments
-                .Select(a => this.TranslateArgument(a))
-                .ToList();
+            var arguments = this.TranslateArguments(invocation.ArgumentList.Arguments);
 
             // Directly invoking a nullable-reference delegate field/property
             // (`handler(args)` where `handler` is `((T) -> R)?`) needs a `!!`
@@ -7597,7 +7591,7 @@ public sealed class CSharpToGSharpTranslator
             {
                 new NonNullAssertionExpression(receiver),
             };
-            callArgs.AddRange(invocation.ArgumentList.Arguments.Select(a => this.TranslateArgument(a)));
+            callArgs.AddRange(this.TranslateArguments(invocation.ArgumentList.Arguments));
             IReadOnlyList<GTypeReference> callTypeArgs = binding.Name is GenericNameSyntax generic
                 ? this.MapTypeArguments(generic)
                 : null;
@@ -7657,6 +7651,175 @@ public sealed class CSharpToGSharpTranslator
         /// the address-of form <c>&amp;x</c>, an inline <c>out var x</c> maps to
         /// <c>out var x</c>, and an <c>out _</c> discard maps to <c>out _</c>.
         /// </summary>
+        // Issue #1727: G# has no named-argument call syntax, so a C# argument list
+        // that uses `name:` must be translated into pure declaration-order
+        // positional form. `Foo(b: 2, a: 1)` was previously emitted in SYNTAX order
+        // (`Foo(2, 1)`) — silently swapping the arguments — and a skipped optional
+        // parameter (`Foo(c: 5)` skipping `a`/`b`) bound the value to the FIRST
+        // parameter instead of `c`. The fast path (no named arguments) is
+        // untouched: it is the overwhelming majority of call sites and must not
+        // change behavior or cost.
+        private List<GExpression> TranslateArguments(SeparatedSyntaxList<ArgumentSyntax> arguments)
+        {
+            if (!arguments.Any(a => a.NameColon != null))
+            {
+                return arguments.Select(a => this.TranslateArgument(a)).ToList();
+            }
+
+            return this.TranslateNamedArguments(arguments);
+        }
+
+        // Reorders a named/mixed argument list into parameter DECLARATION order
+        // (the only order a positional G# call can express), filling any optional
+        // parameter skipped by the named arguments with its default value.
+        //
+        // C# evaluates call-site arguments in LEXICAL (source) order and binds by
+        // name only afterward. Reordering into declaration order therefore changes
+        // observable evaluation order when a moved argument may have a side effect
+        // (a method call, object creation, assignment, increment, or await) — so
+        // that case is reported unsupported instead of silently reordering side
+        // effects (a source-order fallback is emitted so translation still
+        // produces compiling, if diagnostically-flagged, output).
+        private List<GExpression> TranslateNamedArguments(SeparatedSyntaxList<ArgumentSyntax> arguments)
+        {
+            var resolved = new List<(ArgumentSyntax Syntax, IParameterSymbol Parameter)>();
+            foreach (ArgumentSyntax argument in arguments)
+            {
+                if (this.context.SemanticModel.GetOperation(argument) is not IArgumentOperation operation ||
+                    operation.Parameter == null)
+                {
+                    string message = "a named argument could not be resolved to a parameter via the semantic " +
+                        "model; emitted in source order, which may mis-bind (issue #1727).";
+                    this.context.ReportUnsupported(argument, message);
+                    return arguments.Select(a => this.TranslateArgument(a)).ToList();
+                }
+
+                resolved.Add((argument, operation.Parameter));
+            }
+
+            for (int i = 0; i < resolved.Count; i++)
+            {
+                for (int j = i + 1; j < resolved.Count; j++)
+                {
+                    // resolved is in lexical (source) order by construction, so i < j
+                    // is "before" lexically; declaration order disagrees whenever the
+                    // ordinals are not increasing in the same direction.
+                    bool declarationOrderAgrees = resolved[i].Parameter.Ordinal < resolved[j].Parameter.Ordinal;
+                    if (!declarationOrderAgrees &&
+                        (IsPotentiallySideEffecting(resolved[i].Syntax.Expression) ||
+                            IsPotentiallySideEffecting(resolved[j].Syntax.Expression)))
+                    {
+                        string message = "named arguments reorder potentially side-effecting expressions " +
+                            "relative to C#'s lexical evaluation order; no side-effect-preserving G# lowering " +
+                            "yet (issue #1727).";
+                        this.context.ReportUnsupported(resolved[i].Syntax, message);
+                        return arguments.Select(a => this.TranslateArgument(a)).ToList();
+                    }
+                }
+            }
+
+            Dictionary<int, ArgumentSyntax> byOrdinal = resolved.ToDictionary(r => r.Parameter.Ordinal, r => r.Syntax);
+            int maxOrdinal = resolved.Max(r => r.Parameter.Ordinal);
+            IMethodSymbol invokedMethod = resolved[0].Parameter.ContainingSymbol as IMethodSymbol;
+
+            var result = new List<GExpression>();
+            for (int ordinal = 0; ordinal <= maxOrdinal; ordinal++)
+            {
+                if (byOrdinal.TryGetValue(ordinal, out ArgumentSyntax explicitArgument))
+                {
+                    result.Add(this.TranslateArgument(explicitArgument));
+                    continue;
+                }
+
+                IParameterSymbol skippedParameter = invokedMethod != null && ordinal < invokedMethod.Parameters.Length
+                    ? invokedMethod.Parameters[ordinal]
+                    : null;
+                GExpression fillerDefault = this.BuildSkippedNamedArgumentDefault(skippedParameter, arguments);
+                if (fillerDefault == null)
+                {
+                    return arguments.Select(a => this.TranslateArgument(a)).ToList();
+                }
+
+                result.Add(fillerDefault);
+            }
+
+            return result;
+        }
+
+        // Computes the positional filler for an optional parameter that a named
+        // argument list skipped, or `null` (after reporting Unsupported) when no
+        // faithful G# value can be emitted: a caller-info parameter
+        // ([CallerMemberName]/[CallerLineNumber]/[CallerFilePath]/
+        // [CallerArgumentExpression]) needs the value the C# compiler substitutes
+        // at THIS call site, which the parameter's own default does not carry, and
+        // a non-literal default (a `const` field, an enum member, etc.) has no
+        // simple literal form (mirrors the declaration-side limitation already
+        // accepted in BuildOptionalParameterDefault).
+        private GExpression BuildSkippedNamedArgumentDefault(IParameterSymbol skippedParameter, SeparatedSyntaxList<ArgumentSyntax> arguments)
+        {
+            if (skippedParameter == null)
+            {
+                string message = "a named argument list skips a parameter that could not be resolved via the " +
+                    "semantic model (issue #1727).";
+                this.context.ReportUnsupported(arguments.First(), message);
+                return null;
+            }
+
+            bool hasCallerInfo = skippedParameter.GetAttributes().Any(a => a.AttributeClass?.Name is
+                "CallerMemberNameAttribute" or "CallerLineNumberAttribute" or
+                "CallerFilePathAttribute" or "CallerArgumentExpressionAttribute");
+            if (hasCallerInfo)
+            {
+                string message = $"named argument list skips caller-info parameter '{skippedParameter.Name}'; " +
+                    "its call-site-substituted value has no faithful G# positional form yet (issue #1727).";
+                this.context.ReportUnsupported(arguments.First(), message);
+                return null;
+            }
+
+            GTypeReference parameterType = this.typeMapper.Map(
+                skippedParameter.Type,
+                this.context,
+                skippedParameter.Locations.FirstOrDefault());
+            GExpression fillerDefault = this.BuildOptionalParameterDefault(skippedParameter, parameterType);
+            if (fillerDefault == null)
+            {
+                string message = $"named argument list skips parameter '{skippedParameter.Name}' whose default " +
+                    "value is not a simple literal; no faithful G# positional form yet (issue #1727).";
+                this.context.ReportUnsupported(arguments.First(), message);
+            }
+
+            return fillerDefault;
+        }
+
+        // Conservative "no observable side effect" check used only to decide
+        // whether reordering a named argument into declaration position is safe
+        // (issue #1727). A bare literal or a plain identifier/member-access chain
+        // that never invokes anything reads state without changing it; everything
+        // else (calls, object creation, assignment, increment/decrement, await,
+        // and — conservatively — any operator, since it may be an overloaded
+        // operator with side effects) is treated as potentially side-effecting.
+        private static bool IsPotentiallySideEffecting(ExpressionSyntax expression)
+        {
+            switch (expression)
+            {
+                case null:
+                case LiteralExpressionSyntax:
+                case IdentifierNameSyntax:
+                case ThisExpressionSyntax:
+                case PredefinedTypeSyntax:
+                    return false;
+                case ParenthesizedExpressionSyntax parenthesized:
+                    return IsPotentiallySideEffecting(parenthesized.Expression);
+                case MemberAccessExpressionSyntax memberAccess:
+                    return IsPotentiallySideEffecting(memberAccess.Expression);
+                case PrefixUnaryExpressionSyntax prefixUnary
+                    when prefixUnary.IsKind(SyntaxKind.UnaryMinusExpression) || prefixUnary.IsKind(SyntaxKind.UnaryPlusExpression):
+                    return IsPotentiallySideEffecting(prefixUnary.Operand);
+                default:
+                    return true;
+            }
+        }
+
         private GExpression TranslateArgument(ArgumentSyntax argument)
         {
             SyntaxKind refKind = argument.RefKindKeyword.Kind();
@@ -7865,9 +8028,7 @@ public sealed class CSharpToGSharpTranslator
 
             var arguments = creation.ArgumentList == null
                 ? new List<GExpression>()
-                : creation.ArgumentList.Arguments
-                    .Select(a => this.TranslateArgument(a))
-                    .ToList();
+                : this.TranslateArguments(creation.ArgumentList.Arguments);
 
             // A C# delegate creation `new SomeDelegate(target)` wraps a method
             // group, lambda, or another delegate in a named delegate type. G# has
@@ -8427,9 +8588,7 @@ public sealed class CSharpToGSharpTranslator
 
             var arguments = creation.ArgumentList == null
                 ? new List<GExpression>()
-                : creation.ArgumentList.Arguments
-                    .Select(a => this.TranslateArgument(a))
-                    .ToList();
+                : this.TranslateArguments(creation.ArgumentList.Arguments);
 
             bool hasCtorArgs = arguments.Count > 0;
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -7718,6 +7718,40 @@ public sealed class CSharpToGSharpTranslator
                 }
             }
 
+            // A `params` parameter used in EXPANDED form (e.g. `Foo(x: 0, 1, 2, 3)`
+            // for `Foo(int x, params int[] rest)`) makes several arguments share
+            // the SAME `Parameter.Ordinal` (the params parameter's), which a plain
+            // `ToDictionary` throws on. Source order already agrees with
+            // declaration order whenever ordinals are non-decreasing in source
+            // order (the common/legal case, since C# forbids a positional
+            // argument from following a named one that skipped ahead) — that
+            // needs no reordering at all, so just pass it through. Anything else
+            // sharing an ordinal cannot be faithfully expressed as a dense
+            // ordinal->argument map; report unsupported instead of crashing.
+            bool ordinalsNonDecreasing = true;
+            for (int i = 1; i < resolved.Count; i++)
+            {
+                if (resolved[i].Parameter.Ordinal < resolved[i - 1].Parameter.Ordinal)
+                {
+                    ordinalsNonDecreasing = false;
+                    break;
+                }
+            }
+
+            bool hasDuplicateOrdinal = resolved.Select(r => r.Parameter.Ordinal).Distinct().Count() != resolved.Count;
+            if (hasDuplicateOrdinal)
+            {
+                if (ordinalsNonDecreasing)
+                {
+                    return arguments.Select(a => this.TranslateArgument(a)).ToList();
+                }
+
+                string message = "named arguments combined with a params argument in expanded form cannot be " +
+                    "faithfully reordered (issue #1727).";
+                this.context.ReportUnsupported(resolved[0].Syntax, message);
+                return arguments.Select(a => this.TranslateArgument(a)).ToList();
+            }
+
             Dictionary<int, ArgumentSyntax> byOrdinal = resolved.ToDictionary(r => r.Parameter.Ordinal, r => r.Syntax);
             int maxOrdinal = resolved.Max(r => r.Parameter.Ordinal);
             IMethodSymbol invokedMethod = resolved[0].Parameter.ContainingSymbol as IMethodSymbol;


### PR DESCRIPTION
`TranslateArgument(ArgumentSyntax)` never read `argument.NameColon`, and every call site emitted `invocation.ArgumentList.Arguments` in syntax order. G# has no named-argument call syntax, so `Foo(b: 2, a: 1)` was silently emitted as `Foo(2, 1)` (arguments swapped, no diagnostic), and `Foo(c: 5)` against a method with optional leading parameters bound `5` to the FIRST parameter.

## Fix

Added `TranslateArguments`/`TranslateNamedArguments`, used at every call site that previously did `invocation.ArgumentList.Arguments.Select(a => TranslateArgument(a))` (invocations, extension-method/enum-extension rewrites, conditional-access `?.` calls, delegate-`Invoke` calls, object creation, target-typed `new()`, and `base(...)`/`this(...)` constructor initializers):

- No named arguments present → unchanged fast path (pure syntax-order translation, zero behavior/perf change for the overwhelming majority of calls).
- Named/mixed arguments present → each argument is resolved to its target `IParameterSymbol` via `SemanticModel.GetOperation(argument) as IArgumentOperation` (the same shape `TargetsConcreteNumericParameter` already used for issue #1281), then reordered into parameter **declaration** order.
- A skipped optional parameter is filled with its default value by reusing `BuildOptionalParameterDefault` (the existing declaration-side default-value translator).
- A skipped caller-info parameter (`[CallerMemberName]`/`[CallerLineNumber]`/`[CallerFilePath]`/`[CallerArgumentExpression]`) or a default with no simple-literal form reports `Unsupported` instead of emitting a wrong value.
- **Evaluation-order safety:** C# evaluates arguments in lexical (source) order, then binds by name. Reordering into declaration order could change observable evaluation order if a moved argument has a side effect. So if reordering would change the relative order of two arguments where either is potentially side-effecting (anything beyond a literal or a bare identifier/member-access chain — a method call, object creation, assignment, increment, or await), the translator reports `Unsupported` and falls back to the previous syntax-order emission (now diagnostically flagged) rather than silently reordering side effects.

## Tests

Added `Issue1727NamedArgumentReorderTranslationTests` (5 cases): out-of-declaration-order named args reordered positionally, a skipped optional parameter filled with its default, named args already in declaration order translate unchanged, mixed positional+named args reordered correctly, and reordering side-effecting named arguments reports `Unsupported`.

## Verification

- `dotnet build tools/cs2gs/Cs2Gs.Translator/Cs2Gs.Translator.csproj -c Release` — 0 errors.
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release` — 436 passed, 1 failed (`ReportTests.Cli_ReportVerb_RegeneratesBothArtifacts`, pre-existing/unrelated: requires `cs2gs.dll` from a full solution build, not built by this targeted run).

Fixes #1727