### PR TITLE
Fix generic receiver-clause functions rejecting implemented-interface receivers under MLC (GS0155)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -224,7 +224,7 @@ public sealed class Binder
             isAsyncIteratorReturnType: IsAsyncIteratorReturnType,
             tryGetFunctionLiteral: LambdaBinder.TryGetFunctionLiteral,
             inferTypeArguments: InferTypeArguments,
-            substituteType: SubstituteType,
+            substituteType: (t, subst) => SubstituteType(t, subst, scope.References.MapClrTypeToReferences),
             satisfiesConstraint: SatisfiesConstraint,
             describeConstraint: DescribeConstraint,
             getCurrentFunction: () => this.function,
@@ -4005,7 +4005,50 @@ public sealed class Binder
         return null;
     }
 
+    /// <summary>
+    /// Substitutes type parameters in <paramref name="type"/> using
+    /// <paramref name="substitution"/>. Equivalent to calling the
+    /// <see cref="SubstituteType(TypeSymbol, Dictionary{TypeParameterSymbol, TypeSymbol}, Func{Type, Type})"/>
+    /// overload with a <see langword="null"/> CLR-type mapper (safe for
+    /// single-reflection-context callers, i.e. every compile that does not
+    /// pass an explicit <c>/r:</c> reference set to <c>gsc</c>).
+    /// </summary>
+    /// <param name="type">The type to substitute.</param>
+    /// <param name="substitution">The type-parameter to type-argument map.</param>
+    /// <returns>The substituted type.</returns>
     internal static TypeSymbol SubstituteType(TypeSymbol type, Dictionary<TypeParameterSymbol, TypeSymbol> substitution)
+        => SubstituteType(type, substitution, null);
+
+    /// <summary>
+    /// Issue #1926: <paramref name="mapClrType"/> projects a substituted type
+    /// argument's <see cref="TypeSymbol.ClrType"/> into the SAME reflection
+    /// context as the constructed generic's <c>OpenDefinition</c> before
+    /// calling <see cref="Type.MakeGenericType(Type[])"/>. Well-known
+    /// primitive <see cref="TypeSymbol"/>s (e.g. <see cref="TypeSymbol.Int32"/>)
+    /// always carry the host process's live <c>typeof(int)</c>, but a
+    /// <c>gsc</c> compile that supplies an explicit <c>/r:</c> reference set
+    /// resolves imported generics (e.g. <c>IReadOnlyList[T]</c>) through an
+    /// isolated <see cref="System.Reflection.MetadataLoadContext"/>.
+    /// <c>MakeGenericType</c> throws when its generic-definition and
+    /// type-argument <see cref="Type"/>s come from different reflection
+    /// contexts, so closing a generic extension's receiver clause (or any
+    /// other generic member) over a primitive silently fell back to the
+    /// erased <c>object</c>-argument form — which then fails an interface
+    /// conversion check that would otherwise succeed (GS0155: <c>List[T]</c>
+    /// not convertible to a receiver-clause's <c>IReadOnlyList[T]</c>). Passing
+    /// <c>null</c> (the default, single-context callers) skips the projection
+    /// and keeps prior behaviour identical.
+    /// </summary>
+    /// <param name="type">The type to substitute.</param>
+    /// <param name="substitution">The type-parameter to type-argument map.</param>
+    /// <param name="mapClrType">
+    /// Projects a host CLR <see cref="Type"/> into the reflection context that
+    /// the type being substituted was resolved from (typically
+    /// <see cref="Symbols.ReferenceResolver.MapClrTypeToReferences"/>), or
+    /// <see langword="null"/> to skip the projection.
+    /// </param>
+    /// <returns>The substituted type.</returns>
+    internal static TypeSymbol SubstituteType(TypeSymbol type, Dictionary<TypeParameterSymbol, TypeSymbol> substitution, Func<Type, Type> mapClrType)
     {
         if (type is TypeParameterSymbol tp)
         {
@@ -4014,19 +4057,19 @@ public sealed class Binder
 
         if (type is NullableTypeSymbol n)
         {
-            var inner = SubstituteType(n.UnderlyingType, substitution);
+            var inner = SubstituteType(n.UnderlyingType, substitution, mapClrType);
             return ReferenceEquals(inner, n.UnderlyingType) ? type : NullableTypeSymbol.Get(inner);
         }
 
         if (type is SliceTypeSymbol s)
         {
-            var inner = SubstituteType(s.ElementType, substitution);
+            var inner = SubstituteType(s.ElementType, substitution, mapClrType);
             return ReferenceEquals(inner, s.ElementType) ? type : SliceTypeSymbol.Get(inner);
         }
 
         if (type is ArrayTypeSymbol a)
         {
-            var inner = SubstituteType(a.ElementType, substitution);
+            var inner = SubstituteType(a.ElementType, substitution, mapClrType);
             return ReferenceEquals(inner, a.ElementType) ? type : ArrayTypeSymbol.Get(inner, a.Length);
         }
 
@@ -4036,13 +4079,13 @@ public sealed class Binder
             // receiver of a generic extension lowers to a concrete
             // `sequence[U]` at the call site (and downstream
             // `BindExtensionFunctionCall` sees a matching parameter type).
-            var inner = SubstituteType(seq.ElementType, substitution);
+            var inner = SubstituteType(seq.ElementType, substitution, mapClrType);
             return ReferenceEquals(inner, seq.ElementType) ? type : SequenceTypeSymbol.Get(inner);
         }
 
         if (type is AsyncSequenceTypeSymbol aseq)
         {
-            var inner = SubstituteType(aseq.ElementType, substitution);
+            var inner = SubstituteType(aseq.ElementType, substitution, mapClrType);
             return ReferenceEquals(inner, aseq.ElementType) ? type : AsyncSequenceTypeSymbol.Get(inner);
         }
 
@@ -4057,8 +4100,8 @@ public sealed class Binder
             // reference against the unsubstituted method type parameter and
             // fails verification against the closed kickoff return. Directly
             // analogous to the tuple branch below (#813).
-            var newKey = SubstituteType(map.KeyType, substitution);
-            var newValue = SubstituteType(map.ValueType, substitution);
+            var newKey = SubstituteType(map.KeyType, substitution, mapClrType);
+            var newValue = SubstituteType(map.ValueType, substitution, mapClrType);
             return ReferenceEquals(newKey, map.KeyType) && ReferenceEquals(newValue, map.ValueType)
                 ? type
                 : MapTypeSymbol.Get(newKey, newValue);
@@ -4077,7 +4120,7 @@ public sealed class Binder
             var changed = false;
             foreach (var elem in tup.ElementTypes)
             {
-                var substituted = SubstituteType(elem, substitution);
+                var substituted = SubstituteType(elem, substitution, mapClrType);
                 if (!ReferenceEquals(substituted, elem))
                 {
                     changed = true;
@@ -4095,12 +4138,12 @@ public sealed class Binder
             var builder = ImmutableArray.CreateBuilder<TypeSymbol>(fn.ParameterTypes.Length);
             foreach (var paramType in fn.ParameterTypes)
             {
-                var substituted = SubstituteType(paramType, substitution);
+                var substituted = SubstituteType(paramType, substitution, mapClrType);
                 changed |= !ReferenceEquals(substituted, paramType);
                 builder.Add(substituted);
             }
 
-            var substitutedReturn = SubstituteType(fn.ReturnType, substitution);
+            var substitutedReturn = SubstituteType(fn.ReturnType, substitution, mapClrType);
             changed |= !ReferenceEquals(substitutedReturn, fn.ReturnType);
 
             // ADR-0102 follow-up / issue #818: preserve the per-parameter
@@ -4129,7 +4172,7 @@ public sealed class Binder
             var structChanged = false;
             foreach (var arg in ss.TypeArguments)
             {
-                var substituted = SubstituteType(arg, substitution);
+                var substituted = SubstituteType(arg, substitution, mapClrType);
                 structChanged |= !ReferenceEquals(substituted, arg);
                 newStructArgs.Add(substituted);
             }
@@ -4148,7 +4191,7 @@ public sealed class Binder
         // `Box`1+Tag`1<int32>` rather than the open `Box`1+Tag`1<!0>`.
         if (type is StructSymbol nestedRef && nestedRef.TypeArguments.IsDefaultOrEmpty)
         {
-            var newEnclosing = StructSymbol.SubstituteEnclosingArguments(nestedRef, t => SubstituteType(t, substitution));
+            var newEnclosing = StructSymbol.SubstituteEnclosingArguments(nestedRef, t => SubstituteType(t, substitution, mapClrType));
             if (!newEnclosing.IsDefault)
             {
                 return StructSymbol.ConstructNested(nestedRef.Definition ?? nestedRef, newEnclosing);
@@ -4166,7 +4209,7 @@ public sealed class Binder
             var ifaceChanged = false;
             foreach (var arg in ifaceType.TypeArguments)
             {
-                var substituted = SubstituteType(arg, substitution);
+                var substituted = SubstituteType(arg, substitution, mapClrType);
                 ifaceChanged |= !ReferenceEquals(substituted, arg);
                 newIfaceArgs.Add(substituted);
             }
@@ -4188,7 +4231,7 @@ public sealed class Binder
             var anyFree = false;
             foreach (var arg in it.TypeArguments)
             {
-                var substituted = SubstituteType(arg, substitution);
+                var substituted = SubstituteType(arg, substitution, mapClrType);
                 if (!ReferenceEquals(substituted, arg))
                 {
                     changed = true;
@@ -4221,7 +4264,7 @@ public sealed class Binder
                         break;
                     }
 
-                    clrArgs[i] = clr;
+                    clrArgs[i] = mapClrType != null ? mapClrType(clr) : clr;
                 }
 
                 if (allClr)

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -2978,7 +2978,7 @@ internal sealed partial class ExpressionBinder
                 var variadicParam = method.Parameters[method.Parameters.Length - 1];
                 var sliceType = (SliceTypeSymbol)variadicParam.Type;
                 var substitutedSlice = substitution != null
-                    ? (SliceTypeSymbol)Binder.SubstituteType(sliceType, substitution)
+                    ? (SliceTypeSymbol)Binder.SubstituteType(sliceType, substitution, scope.References.MapClrTypeToReferences)
                     : sliceType;
                 var hasVariadicErrors = false;
 
@@ -3046,7 +3046,7 @@ internal sealed partial class ExpressionBinder
                 // open-type-parameter shortcut so generic static out-parameters
                 // (`func G[T](out r T)`) are handled too.
                 var slotSyntax = i < ce.Arguments.Count ? ce.Arguments[i] : null;
-                var substitutedPointeeType = substitution != null ? Binder.SubstituteType(paramType, substitution) : paramType;
+                var substitutedPointeeType = substitution != null ? Binder.SubstituteType(paramType, substitution, scope.References.MapClrTypeToReferences) : paramType;
                 var reboundOutVar = TryRebindInlineOutVarPlaceholder(permutedArgs[i], slotSyntax, method.Parameters[i], substitutedPointeeType);
                 if (reboundOutVar != null)
                 {
@@ -3078,13 +3078,13 @@ internal sealed partial class ExpressionBinder
                     // the literal's concrete signature and the reified
                     // Func/Action TypeSpec at the call site dispatches
                     // through real Invoke without DynamicInvoke marshalling.
-                    var substitutedOpenTarget = (Binder.SubstituteType(openFunctionParameter, substitution) as FunctionTypeSymbol)
+                    var substitutedOpenTarget = (Binder.SubstituteType(openFunctionParameter, substitution, scope.References.MapClrTypeToReferences) as FunctionTypeSymbol)
                         ?? openFunctionParameter;
                     convertedArgs.Add(lambdas.CreateErasedFunctionLiteralAdapter(functionLiteralArgument, substitutedOpenTarget));
                     continue;
                 }
 
-                var expectedType = substitution != null ? Binder.SubstituteType(paramType, substitution) : paramType;
+                var expectedType = substitution != null ? Binder.SubstituteType(paramType, substitution, scope.References.MapClrTypeToReferences) : paramType;
                 var argLoc = i < ce.Arguments.Count ? ce.Arguments[i].Location : ce.Location;
                 convertedArgs.Add(conversions.BindCallArgumentWithRefKind(argLoc, permutedArgs[i], expectedType, method.Parameters[i]));
             }
@@ -3131,7 +3131,7 @@ internal sealed partial class ExpressionBinder
 
             if (substitution != null)
             {
-                var substitutedReturn = Binder.SubstituteType(method.Type, substitution);
+                var substitutedReturn = Binder.SubstituteType(method.Type, substitution, scope.References.MapClrTypeToReferences);
                 if (method.IsAsync && !isAsyncIteratorReturnType(method.Type))
                 {
                     substitutedReturn = lambdas.WrapAsTask(substitutedReturn);
@@ -4033,11 +4033,11 @@ internal sealed partial class ExpressionBinder
             }
 
             var paramType = readSubstitution != null
-                ? Binder.SubstituteType(readIndexer.Parameters[0].Type, readSubstitution)
+                ? Binder.SubstituteType(readIndexer.Parameters[0].Type, readSubstitution, scope.References.MapClrTypeToReferences)
                 : readIndexer.Parameters[0].Type;
             var indexArg = ConvertIndex(paramType);
             var elementType = readSubstitution != null
-                ? Binder.SubstituteType(readIndexer.Type, readSubstitution)
+                ? Binder.SubstituteType(readIndexer.Type, readSubstitution, scope.References.MapClrTypeToReferences)
                 : readIndexer.Type;
             return new BoundUserInstanceCallExpression(
                 null,
@@ -4413,10 +4413,10 @@ internal sealed partial class ExpressionBinder
             }
 
             var paramType = writeSubstitution != null
-                ? Binder.SubstituteType(writeIndexer.Parameters[0].Type, writeSubstitution)
+                ? Binder.SubstituteType(writeIndexer.Parameters[0].Type, writeSubstitution, scope.References.MapClrTypeToReferences)
                 : writeIndexer.Parameters[0].Type;
             var elementType = writeSubstitution != null
-                ? Binder.SubstituteType(writeIndexer.Type, writeSubstitution)
+                ? Binder.SubstituteType(writeIndexer.Type, writeSubstitution, scope.References.MapClrTypeToReferences)
                 : writeIndexer.Type;
 
             var indexArg = conversions.BindConversion(indexSyntax, paramType);

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -48,7 +48,7 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// back-references <see cref="Binder"/> except for the small set of
 /// static helpers that remain on the root (
 /// <see cref="Binder.InferTypeArguments"/>,
-/// <see cref="Binder.SubstituteType"/>,
+/// <see cref="Binder.SubstituteType(TypeSymbol, Dictionary{TypeParameterSymbol, TypeSymbol})"/>,
 /// <see cref="Binder.SatisfiesConstraint"/>,
 /// <see cref="Binder.DescribeConstraint"/>,
 /// <see cref="Binder.GetClrGenericArguments"/>,

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1926ReceiverInterfaceConversionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1926ReceiverInterfaceConversionTests.cs
@@ -1,0 +1,178 @@
+// <copyright file="Issue1926ReceiverInterfaceConversionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Regression tests for issue #1926: a receiver-clause (extension) function
+/// declared over a constructed generic CLR/user interface (e.g.
+/// <c>func (values IReadOnlyList[T]) …</c>) must accept a call-site receiver
+/// whose static type is a concrete class implementing that interface (e.g.
+/// <c>List[T]</c> implements <c>IReadOnlyList[T]</c>) instead of failing with
+/// GS0155.
+/// </summary>
+/// <remarks>
+/// Root cause: <c>Binder.SubstituteType</c> closes a generic receiver-clause's
+/// declared type (e.g. <c>IReadOnlyList[T]</c>) over its inferred type
+/// argument by calling <see cref="Type.MakeGenericType(Type[])"/> on the
+/// interface's open generic definition with the substituted argument's raw
+/// <see cref="TypeSymbol.ClrType"/>. Well-known primitive
+/// <see cref="TypeSymbol"/>s (<see cref="TypeSymbol.Int32"/>, etc.) always
+/// carry the host process's live <c>typeof(int)</c> — but when <c>gsc</c> is
+/// driven with an explicit <c>/r:</c> reference set (as the cs2gs migration
+/// pipeline and MSBuild task both do), the receiver-clause's own declared
+/// type was resolved through an isolated
+/// <see cref="System.Reflection.MetadataLoadContext"/>. Mixing a live and an
+/// MLC-resolved <see cref="Type"/> in <c>MakeGenericType</c> throws
+/// <see cref="ArgumentException"/>, which was silently swallowed and fell
+/// back to an ERASED <c>IReadOnlyList&lt;object&gt;</c> receiver type — a type
+/// that <c>List&lt;int&gt;</c> does NOT implicitly convert to, so the call
+/// site failed GS0155 even though <c>List&lt;int&gt;</c> genuinely implements
+/// <c>IReadOnlyList&lt;int&gt;</c>. The fix projects every substituted type
+/// argument's CLR type into the SAME reflection context as the declared
+/// receiver's open generic definition (mirroring the existing
+/// <c>ReferenceResolver.MapClrTypeToReferences</c> pattern used throughout the
+/// rest of the binder) before calling <c>MakeGenericType</c>.
+/// </remarks>
+public class Issue1926ReceiverInterfaceConversionTests
+{
+    /// <summary>
+    /// Build a <see cref="ReferenceResolver"/> rooted at the BCL reference
+    /// assemblies. Supplying explicit paths forces gsc into the
+    /// <see cref="System.Reflection.MetadataLoadContext"/> resolution path —
+    /// the same path the cs2gs migration pipeline and the MSBuild task drive
+    /// gsc through — reproducing the cross-reflection-context scenario inside
+    /// the unit-test process.
+    /// </summary>
+    private static ReferenceResolver MetadataLoadContextResolver()
+    {
+        var paths = new[]
+        {
+            typeof(object).Assembly.Location,
+            typeof(System.Collections.Generic.List<>).Assembly.Location,
+            typeof(System.Console).Assembly.Location,
+            typeof(System.Linq.Enumerable).Assembly.Location,
+        }
+        .Where(p => !string.IsNullOrEmpty(p))
+        .Distinct(StringComparer.OrdinalIgnoreCase)
+        .ToArray();
+
+        return ReferenceResolver.WithReferences(paths);
+    }
+
+    private static BoundGlobalScope BindWithMlc(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        return Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree), MetadataLoadContextResolver());
+    }
+
+    private static BoundGlobalScope BindDefault(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        return Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+    }
+
+    [Fact]
+    public void GenericExtension_OverClrInterfaceReceiver_AcceptsImplementingClass_UnderMetadataLoadContext()
+    {
+        // Grid G13's ExtensionMethodsGeneric.MiddleElement<T>(this IReadOnlyList<T>)
+        // translated shape: a generic receiver-clause function whose receiver
+        // is the constructed generic CLR interface `IReadOnlyList[T]`, called
+        // on a `List[int32]` receiver.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            func (items IReadOnlyList[T]) MiddleElement[T]() T {
+                return items[items.Count / 2]
+            }
+
+            var numbers = List[int32]{ 1, 2, 3, 4, 5, 6, 7 }
+            numbers.MiddleElement()
+            """;
+
+        var globalScope = BindWithMlc(source);
+        Assert.Empty(globalScope.Diagnostics.Where(d => d.IsError));
+    }
+
+    [Fact]
+    public void GenericExtension_OverClrDictionaryInterfaceReceiver_AcceptsImplementingClass_UnderMetadataLoadContext()
+    {
+        // #1926 must generalize beyond List -> IReadOnlyList: any CLR class
+        // implementing any constructed generic interface (here
+        // Dictionary[K, V] -> IReadOnlyDictionary[K, V]).
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            func (entries IReadOnlyDictionary[K, V]) CountEntries[K, V]() int32 {
+                return entries.Count
+            }
+
+            var scores = Dictionary[string, int32]{ "alice": 90, "bob": 85 }
+            scores.CountEntries()
+            """;
+
+        var globalScope = BindWithMlc(source);
+        Assert.Empty(globalScope.Diagnostics.Where(d => d.IsError));
+    }
+
+    [Fact]
+    public void GenericExtension_OverClrInterfaceReceiver_AcceptsImplementingClass_ReferenceTypeArgument_UnderMetadataLoadContext()
+    {
+        // Generality check: the fix must not be narrowly special-cased to a
+        // single element type. Exercises a reference-type (string) type
+        // argument alongside the value-type (int32) case in the first test,
+        // covering both MakeGenericType argument shapes.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            func (items IReadOnlyList[T]) MiddleElement[T]() T {
+                return items[items.Count / 2]
+            }
+
+            var words = List[string]{ "alpha", "beta", "gamma" }
+            words.MiddleElement()
+            """;
+
+        var globalScope = BindWithMlc(source);
+        Assert.Empty(globalScope.Diagnostics.Where(d => d.IsError));
+    }
+
+    [Fact]
+    public void GenericExtension_OverClrInterfaceReceiver_AcceptsImplementingClass_ControlCase_DefaultResolver()
+    {
+        // Control case: the same call site must already bind (and keep
+        // binding) under the default (non-MLC) reflection context, so the fix
+        // does not regress the common single-context compile path.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            func (items IReadOnlyList[T]) MiddleElement[T]() T {
+                return items[items.Count / 2]
+            }
+
+            var numbers = List[int32]{ 1, 2, 3, 4, 5, 6, 7 }
+            numbers.MiddleElement()
+            """;
+
+        var globalScope = BindDefault(source);
+        Assert.Empty(globalScope.Diagnostics.Where(d => d.IsError));
+    }
+}

--- a/tools/cs2gs/corpus/grid/G13-Extensions-Console/Constructs/ExtensionMethodsGeneric.cs
+++ b/tools/cs2gs/corpus/grid/G13-Extensions-Console/Constructs/ExtensionMethodsGeneric.cs
@@ -9,13 +9,11 @@ namespace Corpus.Grid13.Constructs
 {
     public static class GenericExtensions
     {
-        // NOTE: `this IReadOnlyList<T> items` is avoided on purpose — gsc
-        // cannot convert the List<int> argument to the interface-typed generic
-        // receiver (GS0155: "Cannot convert type
-        // 'System.Collections.Generic.List`1[[System.Int32,...]]' to
-        // 'System.Collections.Generic.IReadOnlyList`1[int32]'"). An exact
-        // receiver type keeps the generic extension green.
-        public static T MiddleElement<T>(this List<T> items)
+        // Issue #1926 (fixed): `this IReadOnlyList<T> items` — a receiver-clause
+        // (extension) function whose declared receiver is a constructed generic
+        // CLR interface must accept a concrete implementing type at the call
+        // site (`List<int>`/`List<string>` both implement `IReadOnlyList<T>`).
+        public static T MiddleElement<T>(this IReadOnlyList<T> items)
         {
             return items[items.Count / 2];
         }


### PR DESCRIPTION
Fixes #1926

## Root cause
`Binder.SubstituteType` closed generic `ImportedTypeSymbol` receiver types (e.g. `IReadOnlyList[T]`) by calling `MakeGenericType` with raw type-argument `ClrType`s, without projecting them into the active reflection context. Under cs2gs's full-framework-reference compile mode (`MetadataLoadContext`), primitive `TypeSymbol`s (e.g. `TypeSymbol.Int32`) always carry the *host process's* live `Type`, while the receiver's open generic definition is MLC-resolved. Mixing them threw `ArgumentException`, which was silently swallowed, falling back to an erased constructed type (`IReadOnlyList<object>` instead of `IReadOnlyList<int32>`). That erased type then correctly failed `Conversion.Classify` against the real `List<int32>` receiver — GS0155, but for the wrong reason.

## Fix
Thread a `mapClrType` projector (`ReferenceResolver.MapClrTypeToReferences`, already used at ~15 other call sites in `Binder.cs`/`ExpressionBinder.Access.cs`) through `SubstituteType`'s generic-closing path, so constructed receiver types close correctly regardless of reflection context. General fix — not special-cased to `List`/`IReadOnlyList`; also verified with `Dictionary`/`IReadOnlyDictionary`.

## Changes
- `Binder.cs`: new `mapClrType`-aware `SubstituteType` overload; core fix in the `ImportedTypeSymbol` MakeGenericType branch; wired into `OverloadResolver` construction.
- `ExpressionBinder.Access.cs`: 9 call sites updated to pass the projector.
- `ExpressionBinder.cs`: doc-comment disambiguation only.
- Re-enabled quarantined `G13-Extensions-Console` `MiddleElement<T>` fixture (`this IReadOnlyList<T> items`); baseline golden unchanged (already matched fixed output).
- `Issue1926ReceiverInterfaceConversionTests.cs`: 4 tests (List→IReadOnlyList + Dictionary→IReadOnlyDictionary under MLC, reference-type-arg variant, default-resolver control case).
- Coverage inventory confirmed canonical via `cs2gs coverage --write` (0 appended).

## Verification
- Full `Core.Tests`: **5293 passed, 0 failed, 1 skipped** (pre-existing skip).
- `cs2gs migrate --baseline tools/cs2gs/triage/gaps.json`: **0 new, 0 regressed** (G13 fully green across translate/compile/ilverify/test-parity).