### PR TITLE
Fix #1852: route constrained CLR interface-call path through handler rebind

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -5980,25 +5980,17 @@ internal sealed partial class ExpressionBinder
             argTypes[i] = t;
         }
 
-        // Issue #1812: `interpolatedStringArgs` is deliberately left null here
-        // (unlike every other CLR-call Resolve site). This path skips the
-        // entire CLR parameter-conversion pass below (see the "deliberately
-        // skip" comment on orderedArgs) because the emitted MemberRef parameter
-        // is the interface type-variable `!0`, passed unconverted. If the flag
-        // let overload resolution pick a FormattableString/handler overload
-        // here, the interpolated-string argument would still flow through as a
-        // plain `string`-typed BoundExpression with no rebind step to convert
-        // it — a worse bug (wrong overload chosen, argument never actually
-        // converted) than the status quo. Wiring this up would require adding
-        // the BuildResolvedClrCallArguments pipeline to a path that exists
-        // specifically to avoid it; left as a documented gap rather than risking
-        // an ilverify mismatch.
+        // Issue #1852 (follow-up from #1812 N1): mark which positional
+        // arguments are interpolated-string literals so overload resolution
+        // treats them as applicable to an IFormattable/FormattableString (or
+        // handler) parameter, just like every other CLR-call Resolve site.
+        var interpolatedStringArgs = ComputeInterpolatedStringArgFlags(ce.Arguments, arguments.Length);
         var resolution = OverloadResolution.Resolve(
             candidates,
             argTypes,
             null,
             scope.References.MapClrTypeToReferences,
-            null,
+            interpolatedStringArgs,
             argumentNames.IsDefault ? null : (IReadOnlyList<string>)argumentNames);
         if (resolution.Outcome != OverloadResolution.ResolutionOutcome.Resolved)
         {
@@ -6014,6 +6006,24 @@ internal sealed partial class ExpressionBinder
         // the direct CLR mapping.
         var returnType = ResolveInstanceReturnTypeFromReceiver(constraintInterface, method)
             ?? MapClrMethodReturnType(method);
+
+        // Issue #1852: re-lower each interpolated-string argument whose
+        // resolved parameter is IFormattable/FormattableString-shaped to
+        // FormattableStringFactory.Create(...) — mirroring
+        // RebindFormattableInterpolationArguments, the same step every other
+        // CLR-call path runs — WITHOUT routing through the rest of
+        // BuildResolvedClrCallArguments (ApplyInterpolatedStringHandlers,
+        // delegate rebind, BindClrParameterConversions). This path
+        // deliberately skips the CLR boxing/conversion pass below (see the
+        // "deliberately skip" comment on orderedArgs): the emitted MemberRef
+        // parameter is the interface type-variable `!0`, passed unconverted,
+        // so routing every argument through the conversion pipeline would
+        // risk an ilverify mismatch. Only the specific interpolated-string
+        // arguments actually bound to a handler parameter are touched; every
+        // other argument (and the overload choice itself, unaffected unless a
+        // candidate's applicability actually depended on the flag) is
+        // unchanged.
+        arguments = RebindFormattableInterpolationArguments(arguments, ce.Arguments, parameters, resolution.ParameterMapping);
 
         // Order positionally for named arguments; deliberately skip the CLR
         // boxing/conversion pass — the emitted MemberRef parameter is the

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1852ConstrainedInterfaceCallRebindTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1852ConstrainedInterfaceCallRebindTests.cs
@@ -1,0 +1,145 @@
+// <copyright file="Issue1852ConstrainedInterfaceCallRebindTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1852 (follow-up N1 from #1812 / PR #1848): the CONSTRAINED CLR
+/// INTERFACE-CALL path (<c>ExpressionBinder.TryBindConstrainedClrInterfaceCall</c>)
+/// is the sixth CLR-call construction shape — a generic method dispatching a
+/// call on a type-parameter receiver constrained to an imported CLR
+/// interface (e.g. <c>func Render[T IIssue1852Renderer](x T) string</c>).
+/// #1812 deliberately left this path's <c>interpolatedStringArgs</c> flag
+/// unset because the path skips the whole CLR parameter-conversion pipeline
+/// (the emitted MemberRef parameter is the interface type-variable
+/// <c>!0</c>, passed unconverted). This fix passes the flag to
+/// <c>OverloadResolution.Resolve</c> and, after the interface method is
+/// selected, re-lowers any interpolated-string argument whose resolved
+/// parameter is IFormattable/FormattableString-shaped via
+/// <c>RebindFormattableInterpolationArguments</c> — mirroring the
+/// instance/extension/base-ctor rebind step — WITHOUT running the rest of
+/// the conversion pipeline that path exists to avoid.
+/// </summary>
+public class Issue1852ConstrainedInterfaceCallRebindTests
+{
+    [Fact]
+    public void ConstrainedInterfaceCall_InterpolatedString_ToFormattableStringParameter_Rebinds()
+    {
+        const string Source = @"package Issue1852Constrained
+import System
+import GSharp.Core.Tests.Fixtures
+
+func Render[T IIssue1852Renderer](x T) string {
+    let n = 42
+    return x.Render(""n=${n:D3}"")
+}
+
+let s = Render(Issue1852RendererFixture())
+Console.WriteLine(s)
+";
+        var output = CompileAndRun(Source, "Issue1852Constrained");
+        Assert.Equal("n=042\n", output.Replace("\r\n", "\n"));
+    }
+
+    [Fact]
+    public void ConstrainedInterfaceCall_MixedInterpolatedAndPlainArgs_RebindsOnlyHandlerArg()
+    {
+        // Generalization: a non-handler positional argument (`tag`, a plain
+        // `string` parameter) precedes the handler-shaped one. Only the
+        // interpolated-string argument bound to the FormattableString
+        // parameter should rebind; the plain-string argument and its
+        // parameter index must be unaffected.
+        const string Source = @"package Issue1852ConstrainedMixed
+import System
+import GSharp.Core.Tests.Fixtures
+
+func RenderTwo[T IIssue1852Renderer](x T) string {
+    let n = 42
+    return x.RenderTwo(""tag"", ""n=${n:D3}"")
+}
+
+let s = RenderTwo(Issue1852RendererFixture())
+Console.WriteLine(s)
+";
+        var output = CompileAndRun(Source, "Issue1852ConstrainedMixed");
+        Assert.Equal("tag:n=042\n", output.Replace("\r\n", "\n"));
+    }
+
+    [Fact]
+    public void ConstrainedInterfaceCall_OrdinaryNonHandlerCall_OverloadChoiceUnchanged()
+    {
+        // Regression guard (per #1812 N1's concern): an ordinary constrained
+        // interface call with no interpolated-string argument at all — the
+        // #1336 `T IComparable[T]` shape — must still resolve/bind/evaluate
+        // identically now that `interpolatedStringArgs` is threaded through.
+        const string source = @"
+package p
+import System
+class C {
+    func Cmp[T IComparable[T]](a T, b T) int32 {
+        return a.CompareTo(b)
+    }
+    func Ok() int32 { return Cmp[int32](1, 2) }
+}
+";
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree) { IsLibrary = true };
+        Assert.Empty(compilation.GlobalScope.Diagnostics);
+    }
+
+    private static string CompileAndRun(string source, string contextName)
+    {
+        using var peStream = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Emit(peStream);
+
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(contextName, isCollectible: true);
+        try
+        {
+            var asm = loadContext.LoadFromStream(peStream);
+            var programType = asm.GetTypes().FirstOrDefault(t => t.Name == "<Program>");
+            Assert.NotNull(programType);
+            var entry = programType!.GetMethod(
+                "<Main>$",
+                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(entry);
+
+            var stdout = Console.Out;
+            var captured = new StringWriter();
+            Console.SetOut(captured);
+            try
+            {
+                entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+            }
+            finally
+            {
+                Console.SetOut(stdout);
+            }
+
+            return captured.ToString();
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+}

--- a/test/Core.Tests/Fixtures/InterpolatedStringHandlerFixtures.cs
+++ b/test/Core.Tests/Fixtures/InterpolatedStringHandlerFixtures.cs
@@ -312,3 +312,31 @@ public class Issue1812BaseCtorFormattableFixture
 
     public Issue1812BaseCtorFormattableFixture(System.FormattableString fs) => this.Rendered = fs.ToString(System.Globalization.CultureInfo.InvariantCulture);
 }
+
+/// <summary>
+/// Issue #1852 fixture: a CLR interface whose sole method takes a
+/// <see cref="System.FormattableString"/> parameter, used as a generic
+/// type-parameter constraint (<c>T IIssue1852Renderer</c>) so a call on the
+/// constrained receiver dispatches through
+/// <c>ExpressionBinder.TryBindConstrainedClrInterfaceCall</c> — the sixth
+/// CLR-call construction shape (found during the #1812 follow-up audit,
+/// tracked as #1852) that must re-lower an interpolated-string argument to
+/// the handler-shaped parameter just like the other five.
+/// </summary>
+public interface IIssue1852Renderer
+{
+    string Render(System.FormattableString fs);
+
+    string RenderTwo(string tag, System.FormattableString fs);
+}
+
+/// <summary>
+/// Issue #1852 fixture: a CLR struct implementing <see cref="IIssue1852Renderer"/>,
+/// used as the type argument satisfying <c>T IIssue1852Renderer</c>.
+/// </summary>
+public struct Issue1852RendererFixture : IIssue1852Renderer
+{
+    public string Render(System.FormattableString fs) => fs.ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+    public string RenderTwo(string tag, System.FormattableString fs) => tag + ":" + fs.ToString(System.Globalization.CultureInfo.InvariantCulture);
+}


### PR DESCRIPTION
Fixes #1852

Follow-up N1 from #1812 (PR #1848): `TryBindConstrainedClrInterfaceCall` (the constrained-generic CLR interface-call path) was a reachable gap where an interpolated-string argument bound to an `IFormattable`/`FormattableString` (handler) parameter on the resolved interface method never rebound — it stayed a plain `string`.

## Fix
- Pass `interpolatedStringArgs` (via `ComputeInterpolatedStringArgFlags`) to this path's `OverloadResolution.Resolve` call, exactly like the instance/extension/base-ctor/static paths #1812 already fixed. This only makes an otherwise-inapplicable interpolated-string-to-`string` parameter candidate additionally applicable against an `IFormattable`/`FormattableString`-shaped parameter — non-handler calls are completely unaffected.
- After the interface method is selected, call the existing `RebindFormattableInterpolationArguments` helper (the same one used by the shared `BuildResolvedClrCallArguments` pipeline) directly, WITHOUT running the rest of that pipeline (`ApplyInterpolatedStringHandlers`, delegate rebind, `BindClrParameterConversions`). This path intentionally skips the full CLR boxing/conversion pass because the emitted MemberRef parameter is the interface type-variable `!0`, passed unconverted — routing every argument through the conversion pipeline would risk an ilverify mismatch. Only the specific interpolated-string arguments that land on a handler-shaped parameter are rebound; everything else in `arguments` is untouched before `BuildOrderedCallArguments` runs as before.
- Removed the now-stale "deliberately left null"/"documented gap" comment; replaced with a comment describing the actual (fixed) behavior.

## Why overload selection is unchanged for ordinary calls
`interpolatedStringArgs` only changes candidate *applicability* in `OverloadResolution.EvaluateCandidate` for the specific arg positions flagged as interpolated-string syntax (see `OverloadResolution.cs` ~1994). When there is no interpolated-string argument, `ComputeInterpolatedStringArgFlags` returns `null` (its existing no-op fast path), so the resolve call and result are byte-for-byte identical to before. Verified with a regression test reusing the \#1336 `T IComparable[T]` constrained-call shape.

## Tests added (`test/Core.Tests/CodeAnalysis/Binding/Issue1852ConstrainedInterfaceCallRebindTests.cs`)
- `ConstrainedInterfaceCall_InterpolatedString_ToFormattableStringParameter_Rebinds`: single handler arg on a constrained-interface call rebinds (`D3` format observable in emitted/run output — `"n=042"`, not `"n=42"`).
- `ConstrainedInterfaceCall_MixedInterpolatedAndPlainArgs_RebindsOnlyHandlerArg`: a plain `string` arg precedes the handler arg — generalizes beyond the single-arg reproducer and checks parameter indexing.
- `ConstrainedInterfaceCall_OrdinaryNonHandlerCall_OverloadChoiceUnchanged`: the \#1336 `IComparable[T]` constrained-call shape (no interpolated string at all) still binds with zero diagnostics.

New fixtures added to `test/Core.Tests/Fixtures/InterpolatedStringHandlerFixtures.cs`: `IIssue1852Renderer` (CLR interface with a `FormattableString` parameter) and `Issue1852RendererFixture` (implementing struct), used as the generic constraint/type-argument.

## Validation
- `dotnet build GSharp.sln -c Release -graph` — succeeds, 0 warnings/errors.
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release --no-build --filter "FullyQualifiedName~Issue1852" -- xUnit.MaxParallelThreads=2` — 3/3 pass.
- Regression sweep: `FullyQualifiedName~Issue1812|Issue1336|Issue1052|Issue1113|Issue1638|Issue976` (32 tests) and `FullyQualifiedName~Interpolat|OverloadResolution|ClrConstructorCall|ClrMemberAccess|ClrMethodGroupConversion` (174 tests) all pass.

Nothing deferred — this closes the gap #1812 documented and #1852 tracked; the path is generalized to any handler-capable parameter position (any index, mixed with non-handler args) on any constrained-generic interface method, not just the single-arg reproducer.