### PR TITLE
Fix cs2gs int-to-float literal promotion string surgery on token text

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/L5ConstructTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/L5ConstructTranslationTests.cs
@@ -194,6 +194,65 @@ namespace Demo
     }
 
     /// <summary>
+    /// The int-to-float promotion in <see cref="TranslateLiteral"/> must derive
+    /// the emitted float text from the literal's bound *value*, not its raw
+    /// token spelling — appending ".0" to the spelling mangles hex (`0xFF` →
+    /// `0xFF.0`, a parse error), silently misses hex spellings that already
+    /// contain an 'E' digit (`0xAE`), and leaves integer suffixes in place
+    /// (`30L` → `30L.0`, a parse error). Binary literals and digit separators
+    /// must promote correctly too, and an already-float argument must never be
+    /// promoted twice (Issue #1740).
+    /// </summary>
+    [Theory]
+    [InlineData("0xFF", "255.0")]
+    [InlineData("0xAE", "174.0")]
+    [InlineData("30L", "30.0")]
+    [InlineData("0b1010", "10.0")]
+    [InlineData("1_000", "1000.0")]
+    [InlineData("30", "30.0")]
+    public void IntegerLiteralSpellings_PromotedToDouble_EmitAsValidFloatLiteral(
+        string literalSpelling, string expectedFloatText)
+    {
+        string printed = TranslateUnit($@"
+namespace Demo
+{{
+    public static class Calc
+    {{
+        public static double Scale(double factor) => factor * 2.0;
+
+        public static double Run() => Scale({literalSpelling});
+    }}
+}}");
+
+        Assert.Contains($"Scale({expectedFloatText})", printed);
+    }
+
+    /// <summary>
+    /// A C# literal that is already floating-point (e.g. <c>2.0</c>) must be
+    /// passed through unchanged when its target parameter is also
+    /// floating-point — the promotion path only applies to integral literals,
+    /// so it must never double-promote or otherwise rewrite an already-float
+    /// spelling (Issue #1740).
+    /// </summary>
+    [Fact]
+    public void FloatLiteral_PassedToDoubleParameter_IsNotDoublePromoted()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public static class Calc
+    {
+        public static double Scale(double factor) => factor * 2.0;
+
+        public static double Run() => Scale(2.0);
+    }
+}");
+
+        Assert.Contains("Scale(2.0)", printed);
+        Assert.DoesNotContain("Scale(2.0.0)", printed);
+    }
+
+    /// <summary>
     /// A parameterless constructor that assigns a constant to a property keeps
     /// its explicit <c>init()</c> body — G# accepts a field member initializer
     /// (<c>var Name T = expr</c>) but rejects a property member initializer

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -2,6 +2,7 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -7033,7 +7034,7 @@ public sealed class CSharpToGSharpTranslator
                     // type (ADR-0115 §B.12).
                     if (this.IsConvertedToFloatingPoint(literal))
                     {
-                        return LiteralExpression.Float(this.ToFloatLiteralText(literal.Token.Text));
+                        return LiteralExpression.Float(this.ToFloatLiteralText(literal.Token.Value));
                     }
 
                     return LiteralExpression.Int(this.NormalizeIntegerLiteralText(literal));
@@ -7133,10 +7134,18 @@ public sealed class CSharpToGSharpTranslator
             return originalIsIntegral && convertedIsFloat;
         }
 
-        private string ToFloatLiteralText(string text)
+        private string ToFloatLiteralText(object value)
         {
-            // A plain integer spelling (`30`) needs a fractional part so the G#
-            // lexer classifies it as float64; an already-float spelling is kept.
+            // The token's *spelling* can be hex (`0xFF`), binary (`0b1010`),
+            // digit-separated (`1_000`), or suffixed (`30L`); appending ".0" to
+            // that raw text either produces an invalid G# float (`0xFF.0`,
+            // `30L.0`) or silently misses cases that already contain a stray
+            // 'e'/'E' hex digit (`0xAE`). Deriving the text from the token's
+            // already-parsed *value* instead sidesteps spelling entirely: format
+            // the numeric value as decimal and ensure it carries a fractional
+            // part so the G# lexer classifies it as float64.
+            double number = Convert.ToDouble(value, CultureInfo.InvariantCulture);
+            string text = number.ToString("R", CultureInfo.InvariantCulture);
             return text.IndexOfAny(new[] { '.', 'e', 'E' }) >= 0 ? text : text + ".0";
         }
 


### PR DESCRIPTION
## Root cause
`ToFloatLiteralText` promoted an int literal to a float literal at a call site (e.g. `M(30)` where `M(double)`) by appending `".0"` to the *raw token spelling*. That broke on anything but plain decimal:
- `0xFF` → `0xFF.0` (invalid G# syntax)
- `0xAE` already contains an `'E'`, so the naive "already has e/E" check treated it as already-float and skipped promotion — it stayed `0xAE` (int32), silently reintroducing the exact type mismatch the promotion exists to prevent
- `30L` → `30L.0` (invalid, suffix never stripped)
- Binary literals (`0b1010`) and digit-separated literals (`1_000`) were equally unhandled

## Fix
Derive the emitted text from the literal's bound *value* (`literal.Token.Value`, already parsed by Roslyn's lexer) instead of the token spelling. `ToFloatLiteralText` now takes the parsed value, converts it to `double`, formats it with round-trippable (`"R"`) invariant-culture text, and appends `".0"` only when the result has no decimal point or exponent. This generalizes over every integer spelling (decimal/hex/binary/suffixed/digit-separated) since parsing already happened once in Roslyn — no token-text pattern matching needed.

## Tests
Added a `[Theory]` in `L5ConstructTranslationTests.cs` covering `0xFF`, `0xAE`, `30L`, `0b1010`, `1_000`, and plain `30`, all promoted to a `double` parameter and asserted to emit valid G# float literals. Added a regression test asserting an already-float argument (`2.0`) passes through unpromoted (no double-promotion).

```
dotnet build GSharp.sln -c Release -graph   → Build succeeded, 0 warnings, 0 errors
dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release --no-build \
  --filter "FullyQualifiedName~IntegerLiteral|FullyQualifiedName~FloatLiteral"
  → Passed: 10, Failed: 0
dotnet test ... --filter "FullyQualifiedName~L5ConstructTranslationTests"
  → Passed: 14, Failed: 0
```

Fixes #1740