### PR TITLE
cs2gs: apply #1072 nullable promotion to explicit-typed locals

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue1737ExplicitTypedLocalNullableTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1737ExplicitTypedLocalNullableTranslationTests.cs
@@ -1,0 +1,163 @@
+// <copyright file="Issue1737ExplicitTypedLocalNullableTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Translator-fidelity tests for issue #1737: the issue-#1072 nullable promotion
+/// (a non-nullable reference local that is null-checked or null-assigned in scope
+/// is really nullable) was only reached for a `var` local. An explicit-typed local
+/// whose declared type equals the initializer's natural type took a shortcut that
+/// omits the type clause entirely and bypassed the promotion, so `T?` was silently
+/// rendered as non-nullable `T`. The fix routes that shape through the same
+/// <c>IsPromotedToNullableReference</c> decision `var` already uses.
+/// </summary>
+public class Issue1737ExplicitTypedLocalNullableTranslationTests
+{
+    [Fact]
+    public void NullAssignedExplicitTypedLocal_SameNaturalType_PromotesToNullable()
+    {
+        // Reported shape: `StreamReader r = new StreamReader(...)` has a declared
+        // type equal to the initializer's natural type, then `r` is later
+        // assigned null.
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class Box { }
+    public class C
+    {
+        public void F()
+        {
+            Box r = new Box();
+            r = null;
+            System.Console.WriteLine(r);
+        }
+    }
+}");
+
+        Assert.Contains("r Box? =", printed);
+    }
+
+    [Fact]
+    public void NullComparedExplicitTypedLocal_SameNaturalType_PromotesToNullable()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class Box { }
+    public class C
+    {
+        public void F()
+        {
+            Box r = new Box();
+            if (r == null) { return; }
+            System.Console.WriteLine(r);
+        }
+    }
+}");
+
+        Assert.Contains("r Box? =", printed);
+    }
+
+    [Fact]
+    public void NullAssignedExplicitTypedLocal_DifferentNaturalType_PromotesToNullable()
+    {
+        // Generalization: an explicit declared type that differs from the
+        // initializer's natural type (already forced through the type-preserving
+        // path) must still get the #1072 promotion when it is later null-assigned.
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class Box { }
+    public class Derived : Box { }
+    public class C
+    {
+        public void F()
+        {
+            Box r = new Derived();
+            r = null;
+            System.Console.WriteLine(r);
+        }
+    }
+}");
+
+        Assert.Contains("r Box? =", printed);
+    }
+
+    [Fact]
+    public void NeverNullExplicitTypedLocal_SameNaturalType_StaysNonNullable()
+    {
+        // Precision guard: a local that is never null-checked nor null-assigned
+        // must not be over-promoted.
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class Box { }
+    public class C
+    {
+        public void F()
+        {
+            Box r = new Box();
+            System.Console.WriteLine(r);
+        }
+    }
+}");
+
+        Assert.Contains("let r = ", printed);
+        Assert.DoesNotContain("r Box? =", printed);
+    }
+
+    [Fact]
+    public void AlreadyNullableExplicitTypedLocal_DoesNotDoublePromote()
+    {
+        // A local already declared `Box?` in C# must render a single `?`, not
+        // a doubled one, when it is also null-assigned in scope.
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class Box { }
+    public class C
+    {
+        public void F()
+        {
+            Box? r = new Box();
+            r = null;
+            System.Console.WriteLine(r);
+        }
+    }
+}");
+
+        Assert.Contains("r Box? =", printed);
+        Assert.DoesNotContain("Box??", printed);
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -3931,6 +3931,18 @@ public sealed class CSharpToGSharpTranslator
                         {
                             emitType = true;
                         }
+                        else if (this.context.GetDeclaredSymbol(declarator) is ILocalSymbol equalTypeLocal
+                            && this.IsPromotedToNullableReference(equalTypeLocal))
+                        {
+                            // Issue #1737: the explicit-type-equals-initializer-type
+                            // shape above bypasses the type clause entirely (relying
+                            // on inference), which would also silently drop the
+                            // #1072 nullable promotion below. Route it through the
+                            // same emitType=true path as every other explicit-typed
+                            // shape so `var x = e;` and `T x = e;` (declared type ==
+                            // natural type) promote identically.
+                            emitType = true;
+                        }
                     }
 
                     if (emitType)


### PR DESCRIPTION
Fixes #1737

## Root cause
`TranslateLocalDeclaration`'s explicit-type branch has a fast path: when the declared type equals the initializer's natural type, it omits the type clause entirely and relies on G# inference (the idiomatic common case, added for #1723/type-preservation work). That fast path never reaches `PromoteIfUsedAsNullable`, so an explicit-typed local like

```csharp
StreamReader r = new StreamReader(f);
r = null;
```

was emitted as non-nullable `r` even though it's later null-assigned, while the identical `var r = new StreamReader(f);` form was already promoted to `r StreamReader?` by the #1072 logic. The two declaration forms drifted onto separate decision paths that could reach different outcomes for the same nullability trigger.

## Fix
Unify the two paths: the equals-type branch now also checks `IsPromotedToNullableReference` (the exact same #1072 predicate the `var`/inferred-type branch calls) and forces `emitType = true` when it fires, routing the local through the existing type-emission + `PromoteIfUsedAsNullable` code that already handles the differs-type shape correctly. No new promotion logic was written — this only removes the branch drift so all three explicit/inferred local shapes share one decision point.

## Scope
- `var x = e;` (inferred) — unchanged, already correct.
- `T x = e;` where `T` == natural type of `e` — **fixed** (the reported gap).
- `T x = e;` where `T` != natural type of `e` — unaffected; already emitted the type clause and called the promotion.
- `T? x = e;` (already nullable in C#) — unaffected; `PromoteIfUsedAsNullable` is a no-op on an already-nullable type, so no double `?`.

No `ReportUnsupported` diagnostic was needed: every local-declaration shape routes through the same, already-correct promotion predicate — there's no sub-case that can't be expressed faithfully in G#.

## Tests
Added `Issue1737ExplicitTypedLocalNullableTranslationTests.cs`:
- explicit-typed local, declared type == initializer type, later null-assigned → promoted (the reported bug).
- same shape, null-compared instead of null-assigned → promoted.
- explicit-typed local, declared type != initializer type (widening/upcast), null-assigned → promoted (generalization/regression guard).
- explicit-typed local never null-checked/assigned → stays non-nullable (no over-promotion).
- local already declared `Box?` in C#, also null-assigned → single `?`, not doubled.

Verified: existing #1072 suites (`Issue1072NullCheckedAsNullableTranslationTests`, `Issue1072FieldInitNullableTests`, `LocalExplicitTypePreservationTests`) and broader `Nullable`/`LocalDecl`/`Oahu`-filtered suites (108 tests) all still pass — no regressions.

Nothing deferred; this fully addresses the reported gap and the requested generalization.