### PR TITLE
cs2gs report: malformed triage artifact counts-and-continues instead of aborting

### DIFF
--- a/tools/cs2gs/Cs2Gs.Report/ReportModel.cs
+++ b/tools/cs2gs/Cs2Gs.Report/ReportModel.cs
@@ -168,8 +168,20 @@ public sealed class ReportModel
                     continue;
                 }
 
-                TriageArtifact artifact = JsonSerializer.Deserialize<TriageArtifact>(
-                    File.ReadAllText(artifactPath), TriageSerialization.Options);
+                TriageArtifact artifact;
+                try
+                {
+                    artifact = JsonSerializer.Deserialize<TriageArtifact>(
+                        File.ReadAllText(artifactPath), TriageSerialization.Options);
+                }
+                catch (JsonException)
+                {
+                    missingArtifactCount++;
+                    Console.Error.WriteLine(
+                        $"cs2gs: warning: triage artifact '{relative}' referenced by app '{app.AppId}' is malformed; gap data is incomplete.");
+                    continue;
+                }
+
                 if (artifact is null)
                 {
                     missingArtifactCount++;

--- a/tools/cs2gs/Cs2Gs.Tests/ReportTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/ReportTests.cs
@@ -292,6 +292,84 @@ public class ReportTests
     }
 
     /// <summary>
+    /// A malformed (invalid-JSON) triage artifact must be counted exactly
+    /// like a missing or null-deserialize artifact — increment
+    /// <see cref="ReportModel.MissingArtifactCount"/> and continue — instead
+    /// of letting the <see cref="System.Text.Json.JsonException"/> escape and
+    /// abort the whole report. One bad artifact must not nuke the rest of the
+    /// run's report (issue #1846).
+    /// </summary>
+    [Fact]
+    public void ReportModel_MalformedTriageArtifact_IsCountedAndReportStillRenders()
+    {
+        string runDir = NewRunDir("malformed-artifact");
+
+        var run = new RunResult
+        {
+            RunId = "2026-03-01T00-00-03Z_malformed",
+            Timestamp = "2026-03-01T00:00:03Z",
+            GscVersion = "0.2.0+test",
+            GscPath = "/path/to/gsc.dll",
+            Succeeded = false,
+            Apps = new List<AppResult>
+            {
+                new AppResult
+                {
+                    AppId = "corpus/L1-Console",
+                    Succeeded = false,
+                    FailureCategory = "translation-unsupported",
+                    Stages = new List<StageResult>
+                    {
+                        new StageResult { Stage = "translate", Status = "failed", ArtifactCount = 1 },
+                        new StageResult { Stage = "compile", Status = "skipped" },
+                        new StageResult { Stage = "ilverify", Status = "skipped" },
+                        new StageResult { Stage = "test-parity", Status = "skipped" },
+                    },
+                    Artifacts = new List<string> { "corpus_L1-Console/translate-malformed.json" },
+                },
+                new AppResult
+                {
+                    AppId = "corpus/L2-Library",
+                    Succeeded = true,
+                    Stages = AllStages("passed"),
+                },
+            },
+        };
+        WriteRunJson(runDir, run);
+
+        // Write invalid JSON to the referenced artifact path: not missing,
+        // not null-deserializing to a valid object — a genuine parse failure.
+        string artifactPath = Path.Combine(runDir, "corpus_L1-Console", "translate-malformed.json");
+        Directory.CreateDirectory(Path.GetDirectoryName(artifactPath));
+        File.WriteAllText(artifactPath, "{ this is not valid json ");
+
+        ReportModel model = ReportModel.FromRunDirectory(runDir);
+
+        Assert.False(model.Succeeded);
+        Assert.Empty(model.Gaps);
+        Assert.Equal(1, model.MissingArtifactCount);
+        Assert.False(model.IsGreen);
+
+        // Both apps still rendered: the malformed artifact did not abort the
+        // rest of the report.
+        Assert.Equal(2, model.Apps.Count);
+        Assert.Contains(model.Apps, a => a.AppId == "corpus/L1-Console");
+        Assert.Contains(model.Apps, a => a.AppId == "corpus/L2-Library");
+
+        string html = HtmlReportWriter.Render(model);
+        Assert.Contains("NOT a green run", html, StringComparison.Ordinal);
+        Assert.Contains("Gap data unavailable", html, StringComparison.Ordinal);
+
+        string json = JsonSummaryWriter.Serialize(model);
+        Assert.Contains("\"missingArtifactCount\": 1", json, StringComparison.Ordinal);
+        Assert.Contains("\"isGreen\": false", json, StringComparison.Ordinal);
+
+        // Report was generated (no abort): exit code is the non-green 1, not
+        // the internal-error 2 reserved for genuinely unexpected failures.
+        Assert.Equal(1, Cs2Gs.Cli.Program.DetermineMigrateExitCode(model.Succeeded, reportGenerated: true));
+    }
+
+    /// <summary>
     /// A FAILED run with no triage artifacts referenced at all (e.g. every
     /// stage errored before it could emit one) must also not be rendered as
     /// green — the empty-gaps message must reflect the failed run, not claim


### PR DESCRIPTION
Fixes #1846

## Bug
`ReportModel.Build` incremented `MissingArtifactCount` and continued for a **missing** triage artifact (`!File.Exists`) and a **null-deserialize** result, but a **malformed** artifact (invalid JSON, `JsonSerializer.Deserialize` throwing `JsonException`) propagated to the outer `GenerateReport` catch and aborted the whole report (exit 2). One bad artifact nuked the entire report instead of being counted like its siblings.

## Fix
Wrapped the per-artifact `Deserialize` call in `tools/cs2gs/Cs2Gs.Report/ReportModel.cs` (`Build`) in a `try/catch (JsonException)`. On catch: increment `MissingArtifactCount`, log the same style of warning, and `continue` — identical to the existing null-deserialize path. This is the only per-artifact deserialize site in the loop (the `run.json` deserialize is a separate, single top-level read, not per-artifact, so it's unaffected and still surfaces via the outer catch as exit 2 for genuinely broken `run.json`).

Catch is scoped to `JsonException` only — a real internal bug still propagates and exits 2.

## Tests
Added `ReportModel_MalformedTriageArtifact_IsCountedAndReportStillRenders` in `tools/cs2gs/Cs2Gs.Tests/ReportTests.cs`, mirroring the structure of `ReportModel_FailedRun_MissingTriageArtifact_IsNotRenderedAsGreen`:
- Writes invalid JSON (`{ this is not valid json`) to the referenced artifact path.
- Asserts `MissingArtifactCount == 1`, `IsGreen == false`, no exception escapes.
- Asserts **both** apps in the run still render in `model.Apps` (the malformed artifact didn't abort the rest of the report).
- Asserts HTML/JSON render the non-green state.
- Asserts `DetermineMigrateExitCode` returns 1 (non-green) — not 2 (internal-error).

## Verification
- `dotnet build GSharp.sln -c Release -graph` — succeeded, 0 warnings/errors.
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release --no-build --filter "FullyQualifiedName~Report"` — 37/37 passed, including `Cli_ReportVerb_RegeneratesBothArtifacts` (whole-solution build dependency) and the new malformed-artifact test.