### PR TITLE
cs2gs: surface report-generation failures and stop rendering failed/incomplete runs as green

### DIFF
--- a/tools/cs2gs/Cs2Gs.Cli/Cs2Gs.Cli.csproj
+++ b/tools/cs2gs/Cs2Gs.Cli/Cs2Gs.Cli.csproj
@@ -38,4 +38,11 @@
     <ProjectReference Include="..\Cs2Gs.Report\Cs2Gs.Report.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Lets Cs2Gs.Tests call the internal migrate exit-code/report-generation
+         seams (GenerateReport, DetermineMigrateExitCode) directly instead of
+         shelling out a full corpus migration just to exercise a failure path. -->
+    <InternalsVisibleTo Include="GSharp.Cs2Gs.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/tools/cs2gs/Cs2Gs.Cli/Program.cs
+++ b/tools/cs2gs/Cs2Gs.Cli/Program.cs
@@ -26,7 +26,12 @@ internal static class Program
     /// Parses the command line and dispatches to a verb.
     /// </summary>
     /// <param name="args">The command-line arguments.</param>
-    /// <returns>The process exit code (non-zero if any app failed).</returns>
+    /// <returns>
+    /// The process exit code: 0 when the run (and, for <c>migrate</c>, its
+    /// report) succeeded, 1 when the run itself found failures/gaps, and 2
+    /// when the tool errored — including when the report could not be
+    /// generated at all, which must never be masked as a clean exit 0.
+    /// </returns>
     internal static async Task<int> Main(string[] args)
     {
         if (args.Length == 0)
@@ -71,6 +76,54 @@ internal static class Program
         Console.Error.WriteLine($"cs2gs: unknown command '{verb}'.");
         PrintUsage();
         return 1;
+    }
+
+    /// <summary>
+    /// Combines the migration outcome with whether the report was actually
+    /// written into the process exit code. Report-generation failure always
+    /// wins (exit 2), regardless of whether every app migrated cleanly — a
+    /// broken/missing report must never look like a clean exit 0, and must be
+    /// distinguishable from "migration ran and found gaps" (exit 1).
+    /// </summary>
+    /// <param name="runSucceeded">Whether every app passed every pipeline stage.</param>
+    /// <param name="reportGenerated">Whether <c>report.html</c>/<c>summary.json</c> were written.</param>
+    /// <returns>0 when the run and the report both succeeded; 2 when the report failed; otherwise 1.</returns>
+    internal static int DetermineMigrateExitCode(bool runSucceeded, bool reportGenerated)
+    {
+        if (!reportGenerated)
+        {
+            return 2;
+        }
+
+        return runSucceeded ? 0 : 1;
+    }
+
+    /// <summary>
+    /// Regenerates <c>report.html</c> + <c>summary.json</c> for the just-completed
+    /// run. Failures here (a malformed triage artifact, a full disk, a missing
+    /// <c>run.json</c>, etc.) are logged to stderr and reported back to the caller
+    /// rather than swallowed, so <see cref="RunMigrateAsync"/> can turn them into a
+    /// non-zero exit code — a broken report must never look like a clean exit 0.
+    /// </summary>
+    /// <param name="runDir">The run directory to build the report from.</param>
+    /// <returns><see langword="true"/> when both artifacts were written; otherwise <see langword="false"/>.</returns>
+    internal static bool GenerateReport(string runDir)
+    {
+        try
+        {
+            ReportModel model = ReportModel.FromRunDirectory(runDir);
+            string htmlPath = HtmlReportWriter.Write(model, runDir);
+            string jsonPath = JsonSummaryWriter.Write(model, runDir);
+            Console.WriteLine();
+            Console.WriteLine($"report:  {htmlPath}");
+            Console.WriteLine($"summary: {jsonPath}");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine("cs2gs: failed to generate report: " + ex.Message);
+            return false;
+        }
     }
 
     private static async Task<int> RunMigrateAsync(string[] args)
@@ -118,9 +171,8 @@ internal static class Program
         PrintSummary(result, pipeline.Stages);
 
         string runDir = ResolveRunDir(options.OutputRoot, result.RunId);
-        GenerateReport(runDir);
-
-        return result.Succeeded ? 0 : 1;
+        bool reportGenerated = GenerateReport(runDir);
+        return DetermineMigrateExitCode(result.Succeeded, reportGenerated);
     }
 
     private static int RunReport(string[] args)
@@ -233,23 +285,6 @@ internal static class Program
         string root = Path.GetFullPath(
             outputRoot ?? Path.Combine(Directory.GetCurrentDirectory(), "cs2gs-runs"));
         return Path.Combine(root, runId);
-    }
-
-    private static void GenerateReport(string runDir)
-    {
-        try
-        {
-            ReportModel model = ReportModel.FromRunDirectory(runDir);
-            string htmlPath = HtmlReportWriter.Write(model, runDir);
-            string jsonPath = JsonSummaryWriter.Write(model, runDir);
-            Console.WriteLine();
-            Console.WriteLine($"report:  {htmlPath}");
-            Console.WriteLine($"summary: {jsonPath}");
-        }
-        catch (Exception ex)
-        {
-            Console.Error.WriteLine("cs2gs: failed to generate report: " + ex.Message);
-        }
     }
 
     private static (string Corpus, List<string> AppIds, PipelineOptions Options)? ParseMigrateArgs(string[] args)

--- a/tools/cs2gs/Cs2Gs.Report/HtmlReportWriter.cs
+++ b/tools/cs2gs/Cs2Gs.Report/HtmlReportWriter.cs
@@ -268,7 +268,25 @@ public static class HtmlReportWriter
 
         if (model.Gaps.Count == 0)
         {
-            sb.Append("<p class=\"empty\">No gaps — every app is green.</p>").Append(Newline);
+            if (model.IsGreen)
+            {
+                sb.Append("<p class=\"empty\">No gaps — every app is green.</p>").Append(Newline);
+            }
+            else if (model.MissingArtifactCount > 0)
+            {
+                sb.Append("<p class=\"empty bad\">Gap data unavailable — ")
+                    .Append(model.MissingArtifactCount.ToString(CultureInfo.InvariantCulture))
+                    .Append(" triage artifact(s) referenced by this run could not be read. ")
+                    .Append("This is NOT a green run; re-run triage or inspect the run directory.</p>")
+                    .Append(Newline);
+            }
+            else
+            {
+                sb.Append("<p class=\"empty bad\">Run FAILED with no recorded gaps — check pipeline logs; ")
+                    .Append("this is NOT a green run.</p>")
+                    .Append(Newline);
+            }
+
             sb.Append("</section>").Append(Newline);
             return;
         }

--- a/tools/cs2gs/Cs2Gs.Report/ReportModel.cs
+++ b/tools/cs2gs/Cs2Gs.Report/ReportModel.cs
@@ -69,6 +69,32 @@ public sealed class ReportModel
     public List<GapReport> Gaps { get; set; } = new List<GapReport>();
 
     /// <summary>
+    /// Gets or sets the number of triage artifact paths referenced by <c>run.json</c>
+    /// that could not be found on disk when the model was built. A run whose apps
+    /// reference artifacts that are missing (deleted, not yet copied, or a
+    /// truncated/partial run) has incomplete gap data even when
+    /// <see cref="Gaps"/> ends up empty; consumers must not read an empty
+    /// <see cref="Gaps"/> list as "no gaps" unless this is also zero. See
+    /// <see cref="IsGreen"/>.
+    /// </summary>
+    [JsonPropertyName("missingArtifactCount")]
+    [JsonPropertyOrder(9)]
+    public int MissingArtifactCount { get; set; }
+
+    /// <summary>
+    /// Gets a value indicating whether the run is genuinely green: it must be
+    /// based on positive evidence — the run itself reported success
+    /// (<see cref="Succeeded"/>), every referenced triage artifact was
+    /// readable (<see cref="MissingArtifactCount"/> is zero), and no gaps were
+    /// discovered (<see cref="Gaps"/> is empty) — never on the mere absence of
+    /// gap data, which can also mean the triage artifacts were missing or the
+    /// run failed outright.
+    /// </summary>
+    [JsonPropertyName("isGreen")]
+    [JsonPropertyOrder(10)]
+    public bool IsGreen => this.Succeeded && this.MissingArtifactCount == 0 && this.Gaps.Count == 0;
+
+    /// <summary>
     /// Gets or sets the absolute run directory the model was built from (i.e.
     /// the directory <see cref="AppReport.Artifacts"/> paths are relative to).
     /// Not part of the <c>summary.json</c> schema; used only so
@@ -125,6 +151,7 @@ public sealed class ReportModel
 
         var apps = new List<AppReport>();
         var artifacts = new List<(string AppId, TriageArtifact Artifact)>();
+        int missingArtifactCount = 0;
 
         foreach (AppResult app in run.Apps.OrderBy(a => a.AppId, StringComparer.Ordinal))
         {
@@ -135,15 +162,23 @@ public sealed class ReportModel
                 string artifactPath = Path.Combine(runDir, relative.Replace('/', Path.DirectorySeparatorChar));
                 if (!File.Exists(artifactPath))
                 {
+                    missingArtifactCount++;
+                    Console.Error.WriteLine(
+                        $"cs2gs: warning: triage artifact '{relative}' referenced by app '{app.AppId}' is missing under {runDir}; gap data is incomplete.");
                     continue;
                 }
 
                 TriageArtifact artifact = JsonSerializer.Deserialize<TriageArtifact>(
                     File.ReadAllText(artifactPath), TriageSerialization.Options);
-                if (artifact is not null)
+                if (artifact is null)
                 {
-                    artifacts.Add((app.AppId, artifact));
+                    missingArtifactCount++;
+                    Console.Error.WriteLine(
+                        $"cs2gs: warning: triage artifact '{relative}' referenced by app '{app.AppId}' did not deserialize; gap data is incomplete.");
+                    continue;
                 }
+
+                artifacts.Add((app.AppId, artifact));
             }
         }
 
@@ -160,6 +195,7 @@ public sealed class ReportModel
             StageOrder = stageOrder,
             Apps = apps,
             Gaps = GroupGaps(artifacts),
+            MissingArtifactCount = missingArtifactCount,
             RunDir = Path.GetFullPath(runDir),
         };
     }

--- a/tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj
+++ b/tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj
@@ -19,6 +19,7 @@
     <ProjectReference Include="..\Cs2Gs.Translator\Cs2Gs.Translator.csproj" />
     <ProjectReference Include="..\Cs2Gs.Pipeline\Cs2Gs.Pipeline.csproj" />
     <ProjectReference Include="..\Cs2Gs.Report\Cs2Gs.Report.csproj" />
+    <ProjectReference Include="..\Cs2Gs.Cli\Cs2Gs.Cli.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/cs2gs/Cs2Gs.Tests/ReportTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/ReportTests.cs
@@ -232,6 +232,206 @@ public class ReportTests
     }
 
     /// <summary>
+    /// A FAILED run whose triage artifacts are missing on disk (deleted,
+    /// partially copied, etc.) must not be rendered as green: the "no gaps"
+    /// message is conditional on <see cref="ReportModel.IsGreen"/> — positive
+    /// evidence of success — not on <see cref="ReportModel.Gaps"/> merely being
+    /// empty, since a missing artifact silently drops its gap from the list
+    /// (issue #1753).
+    /// </summary>
+    [Fact]
+    public void ReportModel_FailedRun_MissingTriageArtifact_IsNotRenderedAsGreen()
+    {
+        string runDir = NewRunDir("missing-artifact");
+
+        var run = new RunResult
+        {
+            RunId = "2026-03-01T00-00-00Z_missing",
+            Timestamp = "2026-03-01T00:00:00Z",
+            GscVersion = "0.2.0+test",
+            GscPath = "/path/to/gsc.dll",
+            Succeeded = false,
+            Apps = new List<AppResult>
+            {
+                new AppResult
+                {
+                    AppId = "corpus/L1-Console",
+                    Succeeded = false,
+                    FailureCategory = "translation-unsupported",
+                    Stages = new List<StageResult>
+                    {
+                        new StageResult { Stage = "translate", Status = "failed", ArtifactCount = 1 },
+                        new StageResult { Stage = "compile", Status = "skipped" },
+                        new StageResult { Stage = "ilverify", Status = "skipped" },
+                        new StageResult { Stage = "test-parity", Status = "skipped" },
+                    },
+
+                    // Referenced but never written: simulates a deleted/partially
+                    // copied triage artifact.
+                    Artifacts = new List<string> { "corpus_L1-Console/translate-missing.json" },
+                },
+            },
+        };
+        WriteRunJson(runDir, run);
+
+        ReportModel model = ReportModel.FromRunDirectory(runDir);
+
+        Assert.False(model.Succeeded);
+        Assert.Empty(model.Gaps);
+        Assert.Equal(1, model.MissingArtifactCount);
+        Assert.False(model.IsGreen);
+
+        string html = HtmlReportWriter.Render(model);
+        Assert.DoesNotContain("every app is green", html, StringComparison.Ordinal);
+        Assert.Contains("NOT a green run", html, StringComparison.Ordinal);
+        Assert.Contains("Gap data unavailable", html, StringComparison.Ordinal);
+
+        string json = JsonSummaryWriter.Serialize(model);
+        Assert.Contains("\"missingArtifactCount\": 1", json, StringComparison.Ordinal);
+        Assert.Contains("\"isGreen\": false", json, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A FAILED run with no triage artifacts referenced at all (e.g. every
+    /// stage errored before it could emit one) must also not be rendered as
+    /// green — the empty-gaps message must reflect the failed run, not claim
+    /// success by omission (issue #1753).
+    /// </summary>
+    [Fact]
+    public void ReportModel_FailedRun_NoArtifactsReferenced_IsNotRenderedAsGreen()
+    {
+        string runDir = NewRunDir("no-artifacts-failed");
+
+        var run = new RunResult
+        {
+            RunId = "2026-03-01T00-00-01Z_noartifacts",
+            Timestamp = "2026-03-01T00:00:01Z",
+            GscVersion = "0.2.0+test",
+            GscPath = "/path/to/gsc.dll",
+            Succeeded = false,
+            Apps = new List<AppResult>
+            {
+                new AppResult
+                {
+                    AppId = "corpus/L1-Console",
+                    Succeeded = false,
+                    FailureCategory = "pipeline-crash",
+                    Stages = AllStages("skipped"),
+                },
+            },
+        };
+        WriteRunJson(runDir, run);
+
+        ReportModel model = ReportModel.FromRunDirectory(runDir);
+
+        Assert.False(model.Succeeded);
+        Assert.Empty(model.Gaps);
+        Assert.Equal(0, model.MissingArtifactCount);
+        Assert.False(model.IsGreen);
+
+        string html = HtmlReportWriter.Render(model);
+        Assert.DoesNotContain("every app is green", html, StringComparison.Ordinal);
+        Assert.Contains("Run FAILED with no recorded gaps", html, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A genuinely green run — every app succeeded, every referenced artifact
+    /// was readable, and zero gaps were found — must still render as green
+    /// (positive evidence, not merely an empty gap list) and, at the CLI layer,
+    /// still exit 0 (issue #1753).
+    /// </summary>
+    [Fact]
+    public void ReportModel_GenuinelyGreenRun_IsRenderedAsGreen()
+    {
+        string runDir = NewRunDir("genuinely-green");
+
+        var run = new RunResult
+        {
+            RunId = "2026-03-01T00-00-02Z_green",
+            Timestamp = "2026-03-01T00:00:02Z",
+            GscVersion = "0.2.0+test",
+            GscPath = "/path/to/gsc.dll",
+            Succeeded = true,
+            Apps = new List<AppResult>
+            {
+                new AppResult
+                {
+                    AppId = "corpus/L1-Console",
+                    Succeeded = true,
+                    Stages = AllStages("passed"),
+                },
+            },
+        };
+        WriteRunJson(runDir, run);
+
+        ReportModel model = ReportModel.FromRunDirectory(runDir);
+
+        Assert.True(model.Succeeded);
+        Assert.Empty(model.Gaps);
+        Assert.Equal(0, model.MissingArtifactCount);
+        Assert.True(model.IsGreen);
+
+        string html = HtmlReportWriter.Render(model);
+        Assert.Contains("every app is green", html, StringComparison.Ordinal);
+
+        Assert.Equal(0, Cs2Gs.Cli.Program.DetermineMigrateExitCode(model.Succeeded, reportGenerated: true));
+    }
+
+    /// <summary>
+    /// <c>migrate</c> must not swallow a report-generation failure: when
+    /// <c>GenerateReport</c> cannot build/write the report (e.g. a corrupt
+    /// <c>run.json</c>), it surfaces the error on stderr and reports failure
+    /// back to the caller instead of silently returning success, and the
+    /// combined migrate exit code is non-zero even though the migration run
+    /// itself passed (issue #1753).
+    /// </summary>
+    [Fact]
+    public void GenerateReport_WhenRunJsonIsMissing_ReturnsFalseAndSurfacesError()
+    {
+        string runDir = NewRunDir("broken-run-json");
+
+        // No run.json written: ReportModel.FromRunDirectory throws
+        // FileNotFoundException, which GenerateReport must catch, log, and
+        // report back as a failure rather than swallow.
+        TextWriter originalError = Console.Error;
+        var captured = new StringWriter();
+        Console.SetError(captured);
+        bool generated;
+        try
+        {
+            generated = Cs2Gs.Cli.Program.GenerateReport(runDir);
+        }
+        finally
+        {
+            Console.SetError(originalError);
+        }
+
+        Assert.False(generated);
+        Assert.Contains("failed to generate report", captured.ToString(), StringComparison.Ordinal);
+
+        // Even though the run itself would have passed, the report failure
+        // must dominate the exit code (non-zero), so a broken report is never
+        // invisible behind a clean exit 0.
+        Assert.Equal(2, Cs2Gs.Cli.Program.DetermineMigrateExitCode(runSucceeded: true, reportGenerated: generated));
+        Assert.Equal(2, Cs2Gs.Cli.Program.DetermineMigrateExitCode(runSucceeded: false, reportGenerated: generated));
+    }
+
+    /// <summary>
+    /// The migrate exit-code seam in isolation: a successful report always
+    /// yields the run's own pass/fail exit code (0/1); a failed report always
+    /// yields 2, regardless of the run's outcome (issue #1753).
+    /// </summary>
+    [Theory]
+    [InlineData(true, true, 0)]
+    [InlineData(false, true, 1)]
+    [InlineData(true, false, 2)]
+    [InlineData(false, false, 2)]
+    public void DetermineMigrateExitCode_ReportFailureDominates(bool runSucceeded, bool reportGenerated, int expected)
+    {
+        Assert.Equal(expected, Cs2Gs.Cli.Program.DetermineMigrateExitCode(runSucceeded, reportGenerated));
+    }
+
+    /// <summary>
     /// The CLI <c>report --run &lt;dir&gt;</c> verb regenerates both
     /// <c>report.html</c> and <c>summary.json</c> from an existing run directory
     /// without re-running the pipeline (ADR-0115 §F).


### PR DESCRIPTION
Fixes both silent-failure paths from #1753.

## Bug 1 — `migrate` swallowed report-generation errors, exit 0, no report
`GenerateReport` caught every exception, logged one stderr line, and returned
`void`. `RunMigrateAsync`'s exit code was computed purely from
`result.Succeeded`, so a run where every app passed but the report itself
failed to write (malformed triage artifact, full disk, bad `run.json`, etc.)
still exited 0 with no `report.html`/`summary.json` on disk — a CI job
gating on the exit code would ship nothing and never notice.

Fix: `GenerateReport` now returns `bool`, and a new pure seam,
`DetermineMigrateExitCode(runSucceeded, reportGenerated)`, combines both
signals: a failed report always yields exit **2** (the same code used for an
uncaught top-level exception), regardless of whether the migration run
itself passed or failed. A legitimate success (report written, run passed)
still exits 0.

## Bug 2 — missing/malformed triage artifacts rendered a FAILED run as green
`ReportModel.Build` silently `continue`d past any referenced triage artifact
file that didn't exist (or deserialized to `null`) — no warning, no record.
`HtmlReportWriter` then printed the hardcoded "No gaps — every app is
green." whenever `model.Gaps` was empty, with no regard for
`model.Succeeded`. A FAILED run whose artifacts were deleted/partially
copied therefore got the "every app is green" message directly under a "Run
FAILED" header.

Fix: `ReportModel` now tracks `MissingArtifactCount` (incremented, with a
stderr warning, for each missing/unreadable artifact) and exposes
`IsGreen = Succeeded && MissingArtifactCount == 0 && Gaps.Count == 0` —
positive evidence of success, never the mere absence of gap data.
`HtmlReportWriter`'s empty-gaps branch now checks `IsGreen` first and
otherwise renders an explicit "NOT a green run" message, distinguishing
missing-artifact runs from failed runs with no artifacts referenced at all.
`summary.json` also now surfaces `missingArtifactCount` and `isGreen` for CI
consumers.

## Tests (`tools/cs2gs/Cs2Gs.Tests/ReportTests.cs`)
- `GenerateReport_WhenRunJsonIsMissing_ReturnsFalseAndSurfacesError` +
  `DetermineMigrateExitCode_ReportFailureDominates` (`[Theory]`, 4 cases):
  bug 1 — a broken report returns `false`/logs to stderr, and the combined
  exit code is always 2, even when the run itself would have passed.
- `ReportModel_FailedRun_MissingTriageArtifact_IsNotRenderedAsGreen` and
  `ReportModel_FailedRun_NoArtifactsReferenced_IsNotRenderedAsGreen`: bug 2 —
  a FAILED run never renders "every app is green", whether its artifacts are
  missing or simply absent.
- `ReportModel_GenuinelyGreenRun_IsRenderedAsGreen`: control — a real green
  run (succeeded, artifacts present, zero gaps) still renders green and still
  maps to exit code 0.

`Cs2Gs.Cli.csproj` now declares `InternalsVisibleTo` for
`GSharp.Cs2Gs.Tests`, and `Cs2Gs.Tests` references `Cs2Gs.Cli`, so these
seams are exercised directly instead of shelling out a full corpus
migration.

## Verification
- `dotnet build GSharp.sln -c Release -graph` — succeeds, 0 warnings/errors.
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release --no-build --filter "FullyQualifiedName~Report|FullyQualifiedName~Migrate"` — 30/30 passed, including the pre-existing `Cli_ReportVerb_RegeneratesBothArtifacts` (needs the whole-solution `cs2gs.dll` build) and all new tests above.

Fixes #1753
