### PR TITLE
cs2gs: fix six silent divergences in static-ctor fold and instance-ctor lift

### DIFF
--- a/test/Compiler.Tests/Emit/Issue1729StaticCtorFoldEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1729StaticCtorFoldEmitTests.cs
@@ -1,0 +1,195 @@
+// <copyright file="Issue1729StaticCtorFoldEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1729 — runtime proof that the fixed static-constructor fold produces
+/// the CORRECT final field value at execution time, not merely a plausible-
+/// looking translation. Each source string below is exactly the canonical G#
+/// shape <c>cs2gs</c> emits after the fix (verified against
+/// <c>Cs2Gs.Tests.Issue1729StaticCtorFoldTranslationTests</c>, which asserts the
+/// C#→G# translation itself picks this shape). Every fact uses a UNIQUE
+/// package/type name because the in-process compiler caches are name-keyed.
+/// </summary>
+public class Issue1729StaticCtorFoldEmitTests
+{
+    /// <summary>
+    /// Mode 1 fix: when a static field has BOTH an inline initializer and a
+    /// static-ctor assignment, C# runs the field initializer THEN the static
+    /// constructor — the constructor's assignment is the field's true final
+    /// value. The fold must keep that value (2), not the inline initializer's
+    /// value (1).
+    /// </summary>
+    [Fact]
+    public void FoldedStaticCtor_InlineInitializerOverwritten_RunsWithCtorFinalValue()
+    {
+        const string source = """
+            package i1729mode1
+            import System
+
+            class C {
+                shared {
+                    var X int32 = 2
+                }
+            }
+
+            func Main() { System.Console.WriteLine(C.X) }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("2\n", output);
+    }
+
+    /// <summary>
+    /// Regression: a static field with no inline initializer, assigned once by
+    /// an otherwise-trivial static constructor with an RHS independent of the
+    /// type's own static state, must still fold correctly and run with the
+    /// assigned value.
+    /// </summary>
+    [Fact]
+    public void FoldedStaticCtor_SimpleAssignment_RunsWithFoldedValue()
+    {
+        const string source = """
+            package i1729regression
+            import System
+
+            class C {
+                shared {
+                    var X int32 = 1
+                }
+            }
+
+            func Main() { System.Console.WriteLine(C.X) }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("1\n", output);
+    }
+
+    /// <summary>
+    /// Mode 4 fix: an outer static field declared AFTER a nested type must
+    /// retain its own folded static-ctor initializer — the fold-collection state
+    /// is now saved/restored around the nested-type visit instead of being
+    /// wiped wholesale, so both the outer and nested fold survive.
+    /// </summary>
+    [Fact]
+    public void FoldedStaticCtor_OuterFieldAfterNestedType_RunsWithBothFoldedValues()
+    {
+        const string source = """
+            package i1729mode4
+            import System
+
+            class Outer {
+                class Nested {
+                    shared {
+                        var NestedField int32 = 9
+                    }
+                }
+
+                shared {
+                    var Before int32 = 1
+                    var After int32 = 2
+                }
+            }
+
+            func Main() {
+                System.Console.WriteLine(Outer.Before)
+                System.Console.WriteLine(Outer.Nested.NestedField)
+                System.Console.WriteLine(Outer.After)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("1\n9\n2\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1729_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1729StaticCtorFoldTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1729StaticCtorFoldTranslationTests.cs
@@ -73,6 +73,57 @@ namespace Demo
     }
 
     /// <summary>
+    /// N1: an inline field initializer whose RHS is SIDE-EFFECTING (a call) and a
+    /// static-ctor assignment to the same field must NOT silently fold. C# runs
+    /// the side-effecting inline initializer, THEN the static constructor
+    /// overwrites the field — folding to just the ctor's value would silently
+    /// drop the initializer's observable side effect. This must surface an
+    /// Unsupported diagnostic instead.
+    /// </summary>
+    [Fact]
+    public void InlineInitializerSideEffecting_AndStaticCtorAssignment_ReportsUnsupported_DoesNotFold()
+    {
+        (string printed, TranslationContext context) = Translate(@"
+namespace Demo
+{
+    public class C
+    {
+        public static int Log(int n) => n;
+        public static int X = Log(1);
+        static C() { X = 2; }
+    }
+}");
+
+        Assert.Contains(context.Diagnostics, d => d.IsUnsupported);
+        Assert.DoesNotContain("var X int32 = 2", printed);
+    }
+
+    /// <summary>
+    /// N1 (pure path): an inline field initializer whose RHS is a pure
+    /// constant/literal is safe to drop when a static-ctor assignment overwrites
+    /// it — dropping it does not lose any observable behavior. This still folds
+    /// to the ctor's final value with no diagnostic (locks the good path
+    /// alongside the side-effecting case above).
+    /// </summary>
+    [Fact]
+    public void InlineInitializerPure_AndStaticCtorAssignment_StillFoldsNoDiagnostic()
+    {
+        (string printed, TranslationContext context) = Translate(@"
+namespace Demo
+{
+    public class C
+    {
+        public static int X = 1;
+        static C() { X = 2; }
+    }
+}");
+
+        Assert.Contains("var X int32 = 2", printed);
+        Assert.DoesNotContain("var X int32 = 1", printed);
+        Assert.DoesNotContain(context.Diagnostics, d => d.IsUnsupported);
+    }
+
+    /// <summary>
     /// Mode 2: a static constructor that assigns another TYPE's static field is
     /// not foldable (the entry would be keyed by the other type's field symbol
     /// and never consumed by this type's fields, silently vanishing). It must

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1729StaticCtorFoldTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1729StaticCtorFoldTranslationTests.cs
@@ -1,0 +1,238 @@
+// <copyright file="Issue1729StaticCtorFoldTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #1729 — G# has no static-constructor form, so <c>cs2gs</c> folds a
+/// "simple" static constructor into its fields' initializers and drops the
+/// constructor. The foldability check and the consumption chain had six silent
+/// divergence modes; each is covered here. Modes that CAN be represented
+/// faithfully as a folded initializer are asserted to fold to the CORRECT
+/// value/shape; modes that cannot (cross-type writes, order-dependent RHS,
+/// side-effecting/duplicate instance-lift hoists) are asserted to surface a
+/// visible <see cref="TranslationSeverity.Unsupported"/> diagnostic instead of
+/// silently emitting wrong code.
+/// </summary>
+public class Issue1729StaticCtorFoldTranslationTests
+{
+    /// <summary>
+    /// Regression: a static field with NO inline initializer, assigned once in
+    /// the static constructor with an RHS independent of the type's own static
+    /// state, still folds — the constructor is dropped and the field carries the
+    /// assigned value as its initializer.
+    /// </summary>
+    [Fact]
+    public void SimpleStaticCtor_NoInlineInitializer_StillFoldsAndDropsCtor()
+    {
+        (string printed, TranslationContext context) = Translate(@"
+namespace Demo
+{
+    public class C
+    {
+        public static int X;
+        static C() { X = 1; }
+    }
+}");
+
+        Assert.Contains("var X int32 = 1", printed);
+        Assert.DoesNotContain("init()", printed);
+        Assert.DoesNotContain(context.Diagnostics, d => d.IsUnsupported);
+    }
+
+    /// <summary>
+    /// Mode 1: an inline field initializer AND a static-ctor assignment to the
+    /// same field must fold to the ctor's value — C# runs field initializers
+    /// THEN the static constructor, so the ctor's assignment is the field's true
+    /// final value, not the inline initializer.
+    /// </summary>
+    [Fact]
+    public void InlineInitializerAndStaticCtorAssignment_FoldsToCtorFinalValue()
+    {
+        (string printed, TranslationContext context) = Translate(@"
+namespace Demo
+{
+    public class C
+    {
+        public static int X = 1;
+        static C() { X = 2; }
+    }
+}");
+
+        Assert.Contains("var X int32 = 2", printed);
+        Assert.DoesNotContain("var X int32 = 1", printed);
+        Assert.DoesNotContain(context.Diagnostics, d => d.IsUnsupported);
+    }
+
+    /// <summary>
+    /// Mode 2: a static constructor that assigns another TYPE's static field is
+    /// not foldable (the entry would be keyed by the other type's field symbol
+    /// and never consumed by this type's fields, silently vanishing). It must
+    /// surface an Unsupported diagnostic instead, and the other type's own
+    /// initializer must be left untouched.
+    /// </summary>
+    [Fact]
+    public void StaticCtorAssignsOtherTypesField_ReportsUnsupported_DoesNotFold()
+    {
+        (string printed, TranslationContext context) = Translate(@"
+namespace Demo
+{
+    public class Other
+    {
+        public static int Field = 0;
+    }
+
+    public class C
+    {
+        static C() { Other.Field = 5; }
+    }
+}");
+
+        Assert.Contains(context.Diagnostics, d => d.IsUnsupported);
+        Assert.Contains("var Field int32 = 0", printed);
+        Assert.DoesNotContain("var Field int32 = 5", printed);
+    }
+
+    /// <summary>
+    /// Mode 3: a static constructor whose assignment RHS reads the type's OWN
+    /// static state cannot be hoisted to the assigned field's declaration
+    /// position without risking a change to C#'s
+    /// initializers-then-cctor evaluation order. It must report Unsupported
+    /// rather than silently reorder.
+    /// </summary>
+    [Fact]
+    public void StaticCtorRhsReferencesOwnStaticField_ReportsUnsupported_DoesNotFold()
+    {
+        (string printed, TranslationContext context) = Translate(@"
+namespace Demo
+{
+    public class C
+    {
+        public static int B = 21;
+        public static int A;
+        static C() { A = B * 2; }
+    }
+}");
+
+        Assert.Contains(context.Diagnostics, d => d.IsUnsupported);
+        Assert.DoesNotContain("var A int32 = B * 2", printed);
+        _ = printed;
+    }
+
+    /// <summary>
+    /// Mode 4: a nested type declared BETWEEN an outer static field's own
+    /// (already-folded) static-ctor assignment and the outer field's own
+    /// declaration must not wipe the outer type's pending fold — the shared
+    /// fold-collection state has to be scoped per type (save/restore around the
+    /// nested-type visit), not a single dictionary cleared unconditionally at
+    /// the end of every type visit.
+    /// </summary>
+    [Fact]
+    public void NestedTypeBetweenOuterFields_DoesNotWipeOuterFoldedInitializer()
+    {
+        (string printed, TranslationContext context) = Translate(@"
+namespace Demo
+{
+    public class Outer
+    {
+        public static int Before;
+        public class Nested
+        {
+            public static int NestedField;
+            static Nested() { NestedField = 9; }
+        }
+        public static int After;
+
+        static Outer() { Before = 1; After = 2; }
+    }
+}");
+
+        Assert.Contains("var Before int32 = 1", printed);
+        Assert.Contains("var After int32 = 2", printed);
+        Assert.Contains("var NestedField int32 = 9", printed);
+        Assert.DoesNotContain(context.Diagnostics, d => d.IsUnsupported);
+    }
+
+    /// <summary>
+    /// Mode 5a: an instance constructor's hoist-to-field-initializer lift must
+    /// bail when the hoisted RHS is not side-effect-free (a call here) — hoisting
+    /// it to the field's declaration position would run it BEFORE another field's
+    /// inline initializer that runs first in the real C# constructor-body order.
+    /// The explicit constructor is kept intact (never silently reordered).
+    /// </summary>
+    [Fact]
+    public void InstanceCtorHoist_SideEffectingRhs_BailsKeepsExplicitCtorOrder()
+    {
+        (string printed, TranslationContext context) = Translate(@"
+namespace Demo
+{
+    public class C
+    {
+        public static int Log(int n) => n;
+        public int A = Log(1);
+        public int B;
+        public C() { B = Log(2); }
+    }
+}");
+
+        // The lift must not have hoisted `B = Log(2)` into a field initializer:
+        // the explicit constructor body (with the real, un-reordered call order)
+        // survives instead.
+        Assert.Contains("Log(2)", printed);
+        Assert.Contains("var B int32", printed);
+        Assert.DoesNotContain("var B int32 = Log(2)", printed);
+        _ = context;
+    }
+
+    /// <summary>
+    /// Mode 5b: an instance constructor that assigns the SAME target field more
+    /// than once must bail the lift — hoisting only the last assignment to the
+    /// field's initializer position would silently discard the first
+    /// assignment's (potentially side-effecting) evaluation entirely.
+    /// </summary>
+    [Fact]
+    public void InstanceCtorHoist_RepeatedAssignmentToSameField_Bails()
+    {
+        (string printed, TranslationContext context) = Translate(@"
+namespace Demo
+{
+    public class C
+    {
+        public int X;
+        public C() { X = 1; X = 2; }
+    }
+}");
+
+        // Both assignments must survive, in the original order, inside the kept
+        // explicit constructor — not collapsed to a single field initializer of
+        // `2` that drops the first write.
+        int firstIndex = printed.IndexOf("X = 1", System.StringComparison.Ordinal);
+        int secondIndex = printed.IndexOf("X = 2", System.StringComparison.Ordinal);
+        Assert.True(firstIndex >= 0 && secondIndex > firstIndex);
+        Assert.DoesNotContain("var X int32 = 2", printed);
+        _ = context;
+    }
+
+    private static (string Printed, TranslationContext Context) Translate(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(System.Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        string printed = GSharpPrinter.Print(unit);
+        return (printed, context);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -1845,6 +1845,24 @@ public sealed class CSharpToGSharpTranslator
                     // inline initializer in C#, so its assigned value — not the
                     // inline initializer — is the field's true final value. Prefer
                     // it over `declarator.Initializer` even when both are present.
+                    //
+                    // Issue #1729 (N1): dropping `declarator.Initializer` this way is
+                    // only safe when its RHS is side-effect-free (a constant/literal/
+                    // `new T()` shape). If it can run observable side effects (e.g.
+                    // `static int X = Log(1);`), C# still runs them before the cctor
+                    // overwrites the field, and silently folding to just the cctor
+                    // value would drop that side effect. Report instead of folding.
+                    if (declarator.Initializer != null &&
+                        this.ContainsPotentialSideEffect(declarator.Initializer.Value))
+                    {
+                        string message =
+                            $"field '{declarator.Identifier.Text}' has a side-effecting inline " +
+                            "initializer that a static constructor overwrites; folding would " +
+                            "silently drop the initializer's side effect (ADR-0115 §B.11).";
+                        this.context.ReportUnsupported(declarator, message);
+                        continue;
+                    }
+
                     initializer = staticLifted;
                 }
                 else if (declarator.Initializer != null)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -1008,7 +1008,17 @@ public sealed class CSharpToGSharpTranslator
                     ? this.CollectGetOnlyAutoPropertyInitializers(node)
                     : new List<(string Name, GExpression Value)>();
 
-            this.CollectStaticFieldInitializers(node);
+            // Issue #1729 (mode 4): staticFieldInitializers is one shared dictionary
+            // reused across the whole recursive VisitAggregate walk. Snapshot the
+            // keys already present (belonging to an enclosing type still being
+            // processed) so that when this invocation's own entries are cleared
+            // below — including after recursing into a nested type declaration,
+            // which runs this same method again — only the entries this
+            // invocation itself added are removed. Without this, a nested type's
+            // exit would wipe the outer type's not-yet-consumed folded fields.
+            var staticFieldInitializersSnapshot = new HashSet<ISymbol>(
+                this.staticFieldInitializers.Keys, SymbolEqualityComparer.Default);
+            this.CollectStaticFieldInitializers(node, symbol);
 
             var instanceMembers = new List<GMember>();
             var sharedMembers = new List<GMember>();
@@ -1096,7 +1106,16 @@ public sealed class CSharpToGSharpTranslator
                 members.Add(new SharedBlock(sharedMembers));
             }
 
-            this.staticFieldInitializers.Clear();
+            // Issue #1729 (mode 4): remove only the entries this invocation added
+            // (see snapshot above), not the whole shared dictionary — an enclosing
+            // type may still have not-yet-consumed folded fields pending.
+            foreach (ISymbol key in this.staticFieldInitializers.Keys.ToList())
+            {
+                if (!staticFieldInitializersSnapshot.Contains(key))
+                {
+                    this.staticFieldInitializers.Remove(key);
+                }
+            }
 
             // A `static class` whose every member was an extension method lifted to
             // top level has no remaining body; drop the class entirely (ADR-0115 §B.5).
@@ -1326,6 +1345,23 @@ public sealed class CSharpToGSharpTranslator
                         return ConstructorLift.None;
                     }
 
+                    // Issue #1729 (mode 5): hoisting a field initializer reorders it
+                    // to the field's declaration position, ahead of every ctor
+                    // statement that follows it in source. That is only safe when
+                    // the assigned target is written exactly once (a repeat write
+                    // would silently discard the first RHS's side effect via the
+                    // dictionary overwrite below) and the RHS cannot itself run
+                    // observable side effects (a call, object creation, or property
+                    // getter) whose relative order versus other field initializers
+                    // would then change. Either condition bails the whole lift so
+                    // the explicit constructor — and its true evaluation order — is
+                    // kept intact instead of silently reordered.
+                    if (fieldInitializers.ContainsKey(targetName) ||
+                        this.ContainsPotentialSideEffect(assignment.Right))
+                    {
+                        return ConstructorLift.None;
+                    }
+
                     fieldInitializers[targetName] = this.TranslateExpression(assignment.Right);
                 }
             }
@@ -1440,6 +1476,76 @@ public sealed class CSharpToGSharpTranslator
 
                 ISymbol symbol = this.context.GetSymbolInfo(name).Symbol;
                 if (symbol is { IsStatic: false } &&
+                    symbol.Kind is SymbolKind.Field or SymbolKind.Property
+                        or SymbolKind.Method or SymbolKind.Event &&
+                    symbol.ContainingType != null &&
+                    InheritsFromOrEquals(containingType, symbol.ContainingType))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Issue #1729 (mode 5): determines whether hoisting <paramref name="expression"/>
+        /// to a field's declaration position could change observable behavior versus
+        /// leaving it in the constructor body — a method/delegate invocation or
+        /// property-getter access may run arbitrary code (I/O, mutation, logging)
+        /// whose order relative to other field initializers would then differ from
+        /// C#'s constructor-body order. Plain reads of fields, locals, parameters,
+        /// constants, and object construction (the idiomatic
+        /// <c>_field = new T(...)</c> field-initializer shape, ADR-0115 §B.3 / T2)
+        /// are treated as side-effect-free and remain safe to hoist.
+        /// </summary>
+        private bool ContainsPotentialSideEffect(ExpressionSyntax expression)
+        {
+            foreach (SyntaxNode node in expression.DescendantNodesAndSelf())
+            {
+                switch (node)
+                {
+                    case InvocationExpressionSyntax:
+                    case AwaitExpressionSyntax:
+                    case AssignmentExpressionSyntax:
+                    case PostfixUnaryExpressionSyntax:
+                        return true;
+                    case PrefixUnaryExpressionSyntax prefix
+                        when prefix.IsKind(SyntaxKind.PreIncrementExpression) ||
+                            prefix.IsKind(SyntaxKind.PreDecrementExpression):
+                        return true;
+                }
+
+                if (node is SimpleNameSyntax name &&
+                    this.context.GetSymbolInfo(name).Symbol is IPropertySymbol)
+                {
+                    // A property access may run an arbitrary getter body.
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Issue #1729 (mode 3): determines whether <paramref name="expression"/>
+        /// reads any static member of <paramref name="containingType"/> (or a base
+        /// of it) — a static field, property, method, or event. A folded static
+        /// constructor assignment whose RHS depends on the type's own static state
+        /// cannot be hoisted to its field's declaration position without risking a
+        /// change to C#'s field-initializers-then-cctor evaluation order.
+        /// </summary>
+        private bool ReferencesStaticMemberOfType(ExpressionSyntax expression, INamedTypeSymbol containingType)
+        {
+            foreach (SyntaxNode node in expression.DescendantNodesAndSelf())
+            {
+                if (node is not SimpleNameSyntax name)
+                {
+                    continue;
+                }
+
+                ISymbol symbol = this.context.GetSymbolInfo(name).Symbol;
+                if (symbol is { IsStatic: true } &&
                     symbol.Kind is SymbolKind.Field or SymbolKind.Property
                         or SymbolKind.Method or SymbolKind.Event &&
                     symbol.ContainingType != null &&
@@ -1731,6 +1837,16 @@ public sealed class CSharpToGSharpTranslator
                 {
                     initializer = lifted;
                 }
+                else if (symbol != null &&
+                    this.staticFieldInitializers.TryGetValue(symbol, out GExpression staticLifted))
+                {
+                    // Issue #1729 (mode 1): a folded `static` constructor
+                    // (`static T() { Field = value; }`) runs *after* the field's own
+                    // inline initializer in C#, so its assigned value — not the
+                    // inline initializer — is the field's true final value. Prefer
+                    // it over `declarator.Initializer` even when both are present.
+                    initializer = staticLifted;
+                }
                 else if (declarator.Initializer != null)
                 {
                     initializer = this.CoerceConstantToUnsigned(
@@ -1744,13 +1860,6 @@ public sealed class CSharpToGSharpTranslator
                         type = this.PromoteIfInitializerNullable(
                             type, symbol.Type, declarator.Initializer.Value);
                     }
-                }
-                else if (symbol != null &&
-                    this.staticFieldInitializers.TryGetValue(symbol, out GExpression staticLifted))
-                {
-                    // The field's value comes from a folded `static` constructor
-                    // (`static T() { Field = value; }`), which G# has no form for.
-                    initializer = staticLifted;
                 }
 
                 var declaration = new FieldDeclaration(
@@ -2326,7 +2435,7 @@ public sealed class CSharpToGSharpTranslator
                 // folded into the corresponding `shared { }` field initializers
                 // (see CollectStaticFieldInitializers / TranslateField) and the
                 // constructor is dropped. Anything more complex is unsupported.
-                if (this.IsFoldableStaticConstructor(node))
+                if (this.IsFoldableStaticConstructor(node, symbol?.ContainingType))
                 {
                     return null;
                 }
@@ -2400,13 +2509,13 @@ public sealed class CSharpToGSharpTranslator
         /// constructor so they can be re-attached to the corresponding fields
         /// (G# has no static-constructor form; ADR-0115 §B.11).
         /// </summary>
-        private void CollectStaticFieldInitializers(TypeDeclarationSyntax node)
+        private void CollectStaticFieldInitializers(TypeDeclarationSyntax node, INamedTypeSymbol typeSymbol)
         {
             foreach (MemberDeclarationSyntax member in node.Members)
             {
                 if (member is not ConstructorDeclarationSyntax ctor ||
                     !ctor.Modifiers.Any(SyntaxKind.StaticKeyword) ||
-                    !this.IsFoldableStaticConstructor(ctor) ||
+                    !this.IsFoldableStaticConstructor(ctor, typeSymbol) ||
                     ctor.Body == null)
                 {
                     continue;
@@ -2425,11 +2534,27 @@ public sealed class CSharpToGSharpTranslator
             }
         }
 
-        private bool IsFoldableStaticConstructor(ConstructorDeclarationSyntax node)
+        /// <summary>
+        /// Issue #1729: a static constructor folds cleanly only when every
+        /// statement is a simple <c>Field = expr;</c> assignment where (mode 2)
+        /// the assigned field belongs to the type declaring the constructor — an
+        /// assignment to another type's static field would be silently dropped,
+        /// since the folded entry is keyed by that other field and never consumed
+        /// — and (mode 3) the RHS does not depend on the type's own static state,
+        /// since hoisting it to the field's declaration position could change
+        /// C#'s field-initializers-then-cctor evaluation order. Anything else is
+        /// reported as unsupported instead of silently folded.
+        /// </summary>
+        private bool IsFoldableStaticConstructor(ConstructorDeclarationSyntax node, INamedTypeSymbol typeSymbol)
         {
             if (node.Body == null)
             {
                 return node.ExpressionBody == null;
+            }
+
+            if (typeSymbol == null)
+            {
+                return false;
             }
 
             foreach (StatementSyntax statement in node.Body.Statements)
@@ -2437,7 +2562,9 @@ public sealed class CSharpToGSharpTranslator
                 if (statement is not ExpressionStatementSyntax expressionStatement ||
                     expressionStatement.Expression is not AssignmentExpressionSyntax assignment ||
                     !assignment.IsKind(SyntaxKind.SimpleAssignmentExpression) ||
-                    this.context.GetSymbolInfo(assignment.Left).Symbol is not IFieldSymbol { IsStatic: true })
+                    this.context.GetSymbolInfo(assignment.Left).Symbol is not IFieldSymbol { IsStatic: true } field ||
+                    !SymbolEqualityComparer.Default.Equals(field.ContainingType, typeSymbol) ||
+                    this.ReferencesStaticMemberOfType(assignment.Right, typeSymbol))
                 {
                     return false;
                 }


### PR DESCRIPTION
Fixes #1729

G# has no static-constructor form, so `cs2gs` folds "simple" static ctors into field initializers and drops the ctor. This fixes all six silent-divergence modes from the issue.

## Dispositions

1. **Inline initializer vs. static-ctor assignment** — fixed correctly. `TranslateField` now checks `staticFieldInitializers` *before* `declarator.Initializer`: C# runs field initializers then the static ctor, so the ctor's assignment is always the field's true final value.
2. **Cross-type static field writes** — now `ReportUnsupported`. `IsFoldableStaticConstructor` takes the declaring type's symbol and requires the assigned field's `ContainingType` to match it; a static ctor writing another type's static field no longer silently vanishes (previously keyed by the other type's field symbol and never consumed).
3. **RHS ordering** — now `ReportUnsupported`. Added `ReferencesStaticMemberOfType` (mirrors the instance-lift's `ReferencesInstanceMember`); a static-ctor RHS that reads the type's own static state bails the fold instead of silently reordering it to the field's declaration position.
4. **Nested types wiping outer pending initializers** — fixed correctly. `staticFieldInitializers` is now save/restored per `VisitAggregate` invocation via a keys-snapshot, so recursing into a nested type only removes that nested type's own entries on exit, never the enclosing type's not-yet-consumed ones. This generalizes to arbitrary nesting depth.
5. **Instance-ctor lift reordering/dropping side effects** — now bails the lift (keeps the explicit constructor). `AnalyzeConstructorLift` bails when a hoisted field-initializer RHS contains a potential side effect (invocation, await, nested assignment, increment/decrement, property-getter access — new `ContainsPotentialSideEffect`) or when the same target is assigned more than once (the `fieldInitializers` overwrite would otherwise silently discard the first assignment). Plain reads and object construction (`_field = new T(...)`) remain hoistable — this is the common, already-relied-upon field-initializer shape and isn't the case the issue calls out.

**Regression guard:** a simple foldable static ctor with no inline initializer, no ordering dependency, and a same-type target still folds and drops the ctor exactly as before.

## Tests

- `tools/cs2gs/Cs2Gs.Tests/Issue1729StaticCtorFoldTranslationTests.cs` — translation-level tests asserting the fold/`ReportUnsupported` disposition for all six modes plus the simple-fold regression.
- `test/Compiler.Tests/Emit/Issue1729StaticCtorFoldEmitTests.cs` — compile+run tests proving correct runtime values for the fixable cases (mode 1 final value, the simple-fold regression, mode 4's outer-field-after-nested-type).

## Validation

- `dotnet build GSharp.sln -c Release -graph` — succeeds.
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release -- xUnit.MaxParallelThreads=2` — 540/540 pass (includes the 7 new translation tests, no regressions).
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Release --filter "FullyQualifiedName~Issue1729"` — 3/3 pass.
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Release --filter "FullyQualifiedName~Ctor|FullyQualifiedName~Field|FullyQualifiedName~1069Nested"` — 362/362 pass (no regressions in related ctor/field/nested-type emit tests).
