### PR TITLE
cs2gs: cache CollectSubclassedBaseTypes per Compilation, scan source assembly only

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue1744SubclassedBaseTypeCacheTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1744SubclassedBaseTypeCacheTests.cs
@@ -1,0 +1,139 @@
+// <copyright file="Issue1744SubclassedBaseTypeCacheTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #1744: <c>CollectSubclassedBaseTypes</c> used to enumerate every
+/// named type across every referenced assembly (the merged
+/// <c>Compilation.GlobalNamespace</c>) on every single document translation,
+/// an O(assemblies × types × documents) cost. It is now memoized per
+/// <see cref="Compilation"/> instance so an N-document batch pays the
+/// enumeration once, and the walk itself only visits the source assembly
+/// (metadata types can never subclass source types).
+/// </summary>
+public class Issue1744SubclassedBaseTypeCacheTests
+{
+    [Fact]
+    public void MultiDocumentBatch_ReusesSameCachedSetAcrossDocuments()
+    {
+        var sourceA = """
+            namespace Probe;
+
+            public class Shape
+            {
+                public virtual string Describe() => "shape";
+            }
+
+            public class Circle : Shape
+            {
+                public override string Describe() => base.Describe() + " circle";
+            }
+            """;
+
+        var sourceB = """
+            namespace Probe;
+
+            public class Widget
+            {
+                public virtual string Name() => "widget";
+            }
+
+            public class Gadget : Widget
+            {
+                public override string Name() => base.Name() + " gadget";
+            }
+            """;
+
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[]
+        {
+            ("A.cs", sourceA),
+            ("B.cs", sourceB),
+        });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippets should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+        Assert.Equal(2, project.Documents.Count);
+
+        var translator = new CSharpToGSharpTranslator();
+        var sets = new List<object>();
+        foreach (LoadedDocument document in project.Documents)
+        {
+            var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+            translator.TranslateDocument(document, context);
+            sets.Add(GetCachedSetFor(project.Compilation));
+        }
+
+        // Every document in the batch shares one `Compilation`, so the cached
+        // subclassed-base-type set produced while translating the first
+        // document must be the exact same object reused for the second —
+        // never recomputed.
+        Assert.NotNull(sets[0]);
+        Assert.Same(sets[0], sets[1]);
+    }
+
+    [Fact]
+    public void DistinctCompilations_GetIndependentCacheEntries()
+    {
+        var source = """
+            namespace Probe;
+
+            public class Base1 { public virtual void M() { } }
+            public class Derived1 : Base1 { public override void M() { } }
+            """;
+
+        LoadedCSharpProject project1 = CSharpProjectLoader.LoadInMemory(new[] { ("A.cs", source) });
+        LoadedCSharpProject project2 = CSharpProjectLoader.LoadInMemory(new[] { ("A.cs", source) });
+        Assert.True(project1.BoundWithoutErrors);
+        Assert.True(project2.BoundWithoutErrors);
+
+        var translator = new CSharpToGSharpTranslator();
+
+        LoadedDocument doc1 = Assert.Single(project1.Documents);
+        var context1 = new TranslationContext(project1.Compilation, doc1.SemanticModel, doc1.FilePath);
+        translator.TranslateDocument(doc1, context1);
+
+        LoadedDocument doc2 = Assert.Single(project2.Documents);
+        var context2 = new TranslationContext(project2.Compilation, doc2.SemanticModel, doc2.FilePath);
+        translator.TranslateDocument(doc2, context2);
+
+        object set1 = GetCachedSetFor(project1.Compilation);
+        object set2 = GetCachedSetFor(project2.Compilation);
+
+        // Two independent `Compilation` instances (even from identical source
+        // text) must not share a cache entry — the cache is keyed by
+        // compilation reference identity, so edits/new compilations are never
+        // served stale data.
+        Assert.NotNull(set1);
+        Assert.NotNull(set2);
+        Assert.NotSame(set1, set2);
+    }
+
+    private static FieldInfo GetCacheField()
+    {
+        FieldInfo field = typeof(CSharpToGSharpTranslator).GetField(
+            "SubclassedBaseTypesCache",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(field);
+        return field;
+    }
+
+    private static object GetCachedSetFor(Compilation compilation)
+    {
+        object table = GetCacheField().GetValue(null);
+        MethodInfo tryGetValue = table.GetType().GetMethod("TryGetValue");
+        var args = new object[] { compilation, null };
+        var found = (bool)tryGetValue.Invoke(table, args);
+        return found ? args[1] : null;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -34,6 +34,22 @@ namespace Cs2Gs.Translator;
 /// </summary>
 public sealed class CSharpToGSharpTranslator
 {
+    // A subclass can only ever be declared in source, never synthesized from a
+    // referenced assembly's metadata, so the set of "is this base type ever
+    // subclassed" facts is a pure function of the *source* assembly's symbol
+    // tree and is invariant across every document translated from the same
+    // `Compilation`. `Compilation.GlobalNamespace` is the merged namespace
+    // across every metadata reference too, so scanning it (as the previous
+    // implementation did) forces materialization of the entire BCL symbol
+    // tree — tens of thousands of `INamedTypeSymbol`s — on every single
+    // document. Caching per `Compilation` (keyed by reference identity via
+    // `ConditionalWeakTable`, so a new/edited `Compilation` naturally gets a
+    // fresh entry and stale ones are collectible) plus restricting the walk to
+    // `compilation.Assembly.GlobalNamespace` (the source assembly only) turns
+    // an O(assemblies × types × documents) cost into a single O(source types)
+    // pass per compilation.
+    private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<Compilation, HashSet<INamedTypeSymbol>> SubclassedBaseTypesCache = new();
+
     /// <summary>
     /// Translates a loaded C# document into a G# <see cref="CompilationUnit"/>,
     /// recording any unsupported constructs on a fresh context. Use
@@ -65,17 +81,21 @@ public sealed class CSharpToGSharpTranslator
         string package = this.ResolvePackage(root, context);
         IReadOnlyList<ImportDirective> imports = this.TranslateImports(root, context);
 
-        HashSet<INamedTypeSymbol> openBases = CollectSubclassedBaseTypes(context.Compilation);
+        HashSet<INamedTypeSymbol> openBases = GetOrCollectSubclassedBaseTypes(context.Compilation);
         HashSet<INamedTypeSymbol> staticUsingTargets = CollectStaticUsingTargets(root, context);
-        var visitor = new DeclarationVisitor(context, new CSharpTypeMapper(), openBases, staticUsingTargets);
 
         // T3 (ADR-0115 §B.1/§B.11): the C# program entry point and its enclosing
         // static class become top-level G#. The entry `Main` body translates to
         // top-level statements (the program entry in G# is top-level statements,
         // not a `Main` method) and the sibling static methods become top-level
         // `func`s — never a `shared { }` block.
+        //
+        // Computed once here and threaded through so the visitor does not
+        // recompute it (`Compilation.GetEntryPoint` re-walks the compilation).
         IMethodSymbol entryPoint = context.Compilation.GetEntryPoint(default);
         INamedTypeSymbol entryType = entryPoint?.ContainingType;
+
+        var visitor = new DeclarationVisitor(context, new CSharpTypeMapper(), openBases, staticUsingTargets, entryPoint);
 
         var members = new List<GNode>();
         var trailingStatements = new List<GNode>();
@@ -143,10 +163,15 @@ public sealed class CSharpToGSharpTranslator
         }
     }
 
+    private static HashSet<INamedTypeSymbol> GetOrCollectSubclassedBaseTypes(Compilation compilation)
+    {
+        return SubclassedBaseTypesCache.GetValue(compilation, CollectSubclassedBaseTypes);
+    }
+
     private static HashSet<INamedTypeSymbol> CollectSubclassedBaseTypes(Compilation compilation)
     {
         var bases = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
-        foreach (INamedTypeSymbol type in EnumerateNamedTypes(compilation.GlobalNamespace))
+        foreach (INamedTypeSymbol type in EnumerateNamedTypes(compilation.Assembly.GlobalNamespace))
         {
             INamedTypeSymbol baseType = type.BaseType;
             if (baseType != null &&
@@ -434,13 +459,19 @@ public sealed class CSharpToGSharpTranslator
             TranslationContext context,
             CSharpTypeMapper typeMapper,
             HashSet<INamedTypeSymbol> subclassedBases,
-            HashSet<INamedTypeSymbol> staticUsingTargets)
+            HashSet<INamedTypeSymbol> staticUsingTargets,
+            IMethodSymbol entryPoint)
         {
             this.context = context;
             this.typeMapper = typeMapper;
             this.subclassedBases = subclassedBases;
             this.staticUsingTargets = staticUsingTargets ?? new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
-            this.entryType = context.Compilation.GetEntryPoint(default)?.ContainingType;
+
+            // `entryPoint` is threaded in by the caller (`TranslateDocument`)
+            // instead of being recomputed here: `Compilation.GetEntryPoint`
+            // re-walks the compilation and was otherwise called twice per
+            // document (once by the caller, once here).
+            this.entryType = entryPoint?.ContainingType;
         }
 
         public override GMember VisitClassDeclaration(ClassDeclarationSyntax node) => this.VisitAggregate(node);


### PR DESCRIPTION
## Root cause

`CollectSubclassedBaseTypes` (`Cs2Gs.Translator/CSharpToGSharpTranslator.cs`) ran `EnumerateNamedTypes(compilation.GlobalNamespace)` once per `TranslateDocument` call. `Compilation.GlobalNamespace` is the *merged* namespace across every metadata reference, so every document translation forced materialization of the entire BCL symbol tree (tens of thousands of `INamedTypeSymbol`s) just to learn which **source** base types are subclassed. Metadata types can never subclass source types, so scanning them was pure waste. An N-document batch paid the full-compilation scan N times — the dominant per-document startup cost on large projects.

## Fix

- Restrict the enumeration to `compilation.Assembly.GlobalNamespace` (the source assembly only) — a subclass can only ever be declared in source.
- Memoize the resulting `HashSet<INamedTypeSymbol>` in a `ConditionalWeakTable<Compilation, HashSet<INamedTypeSymbol>>`, keyed by `Compilation` reference identity. Roslyn reuses the same `Compilation` instance across every document in a batch/project, so the cache collapses the O(assemblies × types × documents) cost to a single O(source types) pass per compilation. A new or edited `Compilation` is a different reference, so it naturally gets a fresh cache entry — no explicit invalidation logic needed — and stale entries are collectible once their `Compilation` is unreachable (no unbounded growth).
- Fixed the sibling issue noted in the report: `Compilation.GetEntryPoint` was computed twice per document (once in `TranslateDocument`, once again in `DeclarationVisitor`'s constructor). It's now computed once in `TranslateDocument` and threaded into `DeclarationVisitor`.

## Tests

Added `tools/cs2gs/Cs2Gs.Tests/Issue1744SubclassedBaseTypeCacheTests.cs`:
- `MultiDocumentBatch_ReusesSameCachedSetAcrossDocuments`: translates two documents that share one `Compilation` and asserts (via reflection into the cache field) that the cached set object is the exact same instance after translating both documents — proving the enumeration ran once for the whole batch, not once per document.
- `DistinctCompilations_GetIndependentCacheEntries`: asserts two distinct `Compilation` instances (even built from identical source text) get independent, non-shared cache entries, so the cache can never serve stale results after an edit produces a new `Compilation`.

Verified:
- `dotnet build GSharp.sln -c Release -graph` — succeeds, 0 errors/warnings.
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release --filter "FullyQualifiedName!~ReportTests"` — 427 passed, 0 failed (the excluded `ReportTests.Cli_ReportVerb_RegeneratesBothArtifacts` is a known pre-existing failure requiring a full solution build of `cs2gs.dll`, unrelated to this change).

Fixes #1744
