### PR TITLE
cs2gs: fix LINQ query lowering — preserve into-continuations, fix range-var typing

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/L3TranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/L3TranslationTests.cs
@@ -98,6 +98,132 @@ namespace Demo
     }
 
     /// <summary>
+    /// Issue #1738: a query continuation (<c>... into y ...</c>) is C#'s own
+    /// sugar for <c>from y in (...) ...</c> (C# spec §12.20.3); the translator
+    /// must lower both halves rather than silently dropping the continuation's
+    /// clauses (<c>where y > 0 select y</c> was previously lost entirely).
+    /// </summary>
+    [Fact]
+    public void QueryContinuation_LowersBothHalvesOfQuery()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    public static class QueryContinuationHost
+    {
+        public static IEnumerable<int> DoubledPositives(IEnumerable<int> numbers) =>
+            from n in numbers select n * 2 into y where y > 0 select y;
+    }
+}");
+
+        Assert.Contains(".Select((n int32) -> n * 2)", printed);
+        Assert.Contains(".Where((y int32) -> y > 0)", printed);
+        Assert.DoesNotContain("from", printed);
+    }
+
+    /// <summary>
+    /// Issue #1738: a query over an array must type the range variable as the
+    /// array's element type (<c>string</c>), not the former placeholder
+    /// (<c>object</c>) an array (a non-<see cref="INamedTypeSymbol"/> source)
+    /// used to fall back to.
+    /// </summary>
+    [Fact]
+    public void QueryOverArray_TypesRangeVariableAsElementType()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    using System.Linq;
+    public static class QueryArrayHost
+    {
+        public static int[] Lengths(string[] words) =>
+            (from w in words select w.Length).ToArray();
+    }
+}");
+
+        Assert.Contains(".Select((w string) -> w.Length)", printed);
+    }
+
+    /// <summary>
+    /// Issue #1738: a query over a dictionary must type the range variable as
+    /// <c>KeyValuePair&lt;TKey, TValue&gt;</c> (the element type
+    /// <c>IEnumerable&lt;KeyValuePair&lt;K,V&gt;&gt;</c> yields), not the
+    /// dictionary's key type (the former "first generic type argument" guess).
+    /// </summary>
+    [Fact]
+    public void QueryOverDictionary_TypesRangeVariableAsKeyValuePair()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    public static class QueryDictionaryHost
+    {
+        public static IEnumerable<string> Keys(Dictionary<string, int> map) =>
+            from kv in map select kv.Key;
+    }
+}");
+
+        Assert.Contains("KeyValuePair", printed);
+        Assert.Contains("kv.Key", printed);
+    }
+
+    /// <summary>
+    /// Issue #1738 regression: a query over a plain <c>IEnumerable&lt;T&gt;</c>
+    /// source (the common case, already correctly typed before this fix) must
+    /// keep working after generalizing range-variable typing to
+    /// <c>GetEnumerableElementType</c>.
+    /// </summary>
+    [Fact]
+    public void QueryOverIEnumerable_StillTypesRangeVariableCorrectly()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    public static class QueryEnumerableHost
+    {
+        public static IEnumerable<int> Evens(IEnumerable<int> numbers) =>
+            from n in numbers where n % 2 == 0 select n * n;
+    }
+}");
+
+        Assert.Contains(".Where((n int32) -> n % 2 == 0)", printed);
+        Assert.Contains(".Select((n int32) -> n * n)", printed);
+    }
+
+    /// <summary>
+    /// Issue #1738: a query clause with no canonical G# lowering yet (a
+    /// <c>group ... by ...</c> select-or-group, here feeding an <c>into</c>
+    /// continuation) must surface a visible <see
+    /// cref="TranslationSeverity.Unsupported"/> diagnostic rather than being
+    /// silently miscompiled or dropped.
+    /// </summary>
+    [Fact]
+    public void GroupByContinuation_ReportsUnsupportedRatherThanDropping()
+    {
+        TranslationContext context = TranslateForDiagnostics(@"
+namespace Demo
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    public static class QueryGroupHost
+    {
+        public static IEnumerable<IGrouping<int, int>> ByParity(IEnumerable<int> numbers) =>
+            from n in numbers group n by n % 2 into g select g;
+    }
+}");
+
+        Assert.Contains(
+            context.Diagnostics,
+            d => d.IsUnsupported && d.ConstructKind == "GroupClause");
+    }
+
+    /// <summary>
     /// ADR-0115 §B.22: a C# switch expression maps to the G# <c>switch</c>
     /// expression colon form, with type, relational, and constant patterns
     /// (<c>samples/SwitchExpression.gs</c>).

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -10267,15 +10267,40 @@ public sealed class CSharpToGSharpTranslator
             FromClauseSyntax from = query.FromClause;
             string rangeVar = from.Identifier.Text;
             GExpression current = this.TranslateExpression(from.Expression);
-
-            GTypeReference rangeType = from.Type != null
-                ? this.MapTypeSyntax(from.Type)
-                : (this.context.GetTypeInfo(from.Expression).Type is INamedTypeSymbol { IsGenericType: true } src
-                    ? this.typeMapper.Map(src.TypeArguments[0], this.context, from.GetLocation())
-                    : new NamedTypeReference(CSharpTypeMapper.UnsupportedPlaceholderType));
+            GTypeReference rangeType = this.ResolveRangeVariableType(from.Type, from.Expression, from);
 
             current = this.LowerQueryBody(query.Body, rangeVar, rangeType, current);
             return current;
+        }
+
+        // Determines a query range variable's element type. An explicit type
+        // (`from T x in xs`) wins; otherwise the type is derived from the source
+        // collection the same way C#'s foreach/query-from does: array element
+        // type, `IEnumerable<T>`'s `T`, or (for a dictionary) the `T` in the
+        // `IEnumerable<KeyValuePair<K,V>>` the dictionary implements — via the
+        // shared `GetEnumerableElementType` helper (issue #1738), not the former
+        // narrow "first generic type argument" guess that mistyped arrays
+        // (`object`) and dictionaries (the key type instead of `KeyValuePair`).
+        private GTypeReference ResolveRangeVariableType(
+            TypeSyntax explicitType, ExpressionSyntax source, SyntaxNode anchor)
+        {
+            if (explicitType != null)
+            {
+                return this.MapTypeSyntax(explicitType);
+            }
+
+            ITypeSymbol sourceType = this.context.GetTypeInfo(source).Type
+                ?? this.context.GetTypeInfo(source).ConvertedType;
+            ITypeSymbol elementType = GetEnumerableElementType(sourceType);
+            if (elementType != null)
+            {
+                return this.typeMapper.Map(elementType, this.context, anchor.GetLocation());
+            }
+
+            this.context.ReportUnsupported(
+                anchor,
+                "query range variable's element type could not be determined from its source collection (ADR-0115 §B).");
+            return new NamedTypeReference(CSharpTypeMapper.UnsupportedPlaceholderType);
         }
 
         private GExpression LowerQueryBody(
@@ -10312,24 +10337,46 @@ public sealed class CSharpToGSharpTranslator
                 }
             }
 
+            // The result element type after this body's select/group runs, used to
+            // type the range variable of an `into` continuation (below). Defaults
+            // to the unchanged range type for an elided identity `select n`.
+            GTypeReference resultType = rangeType;
+
             switch (body.SelectOrGroup)
             {
                 case SelectClauseSyntax select:
                     // An identity projection (`select n`) after another clause is a
                     // no-op the C# compiler elides; keep it only when it transforms.
-                    if (!(select.Expression is IdentifierNameSyntax id && id.Identifier.Text == rangeVar
-                          && body.Clauses.Count > 0))
+                    if (select.Expression is IdentifierNameSyntax id && id.Identifier.Text == rangeVar
+                        && body.Clauses.Count > 0)
                     {
-                        current = this.QueryCall(current, "Select", rangeVar, rangeType, select.Expression);
+                        break;
                     }
 
+                    current = this.QueryCall(current, "Select", rangeVar, rangeType, select.Expression);
+                    resultType = this.context.GetTypeInfo(select.Expression).Type is { } projected
+                        ? this.typeMapper.Map(projected, this.context, select.GetLocation())
+                        : new NamedTypeReference(CSharpTypeMapper.UnsupportedPlaceholderType);
                     break;
 
                 default:
                     this.context.ReportUnsupported(
                         body.SelectOrGroup,
                         $"query '{body.SelectOrGroup.Kind()}' has no canonical G# lowering yet (ADR-0115 §B).");
-                    break;
+                    return current;
+            }
+
+            // `... into y ...` (a query continuation) is the C# spec's own sugar
+            // for `from y in (...) ...` — lower it as a nested query body over the
+            // projected sequence rather than silently dropping the continuation's
+            // clauses (issue #1738).
+            if (body.Continuation != null)
+            {
+                current = this.LowerQueryBody(
+                    body.Continuation.Body,
+                    SanitizeIdentifier(body.Continuation.Identifier.Text),
+                    resultType,
+                    current);
             }
 
             return current;


### PR DESCRIPTION
Fixes #1738

## Fixes

1. **Query continuations silently dropped (`... into y ...`).** `LowerQueryBody` read `body.Clauses` and `body.SelectOrGroup` but never `body.Continuation`, so `from x in xs select f(x) into y where y > 0 select y` lost the `where`/second `select` entirely with no diagnostic. Fixed by lowering the continuation per the C# spec's own desugaring: a nested query over the projected sequence, recursing into `LowerQueryBody` with the continuation's range variable/body and the correctly-inferred result element type.

2. **Range-variable mistyping for arrays/dictionaries.** The element type was inferred as `src.TypeArguments[0]` for any generic `INamedTypeSymbol` source (wrong key type for a `Dictionary<K,V>`) and `object` for anything else (e.g. an array, a non-`INamedTypeSymbol`). Fixed by using the existing `GetEnumerableElementType` helper — array element type, `IEnumerable<T>`'s `T` via the implemented interface, or a dictionary's `KeyValuePair<K,V>` — the same general resolution C#'s own foreach/query-from typing uses. When the element type still can't be determined, a visible `ReportUnsupported` diagnostic fires instead of a silent placeholder.

Both fixes are generalized to all query shapes (not special-cased to the issue's repro), and applied consistently to the top-level `from` clause and every `into`-continuation's implicit `from`.

## Tests added (`tools/cs2gs/Cs2Gs.Tests/L3TranslationTests.cs`)

- `QueryContinuation_LowersBothHalvesOfQuery` — `into` continuation preserved end to end.
- `QueryOverArray_TypesRangeVariableAsElementType` — array source types the range var as the element type, not `object`.
- `QueryOverDictionary_TypesRangeVariableAsKeyValuePair` — dictionary source types the range var as `KeyValuePair<K,V>`, `.Key`/`.Value` resolve.
- `QueryOverIEnumerable_StillTypesRangeVariableCorrectly` — plain `IEnumerable<T>` regression check.
- `GroupByContinuation_ReportsUnsupportedRatherThanDropping` — a query shape G# genuinely can't lower yet (`group ... by ...`) still surfaces a visible `Unsupported` diagnostic rather than silently miscompiling.

## Validation

- `dotnet build GSharp.sln -c Release -graph` — succeeds, 0 warnings/errors.
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release --filter "FullyQualifiedName~L3TranslationTests"` — 21/21 passed.
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release --filter "FullyQualifiedName~Query|FullyQualifiedName~Linq"` — 7/7 passed.

Nothing deferred: both divergences from the issue are fixed generally (not just for the repro shapes), and every sub-case that G#'s grammar genuinely can't express (e.g. `group`/`join` clauses, an undeterminable element type) reports a visible `ReportUnsupported` diagnostic rather than silently dropping or miscompiling.