### PR TITLE
cs2gs: sanitize identifiers at declaration/synthesis sites, not just references

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue1734DeclarationSiteSanitizationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1734DeclarationSiteSanitizationTests.cs
@@ -1,0 +1,397 @@
+// <copyright file="Issue1734DeclarationSiteSanitizationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #1734: <c>SanitizeIdentifier</c> is applied at every C# *reference*
+/// site (<c>TranslateIdentifierName</c> and friends) but was skipped at many
+/// *declaration*/*synthesis* sites, so a member/parameter/local/pattern
+/// designator whose C# name collides with a G# reserved word (e.g. <c>type</c>,
+/// <c>select</c>) was declared under its raw name while every reference to it
+/// was emitted sanitized (<c>type_</c>) — producing G# that either fails to
+/// parse (a bare keyword in declaration position) or fails to bind (declared
+/// <c>type</c> vs referenced <c>type_</c>).
+/// <para>
+/// Every case below asserts that (1) the declaration and every reference use
+/// the identical sanitized spelling, (2) the unsanitized raw form never leaks
+/// into the printed output, and (3) the resulting G# round-trip-parses.
+/// </para>
+/// </summary>
+public class Issue1734DeclarationSiteSanitizationTests
+{
+    [Fact]
+    public void TypeDeclarationName_KeywordCollision_IsSanitizedConsistently()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1734
+{
+    public class type
+    {
+        public int Value;
+    }
+
+    public class Holder
+    {
+        public type Make()
+        {
+            return new type();
+        }
+    }
+}
+");
+
+        Assert.Contains("class type_", rendered, StringComparison.Ordinal);
+        Assert.Contains("Make() type_", rendered, StringComparison.Ordinal);
+        Assert.Contains("return type_()", rendered, StringComparison.Ordinal);
+        AssertNoRawKeywordCollision(rendered, "type");
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void ConstructorLiftPrimaryParameter_KeywordCollision_IsSanitizedConsistently()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1734
+{
+    public class Holder
+    {
+        public readonly string type;
+
+        public Holder(string type)
+        {
+            this.type = type;
+        }
+
+        public string Read() => type;
+    }
+}
+");
+
+        // The lifted primary-constructor parameter and the member it feeds must
+        // agree on the sanitized spelling everywhere: the parameter list, the
+        // parameter-field read inside 'Read', and (if retained) the field itself.
+        Assert.Contains("type_", rendered, StringComparison.Ordinal);
+        AssertNoRawKeywordCollision(rendered, "type");
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void LocalFunction_KeywordCollision_IsSanitizedConsistently()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1734
+{
+    public class Holder
+    {
+        public int Compute()
+        {
+            int type() => 5;
+            return type() + type();
+        }
+    }
+}
+");
+
+        Assert.Contains("type_", rendered, StringComparison.Ordinal);
+        AssertNoRawKeywordCollision(rendered, "type");
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void DeclarationPatternDesignator_KeywordCollision_IsSanitizedConsistently()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1734
+{
+    public class Shape { }
+
+    public class Circle : Shape
+    {
+        public int Radius;
+    }
+
+    public class Holder
+    {
+        public int Describe(Shape shape)
+        {
+            switch (shape)
+            {
+                case Circle type:
+                    return type.Radius;
+                default:
+                    return 0;
+            }
+        }
+    }
+}
+");
+
+        Assert.Contains("type_", rendered, StringComparison.Ordinal);
+        AssertNoRawKeywordCollision(rendered, "type");
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void RecursivePatternNamedDesignator_KeywordCollision_IsSanitizedConsistently()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1734
+{
+    public class Shape { }
+
+    public class Circle : Shape
+    {
+        public int Radius;
+    }
+
+    public class Holder
+    {
+        public int Describe(Shape shape)
+        {
+            switch (shape)
+            {
+                case Circle { Radius: var r } type:
+                    return r + type.Radius;
+                default:
+                    return 0;
+            }
+        }
+    }
+}
+");
+
+        Assert.Contains("type_", rendered, StringComparison.Ordinal);
+        AssertNoRawKeywordCollision(rendered, "type");
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void RecursivePatternSynthesizedDesignator_QualifiedGenericType_UsesRightmostSimpleName()
+    {
+        // The synthesized designator must be derived from the right-most simple
+        // identifier of the type ('List', not the invalid 'list<int>' that
+        // 'Type.ToString()' would yield for a generic type).
+        string rendered = Render(@"
+using System.Collections.Generic;
+
+namespace Corpus.Issue1734
+{
+    public class Holder
+    {
+        public int Describe(object value)
+        {
+            switch (value)
+            {
+                case List<int> { Count: var c }:
+                    return c;
+                default:
+                    return 0;
+            }
+        }
+    }
+}
+");
+
+        Assert.DoesNotContain("list<int>", rendered, StringComparison.Ordinal);
+        Assert.Contains("list", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void PropertyPatternFieldName_KeywordCollision_IsSanitizedConsistently()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1734
+{
+    public class Circle
+    {
+        public int type;
+    }
+
+    public class Holder
+    {
+        public int Describe(Circle circle)
+        {
+            switch (circle)
+            {
+                case Circle { type: var t }:
+                    return t;
+                default:
+                    return 0;
+            }
+        }
+    }
+}
+");
+
+        Assert.Contains("type_", rendered, StringComparison.Ordinal);
+        AssertNoRawKeywordCollision(rendered, "type");
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void ObjectInitializerFieldName_KeywordCollision_IsSanitizedConsistently()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1734
+{
+    public class Circle
+    {
+        public int type;
+    }
+
+    public class Holder
+    {
+        public Circle Make()
+        {
+            return new Circle { type = 3 };
+        }
+    }
+}
+");
+
+        Assert.Contains("type_", rendered, StringComparison.Ordinal);
+        AssertNoRawKeywordCollision(rendered, "type");
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void WithExpressionFieldName_KeywordCollision_IsSanitizedConsistently()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1734
+{
+    public sealed record Circle(int type);
+
+    public class Holder
+    {
+        public Circle Recolor(Circle circle) => circle with { type = 4 };
+    }
+}
+");
+
+        Assert.Contains("type_", rendered, StringComparison.Ordinal);
+        AssertNoRawKeywordCollision(rendered, "type");
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void GenericMethodName_KeywordCollision_IsSanitizedConsistently()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1734
+{
+    public class Box
+    {
+        public T select<T>(T value) => value;
+    }
+
+    public class Holder
+    {
+        public int Use(Box box) => box.select<int>(5);
+    }
+}
+");
+
+        Assert.Contains("select_", rendered, StringComparison.Ordinal);
+        AssertNoRawKeywordCollision(rendered, "select");
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void TypeParameterName_KeywordCollision_IsSanitizedConsistently()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1734
+{
+    public class Box<type>
+    {
+        public type Value;
+
+        public type Read() => Value;
+    }
+}
+");
+
+        Assert.Contains("type_", rendered, StringComparison.Ordinal);
+        AssertNoRawKeywordCollision(rendered, "type");
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void LinqRangeVariable_KeywordCollision_IsSanitizedConsistently()
+    {
+        string rendered = Render(@"
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Corpus.Issue1734
+{
+    public class Holder
+    {
+        public IEnumerable<int> Filter(IEnumerable<int> values)
+        {
+            return from type in values
+                   where type > 0
+                   select type;
+        }
+    }
+}
+");
+
+        Assert.Contains("type_", rendered, StringComparison.Ordinal);
+        AssertNoRawKeywordCollision(rendered, "type");
+        AssertRoundTripParses(rendered);
+    }
+
+    // Asserts that no standalone (word-boundary-delimited) occurrence of the raw
+    // keyword-colliding identifier survives in the printed output — only its
+    // sanitized '<keyword>_' spelling may appear. A bare match would mean some
+    // declaration or reference site still emits the unsanitized, unparseable /
+    // unbound name (issue #1734).
+    private static void AssertNoRawKeywordCollision(string rendered, string keyword)
+    {
+        var regex = new System.Text.RegularExpressions.Regex(
+            $@"(?<![A-Za-z0-9_]){System.Text.RegularExpressions.Regex.Escape(keyword)}(?![A-Za-z0-9_])");
+        System.Text.RegularExpressions.Match match = regex.Match(rendered);
+        Assert.False(
+            match.Success,
+            $"unsanitized raw keyword '{keyword}' leaked into the printed output:\n{rendered}");
+    }
+
+    private static void AssertRoundTripParses(string rendered)
+    {
+        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+
+        Assert.True(
+            result.Success,
+            "Sanitized G# must round-trip-parse. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + rendered);
+    }
+
+    private static string Render(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", source) });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        return GSharpPrinter.Print(unit);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -111,6 +111,14 @@ public sealed class CSharpToGSharpTranslator
         return new CompilationUnit(package, imports, members);
     }
 
+    // Forwards to the canonical identifier sanitizer implemented on the nested
+    // declaration visitor, so callers outside the visitor (e.g.
+    // <see cref="CSharpTypeMapper"/>) can route type-name references through the
+    // exact same sanitizer used at every declaration and reference site inside
+    // the visitor, keeping declared and referenced names in agreement (issue
+    // #1734).
+    internal static string SanitizeIdentifier(string name) => DeclarationVisitor.SanitizeIdentifier(name);
+
     private static IEnumerable<MemberDeclarationSyntax> EnumerateTopLevelDeclarations(CompilationUnitSyntax root)
     {
         foreach (MemberDeclarationSyntax member in root.Members)
@@ -546,6 +554,32 @@ public sealed class CSharpToGSharpTranslator
             }
 
             return (funcs, statements);
+        }
+
+        // The set of hard G# keywords (Cs2Gs.Compiler SyntaxFacts.GetKeywordKind).
+        // A C# identifier that collides with one of these cannot be emitted bare; it
+        // is suffixed with `_` consistently at every declaration and reference site.
+        // Internal (not private) so the outer <see cref="CSharpToGSharpTranslator"/>
+        // forwarding method can expose it to <see cref="CSharpTypeMapper"/>, which
+        // routes type-name references through this exact sanitizer too (issue
+        // #1734).
+        internal static string SanitizeIdentifier(string name)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                return name;
+            }
+
+            // C# verbatim identifiers (`@default`, `@class`) carry a leading `@`
+            // in their syntax text; G# has no verbatim-identifier escape, so strip
+            // it before the reserved-word check (the bare name is then suffixed if
+            // it still collides with a G# keyword).
+            if (name[0] == '@')
+            {
+                name = name.Substring(1);
+            }
+
+            return GSharpReservedWords.Contains(name) ? name + "_" : name;
         }
 
         /// <summary>
@@ -1046,7 +1080,7 @@ public sealed class CSharpToGSharpTranslator
 
             return new TypeDeclaration(
                 kind.Value,
-                node.Identifier.Text,
+                SanitizeIdentifier(node.Identifier.Text),
                 typeParameters: typeParameters,
                 primaryConstructorParameters: primaryCtor,
                 baseType: baseType,
@@ -1259,7 +1293,7 @@ public sealed class CSharpToGSharpTranslator
                 (string Name, ITypeSymbol Type, bool IsProperty) target = paramToTarget[param];
                 GTypeReference type = this.typeMapper.Map(target.Type, this.context, param.Locations.FirstOrDefault());
                 GExpression liftedDefault = this.BuildOptionalParameterDefault(param, type);
-                primaryParameters.Add(new Parameter(target.Name, type, defaultValue: liftedDefault));
+                primaryParameters.Add(new Parameter(SanitizeIdentifier(target.Name), type, defaultValue: liftedDefault));
                 if (target.IsProperty)
                 {
                     propertiesAsParams.Add(target.Name);
@@ -2512,7 +2546,7 @@ public sealed class CSharpToGSharpTranslator
                 _ => Variance.None,
             };
 
-            return new TypeParameter(tp.Name, legacy, flags, variance);
+            return new TypeParameter(SanitizeIdentifier(tp.Name), legacy, flags, variance);
         }
 
         private IReadOnlyList<Parameter> MapPrimaryConstructor(TypeDeclarationSyntax node)
@@ -4767,7 +4801,7 @@ public sealed class CSharpToGSharpTranslator
                 lambda = new LambdaExpression(parameters, blockBody: new BlockStatement(new List<GStatement>()), isAsync: isAsync, returnType: returnType, isFunctionLiteral: true);
             }
 
-            return new LocalFunctionStatement(localFunction.Identifier.Text, lambda);
+            return new LocalFunctionStatement(SanitizeIdentifier(localFunction.Identifier.Text), lambda);
         }
 
         /// <summary>
@@ -7454,7 +7488,7 @@ public sealed class CSharpToGSharpTranslator
             {
                 target = new MemberAccessExpression(
                     this.TranslateExpression(member.Expression),
-                    memberGeneric.Identifier.Text);
+                    SanitizeIdentifier(memberGeneric.Identifier.Text));
                 typeArguments = this.MapTypeArguments(memberGeneric);
             }
             else if (invocation.Expression is MemberBindingExpressionSyntax memberBinding
@@ -7466,7 +7500,7 @@ public sealed class CSharpToGSharpTranslator
                 // bracket-type-argument form so the chained call keeps `[T...]`.
                 target = new MemberAccessExpression(
                     new ConditionalReceiverExpression(),
-                    memberBindingGeneric.Identifier.Text);
+                    SanitizeIdentifier(memberBindingGeneric.Identifier.Text));
                 typeArguments = this.MapTypeArguments(memberBindingGeneric);
             }
             else if (invocation.Expression is IdentifierNameSyntax bareName &&
@@ -7645,8 +7679,8 @@ public sealed class CSharpToGSharpTranslator
             }
 
             IMethodSymbol original = method.ReducedFrom ?? method;
-            ownerName = original.ContainingType?.Name;
-            methodName = original.Name;
+            ownerName = original.ContainingType?.Name is { } containingName ? SanitizeIdentifier(containingName) : null;
+            methodName = SanitizeIdentifier(original.Name);
             return ownerName != null;
         }
 
@@ -8028,14 +8062,14 @@ public sealed class CSharpToGSharpTranslator
                         if (memberElements != null)
                         {
                             fieldInitializers.Add(new FieldInitializer(
-                                name.Identifier.Text,
+                                SanitizeIdentifier(name.Identifier.Text),
                                 new CollectionInitializerExpression(target: null, memberElements)));
                             continue;
                         }
                     }
 
                     fieldInitializers.Add(new FieldInitializer(
-                        name.Identifier.Text,
+                        SanitizeIdentifier(name.Identifier.Text),
                         this.TranslateExpression(assignment.Right)));
                 }
                 else
@@ -8194,7 +8228,7 @@ public sealed class CSharpToGSharpTranslator
                     assignment.Left is IdentifierNameSyntax name)
                 {
                     updates.Add(new FieldInitializer(
-                        name.Identifier.Text,
+                        SanitizeIdentifier(name.Identifier.Text),
                         this.TranslateExpression(assignment.Right)));
                 }
                 else
@@ -8380,28 +8414,6 @@ public sealed class CSharpToGSharpTranslator
             return symbol != null
                 ? this.typeMapper.Map(symbol, this.context, type.GetLocation())
                 : new NamedTypeReference(type.ToString());
-        }
-
-        // The set of hard G# keywords (Cs2Gs.Compiler SyntaxFacts.GetKeywordKind).
-        // A C# identifier that collides with one of these cannot be emitted bare; it
-        // is suffixed with `_` consistently at every declaration and reference site.
-        private static string SanitizeIdentifier(string name)
-        {
-            if (string.IsNullOrEmpty(name))
-            {
-                return name;
-            }
-
-            // C# verbatim identifiers (`@default`, `@class`) carry a leading `@`
-            // in their syntax text; G# has no verbatim-identifier escape, so strip
-            // it before the reserved-word check (the bare name is then suffixed if
-            // it still collides with a G# keyword).
-            if (name[0] == '@')
-            {
-                name = name.Substring(1);
-            }
-
-            return GSharpReservedWords.Contains(name) ? name + "_" : name;
         }
 
         private GExpression TranslatePredefinedTypeExpression(PredefinedTypeSyntax predefined)
@@ -8718,7 +8730,7 @@ public sealed class CSharpToGSharpTranslator
                 case DeclarationPatternSyntax declaration
                     when declaration.Designation is SingleVariableDesignationSyntax variable:
                     return new TypePattern(
-                        variable.Identifier.Text,
+                        SanitizeIdentifier(variable.Identifier.Text),
                         this.MapTypeSyntax(declaration.Type));
 
                 case RecursivePatternSyntax recursive:
@@ -8771,7 +8783,7 @@ public sealed class CSharpToGSharpTranslator
                         }
 
                         fields.Add(new PropertyPatternField(
-                            sub.NameColon.Name.Identifier.Text,
+                            SanitizeIdentifier(sub.NameColon.Name.Identifier.Text),
                             this.TranslatePattern(sub.Pattern, bindings)));
                     }
                 }
@@ -8781,10 +8793,16 @@ public sealed class CSharpToGSharpTranslator
 
             // Typed recursive pattern: synthesize a designator named after the type
             // (`circle`), and rewrite each `Name: var x` property binding to a
-            // member access on that designator (`circle.Radius`).
+            // member access on that designator (`circle.Radius`). The synthesized
+            // designator is derived from the right-most identifier token of the
+            // type syntax (not `Type.ToString()`, which yields an invalid
+            // identifier for a qualified/generic type such as `Ns.Circle` or
+            // `List<int>`), and sanitized like every other declared/synthesized
+            // name so a keyword-colliding designator agrees with its references
+            // (issue #1734).
             string designator = recursive.Designation is SingleVariableDesignationSyntax named
-                ? named.Identifier.Text
-                : LowerCamel(recursive.Type.ToString());
+                ? SanitizeIdentifier(named.Identifier.Text)
+                : SanitizeIdentifier(LowerCamel(GetRightmostTypeName(recursive.Type)));
 
             if (recursive.PropertyPatternClause != null)
             {
@@ -8798,7 +8816,7 @@ public sealed class CSharpToGSharpTranslator
                             boundSymbol,
                             new MemberAccessExpression(
                                 new IdentifierExpression(designator),
-                                sub.NameColon.Name.Identifier.Text)));
+                                SanitizeIdentifier(sub.NameColon.Name.Identifier.Text))));
                     }
                     else
                     {
@@ -8820,6 +8838,27 @@ public sealed class CSharpToGSharpTranslator
             }
 
             return char.ToLowerInvariant(name[0]) + name.Substring(1);
+        }
+
+        // Extracts the right-most simple-name identifier token from a (possibly
+        // qualified/generic) type syntax, e.g. `Ns.Circle` -> "Circle",
+        // `List<int>` -> "List", `Outer.Inner<T>` -> "Inner". `Type.ToString()`
+        // renders the full qualified/generic text, which is not itself a valid
+        // identifier and must never be used to synthesize a designator name
+        // (issue #1734).
+        private static string GetRightmostTypeName(TypeSyntax type)
+        {
+            switch (type)
+            {
+                case QualifiedNameSyntax qualified:
+                    return GetRightmostTypeName(qualified.Right);
+                case AliasQualifiedNameSyntax aliasQualified:
+                    return GetRightmostTypeName(aliasQualified.Name);
+                case SimpleNameSyntax simple:
+                    return simple.Identifier.Text;
+                default:
+                    return type.ToString();
+            }
         }
 
         private GExpression TranslateQuery(QueryExpressionSyntax query)
@@ -8906,7 +8945,7 @@ public sealed class CSharpToGSharpTranslator
             ExpressionSyntax lambdaBody)
         {
             var lambda = new LambdaExpression(
-                new List<Parameter> { new Parameter(rangeVar, rangeType) },
+                new List<Parameter> { new Parameter(SanitizeIdentifier(rangeVar), rangeType) },
                 expressionBody: this.TranslateExpression(lambdaBody));
             return new InvocationExpression(
                 new MemberAccessExpression(receiver, method),

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
@@ -199,7 +199,7 @@ public sealed class CSharpTypeMapper
 
         if (type is ITypeParameterSymbol typeParameter)
         {
-            return new NamedTypeReference(typeParameter.Name);
+            return new NamedTypeReference(CSharpToGSharpTranslator.SanitizeIdentifier(typeParameter.Name));
         }
 
         if (type is INamedTypeSymbol named)
@@ -239,7 +239,7 @@ public sealed class CSharpTypeMapper
             return new NamedTypeReference(this.QualifiedTypeName(named, context));
         }
 
-        return new NamedTypeReference(type.Name);
+        return new NamedTypeReference(CSharpToGSharpTranslator.SanitizeIdentifier(type.Name));
     }
 
     // A nested type is referenced through its containing type(s)
@@ -261,20 +261,20 @@ public sealed class CSharpTypeMapper
     {
         if (named.ContainingType == null)
         {
-            return named.Name;
+            return CSharpToGSharpTranslator.SanitizeIdentifier(named.Name);
         }
 
         // A source nested type only needs qualifying when its simple name is
         // ambiguous within the package (a same-named source homonym exists).
         if (named.Locations.Any(l => l.IsInSource) && !this.HasSourceHomonym(named, context))
         {
-            return named.Name;
+            return CSharpToGSharpTranslator.SanitizeIdentifier(named.Name);
         }
 
         var parts = new List<string>();
         for (INamedTypeSymbol current = named; current != null; current = current.ContainingType)
         {
-            parts.Insert(0, current.Name);
+            parts.Insert(0, CSharpToGSharpTranslator.SanitizeIdentifier(current.Name));
         }
 
         return string.Join(".", parts);


### PR DESCRIPTION
## Root cause

`SanitizeIdentifier` was already routed through every C#→G# *reference* emission site (`TranslateIdentifierName` and friends), but many *declaration*/*synthesis* sites emitted the raw C# identifier text. When a C# name collided with a G# reserved word (e.g. a field/type/parameter/local literally named `type`), the declaration kept the raw name while every reference to it emitted the sanitized `type_` — producing G# that either fails to parse (a keyword in declaration position) or fails to bind (declared `type` vs. referenced `type_`).

## Fix

Generalized the fix: every declared/synthesized identifier now goes through the same canonical `SanitizeIdentifier` used at reference sites, closing the asymmetry site-by-site:

- Type declaration names (class/struct/interface/record).
- Generic type-parameter declarations, plus type-parameter/type-name references resolved through `CSharpTypeMapper` (promoted `SanitizeIdentifier` to `internal` so the type mapper shares the exact same sanitizer).
- Constructor-lift primary-constructor parameter names.
- Local function declarations.
- Declaration-pattern designators (`case Circle type:`).
- Recursive-pattern named designators and property-pattern field names (`case Circle { Radius: var r } type:`).
- The synthesized recursive-pattern designator, now derived from the right-most simple-name token of the type syntax instead of `Type.ToString()` (which is not itself a valid identifier for a qualified/generic type such as `Ns.Circle` or `List<int>`).
- Object-initializer and `with`-expression field names.
- Generic member/call names reached through `MemberAccessExpressionSyntax` and `MemberBindingExpressionSyntax` (null-conditional generic calls).
- The enum-extension owner/method names used to rebuild a lifted static call.
- The LINQ range-variable parameter emitted for `where`/`orderby`/`select`.

## Tests

Added `Issue1734DeclarationSiteSanitizationTests.cs`: one test per declaration/synthesis form above. Each asserts:
1. the sanitized spelling is used identically at the declaration and every reference,
2. the raw keyword-colliding form never leaks into the printed output, and
3. the emitted G# round-trip-parses.

`dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release` → 444/444 passed (no regressions), including the 12 new tests.

Fixes #1734