### PR TITLE
cs2gs: fix multi-dimensional array silent 1-D lowering (#1893)

### DIFF
--- a/docs/cs2gs-coverage-matrix.md
+++ b/docs/cs2gs-coverage-matrix.md
@@ -25,7 +25,7 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | AndPattern | BinaryPatternSyntax | ADR-0115 §B.22 |  | tools/cs2gs/corpus/grid/G04-Patterns-Console/Constructs/AndPattern.cs |  |  |
 | Argument | ArgumentSyntax | ADR-0115 §B |  |  |  |  |
 | ArgumentList | ArgumentListSyntax | ADR-0115 §B |  |  |  |  |
-| ArrayCreationExpression | ArrayCreationExpressionSyntax | ADR-0115 §B.16 |  | tools/cs2gs/corpus/grid/G05-Collections-Console/Constructs/ArrayCreationExpression.cs | https://github.com/DavidObando/gsharp/issues/1893 | Multi-dim arrays silently lowered to 1-D (issue #1893, parity-verified); 1-D/jagged green. |
+| ArrayCreationExpression | ArrayCreationExpressionSyntax | ADR-0115 §B.16 |  | tools/cs2gs/corpus/grid/G05-Collections-Console/Constructs/ArrayCreationExpression.cs | https://github.com/DavidObando/gsharp/issues/1893 | 1-D/jagged green; rank>1 (issue #1893) flat-lowers a tracked local's rectangular `new T[d0, d1, ...]`/`new T[,]{{...}}` to a single backing array with hoisted per-dimension sizes, preserving every index (see ArrayCreationExpressionMultiDim.cs, parity-verified). An untracked rank>1 shape (field/parameter/no-initializer) reports the CS2GS-GAP instead of silently collapsing to 1-D. |
 | ArrayInitializerExpression | InitializerExpressionSyntax | ADR-0115 §B.16 |  | tools/cs2gs/corpus/grid/G05-Collections-Console/Constructs/ArrayInitializerExpression.cs |  |  |
 | ArrayRankSpecifier | ArrayRankSpecifierSyntax | ADR-0115 §B.16 |  |  |  |  |
 | ArrayType | ArrayTypeSyntax | ADR-0115 §B.16 |  |  |  |  |

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1893MultiDimArrayTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1893MultiDimArrayTranslationTests.cs
@@ -1,0 +1,179 @@
+// <copyright file="Issue1893MultiDimArrayTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #1893: a C# rectangular multi-dim array (<c>T[,]</c>) was silently
+/// lowered to a 1-D G# array, dropping every index past the first
+/// (<c>grid[r, c]</c> translated as if it were <c>grid[r]</c>) — a silent
+/// miscompile that crashed at runtime with
+/// <c>IndexOutOfRangeException: Array does not have that many dimensions</c>.
+/// A separate sub-case, the rectangular initializer
+/// (<c>new int[,] {{1, 2, 3}, {4, 5, 6}}</c>), failed to compile entirely
+/// (GS0155) because it lowered to a jagged array-of-<c>object</c>.
+/// <para>
+/// gsc has no rectangular multi-dim array type (only the fixed-length
+/// <c>[N]T</c> / slice <c>[]T</c>, both rank 1), so a tracked <c>T[,]</c>
+/// local (one declared and initialized in the same statement from
+/// <c>new T[d0, d1, ...]</c> or a rectangular initializer) is flat-lowered to
+/// a single backing array of length <c>d0*d1*...</c>, with every
+/// <c>grid[r, c]</c> access (read and write) and <c>grid.GetLength(k)</c> call
+/// rewritten to the faithful row-major flat index/dimension — decision fork
+/// B1 (flat lowering), since fork A (native gsc rectangular arrays) is not
+/// available in gsc's type system today.
+/// </para>
+/// </summary>
+public class Issue1893MultiDimArrayTranslationTests
+{
+    [Fact]
+    public void SizedCreation_FlatLowersWithHoistedDimensionsAndPreservesBothIndices()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1893
+{
+    public class Grid
+    {
+        public static int Run()
+        {
+            int[,] grid = new int[2, 3];
+            grid[0, 0] = 1;
+            grid[0, 1] = 2;
+            grid[0, 2] = 3;
+            grid[1, 0] = 4;
+            grid[1, 1] = 5;
+            grid[1, 2] = 6;
+
+            int sum = 0;
+            for (int r = 0; r < grid.GetLength(0); r++)
+            {
+                for (int c = 0; c < grid.GetLength(1); c++)
+                {
+                    sum += grid[r, c];
+                }
+            }
+
+            return sum;
+        }
+    }
+}
+");
+
+        // Flat backing array: length is the product of the two hoisted dims.
+        Assert.Contains("let gridDim0", rendered, StringComparison.Ordinal);
+        Assert.Contains("let gridDim1", rendered, StringComparison.Ordinal);
+        Assert.Contains("let grid = [gridDim0 * gridDim1]int32", rendered, StringComparison.Ordinal);
+
+        // Every write keeps both indices, flattened row-major (r * cols + c).
+        Assert.Contains("grid[0 * gridDim1 + 0] = 1", rendered, StringComparison.Ordinal);
+        Assert.Contains("grid[1 * gridDim1 + 2] = 6", rendered, StringComparison.Ordinal);
+
+        // The read in the sum loop also keeps both indices.
+        Assert.Contains("grid[r * gridDim1 + c]", rendered, StringComparison.Ordinal);
+
+        // GetLength(0)/GetLength(1) resolve to the tracked per-dimension sizes,
+        // not a call into a rank-1 CLR array's GetLength (which would throw).
+        Assert.Contains("r < gridDim0", rendered, StringComparison.Ordinal);
+        Assert.Contains("c < gridDim1", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("GetLength", rendered, StringComparison.Ordinal);
+
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void RectangularInitializer_FlatLowersToRealElementArrayNotJaggedObject()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1893
+{
+    public class Grid
+    {
+        public static int Run()
+        {
+            int[,] lit = new int[,] { { 1, 2, 3 }, { 4, 5, 6 } };
+            return lit[1, 2];
+        }
+    }
+}
+");
+
+        // Flat element-typed slice literal, row-major, NOT nested `[]object{...}`
+        // (the #1893 GS0155 compile failure).
+        Assert.Contains("let lit = []int32{1, 2, 3, 4, 5, 6}", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("object", rendered, StringComparison.Ordinal);
+
+        // The read keeps both indices, flattened against the constant column
+        // count (3) inferred from the initializer's shape.
+        Assert.Contains("lit[1 * 3 + 2]", rendered, StringComparison.Ordinal);
+
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void UntrackedMultiDimElementAccess_StaysLoudGapInsteadOfSilentlyDroppingIndex()
+    {
+        // A multi-dim array reached through a field (not a direct
+        // declaration-with-initializer local) has no symbol for the translator
+        // to hang per-dimension sizes on, so it must report the CS2GS-GAP
+        // rather than silently translate `grid[r, c]` as `grid[r]` (the
+        // original bug).
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", @"
+namespace Corpus.Issue1893
+{
+    public class Holder
+    {
+        public int[,] Grid;
+
+        public int Get(int r, int c)
+        {
+            return Grid[r, c];
+        }
+    }
+}
+") });
+
+        Assert.True(project.BoundWithoutErrors);
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        Assert.Contains(
+            context.Diagnostics,
+            d => d.Message.Contains("no tracked per-dimension sizes", StringComparison.Ordinal));
+    }
+
+    private static void AssertRoundTripParses(string rendered)
+    {
+        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+
+        Assert.True(
+            result.Success,
+            "Sanitized G# must round-trip-parse. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + rendered);
+    }
+
+    private static string Render(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", source) });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        Cs2Gs.CodeModel.Ast.CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        Assert.Empty(context.Diagnostics);
+        return GSharpPrinter.Print(unit);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -461,6 +461,22 @@ public sealed class CSharpToGSharpTranslator
         private readonly Dictionary<(ISymbol Symbol, SyntaxNode Scope), bool> usedAsNullableCache =
             new Dictionary<(ISymbol, SyntaxNode), bool>(SymbolScopeKeyComparer.Instance);
 
+        // Issue #1893: gsc has no rectangular multi-dimensional array type (only
+        // the fixed-length `[N]T`/slice `[]T`, both rank 1), so a C# `T[,]` local
+        // initialized directly from `new T[d0, d1, ...]` (or a rectangular
+        // initializer `new T[,]{{...}}`) is lowered to a single flat backing
+        // array of length `d0*d1*...`, with each dimension's size hoisted to its
+        // own `let` (or, for a literal initializer, kept as the constant row/
+        // column count). This map remembers, per declared local/field symbol,
+        // the ordered per-dimension size expressions so every later `grid[r, c]`
+        // access and `grid.GetLength(k)` call can rebuild the faithful
+        // row-major flat index/dimension instead of dropping indices. A
+        // multi-dim array reached through any other shape (field, parameter,
+        // return value, reassignment, ...) is not tracked here and reports a
+        // loud CS2GS-GAP rather than silently collapsing to 1-D.
+        private readonly Dictionary<ISymbol, MultiDimArrayInfo> multiDimArrays =
+            new Dictionary<ISymbol, MultiDimArrayInfo>(SymbolEqualityComparer.Default);
+
         // The syntax node whose body is currently being translated. It bounds the
         // data-flow scan that decides whether a local is mutable (var) or
         // immutable (let) per ADR-0115 §B.3.
@@ -3948,6 +3964,23 @@ public sealed class CSharpToGSharpTranslator
                 if (declarator.Initializer == null)
                 {
                     initializer = null;
+                }
+                else if (declarator.Initializer.Value is ArrayCreationExpressionSyntax multiDimCreation &&
+                    multiDimCreation.Type.RankSpecifiers.Count > 0 &&
+                    multiDimCreation.Type.RankSpecifiers[0].Sizes.Count > 1)
+                {
+                    // Issue #1893: `T[,] grid = new T[d0, d1, ...]` / `= new
+                    // T[,]{{...}}` — flat-lower to a tracked backing array (see
+                    // TranslateMultiDimArrayCreationForLocal) rather than the
+                    // general single-dim initializer path below, which would
+                    // silently drop every dimension past the first.
+                    var multiDimPrologue = new List<GStatement>();
+                    initializer = this.TranslateMultiDimArrayCreationForLocal(
+                        multiDimCreation,
+                        SanitizeIdentifier(declarator.Identifier.Text),
+                        this.context.GetDeclaredSymbol(declarator),
+                        multiDimPrologue);
+                    results.AddRange(multiDimPrologue);
                 }
                 else
                 {
@@ -7785,6 +7818,15 @@ public sealed class CSharpToGSharpTranslator
                             sliceRange);
                     }
 
+                    // Issue #1893: a multi-index access (`grid[r, c, ...]`) against
+                    // a genuine multi-dim array (Rank > 1) needs every index — the
+                    // single-index path below only ever reads argument 0.
+                    if (elementAccess.ArgumentList.Arguments.Count > 1 &&
+                        this.context.GetTypeInfo(elementAccess.Expression).Type is IArrayTypeSymbol { Rank: > 1 } multiDimArray)
+                    {
+                        return this.TranslateMultiDimElementAccess(elementAccess, multiDimArray.Rank);
+                    }
+
                     GExpression index = elementAccess.ArgumentList.Arguments.Count > 0
                         ? this.CoerceIndexToInt32(
                             elementAccess,
@@ -8457,6 +8499,23 @@ public sealed class CSharpToGSharpTranslator
         {
             GTypeReference elementType = this.GetArrayElementType(creation, creation.Type.ElementType);
 
+            if (creation.Type.RankSpecifiers.Count > 0 && creation.Type.RankSpecifiers[0].Sizes.Count > 1)
+            {
+                // A rectangular multi-dim `new T[d0, d1, ...]` / `new T[,]{{...}}`
+                // reached from anywhere other than a tracked local declaration
+                // (see TranslateLocalDeclaration) has no symbol to hang its
+                // per-dimension sizes on, so a later `x[i, j]`/`x.GetLength(k)`
+                // could not rebuild the flat index. Rather than silently emit a
+                // lossy 1-D array (the original #1893 bug), report the gap loudly.
+                string multiDimCreationGapMessage =
+                    "multi-dimensional array creation is only supported as the direct initializer of a local " +
+                    "variable declaration (`T[,] x = new T[d0, d1, ...]` or `T[,] x = new T[,]{{...}}`); this " +
+                    "shape has no symbol to track per-dimension sizes against, so it has no canonical " +
+                    "flat-array mapping yet.";
+                this.context.ReportUnsupported(creation, multiDimCreationGapMessage);
+                return new ArrayAllocationExpression(elementType, LiteralExpression.Int("0"));
+            }
+
             if (creation.Initializer != null)
             {
                 // `new T[]{a, b}` / `new T[0]` (with an explicit, possibly empty,
@@ -8486,6 +8545,150 @@ public sealed class CSharpToGSharpTranslator
             }
 
             return new ArrayAllocationExpression(elementType, length);
+        }
+
+        /// <summary>
+        /// Issue #1893: lowers a C# rectangular multi-dim array creation
+        /// (<c>new T[d0, d1, ...]</c> or the initializer form
+        /// <c>new T[,]{{...}}</c>) that is the DIRECT initializer of a tracked
+        /// local declaration to a single flat backing array of length
+        /// <c>d0*d1*...</c>. Registers <paramref name="declaredSymbol"/> in
+        /// <see cref="multiDimArrays"/> so later <c>x[i, j, ...]</c> element
+        /// access and <c>x.GetLength(k)</c> calls can rebuild the row-major flat
+        /// index / per-dimension size instead of the original bug's silent 1-D
+        /// collapse (dropped indices). Runtime-sized dimensions (<c>new T[rows,
+        /// cols]</c>) are each hoisted into their own `let` — evaluated once,
+        /// exactly where C# evaluates them — appended to
+        /// <paramref name="prologue"/> ahead of the declaration statement
+        /// itself; a rectangular initializer's dimensions are compile-time
+        /// constants (the outer/inner element counts) and need no hoist.
+        /// </summary>
+        /// <param name="creation">The multi-dim array-creation syntax.</param>
+        /// <param name="variableBaseName">
+        /// The sanitized declared variable name, used to derive readable
+        /// per-dimension hoisted `let` names (e.g. <c>gridDim0</c>).
+        /// </param>
+        /// <param name="declaredSymbol">
+        /// The declared local/field symbol the array is bound to, or
+        /// <see langword="null"/> if none (tracking is then skipped and later
+        /// accesses report the loud gap).
+        /// </param>
+        /// <param name="prologue">Receives any hoisted dimension `let` statements.</param>
+        /// <returns>The flat-array G# initializer expression.</returns>
+        private GExpression TranslateMultiDimArrayCreationForLocal(
+            ArrayCreationExpressionSyntax creation,
+            string variableBaseName,
+            ISymbol declaredSymbol,
+            List<GStatement> prologue)
+        {
+            GTypeReference elementType = this.GetArrayElementType(creation, creation.Type.ElementType);
+            int rank = creation.Type.RankSpecifiers[0].Sizes.Count;
+            List<GExpression> dimensionSizes;
+            GExpression flatArrayExpression;
+
+            if (creation.Initializer != null)
+            {
+                var dims = new int[rank];
+                var leaves = new List<ExpressionSyntax>();
+                FlattenRectangularArrayInitializer(creation.Initializer, level: 0, rank: rank, dims: dims, leaves: leaves);
+                dimensionSizes = dims
+                    .Select(d => (GExpression)LiteralExpression.Int(d.ToString(CultureInfo.InvariantCulture)))
+                    .ToList();
+                flatArrayExpression = new ArrayLiteralExpression(
+                    elementType,
+                    leaves.Select(this.TranslateExpression).ToList());
+            }
+            else
+            {
+                dimensionSizes = new List<GExpression>();
+                for (int i = 0; i < rank; i++)
+                {
+                    ExpressionSyntax sizeExpr = creation.Type.RankSpecifiers[0].Sizes[i];
+                    GExpression translatedSize = this.CoerceLengthToInt32(sizeExpr, this.TranslateExpression(sizeExpr));
+                    string dimName = SanitizeIdentifier($"{variableBaseName}Dim{i}");
+                    prologue.Add(new LocalDeclarationStatement(BindingKind.Let, dimName, type: null, initializer: translatedSize));
+                    dimensionSizes.Add(new IdentifierExpression(dimName));
+                }
+
+                GExpression length = dimensionSizes.Aggregate((a, b) => new BinaryExpression(a, "*", b));
+                flatArrayExpression = new ArrayAllocationExpression(elementType, length);
+            }
+
+            if (declaredSymbol != null)
+            {
+                this.multiDimArrays[declaredSymbol] = new MultiDimArrayInfo(dimensionSizes);
+            }
+
+            return flatArrayExpression;
+        }
+
+        /// <summary>
+        /// Recursively walks a rectangular multi-dim initializer
+        /// (<c>{{1, 2, 3}, {4, 5, 6}}</c>), recording each level's element count
+        /// into <paramref name="dims"/> (once, from the first branch — C#
+        /// guarantees every branch at a level is the same length) and
+        /// collecting the leaf value expressions into <paramref name="leaves"/>
+        /// in row-major order.
+        /// </summary>
+        private static void FlattenRectangularArrayInitializer(
+            InitializerExpressionSyntax node, int level, int rank, int[] dims, List<ExpressionSyntax> leaves)
+        {
+            dims[level] = node.Expressions.Count;
+            if (level == rank - 1)
+            {
+                leaves.AddRange(node.Expressions);
+                return;
+            }
+
+            foreach (ExpressionSyntax child in node.Expressions)
+            {
+                FlattenRectangularArrayInitializer(
+                    (InitializerExpressionSyntax)child, level + 1, rank, dims, leaves);
+            }
+        }
+
+        /// <summary>
+        /// Issue #1893: translates a multi-index element access
+        /// (<c>grid[r, c, ...]</c>, read or write — an assignment LHS routes
+        /// here too via <see cref="TranslateAssignmentTarget"/>) against a
+        /// tracked flat-lowered multi-dim array to the faithful row-major flat
+        /// index <c>grid[((r * dim1) + c) * ... ]</c>, using every index (the
+        /// original bug dropped every index past the first). An access whose
+        /// receiver was not tracked by <see cref="multiDimArrays"/> (e.g. a
+        /// field, parameter, or return value — see the deliberate scope note on
+        /// <see cref="multiDimArrays"/>) reports the loud gap instead of
+        /// silently collapsing to 1-D.
+        /// </summary>
+        private GExpression TranslateMultiDimElementAccess(ElementAccessExpressionSyntax elementAccess, int rank)
+        {
+            GExpression target = this.TranslateReceiverWithNullForgiveness(elementAccess.Expression);
+            ISymbol receiverSymbol = this.context.GetSymbolInfo(elementAccess.Expression).Symbol;
+            if (receiverSymbol == null ||
+                !this.multiDimArrays.TryGetValue(receiverSymbol, out MultiDimArrayInfo info) ||
+                info.DimensionSizes.Count != rank)
+            {
+                string elementAccessGapMessage =
+                    "multi-dimensional array element access has no tracked per-dimension sizes for this " +
+                    "receiver; only a local initialized directly from `new T[d0, d1, ...]` or a rectangular " +
+                    "initializer is supported, so this access has no canonical flat-array mapping yet.";
+                this.context.ReportUnsupported(elementAccess, elementAccessGapMessage);
+                return new IndexExpression(
+                    target, this.TranslateExpression(elementAccess.ArgumentList.Arguments[0].Expression));
+            }
+
+            List<GExpression> indexArguments = elementAccess.ArgumentList.Arguments
+                .Select(a => this.TranslateExpression(a.Expression))
+                .ToList();
+
+            // Row-major flattening: acc = i0; acc = acc*dim1 + i1; acc = acc*dim2 + i2; ...
+            GExpression flatIndex = indexArguments[0];
+            for (int i = 1; i < rank; i++)
+            {
+                flatIndex = new BinaryExpression(
+                    new BinaryExpression(flatIndex, "*", info.DimensionSizes[i]), "+", indexArguments[i]);
+            }
+
+            return new IndexExpression(target, flatIndex);
         }
 
         private GExpression TranslateStackAlloc(StackAllocArrayCreationExpressionSyntax node)
@@ -9293,6 +9496,37 @@ public sealed class CSharpToGSharpTranslator
         {
             GExpression target;
             IReadOnlyList<GTypeReference> typeArguments = null;
+
+            // Issue #1893: `grid.GetLength(k)` against a genuine multi-dim array
+            // (Rank > 1) has no meaning on the flat backing array gsc actually
+            // holds (a rank-1 `.GetLength(1)` throws
+            // IndexOutOfRangeException at runtime — the original bug's crash).
+            // For a tracked array with a compile-time-constant `k`, substitute
+            // the corresponding hoisted/constant dimension size directly.
+            if (invocation.Expression is MemberAccessExpressionSyntax { Name.Identifier.Text: "GetLength" } getLengthMember &&
+                invocation.ArgumentList.Arguments.Count == 1 &&
+                this.context.GetTypeInfo(getLengthMember.Expression).Type is IArrayTypeSymbol { Rank: > 1 })
+            {
+                ISymbol receiverSymbol = this.context.GetSymbolInfo(getLengthMember.Expression).Symbol;
+                Optional<object> constantDimIndex =
+                    this.context.SemanticModel.GetConstantValue(invocation.ArgumentList.Arguments[0].Expression);
+                if (receiverSymbol != null &&
+                    this.multiDimArrays.TryGetValue(receiverSymbol, out MultiDimArrayInfo getLengthInfo) &&
+                    constantDimIndex.HasValue &&
+                    constantDimIndex.Value is int dimIndex &&
+                    dimIndex >= 0 &&
+                    dimIndex < getLengthInfo.DimensionSizes.Count)
+                {
+                    return getLengthInfo.DimensionSizes[dimIndex];
+                }
+
+                string getLengthGapMessage =
+                    "Array.GetLength on a multi-dimensional array requires a tracked receiver (a local " +
+                    "initialized directly from `new T[d0, d1, ...]` or a rectangular initializer) and a " +
+                    "compile-time-constant dimension index; this call has no canonical G# mapping yet.";
+                this.context.ReportUnsupported(invocation, getLengthGapMessage);
+                return LiteralExpression.Int("0");
+            }
 
             // C# delegate/event invocation `d.Invoke(args)` / `d?.Invoke(args)` maps
             // to G#'s direct function-call form `d(args)` / `d?(args)`: G# invokes a
@@ -11574,6 +11808,25 @@ public sealed class CSharpToGSharpTranslator
                 HashCode.Combine(
                     SymbolEqualityComparer.Default.GetHashCode(obj.Symbol),
                     System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(obj.Scope));
+        }
+
+        // Issue #1893: per-declared-symbol record of a flat-lowered multi-dim
+        // array's per-dimension size expressions. See the field comment on
+        // <see cref="multiDimArrays"/> for the full rationale.
+        private sealed class MultiDimArrayInfo
+        {
+            public MultiDimArrayInfo(IReadOnlyList<GExpression> dimensionSizes)
+            {
+                this.DimensionSizes = dimensionSizes;
+            }
+
+            /// <summary>
+            /// Gets the per-dimension size expressions, outermost dimension
+            /// first, each safe to reference repeatedly (a hoisted `let`
+            /// identifier or a compile-time-constant literal — never a raw
+            /// expression that could re-run a side effect).
+            /// </summary>
+            public IReadOnlyList<GExpression> DimensionSizes { get; }
         }
     }
 }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
@@ -194,6 +194,28 @@ public sealed class CSharpTypeMapper
 
         if (type is IArrayTypeSymbol array)
         {
+            if (array.Rank > 1)
+            {
+                // Issue #1893: gsc has no rectangular multi-dim array type (only
+                // the fixed-length `[N]T`/slice `[]T`, both rank 1). A
+                // multi-dim TYPE reached here (e.g. an explicit `T[,] x;` with
+                // no initializer, a field/parameter/return type) has no symbol
+                // for TranslateLocalDeclaration's flat-lowering to hang
+                // per-dimension sizes on, so — rather than silently returning a
+                // 1-D `ArrayTypeReference` that drops the rank (the original
+                // bug) — report the gap loudly. A local declared AND
+                // initialized in one statement from `new T[d0, d1, ...]` avoids
+                // this path entirely: TranslateLocalDeclaration omits the type
+                // clause and relies on inference over the already-flat-lowered
+                // initializer.
+                string multiDimTypeGapMessage =
+                    $"multi-dimensional array type '{array}' (rank {array.Rank}) has no canonical G# type; " +
+                    "only a local declared and initialized in the same statement from `new T[d0, d1, ...]` " +
+                    "or a rectangular initializer is supported today.";
+                context.Report(new TranslationDiagnostic(
+                    "ArrayType", multiDimTypeGapMessage, location, TranslationSeverity.Unsupported));
+            }
+
             return new ArrayTypeReference(this.Map(array.ElementType, context, location));
         }
 

--- a/tools/cs2gs/corpus/grid/G05-Collections-Console/Constructs/ArrayCreationExpressionMultiDim.cs
+++ b/tools/cs2gs/corpus/grid/G05-Collections-Console/Constructs/ArrayCreationExpressionMultiDim.cs
@@ -1,14 +1,4 @@
-// inventory: ArrayCreationExpression — QUARANTINED at test-parity (SILENT
-// DIVERGENCE): translate and compile PASS, but 'new int[2, 3]' is emitted as
-// the 1-D G# array 'let grid = [2]int32' and every 'grid[r, c]' access drops
-// the second index ('grid[0] = 1; grid[0] = 2; ...'), so grid.GetLength(1)
-// throws at runtime.
-//   expected stdout: 'ArrayCreationExpressionMultiDim: sum=21 rows=2 cols=3'
-//   actual stdout:   '' (crash: System.IndexOutOfRangeException: Array does
-//                    not have that many dimensions. at System.Array.GetLength)
-// The literal form 'new int[,] { { 1, 2, 3 }, { 4, 5, 6 } }' separately fails
-// gsc compile: GS0155 "Cannot convert type '[]object' to 'int32'." because it
-// lowers to []int32{[]object{1, 2, 3}, []object{4, 5, 6}}.
+// inventory: ArrayCreationExpression — multi-dim rank>1 sub-case (#1893).
 using System;
 
 namespace Corpus.Grid05

--- a/tools/cs2gs/corpus/grid/G05-Collections-Console/Program.cs
+++ b/tools/cs2gs/corpus/grid/G05-Collections-Console/Program.cs
@@ -11,6 +11,7 @@ namespace Corpus.Grid05
         {
             AnonymousObjectCreationExpressionFixture.Run();
             ArrayCreationExpressionFixture.Run();
+            ArrayCreationExpressionMultiDimFixture.Run();
             ArrayInitializerExpressionFixture.Run();
             CollectionExpressionFixture.Run();
             CollectionInitializerExpressionFixture.Run();

--- a/tools/cs2gs/corpus/grid/G05-Collections-Console/baseline.stdout.golden
+++ b/tools/cs2gs/corpus/grid/G05-Collections-Console/baseline.stdout.golden
@@ -3,6 +3,8 @@ ArrayCreationExpression: sized=10,20,30
 ArrayCreationExpression: words=alpha,beta
 ArrayCreationExpression: jagged0=1,2 jagged1=3,4,5
 ArrayCreationExpression: withInit=7,8,9
+ArrayCreationExpressionMultiDim: sum=21 rows=2 cols=3
+ArrayCreationExpressionMultiDim: lit[1,2]=6 lit[0,1]=2
 ArrayInitializerExpression: xs=1,2,3
 ArrayInitializerExpression: names=north,south
 ArrayInitializerExpression: single=42 len=1

--- a/tools/cs2gs/coverage/csharp-construct-inventory.json
+++ b/tools/cs2gs/coverage/csharp-construct-inventory.json
@@ -123,7 +123,7 @@
     "rationale": "None",
     "fixture": "tools/cs2gs/corpus/grid/G05-Collections-Console/Constructs/ArrayCreationExpression.cs",
     "issue": "https://github.com/DavidObando/gsharp/issues/1893",
-    "notes": "Multi-dim arrays silently lowered to 1-D (issue #1893, parity-verified); 1-D/jagged green."
+    "notes": "1-D/jagged green; rank\u003E1 (issue #1893) flat-lowers a tracked local\u0027s rectangular \u0060new T[d0, d1, ...]\u0060/\u0060new T[,]{{...}}\u0060 to a single backing array with hoisted per-dimension sizes, preserving every index (see ArrayCreationExpressionMultiDim.cs, parity-verified). An untracked rank\u003E1 shape (field/parameter/no-initializer) reports the CS2GS-GAP instead of silently collapsing to 1-D."
   },
   {
     "kind": "ArrayInitializerExpression",


### PR DESCRIPTION
Fixes #1893

Fork taken: B1 (flat lowering). gsc has no rectangular multi-dim array type — only fixed `[N]T`/slice `[]T`, both rank 1 (checked src/Core/CodeAnalysis/Symbols/ArrayTypeSymbol.cs, no rank/comma syntax anywhere in binder/emitter/spec). Fork A (native gsc support) is out. Chose B1 over B2 (loud gap only) because a faithful general flat lowering is fully tractable and gives correct runtime output, not just a diagnostic.

What changed:
- A tracked `T[,]` local (declared+initialized in one statement from `new T[d0, d1, ...]` or a rectangular initializer `new T[,]{{...}}`) flat-lowers to one backing array of length `d0*d1*...`. Dimension sizes are hoisted once (each evaluated exactly where C# would). Every `grid[r, c]` (read+write) and `grid.GetLength(k)` rewrites to the row-major flat index/dimension — every index preserved, generalized to any rank/element type.
- Example emitted G# for `new int[2,3]`:
  ```
  let gridDim0 = 2
  let gridDim1 = 3
  let grid = [gridDim0 * gridDim1]int32
  grid[r * gridDim1 + c] = v
  ```
- Any untracked multi-dim shape (field, parameter, no-initializer local, return value) has no symbol to hang dims on — reports CS2GS-GAP loudly instead of silently mistranslating (no silent miscompile left anywhere).

DoD:
- [x] Root-cause fix: array TYPE, CREATION (sized+initializer), ELEMENT ACCESS (read+write), generalized to any rank/element type.
- [x] Issue1893MultiDimArrayTranslationTests.cs added (sized creation, rectangular initializer, untracked-gap case). 3/3 pass.
- [x] G05 quarantined fixture re-enabled, Program.cs wired, baseline.stdout.golden recaptured from the C# oracle.
- [x] csharp-construct-inventory.json row updated; `coverage --write` regenerated docs/cs2gs-coverage-matrix.md + golden. No `*.actual` drift.

Verify:
- Translator build: 0 errors.
- gsc build: 0 errors.
- `migrate --app G05-Collections-Console`: translate/compile/ilverify/test-parity all PASS — test-parity confirms G# runtime stdout matches the C# oracle exactly (this is what previously crashed with IndexOutOfRangeException).
- `dotnet test ... --filter FullyQualifiedName~Issue1893`: 3/3 passed.

Deferrals (named, none silent):
- Multi-dim arrays reached via a field, method parameter, return type, or a local not declared+initialized in one statement are not tracked — they report CS2GS-GAP (translate-stage gate failure) rather than translating. No existing corpus fixture uses these shapes today.
- `Array.GetLength(k)` only resolves for a compile-time-constant `k`; a non-constant dimension index on a tracked array also reports the gap.