### PR TITLE
cs2gs: classify inline struct as StructConstruct in triage

### DIFF
--- a/tools/cs2gs/Cs2Gs.Pipeline/TriageBuilder.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TriageBuilder.cs
@@ -35,15 +35,20 @@ public sealed class TriageBuilder
     // keyword (issue #1750 B1), audited from Cs2Gs.CodeModel.Printing.GSharpPrinter:
     // RenderVisibility (public/internal/private/protected), the unsafe/open/
     // sealed/abstract prefixes on RenderTypeDeclaration, the open/override
-    // prefixes on RenderProperty, and the open/override/async prefixes on
-    // RenderMethod. `static`, `virtual`, and `export` are not currently emitted
-    // by the printer but are kept in the set defensively so a future modifier
-    // the printer starts emitting doesn't silently collapse back into the
-    // generic bucket.
+    // prefixes on RenderProperty, the open/override/async prefixes on
+    // RenderMethod, and the `inline` prefix RenderKindKeyword emits ahead of
+    // `struct` for TypeDeclarationKind.InlineStruct (issue #1851). `static`,
+    // `virtual`, and `export` are not currently emitted by the printer but are
+    // kept in the set defensively so a future modifier the printer starts
+    // emitting doesn't silently collapse back into the generic bucket.
+    // `data` (DataClass/DataStruct's `data class`/`data struct`) is
+    // deliberately NOT added here: it is already its own entry in the
+    // construct-keyword list below, so those lines classify as
+    // DataConstruct rather than falling through to the generic bucket.
     private static readonly HashSet<string> ModifierTokens = new HashSet<string>(StringComparer.Ordinal)
     {
         "public", "private", "internal", "protected", "static", "async", "sealed",
-        "abstract", "virtual", "override", "export", "open", "unsafe",
+        "abstract", "virtual", "override", "export", "open", "unsafe", "inline",
     };
 
     /// <summary>

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1750TriageFingerprintStabilityTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1750TriageFingerprintStabilityTests.cs
@@ -193,11 +193,22 @@ public class Issue1750TriageFingerprintStabilityTests
     /// gap and an `async func` gap both fingerprinting as the same
     /// unclassified kind).
     /// </summary>
+    /// <summary>
+    /// (#1851, residual of B1) <c>GSharpPrinter.RenderKindKeyword</c> emits
+    /// the compound keyword <c>inline struct</c> for
+    /// <c>TypeDeclarationKind.InlineStruct</c>. Its leading token, <c>inline</c>,
+    /// is neither a construct keyword nor (pre-fix) a recognized modifier, so
+    /// a modifier-free `inline struct Foo {` line fell through to the generic
+    /// bucket instead of classifying as <c>StructConstruct</c> alongside plain
+    /// `struct` and modifier-prefixed `inline struct` declarations.
+    /// </summary>
     [Theory]
     [InlineData("sealed class Shape {", "ClassConstruct")]
     [InlineData("async func Bump(n int32) int32 {", "FuncConstruct")]
     [InlineData("private func Helper(x int32) int32 {", "FuncConstruct")]
     [InlineData("public static async func F() {", "FuncConstruct")]
+    [InlineData("inline struct Foo {", "StructConstruct")]
+    [InlineData("public inline struct Bar {", "StructConstruct")]
     public void CompileError_ModifierPrefixedConstruct_ClassifiesOnConstructKeyword(string gsLine, string expectedKind)
     {
         var builder = new TriageBuilder("run_1", "2026-06-21T20:00:00Z", "0.2.0+abc", "corpus/Sample");
@@ -258,6 +269,36 @@ public class Issue1750TriageFingerprintStabilityTests
 
         Assert.Equal(a.OffendingCSharpConstruct.Kind, b.OffendingCSharpConstruct.Kind);
         Assert.NotEqual(a.Fingerprint, b.Fingerprint);
+    }
+
+    /// <summary>
+    /// (#1851) `inline struct` fingerprints identically to plain `struct` on
+    /// construct kind (both <c>StructConstruct</c>) since both are the same
+    /// underlying declaration shape, but stays distinct from an unrelated
+    /// `func` construct — proving the `inline` fix lands on the correct
+    /// following keyword rather than merging distinct construct kinds.
+    /// </summary>
+    [Fact]
+    public void CompileError_InlineStruct_MatchesPlainStructButNotFunc()
+    {
+        var builder = new TriageBuilder("run_1", "2026-06-21T20:00:00Z", "0.2.0+abc", "corpus/Sample");
+        var diagnostic = new GscDiagnostic("GS0313", "unexpected token", "error", "Sample.gs", 1, 5);
+
+        var emittedInlineStruct = new EmittedGsFile(
+            "/abs/Sample.gs", "corpus_Sample/Sample.gs", "/abs/Sample.cs", "inline struct Foo {\n}\n");
+        var emittedPlainStruct = new EmittedGsFile(
+            "/abs/Sample.gs", "corpus_Sample/Sample.gs", "/abs/Sample.cs", "struct Foo {\n}\n");
+        var emittedFunc = new EmittedGsFile(
+            "/abs/Sample.gs", "corpus_Sample/Sample.gs", "/abs/Sample.cs", "func Foo() {\n}\n");
+
+        TriageArtifact a = builder.CompileError(diagnostic, emittedInlineStruct);
+        TriageArtifact b = builder.CompileError(diagnostic, emittedPlainStruct);
+        TriageArtifact c = builder.CompileError(diagnostic, emittedFunc);
+
+        Assert.Equal("StructConstruct", a.OffendingCSharpConstruct.Kind);
+        Assert.Equal(a.OffendingCSharpConstruct.Kind, b.OffendingCSharpConstruct.Kind);
+        Assert.NotEqual(a.OffendingCSharpConstruct.Kind, c.OffendingCSharpConstruct.Kind);
+        Assert.NotEqual(a.Fingerprint, c.Fingerprint);
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #1851

`TriageBuilder.ClassifyGsLine` skips a leading run of modifier tokens before classifying a G# line by its construct keyword (#1750 B1). `GSharpPrinter.RenderKindKeyword` emits the compound keyword `inline struct` for `TypeDeclarationKind.InlineStruct`, but `inline` was not in `ModifierTokens`, so a modifier-free `inline struct Foo {` line fell through to the generic `GSharpConstruct` bucket instead of `StructConstruct`.

## Fix
Added `inline` to `ModifierTokens` so the leading-modifier skip consumes it and `struct` becomes the classified token → `StructConstruct`.

## Audit of other compound/prefix keywords in GSharpPrinter
- All other modifier prefixes (public/internal/private/protected, unsafe/open/sealed/abstract, override, async) were already covered by the #1750 fix.
- `data class` / `data struct` (DataClass/DataStruct) are unaffected: `data` is already its own entry in the construct-keyword list, so those lines already classify as `DataConstruct` rather than falling through. No change needed there.
- Nothing else deferred — this closes out the last residual gap from #1750 B1.

## Tests
Added to `Issue1750TriageFingerprintStabilityTests.cs`:
- `inline struct Foo {` → StructConstruct (theory case)
- `public inline struct Bar {` → StructConstruct (theory case, modifier + inline)
- New distinctness test: inline struct fingerprints identically to plain struct (both StructConstruct) but distinct from an unrelated func construct.

## Verification
- `dotnet build GSharp.sln -c Release -graph` — succeeded, 0 warnings/errors.
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release --no-build --filter "FullyQualifiedName~Triage|FullyQualifiedName~ClassifyGsLine|FullyQualifiedName~Issue1750"` — 20/20 passed.