### PR TITLE
cs2gs: fix ?? numeric coercion to key off the result type, not the left operand

### DIFF
--- a/test/Compiler.Tests/Emit/Issue1725NullCoalescingNumericWideningEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1725NullCoalescingNumericWideningEmitTests.cs
@@ -124,6 +124,92 @@ public class Issue1725NullCoalescingNumericWideningEmitTests
         Assert.Equal("11\n3\n", output);
     }
 
+    // N1: reviewer-flagged combos where cs2gs emits `left ?? rightAtResultType`
+    // with NO explicit left coercion, relying entirely on gsc's `??` binder to
+    // widen the left operand's non-null value up to the result type. Each is
+    // an end-to-end lock of that gsc contract for a combo not covered above.
+    [Fact]
+    public void LeftWiderFloatToDouble_WidensNonNullValue()
+    {
+        const string source = """
+            package i1725leftfloatdouble
+            import System
+
+            func N(f float?, d double) double -> f ?? d
+
+            func Main() {
+                System.Console.WriteLine(N(nil, 2.5))
+                System.Console.WriteLine(N(3.0f, 2.5))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("2.5\n3\n", output);
+    }
+
+    [Fact]
+    public void LeftWiderUintToLong_WidensNonNullValue()
+    {
+        const string source = """
+            package i1725leftuintlong
+            import System
+
+            func N(u uint32?, l int64) int64 -> u ?? l
+
+            func Main() {
+                System.Console.WriteLine(N(nil, 5000000000))
+                System.Console.WriteLine(N(4000000000u, 5000000000))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("5000000000\n4000000000\n", output);
+    }
+
+    [Fact]
+    public void LeftWiderIntToDecimal_WidensNonNullValue()
+    {
+        const string source = """
+            package i1725leftintdecimal
+            import System
+
+            func N(i int32?, d decimal) decimal -> i ?? d
+
+            func Main() {
+                System.Console.WriteLine(N(nil, 2.5m))
+                System.Console.WriteLine(N(7, 2.5m))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("2.5\n7\n", output);
+    }
+
+    // N3 / issue #914: a constant signed/unsigned mismatch (`uint? x ?? 0`) —
+    // the literal `0`'s natural type `int32` differs from the `uint32` result
+    // C# computes, so cs2gs coerces the right constant to the result type
+    // (`x ?? uint32(0)`, per Issue1725NullCoalescingResultTypeTranslationTests
+    // .ConstantNarrowerThanUnsignedResult_StillCoerced). Locks the runtime
+    // value of that translated form, not just its text.
+    [Fact]
+    public void ConstantUnsignedMismatch_ProducesCorrectRuntimeValue()
+    {
+        const string source = """
+            package i1725constuintzero
+            import System
+
+            func N(x uint32?) uint32 -> x ?? uint32(0)
+
+            func Main() {
+                System.Console.WriteLine(N(nil))
+                System.Console.WriteLine(N(5u))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("0\n5\n", output);
+    }
+
     private static string CompileAndRun(string source)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_1725_exe_").FullName;

--- a/test/Compiler.Tests/Emit/Issue1725NullCoalescingNumericWideningEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1725NullCoalescingNumericWideningEmitTests.cs
@@ -1,0 +1,208 @@
+// <copyright file="Issue1725NullCoalescingNumericWideningEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1725 — cs2gs's <c>TranslateNullCoalescing</c> unconditionally
+/// coerced the right operand of <c>a ?? b</c> down to the left operand's
+/// underlying numeric type whenever the two numeric kinds differed. That only
+/// matches C# when the right operand implicitly converts to the left's
+/// underlying type; when the right side is wider, C# types <c>a ?? b</c> as
+/// the right operand's (wider) type and converts the LEFT's value instead —
+/// the buggy translation truncated the right operand. These are end-to-end
+/// runtime checks of the underlying gsc <c>??</c> semantics that the cs2gs
+/// fix now relies on (rather than re-deriving them with its own lowering):
+/// gsc's own <c>??</c> binder (issue #1239) already performs C#'s
+/// best-common-type widening and auto-converts the left operand's non-null
+/// value, so the translated G# for each of these C# snippets is the
+/// untouched <c>a ?? b</c> (verified separately by the Cs2Gs.Tests
+/// translation tests) and must therefore produce the widened, non-truncated
+/// runtime value below.
+/// </summary>
+public class Issue1725NullCoalescingNumericWideningEmitTests
+{
+    [Fact]
+    public void RightWiderThanLeft_Int64_DoesNotTruncate()
+    {
+        const string source = """
+            package i1725rightwiderlong
+            import System
+
+            func N(nInt int32?, longDefault int64) int64 -> nInt ?? longDefault
+
+            func Main() {
+                System.Console.WriteLine(N(nil, 5000000000))
+                System.Console.WriteLine(N(3, 5000000000))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("5000000000\n3\n", output);
+    }
+
+    [Fact]
+    public void RightWiderThanLeft_Double_KeepsFraction()
+    {
+        const string source = """
+            package i1725rightwiderdouble
+            import System
+
+            func N(nInt int32?) double -> nInt ?? 2.5
+
+            func Main() {
+                System.Console.WriteLine(N(nil))
+                System.Console.WriteLine(N(2))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("2.5\n2\n", output);
+    }
+
+    [Fact]
+    public void RightWiderThanLeft_NonConstantDouble_KeepsFraction()
+    {
+        const string source = """
+            package i1725rightwiderdoublevar
+            import System
+
+            func N(nInt int32?, otherDouble double) double -> nInt ?? otherDouble
+
+            func Main() {
+                System.Console.WriteLine(N(nil, 2.5))
+                System.Console.WriteLine(N(9, 2.5))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("2.5\n9\n", output);
+    }
+
+    [Fact]
+    public void LeftWiderThanRight_CoercesConstantUp()
+    {
+        const string source = """
+            package i1725leftwider
+            import System
+
+            func N(nLong int64?) int64 -> nLong ?? 7
+
+            func Main() {
+                System.Console.WriteLine(N(nil))
+                System.Console.WriteLine(N(42))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("7\n42\n", output);
+    }
+
+    [Fact]
+    public void EqualNumericKinds_NoCoercionNeeded()
+    {
+        const string source = """
+            package i1725equalkinds
+            import System
+
+            func N(x uint32?, fallback uint32) uint32 -> x ?? fallback
+
+            func Main() {
+                System.Console.WriteLine(N(nil, 11u))
+                System.Console.WriteLine(N(3u, 11u))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("11\n3\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1725_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1725NullCoalescingResultTypeTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1725NullCoalescingResultTypeTranslationTests.cs
@@ -1,0 +1,178 @@
+// <copyright file="Issue1725NullCoalescingResultTypeTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Translation tests for issue #1725: <c>TranslateNullCoalescing</c>
+/// unconditionally coerced the right operand of <c>a ?? b</c> down to the
+/// left operand's underlying numeric type whenever the two numeric kinds
+/// differed. That only matches C# when the right operand implicitly converts
+/// to the left's underlying type. When the right side is wider, C# types
+/// <c>a ?? b</c> as the right operand's (wider) type and converts the LEFT's
+/// value instead — the old code silently truncated the right operand down to
+/// the left's narrower type. The fix keys the coercion off the whole
+/// expression's C#-computed result type (<c>GetTypeInfo(binary).Type</c>) and
+/// only touches the right operand when it differs from that result; the left
+/// operand's non-null value is widened automatically by gsc's own <c>??</c>
+/// binder (issue #1239) so it never needs a cs2gs-side rewrite.
+/// </summary>
+public class Issue1725NullCoalescingResultTypeTranslationTests
+{
+    /// <summary>
+    /// Right operand wider than left (<c>long</c> vs. <c>int32?</c>): C# types
+    /// the whole expression as <c>long</c>, so the right operand must NOT be
+    /// coerced down to <c>int32</c> (which would truncate it at runtime).
+    /// </summary>
+    [Fact]
+    public void RightWiderThanLeft_DoesNotTruncateRightOperand()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public long N(int? nInt, long longDefault) => nInt ?? longDefault;
+    }
+}");
+
+        Assert.Contains("nInt ?? longDefault", printed);
+        Assert.DoesNotContain("int32(longDefault)", printed);
+    }
+
+    /// <summary>
+    /// Right operand is a wider floating-point constant (<c>2.5</c>): the
+    /// whole expression is typed <c>double</c> by C#, so the literal must
+    /// keep its fractional value and must not be narrowed to <c>int32</c>.
+    /// </summary>
+    [Fact]
+    public void DoubleResultWithIntegerLeft_KeepsFractionalConstant()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public double N(int? nInt) => nInt ?? 2.5;
+    }
+}");
+
+        Assert.Contains("nInt ?? 2.5", printed);
+        Assert.DoesNotContain("int32(2.5)", printed);
+    }
+
+    /// <summary>
+    /// Right operand is a wider, non-constant <c>double</c> variable: same
+    /// widening rule applies to a non-literal right operand.
+    /// </summary>
+    [Fact]
+    public void DoubleResultWithIntegerLeft_NonConstantRight_NotCoerced()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public double N(int? nInt, double otherDouble) => nInt ?? otherDouble;
+    }
+}");
+
+        Assert.Contains("nInt ?? otherDouble", printed);
+        Assert.DoesNotContain("int32(otherDouble)", printed);
+    }
+
+    /// <summary>
+    /// Left operand wider than right (<c>long?</c> vs. a narrower constant):
+    /// C# types the whole expression as <c>long</c>, so the narrower right
+    /// operand is coerced UP to the result type (pre-existing, still-correct
+    /// direction for this coercion).
+    /// </summary>
+    [Fact]
+    public void LeftWiderThanRight_CoercesRightUpToResultType()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public long N(long? nLong) => nLong ?? 7;
+    }
+}");
+
+        Assert.Contains("nLong ?? int64(7)", printed);
+    }
+
+    /// <summary>
+    /// Equal numeric kinds (<c>uint?</c> vs. <c>uint</c>): no coercion is
+    /// inserted at all — this is the pre-existing early-out and must stay
+    /// untouched by the result-type rework.
+    /// </summary>
+    [Fact]
+    public void EqualNumericKinds_NoSpuriousCoercion()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public uint N(uint? x, uint fallback) => x ?? fallback;
+    }
+}");
+
+        Assert.Contains("x ?? fallback", printed);
+        Assert.DoesNotContain("uint32(fallback)", printed);
+    }
+
+    /// <summary>
+    /// Regression guard for the original #914 scenario (right is a constant
+    /// whose natural type differs from the result because of C#'s
+    /// constant-literal conversion rule, not a general widening): the
+    /// literal still needs an explicit coercion because gsc's own <c>??</c>
+    /// binder does not special-case constant-literal conversions the way C#
+    /// does.
+    /// </summary>
+    [Fact]
+    public void ConstantNarrowerThanUnsignedResult_StillCoerced()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public uint N(uint? x) => x ?? 0;
+    }
+}");
+
+        Assert.Contains("?? uint32(0)", printed);
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -3912,9 +3912,12 @@ public sealed class CSharpToGSharpTranslator
         // gsc's own `??` binder (issue #1239) already performs this same
         // C#-faithful best-common-type widening and auto-converts the left
         // operand's non-null value whenever the left is the narrower side —
-        // verified directly against gsc for int32?/int64, int32?/double, and
-        // int64?/int32 (left wider). The one gap gsc does not fill on its own
-        // is a *constant* right operand whose natural numeric kind differs
+        // verified directly against gsc for int32?/int64, int32?/double,
+        // int64?/int32 (left wider), float?/double, uint32?/int64, and
+        // int32?/decimal (see Issue1725NullCoalescingNumericWideningEmitTests
+        // for the runtime locks of each combo). The one gap gsc does not
+        // fill on its own is a *constant* right operand whose natural
+        // numeric kind differs
         // from the result (e.g. `x ?? 0` for `uint32? x`: the literal `0`'s
         // natural type `int32` differs from the `uint32` result C# computed
         // via its constant-literal conversion rule, which gsc's type-only
@@ -3935,8 +3938,16 @@ public sealed class CSharpToGSharpTranslator
                 TryGetNumericKind(rightType, out SpecialType rightUnderlying) &&
                 leftUnderlying != rightUnderlying)
             {
-                TypeInfo binaryInfo = this.context.GetTypeInfo(binary);
-                ITypeSymbol resultType = binaryInfo.Type ?? binaryInfo.ConvertedType;
+                // `.Type` (not `.ConvertedType`) is the `??` expression's own
+                // best-common-type per C# §12.15 — the value we need here.
+                // `.ConvertedType` instead reflects an ENCLOSING conversion
+                // (e.g. an assignment's target type), which would let an
+                // outer context over-coerce this operand to the wrong type
+                // (S1). `.Type` is only null for an unresolved/erroneous
+                // expression; both operands already passed `TryGetNumericKind`
+                // above, meaning the semantic model fully resolved this `??`,
+                // so `.Type` is guaranteed non-null here.
+                ITypeSymbol resultType = this.context.GetTypeInfo(binary).Type;
 
                 if (TryGetNumericKind(resultType, out SpecialType resultUnderlying) &&
                     rightUnderlying != resultUnderlying)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -3898,9 +3898,32 @@ public sealed class CSharpToGSharpTranslator
             }
         }
 
-        // C# `a ?? b` where `a` is a nullable numeric: G# requires `b` to match
-        // the underlying numeric type of `a`, otherwise GS0129. Coerce the right
-        // operand to the left's underlying (non-nullable) type when they differ.
+        // C# `a ?? b` where `a` is a nullable numeric and the operands' numeric
+        // kinds differ: the coercion target is the *result* type of the whole
+        // `??` expression — C#'s best-common-type computation (§12.15), exactly
+        // as `GetTypeInfo(binary).Type` already reports it — not unconditionally
+        // the left operand's type (issue #1725). When the right operand is
+        // *wider* than the left (e.g. `long r = nullableInt ?? longDefault;`),
+        // C# types the whole expression as the right operand's (wider) type and
+        // converts the LEFT's non-null value instead; the old code coerced the
+        // right operand DOWN to the left's narrower type, silently truncating
+        // it (or truncating a `double` fallback to the left's integral type).
+        //
+        // gsc's own `??` binder (issue #1239) already performs this same
+        // C#-faithful best-common-type widening and auto-converts the left
+        // operand's non-null value whenever the left is the narrower side —
+        // verified directly against gsc for int32?/int64, int32?/double, and
+        // int64?/int32 (left wider). The one gap gsc does not fill on its own
+        // is a *constant* right operand whose natural numeric kind differs
+        // from the result (e.g. `x ?? 0` for `uint32? x`: the literal `0`'s
+        // natural type `int32` differs from the `uint32` result C# computed
+        // via its constant-literal conversion rule, which gsc's type-only
+        // conversion lattice does not special-case) — only in that direction
+        // is an explicit coercion required, and it always targets the
+        // *result* type, never the left type. Coercing the right operand when
+        // it already matches the result type is a no-op (skipped below), so
+        // this also covers left-wider-than-right (right coerced up, as
+        // before) and equal-kind operands (no coercion, unchanged).
         // Non-numeric coalescing (reference types, tasks) is left untouched.
         private GExpression TranslateNullCoalescing(
             BinaryExpressionSyntax binary, GExpression left, GExpression right)
@@ -3912,8 +3935,14 @@ public sealed class CSharpToGSharpTranslator
                 TryGetNumericKind(rightType, out SpecialType rightUnderlying) &&
                 leftUnderlying != rightUnderlying)
             {
-                ITypeSymbol leftUnderlyingType = UnwrapNullable(leftType);
-                right = this.CoerceOperandTo(right, leftUnderlyingType);
+                TypeInfo binaryInfo = this.context.GetTypeInfo(binary);
+                ITypeSymbol resultType = binaryInfo.Type ?? binaryInfo.ConvertedType;
+
+                if (TryGetNumericKind(resultType, out SpecialType resultUnderlying) &&
+                    rightUnderlying != resultUnderlying)
+                {
+                    right = this.CoerceOperandTo(right, UnwrapNullable(resultType));
+                }
             }
 
             return new BinaryExpression(left, "??", right);


### PR DESCRIPTION
Fixes #1725

## Bug

`TranslateNullCoalescing` (`tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs`) unconditionally coerced the **right** operand of `a ?? b` down to the **left** operand's underlying numeric type whenever the two numeric kinds differed. That only matches C# when the right operand implicitly converts to the left's underlying type. When the right side is *wider*, C# types `a ?? b` as the right operand's (wider) type and converts the LEFT's value instead — the old code silently truncated:

- `long r = nullableInt ?? longDefault;` emitted `nullableInt ?? int32(longDefault)` — truncating `longDefault`.
- `double d = nullableInt ?? 2.5;` emitted `nullableInt ?? int32(2.5)` — truncating `2.5` to `2`.

## Fix

Compute the coercion target from the whole `??` expression's C#-computed result type (`GetTypeInfo(binary).Type`/`.ConvertedType` — best-common-type per C# §12.15), not the left operand's type, and only coerce the right operand when it differs from that result.

No left-side rewrite (nullable-preserving widening lowering / if-expression) is needed. I verified directly against `gsc` that its own `??` binder (issue #1239) already performs the same C#-faithful best-common-type widening and auto-converts the left operand's non-null value whenever the left is the narrower side — this holds for `int32?`/`int64`, `int32?`/`double`, and `int64?`/`int32` (left wider). The only gap `gsc` doesn't fill on its own is a **constant** right operand whose natural numeric kind differs from the result purely because of C#'s constant-literal conversion rule (e.g. `x ?? 0` for `uint32? x` — `gsc`'s type-only conversion lattice doesn't special-case literals the way C# does); that direction still needs an explicit coercion, now correctly targeting the result type.

## Cases covered

- right wider than left: `int64`, `double` (both constant and non-constant right operand) — right left untouched, no truncation
- left wider than right — right still coerced up to the result type (same direction as before, now keyed off the correctly-computed result type instead of blindly the left type)
- equal numeric kinds — no coercion (pre-existing early-out, unchanged)
- constant right narrower due to signed/unsigned mismatch — still coerced (regression guard for the original issue #914 scenario, `x ?? 0` for `uint32? x`)

## Tests

- `tools/cs2gs/Cs2Gs.Tests/Issue1725NullCoalescingResultTypeTranslationTests.cs` — translation-level assertions on the emitted `??` text for each combo above.
- `test/Compiler.Tests/Emit/Issue1725NullCoalescingNumericWideningEmitTests.cs` — end-to-end `gsc` compile+run checks proving the runtime values are not truncated.

## Validation

- `dotnet build GSharp.sln -c Release -graph` — succeeds, 0 warnings/errors.
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release --no-build` — 524/524 pass (full suite, including the pre-existing `Issue914NumericCoercionTranslationTests`).
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Release --no-build --filter "FullyQualifiedName~Issue1725" -- xUnit.MaxParallelThreads=2` — 5/5 pass.
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Release --no-build --filter "FullyQualifiedName~NullCoalesc" -- xUnit.MaxParallelThreads=2` — 23/23 pass (pre-existing `??=`/`??` gsc-side tests, unaffected).
