### PR TITLE
cs2gs CLI: narrow missing-option-value catch to a sentinel exception

### DIFF
--- a/tools/cs2gs/Cs2Gs.Cli/Program.cs
+++ b/tools/cs2gs/Cs2Gs.Cli/Program.cs
@@ -204,7 +204,7 @@ internal static class Program
                 }
             }
         }
-        catch (ArgumentException ex)
+        catch (MissingOptionValueException ex)
         {
             Console.Error.WriteLine("cs2gs: " + ex.Message);
             PrintUsage();
@@ -340,7 +340,7 @@ internal static class Program
                         return null;
                 }
             }
-            catch (ArgumentException ex)
+            catch (MissingOptionValueException ex)
             {
                 Console.Error.WriteLine("cs2gs: " + ex.Message);
                 PrintUsage();
@@ -364,18 +364,21 @@ internal static class Program
     /// <summary>
     /// Reads the value following an option flag (e.g. <c>--gsc &lt;path&gt;</c>).
     /// </summary>
-    /// <exception cref="ArgumentException">
+    /// <exception cref="MissingOptionValueException">
     /// The flag was the last token with no value following it. Callers catch
-    /// this alongside the unknown-option case and route it through the same
-    /// print-usage/return-1 path — a missing value is a usage error, not an
-    /// internal error, so it must not escape to <see cref="Main"/>'s generic
-    /// catch (which reports exit code 2).
+    /// this specific type and route it through the print-usage/return-1 path —
+    /// a missing value is a usage error, not an internal error. Using a
+    /// dedicated sentinel (rather than the base <see cref="ArgumentException"/>)
+    /// keeps that catch from also swallowing an unrelated
+    /// <see cref="ArgumentException"/> thrown by a case body (e.g. a future
+    /// validating option setter), which must still escape to <see cref="Main"/>'s
+    /// generic catch (exit code 2).
     /// </exception>
     private static string NextValue(string[] args, ref int index, string flag)
     {
         if (index + 1 >= args.Length)
         {
-            throw new ArgumentException($"option '{flag}' requires a value.");
+            throw new MissingOptionValueException($"option '{flag}' requires a value.");
         }
 
         return args[++index];
@@ -481,5 +484,18 @@ internal static class Program
         Console.WriteLine("A migrate run also writes report.html + summary.json into the run dir automatically (ADR-0115 §F).");
         Console.WriteLine();
         Console.WriteLine("Exit code is non-zero if any app fails a stage (so CI can gate).");
+    }
+
+    /// <summary>
+    /// Sentinel exception thrown by <see cref="NextValue"/> when an option's
+    /// value is missing, so verb loops can catch exactly this case as a usage
+    /// error without also catching unrelated <see cref="ArgumentException"/>s.
+    /// </summary>
+    private sealed class MissingOptionValueException : ArgumentException
+    {
+        public MissingOptionValueException(string message)
+            : base(message)
+        {
+        }
     }
 }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1756Tests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1756Tests.cs
@@ -20,7 +20,11 @@ namespace Cs2Gs.Tests;
 /// usage (not the internal-error exit 2), <see cref="HtmlReportWriter"/>
 /// slug collisions producing distinct/matching anchors, and the
 /// <see cref="AppReport"/>/<see cref="Cs2Gs.Pipeline.AppResult"/> JSON shape
-/// staying byte-identical after collapsing the duplicated report types.
+/// staying byte-identical after collapsing the duplicated report types. Also
+/// covers #1854, a follow-up that narrows the missing-option-value catch to a
+/// dedicated sentinel exception type (kept in this class/collection so its
+/// <see cref="Console"/>-swapping <c>RunMainAsync</c> helper isn't run
+/// concurrently with another test class's copy of the same pattern).
 /// </summary>
 public class Issue1756Tests
 {
@@ -59,6 +63,54 @@ public class Issue1756Tests
 
         Assert.Equal(1, exitCode);
         Assert.Contains("requires a value", stderr, StringComparison.Ordinal);
+        Assert.Contains("Usage:", stdout, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// <c>NextValue</c> must throw a dedicated sentinel type (a private
+    /// nested subclass of <see cref="ArgumentException"/>), not a plain
+    /// <see cref="ArgumentException"/> — see issue #1854. This is what lets
+    /// the verb loops' catch clauses narrow to exactly the missing-value
+    /// case: catching the sentinel type by name, rather than
+    /// <see cref="ArgumentException"/> itself, means any other
+    /// <see cref="ArgumentException"/> a case body might throw (e.g. a future
+    /// validating option setter) is not caught here and falls through to
+    /// exit 2.
+    /// </summary>
+    [Fact]
+    public void NextValue_MissingValue_ThrowsSentinelType_NotBaseArgumentException()
+    {
+        System.Reflection.MethodInfo nextValue = typeof(Cs2Gs.Cli.Program).GetMethod(
+            "NextValue", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        Assert.NotNull(nextValue);
+
+        var args = new[] { "--gsc" };
+        object[] parameters = { args, 0, "--gsc" };
+
+        var wrapper = Assert.Throws<System.Reflection.TargetInvocationException>(
+            () => nextValue.Invoke(null, parameters));
+        Exception thrown = wrapper.InnerException;
+
+        Assert.IsAssignableFrom<ArgumentException>(thrown);
+        Assert.NotEqual(typeof(ArgumentException), thrown.GetType());
+        Assert.Equal("MissingOptionValueException", thrown.GetType().Name);
+    }
+
+    /// <summary>
+    /// An unknown option (e.g. <c>--bogus</c>) must still exit 1 with usage
+    /// for both verbs, unchanged by the #1854 sentinel-narrowing fix —
+    /// unknown options are detected by the <c>default:</c> switch arm, not by
+    /// <c>NextValue</c>, so they never go through the narrowed catch at all.
+    /// </summary>
+    [Theory]
+    [InlineData("migrate", "--bogus")]
+    [InlineData("report", "--bogus")]
+    public async Task UnknownOption_ExitsOne_WithUsage(string verb, string flag)
+    {
+        (int exitCode, string stdout, string stderr) = await RunMainAsync(verb, flag);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("unknown option", stderr, StringComparison.Ordinal);
         Assert.Contains("Usage:", stdout, StringComparison.Ordinal);
     }
 


### PR DESCRIPTION
Fixes #1854

Follow-up from #1756 (PR #1853), reviewer note N1.

`NextValue`'s missing-option-value throw was a plain `ArgumentException`, caught by both verb loops (`catch (ArgumentException ex)`) to convert it into a usage error (exit 1 + usage) instead of the generic exit-2 internal-error path. That catch was broader than intended: any `ArgumentException` thrown from inside a case body (e.g. a future validating property setter) would also be reclassified as a usage error, masking a genuine internal bug.

## Fix
- Added a private `MissingOptionValueException : ArgumentException` sentinel, thrown by `NextValue`.
- Both the `migrate` and `report` verb loops now `catch (MissingOptionValueException ex)` instead of `catch (ArgumentException ex)`.
- Updated `NextValue`'s doc comment to describe the sentinel and why it's needed.

## Tests
- `Issue1756Tests.MissingOptionValue_ExitsOne_WithUsage_NotInternalError` (existing) still passes unchanged — `migrate --gsc`/`--corpus` and `report --run` with a missing value still exit 1 with usage.
- Added `NextValue_MissingValue_ThrowsSentinelType_NotBaseArgumentException`: reflection-based check that `NextValue` throws the sentinel type, not a plain `ArgumentException` — this is what guarantees a stray `ArgumentException` from a case body would escape the narrowed catch and hit exit 2. (A true end-to-end repro of that path isn't feasible today since `PipelineOptions` setters are plain auto-props with no validation seam; this is noted as a limitation, matching the issue's own framing.)
- Added `UnknownOption_ExitsOne_WithUsage` (`--bogus` for both verbs): confirms unknown-option handling (via the `default:` switch arm, unrelated to `NextValue`) is unchanged.
- New tests were added to `Issue1756Tests.cs` (same test class/collection) rather than a new class, to keep the `Console`-swapping `RunMainAsync` helper single-threaded within xUnit's default collection-level parallelism — a separate class here raced against this one and flaked (a pre-existing test-isolation gap, not a production bug).

## Validation
- `dotnet build GSharp.sln -c Release -graph` — succeeds, 0 warnings/errors.
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release --filter "FullyQualifiedName~Issue1756"` — 12/12 passed, repeated 4x with no flakiness.

Not chasing the pre-existing, unrelated `ReportTests.Cli_ReportVerb_RegeneratesBothArtifacts` flake per task guidance.