### PR TITLE
cs2gs/gsc: support nested collection member with ctor args (issue #1858)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -131,6 +131,28 @@ internal sealed partial class ExpressionBinder
                 continue;
             }
 
+            // Issue #1858: a braced member value `Prop = { a, b }` populates a
+            // (typically get-only) collection member via `.Add(...)` calls —
+            // the same target-less collection-initializer form already
+            // supported by the struct/imported-class composite literals
+            // (issue #1567). Handling it here lets a collection member
+            // combine with constructor arguments in the initializer-suffix
+            // form (gsc issue #522), which neither of those literals covers.
+            if (initSyntax.Value is CollectionInitializerExpressionSyntax { Target: null } bracedInit)
+            {
+                var bracedReceiver = new BoundVariableExpression(initSyntax, tempVar);
+                if (TryEmitMemberCollectionInitializer(bracedReceiver, propertyName, initSyntax.PropertyIdentifier, bracedInit, statements))
+                {
+                    continue;
+                }
+
+                // Not a collection member (or not found) — fall through to the
+                // normal assignment path below, whose own lookup reports the
+                // appropriate diagnostic (unfound member, unassignable, or the
+                // defensive not-collection-initializable report when
+                // BindExpression is reached on the braced value).
+            }
+
             var assignment = BindObjectInitializerAssignment(tempVar, resultType, initSyntax);
             if (assignment == null)
             {

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -9102,7 +9102,17 @@ public class Parser
             suppressStructLiteral = 0;
             try
             {
-                value = ParseExpression();
+                // Issue #1858: `Prop = { a, b }` mirrors the struct-literal
+                // target-less collection-initializer carve-out (issue #1567,
+                // `ParseFieldInitializerValue`) — a brace can never start a
+                // normal expression in value position, so its presence
+                // unambiguously selects the member collection-initializer form
+                // rather than an ordinary assignment value. This lets the
+                // construction-with-initializer-suffix form (issue #522) carry
+                // a nested collection member alongside constructor arguments.
+                value = Current.Kind == SyntaxKind.OpenBraceToken
+                    ? ParseCollectionInitializerExpression(target: null)
+                    : ParseExpression();
             }
             finally
             {

--- a/test/Compiler.Tests/Emit/Issue1858ObjectInitializerCollectionMemberWithCtorArgsEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1858ObjectInitializerCollectionMemberWithCtorArgsEmitTests.cs
@@ -1,0 +1,170 @@
+// <copyright file="Issue1858ObjectInitializerCollectionMemberWithCtorArgsEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1858 — the construction-with-initializer-suffix form
+/// (<c>Target(args) { Name = value, ... }</c>, gsc issue #522) now carries the
+/// same target-less member collection-initializer carve-out already supported
+/// by the colon struct-literal form (issue #1567): a braced member value
+/// (<c>Items = { 1, 2 }</c>) populates a get-only collection member via
+/// <c>Add(...)</c> calls, composing with constructor arguments AND ordinary
+/// scalar members in the same construct. This closes the cs2gs-reported gap
+/// where <c>new Foo(x) { Items = { a, b }, Bar = 2 }</c> had no canonical G#
+/// form (see <c>Cs2Gs.Tests.Issue1858ObjectInitializerCtorArgsPlusCollectionMemberTranslationTests</c>
+/// for the translator-fidelity side). This file proves the emitted form is
+/// not just syntactically valid but semantically correct at runtime.
+/// </summary>
+public class Issue1858ObjectInitializerCollectionMemberWithCtorArgsEmitTests
+{
+    [Fact]
+    public void CtorArgPlusCollectionMemberPlusScalarMember_PopulatesAll()
+    {
+        const string source = """
+            package i1858mixed
+            import System
+            import System.Collections.Generic
+
+            class Foo {
+                prop X int32 { get; init; }
+                prop Bar int32 { get; set; }
+                prop Items IList[int32] { get; init; }
+                init(x int32) {
+                    X = x
+                    Items = List[int32]()
+                }
+            }
+
+            func Main() {
+                let f = Foo(10) { Items = { 1, 2 }, Bar = 3 }
+                System.Console.WriteLine(f.X)
+                System.Console.WriteLine(f.Bar)
+                System.Console.WriteLine(f.Items.Count)
+                System.Console.WriteLine(f.Items[0])
+                System.Console.WriteLine(f.Items[1])
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("10\n3\n2\n1\n2\n", output);
+    }
+
+    [Fact]
+    public void CtorArgPlusOnlyCollectionMember_PopulatesCollection()
+    {
+        const string source = """
+            package i1858onlycoll
+            import System
+            import System.Collections.Generic
+
+            class Foo {
+                prop X int32 { get; init; }
+                prop Items IList[int32] { get; init; }
+                init(x int32) {
+                    X = x
+                    Items = List[int32]()
+                }
+            }
+
+            func Main() {
+                let f = Foo(7) { Items = { 42 } }
+                System.Console.WriteLine(f.X)
+                System.Console.WriteLine(f.Items.Count)
+                System.Console.WriteLine(f.Items[0])
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("7\n1\n42\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1858_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1728ObjectInitializerWithCtorArgsTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1728ObjectInitializerWithCtorArgsTranslationTests.cs
@@ -119,16 +119,15 @@ namespace Demo
     }
 
     [Fact]
-    public void CtorArgsPlusNestedCollectionInitializerMember_ReportsUnsupported()
+    public void CtorArgsPlusNestedCollectionInitializerMember_EmitsFaithfulSuffix()
     {
-        // Issue #1728 honest gap: gsc's construction-with-initializer-suffix
-        // form has no target-less collection-initializer carve-out (unlike the
-        // colon struct-literal form, issue #1567), so a nested `Prop = { a, b }`
-        // member combined with constructor arguments has no canonical G# form
-        // yet. It must be reported, not silently dropped.
-        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[]
-        {
-            ("Snippet.cs", @"
+        // Issue #1858 (follow-up to #1728): gsc's construction-with-
+        // initializer-suffix form now carries the same target-less
+        // collection-initializer carve-out as the colon struct-literal form
+        // (issue #1567), so a nested `Items = { 1, 2 }` member combined with
+        // constructor arguments AND another scalar member (`Bar = 2`) is
+        // translated faithfully — no member is silently dropped.
+        string printed = TranslateUnit(@"
 using System.Collections.Generic;
 
 namespace Demo
@@ -136,28 +135,20 @@ namespace Demo
     public class Foo
     {
         public int X { get; }
+        public int Bar { get; set; }
         public List<int> Items { get; } = new();
         public Foo(int x) { X = x; }
     }
 
     public class C
     {
-        public Foo Make(int x) => new Foo(x) { Items = { 1, 2 } };
+        public Foo Make(int x) => new Foo(x) { Items = { 1, 2 }, Bar = 2 };
     }
-}"),
-        });
-        Assert.True(
-            project.BoundWithoutErrors,
-            "Snippet should bind with no C# errors: " +
-                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+}");
 
-        LoadedDocument document = Assert.Single(project.Documents);
-        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
-        _ = new CSharpToGSharpTranslator().TranslateDocument(document, context);
-
-        Assert.Contains(
-            context.Diagnostics,
-            d => d.Message.Contains("construction-with-initializer-suffix", StringComparison.Ordinal));
+        Assert.Contains("Foo(x)", printed);
+        Assert.Contains("Items = { 1, 2 }", printed);
+        Assert.Contains("Bar = 2", printed);
     }
 
     private static string TranslateUnit(string source)

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1728ObjectInitializerWithCtorArgsTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1728ObjectInitializerWithCtorArgsTranslationTests.cs
@@ -151,7 +151,51 @@ namespace Demo
         Assert.Contains("Bar = 2", printed);
     }
 
+    [Fact]
+    public void CtorArgsPlusNestedObjectInitializerMember_ReportsUnsupported()
+    {
+        // Regression guard (B1, PR #1877 review of issue #1858): a nested
+        // `Sub = { X = 1, Y = 2 }` member is a C# OBJECT initializer, not a
+        // collection initializer — it has no faithful G# form when combined
+        // with constructor arguments. Must still fail loud (ReportUnsupported),
+        // not silently lower each `X = 1` as a bare collection element (which
+        // would emit the semantically wrong `.Add(X = 1)`).
+        (string printed, TranslationContext context) = TranslateUnitWithContext(@"
+namespace Demo
+{
+    public class Sub
+    {
+        public int X { get; set; }
+        public int Y { get; set; }
+    }
+
+    public class Foo
+    {
+        public int X { get; }
+        public Sub Sub { get; } = new Sub();
+        public Foo(int x) { X = x; }
+    }
+
+    public class C
+    {
+        public Foo Make(int x) => new Foo(x) { Sub = { X = 1, Y = 2 } };
+    }
+}");
+
+        Assert.Contains(
+            context.Diagnostics,
+            d => d.Severity == TranslationSeverity.Unsupported &&
+                d.Message.Contains("nested collection/object initializer as a member value"));
+        Assert.DoesNotContain(".Add(X = 1)", printed);
+    }
+
     private static string TranslateUnit(string source)
+    {
+        (string printed, _) = TranslateUnitWithContext(source);
+        return printed;
+    }
+
+    private static (string Printed, TranslationContext Context) TranslateUnitWithContext(string source)
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
         Assert.True(
@@ -169,6 +213,6 @@ namespace Demo
             result.Success,
             "Translated G# must round-trip. Errors:\n" +
                 string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
-        return printed;
+        return (printed, context);
     }
 }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -9585,13 +9585,12 @@ public sealed class CSharpToGSharpTranslator
         /// Builds the canonical G# construction-with-initializer-suffix
         /// <c>Target(args) { Name = value, ... }</c> (gsc issue #522) for a C#
         /// object initializer combined with constructor arguments (issue #1728):
-        /// <c>new T(a, b) { Field = value, ... }</c>. Unlike
-        /// <see cref="BuildObjectInitializerLiteral"/> (the colon struct-literal
-        /// form, no ctor args), this suffix parses each member value as a plain
-        /// expression (gsc's <c>ParseObjectInitializerList</c> → <c>ParseExpression</c>)
-        /// — it has no target-less collection-initializer carve-out (issue #1567),
-        /// so a nested <c>Prop = { a, b }</c> member has no canonical form here yet
-        /// and is reported as unsupported instead of silently dropped.
+        /// <c>new T(a, b) { Field = value, ... }</c>. A nested
+        /// <c>Prop = { a, b }</c> member lowers to the same target-less member
+        /// collection-initializer form used by <see cref="BuildObjectInitializerLiteral"/>
+        /// (issue #1567) — gsc's suffix parser now carries the same carve-out
+        /// (issue #1858), so a collection member composes with constructor
+        /// arguments in one construct instead of being dropped.
         /// </summary>
         private GExpression BuildConstructionWithInitializerSuffix(
             InitializerExpressionSyntax initializer,
@@ -9609,10 +9608,15 @@ public sealed class CSharpToGSharpTranslator
                         (nestedInit.IsKind(SyntaxKind.CollectionInitializerExpression) ||
                          nestedInit.IsKind(SyntaxKind.ObjectInitializerExpression)))
                     {
-                        this.context.ReportUnsupported(
-                            assignment,
-                            "nested collection/object initializer as a member value has no canonical G# form when the outer object creation also has constructor arguments; gsc's construction-with-initializer-suffix form (issue #522) has no target-less collection-initializer carve-out (issue #1728).");
-                        continue;
+                        List<CollectionInitializerElement> memberElements =
+                            this.TranslateCollectionInitializerElements(nestedInit);
+                        if (memberElements != null)
+                        {
+                            memberInitializers.Add(new FieldInitializer(
+                                SanitizeIdentifier(name.Identifier.Text),
+                                new CollectionInitializerExpression(target: null, memberElements)));
+                            continue;
+                        }
                     }
 
                     memberInitializers.Add(new FieldInitializer(

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -9586,11 +9586,14 @@ public sealed class CSharpToGSharpTranslator
         /// <c>Target(args) { Name = value, ... }</c> (gsc issue #522) for a C#
         /// object initializer combined with constructor arguments (issue #1728):
         /// <c>new T(a, b) { Field = value, ... }</c>. A nested
-        /// <c>Prop = { a, b }</c> member lowers to the same target-less member
-        /// collection-initializer form used by <see cref="BuildObjectInitializerLiteral"/>
-        /// (issue #1567) — gsc's suffix parser now carries the same carve-out
-        /// (issue #1858), so a collection member composes with constructor
-        /// arguments in one construct instead of being dropped.
+        /// <c>Prop = { a, b }</c> COLLECTION-initializer member lowers to the
+        /// same target-less member collection-initializer form used by
+        /// <see cref="BuildObjectInitializerLiteral"/> (issue #1567) — gsc's
+        /// suffix parser now carries the same carve-out (issue #1858), so a
+        /// collection member composes with constructor arguments in one
+        /// construct instead of being dropped. A nested <c>Prop = { X = 1 }</c>
+        /// OBJECT-initializer member has no such carve-out and is reported as
+        /// unsupported instead of being silently mistranslated.
         /// </summary>
         private GExpression BuildConstructionWithInitializerSuffix(
             InitializerExpressionSyntax initializer,
@@ -9605,8 +9608,7 @@ public sealed class CSharpToGSharpTranslator
                     assignment.Left is IdentifierNameSyntax name)
                 {
                     if (assignment.Right is InitializerExpressionSyntax nestedInit &&
-                        (nestedInit.IsKind(SyntaxKind.CollectionInitializerExpression) ||
-                         nestedInit.IsKind(SyntaxKind.ObjectInitializerExpression)))
+                        nestedInit.IsKind(SyntaxKind.CollectionInitializerExpression))
                     {
                         List<CollectionInitializerElement> memberElements =
                             this.TranslateCollectionInitializerElements(nestedInit);
@@ -9617,6 +9619,14 @@ public sealed class CSharpToGSharpTranslator
                                 new CollectionInitializerExpression(target: null, memberElements)));
                             continue;
                         }
+                    }
+                    else if (assignment.Right is InitializerExpressionSyntax nestedObjectInit &&
+                        nestedObjectInit.IsKind(SyntaxKind.ObjectInitializerExpression))
+                    {
+                        this.context.ReportUnsupported(
+                            assignment,
+                            "nested collection/object initializer as a member value has no canonical G# form when the outer object creation also has constructor arguments; gsc's construction-with-initializer-suffix form (issue #522) has no target-less collection-initializer carve-out (issue #1728).");
+                        continue;
                     }
 
                     memberInitializers.Add(new FieldInitializer(


### PR DESCRIPTION
Fixes #1858

Follow-up to #1728 / PR #1856. For `new Foo(x) { Items = {1,2}, Bar = 2 }`, cs2gs reported the nested collection-init member `Items` as unsupported and dropped it, but still emitted `Bar = 2` in the construction-with-initializer-suffix. The result was a partially-populated but silently working G# build — the worst outcome per the fail-loudly-or-translate-faithfully contract.

**Option chosen: option 3 (faithful support), not option 1 (fail-whole).** Investigation showed the blocker was narrow: gsc's construction-with-initializer-suffix parser (issue #522, `Target(args) { Name = value, ... }`) simply had no target-less collection-initializer carve-out, unlike the colon struct-literal form that issue #1567 already added. Adding that carve-out to the suffix path, and reusing the existing `TryEmitMemberCollectionInitializer` `.Add(...)` lowering (already shared by the struct-literal and imported-class-literal paths), was a small, low-risk change — cheaper than failing the whole node and losing translation coverage.

**Changes:**
- `src/Core/CodeAnalysis/Syntax/Parser.cs`: `ParseObjectInitializerList` now parses a braced value (`Prop = { a, b }`) as a target-less `CollectionInitializerExpression`, mirroring `ParseFieldInitializerValue` (issue #1567).
- `src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs`: `BindObjectInitializerSuffix` lowers such a member via the existing `TryEmitMemberCollectionInitializer` helper, falling back to the normal assignment path (and its diagnostics) otherwise.
- `tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs`: `BuildConstructionWithInitializerSuffix` now translates a nested collection/object-initializer member the same way `BuildObjectInitializerLiteral` already does, instead of reporting it unsupported and dropping it.

**Tests:**
- `tools/cs2gs/Cs2Gs.Tests/Issue1728ObjectInitializerWithCtorArgsTranslationTests.cs`: replaced the old "reports unsupported" test with `CtorArgsPlusNestedCollectionInitializerMember_EmitsFaithfulSuffix`, asserting `Items`, `Bar`, and the ctor arg all appear in the translated output. The pre-existing plain-#1728 case (`Bar = 2`, no nested collection) and the no-ctor-args #1567 case are unchanged and still pass.
- `test/Compiler.Tests/Emit/Issue1858ObjectInitializerCollectionMemberWithCtorArgsEmitTests.cs` (new): end-to-end gsc compile+run tests proving the emitted G# actually compiles and produces correct runtime values for both a mixed collection+scalar member and a collection-only member, combined with constructor arguments.

**Verification:**
- `dotnet build GSharp.sln -c Release -graph` — succeeds (run twice, including after test additions).
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release` — 639/639 passed (includes #1728 and #1739 regression coverage).
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Release` — 2648/2648 passed (no regressions in gsc parser/binder).
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release --filter \"FullyQualifiedName~ObjectInitializer|FullyQualifiedName~CollectionInitializer|FullyQualifiedName~Parser\"` — 642/642 passed.
- Confirmed the shared `BuildObjectCreationCore` path used by both object-init (#1728) and positional-ctor (#1739) is unaffected — their dedicated test suites pass unchanged.

Nothing deferred: the per-member partial-emit bug is gone, and the nested-collection-plus-ctor-args case is now translated faithfully rather than merely failing loudly.