### PR TITLE
cs2gs: fix silently dropped positional patterns (issue #1887)

### DIFF
--- a/docs/cs2gs-coverage-matrix.md
+++ b/docs/cs2gs-coverage-matrix.md
@@ -6,12 +6,12 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | Status | Count |
 | --- | --- |
 | Unclassified | 0 |
-| Translated | 209 |
+| Translated | 210 |
 | Lowered | 12 |
 | UnsupportedByDesign | 56 |
-| Gap | 44 |
+| Gap | 43 |
 
-## Translated (209)
+## Translated (210)
 
 | Kind | Node type | Rule | Rationale | Fixture | Issue | Notes |
 | --- | --- | --- | --- | --- | --- | --- |
@@ -160,6 +160,7 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | ParenthesizedVariableDesignation | ParenthesizedVariableDesignationSyntax | ADR-0115 §B.30 |  |  |  |  |
 | PointerIndirectionExpression | PrefixUnaryExpressionSyntax | ADR-0115 §B |  |  | https://github.com/DavidObando/gsharp/issues/1925 | Compiles; ilverify-by-design (issue #1933). *(p + i) misbinds in gsc (issue #1925). |
 | PointerType | PointerTypeSyntax | ADR-0115 §B |  |  | https://github.com/DavidObando/gsharp/issues/1933 | Pointer IL is unverifiable by design — pipeline policy issue #1933; compile-level green. |
+| PositionalPatternClause | PositionalPatternClauseSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G04-Patterns-Console/Constructs/PositionalPatternClause.cs | https://github.com/DavidObando/gsharp/issues/1887 | Fixed (was SILENT MISTRANSLATION, issue #1887): a positional subpattern lowers to the same member-access form a property subpattern uses (tuple Item1/Item2, or a record's property via its Deconstruct). Switch-expression bare positional patterns over a raw TUPLE are also supported: gsc's property-pattern binder/emitter/evaluator now accept a ValueTuple subject (previously GS0172). |
 | PostDecrementExpression | PostfixUnaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/PostDecrementExpression.cs |  |  |
 | PostIncrementExpression | PostfixUnaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/PostIncrementExpression.cs |  |  |
 | PreDecrementExpression | PrefixUnaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/PreDecrementExpression.cs |  |  |
@@ -303,7 +304,7 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | XmlText | XmlTextSyntax |  | ToolingScope |  |  | Documentation/tooling structure, not program semantics; doc-comment mapping is ADR-0057 scope. |
 | XmlTextAttribute | XmlTextAttributeSyntax |  | ToolingScope |  |  | Documentation/tooling structure, not program semantics; doc-comment mapping is ADR-0057 scope. |
 
-## Gap (44)
+## Gap (43)
 
 | Kind | Node type | Rule | Rationale | Fixture | Issue | Notes |
 | --- | --- | --- | --- | --- | --- | --- |
@@ -336,7 +337,6 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | ListPattern | ListPatternSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1889 |  |
 | ObjectInitializerExpression | InitializerExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1892 | Initializer assignments emitted as stray statements. |
 | PointerMemberAccessExpression | MemberAccessExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1905 | p->X lowered to p.X; (*p).X compiles. |
-| PositionalPatternClause | PositionalPatternClauseSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1887 | SILENT MISTRANSLATION: sub-patterns dropped to match-anything case { }. |
 | PrimaryConstructorBaseType | PrimaryConstructorBaseTypeSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1909 |  |
 | RangeExpression | RangeExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1896 | Lowers to .Slice(...) which gsc cannot resolve on arrays/strings. |
 | RefExpression | RefExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1900 | ref argument/return seam (&x pass-by-address). |

--- a/src/Core/CodeAnalysis/Binding/PatternBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/PatternBinder.cs
@@ -310,6 +310,29 @@ internal sealed class PatternBinder
     private BoundPattern BindPropertyPattern(PropertyPatternSyntax syntax, TypeSymbol discriminantType)
     {
         var fields = ImmutableArray.CreateBuilder<BoundPropertyPatternField>();
+
+        // Issue #1887: cs2gs lowers a C# positional pattern over a raw tuple
+        // subject (`(0, 0) => ...`) to a G# property pattern keyed on the
+        // tuple's always-present Item1..ItemN fields (`{ Item1: 0, Item2: 0 }`).
+        // A ValueTuple is neither a StructSymbol nor a class, so it needs its
+        // own lookup path alongside the struct/class one below.
+        if (discriminantType is TupleTypeSymbol tupleType)
+        {
+            foreach (var tupleFieldSyntax in syntax.Fields)
+            {
+                if (!TryGetTupleField(tupleType, tupleFieldSyntax.Identifier.Text, out var tupleField))
+                {
+                    Diagnostics.ReportUndefinedFieldOnType(tupleFieldSyntax.Identifier.Location, tupleFieldSyntax.Identifier.Text, discriminantType);
+                    fields.Add(new BoundPropertyPatternField(syntax, new FieldSymbol(tupleFieldSyntax.Identifier.Text, TypeSymbol.Error, Accessibility.Public), BindPattern(tupleFieldSyntax.Pattern, TypeSymbol.Error)));
+                    continue;
+                }
+
+                fields.Add(new BoundPropertyPatternField(syntax, tupleField, BindPattern(tupleFieldSyntax.Pattern, tupleField.Type)));
+            }
+
+            return new BoundPropertyPattern(syntax, discriminantType, fields.ToImmutable());
+        }
+
         if (discriminantType is not StructSymbol structType)
         {
             Diagnostics.ReportPropertyPatternRequiresStructOrClass(syntax.OpenBraceToken.Location, discriminantType);
@@ -329,6 +352,26 @@ internal sealed class PatternBinder
         }
 
         return new BoundPropertyPattern(syntax, discriminantType, fields.ToImmutable());
+    }
+
+    // Issue #1887: resolve a tuple's synthetic Item1..ItemN field by name so a
+    // property/positional pattern (`{ Item1: 0, Item2: 0 }`) binds against a
+    // ValueTuple subject the same way it does against a struct's real fields.
+    private static bool TryGetTupleField(TupleTypeSymbol tupleType, string name, out FieldSymbol field)
+    {
+        field = null;
+        if (name.Length <= 4 || !name.StartsWith("Item", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (!int.TryParse(name.AsSpan(4), out var index) || index < 1 || index > tupleType.Arity)
+        {
+            return false;
+        }
+
+        field = new FieldSymbol(name, tupleType.ElementTypes[index - 1], Accessibility.Public);
+        return true;
     }
 
     private BoundPattern BindRelationalPattern(RelationalPatternSyntax syntax, TypeSymbol discriminantType)

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Patterns.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Patterns.cs
@@ -305,6 +305,49 @@ internal sealed partial class MethodBodyEmitter
         // because a non-nullable static type carries the contract that
         // the value is non-null. Fields are accessed via ldfld on the
         // value (struct: ldfld on value, class: ldfld through ref).
+        if (valueType is TupleTypeSymbol tupleType)
+        {
+            // Issue #1887: cs2gs lowers a C# positional pattern over a raw
+            // tuple to a G# property pattern keyed on the tuple's Item1..ItemN
+            // fields. ValueTuple exposes those as public fields, so each field
+            // is a plain ldfld — same token resolution as EmitTupleElementAccess.
+            var tupleClr = tupleType.ClrType;
+            var arity = tupleType.Arity;
+            foreach (var field in pp.Fields)
+            {
+                var fieldName = field.Field.Name;
+                Action loadTupleChild = () =>
+                {
+                    loadValue();
+                    this.il.OpCode(ILOpCode.Ldfld);
+                    if (tupleClr == null && arity is >= 2 and <= 7)
+                    {
+                        this.il.Token(this.outer.GetTupleFieldReference(tupleType, fieldName));
+                    }
+                    else if (tupleClr == null)
+                    {
+                        throw new NotSupportedException(
+                            $"Tuple of arity {arity} has no CLR backing type; emit not supported.");
+                    }
+                    else if (tupleClr.IsConstructedGenericType)
+                    {
+                        this.il.Token(this.outer.GetFieldReferenceOnConstructedGeneric(tupleClr, fieldName));
+                    }
+                    else
+                    {
+                        var clrField = tupleClr.GetField(fieldName)
+                            ?? throw new InvalidOperationException(
+                                $"ValueTuple type '{tupleClr.FullName}' has no public field '{fieldName}'.");
+                        this.il.Token(this.outer.GetFieldReference(clrField));
+                    }
+                };
+
+                this.EmitPattern(field.Pattern, loadTupleChild, field.Field.Type, failLabel);
+            }
+
+            return;
+        }
+
         if (valueType is not StructSymbol)
         {
             // Defensive: every property-pattern operand should be a

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -1632,6 +1632,19 @@ public sealed class Evaluator
         return field.GetValue(receiver);
     }
 
+    // Issue #1887: reads a tuple's Item1..ItemN element by field name for
+    // property-pattern matching over a positional pattern lowering.
+    private static object GetTupleFieldValue(object tuple, string fieldName)
+    {
+        if (tuple is object[] arr)
+        {
+            var index = int.Parse(fieldName.AsSpan(4), System.Globalization.CultureInfo.InvariantCulture) - 1;
+            return arr[index];
+        }
+
+        return tuple.GetType().GetField(fieldName)?.GetValue(tuple);
+    }
+
     private object EvaluateFunctionLiteralExpression(BoundFunctionLiteralExpression node)
     {
         var captured = new Dictionary<VariableSymbol, object>();
@@ -3386,12 +3399,29 @@ public sealed class Evaluator
                 outBindings[typePattern.Variable] = value;
                 return true;
             case BoundNodeKind.PropertyPattern:
+                var property = (BoundPropertyPattern)pattern;
                 if (value is not StructValue sv)
                 {
+                    // Issue #1887: a positional pattern over a raw tuple lowers
+                    // to a property pattern keyed on Item1..ItemN. Tuple values
+                    // are CLR ValueTuple instances (arity 2-7) or object[].
+                    if (value != null && property.Type is TupleTypeSymbol)
+                    {
+                        foreach (var tupleField in property.Fields)
+                        {
+                            var tupleFieldValue = GetTupleFieldValue(value, tupleField.Field.Name);
+                            if (!TryMatchPattern(tupleField.Pattern, tupleFieldValue, outBindings))
+                            {
+                                return false;
+                            }
+                        }
+
+                        return true;
+                    }
+
                     return false;
                 }
 
-                var property = (BoundPropertyPattern)pattern;
                 foreach (var field in property.Fields)
                 {
                     sv.Fields.TryGetValue(field.Field.Name, out var fieldValue);

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1887TuplePositionalPatternTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1887TuplePositionalPatternTests.cs
@@ -1,0 +1,85 @@
+// <copyright file="Issue1887TuplePositionalPatternTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1887: a C# positional pattern over a raw tuple lowers to a G#
+/// property pattern keyed on the tuple's Item1..ItemN fields. Previously the
+/// property-pattern matcher rejected a ValueTuple subject (GS0172); it now
+/// binds, emits, and evaluates against tuple element fields.
+/// </summary>
+public class Issue1887TuplePositionalPatternTests
+{
+    [Fact]
+    public void SwitchExpression_TuplePropertyPattern_MatchesFirstArm()
+    {
+        AssertEvaluates(@"
+let p = (0, 0)
+let x = switch p { case { Item1: 0, Item2: 0 }: ""origin"" default: ""other"" }
+x
+", "origin");
+    }
+
+    [Fact]
+    public void SwitchExpression_TuplePropertyPattern_FallsThroughToDefault()
+    {
+        AssertEvaluates(@"
+let p = (3, 4)
+let x = switch p { case { Item1: 0, Item2: 0 }: ""origin"" default: ""other"" }
+x
+", "other");
+    }
+
+    [Fact]
+    public void SwitchExpression_TuplePropertyPattern_RelationalSubpattern()
+    {
+        AssertEvaluates(@"
+let p = (3, 4)
+let x = switch p { case { Item1: 0, Item2: 0 }: ""origin"" case { Item1: > 0, Item2: > 0 }: ""ne"" default: ""other"" }
+x
+", "ne");
+    }
+
+    [Fact]
+    public void SwitchExpression_TuplePropertyPattern_DiscardSubpattern()
+    {
+        AssertEvaluates(@"
+let p = (0, 7)
+let x = switch p { case { Item1: 0, Item2: 0 }: ""origin"" case { Item1: 0, Item2: _ }: ""y-axis"" default: ""other"" }
+x
+", "y-axis");
+    }
+
+    [Fact]
+    public void SwitchExpression_TuplePropertyPattern_ArityThree()
+    {
+        AssertEvaluates(@"
+let p = (0, 0, 5)
+let x = switch p { case { Item1: 0, Item2: 0, Item3: 5 }: ""hit"" default: ""miss"" }
+x
+", "hit");
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(source);
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+
+    private static void AssertEvaluates(string source, object expected)
+    {
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(expected, result.Value);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1887PositionalPatternTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1887PositionalPatternTranslationTests.cs
@@ -1,0 +1,219 @@
+// <copyright file="Issue1887PositionalPatternTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #1887: a positional pattern (<c>p is (0, 0)</c>,
+/// <c>p switch { (0, 0) => … }</c>) was silently dropped — the recursive
+/// pattern translation only looped over <c>RecursivePatternSyntax
+/// .PropertyPatternClause</c>, never <c>.PositionalPatternClause</c>, so every
+/// positional subpattern vanished with no diagnostic and every arm became a
+/// match-anything <c>case { }</c>.
+/// <para>
+/// G# has no positional-pattern syntax, but a positional subpattern reads the
+/// exact same members a property subpattern would (a tuple's <c>Item1</c>/
+/// <c>Item2</c>, or a record's positional property via its compiler-
+/// synthesized <c>Deconstruct</c>), so it now lowers to that same nested
+/// member-access form instead of being dropped.
+/// </para>
+/// </summary>
+public class Issue1887PositionalPatternTranslationTests
+{
+    [Fact]
+    public void IsPattern_BareTuplePositionalPattern_LowersToItemMemberTests()
+    {
+        // `origin is (0, 0)` against a `(int, int)` tuple must NOT become
+        // `origin != nil` (the silent-drop bug) — it must test both Item1 AND
+        // Item2.
+        string rendered = Render(@"
+namespace Corpus.Issue1887
+{
+    public class Holder
+    {
+        public bool IsOrigin((int, int) origin)
+        {
+            return origin is (0, 0);
+        }
+    }
+}
+");
+
+        Assert.Contains("origin.Item1 == 0", rendered, StringComparison.Ordinal);
+        Assert.Contains("origin.Item2 == 0", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void IsPattern_TypedRecordPositionalPattern_LowersToPropertyMemberTests()
+    {
+        // `p is Point(0, 0)` against a record: the positional subpatterns bind
+        // through the record's compiler-synthesized `Deconstruct`, whose
+        // out-parameter names match the record's positional properties (X, Y).
+        string rendered = Render(@"
+namespace Corpus.Issue1887
+{
+    public record Point(int X, int Y);
+
+    public class Holder
+    {
+        public bool IsOrigin(Point p)
+        {
+            return p is Point(0, 0);
+        }
+    }
+}
+");
+
+        Assert.Contains("p.X == 0", rendered, StringComparison.Ordinal);
+        Assert.Contains("p.Y == 0", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void SwitchExpression_BarePositionalPatternArms_LowerToPropertyPatternArms()
+    {
+        // The issue's motivating example: every arm of `p switch { (0,0) =>
+        // …, (0,_) => …, (>0,>0) => …, _ => … }` must keep its own positional
+        // subpatterns (constant, discard, relational) instead of collapsing to
+        // an identical match-anything `case { }` in every arm.
+        string rendered = Render(@"
+namespace Corpus.Issue1887
+{
+    public record Point(int X, int Y);
+
+    public class Holder
+    {
+        public string Describe(Point p)
+        {
+            return p switch
+            {
+                (0, 0) => ""origin"",
+                (0, _) => ""y-axis"",
+                ( > 0, > 0) => ""ne"",
+                _ => ""other"",
+            };
+        }
+    }
+}
+");
+
+        Assert.Contains("case { X: 0, Y: 0 }", rendered, StringComparison.Ordinal);
+        Assert.Contains("case { X: 0 }", rendered, StringComparison.Ordinal);
+        Assert.Contains("case { X: > 0, Y: > 0 }", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("case { }:", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void SwitchStatement_ThreeArityTuplePositionalPattern_LowersToNestedItemTests()
+    {
+        // Arity > 2: `(0, 0, 5)` must keep all three positions, not just drop
+        // to a bare tuple-null check.
+        string rendered = Render(@"
+namespace Corpus.Issue1887
+{
+    public class Holder
+    {
+        public bool Classify((int, int, int) triple)
+        {
+            switch (triple)
+            {
+                case (0, 0, 5):
+                    return true;
+                default:
+                    return false;
+            }
+        }
+    }
+}
+");
+
+        Assert.Contains("Item1: 0", rendered, StringComparison.Ordinal);
+        Assert.Contains("Item2: 0", rendered, StringComparison.Ordinal);
+        Assert.Contains("Item3: 5", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void IsPattern_UserDeconstructWithUnrelatedParameterNames_ReportsDiagnosticInsteadOfSilentDrop()
+    {
+        // A hand-written `Deconstruct` whose out-parameter names have no
+        // matching property on the type has no canonical G# member to bind
+        // the positional subpattern to; this must be reported LOUDLY (ADR-0115
+        // §B), never silently dropped to a match-anything test.
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[]
+        {
+            ("Source.cs", @"
+namespace Corpus.Issue1887
+{
+    public class Opaque
+    {
+        public void Deconstruct(out int a, out int b)
+        {
+            a = 1;
+            b = 2;
+        }
+    }
+
+    public class Holder
+    {
+        public bool Test(Opaque o)
+        {
+            return o is (1, 2);
+        }
+    }
+}
+"),
+        });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        Cs2Gs.CodeModel.Ast.CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        string rendered = GSharpPrinter.Print(unit);
+
+        Assert.NotEmpty(context.Diagnostics);
+        Assert.Contains(
+            context.Diagnostics,
+            d => d.Message.Contains("positional subpattern has no canonical G# form", StringComparison.Ordinal));
+    }
+
+    private static void AssertRoundTripParses(string rendered)
+    {
+        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+
+        Assert.True(
+            result.Success,
+            "Sanitized G# must round-trip-parse. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + rendered);
+    }
+
+    private static string Render(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", source) });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        Cs2Gs.CodeModel.Ast.CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        return GSharpPrinter.Print(unit);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -8228,9 +8228,21 @@ public sealed class CSharpToGSharpTranslator
                     this.BuildPatternNarrowingReplacement(receiver, receiverSyntax, recursive.Type);
             }
 
+            // A bare recursive pattern with no type prefix (`{ A: 0 }`, `(0, 0)`)
+            // starts the test with a null check on `receiver` — correct when
+            // `receiver` is a reference type (the common case, e.g. a nullable
+            // record), but a tuple or struct positional pattern (issue #1887,
+            // `(int, int)`) is a VALUE type: it can never be null, and gsc
+            // rejects `!= nil` against one. Skip the null check for a value-type
+            // receiver; the member-access sub-tests below are the whole test
+            // (and if there happen to be none, e.g. every position is a discard,
+            // `true` is the correct always-matches result).
+            bool receiverIsValueType = recursive.Type == null &&
+                this.context.SemanticModel.GetOperation(recursive) is IRecursivePatternOperation { MatchedType.IsValueType: true };
+
             GExpression test = recursive.Type != null
                 ? new BinaryExpression(receiver, "is", new TypeExpression(this.MapTypeSyntax(recursive.Type)))
-                : new BinaryExpression(receiver, "!=", LiteralExpression.Null());
+                : receiverIsValueType ? null : new BinaryExpression(receiver, "!=", LiteralExpression.Null());
 
             if (recursive.PropertyPatternClause != null)
             {
@@ -8245,11 +8257,114 @@ public sealed class CSharpToGSharpTranslator
                     string memberName = sub.NameColon?.Name.Identifier.Text
                         ?? sub.ExpressionColon?.Expression.ToString();
                     GExpression memberAccess = new MemberAccessExpression(receiver, SanitizeIdentifier(memberName));
-                    test = new BinaryExpression(test, "&&", this.TranslatePatternTest(memberAccess, sub.Pattern));
+                    GExpression memberTest = this.TranslatePatternTest(memberAccess, sub.Pattern);
+                    test = test == null ? memberTest : new BinaryExpression(test, "&&", memberTest);
                 }
             }
 
-            return test;
+            if (recursive.PositionalPatternClause != null)
+            {
+                // Issue #1887: `x is (0, 0)` / `x is Point(0, 0)` deconstructs `x`
+                // positionally. G# has no positional-pattern syntax, but a
+                // positional subpattern against a tuple or a record's
+                // (compiler-synthesized) `Deconstruct` reads exactly the same
+                // members a property pattern would — `Item1`/`Item2` for a tuple,
+                // the matching property for a record — so it lowers to the same
+                // nested member-access test a property subpattern uses.
+                SeparatedSyntaxList<SubpatternSyntax> subs = recursive.PositionalPatternClause.Subpatterns;
+                string[] memberNames = this.TryGetPositionalMemberNames(recursive, subs.Count);
+                for (int i = 0; i < subs.Count; i++)
+                {
+                    SubpatternSyntax sub = subs[i];
+                    if (sub.Pattern is DiscardPatternSyntax)
+                    {
+                        // A discard position (`(0, _)`) imposes no constraint —
+                        // same as an omitted field in a property pattern — so it
+                        // contributes no test at all.
+                        continue;
+                    }
+
+                    string memberName = sub.NameColon?.Name.Identifier.Text ?? memberNames?[i];
+                    if (memberName == null)
+                    {
+                        this.context.ReportUnsupported(sub, "positional subpattern has no canonical G# form yet (ADR-0115 §B).");
+                        continue;
+                    }
+
+                    GExpression memberAccess = new MemberAccessExpression(receiver, SanitizeIdentifier(memberName));
+                    GExpression memberTest = this.TranslatePatternTest(memberAccess, sub.Pattern);
+                    test = test == null ? memberTest : new BinaryExpression(test, "&&", memberTest);
+                }
+            }
+
+            // Every position was a discard (`(_, _)`) against a value-type
+            // receiver: no null check applies and no member test was emitted, so
+            // the pattern always matches.
+            return test ?? LiteralExpression.Bool(true);
+        }
+
+        // Resolves the property name each positional subpattern of `recursive`
+        // deconstructs to (issue #1887), so a positional pattern can lower to the
+        // same nested member-access form a property pattern uses. Returns null
+        // when no canonical mapping exists (an explicit `Deconstruct` whose
+        // out-parameters don't share a name with a same-named property), so
+        // callers fall back to the loud "no canonical G# form" diagnostic instead
+        // of silently dropping the subpattern.
+        private string[] TryGetPositionalMemberNames(RecursivePatternSyntax recursive, int arity)
+        {
+            if (this.context.SemanticModel.GetOperation(recursive) is not IRecursivePatternOperation operation)
+            {
+                return null;
+            }
+
+            if (operation.MatchedType is INamedTypeSymbol { IsTupleType: true })
+            {
+                // `(0, 0)` against a `(int, int)` tuple: positions bind to the
+                // always-present `Item1`/`Item2` fields regardless of any
+                // user-declared tuple element names.
+                var tupleNames = new string[arity];
+                for (int i = 0; i < arity; i++)
+                {
+                    tupleNames[i] = "Item" + (i + 1).ToString(CultureInfo.InvariantCulture);
+                }
+
+                return tupleNames;
+            }
+
+            if (operation.DeconstructSymbol is not IMethodSymbol deconstruct || deconstruct.Parameters.Length != arity)
+            {
+                return null;
+            }
+
+            var names = new string[arity];
+            for (int i = 0; i < arity; i++)
+            {
+                string name = deconstruct.Parameters[i].Name;
+                if (!HasMatchingProperty(operation.MatchedType, name))
+                {
+                    return null;
+                }
+
+                names[i] = name;
+            }
+
+            return names;
+        }
+
+        // Walks the base-type chain looking for a property named `name` (a
+        // record's positional properties are declared directly on the record,
+        // but this also covers a Deconstruct that mirrors an inherited property).
+        private static bool HasMatchingProperty(ITypeSymbol type, string name)
+        {
+            for (ITypeSymbol current = type; current != null; current = current.BaseType)
+            {
+                if (current.GetMembers(name).OfType<IPropertySymbol>().Any())
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private void BindPatternDesignation(VariableDesignationSyntax designation, GExpression receiver)
@@ -10998,6 +11113,39 @@ public sealed class CSharpToGSharpTranslator
                     }
                 }
 
+                if (recursive.PositionalPatternClause != null)
+                {
+                    // Issue #1887: a bare positional pattern arm (`(0, 0) =>`,
+                    // `(0, _) or (>0, >0) =>`) has no type prefix, so — same as
+                    // the untyped property-pattern branch above — it lowers to a
+                    // G# property pattern whose fields are the tuple/record
+                    // members each position deconstructs to.
+                    SeparatedSyntaxList<SubpatternSyntax> subs = recursive.PositionalPatternClause.Subpatterns;
+                    string[] memberNames = this.TryGetPositionalMemberNames(recursive, subs.Count);
+                    for (int i = 0; i < subs.Count; i++)
+                    {
+                        SubpatternSyntax sub = subs[i];
+                        if (sub.Pattern is DiscardPatternSyntax)
+                        {
+                            // A discard position (`(0, _)`) imposes no constraint —
+                            // same as an omitted field in a property pattern — so
+                            // it contributes no field at all.
+                            continue;
+                        }
+
+                        string memberName = sub.NameColon?.Name.Identifier.Text ?? memberNames?[i];
+                        if (memberName == null)
+                        {
+                            this.context.ReportUnsupported(sub, "positional subpattern has no canonical G# form yet (ADR-0115 §B).");
+                            continue;
+                        }
+
+                        fields.Add(new PropertyPatternField(
+                            SanitizeIdentifier(memberName),
+                            this.TranslatePattern(sub.Pattern, bindings, usedDesignators)));
+                    }
+                }
+
                 return new PropertyPattern(fields);
             }
 
@@ -11042,6 +11190,50 @@ public sealed class CSharpToGSharpTranslator
                         this.context.ReportUnsupported(
                             sub,
                             "typed property subpattern other than a 'var' binding has no canonical G# form yet (ADR-0115 §B).");
+                    }
+                }
+            }
+
+            if (recursive.PositionalPatternClause != null)
+            {
+                // Issue #1887: a TYPED recursive pattern (`Point(0, 0)`, `Point(var
+                // x, var y)`) lowers to a `TypePattern` GPattern node, which — same
+                // as the typed property-pattern branch above — carries only a
+                // designator and a type, no room for an extra equality/relational
+                // test. A `var` positional subpattern still binds cleanly (a member
+                // access on the designator); anything else has no canonical G#
+                // form in this position (ADR-0115 §B) and is reported loudly rather
+                // than silently dropped. The untyped bare-tuple arm form above
+                // (`(0, 0) =>`) is unaffected and fully supports constant/
+                // relational positional subpatterns.
+                SeparatedSyntaxList<SubpatternSyntax> subs = recursive.PositionalPatternClause.Subpatterns;
+                string[] memberNames = this.TryGetPositionalMemberNames(recursive, subs.Count);
+                for (int i = 0; i < subs.Count; i++)
+                {
+                    SubpatternSyntax sub = subs[i];
+                    if (sub.Pattern is DiscardPatternSyntax)
+                    {
+                        // A discard position (`Point(0, _)`) imposes no
+                        // constraint and binds nothing, so no field is needed.
+                        continue;
+                    }
+
+                    string memberName = sub.NameColon?.Name.Identifier.Text ?? memberNames?[i];
+                    if (memberName != null &&
+                        sub.Pattern is VarPatternSyntax { Designation: SingleVariableDesignationSyntax posBound } &&
+                        this.context.GetDeclaredSymbol(posBound) is { } posBoundSymbol)
+                    {
+                        bindings.Add((
+                            posBoundSymbol,
+                            new MemberAccessExpression(
+                                new IdentifierExpression(designator),
+                                SanitizeIdentifier(memberName))));
+                    }
+                    else
+                    {
+                        this.context.ReportUnsupported(
+                            sub,
+                            "typed positional subpattern other than a 'var' binding has no canonical G# form yet (ADR-0115 §B).");
                     }
                 }
             }

--- a/tools/cs2gs/corpus/grid/G04-Patterns-Console/Constructs/PositionalPatternClause.cs
+++ b/tools/cs2gs/corpus/grid/G04-Patterns-Console/Constructs/PositionalPatternClause.cs
@@ -1,14 +1,9 @@
 // inventory: PositionalPatternClause
-// NOTE: quarantined sub-case: a `switch` EXPRESSION arm's bare positional
-// pattern (`(0, 0) => ...`) lowers to a G# property pattern (`case { Item1: 0,
-// Item2: 0 }`), and gsc's property-pattern matcher only accepts a struct or
-// class value there — not a tuple (GS0172: "Property pattern requires a
-// struct or class value, not '(int32, int32)'"). Same gsc-side limitation as
-// the RecursivePattern.cs fixture's already-quarantined nullable-subject
-// case; kept below is the switch-expression positional-pattern arm form over
-// a record (a class value, so gsc's matcher accepts it) instead of a tuple.
-// The `is`-expression positional-pattern form (a boolean lowering, not a gsc
-// property pattern) is unaffected and IS exercised below over a bare tuple.
+// Issue #1887: a `switch` EXPRESSION arm's bare positional pattern over a raw
+// TUPLE (`(0, 0) => ...`) lowers to a G# property pattern (`case { Item1: 0,
+// Item2: 0 }`); gsc's property-pattern matcher now accepts a ValueTuple
+// subject (previously GS0172). Both the record and raw-tuple switch-expression
+// forms — plus the `is`-expression boolean form — are exercised below.
 using System;
 
 namespace Corpus.Grid04.Constructs
@@ -48,6 +43,20 @@ namespace Corpus.Grid04.Constructs
                     _ => "other",
                 };
                 Console.WriteLine($"PositionalPatternClause: ({p.X}, {p.Y}) -> {quadrant}");
+            }
+
+            (int, int)[] tuplePoints = { (0, 0), (0, 4), (3, 0), (3, 4) };
+            foreach ((int, int) tp in tuplePoints)
+            {
+                string tupleQuadrant = tp switch
+                {
+                    (0, 0) => "origin",
+                    (0, _) => "y-axis",
+                    (_, 0) => "x-axis",
+                    ( > 0, > 0) => "ne",
+                    _ => "other",
+                };
+                Console.WriteLine($"PositionalPatternClause: ({tp.Item1}, {tp.Item2}) tuple-> {tupleQuadrant}");
             }
         }
     }

--- a/tools/cs2gs/corpus/grid/G04-Patterns-Console/Constructs/PositionalPatternClause.cs
+++ b/tools/cs2gs/corpus/grid/G04-Patterns-Console/Constructs/PositionalPatternClause.cs
@@ -1,0 +1,54 @@
+// inventory: PositionalPatternClause
+// NOTE: quarantined sub-case: a `switch` EXPRESSION arm's bare positional
+// pattern (`(0, 0) => ...`) lowers to a G# property pattern (`case { Item1: 0,
+// Item2: 0 }`), and gsc's property-pattern matcher only accepts a struct or
+// class value there — not a tuple (GS0172: "Property pattern requires a
+// struct or class value, not '(int32, int32)'"). Same gsc-side limitation as
+// the RecursivePattern.cs fixture's already-quarantined nullable-subject
+// case; kept below is the switch-expression positional-pattern arm form over
+// a record (a class value, so gsc's matcher accepts it) instead of a tuple.
+// The `is`-expression positional-pattern form (a boolean lowering, not a gsc
+// property pattern) is unaffected and IS exercised below over a bare tuple.
+using System;
+
+namespace Corpus.Grid04.Constructs
+{
+    internal sealed record PpPoint(int X, int Y);
+
+    public static class PositionalPatternClauseFixture
+    {
+        public static void Run()
+        {
+            (int, int) origin = (0, 0);
+            (int, int) onYAxis = (0, 4);
+
+            Console.WriteLine($"PositionalPatternClause: origin is (0, 0) = {origin is (0, 0)}");
+            Console.WriteLine($"PositionalPatternClause: onYAxis is (0, 0) = {onYAxis is (0, 0)}");
+
+            PpPoint? recordOrigin = new PpPoint(0, 0);
+            PpPoint? recordPoint = new PpPoint(3, 4);
+
+            Console.WriteLine($"PositionalPatternClause: recordOrigin is (0, 0) = {recordOrigin is (0, 0)}");
+            Console.WriteLine($"PositionalPatternClause: recordOrigin is PpPoint(0, 0) = {recordOrigin is PpPoint(0, 0)}");
+            Console.WriteLine($"PositionalPatternClause: recordPoint is (0, 0) = {recordPoint is (0, 0)}");
+
+            (int, int, int) triple = (0, 0, 5);
+            bool tripleMatch = triple is (0, 0, 5);
+            Console.WriteLine($"PositionalPatternClause: {triple} is (0, 0, 5) = {tripleMatch}");
+
+            PpPoint[] points = { new PpPoint(0, 0), new PpPoint(0, 4), new PpPoint(3, 4) };
+            foreach (PpPoint p in points)
+            {
+                string quadrant = p switch
+                {
+                    (0, 0) => "origin",
+                    (0, _) => "y-axis",
+                    (_, 0) => "x-axis",
+                    ( > 0, > 0) => "ne",
+                    _ => "other",
+                };
+                Console.WriteLine($"PositionalPatternClause: ({p.X}, {p.Y}) -> {quadrant}");
+            }
+        }
+    }
+}

--- a/tools/cs2gs/corpus/grid/G04-Patterns-Console/Program.cs
+++ b/tools/cs2gs/corpus/grid/G04-Patterns-Console/Program.cs
@@ -19,6 +19,7 @@ namespace Corpus.Grid04
             NotPatternFixture.Run();
             OrPatternFixture.Run();
             ParenthesizedPatternFixture.Run();
+            PositionalPatternClauseFixture.Run();
             RecursivePatternFixture.Run();
             RelationalPatternFixture.Run();
             SwitchExpressionFixture.Run();

--- a/tools/cs2gs/corpus/grid/G04-Patterns-Console/baseline.stdout.golden
+++ b/tools/cs2gs/corpus/grid/G04-Patterns-Console/baseline.stdout.golden
@@ -43,6 +43,15 @@ ParenthesizedPattern: 5 is (> 0 and < 10) or 42 = True
 ParenthesizedPattern: 42 is (> 0 and < 10) or 42 = True
 ParenthesizedPattern: 77 is (> 0 and < 10) or 42 = False
 ParenthesizedPattern: 9 is not (< 0 or > 10) = True
+PositionalPatternClause: origin is (0, 0) = True
+PositionalPatternClause: onYAxis is (0, 0) = False
+PositionalPatternClause: recordOrigin is (0, 0) = True
+PositionalPatternClause: recordOrigin is PpPoint(0, 0) = True
+PositionalPatternClause: recordPoint is (0, 0) = False
+PositionalPatternClause: (0, 0, 5) is (0, 0, 5) = True
+PositionalPatternClause: (0, 0) -> origin
+PositionalPatternClause: (0, 4) -> y-axis
+PositionalPatternClause: (3, 4) -> ne
 RecursivePattern: person is in Lima = True
 RecursivePattern: person has a Lima-range zip
 RecursivePattern: name length 3 = True

--- a/tools/cs2gs/corpus/grid/G04-Patterns-Console/baseline.stdout.golden
+++ b/tools/cs2gs/corpus/grid/G04-Patterns-Console/baseline.stdout.golden
@@ -52,6 +52,10 @@ PositionalPatternClause: (0, 0, 5) is (0, 0, 5) = True
 PositionalPatternClause: (0, 0) -> origin
 PositionalPatternClause: (0, 4) -> y-axis
 PositionalPatternClause: (3, 4) -> ne
+PositionalPatternClause: (0, 0) tuple-> origin
+PositionalPatternClause: (0, 4) tuple-> y-axis
+PositionalPatternClause: (3, 0) tuple-> x-axis
+PositionalPatternClause: (3, 4) tuple-> ne
 RecursivePattern: person is in Lima = True
 RecursivePattern: person has a Lima-range zip
 RecursivePattern: name length 3 = True

--- a/tools/cs2gs/coverage/csharp-construct-inventory.json
+++ b/tools/cs2gs/coverage/csharp-construct-inventory.json
@@ -1644,10 +1644,12 @@
   {
     "kind": "PositionalPatternClause",
     "nodeType": "PositionalPatternClauseSyntax",
-    "status": "Gap",
+    "status": "Translated",
+    "rule": "ADR-0115 \u00A7B",
     "rationale": "None",
+    "fixture": "tools/cs2gs/corpus/grid/G04-Patterns-Console/Constructs/PositionalPatternClause.cs",
     "issue": "https://github.com/DavidObando/gsharp/issues/1887",
-    "notes": "SILENT MISTRANSLATION: sub-patterns dropped to match-anything case { }."
+    "notes": "Fixed (was SILENT MISTRANSLATION, issue #1887): a positional subpattern lowers to the same member-access form a property subpattern uses (tuple Item1/Item2, or a record's property via its Deconstruct). Quarantined sub-case: a switch-expression arm's bare positional pattern over a TUPLE hits gsc GS0172 (property-pattern matcher needs a struct/class, not a tuple); the is-expression boolean form is unaffected."
   },
   {
     "kind": "PostDecrementExpression",

--- a/tools/cs2gs/coverage/csharp-construct-inventory.json
+++ b/tools/cs2gs/coverage/csharp-construct-inventory.json
@@ -1649,7 +1649,7 @@
     "rationale": "None",
     "fixture": "tools/cs2gs/corpus/grid/G04-Patterns-Console/Constructs/PositionalPatternClause.cs",
     "issue": "https://github.com/DavidObando/gsharp/issues/1887",
-    "notes": "Fixed (was SILENT MISTRANSLATION, issue #1887): a positional subpattern lowers to the same member-access form a property subpattern uses (tuple Item1/Item2, or a record's property via its Deconstruct). Quarantined sub-case: a switch-expression arm's bare positional pattern over a TUPLE hits gsc GS0172 (property-pattern matcher needs a struct/class, not a tuple); the is-expression boolean form is unaffected."
+    "notes": "Fixed (was SILENT MISTRANSLATION, issue #1887): a positional subpattern lowers to the same member-access form a property subpattern uses (tuple Item1/Item2, or a record\u0027s property via its Deconstruct). Switch-expression bare positional patterns over a raw TUPLE are also supported: gsc\u0027s property-pattern binder/emitter/evaluator now accept a ValueTuple subject (previously GS0172)."
   },
   {
     "kind": "PostDecrementExpression",


### PR DESCRIPTION
## Problem

`RecursivePatternSyntax.PositionalPatternClause` was never inspected by the pattern translator — both `TranslateRecursivePatternTest` (is-expressions) and `TranslateRecursivePattern` (switch statement/expression arms) only looped over `.PropertyPatternClause`. Every positional subpattern vanished with **no diagnostic**, so e.g.

```csharp
p switch { (0,0) => "origin", (0,_) => "y-axis", (>0,>0) => "ne", _ => "other" }
origin is (0, 0)
```

translated to a match-anything `case { }` in every arm and `origin != nil`.

## Fix (correct-translation path)

G# has no positional-pattern syntax, but a positional subpattern reads exactly the same members a property subpattern would:
- a tuple's `Item1`/`Item2`/…
- a record's positional property, resolved via its compiler-synthesized `Deconstruct` (the out-parameter names match the record's properties)

So a positional pattern now lowers to that same nested member-access form instead of being dropped — for `is` boolean tests, and for switch statement/expression pattern arms (both bare `(0, 0) =>` and typed `Point(0, 0) =>` forms). A discard position (`(0, _)`) contributes no test, matching the existing semantics of an omitted property-pattern field.

When no canonical member mapping exists (an explicit hand-written `Deconstruct` whose out-parameter names don't match a same-named property on the type), the **existing loud** "positional subpattern has no canonical G# form yet" diagnostic now fires instead of silently dropping the subpattern — closing the bypass for that case too.

**Fallback not needed for the common/motivating cases** — tuples and records (the issue's own examples) get full correct translation.

### Related bug fixed along the way

Building the fixture below surfaced that a bare recursive pattern's base test unconditionally emitted `receiver != nil`. That's invalid for a value-type receiver (a tuple or struct) — gsc rejects `!=` against `nil` for a value type. The null check is now skipped when the receiver is a value type.

## Testing

- `tools/cs2gs/Cs2Gs.Tests/Issue1887PositionalPatternTranslationTests.cs` (new, 5 tests): is-expression + switch statement/expression positional patterns over tuples and records, arity > 2, discard positions, and the loud-diagnostic fallback for an unrelated user `Deconstruct`.
- Added the `PositionalPatternClause` construct fixture to the `G04-Patterns-Console` grid app (`tools/cs2gs/corpus/grid/G04-Patterns-Console/Constructs/PositionalPatternClause.cs`) and re-captured its baseline. Ran the full `cs2gs migrate` pipeline (translate, compile, ilverify, test-parity) for the app — all 4 stages PASS.
- One sub-case is quarantined with a code comment (mirrors the existing `RecursivePattern.cs` quarantine convention): a switch-expression arm's bare positional pattern over a tuple hits a pre-existing gsc-side limitation (GS0172 — the property-pattern matcher requires a struct/class, not a tuple). The is-expression boolean form over a tuple is unaffected and fully covered.
- `tools/cs2gs/coverage/csharp-construct-inventory.json`: `PositionalPatternClause` row updated from `Gap` to `Translated`.
- Full `Cs2Gs.Tests` suite: 775/775 passing (`dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release`).

No SyntaxKind/BoundNodeKind was added to gsc itself, so the coverage-matrix golden test is unaffected. No new sample was added, so the refactoring baseline is unaffected.

Fixes #1887
