### PR TITLE
Unify nested-body emit lowering

### DIFF
--- a/src/Core/CodeAnalysis/Lowering/InterpolatedStringHandlerLowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/InterpolatedStringHandlerLowerer.cs
@@ -39,7 +39,7 @@ namespace GSharp.Core.CodeAnalysis.Lowering;
 /// This rewrite is applied only on the emit path; the tree-walk interpreter
 /// renders <see cref="BoundInterpolatedStringExpression"/> directly.
 /// </remarks>
-internal sealed class InterpolatedStringHandlerLowerer : BoundTreeRewriter
+internal sealed class InterpolatedStringHandlerLowerer : NestedFunctionBodyRewriter
 {
     private static readonly System.Type HandlerType = typeof(DefaultInterpolatedStringHandler);
     private static readonly TypeSymbol HandlerTypeSymbol = TypeSymbol.FromClrType(HandlerType);

--- a/src/Core/CodeAnalysis/Lowering/NestedFunctionBodyRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/NestedFunctionBodyRewriter.cs
@@ -1,0 +1,54 @@
+// <copyright file="NestedFunctionBodyRewriter.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Core.CodeAnalysis.Binding;
+
+namespace GSharp.Core.CodeAnalysis.Lowering;
+
+/// <summary>
+/// Shared helper for emit-pipeline rewriters whose transforms are lexical-scope
+/// agnostic and therefore must run inside hosted nested bodies too.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="BoundTreeRewriter"/> intentionally does not recurse into
+/// <see cref="BoundFunctionLiteralExpression.Body"/> or generic local-function
+/// bodies because many callers model lexical scopes. Emit-time lowering passes
+/// such as interpolated-string rewriting and side-effect spilling are scope
+/// neutral, though: if a top-level body gets the transform, a nested hosted
+/// body must get that exact same transform before the emitter sees it.
+/// </para>
+/// <para>
+/// This base class provides that shared descent so the emit pipeline does not
+/// fork between ordinary bodies and lambda/local-function bodies.
+/// </para>
+/// </remarks>
+internal abstract class NestedFunctionBodyRewriter : BoundTreeRewriter
+{
+    /// <inheritdoc/>
+    protected override BoundExpression RewriteFunctionLiteralExpression(BoundFunctionLiteralExpression node)
+    {
+        var body = (BoundBlockStatement)this.RewriteStatement(node.Body);
+        if (ReferenceEquals(body, node.Body))
+        {
+            return node;
+        }
+
+        return new BoundFunctionLiteralExpression(
+            node.Syntax,
+            node.Function,
+            node.FunctionType,
+            body,
+            node.CapturedVariables);
+    }
+
+    /// <inheritdoc/>
+    protected override BoundStatement RewriteLocalFunctionDeclaration(BoundLocalFunctionDeclaration node)
+    {
+        var literal = (BoundFunctionLiteralExpression)this.RewriteFunctionLiteralExpression(node.Literal);
+        return ReferenceEquals(literal, node.Literal)
+            ? node
+            : new BoundLocalFunctionDeclaration(node.Syntax, literal);
+    }
+}

--- a/src/Core/CodeAnalysis/Lowering/SideEffectSpiller.cs
+++ b/src/Core/CodeAnalysis/Lowering/SideEffectSpiller.cs
@@ -64,7 +64,7 @@ namespace GSharp.Core.CodeAnalysis.Lowering;
 /// tree size grows only where duplication risk was real.
 /// </para>
 /// </remarks>
-internal sealed class SideEffectSpiller : BoundTreeRewriter
+internal sealed class SideEffectSpiller : NestedFunctionBodyRewriter
 {
     private const string TempPrefix = "<>spill";
 

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue1928LambdaInterpolatedStringEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue1928LambdaInterpolatedStringEmitTests.cs
@@ -1,0 +1,95 @@
+// <copyright file="Issue1928LambdaInterpolatedStringEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #1928: emit-only lowering must rewrite interpolated strings inside
+/// hosted nested bodies (arrow lambdas, func literals, generic local
+/// functions) the same way it already rewrites ordinary function bodies.
+/// </summary>
+public class Issue1928LambdaInterpolatedStringEmitTests
+{
+    [Fact]
+    public void ArrowLambdaBody_WithInterpolatedString_EmitsAndRuns()
+    {
+        const string Source = @"package Issue1928Arrow
+import System
+import System.Linq
+
+var xs = []int32{1, 2, 3}
+var mapped = xs.Select((x int32) -> ""v=$x"")
+Console.WriteLine(string.Join("","", mapped))
+";
+
+        var output = CompileAndRun(Source, nameof(ArrowLambdaBody_WithInterpolatedString_EmitsAndRuns));
+        Assert.Contains("v=1,v=2,v=3", output);
+    }
+
+    [Fact]
+    public void GenericLocalFunctionBody_WithInterpolatedString_EmitsAndRuns()
+    {
+        const string Source = @"package Issue1928Local
+import System
+
+let format[T] = func(value T) string { return ""v=$value"" }
+Console.WriteLine(format(7))
+";
+
+        var output = CompileAndRun(Source, nameof(GenericLocalFunctionBody_WithInterpolatedString_EmitsAndRuns));
+        Assert.Contains("v=7", output);
+    }
+
+    private static string CompileAndRun(string source, string contextName)
+    {
+        using var peStream = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Emit(peStream);
+
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(contextName, isCollectible: true);
+        try
+        {
+            var asm = loadContext.LoadFromStream(peStream);
+            var programType = asm.GetTypes().FirstOrDefault(t => t.Name == "<Program>");
+            Assert.NotNull(programType);
+            var entry = programType!.GetMethod(
+                "<Main>$",
+                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(entry);
+
+            var stdout = System.Console.Out;
+            var captured = new StringWriter();
+            System.Console.SetOut(captured);
+            try
+            {
+                entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { System.Array.Empty<string>() });
+            }
+            finally
+            {
+                System.Console.SetOut(stdout);
+            }
+
+            return captured.ToString();
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+}

--- a/tools/cs2gs/corpus/grid/G09-Functions-Console/Constructs/ParenthesizedLambdaExpression.cs
+++ b/tools/cs2gs/corpus/grid/G09-Functions-Console/Constructs/ParenthesizedLambdaExpression.cs
@@ -27,12 +27,11 @@ namespace Corpus.Grid09
             };
             Console.WriteLine($"ParenthesizedLambdaExpression: stmt={stmt(5)}");
 
-            // Statement-bodied Action. Uses concatenation, not interpolation:
-            // the gsc emitter cannot yet emit InterpolatedStringExpression
-            // inside lambda bodies (GS9998).
+            // Statement-bodied Action. Keep interpolation here so the grid
+            // catches regressions in nested-body emit lowering (#1928).
             Action<int, int> report = (a, b) =>
             {
-                Console.WriteLine("ParenthesizedLambdaExpression: report=" + a.ToString() + "/" + b.ToString());
+                Console.WriteLine($"ParenthesizedLambdaExpression: report={a}/{b}");
             };
             report(6, 7);
         }


### PR DESCRIPTION
Fixes #1928

Regular bodies already went through the emit-only lowering passes that rewrite interpolated strings before IL emission, but lambda and generic local-function bodies were still being hosted later from raw BoundFunctionLiteralExpression/BoundLocalFunctionDeclaration nodes. Because BoundTreeRewriter intentionally skips nested bodies by default, those hosted bodies bypassed InterpolatedStringHandlerLowerer (and the sibling SideEffectSpiller pass) and could still reach the emitter with a raw BoundInterpolatedStringExpression.

This change adds a shared NestedFunctionBodyRewriter base for scope-neutral emit-pipeline rewriters, then uses it for the interpolated-string and side-effect lowering passes so hosted nested bodies follow the same lowering path as ordinary bodies. Added emit regression coverage for both arrow lambdas and generic local functions, and re-enabled the grid lambda fixture to exercise interpolation directly.