### PR TITLE
Fix #1601: resolve Enum.TryParse[TEnum] (and any struct-constrained BCL generic) over a constrained type parameter

### DIFF
--- a/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
@@ -2931,9 +2931,12 @@ internal static class OverloadResolution
             // checks see through that erasure so a `where T : struct` candidate
             // (e.g. MemoryMarshal.Cast/AsBytes) is not wrongly filtered out and a
             // `where T : class` candidate is not wrongly admitted.
+            // Issue #1601: a value-type-constrained generic type parameter (e.g.
+            // a `TEnum` forwarded from an enclosing `[TEnum Enum struct]`) erases
+            // the same way and must classify as a value type here too.
             var argIsUserValueType = !typeArgSymbols.IsDefaultOrEmpty
                 && i < typeArgSymbols.Length
-                && IsUserValueTypeSymbol(typeArgSymbols[i]);
+                && IsValueTypeErasedSymbol(typeArgSymbols[i]);
 
             if ((special & GenericParameterAttributes.ReferenceTypeConstraint) != 0)
             {
@@ -3051,6 +3054,26 @@ internal static class OverloadResolution
         => symbol is StructSymbol { IsClass: false } or EnumSymbol;
 
     /// <summary>
+    /// Issue #1601: recognizes a type-argument symbol that has no reference-context
+    /// CLR type but is guaranteed to be a non-nullable value type — either a
+    /// same-compilation user value type (see <see cref="IsUserValueTypeSymbol"/>) or
+    /// an in-scope generic type parameter carrying a value-type (<c>struct</c>)
+    /// constraint (e.g. the <c>TEnum</c> of <c>func Parse[TEnum Enum struct]</c>
+    /// forwarded to <c>Enum.TryParse[TEnum]</c>). Both erase to a <c>System.Object</c>
+    /// placeholder in the CLR type-argument vector, so the value-type/struct generic
+    /// constraint checks (and the placeholder closure) need the symbol to classify
+    /// them correctly. Live-reflection <see cref="MethodInfo.MakeGenericMethod(Type[])"/>
+    /// cannot be called with such a symbol because it is not a real runtime
+    /// <see cref="Type"/>, so the closure over a value-type placeholder applies to it
+    /// exactly as it does to a same-compilation user value type.
+    /// </summary>
+    /// <param name="symbol">The recovered type-argument symbol.</param>
+    /// <returns><see langword="true"/> when the symbol erases to a value-type placeholder.</returns>
+    private static bool IsValueTypeErasedSymbol(TypeSymbol symbol)
+        => IsUserValueTypeSymbol(symbol)
+            || symbol is TypeParameterSymbol { HasValueTypeConstraint: true };
+
+    /// <summary>
     /// Issue #1325: attempts to close <paramref name="openDef"/> over a value-type
     /// placeholder for every type-argument slot whose CLR type was erased to a
     /// non-value-type placeholder but whose recovered symbol is a user value
@@ -3082,7 +3105,7 @@ internal static class OverloadResolution
         {
             if (substituted[i] != null
                 && !substituted[i].IsValueType
-                && IsUserValueTypeSymbol(recoveredSymbols[i]))
+                && IsValueTypeErasedSymbol(recoveredSymbols[i]))
             {
                 substituted[i] = typeof(UserValueTypeConstraintPlaceholder);
                 anyUserValueType = true;

--- a/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
@@ -226,8 +226,13 @@ public sealed class ImportedClassSymbol : Symbol
             // so the value-type-constrained generic overload stays applicable;
             // the recovered explicit type-argument symbols drive the constraint
             // check and emit. Without this the call collapses to GS0159.
+            // Issue #1601: the same holds when the pointee is a value-type
+            // (`struct`) constrained generic type parameter (e.g. a `TEnum`
+            // forwarded from an enclosing `[TEnum Enum struct]`), which is also
+            // erased to the placeholder and has no reference-context CLR type.
             if (arguments[i] is BoundAddressOfExpression { Operand.Type: var byRefPointee }
-                && byRefPointee is EnumSymbol or StructSymbol { IsClass: false }
+                && (byRefPointee is EnumSymbol or StructSymbol { IsClass: false }
+                    || byRefPointee is TypeParameterSymbol { HasValueTypeConstraint: true })
                 && byRefPointee.ClrType == null)
             {
                 argTypes[i] = OverloadResolution.InlineOutVarArgumentType;

--- a/test/Compiler.Tests/Emit/Issue1601GenericEnumTryParseForwardEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1601GenericEnumTryParseForwardEmitTests.cs
@@ -1,0 +1,186 @@
+// <copyright file="Issue1601GenericEnumTryParseForwardEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1601 (follow-up to #1599): a generic BCL method whose type parameter
+/// carries a value-type/<c>struct</c> constraint — canonically
+/// <c>Enum.TryParse&lt;TEnum&gt;(string, out TEnum)</c> — invoked with a caller
+/// type argument that is itself an in-scope generic type parameter constrained
+/// to <c>Enum</c>/<c>struct</c> must resolve, bind the inline <c>out var</c> to
+/// that type parameter, and emit a verifiable generic method specification.
+/// <para>
+/// Root cause: the forwarded type parameter <c>TEnum</c> is not a real runtime
+/// <see cref="Type"/>, so it erases to a <c>System.Object</c> placeholder in the
+/// CLR type-argument vector. The placeholder classifies as a reference type, so
+/// the value-type placeholder closure (added by #1599) was skipped and the
+/// candidate was dropped — reported as <c>GS0159</c>, which cascaded to
+/// <c>GS0125</c> on the inline <c>out var</c> local. The fix classifies a
+/// value-type-constrained type parameter as a value-type-erased symbol, exactly
+/// like a same-compilation user value type.
+/// </para>
+/// <para>
+/// These are end-to-end emit + execution tests. The generic method is invoked
+/// with a real BCL enum (<see cref="DayOfWeek"/>) so it can be exercised at
+/// runtime, asserting the parse succeeds and the recovered value is the correct
+/// enum member (observed via <c>ToString()</c>). Each test uses UNIQUE
+/// function/type names so the name-keyed FunctionTypeSymbol cache does not bleed
+/// across the shared in-process test host.
+/// </para>
+/// </summary>
+public class Issue1601GenericEnumTryParseForwardEmitTests
+{
+    [Fact]
+    public void GenericForward_InlineOutVar_ResolvesBindsAndRuns_NoGS0159()
+    {
+        // The generic function forwards its own Enum/struct-constrained type
+        // parameter to Enum.TryParse[TEnum] with an inline `out var`.
+        const string source = """
+            package Probe
+            import System
+
+            func Show1601A[TEnum Enum struct](sample TEnum, arg string) TEnum {
+                if !Enum.TryParse[TEnum](arg, out var result) {
+                    return sample
+                }
+                return result
+            }
+
+            var hit = Show1601A[DayOfWeek](DayOfWeek.Monday, "Friday")
+            Console.WriteLine(hit.ToString())
+            var miss = Show1601A[DayOfWeek](DayOfWeek.Monday, "Nope")
+            Console.WriteLine(miss.ToString())
+            """;
+
+        Assert.Equal("Friday\nMonday\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void GenericForward_IgnoreCaseOverload_ResolvesBindsAndRuns()
+    {
+        // The three-argument `(string, bool ignoreCase, out TEnum)` overload.
+        const string source = """
+            package Probe
+            import System
+
+            func Show1601B[TEnum Enum struct](sample TEnum, arg string) TEnum {
+                if !Enum.TryParse[TEnum](arg, true, out var result) {
+                    return sample
+                }
+                return result
+            }
+
+            var hit = Show1601B[DayOfWeek](DayOfWeek.Monday, "friday")
+            Console.WriteLine(hit.ToString())
+            """;
+
+        Assert.Equal("Friday\n", CompileAndRun(source));
+    }
+
+    [Fact]
+    public void GenericForward_PreDeclaredReceiver_ResolvesBindsAndRuns_NoGS0159()
+    {
+        // The pre-declared receiver variant: `out r` where `r` is typed by the
+        // value-type-constrained type parameter.
+        const string source = """
+            package Probe
+            import System
+
+            func Show1601C[TEnum Enum struct](sample TEnum, arg string) TEnum {
+                var r TEnum = sample
+                if !Enum.TryParse[TEnum](arg, out r) {
+                    return sample
+                }
+                return r
+            }
+
+            var hit = Show1601C[DayOfWeek](DayOfWeek.Monday, "Friday")
+            Console.WriteLine(hit.ToString())
+            """;
+
+        Assert.Equal("Friday\n", CompileAndRun(source));
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1601_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath, null, Array.Empty<string>());
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+                // ignored
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1601GenericEnumTryParseForwardTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1601GenericEnumTryParseForwardTests.cs
@@ -119,6 +119,65 @@ var ok = Enum.TryParse[Color](""Red"", out var result)
         Assert.Empty(diagnostics);
     }
 
+    [Fact]
+    public void GenericForward_NonEnumStructConstrained_MemoryMarshalCast_Resolves()
+    {
+        // Generalization: a DIFFERENT struct-constrained BCL generic method
+        // (MemoryMarshal.Cast<TFrom, TTo>, where TFrom : struct, TTo : struct)
+        // must also close over a forwarded constrained type parameter — proving
+        // the fix is not Enum.TryParse-specific.
+        const string source = @"
+package p
+import System.Runtime.InteropServices
+
+func Cast[TEnum Enum struct](s Span[TEnum]) Span[uint8] {
+    return MemoryMarshal.Cast[TEnum, uint8](s)
+}
+";
+        var diagnostics = Bind(source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0159");
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void UnconstrainedTypeParameter_EnumTryParse_StillErrors()
+    {
+        // Negative control: an UNCONSTRAINED `[T]` must NOT satisfy
+        // Enum.TryParse<TEnum>'s `where TEnum : struct, Enum` constraint. The
+        // fix must not over-loosen constraint checking to admit any type
+        // parameter, only ones that themselves carry a value-type constraint.
+        const string source = @"
+package p
+import System
+
+func Parse[T](arg string) T? {
+    if !Enum.TryParse[T](arg, out var result) {
+        return nil
+    }
+    return result
+}
+";
+        var diagnostics = Bind(source);
+        Assert.Contains(diagnostics, d => d.Id == "GS0159");
+    }
+
+    [Fact]
+    public void UnconstrainedTypeParameter_MemoryMarshalCast_StillErrors()
+    {
+        // Negative control for the non-Enum generalization: an unconstrained
+        // `[T]` must not satisfy MemoryMarshal.Cast's `where T : struct`.
+        const string source = @"
+package p
+import System.Runtime.InteropServices
+
+func Cast[T](s Span[T]) Span[uint8] {
+    return MemoryMarshal.Cast[T, uint8](s)
+}
+";
+        var diagnostics = Bind(source);
+        Assert.Contains(diagnostics, d => d.Id == "GS0159");
+    }
+
     private static IReadOnlyList<Diagnostic> Bind(string source)
     {
         var tree = SyntaxTree.Parse(SourceText.From(source));

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1601GenericEnumTryParseForwardTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1601GenericEnumTryParseForwardTests.cs
@@ -1,0 +1,129 @@
+// <copyright file="Issue1601GenericEnumTryParseForwardTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1601 (follow-up to #1599): a generic BCL method whose type parameter
+/// carries a value-type/<c>struct</c> constraint — canonically
+/// <c>Enum.TryParse&lt;TEnum&gt;(string, out TEnum)</c> — invoked with a caller
+/// type argument that is itself an in-scope generic type parameter constrained
+/// to <c>Enum</c>/<c>struct</c> (as opposed to a concrete enum) must resolve and
+/// bind, with an inline <c>out var</c> local typed as that type parameter.
+/// <para>
+/// Before the fix the type parameter erased to a <c>System.Object</c> placeholder
+/// that <see cref="System.Reflection.GenericParameterAttributes"/> classified as a
+/// reference type, so the value-type placeholder closure was skipped and the
+/// candidate was dropped — reported as <c>GS0159</c> (Cannot find function
+/// TryParse), which cascaded to <c>GS0125</c> on the inline <c>out var</c> local.
+/// </para>
+/// </summary>
+public class Issue1601GenericEnumTryParseForwardTests
+{
+    [Fact]
+    public void GenericForward_InlineOutVar_ResolvesAndBinds_NoGS0159OrGS0125()
+    {
+        // Exact repro from the issue: a generic function forwards its own
+        // Enum/struct-constrained type parameter to Enum.TryParse[TEnum].
+        const string source = @"
+package p
+import System
+
+func Parse[TEnum Enum struct](arg string) TEnum? {
+    if !Enum.TryParse[TEnum](arg, out var result) {
+        return nil
+    }
+    return result
+}
+
+Console.WriteLine(""ok"")
+";
+        var diagnostics = Bind(source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS9999");
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0159");
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0125");
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void GenericForward_IgnoreCaseOverload_ResolvesAndBinds()
+    {
+        // The three-argument `(string, bool ignoreCase, out TEnum)` overload
+        // must also close over the constrained type parameter.
+        const string source = @"
+package p
+import System
+
+func Parse[TEnum Enum struct](arg string) TEnum? {
+    if !Enum.TryParse[TEnum](arg, true, out var result) {
+        return nil
+    }
+    return result
+}
+
+Console.WriteLine(""ok"")
+";
+        var diagnostics = Bind(source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS9999");
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0159");
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0125");
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void GenericForward_PreDeclaredReceiver_Resolves_NoGS0159()
+    {
+        // The pre-declared receiver variant: `out r` where `r` is typed by the
+        // value-type-constrained type parameter.
+        const string source = @"
+package p
+import System
+
+func Parse[TEnum Enum struct](arg string) TEnum {
+    var r TEnum
+    var ok = Enum.TryParse[TEnum](arg, out r)
+    return r
+}
+
+Console.WriteLine(""ok"")
+";
+        var diagnostics = Bind(source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0159");
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void ConcreteEnum_InlineOutVar_StillResolves_Issue1599Regression()
+    {
+        // Control: the concrete same-compilation enum case fixed by #1599 must
+        // keep resolving through the placeholder-recovery path.
+        const string source = @"
+package p
+import System
+
+enum Color { Red, Green }
+
+var ok = Enum.TryParse[Color](""Red"", out var result)
+";
+        var diagnostics = Bind(source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS9999");
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0159");
+        Assert.Empty(diagnostics);
+    }
+
+    private static IReadOnlyList<Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new GSharp.Core.CodeAnalysis.Compilation.Compilation(tree);
+        using var peStream = new System.IO.MemoryStream();
+        return compilation.Emit(peStream).Diagnostics.ToList();
+    }
+}


### PR DESCRIPTION
Follow-up to #1599. A generic function forwarding its own `Enum`/`struct`-constrained type parameter to `Enum.TryParse[TEnum](arg, out var result)` failed to resolve (GS0159 "Cannot find function TryParse"), which cascaded to GS0125 on the inline `out var` local.

**Root cause:** the forwarded type parameter `TEnum` is not a real runtime `Type`, so `TryResolveExplicitMethodTypeArgs` erases it to a `System.Object` placeholder in the CLR type-argument vector. Overload resolution then tries to close the value-type-constrained BCL generic over that placeholder, but the #1599 placeholder-closure path (`TryCloseOverUserValueTypePlaceholders` / `SatisfiesGenericConstraints`) only recognized `EnumSymbol`/`StructSymbol` via `IsUserValueTypeSymbol`. A constrained type parameter matched neither, so the placeholder closure was skipped and the candidate was dropped.

**Fix (generalized, not `Enum.TryParse`-specific):** classify a value-type (`struct`) constrained `TypeParameterSymbol` as a value-type-erased symbol alongside same-compilation user value types.
- `OverloadResolution.IsValueTypeErasedSymbol`: new predicate OR-ing `IsUserValueTypeSymbol` with a `HasValueTypeConstraint` type parameter check; used by both the placeholder-closure and constraint-satisfaction paths.
- `ImportedClassSymbol.TryLookupFunction`: extends the pre-declared by-ref "matches any" sentinel to a value-type-constrained type-parameter pointee.

The recovered symbolic type argument (`TEnum`) drives constraint checking and emit, producing a real generic method specification; invoking with a concrete enum still runs natively. The #1599 concrete-enum case is unchanged.

**Generalization proof:** a test also exercises `MemoryMarshal.Cast<TFrom,TTo>` (a *different* struct-constrained BCL generic, unrelated to `Enum.TryParse`) closed over the same forwarded constrained type parameter, confirming the fix is structural ("type argument is a `TypeParameterSymbol` with a matching constraint") rather than name-keyed to `Enum.TryParse`.

**Negative controls:** an UNCONSTRAINED `[T]` calling `Enum.TryParse[T]` and `MemoryMarshal.Cast[T, uint8]` both still correctly report GS0159, proving constraint-satisfaction wasn't over-loosened to admit any type parameter.

Tests added:
- `test/Core.Tests/CodeAnalysis/Binding/Issue1601GenericEnumTryParseForwardTests.cs` — binding tests for the inline `out var` repro, the `ignoreCase` overload, the pre-declared receiver form, the #1599 concrete-enum regression, the `MemoryMarshal.Cast` generalization, and the two unconstrained negative controls.
- `test/Compiler.Tests/Emit/Issue1601GenericEnumTryParseForwardEmitTests.cs` — end-to-end emit + run tests invoking the generic function with `System.DayOfWeek`, IL-verified.

Verified: whole-solution `dotnet build GSharp.sln -c Release -graph` (0 errors), staged `gsc` compiles and runs the issue's repro (prints `ok`), narrow test filters pass, and a full `Core.Tests` run (5255 passed, 1 pre-existing skip, 0 failed) shows no overload-resolution regressions.

Fixes #1601