### PR TITLE
cs2gs: fix verb --help exit code, missing-option-value exit code, slug collisions, and report/pipeline type duplication

### DIFF
--- a/tools/cs2gs/Cs2Gs.Cli/Cs2Gs.Cli.csproj
+++ b/tools/cs2gs/Cs2Gs.Cli/Cs2Gs.Cli.csproj
@@ -5,9 +5,6 @@
     <TargetFramework>$(NetCoreAppTargetFramework)</TargetFramework>
     <RootNamespace>Cs2Gs.Cli</RootNamespace>
     <AssemblyName>cs2gs</AssemblyName>
-    <!-- The cs2gs Directory.Build.props marks the whole tree IsTestProject=true
-         (skips docs/StyleCop), which also defaults IsPackable=false. Re-enable
-         packing below without re-enabling StyleCop. -->
   </PropertyGroup>
 
   <!-- Ship the C#->G# translator as a .NET tool: `dotnet tool install Gsharp.Cs2Gs`

--- a/tools/cs2gs/Cs2Gs.Cli/Program.cs
+++ b/tools/cs2gs/Cs2Gs.Cli/Program.cs
@@ -128,10 +128,10 @@ internal static class Program
 
     private static async Task<int> RunMigrateAsync(string[] args)
     {
-        (string Corpus, List<string> AppIds, PipelineOptions Options)? parsed = ParseMigrateArgs(args);
+        (string Corpus, List<string> AppIds, PipelineOptions Options)? parsed = ParseMigrateArgs(args, out bool helpRequested);
         if (parsed is null)
         {
-            return 1;
+            return helpRequested ? 0 : 1;
         }
 
         (string corpus, List<string> appIds, PipelineOptions options) = parsed.Value;
@@ -180,22 +180,35 @@ internal static class Program
         string runDir = null;
         string outPath = null;
 
-        for (int i = 0; i < args.Length; i++)
+        try
         {
-            string arg = args[i];
-            switch (arg)
+            for (int i = 0; i < args.Length; i++)
             {
-                case "--run":
-                    runDir = NextValue(args, ref i, arg);
-                    break;
-                case "--out":
-                    outPath = NextValue(args, ref i, arg);
-                    break;
-                default:
-                    Console.Error.WriteLine($"cs2gs: unknown option '{arg}'.");
-                    PrintUsage();
-                    return 1;
+                string arg = args[i];
+                switch (arg)
+                {
+                    case "-h":
+                    case "--help":
+                        PrintUsage();
+                        return 0;
+                    case "--run":
+                        runDir = NextValue(args, ref i, arg);
+                        break;
+                    case "--out":
+                        outPath = NextValue(args, ref i, arg);
+                        break;
+                    default:
+                        Console.Error.WriteLine($"cs2gs: unknown option '{arg}'.");
+                        PrintUsage();
+                        return 1;
+                }
             }
+        }
+        catch (ArgumentException ex)
+        {
+            Console.Error.WriteLine("cs2gs: " + ex.Message);
+            PrintUsage();
+            return 1;
         }
 
         if (string.IsNullOrEmpty(runDir))
@@ -287,8 +300,9 @@ internal static class Program
         return Path.Combine(root, runId);
     }
 
-    private static (string Corpus, List<string> AppIds, PipelineOptions Options)? ParseMigrateArgs(string[] args)
+    private static (string Corpus, List<string> AppIds, PipelineOptions Options)? ParseMigrateArgs(string[] args, out bool helpRequested)
     {
+        helpRequested = false;
         string corpus = null;
         var appIds = new List<string>();
         var options = new PipelineOptions();
@@ -296,27 +310,41 @@ internal static class Program
         for (int i = 0; i < args.Length; i++)
         {
             string arg = args[i];
-            switch (arg)
+            try
             {
-                case "--corpus":
-                    corpus = NextValue(args, ref i, arg);
-                    break;
-                case "--app":
-                    appIds.Add(NextValue(args, ref i, arg));
-                    break;
-                case "--gsc":
-                    options.GscPath = NextValue(args, ref i, arg);
-                    break;
-                case "--out":
-                    options.OutputRoot = NextValue(args, ref i, arg);
-                    break;
-                case "--config":
-                    options.Config = NextValue(args, ref i, arg);
-                    break;
-                default:
-                    Console.Error.WriteLine($"cs2gs: unknown option '{arg}'.");
-                    PrintUsage();
-                    return null;
+                switch (arg)
+                {
+                    case "-h":
+                    case "--help":
+                        helpRequested = true;
+                        PrintUsage();
+                        return null;
+                    case "--corpus":
+                        corpus = NextValue(args, ref i, arg);
+                        break;
+                    case "--app":
+                        appIds.Add(NextValue(args, ref i, arg));
+                        break;
+                    case "--gsc":
+                        options.GscPath = NextValue(args, ref i, arg);
+                        break;
+                    case "--out":
+                        options.OutputRoot = NextValue(args, ref i, arg);
+                        break;
+                    case "--config":
+                        options.Config = NextValue(args, ref i, arg);
+                        break;
+                    default:
+                        Console.Error.WriteLine($"cs2gs: unknown option '{arg}'.");
+                        PrintUsage();
+                        return null;
+                }
+            }
+            catch (ArgumentException ex)
+            {
+                Console.Error.WriteLine("cs2gs: " + ex.Message);
+                PrintUsage();
+                return null;
             }
         }
 
@@ -333,6 +361,16 @@ internal static class Program
         return (corpus, appIds, options);
     }
 
+    /// <summary>
+    /// Reads the value following an option flag (e.g. <c>--gsc &lt;path&gt;</c>).
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// The flag was the last token with no value following it. Callers catch
+    /// this alongside the unknown-option case and route it through the same
+    /// print-usage/return-1 path — a missing value is a usage error, not an
+    /// internal error, so it must not escape to <see cref="Main"/>'s generic
+    /// catch (which reports exit code 2).
+    /// </exception>
     private static string NextValue(string[] args, ref int index, string flag)
     {
         if (index + 1 >= args.Length)

--- a/tools/cs2gs/Cs2Gs.Report/HtmlReportWriter.cs
+++ b/tools/cs2gs/Cs2Gs.Report/HtmlReportWriter.cs
@@ -108,15 +108,17 @@ public static class HtmlReportWriter
 
         outputDir = Path.GetFullPath(outputDir ?? model.RunDir);
 
+        Dictionary<string, string> slugs = BuildSlugMap(model);
+
         var sb = new StringBuilder();
         sb.Append("<!DOCTYPE html>").Append(Newline);
         sb.Append("<html lang=\"en\">").Append(Newline);
         AppendHead(sb, model);
         sb.Append("<body>").Append(Newline);
         AppendHeader(sb, model);
-        AppendMatrix(sb, model);
+        AppendMatrix(sb, model, slugs);
         AppendGaps(sb, model);
-        AppendAppDetails(sb, model, outputDir);
+        AppendAppDetails(sb, model, outputDir, slugs);
         AppendScript(sb);
         sb.Append("</body>").Append(Newline);
         sb.Append("</html>").Append(Newline);
@@ -202,7 +204,7 @@ public static class HtmlReportWriter
             .Append("<dd>").Append(Encode(value)).Append("</dd>").Append(Newline);
     }
 
-    private static void AppendMatrix(StringBuilder sb, ReportModel model)
+    private static void AppendMatrix(StringBuilder sb, ReportModel model, Dictionary<string, string> slugs)
     {
         sb.Append("<section aria-labelledby=\"matrix-h\">").Append(Newline);
         sb.Append("<h2 id=\"matrix-h\">Status matrix</h2>").Append(Newline);
@@ -219,11 +221,11 @@ public static class HtmlReportWriter
         foreach (AppReport app in model.Apps)
         {
             sb.Append("<tr>");
-            sb.Append("<th scope=\"row\"><a href=\"#app-").Append(Slug(app.AppId)).Append("\">")
+            sb.Append("<th scope=\"row\"><a href=\"#app-").Append(slugs[app.AppId]).Append("\">")
                 .Append(Encode(app.AppId)).Append("</a></th>");
             foreach (string stageName in model.StageOrder)
             {
-                StageReport stage = app.Stages.FirstOrDefault(s =>
+                StageResult stage = app.Stages.FirstOrDefault(s =>
                     string.Equals(s.Stage, stageName, StringComparison.Ordinal));
                 AppendMatrixCell(sb, stage);
             }
@@ -236,7 +238,7 @@ public static class HtmlReportWriter
         sb.Append("</section>").Append(Newline);
     }
 
-    private static void AppendMatrixCell(StringBuilder sb, StageReport stage)
+    private static void AppendMatrixCell(StringBuilder sb, StageResult stage)
     {
         string status = stage?.Status ?? "skipped";
         (string Label, string Css, string Word) info = status switch
@@ -429,7 +431,7 @@ public static class HtmlReportWriter
         sb.Append("</details>").Append(Newline);
     }
 
-    private static void AppendAppDetails(StringBuilder sb, ReportModel model, string outputDir)
+    private static void AppendAppDetails(StringBuilder sb, ReportModel model, string outputDir, Dictionary<string, string> slugs)
     {
         sb.Append("<section aria-labelledby=\"apps-h\">").Append(Newline);
         sb.Append("<h2 id=\"apps-h\">App details</h2>").Append(Newline);
@@ -437,7 +439,7 @@ public static class HtmlReportWriter
         foreach (AppReport app in model.Apps)
         {
             string stateClass = app.Succeeded ? "ok" : "bad";
-            sb.Append("<article id=\"app-").Append(Slug(app.AppId)).Append("\" class=\"app-detail\">").Append(Newline);
+            sb.Append("<article id=\"app-").Append(slugs[app.AppId]).Append("\" class=\"app-detail\">").Append(Newline);
             sb.Append("<h3>").Append(Encode(app.AppId))
                 .Append(" <span class=\"state ").Append(stateClass).Append("\">")
                 .Append(app.Succeeded ? "green" : "failing").Append("</span></h3>").Append(Newline);
@@ -450,7 +452,7 @@ public static class HtmlReportWriter
             sb.Append("<table class=\"stage-list\"><thead><tr>")
                 .Append("<th scope=\"col\">stage</th><th scope=\"col\">status</th><th scope=\"col\">artifacts</th>")
                 .Append("</tr></thead><tbody>").Append(Newline);
-            foreach (StageReport stage in app.Stages)
+            foreach (StageResult stage in app.Stages)
             {
                 sb.Append("<tr><td>").Append(Encode(stage.Stage)).Append("</td>")
                     .Append("<td>").Append(Encode(stage.Status)).Append("</td>")
@@ -568,6 +570,39 @@ public static class HtmlReportWriter
             Path.Combine(runDir, artifactRelative.Replace('/', Path.DirectorySeparatorChar)));
         string relativeToOutput = Path.GetRelativePath(outputDir, absoluteArtifact);
         return relativeToOutput.Replace(Path.DirectorySeparatorChar, '/').Replace(Path.AltDirectorySeparatorChar, '/');
+    }
+
+    /// <summary>
+    /// Assigns each app a unique HTML id fragment (used for both the matrix's
+    /// <c>href="#app-…"</c> and the detail <c>id="app-…"</c>) so the anchors
+    /// always resolve. <see cref="Slug"/> folds case and collapses every
+    /// non-alphanumeric run to a single '-', so distinct app ids (e.g.
+    /// <c>corpus/L1-Console</c> and <c>corpus/l1.console</c>) can collide;
+    /// on collision this appends the app's ordinal index in
+    /// <see cref="ReportModel.Apps"/> (already ordinal-sorted, so stable
+    /// across runs) and keeps incrementing until the id is free, which also
+    /// covers 3-way-plus collisions.
+    /// </summary>
+    private static Dictionary<string, string> BuildSlugMap(ReportModel model)
+    {
+        var slugs = new Dictionary<string, string>(StringComparer.Ordinal);
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        for (int i = 0; i < model.Apps.Count; i++)
+        {
+            string appId = model.Apps[i].AppId;
+            string baseSlug = Slug(appId);
+            string candidate = baseSlug;
+            int suffix = i;
+            while (!seen.Add(candidate))
+            {
+                candidate = baseSlug + "-" + suffix.ToString(CultureInfo.InvariantCulture);
+                suffix++;
+            }
+
+            slugs[appId] = candidate;
+        }
+
+        return slugs;
     }
 
     private static string Slug(string value)

--- a/tools/cs2gs/Cs2Gs.Report/ReportModel.cs
+++ b/tools/cs2gs/Cs2Gs.Report/ReportModel.cs
@@ -214,12 +214,12 @@ public sealed class ReportModel
             .GroupBy(s => s.Stage, StringComparer.Ordinal)
             .ToDictionary(g => g.Key, g => g.First(), StringComparer.Ordinal);
 
-        var stages = new List<StageReport>();
+        var stages = new List<StageResult>();
         foreach (string stageName in stageOrder)
         {
             if (byName.TryGetValue(stageName, out StageResult stage))
             {
-                stages.Add(new StageReport
+                stages.Add(new StageResult
                 {
                     Stage = stageName,
                     Status = stage.Status ?? "skipped",
@@ -228,7 +228,7 @@ public sealed class ReportModel
             }
             else
             {
-                stages.Add(new StageReport
+                stages.Add(new StageResult
                 {
                     Stage = stageName,
                     Status = "skipped",
@@ -341,7 +341,7 @@ public sealed class AppReport
     /// <summary>Gets or sets the per-stage statuses, in execution order.</summary>
     [JsonPropertyName("stages")]
     [JsonPropertyOrder(3)]
-    public List<StageReport> Stages { get; set; } = new List<StageReport>();
+    public List<StageResult> Stages { get; set; } = new List<StageResult>();
 
     /// <summary>Gets or sets the run-relative triage artifact paths for this app.</summary>
     [JsonPropertyName("artifacts")]
@@ -352,27 +352,6 @@ public sealed class AppReport
     [JsonPropertyName("fingerprints")]
     [JsonPropertyOrder(5)]
     public List<string> Fingerprints { get; set; } = new List<string>();
-}
-
-/// <summary>
-/// The status of one stage within one app's row (ADR-0115 §C).
-/// </summary>
-public sealed class StageReport
-{
-    /// <summary>Gets or sets the stage name.</summary>
-    [JsonPropertyName("stage")]
-    [JsonPropertyOrder(0)]
-    public string Stage { get; set; }
-
-    /// <summary>Gets or sets the stage status (<c>passed</c>/<c>failed</c>/<c>skipped</c>).</summary>
-    [JsonPropertyName("status")]
-    [JsonPropertyOrder(1)]
-    public string Status { get; set; }
-
-    /// <summary>Gets or sets the number of triage artifacts the stage produced.</summary>
-    [JsonPropertyName("artifactCount")]
-    [JsonPropertyOrder(2)]
-    public int ArtifactCount { get; set; }
 }
 
 /// <summary>

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1756Tests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1756Tests.cs
@@ -1,0 +1,210 @@
+// <copyright file="Issue1756Tests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Cs2Gs.Pipeline;
+using Cs2Gs.Report;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Regression tests for issue #1756's low-severity CLI/report polish batch:
+/// verb-level <c>--help</c> exiting 0, a missing option value exiting 1 with
+/// usage (not the internal-error exit 2), <see cref="HtmlReportWriter"/>
+/// slug collisions producing distinct/matching anchors, and the
+/// <see cref="AppReport"/>/<see cref="Cs2Gs.Pipeline.AppResult"/> JSON shape
+/// staying byte-identical after collapsing the duplicated report types.
+/// </summary>
+public class Issue1756Tests
+{
+    /// <summary>
+    /// <c>cs2gs migrate --help</c> and <c>cs2gs report --help</c> (and
+    /// <c>-h</c>) must print usage and exit 0, not be treated as an unknown
+    /// option (which would exit 1).
+    /// </summary>
+    [Theory]
+    [InlineData("migrate", "--help")]
+    [InlineData("migrate", "-h")]
+    [InlineData("report", "--help")]
+    [InlineData("report", "-h")]
+    public async Task VerbHelp_ExitsZero_AndPrintsUsage(string verb, string helpFlag)
+    {
+        (int exitCode, string stdout, string stderr) = await RunMainAsync(verb, helpFlag);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Usage:", stdout, StringComparison.Ordinal);
+        Assert.Empty(stderr);
+    }
+
+    /// <summary>
+    /// A flag that requires a value but is given none (e.g. <c>--gsc</c> as
+    /// the last token) must exit 1 with usage text, the same as an unknown
+    /// option — not exit 2 (the internal-error code), which must stay
+    /// reserved for genuine internal errors.
+    /// </summary>
+    [Theory]
+    [InlineData("migrate", "--gsc")]
+    [InlineData("migrate", "--corpus")]
+    [InlineData("report", "--run")]
+    public async Task MissingOptionValue_ExitsOne_WithUsage_NotInternalError(string verb, string flag)
+    {
+        (int exitCode, string stdout, string stderr) = await RunMainAsync(verb, flag);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("requires a value", stderr, StringComparison.Ordinal);
+        Assert.Contains("Usage:", stdout, StringComparison.Ordinal);
+    }
+
+    private static async Task<(int ExitCode, string Stdout, string Stderr)> RunMainAsync(params string[] args)
+    {
+        TextWriter originalOut = Console.Out;
+        TextWriter originalError = Console.Error;
+        var capturedOut = new StringWriter();
+        var capturedError = new StringWriter();
+        Console.SetOut(capturedOut);
+        Console.SetError(capturedError);
+        int exitCode;
+        try
+        {
+            exitCode = await Cs2Gs.Cli.Program.Main(args).ConfigureAwait(false);
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+            Console.SetError(originalError);
+        }
+
+        return (exitCode, capturedOut.ToString(), capturedError.ToString());
+    }
+
+    /// <summary>
+    /// Three app ids that all fold to the same <c>Slug</c> under
+    /// case-folding + non-alphanumeric collapsing must still get distinct
+    /// HTML ids, and each matrix row's <c>href="#app-…"</c> must match the
+    /// corresponding detail <c>id="app-…"</c> exactly (three-way collision,
+    /// generalizing beyond a simple pair).
+    /// </summary>
+    [Fact]
+    public void HtmlReport_ThreeWaySlugCollision_ProducesDistinctIds_WithMatchingAnchors()
+    {
+        // "corpus/L1-Console", "corpus/l1.console", and "corpus/L1_Console"
+        // all fold to the same base slug ("corpus-l1-console").
+        var run = new RunResult
+        {
+            RunId = "run-1756",
+            Timestamp = "2026-01-01T00:00:00Z",
+            GscVersion = "0.2.0+test",
+            Succeeded = true,
+            Apps = new List<AppResult>
+            {
+                MakeApp("corpus/L1-Console"),
+                MakeApp("corpus/L1_Console"),
+                MakeApp("corpus/l1.console"),
+            },
+        };
+
+        ReportModel model = ReportModel.Build(run, Directory.GetCurrentDirectory());
+        string html = HtmlReportWriter.Render(model);
+
+        // Every rendered id="app-…" must be unique.
+        var ids = System.Text.RegularExpressions.Regex.Matches(html, "id=\"(app-[^\"]+)\"")
+            .Select(m => m.Groups[1].Value)
+            .ToList();
+        Assert.Equal(3, ids.Count);
+        Assert.Equal(ids.Count, ids.Distinct(StringComparer.Ordinal).Count());
+
+        // Every matrix href="#app-…" must resolve to one of the rendered ids.
+        var hrefs = System.Text.RegularExpressions.Regex.Matches(html, "href=\"#(app-[^\"]+)\"")
+            .Select(m => m.Groups[1].Value)
+            .ToList();
+        Assert.Equal(3, hrefs.Count);
+        foreach (string href in hrefs)
+        {
+            Assert.Contains(href, ids);
+        }
+
+        // Same model rendered twice is byte-identical (deterministic slugs).
+        Assert.Equal(html, HtmlReportWriter.Render(model));
+    }
+
+    private static AppResult MakeApp(string appId)
+    {
+        return new AppResult
+        {
+            AppId = appId,
+            Succeeded = true,
+            Stages = new List<StageResult>
+            {
+                new StageResult { Stage = "translate", Status = "passed" },
+                new StageResult { Stage = "compile", Status = "passed" },
+                new StageResult { Stage = "ilverify", Status = "passed" },
+                new StageResult { Stage = "test-parity", Status = "passed" },
+            },
+        };
+    }
+
+    /// <summary>
+    /// Golden: the <c>summary.json</c> shape for <see cref="AppReport"/>
+    /// (now reusing <see cref="Cs2Gs.Pipeline.StageResult"/> for its
+    /// <c>stages</c> list instead of a byte-identical, hand-duplicated
+    /// <c>StageReport</c> type) must stay exactly what it was before the
+    /// collapse: same property names, order, and values, per app/stage.
+    /// </summary>
+    [Fact]
+    public void JsonSummary_AppAndStageShape_IsByteIdenticalGolden()
+    {
+        var run = new RunResult
+        {
+            RunId = "run-1756-golden",
+            Timestamp = "2026-01-01T00:00:00Z",
+            GscVersion = "0.2.0+test",
+            Succeeded = true,
+            Apps = new List<AppResult>
+            {
+                new AppResult
+                {
+                    AppId = "corpus/L1-Console",
+                    Succeeded = true,
+                    Stages = new List<StageResult>
+                    {
+                        new StageResult { Stage = "translate", Status = "passed", ArtifactCount = 0 },
+                        new StageResult { Stage = "compile", Status = "passed", ArtifactCount = 0 },
+                        new StageResult { Stage = "ilverify", Status = "passed", ArtifactCount = 0 },
+                        new StageResult { Stage = "test-parity", Status = "passed", ArtifactCount = 0 },
+                    },
+                    Artifacts = new List<string>(),
+                    Fingerprints = new List<string>(),
+                },
+            },
+        };
+
+        ReportModel model = ReportModel.Build(run, Directory.GetCurrentDirectory());
+        string json = JsonSummaryWriter.Serialize(model);
+
+        using var doc = JsonDocument.Parse(json);
+        JsonElement app = doc.RootElement.GetProperty("apps")[0];
+
+        // Exact property set + order for the app row.
+        Assert.Equal(
+            new[] { "appId", "succeeded", "failureCategory", "stages", "artifacts", "fingerprints" },
+            app.EnumerateObject().Select(p => p.Name).ToArray());
+
+        JsonElement stage = app.GetProperty("stages")[0];
+
+        // Exact property set + order for each stage row — the shape that
+        // used to live on the now-removed, hand-duplicated StageReport type.
+        Assert.Equal(
+            new[] { "stage", "status", "artifactCount" },
+            stage.EnumerateObject().Select(p => p.Name).ToArray());
+        Assert.Equal("translate", stage.GetProperty("stage").GetString());
+        Assert.Equal("passed", stage.GetProperty("status").GetString());
+        Assert.Equal(0, stage.GetProperty("artifactCount").GetInt32());
+    }
+}


### PR DESCRIPTION
Fixes #1756

Low-severity batch in `Cs2Gs.Cli/Program.cs` and `Cs2Gs.Report`:

1. **`cs2gs migrate --help` / `report --help` no longer exit 1.** `-h`/`--help` is now handled inside both the `migrate` and `report` option loops, printing usage and exiting 0.
2. **Missing option values now exit 1 with usage, not 2.** `NextValue`'s missing-value `ArgumentException` is caught in both loops and routed through the same print-usage/return-1 path as an unknown option. Exit 2 stays reserved for genuine internal errors (escapes `Main`'s generic catch only for real internal failures).
3. **`Slug` collisions no longer produce duplicate HTML ids / broken anchors.** `HtmlReportWriter` now builds a per-render slug map (`BuildSlugMap`) that disambiguates colliding slugs with a stable, incrementing suffix, shared between the matrix's `href="#app-..."` and the detail `id="app-..."`, so ids stay unique and anchors resolve even for 3+-way collisions. Deterministic across runs (built from the already ordinal-sorted app list).
4. **Collapsed `StageReport` into `Cs2Gs.Pipeline.StageResult`.** `StageReport` was byte-identical to `StageResult` (same properties + `JsonPropertyName`/`JsonPropertyOrder`), so `AppReport.Stages` now reuses `StageResult` directly and `BuildAppReport` is simplified. `AppReport`/`GapReport` etc. are kept as-is since they carry the report-side value-add (skipped-stage backfill, sorted lists, fingerprint grouping) that doesn't exist on the pipeline types. The emitted `summary.json` shape (property names/order/values) is unchanged — verified with a golden test.
5. **Removed a stale comment** in `Cs2Gs.Cli.csproj` claiming a nonexistent tree-wide `Directory.Build.props` sets `IsTestProject=true` for the whole cs2gs tree. Only `Cs2Gs.Tests/Directory.Build.props` exists, and it's scoped to itself.

## Tests

Added `Cs2Gs.Tests/Issue1756Tests.cs`:
- `VerbHelp_ExitsZero_AndPrintsUsage`: `migrate`/`report` `--help`/`-h` all exit 0 with usage on stdout and nothing on stderr.
- `MissingOptionValue_ExitsOne_WithUsage_NotInternalError`: `migrate --gsc`/`--corpus` and `report --run` (as the last, value-less token) exit 1 with usage + "requires a value" on stderr, never 2.
- `HtmlReport_ThreeWaySlugCollision_ProducesDistinctIds_WithMatchingAnchors`: three app ids that all fold to the same base slug still get 3 distinct `id="app-..."`s, and every matrix `href="#app-..."` resolves to one of them; also asserts deterministic re-render.
- `JsonSummary_AppAndStageShape_IsByteIdenticalGolden`: asserts the exact property names/order for an app row and its stage rows in `summary.json`, proving the `StageReport`→`StageResult` collapse didn't change the JSON contract.

Existing `ReportTests` (including `Cli_ReportVerb_RegeneratesBothArtifacts`, which needs the whole-solution build for `cs2gs.dll`) still pass.

## Verification

- `dotnet build GSharp.sln -c Release -graph` — succeeded, 0 warnings/errors.
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release --filter "FullyQualifiedName~ReportTests|FullyQualifiedName~Issue1756Tests|FullyQualifiedName~ProcessRunnerTests|FullyQualifiedName~TriageSerializationTests"` — 39/39 passed.
- Manually ran `cs2gs migrate --help`, `cs2gs report --help`, `cs2gs --help` (all exit 0) and `cs2gs migrate --gsc` (no value, now exits 1 with usage instead of 2).