### PR TITLE
cs2gs: stabilize triage fingerprints (crash paths, truncate-after-normalize, structural kind classification)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Pipeline/Fingerprint.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/Fingerprint.cs
@@ -23,6 +23,25 @@ namespace Cs2Gs.Pipeline;
 /// </summary>
 public static class Fingerprint
 {
+    // The normalized-shape length cap (issue #1750): applied to the shape
+    // *after* NormalizeShape runs, never to the raw snippet, so the cut point
+    // is deterministic on already-normalized text instead of depending on
+    // where pre-normalization noise (variable-length identifiers, run-scoped
+    // paths, etc.) happened to land.
+    private const int ShapeMaxLength = 160;
+
+    // Absolute paths (issue #1750): any Windows drive/UNC path or Unix
+    // absolute path with at least one full directory segment. These routinely
+    // embed run-scoped temp/work directories (e.g. a hex run id) whose
+    // segment count and character shape differ machine-to-machine and
+    // run-to-run, so they must be neutralized generically — not by matching
+    // one known prefix — before anything else looks at the text.
+    private static readonly Regex AbsolutePathPattern = new Regex(
+        @"(?:[A-Za-z]:[\\/](?:[^\s""'<>|:]+[\\/])*[^\s""'<>|:]*)" +
+        @"|(?:\\\\[^\s""'<>|:]+(?:\\[^\s""'<>|:]+)+)" +
+        @"|(?:/(?:[^\s""'<>|:]+/)+[^\s""'<>|:]*)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
     // Identifiers: a letter/underscore start then word chars. Collapsed to `id`.
     private static readonly Regex IdentifierPattern = new Regex(
         @"[A-Za-z_][A-Za-z0-9_]*",
@@ -49,7 +68,13 @@ public static class Fingerprint
     /// <param name="stage">The schema stage string (e.g. <c>compile</c>).</param>
     /// <param name="diagnosticId">The diagnostic id (e.g. <c>GS0313</c>).</param>
     /// <param name="constructKind">The offending construct kind.</param>
-    /// <param name="constructSnippet">The raw construct snippet (normalized internally).</param>
+    /// <param name="constructSnippet">
+    /// The <i>raw, untruncated</i> construct snippet. Callers must not
+    /// pre-truncate this value (issue #1750): the shape is normalized first
+    /// and only the normalized shape is length-capped, so the cut point is
+    /// deterministic on stable, already-normalized text rather than on
+    /// whatever raw text happened to precede it.
+    /// </param>
     /// <returns>The fingerprint, rendered as <c>"sha256:" + hex</c>.</returns>
     public static string Compute(
         string category,
@@ -59,6 +84,7 @@ public static class Fingerprint
         string constructSnippet)
     {
         string shape = NormalizeShape(constructSnippet);
+        shape = TruncateShape(shape);
         string payload = string.Join(
             "|",
             category ?? string.Empty,
@@ -75,6 +101,9 @@ public static class Fingerprint
     /// Reduces a construct snippet to its syntactic skeleton: the
     /// <c>normalizedConstructShape</c> of §D.2. Rules, applied in order:
     /// <list type="number">
+    /// <item><description>absolute file paths (any run/work/temp root, Windows
+    /// drive/UNC or Unix) → <c>lit</c> (issue #1750: neutralizes run-scoped
+    /// paths regardless of prefix, before anything else can tokenize them);</description></item>
     /// <item><description>string/char/interpolated literals → <c>lit</c>;</description></item>
     /// <item><description>numeric literals → <c>lit</c>;</description></item>
     /// <item><description>identifiers and keywords → <c>id</c> (strips all names);</description></item>
@@ -82,10 +111,11 @@ public static class Fingerprint
     /// </list>
     /// Punctuation/operators/brackets are preserved as the structural skeleton.
     /// The result keeps the <i>shape</i> (e.g. <c>id id[id] = id(id, lit)</c>)
-    /// while erasing the names, numbers, and positions that vary per occurrence.
+    /// while erasing the names, numbers, paths, and positions that vary per
+    /// occurrence, run, or machine.
     /// </summary>
-    /// <param name="snippet">The raw construct snippet.</param>
-    /// <returns>The normalized syntactic skeleton.</returns>
+    /// <param name="snippet">The raw, untruncated construct snippet.</param>
+    /// <returns>The normalized syntactic skeleton (not length-capped).</returns>
     public static string NormalizeShape(string snippet)
     {
         if (string.IsNullOrEmpty(snippet))
@@ -95,16 +125,40 @@ public static class Fingerprint
 
         string text = snippet.Replace("\r\n", "\n");
 
-        // Literals first so their contents are not mistaken for identifiers.
+        // Absolute paths first: a run-scoped temp/work directory (e.g. a hex
+        // run id) tokenizes inconsistently once its segments are split by the
+        // identifier/number patterns below (a leading digit in the hex id
+        // shifts the token boundary), so the whole path must be recognized
+        // and collapsed as one opaque unit before that happens.
+        text = AbsolutePathPattern.Replace(text, "lit");
+
+        // Literals next so their contents are not mistaken for identifiers.
         text = StringLiteralPattern.Replace(text, "lit");
         text = NumberLiteralPattern.Replace(text, "lit");
 
-        // Every identifier/keyword (now that string contents are gone) → `id`.
-        // A literal placeholder `lit` is itself an identifier-shaped token, so
-        // protect it: replace identifiers except the exact token `lit`.
+        // Every identifier/keyword (now that string/path contents are gone) →
+        // `id`. A literal placeholder `lit` is itself an identifier-shaped
+        // token, so protect it: replace identifiers except the exact token `lit`.
         text = IdentifierPattern.Replace(text, m => m.Value == "lit" ? "lit" : "id");
 
         text = WhitespacePattern.Replace(text, " ");
         return text.Trim();
+    }
+
+    /// <summary>
+    /// Caps the normalized shape length. Applied only after
+    /// <see cref="NormalizeShape"/> (issue #1750) so the cut point falls on
+    /// deterministic, already-normalized text.
+    /// </summary>
+    /// <param name="shape">The normalized shape.</param>
+    /// <returns>The length-capped shape.</returns>
+    private static string TruncateShape(string shape)
+    {
+        if (string.IsNullOrEmpty(shape) || shape.Length <= ShapeMaxLength)
+        {
+            return shape;
+        }
+
+        return shape.Substring(0, ShapeMaxLength) + "…";
     }
 }

--- a/tools/cs2gs/Cs2Gs.Pipeline/Fingerprint.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/Fingerprint.cs
@@ -36,10 +36,15 @@ public static class Fingerprint
     // segment count and character shape differ machine-to-machine and
     // run-to-run, so they must be neutralized generically — not by matching
     // one known prefix — before anything else looks at the text.
+    // The Unix branch (issue #1750 N2) requires only a boundary before the
+    // leading `/` — not a preceding word character, so it doesn't swallow a
+    // bare fraction like `3/4` — then one or more path segments. Unlike the
+    // prior version, a single-segment absolute path (e.g. a run-scoped `/tmp`
+    // or `/root` with no interior segment) is stripped too.
     private static readonly Regex AbsolutePathPattern = new Regex(
         @"(?:[A-Za-z]:[\\/](?:[^\s""'<>|:]+[\\/])*[^\s""'<>|:]*)" +
         @"|(?:\\\\[^\s""'<>|:]+(?:\\[^\s""'<>|:]+)+)" +
-        @"|(?:/(?:[^\s""'<>|:]+/)+[^\s""'<>|:]*)",
+        @"|(?:(?<![A-Za-z0-9_])/[^\s""'<>|:]+(?:/[^\s""'<>|:]*)*)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     // Identifiers: a letter/underscore start then word chars. Collapsed to `id`.

--- a/tools/cs2gs/Cs2Gs.Pipeline/MigrationPipeline.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/MigrationPipeline.cs
@@ -326,32 +326,20 @@ public sealed class MigrationPipeline
 
     private TriageArtifact StageCrashArtifact(TriageBuilder triage, MigrationStageKind stage, Exception ex)
     {
-        // A stage throwing (e.g. project load failure) is itself a captured gap.
-        if (stage == MigrationStageKind.Compile)
+        // A stage throwing (e.g. project load failure) is itself a captured
+        // gap. Fingerprinted via TriageBuilder.StageCrash (issue #1750) on the
+        // exception's runtime type rather than its raw Message, which
+        // routinely embeds run-scoped absolute paths that would otherwise
+        // fingerprint the same recurring crash differently every run/machine.
+        (TriageCategory category, string diagnosticId) = stage switch
         {
-            return triage.CompileError(
-                new GscDiagnostic("GS9999", "stage crashed: " + ex.Message, "error", null, 1, 1),
-                null);
-        }
+            MigrationStageKind.Compile => (TriageCategory.CompileError, "GS9999"),
+            MigrationStageKind.IlVerify => (TriageCategory.IlVerifyFailure, "IlVerifyError"),
+            MigrationStageKind.TestParity => (TriageCategory.TestParityFailure, "STDOUT-MISMATCH"),
+            _ => (TriageCategory.TranslationUnsupported, "PipelineException"),
+        };
 
-        if (stage == MigrationStageKind.IlVerify)
-        {
-            return triage.IlVerifyFailure(
-                new IlVerifyError("IlVerifyError", null, "ilverify stage crashed: " + ex.Message));
-        }
-
-        if (stage == MigrationStageKind.TestParity)
-        {
-            return triage.TestParityStdoutFailure(
-                StdoutParityResult.Mismatch(0, "<no crash>", "test-parity stage crashed: " + ex.Message));
-        }
-
-        var diagnostic = new Translator.TranslationDiagnostic(
-            "PipelineException",
-            stage + " stage threw: " + ex.Message,
-            null,
-            Translator.TranslationSeverity.Unsupported);
-        return triage.TranslationUnsupported(diagnostic);
+        return triage.StageCrash(stage, category, diagnosticId, ex);
     }
 
     private IReadOnlyList<TriageArtifact> WriteArtifacts(

--- a/tools/cs2gs/Cs2Gs.Pipeline/TriageBuilder.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TriageBuilder.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Cs2Gs.Translator;
@@ -29,6 +30,21 @@ public sealed class TriageBuilder
     private static readonly Regex LeadingTokenPattern = new Regex(
         @"^[A-Za-z_][A-Za-z0-9_]*",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    // Every modifier keyword the G# printer can emit ahead of a construct
+    // keyword (issue #1750 B1), audited from Cs2Gs.CodeModel.Printing.GSharpPrinter:
+    // RenderVisibility (public/internal/private/protected), the unsafe/open/
+    // sealed/abstract prefixes on RenderTypeDeclaration, the open/override
+    // prefixes on RenderProperty, and the open/override/async prefixes on
+    // RenderMethod. `static`, `virtual`, and `export` are not currently emitted
+    // by the printer but are kept in the set defensively so a future modifier
+    // the printer starts emitting doesn't silently collapse back into the
+    // generic bucket.
+    private static readonly HashSet<string> ModifierTokens = new HashSet<string>(StringComparer.Ordinal)
+    {
+        "public", "private", "internal", "protected", "static", "async", "sealed",
+        "abstract", "virtual", "override", "export", "open", "unsafe",
+    };
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TriageBuilder"/> class.
@@ -575,7 +591,22 @@ public sealed class TriageBuilder
         // a `for` construct because the keyword happens to appear inside a
         // string literal; the leading token of that line is `let`, which is
         // unaffected by what the string literal contains.
-        Match leadingToken = LeadingTokenPattern.Match(line.TrimStart());
+        // Skip past any leading modifier run (issue #1750 B1) — G# construct
+        // lines routinely carry modifiers ahead of the actual construct
+        // keyword (`sealed class Shape {`, `async func Bump(...)`,
+        // `private func Helper(...)`, `public static func F()`). Matching only
+        // the very first token misclassifies every modifier-prefixed
+        // construct into the generic bucket, colliding structurally distinct
+        // gaps. Walk forward token-by-token — still by syntactic position,
+        // never by scanning the whole line — until the token isn't a modifier.
+        string remainder = line.TrimStart();
+        Match leadingToken = LeadingTokenPattern.Match(remainder);
+        while (leadingToken.Success && ModifierTokens.Contains(leadingToken.Value))
+        {
+            remainder = remainder.Substring(leadingToken.Index + leadingToken.Length).TrimStart();
+            leadingToken = LeadingTokenPattern.Match(remainder);
+        }
+
         if (!leadingToken.Success)
         {
             return "GSharpConstruct";

--- a/tools/cs2gs/Cs2Gs.Pipeline/TriageBuilder.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TriageBuilder.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Cs2Gs.Translator;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
@@ -19,6 +20,15 @@ namespace Cs2Gs.Pipeline;
 public sealed class TriageBuilder
 {
     private const int SnippetMaxLength = 160;
+
+    // The leading identifier/keyword token of a (trimmed) line — the position
+    // a G# statement/declaration keyword actually occupies syntactically.
+    // Used by ClassifyGsLine (issue #1750) instead of scanning the whole line,
+    // which can match keyword text that only happens to appear inside a
+    // string literal.
+    private static readonly Regex LeadingTokenPattern = new Regex(
+        @"^[A-Za-z_][A-Za-z0-9_]*",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TriageBuilder"/> class.
@@ -91,7 +101,7 @@ public sealed class TriageBuilder
             artifact.Stage,
             artifact.Diagnostic.Id,
             artifact.OffendingCSharpConstruct.Kind,
-            artifact.OffendingCSharpConstruct.Snippet);
+            snippet);
         artifact.SuggestedIssue = this.UnsupportedIssue(artifact);
         return artifact;
     }
@@ -137,7 +147,7 @@ public sealed class TriageBuilder
             artifact.Stage,
             artifact.Diagnostic.Id,
             artifact.OffendingCSharpConstruct.Kind,
-            artifact.OffendingCSharpConstruct.Snippet);
+            parseError);
         artifact.SuggestedIssue = this.UnsupportedIssue(artifact);
         return artifact;
     }
@@ -193,7 +203,7 @@ public sealed class TriageBuilder
             artifact.Stage,
             artifact.Diagnostic.Id,
             artifact.OffendingCSharpConstruct.Kind,
-            artifact.OffendingCSharpConstruct.Snippet);
+            message);
         artifact.SuggestedIssue = this.ProjectLoadIssue(artifact);
         return artifact;
     }
@@ -244,7 +254,7 @@ public sealed class TriageBuilder
             artifact.Stage,
             artifact.Diagnostic.Id,
             artifact.OffendingCSharpConstruct.Kind,
-            artifact.OffendingCSharpConstruct.Snippet);
+            snippet ?? diagnostic.Message);
         artifact.SuggestedIssue = this.CompileIssue(artifact);
         return artifact;
     }
@@ -296,7 +306,7 @@ public sealed class TriageBuilder
             artifact.Stage,
             artifact.Diagnostic.Id,
             artifact.OffendingCSharpConstruct.Kind,
-            artifact.OffendingCSharpConstruct.Snippet);
+            error.Method ?? error.RawLine);
         artifact.SuggestedIssue = this.IlVerifyIssue(artifact);
         return artifact;
     }
@@ -347,7 +357,7 @@ public sealed class TriageBuilder
             artifact.Stage,
             artifact.Diagnostic.Id,
             artifact.OffendingCSharpConstruct.Kind,
-            artifact.OffendingCSharpConstruct.Snippet);
+            diff.ExpectedLine ?? diff.ActualLine ?? diff.Describe());
         artifact.SuggestedIssue = this.TestParityIssue(artifact);
         return artifact;
     }
@@ -398,7 +408,7 @@ public sealed class TriageBuilder
             artifact.Stage,
             artifact.Diagnostic.Id,
             artifact.OffendingCSharpConstruct.Kind,
-            artifact.OffendingCSharpConstruct.Snippet);
+            diff.Describe());
         artifact.SuggestedIssue = this.TestParityIssue(artifact);
         return artifact;
     }
@@ -446,8 +456,75 @@ public sealed class TriageBuilder
             artifact.Stage,
             artifact.Diagnostic.Id,
             artifact.OffendingCSharpConstruct.Kind,
-            artifact.OffendingCSharpConstruct.Snippet);
+            message);
         artifact.SuggestedIssue = this.TestParityIssue(artifact);
+        return artifact;
+    }
+
+    /// <summary>
+    /// Builds a triage artifact for an unhandled exception thrown by a stage
+    /// itself, rather than a diagnostic the stage reported normally (issue
+    /// #1750). The offending construct <c>kind</c> is the exception's runtime
+    /// type name — a structural, deterministic signal — rather than any text
+    /// pulled from <see cref="Exception.Message"/>: crash messages routinely
+    /// embed run-scoped absolute paths (temp/work directories that include the
+    /// run id) that differ machine-to-machine and run-to-run, so fingerprinting
+    /// on the raw message text kept the same recurring crash from ever
+    /// deduping. <see cref="Exception.Message"/> is still recorded in full on
+    /// <see cref="TriageDiagnostic.Message"/> for human triage; it is simply
+    /// not the fingerprint's construct-kind signal (its embedded paths are
+    /// also normalized generically by <see cref="Fingerprint.NormalizeShape"/>
+    /// as a second line of defense).
+    /// </summary>
+    /// <param name="stage">The stage that crashed.</param>
+    /// <param name="category">The triage category to file the crash artifact under.</param>
+    /// <param name="diagnosticId">The diagnostic id to stamp (stage-specific, e.g. <c>GS9999</c>).</param>
+    /// <param name="ex">The exception the stage threw.</param>
+    /// <returns>The populated triage artifact.</returns>
+    public TriageArtifact StageCrash(MigrationStageKind stage, TriageCategory category, string diagnosticId, Exception ex)
+    {
+        if (ex is null)
+        {
+            throw new ArgumentNullException(nameof(ex));
+        }
+
+        string kind = ex.GetType().Name;
+        string message = $"{TriageSerialization.StageName(stage)} stage crashed ({kind}): {ex.Message}";
+
+        var artifact = this.NewArtifact(stage, category);
+        artifact.Diagnostic = new TriageDiagnostic
+        {
+            Id = diagnosticId,
+            Message = message,
+            Severity = "error",
+        };
+        artifact.SourceLocation = new TriageSourceLocation
+        {
+            GsFile = null,
+            GsLine = null,
+            GsColumn = null,
+            CsFile = null,
+            CsLine = null,
+            CsColumn = null,
+        };
+        artifact.OffendingCSharpConstruct = new TriageOffendingConstruct
+        {
+            Kind = kind,
+            Snippet = Truncate(message),
+        };
+        artifact.Fingerprint = Fingerprint.Compute(
+            artifact.Category,
+            artifact.Stage,
+            artifact.Diagnostic.Id,
+            artifact.OffendingCSharpConstruct.Kind,
+            message);
+        artifact.SuggestedIssue = category switch
+        {
+            TriageCategory.CompileError => this.CompileIssue(artifact),
+            TriageCategory.IlVerifyFailure => this.IlVerifyIssue(artifact),
+            TriageCategory.TestParityFailure => this.TestParityIssue(artifact),
+            _ => this.UnsupportedIssue(artifact),
+        };
         return artifact;
     }
 
@@ -490,7 +567,21 @@ public sealed class TriageBuilder
             return "GSharpConstruct";
         }
 
-        string trimmed = line.TrimStart();
+        // Structural signal (issue #1750): classify on the *leading* token of
+        // the statement/declaration only — the syntactic position where a G#
+        // keyword actually appears — never on substring content anywhere in
+        // the line. Scanning the whole line (the prior `Contains(" for ")`
+        // behavior) misclassifies a line like `let msg = "run for cover"` as
+        // a `for` construct because the keyword happens to appear inside a
+        // string literal; the leading token of that line is `let`, which is
+        // unaffected by what the string literal contains.
+        Match leadingToken = LeadingTokenPattern.Match(line.TrimStart());
+        if (!leadingToken.Success)
+        {
+            return "GSharpConstruct";
+        }
+
+        string token = leadingToken.Value;
         string[] keywords =
         {
             "func", "class", "struct", "data", "interface", "enum", "let", "const",
@@ -499,8 +590,7 @@ public sealed class TriageBuilder
 
         foreach (string keyword in keywords)
         {
-            if (trimmed.StartsWith(keyword + " ", StringComparison.Ordinal) ||
-                trimmed.Contains(" " + keyword + " ", StringComparison.Ordinal))
+            if (string.Equals(token, keyword, StringComparison.Ordinal))
             {
                 return char.ToUpperInvariant(keyword[0]) + keyword.Substring(1) + "Construct";
             }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1750TriageFingerprintStabilityTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1750TriageFingerprintStabilityTests.cs
@@ -1,0 +1,186 @@
+// <copyright file="Issue1750TriageFingerprintStabilityTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Regression tests for issue #1750: triage fingerprints must be stable
+/// across runs/machines for the same underlying gap. Covers all three
+/// reported leaks: (1) crash artifacts embedding run-scoped absolute paths
+/// from <see cref="Exception.Message"/>, (2) snippets truncated before shape
+/// normalization instead of after, and (3) construct-kind classification
+/// matching keyword text anywhere in a line (including inside string
+/// literals) instead of the line's leading (structural) token.
+/// </summary>
+public class Issue1750TriageFingerprintStabilityTests
+{
+    /// <summary>
+    /// (1) A stage crash fingerprints identically across two "runs" whose
+    /// exception messages differ only in their embedded run-scoped absolute
+    /// paths (a different hex run id and a different absolute root each
+    /// time, one Unix-style and one Windows-style) — the same recurring
+    /// defect must dedup into one issue instead of filing a fresh one every
+    /// run/machine.
+    /// </summary>
+    [Fact]
+    public void StageCrash_SamePathVaryingRuns_ProducesIdenticalFingerprint()
+    {
+        var builder = new TriageBuilder("run_1", "2026-06-21T20:00:00Z", "0.2.0+abc", "corpus/Sample");
+
+        var exUnixRun1 = new InvalidOperationException(
+            "Could not find file '/var/folders/T/cs2gsrun-0a1b2c3d4e/App/Program.cs' during stage 2.");
+        var exUnixRun2 = new InvalidOperationException(
+            "Could not find file '/tmp/cs2gsrun-9f8e7d6c5b4a3210/App/Program.cs' during stage 2.");
+        var exWindowsRun = new InvalidOperationException(
+            "Could not find file 'C:\\Users\\ci\\AppData\\Local\\Temp\\cs2gsrun-abc123\\App\\Program.cs' during stage 2.");
+
+        TriageArtifact a = builder.StageCrash(MigrationStageKind.Compile, TriageCategory.CompileError, "GS9999", exUnixRun1);
+        TriageArtifact b = builder.StageCrash(MigrationStageKind.Compile, TriageCategory.CompileError, "GS9999", exUnixRun2);
+        TriageArtifact c = builder.StageCrash(MigrationStageKind.Compile, TriageCategory.CompileError, "GS9999", exWindowsRun);
+
+        Assert.Equal(a.Fingerprint, b.Fingerprint);
+        Assert.Equal(a.Fingerprint, c.Fingerprint);
+        Assert.StartsWith("sha256:", a.Fingerprint, StringComparison.Ordinal);
+
+        // The construct kind anchors on the deterministic exception type, not
+        // free-text pulled from the message.
+        Assert.Equal(nameof(InvalidOperationException), a.OffendingCSharpConstruct.Kind);
+
+        // A genuinely different exception type for the same stage must still
+        // split into its own fingerprint (it is a different underlying gap).
+        TriageArtifact d = builder.StageCrash(
+            MigrationStageKind.Compile,
+            TriageCategory.CompileError,
+            "GS9999",
+            new NullReferenceException("Object reference not set to an instance of an object."));
+        Assert.NotEqual(a.Fingerprint, d.Fingerprint);
+    }
+
+    /// <summary>
+    /// (1, generalized) <see cref="Fingerprint.NormalizeShape"/> neutralizes
+    /// any absolute path under any root — not just one hardcoded prefix — for
+    /// both Unix and Windows/UNC-style paths.
+    /// </summary>
+    [Fact]
+    public void NormalizeShape_NeutralizesAnyAbsolutePath_RegardlessOfRoot()
+    {
+        Assert.Equal(
+            Fingerprint.NormalizeShape("failed at 'lit'"),
+            Fingerprint.NormalizeShape("failed at '/var/folders/T/cs2gsrun-0a1b2c/App/Program.cs'"));
+        Assert.Equal(
+            Fingerprint.NormalizeShape("failed at 'lit'"),
+            Fingerprint.NormalizeShape("failed at 'C:\\Users\\ci\\Temp\\cs2gsrun-9f9f\\App\\Program.cs'"));
+        Assert.Equal(
+            Fingerprint.NormalizeShape("failed at 'lit'"),
+            Fingerprint.NormalizeShape("failed at '\\\\build-host\\share\\cs2gsrun-42\\App\\Program.cs'"));
+    }
+
+    /// <summary>
+    /// (2) A snippet longer than the truncation cap whose head is identical
+    /// except for pre-normalization noise (here: two differently-sized string
+    /// literal and identifier runs that push the rest of the snippet to
+    /// different absolute offsets) must still normalize to the exact same
+    /// shape and fingerprint — the truncation boundary must be computed on
+    /// already-normalized text, not on the raw snippet.
+    /// </summary>
+    [Fact]
+    public void Fingerprint_NormalizesBeforeTruncating_SoLongSnippetsWithDifferentNoiseDedup()
+    {
+        // Same construct — `let a = f(<identifier>) + 1;` — but the
+        // identifier bound inside f(...) has a very different length, so a
+        // naive "truncate raw text at N chars, then normalize" pipeline would
+        // cut one snippet mid-argument (dropping the closing paren and the
+        // "+ 1;" tail) and the other past the closing paren (keeping it),
+        // producing two different shapes for what is structurally the same
+        // gap.
+        string snippetA = "let a = f(" + new string('x', 155) + ") + 1;";
+        string snippetB = "let a = f(" + new string('x', 145) + ") + 1;";
+        Assert.True(snippetA.Length > 160 || snippetB.Length > 160, "test setup must exceed the truncation cap");
+
+        string fingerprintA = Fingerprint.Compute("compile-error", "compile", "GS0100", "GSharpConstruct", snippetA);
+        string fingerprintB = Fingerprint.Compute("compile-error", "compile", "GS0100", "GSharpConstruct", snippetB);
+
+        Assert.Equal(fingerprintA, fingerprintB);
+
+        // And the normalized shape is exactly what normalize-then-truncate
+        // predicts: the identifier is fully collapsed before any cap applies.
+        Assert.Equal("id id = id(id) + lit;", Fingerprint.NormalizeShape(snippetA));
+        Assert.Equal("id id = id(id) + lit;", Fingerprint.NormalizeShape(snippetB));
+    }
+
+    /// <summary>
+    /// (2) A stage-2 compile-error artifact built from a long emitted G# line
+    /// gets an identical fingerprint across two "runs" that differ only in
+    /// identifier length within that line, even though the raw line exceeds
+    /// the 160-char snippet cap.
+    /// </summary>
+    [Fact]
+    public void CompileError_LongLineDifferingOnlyInIdentifierLength_DedupsToSameFingerprint()
+    {
+        var builder = new TriageBuilder("run_1", "2026-06-21T20:00:00Z", "0.2.0+abc", "corpus/Sample");
+
+        string LongLine(int padLength) => "let a = f(" + new string('x', padLength) + ") + 1;";
+
+        var emittedA = new EmittedGsFile(
+            "/abs/Sample.gs", "corpus_Sample/Sample.gs", "/abs/Sample.cs", "func F() {\n    " + LongLine(155) + "\n}\n");
+        var emittedB = new EmittedGsFile(
+            "/abs/Sample.gs", "corpus_Sample/Sample.gs", "/abs/Sample.cs", "func F() {\n    " + LongLine(120) + "\n}\n");
+
+        var diagnostic = new GscDiagnostic("GS0100", "no overload for 'f'", "error", "Sample.gs", 2, 13);
+
+        TriageArtifact a = builder.CompileError(diagnostic, emittedA);
+        TriageArtifact b = builder.CompileError(diagnostic, emittedB);
+
+        Assert.Equal(a.Fingerprint, b.Fingerprint);
+    }
+
+    /// <summary>
+    /// (3) A G# line whose leading token is <c>let</c> but whose string
+    /// literal body contains a keyword the old substring-scan heuristic would
+    /// misfire on (<c>"for"</c>) classifies structurally as <c>LetConstruct</c>
+    /// — the literal-content heuristic would have classified it as
+    /// <c>ForConstruct</c> instead, splitting an otherwise-identical compile
+    /// error's fingerprint on string-literal content.
+    /// </summary>
+    [Fact]
+    public void CompileError_KeywordInsideStringLiteral_ClassifiesOnLeadingTokenNotLiteralContent()
+    {
+        var builder = new TriageBuilder("run_1", "2026-06-21T20:00:00Z", "0.2.0+abc", "corpus/Sample");
+        var emitted = new EmittedGsFile(
+            "/abs/Sample.gs",
+            "corpus_Sample/Sample.gs",
+            "/abs/Sample.cs",
+            "func F() {\n    let msg = \"run for cover\"\n}\n");
+        var diagnostic = new GscDiagnostic("GS0313", "unexpected token", "error", "Sample.gs", 2, 5);
+
+        TriageArtifact artifact = builder.CompileError(diagnostic, emitted);
+
+        Assert.Equal("LetConstruct", artifact.OffendingCSharpConstruct.Kind);
+
+        // A real `for` loop still classifies as ForConstruct, proving the fix
+        // did not simply stop detecting `for` altogether.
+        var emittedForLoop = new EmittedGsFile(
+            "/abs/Sample.gs",
+            "corpus_Sample/Sample.gs",
+            "/abs/Sample.cs",
+            "func F() {\n    for i in items {\n    }\n}\n");
+        TriageArtifact forArtifact = builder.CompileError(diagnostic, emittedForLoop);
+        Assert.Equal("ForConstruct", forArtifact.OffendingCSharpConstruct.Kind);
+
+        // Two otherwise-identical compile errors that only differ by what a
+        // string literal happens to contain must dedup to the same
+        // fingerprint (the construct kind is a fingerprint component).
+        var emittedOtherLiteral = new EmittedGsFile(
+            "/abs/Sample.gs",
+            "corpus_Sample/Sample.gs",
+            "/abs/Sample.cs",
+            "func F() {\n    let msg = \"while you wait\"\n}\n");
+        TriageArtifact otherLiteralArtifact = builder.CompileError(diagnostic, emittedOtherLiteral);
+        Assert.Equal(artifact.Fingerprint, otherLiteralArtifact.Fingerprint);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1750TriageFingerprintStabilityTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1750TriageFingerprintStabilityTests.cs
@@ -183,4 +183,104 @@ public class Issue1750TriageFingerprintStabilityTests
         TriageArtifact otherLiteralArtifact = builder.CompileError(diagnostic, emittedOtherLiteral);
         Assert.Equal(artifact.Fingerprint, otherLiteralArtifact.Fingerprint);
     }
+
+    /// <summary>
+    /// (B1, post-review regression) A construct line prefixed by one or more
+    /// modifier keywords still classifies on the construct keyword that
+    /// follows the modifiers — not on the leading modifier token itself,
+    /// which would otherwise fall through to the generic <c>GSharpConstruct</c>
+    /// bucket and collide structurally distinct gaps (e.g. a `sealed class`
+    /// gap and an `async func` gap both fingerprinting as the same
+    /// unclassified kind).
+    /// </summary>
+    [Theory]
+    [InlineData("sealed class Shape {", "ClassConstruct")]
+    [InlineData("async func Bump(n int32) int32 {", "FuncConstruct")]
+    [InlineData("private func Helper(x int32) int32 {", "FuncConstruct")]
+    [InlineData("public static async func F() {", "FuncConstruct")]
+    public void CompileError_ModifierPrefixedConstruct_ClassifiesOnConstructKeyword(string gsLine, string expectedKind)
+    {
+        var builder = new TriageBuilder("run_1", "2026-06-21T20:00:00Z", "0.2.0+abc", "corpus/Sample");
+        var emitted = new EmittedGsFile(
+            "/abs/Sample.gs",
+            "corpus_Sample/Sample.gs",
+            "/abs/Sample.cs",
+            "func Outer() {\n    " + gsLine + "\n}\n");
+        var diagnostic = new GscDiagnostic("GS0313", "unexpected token", "error", "Sample.gs", 2, 5);
+
+        TriageArtifact artifact = builder.CompileError(diagnostic, emitted);
+
+        Assert.Equal(expectedKind, artifact.OffendingCSharpConstruct.Kind);
+    }
+
+    /// <summary>
+    /// (B1) Two modifier-prefixed constructs of genuinely different kinds
+    /// (`sealed class` vs `async func`) must NOT collapse to the same
+    /// fingerprint — the regression this test guards against classified both
+    /// as the generic bucket, colliding structurally distinct gaps.
+    /// </summary>
+    [Fact]
+    public void CompileError_DifferentModifierPrefixedConstructs_ProduceDifferentFingerprints()
+    {
+        var builder = new TriageBuilder("run_1", "2026-06-21T20:00:00Z", "0.2.0+abc", "corpus/Sample");
+        var diagnostic = new GscDiagnostic("GS0313", "unexpected token", "error", "Sample.gs", 1, 5);
+
+        var emittedSealedClass = new EmittedGsFile(
+            "/abs/Sample.gs", "corpus_Sample/Sample.gs", "/abs/Sample.cs", "sealed class Shape {\n}\n");
+        var emittedAsyncFunc = new EmittedGsFile(
+            "/abs/Sample.gs", "corpus_Sample/Sample.gs", "/abs/Sample.cs", "async func Bump() {\n}\n");
+
+        TriageArtifact a = builder.CompileError(diagnostic, emittedSealedClass);
+        TriageArtifact b = builder.CompileError(diagnostic, emittedAsyncFunc);
+
+        Assert.NotEqual(a.OffendingCSharpConstruct.Kind, b.OffendingCSharpConstruct.Kind);
+        Assert.NotEqual(a.Fingerprint, b.Fingerprint);
+    }
+
+    /// <summary>
+    /// (N1) Two crashes of the same exception type but with structurally
+    /// different messages (after path-strip + normalize) must NOT collapse to
+    /// the same fingerprint — the crash-message shape, not just
+    /// <c>ex.GetType().Name</c>, is part of the fingerprint.
+    /// </summary>
+    [Fact]
+    public void StageCrash_SameExceptionTypeDifferentMessageShape_ProducesDifferentFingerprint()
+    {
+        var builder = new TriageBuilder("run_1", "2026-06-21T20:00:00Z", "0.2.0+abc", "corpus/Sample");
+
+        var exFileNotFound = new InvalidOperationException(
+            "Could not find file '/var/folders/T/cs2gsrun-0a1b2c/App/Program.cs' during stage 2.");
+        var exBadState = new InvalidOperationException(
+            "Operation is not valid due to the current state of the pipeline.");
+
+        TriageArtifact a = builder.StageCrash(MigrationStageKind.Compile, TriageCategory.CompileError, "GS9999", exFileNotFound);
+        TriageArtifact b = builder.StageCrash(MigrationStageKind.Compile, TriageCategory.CompileError, "GS9999", exBadState);
+
+        Assert.Equal(a.OffendingCSharpConstruct.Kind, b.OffendingCSharpConstruct.Kind);
+        Assert.NotEqual(a.Fingerprint, b.Fingerprint);
+    }
+
+    /// <summary>
+    /// (N2) A single-segment absolute path (no interior directory segment,
+    /// e.g. a bare run-scoped <c>/tmp</c> or <c>/root</c>) normalizes exactly
+    /// like a multi-segment path and dedups stably across "runs" that only
+    /// differ in that bare root.
+    /// </summary>
+    [Fact]
+    public void NormalizeShape_NeutralizesSingleSegmentAbsolutePath()
+    {
+        Assert.Equal(
+            Fingerprint.NormalizeShape("failed at 'lit'"),
+            Fingerprint.NormalizeShape("failed at '/tmp'"));
+        Assert.Equal(
+            Fingerprint.NormalizeShape("failed at 'lit'"),
+            Fingerprint.NormalizeShape("failed at '/root'"));
+
+        // And it must not over-match ordinary non-path text containing a slash:
+        // "3/4" is preceded by a digit, so the Unix-path branch must not
+        // treat it as an absolute path (the numbers are still collapsed to
+        // `lit` by the ordinary numeric-literal rule, not the path rule).
+        Assert.Equal("id id lit/lit id id id", Fingerprint.NormalizeShape("the ratio 3/4 is not one"));
+    }
 }
+


### PR DESCRIPTION
Fixes #1750.

## Root cause (all three)

1. **Crash artifacts fingerprinted on raw `Exception.Message`.** `MigrationPipeline.StageCrashArtifact` embedded `ex.Message` directly into the diagnostic/snippet used for `Fingerprint.Compute`. Crash messages routinely embed run-scoped absolute paths (temp/work directories containing the run id), and a hex run id tokenizes inconsistently across runs depending on whether it starts with a digit or a letter, so the same recurring crash got a fresh fingerprint every run/machine.
2. **Snippets truncated before shape normalization.** Every `TriageBuilder` call site truncated the raw snippet to 160 chars and passed the *truncated* string into `Fingerprint.Compute`, which then normalized it. The truncation cut point depended on raw, pre-normalized text and could land mid-token, so two occurrences of the same construct differing only in identifier length could truncate at different structural points and normalize to different shapes.
3. **`ClassifyGsLine` matched keyword text anywhere in the line**, including inside string literals (`trimmed.Contains(" for ")`), so e.g. `let msg = "run for cover"` misclassified as a `For` construct. Since `kind` is a fingerprint component, otherwise-identical compile errors split fingerprints based on unrelated string-literal content.

## Fix

1. Added `TriageBuilder.StageCrash(stage, category, diagnosticId, ex)`, a single unified path for all four stage-crash artifacts. The construct `kind` is now `ex.GetType().Name` — a stable, structural signal — instead of any text derived from the message. `Exception.Message` is still recorded in full on the artifact for human triage. As a generalized second line of defense, `Fingerprint.NormalizeShape` now strips *any* absolute path (Windows drive/UNC or Unix, any root — not one hardcoded prefix) before the identifier/literal passes run.
2. `Fingerprint.Compute` now takes the raw, untruncated snippet and applies the 160-char cap *after* `NormalizeShape` runs (`TruncateShape`), so the cut point is deterministic on already-normalized text. All `TriageBuilder` call sites were updated to pass the raw snippet to `Fingerprint.Compute` while keeping the existing truncated value for the artifact's human-readable `Snippet` field.
3. `ClassifyGsLine` now classifies only the line's *leading* token (the structural position a G# statement/declaration keyword actually occupies) via a regex match, replacing the `Contains`-anywhere-in-line fallback that could match inside string literals.

## Tests

Added `tools/cs2gs/Cs2Gs.Tests/Issue1750TriageFingerprintStabilityTests.cs`:
- `StageCrash_SamePathVaryingRuns_ProducesIdenticalFingerprint` — same exception type, different Unix/Windows run-scoped paths in the message, dedups to one fingerprint; a different exception type still splits.
- `NormalizeShape_NeutralizesAnyAbsolutePath_RegardlessOfRoot` — generalized path stripping for Unix, Windows drive, and UNC paths.
- `Fingerprint_NormalizesBeforeTruncating_SoLongSnippetsWithDifferentNoiseDedup` + `CompileError_LongLineDifferingOnlyInIdentifierLength_DedupsToSameFingerprint` — a snippet over the 160-char cap whose head differs only in identifier length dedups after normalize-then-truncate.
- `CompileError_KeywordInsideStringLiteral_ClassifiesOnLeadingTokenNotLiteralContent` — a construct whose string literal contains a misleading keyword (`"run for cover"`) classifies as `LetConstruct`, not `ForConstruct`, and dedups with another literal's content; a real `for` loop still classifies correctly.

## Verification

- `dotnet build GSharp.sln -c Release -graph` — succeeded, 0 warnings/errors.
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release --filter "FullyQualifiedName!~L1MigrationEndToEndTests"` — 483/483 passed (heavy e2e gsc/ilverify tests excluded per triage guidance; not touched by this change).

Stayed entirely within the triage/fingerprint/crash-artifact/construct-classification code in `Cs2Gs.Pipeline` (`Fingerprint.cs`, `TriageBuilder.cs`, `MigrationPipeline.cs`) and added one new test file. Did not touch the translator or the stage-4 SDK resolver.
