### PR TITLE
cs2gs: preserve object initializer when constructor arguments are present

### DIFF
--- a/test/Compiler.Tests/Emit/Issue1728ObjectInitializerWithCtorArgsEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1728ObjectInitializerWithCtorArgsEmitTests.cs
@@ -1,0 +1,181 @@
+// <copyright file="Issue1728ObjectInitializerWithCtorArgsEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1728 — a G# construction combining constructor arguments with a
+/// trailing property-initializer suffix (<c>Target(args) { Name = value }</c>,
+/// gsc issue #522) must actually run and set BOTH the constructor-assigned
+/// member AND every suffix-assigned member. This is the native G# form cs2gs
+/// now emits for a C# <c>new Foo(x) { Bar = 2 }</c> (see
+/// <c>Cs2Gs.Tests.Issue1728ObjectInitializerWithCtorArgsTranslationTests</c>
+/// for the translator-fidelity side); this file proves the emitted form is
+/// not just syntactically valid but semantically correct at runtime. Each
+/// test uses a UNIQUE package/type name (Emit-suite convention).
+/// </summary>
+public class Issue1728ObjectInitializerWithCtorArgsEmitTests
+{
+    [Fact]
+    public void CtorArgPlusSingleMemberInitializer_SetsBothMembers()
+    {
+        const string source = """
+            package i1728single
+            import System
+
+            class Foo {
+                prop X int32 { get; init; }
+                prop Bar int32 { get; set; }
+                init(x int32) { X = x }
+            }
+
+            func Main() {
+                let f = Foo(10) { Bar = 2 }
+                System.Console.WriteLine(f.X)
+                System.Console.WriteLine(f.Bar)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("10\n2\n", output);
+    }
+
+    [Fact]
+    public void CtorArgPlusMultiMemberInitializer_SetsAllMembers()
+    {
+        const string source = """
+            package i1728multi
+            import System
+
+            class Foo {
+                prop X int32 { get; init; }
+                prop Bar int32 { get; set; }
+                prop Baz string { get; set; }
+                init(x int32) { X = x }
+            }
+
+            func Main() {
+                let f = Foo(10) { Bar = 2, Baz = "hi" }
+                System.Console.WriteLine(f.X)
+                System.Console.WriteLine(f.Bar)
+                System.Console.WriteLine(f.Baz)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("10\n2\nhi\n", output);
+    }
+
+    [Fact]
+    public void CtorArgPlusMemberInitializer_UsedAsArgumentExpression_Runs()
+    {
+        // The construction-with-initializer-suffix form must compose at any
+        // expression position, not just a `let`/`var` initializer.
+        const string source = """
+            package i1728argpos
+            import System
+
+            class Foo {
+                prop X int32 { get; init; }
+                prop Bar int32 { get; set; }
+                init(x int32) { X = x }
+            }
+
+            func Show(f Foo) { System.Console.WriteLine(f.X + f.Bar) }
+
+            func Main() { Show(Foo(10) { Bar = 2 }) }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("12\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1728_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/GExpression.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/GExpression.cs
@@ -211,6 +211,37 @@ public sealed class CompositeLiteralExpression : GExpression
 }
 
 /// <summary>
+/// A constructor call followed by a property-initializer suffix
+/// <c>Target(args) { Name = value, ... }</c> (gsc issue #522). Used for a C#
+/// object creation that combines constructor ARGUMENTS with an object
+/// initializer (<c>new Foo(x) { Bar = 2 }</c>, issue #1728) — neither the
+/// colon struct literal <c>T{Bar: 2}</c> nor a plain construction call has a
+/// slot for both a positional constructor call and named member
+/// assignments. gsc lowers this suffix form to a synthetic local, the
+/// assignments, then a trailing value, so it is legal at any expression
+/// position.
+/// </summary>
+public sealed class ObjectCreationInitializerExpression : GExpression
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ObjectCreationInitializerExpression"/> class.
+    /// </summary>
+    /// <param name="construction">The constructor call expression.</param>
+    /// <param name="memberInitializers">The member (property/field) initializers applied after construction.</param>
+    public ObjectCreationInitializerExpression(GExpression construction, IReadOnlyList<FieldInitializer> memberInitializers = null)
+    {
+        Construction = construction;
+        MemberInitializers = memberInitializers ?? new List<FieldInitializer>();
+    }
+
+    /// <summary>Gets the constructor call expression.</summary>
+    public GExpression Construction { get; }
+
+    /// <summary>Gets the member initializers applied after construction.</summary>
+    public IReadOnlyList<FieldInitializer> MemberInitializers { get; }
+}
+
+/// <summary>
 /// A single element of a <see cref="CollectionInitializerExpression"/>:
 /// a bare element, a <c>key: value</c> pair, or an <c>[key] = value</c>
 /// indexer entry (ADR-0117).

--- a/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
@@ -437,6 +437,10 @@ public static class GSharpPrinter
                 var inits = string.Join(", ", composite.FieldInitializers.Select(f => $"{f.Name}: {RenderExpression(f.Value, indent)}"));
                 return $"{RenderType(composite.Type)}{{{inits}}}";
 
+            case ObjectCreationInitializerExpression objectCreation:
+                var memberInits = string.Join(", ", objectCreation.MemberInitializers.Select(f => $"{f.Name} = {RenderExpression(f.Value, indent)}"));
+                return $"{RenderExpression(objectCreation.Construction, indent)}{{{memberInits}}}";
+
             case CollectionInitializerExpression collection:
                 return RenderCollectionInitializer(collection, indent);
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1728ObjectInitializerWithCtorArgsTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1728ObjectInitializerWithCtorArgsTranslationTests.cs
@@ -1,0 +1,183 @@
+// <copyright file="Issue1728ObjectInitializerWithCtorArgsTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Translator-fidelity tests for issue #1728 — <c>new Foo(x) { Bar = 2 }</c>
+/// (an object initializer combined with constructor arguments) was silently
+/// dropping the <c>Bar = 2</c> member assignment: the object-initializer
+/// mapping was gated on <c>!hasCtorArgs</c> and neither the struct-zip nor the
+/// bare <c>BuildConstruction</c> fallback looked at the initializer, and no
+/// diagnostic fired. cs2gs must now emit gsc's construction-with-initializer-
+/// suffix form (<c>Target(args) { Name = value, ... }</c>, issue #522) which
+/// preserves both the constructor arguments and every member assignment.
+/// The same hole existed (independently) in the target-typed
+/// <c>new(x) { Bar = 2 }</c> path; both now share one core method.
+/// </summary>
+public class Issue1728ObjectInitializerWithCtorArgsTranslationTests
+{
+    [Fact]
+    public void ExplicitNew_CtorArgsPlusObjectInitializer_EmitsConstructionSuffix()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class Foo
+    {
+        public int X { get; }
+        public int Bar { get; set; }
+        public Foo(int x) { X = x; }
+    }
+
+    public class C
+    {
+        public Foo Make(int x) => new Foo(x) { Bar = 2 };
+    }
+}");
+
+        Assert.Contains("Foo(x)", printed);
+        Assert.Contains("Bar = 2", printed);
+        Assert.DoesNotContain("Bar: 2", printed);
+    }
+
+    [Fact]
+    public void ImplicitNew_CtorArgsPlusObjectInitializer_EmitsConstructionSuffix()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class Foo
+    {
+        public int X { get; }
+        public int Bar { get; set; }
+        public Foo(int x) { X = x; }
+    }
+
+    public class C
+    {
+        public Foo Make(int x) { Foo f = new(x) { Bar = 2 }; return f; }
+    }
+}");
+
+        Assert.Contains("Bar = 2", printed);
+        Assert.DoesNotContain("Bar: 2", printed);
+    }
+
+    [Fact]
+    public void CtorArgsPlusMultiMemberObjectInitializer_EmitsAllAssignments()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class Foo
+    {
+        public int X { get; }
+        public int Bar { get; set; }
+        public string Baz { get; set; }
+        public Foo(int x) { X = x; }
+    }
+
+    public class C
+    {
+        public Foo Make(int x) => new Foo(x) { Bar = 2, Baz = ""hi"" };
+    }
+}");
+
+        Assert.Contains("Bar = 2", printed);
+        Assert.Contains("Baz = \"hi\"", printed);
+    }
+
+    [Fact]
+    public void CtorArgsPlusObjectInitializer_NoCtorArgsStillUsesStructLiteral()
+    {
+        // No-ctor-arg case must be unaffected: still the colon struct literal.
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class Foo
+    {
+        public int Bar { get; set; }
+    }
+
+    public class C
+    {
+        public Foo Make() => new Foo { Bar = 2 };
+    }
+}");
+
+        Assert.Contains("Bar: 2", printed);
+    }
+
+    [Fact]
+    public void CtorArgsPlusNestedCollectionInitializerMember_ReportsUnsupported()
+    {
+        // Issue #1728 honest gap: gsc's construction-with-initializer-suffix
+        // form has no target-less collection-initializer carve-out (unlike the
+        // colon struct-literal form, issue #1567), so a nested `Prop = { a, b }`
+        // member combined with constructor arguments has no canonical G# form
+        // yet. It must be reported, not silently dropped.
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[]
+        {
+            ("Snippet.cs", @"
+using System.Collections.Generic;
+
+namespace Demo
+{
+    public class Foo
+    {
+        public int X { get; }
+        public List<int> Items { get; } = new();
+        public Foo(int x) { X = x; }
+    }
+
+    public class C
+    {
+        public Foo Make(int x) => new Foo(x) { Items = { 1, 2 } };
+    }
+}"),
+        });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        _ = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        Assert.Contains(
+            context.Diagnostics,
+            d => d.Message.Contains("construction-with-initializer-suffix", StringComparison.Ordinal));
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -8477,8 +8477,6 @@ public sealed class CSharpToGSharpTranslator
                 ? this.typeMapper.Map(typeSymbol, this.context, creation.GetLocation())
                 : new NamedTypeReference(creation.Type.ToString());
 
-            bool hasCtorArgs = creation.ArgumentList != null && creation.ArgumentList.Arguments.Count > 0;
-
             var arguments = creation.ArgumentList == null
                 ? new List<GExpression>()
                 : this.TranslateArguments(creation.ArgumentList.Arguments);
@@ -8497,6 +8495,26 @@ public sealed class CSharpToGSharpTranslator
                 return arguments[0];
             }
 
+            return this.BuildObjectCreationCore(typeSymbol, type, arguments, creation.Initializer);
+        }
+
+        /// <summary>
+        /// Shared core for <see cref="TranslateObjectCreation"/> and
+        /// <see cref="TranslateImplicitObjectCreation"/> (issue #1728): both entry
+        /// points map the same C# constructor-call-plus-initializer shapes to the
+        /// same G# forms, and had already drifted apart before this method
+        /// existed (a struct-zip guard present on only one path; a verbatim
+        /// re-inline of <see cref="BuildConstruction"/>). Routing both through
+        /// one method makes that drift structurally impossible.
+        /// </summary>
+        private GExpression BuildObjectCreationCore(
+            ITypeSymbol typeSymbol,
+            GTypeReference type,
+            IReadOnlyList<GExpression> arguments,
+            InitializerExpressionSyntax initializer)
+        {
+            bool hasCtorArgs = arguments.Count > 0;
+
             // A C# collection initializer maps to the canonical G# collection
             // initializer `Target{ ... }` (ADR-0117, issue #479). This covers
             // `new List<int>{1, 2, 3}` (bare elements), `new Dictionary<K,V>{ {k, v} }`
@@ -8504,20 +8522,35 @@ public sealed class CSharpToGSharpTranslator
             // `new Dictionary<K,V>{ ["k"] = v }` (indexer entries). The construction
             // target carries any constructor arguments, matching
             // `new(StringComparer.OrdinalIgnoreCase){ ... }`.
-            if (creation.Initializer != null &&
-                this.TryTranslateCollectionInitializer(creation.Initializer, type, arguments, out GExpression collectionInitializer))
+            if (initializer != null &&
+                this.TryTranslateCollectionInitializer(initializer, type, arguments, out GExpression collectionInitializer))
             {
                 return collectionInitializer;
             }
 
-            // An object initializer `new T { Field = value, ... }` (no/empty
-            // constructor argument list) maps to the canonical G# struct literal
-            // `T{Field: value, ...}` (spec §Struct literals; ADR-0115 §B.11).
-            if (creation.Initializer != null &&
-                creation.Initializer.IsKind(SyntaxKind.ObjectInitializerExpression) &&
-                !hasCtorArgs)
+            if (initializer != null && initializer.IsKind(SyntaxKind.ObjectInitializerExpression))
             {
-                return this.BuildObjectInitializerLiteral(creation.Initializer, type);
+                // An object initializer `new T { Field = value, ... }` with NO
+                // constructor argument list maps to the canonical G# struct
+                // literal `T{Field: value, ...}` (spec §Struct literals; ADR-0115
+                // §B.11).
+                if (!hasCtorArgs)
+                {
+                    return this.BuildObjectInitializerLiteral(initializer, type);
+                }
+
+                // Issue #1728: `new T(a, b) { Field = value, ... }` combines
+                // constructor arguments WITH an object initializer. Neither the
+                // colon struct literal above nor a bare construction call has a
+                // slot for both a positional constructor call and member
+                // assignments — falling through to a bare `BuildConstruction`
+                // here (the original bug) silently drops every assignment. gsc's
+                // construction-with-initializer-suffix form (issue #522,
+                // `Target(args) { Field = value, ... }`) is built for exactly
+                // this: it lowers to a synthetic local, the assignments, then a
+                // trailing value, so it composes at any expression position —
+                // no hoisted-temp workaround is needed.
+                return this.BuildConstructionWithInitializerSuffix(initializer, type, arguments);
             }
 
             // A source-defined value aggregate (`struct` / `data struct`) has no
@@ -8529,8 +8562,13 @@ public sealed class CSharpToGSharpTranslator
             // `Span<T>` — all `SpecialType.None`) DO expose real constructors that
             // G# can call directly (`Guid(bytes, true)`), so they must fall through
             // to a constructor call rather than be zipped into a bogus literal over
-            // the type's *properties*.
-            if (typeSymbol is INamedTypeSymbol { TypeKind: TypeKind.Struct, SpecialType: SpecialType.None } valueType &&
+            // the type's *properties*. An initializer here (reachable only when it
+            // wasn't a plain object initializer, e.g. an unsupported collection
+            // initializer shape) has no field to zip into either, so it must NOT
+            // be silently absorbed into a bogus zip — skip straight to
+            // `BuildConstruction` and let the initializer's own diagnostic stand.
+            if (initializer == null &&
+                typeSymbol is INamedTypeSymbol { TypeKind: TypeKind.Struct, SpecialType: SpecialType.None } valueType &&
                 !valueType.IsTupleType &&
                 !valueType.DeclaringSyntaxReferences.IsEmpty)
             {
@@ -8661,6 +8699,55 @@ public sealed class CSharpToGSharpTranslator
             }
 
             return new CompositeLiteralExpression(type, fieldInitializers);
+        }
+
+        /// <summary>
+        /// Builds the canonical G# construction-with-initializer-suffix
+        /// <c>Target(args) { Name = value, ... }</c> (gsc issue #522) for a C#
+        /// object initializer combined with constructor arguments (issue #1728):
+        /// <c>new T(a, b) { Field = value, ... }</c>. Unlike
+        /// <see cref="BuildObjectInitializerLiteral"/> (the colon struct-literal
+        /// form, no ctor args), this suffix parses each member value as a plain
+        /// expression (gsc's <c>ParseObjectInitializerList</c> → <c>ParseExpression</c>)
+        /// — it has no target-less collection-initializer carve-out (issue #1567),
+        /// so a nested <c>Prop = { a, b }</c> member has no canonical form here yet
+        /// and is reported as unsupported instead of silently dropped.
+        /// </summary>
+        private GExpression BuildConstructionWithInitializerSuffix(
+            InitializerExpressionSyntax initializer,
+            GTypeReference type,
+            IReadOnlyList<GExpression> arguments)
+        {
+            GExpression construction = BuildConstruction(type, arguments);
+            var memberInitializers = new List<FieldInitializer>();
+            foreach (ExpressionSyntax element in initializer.Expressions)
+            {
+                if (element is AssignmentExpressionSyntax assignment &&
+                    assignment.Left is IdentifierNameSyntax name)
+                {
+                    if (assignment.Right is InitializerExpressionSyntax nestedInit &&
+                        (nestedInit.IsKind(SyntaxKind.CollectionInitializerExpression) ||
+                         nestedInit.IsKind(SyntaxKind.ObjectInitializerExpression)))
+                    {
+                        this.context.ReportUnsupported(
+                            assignment,
+                            "nested collection/object initializer as a member value has no canonical G# form when the outer object creation also has constructor arguments; gsc's construction-with-initializer-suffix form (issue #522) has no target-less collection-initializer carve-out (issue #1728).");
+                        continue;
+                    }
+
+                    memberInitializers.Add(new FieldInitializer(
+                        SanitizeIdentifier(name.Identifier.Text),
+                        this.TranslateExpression(assignment.Right)));
+                }
+                else
+                {
+                    this.context.ReportUnsupported(
+                        element,
+                        "object-initializer element is not a simple `Field = value` assignment; no canonical G# construction-with-initializer-suffix form yet (issue #1728).");
+                }
+            }
+
+            return new ObjectCreationInitializerExpression(construction, memberInitializers);
         }
 
         /// <summary>
@@ -9064,65 +9151,7 @@ public sealed class CSharpToGSharpTranslator
                 ? new List<GExpression>()
                 : this.TranslateArguments(creation.ArgumentList.Arguments);
 
-            bool hasCtorArgs = arguments.Count > 0;
-
-            // A target-typed `new() { ... }` carries the same initializer forms as
-            // an explicit `new T() { ... }`; without this the initializer was
-            // silently dropped, emitting a bare `T()` call (GS0130 for value
-            // structs, lost members otherwise).
-            if (creation.Initializer != null &&
-                this.TryTranslateCollectionInitializer(creation.Initializer, type, arguments, out GExpression collectionInitializer))
-            {
-                return collectionInitializer;
-            }
-
-            if (creation.Initializer != null &&
-                creation.Initializer.IsKind(SyntaxKind.ObjectInitializerExpression) &&
-                !hasCtorArgs)
-            {
-                return this.BuildObjectInitializerLiteral(creation.Initializer, type);
-            }
-
-            // A source-defined value aggregate is constructed with a composite
-            // literal; a reference type — or an imported/BCL struct with a real
-            // constructor — with a call on the (bracketed-generic) type name.
-            if (typeSymbol is INamedTypeSymbol { TypeKind: TypeKind.Struct, SpecialType: SpecialType.None } valueType &&
-                !valueType.IsTupleType &&
-                !valueType.DeclaringSyntaxReferences.IsEmpty &&
-                creation.Initializer == null)
-            {
-                // Parameterless target-typed `new()` on a source value struct → empty
-                // struct literal `T{}` (no callable constructor surface in G#).
-                if (arguments.Count == 0)
-                {
-                    return new CompositeLiteralExpression(type, new List<FieldInitializer>());
-                }
-
-                List<string> targetNames = OrderedValueMemberNames(valueType);
-                if (targetNames.Count == arguments.Count)
-                {
-                    var fieldInitializers = new List<FieldInitializer>();
-                    for (int i = 0; i < arguments.Count; i++)
-                    {
-                        fieldInitializers.Add(new FieldInitializer(targetNames[i], arguments[i]));
-                    }
-
-                    return new CompositeLiteralExpression(type, fieldInitializers);
-                }
-            }
-
-            if (type is NamedTypeReference named)
-            {
-                IReadOnlyList<GTypeReference> typeArguments = named.TypeArguments.Count > 0
-                    ? named.TypeArguments
-                    : null;
-                return new InvocationExpression(
-                    new IdentifierExpression(ConstructionCalleeName(named.Name)),
-                    arguments,
-                    typeArguments);
-            }
-
-            return new InvocationExpression(new IdentifierExpression(type.ToString()), arguments);
+            return this.BuildObjectCreationCore(typeSymbol, type, arguments, creation.Initializer);
         }
 
         private GExpression TranslateSwitchExpression(SwitchExpressionSyntax node)


### PR DESCRIPTION
Fixes #1728

## Bug
`new Foo(x) { Bar = 2 }` silently dropped `Bar = 2`: the object-initializer mapping in `TranslateObjectCreation` was gated on `!hasCtorArgs`, and both the struct-zip and `BuildConstruction` fallbacks it fell through to ignore `Initializer` entirely — with no diagnostic. Same hole existed independently in `TranslateImplicitObjectCreation` for `new(x) { Bar = 2 }`.

## Chosen lowering: native construction-with-initializer-suffix (not hoisted-temp)
Neither canonical no-ctor-arg G# form (the colon struct literal `T{Bar: 2}`, or a bare construction call) has a slot for both positional constructor arguments and named member assignments. Rather than reaching for a hoisted-temp lowering, I found gsc already has a native syntax built for exactly this case: the construction-with-initializer-suffix form `Target(args) { Name = value, ... }` (gsc issue #522). The binder (`BindObjectInitializerSuffix` in `ExpressionBinder.Calls.cs`) already lowers this to a synthetic local, the assignments, then a trailing value — a `BoundBlockExpression` legal at ANY expression position. I verified this directly against gsc (compiled and ran `Foo(10) { Bar = 2 }`) before wiring cs2gs to emit it — no null-seam/grammar workaround needed, gsc's own lowering does the work.

## De-duplication
Extracted `BuildObjectCreationCore(ITypeSymbol, GTypeReference, IReadOnlyList<GExpression> arguments, InitializerExpressionSyntax initializer)` as the single shared core for `TranslateObjectCreation` and `TranslateImplicitObjectCreation`. Both entry points now route every initializer/struct-zip/construction decision through this one method, so the drift the issue called out (implicit path guarding struct-zip with `Initializer == null`, explicit path not; implicit path re-inlining `BuildConstruction` verbatim) cannot recur. Each entry point keeps only its own type-resolution and (for the explicit path) the delegate-unwrap special case.

## Honest gap (documented, not silently dropped)
A nested collection/object initializer as a member value combined with constructor arguments (`new Foo(x) { Items = { 1, 2 } }`) has no canonical G# form: gsc's suffix parser (`ParseObjectInitializerList`) parses each member value as a plain expression and has no target-less collection-initializer carve-out (unlike the colon struct-literal form added for issue #1567). This narrow sub-case now reports `ReportUnsupported` instead of silently dropping the member; everything else (any number of scalar/expression member assignments, any ctor-arg count, class or struct-with-real-ctor types) is fully handled.

## New AST/printer support
- `ObjectCreationInitializerExpression` added to the cs2gs code model (`GExpression.cs`), carrying the construction call plus the member initializers.
- `GSharpPrinter` renders it as `Target(args){Name = value, ...}`.

## Tests
- `tools/cs2gs/Cs2Gs.Tests/Issue1728ObjectInitializerWithCtorArgsTranslationTests.cs`: explicit `new`, implicit `new()`, multi-member, no-ctor-arg regression (still emits the colon struct literal unchanged), and the nested-collection-initializer `Unsupported` diagnostic — all round-tripped through the real gsc parser.
- `test/Compiler.Tests/Emit/Issue1728ObjectInitializerWithCtorArgsEmitTests.cs`: end-to-end compile+run (gsc + ilverify + `dotnet exec`) proving both the ctor-set member and every suffix-assigned member are actually set at runtime, including when the construction appears in argument-expression position.

## Validation
- `dotnet build GSharp.sln -c Release -graph` — succeeds, 0 warnings/errors.
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release --no-build` — 535/535 passing (full translator suite, including all pre-existing object-creation/initializer/struct-construction tests).
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Release --no-build --filter "FullyQualifiedName~Issue1728" -- xUnit.MaxParallelThreads=2` — 3/3 passing.

Nothing deferred.