### PR TITLE
cs2gs: run mutability scan for lambdas outside body scope

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue1736OutOfBodyLambdaMutabilityTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1736OutOfBodyLambdaMutabilityTests.cs
@@ -1,0 +1,158 @@
+// <copyright file="Issue1736OutOfBodyLambdaMutabilityTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #1736 — a lambda translated OUTSIDE any body scope (a field/property
+/// initializer, a folded static-ctor RHS, a ctor <c>base(...)</c>/
+/// <c>this(...)</c> argument, etc.) left <c>currentBodyScope</c> null, so the
+/// mutability scan (<c>IsSymbolReassigned</c>) always answered "never
+/// reassigned" for locals declared inside that lambda: a reassigned local
+/// wrongly emitted the immutable <c>let</c> binding, producing an illegal
+/// <c>i++</c>/assignment against a <c>let</c>. <see cref="TranslateLambda"/>
+/// now narrows <c>currentBodyScope</c> to the lambda node itself, fixing every
+/// out-of-body position at once.
+/// </summary>
+public class Issue1736OutOfBodyLambdaMutabilityTests
+{
+    /// <summary>
+    /// A lambda in a FIELD initializer that reassigns a local declared inside
+    /// its own block body must emit that local as mutable (`var`), not `let`.
+    /// </summary>
+    [Fact]
+    public void FieldInitializerLambda_ReassignedLocal_EmitsVar()
+    {
+        (string printed, TranslationContext context) = Translate(@"
+using System;
+namespace Demo
+{
+    public class C
+    {
+        public Func<int> F = () => { int i = 0; i++; return i; };
+    }
+}");
+
+        Assert.Contains("var i = 0", printed);
+        Assert.DoesNotContain("let i", printed);
+        Assert.DoesNotContain(context.Diagnostics, d => d.IsUnsupported);
+    }
+
+    /// <summary>
+    /// Regression guard: a lambda in a field initializer whose local is NEVER
+    /// reassigned still emits the immutable `let` — the fix must not make
+    /// every out-of-body local mutable by default.
+    /// </summary>
+    [Fact]
+    public void FieldInitializerLambda_NonReassignedLocal_StaysLet()
+    {
+        (string printed, TranslationContext context) = Translate(@"
+using System;
+namespace Demo
+{
+    public class C
+    {
+        public Func<int> F = () => { int i = 0; return i + 1; };
+    }
+}");
+
+        Assert.Contains("let i = 0", printed);
+        Assert.DoesNotContain(context.Diagnostics, d => d.IsUnsupported);
+    }
+
+    /// <summary>
+    /// A lambda in a PROPERTY initializer that reassigns a local declared
+    /// inside its own block body must also emit that local as mutable.
+    /// </summary>
+    [Fact]
+    public void PropertyInitializerLambda_ReassignedLocal_EmitsVar()
+    {
+        (string printed, TranslationContext context) = Translate(@"
+using System;
+namespace Demo
+{
+    public class C
+    {
+        public Func<int> F { get; } = () => { int i = 0; i++; return i; };
+    }
+}");
+
+        Assert.Contains("var i = 0", printed);
+        Assert.DoesNotContain("let i", printed);
+        Assert.DoesNotContain(context.Diagnostics, d => d.IsUnsupported);
+    }
+
+    /// <summary>
+    /// Regression guard: a lambda inside a NORMAL method body, whose local is
+    /// reassigned, is unaffected by the fix — it was already correctly
+    /// classified via the enclosing method's body scope, and the narrower
+    /// per-lambda scope (a subset that still contains the lambda's own
+    /// reassignment) must not change that outcome.
+    /// </summary>
+    [Fact]
+    public void InBodyLambda_ReassignedLocal_StillEmitsVar()
+    {
+        (string printed, TranslationContext context) = Translate(@"
+using System;
+namespace Demo
+{
+    public class C
+    {
+        public Func<int> Make()
+        {
+            return () => { int i = 0; i++; return i; };
+        }
+    }
+}");
+
+        Assert.Contains("var i = 0", printed);
+        Assert.DoesNotContain("let i", printed);
+        Assert.DoesNotContain(context.Diagnostics, d => d.IsUnsupported);
+    }
+
+    /// <summary>
+    /// Regression guard: a lambda inside a NORMAL method body, whose local is
+    /// NOT reassigned, still emits `let`.
+    /// </summary>
+    [Fact]
+    public void InBodyLambda_NonReassignedLocal_StillEmitsLet()
+    {
+        (string printed, TranslationContext context) = Translate(@"
+using System;
+namespace Demo
+{
+    public class C
+    {
+        public Func<int> Make()
+        {
+            return () => { int i = 0; return i + 1; };
+        }
+    }
+}");
+
+        Assert.Contains("let i = 0", printed);
+        Assert.DoesNotContain(context.Diagnostics, d => d.IsUnsupported);
+    }
+
+    private static (string Printed, TranslationContext Context) Translate(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(System.Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        string printed = GSharpPrinter.Print(unit);
+        return (printed, context);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -9690,6 +9690,26 @@ public sealed class CSharpToGSharpTranslator
             // since they have no per-statement seam of their own to fall back on.
             List<GStatement> outerSpillPrologue = this.pendingSpillPrologue;
             this.pendingSpillPrologue = null;
+
+            // Issue #1736: a lambda is its own mutability/reference-scan scope,
+            // regardless of WHERE the lambda appears. `currentBodyScope` drives
+            // `IsSymbolReassigned` (via `IsLocalReassigned`/`WithParameterShadows`),
+            // which treats a null scope as "never reassigned" — correct only when
+            // reached from a normal method/accessor body (already scoped by
+            // <see cref="TranslateBody"/>). A lambda translated OUTSIDE any body —
+            // a field/property initializer, a folded static-ctor RHS, a ctor
+            // `base(...)`/`this(...)` argument, an attribute argument, etc. — left
+            // `currentBodyScope` null, so a local declared and reassigned entirely
+            // inside the lambda (e.g. `Func<int> f = () => { int i = 0; i++; return
+            // i; };`) was misclassified as immutable and emitted `let i = 0`
+            // followed by an illegal `i++`. Narrowing the scope to the lambda node
+            // itself here — rather than only widening it at each out-of-body call
+            // site — fixes every such position at once and is idempotent when the
+            // lambda is already inside a normal body: the narrower scope is a
+            // subset of the enclosing one that still contains the lambda's own
+            // reassignments, so nothing that worked before regresses.
+            SyntaxNode previousBodyScope = this.currentBodyScope;
+            this.currentBodyScope = lambda;
             try
             {
                 if (lambda.Body is BlockSyntax block)
@@ -9747,6 +9767,7 @@ public sealed class CSharpToGSharpTranslator
             finally
             {
                 this.pendingSpillPrologue = outerSpillPrologue;
+                this.currentBodyScope = previousBodyScope;
             }
         }
 


### PR DESCRIPTION
Fixes #1736

## Root cause
`TranslateLambda` translated a lambda's block/expression body directly, without ever setting `currentBodyScope`. `IsSymbolReassigned` (which drives `val`/`var` and `let`/`var` classification via `IsLocalReassigned`/`WithParameterShadows`) treats a `null` scope as "never reassigned". Any lambda reached with no enclosing body scope already set — a field initializer, a property initializer, a folded static-ctor RHS, a ctor `base(...)`/`this(...)` argument, an attribute argument, etc. — therefore always classified its own locals as never-reassigned, silently emitting an illegal `let` binding for a local that is actually mutated inside the lambda (e.g. `let i = 0` followed by `i++`).

## Fix
Generalized fix at the single seam where a lambda's own body is translated (`TranslateLambda`), not at each enumerated out-of-body call site: narrow `currentBodyScope` to the lambda node itself for the duration of its own body translation, restoring the previous scope afterward. This covers every current AND future out-of-body position uniformly (field/property initializers, folded static-ctor RHS, ctor base/this args, attribute args, collection/object initializers, etc.) with one change.

Idempotent/safe for the in-body case: when a lambda already sits inside a normal method/accessor body (scoped by `TranslateBody`), narrowing to the lambda is a subset of the enclosing scope that still contains the lambda's own reassignments — the classification outcome is unchanged.

No `ReportUnsupported` needed: G# expresses lambda-local mutability fully in every context tested; the bug was purely a scope-wiring gap, not a genuine expressiveness gap.

## Tests
`Issue1736OutOfBodyLambdaMutabilityTests`:
- field-initializer lambda, reassigned local → `var`
- field-initializer lambda, non-reassigned local → stays `let` (no over-mutable regression)
- property-initializer lambda, reassigned local → `var`
- in-body lambda, reassigned local → unchanged (`var`, regression guard)
- in-body lambda, non-reassigned local → unchanged (`let`, regression guard)

All 5 new tests pass; full `Cs2Gs.Tests` suite (577 tests, excluding the unrelated known-flaky `ReportTests.Cli_ReportVerb_RegeneratesBothArtifacts`) passes with no regressions.