### PR TITLE
cs2gs: translate C# var patterns to canonical G# forms

### DIFF
--- a/docs/cs2gs-coverage-matrix.md
+++ b/docs/cs2gs-coverage-matrix.md
@@ -6,12 +6,12 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | Status | Count |
 | --- | --- |
 | Unclassified | 0 |
-| Translated | 210 |
+| Translated | 211 |
 | Lowered | 12 |
 | UnsupportedByDesign | 56 |
-| Gap | 43 |
+| Gap | 42 |
 
-## Translated (210)
+## Translated (211)
 
 | Kind | Node type | Rule | Rationale | Fixture | Issue | Notes |
 | --- | --- | --- | --- | --- | --- | --- |
@@ -305,7 +305,7 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | XmlText | XmlTextSyntax |  | ToolingScope |  |  | Documentation/tooling structure, not program semantics; doc-comment mapping is ADR-0057 scope. |
 | XmlTextAttribute | XmlTextAttributeSyntax |  | ToolingScope |  |  | Documentation/tooling structure, not program semantics; doc-comment mapping is ADR-0057 scope. |
 
-## Gap (43)
+## Gap (42)
 
 | Kind | Node type | Rule | Rationale | Fixture | Issue | Notes |
 | --- | --- | --- | --- | --- | --- | --- |

--- a/docs/cs2gs-coverage-matrix.md
+++ b/docs/cs2gs-coverage-matrix.md
@@ -219,6 +219,7 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | UsingDirective | UsingDirectiveSyntax | ADR-0115 §B.1 |  | tools/cs2gs/corpus/grid/G06-Types-Console/Constructs/TypeAliasDeclaration.cs | https://github.com/DavidObando/gsharp/issues/1914 | Plain + simple-alias green; alias-any-type (C#12) unsupported (issue #1914). |
 | UsingStatement | UsingStatementSyntax | ADR-0115 §B.29 |  | tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/UsingStatement.cs | https://github.com/DavidObando/gsharp/issues/1903 | await using drops async-dispose semantics (issue #1903). |
 | Utf8StringLiteralExpression | LiteralExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G01-Literals-Console/Constructs/Utf8StringLiteralExpression.cs |  | C# 11 u8 literals translate and reach parity (grid G01). |
+| VarPattern | VarPatternSyntax | ADR-0115 §B.22 |  | tools/cs2gs/corpus/grid/G04-Patterns-Console/Constructs/SwitchExpression.cs |  | Always-matching bind (issue #1888, resolved): an is-pattern/loop-condition `x is var v` lowers to the literal `true` test with `v` bound directly to the receiver; a switch/property-pattern `var v` arm lowers to the G# discard `_` (gsc's own total-arm check) with `v` bound via translator-side substitution to the arm's discriminant/property receiver. |
 | VariableDeclaration | VariableDeclarationSyntax | ADR-0115 §B.3 |  |  |  |  |
 | VariableDeclarator | VariableDeclaratorSyntax | ADR-0115 §B.3 |  |  |  |  |
 | WhenClause | WhenClauseSyntax | ADR-0115 §B.22 |  |  |  | Pattern guards (issue #991, resolved). |
@@ -348,6 +349,5 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | UncheckedExpression | CheckedExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1881 |  |
 | UnsignedRightShiftAssignmentExpression | AssignmentExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1880 | Emits >>>= verbatim; never parses. |
 | UnsignedRightShiftExpression | BinaryExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1880 | Translator crash: Unknown binary operator >>>. |
-| VarPattern | VarPatternSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1888 |  |
 | WithExpression | WithExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1892 | Stray bare assignment emitted before the with-expression. |
 | WithInitializerExpression | InitializerExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1892 |  |

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1888VarPatternTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1888VarPatternTranslationTests.cs
@@ -180,6 +180,37 @@ namespace Corpus.Issue1888
         AssertRoundTripParses(rendered);
     }
 
+    [Fact]
+    public void IsPattern_VarTupleDesignation_StaysLoudGap()
+    {
+        // `var (a, b)` deconstructs — G# has no canonical form, so it must keep
+        // reporting the CS2GS-GAP rather than silently emit a bindingless match.
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", @"
+namespace Corpus.Issue1888
+{
+    public class Holder
+    {
+        public bool Describe((int, int) point)
+        {
+            if (point is var (a, b))
+            {
+                return a == b;
+            }
+
+            return false;
+        }
+    }
+}
+") });
+
+        Assert.True(project.BoundWithoutErrors);
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        Assert.Contains(context.Diagnostics, d => d.Message.Contains("tuple designation", StringComparison.Ordinal));
+    }
+
     private static void AssertRoundTripParses(string rendered)
     {
         RoundTripResult result = GSharpRoundTrip.Validate(rendered);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1888VarPatternTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1888VarPatternTranslationTests.cs
@@ -1,0 +1,209 @@
+// <copyright file="Issue1888VarPatternTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #1888: a C# <c>var</c> pattern (<c>VarPatternSyntax</c>) ALWAYS
+/// matches and binds the subject (or sub-value); it had no canonical G# form
+/// and reported the CS2GS-GAP "pattern 'VarPattern' has no canonical G# form
+/// yet". Covers all three surface positions:
+/// <list type="bullet">
+/// <item>a top-level <c>is</c>-pattern (<c>x is var v</c>) — lowers to the
+/// literal <c>true</c> test with <c>v</c> bound directly to the receiver
+/// (no narrowing, since unlike a type/declaration pattern a <c>var</c>
+/// pattern also matches <see langword="null"/>).</item>
+/// <item>a switch-expression/statement arm (<c>var v =&gt;</c>) — lowers to
+/// the G# discard <c>_</c> (gsc's own total-arm check treats a bare discard
+/// the same as an explicit <c>default:</c>), with <c>v</c> bound via a
+/// translator-side substitution to the arm's discriminant.</item>
+/// <item>a nested property subpattern (<c>{ Prop: var v }</c>) — the same
+/// discard-plus-substitution mapping, with the receiver rewritten to the
+/// member access on the enclosing property.</item>
+/// </list>
+/// </summary>
+public class Issue1888VarPatternTranslationTests
+{
+    [Fact]
+    public void IsPattern_VarBinder_LowersToAlwaysTrueTestWithDirectBind()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1888
+{
+    public class Holder
+    {
+        public string Describe(object product)
+        {
+            if (product is var captured)
+            {
+                return captured.ToString();
+            }
+
+            return ""unreachable"";
+        }
+    }
+}
+");
+
+        Assert.Contains("if true {", rendered, StringComparison.Ordinal);
+        Assert.Contains("product.ToString()", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("captured", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void SwitchExpression_VarArm_LowersToDiscardArmWithSubstitutedBind()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1888
+{
+    public class Holder
+    {
+        public string Describe(int n) => n switch
+        {
+            0 => ""zero"",
+            var v => $""other ({v})"",
+        };
+    }
+}
+");
+
+        Assert.Contains("case _:", rendered, StringComparison.Ordinal);
+        Assert.Contains("other ($n)", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void SwitchStatement_VarArm_LowersToDiscardArmWithSubstitutedBind()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1888
+{
+    public class Holder
+    {
+        public string Describe(int n)
+        {
+            switch (n)
+            {
+                case 0:
+                    return ""zero"";
+                case var v:
+                    return $""other ({v})"";
+            }
+        }
+    }
+}
+");
+
+        Assert.Contains("case _ {", rendered, StringComparison.Ordinal);
+        Assert.Contains("other ($n)", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void PropertyPattern_VarSubpattern_BindsToMemberAccessOnEnclosingProperty()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1888
+{
+    public class Address
+    {
+        public string City;
+    }
+
+    public class Person
+    {
+        public Address Address;
+    }
+
+    public class Holder
+    {
+        public string Describe(Person person)
+        {
+            if (person is { Address: var addr })
+            {
+                return addr.City;
+            }
+
+            return ""unreachable"";
+        }
+    }
+}
+");
+
+        Assert.Contains("person != nil && true", rendered, StringComparison.Ordinal);
+        Assert.Contains("person.Address.City", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("addr", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void SwitchExpression_NestedVarSubpattern_LowersToDiscardFieldWithSubstitutedBind()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1888
+{
+    public class Address
+    {
+        public string City;
+    }
+
+    public class Person
+    {
+        public string Name;
+        public Address Address;
+    }
+
+    public class Holder
+    {
+        public string Describe(Person person) => person switch
+        {
+            { Name: ""Ada"" } => ""ada"",
+            { Address: var addr } => addr.City,
+            _ => ""other"",
+        };
+    }
+}
+");
+
+        Assert.Contains("{ Address: _ }", rendered, StringComparison.Ordinal);
+        Assert.Contains("person.Address.City", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("addr", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    private static void AssertRoundTripParses(string rendered)
+    {
+        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+
+        Assert.True(
+            result.Success,
+            "Sanitized G# must round-trip-parse. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + rendered);
+    }
+
+    private static string Render(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", source) });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        Cs2Gs.CodeModel.Ast.CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        Assert.Empty(context.Diagnostics);
+        return GSharpPrinter.Print(unit);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -8094,6 +8094,20 @@ public sealed class CSharpToGSharpTranslator
                 case RecursivePatternSyntax recursive:
                     return this.TranslateRecursivePatternTest(receiver, recursive, receiverSyntax);
 
+                case VarPatternSyntax varPattern:
+                    // `x is var v` ALWAYS matches (it also matches `null`, unlike a
+                    // type/declaration pattern), so it lowers to the literal `true`
+                    // test; `v` binds directly to the receiver — no non-null
+                    // narrowing, since (unlike `x is T t`) a `var` pattern never
+                    // requires non-null (issue #1888).
+                    if (varPattern.Designation is SingleVariableDesignationSyntax varSingle &&
+                        this.context.GetDeclaredSymbol(varSingle) is { } varBound)
+                    {
+                        this.patternBindings[varBound] = receiver;
+                    }
+
+                    return LiteralExpression.Bool(true);
+
                 case UnaryPatternSyntax unary when unary.IsKind(SyntaxKind.NotPattern):
                     return this.TranslateNotPatternTest(receiver, unary.Pattern, receiverType);
 
@@ -10810,7 +10824,7 @@ public sealed class CSharpToGSharpTranslator
                 // out of scope.
                 var bindings = new List<(ISymbol Symbol, GExpression Replacement)>();
                 var usedDesignators = new HashSet<string>(StringComparer.Ordinal);
-                GPattern pattern = this.TranslatePattern(arm.Pattern, bindings, usedDesignators);
+                GPattern pattern = this.TranslatePattern(arm.Pattern, subject, bindings, usedDesignators);
 
                 foreach ((ISymbol symbol, GExpression replacement) in bindings)
                 {
@@ -10863,7 +10877,7 @@ public sealed class CSharpToGSharpTranslator
                         case CasePatternSwitchLabelSyntax patternLabel:
                             var bindings = new List<(ISymbol Symbol, GExpression Replacement)>();
                             var usedDesignators = new HashSet<string>(StringComparer.Ordinal);
-                            GPattern pattern = this.TranslatePattern(patternLabel.Pattern, bindings, usedDesignators);
+                            GPattern pattern = this.TranslatePattern(patternLabel.Pattern, subject, bindings, usedDesignators);
 
                             // Issue #1730: install the pattern's bindings before
                             // translating the `when` guard and the case body, so
@@ -11034,6 +11048,7 @@ public sealed class CSharpToGSharpTranslator
 
         private GPattern TranslatePattern(
             PatternSyntax pattern,
+            GExpression receiver,
             List<(ISymbol Symbol, GExpression Replacement)> bindings,
             HashSet<string> usedDesignators)
         {
@@ -11057,8 +11072,26 @@ public sealed class CSharpToGSharpTranslator
                         SanitizeIdentifier(variable.Identifier.Text),
                         this.MapTypeSyntax(declaration.Type));
 
+                // `var v` (a top-level switch arm, or a nested `{ Prop: var v }`
+                // subpattern — this method recurses for both) ALWAYS matches, so
+                // there is no real test to lower: it maps to the G# discard token
+                // `_` (which gsc's own exhaustiveness/binder treats as a total
+                // arm — the same as an explicit `default:` — see
+                // BindSwitchExpression's `pattern is BoundDiscardPattern` check),
+                // and `v` binds via a translator-side substitution of every
+                // reference to `receiver` (no runtime pattern is needed since
+                // `var` never narrows and also matches `null`) (issue #1888).
+                case VarPatternSyntax varPattern:
+                    if (varPattern.Designation is SingleVariableDesignationSyntax varVariable &&
+                        this.context.GetDeclaredSymbol(varVariable) is { } varBound)
+                    {
+                        bindings.Add((varBound, receiver));
+                    }
+
+                    return new DiscardPattern();
+
                 case RecursivePatternSyntax recursive:
-                    return this.TranslateRecursivePattern(recursive, bindings, usedDesignators);
+                    return this.TranslateRecursivePattern(recursive, receiver, bindings, usedDesignators);
 
                 // Issue #992: C# `and` / `or` pattern combinators map to G#
                 // `and` / `or`. C# `BinaryPatternSyntax` carries an `and`/`or`
@@ -11067,16 +11100,16 @@ public sealed class CSharpToGSharpTranslator
                     when binary.OperatorToken.IsKind(SyntaxKind.AndKeyword) || binary.OperatorToken.IsKind(SyntaxKind.OrKeyword):
                     return new BinaryPattern(
                         binary.OperatorToken.IsKind(SyntaxKind.AndKeyword),
-                        this.TranslatePattern(binary.Left, bindings, usedDesignators),
-                        this.TranslatePattern(binary.Right, bindings, usedDesignators));
+                        this.TranslatePattern(binary.Left, receiver, bindings, usedDesignators),
+                        this.TranslatePattern(binary.Right, receiver, bindings, usedDesignators));
 
                 // Issue #992: C# `not <pattern>` maps to G# `not <pattern>`.
                 case UnaryPatternSyntax unary
                     when unary.OperatorToken.IsKind(SyntaxKind.NotKeyword):
-                    return new NotPattern(this.TranslatePattern(unary.Pattern, bindings, usedDesignators));
+                    return new NotPattern(this.TranslatePattern(unary.Pattern, receiver, bindings, usedDesignators));
 
                 case ParenthesizedPatternSyntax parenthesized:
-                    return new ParenthesizedPattern(this.TranslatePattern(parenthesized.Pattern, bindings, usedDesignators));
+                    return new ParenthesizedPattern(this.TranslatePattern(parenthesized.Pattern, receiver, bindings, usedDesignators));
 
                 default:
                     this.context.ReportUnsupported(
@@ -11088,6 +11121,7 @@ public sealed class CSharpToGSharpTranslator
 
         private GPattern TranslateRecursivePattern(
             RecursivePatternSyntax recursive,
+            GExpression receiver,
             List<(ISymbol Symbol, GExpression Replacement)> bindings,
             HashSet<string> usedDesignators)
         {
@@ -11107,9 +11141,14 @@ public sealed class CSharpToGSharpTranslator
                             continue;
                         }
 
+                        string fieldName = SanitizeIdentifier(sub.NameColon.Name.Identifier.Text);
                         fields.Add(new PropertyPatternField(
-                            SanitizeIdentifier(sub.NameColon.Name.Identifier.Text),
-                            this.TranslatePattern(sub.Pattern, bindings, usedDesignators)));
+                            fieldName,
+                            this.TranslatePattern(
+                                sub.Pattern,
+                                new MemberAccessExpression(receiver, fieldName),
+                                bindings,
+                                usedDesignators)));
                     }
                 }
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -8105,6 +8105,14 @@ public sealed class CSharpToGSharpTranslator
                     {
                         this.patternBindings[varBound] = receiver;
                     }
+                    else if (varPattern.Designation is ParenthesizedVariableDesignationSyntax)
+                    {
+                        // `var (a, b)` binds the deconstructed elements; G# has no
+                        // canonical form for that, so keep the loud gap rather than
+                        // silently emit a bindingless match (issue #1888). `var _`
+                        // (discard designation) correctly stays a bindingless always-true.
+                        this.context.ReportUnsupported(varPattern, "var pattern with tuple designation ('var (a, b)') has no canonical G# form yet (ADR-0115 §B).");
+                    }
 
                     return LiteralExpression.Bool(true);
 
@@ -11087,6 +11095,10 @@ public sealed class CSharpToGSharpTranslator
                     {
                         bindings.Add((varBound, receiver));
                     }
+                    else if (varPattern.Designation is ParenthesizedVariableDesignationSyntax)
+                    {
+                        this.context.ReportUnsupported(varPattern, "var pattern with tuple designation ('var (a, b)') has no canonical G# form yet (ADR-0115 §B).");
+                    }
 
                     return new DiscardPattern();
 
@@ -11181,7 +11193,11 @@ public sealed class CSharpToGSharpTranslator
 
                         fields.Add(new PropertyPatternField(
                             SanitizeIdentifier(memberName),
-                            this.TranslatePattern(sub.Pattern, bindings, usedDesignators)));
+                            this.TranslatePattern(
+                                sub.Pattern,
+                                new MemberAccessExpression(receiver, SanitizeIdentifier(memberName)),
+                                bindings,
+                                usedDesignators)));
                     }
                 }
 

--- a/tools/cs2gs/corpus/grid/G04-Patterns-Console/Constructs/RecursivePattern.cs
+++ b/tools/cs2gs/corpus/grid/G04-Patterns-Console/Constructs/RecursivePattern.cs
@@ -1,7 +1,5 @@
 // inventory: RecursivePattern
 // NOTE: quarantined sub-cases (all fail after a clean stage-1 translation):
-//   * `var` sub-patterns inside property patterns — CS2GS-GAP at stage 1
-//     ("pattern 'VarPattern' has no canonical G# form yet").
 //   * NESTED property patterns over a reference member, e.g.
 //     `person is { Address: { City: "Lima" } }`: the lowering emits
 //     `person.Address != nil && person.Address.City == ...`. With a
@@ -15,8 +13,9 @@
 //     lowered without a cast: GS0155 ("Cannot convert type 'RpPerson?' to
 //     'object'") then GS0158 ("Cannot find member Name") on the spill local.
 // Kept: top-level property patterns on a nullable subject (constant,
-// relational, and extended `A.B:` sub-patterns) and shallow property-pattern
-// arms in a switch expression over a non-nullable subject.
+// relational, and extended `A.B:` sub-patterns), a `{ Prop: var v }` binder
+// sub-pattern (issue #1888, resolved), and shallow property-pattern arms in a
+// switch expression over a non-nullable subject.
 using System;
 
 namespace Corpus.Grid04.Constructs
@@ -42,14 +41,20 @@ namespace Corpus.Grid04.Constructs
             bool shortName = person is { Name.Length: 3 };
             Console.WriteLine($"RecursivePattern: name length 3 = {shortName}");
 
+            if (person is { Address: var addr })
+            {
+                Console.WriteLine($"RecursivePattern: nested var binds address city = {addr.City}");
+            }
+
             RpPerson router = new RpPerson("Bea", new RpAddress("Cusco", 8000));
             string route = router switch
             {
                 { Name: "Ada" } => "ada route",
-                { Name: "Bea" } => "bea route",
+                { Address: var routedAddr } => $"routed via {routedAddr.City}",
                 _ => "other route",
             };
             Console.WriteLine($"RecursivePattern: routed to {route}");
         }
     }
 }
+

--- a/tools/cs2gs/corpus/grid/G04-Patterns-Console/Constructs/SwitchExpression.cs
+++ b/tools/cs2gs/corpus/grid/G04-Patterns-Console/Constructs/SwitchExpression.cs
@@ -1,7 +1,4 @@
 // inventory: SwitchExpression
-// NOTE: quarantined sub-case: a `var` binder arm (`var v => ...`) fails stage 1
-// with CS2GS-GAP "pattern 'VarPattern' has no canonical G# form yet
-// (ADR-0115 §B)". A discard arm stands in for the catch-all below.
 using System;
 
 namespace Corpus.Grid04.Constructs
@@ -17,7 +14,7 @@ namespace Corpus.Grid04.Constructs
                     < 0 => "negative",
                     0 => "zero",
                     int v when v % 4 == 0 => $"multiple of four ({v})",
-                    _ => "plain positive",
+                    var v => $"plain positive ({v})",
                 };
                 Console.WriteLine($"SwitchExpression: {n} -> {label}");
             }

--- a/tools/cs2gs/corpus/grid/G04-Patterns-Console/baseline.stdout.golden
+++ b/tools/cs2gs/corpus/grid/G04-Patterns-Console/baseline.stdout.golden
@@ -59,7 +59,8 @@ PositionalPatternClause: (3, 4) tuple-> ne
 RecursivePattern: person is in Lima = True
 RecursivePattern: person has a Lima-range zip
 RecursivePattern: name length 3 = True
-RecursivePattern: routed to bea route
+RecursivePattern: nested var binds address city = Lima
+RecursivePattern: routed to routed via Cusco
 RelationalPattern: -10 degrees is freezing
 RelationalPattern: 0 degrees is cold
 RelationalPattern: 15 degrees is cold
@@ -69,6 +70,6 @@ RelationalPattern: 41 degrees is hot
 RelationalPattern: 8 is > 0 = True, 8 is <= 8 = True
 SwitchExpression: -2 -> negative
 SwitchExpression: 0 -> zero
-SwitchExpression: 2 -> plain positive
+SwitchExpression: 2 -> plain positive (2)
 SwitchExpression: 4 -> multiple of four (4)
 SwitchExpression: quarter 3 -> summer

--- a/tools/cs2gs/coverage/csharp-construct-inventory.json
+++ b/tools/cs2gs/coverage/csharp-construct-inventory.json
@@ -2345,9 +2345,11 @@
   {
     "kind": "VarPattern",
     "nodeType": "VarPatternSyntax",
-    "status": "Gap",
+    "status": "Translated",
+    "rule": "ADR-0115 \u00A7B.22",
     "rationale": "None",
-    "issue": "https://github.com/DavidObando/gsharp/issues/1888"
+    "fixture": "tools/cs2gs/corpus/grid/G04-Patterns-Console/Constructs/SwitchExpression.cs",
+    "notes": "Always-matching bind (issue #1888, resolved): an is-pattern/loop-condition \u0060x is var v\u0060 lowers to the literal \u0060true\u0060 test with \u0060v\u0060 bound directly to the receiver; a switch/property-pattern \u0060var v\u0060 arm lowers to the G# discard \u0060_\u0060 (gsc\u0027s own total-arm check) with \u0060v\u0060 bound via translator-side substitution to the arm\u0027s discriminant/property receiver."
   },
   {
     "kind": "VariableDeclaration",


### PR DESCRIPTION
## Summary

C# `var` patterns (`VarPatternSyntax`) ALWAYS match and bind the subject (or sub-value), but cs2gs had no canonical G# translation for them and reported `CS2GS-GAP: is-pattern/pattern 'VarPattern' has no canonical G# form yet`.

Handles all three surface positions:

- **is-pattern / loop-condition** (`x is var v`): lowers to the literal `true` test with `v` bound directly to the receiver — no narrowing, since (unlike a type/declaration pattern) `var` also matches `null`.
- **switch-expression/statement arm** (`var v => ...`): lowers to the G# discard `_`. gsc's own exhaustiveness/binder check (`pattern is BoundDiscardPattern`) already treats a bare discard as a total arm equivalent to `default:`, so this satisfies gsc's "switch expression must have a default arm" requirement without a real runtime test. `v` binds via a translator-side substitution of every reference to the arm's discriminant expression.
- **nested property subpattern** (`{ Prop: var v }`): the same discard + substitution mapping, with the receiver rewritten to the member access on the enclosing property. `TranslatePattern`/`TranslateRecursivePattern` now thread the receiver expression through recursive calls so the substitution reaches any nesting depth (top-level arm, `and`/`or`/`not` combinators, or a property field).

## Corpus / coverage

- Un-quarantines the `G04-Patterns-Console` grid app's var-pattern sub-cases (`SwitchExpression.cs`, `RecursivePattern.cs`) and recaptures its `baseline.stdout.golden`.
- `migrate --app G04-Patterns-Console`: translate/compile/ilverify/test-parity all **PASS**.
- Updates the `VarPattern` row in `tools/cs2gs/coverage/csharp-construct-inventory.json` from `Gap` to `Translated`, and regenerates `docs/cs2gs-coverage-matrix.md` + the Roslyn-surface golden via `cs2gs coverage --write`.

## Tests

- New `Issue1888VarPatternTranslationTests` (5 tests) covering all three positions plus a nested-var-in-switch variant.
- Full `Cs2Gs.Tests` suite: 781/781 passed.

Fixes #1888