### PR TITLE
cs2gs: fix chained-assignment read-back divergence for property/indexer targets (#1845)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue1845ChainedAssignmentReadBackTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1845ChainedAssignmentReadBackTests.cs
@@ -1,0 +1,228 @@
+// <copyright file="Issue1845ChainedAssignmentReadBackTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Regression tests for issue #1845, a follow-up to #1731/#1842. The earlier
+/// fix stopped a chained assignment's inner target from having its
+/// side-effecting receiver/index evaluated twice, but it still re-embedded
+/// the (now duplication-safe) target as the VALUE read back for the next
+/// (outer) link — `a = b = c` lowered to `b = c; a = b`. When the inner
+/// target is a property or indexer, that read-back calls its GETTER, which
+/// C# never does: a plain-`=` chain assigns the RHS VALUE to every target and
+/// only ever calls the SETTERS. The fix binds the RHS to a shared temp once
+/// and assigns that temp to every target in the chain, for chains of any
+/// length, while a compound-operator link (`+=`, …) still reads its target
+/// back afterward — that read is real C# semantics (the link produces a new,
+/// not-yet-known value), unrelated to this bug.
+/// </summary>
+public class Issue1845ChainedAssignmentReadBackTests
+{
+    [Fact]
+    public void ChainedAssignment_PropertyInnerTarget_NeverCallsGetterOnReadBack()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public sealed class Holder
+    {
+        private int backing;
+
+        public int P
+        {
+            get { System.Console.WriteLine(""get""); return this.backing; }
+            set { this.backing = value; }
+        }
+    }
+
+    public sealed class C
+    {
+        private static int SideEffect() => 42;
+
+        public void M()
+        {
+            var obj = new Holder();
+            int a;
+            a = obj.P = SideEffect();
+            System.Console.WriteLine(a);
+        }
+    }
+}");
+
+        // The setter runs once (`obj.P = __spillN`); the getter (`get { … }`
+        // body) is never invoked from the chain lowering itself — only its
+        // own declaration site (`get { System.Console.WriteLine(...) }`)
+        // contains the "get" text, so a single occurrence proves no read-back
+        // call was emitted.
+        Assert.Equal(1, CountOccurrences(printed, "\"get\""));
+        Assert.Contains("__spill", printed);
+        Assert.Contains("obj.P =", printed);
+        Assert.Equal(1, CountOccurrences(printed, "C.SideEffect()"));
+    }
+
+    [Fact]
+    public void ChainedAssignment_ThreeLinkChain_SharesOneComputedValue()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public sealed class C
+    {
+        private static int Next() => 5;
+
+        public void M()
+        {
+            int a, b, c;
+            a = b = c = Next();
+            System.Console.WriteLine(a + b + c);
+        }
+    }
+}");
+
+        // `Next()` is evaluated exactly once, spilled into one shared temp,
+        // and that temp is assigned to all three targets.
+        Assert.Equal(1, CountOccurrences(printed, "C.Next()"));
+        Assert.Contains("__spill", printed);
+
+        string spillTemp = ExtractSpillTempName(printed);
+        Assert.Equal(4, CountOccurrences(printed, spillTemp));
+    }
+
+    [Fact]
+    public void ChainedAssignment_SideEffectingIndexInMiddleTarget_EvaluatesOnceInOrder()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public sealed class C
+    {
+        private int[] buf = new int[10];
+        private int counter;
+
+        private int NextIndex() => counter++;
+
+        public void M()
+        {
+            int a, c;
+            a = buf[NextIndex()] = c = 7;
+            System.Console.WriteLine(a);
+        }
+    }
+}");
+
+        // The index-producing call runs exactly once, spilled into a shared
+        // temp; that temp — not a second `NextIndex()` call — is used as the
+        // element index, and all three targets receive the same literal
+        // value (7).
+        Assert.Equal(1, CountOccurrences(printed, "= NextIndex()"));
+        string spillTemp = ExtractSpillTempName(printed);
+        Assert.Contains($"buf[{spillTemp}] = 7", printed);
+        Assert.Contains("a = 7", printed);
+        Assert.Contains("c = 7", printed);
+    }
+
+    [Fact]
+    public void ChainedAssignment_CompoundInnerLink_StillReadsBackNewValue()
+    {
+        // `a = b += c`: this is NOT the #1845 bug — `b += c` genuinely
+        // produces a new value that only a read-back of `b` can supply, so
+        // the compound link must keep reading its target back afterward.
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public sealed class C
+    {
+        public void M()
+        {
+            int a = 0;
+            int b = 1;
+            int c = 2;
+            a = b += c;
+            System.Console.WriteLine(a);
+            System.Console.WriteLine(b);
+        }
+    }
+}");
+
+        Assert.Contains("b += c", printed);
+        Assert.Contains("a = b", printed);
+    }
+
+    [Fact]
+    public void SimpleAssignment_Unchanged()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public sealed class C
+    {
+        public void M()
+        {
+            int a;
+            int c = 5;
+            a = c;
+            System.Console.WriteLine(a);
+        }
+    }
+}");
+
+        Assert.DoesNotContain("__spill", printed);
+        Assert.Contains("a = c", printed);
+    }
+
+    private static string ExtractSpillTempName(string printed)
+    {
+        int start = printed.IndexOf("__spill", System.StringComparison.Ordinal);
+        Assert.True(start >= 0, "Expected a __spill temp in:\n" + printed);
+        int end = start;
+        while (end < printed.Length && (char.IsLetterOrDigit(printed[end]) || printed[end] == '_'))
+        {
+            end++;
+        }
+
+        return printed.Substring(start, end - start);
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        int count = 0;
+        for (int index = haystack.IndexOf(needle, System.StringComparison.Ordinal);
+            index >= 0;
+            index = haystack.IndexOf(needle, index + needle.Length, System.StringComparison.Ordinal))
+        {
+            count++;
+        }
+
+        return count;
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(System.Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -5260,23 +5260,55 @@ public sealed class CSharpToGSharpTranslator
                 current = link.Right;
             }
 
-            GExpression rhs = this.TranslateExpression(current);
             var statements = new List<GStatement>();
+
+            // C# evaluates every target's receiver/index sub-expression
+            // left-to-right — outermost first, matching source order — BEFORE
+            // the shared RHS is evaluated (`a[F()] = b[G()] = c` runs F() then
+            // G() then c). Spill each target's side-effecting parts here, in
+            // that order; a target that is already an identifier/`this`/field
+            // with no side-effecting sub-part passes through untouched.
+            var safeTargets = new GExpression[lefts.Count];
+            for (int i = 0; i < lefts.Count; i++)
+            {
+                safeTargets[i] = this.MakeDuplicationSafeTarget(lefts[i].Target, statements);
+            }
+
+            GExpression value = this.TranslateExpression(current);
+
+            // Walk the chain innermost-out, assigning to each target in turn.
+            // C# assigns the SAME rhs VALUE to every target in a run of plain
+            // `=` links — it never re-reads an inner target's getter to obtain
+            // the value carried to the next (outer) link (issue #1845): `a =
+            // obj.P = c` calls `P`'s setter once and never its getter. A
+            // compound link (`+=`, …) genuinely produces a NEW value — the
+            // target's old value combined with the operand — so its result
+            // still has to be read back for the next link; that read is real
+            // C# semantics, unrelated to the #1845 divergence, and is left as
+            // it was under the #1731/#1842 fix (the target was already made
+            // safe to re-embed above).
+            bool valueIsShared = false;
             for (int i = lefts.Count - 1; i >= 0; i--)
             {
-                // A chained link's target is READ AGAIN as the value carried to
-                // the next (outer) link — `a = b = c` lowers to `b = c; a = b`.
-                // When the target is more than a bare identifier (e.g.
-                // `buf[Next()]`), re-embedding the SAME translated target node at
-                // both the write and the read-back would silently re-run any
-                // side-effecting sub-expression (`Next()`) a second time (issue
-                // #1731). The outermost link's target (`i == 0`) is never read
-                // back — the chain ends there — so it is left untouched.
-                GExpression target = i > 0
-                    ? this.MakeDuplicationSafeTarget(lefts[i].Target, statements)
-                    : lefts[i].Target;
-                statements.Add(new AssignmentStatement(target, rhs, lefts[i].Op));
-                rhs = target;
+                bool hasOuterLink = i > 0;
+                GExpression assignedValue = value;
+                if (hasOuterLink && lefts[i].Op == "=" && !valueIsShared)
+                {
+                    // About to be assigned to more than one target — spill once
+                    // so the RHS expression is evaluated exactly one time, then
+                    // every remaining target reuses the same temp/trivial value.
+                    assignedValue = this.SpillOperand(value, statements);
+                    value = assignedValue;
+                    valueIsShared = true;
+                }
+
+                statements.Add(new AssignmentStatement(safeTargets[i], assignedValue, lefts[i].Op));
+
+                if (hasOuterLink && lefts[i].Op != "=")
+                {
+                    value = safeTargets[i];
+                    valueIsShared = true;
+                }
             }
 
             return statements;
@@ -5459,15 +5491,17 @@ public sealed class CSharpToGSharpTranslator
             return new IdentifierExpression(temp);
         }
 
-        // Rebuilds an assignment TARGET (the left-hand side of a chained-
-        // assignment link, `a = TARGET = c`) so it is safe to re-embed as a value
-        // read for the enclosing link (`a = TARGET`) without re-evaluating any
-        // side-effecting sub-expression twice — the receiver of a member access
-        // and the index of an element access are each spilled at most once via
-        // <see cref="SpillOperand(GExpression, List{GStatement})"/>, and the
-        // target is rebuilt from those (now-trivial) pieces (issue #1731). A
-        // target that is already an identifier/`this`/literal, or a member
-        // access whose receiver needs no spilling, passes through untouched.
+        // Rebuilds an assignment TARGET (a link's left-hand side in a chained
+        // assignment `a = TARGET = c`) so its receiver/index sub-expression is
+        // evaluated exactly once even though the target is written to (and, for
+        // a compound-operator link, read back — see
+        // <see cref="FlattenChainedAssignment"/>) — the receiver of a member
+        // access and the index of an element access are each spilled at most
+        // once via <see cref="SpillOperand(GExpression, List{GStatement})"/>,
+        // and the target is rebuilt from those (now-trivial) pieces (issue
+        // #1731). A target that is already an identifier/`this`/literal, or a
+        // member access whose receiver needs no spilling, passes through
+        // untouched.
         private GExpression MakeDuplicationSafeTarget(GExpression target, List<GStatement> prologue)
         {
             switch (target)


### PR DESCRIPTION
Fixes #1845

For `a = b = c`, C# assigns the RHS value to both `a` and `b` — it never re-reads `b`. The #1842 fix stopped a chained link's target from having its side-effecting receiver/index evaluated twice, but it still re-embedded that (now duplication-safe) target as the value carried forward to the outer link. When the inner target is a property or indexer, that read-back calls its getter, which C# never does: `a = obj.P = SideEffect()` calls `P`'s setter once and never its getter, but the translated G# was calling the getter to read the value back into `a`.

`FlattenChainedAssignment` now binds the RHS to a single shared value — spilled into a temp only when it is not already trivial (a bare identifier/`this`/literal) — and assigns that same value to every target in the chain, generalized to a chain of any length (`a = b = c = ... = expr`). A compound-operator link (`+=`, etc.) still reads its target back afterward, because that link genuinely produces a new value that only a read-back can supply; that is real C# semantics, unrelated to this divergence, and is left as it was.

Evaluation order is preserved: every target's side-effecting receiver/index sub-expression is now spilled up front, left-to-right in source order (matching C#'s left-to-right target evaluation), before the shared RHS value is computed. A chain mixing side-effecting targets (e.g. `a = buf[F()] = c = expr`) still evaluates each side effect exactly once, in the correct order.

Added `Issue1845ChainedAssignmentReadBackTests` covering:
- a property inner target's getter is never called on read-back
- a 3-link chain assigns one computed value to all three targets
- a side-effecting index in a middle target still evaluates once, in order
- a compound-operator inner link still reads its target back (unaffected by this fix)
- a simple two-operand assignment is unchanged

Verified with a whole-solution build (`dotnet build GSharp.sln -c Release -graph`) followed by the full `Cs2Gs.Tests` suite (631 passed, 0 failed) and the filtered run for the new tests.