### PR TITLE
cs2gs: map positional struct new args by ctor assignment, not member order

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue1739PositionalStructCtorTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1739PositionalStructCtorTranslationTests.cs
@@ -1,0 +1,216 @@
+// <copyright file="Issue1739PositionalStructCtorTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Translator-fidelity tests for issue #1739 — a positional <c>new T(a, b, c)</c>
+/// on a SOURCE struct used to zip the constructor arguments to the struct's
+/// members by bare DECLARATION order, ignoring the constructor's actual
+/// parameter→member assignments (silently swapping/misassigning values
+/// whenever a struct's member order differs from its constructor's parameter
+/// order), and its "settable" member filter actually tested READABILITY. The
+/// fix resolves the exact constructor Roslyn bound for the call site and walks
+/// its body for the trivial per-parameter assign-through pattern; anything
+/// that does not fit that pattern is reported unsupported rather than guessed.
+/// </summary>
+public class Issue1739PositionalStructCtorTranslationTests
+{
+    [Fact]
+    public void MemberOrderDiffersFromCtorOrder_MapsByCtorAssignment_NotDeclarationOrder()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public struct P
+    {
+        public int Y { get; }
+        public int X { get; }
+        public P(int x, int y) { X = x; Y = y; }
+    }
+
+    public class C
+    {
+        public P Make() => new P(1, 2);
+    }
+}");
+
+        Assert.Contains("P{X: 1, Y: 2}", printed);
+        Assert.DoesNotContain("P{Y: 1, X: 2}", printed);
+    }
+
+    [Fact]
+    public void ReadOnlyComputedMember_NeverPickedAsAssignmentTarget()
+    {
+        // Bug #2: the old filter tested `GetMethod != null` (readability) instead
+        // of true settability, so a get-only COMPUTED property (no backing
+        // storage, `=>` bodied) could still shift into the positional zip. It
+        // cannot be a ctor-assignment target (a ctor cannot legally assign it),
+        // so it must never appear in the struct literal.
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public struct Rect
+    {
+        public int Width { get; }
+        public int Height { get; }
+        public int Area => Width * Height;
+        public Rect(int width, int height) { Width = width; Height = height; }
+    }
+
+    public class C
+    {
+        public Rect Make() => new Rect(3, 4);
+    }
+}");
+
+        Assert.Contains("Rect{Width: 3, Height: 4}", printed);
+        Assert.DoesNotContain("Area:", printed);
+    }
+
+    [Fact]
+    public void FieldBasedStruct_OutOfOrderCtorAssignment_MapsCorrectly()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public struct Vec
+    {
+        public double Y;
+        public double X;
+        public Vec(double x, double y) { X = x; Y = y; }
+    }
+
+    public class C
+    {
+        public Vec Make() => new Vec(1.5, 2.5);
+    }
+}");
+
+        Assert.Contains("Vec{X: 1.5, Y: 2.5}", printed);
+        Assert.DoesNotContain("Vec{Y: 1.5, X: 2.5}", printed);
+    }
+
+    [Fact]
+    public void RecordStructPrimaryConstructor_PositionalNew_CallsPrimaryConstructor()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public record struct Pos(int X, int Y);
+
+    public class C
+    {
+        public Pos Make() => new Pos(1, 2);
+    }
+}");
+
+        // `data struct Pos(X, Y)` gets its own real, directly callable primary
+        // constructor in G#, so the positional call maps straight to it — not to
+        // a struct literal (unlike the plain-struct case above).
+        Assert.Contains("Pos(1, 2)", printed);
+    }
+
+    [Fact]
+    public void CtorParameterNotAssignedToAnyMember_ReportsUnsupported()
+    {
+        // `max` feeds no member (e.g. it would drive validation logic elsewhere) —
+        // a struct literal has no ctor body to run that logic in, so the
+        // translator must flag the gap rather than guess a member for it.
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[]
+        {
+            ("Snippet.cs", @"
+namespace Demo
+{
+    public struct Bounded
+    {
+        public int Value { get; }
+        public Bounded(int value, int max) { Value = value; }
+    }
+
+    public class C
+    {
+        public Bounded Make(int value, int max) => new Bounded(value, max);
+    }
+}"),
+        });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        _ = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        Assert.Contains(
+            context.Diagnostics,
+            d => d.Message.Contains("issue #1739", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void CtorAssignsTransformedValue_ReportsUnsupported()
+    {
+        // `Value = raw * 2` is a transformation, not a plain parameter
+        // assign-through — a struct literal cannot replay that logic.
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[]
+        {
+            ("Snippet.cs", @"
+namespace Demo
+{
+    public struct Scaled
+    {
+        public int Value { get; }
+        public Scaled(int raw) { Value = raw * 2; }
+    }
+
+    public class C
+    {
+        public Scaled Make(int raw) => new Scaled(raw);
+    }
+}"),
+        });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        _ = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        Assert.Contains(
+            context.Diagnostics,
+            d => d.Message.Contains("issue #1739", StringComparison.Ordinal));
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -9214,7 +9214,7 @@ public sealed class CSharpToGSharpTranslator
                 return arguments[0];
             }
 
-            return this.BuildObjectCreationCore(typeSymbol, type, arguments, creation.Initializer);
+            return this.BuildObjectCreationCore(creation, typeSymbol, type, arguments, creation.Initializer);
         }
 
         /// <summary>
@@ -9227,6 +9227,7 @@ public sealed class CSharpToGSharpTranslator
         /// one method makes that drift structurally impossible.
         /// </summary>
         private GExpression BuildObjectCreationCore(
+            BaseObjectCreationExpressionSyntax creationNode,
             ITypeSymbol typeSymbol,
             GTypeReference type,
             IReadOnlyList<GExpression> arguments,
@@ -9276,8 +9277,11 @@ public sealed class CSharpToGSharpTranslator
             // callable constructor surface in G#: it is constructed with a struct
             // literal `T{Field: value, ...}` (spec §Struct literals). Map the
             // positional C# `new T(a, b)` to that literal by zipping the arguments
-            // with the type's settable instance members in declaration order
-            // (ADR-0115 §B.4). Imported/BCL structs (e.g. `Guid`, `DateTime`,
+            // with the members the actual invoked constructor assigns them to
+            // (issue #1739 — NOT the type's members in bare declaration order,
+            // which silently swaps/misassigns values whenever a struct's member
+            // declaration order differs from its constructor's parameter order).
+            // Imported/BCL structs (e.g. `Guid`, `DateTime`,
             // `Span<T>` — all `SpecialType.None`) DO expose real constructors that
             // G# can call directly (`Guid(bytes, true)`), so they must fall through
             // to a constructor call rather than be zipped into a bogus literal over
@@ -9300,8 +9304,34 @@ public sealed class CSharpToGSharpTranslator
                     return new CompositeLiteralExpression(type, new List<FieldInitializer>());
                 }
 
-                List<string> targetNames = OrderedValueMemberNames(valueType);
-                if (targetNames.Count == arguments.Count)
+                // Issue #1739: the positional arguments must zip to the members the
+                // ACTUAL invoked constructor assigns them to (in ITS parameter
+                // order), never to `valueType`'s members in bare declaration order —
+                // a hand-written struct is free to declare members in any order
+                // relative to its constructor's parameter list, and a "trivial" ctor
+                // parameter can rename or transform on its way to the member.
+                // `GetSymbolInfo` gives the exact overload Roslyn resolved for this
+                // call site (handling overloads precisely, unlike an arity guess),
+                // and `arguments` is already reordered by `TranslateArguments` into
+                // that constructor's parameter DECLARATION order.
+                var ctorSymbol = this.context.GetSymbolInfo(creationNode).Symbol as IMethodSymbol;
+
+                // A `record struct` / `data struct`'s POSITIONAL primary constructor
+                // is declared as its OWN G# primary constructor (e.g. `data struct
+                // Pos(X int32, Y int32)`) and, unlike a plain struct, IS directly
+                // callable in G# — so `new Pos(1, 2)` maps to the genuine
+                // constructor call `Pos(1, 2)`, not a struct literal; that also
+                // sidesteps the fact that a record's primary ctor has no
+                // `ConstructorDeclarationSyntax` body to walk.
+                if (valueType.IsRecord &&
+                    ctorSymbol != null &&
+                    ctorSymbol.DeclaringSyntaxReferences.Length == 1 &&
+                    ctorSymbol.DeclaringSyntaxReferences[0].GetSyntax() is not ConstructorDeclarationSyntax)
+                {
+                    return BuildConstruction(type, arguments);
+                }
+
+                if (this.TryMapCtorParametersToMembers(ctorSymbol, valueType, out List<string> targetNames, out string unsupportedReason))
                 {
                     var fieldInitializers = new List<FieldInitializer>();
                     for (int i = 0; i < arguments.Count; i++)
@@ -9311,6 +9341,11 @@ public sealed class CSharpToGSharpTranslator
 
                     return new CompositeLiteralExpression(type, fieldInitializers);
                 }
+
+                // The constructor's logic cannot be expressed by a G# struct literal
+                // (it has no callable constructor body to run the logic in) — report
+                // it rather than emit a silently-wrong positional zip (issue #1739).
+                this.context.ReportUnsupported(creationNode, unsupportedReason);
             }
 
             return BuildConstruction(type, arguments);
@@ -9563,27 +9598,122 @@ public sealed class CSharpToGSharpTranslator
             return elements;
         }
 
-        private static List<string> OrderedValueMemberNames(INamedTypeSymbol valueType)
+        /// <summary>
+        /// Resolves a source struct's positional constructor to the members its
+        /// parameters actually initialize, in constructor parameter order (issue
+        /// #1739). Only the trivial "assign-through" ctor shape is resolved — every
+        /// statement a plain <c>Member = param;</c> assignment, one per parameter,
+        /// with no transformation, no chained <c>this(...)</c>/<c>base(...)</c>
+        /// call, and no expression-bodied ctor. A G# struct literal has no callable
+        /// constructor body to run other logic in, so any ctor that does not fit
+        /// this shape cannot be translated correctly — the caller reports it
+        /// unsupported rather than falling back to a guessed member order.
+        /// </summary>
+        /// <param name="ctorSymbol">The constructor symbol resolved for the <c>new</c> call site (via the semantic model), or <see langword="null"/> if unresolved.</param>
+        /// <param name="valueType">The source struct type being constructed.</param>
+        /// <param name="targetNames">On success, the member name each positional argument (in argument order) initializes.</param>
+        /// <param name="unsupportedReason">On failure, a human-readable reason suitable for <see cref="TranslationContext.ReportUnsupported"/>.</param>
+        /// <returns><see langword="true"/> if every constructor parameter was resolved to exactly one member.</returns>
+        private bool TryMapCtorParametersToMembers(
+            IMethodSymbol ctorSymbol,
+            INamedTypeSymbol valueType,
+            out List<string> targetNames,
+            out string unsupportedReason)
         {
-            // Settable instance members in declaration order: positional `data
-            // struct` parameters surface as auto-properties, a hand-written
-            // `struct` exposes auto-properties or fields; either maps to the
-            // struct-literal field list.
-            var props = valueType.GetMembers()
-                .OfType<IPropertySymbol>()
-                .Where(p => !p.IsStatic && !p.IsIndexer && p.GetMethod != null)
-                .Select(p => p.Name)
-                .ToList();
-            if (props.Count > 0)
+            targetNames = null;
+
+            if (ctorSymbol == null || ctorSymbol.MethodKind != MethodKind.Constructor)
             {
-                return props;
+                unsupportedReason = "the invoked struct constructor could not be resolved via the semantic " +
+                    "model; a positional G# struct literal cannot be built without knowing which member each " +
+                    "argument initializes (issue #1739).";
+                return false;
             }
 
-            return valueType.GetMembers()
-                .OfType<IFieldSymbol>()
-                .Where(f => !f.IsStatic && !f.IsImplicitlyDeclared)
-                .Select(f => f.Name)
-                .ToList();
+            // A `record struct` / `data struct`'s POSITIONAL primary constructor
+            // (`data struct Point(int X, int Y)`) never reaches this point — the
+            // caller routes it to a genuine constructor call instead (records have
+            // a real, directly callable primary constructor in G#), since it has
+            // no `ConstructorDeclarationSyntax` body to walk here.
+            if (ctorSymbol.DeclaringSyntaxReferences.Length != 1 ||
+                ctorSymbol.DeclaringSyntaxReferences[0].GetSyntax() is not ConstructorDeclarationSyntax ctorSyntax ||
+                ctorSyntax.Body == null ||
+                ctorSyntax.Initializer != null)
+            {
+                unsupportedReason = "struct constructor is not a simple block-bodied constructor with no " +
+                    "chained this()/base() call; a positional G# struct literal cannot express its logic " +
+                    "(issue #1739).";
+                return false;
+            }
+
+            // The constructor may live in a different file than the one currently
+            // being translated (the active `this.context.SemanticModel` is pinned
+            // to the current tree), so its body must be analyzed via a semantic
+            // model for ITS OWN tree.
+            SemanticModel ctorModel = this.context.Compilation.GetSemanticModel(ctorSyntax.SyntaxTree);
+
+            var paramToMember = new Dictionary<IParameterSymbol, string>(SymbolEqualityComparer.Default);
+            foreach (StatementSyntax statement in ctorSyntax.Body.Statements)
+            {
+                if (statement is not ExpressionStatementSyntax exprStatement ||
+                    exprStatement.Expression is not AssignmentExpressionSyntax assignment ||
+                    !assignment.OperatorToken.IsKind(SyntaxKind.EqualsToken))
+                {
+                    unsupportedReason = "struct constructor has a statement other than a plain member " +
+                        "assignment; a positional G# struct literal cannot express its logic (issue #1739).";
+                    return false;
+                }
+
+                ISymbol leftSymbol = ctorModel.GetSymbolInfo(assignment.Left).Symbol;
+
+                // Any field or property this constructor legally assigns is a
+                // valid struct-literal target — the C# compiler already enforces
+                // that only a setter/init accessor OR (for a get-only auto-
+                // property) the declaring type's OWN constructor may assign it.
+                // Issue #1739's second defect was a stale "settable" filter that
+                // actually tested READABILITY (`GetMethod != null`), which could
+                // admit a get-only COMPUTED property (no backing storage) as a
+                // zip target; that class of member can never appear here because
+                // the ctor could not legally assign it in the first place.
+                string memberName = leftSymbol switch
+                {
+                    IFieldSymbol f when !f.IsStatic && SymbolEqualityComparer.Default.Equals(f.ContainingType, valueType) => f.Name,
+                    IPropertySymbol p when !p.IsStatic && SymbolEqualityComparer.Default.Equals(p.ContainingType, valueType) => p.Name,
+                    _ => null,
+                };
+
+                // The right-hand side must be exactly a reference to one of the
+                // constructor's OWN parameters — anything else (a literal, a
+                // computed expression, a call) is a transformation the struct
+                // literal cannot replay.
+                ISymbol rightSymbol = ctorModel.GetSymbolInfo(assignment.Right).Symbol;
+                bool isPlainParameterAssign = memberName != null &&
+                    rightSymbol is IParameterSymbol rightParameter &&
+                    SymbolEqualityComparer.Default.Equals(rightParameter.ContainingSymbol, ctorSymbol) &&
+                    !paramToMember.ContainsKey(rightParameter);
+
+                if (!isPlainParameterAssign)
+                {
+                    unsupportedReason = "struct constructor assigns a member from something other than a " +
+                        "plain, once-only parameter reference (a transformation, method call, or repeated " +
+                        "parameter use); a positional G# struct literal cannot express its logic (issue #1739).";
+                    return false;
+                }
+
+                paramToMember[(IParameterSymbol)rightSymbol] = memberName;
+            }
+
+            if (paramToMember.Count != ctorSymbol.Parameters.Length)
+            {
+                unsupportedReason = "struct constructor does not assign every parameter directly to a member " +
+                    "(some parameter feeds other logic, e.g. validation); a positional G# struct literal cannot " +
+                    "express its logic (issue #1739).";
+                return false;
+            }
+
+            targetNames = ctorSymbol.Parameters.Select(p => paramToMember[p]).ToList();
+            unsupportedReason = null;
+            return true;
         }
 
         private GExpression TranslateCast(CastExpressionSyntax cast)
@@ -9891,7 +10021,7 @@ public sealed class CSharpToGSharpTranslator
                 ? new List<GExpression>()
                 : this.TranslateArguments(creation.ArgumentList.Arguments);
 
-            return this.BuildObjectCreationCore(typeSymbol, type, arguments, creation.Initializer);
+            return this.BuildObjectCreationCore(creation, typeSymbol, type, arguments, creation.Initializer);
         }
 
         private GExpression TranslateSwitchExpression(SwitchExpressionSyntax node)


### PR DESCRIPTION
Fixes #1739

## Bug
`new T(a, b, c)` on a SOURCE struct zipped positional constructor arguments to the struct's members by bare DECLARATION order, ignoring the constructor's actual parameter→member assignments. A struct whose member declaration order differs from its constructor's parameter order (or whose ctor transforms a parameter before assigning it) got silently wrong/swapped values. The member filter documented as 'settable' actually tested readability (`GetMethod != null`), which could admit a get-only computed property as an assignment target.

## Fix
- The translator now resolves the EXACT constructor symbol Roslyn bound for the `new` call site (`GetSymbolInfo`, handling overloads precisely) and walks its body for the trivial per-parameter assign-through pattern (`Member = param;`) to build the parameter→member mapping — never guessed from declaration order.
- A constructor that doesn't fit that shape (a transformation, an unassigned parameter, a non-trivial statement, a chained `this()`/`base()`, an unresolvable ctor) is reported via a VISIBLE `ReportUnsupported` diagnostic instead of silently emitting a mis-mapped struct literal.
- A `record struct`'s positional primary constructor is real and directly callable in G# (`data struct Pos(X int32, Y int32)`), so it now maps to a genuine constructor call (`Pos(1, 2)`) instead of a struct literal — more correct than either the old or a naive new approach.
- The 'settable' filter bug is subsumed: the new ctor-assignment-driven mapping only ever considers members the constructor legally assigned, so a get-only computed property (no backing storage) can never be picked — it's architecturally impossible now, not just re-filtered.

## Tests added (`tools/cs2gs/Cs2Gs.Tests/Issue1739PositionalStructCtorTranslationTests.cs`)
- Member declared out of ctor-parameter order → correct mapping (the exact repro from the issue).
- Field-based struct, out-of-order ctor assignment → correct mapping.
- Get-only COMPUTED property alongside real ctor-assigned members → never picked as a target.
- `record struct` positional primary constructor → genuine constructor call.
- Ctor parameter not assigned to any member (feeds other logic) → `ReportUnsupported`.
- Ctor assigns a transformed value (`raw * 2`) → `ReportUnsupported`.

Existing regression tests (declaration order matching ctor order, imported/BCL struct ctor calls, object-initializer-with-ctor-args) all still pass.

## Verification
- `dotnet build GSharp.sln -c Release -graph` — succeeds, 0 warnings/errors.
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release --filter "FullyQualifiedName!~Emit"` — 553/553 passed.
- Nothing deferred: both defects from the issue are fixed, generalized to any source struct/ctor shape (not just the repro), with a real diagnostic seam for any case a G# struct literal genuinely cannot express.