### PR TITLE
cs2gs: fix for-loop continue skipping incrementors in while-lowering (#1732)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue1732LoopLoweringTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1732LoopLoweringTranslationTests.cs
@@ -287,6 +287,65 @@ namespace Demo
                 d.Message.Contains("try") && d.Message.Contains("finally"));
     }
 
+    /// <summary>
+    /// A <c>continue</c> nested inside a <c>fixed</c> block within a
+    /// while-lowered <c>for</c> (two declarators/incrementors, issue #914).
+    /// Unlike <c>try</c>/<c>finally</c>, a <c>fixed</c> block has no exit-time
+    /// side effect that could be reordered by duplicating the incrementors
+    /// ahead of the <c>continue</c> — it only un-pins a pointer — so this shape
+    /// DOES have a faithful lowering and must NOT be reported as unsupported.
+    /// Pre-fix, <c>RewriteOwnLoopContinue</c> had no <see cref="FixedStatement"/>
+    /// case, fell through to <c>default</c>, and left the <c>continue</c>
+    /// unrewritten: both incrementors were then silently skipped, corrupting
+    /// the iteration count.
+    /// </summary>
+    [Fact]
+    public void ForContinueInsideFixed_StillRunsIncrementorsAndTerminatesWithCorrectCount()
+    {
+        string printed = TranslateAndValidate(@"
+using System;
+
+namespace Demo
+{
+    public sealed class C
+    {
+        public static unsafe void Run()
+        {
+            byte[] data = { 10, 20, 30, 40, 50 };
+            int sum = 0;
+            int i;
+            int n;
+            for (i = 0, n = 0; i < data.Length; i++, n++)
+            {
+                fixed (byte* p = data)
+                {
+                    if (i == 2)
+                    {
+                        continue;
+                    }
+
+                    sum += p[i];
+                }
+            }
+
+            Console.WriteLine(sum + "","" + i + "","" + n);
+        }
+    }
+}");
+
+        // Structural check: the incrementors are duplicated INSIDE the fixed
+        // block, ahead of the continue (mirroring the plain-body case).
+        Assert.Contains("fixed p *uint8 = data {", printed);
+        Assert.True(printed.IndexOf("i++", StringComparison.Ordinal) <
+            printed.IndexOf("continue", StringComparison.Ordinal));
+
+        string stdout = CompileAndRun(printed, "C.Run()");
+
+        // C# baseline: i = 0..4 (5 iterations), sum skips i == 2 ->
+        // 10+20+40+50 = 120; both i and n reach 5 when the loop exits normally.
+        Assert.Equal("120,5,5", stdout.Trim());
+    }
+
     private static string TranslateAndValidate(string source)
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1732LoopLoweringTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1732LoopLoweringTranslationTests.cs
@@ -1,0 +1,381 @@
+// <copyright file="Issue1732LoopLoweringTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Regression tests for issue #1732: two loop lowerings silently diverged from
+/// C# semantics.
+/// <para>
+/// (1) A <c>do</c>/<c>while</c> whose condition needs a body-prologue hoist (an
+/// <c>is</c>-pattern binder or a value-position assignment, issue #1723) must
+/// still run the body once BEFORE the hoisted clause is evaluated — C#'s
+/// <c>do</c>/<c>while</c> always tests the condition AFTER the body.
+/// </para>
+/// <para>
+/// (2) A C-style <c>for</c> lowered to a <c>while</c> (multiple
+/// declarators/incrementors, or a hoisted condition, issue #914/#1723) must
+/// still run its incrementor(s) when the body executes a loop-targeting
+/// <c>continue</c> — a G# <c>continue</c> is a goto straight past the WHOLE
+/// lowered body (ADR-0070), so without duplicating the incrementor(s) ahead of
+/// the <c>continue</c> they were silently skipped, corrupting the iteration
+/// count or looping forever.
+/// </para>
+/// Every behavioral claim here is verified by actually compiling the translated
+/// G# with the real <c>gsc</c> and running it — not just by inspecting the
+/// printed text — so a regression that only breaks at runtime (e.g. an
+/// infinite loop) cannot slip through a purely structural assertion.
+/// </summary>
+public class Issue1732LoopLoweringTranslationTests
+{
+    /// <summary>
+    /// <c>do { bodyRuns++; } while ((n = Probe()) &lt; 0)</c>: the condition
+    /// carries a value-position assignment, forcing the condition-hoist lowering
+    /// (issue #1723) for the do-while. C# always runs the body once before the
+    /// FIRST condition test, so <c>bodyRuns</c> must be 1 and <c>Probe</c> must
+    /// have been called exactly once — and only AFTER the body ran once, not
+    /// before.
+    /// </summary>
+    [Fact]
+    public void DoWhileHoistedCondition_RunsBodyOnceBeforeFirstConditionTest()
+    {
+        string printed = TranslateAndValidate(@"
+using System;
+
+namespace Demo
+{
+    public sealed class C
+    {
+        private static int calls = 0;
+
+        private static int Probe()
+        {
+            calls++;
+            return calls;
+        }
+
+        public static void Run()
+        {
+            int n = 0;
+            int bodyRuns = 0;
+            do
+            {
+                bodyRuns++;
+            }
+            while ((n = Probe()) < 0);
+
+            Console.WriteLine(bodyRuns + "","" + n + "","" + calls);
+        }
+    }
+}");
+
+        // Structural check: the hoisted assignment/break-guard trails the body
+        // (do-while tail hoist), not leads it.
+        Assert.Contains("} while true", printed);
+        Assert.True(printed.IndexOf("bodyRuns++", StringComparison.Ordinal) <
+            printed.IndexOf("n = C.Probe()", StringComparison.Ordinal));
+
+        // Behavioral check: body ran once, Probe was called exactly once, AFTER
+        // the body (a bug that hoisted the condition BEFORE the body would
+        // instead report "0,1,1" or skip the body when the pre-hoisted guard's
+        // stale read looked false, or call Probe twice).
+        string stdout = CompileAndRun(printed, "C.Run()");
+        Assert.Equal("1,1,1", stdout.Trim());
+    }
+
+    /// <summary>
+    /// A C-style <c>for</c> with two declarators/incrementors (forces the
+    /// while-lowering, issue #914) whose body has a loop-level <c>continue</c>.
+    /// C# still runs BOTH incrementors on every <c>continue</c>; the buggy
+    /// while-lowering left <c>i</c> stuck at 2 forever (an infinite loop) because
+    /// the trailing incrementors were skipped. This test would hang under the
+    /// pre-fix lowering; it terminates and produces the exact C# iteration
+    /// count/sum under the fix.
+    /// </summary>
+    [Fact]
+    public void ForContinue_StillRunsIncrementorsAndTerminatesWithCorrectCount()
+    {
+        string printed = TranslateAndValidate(@"
+using System;
+
+namespace Demo
+{
+    public sealed class C
+    {
+        public static void Run()
+        {
+            int sum = 0;
+            int i;
+            int n;
+            for (i = 0, n = 0; i < 5; i++, n++)
+            {
+                if (i == 2)
+                {
+                    continue;
+                }
+
+                sum += i;
+            }
+
+            Console.WriteLine(sum + "","" + i + "","" + n);
+        }
+    }
+}");
+
+        string stdout = CompileAndRun(printed, "C.Run()");
+
+        // C# baseline: i = 0..4 (5 iterations), sum skips i == 2 -> 0+1+3+4 = 8;
+        // both i and n reach 5 when the loop exits normally.
+        Assert.Equal("8,5,5", stdout.Trim());
+    }
+
+    /// <summary>
+    /// Nested <c>for</c> loops: the INNER loop's <c>continue</c> must only skip
+    /// (and still increment) the inner loop's own incrementors, never the outer
+    /// loop's. The outer loop here is a plain single-incrementor <c>for</c> (the
+    /// native G# <c>for</c>, unaffected by the while-lowering) wrapping an inner
+    /// multi-declarator <c>for</c> that requires the fix.
+    /// </summary>
+    [Fact]
+    public void NestedForContinue_OnlyIncrementsInnerLoop()
+    {
+        string printed = TranslateAndValidate(@"
+using System;
+
+namespace Demo
+{
+    public sealed class C
+    {
+        public static void Run()
+        {
+            int outerSum = 0;
+            for (int oi = 0; oi < 3; oi++)
+            {
+                int ii;
+                int extra;
+                for (ii = 0, extra = 0; ii < 3; ii++, extra++)
+                {
+                    if (ii == 1)
+                    {
+                        continue;
+                    }
+
+                    outerSum += ii;
+                }
+            }
+
+            Console.WriteLine(outerSum);
+        }
+    }
+}");
+
+        string stdout = CompileAndRun(printed, "C.Run()");
+
+        // Per outer iteration the inner loop sums ii = 0, 2 (skips 1) -> 2; three
+        // outer iterations -> 6. An outer-loop miscount (e.g. the inner
+        // continue's rewrite leaking into the outer loop's incrementor) would
+        // produce a different total or hang.
+        Assert.Equal("6", stdout.Trim());
+    }
+
+    /// <summary>
+    /// A single-incrementor <c>for</c> with no other reason to lower (plain
+    /// condition, one declarator) uses G#'s NATIVE <c>for</c> statement, not the
+    /// while-lowering — so its <c>continue</c> was never affected by this bug.
+    /// Regression guard: the fix must not change this already-correct path.
+    /// </summary>
+    [Fact]
+    public void SingleIncrementorForContinue_UsesNativeForAndIsUnaffected()
+    {
+        string printed = TranslateAndValidate(@"
+using System;
+
+namespace Demo
+{
+    public sealed class C
+    {
+        public static void Run()
+        {
+            int sum = 0;
+            for (int i = 0; i < 5; i++)
+            {
+                if (i == 2)
+                {
+                    continue;
+                }
+
+                sum += i;
+            }
+
+            Console.WriteLine(sum);
+        }
+    }
+}");
+
+        Assert.Contains("for var i = 0", printed);
+        Assert.DoesNotContain("while true {", printed);
+
+        string stdout = CompileAndRun(printed, "C.Run()");
+        Assert.Equal("8", stdout.Trim());
+    }
+
+    /// <summary>
+    /// A <c>continue</c> nested inside a <c>try</c>/<c>finally</c> within a
+    /// while-lowered <c>for</c>: C# runs the <c>finally</c> BEFORE the
+    /// incrementors re-run, but duplicating the incrementors textually ahead of
+    /// the <c>continue</c> (this fix's technique) would instead run them BEFORE
+    /// the <c>finally</c> — reordering an observable side effect. This shape has
+    /// no faithful lowering here, so it must surface as a visible
+    /// <see cref="TranslationSeverity.Unsupported"/> diagnostic instead of
+    /// silently reordering.
+    /// </summary>
+    [Fact]
+    public void ForContinueInsideTryFinally_ReportsUnsupportedInsteadOfReordering()
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[]
+        {
+            ("Snippet.cs", @"
+using System;
+
+namespace Demo
+{
+    public sealed class C
+    {
+        public static void Run()
+        {
+            int i;
+            int n;
+            for (i = 0, n = 0; i < 3; i++, n++)
+            {
+                try
+                {
+                    if (i == 1)
+                    {
+                        continue;
+                    }
+                }
+                finally
+                {
+                    Console.WriteLine(""finally "" + i);
+                }
+            }
+        }
+    }
+}"),
+        });
+        Assert.True(project.BoundWithoutErrors, string.Join("\n", project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        _ = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        Assert.Contains(
+            context.Diagnostics,
+            d => d.Severity == TranslationSeverity.Unsupported &&
+                d.Message.Contains("try") && d.Message.Contains("finally"));
+    }
+
+    private static string TranslateAndValidate(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        Assert.DoesNotContain(
+            context.Diagnostics,
+            d => d.Severity == TranslationSeverity.Unsupported);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+
+    /// <summary>
+    /// Compiles <paramref name="printed"/> (with <paramref name="callExpression"/>
+    /// appended as a top-level entry statement) with the real <c>gsc</c> and runs
+    /// it, returning stdout. Skipped (never called with a build where gsc isn't
+    /// present) is not needed here: this project's own build gate always
+    /// produces <c>out/bin/{config}/Compiler/gsc.dll</c> before tests run.
+    /// </summary>
+    private static string CompileAndRun(string printed, string callExpression)
+    {
+        string compiler = FindCompiler();
+        Assert.True(compiler != null, "gsc.dll must be built (dotnet build GSharp.sln) before running this test.");
+
+        string workDir = Path.Combine(AppContext.BaseDirectory, "issue-1732-e2e", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(workDir);
+        string gsPath = Path.Combine(workDir, "Snippet.gs");
+        string dllPath = Path.Combine(workDir, "Snippet.dll");
+        File.WriteAllText(gsPath, printed + Environment.NewLine + callExpression + Environment.NewLine);
+
+        (int compileExit, string compileOut) = RunDotnet(
+            $"\"{compiler}\" /target:exe /out:\"{dllPath}\" \"{gsPath}\"");
+        Assert.True(
+            compileExit == 0 && !compileOut.Contains("error", StringComparison.OrdinalIgnoreCase),
+            "gsc must compile the translated snippet with zero errors. Output:\n" + compileOut +
+                "\n\nTranslated G#:\n" + printed);
+
+        (int runExit, string stdout) = RunDotnet($"\"{dllPath}\"");
+        Assert.True(runExit == 0, "Translated snippet must run successfully. Output:\n" + stdout);
+        return stdout;
+    }
+
+    private static (int Exit, string Output) RunDotnet(string arguments)
+    {
+        var psi = new ProcessStartInfo("dotnet", arguments)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        using var process = Process.Start(psi);
+        var output = new StringBuilder();
+        output.Append(process.StandardOutput.ReadToEnd());
+        output.Append(process.StandardError.ReadToEnd());
+        process.WaitForExit();
+        return (process.ExitCode, output.ToString());
+    }
+
+    private static string FindCompiler()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            foreach (string config in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(dir.FullName, "out", "bin", config, "Compiler", "gsc.dll");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            dir = dir.Parent;
+        }
+
+        return null;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -6154,7 +6154,7 @@ public sealed class CSharpToGSharpTranslator
                 }
                 else
                 {
-                    translatedBody = DuplicateIncrementorsBeforeOwnLoopContinue(translatedBody, incrementorStatements);
+                    translatedBody = this.DuplicateIncrementorsBeforeOwnLoopContinue(forStatement, translatedBody, incrementorStatements);
                 }
             }
 
@@ -6197,14 +6197,98 @@ public sealed class CSharpToGSharpTranslator
         /// <c>continue</c>.
         /// </para>
         /// </summary>
-        private static BlockStatement DuplicateIncrementorsBeforeOwnLoopContinue(
+        private BlockStatement DuplicateIncrementorsBeforeOwnLoopContinue(
+            ForStatementSyntax forStatement,
             BlockStatement body,
             IReadOnlyList<GStatement> incrementorStatements)
         {
-            return (BlockStatement)RewriteOwnLoopContinue(body, incrementorStatements);
+            return (BlockStatement)this.RewriteOwnLoopContinue(forStatement, body, incrementorStatements);
         }
 
-        private static GStatement RewriteOwnLoopContinue(GStatement statement, IReadOnlyList<GStatement> incrementorStatements)
+        // True when `statement` (a TRANSLATED G# node) transitively holds a
+        // `ContinueStatement` that targets THIS loop, mirroring
+        // <see cref="BodyContainsOwnLoopContinue"/> but walking the G# AST
+        // instead of the C# syntax tree — used by <see
+        // cref="RewriteOwnLoopContinue"/>'s `default` arm so an unhandled
+        // body-carrying G# statement kind is reported (issue #1732) instead of
+        // silently passing an unrewritten own-loop `continue` through (which
+        // would skip the duplicated incrementors, reproducing the original
+        // miscompile). Boundaries match <see cref="RewriteOwnLoopContinue"/>:
+        // a nested loop or local function never contributes its own
+        // `continue`s to this check.
+        private static bool ContainsOwnLoopContinue(GStatement statement)
+        {
+            switch (statement)
+            {
+                case ContinueStatement:
+                    return true;
+
+                case BlockStatement block:
+                    foreach (GStatement inner in block.Statements)
+                    {
+                        if (ContainsOwnLoopContinue(inner))
+                        {
+                            return true;
+                        }
+                    }
+
+                    return false;
+
+                case IfStatement ifStatement:
+                    return ContainsOwnLoopContinue(ifStatement.Then)
+                        || (ifStatement.ElseBranch != null && ContainsOwnLoopContinue(ifStatement.ElseBranch));
+
+                case TryStatement tryStatement:
+                    if (ContainsOwnLoopContinue(tryStatement.TryBlock))
+                    {
+                        return true;
+                    }
+
+                    foreach (CatchClause catchClause in tryStatement.CatchClauses)
+                    {
+                        if (ContainsOwnLoopContinue(catchClause.Body))
+                        {
+                            return true;
+                        }
+                    }
+
+                    // FinallyBlock deliberately excluded: C# forbids a jump
+                    // statement leaving a `finally`, so it can never itself
+                    // hold an own-loop `continue`.
+                    return false;
+
+                case SwitchStatement switchStatement:
+                    foreach (SwitchStatementCase switchCase in switchStatement.Cases)
+                    {
+                        if (ContainsOwnLoopContinue(switchCase.Body))
+                        {
+                            return true;
+                        }
+                    }
+
+                    return false;
+
+                case FixedStatement fixedStatement:
+                    return ContainsOwnLoopContinue(fixedStatement.Body);
+
+                // Boundaries: a nested loop's own continue seam, or a nested
+                // local function (its own statement seam) — never counts.
+                case WhileStatement:
+                case ForStatement:
+                case DoWhileStatement:
+                case ForInStatement:
+                case LocalFunctionStatement:
+                    return false;
+
+                default:
+                    return false;
+            }
+        }
+
+        private GStatement RewriteOwnLoopContinue(
+            ForStatementSyntax forStatement,
+            GStatement statement,
+            IReadOnlyList<GStatement> incrementorStatements)
         {
             switch (statement)
             {
@@ -6219,7 +6303,7 @@ public sealed class CSharpToGSharpTranslator
                     var rewritten = new List<GStatement>(block.Statements.Count);
                     foreach (GStatement inner in block.Statements)
                     {
-                        rewritten.Add(RewriteOwnLoopContinue(inner, incrementorStatements));
+                        rewritten.Add(this.RewriteOwnLoopContinue(forStatement, inner, incrementorStatements));
                     }
 
                     return new BlockStatement(rewritten, block.IsUnsafe);
@@ -6229,10 +6313,10 @@ public sealed class CSharpToGSharpTranslator
                 {
                     GStatement elseBranch = ifStatement.ElseBranch == null
                         ? null
-                        : RewriteOwnLoopContinue(ifStatement.ElseBranch, incrementorStatements);
+                        : this.RewriteOwnLoopContinue(forStatement, ifStatement.ElseBranch, incrementorStatements);
                     return new IfStatement(
                         ifStatement.Condition,
-                        (BlockStatement)RewriteOwnLoopContinue(ifStatement.Then, incrementorStatements),
+                        (BlockStatement)this.RewriteOwnLoopContinue(forStatement, ifStatement.Then, incrementorStatements),
                         elseBranch);
                 }
 
@@ -6244,11 +6328,11 @@ public sealed class CSharpToGSharpTranslator
                         catchClauses.Add(new CatchClause(
                             catchClause.VariableName,
                             catchClause.ExceptionType,
-                            (BlockStatement)RewriteOwnLoopContinue(catchClause.Body, incrementorStatements)));
+                            (BlockStatement)this.RewriteOwnLoopContinue(forStatement, catchClause.Body, incrementorStatements)));
                     }
 
                     return new TryStatement(
-                        (BlockStatement)RewriteOwnLoopContinue(tryStatement.TryBlock, incrementorStatements),
+                        (BlockStatement)this.RewriteOwnLoopContinue(forStatement, tryStatement.TryBlock, incrementorStatements),
                         catchClauses,
                         tryStatement.FinallyBlock);
                 }
@@ -6260,11 +6344,20 @@ public sealed class CSharpToGSharpTranslator
                     {
                         cases.Add(new SwitchStatementCase(
                             switchCase.Pattern,
-                            (BlockStatement)RewriteOwnLoopContinue(switchCase.Body, incrementorStatements),
+                            (BlockStatement)this.RewriteOwnLoopContinue(forStatement, switchCase.Body, incrementorStatements),
                             switchCase.Guard));
                     }
 
                     return new SwitchStatement(switchStatement.Subject, cases);
+                }
+
+                case FixedStatement fixedStatement:
+                {
+                    return new FixedStatement(
+                        fixedStatement.Name,
+                        fixedStatement.PointerType,
+                        fixedStatement.Source,
+                        (BlockStatement)this.RewriteOwnLoopContinue(forStatement, fixedStatement.Body, incrementorStatements));
                 }
 
                 // Boundaries: a nested loop's own continue seam, or a nested
@@ -6277,6 +6370,19 @@ public sealed class CSharpToGSharpTranslator
                     return statement;
 
                 default:
+                    // Any other body-carrying G# statement kind that reaches
+                    // here was missed by the cases above. Silently returning
+                    // it unchanged would let an own-loop `continue` buried
+                    // inside it skip the duplicated incrementors — the same
+                    // silent miscompile this rewrite exists to fix (issue
+                    // #1732). Report it instead of guessing a lowering.
+                    if (ContainsOwnLoopContinue(statement))
+                    {
+                        this.context.ReportUnsupported(
+                            forStatement,
+                            $"a 'continue' inside a '{statement.GetType().Name}' within this 'for' loop has no incrementor-duplication lowering yet (issue #1732).");
+                    }
+
                     return statement;
             }
         }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -5251,6 +5251,18 @@ public sealed class CSharpToGSharpTranslator
             return true;
         }
 
+        // True for a node that starts a NEW `continue` seam: a nested loop (its
+        // own `continue` target) or a lambda/local function (C# forbids a jump
+        // statement crossing that boundary at all). Shared by the do-while tail
+        // hoist scan (issue #1723) and the for→while incrementor-on-continue fix
+        // (issue #1732) so both agree on what "targets THIS loop" means. Note a
+        // `switch` is NOT a boundary: `continue` (unlike `break`) passes through a
+        // `switch` straight to the enclosing loop.
+        private static bool IsOwnLoopContinueBoundary(SyntaxNode node) =>
+            node is ForStatementSyntax or ForEachStatementSyntax or ForEachVariableStatementSyntax or
+                WhileStatementSyntax or DoStatementSyntax or
+                AnonymousFunctionExpressionSyntax or LocalFunctionStatementSyntax;
+
         // True when `body` has a `continue` that targets THIS loop. Descent stops
         // at any nested loop/switch (its own `continue`/`break` seam) and at
         // nested lambdas/local functions (their own statement seam), so a
@@ -5259,12 +5271,42 @@ public sealed class CSharpToGSharpTranslator
         // #1723).
         private static bool BodyContainsOwnLoopContinue(StatementSyntax body)
         {
-            bool DescendGuard(SyntaxNode node) =>
-                node is not (ForStatementSyntax or ForEachStatementSyntax or ForEachVariableStatementSyntax or
-                    WhileStatementSyntax or DoStatementSyntax or
-                    AnonymousFunctionExpressionSyntax or LocalFunctionStatementSyntax);
+            bool DescendGuard(SyntaxNode node) => !IsOwnLoopContinueBoundary(node);
 
             return body.DescendantNodesAndSelf(descendIntoChildren: DescendGuard).OfType<ContinueStatementSyntax>().Any();
+        }
+
+        // True when an own-loop `continue` inside `body` sits under a `try` that
+        // has a `finally` clause (reachable without crossing this loop's own
+        // boundary). C# runs that `finally` on the way out of the `continue`
+        // BEFORE the for-loop's incrementors re-run; duplicating the incrementors
+        // right before the `continue` (see
+        // <see cref="DuplicateIncrementorsBeforeOwnLoopContinue"/>) would instead
+        // run them BEFORE the `finally`, reordering an observable side effect.
+        // This shape has no faithful lowering here, so the caller reports it
+        // instead of silently reordering (issue #1732).
+        private static bool OwnLoopContinueCrossesFinally(StatementSyntax body)
+        {
+            bool DescendGuard(SyntaxNode node) => !IsOwnLoopContinueBoundary(node);
+
+            foreach (ContinueStatementSyntax continueStatement in
+                body.DescendantNodesAndSelf(descendIntoChildren: DescendGuard).OfType<ContinueStatementSyntax>())
+            {
+                for (SyntaxNode ancestor = continueStatement.Parent; ancestor != null; ancestor = ancestor.Parent)
+                {
+                    if (ancestor is TryStatementSyntax tryStatement && tryStatement.Finally != null)
+                    {
+                        return true;
+                    }
+
+                    if (ancestor == body)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            return false;
         }
 
         /// <summary>
@@ -6048,14 +6090,20 @@ public sealed class CSharpToGSharpTranslator
         /// scrutinee local plus `if !test { break }` guards) at the TOP of the body,
         /// re-run every iteration exactly where C# would re-test the condition
         /// (issue #1723).
+        /// <para>
+        /// In C# the incrementors also run when the body executes a loop-targeting
+        /// <c>continue</c>, but a G# <c>continue</c> is a goto straight past the
+        /// WHOLE lowered <c>while</c> body — so the trailing incrementors below
+        /// would be silently skipped. When the body has such a <c>continue</c>, it
+        /// is rewritten (<see cref="DuplicateIncrementorsBeforeOwnLoopContinue"/>) to duplicate the
+        /// incrementors immediately ahead of every own-loop <c>continue</c>, so they
+        /// still run before the condition re-test either way (issue #1732). The one
+        /// shape that rewrite cannot do faithfully — the <c>continue</c> sits inside
+        /// a <c>try</c>/<c>finally</c>, where C# runs <c>finally</c> before the
+        /// incrementors — is reported via <c>ReportUnsupported</c> instead of
+        /// silently reordering that side effect.
+        /// </para>
         /// </summary>
-        /// <remarks>
-        /// Fidelity caveat: in C# the incrementors also run when the body executes a
-        /// loop-targeting <c>continue</c>; in this while-lowering the trailing
-        /// incrementors are SKIPPED on <c>continue</c>. The decoder loops this fix
-        /// targets do not use a loop-level <c>continue</c>, so the lowering is
-        /// faithful for them; a warning would be required to generalise this.
-        /// </remarks>
         private GStatement LowerForToWhile(ForStatementSyntax forStatement)
         {
             var outer = new List<GStatement>();
@@ -6088,17 +6136,149 @@ public sealed class CSharpToGSharpTranslator
                 conditionPrologue = new List<GStatement>();
             }
 
-            var bodyStatements = new List<GStatement>(conditionPrologue);
-            bodyStatements.AddRange(this.TranslateStatementAsBlock(forStatement.Statement).Statements);
-
-            foreach (ExpressionSyntax inc in forStatement.Incrementors)
+            List<ExpressionSyntax> incrementorExpressions = forStatement.Incrementors.ToList();
+            var incrementorStatements = new List<GStatement>();
+            foreach (ExpressionSyntax inc in incrementorExpressions)
             {
-                bodyStatements.AddRange(this.TranslateExpressionStatements(inc));
+                incrementorStatements.AddRange(this.TranslateExpressionStatements(inc));
             }
+
+            BlockStatement translatedBody = this.TranslateStatementAsBlock(forStatement.Statement);
+            if (incrementorStatements.Count > 0 && BodyContainsOwnLoopContinue(forStatement.Statement))
+            {
+                if (OwnLoopContinueCrossesFinally(forStatement.Statement))
+                {
+                    this.context.ReportUnsupported(
+                        forStatement,
+                        "a 'continue' inside a 'try'/'finally' within this 'for' loop has no side-effect-preserving G# lowering yet (issue #1732).");
+                }
+                else
+                {
+                    translatedBody = DuplicateIncrementorsBeforeOwnLoopContinue(translatedBody, incrementorStatements);
+                }
+            }
+
+            var bodyStatements = new List<GStatement>(conditionPrologue);
+            bodyStatements.AddRange(translatedBody.Statements);
+            bodyStatements.AddRange(incrementorStatements);
 
             outer.Add(new WhileStatement(GuardBlockCondition(condition), new BlockStatement(bodyStatements)));
 
             return new BlockStatement(outer);
+        }
+
+        /// <summary>
+        /// Duplicates a <c>for</c> loop's already-translated incrementor
+        /// statements immediately ahead of every <c>continue</c> that targets
+        /// THIS loop. G#'s while-lowering (<see cref="LowerForToWhile"/>) appends
+        /// the incrementors as trailing statements in the lowered <c>while</c>
+        /// body, but a G# <c>continue</c> is a goto straight past the WHOLE body
+        /// (ADR-0070's continueLabel) — so without this rewrite the trailing
+        /// incrementors are silently skipped on <c>continue</c>, unlike C#'s
+        /// <c>for</c>, which always runs them before re-testing the condition
+        /// (issue #1732).
+        /// <para>
+        /// Operates on the TRANSLATED G# statement tree, not the C# syntax tree:
+        /// rebuilding a Roslyn syntax subtree to splice in the incrementors would
+        /// re-parent untouched sibling nodes onto a detached tree, breaking any
+        /// later <c>SemanticModel.GetSymbolInfo</c> call on them
+        /// (<see cref="ArgumentException"/> "Syntax node is not within syntax
+        /// tree"). The G# AST has no such constraint, so the rewrite happens
+        /// here, after translation.
+        /// </para>
+        /// <para>
+        /// Descent stops at a nested loop (<see cref="WhileStatement"/>,
+        /// <see cref="ForStatement"/>, <see cref="DoWhileStatement"/>,
+        /// <see cref="ForInStatement"/>) or a nested
+        /// <see cref="LocalFunctionStatement"/> — each is its own
+        /// <c>continue</c> seam, mirroring <see cref="BodyContainsOwnLoopContinue"/>.
+        /// A <c>finally</c> block is left untouched: C# forbids a jump statement
+        /// leaving a <c>finally</c>, so it can never itself contain an own-loop
+        /// <c>continue</c>.
+        /// </para>
+        /// </summary>
+        private static BlockStatement DuplicateIncrementorsBeforeOwnLoopContinue(
+            BlockStatement body,
+            IReadOnlyList<GStatement> incrementorStatements)
+        {
+            return (BlockStatement)RewriteOwnLoopContinue(body, incrementorStatements);
+        }
+
+        private static GStatement RewriteOwnLoopContinue(GStatement statement, IReadOnlyList<GStatement> incrementorStatements)
+        {
+            switch (statement)
+            {
+                case ContinueStatement:
+                {
+                    var replaced = new List<GStatement>(incrementorStatements) { statement };
+                    return new BlockStatement(replaced);
+                }
+
+                case BlockStatement block:
+                {
+                    var rewritten = new List<GStatement>(block.Statements.Count);
+                    foreach (GStatement inner in block.Statements)
+                    {
+                        rewritten.Add(RewriteOwnLoopContinue(inner, incrementorStatements));
+                    }
+
+                    return new BlockStatement(rewritten, block.IsUnsafe);
+                }
+
+                case IfStatement ifStatement:
+                {
+                    GStatement elseBranch = ifStatement.ElseBranch == null
+                        ? null
+                        : RewriteOwnLoopContinue(ifStatement.ElseBranch, incrementorStatements);
+                    return new IfStatement(
+                        ifStatement.Condition,
+                        (BlockStatement)RewriteOwnLoopContinue(ifStatement.Then, incrementorStatements),
+                        elseBranch);
+                }
+
+                case TryStatement tryStatement:
+                {
+                    var catchClauses = new List<CatchClause>(tryStatement.CatchClauses.Count);
+                    foreach (CatchClause catchClause in tryStatement.CatchClauses)
+                    {
+                        catchClauses.Add(new CatchClause(
+                            catchClause.VariableName,
+                            catchClause.ExceptionType,
+                            (BlockStatement)RewriteOwnLoopContinue(catchClause.Body, incrementorStatements)));
+                    }
+
+                    return new TryStatement(
+                        (BlockStatement)RewriteOwnLoopContinue(tryStatement.TryBlock, incrementorStatements),
+                        catchClauses,
+                        tryStatement.FinallyBlock);
+                }
+
+                case SwitchStatement switchStatement:
+                {
+                    var cases = new List<SwitchStatementCase>(switchStatement.Cases.Count);
+                    foreach (SwitchStatementCase switchCase in switchStatement.Cases)
+                    {
+                        cases.Add(new SwitchStatementCase(
+                            switchCase.Pattern,
+                            (BlockStatement)RewriteOwnLoopContinue(switchCase.Body, incrementorStatements),
+                            switchCase.Guard));
+                    }
+
+                    return new SwitchStatement(switchStatement.Subject, cases);
+                }
+
+                // Boundaries: a nested loop's own continue seam, or a nested
+                // local function (its own statement seam) — never descend.
+                case WhileStatement:
+                case ForStatement:
+                case DoWhileStatement:
+                case ForInStatement:
+                case LocalFunctionStatement:
+                    return statement;
+
+                default:
+                    return statement;
+            }
         }
 
         private bool IsLocalReassigned(ILocalSymbol local)


### PR DESCRIPTION
Fixes #1732

## Summary

Issue #1732 flagged two loop-lowering divergences from C# semantics in `CSharpToGSharpTranslator.cs`.

### 1. do-while condition hoist ordering

The issue quoted code that unconditionally prepended the hoisted assignment/break-guard before the body for both `while` and `do`/`while`. That code path had already been fixed by the prior #1723 work: the do-while lowering now appends the hoisted clause **after** the body (matching C#'s post-test semantics), and reports `Unsupported` when a loop-level `continue` would skip the tail hoist. No further change was needed here — added execution-based regression tests to lock in the current (correct) behavior.

### 2. for→while lowering skips incrementors on continue (the real bug)

`LowerForToWhile` (used for a C-style `for` with multiple declarators/incrementors, or a condition needing clause-hoisting) appended the incrementor(s) as trailing statements in the lowered `while` body. Because a G# `continue` is a goto straight past the *whole* loop body (ADR-0070), a loop-level `continue` silently skipped those trailing incrementors — corrupting the iteration count, or looping forever if the skipped incrementor was the only thing advancing the loop variable.

**Fix:** after translating the `for`'s incrementor(s) into G# statements, duplicate them immediately ahead of every `continue` that targets *this* loop (nested loops' own continues, and lambdas/local functions, are left untouched — mirrors the existing `BodyContainsOwnLoopContinue`/`IsOwnLoopContinueBoundary` loop-boundary logic from #1723). The rewrite runs on the already-translated G# statement tree (not the C# syntax tree) — an earlier attempt at a Roslyn `CSharpSyntaxRewriter`-based fix detached sibling nodes from their `SemanticModel`, breaking symbol lookups for unrelated statements in the same body.

**One shape has no faithful lowering:** a `continue` inside a `try`/`finally` within the loop. C# runs the `finally` *before* the incrementors re-run, but duplicating the incrementors ahead of the `continue` would run them *before* the `finally` instead — reordering an observable side effect. This case now reports a visible `ReportUnsupported` diagnostic instead of silently reordering.

## Tests (`tools/cs2gs/Cs2Gs.Tests/Issue1732LoopLoweringTranslationTests.cs`)

Every behavioral claim is verified by actually compiling the translated G# with the real `gsc` and running it (not just inspecting printed text), so a regression that only manifests at runtime (e.g. an infinite loop) can't slip through:

- `DoWhileHoistedCondition_RunsBodyOnceBeforeFirstConditionTest` — do-while with a value-position-assignment condition (forces the hoist path): body runs once, the probe is called exactly once, after the body.
- `ForContinue_StillRunsIncrementorsAndTerminatesWithCorrectCount` — multi-declarator/incrementor `for` with a `continue`: terminates (would hang pre-fix) with the exact C# sum/iteration count.
- `NestedForContinue_OnlyIncrementsInnerLoop` — inner loop's `continue` only affects the inner incrementors, outer loop unaffected.
- `SingleIncrementorForContinue_UsesNativeForAndIsUnaffected` — regression guard: the already-correct native G# `for` path is untouched.
- `ForContinueInsideTryFinally_ReportsUnsupportedInsteadOfReordering` — asserts the `Unsupported` diagnostic fires for the try/finally case.

## Verification

- `dotnet build GSharp.sln -c Release -graph` — succeeds, 0 warnings/errors.
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release` — 568 tests, all pass except one known-flaky test (`TestParityStageTests.L1_AllFourStages_AreGreen_WithStdoutParity`, an MSBuild obj-cache race from parallel test execution, unrelated to this change — passes in isolation and untouched by this diff).

Nothing deferred: both sub-cases from the issue are addressed (part 1 was already fixed, verified with new tests; part 2 is fixed here), and the one genuinely unsupportable shape (continue inside try/finally) is reported visibly rather than silently miscompiled.
