### PR TITLE
cs2gs: fix 4 silent-divergence bugs (issue #1741)

### DIFF
--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/GMember.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/GMember.cs
@@ -355,13 +355,18 @@ public sealed class DestructorDeclaration : GMember
     /// Initializes a new instance of the <see cref="DestructorDeclaration"/> class.
     /// </summary>
     /// <param name="body">The finalizer body.</param>
-    public DestructorDeclaration(BlockStatement body)
+    /// <param name="attributes">The finalizer attributes.</param>
+    public DestructorDeclaration(BlockStatement body, IReadOnlyList<AttributeUse> attributes = null)
     {
         Body = body;
+        Attributes = attributes ?? new List<AttributeUse>();
     }
 
     /// <summary>Gets the finalizer body.</summary>
     public BlockStatement Body { get; }
+
+    /// <summary>Gets the finalizer attributes.</summary>
+    public IReadOnlyList<AttributeUse> Attributes { get; }
 }
 
 /// <summary>
@@ -379,11 +384,17 @@ public sealed class EventDeclaration : GMember
     /// <param name="name">The event name.</param>
     /// <param name="type">The handler/delegate type.</param>
     /// <param name="visibility">The accessibility.</param>
-    public EventDeclaration(string name, GTypeReference type, Visibility visibility = Visibility.Default)
+    /// <param name="attributes">The event attributes.</param>
+    public EventDeclaration(
+        string name,
+        GTypeReference type,
+        Visibility visibility = Visibility.Default,
+        IReadOnlyList<AttributeUse> attributes = null)
     {
         Name = name;
         Type = type;
         Visibility = visibility;
+        Attributes = attributes ?? new List<AttributeUse>();
     }
 
     /// <summary>Gets the event name.</summary>
@@ -394,4 +405,7 @@ public sealed class EventDeclaration : GMember
 
     /// <summary>Gets the accessibility.</summary>
     public Visibility Visibility { get; }
+
+    /// <summary>Gets the event attributes.</summary>
+    public IReadOnlyList<AttributeUse> Attributes { get; }
 }

--- a/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
@@ -1158,9 +1158,9 @@ public static class GSharpPrinter
             case ConstructorDeclaration constructor:
                 return RenderConstructor(constructor, indent);
             case DestructorDeclaration destructor:
-                return $"{Indent(indent)}deinit {RenderBlock(destructor.Body, indent)}";
+                return $"{RenderAttributeBlock(destructor.Attributes, indent)}{Indent(indent)}deinit {RenderBlock(destructor.Body, indent)}";
             case EventDeclaration eventDeclaration:
-                return $"{Indent(indent)}{RenderVisibility(eventDeclaration.Visibility)}event {eventDeclaration.Name} {RenderType(eventDeclaration.Type)}";
+                return $"{RenderAttributeBlock(eventDeclaration.Attributes, indent)}{Indent(indent)}{RenderVisibility(eventDeclaration.Visibility)}event {eventDeclaration.Name} {RenderType(eventDeclaration.Type)}";
             case SharedBlock sharedBlock:
                 return RenderSharedBlock(sharedBlock, indent);
             default:

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1741SilentDivergenceTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1741SilentDivergenceTests.cs
@@ -1,0 +1,229 @@
+// <copyright file="Issue1741SilentDivergenceTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #1741: four SILENT-DIVERGENCE bugs where the translator either
+/// altered the translated API surface or dropped information with no
+/// diagnostic. Each case here either now translates faithfully or reports a
+/// <see cref="TranslationDiagnostic"/> (mirroring the existing
+/// <c>protected internal</c> mapping at <c>MapVisibility</c>).
+/// </summary>
+public class Issue1741SilentDivergenceTests
+{
+    /// <summary>
+    /// An accessor-level accessibility modifier (<c>{ get; private set; }</c>)
+    /// used to collapse to the plain auto form, silently widening a
+    /// private-set property to fully public. G# has no per-accessor
+    /// accessibility, so the loss is now diagnosed instead of silent.
+    /// </summary>
+    [Fact]
+    public void PrivateSetAccessor_ReportsAccessibilityLossDiagnostic()
+    {
+        (CompilationUnit unit, TranslationContext context) = Translate(@"
+namespace Demo
+{
+    public class C
+    {
+        public int X { get; private set; }
+    }
+}");
+        Assert.Contains(
+            context.Diagnostics,
+            d => d.Severity == TranslationSeverity.Warning
+                && d.Message.Contains("narrower accessibility", StringComparison.OrdinalIgnoreCase));
+        Assert.NotNull(unit);
+    }
+
+    /// <summary>
+    /// A protected get-accessor on a public property must also be diagnosed;
+    /// the fix generalizes to any accessor with a narrowing modifier, not just
+    /// <c>private set</c>.
+    /// </summary>
+    [Fact]
+    public void ProtectedGetAccessor_ReportsAccessibilityLossDiagnostic()
+    {
+        (_, TranslationContext context) = Translate(@"
+namespace Demo
+{
+    public class C
+    {
+        public int X { protected get; set; }
+    }
+}");
+        Assert.Contains(
+            context.Diagnostics,
+            d => d.Severity == TranslationSeverity.Warning
+                && d.Message.Contains("narrower accessibility", StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// A plain read-write auto-property with no accessor modifiers must not be
+    /// flagged: there is nothing being narrowed.
+    /// </summary>
+    [Fact]
+    public void PlainAutoProperty_NoAccessibilityLossDiagnostic()
+    {
+        (_, TranslationContext context) = Translate(@"
+namespace Demo
+{
+    public class C
+    {
+        public int X { get; set; }
+    }
+}");
+        Assert.DoesNotContain(
+            context.Diagnostics,
+            d => d.Message.Contains("narrower accessibility", StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// An attribute on a field-like event must round-trip into the printed
+    /// G#, not vanish.
+    /// </summary>
+    [Fact]
+    public void EventAttribute_TranslatesFaithfully()
+    {
+        (CompilationUnit unit, _) = Translate(@"
+using System;
+
+namespace Demo
+{
+    public class C
+    {
+        [Obsolete]
+        public event EventHandler X;
+    }
+}");
+        TypeDeclaration type = unit.Members.OfType<TypeDeclaration>().Single(t => t.Name == "C");
+        EventDeclaration ev = type.Members.OfType<EventDeclaration>().Single(e => e.Name == "X");
+        Assert.Single(ev.Attributes);
+
+        string printed = GSharpPrinter.Print(unit);
+        Assert.Contains("Obsolete", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// An attribute on a finalizer must round-trip into the printed G#, not
+    /// vanish.
+    /// </summary>
+    [Fact]
+    public void FinalizerAttribute_TranslatesFaithfully()
+    {
+        (CompilationUnit unit, _) = Translate(@"
+using System;
+
+namespace Demo
+{
+    public class C
+    {
+        [Obsolete]
+        ~C() { }
+    }
+}");
+        TypeDeclaration type = unit.Members.OfType<TypeDeclaration>().Single(t => t.Name == "C");
+        DestructorDeclaration destructor = type.Members.OfType<DestructorDeclaration>().Single();
+        Assert.Single(destructor.Attributes);
+
+        string printed = GSharpPrinter.Print(unit);
+        Assert.Contains("Obsolete", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A user class literally named <c>Enum</c> must keep its own base clause;
+    /// the old fragile string-name guard (<c>csBase.Name != "Enum"</c>) dropped
+    /// it purely because of the name match.
+    /// </summary>
+    [Fact]
+    public void UserClassNamedEnum_KeepsBaseClause()
+    {
+        (CompilationUnit unit, _) = Translate(@"
+namespace Demo
+{
+    public class Enum
+    {
+    }
+
+    public class Foo : Enum
+    {
+    }
+}");
+        TypeDeclaration foo = unit.Members.OfType<TypeDeclaration>().Single(t => t.Name == "Foo");
+        Assert.NotNull(foo.BaseType);
+    }
+
+    /// <summary>
+    /// A real local variable named <c>_</c> is a genuine assignment target in
+    /// C#; the old name-based discard check dropped the assignment even
+    /// though <c>_</c> here is a real variable in scope, not
+    /// <see cref="Microsoft.CodeAnalysis.IDiscardSymbol"/>.
+    /// </summary>
+    [Fact]
+    public void RealVariableNamedUnderscore_AssignmentIsPreserved()
+    {
+        (CompilationUnit unit, _) = Translate(@"
+namespace Demo
+{
+    public class C
+    {
+        public void M()
+        {
+            int _ = 0;
+            _ = 5;
+        }
+    }
+}");
+        string printed = GSharpPrinter.Print(unit);
+        Assert.Contains("_ = 5", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A genuine C# discard (<c>_ = e;</c> with no <c>_</c> variable in scope)
+    /// must still drop the assignment and keep only the RHS, exactly as
+    /// before (issue #914).
+    /// </summary>
+    [Fact]
+    public void TrueDiscard_StillDropsAssignment()
+    {
+        (CompilationUnit unit, _) = Translate(@"
+namespace Demo
+{
+    public class C
+    {
+        public int Next() => 1;
+
+        public void M()
+        {
+            _ = Next();
+        }
+    }
+}");
+        string printed = GSharpPrinter.Print(unit);
+        Assert.DoesNotContain("_ =", printed, StringComparison.Ordinal);
+        Assert.Contains("Next()", printed, StringComparison.Ordinal);
+    }
+
+    private static (CompilationUnit Unit, TranslationContext Context) Translate(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        return (unit, context);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -1835,7 +1835,9 @@ public sealed class CSharpToGSharpTranslator
                     // A C# finalizer `~T()` maps to the G# `deinit { ... }` block
                     // (ADR-0068, reference types only).
                     yield return (
-                        new DestructorDeclaration(this.TranslateBody(destructor, $"finalizer on '{destructor.Identifier.Text}'")),
+                        new DestructorDeclaration(
+                            this.TranslateBody(destructor, $"finalizer on '{destructor.Identifier.Text}'"),
+                            this.MapAttributes(destructor.AttributeLists)),
                         false);
                     break;
 
@@ -1887,7 +1889,8 @@ public sealed class CSharpToGSharpTranslator
                 var declaration = new EventDeclaration(
                     SanitizeIdentifier(declarator.Identifier.Text),
                     type,
-                    MapVisibility(symbol, this.context, node));
+                    MapVisibility(symbol, this.context, node),
+                    this.MapAttributes(node.AttributeLists));
 
                 yield return (declaration, symbol != null && symbol.IsStatic);
             }
@@ -2542,6 +2545,30 @@ public sealed class CSharpToGSharpTranslator
             }
 
             IReadOnlyList<AccessorDeclarationSyntax> declared = node.AccessorList.Accessors;
+
+            // Issue #1741: an accessor-level accessibility modifier (`{ get; private
+            // set; }`) narrows just that accessor; G# has no per-accessor
+            // accessibility, so it would silently widen back to the property's own
+            // accessibility. Diagnose the loss instead of translating it silently.
+            foreach (AccessorDeclarationSyntax accessor in declared)
+            {
+                SyntaxToken accessibilityModifier = accessor.Modifiers.FirstOrDefault(m =>
+                    m.IsKind(SyntaxKind.PrivateKeyword) ||
+                    m.IsKind(SyntaxKind.ProtectedKeyword) ||
+                    m.IsKind(SyntaxKind.InternalKeyword));
+                if (accessibilityModifier.IsKind(SyntaxKind.None))
+                {
+                    continue;
+                }
+
+                string accessorMods = string.Join(" ", accessor.Modifiers.Select(m => m.ValueText));
+                this.context.Report(new TranslationDiagnostic(
+                    accessor.Kind().ToString(),
+                    $"{displayName} accessor '{accessorMods} {accessor.Keyword.ValueText}' has narrower accessibility than the property; G# has no per-accessor accessibility, so it is widened to the property's own accessibility (ADR-0115 §B.11).",
+                    accessor.GetLocation(),
+                    TranslationSeverity.Warning));
+            }
+
             bool anyBodied = declared.Any(a => a.Body != null || a.ExpressionBody != null);
             bool hasSet = declared.Any(a => a.IsKind(SyntaxKind.SetAccessorDeclaration));
             bool hasGet = declared.Any(a => a.IsKind(SyntaxKind.GetAccessorDeclaration));
@@ -2787,7 +2814,7 @@ public sealed class CSharpToGSharpTranslator
                 csBase.SpecialType != SpecialType.System_Object &&
                 csBase.SpecialType != SpecialType.System_ValueType &&
                 csBase.TypeKind == TypeKind.Class &&
-                csBase.Name != "Enum")
+                csBase.SpecialType != SpecialType.System_Enum)
             {
                 baseType = this.typeMapper.Map(csBase, this.context, location);
             }
@@ -4848,6 +4875,23 @@ public sealed class CSharpToGSharpTranslator
         }
 
         /// <summary>
+        /// Issue #1741: whether an identifier named <c>_</c> is a true C# discard
+        /// (<see cref="IDiscardSymbol"/>) rather than a real variable/field named
+        /// <c>_</c> that happens to be in scope. A real <c>_</c> binding is a normal
+        /// assignment target, not a discard, and must not be dropped.
+        /// </summary>
+        /// <param name="identifier">The <c>_</c> identifier on the assignment's left side.</param>
+        /// <returns><c>true</c> when <paramref name="identifier"/> is a genuine discard.</returns>
+        private bool IsTrueDiscard(IdentifierNameSyntax identifier)
+        {
+            ISymbol symbol = this.context.GetSymbolInfo(identifier).Symbol;
+
+            // No symbol at all means there is no real `_` binding in scope, so this
+            // is a genuine discard; fall back to the name-based check.
+            return symbol is IDiscardSymbol or null;
+        }
+
+        /// <summary>
         /// Translates an expression-statement that may expand into several G#
         /// statements: a tuple deconstruction (<c>var (a, b) = e</c>) or a chained
         /// assignment (<c>a = b = c</c>), neither of which has a single-statement G#
@@ -4858,7 +4902,8 @@ public sealed class CSharpToGSharpTranslator
             if (expression is AssignmentExpressionSyntax assignment &&
                 assignment.IsKind(SyntaxKind.SimpleAssignmentExpression))
             {
-                if (assignment.Left is IdentifierNameSyntax { Identifier.ValueText: "_" })
+                if (assignment.Left is IdentifierNameSyntax { Identifier.ValueText: "_" } discardCandidate &&
+                    this.IsTrueDiscard(discardCandidate))
                 {
                     // C# statement-level discard `_ = e` (Roslyn parses the `_`
                     // target as an IdentifierNameSyntax). G# has no discard target


### PR DESCRIPTION
Fixes #1741

This fixes all four silent-divergence bugs where cs2gs altered the translated API surface or dropped information with no diagnostic.

1. Accessor-level accessibility (`{ get; private set; }`) still collapses to the plain auto form (G# has no per-accessor accessibility), but MapAccessors now emits a TranslationDiagnostic warning whenever any accessor carries a narrowing accessibility modifier (private/protected/internal on get/set/init), generalized beyond the single private-set example. Fixed by diagnostic.

2. Attributes on field-like events and finalizers used to vanish silently. EventDeclaration and DestructorDeclaration in the code model gained an Attributes property (mirroring MethodDeclaration/PropertyDeclaration), the printer now renders them, and the translator maps AttributeLists for both instead of dropping them. Fixed faithfully.

3. The base-class-drop guard for real System.Enum used a fragile `csBase.Name != "Enum"` string check, which also dropped the base clause for any user class literally named Enum. Replaced with the symbol-based `csBase.SpecialType != SpecialType.System_Enum` check. Fixed faithfully.

4. Statement-level discard detection (`_ = e;`) was name-based and dropped the assignment even when a real variable named `_` was in scope (not a discard). Now checks the semantic model for a true IDiscardSymbol, falling back to the name-based check only when there is genuinely no symbol (real discard). Fixed faithfully.

Added tools/cs2gs/Cs2Gs.Tests/Issue1741SilentDivergenceTests.cs (8 tests) covering diagnostic emission and faithful-translation output for all four cases. Whole-solution build (`dotnet build GSharp.sln -c Release -graph`) succeeds, and the full Cs2Gs.Tests suite passes (617/617).