### PR TITLE
cs2gs: fix assignment-target null-forgiveness gaps and .Invoke bypass

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue1735AssignmentTargetNullForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1735AssignmentTargetNullForgivenessTranslationTests.cs
@@ -1,0 +1,207 @@
+// <copyright file="Issue1735AssignmentTargetNullForgivenessTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Translator-fidelity tests for issue #1735, three follow-up gaps in the
+/// nullable-receiver <c>!!</c> assertion machinery added by #1594/#1598:
+///
+/// <list type="number">
+/// <item>
+/// <see cref="CSharpToGSharpTranslator"/>'s assignment-target path
+/// (<c>TranslateAssignmentTarget</c>) returned early for an implicit-this
+/// instance property/field receiver, so a nullable receiver on the LEFT of an
+/// assignment never got the same <c>!!</c> its read-side twin gets — emitting
+/// an unforgiven <c>this.Prop.Member = v</c> (GS0158) instead of
+/// <c>this.Prop!!.Member = v</c>.
+/// </item>
+/// <item>
+/// That same branch hard-coded <c>this</c> even inside a lifted owned-struct
+/// receiver-clause method (issue #938), where the receiver is not <c>this</c>
+/// but the receiver-clause parameter (<c>self</c>).
+/// </item>
+/// <item>
+/// A delegate/event invoked via the explicit <c>.Invoke(...)</c> spelling
+/// bypassed the #1598 callee-forgiveness path entirely (only the direct-call
+/// sugar <c>d(args)</c> routed through it), so a nullable delegate field
+/// invoked as <c>field.Invoke(x)</c> emitted a bare, unforgiven
+/// <c>field(x)</c> (GS0131).
+/// </item>
+/// </list>
+/// </summary>
+public class Issue1735AssignmentTargetNullForgivenessTranslationTests
+{
+    [Fact]
+    public void ImplicitThisNullableProperty_AssignmentTarget_EmitsNonNullAssertion()
+    {
+        string printed = TranslateUnit(@"
+#nullable enable
+namespace Demo
+{
+    public class Inner { public int Value; }
+    public class C
+    {
+        private Inner? Child => new Inner();
+        public void F()
+        {
+            if (Child == null) return;
+            Child.Value = 5;
+        }
+    }
+}");
+
+        Assert.Contains("this.Child!!.Value = 5", printed);
+    }
+
+    [Fact]
+    public void ExplicitNullableReceiver_AssignmentTarget_EmitsNonNullAssertion()
+    {
+        string printed = TranslateUnit(@"
+#nullable enable
+namespace Demo
+{
+    public class Inner { public int Value; }
+    public class Outer { public Inner? Child => null; }
+    public class C
+    {
+        public void F(Outer o)
+        {
+            if (o.Child == null) return;
+            o.Child.Value = 5;
+        }
+    }
+}");
+
+        Assert.Contains("o.Child!!.Value = 5", printed);
+    }
+
+    [Fact]
+    public void OwnedStructReceiverClause_ImplicitThisNullableField_UsesActualReceiverNotThis()
+    {
+        // Issue #938: a struct instance method is lifted to the receiver-clause
+        // form (`func (self Vec) F()`), so an implicit-this reference inside the
+        // body must qualify through the receiver-clause parameter, not `this`
+        // (which does not exist there). Combined with the nullable-receiver
+        // assertion, the assignment target must read `self.Child!!.Value = 5`.
+        string printed = TranslateUnit(@"
+#nullable enable
+namespace Demo
+{
+    public class Inner { public int Value; }
+    public struct Vec
+    {
+        public Inner? Child;
+        public void F()
+        {
+            if (Child == null) return;
+            Child.Value = 5;
+        }
+    }
+}");
+
+        Assert.DoesNotContain("this.Child", printed);
+        Assert.Contains("self.Child!!.Value = 5", printed);
+    }
+
+    [Fact]
+    public void NonNullableReceiver_AssignmentTarget_DoesNotAssert()
+    {
+        // Precision guard: a non-nullable implicit-this property/field receiver
+        // still needs the `this.` qualification (GS0158/GS9998) but must never
+        // get a spurious `!!`.
+        string printed = TranslateUnit(@"
+#nullable enable
+namespace Demo
+{
+    public class Inner { public int Value; }
+    public class C
+    {
+        private Inner Child { get; } = new Inner();
+        public void F()
+        {
+            Child.Value = 5;
+        }
+    }
+}");
+
+        Assert.Contains("this.Child.Value = 5", printed);
+        Assert.DoesNotContain("!!", printed);
+    }
+
+    [Fact]
+    public void NullableDelegateField_ExplicitInvokeSpelling_EmitsNonNullAssertion()
+    {
+        // Issue #1598 forgives the callee of the direct-call sugar `field(x)`.
+        // The explicit `.Invoke(x)` spelling must be forgiven identically.
+        string printed = TranslateUnit(@"
+#nullable enable
+using System;
+namespace Demo
+{
+    public class C
+    {
+        private Action<int>? handler;
+        public void F()
+        {
+            if (handler == null) return;
+            handler.Invoke(1);
+        }
+    }
+}");
+
+        Assert.Contains("handler!!(1)", printed);
+    }
+
+    [Fact]
+    public void NonNullableDelegateField_ExplicitInvokeSpelling_DoesNotAssert()
+    {
+        string printed = TranslateUnit(@"
+#nullable enable
+using System;
+namespace Demo
+{
+    public class C
+    {
+        private Action<int> handler = _ => { };
+        public void F()
+        {
+            handler.Invoke(1);
+        }
+    }
+}");
+
+        Assert.DoesNotContain("!!", printed);
+        Assert.Contains("handler(1)", printed);
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -4575,14 +4575,24 @@ public sealed class CSharpToGSharpTranslator
         //     property/field of the enclosing type. gsc resolves a bare-identifier
         //     assignment receiver as a variable/parameter; an implicit-this property
         //     receiver has no local slot, so the member write fails (GS0158 /
-        //     GS9998). Qualifying it as `this.Prop.Member = v` routes the write
-        //     through the expression-receiver path, which binds correctly.
+        //     GS9998). Qualifying it as `this.Prop.Member = v` (or `self.Prop.Member
+        //     = v` inside a lifted receiver-clause func, issue #938 — see
+        //     <paramref name="left"/>'s <see cref="currentReceiverName"/>) routes the
+        //     write through the expression-receiver path, which binds correctly.
+        //     When `Prop` is itself declared-nullable (or promoted, issue #1072),
+        //     the same `!!` the read path applies is inserted on the qualified
+        //     receiver (`this.Prop!!.Member = v`) — the qualification and the
+        //     null-forgiveness are independent fixes and compose.
         //
         //   • `recv.Member = v` where `recv` is a declared-nullable receiver that
-        //     Roslyn flow-proved non-null. gsc does not flow-narrow an *assignment*
-        //     receiver (only reads), so the bare nullable receiver fails to bind the
-        //     setter (GS0158). A `recv!!.Member = v` re-establishes the non-null fact
-        //     (mirrors the read-side <see cref="TranslateReceiverWithNullForgiveness"/>).
+        //     Roslyn flow-proved non-null (or was promoted to nullable, #1072).
+        //     gsc does not flow-narrow an *assignment* receiver (only reads), so the
+        //     bare nullable receiver fails to bind the setter (GS0158). A
+        //     `recv!!.Member = v` re-establishes the non-null fact (mirrors the
+        //     read-side <see cref="TranslateReceiverWithNullForgiveness"/> and its
+        //     flow-independent <see cref="ReceiverIsNullableReferenceFieldOrProperty"/>
+        //     companion, so nullable-oblivious corpora get the same assertion the
+        //     read path does).
         private GExpression TranslateAssignmentTarget(ExpressionSyntax left)
         {
             if (left is MemberAccessExpressionSyntax member)
@@ -4591,13 +4601,24 @@ public sealed class CSharpToGSharpTranslator
                     this.context.GetSymbolInfo(receiverId).Symbol is { IsStatic: false } receiverSymbol &&
                     receiverSymbol.Kind is SymbolKind.Property or SymbolKind.Field)
                 {
-                    GExpression thisQualified = new MemberAccessExpression(
-                        new ThisExpression(), SanitizeIdentifier(receiverId.Identifier.Text));
+                    GExpression qualifier = this.currentReceiverName != null
+                        ? new IdentifierExpression(this.currentReceiverName)
+                        : new ThisExpression();
+                    GExpression qualifiedReceiver = new MemberAccessExpression(
+                        qualifier, SanitizeIdentifier(receiverId.Identifier.Text));
+
+                    if (this.ReceiverNeedsNullForgiveness(receiverId) ||
+                        this.ReceiverIsNullableReferenceFieldOrProperty(receiverId))
+                    {
+                        qualifiedReceiver = new NonNullAssertionExpression(qualifiedReceiver);
+                    }
+
                     return new MemberAccessExpression(
-                        thisQualified, SanitizeIdentifier(member.Name.Identifier.Text));
+                        qualifiedReceiver, SanitizeIdentifier(member.Name.Identifier.Text));
                 }
 
                 if (this.ReceiverNeedsNullForgiveness(member.Expression) ||
+                    this.ReceiverIsNullableReferenceFieldOrProperty(member.Expression) ||
                     (member.Expression is IdentifierNameSyntax hoistedId &&
                      this.context.GetSymbolInfo(hoistedId).Symbol is { } hoistedSymbol &&
                      this.hoistedNullableGuardLocals.Contains(hoistedSymbol)))
@@ -8419,7 +8440,13 @@ public sealed class CSharpToGSharpTranslator
             {
                 case MemberAccessExpressionSyntax member
                     when member.Name.Identifier.Text == "Invoke":
-                    receiver = this.TranslateExpression(member.Expression);
+                    // A nullable delegate/event receiver spelled `field.Invoke(...)`
+                    // needs the same `!!` the direct-call spelling `field(...)` gets
+                    // below (#1598): route through the shared receiver-forgiveness
+                    // helper rather than a bare translate, or the `.Invoke` spelling
+                    // bypasses the assertion and emits an unforgiven `field(...)`
+                    // (GS0131).
+                    receiver = this.TranslateReceiverWithNullForgiveness(member.Expression);
                     return true;
 
                 case MemberBindingExpressionSyntax binding


### PR DESCRIPTION
Fixes #1735

Follow-ups to #1594/#1598's nullable-receiver `!!` assertion machinery in `Cs2Gs.Translator/CSharpToGSharpTranslator.cs`. Fixes 3 gaps:

1. **Assignment-target path skipped the assertion**: `TranslateAssignmentTarget`'s implicit-this branch returned early for any implicit-this instance property/field receiver, before reaching the null-forgiveness check. A nullable receiver on the LEFT of an assignment (`Prop.Member = v`) emitted the unforgiven `this.Prop.Member = v` (GS0158) instead of `this.Prop!!.Member = v`.
2. **Same branch hard-coded `this`**: inside a lifted owned-struct receiver-clause method (issue #938), the receiver is the receiver-clause parameter (e.g. `self`), not `this` — which does not exist there.
3. **`.Invoke(...)` bypassed the #1598 fix**: `TryGetDelegateInvokeReceiver` translated the `.Invoke` receiver bare instead of through `TranslateReceiverWithNullForgiveness`, so a nullable delegate field invoked as `field.Invoke(x)` emitted an unforgiven `field(x)` (GS0131), even though the direct-call sugar `field(x)` was already forgiven.

### Fix
- `TranslateAssignmentTarget`'s implicit-this branch now builds the qualifier via `currentReceiverName` (the same mechanism `TranslateIdentifierName` already uses for the read path) when set, falling back to `this` otherwise, and composes it with the existing `ReceiverNeedsNullForgiveness`/`ReceiverIsNullableReferenceFieldOrProperty` checks — the qualification and the null-forgiveness are independent and now compose.
- The general (non-implicit-this) assignment-target branch also gained the flow-independent `ReceiverIsNullableReferenceFieldOrProperty` check, matching the read path's parity for nullable-oblivious corpora (previously it only checked flow-based `ReceiverNeedsNullForgiveness`).
- `TryGetDelegateInvokeReceiver`'s `.Invoke` case now routes through `TranslateReceiverWithNullForgiveness` instead of a bare translate, so both call spellings (`field(x)` and `field.Invoke(x)`) are forgiven identically.

No `ReportUnsupported` branches were needed: all three gaps are fixed by reusing the existing, already-proven read-path helpers (`ReceiverNeedsNullForgiveness`, `ReceiverIsNullableReferenceFieldOrProperty`, `TranslateReceiverWithNullForgiveness`) on the write/Invoke paths, so no genuinely-inexpressible shape was introduced.

### Tests
Added `tools/cs2gs/Cs2Gs.Tests/Issue1735AssignmentTargetNullForgivenessTranslationTests.cs` (6 tests):
- implicit-this nullable property as assignment target → `this.Child!!.Value = 5`
- explicit non-`this` nullable receiver as assignment target → `o.Child!!.Value = 5`
- owned-struct receiver-clause method, implicit-this nullable field assignment target → `self.Child!!.Value = 5` (not `this.Child`)
- non-nullable receiver assignment target → `this.Child.Value = 5`, no spurious `!!` (regression)
- nullable delegate field via `.Invoke(...)` → `handler!!(1)`
- non-nullable delegate field via `.Invoke(...)` → `handler(1)`, no spurious `!!` (regression)

### Verification
- `dotnet build GSharp.sln -c Release -graph`: 0 warnings, 0 errors.
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release --filter "FullyQualifiedName~Issue1735"`: 6/6 passed.
- Full regression sweep across all related null-forgiveness/assignment/delegate/receiver suites (`NullForgiv`, `1594`, `1598`, `1354`, `1535`, `914`, `ForEachNullForgiv`, `GoldenTests`, `Assignment`, `Delegate`, `Invoke`, `Receiver`): 167/167 passed, 0 failures.

Nothing deferred — all three gaps from the issue are fully fixed and generalized (not limited to the repro's specific shape).