### PR TITLE
Fix #1749: stage-4 test parity false-green modes

### DIFF
--- a/tools/cs2gs/Cs2Gs.Pipeline/CorpusDiscovery.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/CorpusDiscovery.cs
@@ -6,6 +6,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Xml;
+using System.Xml.Linq;
 
 namespace Cs2Gs.Pipeline;
 
@@ -123,16 +125,43 @@ public static class CorpusDiscovery
             File.Exists(baseline) ? baseline : null);
     }
 
+    /// <summary>
+    /// Reads the effective <c>&lt;OutputType&gt;</c> from an SDK-style csproj by
+    /// parsing it as XML (issue #1749 mode 3): a substring match on the literal
+    /// text <c>&lt;OutputType&gt;Exe&lt;/OutputType&gt;</c> silently
+    /// misclassifies any benign reformat (added whitespace/attributes,
+    /// <c>WinExe</c>) as <c>Library</c>, which flips <c>gsc</c> to
+    /// <c>/target:library</c> and drops stdout-parity verification entirely. A
+    /// project can declare <c>&lt;OutputType&gt;</c> in more than one (possibly
+    /// conditioned) <c>PropertyGroup</c>; the last element in document order
+    /// wins, approximating MSBuild's last-one-wins evaluation.
+    /// </summary>
+    /// <param name="projectPath">The <c>.csproj</c> path.</param>
+    /// <returns>
+    /// <see cref="TargetKind.Exe"/> for <c>Exe</c>/<c>WinExe</c> (both produce a
+    /// runnable executable); <see cref="TargetKind.Library"/> for
+    /// <c>Library</c> or a missing/unrecognized value.
+    /// </returns>
     private static TargetKind ReadTargetKind(string projectPath)
     {
         try
         {
-            string text = File.ReadAllText(projectPath);
-            return text.Contains("<OutputType>Exe</OutputType>", StringComparison.OrdinalIgnoreCase)
+            XDocument doc = XDocument.Load(projectPath);
+            string outputType = doc.Descendants()
+                .Where(e => string.Equals(e.Name.LocalName, "OutputType", StringComparison.OrdinalIgnoreCase))
+                .Select(e => e.Value?.Trim())
+                .LastOrDefault(v => !string.IsNullOrEmpty(v));
+
+            return string.Equals(outputType, "Exe", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(outputType, "WinExe", StringComparison.OrdinalIgnoreCase)
                 ? TargetKind.Exe
                 : TargetKind.Library;
         }
         catch (IOException)
+        {
+            return TargetKind.Library;
+        }
+        catch (XmlException)
         {
             return TargetKind.Library;
         }

--- a/tools/cs2gs/Cs2Gs.Pipeline/GsharpTestProjectRunner.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/GsharpTestProjectRunner.cs
@@ -192,11 +192,14 @@ public class GsharpTestProjectRunner
         // restore always fails and library parity is silently disabled. Pass
         // the repo `nuget.config` explicitly so restore finds the feed
         // regardless of where the scaffold lives.
+        // `dotnet test` forwards unrecognized args to MSBuild's VSTest target,
+        // and MSBuild has no `--configfile` switch (that's a `dotnet restore`/
+        // `dotnet nuget` only switch) - it fails hard with MSB1001. The
+        // MSBuild-property form works for build/restore/test alike.
         string repoNugetConfig = Path.Combine(this.RepoRoot, "nuget.config");
         if (File.Exists(repoNugetConfig))
         {
-            args.Add("--configfile");
-            args.Add(repoNugetConfig);
+            args.Add($"-p:RestoreConfigFile={repoNugetConfig}");
         }
 
         (int exit, string output) = this.RunDotnet(args, workDir);

--- a/tools/cs2gs/Cs2Gs.Pipeline/GsharpTestProjectRunner.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/GsharpTestProjectRunner.cs
@@ -37,7 +37,7 @@ public enum GsharpTestRunStatus
 /// root so the repo-shared build (Nerdbank.GitVersioning, StyleCop) does not
 /// apply to the generated G# project.
 /// </summary>
-public sealed class GsharpTestProjectRunner
+public class GsharpTestProjectRunner
 {
     private const string SdkPackageId = "Gsharp.NET.Sdk";
     private const string SdkPackagePrefix = SdkPackageId + ".";
@@ -115,7 +115,7 @@ public sealed class GsharpTestProjectRunner
     /// <param name="project">The translated G# test project to build and run.</param>
     /// <param name="workDir">The directory to scaffold the project under.</param>
     /// <returns>The run result (build status, output, TRX path, parsed outcomes).</returns>
-    public GsharpTestRunResult Run(GsharpTestProject project, string workDir)
+    public virtual GsharpTestRunResult Run(GsharpTestProject project, string workDir)
     {
         if (project is null)
         {
@@ -172,7 +172,7 @@ public sealed class GsharpTestProjectRunner
             File.Delete(trxPath);
         }
 
-        var args = new[]
+        var args = new List<string>
         {
             "test",
             testsProjectPath,
@@ -183,6 +183,21 @@ public sealed class GsharpTestProjectRunner
             "--results-directory",
             trxDir,
         };
+
+        // Issue #1749 mode 1: the generated project is scaffolded under
+        // `workDir`, which NuGet restore reaches by walking *up* from looking
+        // for `nuget.config`. When `--output` places `workDir` outside the repo
+        // (a non-default `OutputRoot`), that walk never finds the repo
+        // `nuget.config` that points restore at the local `.nugs` feed, so
+        // restore always fails and library parity is silently disabled. Pass
+        // the repo `nuget.config` explicitly so restore finds the feed
+        // regardless of where the scaffold lives.
+        string repoNugetConfig = Path.Combine(this.RepoRoot, "nuget.config");
+        if (File.Exists(repoNugetConfig))
+        {
+            args.Add("--configfile");
+            args.Add(repoNugetConfig);
+        }
 
         (int exit, string output) = this.RunDotnet(args, workDir);
 

--- a/tools/cs2gs/Cs2Gs.Pipeline/IMigrationStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/IMigrationStage.cs
@@ -172,9 +172,23 @@ public sealed class StageOutcome
     /// <summary>Gets the triage artifacts the stage produced (empty on success).</summary>
     public IReadOnlyList<TriageArtifact> Artifacts { get; }
 
-    /// <summary>Creates a passing outcome with no artifacts.</summary>
+    /// <summary>
+    /// Creates a passing outcome with no artifacts.
+    /// </summary>
     /// <returns>A passing <see cref="StageOutcome"/>.</returns>
     public static StageOutcome Passed() => new StageOutcome(StageStatus.Passed, Array.Empty<TriageArtifact>());
+
+    /// <summary>
+    /// Creates a skipped outcome (issue #1749 mode 1): the stage ran but a
+    /// verification it depends on is genuinely unavailable (e.g. no
+    /// locally-built SDK, or a downstream translation step that has not landed
+    /// yet) — "not verified", distinct from both <see cref="Passed"/> ("verified
+    /// green") and <see cref="Failed"/> ("verified and broke"). Never use this
+    /// for a build/test that ran and broke; that is a real regression and must
+    /// be reported <see cref="Failed"/>.
+    /// </summary>
+    /// <returns>A skipped <see cref="StageOutcome"/>.</returns>
+    public static StageOutcome Skipped() => new StageOutcome(StageStatus.Skipped, Array.Empty<TriageArtifact>());
 
     /// <summary>Creates a failing outcome carrying the supplied artifacts.</summary>
     /// <param name="artifacts">The triage artifacts that describe the failure.</param>

--- a/tools/cs2gs/Cs2Gs.Pipeline/MigrationPipeline.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/MigrationPipeline.cs
@@ -274,6 +274,23 @@ public sealed class MigrationPipeline
                 continue;
             }
 
+            if (outcome.Status == StageStatus.Skipped)
+            {
+                // "Not verified" (issue #1749): a genuinely-unavailable
+                // dependency (no locally-built SDK, a translation step not
+                // implemented yet) is neither a pass nor a failure. It must not
+                // render as green, so it gets its own status rather than
+                // StageStatus.Passed, but it also does not fail the app or
+                // short-circuit later stages.
+                appResult.Stages.Add(new StageResult
+                {
+                    Stage = stageName,
+                    Status = "skipped",
+                    ArtifactCount = 0,
+                });
+                continue;
+            }
+
             IReadOnlyList<TriageArtifact> written = this.WriteArtifacts(
                 outcome.Artifacts, appRunDir, runDir, priorHistory, appResult);
 

--- a/tools/cs2gs/Cs2Gs.Pipeline/MigrationStageKind.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/MigrationStageKind.cs
@@ -48,7 +48,13 @@ public enum TriageCategory
 /// </summary>
 public enum StageStatus
 {
-    /// <summary>The stage did not run (a prior stage failed and short-circuited it).</summary>
+    /// <summary>
+    /// The stage was not verified: either it did not run (a prior stage failed
+    /// and short-circuited it), or it ran but a dependency it needs to verify
+    /// (e.g. a locally-built SDK, or a not-yet-implemented translation step) is
+    /// genuinely unavailable. Distinct from <see cref="Passed"/> — "not
+    /// verified" must never render as "verified green" (issue #1749).
+    /// </summary>
     Skipped,
 
     /// <summary>The stage ran and its pass gate held.</summary>

--- a/tools/cs2gs/Cs2Gs.Pipeline/StdoutParity.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/StdoutParity.cs
@@ -51,13 +51,27 @@ public static class StdoutParity
     }
 
     /// <summary>
-    /// Normalizes captured text the same way as the L1 end-to-end test: CRLF→LF
-    /// and exactly one trailing newline.
+    /// Normalizes captured text the same way as the L1 end-to-end test: CRLF→LF,
+    /// then tolerate exactly one unavoidable terminal newline. Issue #1749 mode
+    /// 2: <c>TrimEnd('\n')</c> strips *every* trailing newline, so
+    /// <c>"a\n\n\n"</c> and <c>"a\n"</c> normalized equal — a migrated program
+    /// that gains/loses trailing blank lines would falsely byte-parity-match.
+    /// Stripping at most one trailing newline before re-appending one keeps
+    /// that single terminal newline tolerated while any extra trailing blank
+    /// line still registers as a real difference.
     /// </summary>
     /// <param name="text">The text to normalize (null treated as empty).</param>
     /// <returns>The normalized text.</returns>
-    public static string Normalize(string text) =>
-        (text ?? string.Empty).Replace("\r\n", "\n").TrimEnd('\n') + "\n";
+    public static string Normalize(string text)
+    {
+        string normalized = (text ?? string.Empty).Replace("\r\n", "\n");
+        if (normalized.EndsWith("\n", StringComparison.Ordinal))
+        {
+            normalized = normalized.Substring(0, normalized.Length - 1);
+        }
+
+        return normalized + "\n";
+    }
 }
 
 /// <summary>

--- a/tools/cs2gs/Cs2Gs.Pipeline/TestParityStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TestParityStage.cs
@@ -170,8 +170,10 @@ public sealed class TestParityStage : IMigrationStage
 
         if (tests.PendingReason is not null)
         {
+            // Gated intentionally (ADR-0115 §E) until test-translation lands —
+            // "not verified yet", never a fabricated pass (issue #1749).
             this.Note(context, "library xUnit parity SKIPPED: " + tests.PendingReason);
-            return StageOutcome.Passed();
+            return StageOutcome.Skipped();
         }
 
         BaselineTestsOracle oracle = BaselineTestsOracle.Load(context.App.TestsBaselinePath);
@@ -194,16 +196,25 @@ public sealed class TestParityStage : IMigrationStage
 
         if (run.Status == GsharpTestRunStatus.Unavailable)
         {
+            // The SDK/tooling this verification needs is genuinely absent (no
+            // locally-built Gsharp.NET.Sdk nupkg) — "not verified", not a pass
+            // (issue #1749 mode 1).
             this.Note(context, "library xUnit parity SKIPPED: " + run.UnavailableReason);
-            return StageOutcome.Passed();
+            return StageOutcome.Skipped();
         }
 
         if (run.Status == GsharpTestRunStatus.BuildFailed)
         {
-            string buildNote = "library xUnit parity SKIPPED: the translated G# test project did not build " +
-                "(test-translation pending map-advanced).\n" + Truncate(run.Output);
+            // A library that green-built standalone `gsc` in stage 2 but fails
+            // to build its translated G# test project here is a real
+            // regression, not "translation pending" — report it as a failure
+            // (issue #1749 mode 1), never a fabricated pass.
+            string buildNote = "library xUnit parity FAILED: the translated G# test project did not build.\n" +
+                Truncate(run.Output);
             this.Note(context, buildNote);
-            return StageOutcome.Passed();
+            TriageArtifact buildArtifact = context.Triage.TestParityLibraryBuildFailure(
+                run.Output, EmittedGsRelative(context));
+            return StageOutcome.Failed(new[] { buildArtifact });
         }
 
         TestParityResult parity = TestParityComparison.Compare(oracle.Tests, run.Results);

--- a/tools/cs2gs/Cs2Gs.Pipeline/TriageBuilder.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TriageBuilder.cs
@@ -403,6 +403,54 @@ public sealed class TriageBuilder
         return artifact;
     }
 
+    /// <summary>
+    /// Builds a stage-4 <c>test-parity-failure</c> artifact for a library app
+    /// whose translated G# test project failed to build against the
+    /// locally-built <c>Gsharp.NET.Sdk</c> (issue #1749 mode 1). A library that
+    /// green-built standalone with <c>gsc</c> in stage 2 but fails to build here
+    /// is a real regression — the SDK/build surface broke, not "not verified
+    /// yet" — so this is reported as a failure, never a skip. The diagnostic id
+    /// is <c>LIBRARY-BUILD-FAILED</c>; the message is the tail of the captured
+    /// <c>dotnet test</c> output.
+    /// </summary>
+    /// <param name="output">The captured <c>dotnet test</c> output (already truncated by the caller).</param>
+    /// <param name="gsFile">The emitted G# library file (relative path), or null.</param>
+    /// <returns>The populated triage artifact.</returns>
+    public TriageArtifact TestParityLibraryBuildFailure(string output, string gsFile = null)
+    {
+        string message = string.IsNullOrWhiteSpace(output) ? "(no build output captured)" : output.Trim();
+
+        var artifact = this.NewArtifact(MigrationStageKind.TestParity, TriageCategory.TestParityFailure);
+        artifact.Diagnostic = new TriageDiagnostic
+        {
+            Id = "LIBRARY-BUILD-FAILED",
+            Message = message,
+            Severity = "error",
+        };
+        artifact.SourceLocation = new TriageSourceLocation
+        {
+            GsFile = gsFile,
+            GsLine = null,
+            GsColumn = null,
+            CsFile = null,
+            CsLine = null,
+            CsColumn = null,
+        };
+        artifact.OffendingCSharpConstruct = new TriageOffendingConstruct
+        {
+            Kind = "LibraryBuild",
+            Snippet = Truncate(message),
+        };
+        artifact.Fingerprint = Fingerprint.Compute(
+            artifact.Category,
+            artifact.Stage,
+            artifact.Diagnostic.Id,
+            artifact.OffendingCSharpConstruct.Kind,
+            artifact.OffendingCSharpConstruct.Snippet);
+        artifact.SuggestedIssue = this.TestParityIssue(artifact);
+        return artifact;
+    }
+
     private static (string File, int? Line, int? Column, string Snippet) ResolveCSharpLocation(Location location)
     {
         if (location is null || !location.IsInSource)
@@ -608,6 +656,7 @@ public sealed class TriageBuilder
         string title = $"[cs2gs] test-parity {artifact.Diagnostic.Id} in migrated {this.CorpusAppId} " +
             $"({artifact.OffendingCSharpConstruct.Kind})";
         bool isStdout = string.Equals(artifact.Diagnostic.Id, "STDOUT-MISMATCH", StringComparison.Ordinal);
+        bool isBuildFailure = string.Equals(artifact.Diagnostic.Id, "LIBRARY-BUILD-FAILED", StringComparison.Ordinal);
         string repro = isStdout
             ? "**Reproduction:** `cs2gs migrate` translates the corpus app, compiles it with `gsc`, runs the " +
                 "produced program, and compares its stdout to `baseline.stdout.golden`."
@@ -620,6 +669,8 @@ public sealed class TriageBuilder
             $"- Failure: `{artifact.Diagnostic.Id}`",
             $"- Detail: {artifact.Diagnostic.Message}",
             isStdout ? "- This is a behavioral divergence: the program compiled but produced different output." :
+                isBuildFailure ? "- This is a build regression: the app compiled with `gsc` in stage 2 but the " +
+                    "translated G# test project failed to build against the locally-built SDK here." :
                 $"- Failing test: `{artifact.OffendingCSharpConstruct.Kind}`",
             string.Empty,
             repro,

--- a/tools/cs2gs/Cs2Gs.Tests/CorpusDiscoveryTargetKindTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/CorpusDiscoveryTargetKindTests.cs
@@ -1,0 +1,111 @@
+// <copyright file="CorpusDiscoveryTargetKindTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Regression tests for issue #1749 mode 3: <c>CorpusDiscovery.ReadTargetKind</c>
+/// used to match the literal substring <c>&lt;OutputType&gt;Exe&lt;/OutputType&gt;</c>,
+/// so any benign reformat (extra whitespace, an attribute, <c>WinExe</c>)
+/// silently reclassified the app as <see cref="TargetKind.Library"/>, which
+/// flips <c>gsc</c> to <c>/target:library</c> and — because stdout-parity
+/// requires <see cref="TargetKind.Exe"/> — drops stdout-parity verification
+/// entirely. The fix parses the csproj as XML instead.
+/// </summary>
+public class CorpusDiscoveryTargetKindTests
+{
+    [Theory]
+    [InlineData("<OutputType>Exe</OutputType>", TargetKind.Exe)]
+    [InlineData("<OutputType> Exe </OutputType>", TargetKind.Exe)]
+    [InlineData("<OutputType>WinExe</OutputType>", TargetKind.Exe)]
+    [InlineData("<OutputType>exe</OutputType>", TargetKind.Exe)]
+    [InlineData("<OutputType>Library</OutputType>", TargetKind.Library)]
+    [InlineData("", TargetKind.Library)]
+    [InlineData("<OutputType Condition=\"'$(Configuration)'=='Debug'\">Exe</OutputType>", TargetKind.Exe)]
+    public void Discover_ClassifiesTargetKind_FromParsedOutputType(string outputTypeElement, TargetKind expected)
+    {
+        string appDir = NewScratchApp("MyApp", outputTypeElement);
+
+        CorpusApp app = Assert.Single(CorpusDiscovery.Discover(Path.GetDirectoryName(appDir)));
+
+        Assert.Equal(expected, app.TargetKind);
+    }
+
+    /// <summary>
+    /// The old literal substring match's exact failure cases (formatting or a
+    /// <c>WinExe</c> variant) must now classify as <see cref="TargetKind.Exe"/>,
+    /// not silently fall back to <see cref="TargetKind.Library"/>.
+    /// </summary>
+    [Theory]
+    [InlineData("<OutputType> Exe </OutputType>")]
+    [InlineData("<OutputType>WinExe</OutputType>")]
+    public void Discover_FormattingOrWinExe_NeverMisclassifiesAsLibrary(string outputTypeElement)
+    {
+        string appDir = NewScratchApp("ReformattedApp", outputTypeElement);
+
+        CorpusApp app = Assert.Single(CorpusDiscovery.Discover(Path.GetDirectoryName(appDir)));
+
+        Assert.Equal(TargetKind.Exe, app.TargetKind);
+    }
+
+    /// <summary>
+    /// Multiple <c>PropertyGroup</c>s (SDK-style, with an earlier stale value)
+    /// resolve to the last <c>OutputType</c> in document order.
+    /// </summary>
+    [Fact]
+    public void Discover_MultiplePropertyGroups_LastOutputTypeWins()
+    {
+        string root = NewScratchDir("multi-propertygroup");
+        string appFolder = Path.Combine(root, "MultiApp");
+        Directory.CreateDirectory(appFolder);
+        File.WriteAllText(Path.Combine(appFolder, "MultiApp.csproj"), $@"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+</Project>
+");
+        File.WriteAllText(Path.Combine(appFolder, "Program.cs"), "class Program { static void Main() { } }");
+
+        CorpusApp app = Assert.Single(CorpusDiscovery.Discover(root));
+
+        Assert.Equal(TargetKind.Exe, app.TargetKind);
+    }
+
+    private static string NewScratchApp(string appName, string outputTypeElement)
+    {
+        string root = NewScratchDir(appName);
+        string appFolder = Path.Combine(root, appName);
+        Directory.CreateDirectory(appFolder);
+        File.WriteAllText(Path.Combine(appFolder, appName + ".csproj"), $@"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    {outputTypeElement}
+  </PropertyGroup>
+</Project>
+");
+        File.WriteAllText(Path.Combine(appFolder, "Program.cs"), "class Program { static void Main() { } }");
+        return appFolder;
+    }
+
+    private static string NewScratchDir(string label)
+    {
+        // Not AppContext.BaseDirectory: it sits under out/bin/<Config>/..., and
+        // CorpusDiscovery.Discover deliberately excludes anything under a
+        // "/bin/" or "/obj/" path segment (build output noise), which would
+        // make Discover find zero apps here.
+        string root = Path.Combine(Path.GetTempPath(), "cs2gs-corpus-discovery-tests", label, Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/StdoutParityNormalizeTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/StdoutParityNormalizeTests.cs
@@ -1,0 +1,53 @@
+// <copyright file="StdoutParityNormalizeTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Regression tests for issue #1749 mode 2:
+/// <see cref="StdoutParity.Normalize"/> used to <c>TrimEnd('\n')</c>, which
+/// strips *every* trailing newline, making <c>"a\n\n\n"</c> normalize equal to
+/// <c>"a\n"</c>. A migrated program that gains/loses trailing blank lines (a
+/// plausible <c>WriteLine</c> translation bug) would then falsely pass
+/// byte-parity. The fix strips at most one trailing newline before
+/// re-appending exactly one, so a single unavoidable terminal newline is still
+/// tolerated but any *extra* trailing blank line registers as a real
+/// difference.
+/// </summary>
+public class StdoutParityNormalizeTests
+{
+    [Fact]
+    public void Normalize_TripleTrailingNewline_DiffersFromSingle()
+    {
+        Assert.NotEqual(StdoutParity.Normalize("a\n\n\n"), StdoutParity.Normalize("a\n"));
+    }
+
+    [Fact]
+    public void Normalize_SingleTerminalNewline_IsTolerated()
+    {
+        Assert.Equal(StdoutParity.Normalize("a\n"), StdoutParity.Normalize("a"));
+    }
+
+    [Fact]
+    public void Normalize_ExtraTrailingBlankLine_IsDetectedAsDifferent()
+    {
+        Assert.NotEqual(StdoutParity.Normalize("a\nb\n"), StdoutParity.Normalize("a\nb\n\n"));
+    }
+
+    [Fact]
+    public void Compare_ExtraTrailingBlankLine_IsAMismatch()
+    {
+        StdoutParityResult result = StdoutParity.Compare("a\nb\n", "a\nb\n\n");
+        Assert.False(result.IsMatch);
+    }
+
+    [Fact]
+    public void Normalize_CrlfAndLf_NormalizeEqual()
+    {
+        Assert.Equal(StdoutParity.Normalize("a\r\nb\r\n"), StdoutParity.Normalize("a\nb\n"));
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/TestParityEngineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/TestParityEngineTests.cs
@@ -248,17 +248,21 @@ public class TestParityEngineTests
     }
 
     /// <summary>
-    /// Stdout parity normalizes CRLF→LF and a single trailing newline (the L1
-    /// recipe), so a golden and an actual that differ only in line endings and
-    /// trailing whitespace still match.
+    /// Stdout parity normalizes CRLF→LF and tolerates exactly one unavoidable
+    /// terminal newline (the L1 recipe), so a golden and an actual that differ
+    /// only in line endings and that single trailing newline still match.
+    /// Issue #1749 mode 2: this must NOT extend to collapsing *every* trailing
+    /// newline — see <see cref="StdoutParityNormalizeTests"/> for the case this
+    /// regressed (extra trailing blank lines must still be detected).
     /// </summary>
     [Fact]
-    public void StdoutParity_Normalizes_LineEndingsAndTrailingNewline()
+    public void StdoutParity_Normalizes_LineEndingsAndSingleTrailingNewline()
     {
-        StdoutParityResult result = StdoutParity.Compare("line1\nline2\n", "line1\r\nline2\r\n\n\n");
+        StdoutParityResult result = StdoutParity.Compare("line1\nline2\n", "line1\r\nline2\r\n");
 
         Assert.True(result.IsMatch);
     }
+
 
     /// <summary>
     /// A stdout mismatch isolates the first differing line (1-based) and both

--- a/tools/cs2gs/Cs2Gs.Tests/TestParityStageFalseGreenTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/TestParityStageFalseGreenTests.cs
@@ -1,0 +1,205 @@
+// <copyright file="TestParityStageFalseGreenTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Regression tests for issue #1749 mode 1: the stage-4 (ADR-0115 §C/§E)
+/// library xUnit-parity path used to report <see cref="StageOutcome.Passed"/>
+/// for both <see cref="GsharpTestRunStatus.Unavailable"/> (no locally-built SDK
+/// — genuinely not verified) and <see cref="GsharpTestRunStatus.BuildFailed"/>
+/// (the translated G# test project failed to build — a real regression, since
+/// the same library green-built standalone <c>gsc</c> in stage 2). Both
+/// silently reported "passed" in the machine-readable <see cref="StageResult"/>.
+/// Now <c>Unavailable</c> maps to the distinct <see cref="StageStatus.Skipped"/>
+/// ("not verified", never green) and <c>BuildFailed</c> maps to
+/// <see cref="StageStatus.Failed"/> (a genuine regression).
+/// </summary>
+public class TestParityStageFalseGreenTests
+{
+    /// <summary>
+    /// A locally-built-SDK-unavailable run must report <c>skipped</c>, never
+    /// <c>passed</c>: "not verified" must not render as "verified green".
+    /// </summary>
+    [Fact]
+    public async Task LibraryParity_SdkUnavailable_IsSkipped_NotPassed()
+    {
+        string compiler = FindCompiler();
+        if (compiler is null)
+        {
+            return;
+        }
+
+        StageOutcome outcome = await RunLibraryParityWithFakeResult(
+            compiler, GsharpTestRunResult.Unavailable("no locally-built Gsharp.NET.Sdk nupkg"));
+
+        Assert.Equal(StageStatus.Skipped, outcome.Status);
+        Assert.NotEqual(StageStatus.Passed, outcome.Status);
+        Assert.Empty(outcome.Artifacts);
+    }
+
+    /// <summary>
+    /// A translated G# test project that fails to build is a genuine
+    /// regression (the library already green-built standalone <c>gsc</c> in
+    /// stage 2) and must FAIL the stage — never <c>passed</c>, and never
+    /// silently downgraded to a skip either.
+    /// </summary>
+    [Fact]
+    public async Task LibraryParity_BuildFailed_FailsStage_NotPassedOrSkipped()
+    {
+        string compiler = FindCompiler();
+        if (compiler is null)
+        {
+            return;
+        }
+
+        StageOutcome outcome = await RunLibraryParityWithFakeResult(
+            compiler, GsharpTestRunResult.BuildFailed(1, "error GS9999: something broke"));
+
+        Assert.Equal(StageStatus.Failed, outcome.Status);
+        Assert.NotEqual(StageStatus.Passed, outcome.Status);
+        Assert.NotEqual(StageStatus.Skipped, outcome.Status);
+        Assert.NotEmpty(outcome.Artifacts);
+        Assert.Contains(outcome.Artifacts, a => a.Diagnostic.Id == "LIBRARY-BUILD-FAILED");
+    }
+
+    /// <summary>
+    /// Wired through <see cref="MigrationPipeline"/> (not just the stage in
+    /// isolation): a skipped stage-4 must show up as <c>"skipped"</c> in the
+    /// machine-readable <see cref="StageResult"/>, not <c>"passed"</c> — the
+    /// overall pipeline must never treat "not verified" as green.
+    /// </summary>
+    [Fact]
+    public async Task Pipeline_SkippedStage_ReportsSkipped_NotPassed()
+    {
+        string compiler = FindCompiler();
+        if (compiler is null)
+        {
+            return;
+        }
+
+        (CorpusApp app, string outRoot) = NewMinimalLibraryApp("pipeline-skip");
+        var fakeRunner = new FakeGsharpTestProjectRunner(
+            GsharpTestRunResult.Unavailable("no locally-built Gsharp.NET.Sdk nupkg"));
+        var options = new PipelineOptions { GscPath = compiler, OutputRoot = outRoot };
+        var pipeline = new MigrationPipeline(options, new IMigrationStage[] { new TestParityStage(fakeRunner) });
+
+        RunResult result = await pipeline.RunAsync(new[] { app });
+        AppResult appResult = Assert.Single(result.Apps);
+        StageResult stage = Assert.Single(appResult.Stages);
+
+        Assert.Equal("skipped", stage.Status);
+        Assert.NotEqual("passed", stage.Status);
+    }
+
+    private static async Task<StageOutcome> RunLibraryParityWithFakeResult(
+        string compiler, GsharpTestRunResult fakeResult)
+    {
+        (CorpusApp app, string outRoot) = NewMinimalLibraryApp("testparity-falsegreen");
+        var fakeRunner = new FakeGsharpTestProjectRunner(fakeResult);
+        var stage = new TestParityStage(fakeRunner);
+
+        var options = new PipelineOptions { GscPath = compiler };
+        var gsc = new GscInvoker(compiler);
+        var triage = new TriageBuilder("run_1", "2026-06-21T20:00:00Z", gsc.GetVersion(), app.Id);
+        var context = new StageExecutionContext(app, options, gsc, outRoot, triage);
+
+        return await stage.ExecuteAsync(context);
+    }
+
+    /// <summary>
+    /// Builds a corpus app whose sibling <c>.Tests</c> project loads and
+    /// translates cleanly (a plain class/method, no xUnit attributes, so it
+    /// never hits the "test-translation pending map-advanced" gate) so the
+    /// library-parity path reaches <see cref="GsharpTestProjectRunner.Run"/>.
+    /// </summary>
+    private static (CorpusApp App, string OutRoot) NewMinimalLibraryApp(string label)
+    {
+        string testsDir = NewScratchDir(label);
+        string testsProjectPath = Path.Combine(testsDir, "Minimal.Tests.csproj");
+        File.WriteAllText(testsProjectPath, @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+</Project>
+");
+        File.WriteAllText(
+            Path.Combine(testsDir, "NoOpTests.cs"),
+            "public class NoOpTests { public void DoesNothing() { } }");
+
+        string baselinePath = Path.Combine(testsDir, "baseline.tests.json");
+        File.WriteAllText(
+            baselinePath,
+            "{\"schemaVersion\":\"1.0\",\"app\":\"Minimal.Tests\",\"framework\":\"xunit\"," +
+            "\"total\":0,\"passed\":0,\"failed\":0,\"skipped\":0,\"tests\":[]}");
+
+        var app = new CorpusApp(
+            "test/MinimalLibrary",
+            testsProjectPath,
+            TargetKind.Library,
+            testsProjectPath: testsProjectPath,
+            testsBaselinePath: baselinePath);
+
+        return (app, NewOutputRoot(label));
+    }
+
+    private static string NewOutputRoot(string label)
+    {
+        string root = Path.Combine(AppContext.BaseDirectory, "pipeline-tests", label, Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string NewScratchDir(string label)
+    {
+        string root = Path.Combine(AppContext.BaseDirectory, "loader-tests", label, Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string FindCompiler()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            foreach (string config in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(dir.FullName, "out", "bin", config, "Compiler", "gsc.dll");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            dir = dir.Parent;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// A test double standing in for the real <see cref="GsharpTestProjectRunner"/>
+    /// (which shells out to real <c>dotnet test</c>): returns a fixed result
+    /// without touching disk/process, mirroring the existing
+    /// <c>CrashingIlVerifyRunner</c> pattern used for <see cref="IlVerifyStage"/>.
+    /// </summary>
+    private sealed class FakeGsharpTestProjectRunner : GsharpTestProjectRunner
+    {
+        private readonly GsharpTestRunResult result;
+
+        public FakeGsharpTestProjectRunner(GsharpTestRunResult result)
+        {
+            this.result = result;
+        }
+
+        public override GsharpTestRunResult Run(GsharpTestProject project, string workDir) => this.result;
+    }
+}


### PR DESCRIPTION
Three independent false-green modes in cs2gs stage-4 test parity (ADR-0115 §C), each converting "not verified" into "reported green":

1. **Build failures / missing SDK reported passed.** `TestParityStage` returned `StageOutcome.Passed()` for both a genuinely unavailable local SDK/tooling and for a translated library test project that actually failed to build. Added a new `StageOutcome.Skipped()` / `StageStatus.Skipped`, wired through `MigrationPipeline` into the machine-readable `StageResult.Status` (`"skipped"`, distinct from and never rendered as `"passed"`). `GsharpTestRunStatus.Unavailable` and the test-translation-pending gate now map to `Skipped` (a genuinely unavailable dependency — not verified, not a failure). `GsharpTestRunStatus.BuildFailed` now maps to `Failed` with a new `LIBRARY-BUILD-FAILED` triage artifact, since a library that compiled standalone with `gsc` in stage 2 but fails to build here is a real regression, not something to skip quietly. Also investigated the `OutputRoot`/`nuget.config` discovery bug: the generated test project's restore now passes `--configfile <repoRoot>/nuget.config` explicitly, so the local `.nugs` feed resolves even when `OutputRoot` scaffolds outside the repo (previously restore always failed silently in that case).

2. **Stdout normalization collapsed all trailing newlines.** `StdoutParity.Normalize` used `TrimEnd('\n')`, so `"a\n\n\n"` normalized equal to `"a\n"`. Now strips at most one trailing newline before re-appending exactly one, so the single unavoidable terminal newline is still tolerated but any extra trailing blank line is a real, detected difference.

3. **OutputType detected by literal substring match.** `CorpusDiscovery.ReadTargetKind` matched the literal text `<OutputType>Exe</OutputType>`, so a benign reformat (whitespace, an attribute, `WinExe`) silently reclassified an executable as a library, flipping `gsc` to `/target:library` and dropping stdout-parity verification entirely. Now parses the csproj with `XDocument`, matching `Exe`/`WinExe` case-insensitively (last `OutputType` element wins across PropertyGroups, approximating MSBuild evaluation).

Added `Cs2Gs.Tests` coverage for all three modes (including the wiring through `MigrationPipeline` so a skipped stage renders as `"skipped"`, never `"passed"`), and fixed a pre-existing `TestParityEngineTests` case that asserted the old, buggy multi-trailing-newline-collapse behavior.

Verified: `dotnet build tools/cs2gs/Cs2Gs.Pipeline/Cs2Gs.Pipeline.csproj -c Release` and the `Cs2Gs.Tests` project both build clean; `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release` passes 449/450 (the one failure, `ReportTests.Cli_ReportVerb_RegeneratesBothArtifacts`, is pre-existing and requires a whole-solution build to produce `cs2gs.dll`, unrelated to this change).

Fixes #1749.