### PR TITLE
cs2gs: stop compound chained-assignment links re-reading the getter for outer '=' links

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue1875CompoundLinkReadBackTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1875CompoundLinkReadBackTests.cs
@@ -1,0 +1,287 @@
+// <copyright file="Issue1875CompoundLinkReadBackTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Regression tests for issue #1875, a follow-up to #1845/#1731. #1845 made a
+/// run of plain `=` links in a chained assignment reuse a single spilled RHS
+/// value instead of re-reading an inner target's getter for each outer link.
+/// One case was left over: a COMPOUND link (`+=`, …) followed by outer plain
+/// `=` links. `a = b = c.P += d` legitimately reads `c.P`'s getter once as
+/// part of the compound operation, but the outer `=` links (`b =`, `a =`)
+/// used to re-embed the target expression `c.P` itself as their value
+/// source — re-running the getter once per outer link. The fix expands the
+/// compound link into read-old/combine/store-new, capturing the combined
+/// value directly so every outer `=` link reuses that value instead of
+/// re-reading the target.
+/// </summary>
+public class Issue1875CompoundLinkReadBackTests
+{
+    [Fact]
+    public void ChainedAssignment_CompoundPropertyTarget_GetterReadExactlyOnce()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public sealed class Holder
+    {
+        private int backing;
+
+        public int P
+        {
+            get { System.Console.WriteLine(""get""); return this.backing; }
+            set { this.backing = value; }
+        }
+    }
+
+    public sealed class C
+    {
+        public void M()
+        {
+            var c = new Holder();
+            int a, b;
+            a = b = c.P += 3;
+            System.Console.WriteLine(a);
+            System.Console.WriteLine(b);
+        }
+    }
+}");
+
+        // The getter's own declaration also contains the literal "get" text
+        // (its body), so exactly one occurrence proves the chain lowering
+        // itself never calls the getter a second time for the outer `a =`/
+        // `b =` links.
+        Assert.Equal(1, CountOccurrences(printed, "\"get\""));
+        Assert.Contains("c.P =", printed);
+        Assert.Contains("b =", printed);
+        Assert.Contains("a =", printed);
+    }
+
+    [Fact]
+    public void ChainedAssignment_CompoundPropertyTarget_OuterLinksReuseStoredValue()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public sealed class Holder
+    {
+        private int backing;
+
+        public int P
+        {
+            get => this.backing;
+            set { this.backing = value; }
+        }
+    }
+
+    public sealed class C
+    {
+        public void M()
+        {
+            var c = new Holder();
+            int a, b;
+            a = b = c.P += 3;
+            System.Console.WriteLine(a);
+            System.Console.WriteLine(b);
+        }
+    }
+}");
+
+        // The combined value is spilled once into a shared temp; `c.P`'s
+        // setter is assigned that temp, and both outer links (`b`, `a`) are
+        // assigned the SAME temp — never `c.P` itself.
+        // The combined value is spilled once into a shared temp; `c.P`'s
+        // setter is assigned that temp, and both outer links (`b`, `a`) are
+        // assigned the SAME temp — never `c.P` itself.
+        int assignIndex = printed.IndexOf("c.P = __spill", System.StringComparison.Ordinal);
+        Assert.True(assignIndex >= 0, "Expected `c.P = __spillN` in:\n" + printed);
+        string spillTemp = ExtractSpillTempName(printed.Substring(assignIndex));
+        Assert.Contains($"c.P = {spillTemp}", printed);
+        Assert.Contains($"b = {spillTemp}", printed);
+        Assert.Contains($"a = {spillTemp}", printed);
+        Assert.DoesNotContain("b = c.P", printed);
+        Assert.DoesNotContain("a = c.P", printed);
+    }
+
+    [Fact]
+    public void ChainedAssignment_CompoundIndexerTarget_ThreeOuterLinks_ReadsBackOnce()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public sealed class Holder
+    {
+        private int[] backing = new int[4];
+
+        public int this[int i]
+        {
+            get { System.Console.WriteLine(""get""); return this.backing[i]; }
+            set { this.backing[i] = value; }
+        }
+    }
+
+    public sealed class C
+    {
+        public void M()
+        {
+            var arr = new Holder();
+            int a, b, d;
+            a = b = d = arr[0] += 3;
+            System.Console.WriteLine(a);
+            System.Console.WriteLine(b);
+            System.Console.WriteLine(d);
+        }
+    }
+}");
+
+        // Three outer `=` links above the compound indexer link still only
+        // read the getter once.
+        Assert.Equal(1, CountOccurrences(printed, "\"get\""));
+    }
+
+    [Fact]
+    public void ChainedAssignment_SideEffectingReceiver_EvaluatedOnceInOrder()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public sealed class Holder
+    {
+        public int P { get; set; }
+    }
+
+    public sealed class C
+    {
+        private static int calls;
+
+        private static Holder GetHolder()
+        {
+            calls++;
+            return new Holder();
+        }
+
+        public void M()
+        {
+            int a, b;
+            a = b = GetHolder().P += 3;
+            System.Console.WriteLine(a);
+            System.Console.WriteLine(b);
+        }
+    }
+}");
+
+        // The receiver-producing call (`GetHolder()`) is evaluated exactly
+        // once, spilled into a temp, and that temp's `.P` is what the
+        // compound link reads/writes.
+        Assert.Equal(1, CountOccurrences(printed, "C.GetHolder()"));
+    }
+
+    [Fact]
+    public void ChainedAssignment_TrivialCompoundTarget_Unchanged()
+    {
+        // `a = b += c`: `b` is a bare local, not a property/indexer, so
+        // re-embedding it as the outer link's value has no observable getter
+        // effect — the #1845-era read-back lowering for compound links is
+        // preserved as-is for this case (no unnecessary spill/expansion).
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public sealed class C
+    {
+        public void M()
+        {
+            int a = 0;
+            int b = 1;
+            int c = 2;
+            a = b += c;
+            System.Console.WriteLine(a);
+            System.Console.WriteLine(b);
+        }
+    }
+}");
+
+        Assert.Contains("b += c", printed);
+        Assert.Contains("a = b", printed);
+    }
+
+    [Fact]
+    public void ChainedAssignment_PlainOnlyChain_StillSharesOneComputedValue()
+    {
+        // Pure #1845 case (no compound link at all) must still work unchanged.
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public sealed class C
+    {
+        private static int Next() => 5;
+
+        public void M()
+        {
+            int a, b, c;
+            a = b = c = Next();
+            System.Console.WriteLine(a + b + c);
+        }
+    }
+}");
+
+        Assert.Equal(1, CountOccurrences(printed, "C.Next()"));
+        string spillTemp = ExtractSpillTempName(printed);
+        Assert.Equal(4, CountOccurrences(printed, spillTemp));
+    }
+
+    private static string ExtractSpillTempName(string printed)
+    {
+        int start = printed.IndexOf("__spill", System.StringComparison.Ordinal);
+        Assert.True(start >= 0, "Expected a __spill temp in:\n" + printed);
+        int end = start;
+        while (end < printed.Length && (char.IsLetterOrDigit(printed[end]) || printed[end] == '_'))
+        {
+            end++;
+        }
+
+        return printed.Substring(start, end - start);
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        int count = 0;
+        for (int index = haystack.IndexOf(needle, System.StringComparison.Ordinal);
+            index >= 0;
+            index = haystack.IndexOf(needle, index + needle.Length, System.StringComparison.Ordinal))
+        {
+            count++;
+        }
+
+        return count;
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(System.Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -5286,7 +5286,15 @@ public sealed class CSharpToGSharpTranslator
             // still has to be read back for the next link; that read is real
             // C# semantics, unrelated to the #1845 divergence, and is left as
             // it was under the #1731/#1842 fix (the target was already made
-            // safe to re-embed above).
+            // safe to re-embed above). BUT when a compound link itself has an
+            // outer `=` link depending on its result (`a = b = c.P += d`), G#
+            // assignment is statement-only (no expression form), so the only
+            // way to hand the produced value up the chain is to re-embed the
+            // target. Re-embedding the target expression as-is re-reads its
+            // getter once per outer link (issue #1875) — instead of doing
+            // that, the read/combine/store is expanded manually (mirroring
+            // exactly what the compound operator does) so the combined value
+            // is captured directly, with no re-read at all.
             bool valueIsShared = false;
             for (int i = lefts.Count - 1; i >= 0; i--)
             {
@@ -5302,17 +5310,69 @@ public sealed class CSharpToGSharpTranslator
                     valueIsShared = true;
                 }
 
+                if (hasOuterLink && lefts[i].Op != "=" &&
+                    !IsTrivialOperand(safeTargets[i]) &&
+                    CompoundToBinaryOperator(lefts[i].Op) is string binaryOp)
+                {
+                    // `c.P += d` reused above (`a = b = c.P += d`): re-embedding
+                    // a NON-trivial target (a property/indexer read, unlike a
+                    // bare local) would re-run its getter once per outer link
+                    // (issue #1875). Instead read c.P's getter exactly once,
+                    // combine it with the operand, and store the result — the
+                    // combined value (not a re-read of c.P) is what every
+                    // outer `=` link reuses, matching C#'s single-getter-call
+                    // semantics. A trivial target (bare local/`this`) has no
+                    // getter to protect, so it keeps the simpler read-back
+                    // below unchanged.
+                    GExpression oldValue = this.SpillOperand(safeTargets[i], statements);
+                    GExpression newValue = this.SpillOperand(new BinaryExpression(oldValue, binaryOp, assignedValue), statements);
+                    statements.Add(new AssignmentStatement(safeTargets[i], newValue, "="));
+                    value = newValue;
+                    valueIsShared = true;
+                    continue;
+                }
+
                 statements.Add(new AssignmentStatement(safeTargets[i], assignedValue, lefts[i].Op));
 
                 if (hasOuterLink && lefts[i].Op != "=")
                 {
-                    value = safeTargets[i];
+                    // Trivial target (bare local/`this`): reading it back has
+                    // no getter to worry about, so it stays the simple
+                    // read-back this fix has always used for compound links.
+                    // `??=` also lands here regardless of target triviality —
+                    // it has no side-effect-free binary-expression equivalent
+                    // (it must only evaluate/store the right-hand side when
+                    // the target is null) — so a non-trivial `??=` target
+                    // costs one extra getter call total (not one per outer
+                    // link), the minimum faithful cost without reimplementing
+                    // its short-circuit semantics.
+                    value = IsTrivialOperand(safeTargets[i]) ? safeTargets[i] : this.SpillOperand(safeTargets[i], statements);
                     valueIsShared = true;
                 }
             }
 
             return statements;
         }
+
+        // Maps a C# compound-assignment operator token (`+=`, `-=`, …) to its
+        // underlying binary operator (`+`, `-`, …), or null for `??=` (which
+        // has no side-effect-preserving binary-expression equivalent — see
+        // <see cref="FlattenChainedAssignment"/>).
+        private static string CompoundToBinaryOperator(string compoundOp) => compoundOp switch
+        {
+            "+=" => "+",
+            "-=" => "-",
+            "*=" => "*",
+            "/=" => "/",
+            "%=" => "%",
+            "&=" => "&",
+            "|=" => "|",
+            "^=" => "^",
+            "<<=" => "<<",
+            ">>=" => ">>",
+            ">>>=" => ">>>",
+            _ => null,
+        };
 
         private IEnumerable<GStatement> LowerTupleAssignment(
             TupleExpressionSyntax leftTuple,


### PR DESCRIPTION
Fixes #1875

Follow-up to #1845/#1731. #1845 made a run of plain `=` links in a chained assignment reuse a single spilled RHS value instead of re-reading an inner target's getter for each outer link. One case was left over: a compound link (`+=`, …) followed by outer plain `=` links.

In `a = b = c.P += d`, the `+=` link legitimately reads `c.P`'s getter once as part of the compound operation (read old, combine, store new — genuine C# semantics). But the outer plain `=` links (`b =`, `a =`) were re-embedding the target expression `c.P` itself as their value source, calling the getter again once per outer link — a divergence from C#, which uses the value the compound assignment produced directly, with no re-read.

`FlattenChainedAssignment` now expands a compound link that has an outer `=` link depending on it into its read/combine/store parts, when the target is non-trivial (a property/indexer read, not a bare local): read the old value once, combine it with the operand via the underlying binary operator, store the result, and reuse that combined value for every outer `=` link. This reproduces C#'s exact getter/setter call count — one read, one write — no matter how many outer links share the value.

`??=` has no side-effect-free binary-expression equivalent (it only evaluates/stores the right-hand side when the target is null), so it keeps the native compound statement and falls back to a single spilled read-back of the target — one extra getter call total, not one per outer link.

A trivial compound target (a bare local or `this`) has no getter to protect, so it's left exactly as before — the #1845-era read-back lowering is unchanged for that case, and existing #1845 tests pass unmodified.

Added `Issue1875CompoundLinkReadBackTests` covering: a single-getter-call property target, outer links reusing the shared temp (not re-reading `c.P`), a 3-outer-link indexer chain, a side-effecting receiver evaluated once in order, an unaffected trivial-target compound chain, and an unaffected plain-only chain (#1845 regression guard).

Verified with a whole-solution build (`dotnet build GSharp.sln -c Release -graph`) and the full `Cs2Gs.Tests` suite (645/645 passing), plus a targeted run of the #1723/#1731/#1845/#1875 regression classes (43/43 passing).