### PR TITLE
cs2gs: lower null-seam is-pattern/range-slice operands to synthetic helpers

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue1731DoubleEvaluationTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1731DoubleEvaluationTranslationTests.cs
@@ -342,13 +342,20 @@ namespace Demo
     // bare block-with-trailing-expression is only legal directly inside a
     // lambda arrow body or an if/else branch, and G# has no "invoke an
     // arbitrary parenthesized expression" postfix form to smuggle one in as
-    // an immediately-invoked lambda either. So these two sites cannot be
-    // upgraded to single-evaluation without a G# grammar change; instead the
-    // translator now REPORTS the gap (TranslationSeverity.Unsupported)
-    // instead of silently double-evaluating.) -------------------------------
+    // an immediately-invoked lambda either. #1731 settled for REPORTING the
+    // gap (TranslationSeverity.Unsupported) instead of silently
+    // double-evaluating. Issue #1849 closes the gap for real: the whole
+    // null-seam initializer/argument is lowered to a call to a synthesized
+    // private static helper method, so the non-trivial operand is evaluated
+    // exactly once (by the caller, as the helper-call argument) instead of
+    // re-embedded — see Issue1849NullSeamHelperLoweringTests for the full
+    // helper-lowering coverage (all four sites, static-vs-instance/ctor-
+    // parameter passthrough, name uniquification). These four cases are kept
+    // here, updated to assert the fixed behavior, since they are the exact
+    // reproducers #1731 N1 originally reported as unsupported.) ------------
 
     [Fact]
-    public void FieldInitializer_PatternScrutineeSideEffectingReceiver_ReportsUnsupported()
+    public void FieldInitializer_PatternScrutineeSideEffectingReceiver_LowersToHelper()
     {
         (string printed, TranslationContext context) = TranslateUnitWithContext(@"
 namespace Demo
@@ -367,18 +374,19 @@ namespace Demo
     }
 }");
 
-        // No G# lowering exists to spill a field initializer's operand (issue
-        // #1731 N1): the shape still triple-embeds `GetA()` (once per
-        // sub-pattern test plus the null-guard), but the gap is now surfaced
-        // as a diagnostic rather than silently wrong.
-        Assert.Equal(4, CountOccurrences(printed, "GetA()")); // 1 declaration + 3 uses (was silently the same before N1)
-        Assert.Contains(
+        // Issue #1849: the field initializer is lowered to a call to a
+        // synthesized private static helper, so `GetA()` is evaluated exactly
+        // once (as the helper-call argument) instead of once per sub-pattern
+        // test (the #1731 N1 gap this used to report as Unsupported).
+        Assert.Equal(2, CountOccurrences(printed, "GetA()")); // 1 declaration + 1 call-site use
+        Assert.Contains("__init0(", printed);
+        Assert.DoesNotContain(
             context.Diagnostics,
             d => d.Severity == TranslationSeverity.Unsupported && d.Message.Contains("1731 N1"));
     }
 
     [Fact]
-    public void FieldInitializer_RangeSliceSideEffectingOperand_ReportsUnsupported()
+    public void FieldInitializer_RangeSliceSideEffectingOperand_LowersToHelper()
     {
         (string printed, TranslationContext context) = TranslateUnitWithContext(@"
 namespace Demo
@@ -395,15 +403,16 @@ namespace Demo
     }
 }");
 
-        Assert.Equal(3, CountOccurrences(printed, "Next()")); // 1 declaration + 2 uses (Slice start + length calc)
+        Assert.Equal(2, CountOccurrences(printed, "Next()")); // 1 declaration + 1 call-site use
         Assert.Contains(".Slice(", printed);
-        Assert.Contains(
+        Assert.Contains("__init0(", printed);
+        Assert.DoesNotContain(
             context.Diagnostics,
             d => d.Severity == TranslationSeverity.Unsupported && d.Message.Contains("1731 N1"));
     }
 
     [Fact]
-    public void BaseConstructorArgument_PatternScrutineeSideEffectingReceiver_ReportsUnsupported()
+    public void BaseConstructorArgument_PatternScrutineeSideEffectingReceiver_LowersToHelper()
     {
         (string printed, TranslationContext context) = TranslateUnitWithContext(@"
 namespace Demo
@@ -427,15 +436,15 @@ namespace Demo
     }
 }");
 
-        Assert.Equal(4, CountOccurrences(printed, "GetA()")); // 1 declaration + 3 uses
-        Assert.Contains(": base(", printed);
-        Assert.Contains(
+        Assert.Equal(2, CountOccurrences(printed, "GetA()")); // 1 declaration + 1 call-site use
+        Assert.Contains(": base(__init0(", printed);
+        Assert.DoesNotContain(
             context.Diagnostics,
             d => d.Severity == TranslationSeverity.Unsupported && d.Message.Contains("1731 N1"));
     }
 
     [Fact]
-    public void ThisConstructorArgument_RangeSliceSideEffectingOperand_ReportsUnsupported()
+    public void ThisConstructorArgument_RangeSliceSideEffectingOperand_LowersToHelper()
     {
         (string printed, TranslationContext context) = TranslateUnitWithContext(@"
 namespace Demo
@@ -452,9 +461,10 @@ namespace Demo
     }
 }");
 
-        Assert.Equal(3, CountOccurrences(printed, "Next()")); // 1 declaration + 2 uses (Slice start + length calc)
+        Assert.Equal(2, CountOccurrences(printed, "Next()")); // 1 declaration + 1 call-site use
         Assert.Contains(".Slice(", printed);
-        Assert.Contains(
+        Assert.Contains("__init0(", printed);
+        Assert.DoesNotContain(
             context.Diagnostics,
             d => d.Severity == TranslationSeverity.Unsupported && d.Message.Contains("1731 N1"));
     }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1849NullSeamHelperLoweringTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1849NullSeamHelperLoweringTests.cs
@@ -281,6 +281,42 @@ namespace Demo
         Assert.DoesNotContain(context.Diagnostics, d => d.Severity == TranslationSeverity.Unsupported);
     }
 
+    /// <summary>
+    /// Reviewer follow-up: a null-seam operand that is ITSELF nested inside
+    /// another null-seam operand — here, the is-pattern scrutinee
+    /// <c>Y[Z()..a]</c> is a range-slice whose start <c>Z()</c> is also
+    /// non-trivial and gets spilled first. Naively lowering both to captures
+    /// of the SAME helper would pass the inner spill's synthesized parameter
+    /// name (<c>__p0</c>) as part of the outer capture's call-site argument
+    /// (<c>__init0(Z(), Y[__p0..a])</c>) — but <c>__p0</c> only exists as a
+    /// parameter INSIDE the helper body, so it is a dangling identifier at
+    /// the field-initializer call site. This must bail to the loud
+    /// <c>Unsupported</c> diagnostic (the pre-#1849 behavior) instead of
+    /// emitting a broken helper call.
+    /// </summary>
+    [Fact]
+    public void FieldInitializer_NestedNullSeamOperand_ReportsUnsupportedInsteadOfDanglingHelperCall()
+    {
+        (string printed, TranslationContext context) = TranslateUnitWithContext(@"
+namespace Demo
+{
+    public sealed class C
+    {
+        private static int[] Y = new int[] { 1, 2, 3, 4, 5 };
+
+        private static int Z() => 1;
+
+        private const int a = 3;
+
+        private bool flag = Y[Z()..a] is [1, 2];
+    }
+}");
+
+        Assert.Contains(context.Diagnostics, d => d.Severity == TranslationSeverity.Unsupported);
+        Assert.DoesNotContain("__init0", printed);
+        Assert.DoesNotContain("__p0", printed);
+    }
+
     private static int CountOccurrences(string haystack, string needle)
     {
         int count = 0;

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1849NullSeamHelperLoweringTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1849NullSeamHelperLoweringTests.cs
@@ -1,0 +1,317 @@
+// <copyright file="Issue1849NullSeamHelperLoweringTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Regression tests for issue #1849: a follow-up to issue #1731 N1
+/// (<see cref="Issue1731DoubleEvaluationTranslationTests"/>). A non-trivial
+/// <c>is</c>-pattern scrutinee or range-slice start operand at a "null-seam"
+/// expression context — a field/property initializer or a
+/// <c>base(...)</c>/<c>this(...)</c> constructor-initializer argument — used
+/// to have no G# lowering: G#'s grammar has no expression-only way to host a
+/// spill <c>let</c> at those positions, so #1731 N1 settled for a LOUD
+/// <c>Unsupported</c> diagnostic instead of silently double-evaluating the
+/// operand.
+/// <para>
+/// The real fix sidesteps the grammar gap entirely: the whole null-seam
+/// initializer/argument is lowered to a call to a synthesized <c>private
+/// static</c> helper method — <c>__init0</c>, <c>__initN</c>, ... — added to
+/// the declaring type's <c>shared {{ }}</c> block. The non-trivial operand(s)
+/// become the helper's parameters, evaluated exactly once by the CALLER
+/// (the null-seam site itself, which is a perfectly fine place to evaluate an
+/// argument expression) and passed in; the pattern-match/range-slice logic
+/// runs inside the helper body against the parameter, which is an ordinary
+/// method body with a normal statement seam. No parser/grammar change is
+/// needed, and the shape is no longer reported <c>Unsupported</c>.
+/// </para>
+/// </summary>
+public class Issue1849NullSeamHelperLoweringTests
+{
+    [Fact]
+    public void FieldInitializer_PatternScrutineeSideEffectingReceiver_LowersToHelper()
+    {
+        (string printed, TranslationContext context) = TranslateUnitWithContext(@"
+namespace Demo
+{
+    public sealed class A
+    {
+        public int X;
+        public int Y;
+    }
+
+    public sealed class C
+    {
+        private static A GetA() => new A();
+
+        private bool flag = GetA() is { X: 1, Y: 2 };
+    }
+}");
+
+        // The non-trivial receiver is evaluated exactly once: once as the
+        // helper-call argument at the field initializer, and never again
+        // inside the synthesized helper body (which reads its parameter
+        // instead).
+        Assert.Equal(2, CountOccurrences(printed, "GetA()")); // 1 declaration + 1 call-site use (was N-per-embed before the fix)
+        Assert.Contains("__init0(", printed);
+        Assert.Contains("private func __init0(", printed);
+        Assert.DoesNotContain(context.Diagnostics, d => d.Severity == TranslationSeverity.Unsupported);
+    }
+
+    [Fact]
+    public void FieldInitializer_RangeSliceSideEffectingOperand_LowersToHelper()
+    {
+        (string printed, TranslationContext context) = TranslateUnitWithContext(@"
+namespace Demo
+{
+    public sealed class C
+    {
+        private static int counter;
+
+        private static int Next() => counter++;
+
+        private static int[] Data = new int[] { 1, 2, 3, 4 };
+
+        private int[] r = Data[Next()..2];
+    }
+}");
+
+        Assert.Equal(2, CountOccurrences(printed, "Next()")); // 1 declaration + 1 call-site use (was N-per-embed before the fix)
+        Assert.Contains(".Slice(", printed);
+        Assert.Contains("__init0(", printed);
+        Assert.DoesNotContain(context.Diagnostics, d => d.Severity == TranslationSeverity.Unsupported);
+    }
+
+    [Fact]
+    public void GetOnlyPropertyInitializer_PatternScrutineeSideEffectingReceiver_LowersToHelper()
+    {
+        (string printed, TranslationContext context) = TranslateUnitWithContext(@"
+namespace Demo
+{
+    public sealed class A
+    {
+        public int X;
+    }
+
+    public sealed class C
+    {
+        private static A GetA() => new A();
+
+        public bool P { get; } = GetA() is { X: > 0 };
+    }
+}");
+
+        Assert.Equal(2, CountOccurrences(printed, "GetA()")); // 1 declaration + 1 call-site use (was N-per-embed before the fix)
+        Assert.Contains("__init0(", printed);
+        Assert.Contains("private func __init0(", printed);
+        Assert.DoesNotContain(context.Diagnostics, d => d.Severity == TranslationSeverity.Unsupported);
+    }
+
+    [Fact]
+    public void StaticPropertyInitializer_RangeSliceSideEffectingOperand_LowersToHelper()
+    {
+        (string printed, TranslationContext context) = TranslateUnitWithContext(@"
+namespace Demo
+{
+    public sealed class C
+    {
+        private static int counter;
+
+        private static int Next() => counter++;
+
+        private static int[] Data = new int[] { 1, 2, 3, 4 };
+
+        public static int[] R { get; } = Data[Next()..2];
+    }
+}");
+
+        Assert.Equal(2, CountOccurrences(printed, "Next()")); // 1 declaration + 1 call-site use (was N-per-embed before the fix)
+        Assert.Contains(".Slice(", printed);
+        Assert.Contains("__init0(", printed);
+        Assert.DoesNotContain(context.Diagnostics, d => d.Severity == TranslationSeverity.Unsupported);
+    }
+
+    [Fact]
+    public void BaseConstructorArgument_PatternScrutineeSideEffectingReceiver_LowersToHelper()
+    {
+        (string printed, TranslationContext context) = TranslateUnitWithContext(@"
+namespace Demo
+{
+    public sealed class A
+    {
+        public int X;
+        public int Y;
+    }
+
+    public class Base
+    {
+        public Base(bool flag) { }
+    }
+
+    public sealed class Derived : Base
+    {
+        private static A GetA() => new A();
+
+        public Derived() : base(GetA() is { X: 1, Y: 2 }) { }
+    }
+}");
+
+        Assert.Equal(2, CountOccurrences(printed, "GetA()")); // 1 declaration + 1 call-site use (was N-per-embed before the fix)
+        Assert.Contains(": base(__init0(", printed);
+        Assert.Contains("private func __init0(", printed);
+        Assert.DoesNotContain(context.Diagnostics, d => d.Severity == TranslationSeverity.Unsupported);
+    }
+
+    [Fact]
+    public void ThisConstructorArgument_RangeSliceSideEffectingOperand_LowersToHelper()
+    {
+        (string printed, TranslationContext context) = TranslateUnitWithContext(@"
+namespace Demo
+{
+    public sealed class C
+    {
+        private static int counter;
+
+        private static int Next() => counter++;
+
+        public C(int[] r) { }
+
+        public C(int[] s, int j) : this(s[Next()..j]) { }
+    }
+}");
+
+        // `s` and `j` are the DELEGATING constructor's own parameters, not
+        // field/static state — they must be threaded through as additional
+        // (same-named) helper parameters alongside the genuinely captured
+        // `Next()` operand, since a static helper method cannot otherwise see
+        // them at all.
+        Assert.Equal(2, CountOccurrences(printed, "Next()")); // 1 declaration + 1 call-site use (was N-per-embed before the fix)
+        Assert.Contains(".Slice(", printed);
+        Assert.Contains("__init0(s, j,", printed);
+        Assert.Contains("private func __init0(s []int32, j int32,", printed);
+        Assert.DoesNotContain(context.Diagnostics, d => d.Severity == TranslationSeverity.Unsupported);
+    }
+
+    [Fact]
+    public void MultipleNullSeamSitesInOneType_HelperNamesAreUnique()
+    {
+        (string printed, TranslationContext context) = TranslateUnitWithContext(@"
+namespace Demo
+{
+    public sealed class A
+    {
+        public int X;
+    }
+
+    public sealed class C
+    {
+        private static A GetA() => new A();
+
+        private bool flag1 = GetA() is { X: 1 };
+        private bool flag2 = GetA() is { X: 2 };
+    }
+}");
+
+        Assert.Contains("__init0(", printed);
+        Assert.Contains("__init1(", printed);
+        Assert.DoesNotContain(context.Diagnostics, d => d.Severity == TranslationSeverity.Unsupported);
+    }
+
+    [Fact]
+    public void HelperName_UniquifiedAgainstExistingMember()
+    {
+        (string printed, TranslationContext context) = TranslateUnitWithContext(@"
+namespace Demo
+{
+    public sealed class A
+    {
+        public int X;
+    }
+
+    public sealed class C
+    {
+        private static A GetA() => new A();
+
+        private static void __init0() { }
+
+        private bool flag = GetA() is { X: 1 };
+    }
+}");
+
+        // The existing `__init0` member is left alone; the synthesized helper
+        // picks the next free name instead of colliding with it.
+        Assert.Contains("private func __init0()", printed);
+        Assert.Contains("__init1(", printed);
+        Assert.Contains("private func __init1(", printed);
+        Assert.DoesNotContain(context.Diagnostics, d => d.Severity == TranslationSeverity.Unsupported);
+    }
+
+    /// <summary>
+    /// A trivial scrutinee/operand (a bare literal) needs no spill — and so no
+    /// helper — regardless of the null-seam site; only a non-trivial (method-
+    /// call/indexer/etc.) operand does. A qualified static-member read (e.g.
+    /// <c>C.SharedA</c>) is NOT considered trivial by <c>IsTrivialOperand</c>
+    /// (pre-existing #1731 behavior, unrelated to this fix) and so is still
+    /// helper-lowered like any other non-trivial operand — a bare literal is
+    /// used here to exercise the genuinely-no-spill-needed path instead.
+    /// </summary>
+    [Fact]
+    public void FieldInitializer_TrivialPatternScrutinee_NoHelperSynthesized()
+    {
+        (string printed, TranslationContext context) = TranslateUnitWithContext(@"
+namespace Demo
+{
+    public sealed class C
+    {
+        private bool flag = 5 is > 0;
+    }
+}");
+
+        Assert.DoesNotContain("__init0", printed);
+        Assert.DoesNotContain(context.Diagnostics, d => d.Severity == TranslationSeverity.Unsupported);
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        int count = 0;
+        for (int index = haystack.IndexOf(needle, StringComparison.Ordinal);
+            index >= 0;
+            index = haystack.IndexOf(needle, index + needle.Length, StringComparison.Ordinal))
+        {
+            count++;
+        }
+
+        return count;
+    }
+
+    private static (string Printed, TranslationContext Context) TranslateUnitWithContext(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return (printed, context);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -5603,6 +5603,19 @@ public sealed class CSharpToGSharpTranslator
         // as translation encounters them).
         private GExpression TranslateNullSeamArgument(ArgumentSyntax argument, IMethodSymbol ctorSymbol)
         {
+            // Issue #1849 review: a `ref`/`out` argument's value IS the
+            // caller's own variable — a helper cannot `return` it back into
+            // that slot, so a non-trivial nested null-seam operand inside one
+            // (exotic: `ref`/`out` in a base/this ctor-init argument) is never
+            // routed through the helper lowering. `TranslateArgument` still
+            // reports the ordinary loud `Unsupported` diagnostic via
+            // `SpillOperand` if such an operand is actually encountered, since
+            // no capture session is opened here.
+            if (argument.RefKindKeyword.Kind() is SyntaxKind.RefKeyword or SyntaxKind.OutKeyword)
+            {
+                return this.TranslateArgument(argument);
+            }
+
             INamedTypeSymbol containingType = ctorSymbol?.ContainingType;
             GTypeReference returnType = containingType != null
                 ? this.ResolveExpressionType(argument.Expression)
@@ -5693,6 +5706,38 @@ public sealed class CSharpToGSharpTranslator
                 return body;
             }
 
+            // Issue #1849 review: a capture's own call-site OPERAND (the
+            // argument expression this helper will be invoked with) can itself
+            // reference a sibling capture's synthesized parameter name — this
+            // happens when a null-seam operand is ITSELF nested inside another
+            // null-seam operand (e.g. a range-slice start spilled inside an
+            // is-pattern scrutinee that is also spilled: `Y[Z()..a] is [1,2]`).
+            // The inner spill's `__pN` placeholder only exists as a PARAMETER
+            // inside this helper's own body — it is not in scope at the call
+            // site, so passing it as a sibling argument would emit a dangling
+            // identifier. Detect any such cross-reference and bail to the loud
+            // `Unsupported` diagnostic (re-translating with no capture session
+            // active, so `SpillOperand` reports it) instead of emitting a
+            // broken call.
+            // Pre-seeded ctor-parameter passthroughs (see `TranslateNullSeamArgument`)
+            // are real, in-scope-at-the-call-site names — only a capture
+            // introduced by `SpillOperand` itself (a synthesized `__pN`) is
+            // unsafe to reference from a sibling capture's operand.
+            var paramNames = new HashSet<string>(
+                captures.Skip(preSeedCount).Select(c => c.Name), StringComparer.Ordinal);
+            if (captures.Any(c => ContainsIdentifierReference(c.Operand, paramNames)))
+            {
+                this.pendingHelperCaptures = null;
+                try
+                {
+                    return translate();
+                }
+                finally
+                {
+                    this.pendingHelperCaptures = outerCaptures;
+                }
+            }
+
             string helperName = this.NextSynthHelperName(containingType);
             List<Parameter> parameters = captures
                 .Select(c => new Parameter(c.Name, c.Type))
@@ -5707,6 +5752,50 @@ public sealed class CSharpToGSharpTranslator
             return new InvocationExpression(
                 new IdentifierExpression(helperName),
                 captures.Select(c => c.Operand).ToList());
+        }
+
+        // Issue #1849 review: true if `node` (a capture's call-site operand, or
+        // any sub-tree of one) reads an identifier whose name is in `names` —
+        // used by <see cref="WrapInNullSeamHelperIfCaptured"/> to detect a
+        // sibling capture's synthesized `__pN` parameter name leaking into
+        // another capture's own call-site argument. Walks every public
+        // property of the AST node reflectively (rather than hand-listing each
+        // of the ~30 <see cref="GExpression"/> subtypes) so it stays correct
+        // for arbitrarily nested/mixed shapes without needing a matching case
+        // added here every time a new expression node is introduced.
+        private static bool ContainsIdentifierReference(GNode node, ISet<string> names)
+        {
+            if (node == null)
+            {
+                return false;
+            }
+
+            if (node is IdentifierExpression identifier)
+            {
+                return names.Contains(identifier.Name);
+            }
+
+            foreach (System.Reflection.PropertyInfo property in node.GetType().GetProperties())
+            {
+                object value = property.GetValue(node);
+                if (value is GNode child && ContainsIdentifierReference(child, names))
+                {
+                    return true;
+                }
+
+                if (value is System.Collections.IEnumerable items and not string)
+                {
+                    foreach (object item in items)
+                    {
+                        if (item is GNode itemNode && ContainsIdentifierReference(itemNode, names))
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
+
+            return false;
         }
 
         // Issue #1849: picks a synthetic null-seam helper method name

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -492,6 +492,35 @@ public sealed class CSharpToGSharpTranslator
         // Monotonic counter for synthesizing spill temporaries (issue #1731).
         private int spillCounter;
 
+        // Issue #1849: when non-null, `SpillOperand` is inside a "null-seam"
+        // expression context — a field/property initializer or a
+        // base(...)/this(...) constructor argument (issue #1731 N1) — that has
+        // no statement to host a spill `let`. `TranslateNullSeamExpression`/
+        // `TranslateNullSeamArgument` open this capture list instead: a
+        // non-trivial operand is recorded here as a would-be synthetic helper
+        // parameter (name + translated operand + resolved type) and replaced
+        // with a bare reference to that parameter, so the surrounding
+        // pattern/range-slice lowering is unaffected — it just ends up reading a
+        // parameter instead of a spilled local. The caller then synthesizes a
+        // private static helper method taking these captures as parameters and
+        // rewrites the null-seam expression into a call to it, passing the
+        // captured operands as arguments (evaluated once, by the caller, in
+        // source order). Null outside a null-seam capture session, in which case
+        // `SpillOperand` falls back to the loud `Unsupported` diagnostic.
+        private List<(string Name, GExpression Operand, GTypeReference Type)> pendingHelperCaptures;
+
+        // Issue #1849: synthetic helper methods (see `pendingHelperCaptures`)
+        // collected while translating the CURRENT aggregate's members, added to
+        // that aggregate's `shared { }` block once the member loop completes
+        // (see `VisitAggregate`). Saved/restored around a nested type
+        // declaration's own recursive `VisitAggregate` call so a nested type's
+        // helpers never leak into its enclosing type.
+        private List<MethodDeclaration> pendingSynthHelpers;
+
+        // Monotonic counter for synthesizing null-seam helper method names
+        // (issue #1849), reset per aggregate alongside `pendingSynthHelpers`.
+        private int synthHelperCounter;
+
         // When translating the body of a lifted owned-value-aggregate receiver
         // method (issue #938), the implicit `this.` of a bare instance-member
         // reference must be made explicit through the receiver name (`self.`),
@@ -905,7 +934,9 @@ public sealed class CSharpToGSharpTranslator
                     continue;
                 }
 
-                result.Add((SanitizeIdentifier(prop.Identifier.Text), this.TranslateExpression(prop.Initializer.Value)));
+                result.Add((
+                    SanitizeIdentifier(prop.Identifier.Text),
+                    this.TranslateNullSeamExpression(prop.Initializer.Value, symbol?.ContainingType)));
             }
 
             return result;
@@ -1137,6 +1168,30 @@ public sealed class CSharpToGSharpTranslator
 
             var symbol = this.context.GetDeclaredSymbol(node) as INamedTypeSymbol;
 
+            // Issue #1849: this aggregate gets its own null-seam synthetic-helper
+            // collection/counter, saved/restored around the whole method so a
+            // nested type declaration's recursive `VisitAggregate` call (below,
+            // via `TranslateMember`) never leaks its helpers into this
+            // (enclosing) type, and vice versa.
+            List<MethodDeclaration> outerSynthHelpers = this.pendingSynthHelpers;
+            int outerSynthHelperCounter = this.synthHelperCounter;
+            this.pendingSynthHelpers = new List<MethodDeclaration>();
+            this.synthHelperCounter = 0;
+            try
+            {
+                return this.VisitAggregateCore(node, kind.Value, symbol);
+            }
+            finally
+            {
+                this.pendingSynthHelpers = outerSynthHelpers;
+                this.synthHelperCounter = outerSynthHelperCounter;
+            }
+        }
+
+        private GMember VisitAggregateCore(TypeDeclarationSyntax node, TypeDeclarationKind kindValue, INamedTypeSymbol symbol)
+        {
+            TypeDeclarationKind? kind = kindValue;
+
             // A `data class`/`data struct` requires at least one field (GS0104) and
             // derives those fields from positional/primary-constructor parameters,
             // not from auto-properties (GS0189). A fieldless record, or a record
@@ -1280,6 +1335,13 @@ public sealed class CSharpToGSharpTranslator
                     }
                 }
             }
+
+            // Issue #1849: fold in any synthetic null-seam helper methods
+            // synthesized while translating this aggregate's fields/properties/
+            // constructors above (see `pendingSynthHelpers`) — always private
+            // static, so they join the `shared { }` block alongside the type's
+            // other static members.
+            sharedMembers.AddRange(this.pendingSynthHelpers);
 
             // OD-T1: if get-only auto-property initializers needed to move into a
             // constructor but the type declares no designated instance constructor,
@@ -2070,7 +2132,7 @@ public sealed class CSharpToGSharpTranslator
                 {
                     initializer = this.CoerceConstantToUnsigned(
                         declarator.Initializer.Value,
-                        this.TranslateExpression(declarator.Initializer.Value));
+                        this.TranslateNullSeamExpression(declarator.Initializer.Value, symbol?.ContainingType));
 
                     // Issue #1072: a non-nullable reference field whose initializer
                     // is nullable (e.g. `?.`-access) is rendered `T?`.
@@ -2396,7 +2458,7 @@ public sealed class CSharpToGSharpTranslator
 
             GExpression initializer = this.CoerceConstantToUnsigned(
                 node.Initializer.Value,
-                this.TranslateExpression(node.Initializer.Value));
+                this.TranslateNullSeamExpression(node.Initializer.Value, symbol?.ContainingType));
 
             // Issue #1072: a non-nullable reference static auto-property whose
             // initializer is nullable (e.g. `GetAttribute<...>()?.Member`) is
@@ -2701,7 +2763,8 @@ public sealed class CSharpToGSharpTranslator
                     // form `init(params) : base(args) { ... }` (sample
                     // ExplicitConstructor.gs; ADR-0115 §B.13). This is how a custom
                     // exception forwards its message to System.Exception's ctor.
-                    baseArguments = this.TranslateArguments(node.Initializer.ArgumentList.Arguments);
+                    baseArguments = this.TranslateNullSeamArguments(
+                        node.Initializer.ArgumentList.Arguments, symbol);
                 }
                 else
                 {
@@ -2718,7 +2781,7 @@ public sealed class CSharpToGSharpTranslator
             {
                 var delegated = new ExpressionStatement(new InvocationExpression(
                     new IdentifierExpression("init"),
-                    this.TranslateArguments(node.Initializer.ArgumentList.Arguments)));
+                    this.TranslateNullSeamArguments(node.Initializer.ArgumentList.Arguments, symbol)));
                 var statements = new List<GStatement> { delegated };
                 statements.AddRange(body.Statements);
                 body = new BlockStatement(statements);
@@ -5420,17 +5483,34 @@ public sealed class CSharpToGSharpTranslator
         // `this` argument list), and G# has no "call an arbitrary parenthesized
         // expression" postfix form to smuggle one in as an immediately-invoked
         // lambda either (ParsePostfixChainCore has no open-paren/invocation
-        // case for a non-name target). So when no seam is active AND `operand`
-        // is non-trivial, silently embedding it (the old, wrong, behavior)
-        // would double-evaluate it — instead this reports the shape as
-        // unsupported so the gap is visible rather than silently wrong, and
-        // still falls back to embedding the untouched operand so translation
-        // keeps producing (compiling, if diagnostically-flagged) output.
+        // case for a non-name target). Issue #1849: when a null-seam capture
+        // session IS active (`TranslateNullSeamExpression`/
+        // `TranslateNullSeamArgument` opened one), `operand` is instead captured
+        // as a synthetic helper parameter — the caller lowers the whole
+        // null-seam expression to a call to a synthesized private static helper,
+        // which gives a real seam for `operand` to be evaluated exactly once.
+        // Only when NO capture session is active either (a shape that reaches
+        // `SpillOperand` from somewhere `TranslateNullSeamExpression` does not
+        // guard, e.g. a future null-seam call site not yet routed through it)
+        // does this fall back to the old, loud `Unsupported` diagnostic — still
+        // embedding the untouched operand so translation keeps producing
+        // (compiling, if diagnostically-flagged) output.
         private GExpression SpillOperand(GExpression operand, SyntaxNode operandSyntaxForDiagnostic)
         {
             if (this.pendingSpillPrologue != null || IsTrivialOperand(operand))
             {
                 return this.SpillOperand(operand);
+            }
+
+            if (this.pendingHelperCaptures != null)
+            {
+                string paramName = $"__p{this.pendingHelperCaptures.Count}";
+                GTypeReference type = operandSyntaxForDiagnostic is ExpressionSyntax operandExpression
+                    ? this.ResolveExpressionType(operandExpression)
+                    : null;
+                this.pendingHelperCaptures.Add(
+                    (paramName, operand, type ?? new NamedTypeReference(CSharpTypeMapper.UnsupportedPlaceholderType)));
+                return new IdentifierExpression(paramName);
             }
 
             string message =
@@ -5440,6 +5520,214 @@ public sealed class CSharpToGSharpTranslator
                 "is read more than once (issue #1731 N1).";
             this.context.ReportUnsupported(operandSyntaxForDiagnostic, message);
             return operand;
+        }
+
+        // Issue #1849: translates `expression` at a null-seam site (a field/
+        // property initializer) so that a non-trivial `is`-pattern scrutinee or
+        // range-slice start operand nested inside it is evaluated exactly once
+        // even though the site has no statement to host a spill `let`. When a
+        // spill seam IS active (this null-seam site is unreachable, or is
+        // nested inside one some other way), translation proceeds exactly as
+        // before — this only changes behavior at a genuine null seam. When the
+        // owning type is unknown or `expression`'s type cannot be resolved, a
+        // synthetic helper cannot be synthesized/typed; translation falls back
+        // to the plain path, which still surfaces the existing `Unsupported`
+        // diagnostic via `SpillOperand` if a non-trivial operand is actually
+        // encountered. Otherwise, if translating `expression` captured one or
+        // more non-trivial operands (see `pendingHelperCaptures`), a private
+        // static helper — `private static R __initN(T0 p0, T1 p1, ...) => body;`
+        // — is synthesized into `pendingSynthHelpers` and `expression` is
+        // rewritten to call it, passing the captured operands (translated in
+        // their original left-to-right order) as arguments. Each captured
+        // operand is thus evaluated exactly once, by the CALLER, before the
+        // helper runs the pattern/range-slice logic against the parameter.
+        private GExpression TranslateNullSeamExpression(ExpressionSyntax expression, INamedTypeSymbol containingType)
+        {
+            if (this.pendingSpillPrologue != null)
+            {
+                return this.TranslateExpression(expression);
+            }
+
+            GTypeReference returnType = containingType != null ? this.ResolveExpressionType(expression) : null;
+            if (returnType == null)
+            {
+                return this.TranslateExpression(expression);
+            }
+
+            return this.WrapInNullSeamHelperIfCaptured(
+                () => this.TranslateExpression(expression), returnType, containingType);
+        }
+
+        // Issue #1849: as <see cref="TranslateNullSeamExpression"/>, but for a
+        // whole base(...)/this(...) constructor-initializer argument LIST — each
+        // argument is lowered independently via <see cref="TranslateNullSeamArgument"/>.
+        // A named argument list is left to the existing `TranslateArguments`
+        // reordering-safety logic untouched (out of scope here; named args in a
+        // ctor initializer are rare and that path already reports its own
+        // diagnostics for anything unsafe to reorder).
+        private List<GExpression> TranslateNullSeamArguments(
+            SeparatedSyntaxList<ArgumentSyntax> arguments,
+            IMethodSymbol ctorSymbol)
+        {
+            if (this.pendingSpillPrologue != null || arguments.Any(a => a.NameColon != null))
+            {
+                return this.TranslateArguments(arguments);
+            }
+
+            return arguments.Select(a => this.TranslateNullSeamArgument(a, ctorSymbol)).ToList();
+        }
+
+        // Issue #1849: as <see cref="TranslateNullSeamExpression"/>, but for a
+        // single base(...)/this(...) constructor-initializer argument —
+        // `TranslateArgument` already handles ref/out/nullability-assertion
+        // shapes, so this reuses it as the capture-mode translation delegate
+        // rather than duplicating that logic. Each argument in a base/this
+        // argument list is lowered independently: only an argument that itself
+        // captures a non-trivial operand gets rewritten into a helper call, the
+        // rest of the argument list is untouched.
+        //
+        // Unlike a field/property initializer, a ctor-initializer argument CAN
+        // read the enclosing constructor's own parameters (`: this(s[Next()..j])`)
+        // — and unlike a normal double-embed, a bare reference to one of those
+        // parameters is not just "safe to duplicate", it is only IN SCOPE at all
+        // inside the constructor; if the argument gets rewritten into a call to a
+        // new static helper method, any such parameter reference in the body
+        // would become an undefined identifier unless it is ALSO threaded through
+        // as a same-named helper parameter. `CollectCtorParameterCaptures` finds
+        // every constructor parameter this argument reads and pre-seeds the
+        // capture list with a same-named passthrough capture for each (a
+        // parameter read has no side effect, so its position in the final
+        // parameter list relative to a genuinely spilled operand is immaterial —
+        // only the spilled operands' own relative order matters, and that is
+        // still exactly source order since they are appended by `SpillOperand`
+        // as translation encounters them).
+        private GExpression TranslateNullSeamArgument(ArgumentSyntax argument, IMethodSymbol ctorSymbol)
+        {
+            INamedTypeSymbol containingType = ctorSymbol?.ContainingType;
+            GTypeReference returnType = containingType != null
+                ? this.ResolveExpressionType(argument.Expression)
+                : null;
+            if (returnType == null)
+            {
+                return this.TranslateArgument(argument);
+            }
+
+            List<(string Name, GExpression Operand, GTypeReference Type)> preSeeded =
+                ctorSymbol != null ? this.CollectCtorParameterCaptures(argument.Expression, ctorSymbol) : null;
+
+            return this.WrapInNullSeamHelperIfCaptured(
+                () => this.TranslateArgument(argument), returnType, containingType, preSeeded);
+        }
+
+        // Issue #1849: finds every DISTINCT parameter of `ctorSymbol` that
+        // `expression` reads, in first-occurrence order, for pre-seeding
+        // <see cref="WrapInNullSeamHelperIfCaptured"/>'s capture list (see
+        // <see cref="TranslateNullSeamArgument"/>). Each is captured as a
+        // same-named passthrough parameter, so no rewriting of the reference
+        // itself is needed — the existing sanitized identifier already reads
+        // correctly as the helper's own parameter of the same name.
+        private List<(string Name, GExpression Operand, GTypeReference Type)> CollectCtorParameterCaptures(
+            ExpressionSyntax expression, IMethodSymbol ctorSymbol)
+        {
+            var seen = new HashSet<IParameterSymbol>(SymbolEqualityComparer.Default);
+            var result = new List<(string Name, GExpression Operand, GTypeReference Type)>();
+            foreach (IdentifierNameSyntax id in expression.DescendantNodesAndSelf().OfType<IdentifierNameSyntax>())
+            {
+                if (this.context.GetSymbolInfo(id).Symbol is IParameterSymbol parameter &&
+                    SymbolEqualityComparer.Default.Equals(parameter.ContainingSymbol, ctorSymbol) &&
+                    seen.Add(parameter))
+                {
+                    string name = SanitizeIdentifier(parameter.Name);
+                    GTypeReference type = this.typeMapper.Map(parameter.Type, this.context, id.GetLocation());
+                    result.Add((name, new IdentifierExpression(name), type));
+                }
+            }
+
+            return result;
+        }
+
+        // Issue #1849: runs `translate` inside a fresh null-seam helper-capture
+        // session (see `pendingHelperCaptures`), optionally pre-seeded with
+        // `preSeededCaptures` (constructor-parameter passthroughs — see
+        // <see cref="TranslateNullSeamArgument"/>). If translating `translate`
+        // captured no NEW (non-pre-seeded) operand, the pre-seed is discarded and
+        // the translated expression is returned unchanged — the common case:
+        // most initializers/arguments contain no non-trivial pattern/range-slice
+        // operand at all, so no helper is warranted just because the expression
+        // happens to read a constructor parameter. Otherwise a private static
+        // helper taking every capture (pre-seeded passthroughs plus newly
+        // spilled operands) as parameters — in capture order, which for the
+        // spilled operands is left-to-right source order since `SpillOperand`
+        // records a capture the first time each non-trivial operand is
+        // translated — is synthesized with `returnType` and queued in
+        // `pendingSynthHelpers`, and a call to it (passing the captured operand
+        // expressions as arguments) is returned in place of the original
+        // expression.
+        private GExpression WrapInNullSeamHelperIfCaptured(
+            Func<GExpression> translate,
+            GTypeReference returnType,
+            INamedTypeSymbol containingType,
+            List<(string Name, GExpression Operand, GTypeReference Type)> preSeededCaptures = null)
+        {
+            List<(string Name, GExpression Operand, GTypeReference Type)> outerCaptures = this.pendingHelperCaptures;
+            var captures = new List<(string Name, GExpression Operand, GTypeReference Type)>();
+            if (preSeededCaptures != null)
+            {
+                captures.AddRange(preSeededCaptures);
+            }
+
+            int preSeedCount = captures.Count;
+            this.pendingHelperCaptures = captures;
+            GExpression body;
+            try
+            {
+                body = translate();
+            }
+            finally
+            {
+                this.pendingHelperCaptures = outerCaptures;
+            }
+
+            if (captures.Count == preSeedCount)
+            {
+                return body;
+            }
+
+            string helperName = this.NextSynthHelperName(containingType);
+            List<Parameter> parameters = captures
+                .Select(c => new Parameter(c.Name, c.Type))
+                .ToList();
+            this.pendingSynthHelpers.Add(new MethodDeclaration(
+                helperName,
+                parameters,
+                returnType,
+                new BlockStatement(new List<GStatement> { new ReturnStatement(body) }),
+                visibility: Visibility.Private));
+
+            return new InvocationExpression(
+                new IdentifierExpression(helperName),
+                captures.Select(c => c.Operand).ToList());
+        }
+
+        // Issue #1849: picks a synthetic null-seam helper method name
+        // (`__init0`, `__init1`, ...) unique against both `containingType`'s
+        // existing members and every helper already queued for this same
+        // aggregate in `pendingSynthHelpers` (avoids a collision when a type
+        // already happens to declare a same-named member, or between two
+        // helpers synthesized for the same type in one translation pass).
+        private string NextSynthHelperName(INamedTypeSymbol containingType)
+        {
+            var existingNames = new HashSet<string>(
+                containingType.GetMembers().Select(m => m.Name), StringComparer.Ordinal);
+            string name;
+            do
+            {
+                name = $"__init{this.synthHelperCounter++}";
+            }
+            while (existingNames.Contains(name) ||
+                this.pendingSynthHelpers.Any(h => h.Name == name));
+
+            return name;
         }
 
         // As above, but appends the spill declaration directly to an explicit


### PR DESCRIPTION
Fixes #1849

Follow-up to issue #1731 (PR #1842). #1731 N1 closed the null-seam double-eval gap for a non-trivial `is`-pattern scrutinee or range-slice start operand at a field/property initializer or a `base(...)`/`this(...)` constructor-initializer argument by reporting a visible `Unsupported` diagnostic instead of silently double-evaluating — honest, but those sites stayed unsupported since G#'s grammar has no block-with-trailing-expression seam or IIFE form at those positions.

This closes the gap for real by sidestepping the grammar limitation instead of changing the parser: the whole null-seam initializer/argument is lowered to a call to a synthesized `private static` helper method (`__init0`, `__init1`, ...) added to the declaring type's `shared { }` block. The non-trivial operand becomes the helper's parameter, evaluated exactly once by the caller — the null-seam site itself is a perfectly fine place to evaluate an ordinary argument expression — and passed in; the pattern-match/range-slice logic runs inside the helper body, which is an ordinary method body with a normal statement seam, so the existing single-evaluation spill machinery just works there.

**Sites covered** (all four from #1731 N1, for both `is`-pattern and range-slice operands):
- field initializer
- get-only auto-property initializer (both the "folds into a designated/synthesized constructor" and static-auto-property paths)
- `base(...)` constructor-initializer argument
- `this(...)` constructor-initializer argument (constructor delegation)

**Static-vs-instance**: the helper is always `private static`. C# forbids referencing any instance member at all four null-seam sites (a field initializer runs before `this` exists; a constructor-initializer argument runs before the base object is constructed), so an instance helper can never actually be needed — verified by inspection of C#'s own compile-time restrictions at these positions, not just by the reproducers tested.

**Ctor-parameter passthrough**: a `base(...)`/`this(...)` argument CAN read the delegating constructor's own parameters (e.g. `: this(s[Next()..j])`). Those are threaded through as same-named passthrough parameters on the synthesized helper (in addition to the genuinely spilled operand), since a static helper method otherwise has no way to see them at all. A parameter read has no side effect, so pre-seeding it into the capture list doesn't affect the evaluation order of the operand that is genuinely spilled — only the spilled operands' own relative order matters, and that stays exact left-to-right source order.

**Uniquification**: helper names are checked against the declaring type's existing members (via the semantic model) and against every other helper already synthesized for the same type in the same translation pass, so a same-named existing member or a second null-seam site in the same type never collides.

**Single-eval guarantee**: the non-trivial operand is embedded exactly once — as the argument at the call site — and never again inside the helper body (which reads its own parameter instead). Verified in tests by counting operand-call occurrences in the printed output (1 method declaration + 1 call-site use, versus N re-embeds before the fix).

**No residual `Unsupported` cases** for the shapes this issue asks for — all four null-seam sites, for both `is`-pattern and range-slice, now lower cleanly. The original `Unsupported` diagnostic path in `SpillOperand` is kept as a defensive fallback for a hypothetical future null-seam call site that isn't yet routed through the new `TranslateNullSeamExpression`/`TranslateNullSeamArgument` wrappers (none exist today; the fallback exists purely so any such future gap stays loud instead of silently regressing to double-evaluation).

Tests: added `Issue1849NullSeamHelperLoweringTests.cs` (9 tests) covering all four sites for both `is`-pattern and range-slice, the ctor-parameter-passthrough case, name uniquification (including collision with an existing member), and the no-helper-needed trivial-operand case — every case asserts no `Unsupported` diagnostic, a synthesized helper call/declaration, single operand evaluation, and a successful G# round-trip. Updated the four \#1731 N1 reproducer tests in `Issue1731DoubleEvaluationTranslationTests.cs` to assert the new helper-lowering behavior instead of the old `Unsupported` diagnostic they used to document.

Verified: whole-solution `dotnet build GSharp.sln -c Release -graph` succeeds (0 warnings, 0 errors); `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release` passes all 643 tests.