### PR TITLE
cs2gs: fix invalid/colliding recursive-pattern designators (issue #1839)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue1839PatternDesignatorAndEnumExtensionTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1839PatternDesignatorAndEnumExtensionTests.cs
@@ -1,0 +1,238 @@
+// <copyright file="Issue1839PatternDesignatorAndEnumExtensionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #1839: a follow-up to #1836/#1734's declaration-site sanitization
+/// fix. Two corner cases remained in <c>GetRightmostTypeName</c>'s synthesized
+/// recursive-pattern designator:
+/// <list type="bullet">
+/// <item>N2 — a predefined/composite type pattern (<c>int?</c>, <c>int[]</c>,
+/// a tuple, a pointer) fell back to <c>Type.ToString()</c>, which is not a
+/// valid identifier, and was emitted unsanitized.</item>
+/// <item>N3 — two typed recursive subpatterns within the SAME arm whose
+/// rightmost simple name collapses to the same designator (e.g. <c>Ns.Circle</c>
+/// and <c>Other.Circle</c>) silently shadowed one another as two same-named
+/// locals in one scope.</item>
+/// </list>
+/// This file also adds the N1 parity test for the enum-extension owner/method
+/// sanitization site (<c>TryGetEnumExtension</c>), the one site from #1836 that
+/// had no dedicated test.
+/// </summary>
+public class Issue1839PatternDesignatorAndEnumExtensionTests
+{
+    [Fact]
+    public void RecursivePatternSynthesizedDesignator_NullableElementArrayTypePattern_UsesElementTypeName()
+    {
+        // `int?[]` is a legal array-of-nullable-value-type pattern (the
+        // restriction against a nullable type directly in a pattern applies to
+        // the pattern's own type, not to an array's element type). Recursing
+        // into the array's element type first yields `int?`, itself a
+        // `NullableTypeSyntax`, which must in turn recurse into `int` (mapped
+        // to its BCL name, not the invalid `Type.ToString()` text `int?[]`).
+        string rendered = Render(@"
+namespace Corpus.Issue1839
+{
+    public class Holder
+    {
+        public int Describe(object value)
+        {
+            switch (value)
+            {
+                case int?[] { Length: var len }:
+                    return len;
+                default:
+                    return 0;
+            }
+        }
+    }
+}
+");
+
+        Assert.DoesNotContain("int?[]", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void RecursivePatternSynthesizedDesignator_ArrayTypePattern_UsesElementTypeName()
+    {
+        // `int[]` has no simple-name token either; the designator is derived
+        // from the `int` element type, not the invalid `Type.ToString()` text
+        // `int[]`.
+        string rendered = Render(@"
+namespace Corpus.Issue1839
+{
+    public class Holder
+    {
+        public int Describe(object value)
+        {
+            switch (value)
+            {
+                case int[] { Length: var len }:
+                    return len;
+                default:
+                    return 0;
+            }
+        }
+    }
+}
+");
+
+        Assert.DoesNotContain("int[]", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void RecursivePatternSynthesizedDesignator_TupleTypePattern_ReportsDiagnosticInsteadOfGarbage()
+    {
+        // A tuple type has no single simple name to derive a faithful
+        // designator from; a diagnostic must be reported rather than emitting
+        // the invalid `Type.ToString()` text `(int, int)`.
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[]
+        {
+            ("Source.cs", @"
+namespace Corpus.Issue1839
+{
+    public class Holder
+    {
+        public int Describe((int, int) value)
+        {
+            switch (value)
+            {
+                case (int, int) { Item1: var a }:
+                    return a;
+                default:
+                    return 0;
+            }
+        }
+    }
+}
+"),
+        });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        Cs2Gs.CodeModel.Ast.CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        string rendered = GSharpPrinter.Print(unit);
+
+        Assert.NotEmpty(context.Diagnostics);
+        Assert.DoesNotContain("(int, int)", rendered, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RecursivePatternSynthesizedDesignator_SameRightmostNameInOneArm_AreUniquified()
+    {
+        // `Ns.Circle` and `Other.Circle` both collapse to the same rightmost
+        // simple name ('Circle'), but they appear as two subpatterns of the
+        // SAME 'or' arm (one scope): the synthesized designators must be made
+        // distinct (a uniquifier suffix) rather than colliding as two same-named
+        // 'circle' locals.
+        string rendered = Render(@"
+namespace Corpus.Issue1839
+{
+    namespace Ns
+    {
+        public class Circle
+        {
+            public int Radius;
+        }
+    }
+
+    namespace Other
+    {
+        public class Circle
+        {
+            public int Radius;
+        }
+    }
+
+    public class Holder
+    {
+        public int Describe(object value)
+        {
+            switch (value)
+            {
+                case Ns.Circle or Other.Circle:
+                    return 1;
+                default:
+                    return 0;
+            }
+        }
+    }
+}
+");
+
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void EnumExtensionOwnerAndMethodName_KeywordCollision_IsSanitizedConsistently()
+    {
+        // Issue #1836 (N1 parity): the null-conditional enum-extension call
+        // rewrite (`TryGetEnumExtension`) synthesizes an `Owner.Method(receiver, …)`
+        // static-call form from the extension's declaring type and method
+        // names. Both must be sanitized consistently, so a keyword-colliding
+        // owner/method name agrees between the synthesized call and (if it were
+        // ever declared elsewhere) its declaration.
+        string rendered = Render(@"
+namespace Corpus.Issue1839
+{
+    public enum Color { Red, Green, Blue }
+
+    public static class @select
+    {
+        public static string type(this Color color) => color.ToString();
+    }
+
+    public class Holder
+    {
+        public string Describe(Color? color) => color?.type();
+    }
+}
+");
+
+        Assert.Contains("select_", rendered, StringComparison.Ordinal);
+        Assert.Contains("type_", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    private static void AssertRoundTripParses(string rendered)
+    {
+        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+
+        Assert.True(
+            result.Success,
+            "Sanitized G# must round-trip-parse. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + rendered);
+    }
+
+    private static string Render(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", source) });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        Cs2Gs.CodeModel.Ast.CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        return GSharpPrinter.Print(unit);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -10082,7 +10082,8 @@ public sealed class CSharpToGSharpTranslator
                 // guard first (the prior order) resolved `r` while it was still
                 // out of scope.
                 var bindings = new List<(ISymbol Symbol, GExpression Replacement)>();
-                GPattern pattern = this.TranslatePattern(arm.Pattern, bindings);
+                var usedDesignators = new HashSet<string>(StringComparer.Ordinal);
+                GPattern pattern = this.TranslatePattern(arm.Pattern, bindings, usedDesignators);
 
                 foreach ((ISymbol symbol, GExpression replacement) in bindings)
                 {
@@ -10134,7 +10135,8 @@ public sealed class CSharpToGSharpTranslator
                     {
                         case CasePatternSwitchLabelSyntax patternLabel:
                             var bindings = new List<(ISymbol Symbol, GExpression Replacement)>();
-                            GPattern pattern = this.TranslatePattern(patternLabel.Pattern, bindings);
+                            var usedDesignators = new HashSet<string>(StringComparer.Ordinal);
+                            GPattern pattern = this.TranslatePattern(patternLabel.Pattern, bindings, usedDesignators);
 
                             // Issue #1730: install the pattern's bindings before
                             // translating the `when` guard and the case body, so
@@ -10305,7 +10307,8 @@ public sealed class CSharpToGSharpTranslator
 
         private GPattern TranslatePattern(
             PatternSyntax pattern,
-            List<(ISymbol Symbol, GExpression Replacement)> bindings)
+            List<(ISymbol Symbol, GExpression Replacement)> bindings,
+            HashSet<string> usedDesignators)
         {
             switch (pattern)
             {
@@ -10328,7 +10331,7 @@ public sealed class CSharpToGSharpTranslator
                         this.MapTypeSyntax(declaration.Type));
 
                 case RecursivePatternSyntax recursive:
-                    return this.TranslateRecursivePattern(recursive, bindings);
+                    return this.TranslateRecursivePattern(recursive, bindings, usedDesignators);
 
                 // Issue #992: C# `and` / `or` pattern combinators map to G#
                 // `and` / `or`. C# `BinaryPatternSyntax` carries an `and`/`or`
@@ -10337,16 +10340,16 @@ public sealed class CSharpToGSharpTranslator
                     when binary.OperatorToken.IsKind(SyntaxKind.AndKeyword) || binary.OperatorToken.IsKind(SyntaxKind.OrKeyword):
                     return new BinaryPattern(
                         binary.OperatorToken.IsKind(SyntaxKind.AndKeyword),
-                        this.TranslatePattern(binary.Left, bindings),
-                        this.TranslatePattern(binary.Right, bindings));
+                        this.TranslatePattern(binary.Left, bindings, usedDesignators),
+                        this.TranslatePattern(binary.Right, bindings, usedDesignators));
 
                 // Issue #992: C# `not <pattern>` maps to G# `not <pattern>`.
                 case UnaryPatternSyntax unary
                     when unary.OperatorToken.IsKind(SyntaxKind.NotKeyword):
-                    return new NotPattern(this.TranslatePattern(unary.Pattern, bindings));
+                    return new NotPattern(this.TranslatePattern(unary.Pattern, bindings, usedDesignators));
 
                 case ParenthesizedPatternSyntax parenthesized:
-                    return new ParenthesizedPattern(this.TranslatePattern(parenthesized.Pattern, bindings));
+                    return new ParenthesizedPattern(this.TranslatePattern(parenthesized.Pattern, bindings, usedDesignators));
 
                 default:
                     this.context.ReportUnsupported(
@@ -10358,7 +10361,8 @@ public sealed class CSharpToGSharpTranslator
 
         private GPattern TranslateRecursivePattern(
             RecursivePatternSyntax recursive,
-            List<(ISymbol Symbol, GExpression Replacement)> bindings)
+            List<(ISymbol Symbol, GExpression Replacement)> bindings,
+            HashSet<string> usedDesignators)
         {
             // A pure property pattern (`{ A: 0, B: 0 }`) with no type maps to the
             // G# property pattern; a typed recursive pattern (`Circle { Radius: var r }`)
@@ -10378,7 +10382,7 @@ public sealed class CSharpToGSharpTranslator
 
                         fields.Add(new PropertyPatternField(
                             SanitizeIdentifier(sub.NameColon.Name.Identifier.Text),
-                            this.TranslatePattern(sub.Pattern, bindings)));
+                            this.TranslatePattern(sub.Pattern, bindings, usedDesignators)));
                     }
                 }
 
@@ -10397,6 +10401,15 @@ public sealed class CSharpToGSharpTranslator
             string designator = recursive.Designation is SingleVariableDesignationSyntax named
                 ? SanitizeIdentifier(named.Identifier.Text)
                 : SanitizeIdentifier(LowerCamel(GetRightmostTypeName(recursive.Type)));
+
+            // Issue #1839 (N3): two typed recursive subpatterns within the SAME
+            // arm/scope (e.g. `Ns.Circle or Other.Circle`) can synthesize the
+            // identical designator from their distinct rightmost simple names,
+            // which would silently shadow one another as two `circle` locals.
+            // Uniquify on collision within this arm's shared `usedDesignators`
+            // scope (threaded alongside `bindings`) rather than emitting a
+            // colliding declaration.
+            designator = Uniquify(designator, usedDesignators);
 
             if (recursive.PropertyPatternClause != null)
             {
@@ -10434,13 +10447,43 @@ public sealed class CSharpToGSharpTranslator
             return char.ToLowerInvariant(name[0]) + name.Substring(1);
         }
 
+        // Issue #1839 (N3): appends a numeric suffix (`circle_2`, `circle_3`, …)
+        // when `name` was already used earlier in the same arm/scope, so two
+        // typed recursive subpatterns that happen to collapse to the same
+        // designator (distinct types sharing a rightmost simple name, or an
+        // explicit designation colliding with a synthesized one) get distinct,
+        // compilable locals instead of silently shadowing one another.
+        private static string Uniquify(string name, HashSet<string> usedDesignators)
+        {
+            string candidate = name;
+            int suffix = 2;
+            while (!usedDesignators.Add(candidate))
+            {
+                candidate = $"{name}_{suffix}";
+                suffix++;
+            }
+
+            return candidate;
+        }
+
         // Extracts the right-most simple-name identifier token from a (possibly
         // qualified/generic) type syntax, e.g. `Ns.Circle` -> "Circle",
         // `List<int>` -> "List", `Outer.Inner<T>` -> "Inner". `Type.ToString()`
         // renders the full qualified/generic text, which is not itself a valid
         // identifier and must never be used to synthesize a designator name
         // (issue #1734).
-        private static string GetRightmostTypeName(TypeSyntax type)
+        //
+        // Issue #1839 (N2): a predefined type (`int`) resolves to its BCL name
+        // via the semantic model — the same resolution `TranslatePredefinedTypeExpression`
+        // uses for a predefined-type expression receiver — rather than the
+        // lowercase keyword text (`int`), which is itself a G# keyword and not a
+        // valid designator once sanitized. Nullable/array types recurse into
+        // their element type, since `int?`/`int[]` designate the same underlying
+        // simple type as `int`. A tuple, pointer, or function-pointer type has no
+        // single simple name to derive a faithful designator from, so a
+        // diagnostic is reported instead of emitting the unsanitized, invalid
+        // `Type.ToString()` text (`(int, int)`, `int*`, `delegate*<int, int>`).
+        private string GetRightmostTypeName(TypeSyntax type)
         {
             switch (type)
             {
@@ -10450,6 +10493,20 @@ public sealed class CSharpToGSharpTranslator
                     return GetRightmostTypeName(aliasQualified.Name);
                 case SimpleNameSyntax simple:
                     return simple.Identifier.Text;
+                case PredefinedTypeSyntax predefined:
+                    ITypeSymbol predefinedSymbol = this.context.GetTypeInfo(predefined).Type;
+                    return predefinedSymbol?.Name ?? predefined.Keyword.Text;
+                case NullableTypeSyntax nullable:
+                    return GetRightmostTypeName(nullable.ElementType);
+                case ArrayTypeSyntax array:
+                    return GetRightmostTypeName(array.ElementType);
+                case TupleTypeSyntax:
+                case PointerTypeSyntax:
+                case FunctionPointerTypeSyntax:
+                    this.context.ReportUnsupported(
+                        type,
+                        $"recursive pattern designator cannot be synthesized from type '{type.Kind()}'; give the pattern an explicit designation (ADR-0115 §B).");
+                    return "value";
                 default:
                     return type.ToString();
             }


### PR DESCRIPTION
Fixes #1839

Follow-up to #1836 (which fixed #1734). The declaration-site sanitization from that PR was correct, but two corner cases remained in the synthesized pattern-designator name from `GetRightmostTypeName` (`tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs`).

**N2 — predefined/composite type patterns.** `GetRightmostTypeName` fell back to `type.ToString()` for `PredefinedTypeSyntax`, `NullableTypeSyntax`, `ArrayTypeSyntax`, `TupleTypeSyntax`, `PointerTypeSyntax`, and `FunctionPointerTypeSyntax`. That text (`int?`, `int[]`, `(int, int)`, ...) is not itself a valid identifier and was emitted unsanitized as an invalid designator. Now handled per kind:
- `PredefinedTypeSyntax` resolves the BCL type name from the semantic model — the same resolution `TranslatePredefinedTypeExpression` already uses for a predefined-type expression receiver — instead of the lowercase keyword text (itself a G# keyword).
- `NullableTypeSyntax` / `ArrayTypeSyntax` recurse into the element type, since these have no simple name of their own but designate the same underlying type.
- `TupleTypeSyntax` / `PointerTypeSyntax` / `FunctionPointerTypeSyntax` have no single simple name to derive a faithful designator from, so a `TranslationDiagnostic` is reported instead of emitting the invalid `Type.ToString()` text.

**N3 — same-arm designator collision.** Two typed recursive subpatterns within the same arm (for example an `or` pattern combining two types with the same rightmost simple name, like `Ns.Circle or Other.Circle`) previously synthesized the identical designator and silently collided as two same-named locals in one scope. Fixed with a per-arm uniquifier (`circle`, `circle_2`, `circle_3`, ...): the switch-arm/label call sites thread a `HashSet<string>` of used designators alongside the existing per-arm `bindings` list through pattern translation, and `TranslateRecursivePattern` uniquifies its designator against that set before using it at both the declaration site and any member-access references within the same call — so the declaration and its uses always agree.

**N1 — test parity.** The enum-extension owner/method sanitization site (`TryGetEnumExtension`) had no dedicated test, the one site from #1836 without coverage. Added one for parity with the other declaration-site sanitization tests.

New test file: `tools/cs2gs/Cs2Gs.Tests/Issue1839PatternDesignatorAndEnumExtensionTests.cs`, covering all three cases (N2 nullable/array/tuple designators, N3 same-arm uniquification, N1 enum-extension sanitization).

Verified with a whole-solution build (`dotnet build GSharp.sln -c Release -graph`) followed by the full `Cs2Gs.Tests` suite (628 tests, all passing).
