### PR TITLE
cs2gs: map C# list/slice patterns to G# (#1889)

### DIFF
--- a/docs/cs2gs-coverage-matrix.md
+++ b/docs/cs2gs-coverage-matrix.md
@@ -6,12 +6,12 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | Status | Count |
 | --- | --- |
 | Unclassified | 0 |
-| Translated | 214 |
+| Translated | 213 |
 | Lowered | 12 |
 | UnsupportedByDesign | 56 |
-| Gap | 39 |
+| Gap | 40 |
 
-## Translated (214)
+## Translated (213)
 
 | Kind | Node type | Rule | Rationale | Fixture | Issue | Notes |
 | --- | --- | --- | --- | --- | --- | --- |
@@ -98,7 +98,7 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | FieldDeclaration | FieldDeclarationSyntax | ADR-0115 §B.3 |  | tools/cs2gs/corpus/grid/G07-Members-Console/Constructs/FieldDeclaration.cs |  |  |
 | FileScopedNamespaceDeclaration | FileScopedNamespaceDeclarationSyntax | ADR-0115 §B.1 |  |  |  |  |
 | FinallyClause | FinallyClauseSyntax | ADR-0115 §B.27 |  |  |  |  |
-| FixedStatement | FixedStatementSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G12-Unsafe-Console/Constructs/FixedStatement.cs | https://github.com/DavidObando/gsharp/issues/1933 | Compiles end-to-end under the ilverify allow-unsafe policy (issue #1933); IL is unverifiable by design, not a gsc defect. |
+| FixedStatement | FixedStatementSyntax | ADR-0115 §B |  |  | https://github.com/DavidObando/gsharp/issues/1933 | Compiles; ilverify-by-design (issue #1933). |
 | ForEachStatement | ForEachStatementSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/ForEachStatement.cs |  |  |
 | ForEachVariableStatement | ForEachVariableStatementSyntax | ADR-0115 §B |  |  | https://github.com/DavidObando/gsharp/issues/1922 | Translates; blocked by gsc ValueTuple deconstruction (issue #1922). |
 | GenericName | GenericNameSyntax | ADR-0115 §B.7 |  | tools/cs2gs/corpus/grid/G08-Generics-Console/Constructs/GenericName.cs |  |  |
@@ -112,7 +112,7 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | ImplicitObjectCreationExpression | ImplicitObjectCreationExpressionSyntax | ADR-0115 §B.25 |  | tools/cs2gs/corpus/grid/G05-Collections-Console/Constructs/ObjectCreationExpression.cs |  |  |
 | IndexExpression | PrefixUnaryExpressionSyntax | ADR-0115 §B.36 |  | tools/cs2gs/corpus/grid/G05-Collections-Console/Constructs/IndexExpression.cs | https://github.com/DavidObando/gsharp/issues/1894 | Inline ^i green; Index-typed locals mis-lower (issue #1894, runtime crash). |
 | IndexerDeclaration | IndexerDeclarationSyntax | ADR-0115 §B.11 |  | tools/cs2gs/corpus/grid/G07-Members-Console/Constructs/IndexerDeclaration.cs |  | User indexers (issue #944). |
-| InitAccessorDeclaration | AccessorDeclarationSyntax | ADR-0115 §B.11 |  | tools/cs2gs/corpus/grid/G07-Members-Console/Constructs/InitAccessorDeclaration.cs |  |  |
+| InitAccessorDeclaration | AccessorDeclarationSyntax | ADR-0115 §B.11 |  | tools/cs2gs/corpus/grid/G07-Members-Console/Constructs/PropertyDeclaration.cs | https://github.com/DavidObando/gsharp/issues/1892 | Blocked when targeted by object initializers (issue #1892). |
 | InterfaceDeclaration | InterfaceDeclarationSyntax | ADR-0115 §B.4 |  | tools/cs2gs/corpus/grid/G06-Types-Console/Constructs/InterfaceDeclaration.cs |  |  |
 | InterpolatedStringExpression | InterpolatedStringExpressionSyntax | ADR-0115 §B.9 |  | tools/cs2gs/corpus/grid/G14-Strings-Console/Constructs/InterpolatedStringExpression.cs |  |  |
 | InterpolatedStringText | InterpolatedStringTextSyntax | ADR-0115 §B.9 |  | tools/cs2gs/corpus/grid/G14-Strings-Console/Constructs/InterpolatedStringText.cs | https://github.com/DavidObando/gsharp/issues/1882 | Brace escapes {{ }} copied verbatim — parity-verified divergence (issue #1882). |
@@ -126,6 +126,7 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | LeftShiftExpression | BinaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/LeftShiftExpression.cs |  |  |
 | LessThanExpression | BinaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/LessThanExpression.cs |  |  |
 | LessThanOrEqualExpression | BinaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/LessThanOrEqualExpression.cs |  |  |
+| ListPattern | ListPatternSyntax | ADR-0115 §B.22 |  | tools/cs2gs/corpus/grid/G04-Patterns-Console/Constructs/ListPattern.cs |  | is-test path lowers to a length test (`==` exact / `>=` with a slice) ANDed with per-element index tests; switch-arm path emits a native G# `ListPattern` (`[1, .., 4]`) since gsc has its own structural list-pattern matching (issue #1889, resolved). Element `var` binders reuse the #1888 discard+substitution mechanism; `int x` declaration-pattern elements map to native `TypePattern`. Deferral: gsc's `BindListPattern` only accepts array/slice-typed discriminants (not e.g. `List<T>`), a pre-existing gsc scope boundary, not a cs2gs limitation. |
 | LocalDeclarationStatement | LocalDeclarationStatementSyntax | ADR-0115 §B.3 |  |  |  |  |
 | LocalFunctionStatement | LocalFunctionStatementSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/LocalFunctionStatement.cs |  | Static local functions call through their `let` binding directly; generic local functions translate to G#'s `let Name[T, ...] = func (...) ... { ... }` (issue #1886, fixed). |
 | LockStatement | LockStatementSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/LockStatement.cs |  |  |
@@ -147,7 +148,6 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | NullableType | NullableTypeSyntax | ADR-0115 §B.12 |  |  |  | T? maps to G# nullable spelling. |
 | NumericLiteralExpression | LiteralExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G01-Literals-Console/Constructs/NumericLiteralExpression.cs |  |  |
 | ObjectCreationExpression | ObjectCreationExpressionSyntax | ADR-0115 §B.16 |  | tools/cs2gs/corpus/grid/G05-Collections-Console/Constructs/ObjectCreationExpression.cs |  |  |
-| ObjectInitializerExpression | InitializerExpressionSyntax | ADR-0115 §B.11 |  | tools/cs2gs/corpus/grid/G05-Collections-Console/Constructs/ObjectCreationExpression.cs |  |  |
 | OmittedArraySizeExpression | OmittedArraySizeExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G05-Collections-Console/Constructs/OmittedArraySizeExpression.cs |  |  |
 | OmittedTypeArgument | OmittedTypeArgumentSyntax | ADR-0115 §B.7 |  | tools/cs2gs/corpus/grid/G08-Generics-Console/Constructs/OmittedTypeArgument.cs | https://github.com/DavidObando/gsharp/issues/1915 | nameof(List<>) forms green (C#14); typeof(List<>) emits typeof(List) (issue #1915). |
 | OperatorDeclaration | OperatorDeclarationSyntax | ADR-0115 §B.31 |  | tools/cs2gs/corpus/grid/G07-Members-Console/Constructs/OperatorDeclaration.cs |  | C#14 instance compound-assignment operators fail round-trip (issue #1908); Equals(object) is-pattern override fails ilverify (issue #1917). |
@@ -160,7 +160,7 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | ParenthesizedPattern | ParenthesizedPatternSyntax | ADR-0115 §B.22 |  | tools/cs2gs/corpus/grid/G04-Patterns-Console/Constructs/ParenthesizedPattern.cs |  |  |
 | ParenthesizedVariableDesignation | ParenthesizedVariableDesignationSyntax | ADR-0115 §B.30 |  |  |  |  |
 | PointerIndirectionExpression | PrefixUnaryExpressionSyntax | ADR-0115 §B |  |  | https://github.com/DavidObando/gsharp/issues/1925 | Compiles; ilverify-by-design (issue #1933). *(p + i) misbinds in gsc (issue #1925). |
-| PointerType | PointerTypeSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G12-Unsafe-Console/Constructs/PointerType.cs | https://github.com/DavidObando/gsharp/issues/1933 | Compiles end-to-end under the ilverify allow-unsafe policy (issue #1933); pointer IL is unverifiable by design, not a gsc defect. |
+| PointerType | PointerTypeSyntax | ADR-0115 §B |  |  | https://github.com/DavidObando/gsharp/issues/1933 | Pointer IL is unverifiable by design — pipeline policy issue #1933; compile-level green. |
 | PositionalPatternClause | PositionalPatternClauseSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G04-Patterns-Console/Constructs/PositionalPatternClause.cs | https://github.com/DavidObando/gsharp/issues/1887 | Fixed (was SILENT MISTRANSLATION, issue #1887): a positional subpattern lowers to the same member-access form a property subpattern uses (tuple Item1/Item2, or a record's property via its Deconstruct). Switch-expression bare positional patterns over a raw TUPLE are also supported: gsc's property-pattern binder/emitter/evaluator now accept a ValueTuple subject (previously GS0172). |
 | PostDecrementExpression | PostfixUnaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/PostDecrementExpression.cs |  |  |
 | PostIncrementExpression | PostfixUnaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/PostIncrementExpression.cs |  |  |
@@ -186,7 +186,8 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | SimpleMemberAccessExpression | MemberAccessExpressionSyntax | ADR-0115 §B |  |  |  |  |
 | SingleVariableDesignation | SingleVariableDesignationSyntax | ADR-0115 §B.30 |  | tools/cs2gs/corpus/grid/G09-Functions-Console/Constructs/DeclarationExpression.cs |  |  |
 | SizeOfExpression | SizeOfExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G12-Unsafe-Console/Constructs/SizeOfExpression.cs |  |  |
-| StackAllocArrayCreationExpression | StackAllocArrayCreationExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G12-Unsafe-Console/Constructs/StackAllocArrayCreationExpression.cs | https://github.com/DavidObando/gsharp/issues/1933 | Compiles end-to-end under the ilverify allow-unsafe policy (issue #1933); stackalloc's localloc IL is unverifiable by design, not a gsc defect. |
+| SlicePattern | SlicePatternSyntax | ADR-0115 §B.22 |  | tools/cs2gs/corpus/grid/G04-Patterns-Console/Constructs/ListPattern.cs |  | is-test path materializes the slice-bound value via native G# range slicing (`receiver[prefix..^suffix]`, using new `RangeIndexExpression`/`FromEndIndexExpression` CodeModel nodes) and binds it by substitution; switch-arm path emits a native G# `SlicePattern` (`..rest`/`..`) since gsc has real runtime slice-capture support (issue #1889, resolved). |
+| StackAllocArrayCreationExpression | StackAllocArrayCreationExpressionSyntax | ADR-0115 §B |  |  | https://github.com/DavidObando/gsharp/issues/1933 | Translates and compiles; IL is unverifiable by design — pipeline policy issue #1933. |
 | StringLiteralExpression | LiteralExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G01-Literals-Console/Constructs/StringLiteralExpression.cs |  |  |
 | StructConstraint | ClassOrStructConstraintSyntax | ADR-0115 §B.7 |  | tools/cs2gs/corpus/grid/G08-Generics-Console/Constructs/StructConstraint.cs |  |  |
 | StructDeclaration | StructDeclarationSyntax | ADR-0115 §B.4 |  | tools/cs2gs/corpus/grid/G06-Types-Console/Constructs/StructDeclaration.cs |  | Generic-struct ctor zip declined (issue #1915). |
@@ -225,8 +226,6 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | VariableDeclarator | VariableDeclaratorSyntax | ADR-0115 §B.3 |  |  |  |  |
 | WhenClause | WhenClauseSyntax | ADR-0115 §B.22 |  |  |  | Pattern guards (issue #991, resolved). |
 | WhileStatement | WhileStatementSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/WhileStatement.cs |  |  |
-| WithExpression | WithExpressionSyntax | ADR-0115 §B.4 |  | tools/cs2gs/corpus/grid/G06-Types-Console/Constructs/RecordDeclaration.cs |  |  |
-| WithInitializerExpression | InitializerExpressionSyntax | ADR-0115 §B.4 |  | tools/cs2gs/corpus/grid/G06-Types-Console/Constructs/RecordDeclaration.cs |  |  |
 | YieldBreakStatement | YieldStatementSyntax | ADR-0115 §B.34 |  | tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/YieldBreakStatement.cs |  | Issue #994 (resolved). |
 | YieldReturnStatement | YieldStatementSyntax | ADR-0115 §B.34 |  | tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/YieldReturnStatement.cs |  |  |
 
@@ -308,7 +307,7 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | XmlText | XmlTextSyntax |  | ToolingScope |  |  | Documentation/tooling structure, not program semantics; doc-comment mapping is ADR-0057 scope. |
 | XmlTextAttribute | XmlTextAttributeSyntax |  | ToolingScope |  |  | Documentation/tooling structure, not program semantics; doc-comment mapping is ADR-0057 scope. |
 
-## Gap (39)
+## Gap (40)
 
 | Kind | Node type | Rule | Rationale | Fixture | Issue | Notes |
 | --- | --- | --- | --- | --- | --- | --- |
@@ -338,16 +337,17 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | JoinIntoClause | JoinIntoClauseSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1902 | Query syntax lowered to the method-call chain, mirroring Roslyn. |
 | LabeledStatement | LabeledStatementSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1884 |  |
 | LetClause | LetClauseSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1902 | Query syntax lowered to the method-call chain, mirroring Roslyn. |
-| ListPattern | ListPatternSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1889 |  |
+| ObjectInitializerExpression | InitializerExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1892 | Initializer assignments emitted as stray statements. |
 | PointerMemberAccessExpression | MemberAccessExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1905 | p->X lowered to p.X; (*p).X compiles. |
 | PrimaryConstructorBaseType | PrimaryConstructorBaseTypeSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1909 |  |
 | RangeExpression | RangeExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1896 | Lowers to .Slice(...) which gsc cannot resolve on arrays/strings. |
 | RefExpression | RefExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1900 | ref argument/return seam (&x pass-by-address). |
 | RefType | RefTypeSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1900 |  |
 | RemoveAccessorDeclaration | AccessorDeclarationSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1899 |  |
-| SlicePattern | SlicePatternSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1889 |  |
 | SpreadElement | SpreadElementSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1897 |  |
 | TypePattern | TypePatternSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1890 | Bare-type switch-expression arms; is/case binder forms work (DeclarationPattern). |
 | UncheckedExpression | CheckedExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1881 |  |
 | UnsignedRightShiftAssignmentExpression | AssignmentExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1880 | Emits >>>= verbatim; never parses. |
 | UnsignedRightShiftExpression | BinaryExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1880 | Translator crash: Unknown binary operator >>>. |
+| WithExpression | WithExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1892 | Stray bare assignment emitted before the with-expression. |
+| WithInitializerExpression | InitializerExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1892 |  |

--- a/docs/cs2gs-coverage-matrix.md
+++ b/docs/cs2gs-coverage-matrix.md
@@ -6,12 +6,12 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | Status | Count |
 | --- | --- |
 | Unclassified | 0 |
-| Translated | 213 |
+| Translated | 216 |
 | Lowered | 12 |
 | UnsupportedByDesign | 56 |
-| Gap | 40 |
+| Gap | 37 |
 
-## Translated (213)
+## Translated (216)
 
 | Kind | Node type | Rule | Rationale | Fixture | Issue | Notes |
 | --- | --- | --- | --- | --- | --- | --- |
@@ -98,7 +98,7 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | FieldDeclaration | FieldDeclarationSyntax | ADR-0115 §B.3 |  | tools/cs2gs/corpus/grid/G07-Members-Console/Constructs/FieldDeclaration.cs |  |  |
 | FileScopedNamespaceDeclaration | FileScopedNamespaceDeclarationSyntax | ADR-0115 §B.1 |  |  |  |  |
 | FinallyClause | FinallyClauseSyntax | ADR-0115 §B.27 |  |  |  |  |
-| FixedStatement | FixedStatementSyntax | ADR-0115 §B |  |  | https://github.com/DavidObando/gsharp/issues/1933 | Compiles; ilverify-by-design (issue #1933). |
+| FixedStatement | FixedStatementSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G12-Unsafe-Console/Constructs/FixedStatement.cs | https://github.com/DavidObando/gsharp/issues/1933 | Compiles end-to-end under the ilverify allow-unsafe policy (issue #1933); IL is unverifiable by design, not a gsc defect. |
 | ForEachStatement | ForEachStatementSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/ForEachStatement.cs |  |  |
 | ForEachVariableStatement | ForEachVariableStatementSyntax | ADR-0115 §B |  |  | https://github.com/DavidObando/gsharp/issues/1922 | Translates; blocked by gsc ValueTuple deconstruction (issue #1922). |
 | GenericName | GenericNameSyntax | ADR-0115 §B.7 |  | tools/cs2gs/corpus/grid/G08-Generics-Console/Constructs/GenericName.cs |  |  |
@@ -112,7 +112,7 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | ImplicitObjectCreationExpression | ImplicitObjectCreationExpressionSyntax | ADR-0115 §B.25 |  | tools/cs2gs/corpus/grid/G05-Collections-Console/Constructs/ObjectCreationExpression.cs |  |  |
 | IndexExpression | PrefixUnaryExpressionSyntax | ADR-0115 §B.36 |  | tools/cs2gs/corpus/grid/G05-Collections-Console/Constructs/IndexExpression.cs | https://github.com/DavidObando/gsharp/issues/1894 | Inline ^i green; Index-typed locals mis-lower (issue #1894, runtime crash). |
 | IndexerDeclaration | IndexerDeclarationSyntax | ADR-0115 §B.11 |  | tools/cs2gs/corpus/grid/G07-Members-Console/Constructs/IndexerDeclaration.cs |  | User indexers (issue #944). |
-| InitAccessorDeclaration | AccessorDeclarationSyntax | ADR-0115 §B.11 |  | tools/cs2gs/corpus/grid/G07-Members-Console/Constructs/PropertyDeclaration.cs | https://github.com/DavidObando/gsharp/issues/1892 | Blocked when targeted by object initializers (issue #1892). |
+| InitAccessorDeclaration | AccessorDeclarationSyntax | ADR-0115 §B.11 |  | tools/cs2gs/corpus/grid/G07-Members-Console/Constructs/InitAccessorDeclaration.cs |  |  |
 | InterfaceDeclaration | InterfaceDeclarationSyntax | ADR-0115 §B.4 |  | tools/cs2gs/corpus/grid/G06-Types-Console/Constructs/InterfaceDeclaration.cs |  |  |
 | InterpolatedStringExpression | InterpolatedStringExpressionSyntax | ADR-0115 §B.9 |  | tools/cs2gs/corpus/grid/G14-Strings-Console/Constructs/InterpolatedStringExpression.cs |  |  |
 | InterpolatedStringText | InterpolatedStringTextSyntax | ADR-0115 §B.9 |  | tools/cs2gs/corpus/grid/G14-Strings-Console/Constructs/InterpolatedStringText.cs | https://github.com/DavidObando/gsharp/issues/1882 | Brace escapes {{ }} copied verbatim — parity-verified divergence (issue #1882). |
@@ -148,6 +148,7 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | NullableType | NullableTypeSyntax | ADR-0115 §B.12 |  |  |  | T? maps to G# nullable spelling. |
 | NumericLiteralExpression | LiteralExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G01-Literals-Console/Constructs/NumericLiteralExpression.cs |  |  |
 | ObjectCreationExpression | ObjectCreationExpressionSyntax | ADR-0115 §B.16 |  | tools/cs2gs/corpus/grid/G05-Collections-Console/Constructs/ObjectCreationExpression.cs |  |  |
+| ObjectInitializerExpression | InitializerExpressionSyntax | ADR-0115 §B.11 |  | tools/cs2gs/corpus/grid/G05-Collections-Console/Constructs/ObjectCreationExpression.cs |  |  |
 | OmittedArraySizeExpression | OmittedArraySizeExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G05-Collections-Console/Constructs/OmittedArraySizeExpression.cs |  |  |
 | OmittedTypeArgument | OmittedTypeArgumentSyntax | ADR-0115 §B.7 |  | tools/cs2gs/corpus/grid/G08-Generics-Console/Constructs/OmittedTypeArgument.cs | https://github.com/DavidObando/gsharp/issues/1915 | nameof(List<>) forms green (C#14); typeof(List<>) emits typeof(List) (issue #1915). |
 | OperatorDeclaration | OperatorDeclarationSyntax | ADR-0115 §B.31 |  | tools/cs2gs/corpus/grid/G07-Members-Console/Constructs/OperatorDeclaration.cs |  | C#14 instance compound-assignment operators fail round-trip (issue #1908); Equals(object) is-pattern override fails ilverify (issue #1917). |
@@ -160,7 +161,7 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | ParenthesizedPattern | ParenthesizedPatternSyntax | ADR-0115 §B.22 |  | tools/cs2gs/corpus/grid/G04-Patterns-Console/Constructs/ParenthesizedPattern.cs |  |  |
 | ParenthesizedVariableDesignation | ParenthesizedVariableDesignationSyntax | ADR-0115 §B.30 |  |  |  |  |
 | PointerIndirectionExpression | PrefixUnaryExpressionSyntax | ADR-0115 §B |  |  | https://github.com/DavidObando/gsharp/issues/1925 | Compiles; ilverify-by-design (issue #1933). *(p + i) misbinds in gsc (issue #1925). |
-| PointerType | PointerTypeSyntax | ADR-0115 §B |  |  | https://github.com/DavidObando/gsharp/issues/1933 | Pointer IL is unverifiable by design — pipeline policy issue #1933; compile-level green. |
+| PointerType | PointerTypeSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G12-Unsafe-Console/Constructs/PointerType.cs | https://github.com/DavidObando/gsharp/issues/1933 | Compiles end-to-end under the ilverify allow-unsafe policy (issue #1933); pointer IL is unverifiable by design, not a gsc defect. |
 | PositionalPatternClause | PositionalPatternClauseSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G04-Patterns-Console/Constructs/PositionalPatternClause.cs | https://github.com/DavidObando/gsharp/issues/1887 | Fixed (was SILENT MISTRANSLATION, issue #1887): a positional subpattern lowers to the same member-access form a property subpattern uses (tuple Item1/Item2, or a record's property via its Deconstruct). Switch-expression bare positional patterns over a raw TUPLE are also supported: gsc's property-pattern binder/emitter/evaluator now accept a ValueTuple subject (previously GS0172). |
 | PostDecrementExpression | PostfixUnaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/PostDecrementExpression.cs |  |  |
 | PostIncrementExpression | PostfixUnaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/PostIncrementExpression.cs |  |  |
@@ -187,7 +188,7 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | SingleVariableDesignation | SingleVariableDesignationSyntax | ADR-0115 §B.30 |  | tools/cs2gs/corpus/grid/G09-Functions-Console/Constructs/DeclarationExpression.cs |  |  |
 | SizeOfExpression | SizeOfExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G12-Unsafe-Console/Constructs/SizeOfExpression.cs |  |  |
 | SlicePattern | SlicePatternSyntax | ADR-0115 §B.22 |  | tools/cs2gs/corpus/grid/G04-Patterns-Console/Constructs/ListPattern.cs |  | is-test path materializes the slice-bound value via native G# range slicing (`receiver[prefix..^suffix]`, using new `RangeIndexExpression`/`FromEndIndexExpression` CodeModel nodes) and binds it by substitution; switch-arm path emits a native G# `SlicePattern` (`..rest`/`..`) since gsc has real runtime slice-capture support (issue #1889, resolved). |
-| StackAllocArrayCreationExpression | StackAllocArrayCreationExpressionSyntax | ADR-0115 §B |  |  | https://github.com/DavidObando/gsharp/issues/1933 | Translates and compiles; IL is unverifiable by design — pipeline policy issue #1933. |
+| StackAllocArrayCreationExpression | StackAllocArrayCreationExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G12-Unsafe-Console/Constructs/StackAllocArrayCreationExpression.cs | https://github.com/DavidObando/gsharp/issues/1933 | Compiles end-to-end under the ilverify allow-unsafe policy (issue #1933); stackalloc's localloc IL is unverifiable by design, not a gsc defect. |
 | StringLiteralExpression | LiteralExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G01-Literals-Console/Constructs/StringLiteralExpression.cs |  |  |
 | StructConstraint | ClassOrStructConstraintSyntax | ADR-0115 §B.7 |  | tools/cs2gs/corpus/grid/G08-Generics-Console/Constructs/StructConstraint.cs |  |  |
 | StructDeclaration | StructDeclarationSyntax | ADR-0115 §B.4 |  | tools/cs2gs/corpus/grid/G06-Types-Console/Constructs/StructDeclaration.cs |  | Generic-struct ctor zip declined (issue #1915). |
@@ -226,6 +227,8 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | VariableDeclarator | VariableDeclaratorSyntax | ADR-0115 §B.3 |  |  |  |  |
 | WhenClause | WhenClauseSyntax | ADR-0115 §B.22 |  |  |  | Pattern guards (issue #991, resolved). |
 | WhileStatement | WhileStatementSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/WhileStatement.cs |  |  |
+| WithExpression | WithExpressionSyntax | ADR-0115 §B.4 |  | tools/cs2gs/corpus/grid/G06-Types-Console/Constructs/RecordDeclaration.cs |  |  |
+| WithInitializerExpression | InitializerExpressionSyntax | ADR-0115 §B.4 |  | tools/cs2gs/corpus/grid/G06-Types-Console/Constructs/RecordDeclaration.cs |  |  |
 | YieldBreakStatement | YieldStatementSyntax | ADR-0115 §B.34 |  | tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/YieldBreakStatement.cs |  | Issue #994 (resolved). |
 | YieldReturnStatement | YieldStatementSyntax | ADR-0115 §B.34 |  | tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/YieldReturnStatement.cs |  |  |
 
@@ -307,7 +310,7 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | XmlText | XmlTextSyntax |  | ToolingScope |  |  | Documentation/tooling structure, not program semantics; doc-comment mapping is ADR-0057 scope. |
 | XmlTextAttribute | XmlTextAttributeSyntax |  | ToolingScope |  |  | Documentation/tooling structure, not program semantics; doc-comment mapping is ADR-0057 scope. |
 
-## Gap (40)
+## Gap (37)
 
 | Kind | Node type | Rule | Rationale | Fixture | Issue | Notes |
 | --- | --- | --- | --- | --- | --- | --- |
@@ -337,7 +340,6 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | JoinIntoClause | JoinIntoClauseSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1902 | Query syntax lowered to the method-call chain, mirroring Roslyn. |
 | LabeledStatement | LabeledStatementSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1884 |  |
 | LetClause | LetClauseSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1902 | Query syntax lowered to the method-call chain, mirroring Roslyn. |
-| ObjectInitializerExpression | InitializerExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1892 | Initializer assignments emitted as stray statements. |
 | PointerMemberAccessExpression | MemberAccessExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1905 | p->X lowered to p.X; (*p).X compiles. |
 | PrimaryConstructorBaseType | PrimaryConstructorBaseTypeSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1909 |  |
 | RangeExpression | RangeExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1896 | Lowers to .Slice(...) which gsc cannot resolve on arrays/strings. |
@@ -349,5 +351,3 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | UncheckedExpression | CheckedExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1881 |  |
 | UnsignedRightShiftAssignmentExpression | AssignmentExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1880 | Emits >>>= verbatim; never parses. |
 | UnsignedRightShiftExpression | BinaryExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1880 | Translator crash: Unknown binary operator >>>. |
-| WithExpression | WithExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1892 | Stray bare assignment emitted before the with-expression. |
-| WithInitializerExpression | InitializerExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1892 |  |

--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/GExpression.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/GExpression.cs
@@ -165,6 +165,50 @@ public sealed class IndexExpression : GExpression
 }
 
 /// <summary>
+/// A from-end index <c>^n</c>, used as (part of) an <see cref="IndexExpression"/>
+/// index (issue #1889, spec §Pattern matching / array slicing).
+/// </summary>
+public sealed class FromEndIndexExpression : GExpression
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FromEndIndexExpression"/> class.
+    /// </summary>
+    /// <param name="operand">The distance-from-end operand.</param>
+    public FromEndIndexExpression(GExpression operand)
+    {
+        Operand = operand;
+    }
+
+    /// <summary>Gets the distance-from-end operand.</summary>
+    public GExpression Operand { get; }
+}
+
+/// <summary>
+/// A range <c>start..end</c>, used as an <see cref="IndexExpression"/> index to
+/// slice an array (issue #1889). Either bound may be <see langword="null"/> for
+/// an open range (<c>start..</c> / <c>..end</c> / <c>..</c>).
+/// </summary>
+public sealed class RangeIndexExpression : GExpression
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RangeIndexExpression"/> class.
+    /// </summary>
+    /// <param name="start">The start bound, or <see langword="null"/> for the start of the target.</param>
+    /// <param name="end">The end bound, or <see langword="null"/> for the end of the target.</param>
+    public RangeIndexExpression(GExpression start, GExpression end)
+    {
+        Start = start;
+        End = end;
+    }
+
+    /// <summary>Gets the start bound, or <see langword="null"/>.</summary>
+    public GExpression Start { get; }
+
+    /// <summary>Gets the end bound, or <see langword="null"/>.</summary>
+    public GExpression End { get; }
+}
+
+/// <summary>
 /// A field initializer inside a composite literal (<c>Name: value</c>).
 /// </summary>
 public sealed class FieldInitializer : GNode

--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/GPattern.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/GPattern.cs
@@ -199,3 +199,50 @@ public sealed class ParenthesizedPattern : GPattern
     /// <summary>Gets the inner pattern.</summary>
     public GPattern Pattern { get; }
 }
+
+/// <summary>
+/// A list pattern <c>[1, .., 4]</c> matching an array/slice element-by-element,
+/// with at most one <see cref="SlicePattern"/> element (issue #1889, spec
+/// §Pattern matching, <c>ListPattern</c>).
+/// </summary>
+public sealed class ListPattern : GPattern
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ListPattern"/> class.
+    /// </summary>
+    /// <param name="elements">The element patterns, in source order.</param>
+    public ListPattern(IReadOnlyList<GPattern> elements)
+    {
+        Elements = elements ?? new List<GPattern>();
+    }
+
+    /// <summary>Gets the element patterns, in source order.</summary>
+    public IReadOnlyList<GPattern> Elements { get; }
+}
+
+/// <summary>
+/// A slice ("rest") subpattern inside a <see cref="ListPattern"/>, e.g. the
+/// <c>..</c> in <c>[1, .., 4]</c> — a discard slice, a named capture
+/// <c>..rest</c> binding the middle slice to a new <c>[]T</c> variable, or a
+/// nested sub-pattern matched against the middle slice (issue #1889, spec
+/// §Pattern matching, <c>SlicePattern</c>).
+/// </summary>
+public sealed class SlicePattern : GPattern
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SlicePattern"/> class.
+    /// </summary>
+    /// <param name="designator">The capture name, or <see langword="null"/> for a discard/nested-pattern slice.</param>
+    /// <param name="pattern">The nested sub-pattern matched against the slice, or <see langword="null"/>.</param>
+    public SlicePattern(string designator, GPattern pattern = null)
+    {
+        Designator = designator;
+        Pattern = pattern;
+    }
+
+    /// <summary>Gets the capture name, or <see langword="null"/>.</summary>
+    public string Designator { get; }
+
+    /// <summary>Gets the nested sub-pattern matched against the slice, or <see langword="null"/>.</summary>
+    public GPattern Pattern { get; }
+}

--- a/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
@@ -442,6 +442,14 @@ public static class GSharpPrinter
             case IndexExpression index:
                 return $"{RenderExpression(index.Target, indent)}[{RenderExpression(index.Index, indent)}]";
 
+            case FromEndIndexExpression fromEnd:
+                return $"^{RenderExpression(fromEnd.Operand, indent)}";
+
+            case RangeIndexExpression range:
+                var rangeStart = range.Start != null ? RenderExpression(range.Start, indent) : string.Empty;
+                var rangeEnd = range.End != null ? RenderExpression(range.End, indent) : string.Empty;
+                return $"{rangeStart}..{rangeEnd}";
+
             case CompositeLiteralExpression composite:
                 var inits = string.Join(", ", composite.FieldInitializers.Select(f => $"{f.Name}: {RenderExpression(f.Value, indent)}"));
                 return $"{RenderType(composite.Type)}{{{inits}}}";
@@ -748,6 +756,17 @@ public static class GSharpPrinter
 
             case ParenthesizedPattern paren:
                 return $"({RenderPattern(paren.Pattern, indent)})";
+
+            case ListPattern list:
+                return $"[{string.Join(", ", list.Elements.Select(e => RenderPattern(e, indent)))}]";
+
+            case SlicePattern slice:
+                if (slice.Pattern != null)
+                {
+                    return $"..{RenderPattern(slice.Pattern, indent)}";
+                }
+
+                return slice.Designator != null ? $"..{slice.Designator}" : "..";
 
             default:
                 throw new ArgumentException($"Unsupported pattern: {pattern?.GetType().Name}");

--- a/tools/cs2gs/Cs2Gs.Tests/Coverage/GNodeSamples.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Coverage/GNodeSamples.cs
@@ -63,6 +63,9 @@ public static class GNodeSamples
             [typeof(MemberAccessExpression)] = () => Expr(new MemberAccessExpression(Id("a"), "B")),
             [typeof(InvocationExpression)] = () => Expr(new InvocationExpression(Id("f"), List<GExpression>(Id("v")))),
             [typeof(IndexExpression)] = () => Expr(new IndexExpression(Id("a"), Int("0"))),
+            [typeof(FromEndIndexExpression)] = () => Expr(new IndexExpression(Id("a"), new FromEndIndexExpression(Int("1")))),
+            [typeof(RangeIndexExpression)] = () => Expr(new IndexExpression(
+                Id("a"), new RangeIndexExpression(Int("1"), new FromEndIndexExpression(Int("1"))))),
             [typeof(FieldInitializer)] = CompositeLiteralSample,
             [typeof(CompositeLiteralExpression)] = CompositeLiteralSample,
             [typeof(ObjectCreationInitializerExpression)] = () => Expr(new ObjectCreationInitializerExpression(
@@ -210,6 +213,10 @@ public static class GNodeSamples
                 new ConstantPattern(Int("2")))),
             [typeof(NotPattern)] = () => Pattern(new NotPattern(new ConstantPattern(Int("1")))),
             [typeof(ParenthesizedPattern)] = () => Pattern(new ParenthesizedPattern(new ConstantPattern(Int("1")))),
+            [typeof(ListPattern)] = () => Pattern(new ListPattern(List<GPattern>(
+                new ConstantPattern(Int("1")), new SlicePattern(null), new ConstantPattern(Int("4"))))),
+            [typeof(SlicePattern)] = () => Pattern(new ListPattern(List<GPattern>(
+                new DiscardPattern(), new SlicePattern("rest")))),
 
             // Type references.
             [typeof(NamedTypeReference)] = () => Field(new NamedTypeReference("List", List<GTypeReference>(Type("int32")))),

--- a/tools/cs2gs/Cs2Gs.Tests/Coverage/code-model-surface.golden.txt
+++ b/tools/cs2gs/Cs2Gs.Tests/Coverage/code-model-surface.golden.txt
@@ -13,6 +13,7 @@ ConditionalAccessExpression
 ConditionalReceiverExpression
 ConversionExpression
 DefaultValueExpression
+FromEndIndexExpression
 IdentifierExpression
 IfExpression
 IncrementDecrementExpression
@@ -26,6 +27,7 @@ NonNullAssertionExpression
 ObjectCreationInitializerExpression
 OutArgumentExpression
 ParenthesizedExpression
+RangeIndexExpression
 StackAllocExpression
 SwitchExpression
 ThisExpression
@@ -77,10 +79,12 @@ TypeDeclaration
 BinaryPattern
 ConstantPattern
 DiscardPattern
+ListPattern
 NotPattern
 ParenthesizedPattern
 PropertyPattern
 RelationalPattern
+SlicePattern
 TypePattern
 
 [GTypeReference]

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1889ListPatternTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1889ListPatternTranslationTests.cs
@@ -1,0 +1,215 @@
+// <copyright file="Issue1889ListPatternTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #1889: a C# list pattern (<c>ListPatternSyntax</c>) and its slice
+/// ("rest") subpattern (<c>SlicePatternSyntax</c>) had no canonical G# form and
+/// reported the CS2GS-GAP "is-pattern 'ListPattern' has no canonical G# form
+/// yet". G# has a native list/slice pattern (spec §Pattern matching), so both
+/// pattern-translation paths now emit it directly:
+/// <list type="bullet">
+/// <item>a top-level <c>is</c>-pattern (`x is [...]`) — G#'s <c>is</c> operator
+/// only tests a type, so it lowers to a hand-composed boolean (a length test
+/// ANDed with a per-element test), mirroring the existing property/positional
+/// pattern lowering.</item>
+/// <item>a switch-expression/statement arm (`case [...]:` / `case [...] {`) —
+/// lowers directly to G#'s native <c>ListPattern</c>/<c>SlicePattern</c>, since
+/// gsc's own pattern binder performs the length/element matching at runtime.</item>
+/// </list>
+/// </summary>
+public class Issue1889ListPatternTranslationTests
+{
+    [Fact]
+    public void IsPattern_ExactLengthConstantElements_LowersToLengthAndElementTests()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1889
+{
+    public class Holder
+    {
+        public bool Describe(int[] values)
+        {
+            if (values is [1, 2, 3, 4])
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}
+");
+
+        Assert.Contains("values.Length == 4", rendered, StringComparison.Ordinal);
+        Assert.Contains("values[0] == 1", rendered, StringComparison.Ordinal);
+        Assert.Contains("values[3] == 4", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void IsPattern_SliceInMiddle_LowersToMinLengthAndEdgeTests()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1889
+{
+    public class Holder
+    {
+        public bool Describe(int[] values)
+        {
+            if (values is [1, .., 4])
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}
+");
+
+        Assert.Contains("values.Length >= 2", rendered, StringComparison.Ordinal);
+        Assert.Contains("values[0] == 1", rendered, StringComparison.Ordinal);
+        Assert.Contains("values[values.Length - 1] == 4", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void IsPattern_Empty_LowersToLengthZeroTest()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1889
+{
+    public class Holder
+    {
+        public bool Describe(int[] values)
+        {
+            if (values is [])
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}
+");
+
+        Assert.Contains("values.Length == 0", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void IsPattern_HeadAndRestBinders_BindHeadByIndexAndRestBySlice()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1889
+{
+    public class Holder
+    {
+        public int Describe(int[] values)
+        {
+            if (values is [var head, .. var rest])
+            {
+                return head + rest.Length;
+            }
+
+            return -1;
+        }
+    }
+}
+");
+
+        Assert.Contains("values.Length >= 1", rendered, StringComparison.Ordinal);
+        Assert.Contains("values[0] + values[1..].Length", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void SwitchExpression_ListPatternArms_LowerToNativeListAndSlicePatterns()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1889
+{
+    public class Holder
+    {
+        public string Describe(int[] values) => values switch
+        {
+            [] => ""empty"",
+            [1, .., 4] => ""edges"",
+            [var head, .. var rest] => $""{head}:{rest.Length}"",
+            _ => ""other"",
+        };
+    }
+}
+");
+
+        Assert.Contains("case []:", rendered, StringComparison.Ordinal);
+        Assert.Contains("case [1, .., 4]:", rendered, StringComparison.Ordinal);
+        Assert.Contains("case [_, ..rest]:", rendered, StringComparison.Ordinal);
+        Assert.Contains("\"${values[0]}:${rest.Length}\"", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void SwitchStatement_ListPatternArm_LowersToNativeListPattern()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1889
+{
+    public class Holder
+    {
+        public string Describe(int[] values)
+        {
+            switch (values)
+            {
+                case [1, .., 4]:
+                    return ""edges"";
+                default:
+                    return ""other"";
+            }
+        }
+    }
+}
+");
+
+        Assert.Contains("case [1, .., 4] {", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    private static void AssertRoundTripParses(string rendered)
+    {
+        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+
+        Assert.True(
+            result.Success,
+            "Sanitized G# must round-trip-parse. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + rendered);
+    }
+
+    private static string Render(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", source) });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        Cs2Gs.CodeModel.Ast.CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        Assert.Empty(context.Diagnostics);
+        return GSharpPrinter.Print(unit);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1889ListPatternTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1889ListPatternTranslationTests.cs
@@ -84,6 +84,36 @@ namespace Corpus.Issue1889
     }
 
     [Fact]
+    public void IsPattern_ElementsAfterSlice_IndexFromEnd()
+    {
+        // The elements AFTER a slice must be indexed end-relative, not from the
+        // front: `[1, .., 4, 5]` → last two are `^2`/`^1`, i.e. Length-2/Length-1.
+        string rendered = Render(@"
+namespace Corpus.Issue1889
+{
+    public class Holder
+    {
+        public bool Describe(int[] values)
+        {
+            if (values is [1, .., 4, 5])
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}
+");
+
+        Assert.Contains("values.Length >= 3", rendered, StringComparison.Ordinal);
+        Assert.Contains("values[0] == 1", rendered, StringComparison.Ordinal);
+        Assert.Contains("values[values.Length - 2] == 4", rendered, StringComparison.Ordinal);
+        Assert.Contains("values[values.Length - 1] == 5", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
     public void IsPattern_Empty_LowersToLengthZeroTest()
     {
         string rendered = Render(@"

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -8189,12 +8189,143 @@ public sealed class CSharpToGSharpTranslator
                     return new ParenthesizedExpression(
                         this.TranslatePatternTest(receiver, parenthesized.Pattern, receiverType, receiverSyntax));
 
+                case ListPatternSyntax listPattern:
+                    return this.TranslateListPatternTest(receiver, listPattern, receiverType);
+
                 default:
                     this.context.ReportUnsupported(
                         pattern,
                         $"is-pattern '{pattern.Kind()}' has no canonical G# form yet (ADR-0115 §B).");
                     return new BinaryExpression(receiver, "!=", LiteralExpression.Null());
             }
+        }
+
+        // Issue #1889: G#'s `is` operator only tests a type (ADR-0115 §B), so —
+        // same as the recursive/positional-pattern branches above — a list
+        // pattern lowers to a hand-composed boolean: a length test (exact when
+        // there is no slice, a minimum when there is) ANDed with a per-element
+        // test against the element read at that position. An element before the
+        // (at most one) slice reads forward from the start; an element after it
+        // reads backward from the end (gsc has no negative array index, so
+        // `Length - distanceFromEnd` spells that out). A discard element
+        // contributes no test, matching the positional-pattern discard carve-out.
+        private GExpression TranslateListPatternTest(GExpression receiver, ListPatternSyntax listPattern, ITypeSymbol receiverType)
+        {
+            SeparatedSyntaxList<PatternSyntax> elements = listPattern.Patterns;
+            int sliceIndex = FindSlicePatternIndex(elements);
+            ITypeSymbol elementType = GetEnumerableElementType(receiverType);
+            var lengthAccess = new MemberAccessExpression(receiver, "Length");
+
+            GExpression test = sliceIndex < 0
+                ? new BinaryExpression(lengthAccess, "==", LiteralExpression.Int(elements.Count.ToString()))
+                : new BinaryExpression(lengthAccess, ">=", LiteralExpression.Int((elements.Count - 1).ToString()));
+
+            for (int i = 0; i < elements.Count; i++)
+            {
+                PatternSyntax element = elements[i];
+                if (element is SlicePatternSyntax slice)
+                {
+                    GExpression sliceTest = this.TranslateSlicePatternTest(receiver, slice, i, elements.Count - i - 1, receiverType);
+                    if (sliceTest != null)
+                    {
+                        test = new BinaryExpression(test, "&&", sliceTest);
+                    }
+
+                    continue;
+                }
+
+                if (element is DiscardPatternSyntax)
+                {
+                    continue;
+                }
+
+                GExpression elementReceiver = this.BuildListElementReceiver(receiver, lengthAccess, i, elements.Count, sliceIndex);
+                GExpression elementTest = this.TranslatePatternTest(elementReceiver, element, elementType);
+                test = new BinaryExpression(test, "&&", elementTest);
+            }
+
+            return test;
+        }
+
+        // Issue #1889: a slice ("rest") subpattern either captures the middle
+        // slice (`.. var rest`/`.. T rest`, a binder — registered as a
+        // patternBindings substitution, same mechanism as a top-level `var`/
+        // declaration pattern) or tests it against a nested subpattern (`..[>
+        // 0]`, recursed against the materialized slice value); a bare `..`
+        // contributes neither. Returns `null` when there is no additional
+        // boolean test to AND in (a bare discard slice, or a successful bind).
+        private GExpression TranslateSlicePatternTest(
+            GExpression receiver, SlicePatternSyntax slice, int prefixCount, int suffixCount, ITypeSymbol receiverType)
+        {
+            switch (slice.Pattern)
+            {
+                case null:
+                    return null;
+
+                case VarPatternSyntax { Designation: SingleVariableDesignationSyntax variable }
+                    when this.context.GetDeclaredSymbol(variable) is { } boundSymbol:
+                    this.patternBindings[boundSymbol] = BuildSliceExpression(receiver, prefixCount, suffixCount);
+                    return null;
+
+                case VarPatternSyntax { Designation: DiscardDesignationSyntax }:
+                    return null;
+
+                case VarPatternSyntax varTuple when varTuple.Designation is ParenthesizedVariableDesignationSyntax:
+                    this.context.ReportUnsupported(varTuple, "var pattern with tuple designation ('var (a, b)') has no canonical G# form yet (ADR-0115 §B).");
+                    return null;
+
+                case DeclarationPatternSyntax { Designation: SingleVariableDesignationSyntax declVariable }
+                    when this.context.GetDeclaredSymbol(declVariable) is { } declBoundSymbol:
+                    // A typed slice capture (`.. T rest`) can only ever narrow to
+                    // the slice's own `[]T` type, so the (redundant) type check is
+                    // dropped — same bind-only treatment as the `var` capture above.
+                    this.patternBindings[declBoundSymbol] = BuildSliceExpression(receiver, prefixCount, suffixCount);
+                    return null;
+
+                default:
+                    // A nested subpattern tested against the middle slice (e.g.
+                    // `.. { Length: 0 }`, `.. [1, 2]`) — recurse the normal
+                    // boolean-test lowering against the materialized slice value.
+                    return this.TranslatePatternTest(BuildSliceExpression(receiver, prefixCount, suffixCount), slice.Pattern, receiverType);
+            }
+        }
+
+        // Issue #1889: the index of an element read forward from the start (no
+        // slice yet seen, or before it) vs. backward from the end (past it) —
+        // shared by the boolean-test and G#-pattern lowering paths.
+        private GExpression BuildListElementReceiver(GExpression receiver, GExpression lengthAccess, int index, int elementCount, int sliceIndex)
+        {
+            if (sliceIndex < 0 || index < sliceIndex)
+            {
+                return new IndexExpression(receiver, LiteralExpression.Int(index.ToString()));
+            }
+
+            return new IndexExpression(
+                receiver,
+                new BinaryExpression(lengthAccess, "-", LiteralExpression.Int((elementCount - index).ToString())));
+        }
+
+        // Issue #1889: the materialized slice value for a list pattern's `..`
+        // element — `receiver[prefix..^suffix]` (open at whichever end has a
+        // zero count), matching gsc's own array-slice binder (BindArraySlice).
+        private static GExpression BuildSliceExpression(GExpression receiver, int prefixCount, int suffixCount)
+        {
+            GExpression start = prefixCount == 0 ? null : LiteralExpression.Int(prefixCount.ToString());
+            GExpression end = suffixCount == 0 ? null : new FromEndIndexExpression(LiteralExpression.Int(suffixCount.ToString()));
+            return new IndexExpression(receiver, new RangeIndexExpression(start, end));
+        }
+
+        private static int FindSlicePatternIndex(SeparatedSyntaxList<PatternSyntax> elements)
+        {
+            for (int i = 0; i < elements.Count; i++)
+            {
+                if (elements[i] is SlicePatternSyntax)
+                {
+                    return i;
+                }
+            }
+
+            return -1;
         }
 
         private GExpression TranslateNotPatternTest(
@@ -11370,11 +11501,101 @@ public sealed class CSharpToGSharpTranslator
                 case ParenthesizedPatternSyntax parenthesized:
                     return new ParenthesizedPattern(this.TranslatePattern(parenthesized.Pattern, receiver, bindings, usedDesignators));
 
+                case ListPatternSyntax listPattern:
+                    return this.TranslateListPattern(listPattern, receiver, bindings, usedDesignators);
+
                 default:
                     this.context.ReportUnsupported(
                         pattern,
                         $"pattern '{pattern.Kind()}' has no canonical G# form yet (ADR-0115 §B).");
                     return new DiscardPattern();
+            }
+        }
+
+        // Issue #1889: G# has a native list pattern (spec §Pattern matching,
+        // ListPatternSyntax/SlicePatternSyntax) that structurally matches an
+        // array/slice element-by-element — unlike the property/positional-
+        // pattern branches above, no manual member-test composition is needed;
+        // gsc's own pattern binder tests length and element shape at runtime.
+        // Each non-slice, non-discard element still recurses through the shared
+        // `TranslatePattern` so a `var`/declaration binder at that position picks
+        // up the SAME discard-plus-substitution treatment as everywhere else
+        // (issue #1888) — the substitution receiver is the element read at that
+        // position (forward from the start, or backward from the end once past
+        // the slice, since gsc has no negative array index).
+        private GPattern TranslateListPattern(
+            ListPatternSyntax listPattern,
+            GExpression receiver,
+            List<(ISymbol Symbol, GExpression Replacement)> bindings,
+            HashSet<string> usedDesignators)
+        {
+            SeparatedSyntaxList<PatternSyntax> elements = listPattern.Patterns;
+            int sliceIndex = FindSlicePatternIndex(elements);
+            var lengthAccess = new MemberAccessExpression(receiver, "Length");
+            var translated = new List<GPattern>(elements.Count);
+
+            for (int i = 0; i < elements.Count; i++)
+            {
+                PatternSyntax element = elements[i];
+                if (element is SlicePatternSyntax slice)
+                {
+                    translated.Add(this.TranslateSlicePattern(slice, receiver, i, elements.Count - i - 1, bindings, usedDesignators));
+                    continue;
+                }
+
+                if (element is DiscardPatternSyntax)
+                {
+                    translated.Add(new DiscardPattern());
+                    continue;
+                }
+
+                GExpression elementReceiver = this.BuildListElementReceiver(receiver, lengthAccess, i, elements.Count, sliceIndex);
+                translated.Add(this.TranslatePattern(element, elementReceiver, bindings, usedDesignators));
+            }
+
+            return new ListPattern(translated);
+        }
+
+        // Issue #1889: a named capture (`.. var rest`/`.. T rest`) binds directly
+        // to G#'s own slice-capture designator (`..rest`) — a REAL runtime
+        // binding (unlike a scalar element's `var`, this one needs no
+        // discard-plus-substitution: the captured name IS the designator, so
+        // references to it in the arm body resolve naturally). A nested
+        // subpattern (`..[> 0]`) recurses through `TranslatePattern` against the
+        // materialized slice value, matching G#'s own `SlicePattern.Pattern`
+        // (spec §Pattern matching). A bare `..` carries neither.
+        private GPattern TranslateSlicePattern(
+            SlicePatternSyntax slice,
+            GExpression receiver,
+            int prefixCount,
+            int suffixCount,
+            List<(ISymbol Symbol, GExpression Replacement)> bindings,
+            HashSet<string> usedDesignators)
+        {
+            switch (slice.Pattern)
+            {
+                case null:
+                    return new SlicePattern(designator: null);
+
+                case VarPatternSyntax { Designation: SingleVariableDesignationSyntax variable }:
+                    return new SlicePattern(SanitizeIdentifier(variable.Identifier.Text));
+
+                case VarPatternSyntax { Designation: DiscardDesignationSyntax }:
+                    return new SlicePattern(designator: null);
+
+                case VarPatternSyntax varTuple when varTuple.Designation is ParenthesizedVariableDesignationSyntax:
+                    this.context.ReportUnsupported(varTuple, "var pattern with tuple designation ('var (a, b)') has no canonical G# form yet (ADR-0115 §B).");
+                    return new SlicePattern(designator: null);
+
+                case DeclarationPatternSyntax { Designation: SingleVariableDesignationSyntax declVariable }:
+                    // G#'s slice capture designator is always typed as the
+                    // slice's own `[]T`, so the (redundant) C# declared type is
+                    // dropped — same bind-only treatment as the `var` capture above.
+                    return new SlicePattern(SanitizeIdentifier(declVariable.Identifier.Text));
+
+                default:
+                    GExpression sliceValue = BuildSliceExpression(receiver, prefixCount, suffixCount);
+                    return new SlicePattern(designator: null, this.TranslatePattern(slice.Pattern, sliceValue, bindings, usedDesignators));
             }
         }
 

--- a/tools/cs2gs/corpus/grid/G04-Patterns-Console/Constructs/ListPattern.cs
+++ b/tools/cs2gs/corpus/grid/G04-Patterns-Console/Constructs/ListPattern.cs
@@ -1,0 +1,65 @@
+// inventory: ListPattern, SlicePattern
+using System;
+
+namespace Corpus.Grid04.Constructs
+{
+    public static class ListPatternFixture
+    {
+        public static void Run()
+        {
+            int[] exact = { 1, 2, 3, 4 };
+            if (exact is [1, 2, 3, 4])
+            {
+                Console.WriteLine("ListPattern: exact length match");
+            }
+
+            int[] edges = { 1, 9, 9, 4 };
+            if (edges is [1, .., 4])
+            {
+                Console.WriteLine("ListPattern: edge slice match");
+            }
+
+            int[] empty = { };
+            if (empty is [])
+            {
+                Console.WriteLine("ListPattern: empty match");
+            }
+
+            int[] headRest = { 10, 20, 30 };
+            if (headRest is [var head, .. var rest])
+            {
+                Console.WriteLine($"ListPattern: head={head} restLength={rest.Length}");
+            }
+
+            int[] switchEdges = { 1, 2, 3, 4 };
+            string classifyEdges = switchEdges switch
+            {
+                [] => "empty",
+                [1, .., 4] => "edges",
+                [var only] => $"single:{only}",
+                _ => "other",
+            };
+            Console.WriteLine($"ListPattern: switch({classifyEdges}) = edges expected");
+
+            int[] switchEmpty = { };
+            string classifyEmpty = switchEmpty switch
+            {
+                [] => "empty",
+                [1, .., 4] => "edges",
+                [var only] => $"single:{only}",
+                _ => "other",
+            };
+            Console.WriteLine($"ListPattern: switch({classifyEmpty}) = empty expected");
+
+            int[] switchSingle = { 7 };
+            string classifySingle = switchSingle switch
+            {
+                [] => "empty",
+                [1, .., 4] => "edges",
+                [var only] => $"single:{only}",
+                _ => "other",
+            };
+            Console.WriteLine($"ListPattern: switch({classifySingle}) = single expected");
+        }
+    }
+}

--- a/tools/cs2gs/corpus/grid/G04-Patterns-Console/Program.cs
+++ b/tools/cs2gs/corpus/grid/G04-Patterns-Console/Program.cs
@@ -16,6 +16,7 @@ namespace Corpus.Grid04
             DeclarationPatternFixture.Run();
             DiscardPatternFixture.Run();
             ExpressionColonFixture.Run();
+            ListPatternFixture.Run();
             NotPatternFixture.Run();
             OrPatternFixture.Run();
             ParenthesizedPatternFixture.Run();

--- a/tools/cs2gs/corpus/grid/G04-Patterns-Console/baseline.stdout.golden
+++ b/tools/cs2gs/corpus/grid/G04-Patterns-Console/baseline.stdout.golden
@@ -24,6 +24,13 @@ DiscardPattern: 2 -> nonzero
 DiscardPattern: -5 -> negative
 ExpressionColon: line starts on y-axis = True
 ExpressionColon: line ends above 4 = True
+ListPattern: exact length match
+ListPattern: edge slice match
+ListPattern: empty match
+ListPattern: head=10 restLength=2
+ListPattern: switch(edges) = edges expected
+ListPattern: switch(empty) = empty expected
+ListPattern: switch(single:7) = single expected
 NotPattern: "abc" is not null = True
 NotPattern: "abc" is not int = True
 NotPattern: null is not null = False

--- a/tools/cs2gs/coverage/csharp-construct-inventory.json
+++ b/tools/cs2gs/coverage/csharp-construct-inventory.json
@@ -1293,9 +1293,11 @@
   {
     "kind": "ListPattern",
     "nodeType": "ListPatternSyntax",
-    "status": "Gap",
+    "status": "Translated",
+    "rule": "ADR-0115 \u00A7B.22",
     "rationale": "None",
-    "issue": "https://github.com/DavidObando/gsharp/issues/1889"
+    "fixture": "tools/cs2gs/corpus/grid/G04-Patterns-Console/Constructs/ListPattern.cs",
+    "notes": "is-test path lowers to a length test (\u0060==\u0060 exact / \u0060\u003E=\u0060 with a slice) ANDed with per-element index tests; switch-arm path emits a native G# \u0060ListPattern\u0060 (\u0060[1, .., 4]\u0060) since gsc has its own structural list-pattern matching (issue #1889, resolved). Element \u0060var\u0060 binders reuse the #1888 discard\u002Bsubstitution mechanism; \u0060int x\u0060 declaration-pattern elements map to native \u0060TypePattern\u0060. Deferral: gsc\u0027s \u0060BindListPattern\u0060 only accepts array/slice-typed discriminants (not e.g. \u0060List\u003CT\u003E\u0060), a pre-existing gsc scope boundary, not a cs2gs limitation."
   },
   {
     "kind": "LoadDirectiveTrivia",
@@ -1994,9 +1996,11 @@
   {
     "kind": "SlicePattern",
     "nodeType": "SlicePatternSyntax",
-    "status": "Gap",
+    "status": "Translated",
+    "rule": "ADR-0115 \u00A7B.22",
     "rationale": "None",
-    "issue": "https://github.com/DavidObando/gsharp/issues/1889"
+    "fixture": "tools/cs2gs/corpus/grid/G04-Patterns-Console/Constructs/ListPattern.cs",
+    "notes": "is-test path materializes the slice-bound value via native G# range slicing (\u0060receiver[prefix..^suffix]\u0060, using new \u0060RangeIndexExpression\u0060/\u0060FromEndIndexExpression\u0060 CodeModel nodes) and binds it by substitution; switch-arm path emits a native G# \u0060SlicePattern\u0060 (\u0060..rest\u0060/\u0060..\u0060) since gsc has real runtime slice-capture support (issue #1889, resolved)."
   },
   {
     "kind": "SpreadElement",


### PR DESCRIPTION
Fixes #1889

cs2gs translator: root-cause fix, both pattern paths.

DoD:
- [x] translator fixed at root, is-test path + switch-arm path both handle list/slice patterns, any count/position/nesting
- [x] Issue1889ListPatternTranslationTests.cs added, 6 tests pass
- [x] G04 fixture Constructs/ListPattern.cs added, baseline.stdout.golden re-captured, migrate G04 all 4 stages PASS
- [x] coverage inventory ListPattern/SlicePattern Gap -> Translated, docs regenerated, no .actual drift

G# surface emitted:
- is-test: length test ANDed with per-element index tests, e.g. `values.Length >= 2 && values[0] == 1 && values[values.Length - 1] == 4`; slice-bind materializes via `values[1..^1]`
- switch-arm: native G# list/slice pattern, e.g. `case [1, .., 4]:`, `case [var head, ..rest]:`

Deferral (gsc scope boundary, not cs2gs): gsc's BindListPattern only accepts array/slice-typed discriminants; a metadata-typed array (e.g. from Array.Empty<T>()) is rejected by gsc even though it's a real array. Unrelated to pattern translation itself, kept out of scope.