### PR TITLE
Enforce base-type constraints (Enum, not just ValueType) on value-type-erased type args

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -1316,6 +1316,60 @@ internal sealed partial class ExpressionBinder
     }
 
     /// <summary>
+    /// Issue #1833: scans every public static/instance generic method named
+    /// <paramref name="methodName"/> on <paramref name="classType"/> whose
+    /// arity matches the explicit type-argument list, looking for one whose
+    /// only structural mismatch is a value-type-erased type argument (a
+    /// concrete non-enum struct, or a bare <c>[T struct]</c> type parameter)
+    /// failing an explicit base-class constraint — e.g. <c>Enum.TryParse</c>'s
+    /// <c>where TEnum : Enum</c> bound. Reports the constraint-violation
+    /// diagnostic (<c>GS0152</c>, the same one user-declared generic
+    /// functions/types already use) and returns <see langword="true"/> on the
+    /// first hit; other reasons a candidate is inapplicable (arity, argument
+    /// types, an unconstrained type parameter, ...) are left to the caller's
+    /// existing "cannot find function" fallback.
+    /// </summary>
+    /// <param name="classType">The imported class's CLR <see cref="Type"/>.</param>
+    /// <param name="methodName">The called method's name.</param>
+    /// <param name="explicitTypeArgs">The resolved explicit CLR type arguments.</param>
+    /// <param name="typeArgSymbols">The resolved symbolic type-argument vector.</param>
+    /// <param name="location">The text location to attach the diagnostic to.</param>
+    /// <returns><see langword="true"/> when a violation was found and reported.</returns>
+    private bool TryReportGenericValueTypeBaseConstraintViolation(Type classType, string methodName, System.Type[] explicitTypeArgs, ImmutableArray<TypeSymbol> typeArgSymbols, TextLocation location)
+    {
+        if (classType is null || explicitTypeArgs is null || explicitTypeArgs.Length == 0 || typeArgSymbols.IsDefaultOrEmpty)
+        {
+            return false;
+        }
+
+        MethodInfo[] candidates;
+        try
+        {
+            candidates = classType
+                .GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance)
+                .Where(m => m.Name == methodName
+                    && m.IsGenericMethodDefinition
+                    && m.GetGenericArguments().Length == explicitTypeArgs.Length)
+                .ToArray();
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+
+        foreach (var candidate in candidates)
+        {
+            if (OverloadResolution.TryDescribeValueTypeBaseConstraintViolation(candidate, explicitTypeArgs, typeArgSymbols, out var typeParameterName, out var typeArgument, out var constraintDescription))
+            {
+                Diagnostics.ReportTypeArgumentDoesNotSatisfyConstraint(location, typeParameterName, typeArgument, constraintDescription);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Issue #320: computes a return-type override for an imported generic method
     /// closed over explicit type arguments. When the method's open return type is
     /// exactly one of its method type parameters, the real return type is the
@@ -3104,6 +3158,22 @@ internal sealed partial class ExpressionBinder
             if (TryBindNestedTypeConstructorCall(classSymbol.ClassType, ce, out var nestedCtorResult))
             {
                 return nestedCtorResult;
+            }
+
+            // Issue #1833: a value-type-erased type argument (a concrete
+            // non-enum struct, or a bare `[T struct]` type parameter) explicitly
+            // supplied to a generic BCL method whose type parameter carries an
+            // `Enum` (or any other concrete) base-class constraint is now
+            // rejected by `SatisfiesGenericConstraints`, so the candidate above
+            // was silently dropped exactly like any other inapplicable overload.
+            // Report the specific constraint violation here — before falling
+            // back to the generic "cannot find function" diagnostic — so the
+            // caller gets a clear bind-time error instead of only discovering
+            // the problem at CLR verification.
+            if (explicitTypeArgs != null
+                && TryReportGenericValueTypeBaseConstraintViolation(classSymbol.ClassType, methodName, explicitTypeArgs, typeArgSymbols, ce.Location))
+            {
+                return new BoundErrorExpression(null);
             }
 
             Diagnostics.ReportUnableToFindFunction(ce.Location, methodName);

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution.cs
@@ -1148,6 +1148,100 @@ internal static class OverloadResolution
     }
 
     /// <summary>
+    /// Issue #1833: identifies a generic candidate whose only structural
+    /// mismatch is a value-type-erased type argument (a same-compilation user
+    /// struct/enum, or a struct-constrained type parameter) that fails to
+    /// satisfy an explicit CLR base-class constraint — e.g. a concrete
+    /// non-enum struct, or a plain <c>[T struct]</c> type parameter, forwarded
+    /// to <c>Enum.TryParse[TEnum]</c>'s <c>where TEnum : Enum</c> bound. This
+    /// distinguishes that specific "binds through overload resolution but only
+    /// fails CLR verification" hole from every other reason a candidate can be
+    /// inapplicable (arity mismatch, wrong argument types, an unconstrained type
+    /// parameter, ...), which must keep surfacing the generic "cannot find
+    /// function" diagnostic exactly as it did before <c>#1833</c>.
+    /// </summary>
+    /// <param name="openMethod">The open generic method definition considered as a candidate.</param>
+    /// <param name="typeArgs">The CLR type arguments (with user value types erased).</param>
+    /// <param name="typeArgSymbols">The recovered symbolic type-argument vector.</param>
+    /// <param name="typeParameterName">On success, the violated type parameter's name.</param>
+    /// <param name="typeArgument">On success, the offending type-argument symbol.</param>
+    /// <param name="constraintDescription">On success, a human-readable description of the violated constraint.</param>
+    /// <returns><see langword="true"/> when a base-constraint violation of this specific shape was found.</returns>
+    internal static bool TryDescribeValueTypeBaseConstraintViolation(
+        MethodInfo openMethod,
+        Type[] typeArgs,
+        ImmutableArray<TypeSymbol> typeArgSymbols,
+        out string typeParameterName,
+        out TypeSymbol typeArgument,
+        out string constraintDescription)
+    {
+        typeParameterName = null;
+        typeArgument = null;
+        constraintDescription = null;
+
+        if (openMethod is null || typeArgs is null || typeArgSymbols.IsDefaultOrEmpty)
+        {
+            return false;
+        }
+
+        Type[] typeParams;
+        try
+        {
+            typeParams = openMethod.GetGenericArguments();
+        }
+        catch (Exception ex) when (IsMetadataLoadFailure(ex))
+        {
+            return false;
+        }
+
+        if (typeParams.Length != typeArgs.Length || typeParams.Length != typeArgSymbols.Length)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < typeParams.Length; i++)
+        {
+            var arg = typeArgs[i];
+            if (arg is null || arg.IsGenericParameter || !IsValueTypeErasedSymbol(typeArgSymbols[i]))
+            {
+                continue;
+            }
+
+            var param = typeParams[i];
+            Type[] typeConstraints;
+            try
+            {
+                typeConstraints = param.GetGenericParameterConstraints();
+            }
+            catch (Exception ex) when (IsMetadataLoadFailure(ex))
+            {
+                continue;
+            }
+
+            foreach (var constraint in typeConstraints)
+            {
+                if (constraint is null
+                    || constraint.IsInterface
+                    || constraint.IsGenericParameter
+                    || constraint.ContainsGenericParameters)
+                {
+                    continue;
+                }
+
+                if (!ValueTypeErasedSymbolSatisfiesBaseConstraint(typeArgSymbols[i], constraint))
+                {
+                    typeParameterName = param.Name;
+                    typeArgument = typeArgSymbols[i];
+                    constraintDescription = constraint.FullName ?? constraint.Name;
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Substitutes inferred method-type-parameter <paramref name="bounds"/> into
     /// <paramref name="type"/>, succeeding only when the result is fully closed
     /// (contains no remaining generic parameters). Used by
@@ -3013,13 +3107,29 @@ internal static class OverloadResolution
                 // `System.ValueType` base constraint in metadata (and an enum a
                 // `System.Enum` one). A same-compilation user value type is erased
                 // to a `System.Object` placeholder, which is not name-assignable
-                // to `ValueType`/`Enum`, so without this guard the candidate is
-                // wrongly rejected here even though the struct check above passed.
-                if (argIsUserValueType
-                    && (string.Equals(constraint.FullName, "System.ValueType", StringComparison.Ordinal)
-                        || string.Equals(constraint.FullName, "System.Enum", StringComparison.Ordinal)))
+                // to `ValueType`/`Enum` by the plain `IsAssignableByName` check
+                // below, so a base-type (class, non-interface) constraint needs
+                // the symbolic derivation check instead.
+                // Issue #1833: the former version of this guard unconditionally
+                // treated *every* `ValueType`/`Enum`-named constraint as satisfied
+                // once `argIsUserValueType` was true — so a plain (non-enum)
+                // struct, or a bare `[T struct]` type parameter with no `Enum`
+                // bound, silently bound through `Enum.TryParse[T]`'s `where T :
+                // Enum` constraint and only failed later at CLR verification.
+                // `ValueTypeErasedSymbolSatisfiesBaseConstraint` walks the
+                // recovered symbol's real derivation/constraint chain so
+                // `ValueType`/`Object` are still trivially satisfied by any
+                // struct/enum, but `Enum` (or any other concrete base) is only
+                // satisfied by an actual enum or a type parameter that itself
+                // carries that same base bound.
+                if (argIsUserValueType && !constraint.IsInterface)
                 {
-                    continue;
+                    if (ValueTypeErasedSymbolSatisfiesBaseConstraint(typeArgSymbols[i], constraint))
+                    {
+                        continue;
+                    }
+
+                    return false;
                 }
 
                 try
@@ -3072,6 +3182,78 @@ internal static class OverloadResolution
     private static bool IsValueTypeErasedSymbol(TypeSymbol symbol)
         => IsUserValueTypeSymbol(symbol)
             || symbol is TypeParameterSymbol { HasValueTypeConstraint: true };
+
+    /// <summary>
+    /// Issue #1833: determines whether a value-type-erased type-argument symbol
+    /// (see <see cref="IsValueTypeErasedSymbol"/>) satisfies an explicit CLR
+    /// base-class (non-interface) constraint <paramref name="constraint"/>,
+    /// generalizing the former hardcoded `System.ValueType`/`System.Enum` name
+    /// check into a walk of the symbol's own derivation/constraint chain.
+    /// <list type="bullet">
+    /// <item><description><c>System.ValueType</c> and <c>System.Object</c> are
+    /// trivially satisfied by every struct/enum — every value type derives from
+    /// them.</description></item>
+    /// <item><description>A concrete enum (<see cref="EnumSymbol"/>) satisfies
+    /// exactly <c>System.Enum</c> — no other base class is possible for an
+    /// enum.</description></item>
+    /// <item><description>A plain struct (<see cref="StructSymbol"/>) satisfies
+    /// neither — a value type has no symbolic base beyond
+    /// <c>ValueType</c>/<c>Object</c> under the CLR, so any other base-class
+    /// constraint (most notably <c>Enum</c>) is unsatisfiable.</description></item>
+    /// <item><description>An in-scope generic type parameter
+    /// (<see cref="TypeParameterSymbol"/>, e.g. the forwarded <c>TEnum</c> of
+    /// <c>[TEnum Enum struct]</c>) satisfies <paramref name="constraint"/> only
+    /// when its own <see cref="TypeParameterSymbol.ClassConstraint"/> resolves to
+    /// the same CLR type (transitively, through a chain of forwarded
+    /// constraints) — a bare <c>struct</c> constraint with no class bound does
+    /// not prove anything about <c>Enum</c> or any other base.</description></item>
+    /// </list>
+    /// </summary>
+    /// <param name="symbol">The recovered value-type-erased type-argument symbol.</param>
+    /// <param name="constraint">The CLR base-class constraint to check against.</param>
+    /// <returns><see langword="true"/> when the symbol provably satisfies the constraint.</returns>
+    private static bool ValueTypeErasedSymbolSatisfiesBaseConstraint(TypeSymbol symbol, Type constraint)
+    {
+        if (constraint is null)
+        {
+            return true;
+        }
+
+        if (constraint.IsSameAs(typeof(object))
+            || string.Equals(constraint.FullName, "System.ValueType", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        var current = symbol;
+        while (current != null)
+        {
+            switch (current)
+            {
+                case EnumSymbol:
+                    return string.Equals(constraint.FullName, "System.Enum", StringComparison.Ordinal);
+
+                case StructSymbol:
+                    return false;
+
+                case TypeParameterSymbol typeParam:
+                    var classConstraint = typeParam.ClassConstraint;
+                    if (classConstraint?.ClrType != null
+                        && string.Equals(classConstraint.ClrType.FullName, constraint.FullName, StringComparison.Ordinal))
+                    {
+                        return true;
+                    }
+
+                    current = classConstraint;
+                    continue;
+
+                default:
+                    return false;
+            }
+        }
+
+        return false;
+    }
 
     /// <summary>
     /// Issue #1325: attempts to close <paramref name="openDef"/> over a value-type

--- a/test/Compiler.Tests/Emit/Issue1833EnumConstraintViolationEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1833EnumConstraintViolationEmitTests.cs
@@ -1,0 +1,126 @@
+// <copyright file="Issue1833EnumConstraintViolationEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1833 (follow-up review note on PR #1832 / #1601): a value-type-erased
+/// type argument that is <c>struct</c>-constrained but <b>not</b>
+/// <c>Enum</c>-constrained — a concrete non-enum user struct, or a bare
+/// <c>[T struct]</c> type parameter — passed to a BCL generic method whose
+/// type parameter carries a real <c>System.Enum</c> base-class constraint
+/// (<c>Enum.IsDefined&lt;TEnum&gt;</c>) must be rejected by the compiler with a
+/// clear <c>GS0152</c> constraint-violation diagnostic at bind time. Before the
+/// fix, <c>OverloadResolution.SatisfiesGenericConstraints</c> unconditionally
+/// treated any <c>System.Enum</c>-named base constraint as satisfied once the
+/// argument was classified as a value-type-erased symbol, so the candidate
+/// bound through overload resolution and only failed later — at CLR
+/// verification/emit, or as a runtime crash — instead of failing cleanly here
+/// at <c>gsc</c> compile time.
+/// <para>
+/// This is an end-to-end compiler-driver test (mirrors
+/// <c>Issue1601GenericEnumTryParseForwardEmitTests.CompileAndRun</c>): it
+/// invokes <see cref="Program.Main(string[])"/> exactly as the <c>gsc</c> CLI
+/// does and asserts the process reports a non-zero exit with the GS0152
+/// diagnostic — never a PE emitted at all, and never an unhandled exception
+/// (which would surface as a non-graceful crash instead of a diagnostic).
+/// </para>
+/// </summary>
+public class Issue1833EnumConstraintViolationEmitTests
+{
+    [Fact]
+    public void ConcreteNonEnumStruct_EnumIsDefined_FailsCompileWithConstraintDiagnostic_NotCrash()
+    {
+        const string source = """
+            package Probe
+            import System
+
+            struct Point1833A {
+                var X int32
+                var Y int32
+            }
+
+            var pt = Point1833A(1, 2)
+            var ok = Enum.IsDefined[Point1833A](pt)
+            """;
+
+        var (exitCode, stdout, stderr) = Compile(source);
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("GS0152", stdout + stderr);
+        Assert.DoesNotContain("GS9999", stdout + stderr);
+        Assert.DoesNotContain("Unhandled exception", stdout + stderr);
+    }
+
+    [Fact]
+    public void StructOnlyTypeParameter_ForwardedToEnumIsDefined_FailsCompileWithConstraintDiagnostic()
+    {
+        const string source = """
+            package Probe
+            import System
+
+            func Check1833B[T struct](v T) bool {
+                return Enum.IsDefined[T](v)
+            }
+            """;
+
+        var (exitCode, stdout, stderr) = Compile(source);
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("GS0152", stdout + stderr);
+        Assert.DoesNotContain("GS9999", stdout + stderr);
+        Assert.DoesNotContain("Unhandled exception", stdout + stderr);
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) Compile(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue1833_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            return (compileExit, compileOut.ToString(), compileErr.ToString());
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+                // ignored
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1833EnumConstraintViolationTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1833EnumConstraintViolationTests.cs
@@ -1,0 +1,174 @@
+// <copyright file="Issue1833EnumConstraintViolationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1833 (follow-up review note on PR #1832 / #1601): a type argument
+/// that is <c>struct</c>-constrained but <b>not</b> <c>Enum</c>-constrained — a
+/// concrete non-enum user struct, or a bare <c>[T struct]</c> type parameter —
+/// passed to a method whose type parameter carries a real <c>System.Enum</c>
+/// base-class constraint (e.g. <c>Enum.IsDefined&lt;TEnum&gt;</c> — <b>not</b>
+/// <c>Enum.TryParse</c>, whose real BCL signature only constrains
+/// <c>TEnum : struct</c> with no <c>Enum</c> base bound at all) must be
+/// rejected at bind time with a clear <c>GS0152</c> constraint-violation
+/// diagnostic instead of silently binding through overload resolution and
+/// only failing later at CLR verification.
+/// <para>
+/// Root cause: <c>OverloadResolution.SatisfiesGenericConstraints</c>'s
+/// base-type-constraint loop treated <em>every</em> <c>System.ValueType</c>-
+/// or <c>System.Enum</c>-named constraint as satisfied once the argument was
+/// classified as a value-type-erased symbol (<c>IsValueTypeErasedSymbol</c>,
+/// added by #1601). That is correct for <c>ValueType</c> (any struct/enum
+/// satisfies it) but wrong for <c>Enum</c> — a plain struct, or a struct-only
+/// type parameter, does not derive from <c>System.Enum</c>. The fix walks the
+/// recovered symbol's real derivation/constraint chain
+/// (<c>ValueTypeErasedSymbolSatisfiesBaseConstraint</c>) so only an actual enum
+/// (or a type parameter that itself carries an <c>Enum</c> bound) satisfies the
+/// <c>Enum</c> constraint, while <c>ValueType</c>/<c>Object</c> remain
+/// trivially satisfied by any value type.
+/// </para>
+/// </summary>
+public class Issue1833EnumConstraintViolationTests
+{
+    [Fact]
+    public void ConcreteNonEnumStruct_EnumIsDefined_ReportsConstraintViolation_NotCrash()
+    {
+        // (a) A concrete user struct (not an enum) explicitly supplied as
+        // Enum.IsDefined's type argument must be rejected at bind time with
+        // the GS0152 constraint-violation diagnostic — not silently bound
+        // (which would only fail later at CLR verification/emit).
+        const string source = @"
+package p
+import System
+
+struct Point {
+    var X int32
+    var Y int32
+}
+
+var pt = Point(1, 2)
+var ok = Enum.IsDefined[Point](pt)
+";
+        var diagnostics = Bind(source);
+        Assert.Contains(diagnostics, d => d.Id == "GS0152");
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS9999");
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0159");
+    }
+
+    [Fact]
+    public void StructOnlyTypeParameter_ForwardedToEnumIsDefined_ReportsConstraintViolation()
+    {
+        // (b) A bare `[T struct]` type parameter (struct-constrained but NOT
+        // Enum-constrained) forwarded to Enum.IsDefined[T] must also be
+        // rejected at bind time with GS0152 — it is indistinguishable from an
+        // arbitrary non-enum struct from Enum.IsDefined's point of view.
+        const string source = @"
+package p
+import System
+
+func Check[T struct](v T) bool {
+    return Enum.IsDefined[T](v)
+}
+";
+        var diagnostics = Bind(source);
+        Assert.Contains(diagnostics, d => d.Id == "GS0152");
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS9999");
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0159");
+    }
+
+    [Fact]
+    public void EnumConstrainedTypeParameter_EnumIsDefined_DoesNotFalsePositive()
+    {
+        // Negative control mirroring (a)/(b): an in-scope type parameter that
+        // itself genuinely carries the `Enum` bound (`[TEnum Enum struct]`)
+        // must NOT trip the new GS0152 constraint-violation diagnostic when
+        // forwarded to Enum.IsDefined[TEnum] — `ValueTypeErasedSymbolSatisfies
+        // BaseConstraint` must recognize its `ClassConstraint` as the real
+        // `System.Enum` bound. (Whether the call resolves end-to-end is
+        // unaffected by this fix either way — see the dedicated Enum.TryParse
+        // regression test below for the full round-trip guard.)
+        const string source = @"
+package p
+import System
+
+func Check[TEnum Enum struct](v TEnum) bool {
+    return Enum.IsDefined[TEnum](v)
+}
+";
+        var diagnostics = Bind(source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS9999");
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0152");
+    }
+
+    [Fact]
+    public void ConcreteEnum_EnumTryParse_StillBinds_Issue1601Regression()
+    {
+        // (c) Regression guard for the exact #1601 repro shape:
+        // Enum.TryParse[TEnum] with TEnum: Enum, struct forwarded, and the
+        // concrete same-compilation enum control — Enum.TryParse's real BCL
+        // constraint is only `struct` (no `Enum` base), so this must be
+        // completely unaffected by the new base-constraint enforcement.
+        const string source = @"
+package p
+import System
+
+func Parse[TEnum Enum struct](arg string) TEnum? {
+    if !Enum.TryParse[TEnum](arg, out var result) {
+        return nil
+    }
+    return result
+}
+
+enum Color { Red, Green }
+
+var ok = Enum.TryParse[Color](""Red"", out var concrete)
+";
+        var diagnostics = Bind(source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS9999");
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0159");
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0152");
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void StructOnlyTypeParameter_MemoryMarshalCast_StillBinds_GeneralizationPositiveCase()
+    {
+        // (d) Generalization positive control: the SAME bare `[T struct]` type
+        // parameter that must be REJECTED against Enum.IsDefined's `Enum` bound
+        // (test (b) above) must still be ACCEPTED against a method whose only
+        // base-type constraint is the implicit `ValueType` one (MemoryMarshal
+        // .Cast's `where TFrom : struct, TTo : struct`) — proving the fix
+        // enforces the ACTUAL constraint instead of blanket-rejecting every
+        // value-type-erased argument.
+        const string source = @"
+package p
+import System.Runtime.InteropServices
+
+func Cast[T struct](s Span[T]) Span[uint8] {
+    return MemoryMarshal.Cast[T, uint8](s)
+}
+";
+        var diagnostics = Bind(source);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS9999");
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0159");
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0152");
+        Assert.Empty(diagnostics);
+    }
+
+    private static IReadOnlyList<Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new GSharp.Core.CodeAnalysis.Compilation.Compilation(tree);
+        using var peStream = new System.IO.MemoryStream();
+        return compilation.Emit(peStream).Diagnostics.ToList();
+    }
+}


### PR DESCRIPTION
## Root cause

`OverloadResolution.SatisfiesGenericConstraints`'s base-type-constraint loop (whose value-type-erasure handling was introduced/widened by #1601's `IsValueTypeErasedSymbol`) unconditionally treated a value-type-erased type argument as satisfying **any** `System.ValueType`- or `System.Enum`-named base constraint. That's correct for `ValueType`/`Object` (every struct/enum trivially derives from them) but wrong for `Enum`: a plain user struct, or a bare `[T struct]` type parameter, does not derive from `System.Enum`.

As a result, a `struct`-but-not-`Enum` type argument could bind through overload resolution against a BCL method with a real `Enum` base-class constraint (e.g. `Enum.IsDefined<TEnum>`) and only fail later — at CLR verification or as a runtime crash — instead of failing cleanly at bind time. #1832 (the #1601 fix) widened exposure to this pre-existing hole.

## Fix

Replaced the hardcoded name-check skip with `ValueTypeErasedSymbolSatisfiesBaseConstraint`, which walks the recovered type argument's real derivation/constraint chain:
- `ValueType`/`Object` — trivially satisfied by any value type.
- `EnumSymbol` — satisfies exactly `System.Enum`.
- `StructSymbol` — satisfies neither (no base beyond `ValueType`/`Object` exists for a value type under the CLR).
- `TypeParameterSymbol` — satisfies a constraint only when its own `ClassConstraint` resolves (transitively) to the same CLR type; a bare `struct` constraint proves nothing about `Enum` or any other base.

This generalizes to **all** base-type constraints, not just `Enum`, while still allowing any concretely-satisfying base (e.g. `MemoryMarshal.Cast`'s `ValueType`-only bound stays satisfied for a bare `[T struct]` parameter).

Added `TryDescribeValueTypeBaseConstraintViolation` (`OverloadResolution`) and `TryReportGenericValueTypeBaseConstraintViolation` (`ExpressionBinder.Calls`) to identify the specific violated constraint for a rejected generic BCL call candidate and report it via the existing **`GS0152`** (`ReportTypeArgumentDoesNotSatisfyConstraint`) diagnostic — reusing the same diagnostic already used for user-defined generic constraint violations — instead of deferring to the generic `GS0159` "cannot find function" fallback or letting the call bind and fail later at emit/verification/runtime.

## #1601 regression check

`Enum.TryParse`'s real BCL constraint is only `struct` (no `Enum` base at all), so `TEnum: Enum, struct` forwarding through `Enum.TryParse` continues to bind and run exactly as before — verified explicitly with a dedicated regression test plus the full pre-existing `Issue1601GenericEnumTryParseForwardTests`/`Issue1601GenericEnumTryParseForwardEmitTests` suites (all passing, unchanged).

## Tests

- `test/Core.Tests/.../Issue1833EnumConstraintViolationTests.cs` (binder-level):
  - (a) concrete non-enum struct rejected against `Enum.IsDefined[T]` → `GS0152`.
  - (b) bare `[T struct]` parameter rejected against `Enum.IsDefined[T]` → `GS0152`.
  - negative control: an `Enum`-constrained type parameter does NOT falsely trip `GS0152`.
  - (c) `Enum.TryParse`-based #1601 regression guard — still binds cleanly.
  - (d) generalization positive control: the same `[T struct]` parameter from (b) still binds against `MemoryMarshal.Cast`'s `ValueType`-only constraint.
- `test/Compiler.Tests/Emit/Issue1833EnumConstraintViolationEmitTests.cs` (end-to-end compiler-driver, mirrors `Issue1601GenericEnumTryParseForwardEmitTests`'s `CompileAndRun` pattern): proves cases (a) and (b) fail `gsc` compilation with `GS0152` and never reach emit, rather than crashing.

Full `Core.Tests` suite (5260 tests) passes with no regressions. Targeted `Compiler.Tests` Emit suite (new + #1601 tests) passes.

## Also fixed in passing

A reference-identity `constraint == typeof(object)` check introduced while writing the fix was caught by the existing `Issue835` typeof-identity regression guard test and replaced with the required `ClrTypeUtilities.IsSameAs(...)` FullName-based comparison.

## Not fixed (pre-existing, unrelated, out of scope)

Discovered via `git stash` bisection while probing test candidates — both predate this change and are independent of the constraint-checking logic this fix addresses:
- `Enum.GetNames[T]()`/`Enum.GetValues[T]()` (zero-argument generic calls) fail to resolve entirely (`GS0159`), even for a valid concrete enum.
- Passing an actual value of an erased type parameter or same-compilation enum as a **by-value** argument (not `out`) to a BCL generic method (e.g. `Enum.IsDefined[TEnum](v)`, `Enum.GetName[TEnum](v)`) fails to resolve (`GS0159`), even for a legitimate call. `Enum.TryParse`'s `out TEnum` usage sidesteps this because it's an out-parameter rather than a converted-in value.

Flagging these as follow-up candidates if desired; not addressed here per root-cause-only scope for #1833.

Fixes #1833
