### PR TITLE
Fix #1751: scope LoadPriorRetryEntries to the writer's exact artifact path

### DIFF
--- a/tools/cs2gs/Cs2Gs.Pipeline/MigrationPipeline.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/MigrationPipeline.cs
@@ -166,33 +166,44 @@ public sealed class MigrationPipeline
             .Where(d => !string.Equals(new DirectoryInfo(d).Name, currentRunId, StringComparison.Ordinal))
             .OrderBy(d => new DirectoryInfo(d).Name, StringComparer.Ordinal))
         {
-            foreach (string file in Directory.EnumerateFiles(priorRunDir, "*.json", SearchOption.AllDirectories))
+            // Retry-entry artifacts are written by WriteArtifacts() (below) at
+            // exactly one location: <runDir>/<sanitizedAppId>/<stage>-<hash>.json
+            // (top-level files directly under each app's run directory; see
+            // WriteArtifacts). A recursive "*.json" scan of priorRunDir also
+            // walks into stage-4 (test-parity) scaffolds such as
+            // <appDir>/test-parity/<Lib>/obj/, whose NuGet-restore JSON
+            // (project.assets.json, *.nuget.*.json, MSBuild caches) can be
+            // several MB each and grows with every prior run — making this
+            // loop cost quadratic over the lifetime of an output root
+            // (issue #1751). Enumerate only the app directories directly
+            // under priorRunDir, and only the top-level files in each,
+            // matching the writer's layout exactly instead of descending into
+            // build artifacts.
+            foreach (string appDir in Directory.EnumerateDirectories(priorRunDir))
             {
-                if (string.Equals(Path.GetFileName(file), "run.json", StringComparison.Ordinal))
+                foreach (string file in Directory.EnumerateFiles(appDir, "*.json", SearchOption.TopDirectoryOnly))
                 {
-                    continue;
-                }
-
-                TriageArtifact prior = TryReadArtifact(file);
-                if (prior?.Fingerprint is null)
-                {
-                    continue;
-                }
-
-                if (!map.TryGetValue(prior.Fingerprint, out List<TriageRetryEntry> entries))
-                {
-                    entries = new List<TriageRetryEntry>();
-                    map[prior.Fingerprint] = entries;
-                }
-
-                if (entries.All(e => !string.Equals(e.RunId, prior.RunId, StringComparison.Ordinal)))
-                {
-                    entries.Add(new TriageRetryEntry
+                    TriageArtifact prior = TryReadArtifact(file);
+                    if (prior?.Fingerprint is null)
                     {
-                        RunId = prior.RunId,
-                        GscVersion = prior.GscVersion,
-                        Result = "fail",
-                    });
+                        continue;
+                    }
+
+                    if (!map.TryGetValue(prior.Fingerprint, out List<TriageRetryEntry> entries))
+                    {
+                        entries = new List<TriageRetryEntry>();
+                        map[prior.Fingerprint] = entries;
+                    }
+
+                    if (entries.All(e => !string.Equals(e.RunId, prior.RunId, StringComparison.Ordinal)))
+                    {
+                        entries.Add(new TriageRetryEntry
+                        {
+                            RunId = prior.RunId,
+                            GscVersion = prior.GscVersion,
+                            Result = "fail",
+                        });
+                    }
                 }
             }
         }

--- a/tools/cs2gs/Cs2Gs.Tests/MigrationPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/MigrationPipelineTests.cs
@@ -5,6 +5,8 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Cs2Gs.Pipeline;
@@ -277,6 +279,92 @@ public class MigrationPipelineTests
         Assert.NotEmpty(artifact.RetryHistory);
         Assert.Contains(artifact.RetryHistory, e => e.RunId == first.RunId);
         Assert.All(artifact.RetryHistory, e => Assert.Equal("fail", e.Result));
+    }
+
+    /// <summary>
+    /// Issue #1751 regression guard: a prior run directory that also contains a
+    /// stage-4 (test-parity) NuGet-restore scaffold under
+    /// <c>&lt;appDir&gt;/test-parity/&lt;Lib&gt;/obj/</c> (e.g.
+    /// <c>project.assets.json</c>, <c>*.nuget.dgspec.json</c>) must not have
+    /// those decoy JSON files opened at all — <see cref="LoadPriorRetryEntries"/>
+    /// (reached via reflection since it is a pipeline-internal helper) is
+    /// scoped to exactly the writer's layout, <c>&lt;runDir&gt;/&lt;appDir&gt;/*.json</c>
+    /// (top-level only), so it never descends into <c>obj/</c>. The decoy
+    /// files are chmod'd unreadable as a canary: were they opened, the
+    /// unhandled <see cref="UnauthorizedAccessException"/> would fail this
+    /// test loudly (only <see cref="JsonException"/>/<see cref="IOException"/>
+    /// are swallowed by <c>TryReadArtifact</c>). Skipped on Windows, which has
+    /// no POSIX permission bits to enforce the canary.
+    /// </summary>
+    [Fact]
+    public void LoadPriorRetryEntries_IgnoresObjArtifacts_AndDoesNotDescendIntoThem()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return;
+        }
+
+        string outputRoot = NewOutputRoot("retry-scan-scope");
+        string priorRunDir = Path.Combine(outputRoot, "2026-01-01T00-00-00Z_aaaaaa");
+        string appDir = Path.Combine(priorRunDir, "corpus_Sample");
+        Directory.CreateDirectory(appDir);
+
+        // The real retry-entry artifact: written by WriteArtifacts() directly
+        // under the app's run directory as "<stage>-<12hex fingerprint>.json".
+        var builder = new TriageBuilder(
+            "2026-01-01T00-00-00Z_aaaaaa", "2026-01-01T00:00:00Z", "0.2.0+abc", "corpus/Sample");
+        var diagnostic = new GscDiagnostic("GS0100", "no overload for 'g'", "error", "Sample.gs", 2, 13);
+        TriageArtifact real = builder.CompileError(diagnostic, null);
+        string realFile = Path.Combine(appDir, "compile-" + FingerprintShort(real.Fingerprint) + ".json");
+        File.WriteAllText(realFile, JsonSerializer.Serialize(real, TriageSerialization.Options));
+
+        // Decoy stage-4 NuGet/MSBuild artifacts nested under obj/, exactly the
+        // layout GsharpTestProjectRunner.Run() scaffolds
+        // (<appDir>/test-parity/<Lib>/obj/*.json). Made unreadable so any
+        // attempt to open them throws instead of silently succeeding.
+        string objDir = Path.Combine(appDir, "test-parity", "Sample", "obj");
+        Directory.CreateDirectory(objDir);
+        string[] decoys =
+        {
+            Path.Combine(objDir, "project.assets.json"),
+            Path.Combine(objDir, "Sample.csproj.nuget.dgspec.json"),
+            Path.Combine(objDir, "Sample.csproj.nuget.g.props.json"),
+        };
+        foreach (string decoy in decoys)
+        {
+            File.WriteAllText(decoy, new string('x', 1024)); // not even valid JSON
+            File.SetUnixFileMode(decoy, UnixFileMode.None); // canary: reading this throws
+        }
+
+        try
+        {
+            MethodInfo method = typeof(MigrationPipeline).GetMethod(
+                "LoadPriorRetryEntries", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
+
+            var result = (System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.List<TriageRetryEntry>>)
+                method.Invoke(null, new object[] { outputRoot, "2026-01-02T00-00-00Z_bbbbbb" });
+
+            TriageRetryEntry entry = Assert.Single(Assert.Single(result).Value);
+            Assert.Equal("2026-01-01T00-00-00Z_aaaaaa", entry.RunId);
+            Assert.Single(result); // exactly the one real fingerprint, nothing from the decoys
+        }
+        finally
+        {
+            // Restore permissions so test cleanup (temp-dir deletion) can proceed.
+            foreach (string decoy in decoys)
+            {
+                File.SetUnixFileMode(decoy, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+            }
+        }
+    }
+
+    private static string FingerprintShort(string fingerprint)
+    {
+        string hex = fingerprint.StartsWith("sha256:", StringComparison.Ordinal)
+            ? fingerprint.Substring("sha256:".Length)
+            : fingerprint;
+        return hex.Length <= 12 ? hex : hex.Substring(0, 12);
     }
 
     private static string NewOutputRoot(string label)


### PR DESCRIPTION
## Root cause
`WriteArtifacts()` writes each retry-entry artifact at exactly one location: `<runDir>/<sanitizedAppId>/<stage>-<12hex fingerprint>.json`, a top-level file directly under each app's per-run directory.

`LoadPriorRetryEntries()` instead did `Directory.EnumerateFiles(priorRunDir, "*.json", SearchOption.AllDirectories)` — a recursive scan that also descends into the stage-4 (test-parity) NuGet-restore scaffold `GsharpTestProjectRunner` creates under `<appDir>/test-parity/<Lib>/obj/` (`project.assets.json`, `*.nuget.dgspec.json`, other MSBuild caches). Those files can be several MB each and are read + JSON-deserialized on every retry-entry load. Every new run adds another prior run's `obj/` tree to the scan, so the cost of starting a run grows **quadratically** with the number of prior runs under an output root — the exact loop the retry-history feature exists for.

## Fix
Enumerate only the app directories directly under each prior run directory, then only the top-level files in each app directory (`SearchOption.TopDirectoryOnly`) — matching the writer's layout exactly instead of blind-globbing. This is robust to any prior-run layout because it targets the deterministic path the writer uses, rather than excluding specific artifact names.

The old `run.json` filename exclusion is now redundant (`run.json` lives at the run-directory root, one level above where the loader now looks) but is left in place as a harmless defensive check.

## Test
Added `LoadPriorRetryEntries_IgnoresObjArtifacts_AndDoesNotDescendIntoThem`, which reproduces the writer's layout plus a decoy `test-parity/<Lib>/obj/` scaffold side by side, chmod's the decoy JSON files unreadable as a canary, and asserts:
- the loader returns only the real retry entry (not anything from the decoys)
- the decoy files are never opened (verified: fails with `UnauthorizedAccessException` against the pre-fix recursive scan; passes with the fix)

## Verification
- `dotnet build GSharp.sln -c Release -graph` — build succeeded, 0 warnings/errors.
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release --filter "FullyQualifiedName~MigrationPipelineTests"` — 9/9 passed.
- Confirmed the new test fails (UnauthorizedAccessException opening a decoy obj/ file) when re-run against the pre-fix code, then passes again with the fix restored.

Fixes #1751