### PR TITLE
Memoize IsUsedAsNullable/IsSymbolReassigned to fix quadratic cs2gs cost

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue1743MemoizedSymbolQueryTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1743MemoizedSymbolQueryTranslationTests.cs
@@ -1,0 +1,153 @@
+// <copyright file="Issue1743MemoizedSymbolQueryTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Translator-fidelity + memoization tests for issue #1743: <c>IsUsedAsNullable</c>
+/// and <c>IsSymbolReassigned</c> each re-walked their whole scope (containing type
+/// / enclosing body) on EVERY call for the same symbol, an O(accesses × type size)
+/// cost in a nullable-oblivious corpus (every field/property receiver access
+/// triggers the walk). Both are now memoized per (symbol, scope) on the
+/// translator instance. These tests pin that the memoized answer is unchanged
+/// from the un-memoized one (a field that IS used as nullable still gets its
+/// <c>!!</c> forgiveness / <c>T?</c> type, one that is NOT still doesn't; a
+/// reassigned local still renders <c>var</c>, a never-reassigned one still
+/// renders <c>let</c>) and that repeatedly querying the same symbol answers
+/// identically every time (whether served from a fresh walk or the memoized
+/// cache).
+/// </summary>
+public class Issue1743MemoizedSymbolQueryTranslationTests
+{
+    [Fact]
+    public void FieldUsedAsNullable_StillGetsNullForgiveness()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        private string name;
+        private string other;
+
+        public void F()
+        {
+            if (this.name == null) { }
+            System.Console.WriteLine(this.name.Length);
+            System.Console.WriteLine(this.other.Length);
+        }
+    }
+}");
+
+        // `name` is null-checked elsewhere in the type, so its every receiver
+        // use gets the flow-independent `!!` forgiveness (issue #1072).
+        Assert.Contains("name!!.Length", printed);
+
+        // `other` is never compared/assigned to null anywhere in the type, so
+        // it stays a bare (non-promoted) receiver.
+        Assert.DoesNotContain("other!!.Length", printed);
+    }
+
+    [Fact]
+    public void ReassignedLocal_StillRendersVar_NonReassignedLocal_StillRendersLet()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        public void F()
+        {
+            int x = 1;
+            x = 2;
+            int y = 1;
+            System.Console.WriteLine(x + y);
+        }
+    }
+}");
+
+        Assert.Contains("var x = 1", printed);
+        Assert.DoesNotContain("let x", printed);
+
+        Assert.Contains("let y = 1", printed);
+        Assert.DoesNotContain("var y", printed);
+    }
+
+    [Fact]
+    public void RepeatedReceiverAndReassignmentQueries_AreIdempotent()
+    {
+        // Same symbol (`this.name` field, local `x`) queried many times over —
+        // each call must answer identically to every other call for that
+        // symbol, whether served from a fresh walk or the memoized cache
+        // (issue #1743).
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class C
+    {
+        private string name;
+
+        public void F()
+        {
+            if (this.name == null) { }
+            System.Console.WriteLine(this.name.Length);
+            System.Console.WriteLine(this.name.Length);
+            System.Console.WriteLine(this.name.Length);
+            int x = 1;
+            x = 2;
+            x = 3;
+            System.Console.WriteLine(x);
+        }
+    }
+}");
+
+        int nameForgivenessCount = CountOccurrences(printed, "name!!.Length");
+        Assert.Equal(3, nameForgivenessCount);
+
+        Assert.Contains("var x = 1", printed);
+        Assert.DoesNotContain("let x", printed);
+    }
+
+    private static int CountOccurrences(string text, string value)
+    {
+        int count = 0;
+        int index = 0;
+        while ((index = text.IndexOf(value, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += value.Length;
+        }
+
+        return count;
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -440,6 +440,27 @@ public sealed class CSharpToGSharpTranslator
         private readonly Dictionary<ISymbol, GExpression> staticFieldInitializers =
             new Dictionary<ISymbol, GExpression>(SymbolEqualityComparer.Default);
 
+        // Issue #1743: both <see cref="IsSymbolReassigned"/> and
+        // <see cref="IsUsedAsNullable"/> answer a question that depends only on
+        // (symbol, scope) — never on WHEN it's asked — yet each call re-walks
+        // every descendant node of the scope (a whole method/type/body) looking
+        // for it. A file with hundreds of field/property receiver checks was
+        // rescanning its whole containing type hundreds of times
+        // (O(accesses × type size)). Keyed on the (symbol, scope) pair rather
+        // than the symbol alone: nothing here actually requires the extra scope
+        // key today (see the two methods' own comments), but it costs nothing
+        // and removes any doubt if a future caller ever passes a different scope
+        // for the same symbol. Scoped to this translator instance: symbols/
+        // scopes come from a specific `SemanticModel`/syntax tree, so even a
+        // translator instance reused across documents/compilations (as some
+        // tests do) never gets a stale cross-document hit — different
+        // compilations produce different (non-equal) symbol/node instances.
+        private readonly Dictionary<(ISymbol Symbol, SyntaxNode Scope), bool> symbolReassignedCache =
+            new Dictionary<(ISymbol, SyntaxNode), bool>(SymbolScopeKeyComparer.Instance);
+
+        private readonly Dictionary<(ISymbol Symbol, SyntaxNode Scope), bool> usedAsNullableCache =
+            new Dictionary<(ISymbol, SyntaxNode), bool>(SymbolScopeKeyComparer.Instance);
+
         // The syntax node whose body is currently being translated. It bounds the
         // data-flow scan that decides whether a local is mutable (var) or
         // immutable (let) per ADR-0115 §B.3.
@@ -6796,6 +6817,19 @@ public sealed class CSharpToGSharpTranslator
                 return false;
             }
 
+            var key = (symbol, scope);
+            if (this.symbolReassignedCache.TryGetValue(key, out bool cached))
+            {
+                return cached;
+            }
+
+            bool result = this.ComputeIsSymbolReassigned(symbol, scope);
+            this.symbolReassignedCache[key] = result;
+            return result;
+        }
+
+        private bool ComputeIsSymbolReassigned(ISymbol symbol, SyntaxNode scope)
+        {
             foreach (SyntaxNode node in scope.DescendantNodes())
             {
                 switch (node)
@@ -6846,6 +6880,19 @@ public sealed class CSharpToGSharpTranslator
                 return false;
             }
 
+            var key = (symbol, scope);
+            if (this.usedAsNullableCache.TryGetValue(key, out bool cached))
+            {
+                return cached;
+            }
+
+            bool result = this.ComputeIsUsedAsNullable(symbol, scope);
+            this.usedAsNullableCache[key] = result;
+            return result;
+        }
+
+        private bool ComputeIsUsedAsNullable(ISymbol symbol, SyntaxNode scope)
+        {
             // The scope is scanned with the current document's semantic model, so a
             // node from another syntax tree (e.g. an inherited field declared in a
             // different file) cannot be queried here — `GetSymbolInfo` would throw
@@ -10580,6 +10627,26 @@ public sealed class CSharpToGSharpTranslator
             /// </summary>
             public IReadOnlyList<GStatement> ResidualInitStatements { get; init; } =
                 new List<GStatement>();
+        }
+
+        // Issue #1743: equality for the (symbol, scope) cache key used by
+        // <see cref="IsSymbolReassigned"/>/<see cref="IsUsedAsNullable"/>'s
+        // memoization. Symbols compare via the Roslyn-recommended
+        // <see cref="SymbolEqualityComparer.Default"/>; scope nodes compare by
+        // reference (the same `SyntaxNode` instance is what every call site
+        // passes for a given symbol).
+        private sealed class SymbolScopeKeyComparer : IEqualityComparer<(ISymbol Symbol, SyntaxNode Scope)>
+        {
+            public static readonly SymbolScopeKeyComparer Instance = new SymbolScopeKeyComparer();
+
+            public bool Equals((ISymbol Symbol, SyntaxNode Scope) x, (ISymbol Symbol, SyntaxNode Scope) y) =>
+                SymbolEqualityComparer.Default.Equals(x.Symbol, y.Symbol) &&
+                ReferenceEquals(x.Scope, y.Scope);
+
+            public int GetHashCode((ISymbol Symbol, SyntaxNode Scope) obj) =>
+                HashCode.Combine(
+                    SymbolEqualityComparer.Default.GetHashCode(obj.Symbol),
+                    System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(obj.Scope));
         }
     }
 }


### PR DESCRIPTION
Fixes #1743

Fixed a quadratic (O(accesses × containing-type size)) performance bug in the cs2gs C#→G# translator, in the nullable-flow/nullable-promotion passes in `tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs`.

## What was quadratic

`ReceiverIsNullableReferenceFieldOrProperty`/`ReceiverNeedsNullForgiveness` fall through to `IsPromotedToNullableReference`, which calls `IsUsedAsNullable(symbol, GetNullabilityScope(symbol))`. In a nullable-oblivious corpus (e.g. Oahu), the field/property's declared `NullableAnnotation` is never `Annotated`, so this fallback fires for every single field/property receiver of every member/element access and invocation. `IsUsedAsNullable` re-walks `DescendantNodes()` of the whole containing type looking for a null-check/null-assignment of that symbol, on every call — even though the answer only depends on the symbol and never changes. A type with hundreds of receiver accesses rescanned the whole type hundreds of times.

`IsSymbolReassigned` (used both by `IsLocalReassigned` and `WithParameterShadows`) has the identical shape: it re-walks the whole enclosing body/method on every call for every local/parameter, un-memoized.

## How it's fixed

Both methods now memoize their result in a per-translator-instance `Dictionary<(ISymbol Symbol, SyntaxNode Scope), bool>`, using `SymbolEqualityComparer.Default` for the symbol and reference equality for the scope node (see the new `SymbolScopeKeyComparer`). The original method bodies were renamed to `ComputeIsSymbolReassigned`/`ComputeIsUsedAsNullable` and are only invoked on a cache miss.

## Why the cache key is safe

The key includes the scope node, not just the symbol, even though inspecting `GetNullabilityScope` and both `IsSymbolReassigned` call sites shows the scope passed in is already a pure, deterministic function of the symbol in every current code path (a field's scope is its containing type's declaration, a local's scope is its enclosing block, a parameter's scope is its containing method — none of that varies call to call for the same symbol). Including the scope anyway costs nothing and removes any doubt if a future caller ever passes a different scope for the same symbol — it can never serve a stale answer for a different scope.

## Cache lifetime

The cache lives on the translator instance. Production call sites (`TranslateStage`, `TestParityStage`) construct a brand-new `CSharpToGSharpTranslator` per document, so this is a non-issue there. Some tests reuse a single translator instance across multiple documents/compilations (mirroring the existing `Issue1744SubclassedBaseTypeCacheTests` pattern); this stays correct because symbols and scope nodes from different compilations/syntax trees are never equal to each other under `SymbolEqualityComparer.Default`/reference equality, so there's no cross-document staleness risk even without explicit cache clearing.

## Tests

Added `tools/cs2gs/Cs2Gs.Tests/Issue1743MemoizedSymbolQueryTranslationTests.cs`:
- `FieldUsedAsNullable_StillGetsNullForgiveness` — a field that IS null-checked elsewhere still gets its `!!` receiver forgiveness; a sibling field that is never null-checked/assigned stays bare (behavioral parity, positive/negative).
- `ReassignedLocal_StillRendersVar_NonReassignedLocal_StillRendersLet` — same parity check for `IsSymbolReassigned`.
- `RepeatedReceiverAndReassignmentQueries_AreIdempotent` — the same field receiver accessed three times and the same local reassigned three times all get an identical answer, proving the memoized path behaves exactly like the original per-call walk (idempotence).

## Verification

- `dotnet build GSharp.sln -c Release -graph` — succeeds, 0 warnings/errors.
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release --filter "FullyQualifiedName~Issue1743MemoizedSymbolQueryTranslationTests"` — 3/3 pass.
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release` (full suite) — 618/618 pass, including the pre-existing `ReportTests.Cli_ReportVerb_RegeneratesBothArtifacts` (no flakiness observed after the whole-solution build).

Nothing deferred — both flagged methods (`IsUsedAsNullable` and `IsSymbolReassigned`) are memoized.
