### PR TITLE
cs2gs: fix switch pattern-binding ordering (statement bindings discarded, expression guard translated too early)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue1730SwitchPatternBindingTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1730SwitchPatternBindingTests.cs
@@ -1,0 +1,186 @@
+// <copyright file="Issue1730SwitchPatternBindingTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #1730: two related pattern-binding ordering bugs.
+///
+/// (1) A switch-STATEMENT pattern label's bindings (`case Circle { Radius: var r }:`)
+/// were computed and then discarded — the case body was translated before the
+/// bindings were installed, so a reference to the bound variable in the body
+/// resolved to a bare, undeclared name.
+///
+/// (2) A switch-EXPRESSION arm's `when` guard was translated before the arm's
+/// pattern bindings were installed, so a guard referencing a bound variable
+/// (`Circle { Radius: var r } when r > 0 => ...`) resolved it while still out
+/// of scope.
+///
+/// Both are fixed by installing each pattern's bindings before translating
+/// anything that can reference them (guard and body alike), scoped per
+/// case/arm exactly like the existing `TranslateIf` condition-binding scope.
+/// </summary>
+public class Issue1730SwitchPatternBindingTests
+{
+    private const string ShapesPrelude = @"
+namespace Demo
+{
+    public class Shape { }
+
+    public class Circle : Shape
+    {
+        public int Radius;
+    }
+";
+
+    /// <summary>
+    /// A switch-statement pattern label's `var` property binding must be
+    /// installed before the case body is translated, so a body reference to
+    /// the bound variable resolves to the rewritten member access instead of a
+    /// bare, undeclared name.
+    /// </summary>
+    [Fact]
+    public void SwitchStatement_RecursivePatternVarBinding_UsedInBody_ResolvesToMemberAccess()
+    {
+        string printed = TranslateUnit(ShapesPrelude + @"
+    public static class Shapes
+    {
+        public static int Describe(Shape shape)
+        {
+            switch (shape)
+            {
+                case Circle { Radius: var r }:
+                    return r;
+                default:
+                    return 0;
+            }
+        }
+    }
+}");
+
+        Assert.Contains("circle.Radius", printed);
+        Assert.DoesNotContain("return r", printed);
+    }
+
+    /// <summary>
+    /// A switch-statement pattern label's `when` guard must also see the
+    /// pattern's own bindings (the guard and the body share the same
+    /// installed scope).
+    /// </summary>
+    [Fact]
+    public void SwitchStatement_RecursivePatternVarBinding_UsedInGuard_ResolvesToMemberAccess()
+    {
+        string printed = TranslateUnit(ShapesPrelude + @"
+    public static class Shapes
+    {
+        public static int Describe(Shape shape)
+        {
+            switch (shape)
+            {
+                case Circle { Radius: var r } when r > 0:
+                    return r;
+                default:
+                    return 0;
+            }
+        }
+    }
+}");
+
+        Assert.Contains("when circle.Radius > 0", printed);
+        Assert.Contains("circle.Radius", printed);
+        Assert.DoesNotContain("when r > 0", printed);
+        Assert.DoesNotContain("return r", printed);
+    }
+
+    /// <summary>
+    /// A switch-expression arm's `when` guard must be translated AFTER the
+    /// arm's pattern bindings are installed, so a guard referencing the bound
+    /// variable (`Circle { Radius: var r } when r > 0 => ...`) sees it in
+    /// scope, exactly like the arm's result expression does.
+    /// </summary>
+    [Fact]
+    public void SwitchExpression_RecursivePatternVarBinding_GuardAndResult_BothSeeBinding()
+    {
+        string printed = TranslateUnit(ShapesPrelude + @"
+    public static class Shapes
+    {
+        public static int Describe(Shape shape) => shape switch
+        {
+            Circle { Radius: var r } when r > 0 => r,
+            _ => 0,
+        };
+    }
+}");
+
+        Assert.Contains("when circle.Radius > 0", printed);
+        Assert.Contains("circle.Radius", printed);
+        Assert.DoesNotContain("when r > 0", printed);
+        Assert.DoesNotContain("=> r,", printed);
+    }
+
+    /// <summary>
+    /// Distinct sections in the same switch statement each carry their own
+    /// pattern binding, and each section's binding must not leak into a
+    /// sibling section's body.
+    /// </summary>
+    [Fact]
+    public void SwitchStatement_MultipleSections_EachInstallsOwnBindingWithoutLeaking()
+    {
+        string printed = TranslateUnit(ShapesPrelude + @"
+    public class Square : Shape
+    {
+        public int Side;
+    }
+
+    public static class Shapes
+    {
+        public static int Area(Shape shape)
+        {
+            switch (shape)
+            {
+                case Circle { Radius: var r }:
+                    return r;
+                case Square { Side: var r }:
+                    return r;
+                default:
+                    return 0;
+            }
+        }
+    }
+}");
+
+        Assert.Contains("circle.Radius", printed);
+        Assert.Contains("square.Side", printed);
+        Assert.DoesNotContain("return r", printed);
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -9207,11 +9207,11 @@ public sealed class CSharpToGSharpTranslator
 
             foreach (SwitchExpressionArmSyntax arm in node.Arms)
             {
-                // Issue #991: C# `when` guards now have a canonical G# form.
-                GExpression guard = arm.WhenClause != null
-                    ? this.TranslateExpression(arm.WhenClause.Condition)
-                    : null;
-
+                // Issue #1730: the pattern's bindings must be installed BEFORE the
+                // `when` guard is translated, since the guard can reference them
+                // (`Circle { Radius: var r } when r > 0 => ...`). Translating the
+                // guard first (the prior order) resolved `r` while it was still
+                // out of scope.
                 var bindings = new List<(ISymbol Symbol, GExpression Replacement)>();
                 GPattern pattern = this.TranslatePattern(arm.Pattern, bindings);
 
@@ -9220,9 +9220,14 @@ public sealed class CSharpToGSharpTranslator
                     this.patternBindings[symbol] = replacement;
                 }
 
+                GExpression guard;
                 GExpression body;
                 try
                 {
+                    // Issue #991: C# `when` guards now have a canonical G# form.
+                    guard = arm.WhenClause != null
+                        ? this.TranslateExpression(arm.WhenClause.Condition)
+                        : null;
                     body = this.TranslateExpression(arm.Expression);
                 }
                 finally
@@ -9248,9 +9253,11 @@ public sealed class CSharpToGSharpTranslator
             {
                 // A G# switch-statement arm carries a single pattern; a C# section
                 // that stacks multiple `case` labels (fall-through) has no canonical
-                // G# form, so each label is emitted as its own arm sharing the body.
+                // G# form, so each label is emitted as its own arm. The body is
+                // translated per-label (not once per section) because a pattern
+                // label's bindings (issue #1730) must be installed before the body
+                // is translated, and bindings can differ across stacked labels.
                 var labels = section.Labels.ToList();
-                BlockStatement body = this.TranslateSwitchSectionBody(section);
 
                 foreach (SwitchLabelSyntax label in labels)
                 {
@@ -9260,21 +9267,45 @@ public sealed class CSharpToGSharpTranslator
                             var bindings = new List<(ISymbol Symbol, GExpression Replacement)>();
                             GPattern pattern = this.TranslatePattern(patternLabel.Pattern, bindings);
 
-                            // Issue #991: C# `when` guards now have a canonical G# form.
-                            GExpression guard = patternLabel.WhenClause != null
-                                ? this.TranslateExpression(patternLabel.WhenClause.Condition)
-                                : null;
-                            cases.Add(new SwitchStatementCase(pattern, body, guard));
+                            // Issue #1730: install the pattern's bindings before
+                            // translating the `when` guard and the case body, so
+                            // both see the bound variable (`case Circle { Radius:
+                            // var r } when r > 0: return r;`). The bindings are
+                            // scoped to this label only.
+                            foreach ((ISymbol symbol, GExpression replacement) in bindings)
+                            {
+                                this.patternBindings[symbol] = replacement;
+                            }
+
+                            GExpression guard;
+                            BlockStatement patternBody;
+                            try
+                            {
+                                // Issue #991: C# `when` guards now have a canonical G# form.
+                                guard = patternLabel.WhenClause != null
+                                    ? this.TranslateExpression(patternLabel.WhenClause.Condition)
+                                    : null;
+                                patternBody = this.TranslateSwitchSectionBody(section);
+                            }
+                            finally
+                            {
+                                foreach ((ISymbol symbol, _) in bindings)
+                                {
+                                    this.patternBindings.Remove(symbol);
+                                }
+                            }
+
+                            cases.Add(new SwitchStatementCase(pattern, patternBody, guard));
                             break;
 
                         case CaseSwitchLabelSyntax valueLabel:
                             cases.Add(new SwitchStatementCase(
                                 new ConstantPattern(this.TranslateExpression(valueLabel.Value)),
-                                body));
+                                this.TranslateSwitchSectionBody(section)));
                             break;
 
                         case DefaultSwitchLabelSyntax:
-                            cases.Add(new SwitchStatementCase(null, body));
+                            cases.Add(new SwitchStatementCase(null, this.TranslateSwitchSectionBody(section)));
                             break;
 
                         default:


### PR DESCRIPTION
Fixes #1730

Two related ordering bugs in switch translation (`Cs2Gs.Translator/CSharpToGSharpTranslator.cs`):

1. **Switch-statement pattern bindings were thrown away.** `TranslateSwitchStatement` translated the section body *before* the label loop that computes each pattern label's bindings ran, and the computed bindings were never installed into `this.patternBindings`. A body referencing a pattern-bound variable (e.g. `case Circle { Radius: var r }: return r;`) emitted a bare, undeclared `r` — output that fails to compile in gsc (GS0125), with no diagnostic raised.
2. **Switch-expression `when` guards were translated before bindings were installed.** `TranslateSwitchExpression` translated the arm's guard, *then* installed the arm's pattern bindings, so a guard referencing a bound variable (`Circle { Radius: var r } when r > 0 => ...`) resolved it while still out of scope.

### Fix

For both switch forms, each pattern's bindings are now installed into `this.patternBindings` before translating anything that can reference them (guard, then body/result), and removed afterward — mirroring the scoped install/remove already used by `TranslateIf` for its condition-binding scope.

- Switch-statement: bindings are installed per label, the guard is translated, then the case body is translated (previously computed once per section up front), then bindings are removed. The body is now translated per-label instead of once per section, since stacked labels can carry different bindings.
- Switch-expression: bindings are installed before the guard (previously guard-then-bindings), then the guard and result expression are both translated inside the same scope.

This generalizes to every pattern-binding shape the translator already supports (declaration pattern, recursive/property pattern with `var`, combinators) via the shared `TranslatePattern`/`bindings` list — no special-casing for the repro shape. Pattern shapes the translator genuinely can't express already raise `ReportUnsupported` in `TranslatePattern`/`TranslateRecursivePattern` (e.g. positional subpatterns, non-`var` typed property subpatterns); this fix does not touch that behavior — it only fixes when/whether the bindings that *are* successfully collected get installed.

### Tests

Added `Issue1730SwitchPatternBindingTests.cs`:
- switch statement: recursive/`var`-bound property pattern used in the case body → resolves to the member access, not a bare undeclared name.
- switch statement: same pattern's `when` guard also sees the binding.
- switch expression: arm's guard *and* result expression both see the binding.
- sibling switch sections each install their own binding without leaking into each other's body.

Full `Cs2Gs.Tests` suite (560 tests) passes with no regressions.