### PR TITLE
cs2gs: fix report --out artifact-link 404s and file-vs-dir heuristic

### DIFF
--- a/tools/cs2gs/Cs2Gs.Cli/Program.cs
+++ b/tools/cs2gs/Cs2Gs.Cli/Program.cs
@@ -160,26 +160,72 @@ internal static class Program
         }
 
         string targetDir = runDir;
+        string htmlFileName = null;
+        string jsonFileName = null;
         if (!string.IsNullOrEmpty(outPath))
         {
-            targetDir = Directory.Exists(outPath) || HasNoExtension(outPath)
-                ? outPath
-                : Path.GetDirectoryName(Path.GetFullPath(outPath));
+            (targetDir, htmlFileName, jsonFileName) = ResolveOutTarget(outPath);
             Directory.CreateDirectory(targetDir);
         }
 
         ReportModel model = ReportModel.FromRunDirectory(runDir);
-        string htmlPath = HtmlReportWriter.Write(model, targetDir);
-        string jsonPath = JsonSummaryWriter.Write(model, targetDir);
+        string htmlPath = HtmlReportWriter.Write(model, targetDir, htmlFileName);
+        string jsonPath = JsonSummaryWriter.Write(model, targetDir, jsonFileName);
 
         Console.WriteLine($"report:  {htmlPath}");
         Console.WriteLine($"summary: {jsonPath}");
         return 0;
     }
 
-    private static bool HasNoExtension(string path)
+    /// <summary>
+    /// Decides whether a user-supplied <c>--out &lt;file-or-dir&gt;</c> path names
+    /// a directory or a specific output file, and resolves it to a
+    /// (targetDir, htmlFileName, jsonFileName) triple. The rule, in order:
+    /// <list type="number">
+    /// <item>A path ending in a directory separator is always a directory.</item>
+    /// <item>An existing directory is a directory.</item>
+    /// <item>An existing file is that exact file (its parent is the target dir).</item>
+    /// <item>A non-existent path whose extension is a recognized report
+    /// extension (<c>.html</c>, <c>.htm</c>, <c>.json</c>) is a to-be-created
+    /// file with that name.</item>
+    /// <item>Anything else (no extension, or an unrecognized/dotted name such
+    /// as <c>run.2026-07-01</c>) is a to-be-created directory.</item>
+    /// </list>
+    /// When resolved as a file, the file's own extension picks which artifact
+    /// it renames (<c>.json</c> renames <c>summary.json</c>; anything else
+    /// renames <c>report.html</c>); the other artifact keeps its default name
+    /// in the same directory, since one <c>--out</c> file name cannot cover two
+    /// distinct output artifacts.
+    /// </summary>
+    /// <param name="outPath">The raw <c>--out</c> value.</param>
+    /// <returns>The resolved target directory and optional per-writer file names.</returns>
+    private static (string TargetDir, string HtmlFileName, string JsonFileName) ResolveOutTarget(string outPath)
     {
-        return string.IsNullOrEmpty(Path.GetExtension(path));
+        bool trailingSeparator = outPath.EndsWith(Path.DirectorySeparatorChar) ||
+            outPath.EndsWith(Path.AltDirectorySeparatorChar);
+        string fullPath = Path.GetFullPath(outPath);
+
+        bool isDirectory = trailingSeparator
+            || Directory.Exists(fullPath)
+            || (!File.Exists(fullPath) && !IsRecognizedReportExtension(fullPath));
+
+        if (isDirectory)
+        {
+            return (fullPath, null, null);
+        }
+
+        string targetDir = Path.GetDirectoryName(fullPath);
+        string fileName = Path.GetFileName(fullPath);
+        bool isJson = string.Equals(Path.GetExtension(fileName), ".json", StringComparison.OrdinalIgnoreCase);
+        return isJson ? (targetDir, null, fileName) : (targetDir, fileName, null);
+    }
+
+    private static bool IsRecognizedReportExtension(string path)
+    {
+        string extension = Path.GetExtension(path);
+        return string.Equals(extension, ".html", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(extension, ".htm", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(extension, ".json", StringComparison.OrdinalIgnoreCase);
     }
 
     private static string ResolveRunDir(string outputRoot, string runId)
@@ -352,7 +398,12 @@ internal static class Program
         Console.WriteLine();
         Console.WriteLine("report options:");
         Console.WriteLine("  --run <dir>       Existing run directory containing run.json (required).");
-        Console.WriteLine("  --out <dir>       Output directory for report.html + summary.json (default: the run dir).");
+        Console.WriteLine("  --out <file-or-dir>");
+        Console.WriteLine("                    Output location for report.html + summary.json (default: the run dir).");
+        Console.WriteLine("                    A trailing slash or an existing directory is always a directory.");
+        Console.WriteLine("                    A path ending in .html/.htm/.json (or an existing file) names that one");
+        Console.WriteLine("                    output file directly; the other artifact keeps its default name");
+        Console.WriteLine("                    alongside it. Any other path is created as a directory.");
         Console.WriteLine();
         Console.WriteLine("A migrate run also writes report.html + summary.json into the run dir automatically (ADR-0115 §F).");
         Console.WriteLine();

--- a/tools/cs2gs/Cs2Gs.Report/HtmlReportWriter.cs
+++ b/tools/cs2gs/Cs2Gs.Report/HtmlReportWriter.cs
@@ -87,16 +87,26 @@ public static class HtmlReportWriter
         "})();") + Newline;
 
     /// <summary>
-    /// Renders the model to a self-contained HTML document.
+    /// Renders the model to a self-contained HTML document. Triage-artifact
+    /// links are resolved relative to <paramref name="outputDir"/> (defaulting
+    /// to <see cref="ReportModel.RunDir"/>, i.e. as if the document were
+    /// written into the run dir) so the same model renders correct, clickable
+    /// links no matter where <c>report.html</c> ultimately lives.
     /// </summary>
     /// <param name="model">The aggregated report model.</param>
+    /// <param name="outputDir">
+    /// The directory the rendered document will be written into. Defaults to
+    /// <see cref="ReportModel.RunDir"/> when <see langword="null"/>.
+    /// </param>
     /// <returns>The deterministic HTML text.</returns>
-    public static string Render(ReportModel model)
+    public static string Render(ReportModel model, string outputDir = null)
     {
         if (model is null)
         {
             throw new ArgumentNullException(nameof(model));
         }
+
+        outputDir = Path.GetFullPath(outputDir ?? model.RunDir);
 
         var sb = new StringBuilder();
         sb.Append("<!DOCTYPE html>").Append(Newline);
@@ -106,7 +116,7 @@ public static class HtmlReportWriter
         AppendHeader(sb, model);
         AppendMatrix(sb, model);
         AppendGaps(sb, model);
-        AppendAppDetails(sb, model);
+        AppendAppDetails(sb, model, outputDir);
         AppendScript(sb);
         sb.Append("</body>").Append(Newline);
         sb.Append("</html>").Append(Newline);
@@ -114,21 +124,29 @@ public static class HtmlReportWriter
     }
 
     /// <summary>
-    /// Writes <c>report.html</c> under the run directory and returns its path.
+    /// Writes <c>report.html</c> into <paramref name="outputDir"/> (which may
+    /// differ from the run dir the model was built from) and returns its path.
+    /// Triage-artifact links are rewritten relative to <paramref name="outputDir"/>
+    /// so they resolve from wherever the document is written.
     /// </summary>
     /// <param name="model">The aggregated report model.</param>
-    /// <param name="runDir">The run directory to write into.</param>
+    /// <param name="outputDir">The directory to write <c>report.html</c> into.</param>
+    /// <param name="fileName">
+    /// The file name to write, defaulting to <see cref="FileName"/> (<c>report.html</c>)
+    /// when <see langword="null"/> or empty. Lets <c>--out &lt;file&gt;</c> honor a
+    /// user-supplied report file name.
+    /// </param>
     /// <returns>The full path of the written file.</returns>
-    public static string Write(ReportModel model, string runDir)
+    public static string Write(ReportModel model, string outputDir, string fileName = null)
     {
-        if (string.IsNullOrEmpty(runDir))
+        if (string.IsNullOrEmpty(outputDir))
         {
-            throw new ArgumentException("Run directory is required.", nameof(runDir));
+            throw new ArgumentException("Output directory is required.", nameof(outputDir));
         }
 
-        Directory.CreateDirectory(runDir);
-        string path = Path.Combine(runDir, FileName);
-        File.WriteAllText(path, Render(model));
+        Directory.CreateDirectory(outputDir);
+        string path = Path.Combine(outputDir, string.IsNullOrEmpty(fileName) ? FileName : fileName);
+        File.WriteAllText(path, Render(model, outputDir));
         return path;
     }
 
@@ -393,7 +411,7 @@ public static class HtmlReportWriter
         sb.Append("</details>").Append(Newline);
     }
 
-    private static void AppendAppDetails(StringBuilder sb, ReportModel model)
+    private static void AppendAppDetails(StringBuilder sb, ReportModel model, string outputDir)
     {
         sb.Append("<section aria-labelledby=\"apps-h\">").Append(Newline);
         sb.Append("<h2 id=\"apps-h\">App details</h2>").Append(Newline);
@@ -430,7 +448,8 @@ public static class HtmlReportWriter
                 sb.Append("<ul class=\"artifacts\">").Append(Newline);
                 foreach (string artifact in app.Artifacts)
                 {
-                    sb.Append("<li><a href=\"").Append(Encode(EncodeUriPath(artifact))).Append("\">")
+                    string href = ResolveArtifactHref(model.RunDir, outputDir, artifact);
+                    sb.Append("<li><a href=\"").Append(Encode(EncodeUriPath(href))).Append("\">")
                         .Append(Encode(artifact)).Append("</a></li>").Append(Newline);
                 }
 
@@ -510,6 +529,27 @@ public static class HtmlReportWriter
         }
 
         return string.Join("/", relative.Split('/').Select(Uri.EscapeDataString));
+    }
+
+    /// <summary>
+    /// Resolves a triage-artifact path (stored relative to <paramref name="runDir"/>
+    /// in <c>run.json</c>) to a link that is valid relative to
+    /// <paramref name="outputDir"/>, the directory <c>report.html</c> is actually
+    /// written into. Uses <see cref="Path.GetRelativePath(string, string)"/> so it
+    /// works for any relationship between the two directories (parent, sibling,
+    /// nested, or the same directory) and normalizes the result to forward
+    /// slashes for use as a URI path.
+    /// </summary>
+    /// <param name="runDir">The absolute run directory the artifact path is relative to.</param>
+    /// <param name="outputDir">The absolute directory the document is written into.</param>
+    /// <param name="artifactRelative">The run-relative artifact path from <c>run.json</c>.</param>
+    /// <returns>The href, relative to <paramref name="outputDir"/>, with forward-slash separators.</returns>
+    private static string ResolveArtifactHref(string runDir, string outputDir, string artifactRelative)
+    {
+        string absoluteArtifact = Path.GetFullPath(
+            Path.Combine(runDir, artifactRelative.Replace('/', Path.DirectorySeparatorChar)));
+        string relativeToOutput = Path.GetRelativePath(outputDir, absoluteArtifact);
+        return relativeToOutput.Replace(Path.DirectorySeparatorChar, '/').Replace(Path.AltDirectorySeparatorChar, '/');
     }
 
     private static string Slug(string value)

--- a/tools/cs2gs/Cs2Gs.Report/JsonSummaryWriter.cs
+++ b/tools/cs2gs/Cs2Gs.Report/JsonSummaryWriter.cs
@@ -39,20 +39,25 @@ public static class JsonSummaryWriter
     }
 
     /// <summary>
-    /// Writes <c>summary.json</c> under the run directory and returns its path.
+    /// Writes the JSON summary into <paramref name="outputDir"/> and returns its path.
     /// </summary>
     /// <param name="model">The aggregated report model.</param>
-    /// <param name="runDir">The run directory to write into.</param>
+    /// <param name="outputDir">The directory to write into.</param>
+    /// <param name="fileName">
+    /// The file name to write, defaulting to <see cref="FileName"/> (<c>summary.json</c>)
+    /// when <see langword="null"/> or empty. Lets <c>--out &lt;file&gt;</c> honor a
+    /// user-supplied summary file name.
+    /// </param>
     /// <returns>The full path of the written file.</returns>
-    public static string Write(ReportModel model, string runDir)
+    public static string Write(ReportModel model, string outputDir, string fileName = null)
     {
-        if (string.IsNullOrEmpty(runDir))
+        if (string.IsNullOrEmpty(outputDir))
         {
-            throw new ArgumentException("Run directory is required.", nameof(runDir));
+            throw new ArgumentException("Output directory is required.", nameof(outputDir));
         }
 
-        Directory.CreateDirectory(runDir);
-        string path = Path.Combine(runDir, FileName);
+        Directory.CreateDirectory(outputDir);
+        string path = Path.Combine(outputDir, string.IsNullOrEmpty(fileName) ? FileName : fileName);
         File.WriteAllText(path, Serialize(model));
         return path;
     }

--- a/tools/cs2gs/Cs2Gs.Report/ReportModel.cs
+++ b/tools/cs2gs/Cs2Gs.Report/ReportModel.cs
@@ -69,6 +69,16 @@ public sealed class ReportModel
     public List<GapReport> Gaps { get; set; } = new List<GapReport>();
 
     /// <summary>
+    /// Gets or sets the absolute run directory the model was built from (i.e.
+    /// the directory <see cref="AppReport.Artifacts"/> paths are relative to).
+    /// Not part of the <c>summary.json</c> schema; used only so
+    /// <see cref="HtmlReportWriter"/> can re-resolve artifact links when
+    /// <c>report.html</c> is written somewhere other than the run dir.
+    /// </summary>
+    [JsonIgnore]
+    public string RunDir { get; set; }
+
+    /// <summary>
     /// Builds a <see cref="ReportModel"/> from a run directory by reading its
     /// <c>run.json</c> and every referenced triage artifact.
     /// </summary>
@@ -150,6 +160,7 @@ public sealed class ReportModel
             StageOrder = stageOrder,
             Apps = apps,
             Gaps = GroupGaps(artifacts),
+            RunDir = Path.GetFullPath(runDir),
         };
     }
 

--- a/tools/cs2gs/Cs2Gs.Tests/ReportTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/ReportTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using Cs2Gs.Pipeline;
 using Cs2Gs.Report;
 using Xunit;
@@ -263,6 +264,144 @@ public class ReportTests
         Assert.Equal(0, process.ExitCode);
         Assert.True(File.Exists(Path.Combine(runDir, "report.html")), stdout);
         Assert.True(File.Exists(Path.Combine(runDir, "summary.json")), stdout);
+
+        AssertArtifactLinksResolve(Path.Combine(runDir, "report.html"), runDir);
+    }
+
+    /// <summary>
+    /// <c>report --out</c> to a directory other than the run dir (sibling or
+    /// parent) must still emit triage-artifact links that resolve to the real
+    /// artifact files from the report's actual location (issue #1754, bug 1).
+    /// </summary>
+    [Theory]
+    [InlineData("sibling")]
+    [InlineData("nested/deeper")]
+    [InlineData("..")]
+    public void Cli_ReportVerb_OutToOtherDir_LinksResolveToRealArtifacts(string relativeOut)
+    {
+        string cliDll = FindCliDll();
+        Assert.True(cliDll is not null, "cs2gs.dll not found; build the solution first.");
+
+        string runDir = WriteSyntheticRun();
+        string outDir = Path.GetFullPath(Path.Combine(runDir, relativeOut, "report-out-" + Guid.NewGuid().ToString("N")));
+
+        string stdout = RunCli(cliDll, "report", "--run", runDir, "--out", outDir);
+
+        string htmlPath = Path.Combine(outDir, "report.html");
+        Assert.True(File.Exists(htmlPath), stdout);
+        Assert.True(File.Exists(Path.Combine(outDir, "summary.json")), stdout);
+
+        AssertArtifactLinksResolve(htmlPath, outDir);
+    }
+
+    /// <summary>
+    /// <c>report --out &lt;dir&gt;/&lt;file&gt;.html</c> honors the supplied file
+    /// name for <c>report.html</c> instead of silently discarding it, while
+    /// <c>summary.json</c> keeps its default name alongside it (issue #1754,
+    /// bug 2).
+    /// </summary>
+    [Fact]
+    public void Cli_ReportVerb_OutWithExplicitHtmlFileName_UsesGivenFileName()
+    {
+        string cliDll = FindCliDll();
+        Assert.True(cliDll is not null, "cs2gs.dll not found; build the solution first.");
+
+        string runDir = WriteSyntheticRun();
+        string outDir = Path.Combine(runDir, "custom-" + Guid.NewGuid().ToString("N"));
+        string outFile = Path.Combine(outDir, "mysummary.html");
+
+        string stdout = RunCli(cliDll, "report", "--run", runDir, "--out", outFile);
+
+        Assert.True(File.Exists(outFile), stdout);
+        Assert.False(File.Exists(Path.Combine(outDir, "report.html")), stdout);
+        Assert.True(File.Exists(Path.Combine(outDir, "summary.json")), stdout);
+
+        AssertArtifactLinksResolve(outFile, outDir);
+    }
+
+    /// <summary>
+    /// <c>report --out &lt;dir&gt;/&lt;file&gt;.json</c> honors the supplied file
+    /// name for <c>summary.json</c>, while <c>report.html</c> keeps its default
+    /// name (issue #1754, bug 2).
+    /// </summary>
+    [Fact]
+    public void Cli_ReportVerb_OutWithExplicitJsonFileName_UsesGivenFileName()
+    {
+        string cliDll = FindCliDll();
+        Assert.True(cliDll is not null, "cs2gs.dll not found; build the solution first.");
+
+        string runDir = WriteSyntheticRun();
+        string outDir = Path.Combine(runDir, "custom-" + Guid.NewGuid().ToString("N"));
+        string outFile = Path.Combine(outDir, "run-summary.json");
+
+        string stdout = RunCli(cliDll, "report", "--run", runDir, "--out", outFile);
+
+        Assert.True(File.Exists(outFile), stdout);
+        Assert.False(File.Exists(Path.Combine(outDir, "summary.json")), stdout);
+        Assert.True(File.Exists(Path.Combine(outDir, "report.html")), stdout);
+    }
+
+    /// <summary>
+    /// A <c>--out</c> path with a dotted-but-unrecognized "extension" (e.g. a
+    /// dated directory name) is still treated as a directory, not
+    /// misinterpreted as a file (issue #1754, bug 2 edge case).
+    /// </summary>
+    [Fact]
+    public void Cli_ReportVerb_OutWithDottedDirectoryName_TreatedAsDirectory()
+    {
+        string cliDll = FindCliDll();
+        Assert.True(cliDll is not null, "cs2gs.dll not found; build the solution first.");
+
+        string runDir = WriteSyntheticRun();
+        string outDir = Path.Combine(runDir, "out", "run.2026-07-01");
+
+        string stdout = RunCli(cliDll, "report", "--run", runDir, "--out", outDir);
+
+        Assert.True(File.Exists(Path.Combine(outDir, "report.html")), stdout);
+        Assert.True(File.Exists(Path.Combine(outDir, "summary.json")), stdout);
+    }
+
+    /// <summary>
+    /// Parses every triage-artifact <c>href</c> out of a rendered
+    /// <c>report.html</c> and asserts each one resolves, relative to
+    /// <paramref name="reportDir"/>, to a triage artifact file that actually
+    /// exists.
+    /// </summary>
+    private static void AssertArtifactLinksResolve(string reportHtmlPath, string reportDir)
+    {
+        string html = File.ReadAllText(reportHtmlPath);
+        MatchCollection matches = Regex.Matches(html, "<li><a href=\"([^\"]+)\">");
+        Assert.NotEmpty(matches);
+
+        foreach (Match match in matches)
+        {
+            string href = Uri.UnescapeDataString(match.Groups[1].Value);
+            string resolved = Path.GetFullPath(Path.Combine(reportDir, href.Replace('/', Path.DirectorySeparatorChar)));
+            Assert.True(File.Exists(resolved), $"artifact link '{href}' does not resolve to an existing file at '{resolved}'.");
+        }
+    }
+
+    private static string RunCli(string cliDll, params string[] args)
+    {
+        var psi = new System.Diagnostics.ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        psi.ArgumentList.Add(cliDll);
+        foreach (string arg in args)
+        {
+            psi.ArgumentList.Add(arg);
+        }
+
+        using var process = System.Diagnostics.Process.Start(psi);
+        string stdout = process.StandardOutput.ReadToEnd();
+        string stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        Assert.Equal(0, process.ExitCode);
+        return stdout + stderr;
     }
 
     private static string FindCliDll()


### PR DESCRIPTION
Fixes two bugs in `cs2gs report --out`:

1. **Artifact links 404 from any `--out` other than the run dir.** `AppReport.Artifacts` stores paths relative to the run dir (as read from `run.json`). `HtmlReportWriter` emitted these run-relative strings verbatim as `href`s, so as soon as `report.html` was written somewhere other than the run dir, every triage-artifact link 404ed. Fix: `ReportModel` now carries the absolute `RunDir` it was built from (`[JsonIgnore]`, not part of `summary.json`), and `HtmlReportWriter.Render`/`Write` take the output directory and recompute each href with `Path.GetRelativePath(outputDir, Path.Combine(runDir, artifact))`, normalized to forward slashes for the URI. This works for any relationship between the run dir and `--out` (parent, sibling, nested, or the same dir).

2. **The file-vs-dir heuristic silently discarded a user-supplied file name.** The old rule (`Directory.Exists(outPath) || no-extension`) dropped the intended file name whenever a path had a recognized extension but a non-existent parent, mistreated dotted-but-unrecognized names (e.g. `out/run.2026-07-01`) as a file's parent directory, and threw when an existing extensionless file was passed. Fix — explicit rule in `Program.ResolveOutTarget`:
   1. a trailing separator is always a directory;
   2. an existing directory is a directory;
   3. an existing file is that exact file;
   4. a non-existent path is a file only if its extension is a recognized report extension (`.html`/`.htm`/`.json`);
   5. anything else is created as a directory.

   When resolved as a file, its extension picks which artifact it renames (`.json` renames `summary.json`, otherwise `report.html`); the other artifact keeps its default name alongside it, since one `--out` file name can't cover two distinct output files. `HtmlReportWriter.Write`/`JsonSummaryWriter.Write` gained an optional `fileName` parameter to support this.

Tests added in `Cs2Gs.Tests/ReportTests.cs`:
- `Cli_ReportVerb_OutToOtherDir_LinksResolveToRealArtifacts` (sibling/nested/parent `--out`): parses every artifact `href` from the generated `report.html` and asserts it resolves (via `Path.GetRelativePath`) to a real triage-artifact file.
- `Cli_ReportVerb_OutWithExplicitHtmlFileName_UsesGivenFileName` / `..._OutWithExplicitJsonFileName_UsesGivenFileName`: an explicit `--out <dir>/<file>.html|.json` is honored exactly, with the sibling artifact keeping its default name.
- `Cli_ReportVerb_OutWithDottedDirectoryName_TreatedAsDirectory`: a dotted-but-unrecognized `--out` path is still treated as a directory.
- `Cli_ReportVerb_RegeneratesBothArtifacts` (existing, default no-`--out` case) now also asserts link resolution via the new `AssertArtifactLinksResolve` helper.

Verified: `dotnet build GSharp.sln -c Release -graph` succeeds; `dotnet test -c Release --no-build --filter FullyQualifiedName~ReportTests` → 13/13 passed, including the CLI-invoked `cs2gs.dll` tests.

Fixes #1754