### PR TITLE
Add lock keyword to G# and fix cs2gs lock translation (#1885)

### DIFF
--- a/docs/coverage-matrix.md
+++ b/docs/coverage-matrix.md
@@ -142,6 +142,8 @@ LessToken
 LetKeyword
 ListPattern
 LiteralExpression
+LockKeyword
+LockStatement
 MakeChannelExpression
 MapCreationExpression
 MapEntry

--- a/docs/cs2gs-coverage-matrix.md
+++ b/docs/cs2gs-coverage-matrix.md
@@ -6,12 +6,12 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | Status | Count |
 | --- | --- |
 | Unclassified | 0 |
-| Translated | 208 |
+| Translated | 209 |
 | Lowered | 10 |
 | UnsupportedByDesign | 56 |
-| Gap | 47 |
+| Gap | 46 |
 
-## Translated (208)
+## Translated (209)
 
 | Kind | Node type | Rule | Rationale | Fixture | Issue | Notes |
 | --- | --- | --- | --- | --- | --- | --- |
@@ -128,6 +128,7 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | LessThanOrEqualExpression | BinaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/LessThanOrEqualExpression.cs |  |  |
 | LocalDeclarationStatement | LocalDeclarationStatementSyntax | ADR-0115 §B.3 |  |  |  |  |
 | LocalFunctionStatement | LocalFunctionStatementSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/LocalFunctionStatement.cs | https://github.com/DavidObando/gsharp/issues/1886 | static local functions mislower at call sites; generic local functions unrepresentable (issue #1886). |
+| LockStatement | LockStatementSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/LockStatement.cs |  |  |
 | LogicalAndExpression | BinaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/LogicalAndExpression.cs |  |  |
 | LogicalNotExpression | PrefixUnaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/LogicalNotExpression.cs |  |  |
 | LogicalOrExpression | BinaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/LogicalOrExpression.cs |  |  |
@@ -300,7 +301,7 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | XmlText | XmlTextSyntax |  | ToolingScope |  |  | Documentation/tooling structure, not program semantics; doc-comment mapping is ADR-0057 scope. |
 | XmlTextAttribute | XmlTextAttributeSyntax |  | ToolingScope |  |  | Documentation/tooling structure, not program semantics; doc-comment mapping is ADR-0057 scope. |
 
-## Gap (47)
+## Gap (46)
 
 | Kind | Node type | Rule | Rationale | Fixture | Issue | Notes |
 | --- | --- | --- | --- | --- | --- | --- |
@@ -333,7 +334,6 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | LabeledStatement | LabeledStatementSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1884 |  |
 | LetClause | LetClauseSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1902 | Query syntax lowered to the method-call chain, mirroring Roslyn. |
 | ListPattern | ListPatternSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1889 |  |
-| LockStatement | LockStatementSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1885 | Lowers to Monitor.Enter/Exit but omits import System.Threading. |
 | ObjectInitializerExpression | InitializerExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1892 | Initializer assignments emitted as stray statements. |
 | PointerMemberAccessExpression | MemberAccessExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1905 | p->X lowered to p.X; (*p).X compiles. |
 | PositionalPatternClause | PositionalPatternClauseSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1887 | SILENT MISTRANSLATION: sub-patterns dropped to match-anything case { }. |

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.cs
@@ -174,6 +174,8 @@ internal sealed class StatementBinder
                 return BindForRangeStatement((ForRangeStatementSyntax)syntax);
             case SyntaxKind.WhileStatement:
                 return BindWhileStatement((WhileStatementSyntax)syntax);
+            case SyntaxKind.LockStatement:
+                return BindLockStatement((LockStatementSyntax)syntax);
             case SyntaxKind.DoWhileStatement:
                 return BindDoWhileStatement((DoWhileStatementSyntax)syntax);
             case SyntaxKind.LabeledStatement:
@@ -3784,6 +3786,92 @@ internal sealed class StatementBinder
     {
         // ADR-0070: `while cond { body }` shares the lowering of `for cond { body }`.
         return BindForConditionStatementCore(syntax, syntax.Condition, syntax.Body, labelName: null);
+    }
+
+    /// <summary>
+    /// Issue #1885: lowers <c>lock expr { body }</c> to the classic
+    /// <c>System.Threading.Monitor.Enter</c> / <c>try</c> / <c>finally</c> /
+    /// <c>Monitor.Exit</c> pattern, evaluating <c>expr</c> exactly once into a
+    /// synthesized readonly local so <c>Enter</c> and <c>Exit</c> always
+    /// agree on the same monitor. Any reference-type target is accepted; a
+    /// value-type target is rejected (matches C# CS0185) because Monitor
+    /// would box a fresh copy on every entry, defeating mutual exclusion.
+    /// </summary>
+    private BoundStatement BindLockStatement(LockStatementSyntax syntax)
+    {
+        var target = bindExpression(syntax.Expression);
+        if (target is BoundErrorExpression)
+        {
+            return BindErrorStatement();
+        }
+
+        if (!IsLockableReferenceType(target.Type))
+        {
+            Diagnostics.ReportLockTargetMustBeReferenceType(syntax.Expression.Location, target.Type ?? TypeSymbol.Error);
+            return BindErrorStatement();
+        }
+
+        var tempVar = new LocalVariableSymbol($"$lock$target${binderCtx.SyntheticLocalCounter++}", isReadOnly: true, target.Type);
+        scope.TryDeclareVariable(tempVar);
+        var tempDecl = new BoundVariableDeclaration(syntax, tempVar, target);
+        BoundExpression TempAsObject()
+        {
+            var read = new BoundVariableExpression(syntax, tempVar);
+            return read.Type == TypeSymbol.Object ? read : new BoundConversionExpression(syntax, TypeSymbol.Object, read);
+        }
+
+        var monitorType = typeof(System.Threading.Monitor);
+        var importedClass = new ImportedClassSymbol(monitorType, declaration: null);
+        var enterMethod = monitorType.GetMethod("Enter", new[] { typeof(object) });
+        var exitMethod = monitorType.GetMethod("Exit", new[] { typeof(object) });
+        var enterFn = new ImportedFunctionSymbol(enterMethod.Name, importedClass, enterMethod, declaration: null);
+        var exitFn = new ImportedFunctionSymbol(exitMethod.Name, importedClass, exitMethod, declaration: null);
+
+        var enterStmt = new BoundExpressionStatement(
+            syntax,
+            new BoundImportedCallExpression(syntax, enterFn, ImmutableArray.Create(TempAsObject())));
+
+        var body = BindStatement(syntax.Body);
+        var exitCall = new BoundImportedCallExpression(syntax, exitFn, ImmutableArray.Create(TempAsObject()));
+        var tryStmt = BuildCleanupTryStatement(ImmutableArray.Create(body), exitCall);
+
+        return new BoundBlockStatement(syntax, ImmutableArray.Create<BoundStatement>(tempDecl, enterStmt, tryStmt));
+    }
+
+    /// <summary>
+    /// Issue #1885: true when <paramref name="type"/> is a reference type and
+    /// therefore a legal <c>lock</c> target. Unwraps a nullable annotation to
+    /// check the underlying type. G# classes (<see cref="StructSymbol"/> with
+    /// <c>IsClass</c>), interfaces, arrays, delegates, and function-value
+    /// types are always reference types; imported CLR types defer to
+    /// <c>ClrType.IsValueType</c>.
+    /// </summary>
+    private static bool IsLockableReferenceType(TypeSymbol type)
+    {
+        if (type == null || type == TypeSymbol.Error)
+        {
+            return true;
+        }
+
+        if (type is NullableTypeSymbol nullable)
+        {
+            type = nullable.UnderlyingType;
+        }
+
+        switch (type)
+        {
+            case StructSymbol structType:
+                return structType.IsClass;
+            case EnumSymbol:
+                return false;
+            case InterfaceSymbol:
+            case ArrayTypeSymbol:
+            case DelegateTypeSymbol:
+            case FunctionTypeSymbol:
+                return true;
+        }
+
+        return type.ClrType == null || !type.ClrType.IsValueType;
     }
 
     private BoundStatement BindDoWhileStatement(DoWhileStatementSyntax syntax)

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -638,6 +638,21 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
     }
 
     /// <summary>
+    /// Reports that the operand of a <c>lock</c> statement is not a
+    /// reference type (issue #1885). <c>lock</c> lowers to
+    /// <c>System.Threading.Monitor.Enter/Exit</c>, which requires a
+    /// reference-type argument; locking on a value type would box a fresh
+    /// copy on every entry, defeating mutual exclusion (matches C# CS0185).
+    /// </summary>
+    /// <param name="location">The text location of the operand.</param>
+    /// <param name="type">The offending operand type.</param>
+    public void ReportLockTargetMustBeReferenceType(TextLocation location, TypeSymbol type)
+    {
+        var message = $"'{type.Name}' is not a reference type as required by the 'lock' statement.";
+        Report(location, "GS0461", message);
+    }
+
+    /// <summary>
     /// Reports that the operand of a channel-receive expression (<c>&lt;-ch</c>) is not a channel (Phase 5.5 / ADR-0022).
     /// </summary>
     /// <param name="location">The text location of the operand.</param>

--- a/src/Core/CodeAnalysis/Syntax/LockStatementSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/LockStatementSyntax.cs
@@ -1,0 +1,43 @@
+// <copyright file="LockStatementSyntax.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Core.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Represents a <c>lock expr { body }</c> statement (issue #1885). Mutual
+/// exclusion follows the classic <c>System.Threading.Monitor.Enter</c> /
+/// <c>try</c> / <c>finally</c> / <c>Monitor.Exit</c> pattern C# uses to
+/// lower <c>lock (expr) { body }</c>.
+/// </summary>
+public sealed class LockStatementSyntax : StatementSyntax
+{
+    /// <summary>Initializes a new instance of the <see cref="LockStatementSyntax"/> class.</summary>
+    /// <param name="syntaxTree">The parent syntax tree.</param>
+    /// <param name="lockKeyword">The <c>lock</c> keyword.</param>
+    /// <param name="expression">The lock-target expression.</param>
+    /// <param name="body">The body statement.</param>
+    public LockStatementSyntax(
+        SyntaxTree syntaxTree,
+        SyntaxToken lockKeyword,
+        ExpressionSyntax expression,
+        StatementSyntax body)
+        : base(syntaxTree)
+    {
+        LockKeyword = lockKeyword;
+        Expression = expression;
+        Body = body;
+    }
+
+    /// <inheritdoc/>
+    public override SyntaxKind Kind => SyntaxKind.LockStatement;
+
+    /// <summary>Gets the <c>lock</c> keyword.</summary>
+    public SyntaxToken LockKeyword { get; }
+
+    /// <summary>Gets the lock-target expression.</summary>
+    public ExpressionSyntax Expression { get; }
+
+    /// <summary>Gets the body statement.</summary>
+    public StatementSyntax Body { get; }
+}

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -4850,6 +4850,8 @@ public class Parser
                 return ParseWhileStatement();
             case SyntaxKind.DoKeyword:
                 return ParseDoWhileStatement();
+            case SyntaxKind.LockKeyword:
+                return ParseLockStatement();
             case SyntaxKind.BreakKeyword:
                 return ParseBreakStatement();
             case SyntaxKind.ContinueKeyword:
@@ -5896,6 +5898,17 @@ public class Parser
         var condition = ParseExpressionInBodyHeader();
         var body = ParseStatement();
         return new WhileStatementSyntax(syntaxTree, keyword, condition, body);
+    }
+
+    private StatementSyntax ParseLockStatement()
+    {
+        // Issue #1885: `lock expr { body }` — mutual exclusion around body,
+        // lowered by the binder to the classic Monitor Enter/try/finally/Exit
+        // pattern.
+        var keyword = MatchToken(SyntaxKind.LockKeyword);
+        var expression = ParseExpressionInBodyHeader();
+        var body = ParseStatement();
+        return new LockStatementSyntax(syntaxTree, keyword, expression, body);
     }
 
     private StatementSyntax ParseDoWhileStatement()

--- a/src/Core/CodeAnalysis/Syntax/SyntaxFacts.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxFacts.cs
@@ -232,6 +232,8 @@ public static class SyntaxFacts
                 return SyntaxKind.VarKeyword;
             case "while":
                 return SyntaxKind.WhileKeyword;
+            case "lock":
+                return SyntaxKind.LockKeyword;
             default:
                 return SyntaxKind.IdentifierToken;
         }
@@ -498,6 +500,8 @@ public static class SyntaxFacts
                 return "var";
             case SyntaxKind.WhileKeyword:
                 return "while";
+            case SyntaxKind.LockKeyword:
+                return "lock";
             default:
                 return null;
         }

--- a/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
@@ -145,6 +145,7 @@ public enum SyntaxKind
     UsingKeyword,
     VarKeyword,
     WhileKeyword,
+    LockKeyword,
 
     // compilation
     CompilationUnit,
@@ -225,6 +226,7 @@ public enum SyntaxKind
     ThrowExpression,
     UsingStatement,
     DeferStatement,
+    LockStatement,
     CatchKeyword,
     FinallyKeyword,
     StructDeclaration,

--- a/src/vscode-gsharp/syntaxes/gsharp.tmLanguage.json
+++ b/src/vscode-gsharp/syntaxes/gsharp.tmLanguage.json
@@ -203,7 +203,7 @@
         },
         {
           "name": "keyword.control.flow.gsharp",
-          "match": "\\b(try|catch|finally|throw|defer)\\b"
+          "match": "\\b(try|catch|finally|throw|defer|lock)\\b"
         },
         {
           "name": "keyword.control.async.gsharp",

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1885LockStatementTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1885LockStatementTests.cs
@@ -1,0 +1,126 @@
+// <copyright file="Issue1885LockStatementTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1885: G# gains a first-class <c>lock target { body }</c> statement
+/// with the same semantics as C#'s <c>lock</c> — <c>Monitor.Enter</c>, then
+/// <c>try { body } finally { Monitor.Exit }</c>. Previously cs2gs lowered
+/// C# <c>lock</c> to raw <c>Monitor.Enter</c>/<c>Monitor.Exit</c> calls
+/// without ever emitting <c>import System.Threading</c>, so the translated
+/// G# failed to compile (GS0157). These tests exercise the new <c>lock</c>
+/// keyword directly at the gsc level (parse, bind, evaluate).
+/// </summary>
+public class Issue1885LockStatementTests
+{
+    [Fact]
+    public void Lock_RunsBody_AndReturnsMutatedValue()
+    {
+        var source = @"
+class Gate {}
+
+var g = Gate{}
+var total = 0
+lock g {
+    total = total + 1
+    total = total + 1
+}
+total
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(2, result.Value);
+    }
+
+    [Fact]
+    public void Lock_ReleasesOnException_ViaFinally()
+    {
+        // The body throws; a `finally`-released monitor lets a later `lock`
+        // against the SAME target re-acquire it with no deadlock — the
+        // deterministic proof that `lock` lowers through try/finally.
+        var source = @"
+import System
+
+class Gate {}
+
+var g = Gate{}
+var trace = """"
+try {
+    lock g {
+        trace = trace + ""a""
+        throw Exception(""boom"")
+    }
+} catch (e Exception) {
+    trace = trace + ""c""
+}
+
+lock g {
+    trace = trace + ""b""
+}
+
+trace
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("acb", result.Value);
+    }
+
+    [Fact]
+    public void Lock_EvaluatesTargetExactlyOnce()
+    {
+        // A non-trivial (side-effecting) lock target must be evaluated
+        // exactly once — not once for Enter and again for Exit.
+        var source = @"
+class Gate {}
+
+func GetGate() Gate {
+    callCount = callCount + 1
+    return Gate{}
+}
+
+var callCount = 0
+lock GetGate() {
+    var x = 1
+}
+callCount
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(1, result.Value);
+    }
+
+    [Fact]
+    public void Lock_OnValueTypeTarget_IsDiagnosed()
+    {
+        var diagnostics = Bind(@"
+var n = 1
+lock n {
+    var x = 1
+}
+");
+        Assert.NotEmpty(diagnostics);
+        Assert.Contains(diagnostics, d => d.Message.Contains("reference type"));
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+
+    private static ImmutableArray<Diagnostic> Bind(string source)
+        => Evaluate(source).Diagnostics;
+}

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue1675SyntaxNodeChildEnumerationTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue1675SyntaxNodeChildEnumerationTests.cs
@@ -75,6 +75,9 @@ public class Issue1675SyntaxNodeChildEnumerationTests
 
         // await using / await for
         "package p\nimport System\nasync func F(stream any) {\n  await using let r = stream\n  await for v in stream {\n  }\n}\n",
+
+        // lock statement (issue #1885)
+        "package p\nclass Gate {}\nfunc F(g Gate) {\n  lock g {\n    var x = 1\n  }\n}\n",
     };
 
     /// <summary>

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue1885LockStatementParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue1885LockStatementParserTests.cs
@@ -1,0 +1,57 @@
+// <copyright file="Issue1885LockStatementParserTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Issue #1885: parser-level tests for the new <c>lock target { body }</c>
+/// statement.
+/// </summary>
+public class Issue1885LockStatementParserTests
+{
+    [Fact]
+    public void Parses_BareLock()
+    {
+        const string source = """
+            package P
+            var gate = 0
+            lock gate { gate = gate + 1 }
+            """;
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var stmt = tree.Root.Members
+            .OfType<GlobalStatementSyntax>()
+            .Select(g => g.Statement)
+            .OfType<LockStatementSyntax>()
+            .Single();
+        Assert.Equal(SyntaxKind.LockKeyword, stmt.LockKeyword.Kind);
+        Assert.NotNull(stmt.Expression);
+        Assert.IsType<BlockStatementSyntax>(stmt.Body);
+    }
+
+    [Fact]
+    public void Parses_LockWithSingleStatementBody()
+    {
+        const string source = """
+            package P
+            var gate = 0
+            lock gate
+                gate = gate + 1
+            """;
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var stmt = tree.Root.Members
+            .OfType<GlobalStatementSyntax>()
+            .Select(g => g.Statement)
+            .OfType<LockStatementSyntax>()
+            .Single();
+        Assert.IsType<ExpressionStatementSyntax>(stmt.Body);
+    }
+}

--- a/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
+++ b/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
@@ -142,6 +142,8 @@ LessToken
 LetKeyword
 ListPattern
 LiteralExpression
+LockKeyword
+LockStatement
 MakeChannelExpression
 MapCreationExpression
 MapEntry

--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/GStatement.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/GStatement.cs
@@ -204,6 +204,32 @@ public sealed class WhileStatement : GStatement
 }
 
 /// <summary>
+/// A <c>lock target { body }</c> statement (issue #1885). G# has a first-class
+/// <c>lock</c> keyword mirroring C#'s mutual-exclusion statement, so the
+/// translator emits it directly rather than lowering to the
+/// <c>Monitor.Enter</c>/try-finally/<c>Monitor.Exit</c> pattern by hand.
+/// </summary>
+public sealed class LockStatement : GStatement
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LockStatement"/> class.
+    /// </summary>
+    /// <param name="target">The lock-target expression.</param>
+    /// <param name="body">The protected body.</param>
+    public LockStatement(GExpression target, BlockStatement body)
+    {
+        Target = target;
+        Body = body;
+    }
+
+    /// <summary>Gets the lock-target expression.</summary>
+    public GExpression Target { get; }
+
+    /// <summary>Gets the protected body.</summary>
+    public BlockStatement Body { get; }
+}
+
+/// <summary>
 /// A C-style three-clause <c>for init; cond; incr { }</c> loop. Each clause is
 /// optional. The init/incr clauses are "simple" statements (local declaration,
 /// assignment, increment/decrement, or expression statement) per the G# grammar

--- a/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
@@ -850,6 +850,9 @@ public static class GSharpPrinter
             case WhileStatement whileStatement:
                 return $"{pad}while {RenderExpression(whileStatement.Condition, indent)} {RenderBlock(whileStatement.Body, indent)}";
 
+            case LockStatement lockStatement:
+                return $"{pad}lock {RenderExpression(lockStatement.Target, indent)} {RenderBlock(lockStatement.Body, indent)}";
+
             case ForStatement forStatement:
                 return RenderForStatement(forStatement, indent);
 

--- a/tools/cs2gs/Cs2Gs.Tests/Coverage/GNodeSamples.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Coverage/GNodeSamples.cs
@@ -125,6 +125,7 @@ public static class GNodeSamples
                 body: Block(new ReturnStatement(Int("1"))))),
             [typeof(IfStatement)] = () => Stmts(new IfStatement(Id("c"), Block(), Block())),
             [typeof(WhileStatement)] = () => Stmts(new WhileStatement(Id("c"), Block())),
+            [typeof(LockStatement)] = () => Stmts(new LockStatement(Id("gate"), Block())),
             [typeof(ForStatement)] = () => Stmts(new ForStatement(
                 new LocalDeclarationStatement(BindingKind.Var, "i", initializer: Int("0")),
                 new BinaryExpression(Id("i"), "<", Int("3")),

--- a/tools/cs2gs/Cs2Gs.Tests/Coverage/code-model-surface.golden.txt
+++ b/tools/cs2gs/Cs2Gs.Tests/Coverage/code-model-surface.golden.txt
@@ -51,6 +51,7 @@ IfStatement
 IncrementDecrementStatement
 LocalDeclarationStatement
 LocalFunctionStatement
+LockStatement
 RawStatement
 ReturnStatement
 SwitchStatement

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1731DoubleEvaluationTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1731DoubleEvaluationTranslationTests.cs
@@ -15,70 +15,25 @@ namespace Cs2Gs.Tests;
 /// <summary>
 /// Regression tests for issue #1731: several lowerings re-embedded the SAME
 /// translated operand at two output positions instead of translating it once
-/// — a <c>lock (target)</c>'s target (once for <c>Monitor.Enter</c>, once for
-/// <c>Monitor.Exit</c>), a chained assignment's inner target (once as the
-/// write, once as the next link's read), an <c>is</c>-pattern's scrutinee
-/// (once per sub-pattern/binder reference), and a range-slice's start operand
-/// (once as the <c>Slice</c> argument, once inside the length computation).
-/// When the operand has a side effect (a method call, an increment) or reads
-/// a mutable value, duplicating it silently changes C# semantics by running
-/// it twice. The fix spills any non-trivial operand into a single <c>let</c>
-/// via a shared helper and references the local at both positions, while a
-/// bare local/<c>this</c>/literal operand is left untouched (no spurious
-/// temp). Every snippet must round-trip through the real G# parser.
+/// — a chained assignment's inner target (once as the write, once as the next
+/// link's read), an <c>is</c>-pattern's scrutinee (once per sub-pattern/binder
+/// reference), and a range-slice's start operand (once as the <c>Slice</c>
+/// argument, once inside the length computation). When the operand has a side
+/// effect (a method call, an increment) or reads a mutable value, duplicating
+/// it silently changes C# semantics by running it twice. The fix spills any
+/// non-trivial operand into a single <c>let</c> via a shared helper and
+/// references the local at both positions, while a bare local/<c>this</c>/
+/// literal operand is left untouched (no spurious temp). Every snippet must
+/// round-trip through the real G# parser.
+///
+/// The original <c>lock</c> double-evaluation cases (target embedded once for
+/// <c>Monitor.Enter</c>, once for <c>Monitor.Exit</c>) are now moot: G# has a
+/// first-class <c>lock</c> keyword (issue #1885), so the translator emits the
+/// target expression exactly once and single-evaluation is gsc's job, not the
+/// translator's — see <see cref="Issue1885LockStatementTranslationTests"/>.
 /// </summary>
 public class Issue1731DoubleEvaluationTranslationTests
 {
-    [Fact]
-    public void Lock_MethodCallTarget_EvaluatesTargetOnce()
-    {
-        string printed = TranslateUnit(@"
-namespace Demo
-{
-    public sealed class C
-    {
-        private static object GetSyncRoot() => new object();
-
-        public void M()
-        {
-            lock (GetSyncRoot())
-            {
-                System.Console.WriteLine(1);
-            }
-        }
-    }
-}");
-
-        Assert.Equal(2, CountOccurrences(printed, "GetSyncRoot()")); // 1 declaration + 1 call (was 1 declaration + 2 calls before the fix)
-        Assert.Contains("Monitor.Enter(", printed);
-        Assert.Contains("Monitor.Exit(", printed);
-    }
-
-    [Fact]
-    public void Lock_SimpleFieldTarget_NoUnnecessaryTemp()
-    {
-        string printed = TranslateUnit(@"
-namespace Demo
-{
-    public sealed class C
-    {
-        private readonly object gate = new object();
-
-        public void M()
-        {
-            lock (gate)
-            {
-                System.Console.WriteLine(1);
-            }
-        }
-    }
-}");
-
-        Assert.DoesNotContain("__spill", printed);
-        Assert.Contains("Monitor.Enter(gate)", printed);
-        Assert.Contains("Monitor.Exit(gate)", printed);
-    }
-
     [Fact]
     public void ChainedAssignment_SideEffectingIndexTarget_EvaluatesIndexOnce()
     {

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1885LockStatementTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1885LockStatementTranslationTests.cs
@@ -1,0 +1,101 @@
+// <copyright file="Issue1885LockStatementTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Regression tests for issue #1885: a C# <c>lock (expr) { … }</c> statement
+/// used to lower to a hand-rolled <c>Monitor.Enter</c>/try-finally/
+/// <c>Monitor.Exit</c> sequence that referenced <c>Monitor</c> without ever
+/// emitting <c>import System.Threading</c>, so the translated G# failed to
+/// compile with GS0157. G# now has a first-class <c>lock</c> keyword with the
+/// same semantics, so the translator emits it directly and no import is
+/// needed at all.
+/// </summary>
+public class Issue1885LockStatementTranslationTests
+{
+    [Fact]
+    public void LockStatement_TranslatesToGSharpLockKeyword_NotMonitorCalls()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public sealed class Counter
+    {
+        private readonly object gate = new object();
+        private int value;
+
+        public void Increment()
+        {
+            lock (gate)
+            {
+                value = value + 1;
+            }
+        }
+    }
+}");
+
+        // The G# `lock` keyword is emitted directly — no Monitor.Enter/Exit
+        // hand-lowering, and (critically) no import of System.Threading is
+        // needed since `lock` is a language construct, not a library call.
+        Assert.Contains("lock gate {", printed);
+        Assert.DoesNotContain("Monitor", printed);
+        Assert.DoesNotContain("System.Threading", printed);
+    }
+
+    /// <summary>
+    /// Any reference-type target — not just a field literally named <c>Gate</c>
+    /// — must translate. Locking on a freshly allocated local object (a common
+    /// dedicated-lock-object idiom) exercises a non-field target.
+    /// </summary>
+    [Fact]
+    public void LockStatement_OnLocalObjectTarget_Translates()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public sealed class Worker
+    {
+        public void Run()
+        {
+            object sync = new object();
+            lock (sync)
+            {
+                System.Console.WriteLine(""in lock"");
+            }
+        }
+    }
+}");
+
+        Assert.Contains("lock sync {", printed);
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        Cs2Gs.CodeModel.Ast.CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/OahuFoundationTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuFoundationTranslationTests.cs
@@ -262,8 +262,10 @@ namespace Demo
     }
 
     /// <summary>
-    /// ADR-0115 §B: `lock (x) { .. }` lowers to a `Monitor.Enter`/`try`/`finally`
-    /// `Monitor.Exit` pair and a local function maps to a `let name = lambda`.
+    /// Issue #1885: `lock (x) { .. }` maps directly to G#'s native `lock x { .. }`
+    /// keyword (no more hand-rolled `Monitor.Enter`/`try`/`finally`/
+    /// `Monitor.Exit`, which used to omit `import System.Threading` and fail
+    /// GS0157). A local function maps to a `let name = lambda`.
     /// </summary>
     [Fact]
     public void LockAndLocalFunction_MapToNativeForms()
@@ -285,8 +287,8 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("Monitor.Enter", printed);
-        Assert.Contains("Monitor.Exit", printed);
+        Assert.Contains("lock this.gate {", printed);
+        Assert.DoesNotContain("Monitor", printed);
         Assert.Contains("Twice = ", printed);
     }
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -5520,32 +5520,14 @@ public sealed class CSharpToGSharpTranslator
 
         private GStatement TranslateLock(LockStatementSyntax lockStatement)
         {
-            // G# has no `lock` keyword; the canonical lowering is the BCL
-            // monitor pattern `Monitor.Enter(x)` followed by
-            // `try { body } finally { Monitor.Exit(x) }` (ADR-0115 §B). The
-            // translated target is embedded at BOTH the `Enter` and `Exit` call
-            // sites; C# evaluates a `lock` operand exactly once, so a non-trivial
-            // target (e.g. `GetSyncRoot()`) is spilled into a preceding local and
-            // both calls reference that local instead (issue #1731) — `Enter` and
-            // `Exit` then always agree on the same monitor.
-            GExpression target = this.SpillOperand(this.TranslateExpression(lockStatement.Expression));
-
-            GStatement enter = new ExpressionStatement(new InvocationExpression(
-                new MemberAccessExpression(new IdentifierExpression("Monitor"), "Enter"),
-                new List<GExpression> { target }));
-
+            // Issue #1885: G# has a first-class `lock target { body }` statement
+            // with the SAME single-evaluation, Monitor.Enter/try-finally/
+            // Monitor.Exit semantics as C#'s `lock`, so the translated target
+            // is emitted once and gsc lowers it — no manual Monitor lowering
+            // (and no missing `import System.Threading`) needed here.
+            GExpression target = this.TranslateExpression(lockStatement.Expression);
             BlockStatement body = this.TranslateStatementAsBlock(lockStatement.Statement);
-
-            var finallyBlock = new BlockStatement(new List<GStatement>
-            {
-                new ExpressionStatement(new InvocationExpression(
-                    new MemberAccessExpression(new IdentifierExpression("Monitor"), "Exit"),
-                    new List<GExpression> { target })),
-            });
-
-            var tryStatement = new TryStatement(body, new List<CatchClause>(), finallyBlock);
-
-            return new BlockStatement(new List<GStatement> { enter, tryStatement });
+            return new LockStatement(target, body);
         }
 
         // True when duplicating `expression` in the output has no observable

--- a/tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/LockStatement.cs
+++ b/tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/LockStatement.cs
@@ -1,0 +1,42 @@
+// inventory: LockStatement
+using System;
+
+namespace Corpus.Grid03.Constructs
+{
+    public static class LockStatementFixture
+    {
+        private static readonly object Gate = new object();
+        private static int _counter;
+
+        public static void Run()
+        {
+            lock (Gate)
+            {
+                _counter++;
+                Console.WriteLine($"LockStatement: counter={_counter}");
+            }
+
+            try
+            {
+                lock (Gate)
+                {
+                    Console.WriteLine("LockStatement: about to throw");
+                    throw new InvalidOperationException("boom");
+                }
+            }
+            catch (InvalidOperationException ex)
+            {
+                Console.WriteLine($"LockStatement: caught {ex.Message}");
+            }
+
+            // The prior lock's body threw, but `finally` must still release
+            // the monitor — re-acquiring the SAME gate here with no deadlock
+            // is the deterministic proof (issue #1885).
+            lock (Gate)
+            {
+                _counter++;
+                Console.WriteLine($"LockStatement: counter={_counter}");
+            }
+        }
+    }
+}

--- a/tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Program.cs
+++ b/tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Program.cs
@@ -20,6 +20,7 @@ namespace Corpus.Grid03
             ForStatementFixture.Run();
             IfStatementFixture.Run();
             LocalFunctionStatementFixture.Run();
+            LockStatementFixture.Run();
             ReturnStatementFixture.Run();
             SwitchStatementFixture.Run();
             ThrowStatementFixture.Run();

--- a/tools/cs2gs/corpus/grid/G03-ControlFlow-Console/baseline.stdout.golden
+++ b/tools/cs2gs/corpus/grid/G03-ControlFlow-Console/baseline.stdout.golden
@@ -30,6 +30,10 @@ IfStatement: 12 is even (if without else)
 IfStatement: 12 is between 10 and 20 (nested if)
 LocalFunctionStatement: Add(3, 4) = 7
 LocalFunctionStatement: AddSeed(7) with captured seed = 12
+LockStatement: counter=1
+LockStatement: about to throw
+LockStatement: caught boom
+LockStatement: counter=2
 ReturnStatement: Classify(-4) = negative
 ReturnStatement: Classify(0) = zero
 ReturnStatement: Classify(9) = positive

--- a/tools/cs2gs/coverage/csharp-construct-inventory.json
+++ b/tools/cs2gs/coverage/csharp-construct-inventory.json
@@ -1321,10 +1321,10 @@
   {
     "kind": "LockStatement",
     "nodeType": "LockStatementSyntax",
-    "status": "Gap",
+    "status": "Translated",
+    "rule": "ADR-0115 \u00A7B",
     "rationale": "None",
-    "issue": "https://github.com/DavidObando/gsharp/issues/1885",
-    "notes": "Lowers to Monitor.Enter/Exit but omits import System.Threading."
+    "fixture": "tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/LockStatement.cs"
   },
   {
     "kind": "LogicalAndExpression",


### PR DESCRIPTION
## Problem
`lock (Gate) { ... }` in cs2gs translated to a hand-lowered `Monitor.Enter`/`Monitor.Exit` try/finally, but the emitted G# never got `import System.Threading`, so the output failed to compile with GS0157.

## Fix
Instead of patching the missing import, `lock` is now a first-class G# statement:

- **Lexer/parser/syntax**: new `lock` keyword, `LockStatementSyntax` (mirrors `while`: `lock expr { body }`, no parens).
- **Binder**: `BindLockStatement` spills the lock target into a synthesized readonly local (evaluated exactly once), then binds `Monitor.Enter`/try/finally/`Monitor.Exit` using the same imported-CLR-call machinery other intrinsics already use to call CLR statics without a user-visible `import` — and reuses the existing `BuildCleanupTryStatement` helper (shared with `using`/`defer`). No new `BoundNodeKind`; Lowerer/Emitter/Evaluator required zero changes.
- **Diagnostics**: new GS0461 when the lock target is a value type (matches C# CS0185). Any reference type works — classes, interfaces, arrays, delegates, function values, imported CLR reference types.
- **cs2gs**: `TranslateLock` now emits the new G# `LockStatement` AST node directly instead of hand-lowering to Monitor calls, so translated output never needs the import and round-trips through the real G# parser.

## Tests
- `Issue1885LockStatementTests` (binder/evaluator): body mutation, finally releases monitor after body throws, target evaluated exactly once, value-type target diagnosed.
- `Issue1885LockStatementParserTests`: block and single-statement bodies parse.
- `Issue1885LockStatementTranslationTests` (cs2gs): field target and local-variable target translate to G# `lock`, no `Monitor`/`System.Threading` in output, round-trips through the G# parser.
- Updated two pre-existing cs2gs tests (`Issue1731DoubleEvaluationTranslationTests`, `OahuFoundationTranslationTests`) that asserted the old Monitor-lowering output.
- Added a `LockStatement` grid fixture under `tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs` (deterministic: lock+increment, lock body that throws, re-lock on the same gate afterward to prove no deadlock) and recaptured `baseline.stdout.golden`.
- `tools/cs2gs/coverage/csharp-construct-inventory.json`: `LockStatement` moved from `Gap` to `Translated`; regenerated `docs/cs2gs-coverage-matrix.md`.
- Updated `test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt` + `docs/coverage-matrix.md` for the new `LockKeyword`/`LockStatement` syntax kinds.

### Results
- Core.Tests (all except Emit, run narrow per memory constraints): 4638/4638 passed.
- cs2gs Cs2Gs.Tests (full suite): 770/770 passed.
- Grid fixture G03 stdout matches recaptured baseline exactly.
- Manual smoke test compiling+running a lock-protected counter through the real `gsc.dll` IL backend (not just the interpreter) confirmed correct runtime semantics.

Full Core.Tests Emit suite was not run wholesale (16GB RAM constraint); emit correctness for this change was verified via the manual gsc.dll smoke test above, and no Emitter code changed since lock reuses existing bound node kinds.

Fixes #1885