### PR TITLE
Add generic function literals to G# and fix cs2gs local-function translation (#1886)

### DIFF
--- a/docs/coverage-matrix.md
+++ b/docs/coverage-matrix.md
@@ -330,6 +330,7 @@ LabelStatement
 LenExpression
 ListPattern
 LiteralExpression
+LocalFunctionDeclaration
 MakeChannelExpression
 MapDeleteExpression
 MapLiteralExpression

--- a/docs/cs2gs-coverage-matrix.md
+++ b/docs/cs2gs-coverage-matrix.md
@@ -127,7 +127,7 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | LessThanExpression | BinaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/LessThanExpression.cs |  |  |
 | LessThanOrEqualExpression | BinaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/LessThanOrEqualExpression.cs |  |  |
 | LocalDeclarationStatement | LocalDeclarationStatementSyntax | ADR-0115 §B.3 |  |  |  |  |
-| LocalFunctionStatement | LocalFunctionStatementSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/LocalFunctionStatement.cs | https://github.com/DavidObando/gsharp/issues/1886 | static local functions mislower at call sites; generic local functions unrepresentable (issue #1886). |
+| LocalFunctionStatement | LocalFunctionStatementSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/LocalFunctionStatement.cs |  | Static local functions call through their `let` binding directly; generic local functions translate to G#'s `let Name[T, ...] = func (...) ... { ... }` (issue #1886, fixed). |
 | LockStatement | LockStatementSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/LockStatement.cs |  |  |
 | LogicalAndExpression | BinaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/LogicalAndExpression.cs |  |  |
 | LogicalNotExpression | PrefixUnaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/LogicalNotExpression.cs |  |  |

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -246,7 +246,8 @@ public sealed class Binder
             resolveClrTypeForGenericArg: ResolveClrTypeForGenericArg,
             getCurrentFunction: () => this.function,
             setCurrentFunction: fn => this.function = fn,
-            bindLambdaBodyExpression: syntax => expressions.BindLambdaBodyExpression(syntax));
+            bindLambdaBodyExpression: syntax => expressions.BindLambdaBodyExpression(syntax),
+            bindTypeParameterList: syntax => declarations.BindTypeParameterList(syntax));
         statements = new StatementBinder(
             binderCtx,
             conversions,
@@ -264,7 +265,8 @@ public sealed class Binder
             resolveAccessibility: ResolveAccessibility,
             bindVariableDeclarationAttributes: (annotations, positionDescription) => declarations.BindAttributes(annotations, AttributeTargetKind.Field, VariableDeclarationAllowedTargets, positionDescription, System.AttributeTargets.Field),
             getCurrentFunction: () => this.function,
-            bindLambdaWithTargetType: (syntax, targetType) => lambdas.BindLambdaExpression(syntax, targetType));
+            bindLambdaWithTargetType: (syntax, targetType) => lambdas.BindLambdaExpression(syntax, targetType),
+            bindGenericLocalFunctionDeclaration: syntax => lambdas.BindGenericLocalFunctionDeclaration(syntax));
         declarations = new DeclarationBinder(
             binderCtx,
             conversions,

--- a/src/Core/CodeAnalysis/Binding/BoundLocalFunctionDeclaration.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundLocalFunctionDeclaration.cs
@@ -1,0 +1,39 @@
+// <copyright file="BoundLocalFunctionDeclaration.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Core.CodeAnalysis.Syntax;
+
+namespace GSharp.Core.CodeAnalysis.Binding;
+
+/// <summary>
+/// Bound declaration of a generic local function (issue #1886), e.g.
+/// <c>let First[T] = func (a T, b T) T { ... }</c>. Unlike an ordinary
+/// <see cref="BoundVariableDeclaration"/>, this does not create a runtime
+/// variable/delegate value: a CLR delegate cannot close over an unbound
+/// generic method, so the wrapped <see cref="Literal"/>'s function is
+/// declared directly into the enclosing scope as a callable
+/// <see cref="Symbols.FunctionSymbol"/> and calls to it are resolved through
+/// ordinary generic overload resolution, not an indirect delegate call.
+/// </summary>
+public sealed class BoundLocalFunctionDeclaration : BoundStatement
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BoundLocalFunctionDeclaration"/> class.
+    /// </summary>
+    /// <param name="syntax">The originating syntax.</param>
+    /// <param name="literal">The bound function literal carrying the generic function's parameters, return type, and body.</param>
+    public BoundLocalFunctionDeclaration(SyntaxNode syntax, BoundFunctionLiteralExpression literal)
+        : base(syntax)
+    {
+        Literal = literal;
+    }
+
+    /// <inheritdoc/>
+    public override BoundNodeKind Kind => BoundNodeKind.LocalFunctionDeclaration;
+
+    /// <summary>
+    /// Gets the bound function literal declaring this local function's shape and body.
+    /// </summary>
+    public BoundFunctionLiteralExpression Literal { get; }
+}

--- a/src/Core/CodeAnalysis/Binding/BoundNodeKind.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundNodeKind.cs
@@ -16,6 +16,7 @@ public enum BoundNodeKind
     // Statements
     BlockStatement,
     VariableDeclaration,
+    LocalFunctionDeclaration,
     IfStatement,
     ForInfiniteStatement,
     ForEllipsisStatement,

--- a/src/Core/CodeAnalysis/Binding/BoundNodePrinter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundNodePrinter.cs
@@ -48,6 +48,9 @@ public static class BoundNodePrinter
             case BoundNodeKind.VariableDeclaration:
                 WriteVariableDeclaration((BoundVariableDeclaration)node, writer);
                 break;
+            case BoundNodeKind.LocalFunctionDeclaration:
+                WriteLocalFunctionDeclaration((BoundLocalFunctionDeclaration)node, writer);
+                break;
             case BoundNodeKind.IfStatement:
                 WriteIfStatement((BoundIfStatement)node, writer);
                 break;
@@ -417,6 +420,31 @@ public static class BoundNodePrinter
 
         writer.WriteSpace();
         node.Initializer.WriteTo(writer);
+        writer.WriteLine();
+    }
+
+    private static void WriteLocalFunctionDeclaration(BoundLocalFunctionDeclaration node, IndentedTextWriter writer)
+    {
+        writer.WriteKeyword(SyntaxKind.LetKeyword);
+        writer.WriteSpace();
+        writer.WriteIdentifier(node.Literal.Function.Name);
+        writer.WritePunctuation(SyntaxKind.OpenSquareBracketToken);
+        for (var i = 0; i < node.Literal.Function.TypeParameters.Length; i++)
+        {
+            if (i > 0)
+            {
+                writer.WritePunctuation(SyntaxKind.CommaToken);
+                writer.WriteSpace();
+            }
+
+            writer.WriteIdentifier(node.Literal.Function.TypeParameters[i].Name);
+        }
+
+        writer.WritePunctuation(SyntaxKind.CloseSquareBracketToken);
+        writer.WriteSpace();
+        writer.WritePunctuation(SyntaxKind.EqualsToken);
+        writer.WriteSpace();
+        node.Literal.WriteTo(writer);
         writer.WriteLine();
     }
 

--- a/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -25,6 +25,8 @@ public abstract class BoundTreeRewriter
                 return RewriteBlockStatement((BoundBlockStatement)node);
             case BoundNodeKind.VariableDeclaration:
                 return RewriteVariableDeclaration((BoundVariableDeclaration)node);
+            case BoundNodeKind.LocalFunctionDeclaration:
+                return RewriteLocalFunctionDeclaration((BoundLocalFunctionDeclaration)node);
             case BoundNodeKind.IfStatement:
                 return RewriteIfStatement((BoundIfStatement)node);
             case BoundNodeKind.ForInfiniteStatement:
@@ -125,6 +127,14 @@ public abstract class BoundTreeRewriter
         }
 
         return new BoundVariableDeclaration(null, node.Variable, initializer, node.ConstantValue);
+    }
+
+    /// <summary>Rewrites a generic local-function declaration (issue #1886). The literal's body is intentionally not rewritten here — it forms a separate lexical scope, exactly like <see cref="RewriteFunctionLiteralExpression"/>, and is lowered independently at the point it is hosted for emission.</summary>
+    /// <param name="node">The node to rewrite.</param>
+    /// <returns>The rewritten node.</returns>
+    protected virtual BoundStatement RewriteLocalFunctionDeclaration(BoundLocalFunctionDeclaration node)
+    {
+        return node;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/BoundTreeWalker.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeWalker.cs
@@ -72,6 +72,9 @@ public abstract class BoundTreeWalker
             case BoundNodeKind.VariableDeclaration:
                 VisitVariableDeclaration((BoundVariableDeclaration)node);
                 break;
+            case BoundNodeKind.LocalFunctionDeclaration:
+                VisitLocalFunctionDeclaration((BoundLocalFunctionDeclaration)node);
+                break;
             case BoundNodeKind.IfStatement:
                 VisitIfStatement((BoundIfStatement)node);
                 break;
@@ -406,6 +409,13 @@ public abstract class BoundTreeWalker
     protected virtual void VisitVariableDeclaration(BoundVariableDeclaration node)
     {
         VisitExpression(node.Initializer);
+    }
+
+    /// <summary>Visits a generic local-function declaration (issue #1886) by descending into its function literal, mirroring <see cref="VisitVariableDeclaration"/>.</summary>
+    /// <param name="node">The node to visit.</param>
+    protected virtual void VisitLocalFunctionDeclaration(BoundLocalFunctionDeclaration node)
+    {
+        VisitExpression(node.Literal);
     }
 
     protected virtual void VisitIfStatement(BoundIfStatement node)

--- a/src/Core/CodeAnalysis/Binding/ControlFlowGraph.cs
+++ b/src/Core/CodeAnalysis/Binding/ControlFlowGraph.cs
@@ -347,6 +347,7 @@ public sealed class ControlFlowGraph
                         StartBlock();
                         break;
                     case BoundNodeKind.VariableDeclaration:
+                    case BoundNodeKind.LocalFunctionDeclaration:
                     case BoundNodeKind.ExpressionStatement:
                         statements.Add(statement);
                         break;
@@ -486,6 +487,7 @@ public sealed class ControlFlowGraph
 
                             break;
                         case BoundNodeKind.VariableDeclaration:
+                        case BoundNodeKind.LocalFunctionDeclaration:
                         case BoundNodeKind.LabelStatement:
                         case BoundNodeKind.ExpressionStatement:
                         case BoundNodeKind.TryStatement:

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -6066,7 +6066,16 @@ internal sealed class DeclarationBinder
             && receiverType is not StructSymbol;
     }
 
-    private ImmutableArray<TypeParameterSymbol> BindTypeParameterList(TypeParameterListSyntax syntax)
+    /// <summary>
+    /// Binds a type-parameter list without constraint pre-publication. Made
+    /// <c>internal</c> (issue #1886) so <see cref="LambdaBinder"/> can bind the
+    /// <c>[T, U, ...]</c> list on a generic <c>let</c>-bound local function
+    /// declaration (<c>let Name[T] = func (...) ... { ... }</c>) using the exact
+    /// same routine as generic delegate/type declarations.
+    /// </summary>
+    /// <param name="syntax">The type-parameter list syntax.</param>
+    /// <returns>The bound type-parameter symbols.</returns>
+    internal ImmutableArray<TypeParameterSymbol> BindTypeParameterList(TypeParameterListSyntax syntax)
         => BindTypeParameterList(syntax, onBareSymbolsPublished: null);
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -75,6 +75,7 @@ internal sealed class LambdaBinder
     private readonly Func<FunctionSymbol> getCurrentFunction;
     private readonly Action<FunctionSymbol> setCurrentFunction;
     private readonly Func<ExpressionSyntax, BoundExpression> bindLambdaBodyExpression;
+    private readonly Func<TypeParameterListSyntax, ImmutableArray<TypeParameterSymbol>> bindTypeParameterList;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="LambdaBinder"/>
@@ -125,6 +126,12 @@ internal sealed class LambdaBinder
     /// optional callback that binds an arrow-lambda body expression.
     /// Required only when <see cref="BindLambdaExpression"/> is
     /// invoked; the function-literal pipeline does not need it.</param>
+    /// <param name="bindTypeParameterList">Issue #1886: callback that
+    /// binds a <c>[T, U, ...]</c> type-parameter list to
+    /// <see cref="TypeParameterSymbol"/>s, reusing
+    /// <see cref="DeclarationBinder.BindTypeParameterList(TypeParameterListSyntax)"/>.
+    /// Required only when <see cref="BindGenericLocalFunctionDeclaration"/>
+    /// is invoked.</param>
     public LambdaBinder(
         BinderContext binderCtx,
         ConversionClassifier conversions,
@@ -135,7 +142,8 @@ internal sealed class LambdaBinder
         Func<TypeSymbol, Type> resolveClrTypeForGenericArg,
         Func<FunctionSymbol> getCurrentFunction,
         Action<FunctionSymbol> setCurrentFunction,
-        Func<ExpressionSyntax, BoundExpression> bindLambdaBodyExpression = null)
+        Func<ExpressionSyntax, BoundExpression> bindLambdaBodyExpression = null,
+        Func<TypeParameterListSyntax, ImmutableArray<TypeParameterSymbol>> bindTypeParameterList = null)
     {
         this.binderCtx = binderCtx ?? throw new ArgumentNullException(nameof(binderCtx));
         this.conversions = conversions ?? throw new ArgumentNullException(nameof(conversions));
@@ -147,6 +155,7 @@ internal sealed class LambdaBinder
         this.getCurrentFunction = getCurrentFunction ?? throw new ArgumentNullException(nameof(getCurrentFunction));
         this.setCurrentFunction = setCurrentFunction ?? throw new ArgumentNullException(nameof(setCurrentFunction));
         this.bindLambdaBodyExpression = bindLambdaBodyExpression;
+        this.bindTypeParameterList = bindTypeParameterList;
     }
 
     private DiagnosticBag Diagnostics => binderCtx.Diagnostics;
@@ -201,8 +210,14 @@ internal sealed class LambdaBinder
     /// the captured outer variables by inspecting the bound body.
     /// </summary>
     /// <param name="syntax">The function-literal syntax node.</param>
+    /// <param name="explicitName">Issue #1886: when non-null, names the
+    /// synthetic <see cref="FunctionSymbol"/> after this value (e.g. the
+    /// identifier of a <c>let Name[T] = func (...) ... { ... }</c> generic
+    /// local-function declaration) instead of the default
+    /// <c>&lt;lambdaN&gt;</c> synthetic name, so scope-based name lookup
+    /// (<see cref="BoundScope.TryDeclareFunction"/>) can find it.</param>
     /// <returns>The bound function-literal expression.</returns>
-    public BoundExpression BindFunctionLiteralExpression(FunctionLiteralExpressionSyntax syntax)
+    public BoundExpression BindFunctionLiteralExpression(FunctionLiteralExpressionSyntax syntax, string explicitName = null)
     {
         // Phase 4.7: function literal `[async] func(p1 T1, p2 T2) R { body }`.
         // Bind parameters, push a new scope chained to the current scope so
@@ -276,7 +291,7 @@ internal sealed class LambdaBinder
 
         var fnType = FunctionTypeSymbol.Get(parameterTypes.MoveToImmutable(), BuildVariadicFlagsIfAny(parameterSymbols), observableReturnType);
         var synthetic = new FunctionSymbol(
-            $"<lambda{System.Threading.Interlocked.Increment(ref binderCtx.SyntheticLocalCounter)}>",
+            explicitName ?? $"<lambda{System.Threading.Interlocked.Increment(ref binderCtx.SyntheticLocalCounter)}>",
             parameterSymbols.ToImmutable(),
             returnType);
         synthetic.IsAsync = syntax.IsAsync;
@@ -357,6 +372,70 @@ internal sealed class LambdaBinder
         }
 
         return new BoundFunctionLiteralExpression(null, synthetic, fnType, (BoundBlockStatement)body, captured);
+    }
+
+    /// <summary>
+    /// Issue #1886: binds a generic local-function declaration
+    /// <c>let Name[T, U, ...] = func (a T, b U) ... { ... }</c>. A CLR
+    /// delegate cannot close over an unbound generic method, so this does
+    /// NOT produce a runtime variable/closure value — it binds the
+    /// <c>[T, U, ...]</c> list, binds the function literal against those
+    /// type parameters (so <c>T</c>/<c>U</c> resolve in the parameter,
+    /// return-type, and body clauses), marks the resulting
+    /// <see cref="FunctionSymbol"/> as generic, and declares it directly
+    /// into the enclosing scope so calls resolve through the ordinary
+    /// generic overload-resolution / type-inference call path — the exact
+    /// mechanism already used for top-level generic functions — instead of
+    /// through an indirect delegate call.
+    /// </summary>
+    /// <param name="syntax">The <c>let Name[T, ...] = ...</c> variable declaration syntax.</param>
+    /// <returns>The bound statement (a no-op declaration; the underlying method is emitted independently).</returns>
+    public BoundStatement BindGenericLocalFunctionDeclaration(VariableDeclarationSyntax syntax)
+    {
+        var name = syntax.Identifier.Text;
+        if (syntax.Keyword.Kind != SyntaxKind.LetKeyword || syntax.Initializer is not FunctionLiteralExpressionSyntax literalSyntax)
+        {
+            Diagnostics.ReportGenericLocalFunctionMustBeLetBoundLiteral(syntax.Identifier.Location, name);
+            return new BoundBlockStatement(syntax, ImmutableArray<BoundStatement>.Empty);
+        }
+
+        var previousTypeParameters = binderCtx.CurrentTypeParameters;
+        binderCtx.CurrentTypeParameters = new Dictionary<string, TypeParameterSymbol>();
+        ImmutableArray<TypeParameterSymbol> typeParameters;
+        try
+        {
+            typeParameters = bindTypeParameterList(syntax.TypeParameterList);
+
+            // Re-establish the type-parameter scope merged with any enclosing
+            // ones (mirrors DeclarationBinder.BindDelegateDeclaration) so the
+            // literal's parameter/return/body clauses resolve T, U, ….
+            binderCtx.CurrentTypeParameters = previousTypeParameters == null
+                ? new Dictionary<string, TypeParameterSymbol>()
+                : new Dictionary<string, TypeParameterSymbol>(previousTypeParameters);
+            foreach (var tp in typeParameters)
+            {
+                binderCtx.CurrentTypeParameters[tp.Name] = tp;
+            }
+
+            var literal = (BoundFunctionLiteralExpression)BindFunctionLiteralExpression(literalSyntax, explicitName: name);
+            literal.Function.TypeParameters = typeParameters;
+
+            if (literal.CapturedVariables.Length > 0)
+            {
+                Diagnostics.ReportGenericLocalFunctionCannotCapture(syntax.Identifier.Location, name);
+            }
+
+            if (!Scope.TryDeclareFunction(literal.Function))
+            {
+                Diagnostics.ReportSymbolAlreadyDeclared(syntax.Identifier.Location, name);
+            }
+
+            return new BoundLocalFunctionDeclaration(syntax, literal);
+        }
+        finally
+        {
+            binderCtx.CurrentTypeParameters = previousTypeParameters;
+        }
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.cs
@@ -87,6 +87,7 @@ internal sealed class StatementBinder
     private readonly BindVariableDeclarationAttributesDelegate bindVariableDeclarationAttributes;
     private readonly Func<FunctionSymbol> getCurrentFunction;
     private readonly Func<LambdaExpressionSyntax, FunctionTypeSymbol, BoundExpression> bindLambdaWithTargetType;
+    private readonly Func<VariableDeclarationSyntax, BoundStatement> bindGenericLocalFunctionDeclaration;
 
     public StatementBinder(
         BinderContext binderCtx,
@@ -105,7 +106,8 @@ internal sealed class StatementBinder
         Func<SyntaxToken, Accessibility> resolveAccessibility,
         BindVariableDeclarationAttributesDelegate bindVariableDeclarationAttributes,
         Func<FunctionSymbol> getCurrentFunction,
-        Func<LambdaExpressionSyntax, FunctionTypeSymbol, BoundExpression> bindLambdaWithTargetType = null)
+        Func<LambdaExpressionSyntax, FunctionTypeSymbol, BoundExpression> bindLambdaWithTargetType = null,
+        Func<VariableDeclarationSyntax, BoundStatement> bindGenericLocalFunctionDeclaration = null)
     {
         this.binderCtx = binderCtx ?? throw new ArgumentNullException(nameof(binderCtx));
         this.conversions = conversions ?? throw new ArgumentNullException(nameof(conversions));
@@ -124,6 +126,7 @@ internal sealed class StatementBinder
         this.bindVariableDeclarationAttributes = bindVariableDeclarationAttributes ?? throw new ArgumentNullException(nameof(bindVariableDeclarationAttributes));
         this.getCurrentFunction = getCurrentFunction ?? throw new ArgumentNullException(nameof(getCurrentFunction));
         this.bindLambdaWithTargetType = bindLambdaWithTargetType;
+        this.bindGenericLocalFunctionDeclaration = bindGenericLocalFunctionDeclaration;
     }
 
     private DiagnosticBag Diagnostics => binderCtx.Diagnostics;
@@ -858,6 +861,17 @@ internal sealed class StatementBinder
         if (syntax.HasRefKindModifier)
         {
             return BindRefAliasLocalDeclaration(syntax);
+        }
+
+        // Issue #1886: `let Name[T, ...] = func (...) ... { ... }` declares a generic local
+        // function. Route to the dedicated LambdaBinder path instead of the ordinary
+        // variable-declaration binder — a generic function value cannot be represented as a
+        // delegate stored in a variable.
+        if (syntax.TypeParameterList != null)
+        {
+            return bindGenericLocalFunctionDeclaration != null
+                ? bindGenericLocalFunctionDeclaration(syntax)
+                : throw new InvalidOperationException("Generic local-function declarations require bindGenericLocalFunctionDeclaration to be wired.");
         }
 
         var isReadOnly = syntax.Keyword?.Kind == SyntaxKind.ConstKeyword

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -653,6 +653,34 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
     }
 
     /// <summary>
+    /// Reports that a generic local-function declaration (<c>let Name[T, ...] = func (...) ... { ... }</c>,
+    /// issue #1886) is not a <c>let</c>-bound function-literal initializer. A generic function value cannot
+    /// be represented as a delegate stored in a variable (a CLR delegate cannot close over an unbound
+    /// generic method), so this form only makes sense as a direct <c>let</c> binding of a function literal.
+    /// </summary>
+    /// <param name="location">The text location of the declaration's identifier.</param>
+    /// <param name="name">The name of the declared local function.</param>
+    public void ReportGenericLocalFunctionMustBeLetBoundLiteral(TextLocation location, string name)
+    {
+        var message = $"Generic local function '{name}' must be declared with 'let {name}[...] = func (...) ... {{ ... }}'.";
+        Report(location, "GS0462", message);
+    }
+
+    /// <summary>
+    /// Reports that a generic local function (issue #1886) captures one or more outer variables. Generic
+    /// local functions are emitted as genuine (non-delegate) generic methods, not closures; supporting
+    /// captures would require a generic closure display-class with its own reified type parameters, which
+    /// is out of scope for this feature.
+    /// </summary>
+    /// <param name="location">The text location of the declaration's identifier.</param>
+    /// <param name="name">The name of the declared local function.</param>
+    public void ReportGenericLocalFunctionCannotCapture(TextLocation location, string name)
+    {
+        var message = $"Generic local function '{name}' cannot capture variables from the enclosing scope.";
+        Report(location, "GS0463", message);
+    }
+
+    /// <summary>
     /// Reports that the operand of a channel-receive expression (<c>&lt;-ch</c>) is not a channel (Phase 5.5 / ADR-0022).
     /// </summary>
     /// <param name="location">The text location of the operand.</param>

--- a/src/Core/CodeAnalysis/Emit/ClosureEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ClosureEmitter.cs
@@ -226,8 +226,22 @@ internal sealed class ClosureEmitter
                 // encloser's type parameters, which this synthesis does not model.
                 // All other non-capturing lambdas keep the existing top-level
                 // `<Program>` static placement.
+                //
+                // Issue #1886: a GENERIC local function (`let Name[T] = func
+                // (...) ... {...}`) is declared as a real (non-capturing, by
+                // binder rule GS0463) FunctionSymbol resolved through direct
+                // `BoundCallExpression` calls, not through the delegate-value
+                // indirect-call path that consults ClosureInfos to redirect to
+                // `closure.InvokeMethod`. Nesting it here would also require
+                // this display class's fieldless Invoke method to itself be
+                // generic, which SynthesizeDisplayClass does not model. Since
+                // generic local functions can never capture (and therefore
+                // never need the accessibility-domain trick this nesting
+                // exists for), always keep them on the top-level `<Program>`
+                // static placement.
                 if (literal.Function == null
                     || literal.Function.IsAsync
+                    || literal.Function.IsGeneric
                     || literal.Function.LexicalEnclosingType is not StructSymbol zeroCaptureEnclosing
                     || !zeroCaptureEnclosing.TypeParameters.IsDefaultOrEmpty)
                 {

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.cs
@@ -275,6 +275,11 @@ internal sealed partial class MethodBodyEmitter
                 this.EmitExpression(decl.Initializer);
                 this.EmitStoreVariable(decl.Variable);
                 break;
+            case BoundLocalFunctionDeclaration:
+                // Issue #1886: a generic local function is not a runtime value — no slot, no
+                // codegen here. Its underlying method is discovered and emitted independently
+                // via the non-capturing-lambda hosting pipeline (see SlotPlanner.CollectFunctionLiterals).
+                break;
             case BoundLabelStatement lbl:
                 this.il.MarkLabel(this.labels[lbl.Label]);
                 break;

--- a/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/SpillSequenceSpiller.cs
@@ -180,6 +180,11 @@ public static class SpillSequenceSpiller
                 case BoundPatternSwitchStatement:
                 case BoundAwaitSequencePoint:
                 case BoundYieldStatement:
+                case BoundLocalFunctionDeclaration:
+                    // Issue #1886: a generic local function's literal body is a
+                    // separate lexical scope (mirrors BoundTreeRewriter's
+                    // RewriteFunctionLiteralExpression) lowered independently
+                    // when hosted for emission — nothing here to spill.
                     builder.Add(statement);
                     return false;
 

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -5280,6 +5280,12 @@ public class Parser
         }
 
         var identifier = MatchToken(SyntaxKind.IdentifierToken);
+
+        // Issue #1886: `let Name[T] = func (...) ... { ... }` attaches a generic
+        // type-parameter list to a let-bound function literal, since the literal
+        // itself (being anonymous) has nowhere to carry one. Only meaningful on
+        // `let` bindings; `var`/`const` simply never see a `[` here in practice.
+        var typeParameterList = ParseOptionalTypeParameterList();
         var typeClause = ParseOptionalTypeClause();
 
         // A `var` declaration may omit its initializer when an explicit type
@@ -5303,6 +5309,7 @@ public class Parser
                 equalsToken: null,
                 initializer: null);
             decl.ScopedModifier = scopedModifier;
+            decl.TypeParameterList = typeParameterList;
             return decl;
         }
 
@@ -5311,6 +5318,7 @@ public class Parser
         var result = new VariableDeclarationSyntax(syntaxTree, accessibilityModifier, keyword, identifier, typeClause, equals, initializer);
         result.ScopedModifier = scopedModifier;
         result.RefKindModifier = refKindModifier;
+        result.TypeParameterList = typeParameterList;
         return result;
     }
 

--- a/src/Core/CodeAnalysis/Syntax/VariableDeclarationSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/VariableDeclarationSyntax.cs
@@ -15,6 +15,7 @@ public sealed class VariableDeclarationSyntax : StatementSyntax
     // invalidate the node's cached span (issue #1675).
     private SyntaxToken scopedModifier;
     private SyntaxToken refKindModifier;
+    private TypeParameterListSyntax typeParameterList;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="VariableDeclarationSyntax"/> class.
@@ -127,6 +128,25 @@ public sealed class VariableDeclarationSyntax : StatementSyntax
     /// Gets the variable identifier.
     /// </summary>
     public SyntaxToken Identifier { get; }
+
+    /// <summary>
+    /// Gets or sets the optional generic type-parameter list (e.g. <c>[T]</c>, <c>[T, U]</c>) on a
+    /// <c>let</c>-bound generic function literal (issue #1886):
+    /// <c>let First[T] = func (a T, b T) T { ... }</c>. <c>null</c> for non-generic declarations.
+    /// Assigned by the parser.
+    /// </summary>
+    public TypeParameterListSyntax TypeParameterList
+    {
+        get => typeParameterList;
+        set
+        {
+            typeParameterList = value;
+            InvalidateCachedSpan();
+        }
+    }
+
+    /// <summary>Gets a value indicating whether this declaration carries a generic type-parameter list (issue #1886).</summary>
+    public bool IsGeneric => TypeParameterList != null;
 
     /// <summary>
     /// GEts the optional type clause.

--- a/test/Compiler.Tests/Emit/Issue1886GenericLocalFunctionEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1886GenericLocalFunctionEmitTests.cs
@@ -1,0 +1,238 @@
+// <copyright file="Issue1886GenericLocalFunctionEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1886: a generic local function (`T First&lt;T&gt;(a, b) { ... }` in C#)
+/// could not be represented in G# because function literals had no way to
+/// declare type parameters — `let First = func (a T, b T) T { ... }` fails
+/// with GS0113 (`T` doesn't exist). These tests exercise the new
+/// `let Name[T, ...] = func (...) ... { ... }` generic function-literal
+/// syntax end to end: parse, bind, emit, and run, for both single and
+/// multi type-parameter shapes, plus the capture-rejection diagnostic
+/// (GS0463) for a generic local function that reads an outer variable.
+/// </summary>
+public class Issue1886GenericLocalFunctionEmitTests
+{
+    [Fact]
+    public void GenericLocalFunction_SingleTypeParameter_CalledWithDifferentTypeArguments()
+    {
+        var source = """
+            package P
+
+            let First[T] = func (a T, b T) T {
+                return a
+            }
+            Console.WriteLine(First(1, 2))
+            Console.WriteLine(First("x", "y"))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("1\nx\n", output);
+    }
+
+    [Fact]
+    public void GenericLocalFunction_MultipleTypeParameters_InferredFromArguments()
+    {
+        var source = """
+            package P
+
+            let Combine[T, U] = func (a T, b U) string {
+                return a.ToString() + b.ToString()
+            }
+            Console.WriteLine(Combine(1, "y"))
+            Console.WriteLine(Combine(3, 4))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("1y\n34\n", output);
+    }
+
+    [Fact]
+    public void GenericLocalFunction_NestedInsideAnOrdinaryFunction_Works()
+    {
+        var source = """
+            package P
+
+            func Foo() int32 {
+                let Identity[T] = func (a T) T {
+                    return a
+                }
+                return Identity(42)
+            }
+            Console.WriteLine(Foo())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void GenericLocalFunction_NestedInsideAClassSharedMethod_Works()
+    {
+        // Regression: ClosureEmitter.SynthesizeClosures reroutes every
+        // non-capturing lambda lexically declared inside a non-generic user
+        // type into a nested (fieldless) display class (issue #1469), but the
+        // direct-call emission path for a real FunctionSymbol (which is how a
+        // generic local function resolves) never consults that rerouting map
+        // — only the delegate-value indirect-call path does. That mismatch
+        // threw "Call to function 'First' has no emitted MethodDef." at
+        // compile time when a generic local function lived inside a class's
+        // `shared` method (surfaced by the cs2gs grid corpus fixtures).
+        var source = """
+            package P
+
+            class Fixture {
+                shared {
+                    func Run() {
+                        let First[T] = func (a T, b T) T {
+                            return a
+                        }
+                        Console.WriteLine(First(1, 2))
+                        Console.WriteLine(First("x", "y"))
+                    }
+                }
+            }
+            Fixture.Run()
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("1\nx\n", output);
+    }
+
+    [Fact]
+    public void GenericLocalFunction_CapturingOuterVariable_ReportsGS0463()
+    {
+        var source = """
+            package P
+
+            func Foo() {
+                let outer = 5
+                let Bad[T] = func (a T) T {
+                    Console.WriteLine(outer)
+                    return a
+                }
+                Console.WriteLine(Bad(1))
+            }
+            Foo()
+            """;
+
+        var (exitCode, stdout, stderr) = CompileAndRunRaw(source, expectSuccess: false);
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("GS0463", stdout + stderr);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var (exitCode, stdout, stderr) = CompileAndRunRaw(source, expectSuccess: true);
+        Assert.True(
+            exitCode == 0,
+            $"exited {exitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout;
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) CompileAndRunRaw(
+        string source,
+        bool expectSuccess)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1886_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+            };
+
+            foreach (var bcl in BclReferences.Value)
+            {
+                args.Add("/r:" + bcl);
+            }
+
+            args.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            if (!expectSuccess)
+            {
+                return (compileExit, compileOut.ToString(), compileErr.ToString());
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            return (proc.ExitCode, stdout.Replace("\r\n", "\n"), stderr.Replace("\r\n", "\n"));
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static readonly Lazy<IReadOnlyList<string>> BclReferences = new(() =>
+    {
+        var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location);
+        if (string.IsNullOrEmpty(runtimeDir) || !Directory.Exists(runtimeDir))
+        {
+            return Array.Empty<string>();
+        }
+
+        return Directory.EnumerateFiles(runtimeDir, "*.dll", SearchOption.TopDirectoryOnly)
+            .Where(p =>
+            {
+                var name = Path.GetFileName(p);
+                return name.StartsWith("System.", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "mscorlib.dll", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "netstandard.dll", StringComparison.OrdinalIgnoreCase);
+            })
+            .ToList();
+    });
+}

--- a/test/Core.Tests/CodeAnalysis/BoundNodeKindExhaustivenessTests.cs
+++ b/test/Core.Tests/CodeAnalysis/BoundNodeKindExhaustivenessTests.cs
@@ -60,6 +60,7 @@ public class BoundNodeKindExhaustivenessTests
         // Statement kinds — dispatched via EmitStatement, not EmitExpression.
         "BlockStatement",
         "VariableDeclaration",
+        "LocalFunctionDeclaration",
         "IfStatement",
         "ForInfiniteStatement",
         "ForEllipsisStatement",
@@ -206,6 +207,7 @@ public class BoundNodeKindExhaustivenessTests
         // Statement kinds — not expressions.
         "BlockStatement",
         "VariableDeclaration",
+        "LocalFunctionDeclaration",
         "IfStatement",
         "ForInfiniteStatement",
         "ForEllipsisStatement",

--- a/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
+++ b/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
@@ -330,6 +330,7 @@ LabelStatement
 LenExpression
 ListPattern
 LiteralExpression
+LocalFunctionDeclaration
 MakeChannelExpression
 MapDeleteExpression
 MapLiteralExpression

--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/GStatement.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/GStatement.cs
@@ -2,6 +2,7 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
 
 namespace Cs2Gs.CodeModel.Ast;
@@ -632,10 +633,12 @@ public sealed class LocalFunctionStatement : GStatement
     /// </summary>
     /// <param name="name">The local function name.</param>
     /// <param name="lambda">The function literal holding the parameters / body.</param>
-    public LocalFunctionStatement(string name, LambdaExpression lambda)
+    /// <param name="typeParameters">Issue #1886: the local function's type-parameter names (e.g. <c>["T"]</c> for <c>T First&lt;T&gt;(...)</c>), or <c>null</c>/empty when non-generic.</param>
+    public LocalFunctionStatement(string name, LambdaExpression lambda, IReadOnlyList<string> typeParameters = null)
     {
         Name = name;
         Lambda = lambda;
+        TypeParameters = typeParameters ?? Array.Empty<string>();
     }
 
     /// <summary>Gets the local function name.</summary>
@@ -643,6 +646,9 @@ public sealed class LocalFunctionStatement : GStatement
 
     /// <summary>Gets the function literal.</summary>
     public LambdaExpression Lambda { get; }
+
+    /// <summary>Gets the type-parameter names (issue #1886), empty when non-generic.</summary>
+    public IReadOnlyList<string> TypeParameters { get; }
 }
 
 /// <summary>

--- a/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
@@ -901,7 +901,10 @@ public static class GSharpPrinter
                 return $"{pad}{RenderBinding(deconstruction.Binding)} ({targets}) = {RenderExpression(deconstruction.Initializer, indent)}";
 
             case LocalFunctionStatement localFunction:
-                return $"{pad}{RenderBinding(BindingKind.Let)} {localFunction.Name} = {RenderExpression(localFunction.Lambda, indent)}";
+                var typeParamSuffix = localFunction.TypeParameters.Count > 0
+                    ? $"[{string.Join(", ", localFunction.TypeParameters)}]"
+                    : string.Empty;
+                return $"{pad}{RenderBinding(BindingKind.Let)} {localFunction.Name}{typeParamSuffix} = {RenderExpression(localFunction.Lambda, indent)}";
 
             default:
                 throw new ArgumentException($"Unsupported statement: {statement?.GetType().Name}");

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1886StaticGenericLocalFunctionTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1886StaticGenericLocalFunctionTranslationTests.cs
@@ -1,0 +1,112 @@
+// <copyright file="Issue1886StaticGenericLocalFunctionTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Regression tests for issue #1886:
+/// <list type="number">
+/// <item><description>A <c>static</c> local function's call site was translated
+/// as a class-member access (<c>Fixture.Square(6)</c>, GS0158) instead of a
+/// direct call to its <c>let</c> binding (<c>Square(6)</c>) — Roslyn reports a
+/// local function's <c>ContainingType</c> as the enclosing type even though it
+/// is not a sibling type member.</description></item>
+/// <item><description>A generic local function (<c>T First&lt;T&gt;(a, b)</c>)
+/// could not be represented at all because G# function literals had no way to
+/// declare type parameters (GS0113 on the body's <c>T</c>). cs2gs now emits the
+/// new <c>let Name[T, ...] = func (...) ... { ... }</c> generic
+/// function-literal syntax.</description></item>
+/// </list>
+/// </summary>
+public class Issue1886StaticGenericLocalFunctionTranslationTests
+{
+    [Fact]
+    public void StaticLocalFunction_CallSite_IsBareIdentifierCall_NotMemberAccess()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class Fixture
+    {
+        public void M()
+        {
+            static int Square(int x) => x * x;
+            System.Console.WriteLine(Square(6));
+        }
+    }
+}");
+
+        Assert.Contains("Square(6)", printed);
+        Assert.DoesNotContain("Fixture.Square", printed);
+    }
+
+    [Fact]
+    public void GenericLocalFunction_TranslatesToGenericFunctionLiteralLetBinding()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class Fixture
+    {
+        public void M()
+        {
+            T First<T>(T a, T b) => a;
+            System.Console.WriteLine(First(1, 2));
+            System.Console.WriteLine(First(""x"", ""y""));
+        }
+    }
+}");
+
+        Assert.Contains("let First[T]", printed);
+        Assert.Contains("First(1, 2)", printed);
+        Assert.DoesNotContain("Fixture.First", printed);
+    }
+
+    [Fact]
+    public void GenericLocalFunction_MultipleTypeParameters_TranslatesAllOfThem()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public class Fixture
+    {
+        public void M()
+        {
+            string Combine<T, U>(T a, U b) => a.ToString() + b.ToString();
+            System.Console.WriteLine(Combine(1, ""y""));
+        }
+    }
+}");
+
+        Assert.Contains("let Combine[T, U]", printed);
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(System.Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -6036,7 +6036,15 @@ public sealed class CSharpToGSharpTranslator
                 this.pendingSpillPrologue = outerSpillPrologue;
             }
 
-            return new LocalFunctionStatement(SanitizeIdentifier(localFunction.Identifier.Text), lambda);
+            // Issue #1886: a generic local function (`T First<T>(a, b) { ... }`)
+            // carries its type parameters on the `let` binding, not the anonymous
+            // function literal (which has no name to hang `[T]` off) — see
+            // `let Name[T, U] = func (...) ... { ... }` in G#.
+            var typeParameters = localFunction.TypeParameterList?.Parameters
+                .Select(tp => SanitizeIdentifier(tp.Identifier.Text))
+                .ToList();
+
+            return new LocalFunctionStatement(SanitizeIdentifier(localFunction.Identifier.Text), lambda, typeParameters);
         }
 
         /// <summary>
@@ -9148,7 +9156,7 @@ public sealed class CSharpToGSharpTranslator
                 typeArguments = this.MapTypeArguments(memberBindingGeneric);
             }
             else if (invocation.Expression is IdentifierNameSyntax bareName &&
-                this.context.GetSymbolInfo(bareName).Symbol is IMethodSymbol { IsStatic: true } staticMethod &&
+                this.context.GetSymbolInfo(bareName).Symbol is IMethodSymbol { IsStatic: true, MethodKind: not MethodKind.LocalFunction } staticMethod &&
                 staticMethod.ContainingType is { TypeKind: TypeKind.Class or TypeKind.Struct } owner &&
                 !owner.IsImplicitlyDeclared &&
                 !this.IsStaticUsingTarget(owner) &&
@@ -9161,6 +9169,12 @@ public sealed class CSharpToGSharpTranslator
                 // A bare call to a `using static` member is the exception
                 // (ADR-0134): gsc brings it into scope through `import Owner`,
                 // so it is left unqualified above.
+                // Issue #1886: a `static` LOCAL function is NOT a sibling type
+                // member — Roslyn still reports its enclosing TYPE as
+                // `ContainingType`, but cs2gs already lowers it to a local `let`
+                // binding (see TranslateLocalFunction), so its call must stay a
+                // bare identifier call, never `Owner.Name(...)`. Excluded above
+                // via `MethodKind: not MethodKind.LocalFunction`.
                 target = new MemberAccessExpression(
                     this.StaticQualifierReceiver(owner, bareName.GetLocation()),
                     staticMethod.Name);

--- a/tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/LocalFunctionStatement.cs
+++ b/tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/LocalFunctionStatement.cs
@@ -1,10 +1,8 @@
 // inventory: LocalFunctionStatement
-// NOTE: quarantined sub-cases (fail gsc compile after translation):
-//   * static local function — call site is emitted as a class-member access
-//     (`LocalFunctionStatementFixture.Square(6)`) that does not exist (GS0158).
-//   * generic local function — lowered to `func (a T, b T) T` where 'T' is not
-//     a known type (GS0113), cascading GS0124/GS0122.
-// Plain and capturing local functions are kept below.
+// Plain, captured, static, and generic local functions are all exercised below
+// (issue #1886: static local functions now call through their `let` binding
+// directly instead of a nonexistent class-member access, and generic local
+// functions translate to G#'s `let Name[T, ...] = func (...) ... { ... }`).
 using System;
 
 namespace Corpus.Grid03.Constructs
@@ -27,6 +25,21 @@ namespace Corpus.Grid03.Constructs
             }
 
             Console.WriteLine($"LocalFunctionStatement: AddSeed(7) with captured seed = {AddSeed(7)}");
+
+            static int Square(int x)
+            {
+                return x * x;
+            }
+
+            Console.WriteLine($"LocalFunctionStatement: Square(6) = {Square(6)}");
+
+            T First<T>(T a, T b)
+            {
+                return a;
+            }
+
+            Console.WriteLine($"LocalFunctionStatement: First(1, 2) = {First(1, 2)}");
+            Console.WriteLine($"LocalFunctionStatement: First(\"x\", \"y\") = {First("x", "y")}");
         }
     }
 }

--- a/tools/cs2gs/corpus/grid/G03-ControlFlow-Console/baseline.stdout.golden
+++ b/tools/cs2gs/corpus/grid/G03-ControlFlow-Console/baseline.stdout.golden
@@ -30,6 +30,9 @@ IfStatement: 12 is even (if without else)
 IfStatement: 12 is between 10 and 20 (nested if)
 LocalFunctionStatement: Add(3, 4) = 7
 LocalFunctionStatement: AddSeed(7) with captured seed = 12
+LocalFunctionStatement: Square(6) = 36
+LocalFunctionStatement: First(1, 2) = 1
+LocalFunctionStatement: First("x", "y") = x
 LockStatement: counter=1
 LockStatement: about to throw
 LockStatement: caught boom

--- a/tools/cs2gs/corpus/grid/G09-Functions-Console/Constructs/LocalFunctionStatementGeneric.cs
+++ b/tools/cs2gs/corpus/grid/G09-Functions-Console/Constructs/LocalFunctionStatementGeneric.cs
@@ -1,4 +1,6 @@
 // inventory: LocalFunctionStatement
+// Issue #1886: generic local functions (`T Echo<T>(T v)`) now translate to G#'s
+// `let Echo[T] = func (value T) T { ... }` generic function-literal syntax.
 using System;
 
 namespace Corpus.Grid09
@@ -7,9 +9,13 @@ namespace Corpus.Grid09
     {
         public static void Run()
         {
-            // QUARANTINED (GS0113): generic local functions (T Echo<T>(T v))
-            // are emitted as 'let Echo = func (value T) T { ... }' — G#
-            // lambdas cannot declare type parameters, so 'T' does not resolve.
+            T Echo<T>(T v)
+            {
+                return v;
+            }
+
+            Console.WriteLine($"LocalFunctionStatementGeneric: Echo(7)={Echo(7)}");
+            Console.WriteLine($"LocalFunctionStatementGeneric: Echo(\"hi\")={Echo("hi")}");
 
             // Local function used as a Func<> value.
             static int Square(int x)

--- a/tools/cs2gs/corpus/grid/G09-Functions-Console/baseline.stdout.golden
+++ b/tools/cs2gs/corpus/grid/G09-Functions-Console/baseline.stdout.golden
@@ -7,6 +7,8 @@ DeclarationExpression: outTyped=7 ok=True
 DeclarationExpression: discardParse=False
 DeclarationExpression: tryGet=36
 DeclarationExpression: missing=0 found=False
+LocalFunctionStatementGeneric: Echo(7)=7
+LocalFunctionStatementGeneric: Echo("hi")=hi
 LocalFunctionStatementGeneric: asFunc=36
 LocalFunctionStatementGeneric: shift=101
 MethodGroupConversion: func=42

--- a/tools/cs2gs/coverage/csharp-construct-inventory.json
+++ b/tools/cs2gs/coverage/csharp-construct-inventory.json
@@ -1315,8 +1315,7 @@
     "rule": "ADR-0115 \u00A7B",
     "rationale": "None",
     "fixture": "tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/LocalFunctionStatement.cs",
-    "issue": "https://github.com/DavidObando/gsharp/issues/1886",
-    "notes": "static local functions mislower at call sites; generic local functions unrepresentable (issue #1886)."
+    "notes": "Static local functions call through their \u0060let\u0060 binding directly; generic local functions translate to G#\u0027s \u0060let Name[T, ...] = func (...) ... { ... }\u0060 (issue #1886, fixed)."
   },
   {
     "kind": "LockStatement",


### PR DESCRIPTION
## Problem

Two related cs2gs/G# gaps (issue #1886):

1. A `static` local function's call site translated to a class-member access (`Fixture.Square(6)`) instead of calling its `let` binding directly (`Square(6)`) — `GS0158`.
2. A generic local function (`T First<T>(a, b)`) had no G# representation: it lowered to `let First = func (a T, b T) T {...}`, and G# function literals could not declare type parameters — `GS0113: Type 'T' doesn't exist`.

## Fix

- **G# language**: added generic function-literal syntax `let Name[T, U, ...] = func (...) ReturnType {...}` (any arity). Implemented end to end:
  - Parser: optional type-parameter list on a `let` binding.
  - Binder: a new `BoundLocalFunctionDeclaration` node declares the literal as a real generic `FunctionSymbol` (not a delegate value), resolved through the existing generic overload-resolution/call-binding path used by generic methods. Calls are ordinary `BoundCallExpression`s. New diagnostics `GS0461` (malformed declaration) and `GS0462` (a generic local function cannot capture outer variables — deliberate scope limit, see below).
  - Wired the new node through the tree walker, rewriter, printer, control-flow graph, and the async spiller.
  - Emit reuses the existing non-capturing-lambda-to-static-method hosting path (already generic-aware) — no core emission changes needed for the happy path.
  - Fixed a real bug surfaced by the grid corpus: `ClosureEmitter.SynthesizeClosures` was rerouting any non-capturing function literal declared inside a non-generic user type into a nested display class (issue #1469's accessibility trick). That rerouting is never consulted by the direct-call emission path, so a generic local function nested inside a class method threw `"Call to function 'X' has no emitted MethodDef."` at compile time. Since a generic local function can never capture, it never needs that trick — it is now excluded from the rerouting and always hosted on the top-level `<Program>` static method.

- **cs2gs**: fixed the bare-static-call rewrite guard to exclude `MethodKind.LocalFunction` (so static local functions are no longer misdiagnosed as `Owner.Method(...)`), and updated `TranslateLocalFunction` to translate a generic C# local function to the new `let Name[T, ...] = func ...` syntax.

- **Corpus**: re-enabled the quarantined `LocalFunctionStatement` grid fixtures (`G03-ControlFlow-Console`, `G09-Functions-Console`) with real static and generic local-function cases, re-captured their C# baselines, and verified the full cs2gs `migrate` pipeline (translate, gsc compile, ilverify, stdout parity) is green for both apps. Updated the `csharp-construct-inventory.json` row.

## Tests

- `test/Compiler.Tests/Emit/Issue1886GenericLocalFunctionEmitTests.cs` (5 gsc-level tests): single/multi type-parameter generic local functions, nested inside an ordinary function, nested inside a class's `shared` method (the closure-emitter regression), and the capture-rejection diagnostic.
- `tools/cs2gs/Cs2Gs.Tests/Issue1886StaticGenericLocalFunctionTranslationTests.cs` (3 tests): static local-function call-site translation, single- and multi-type-parameter generic local-function translation.
- `test/Core.Tests/CoverageMatrix` golden + `BoundNodeKindExhaustivenessTests` updated/passing for the new `BoundNodeKind.LocalFunctionDeclaration`.
- Ran narrowly: new Issue1886 suites, `BoundNodeKindExhaustivenessTests`, `CoverageMatrixGoldenTests`, `ConstructInventoryGoldenTests`, full `Cs2Gs.Tests` (772 passed), full `Compiler.Tests/Emit` (2462 passed), closure/#1469/#1335 regression tests (72 passed) — all green.

## Known, deliberate limitation

A generic local function cannot capture outer variables (diagnosed as `GS0462`). Supporting captures would require reifying the enclosing closure's display class with its own generic type parameters, a materially larger feature; this is out of scope for this fix and documented via the diagnostic.

Fixes #1886
