### PR TITLE
gsc: infer generic-method type args over user generic types

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -3827,6 +3827,26 @@ public sealed class Binder
 
             InferTypeArguments(pf.ReturnType, af.ReturnType, substitution);
         }
+        else if (TryGetUserGenericArguments(parameterType, out var userParamDef, out var userParamArgs)
+            && userParamArgs.Any(TypeSymbol.ContainsTypeParameter))
+        {
+            // Issue #1932: mirror the ImportedTypeSymbol (`List[T]`) inference
+            // below for USER-DEFINED generic types (struct/class `StructSymbol`,
+            // `interface InterfaceSymbol`) — e.g. parameter `Pair[T]` matched
+            // against argument `Pair[string]`, or parameter `IHolder[T]`
+            // matched against an argument whose type implements `IHolder[string]`.
+            // Unify positionally against whichever constructed instance (the
+            // argument itself, or one of its implemented interfaces) shares the
+            // parameter's generic definition.
+            if (TryFindUserGenericArguments(argumentType, userParamDef, out var userArgArgs)
+                && userParamArgs.Length == userArgArgs.Length)
+            {
+                for (var i = 0; i < userParamArgs.Length; i++)
+                {
+                    InferTypeArguments(userParamArgs[i], userArgArgs[i], substitution);
+                }
+            }
+        }
         else if (parameterType is ImportedTypeSymbol pit && pit.HasTypeParameterArgument)
         {
             // #313: infer from a generic type parameterized by an in-scope type
@@ -3867,6 +3887,59 @@ public sealed class Binder
                 }
             }
         }
+    }
+
+    // Issue #1932: extract the generic definition + constructed type arguments
+    // of a USER-DEFINED generic type (`struct`/`class` -> StructSymbol,
+    // `interface` -> InterfaceSymbol), so generic-method inference can unify
+    // a parameter like `Pair[T]` against an argument like `Pair[string]` the
+    // same way it already does for imported CLR generics (`List[T]`).
+    private static bool TryGetUserGenericArguments(TypeSymbol type, out TypeSymbol definition, out ImmutableArray<TypeSymbol> typeArguments)
+    {
+        switch (type)
+        {
+            case StructSymbol s when !s.TypeArguments.IsDefaultOrEmpty:
+                definition = s.Definition;
+                typeArguments = s.TypeArguments;
+                return true;
+            case InterfaceSymbol i when !i.TypeArguments.IsDefaultOrEmpty:
+                definition = i.Definition;
+                typeArguments = i.TypeArguments;
+                return true;
+            default:
+                definition = null;
+                typeArguments = ImmutableArray<TypeSymbol>.Empty;
+                return false;
+        }
+    }
+
+    // Issue #1932: find the constructed type arguments for `definition` on
+    // `type` itself, or (when `type` is a struct/class) on one of its
+    // implemented interfaces — e.g. matching parameter `IHolder[T]` against
+    // an argument struct/class that implements `IHolder[string]`.
+    private static bool TryFindUserGenericArguments(TypeSymbol type, TypeSymbol definition, out ImmutableArray<TypeSymbol> typeArguments)
+    {
+        if (TryGetUserGenericArguments(type, out var ownDefinition, out typeArguments)
+            && ReferenceEquals(ownDefinition, definition))
+        {
+            return true;
+        }
+
+        if (type is StructSymbol s && !s.Interfaces.IsDefaultOrEmpty)
+        {
+            foreach (var iface in s.Interfaces)
+            {
+                if (TryGetUserGenericArguments(iface, out var ifaceDefinition, out var ifaceArgs)
+                    && ReferenceEquals(ifaceDefinition, definition))
+                {
+                    typeArguments = ifaceArgs;
+                    return true;
+                }
+            }
+        }
+
+        typeArguments = ImmutableArray<TypeSymbol>.Empty;
+        return false;
     }
 
     // #313: surface the CLR generic arguments of an argument type (e.g. the

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1932GenericMethodInferenceOverUserTypeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1932GenericMethodInferenceOverUserTypeTests.cs
@@ -1,0 +1,125 @@
+// <copyright file="Issue1932GenericMethodInferenceOverUserTypeTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1932: generic-method type-argument inference must unify a
+/// parameter over a USER-DEFINED generic type (a G# <c>struct</c>/<c>class</c>
+/// -&gt; <see cref="StructSymbol"/>, or <c>interface</c> -&gt;
+/// <see cref="InterfaceSymbol"/>) against a constructed argument of that same
+/// type, the same way it already does for imported CLR generics such as
+/// <c>List[T]</c> (issue #313). Previously only the CLR-generic path was
+/// handled in <c>Binder.InferTypeArguments</c>, so calling a generic function
+/// with a user generic struct/class/interface argument required an explicit
+/// type argument.
+/// </summary>
+public class Issue1932GenericMethodInferenceOverUserTypeTests
+{
+    [Fact]
+    public void GenericStructArgument_InfersTypeArgument_NoExplicitTypeArgNeeded()
+    {
+        var source = @"
+struct Pair[T] {
+    var First T
+    var Second T
+}
+
+func Swap[T](p Pair[T]) Pair[T] {
+    return Pair[T]{First: p.Second, Second: p.First}
+}
+
+var pair = Pair[string]{First: ""a"", Second: ""b""}
+var swapped = Swap(pair)
+swapped.First + "","" + swapped.Second
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("b,a", result.Value);
+    }
+
+    [Fact]
+    public void GenericClassArgument_InfersTypeArgument()
+    {
+        var source = @"
+class Box[T] {
+    var Value T
+}
+
+func Unwrap[T](b Box[T]) T {
+    return b.Value
+}
+
+var box = Box[int32]{Value: 42}
+Unwrap(box)
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void GenericInterfaceParameter_InfersTypeArgument_FromImplementingArgument()
+    {
+        // A user struct implementing a user generic interface must also
+        // unify: parameter `IHolder[T]` against an argument whose static type
+        // implements `IHolder[string]` (not `IHolder[T]` itself).
+        var source = @"
+interface IHolder[T] {
+    func Get() T;
+}
+
+struct StringBox : IHolder[string] {
+    var Value string
+    func Get() string { return Value }
+}
+
+func Describe[T](h IHolder[T]) T {
+    return h.Get()
+}
+
+Describe(StringBox{Value: ""hi""})
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("hi", result.Value);
+    }
+
+    [Fact]
+    public void ExplicitTypeArgument_StillWorks_ControlCase()
+    {
+        var source = @"
+struct Pair[T] {
+    var First T
+    var Second T
+}
+
+func Swap[T](p Pair[T]) Pair[T] {
+    return Pair[T]{First: p.Second, Second: p.First}
+}
+
+var pair = Pair[string]{First: ""a"", Second: ""b""}
+var swapped = Swap[string](pair)
+swapped.First
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("b", result.Value);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var syntaxTree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(syntaxTree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}

--- a/tools/cs2gs/corpus/grid/G08-Generics-Console/Constructs/TypeParameterList.cs
+++ b/tools/cs2gs/corpus/grid/G08-Generics-Console/Constructs/TypeParameterList.cs
@@ -3,10 +3,11 @@
 //   * a generic STRUCT (`struct Slot<T>` with `_content = content` in its ctor)
 //     fails translate with CS2GS-GAP "struct constructor assigns a member from
 //     something other than a plain, once-only parameter reference" — the same
-//     pattern on non-generic structs passes (G06 StructDeclaration);
-//   * calling a generic method with an INFERRED type argument over a user generic
-//     type (`Swapper.Swap(pair)`) compiles in C# but the emitted G# fails with
-//     GS0151 "Cannot infer type argument 'T'"; the call below is explicit instead.
+//     pattern on non-generic structs passes (G06 StructDeclaration).
+// gsc issue #1932 (fixed): calling a generic method with an INFERRED type
+// argument over a user generic type (`Swapper.Swap(pair)`) used to fail with
+// GS0151 "Cannot infer type argument 'T'" even though the explicit form
+// `Swapper.Swap<string>(pair)` worked; both forms are exercised below now.
 using System;
 
 namespace Corpus.Grid08
@@ -62,6 +63,9 @@ namespace Corpus.Grid08
 
             Pair<string> swapped = Swapper.Swap<string>(pair);
             Console.WriteLine("TypeParameterList: swapped-first=" + swapped.First());
+
+            Pair<string> inferredSwapped = Swapper.Swap(pair);
+            Console.WriteLine("TypeParameterList: inferred-swapped-first=" + inferredSwapped.First());
 
             IPairView<string> view = pair;
             Console.WriteLine("TypeParameterList: interface-first=" + view.First());

--- a/tools/cs2gs/corpus/grid/G08-Generics-Console/baseline.stdout.golden
+++ b/tools/cs2gs/corpus/grid/G08-Generics-Console/baseline.stdout.golden
@@ -19,5 +19,6 @@ TypeConstraint: base=ribbit
 TypeConstraint: interface=kermit
 TypeParameterList: first=left
 TypeParameterList: swapped-first=right
+TypeParameterList: inferred-swapped-first=right
 TypeParameterList: interface-first=left
 TypeParameterList: size=2


### PR DESCRIPTION
Fixes #1932

## Bug
`Binder.InferTypeArguments` only unified a generic parameter against imported CLR generics (`ImportedTypeSymbol`, e.g. `List[T]`). A parameter typed as a user-declared generic **struct/class** (`StructSymbol`) or **interface** (`InterfaceSymbol`) — e.g. `Pair[T]` — fell through every case with no match, so its type parameter was never bound and GS0151 fired even though `Swap[string](pair)` worked.

## Fix (generalized, not repro-specific)
Added one shared branch in `InferTypeArguments` (`src/Core/CodeAnalysis/Binding/Binder.cs`) that handles any user generic type:
- `TryGetUserGenericArguments` extracts `(Definition, TypeArguments)` uniformly from `StructSymbol` (covers both `struct` and `class`) or `InterfaceSymbol`.
- `TryFindUserGenericArguments` matches the argument's own generic shape against the parameter's definition, and — since a struct/class need not directly *be* the interface parameter type — also walks the argument's implemented `Interfaces` to find a matching constructed instance (so `Describe[T](h IHolder[T])` infers `T` from an argument struct that implements `IHolder[string]`).

This is the same shared inference path used by every generic-function/method call site, so the fix applies uniformly regardless of caller.

Verified manually with struct, class, and interface-implementing argument shapes (all now infer without an explicit type argument); existing explicit-type-argument and CLR-generic inference paths are unaffected.

## Tests
- `test/Core.Tests/CodeAnalysis/Binding/Issue1932GenericMethodInferenceOverUserTypeTests.cs` — struct, class, and interface-implementation inference, plus an explicit-type-argument control case.
- Un-quarantined the `grid/G08-Generics-Console/Constructs/TypeParameterList.cs` probe, which already documented this exact gap inline (`Swapper.Swap(pair)` forced to the explicit form); added the inferred call alongside it and recaptured `baseline.stdout.golden`. Verified the full `cs2gs migrate --app corpus/G08-Generics-Console` pipeline (translate/compile/ilverify/test-parity) passes green.

## DoD / judgment calls
- `tools/cs2gs/coverage/csharp-construct-inventory.json`: not updated — that ledger tracks per-Roslyn-`SyntaxKind` translation status (`cs2gs coverage` reports "in sync" after this change), not gsc compiler diagnostics. This is a gsc binder bug, not a cs2gs translation gap, so there's no matching row to update.
- No entry existed in `tools/cs2gs/triage/gaps.json` for this gap (it was only documented inline in the fixture's quarantine comment), so nothing needed removing there.

All other DoD items completed.
