### PR TITLE
cs2gs: fix enum-typed default/attribute values and NaN/Infinity defaults

### DIFF
--- a/test/Compiler.Tests/Emit/Issue1733FloatInfinityDefaultEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1733FloatInfinityDefaultEmitTests.cs
@@ -1,0 +1,149 @@
+// <copyright file="Issue1733FloatInfinityDefaultEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1733 N1: <c>cs2gs</c> emits a <c>double</c>/<c>float</c>
+/// <c>PositiveInfinity</c>/<c>NegativeInfinity</c> default as the qualified BCL
+/// member reference <c>System.Double.PositiveInfinity</c>/<c>NegativeInfinity</c>
+/// (and the <c>System.Single</c> equivalents) — the same spelling
+/// <c>Issue1616FloatNaNOperatorEmitTests</c> already proves G# resolves for
+/// <c>System.Double.NaN</c>/<c>System.Single.NaN</c>. This end-to-end emit test
+/// proves G# ALSO resolves the <c>PositiveInfinity</c>/<c>NegativeInfinity</c>
+/// spelling for both <c>double</c> and <c>float</c>, confirming the cs2gs emitted
+/// spelling is correct (not just NaN).
+/// </summary>
+public class Issue1733FloatInfinityDefaultEmitTests
+{
+    [Fact]
+    public void EndToEnd_Float64_PositiveAndNegativeInfinity_Resolve()
+    {
+        const string source = """
+            package i1733f64inf
+            import System
+
+            func Main() {
+                var posInf = System.Double.PositiveInfinity
+                var negInf = System.Double.NegativeInfinity
+                System.Console.WriteLine(posInf)
+                System.Console.WriteLine(negInf)
+                System.Console.WriteLine(posInf > 1.0)
+                System.Console.WriteLine(negInf < -1.0)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("\u221e\n-\u221e\nTrue\nTrue\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_Float32_PositiveAndNegativeInfinity_Resolve()
+    {
+        const string source = """
+            package i1733f32inf
+            import System
+
+            func Main() {
+                var posInf = System.Single.PositiveInfinity
+                var negInf = System.Single.NegativeInfinity
+                System.Console.WriteLine(posInf)
+                System.Console.WriteLine(negInf)
+                System.Console.WriteLine(posInf > float32(1.0))
+                System.Console.WriteLine(negInf < float32(-1.0))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("\u221e\n-\u221e\nTrue\nTrue\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1733inf_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue1733FloatInfinityDefaultEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1733FloatInfinityDefaultEmitTests.cs
@@ -41,7 +41,8 @@ public class Issue1733FloatInfinityDefaultEmitTests
             """;
 
         var output = CompileAndRun(source);
-        Assert.Equal("\u221e\n-\u221e\nTrue\nTrue\n", output);
+        var expected = $"{double.PositiveInfinity}\n{double.NegativeInfinity}\nTrue\nTrue\n";
+        Assert.Equal(expected, output);
     }
 
     [Fact]
@@ -62,7 +63,8 @@ public class Issue1733FloatInfinityDefaultEmitTests
             """;
 
         var output = CompileAndRun(source);
-        Assert.Equal("\u221e\n-\u221e\nTrue\nTrue\n", output);
+        var expected = $"{float.PositiveInfinity}\n{float.NegativeInfinity}\nTrue\nTrue\n";
+        Assert.Equal(expected, output);
     }
 
     private static string CompileAndRun(string source)

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1733EnumAndFloatDefaultTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1733EnumAndFloatDefaultTranslationTests.cs
@@ -3,11 +3,15 @@
 // </copyright>
 
 using System;
+using System.Collections.Immutable;
+using System.IO;
 using System.Linq;
 using Cs2Gs.CodeModel.Ast;
 using Cs2Gs.CodeModel.Printing;
 using Cs2Gs.Translator;
 using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
 
 namespace Cs2Gs.Tests;
@@ -39,6 +43,17 @@ namespace Corpus.Issue1733
     [Flags]
     public enum Toppings { None = 0, Cheese = 1, Olives = 2, Pepperoni = 4 }
 
+    // N2: a ulong-backed [Flags] enum with a high-bit member above
+    // long.MaxValue. Convert.ToInt64 throws OverflowException on such a value;
+    // MapEnumConstant must resolve/decompose it without crashing.
+    [Flags]
+    public enum BigFlags : ulong
+    {
+        None = 0,
+        Small = 1UL,
+        Big = 0x8000_0000_0000_0000UL,
+    }
+
     public class KindAttribute : Attribute
     {
         public KindAttribute(Color color) { }
@@ -49,6 +64,8 @@ namespace Corpus.Issue1733
         public void Paint(Color c = Color.Blue) { }
 
         public void Sprinkle(Toppings t = Toppings.Cheese | Toppings.Olives) { }
+
+        public void BigFlagCombo(BigFlags b = BigFlags.Big | BigFlags.Small) { }
 
         public void Undefined(Color c = (Color)99) { }
 
@@ -86,6 +103,16 @@ namespace Corpus.Issue1733
 
         // Decomposed in descending-value order (Olives=2 before Cheese=1).
         Assert.Contains("t Toppings = Toppings.Olives | Toppings.Cheese", rendered, StringComparison.Ordinal);
+    }
+
+    // N2: a ulong [Flags] enum member above long.MaxValue must not crash
+    // Convert.ToInt64 (OverflowException) and must resolve/decompose correctly.
+    [Fact]
+    public void UInt64FlagsEnumWithHighBitMember_DoesNotCrash_AndRendersAsOrOfMembers()
+    {
+        string rendered = Render();
+
+        Assert.Contains("b BigFlags = BigFlags.Big | BigFlags.Small", rendered, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -134,6 +161,81 @@ namespace Corpus.Issue1733
         Assert.Contains("nan float32 = System.Single.NaN", rendered, StringComparison.Ordinal);
         Assert.Contains("posInf float32 = System.Single.PositiveInfinity", rendered, StringComparison.Ordinal);
         Assert.Contains("negInf float32 = System.Single.NegativeInfinity", rendered, StringComparison.Ordinal);
+    }
+
+    // N3: a parameter symbol declared in a REFERENCED (metadata) assembly has no
+    // `DeclaringSyntaxReferences`, so the old code (using that alone as the
+    // diagnostic anchor) silently dropped the default with NO diagnostic. Here,
+    // `ExternalLib.Service.Configure`'s `level` parameter is compiled into a
+    // separate metadata assembly with a default that matches no `Level` member;
+    // a named-argument call that skips it must still resolve `MapConstantDefault`
+    // to a non-null fallback node (the call-site argument list) so the
+    // Unsupported diagnostic fires instead of being swallowed.
+    [Fact]
+    public void MetadataEnumParameterDefault_WithNoMatchingMember_StillReportsUnsupported()
+    {
+        MetadataReference libraryReference = CompileExternalLibraryReference();
+
+        const string CallerSource = @"
+namespace Corpus.Issue1733.Caller
+{
+    public class Caller
+    {
+        public void Invoke()
+        {
+            ExternalLib.Service.Configure(extra: 5);
+        }
+    }
+}
+";
+
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Caller.cs", CallerSource) },
+            CSharpProjectLoader.RuntimeReferences().Append(libraryReference).ToImmutableArray());
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        Assert.Contains(
+            context.Diagnostics,
+            d => d.IsUnsupported && d.Message.Contains("'99'", StringComparison.Ordinal));
+    }
+
+    private static MetadataReference CompileExternalLibraryReference()
+    {
+        const string LibrarySource = @"
+namespace ExternalLib
+{
+    public enum Level { Low = 1, High = 2 }
+
+    public static class Service
+    {
+        public static void Configure(string name = ""a"", Level level = (Level)99, int extra = 0) { }
+    }
+}
+";
+        var tree = CSharpSyntaxTree.ParseText(LibrarySource, new CSharpParseOptions(LanguageVersion.Latest));
+        CSharpCompilation compilation = CSharpCompilation.Create(
+            "Cs2Gs.Issue1733.ExternalLib",
+            new[] { tree },
+            CSharpProjectLoader.RuntimeReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        using var stream = new MemoryStream();
+        Microsoft.CodeAnalysis.Emit.EmitResult emitResult = compilation.Emit(stream);
+        Assert.True(
+            emitResult.Success,
+            "external library fixture should compile: " +
+                string.Join(Environment.NewLine, emitResult.Diagnostics));
+
+        stream.Position = 0;
+        return MetadataReference.CreateFromStream(stream);
     }
 
     private static string Render()

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1733EnumAndFloatDefaultTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1733EnumAndFloatDefaultTranslationTests.cs
@@ -1,0 +1,160 @@
+// <copyright file="Issue1733EnumAndFloatDefaultTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #1733: <c>MapConstantDefault</c> and <c>MapAttributeArgumentValue</c>
+/// previously rendered an enum-typed default/attribute-argument as its boxed
+/// underlying integer (e.g. <c>3</c>) rather than the enum member it names.
+/// <see cref="CSharpToGSharpTranslator.VisitEnumDeclaration"/> drops the C#
+/// explicit case values, so a translated enum is renumbered by declaration
+/// order — the raw integer could silently name the WRONG member (or none) under
+/// the new numbering. Enum-typed constants now resolve to the qualified member
+/// reference (<c>EnumType.Member</c>), a <c>[Flags]</c> OR-combination when no
+/// single member matches, or a visible <c>Unsupported</c> diagnostic when
+/// neither applies. Separately, <c>double.NaN</c>/<c>PositiveInfinity</c>/
+/// <c>NegativeInfinity</c> (and the <c>float</c> equivalents) previously
+/// rendered as the bare, unresolved identifiers <c>NaN</c>/<c>Infinity</c>;
+/// they now render as the qualified BCL member (<c>System.Double.NaN</c>, …).
+/// </summary>
+public class Issue1733EnumAndFloatDefaultTranslationTests
+{
+    private const string Source = @"
+using System;
+
+namespace Corpus.Issue1733
+{
+    public enum Color { Red, Green, Blue }
+
+    [Flags]
+    public enum Toppings { None = 0, Cheese = 1, Olives = 2, Pepperoni = 4 }
+
+    public class KindAttribute : Attribute
+    {
+        public KindAttribute(Color color) { }
+    }
+
+    public class Widgets
+    {
+        public void Paint(Color c = Color.Blue) { }
+
+        public void Sprinkle(Toppings t = Toppings.Cheese | Toppings.Olives) { }
+
+        public void Undefined(Color c = (Color)99) { }
+
+        [Kind(Color.Green)]
+        public void Tagged() { }
+
+        public void FiniteFloat(double d = 1.5, float f = 2.5f) { }
+
+        public void SpecialDouble(
+            double nan = double.NaN,
+            double posInf = double.PositiveInfinity,
+            double negInf = double.NegativeInfinity) { }
+
+        public void SpecialFloat(
+            float nan = float.NaN,
+            float posInf = float.PositiveInfinity,
+            float negInf = float.NegativeInfinity) { }
+    }
+}
+";
+
+    [Fact]
+    public void EnumParameterDefault_RendersAsMemberReference_NotRawInt()
+    {
+        string rendered = Render();
+
+        Assert.Contains("c Color = Color.Blue", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("c Color = 2", rendered, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FlagsEnumParameterDefault_RendersAsOrOfMembers()
+    {
+        string rendered = Render();
+
+        // Decomposed in descending-value order (Olives=2 before Cheese=1).
+        Assert.Contains("t Toppings = Toppings.Olives | Toppings.Cheese", rendered, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void UndefinedEnumValue_ReportsUnsupported()
+    {
+        (_, TranslationContext context) = Translate();
+
+        Assert.Contains(
+            context.Diagnostics,
+            d => d.IsUnsupported && d.Message.Contains("'99'", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void EnumAttributeArgument_RendersAsMemberReference_NotRawInt()
+    {
+        string rendered = Render();
+
+        Assert.Contains("@Kind(Color.Green)", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("@Kind(1)", rendered, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FiniteFloatDefaults_StillRenderAsLiterals()
+    {
+        string rendered = Render();
+
+        Assert.Contains("d float64 = 1.5", rendered, StringComparison.Ordinal);
+        Assert.Contains("f float32 = 2.5", rendered, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DoubleSpecialDefaults_RenderAsQualifiedBclMembers_NotBareIdentifiers()
+    {
+        string rendered = Render();
+
+        Assert.Contains("nan float64 = System.Double.NaN", rendered, StringComparison.Ordinal);
+        Assert.Contains("posInf float64 = System.Double.PositiveInfinity", rendered, StringComparison.Ordinal);
+        Assert.Contains("negInf float64 = System.Double.NegativeInfinity", rendered, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FloatSpecialDefaults_RenderAsQualifiedBclMembers_NotBareIdentifiers()
+    {
+        string rendered = Render();
+
+        Assert.Contains("nan float32 = System.Single.NaN", rendered, StringComparison.Ordinal);
+        Assert.Contains("posInf float32 = System.Single.PositiveInfinity", rendered, StringComparison.Ordinal);
+        Assert.Contains("negInf float32 = System.Single.NegativeInfinity", rendered, StringComparison.Ordinal);
+    }
+
+    private static string Render()
+    {
+        (CompilationUnit unit, _) = Translate();
+        return GSharpPrinter.Print(unit);
+    }
+
+    private static (CompilationUnit Unit, TranslationContext Context) Translate()
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Widgets.cs", Source) });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        return (unit, context);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -904,9 +904,20 @@ public sealed class CSharpToGSharpTranslator
                     (c.Initializer == null || c.Initializer.ThisOrBaseKeyword.IsKind(SyntaxKind.BaseKeyword)));
         }
 
-        private static GExpression MapConstantDefault(IParameterSymbol symbol)
+        private GExpression MapConstantDefault(IParameterSymbol symbol)
         {
             object value = symbol.ExplicitDefaultValue;
+
+            // Issue #1733: an enum-typed default (`Color c = Color.Blue`) must
+            // resolve to the member reference, not `symbol.ExplicitDefaultValue`'s
+            // boxed underlying integer — see the remarks on
+            // <see cref="MapEnumConstant"/>.
+            if (value != null && symbol.Type?.TypeKind == TypeKind.Enum && IsIntegral(value))
+            {
+                SyntaxNode node = symbol.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax();
+                return this.MapEnumConstant(symbol.Type, value, node, $"parameter '{symbol.Name}''s default value");
+            }
+
             switch (value)
             {
                 case null:
@@ -918,14 +929,136 @@ public sealed class CSharpToGSharpTranslator
                 case char c:
                     return LiteralExpression.Char(c.ToString());
                 case double d:
-                    return LiteralExpression.Float(d.ToString(CultureInfo.InvariantCulture));
+                    return MapSpecialFloatConstant(d, isDouble: true) ??
+                        LiteralExpression.Float(d.ToString(CultureInfo.InvariantCulture));
                 case float f:
-                    return LiteralExpression.Float(f.ToString(CultureInfo.InvariantCulture));
+                    return MapSpecialFloatConstant(f, isDouble: false) ??
+                        LiteralExpression.Float(f.ToString(CultureInfo.InvariantCulture));
                 default:
                     return IsIntegral(value)
                         ? LiteralExpression.Int(System.Convert.ToString(value, CultureInfo.InvariantCulture))
                         : null;
             }
+        }
+
+        /// <summary>
+        /// Issue #1733: <c>double</c>/<c>float</c>'s special non-finite values
+        /// (<c>NaN</c>, <c>PositiveInfinity</c>, <c>NegativeInfinity</c>) have no
+        /// numeric-literal spelling — <c>d.ToString(CultureInfo.InvariantCulture)</c>
+        /// renders them as the bare words <c>"NaN"</c>/<c>"Infinity"</c>/
+        /// <c>"-Infinity"</c>, which G# reads as unresolved identifiers. G# exposes
+        /// the BCL fields directly (`System.Double.NaN`, `System.Single.NaN`, …;
+        /// see <c>Issue1616FloatNaNOperatorEmitTests</c>/<c>Issue1617…</c>), so those
+        /// are emitted as a fully-qualified member reference instead — qualified so
+        /// the reference resolves even when the C# source has no <c>using
+        /// System;</c> (a bare <c>double</c>/<c>float</c> default never requires
+        /// one).
+        /// </summary>
+        /// <param name="value">The floating-point value.</param>
+        /// <param name="isDouble">Whether <paramref name="value"/> is a <c>double</c> (vs. <c>float</c>).</param>
+        /// <returns>The qualified BCL member reference, or <see langword="null"/> when <paramref name="value"/> is an ordinary finite value.</returns>
+        private static GExpression MapSpecialFloatConstant(double value, bool isDouble)
+        {
+            string owner = isDouble ? "System.Double" : "System.Single";
+            if (double.IsNaN(value))
+            {
+                return new MemberAccessExpression(new IdentifierExpression(owner), "NaN");
+            }
+
+            if (double.IsPositiveInfinity(value))
+            {
+                return new MemberAccessExpression(new IdentifierExpression(owner), "PositiveInfinity");
+            }
+
+            if (double.IsNegativeInfinity(value))
+            {
+                return new MemberAccessExpression(new IdentifierExpression(owner), "NegativeInfinity");
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Issue #1733: resolves an enum-typed constant's boxed underlying integral
+        /// value to the qualified enum-member reference(s) it represents
+        /// (<c>EnumType.Member</c>), rather than the raw integer. <see
+        /// cref="VisitEnumDeclaration"/> drops the C# explicit case values, so
+        /// translated enums are renumbered by declaration order; emitting the bare
+        /// underlying int (as <c>IParameterSymbol.ExplicitDefaultValue</c> /
+        /// <c>SemanticModel.GetConstantValue</c> box it) would silently bind to
+        /// whichever member happens to hold that ordinal under the NEW numbering —
+        /// wrong, and worse than a compile error because it is silent. Resolving to
+        /// the member NAME instead lets it track the renumbering correctly.
+        /// A <c>[Flags]</c> combination (`A | B`) with no single matching member is
+        /// decomposed into the OR of the matching member names; a value that
+        /// matches no member (and no flag combination) has no safe G# spelling and
+        /// is reported as unsupported rather than emitting a raw int that
+        /// renumbering would silently corrupt.
+        /// </summary>
+        /// <param name="enumType">The parameter/attribute-argument's enum type.</param>
+        /// <param name="rawValue">The boxed underlying integral constant value.</param>
+        /// <param name="node">The C# node to anchor an unsupported diagnostic to, or <see langword="null"/> to suppress the diagnostic.</param>
+        /// <param name="constructDescription">A human-readable description of the constant's origin, for the diagnostic message.</param>
+        /// <returns>The member reference (or OR'd flag combination) expression, or <see langword="null"/> when no member/combination matches.</returns>
+        private GExpression MapEnumConstant(ITypeSymbol enumType, object rawValue, SyntaxNode node, string constructDescription)
+        {
+            if (enumType is not INamedTypeSymbol { TypeKind: TypeKind.Enum } namedEnum)
+            {
+                return null;
+            }
+
+            string enumTypeName = this.typeMapper.Map(namedEnum, this.context, node?.GetLocation()) is NamedTypeReference typeRef
+                ? typeRef.Name
+                : SanitizeIdentifier(namedEnum.Name);
+            long target = System.Convert.ToInt64(rawValue, CultureInfo.InvariantCulture);
+
+            List<IFieldSymbol> members = namedEnum.GetMembers()
+                .OfType<IFieldSymbol>()
+                .Where(m => m.HasConstantValue)
+                .ToList();
+
+            foreach (IFieldSymbol member in members)
+            {
+                if (System.Convert.ToInt64(member.ConstantValue, CultureInfo.InvariantCulture) == target)
+                {
+                    return new MemberAccessExpression(new IdentifierExpression(enumTypeName), SanitizeIdentifier(member.Name));
+                }
+            }
+
+            bool isFlags = namedEnum.GetAttributes()
+                .Any(a => a.AttributeClass?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) == "global::System.FlagsAttribute");
+            if (isFlags && target != 0)
+            {
+                long remaining = target;
+                GExpression combined = null;
+                foreach (IFieldSymbol member in members.OrderByDescending(
+                    m => System.Convert.ToInt64(m.ConstantValue, CultureInfo.InvariantCulture)))
+                {
+                    long memberValue = System.Convert.ToInt64(member.ConstantValue, CultureInfo.InvariantCulture);
+                    if (memberValue == 0 || (remaining & memberValue) != memberValue)
+                    {
+                        continue;
+                    }
+
+                    GExpression memberExpr = new MemberAccessExpression(new IdentifierExpression(enumTypeName), SanitizeIdentifier(member.Name));
+                    combined = combined == null ? memberExpr : new BinaryExpression(combined, "|", memberExpr);
+                    remaining &= ~memberValue;
+                }
+
+                if (remaining == 0 && combined != null)
+                {
+                    return combined;
+                }
+            }
+
+            if (node != null)
+            {
+                this.context.ReportUnsupported(
+                    node,
+                    $"{constructDescription} is the enum value '{target}' of '{namedEnum.Name}', which matches no member or [Flags] combination; G# renumbers enum members by declaration order so the raw underlying integer cannot be emitted safely.");
+            }
+
+            return null;
         }
 
         private GMember VisitAggregate(TypeDeclarationSyntax node)
@@ -2852,7 +2985,7 @@ public sealed class CSharpToGSharpTranslator
                 return null;
             }
 
-            GExpression defaultValue = MapConstantDefault(symbol);
+            GExpression defaultValue = this.MapConstantDefault(symbol);
             if (defaultValue != null)
             {
                 return defaultValue;
@@ -2998,6 +3131,23 @@ public sealed class CSharpToGSharpTranslator
             Optional<object> constant = this.context.SemanticModel.GetConstantValue(argument.Expression);
             if (constant.HasValue)
             {
+                // Issue #1733: an enum-typed attribute argument (e.g.
+                // `[Kind(Color.Blue)]`) constant-folds to its boxed underlying
+                // integer just like an enum-typed parameter default; resolve it to
+                // the member reference via the same helper used for
+                // <see cref="MapConstantDefault"/> rather than emit the raw int
+                // (see <see cref="MapEnumConstant"/> remarks on renumbering).
+                ITypeSymbol argumentType = this.context.GetTypeInfo(argument.Expression).ConvertedType;
+                if (constant.Value != null && argumentType?.TypeKind == TypeKind.Enum && IsIntegral(constant.Value))
+                {
+                    GExpression enumValue = this.MapEnumConstant(
+                        argumentType, constant.Value, argument, "attribute argument");
+                    if (enumValue != null)
+                    {
+                        return enumValue;
+                    }
+                }
+
                 switch (constant.Value)
                 {
                     case null:
@@ -3008,6 +3158,10 @@ public sealed class CSharpToGSharpTranslator
                         return new IdentifierExpression(b ? "true" : "false");
                     case char c:
                         return LiteralExpression.Char(c.ToString());
+                    case double d when MapSpecialFloatConstant(d, isDouble: true) is { } specialD:
+                        return specialD;
+                    case float f when MapSpecialFloatConstant(f, isDouble: false) is { } specialF:
+                        return specialF;
                     default:
                         if (IsIntegral(constant.Value))
                         {

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -904,7 +904,7 @@ public sealed class CSharpToGSharpTranslator
                     (c.Initializer == null || c.Initializer.ThisOrBaseKeyword.IsKind(SyntaxKind.BaseKeyword)));
         }
 
-        private GExpression MapConstantDefault(IParameterSymbol symbol)
+        private GExpression MapConstantDefault(IParameterSymbol symbol, SyntaxNode fallbackNode)
         {
             object value = symbol.ExplicitDefaultValue;
 
@@ -914,7 +914,13 @@ public sealed class CSharpToGSharpTranslator
             // <see cref="MapEnumConstant"/>.
             if (value != null && symbol.Type?.TypeKind == TypeKind.Enum && IsIntegral(value))
             {
-                SyntaxNode node = symbol.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax();
+                // A parameter symbol declared in a REFERENCED assembly (e.g. a
+                // base-class/interface method whose parameters are enumerated via
+                // `IMethodSymbol.Parameters` rather than parsed from local syntax)
+                // has no `DeclaringSyntaxReferences` — fall back to the call-site
+                // node already in hand so the Unsupported diagnostic still fires
+                // instead of the default being dropped silently.
+                SyntaxNode node = symbol.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax() ?? fallbackNode;
                 return this.MapEnumConstant(symbol.Type, value, node, $"parameter '{symbol.Name}''s default value");
             }
 
@@ -1010,7 +1016,19 @@ public sealed class CSharpToGSharpTranslator
             string enumTypeName = this.typeMapper.Map(namedEnum, this.context, node?.GetLocation()) is NamedTypeReference typeRef
                 ? typeRef.Name
                 : SanitizeIdentifier(namedEnum.Name);
-            long target = System.Convert.ToInt64(rawValue, CultureInfo.InvariantCulture);
+
+            // Issue #1733 N2: comparing/decomposing the constant as `long` throws
+            // `OverflowException` (crashing the translator on otherwise-valid input)
+            // for a `ulong`-backed enum member whose value exceeds `long.MaxValue`
+            // (e.g. `[Flags] enum X : ulong { Big = 0x8000000000000000 }`).
+            // Every C# enum underlying type's bit pattern fits in 64 bits, so
+            // reinterpreting the raw bits as `ulong` (via <see cref="ToEnumBitPattern"/>)
+            // makes equality and the [Flags] bitwise math below overflow-free for
+            // every underlying type (byte/sbyte/short/ushort/int/uint/long/ulong)
+            // without needing to special-case each one beyond picking the
+            // reinterpretation rule.
+            SpecialType underlyingType = namedEnum.EnumUnderlyingType?.SpecialType ?? SpecialType.System_Int32;
+            ulong target = ToEnumBitPattern(rawValue, underlyingType);
 
             List<IFieldSymbol> members = namedEnum.GetMembers()
                 .OfType<IFieldSymbol>()
@@ -1019,7 +1037,7 @@ public sealed class CSharpToGSharpTranslator
 
             foreach (IFieldSymbol member in members)
             {
-                if (System.Convert.ToInt64(member.ConstantValue, CultureInfo.InvariantCulture) == target)
+                if (ToEnumBitPattern(member.ConstantValue, underlyingType) == target)
                 {
                     return new MemberAccessExpression(new IdentifierExpression(enumTypeName), SanitizeIdentifier(member.Name));
                 }
@@ -1029,12 +1047,12 @@ public sealed class CSharpToGSharpTranslator
                 .Any(a => a.AttributeClass?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) == "global::System.FlagsAttribute");
             if (isFlags && target != 0)
             {
-                long remaining = target;
+                ulong remaining = target;
                 GExpression combined = null;
                 foreach (IFieldSymbol member in members.OrderByDescending(
-                    m => System.Convert.ToInt64(m.ConstantValue, CultureInfo.InvariantCulture)))
+                    m => ToEnumBitPattern(m.ConstantValue, underlyingType)))
                 {
-                    long memberValue = System.Convert.ToInt64(member.ConstantValue, CultureInfo.InvariantCulture);
+                    ulong memberValue = ToEnumBitPattern(member.ConstantValue, underlyingType);
                     if (memberValue == 0 || (remaining & memberValue) != memberValue)
                     {
                         continue;
@@ -1055,10 +1073,36 @@ public sealed class CSharpToGSharpTranslator
             {
                 this.context.ReportUnsupported(
                     node,
-                    $"{constructDescription} is the enum value '{target}' of '{namedEnum.Name}', which matches no member or [Flags] combination; G# renumbers enum members by declaration order so the raw underlying integer cannot be emitted safely.");
+                    $"{constructDescription} is the enum value '{System.Convert.ToString(rawValue, CultureInfo.InvariantCulture)}' of '{namedEnum.Name}', which matches no member or [Flags] combination; G# renumbers enum members by declaration order so the raw underlying integer cannot be emitted safely.");
             }
 
             return null;
+        }
+
+        /// <summary>
+        /// Issue #1733 N2: reinterprets a boxed enum-underlying-type value as its
+        /// raw 64-bit pattern so equality/bitwise comparisons never throw
+        /// <see cref="System.OverflowException"/> — <c>Convert.ToInt64</c> throws for
+        /// any <c>ulong</c> value above <c>long.MaxValue</c>, and a naive
+        /// <c>Convert.ToUInt64</c> throws for any negative signed value. Unsigned
+        /// underlying types (<c>byte</c>/<c>ushort</c>/<c>uint</c>/<c>ulong</c>)
+        /// convert straight to <c>ulong</c>; signed types (<c>sbyte</c>/<c>short</c>/
+        /// <c>int</c>/<c>long</c>, and any other/unknown underlying type) go through
+        /// <c>long</c> first and reinterpret its two's-complement bits as
+        /// <c>ulong</c> — equality and bitwise AND/OR/NOT are bit-pattern operations,
+        /// so this reinterpretation is exact for both comparisons and [Flags]
+        /// decomposition regardless of signedness.
+        /// </summary>
+        private static ulong ToEnumBitPattern(object value, SpecialType underlyingType)
+        {
+            return underlyingType switch
+            {
+                SpecialType.System_Byte or
+                SpecialType.System_UInt16 or
+                SpecialType.System_UInt32 or
+                SpecialType.System_UInt64 => System.Convert.ToUInt64(value, CultureInfo.InvariantCulture),
+                _ => unchecked((ulong)System.Convert.ToInt64(value, CultureInfo.InvariantCulture)),
+            };
         }
 
         private GMember VisitAggregate(TypeDeclarationSyntax node)
@@ -1528,7 +1572,7 @@ public sealed class CSharpToGSharpTranslator
             {
                 (string Name, ITypeSymbol Type, bool IsProperty) target = paramToTarget[param];
                 GTypeReference type = this.typeMapper.Map(target.Type, this.context, param.Locations.FirstOrDefault());
-                GExpression liftedDefault = this.BuildOptionalParameterDefault(param, type);
+                GExpression liftedDefault = this.BuildOptionalParameterDefault(param, type, node);
                 primaryParameters.Add(new Parameter(SanitizeIdentifier(target.Name), type, defaultValue: liftedDefault));
                 if (target.IsProperty)
                 {
@@ -2440,7 +2484,7 @@ public sealed class CSharpToGSharpTranslator
                 : new NamedTypeReference(CSharpTypeMapper.UnsupportedPlaceholderType);
 
             List<Parameter> indexParameters = symbol != null
-                ? symbol.Parameters.Select(this.MapParameter).ToList()
+                ? symbol.Parameters.Select(p => this.MapParameter(p, node)).ToList()
                 : this.MapParameterList(node.ParameterList);
 
             List<PropertyAccessor> accessors = this.MapAccessors(node, "indexer 'this[]'");
@@ -2903,7 +2947,12 @@ public sealed class CSharpToGSharpTranslator
                     source = source.Skip(1);
                 }
 
-                return source.Select(this.MapParameter).ToList();
+                // Fall back to the parameter LIST's syntax as the diagnostic anchor
+                // for each parameter symbol here: when `symbol` overrides/implements
+                // a member from a REFERENCED assembly, its `IParameterSymbol`s have
+                // no `DeclaringSyntaxReferences` of their own (see
+                // <see cref="MapConstantDefault"/> remarks).
+                return source.Select(p => this.MapParameter(p, syntax)).ToList();
             }
 
             return syntax == null ? new List<Parameter>() : this.MapParameterList(syntax);
@@ -2916,14 +2965,14 @@ public sealed class CSharpToGSharpTranslator
             {
                 if (this.context.GetDeclaredSymbol(parameter) is IParameterSymbol symbol)
                 {
-                    parameters.Add(this.MapParameter(symbol));
+                    parameters.Add(this.MapParameter(symbol, parameter));
                 }
             }
 
             return parameters;
         }
 
-        private Parameter MapParameter(IParameterSymbol symbol)
+        private Parameter MapParameter(IParameterSymbol symbol, SyntaxNode fallbackNode)
         {
             string refKind = symbol.RefKind switch
             {
@@ -2951,7 +3000,7 @@ public sealed class CSharpToGSharpTranslator
                 type = this.PromoteIfUsedAsNullable(type, symbol);
             }
 
-            GExpression defaultValue = this.BuildOptionalParameterDefault(symbol, type);
+            GExpression defaultValue = this.BuildOptionalParameterDefault(symbol, type, fallbackNode);
 
             return new Parameter(SanitizeIdentifier(symbol.Name), type, variadic, refKind, defaultValue);
         }
@@ -2978,14 +3027,14 @@ public sealed class CSharpToGSharpTranslator
         /// and is omitted, never translated. So `SpillOperand`'s no-seam
         /// fallback can never be reached from here.
         /// </remarks>
-        private GExpression BuildOptionalParameterDefault(IParameterSymbol symbol, GTypeReference type)
+        private GExpression BuildOptionalParameterDefault(IParameterSymbol symbol, GTypeReference type, SyntaxNode fallbackNode)
         {
             if (!symbol.HasExplicitDefaultValue)
             {
                 return null;
             }
 
-            GExpression defaultValue = this.MapConstantDefault(symbol);
+            GExpression defaultValue = this.MapConstantDefault(symbol, fallbackNode);
             if (defaultValue != null)
             {
                 return defaultValue;
@@ -8578,7 +8627,7 @@ public sealed class CSharpToGSharpTranslator
                 skippedParameter.Type,
                 this.context,
                 skippedParameter.Locations.FirstOrDefault());
-            GExpression fillerDefault = this.BuildOptionalParameterDefault(skippedParameter, parameterType);
+            GExpression fillerDefault = this.BuildOptionalParameterDefault(skippedParameter, parameterType, arguments.First());
             if (fillerDefault == null)
             {
                 string message = $"named argument list skips parameter '{skippedParameter.Name}' whose default " +
@@ -9419,7 +9468,7 @@ public sealed class CSharpToGSharpTranslator
             // G# arrow lambda always names the parameter type (ADR-0074).
             if (this.context.GetDeclaredSymbol(parameter) is IParameterSymbol symbol)
             {
-                return this.MapParameter(symbol);
+                return this.MapParameter(symbol, parameter);
             }
 
             GTypeReference type = parameter.Type != null


### PR DESCRIPTION
Fixes #1733

## Enum-default fix
`MapConstantDefault` (parameter defaults) and `MapAttributeArgumentValue` (attribute arguments) previously rendered an enum-typed constant as its boxed underlying integer (e.g. `Color c = Color.Blue` became `c Color = 2`). Because `VisitEnumDeclaration` drops explicit C# enum case values and renumbers G# enum members by declaration order, that raw int could silently bind to the WRONG member (or none) post-translation.

Both call sites now go through a new shared `MapEnumConstant` helper:
- Exact single-member match → emits the qualified member reference (`EnumType.Member`), reusing the type mapper so nested/homonym-qualified names stay consistent with the rest of the translator.
- `[Flags]` value with no single member match → decomposed into an OR of member references (`Toppings.Olives | Toppings.Cheese`).
- Value matching neither a member nor a flag combination (e.g. `(Color)99`) → visible `Unsupported` diagnostic instead of silently emitting the raw int (attribute arguments can't be dropped, so the int is still emitted there as a last resort, but now loudly flagged; parameter defaults are omitted, matching the pre-existing "not a simple literal" fallback).

## Float-special fix
`double.NaN`/`PositiveInfinity`/`NegativeInfinity` (and the `float` equivalents) previously rendered as the bare, unresolved identifiers `NaN`/`Infinity`/`-Infinity` via `ToString()`. They now render as the qualified BCL member G# already exposes for these values — `System.Double.NaN`, `System.Single.PositiveInfinity`, etc. — matching the spelling used elsewhere in the G# test suite (`Issue1616FloatNaNOperatorEmitTests`, `Issue1617NaNOrderedComparisonEmitTests`). Fully qualified so it resolves even without a source `using System;`. Ordinary finite float/double defaults and attribute arguments are untouched (verified no regression against the existing xUnit `[InlineData(3.0, 4.0, 12.0)]` attribute test).

## Tests added
`Issue1733EnumAndFloatDefaultTranslationTests`:
- enum parameter default → `EnumType.Member`
- `[Flags]` combined parameter default → OR of members
- out-of-range enum value → asserts the `Unsupported` diagnostic fires
- enum attribute argument → `EnumType.Member`
- finite float/double defaults → unchanged literal rendering (no regression)
- `double`/`float` NaN/PositiveInfinity/NegativeInfinity defaults → qualified BCL member

Nothing deferred: both divergences from the issue (enum defaults+attributes, and float specials) are fixed and covered by tests. Build: `dotnet build GSharp.sln -c Release -graph` — 0 warnings/errors. Tests: targeted `Cs2Gs.Tests` filters (Issue1733/Default/Enum/Attribute/Literal/Constant/Parameter) — all green.