### PR TITLE
cs2gs: fix defer printer/parser mismatch (drop block form)

### DIFF
--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue1930DeferExpressionOnlyParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue1930DeferExpressionOnlyParserTests.cs
@@ -1,0 +1,61 @@
+// <copyright file="Issue1930DeferExpressionOnlyParserTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Issue #1930: the cs2gs code model/printer used to emit <c>defer { … }</c>
+/// (a block body) while <c>Parser.ParseDeferStatement</c> only ever accepted
+/// a single expression operand, per ADR-0030 ("Add <c>defer call(arg1,
+/// arg2, …)</c> as a statement"). The fix keeps the parser as the source of
+/// truth — a single call-expression operand — and updates the cs2gs code
+/// model/printer to match instead of teaching the parser a block form. These
+/// tests pin down the parser's expression-only contract so it cannot drift
+/// back out of sync with the printer again.
+/// </summary>
+public class Issue1930DeferExpressionOnlyParserTests
+{
+    [Fact]
+    public void Parses_DeferWithCallExpression()
+    {
+        const string source = """
+            package P
+            func cleanup() { }
+            {
+                defer cleanup()
+            }
+            """;
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var deferStmt = tree.Root.Members
+            .OfType<GlobalStatementSyntax>()
+            .Select(g => g.Statement)
+            .OfType<BlockStatementSyntax>()
+            .SelectMany(b => b.Statements)
+            .OfType<DeferStatementSyntax>()
+            .Single();
+        Assert.Equal(SyntaxKind.DeferKeyword, deferStmt.DeferKeyword.Kind);
+        Assert.IsType<CallExpressionSyntax>(deferStmt.Expression);
+    }
+
+    [Fact]
+    public void DoesNotParse_DeferWithBlockBody()
+    {
+        // The block form the cs2gs printer used to emit before the #1930 fix.
+        const string source = """
+            package P
+            {
+                defer { }
+            }
+            """;
+        var tree = SyntaxTree.Parse(source);
+
+        Assert.NotEmpty(tree.Diagnostics);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/GStatement.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/GStatement.cs
@@ -370,21 +370,23 @@ public sealed class ThrowStatement : GStatement
 }
 
 /// <summary>
-/// A <c>defer</c> statement (minimal node; the body runs on scope exit).
+/// A <c>defer</c> statement. Per ADR-0030, the operand is a single call
+/// expression that runs on scope exit (LIFO); G# has no block-bodied
+/// <c>defer { … }</c> form.
 /// </summary>
 public sealed class DeferStatement : GStatement
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="DeferStatement"/> class.
     /// </summary>
-    /// <param name="body">The deferred block.</param>
-    public DeferStatement(BlockStatement body)
+    /// <param name="call">The deferred call expression.</param>
+    public DeferStatement(GExpression call)
     {
-        Body = body;
+        Call = call;
     }
 
-    /// <summary>Gets the deferred block.</summary>
-    public BlockStatement Body { get; }
+    /// <summary>Gets the deferred call expression.</summary>
+    public GExpression Call { get; }
 }
 
 /// <summary>

--- a/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
@@ -870,7 +870,7 @@ public static class GSharpPrinter
                 return $"{pad}{forKeyword} {loopVars} in {RenderExpression(forIn.Iterable, indent)} {RenderBlock(forIn.Body, indent)}";
 
             case DeferStatement defer:
-                return $"{pad}defer {RenderBlock(defer.Body, indent)}";
+                return $"{pad}defer {RenderExpression(defer.Call, indent)}";
 
             case TryStatement tryStatement:
                 return RenderTry(tryStatement, indent);

--- a/tools/cs2gs/Cs2Gs.Tests/Coverage/GNodeSamples.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Coverage/GNodeSamples.cs
@@ -137,8 +137,7 @@ public static class GNodeSamples
             [typeof(ForInStatement)] = () => Stmts(new ForInStatement("item", Id("items"), Block())),
             [typeof(ThrowStatement)] = () => Stmts(new ThrowStatement(
                 new InvocationExpression(Id("Exception"), List<GExpression>(LiteralExpression.String("boom"))))),
-            [typeof(DeferStatement)] = () => Stmts(new DeferStatement(Block(
-                new ExpressionStatement(new InvocationExpression(Id("cleanup")))))),
+            [typeof(DeferStatement)] = () => Stmts(new DeferStatement(new InvocationExpression(Id("cleanup")))),
             [typeof(RawStatement)] = () => Stmts(new RawStatement("let raw = 1")),
             [typeof(CatchClause)] = TrySample,
             [typeof(TryStatement)] = TrySample,

--- a/tools/cs2gs/Cs2Gs.Tests/Coverage/PrinterExhaustivenessTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Coverage/PrinterExhaustivenessTests.cs
@@ -27,12 +27,7 @@ public class PrinterExhaustivenessTests
     /// entry is asserted to still fail: fixing the gap flips the test and
     /// forces removal from this list. Keep this list as small as possible.
     /// </summary>
-    private static readonly IReadOnlyDictionary<Type, string> KnownRoundTripGaps = new Dictionary<Type, string>
-    {
-        [typeof(DeferStatement)] = "the printer renders `defer { … }` (block body) but the G# parser " +
-            "only accepts `defer <expression>` (Parser.ParseDeferStatement; sample Defer.gs uses " +
-            "`defer record(\"x\")`), so every printed DeferStatement fails to re-parse with GS0005.",
-    };
+    private static readonly IReadOnlyDictionary<Type, string> KnownRoundTripGaps = new Dictionary<Type, string>();
 
     /// <summary>
     /// MemberData source: the simple name of every registered sample type,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1930DeferBlockFormRoundTripTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1930DeferBlockFormRoundTripTests.cs
@@ -1,0 +1,55 @@
+// <copyright file="Issue1930DeferBlockFormRoundTripTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Regression tests for issue #1930: <see cref="DeferStatement"/> used to
+/// hold a <see cref="BlockStatement"/> body and the printer rendered
+/// <c>defer { … }</c>, but the G# parser (<c>Parser.ParseDeferStatement</c>)
+/// only ever accepted a single expression operand, per ADR-0030 (the
+/// operand must bind to a call expression). Every printed
+/// <see cref="DeferStatement"/> therefore failed to re-parse with GS0005.
+/// The fix makes the code model match the documented, parser-enforced
+/// canonical form: <c>defer &lt;call-expression&gt;</c>, no block form.
+/// </summary>
+public class Issue1930DeferBlockFormRoundTripTests
+{
+    [Fact]
+    public void DeferStatement_PrintsSingleCallExpression_NotBlock()
+    {
+        var printed = GSharpPrinter.Print(DeferSample());
+
+        Assert.Contains("defer cleanup()", printed);
+        Assert.DoesNotContain("defer {", printed);
+    }
+
+    [Fact]
+    public void DeferStatement_PrintedForm_RoundTripsThroughRealParser()
+    {
+        var printed = GSharpPrinter.Print(DeferSample());
+        var result = GSharpRoundTrip.Validate(printed);
+
+        Assert.True(result.Success, $"Printed G#:\n{printed}\nParse errors:\n{string.Join("\n", result.Errors)}");
+    }
+
+    private static CompilationUnit DeferSample() =>
+        new CompilationUnit(
+            "Demo",
+            members: new List<GNode>
+            {
+                new MethodDeclaration(
+                    "Run",
+                    body: new BlockStatement(new List<GStatement>
+                    {
+                        new DeferStatement(new InvocationExpression(new IdentifierExpression("cleanup"))),
+                    })),
+            });
+}


### PR DESCRIPTION
## Problem
`PrinterExhaustivenessTests` quarantined `DeferStatement` in `KnownRoundTripGaps`: the cs2gs code model's `DeferStatement` held a `BlockStatement` body, and `GSharpPrinter` rendered `defer { ... }`. But `Parser.ParseDeferStatement` (and ADR-0030, "defer and block-scoped cleanup convergence") only ever accept a single call-expression operand: `defer call(arg1, arg2, ...)`. Every printed `DeferStatement` therefore failed to re-parse with GS0005.

## Root cause / fix
ADR-0030 is the documented source of truth and the parser already matches it — `defer` binds a single call expression, evaluated eagerly, lowered to `try/finally` at scope exit (LIFO). The block form was never a real target: C# has no `defer` keyword, so `DeferStatement` is a synthetic code-model node exercised only by printer/round-trip coverage tests, not by any real C#-to-G# translation path.

So the fix is on the cs2gs side, keeping the parser unchanged:
- `DeferStatement` now carries a single `GExpression` (the deferred call) instead of a `BlockStatement`.
- `GSharpPrinter` renders `defer <expr>` instead of `defer { ... }`.
- `GNodeSamples`'s `DeferStatement` sample updated to the new shape.
- The `KnownRoundTripGaps` entry for `DeferStatement` in `PrinterExhaustivenessTests` is removed — the sample now round-trips cleanly through the real G# parser (verified: removing it without a matching fix fails the test, per its own self-check).

## Tests
- `tools/cs2gs/Cs2Gs.Tests/Issue1930DeferBlockFormRoundTripTests.cs` — printer emits `defer cleanup()` (not `defer {`), and the printed form round-trips through the real parser.
- `test/Core.Tests/CodeAnalysis/Syntax/Issue1930DeferExpressionOnlyParserTests.cs` — pins the parser's expression-only contract (`defer cleanup()` parses; `defer { }` does not) so it can't silently drift back out of sync with the printer.

## Coverage / corpus
No C# construct maps to `defer` (C# has no such keyword), so no grid corpus fixture or `csharp-construct-inventory.json` row references it — regenerating the coverage inventory (`cs2gs coverage --write`) produced no diff. No grid fixture was quarantined for this issue; none needed adding.

## Validation
- `dotnet build src/Compiler/Compiler.csproj -c Release` — clean.
- `dotnet build tools/cs2gs/Cs2Gs.Cli/Cs2Gs.Cli.csproj -c Release` — clean.
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release` — **5283 passed, 0 failed, 1 skipped** (pre-existing unrelated skip).
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release` — **795 passed, 0 failed**.
- Full corpus migrate against `tools/cs2gs/triage/gaps.json` baseline: **0 new, 0 regressed** (pre-existing `#1929` gap unrelated to this change).

Fixes #1930