### PR TITLE
cs2gs: fix stage-4 SDK resolution pinning stale bits (stale nupkg + prerelease ordering)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Pipeline/GsharpTestProjectRunner.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/GsharpTestProjectRunner.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Security.Cryptography;
 
 namespace Cs2Gs.Pipeline;
 
@@ -202,6 +203,16 @@ public class GsharpTestProjectRunner
             args.Add($"-p:RestoreConfigFile={repoNugetConfig}");
         }
 
+        // Bug #1752 (part 1): NuGet's shared global-packages folder keys its
+        // extracted package cache on id+version alone, so a same-version
+        // rebuilt SDK nupkg copied into `.nugs` (see EnsureInLocalFeed) would
+        // still resolve to the stale extraction left behind by an earlier run.
+        // Point restore at a packages folder scoped to this work dir so every
+        // run extracts the current `.nugs` nupkg contents fresh, regardless of
+        // what is already sitting in the shared global cache.
+        string isolatedPackagesPath = Path.Combine(workDir, ".nuget-packages");
+        args.Add($"-p:RestorePackagesPath={isolatedPackagesPath}");
+
         (int exit, string output) = this.RunDotnet(args, workDir);
 
         if (!File.Exists(trxPath))
@@ -213,23 +224,21 @@ public class GsharpTestProjectRunner
         return GsharpTestRunResult.Ran(exit, output, trxPath, results);
     }
 
-    private static string ParseVersion(string fileName)
+    /// <summary>
+    /// Compares two dotted-numeric SDK versions (with an optional prerelease
+    /// suffix) per SemVer 2.0.0 §11 precedence: numeric release components
+    /// compare numerically (so <c>1.10.0</c> outranks <c>1.9.0</c>), a version
+    /// WITHOUT a prerelease tag outranks the same release WITH one (a
+    /// prerelease precedes its release), and when both carry a prerelease tag
+    /// its dot-separated identifiers are compared per §11.4 (numeric
+    /// identifiers compare numerically and are lower than alphanumeric ones,
+    /// which compare ordinally).
+    /// </summary>
+    /// <param name="left">The left-hand version.</param>
+    /// <param name="right">The right-hand version.</param>
+    /// <returns>A negative, zero, or positive value as <paramref name="left"/> is lower than, equal to, or higher than <paramref name="right"/>.</returns>
+    internal static int CompareVersions(string left, string right)
     {
-        if (!fileName.StartsWith(SdkPackagePrefix, StringComparison.Ordinal) ||
-            !fileName.EndsWith(".nupkg", StringComparison.Ordinal))
-        {
-            return null;
-        }
-
-        return fileName.Substring(
-            SdkPackagePrefix.Length,
-            fileName.Length - SdkPackagePrefix.Length - ".nupkg".Length);
-    }
-
-    private static int CompareVersions(string left, string right)
-    {
-        // Compare the dotted numeric release components (e.g. 0.2.107) numerically
-        // so 0.2.107 outranks 0.2.99, falling back to ordinal on the build suffix.
         (int[] LeftNumbers, string LeftSuffix) a = SplitVersion(left);
         (int[] RightNumbers, string RightSuffix) b = SplitVersion(right);
 
@@ -244,7 +253,61 @@ public class GsharpTestProjectRunner
             }
         }
 
-        return string.CompareOrdinal(a.LeftSuffix, b.RightSuffix);
+        bool leftHasSuffix = a.LeftSuffix.Length > 0;
+        bool rightHasSuffix = b.RightSuffix.Length > 0;
+        if (leftHasSuffix != rightHasSuffix)
+        {
+            // Absent prerelease tag (release) outranks a present one.
+            return leftHasSuffix ? -1 : 1;
+        }
+
+        if (!leftHasSuffix)
+        {
+            return 0;
+        }
+
+        return ComparePrereleaseIdentifiers(a.LeftSuffix, b.RightSuffix);
+    }
+
+    /// <summary>
+    /// Copies <paramref name="nupkgPath"/> into the repo's local <c>.nugs</c>
+    /// feed, refreshing it when the destination already exists but its content
+    /// differs from the source (a same-version rebuild), while leaving an
+    /// unchanged nupkg untouched.
+    /// </summary>
+    /// <param name="repoRoot">The repository root containing the <c>.nugs</c> feed.</param>
+    /// <param name="nupkgPath">The source nupkg to stage.</param>
+    internal static void EnsureInLocalFeed(string repoRoot, string nupkgPath)
+    {
+        string feed = Path.Combine(repoRoot, ".nugs");
+        Directory.CreateDirectory(feed);
+        string target = Path.Combine(feed, Path.GetFileName(nupkgPath));
+
+        // Bug #1752 (part 1): a rebuilt SDK nupkg with an unchanged version
+        // string used to be silently skipped here (`if (!File.Exists(target))`),
+        // pinning stale bits in the `.nugs` feed forever. Refresh whenever the
+        // source nupkg's content actually differs from what is already staged,
+        // so a same-version rebuild is picked up while an unchanged nupkg is
+        // not needlessly re-copied.
+        if (File.Exists(target) && FilesAreIdentical(nupkgPath, target))
+        {
+            return;
+        }
+
+        File.Copy(nupkgPath, target, overwrite: true);
+    }
+
+    private static string ParseVersion(string fileName)
+    {
+        if (!fileName.StartsWith(SdkPackagePrefix, StringComparison.Ordinal) ||
+            !fileName.EndsWith(".nupkg", StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        return fileName.Substring(
+            SdkPackagePrefix.Length,
+            fileName.Length - SdkPackagePrefix.Length - ".nupkg".Length);
     }
 
     private static (int[] Numbers, string Suffix) SplitVersion(string version)
@@ -268,6 +331,49 @@ public class GsharpTestProjectRunner
         return (numbers, suffix);
     }
 
+    private static int ComparePrereleaseIdentifiers(string left, string right)
+    {
+        string[] leftIds = left.Split('.');
+        string[] rightIds = right.Split('.');
+
+        int count = Math.Min(leftIds.Length, rightIds.Length);
+        for (int i = 0; i < count; i++)
+        {
+            int cmp = ComparePrereleaseIdentifier(leftIds[i], rightIds[i]);
+            if (cmp != 0)
+            {
+                return cmp;
+            }
+        }
+
+        // A larger set of identifiers outranks a smaller one when the shared
+        // prefix is otherwise equal (SemVer §11.4.4).
+        return leftIds.Length.CompareTo(rightIds.Length);
+    }
+
+    private static int ComparePrereleaseIdentifier(string left, string right)
+    {
+        bool leftNumeric = IsNumericIdentifier(left, out int leftNum);
+        bool rightNumeric = IsNumericIdentifier(right, out int rightNum);
+
+        if (leftNumeric && rightNumeric)
+        {
+            return leftNum.CompareTo(rightNum);
+        }
+
+        if (leftNumeric != rightNumeric)
+        {
+            // Numeric identifiers always have lower precedence than
+            // alphanumeric identifiers (SemVer §11.4.3).
+            return leftNumeric ? -1 : 1;
+        }
+
+        return string.CompareOrdinal(left, right);
+    }
+
+    private static bool IsNumericIdentifier(string value, out int number) =>
+        int.TryParse(value, out number) && value.Length > 0;
+
     private string FindNupkgForVersion(string version)
     {
         (string NupkgPath, string Version)? resolved = ResolveLocalSdkPackage(this.RepoRoot);
@@ -290,15 +396,23 @@ public class GsharpTestProjectRunner
         return null;
     }
 
-    private static void EnsureInLocalFeed(string repoRoot, string nupkgPath)
+    private static bool FilesAreIdentical(string left, string right)
     {
-        string feed = Path.Combine(repoRoot, ".nugs");
-        Directory.CreateDirectory(feed);
-        string target = Path.Combine(feed, Path.GetFileName(nupkgPath));
-        if (!File.Exists(target))
+        var leftInfo = new FileInfo(left);
+        var rightInfo = new FileInfo(right);
+        if (leftInfo.Length != rightInfo.Length)
         {
-            File.Copy(nupkgPath, target);
+            return false;
         }
+
+        return ComputeHash(left).SequenceEqual(ComputeHash(right));
+    }
+
+    private static byte[] ComputeHash(string path)
+    {
+        using FileStream stream = File.OpenRead(path);
+        using SHA256 sha256 = SHA256.Create();
+        return sha256.ComputeHash(stream);
     }
 
     private static void WriteIsolationBoundary(string workDir)

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1752SdkResolutionTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1752SdkResolutionTests.cs
@@ -1,0 +1,127 @@
+// <copyright file="Issue1752SdkResolutionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #1752: stage-4 SDK resolution used to pin stale bits two ways —
+/// (1) <c>EnsureInLocalFeed</c> never refreshed a same-version rebuilt nupkg
+/// once one of that name already existed in the local <c>.nugs</c> feed, and
+/// (2) <c>CompareVersions</c> ranked a prerelease suffix above its release
+/// (e.g. <c>0.2.107-beta</c> outranked <c>0.2.107</c>) because an empty suffix
+/// ordinally compares less than any non-empty one — backwards from SemVer.
+/// </summary>
+public class Issue1752SdkResolutionTests
+{
+    // --- Bug 2: CompareVersions SemVer precedence -----------------------
+
+    [Fact]
+    public void CompareVersions_ReleaseOutranksSamePrerelease()
+    {
+        Assert.True(GsharpTestProjectRunner.CompareVersions("1.2.0", "1.2.0-preview") > 0);
+        Assert.True(GsharpTestProjectRunner.CompareVersions("1.2.0-preview", "1.2.0") < 0);
+    }
+
+    [Fact]
+    public void CompareVersions_PrereleaseIdentifiersComparedAlphabetically()
+    {
+        Assert.True(GsharpTestProjectRunner.CompareVersions("1.2.0-alpha", "1.2.0-beta") < 0);
+        Assert.True(GsharpTestProjectRunner.CompareVersions("1.2.0-beta", "1.2.0-alpha") > 0);
+    }
+
+    [Fact]
+    public void CompareVersions_HigherPatchOutranksLower()
+    {
+        Assert.True(GsharpTestProjectRunner.CompareVersions("1.2.1", "1.2.0") > 0);
+        Assert.True(GsharpTestProjectRunner.CompareVersions("1.2.0", "1.2.1") < 0);
+    }
+
+    [Fact]
+    public void CompareVersions_EqualVersionsCompareEqual()
+    {
+        Assert.Equal(0, GsharpTestProjectRunner.CompareVersions("1.2.0", "1.2.0"));
+        Assert.Equal(0, GsharpTestProjectRunner.CompareVersions("1.2.0-beta", "1.2.0-beta"));
+    }
+
+    [Fact]
+    public void CompareVersions_MultiDigitComponentsCompareNumericallyNotLexically()
+    {
+        Assert.True(GsharpTestProjectRunner.CompareVersions("1.10.0", "1.9.0") > 0);
+        Assert.True(GsharpTestProjectRunner.CompareVersions("1.9.0", "1.10.0") < 0);
+    }
+
+    [Fact]
+    public void CompareVersions_NumericPrereleaseIdentifiersCompareNumerically()
+    {
+        // SemVer §11.4.2: numeric identifiers compare numerically, so "9" < "10"
+        // even though "9" > "10" ordinally.
+        Assert.True(GsharpTestProjectRunner.CompareVersions("1.2.0-9", "1.2.0-10") < 0);
+    }
+
+    // --- Bug 1: EnsureInLocalFeed refresh-on-change -----------------------
+
+    [Fact]
+    public void EnsureInLocalFeed_RefreshesWhenSameVersionNupkgContentChanged()
+    {
+        string repoRoot = CreateTempDir();
+        try
+        {
+            string source = Path.Combine(repoRoot, "source.nupkg");
+            File.WriteAllText(source, "original bits");
+
+            GsharpTestProjectRunner.EnsureInLocalFeed(repoRoot, source);
+            string target = Path.Combine(repoRoot, ".nugs", "source.nupkg");
+            Assert.Equal("original bits", File.ReadAllText(target));
+
+            // Same file name/version, rebuilt with different content.
+            File.WriteAllText(source, "rebuilt bits");
+            GsharpTestProjectRunner.EnsureInLocalFeed(repoRoot, source);
+
+            Assert.Equal("rebuilt bits", File.ReadAllText(target));
+        }
+        finally
+        {
+            Directory.Delete(repoRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void EnsureInLocalFeed_DoesNotReCopyWhenNupkgUnchanged()
+    {
+        string repoRoot = CreateTempDir();
+        try
+        {
+            string source = Path.Combine(repoRoot, "source.nupkg");
+            File.WriteAllText(source, "same bits");
+
+            GsharpTestProjectRunner.EnsureInLocalFeed(repoRoot, source);
+            string target = Path.Combine(repoRoot, ".nugs", "source.nupkg");
+            DateTime firstWriteTimeUtc = File.GetLastWriteTimeUtc(target);
+
+            // Re-run with byte-identical content: the staged copy must not be
+            // needlessly rewritten.
+            System.Threading.Thread.Sleep(15);
+            GsharpTestProjectRunner.EnsureInLocalFeed(repoRoot, source);
+
+            Assert.Equal(firstWriteTimeUtc, File.GetLastWriteTimeUtc(target));
+            Assert.Equal("same bits", File.ReadAllText(target));
+        }
+        finally
+        {
+            Directory.Delete(repoRoot, recursive: true);
+        }
+    }
+
+    private static string CreateTempDir()
+    {
+        string dir = Path.Combine(Path.GetTempPath(), "gsharp-1752-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+}


### PR DESCRIPTION
Fixes two related bugs in `GsharpTestProjectRunner` (stage 4, ADR-0115 section C/E) that let the pipeline quietly test bits other than what was just built.

## Bug 1: rebuilt same-version nupkg never refreshed
`EnsureInLocalFeed` only copied the SDK nupkg into the local `.nugs` feed `if (!File.Exists(target))`. Rebuilding the SDK with an unchanged NBGV version (the normal edit/rebuild/rerun dev loop) left the stale `.nugs` copy in place forever, and even a fresh copy would not invalidate what NuGet's global-packages folder had already extracted for that version.

Fix: `EnsureInLocalFeed` now hash-compares the source nupkg against the staged copy and overwrites it whenever the content differs (an unchanged nupkg is left untouched, no needless re-copy). `Run` also now passes `-p:RestorePackagesPath=<workDir>/.nuget-packages` so every run extracts the current `.nugs` contents into an isolated packages folder instead of silently reusing whatever a prior run already extracted into the shared global cache.

## Bug 2: CompareVersions ranked a prerelease above its release
The comparator fell back to `string.CompareOrdinal(a.Suffix, b.Suffix)` on the build suffix. An empty suffix (a release) ordinally compares less than any non-empty one (a prerelease), so e.g. `0.2.107-beta` outranked `0.2.107`, the opposite of SemVer. With both nupkgs present, `ResolveLocalSdkPackage` pinned the prerelease.

Fix: implemented SemVer 2.0.0 section 11 precedence, numeric release components compare numerically first, then an absent prerelease tag outranks a present one, and when both carry a prerelease tag its dot-separated identifiers are compared per section 11.4 (numeric identifiers compare numerically and rank below alphanumeric ones, which compare ordinally).

## Tests
Added `Issue1752SdkResolutionTests`:
- `CompareVersions`: release-vs-prerelease (`1.2.0` vs `1.2.0-preview`), prerelease-vs-prerelease (`alpha` vs `beta`), patch bump (`1.2.1` vs `1.2.0`), equal versions, multi-digit components (`1.10.0` vs `1.9.0`), numeric prerelease identifiers (`1.2.0-9` vs `1.2.0-10`).
- `EnsureInLocalFeed`: same-version nupkg with changed content is refreshed; unchanged same-version nupkg is not re-copied (verified via unchanged last-write-time).

Ran narrowly:
```
dotnet build GSharp.sln -c Release -graph   # succeeded, 0 errors
dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release --no-build \
  --filter "FullyQualifiedName~GsharpTestProjectRunner|FullyQualifiedName~TestParity|FullyQualifiedName~Issue1752"
# Passed! 27/27
```

Fixes #1752
