### PR TITLE
cs2gs: fix aggregate rollup rendering unverified runs as green (issue #1831)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Cli/Program.cs
+++ b/tools/cs2gs/Cs2Gs.Cli/Program.cs
@@ -436,8 +436,15 @@ internal static class Program
         }
 
         Console.WriteLine();
-        int passed = result.Apps.Count(a => a.Succeeded);
-        string verdict = result.Succeeded ? "PASSED" : "FAILED";
+
+        // Same precedence as the report (issue #1831): a run-level failure
+        // always wins; otherwise call out unverified apps rather than
+        // rendering them as a plain pass.
+        int passed = result.Apps.Count(a => a.Succeeded && !a.Unverified);
+        int unverified = result.Apps.Count(a => a.Unverified);
+        string verdict = !result.Succeeded
+            ? "FAILED"
+            : unverified > 0 ? $"PASSED ({unverified} unverified)" : "PASSED";
         Console.WriteLine($"{passed}/{result.Apps.Count} apps green; run {verdict}.");
     }
 

--- a/tools/cs2gs/Cs2Gs.Pipeline/MigrationPipeline.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/MigrationPipeline.cs
@@ -131,6 +131,11 @@ public sealed class MigrationPipeline
             }
         }
 
+        if (runResult.Succeeded && runResult.Apps.Any(a => a.Unverified))
+        {
+            runResult.Unverified = true;
+        }
+
         string runJsonPath = Path.Combine(runDir, "run.json");
         File.WriteAllText(runJsonPath, JsonSerializer.Serialize(runResult, TriageSerialization.Options));
 
@@ -319,6 +324,13 @@ public sealed class MigrationPipeline
             }
 
             shortCircuited = true;
+        }
+
+        if (appResult.Succeeded && appResult.Stages.Any(s => s.Status == "skipped"))
+        {
+            // No stage failed, but at least one was genuinely unverified
+            // (issue #1831): don't let that roll up as green.
+            appResult.Unverified = true;
         }
 
         return appResult;

--- a/tools/cs2gs/Cs2Gs.Pipeline/RunResult.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/RunResult.cs
@@ -40,9 +40,22 @@ public sealed class RunResult
     [JsonPropertyOrder(4)]
     public bool Succeeded { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether no app failed but at least one
+    /// app has an unverified stage (a genuinely-unavailable dependency, e.g.
+    /// no locally-built SDK). Mutually exclusive with a "failed" run: a
+    /// skipped stage never overrides a failed one (ADR-0115 §C). Distinct
+    /// from <see cref="Succeeded"/> so the aggregate
+    /// rollup cannot render "not verified" as verified-green (issue #1831,
+    /// following the per-stage fix in issue #1749).
+    /// </summary>
+    [JsonPropertyName("unverified")]
+    [JsonPropertyOrder(5)]
+    public bool Unverified { get; set; }
+
     /// <summary>Gets or sets the per-app results.</summary>
     [JsonPropertyName("apps")]
-    [JsonPropertyOrder(5)]
+    [JsonPropertyOrder(6)]
     public List<AppResult> Apps { get; set; } = new List<AppResult>();
 }
 
@@ -62,24 +75,37 @@ public sealed class AppResult
     [JsonPropertyOrder(1)]
     public bool Succeeded { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether no stage failed but at least
+    /// one stage is <c>skipped</c> (a genuinely-unavailable dependency, not a
+    /// pass). Never <see langword="true"/> when <see cref="Succeeded"/> is
+    /// <see langword="false"/> — a failed stage always takes precedence
+    /// (ADR-0115 §C). This is the app-level counterpart of the per-stage
+    /// "skipped" status (issue #1749); it exists so the aggregate rollup does
+    /// not render an unverified app as green (issue #1831).
+    /// </summary>
+    [JsonPropertyName("unverified")]
+    [JsonPropertyOrder(2)]
+    public bool Unverified { get; set; }
+
     /// <summary>Gets or sets the category of the first failing stage, or null when green.</summary>
     [JsonPropertyName("failureCategory")]
-    [JsonPropertyOrder(2)]
+    [JsonPropertyOrder(3)]
     public string FailureCategory { get; set; }
 
     /// <summary>Gets or sets the per-stage results, in execution order.</summary>
     [JsonPropertyName("stages")]
-    [JsonPropertyOrder(3)]
+    [JsonPropertyOrder(4)]
     public List<StageResult> Stages { get; set; } = new List<StageResult>();
 
     /// <summary>Gets or sets the run-relative paths of the triage artifacts produced for this app.</summary>
     [JsonPropertyName("artifacts")]
-    [JsonPropertyOrder(4)]
+    [JsonPropertyOrder(5)]
     public List<string> Artifacts { get; set; } = new List<string>();
 
     /// <summary>Gets or sets the distinct fingerprints captured for this app.</summary>
     [JsonPropertyName("fingerprints")]
-    [JsonPropertyOrder(5)]
+    [JsonPropertyOrder(6)]
     public List<string> Fingerprints { get; set; } = new List<string>();
 }
 

--- a/tools/cs2gs/Cs2Gs.Report/HtmlReportWriter.cs
+++ b/tools/cs2gs/Cs2Gs.Report/HtmlReportWriter.cs
@@ -43,7 +43,7 @@ public static class HtmlReportWriter
         "h3{font-size:1rem;margin:0 0 .5rem;}",
         "a{color:#0969da;}",
         ".run-header .verdict{display:inline-block;font-weight:700;padding:.15rem .6rem;border-radius:999px;color:#fff;}",
-        ".verdict.ok{background:var(--ok);} .verdict.bad{background:var(--bad);}",
+        ".verdict.ok{background:var(--ok);} .verdict.bad{background:var(--bad);} .verdict.skip{background:var(--skip);}",
         ".provenance{display:grid;grid-template-columns:max-content 1fr;gap:.15rem 1rem;margin:.75rem 0 0;}",
         ".provenance dt{font-weight:600;color:var(--skip);} .provenance dd{margin:0;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;}",
         "table{border-collapse:collapse;width:100%;}",
@@ -65,7 +65,7 @@ public static class HtmlReportWriter
         ".toggle{margin:.5rem 0;cursor:pointer;background:#fff;border:1px solid var(--line);border-radius:6px;padding:.3rem .7rem;font:inherit;}",
         ".app-detail{border:1px solid var(--line);border-radius:6px;padding:1rem;margin:0 0 1rem;}",
         ".state{font-size:.75rem;padding:.1rem .5rem;border-radius:999px;color:#fff;vertical-align:middle;}",
-        ".state.ok{background:var(--ok);} .state.bad{background:var(--bad);}",
+        ".state.ok{background:var(--ok);} .state.bad{background:var(--bad);} .state.skip{background:var(--skip);}",
         ".stage-list th,.stage-list td{border:1px solid var(--line);padding:.3rem .6rem;text-align:left;}",
         ".meta-line .k,.artifact-h{font-weight:600;color:var(--skip);}",
         ".empty{color:var(--skip);}") + Newline;
@@ -180,8 +180,15 @@ public static class HtmlReportWriter
 
     private static void AppendHeader(StringBuilder sb, ReportModel model)
     {
-        string verdict = model.Succeeded ? "PASSED" : "FAILED";
-        string verdictClass = model.Succeeded ? "ok" : "bad";
+        // Precedence per ADR-0115 §C (issue #1831): a failed run is always
+        // "FAILED"/red; otherwise, any unverified app makes the run
+        // "PASSED (unverified)"/skip-colored rather than a plain green pass —
+        // "not verified" must never render as verified-green, one level up
+        // from the per-stage fix in issue #1749.
+        string verdict = !model.Succeeded
+            ? "FAILED"
+            : model.Unverified ? "PASSED (unverified)" : "PASSED";
+        string verdictClass = !model.Succeeded ? "bad" : model.Unverified ? "skip" : "ok";
 
         sb.Append("<header class=\"run-header\">").Append(Newline);
         sb.Append("<h1>cs2gs migration report</h1>").Append(Newline);
@@ -189,7 +196,14 @@ public static class HtmlReportWriter
             .Append("Run ").Append(verdict).Append(" — ")
             .Append(model.GreenApps.ToString(CultureInfo.InvariantCulture)).Append('/')
             .Append(model.TotalApps.ToString(CultureInfo.InvariantCulture))
-            .Append(" apps green</p>").Append(Newline);
+            .Append(" apps green");
+        if (model.UnverifiedApps > 0)
+        {
+            sb.Append(", ").Append(model.UnverifiedApps.ToString(CultureInfo.InvariantCulture))
+                .Append(" unverified");
+        }
+
+        sb.Append("</p>").Append(Newline);
         sb.Append("<dl class=\"provenance\">").Append(Newline);
         AppendDefinition(sb, "Run id", model.RunId);
         AppendDefinition(sb, "Timestamp", model.Timestamp);
@@ -438,11 +452,16 @@ public static class HtmlReportWriter
 
         foreach (AppReport app in model.Apps)
         {
-            string stateClass = app.Succeeded ? "ok" : "bad";
+            // Same precedence as the run header (issue #1831): failed apps
+            // are "bad"/red; an unverified-but-not-failed app is "skip"/gray
+            // (reusing the per-stage skip color from issue #1749), never
+            // green.
+            string stateClass = !app.Succeeded ? "bad" : app.Unverified ? "skip" : "ok";
+            string stateLabel = !app.Succeeded ? "failing" : app.Unverified ? "unverified" : "green";
             sb.Append("<article id=\"app-").Append(slugs[app.AppId]).Append("\" class=\"app-detail\">").Append(Newline);
             sb.Append("<h3>").Append(Encode(app.AppId))
                 .Append(" <span class=\"state ").Append(stateClass).Append("\">")
-                .Append(app.Succeeded ? "green" : "failing").Append("</span></h3>").Append(Newline);
+                .Append(stateLabel).Append("</span></h3>").Append(Newline);
 
             if (!string.IsNullOrEmpty(app.FailureCategory))
             {

--- a/tools/cs2gs/Cs2Gs.Report/ReportModel.cs
+++ b/tools/cs2gs/Cs2Gs.Report/ReportModel.cs
@@ -43,29 +43,49 @@ public sealed class ReportModel
     [JsonPropertyOrder(3)]
     public bool Succeeded { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether no app failed but at least one
+    /// app is unverified (a genuinely-unavailable dependency for one of its
+    /// stages). Mirrors <see cref="RunResult.Unverified"/>; kept distinct from
+    /// <see cref="Succeeded"/> so the run headline cannot render "not
+    /// verified" as verified-green (issue #1831).
+    /// </summary>
+    [JsonPropertyName("unverified")]
+    [JsonPropertyOrder(4)]
+    public bool Unverified { get; set; }
+
     /// <summary>Gets or sets the total number of apps in the run.</summary>
     [JsonPropertyName("totalApps")]
-    [JsonPropertyOrder(4)]
+    [JsonPropertyOrder(5)]
     public int TotalApps { get; set; }
 
     /// <summary>Gets or sets the number of apps green across every stage.</summary>
     [JsonPropertyName("greenApps")]
-    [JsonPropertyOrder(5)]
+    [JsonPropertyOrder(6)]
     public int GreenApps { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of apps that did not fail but have at least one
+    /// unverified stage. Counted separately from <see cref="GreenApps"/> —
+    /// never both (issue #1831).
+    /// </summary>
+    [JsonPropertyName("unverifiedApps")]
+    [JsonPropertyOrder(7)]
+    public int UnverifiedApps { get; set; }
 
     /// <summary>Gets or sets the stage names in execution order (Translate→Compile→IlVerify→TestParity).</summary>
     [JsonPropertyName("stageOrder")]
-    [JsonPropertyOrder(6)]
+    [JsonPropertyOrder(8)]
     public List<string> StageOrder { get; set; } = new List<string>();
 
     /// <summary>Gets or sets the per-app results, sorted by app id, each with its stages in execution order.</summary>
     [JsonPropertyName("apps")]
-    [JsonPropertyOrder(7)]
+    [JsonPropertyOrder(9)]
     public List<AppReport> Apps { get; set; } = new List<AppReport>();
 
     /// <summary>Gets or sets the discovered gaps, grouped by fingerprint and sorted by fingerprint.</summary>
     [JsonPropertyName("gaps")]
-    [JsonPropertyOrder(8)]
+    [JsonPropertyOrder(10)]
     public List<GapReport> Gaps { get; set; } = new List<GapReport>();
 
     /// <summary>
@@ -78,21 +98,23 @@ public sealed class ReportModel
     /// <see cref="IsGreen"/>.
     /// </summary>
     [JsonPropertyName("missingArtifactCount")]
-    [JsonPropertyOrder(9)]
+    [JsonPropertyOrder(11)]
     public int MissingArtifactCount { get; set; }
 
     /// <summary>
     /// Gets a value indicating whether the run is genuinely green: it must be
     /// based on positive evidence — the run itself reported success
-    /// (<see cref="Succeeded"/>), every referenced triage artifact was
-    /// readable (<see cref="MissingArtifactCount"/> is zero), and no gaps were
-    /// discovered (<see cref="Gaps"/> is empty) — never on the mere absence of
-    /// gap data, which can also mean the triage artifacts were missing or the
-    /// run failed outright.
+    /// (<see cref="Succeeded"/>) with nothing left unverified
+    /// (<see cref="Unverified"/> is <see langword="false"/>), every referenced
+    /// triage artifact was readable (<see cref="MissingArtifactCount"/> is
+    /// zero), and no gaps were discovered (<see cref="Gaps"/> is empty) —
+    /// never on the mere absence of gap data, which can also mean the triage
+    /// artifacts were missing or the run failed outright.
     /// </summary>
     [JsonPropertyName("isGreen")]
-    [JsonPropertyOrder(10)]
-    public bool IsGreen => this.Succeeded && this.MissingArtifactCount == 0 && this.Gaps.Count == 0;
+    [JsonPropertyOrder(12)]
+    public bool IsGreen => this.Succeeded && !this.Unverified
+        && this.MissingArtifactCount == 0 && this.Gaps.Count == 0;
 
     /// <summary>
     /// Gets or sets the absolute run directory the model was built from (i.e.
@@ -194,7 +216,10 @@ public sealed class ReportModel
             }
         }
 
-        int greenApps = run.Apps.Count(a => a.Succeeded);
+        // A green app must be verified: succeeded AND not merely skipped
+        // (issue #1831). Unverified apps get their own bucket, never green's.
+        int greenApps = run.Apps.Count(a => a.Succeeded && !a.Unverified);
+        int unverifiedApps = run.Apps.Count(a => a.Unverified);
 
         return new ReportModel
         {
@@ -202,8 +227,10 @@ public sealed class ReportModel
             Timestamp = run.Timestamp,
             GscVersion = run.GscVersion,
             Succeeded = run.Succeeded,
+            Unverified = run.Unverified,
             TotalApps = run.Apps.Count,
             GreenApps = greenApps,
+            UnverifiedApps = unverifiedApps,
             StageOrder = stageOrder,
             Apps = apps,
             Gaps = GroupGaps(artifacts),
@@ -253,6 +280,7 @@ public sealed class ReportModel
         {
             AppId = app.AppId,
             Succeeded = app.Succeeded,
+            Unverified = app.Unverified,
             FailureCategory = app.FailureCategory,
             Stages = stages,
             Artifacts = (app.Artifacts ?? new List<string>())
@@ -345,24 +373,33 @@ public sealed class AppReport
     [JsonPropertyOrder(1)]
     public bool Succeeded { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether no stage failed but at least
+    /// one is unverified. Never <see langword="true"/> together with a
+    /// <see langword="false"/> <see cref="Succeeded"/> (issue #1831).
+    /// </summary>
+    [JsonPropertyName("unverified")]
+    [JsonPropertyOrder(2)]
+    public bool Unverified { get; set; }
+
     /// <summary>Gets or sets the first failing stage's category, or null when green.</summary>
     [JsonPropertyName("failureCategory")]
-    [JsonPropertyOrder(2)]
+    [JsonPropertyOrder(3)]
     public string FailureCategory { get; set; }
 
     /// <summary>Gets or sets the per-stage statuses, in execution order.</summary>
     [JsonPropertyName("stages")]
-    [JsonPropertyOrder(3)]
+    [JsonPropertyOrder(4)]
     public List<StageResult> Stages { get; set; } = new List<StageResult>();
 
     /// <summary>Gets or sets the run-relative triage artifact paths for this app.</summary>
     [JsonPropertyName("artifacts")]
-    [JsonPropertyOrder(4)]
+    [JsonPropertyOrder(5)]
     public List<string> Artifacts { get; set; } = new List<string>();
 
     /// <summary>Gets or sets the distinct fingerprints captured for this app.</summary>
     [JsonPropertyName("fingerprints")]
-    [JsonPropertyOrder(5)]
+    [JsonPropertyOrder(6)]
     public List<string> Fingerprints { get; set; } = new List<string>();
 }
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1756Tests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1756Tests.cs
@@ -243,9 +243,10 @@ public class Issue1756Tests
         using var doc = JsonDocument.Parse(json);
         JsonElement app = doc.RootElement.GetProperty("apps")[0];
 
-        // Exact property set + order for the app row.
+        // Exact property set + order for the app row (extended for issue
+        // #1831 with "unverified", inserted right after "succeeded").
         Assert.Equal(
-            new[] { "appId", "succeeded", "failureCategory", "stages", "artifacts", "fingerprints" },
+            new[] { "appId", "succeeded", "unverified", "failureCategory", "stages", "artifacts", "fingerprints" },
             app.EnumerateObject().Select(p => p.Name).ToArray());
 
         JsonElement stage = app.GetProperty("stages")[0];

--- a/tools/cs2gs/Cs2Gs.Tests/MigrationPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/MigrationPipelineTests.cs
@@ -359,6 +359,109 @@ public class MigrationPipelineTests
         }
     }
 
+    /// <summary>
+    /// A stage-2 skip (e.g. a genuinely-unavailable dependency) with no
+    /// failing stage rolls up to an app that is <see cref="AppResult.Unverified"/>
+    /// but still <see cref="AppResult.Succeeded"/>, and a run that is
+    /// <see cref="RunResult.Unverified"/> but still <see cref="RunResult.Succeeded"/>
+    /// — never "green" but also never exiting non-zero (issue #1831).
+    /// </summary>
+    [Fact]
+    public async Task SkippedStage_NoFailure_RollsUpToUnverified_NotGreen_AppAndRun()
+    {
+        string compiler = FindCompiler();
+        if (compiler is null)
+        {
+            return;
+        }
+
+        string corpus = ResolveCorpusDir();
+        string outRoot = NewOutputRoot("skip-rollup");
+        var options = new PipelineOptions { GscPath = compiler, OutputRoot = outRoot };
+        var pipeline = new MigrationPipeline(
+            options,
+            new IMigrationStage[] { new PassStage(MigrationStageKind.Translate), new SkipStage(MigrationStageKind.Compile) });
+
+        CorpusApp l1 = CorpusDiscovery.FindById(corpus, "corpus/L1-Console");
+        Assert.NotNull(l1);
+
+        RunResult result = await pipeline.RunAsync(new[] { l1 });
+        AppResult app = Assert.Single(result.Apps);
+
+        Assert.True(app.Succeeded);
+        Assert.True(app.Unverified);
+        Assert.True(result.Succeeded);
+        Assert.True(result.Unverified);
+    }
+
+    /// <summary>
+    /// A failed stage takes precedence over a later skip in the same app: the
+    /// app and run are "Failed" (<see cref="AppResult.Succeeded"/> /
+    /// <see cref="RunResult.Succeeded"/> both <see langword="false"/>), never
+    /// "Unverified" — the general rollup precedence is Failed &gt; Skipped &gt;
+    /// Green (issue #1831).
+    /// </summary>
+    [Fact]
+    public async Task FailedStage_TakesPrecedenceOverSkip_AppAndRunAreFailed_NotUnverified()
+    {
+        string compiler = FindCompiler();
+        if (compiler is null)
+        {
+            return;
+        }
+
+        string corpus = ResolveCorpusDir();
+        string outRoot = NewOutputRoot("fail-precedence");
+        var options = new PipelineOptions { GscPath = compiler, OutputRoot = outRoot };
+        var pipeline = new MigrationPipeline(
+            options,
+            new IMigrationStage[] { new FailStage(MigrationStageKind.Translate) });
+
+        CorpusApp l1 = CorpusDiscovery.FindById(corpus, "corpus/L1-Console");
+        Assert.NotNull(l1);
+
+        RunResult result = await pipeline.RunAsync(new[] { l1 });
+        AppResult app = Assert.Single(result.Apps);
+
+        Assert.False(app.Succeeded);
+        Assert.False(app.Unverified);
+        Assert.False(result.Succeeded);
+        Assert.False(result.Unverified);
+    }
+
+    /// <summary>A fixed-outcome stage double, used to drive pipeline rollup tests deterministically.</summary>
+    private sealed class PassStage : IMigrationStage
+    {
+        public PassStage(MigrationStageKind kind) => this.Kind = kind;
+
+        public MigrationStageKind Kind { get; }
+
+        public Task<StageOutcome> ExecuteAsync(StageExecutionContext context, CancellationToken cancellationToken = default) =>
+            Task.FromResult(StageOutcome.Passed());
+    }
+
+    /// <summary>A fixed-outcome stage double that reports <see cref="StageStatus.Skipped"/>.</summary>
+    private sealed class SkipStage : IMigrationStage
+    {
+        public SkipStage(MigrationStageKind kind) => this.Kind = kind;
+
+        public MigrationStageKind Kind { get; }
+
+        public Task<StageOutcome> ExecuteAsync(StageExecutionContext context, CancellationToken cancellationToken = default) =>
+            Task.FromResult(StageOutcome.Skipped());
+    }
+
+    /// <summary>A fixed-outcome stage double that reports <see cref="StageStatus.Failed"/>.</summary>
+    private sealed class FailStage : IMigrationStage
+    {
+        public FailStage(MigrationStageKind kind) => this.Kind = kind;
+
+        public MigrationStageKind Kind { get; }
+
+        public Task<StageOutcome> ExecuteAsync(StageExecutionContext context, CancellationToken cancellationToken = default) =>
+            Task.FromResult(StageOutcome.Failed(Array.Empty<TriageArtifact>()));
+    }
+
     private static string FingerprintShort(string fingerprint)
     {
         string hex = fingerprint.StartsWith("sha256:", StringComparison.Ordinal)

--- a/tools/cs2gs/Cs2Gs.Tests/ReportTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/ReportTests.cs
@@ -39,6 +39,11 @@ public class ReportTests
         Assert.Equal(1, model.GreenApps);
         Assert.False(model.Succeeded);
 
+        // A failed run is never "unverified" (issue #1831): failed takes
+        // precedence over the skipped stages the failing apps also carry.
+        Assert.False(model.Unverified);
+        Assert.Equal(0, model.UnverifiedApps);
+
         // Apps sorted by id.
         Assert.Equal(
             new[] { "corpus/L1-Console", "corpus/L2-Library", "corpus/L3-Library" },
@@ -67,6 +72,9 @@ public class ReportTests
         Assert.Equal(
             model.Gaps.Select(g => g.Fingerprint).OrderBy(f => f, StringComparer.Ordinal).ToArray(),
             model.Gaps.Select(g => g.Fingerprint).ToArray());
+
+        // Failed run stays red/non-zero exit (issue #1831 must not touch this).
+        Assert.Equal(1, Cs2Gs.Cli.Program.DetermineMigrateExitCode(model.Succeeded, reportGenerated: true));
     }
 
     /// <summary>
@@ -449,9 +457,73 @@ public class ReportTests
         Assert.Equal(0, model.MissingArtifactCount);
         Assert.True(model.IsGreen);
 
+        // Nothing skipped: not unverified, and the app is counted green.
+        Assert.False(model.Unverified);
+        Assert.Equal(0, model.UnverifiedApps);
+        Assert.Equal(1, model.GreenApps);
+
         string html = HtmlReportWriter.Render(model);
         Assert.Contains("every app is green", html, StringComparison.Ordinal);
 
+        Assert.Equal(0, Cs2Gs.Cli.Program.DetermineMigrateExitCode(model.Succeeded, reportGenerated: true));
+    }
+
+    /// <summary>
+    /// A run with an unverified stage (e.g. no locally-built SDK for
+    /// <c>compile</c>) but no failed stage must not roll up to a green app or
+    /// a plain "PASSED" verdict — the aggregate rollup must carry the same
+    /// "not verified" honesty as the per-stage <c>skipped</c> cell (issue
+    /// #1749), one level up (issue #1831). Exit code must still be 0: a
+    /// genuinely-unavailable SDK must never turn CI red.
+    /// </summary>
+    [Fact]
+    public void ReportModel_SkippedStageNoFailure_IsUnverifiedNotGreen_AndExitsZero()
+    {
+        string runDir = NewRunDir("unverified");
+
+        var run = new RunResult
+        {
+            RunId = "2026-03-01T00-00-03Z_unverified",
+            Timestamp = "2026-03-01T00:00:03Z",
+            GscVersion = "0.2.0+test",
+            GscPath = "/path/to/gsc.dll",
+            Succeeded = true,
+            Unverified = true,
+            Apps = new List<AppResult>
+            {
+                new AppResult
+                {
+                    AppId = "corpus/L1-Console",
+                    Succeeded = true,
+                    Unverified = true,
+                    Stages = new List<StageResult>
+                    {
+                        new StageResult { Stage = "translate", Status = "passed" },
+                        new StageResult { Stage = "compile", Status = "skipped" },
+                        new StageResult { Stage = "ilverify", Status = "skipped" },
+                        new StageResult { Stage = "test-parity", Status = "skipped" },
+                    },
+                },
+            },
+        };
+        WriteRunJson(runDir, run);
+
+        ReportModel model = ReportModel.FromRunDirectory(runDir);
+
+        Assert.True(model.Succeeded);
+        Assert.True(model.Unverified);
+        Assert.Equal(1, model.TotalApps);
+        Assert.Equal(0, model.GreenApps);
+        Assert.Equal(1, model.UnverifiedApps);
+        Assert.False(model.IsGreen);
+
+        string html = HtmlReportWriter.Render(model);
+        Assert.DoesNotContain("every app is green", html, StringComparison.Ordinal);
+        Assert.Contains("PASSED (unverified)", html, StringComparison.Ordinal);
+        Assert.Contains("1 unverified", html, StringComparison.Ordinal);
+        Assert.Contains("class=\"state skip\">unverified</span>", html, StringComparison.Ordinal);
+
+        // Skipped-only must not turn the run red or non-zero (SDK-absent CI is legitimate).
         Assert.Equal(0, Cs2Gs.Cli.Program.DetermineMigrateExitCode(model.Succeeded, reportGenerated: true));
     }
 


### PR DESCRIPTION
Fixes #1831

Follow-up to #1749 (PR #1830). #1749 introduced `StageStatus.Skipped` so a not-verified per-stage cell (SDK/tooling absent, or a not-yet-implemented step) renders as SKIP instead of a false PASSED. That same "not verified renders as verified-green" inversion persisted one level up, at the app/run aggregate rollup (ADR-0115 §C): `MigrationPipeline` only set `AppResult.Succeeded = false` on a `Failed` stage, leaving a `Skipped`-only app/run at `Succeeded = true`, which `HtmlReportWriter` rendered as a plain green app and `Cli/Program` reported as a PASSED run.

## Fix

Added a new `Unverified` flag alongside `Succeeded` on `AppResult`, `RunResult`, `ReportModel`, and `AppReport`, following one general rollup precedence applied consistently everywhere: any `Failed` stage wins (red/non-zero exit, unchanged); else any `Skipped` stage makes the app/run `Unverified` (still `Succeeded`, but labeled distinctly rather than green); else it is genuinely green.

- **`Cs2Gs.Pipeline/MigrationPipeline.cs`**: after the per-app stage loop, sets `AppResult.Unverified` when no stage failed but at least one was skipped; after the per-app run loop, sets `RunResult.Unverified` the same way for the whole run.
- **`Cs2Gs.Pipeline/RunResult.cs`**: adds `AppResult.Unverified` / `RunResult.Unverified` (serialized as `unverified`).
- **`Cs2Gs.Report/ReportModel.cs`**: adds `ReportModel.Unverified`, `ReportModel.UnverifiedApps`, and `AppReport.Unverified`; `GreenApps` now excludes unverified apps, and `IsGreen` also requires `!Unverified`.
- **`Cs2Gs.Report/HtmlReportWriter.cs`**: renders a "PASSED (unverified)" headline and a `skip`-colored verdict/state (reusing the existing `--skip` color already used for the per-stage SKIP cells, issue #1749) instead of a plain green PASSED/state, for both the run header and each app's detail block.
- **`Cs2Gs.Cli/Program.cs`**: the migrate summary line reports "PASSED (N unverified)" instead of a plain PASSED when any app is unverified.

## Exit code semantics — unchanged

`DetermineMigrateExitCode` still keys only off `RunResult.Succeeded`, which is untouched by this change (only a `Failed` stage ever sets it false). A skipped-only run — e.g. no locally-built SDK, or test-parity not yet implemented — still exits 0. This is a labeling fix, not a new failure mode: legitimate CI environments without the SDK will not turn red.

## Tests

Added in `Cs2Gs.Tests`:
- `ReportModel_SkippedStageNoFailure_IsUnverifiedNotGreen_AndExitsZero` (ReportTests.cs) — a skipped-only run is unverified, not green, and still exits 0.
- Extended `ReportModel_GroupsByFingerprint_PreservesStageOrder_MergesRetryHistory` and `ReportModel_GenuinelyGreenRun_IsRenderedAsGreen` (ReportTests.cs) with `Unverified`/`UnverifiedApps`/exit-code assertions for the failed and all-passed cases respectively.
- `SkippedStage_NoFailure_RollsUpToUnverified_NotGreen_AppAndRun` and `FailedStage_TakesPrecedenceOverSkip_AppAndRunAreFailed_NotUnverified` (MigrationPipelineTests.cs) — end-to-end pipeline-level rollup tests using fixed-outcome stage doubles.
- Updated the pre-existing `JsonSummary_AppAndStageShape_IsByteIdenticalGolden` golden-schema test (Issue1756Tests.cs) for the new `unverified` field.

Verified with a full `dotnet build GSharp.sln -c Release -graph` (0 errors) and `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release`: 626/626 passing, including the previously-flaky `ReportTests.Cli_ReportVerb_RegeneratesBothArtifacts`.

Nothing deferred.
