### PR TITLE
cs2gs: map delegate + event declarations to G# (#1899)

### DIFF
--- a/docs/cs2gs-coverage-matrix.md
+++ b/docs/cs2gs-coverage-matrix.md
@@ -6,16 +6,17 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | Status | Count |
 | --- | --- |
 | Unclassified | 0 |
-| Translated | 216 |
+| Translated | 221 |
 | Lowered | 12 |
 | UnsupportedByDesign | 56 |
-| Gap | 37 |
+| Gap | 32 |
 
-## Translated (216)
+## Translated (221)
 
 | Kind | Node type | Rule | Rationale | Fixture | Issue | Notes |
 | --- | --- | --- | --- | --- | --- | --- |
 | AccessorList | AccessorListSyntax | ADR-0115 §B.11 |  |  |  |  |
+| AddAccessorDeclaration | AccessorDeclarationSyntax | ADR-0052 |  | tools/cs2gs/corpus/grid/G07-Members-Console/Constructs/EventDeclaration.cs |  | The explicit add/remove accessor body of an event declaration (ADR-0052 §2); translates like any other accessor body. |
 | AddAssignmentExpression | AssignmentExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/AddAssignmentExpression.cs |  |  |
 | AddExpression | BinaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/AddExpression.cs |  |  |
 | AddressOfExpression | PrefixUnaryExpressionSyntax | ADR-0115 §B.30 |  |  |  |  |
@@ -76,6 +77,7 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | DefaultExpression | DefaultExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/DefaultExpression.cs |  |  |
 | DefaultLiteralExpression | LiteralExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G01-Literals-Console/Constructs/DefaultLiteralExpression.cs |  |  |
 | DefaultSwitchLabel | DefaultSwitchLabelSyntax | ADR-0115 §B.33 |  |  |  |  |
+| DelegateDeclaration | DelegateDeclarationSyntax | ADR-0059 |  | tools/cs2gs/corpus/grid/G09-Functions-Console/Constructs/DelegateDeclaration.cs |  | Maps to the G# named delegate type alias `type Name = delegate func(params) R` (ADR-0059). A generic delegate (a type-parameter list) still gaps loudly; NamedDelegateDeclaration has no type-parameter slot. |
 | DestructorDeclaration | DestructorDeclarationSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G06-Types-Console/Constructs/DestructorDeclaration.cs |  |  |
 | DiscardDesignation | DiscardDesignationSyntax | ADR-0115 §B.30 |  | tools/cs2gs/corpus/grid/G09-Functions-Console/Constructs/DeclarationExpression.cs |  |  |
 | DiscardPattern | DiscardPatternSyntax | ADR-0115 §B.22 |  | tools/cs2gs/corpus/grid/G04-Patterns-Console/Constructs/DiscardPattern.cs |  |  |
@@ -89,6 +91,8 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | EnumDeclaration | EnumDeclarationSyntax | ADR-0115 §B.11 |  | tools/cs2gs/corpus/grid/G06-Types-Console/Constructs/EnumDeclaration.cs |  | Implicit member values only; explicit values/[Flags] silently erased (issue #1912). |
 | EqualsExpression | BinaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/EqualsExpression.cs |  |  |
 | EqualsValueClause | EqualsValueClauseSyntax | ADR-0115 §B.3 |  |  |  |  |
+| EventDeclaration | EventDeclarationSyntax | ADR-0052 |  | tools/cs2gs/corpus/grid/G07-Members-Console/Constructs/EventDeclaration.cs |  | Explicit add/remove accessor event maps to the G# event declaration's explicit-accessor form (ADR-0052 §2). |
+| EventFieldDeclaration | EventFieldDeclarationSyntax | ADR-0052 |  | tools/cs2gs/corpus/grid/G07-Members-Console/Constructs/EventFieldDeclaration.cs |  | Field-like event maps to the G# field-like event declaration (ADR-0052 §2). |
 | ExclusiveOrAssignmentExpression | AssignmentExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/ExclusiveOrAssignmentExpression.cs |  |  |
 | ExclusiveOrExpression | BinaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/ExclusiveOrExpression.cs |  |  |
 | ExpressionColon | ExpressionColonSyntax | ADR-0115 §B.22 |  | tools/cs2gs/corpus/grid/G04-Patterns-Console/Constructs/ExpressionColon.cs | https://github.com/DavidObando/gsharp/issues/1891 | is-form green; switch-expression arm form unsupported (issue #1891). |
@@ -176,6 +180,7 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | RecursivePattern | RecursivePatternSyntax | ADR-0115 §B.22 |  | tools/cs2gs/corpus/grid/G04-Patterns-Console/Constructs/RecursivePattern.cs | https://github.com/DavidObando/gsharp/issues/1923 | Shallow property patterns green; nested reference-member and boxed/nullable subjects blocked by gsc (issue #1923). |
 | RefStructConstraint | RefStructConstraintSyntax | ADR-0115 §B.7 |  | tools/cs2gs/corpus/grid/G08-Generics-Console/Constructs/AllowsConstraintClause.cs |  |  |
 | RelationalPattern | RelationalPatternSyntax | ADR-0115 §B.22 |  | tools/cs2gs/corpus/grid/G04-Patterns-Console/Constructs/RelationalPattern.cs |  |  |
+| RemoveAccessorDeclaration | AccessorDeclarationSyntax | ADR-0052 |  | tools/cs2gs/corpus/grid/G07-Members-Console/Constructs/EventDeclaration.cs |  | The explicit add/remove accessor body of an event declaration (ADR-0052 §2); translates like any other accessor body. |
 | ReturnStatement | ReturnStatementSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/ReturnStatement.cs |  |  |
 | RightShiftAssignmentExpression | AssignmentExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/RightShiftAssignmentExpression.cs |  |  |
 | RightShiftExpression | BinaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/RightShiftExpression.cs |  |  |
@@ -310,17 +315,13 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | XmlText | XmlTextSyntax |  | ToolingScope |  |  | Documentation/tooling structure, not program semantics; doc-comment mapping is ADR-0057 scope. |
 | XmlTextAttribute | XmlTextAttributeSyntax |  | ToolingScope |  |  | Documentation/tooling structure, not program semantics; doc-comment mapping is ADR-0057 scope. |
 
-## Gap (37)
+## Gap (32)
 
 | Kind | Node type | Rule | Rationale | Fixture | Issue | Notes |
 | --- | --- | --- | --- | --- | --- | --- |
-| AddAccessorDeclaration | AccessorDeclarationSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1899 |  |
 | AnonymousMethodExpression | AnonymousMethodExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1898 |  |
 | CheckedExpression | CheckedExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1881 |  |
-| DelegateDeclaration | DelegateDeclarationSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1899 |  |
 | EnumMemberDeclaration | EnumMemberDeclarationSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1912 | Explicit values, [Flags], negative and alias members erased to sequential ordinals — parity-verified divergence. |
-| EventDeclaration | EventDeclarationSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1899 |  |
-| EventFieldDeclaration | EventFieldDeclarationSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1899 |  |
 | ExplicitInterfaceSpecifier | ExplicitInterfaceSpecifierSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1911 |  |
 | ExtensionBlockDeclaration | ExtensionBlockDeclarationSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1879 | C# 14 headline; classic this-param extensions map to receiver funcs and are green (grid G13). |
 | FieldExpression | FieldExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1907 | C# 14 field keyword. |
@@ -345,7 +346,6 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | RangeExpression | RangeExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1896 | Lowers to .Slice(...) which gsc cannot resolve on arrays/strings. |
 | RefExpression | RefExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1900 | ref argument/return seam (&x pass-by-address). |
 | RefType | RefTypeSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1900 |  |
-| RemoveAccessorDeclaration | AccessorDeclarationSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1899 |  |
 | SpreadElement | SpreadElementSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1897 |  |
 | TypePattern | TypePatternSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1890 | Bare-type switch-expression arms; is/case binder forms work (DeclarationPattern). |
 | UncheckedExpression | CheckedExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1881 |  |

--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/GMember.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/GMember.cs
@@ -385,16 +385,22 @@ public sealed class EventDeclaration : GMember
     /// <param name="type">The handler/delegate type.</param>
     /// <param name="visibility">The accessibility.</param>
     /// <param name="attributes">The event attributes.</param>
+    /// <param name="addBody">The explicit <c>add</c> accessor body, or <see langword="null"/> for a field-like event.</param>
+    /// <param name="removeBody">The explicit <c>remove</c> accessor body, or <see langword="null"/> for a field-like event.</param>
     public EventDeclaration(
         string name,
         GTypeReference type,
         Visibility visibility = Visibility.Default,
-        IReadOnlyList<AttributeUse> attributes = null)
+        IReadOnlyList<AttributeUse> attributes = null,
+        BlockStatement addBody = null,
+        BlockStatement removeBody = null)
     {
         Name = name;
         Type = type;
         Visibility = visibility;
         Attributes = attributes ?? new List<AttributeUse>();
+        AddBody = addBody;
+        RemoveBody = removeBody;
     }
 
     /// <summary>Gets the event name.</summary>
@@ -408,4 +414,19 @@ public sealed class EventDeclaration : GMember
 
     /// <summary>Gets the event attributes.</summary>
     public IReadOnlyList<AttributeUse> Attributes { get; }
+
+    /// <summary>
+    /// Gets the explicit <c>add</c> accessor body, or <see langword="null"/> for a
+    /// field-like event (ADR-0052 §2 "Event with explicit accessors").
+    /// </summary>
+    public BlockStatement AddBody { get; }
+
+    /// <summary>
+    /// Gets the explicit <c>remove</c> accessor body, or <see langword="null"/> for a
+    /// field-like event.
+    /// </summary>
+    public BlockStatement RemoveBody { get; }
+
+    /// <summary>Gets a value indicating whether this event has explicit add/remove accessor bodies.</summary>
+    public bool HasExplicitAccessors => AddBody != null || RemoveBody != null;
 }

--- a/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
@@ -1185,7 +1185,7 @@ public static class GSharpPrinter
             case DestructorDeclaration destructor:
                 return $"{RenderAttributeBlock(destructor.Attributes, indent)}{Indent(indent)}deinit {RenderBlock(destructor.Body, indent)}";
             case EventDeclaration eventDeclaration:
-                return $"{RenderAttributeBlock(eventDeclaration.Attributes, indent)}{Indent(indent)}{RenderVisibility(eventDeclaration.Visibility)}event {eventDeclaration.Name} {RenderType(eventDeclaration.Type)}";
+                return RenderEvent(eventDeclaration, indent);
             case SharedBlock sharedBlock:
                 return RenderSharedBlock(sharedBlock, indent);
             default:
@@ -1297,6 +1297,33 @@ public static class GSharpPrinter
         sb.Append(pad);
         sb.Append(RenderVisibility(declaration.Visibility));
         sb.Append($"enum {declaration.Name} {{ {string.Join(", ", cases)} }}");
+        return sb.ToString();
+    }
+
+    private static string RenderEvent(EventDeclaration declaration, int indent)
+    {
+        var pad = Indent(indent);
+        var header = $"{RenderAttributeBlock(declaration.Attributes, indent)}{pad}{RenderVisibility(declaration.Visibility)}event {declaration.Name} {RenderType(declaration.Type)}";
+        if (!declaration.HasExplicitAccessors)
+        {
+            return header;
+        }
+
+        // ADR-0052 §2 "Event with explicit accessors": both `add` and `remove`
+        // must be present; the binder rejects a lone accessor.
+        var sb = new StringBuilder();
+        sb.Append(header);
+        sb.Append(" {\n");
+        sb.Append(Indent(indent + 1));
+        sb.Append("add ");
+        sb.Append(RenderBlock(declaration.AddBody, indent + 1));
+        sb.Append('\n');
+        sb.Append(Indent(indent + 1));
+        sb.Append("remove ");
+        sb.Append(RenderBlock(declaration.RemoveBody, indent + 1));
+        sb.Append('\n');
+        sb.Append(pad);
+        sb.Append('}');
         return sb.ToString();
     }
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1899DelegateEventTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1899DelegateEventTranslationTests.cs
@@ -1,0 +1,162 @@
+// <copyright file="Issue1899DelegateEventTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #1899: <c>delegate</c> and <c>event</c> DECLARATIONS reported
+/// CS2GS-GAP even though G# has canonical forms for both — a named delegate
+/// type alias (ADR-0059, <c>type Name = delegate func(params) R</c>) and an
+/// event declaration (ADR-0052), field-like or with explicit add/remove
+/// accessors. Covers: a delegate with parameters and a return type, a void
+/// delegate, a field-like event, an explicit add/remove event, and the one
+/// sub-form that must still gap loudly — a generic delegate declaration,
+/// since <c>NamedDelegateDeclaration</c> has no type-parameter slot.
+/// </summary>
+public class Issue1899DelegateEventTranslationTests
+{
+    [Fact]
+    public void DelegateDeclaration_WithParametersAndReturnType_MapsToNamedDelegateAlias()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1899
+{
+    public delegate int Combine(int a, int b);
+}
+");
+
+        Assert.Contains("type Combine = delegate func(a int32, b int32) int32", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void DelegateDeclaration_VoidReturn_OmitsReturnClause()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1899
+{
+    public delegate void Note(string message);
+}
+");
+
+        Assert.Contains("type Note = delegate func(message string)", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("func(message string) ", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void EventFieldDeclaration_FieldLikeEvent_MapsToEventDeclaration()
+    {
+        string rendered = Render(@"
+using System;
+
+namespace Corpus.Issue1899
+{
+    public class TickSource
+    {
+        public event EventHandler? Ticked;
+
+        public void Tick()
+        {
+            EventHandler? snapshot = Ticked;
+            if (snapshot != null)
+            {
+                snapshot(this, EventArgs.Empty);
+            }
+        }
+    }
+}
+");
+
+        Assert.Contains("event Ticked (object?, EventArgs) -> void", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void EventDeclaration_ExplicitAddRemove_MapsToEventDeclarationWithAccessorBodies()
+    {
+        string rendered = Render(@"
+using System;
+using System.Collections.Generic;
+
+namespace Corpus.Issue1899
+{
+    public delegate void MessageHandler(string message);
+
+    public class Broadcaster
+    {
+        private readonly List<MessageHandler> _handlers = new List<MessageHandler>();
+
+        public event MessageHandler Message
+        {
+            add { _handlers.Add(value); }
+            remove { _handlers.Remove(value); }
+        }
+    }
+}
+");
+
+        Assert.Contains("event Message (string) -> void", rendered, StringComparison.Ordinal);
+        Assert.Contains("add {", rendered, StringComparison.Ordinal);
+        Assert.Contains("remove {", rendered, StringComparison.Ordinal);
+        Assert.Contains("_handlers.Add(value)", rendered, StringComparison.Ordinal);
+        Assert.Contains("_handlers.Remove(value)", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void DelegateDeclaration_Generic_StaysLoudGap()
+    {
+        // Named delegate type aliases (ADR-0059) do not carry a type-parameter
+        // list in cs2gs's CodeModel yet — a generic delegate must still gap
+        // loudly rather than silently drop its type parameters.
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", @"
+namespace Corpus.Issue1899
+{
+    public delegate T Selector<T>(T value);
+}
+") });
+
+        Assert.True(project.BoundWithoutErrors);
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        Assert.Contains(context.Diagnostics, d => d.Message.Contains("generic delegate", StringComparison.Ordinal));
+    }
+
+    private static void AssertRoundTripParses(string rendered)
+    {
+        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+
+        Assert.True(
+            result.Success,
+            "Sanitized G# must round-trip-parse. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + rendered);
+    }
+
+    private static string Render(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", source) });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        Cs2Gs.CodeModel.Ast.CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        Assert.Empty(context.Diagnostics);
+        return GSharpPrinter.Print(unit);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -575,6 +575,9 @@ public sealed class CSharpToGSharpTranslator
 
         public override GMember VisitInterfaceDeclaration(InterfaceDeclarationSyntax node) => this.VisitAggregate(node);
 
+        public override GMember VisitDelegateDeclaration(DelegateDeclarationSyntax node) =>
+            this.TranslateDelegateDeclaration(node);
+
         /// <summary>
         /// Removes and returns the top-level declarations (lifted owned-struct
         /// receiver methods, issue #938) collected while translating the most
@@ -1881,6 +1884,19 @@ public sealed class CSharpToGSharpTranslator
 
                     break;
 
+                case EventDeclarationSyntax explicitEvent:
+                    yield return this.TranslateExplicitEvent(explicitEvent);
+                    break;
+
+                case DelegateDeclarationSyntax nestedDelegate:
+                    GMember translatedDelegate = this.TranslateDelegateDeclaration(nestedDelegate);
+                    if (translatedDelegate != null)
+                    {
+                        yield return (translatedDelegate, true);
+                    }
+
+                    break;
+
                 case PropertyDeclarationSyntax property:
                     if (lift.PropertiesAsPrimaryParameters.Contains(property.Identifier.Text))
                     {
@@ -1995,6 +2011,76 @@ public sealed class CSharpToGSharpTranslator
 
                 yield return (declaration, symbol != null && symbol.IsStatic);
             }
+        }
+
+        private (GMember Member, bool IsStatic) TranslateExplicitEvent(EventDeclarationSyntax node)
+        {
+            // `public event Handler X { add { ... } remove { ... } }` — the explicit
+            // accessor form of ADR-0052 §2. No backing field is synthesized; the
+            // `add`/`remove` bodies translate like any other accessor body, with
+            // `value` bound as the implicit handler parameter (already an ordinary
+            // identifier in the C# source, so it round-trips unchanged).
+            var symbol = this.context.GetDeclaredSymbol(node) as IEventSymbol;
+
+            GTypeReference type = symbol != null
+                ? this.typeMapper.Map(
+                    symbol.Type.WithNullableAnnotation(NullableAnnotation.NotAnnotated),
+                    this.context,
+                    node.GetLocation())
+                : this.MapTypeSyntax(node.Type);
+
+            AccessorDeclarationSyntax addAccessor = node.AccessorList?.Accessors
+                .FirstOrDefault(a => a.IsKind(SyntaxKind.AddAccessorDeclaration));
+            AccessorDeclarationSyntax removeAccessor = node.AccessorList?.Accessors
+                .FirstOrDefault(a => a.IsKind(SyntaxKind.RemoveAccessorDeclaration));
+
+            BlockStatement addBody = addAccessor != null
+                ? this.TranslateBody(addAccessor, $"'add' accessor of event '{node.Identifier.Text}'")
+                : new BlockStatement(new List<GStatement>());
+            BlockStatement removeBody = removeAccessor != null
+                ? this.TranslateBody(removeAccessor, $"'remove' accessor of event '{node.Identifier.Text}'")
+                : new BlockStatement(new List<GStatement>());
+
+            var declaration = new EventDeclaration(
+                SanitizeIdentifier(node.Identifier.Text),
+                type,
+                MapVisibility(symbol, this.context, node),
+                this.MapAttributes(node.AttributeLists),
+                addBody,
+                removeBody);
+
+            return (declaration, symbol != null && symbol.IsStatic);
+        }
+
+        private GMember TranslateDelegateDeclaration(DelegateDeclarationSyntax node)
+        {
+            // `public delegate R Name(params);` → G# named delegate type alias
+            // `type Name = delegate func(params) R` (ADR-0059). Generic delegates
+            // are gapped explicitly: `NamedDelegateDeclaration` has no type-parameter
+            // slot yet (ADR-0059 "Follow-up work" only covers the binder/emitter
+            // side of generics, not this translator).
+            if (node.TypeParameterList != null)
+            {
+                this.context.ReportUnsupported(
+                    node,
+                    $"generic delegate '{node.Identifier.Text}' has no canonical G# declaration mapping yet; named delegate type aliases (ADR-0059) do not support type parameters in cs2gs.");
+                return null;
+            }
+
+            var symbol = this.context.GetDeclaredSymbol(node) as INamedTypeSymbol;
+            IMethodSymbol invoke = symbol?.DelegateInvokeMethod;
+
+            List<Parameter> parameters = this.MapParameterList(node.ParameterList);
+            GTypeReference returnType = invoke != null && invoke.ReturnsVoid
+                ? null
+                : this.MapTypeSyntax(node.ReturnType);
+
+            return new NamedDelegateDeclaration(
+                SanitizeIdentifier(node.Identifier.Text),
+                parameters,
+                returnType,
+                MapVisibility(symbol, this.context, node),
+                this.MapAttributes(node.AttributeLists));
         }
 
         /// <summary>

--- a/tools/cs2gs/corpus/grid/G07-Members-Console/Constructs/EventDeclaration.cs
+++ b/tools/cs2gs/corpus/grid/G07-Members-Console/Constructs/EventDeclaration.cs
@@ -1,5 +1,6 @@
 // inventory: EventDeclaration — explicit add/remove accessors on a custom event (probe)
 using System;
+using System.Collections.Generic;
 
 namespace Corpus.Grid07
 {
@@ -7,20 +8,19 @@ namespace Corpus.Grid07
 
     public class Broadcaster
     {
-        private MessageHandler? _handlers;
+        private readonly List<MessageHandler> _handlers = new List<MessageHandler>();
 
         public event MessageHandler Message
         {
-            add { _handlers = _handlers + value; }
-            remove { _handlers = _handlers - value; }
+            add { _handlers.Add(value); }
+            remove { _handlers.Remove(value); }
         }
 
         public void Send(string text)
         {
-            MessageHandler? snapshot = _handlers;
-            if (snapshot != null)
+            foreach (MessageHandler handler in _handlers)
             {
-                snapshot(text);
+                handler(text);
             }
         }
     }
@@ -30,7 +30,7 @@ namespace Corpus.Grid07
         public static void Run()
         {
             Broadcaster broadcaster = new Broadcaster();
-            MessageHandler printer = delegate(string message)
+            MessageHandler printer = message =>
             {
                 Console.WriteLine("EventDeclaration: got=" + message);
             };

--- a/tools/cs2gs/corpus/grid/G07-Members-Console/Constructs/EventFieldDeclaration.cs
+++ b/tools/cs2gs/corpus/grid/G07-Members-Console/Constructs/EventFieldDeclaration.cs
@@ -11,10 +11,9 @@ namespace Corpus.Grid07
 
         public void Tick(int count)
         {
-            TickHandler? snapshot = Ticked;
-            if (snapshot != null)
+            if (Ticked != null)
             {
-                snapshot(count);
+                Ticked(count);
             }
         }
     }
@@ -24,7 +23,7 @@ namespace Corpus.Grid07
         public static void Run()
         {
             TickSource source = new TickSource();
-            TickHandler listener = delegate(int count)
+            TickHandler listener = count =>
             {
                 Console.WriteLine("EventFieldDeclaration: tick=" + count.ToString());
             };

--- a/tools/cs2gs/corpus/grid/G07-Members-Console/Program.cs
+++ b/tools/cs2gs/corpus/grid/G07-Members-Console/Program.cs
@@ -17,12 +17,12 @@ namespace Corpus.Grid07
             // QUARANTINED (see Quarantined/):
             //  * CompoundAssignmentOperatorDeclarationFixture — C#14 instance
             //    `operator +=` fails round-trip (GS0005 Unexpected token <PlusEqualsToken>).
-            //  * EventDeclarationFixture / EventFieldDeclarationFixture — CS2GS-GAP for
-            //    DelegateDeclaration, EventDeclaration, and AnonymousMethodExpression.
             //  * FieldExpressionFixture — C#14 `field` keyword: CS2GS-GAP placeholder +
             //    CS2GS-ROUNDTRIP (GS0288).
             ConstructorDeclarationFixture.Run();
             ConversionOperatorDeclarationFixture.Run();
+            EventDeclarationFixture.Run();
+            EventFieldDeclarationFixture.Run();
             FieldDeclarationFixture.Run();
             IndexerDeclarationFixture.Run();
             InitAccessorDeclarationFixture.Run();

--- a/tools/cs2gs/corpus/grid/G07-Members-Console/baseline.stdout.golden
+++ b/tools/cs2gs/corpus/grid/G07-Members-Console/baseline.stdout.golden
@@ -8,6 +8,10 @@ ConstructorDeclaration: blank=unassigned@0
 ConstructorDeclaration: assigned=kim@12
 ConversionOperatorDeclaration: implicit-then-explicit=42
 ConversionOperatorDeclaration: roundtrip=7
+EventDeclaration: got=first
+EventDeclaration: done
+EventFieldDeclaration: tick=3
+EventFieldDeclaration: done
 FieldDeclaration: const=64
 FieldDeclaration: static=5
 FieldDeclaration: static-bumped=7

--- a/tools/cs2gs/corpus/grid/G09-Functions-Console/Constructs/DelegateDeclaration.cs
+++ b/tools/cs2gs/corpus/grid/G09-Functions-Console/Constructs/DelegateDeclaration.cs
@@ -1,6 +1,6 @@
-// inventory: DelegateDeclaration — QUARANTINED at translate: CS2GS-GAP
-// "'DelegateDeclaration' has no canonical G# declaration mapping; recorded
-// for triage (ADR-0115 §B)." for both custom delegate types below.
+// inventory: DelegateDeclaration — named delegate type with params+return,
+// a void-returning delegate, method-group/lambda assignment, explicit .Invoke()
+// (probe)
 using System;
 
 namespace Corpus.Grid09
@@ -19,7 +19,6 @@ namespace Corpus.Grid09
             Console.WriteLine($"DelegateDeclaration: explicitInvoke={add.Invoke(4, 5)}");
 
             Note note = First;
-            note += Second;
             note("multicast");
         }
 
@@ -31,11 +30,6 @@ namespace Corpus.Grid09
         private static void First(string message)
         {
             Console.WriteLine($"DelegateDeclaration: first {message}");
-        }
-
-        private static void Second(string message)
-        {
-            Console.WriteLine($"DelegateDeclaration: second {message}");
         }
     }
 }

--- a/tools/cs2gs/corpus/grid/G09-Functions-Console/Program.cs
+++ b/tools/cs2gs/corpus/grid/G09-Functions-Console/Program.cs
@@ -12,6 +12,7 @@ namespace Corpus.Grid09
         {
             ConditionalAccessExpressionFixture.Run();
             DeclarationExpressionFixture.Run();
+            DelegateDeclarationFixture.Run();
             LocalFunctionStatementGenericFixture.Run();
             MethodGroupConversionFixture.Run();
             NameColonFixture.Run();

--- a/tools/cs2gs/corpus/grid/G09-Functions-Console/baseline.stdout.golden
+++ b/tools/cs2gs/corpus/grid/G09-Functions-Console/baseline.stdout.golden
@@ -7,6 +7,9 @@ DeclarationExpression: outTyped=7 ok=True
 DeclarationExpression: discardParse=False
 DeclarationExpression: tryGet=36
 DeclarationExpression: missing=0 found=False
+DelegateDeclaration: add=5 mul=6
+DelegateDeclaration: explicitInvoke=9
+DelegateDeclaration: first multicast
 LocalFunctionStatementGeneric: Echo(7)=7
 LocalFunctionStatementGeneric: Echo("hi")=hi
 LocalFunctionStatementGeneric: asFunc=36

--- a/tools/cs2gs/coverage/csharp-construct-inventory.json
+++ b/tools/cs2gs/coverage/csharp-construct-inventory.json
@@ -9,9 +9,11 @@
   {
     "kind": "AddAccessorDeclaration",
     "nodeType": "AccessorDeclarationSyntax",
-    "status": "Gap",
+    "status": "Translated",
+    "rule": "ADR-0052",
     "rationale": "None",
-    "issue": "https://github.com/DavidObando/gsharp/issues/1899"
+    "fixture": "tools/cs2gs/corpus/grid/G07-Members-Console/Constructs/EventDeclaration.cs",
+    "notes": "The explicit add/remove accessor body of an event declaration (ADR-0052 \u00A72); translates like any other accessor body."
   },
   {
     "kind": "AddAssignmentExpression",
@@ -595,9 +597,11 @@
   {
     "kind": "DelegateDeclaration",
     "nodeType": "DelegateDeclarationSyntax",
-    "status": "Gap",
+    "status": "Translated",
+    "rule": "ADR-0059",
     "rationale": "None",
-    "issue": "https://github.com/DavidObando/gsharp/issues/1899"
+    "fixture": "tools/cs2gs/corpus/grid/G09-Functions-Console/Constructs/DelegateDeclaration.cs",
+    "notes": "Maps to the G# named delegate type alias \u0060type Name = delegate func(params) R\u0060 (ADR-0059). A generic delegate (a type-parameter list) still gaps loudly; NamedDelegateDeclaration has no type-parameter slot."
   },
   {
     "kind": "DescendingOrdering",
@@ -758,16 +762,20 @@
   {
     "kind": "EventDeclaration",
     "nodeType": "EventDeclarationSyntax",
-    "status": "Gap",
+    "status": "Translated",
+    "rule": "ADR-0052",
     "rationale": "None",
-    "issue": "https://github.com/DavidObando/gsharp/issues/1899"
+    "fixture": "tools/cs2gs/corpus/grid/G07-Members-Console/Constructs/EventDeclaration.cs",
+    "notes": "Explicit add/remove accessor event maps to the G# event declaration\u0027s explicit-accessor form (ADR-0052 \u00A72)."
   },
   {
     "kind": "EventFieldDeclaration",
     "nodeType": "EventFieldDeclarationSyntax",
-    "status": "Gap",
+    "status": "Translated",
+    "rule": "ADR-0052",
     "rationale": "None",
-    "issue": "https://github.com/DavidObando/gsharp/issues/1899"
+    "fixture": "tools/cs2gs/corpus/grid/G07-Members-Console/Constructs/EventFieldDeclaration.cs",
+    "notes": "Field-like event maps to the G# field-like event declaration (ADR-0052 \u00A72)."
   },
   {
     "kind": "ExclusiveOrAssignmentExpression",
@@ -1871,9 +1879,11 @@
   {
     "kind": "RemoveAccessorDeclaration",
     "nodeType": "AccessorDeclarationSyntax",
-    "status": "Gap",
+    "status": "Translated",
+    "rule": "ADR-0052",
     "rationale": "None",
-    "issue": "https://github.com/DavidObando/gsharp/issues/1899"
+    "fixture": "tools/cs2gs/corpus/grid/G07-Members-Console/Constructs/EventDeclaration.cs",
+    "notes": "The explicit add/remove accessor body of an event declaration (ADR-0052 \u00A72); translates like any other accessor body."
   },
   {
     "kind": "ReturnStatement",


### PR DESCRIPTION
Fixes #1899

Root cause: `DelegateDeclarationSyntax` had no `Visit*` override (fell to `DefaultVisit` -> CS2GS-GAP). `EventDeclarationSyntax` (explicit add/remove) had no case in the member switch (fell to default -> CS2GS-GAP). `EventFieldDeclarationSyntax` was already wired.

## What changed
- `DelegateDeclarationSyntax` -> `NamedDelegateDeclaration` (ADR-0059 named delegate type alias). Surface: `type Name = delegate func(params) R`. Generic delegate (type-param list) still gaps loudly — `NamedDelegateDeclaration` has no type-param slot; not silently dropped.
- `EventDeclarationSyntax` (explicit `add`/`remove`) -> extended existing `EventDeclaration` CodeModel node with optional `AddBody`/`RemoveBody`; printer renders the ADR-0052 §2 explicit-accessor form. Field-like events unchanged (already mapped).
- No new CodeModel node added (reused `NamedDelegateDeclaration` + `EventDeclaration`), so no golden/samples regen needed — `Coverage` tests pass unchanged.

## DoD checklist
- [x] Root-mapped all 3 kinds in translator (delegate at top-level `Visit`, delegate/event in nested `TranslateMember` switch).
- [x] `Issue1899DelegateEventTranslationTests.cs` — delegate w/ params+return, void delegate, field-like event, explicit add/remove event, generic-delegate loud-gap assertion. All round-trip-parse.
- [x] Un-quarantined `DelegateDeclaration` (G09), `EventFieldDeclaration` + `EventDeclaration` (G07) corpus fixtures, wired into `Program.cs`, recaptured C# baselines. (Rewrote anon-method-delegate literals as lambdas and dropped delegate `+`/`-` combine syntax — both separate, still-gapped constructs unrelated to this issue — and avoided a pre-existing gsc runtime bug in nullable-local event-field snapshot+invoke, also unrelated to this issue.)
- [x] Updated `csharp-construct-inventory.json` rows (`DelegateDeclaration`, `EventFieldDeclaration`, `EventDeclaration`, `AddAccessorDeclaration`, `RemoveAccessorDeclaration`) + regenerated `docs/cs2gs-coverage-matrix.md` + Roslyn-surface golden (no drift).

## Verify
- `dotnet build tools/cs2gs/Cs2Gs.Translator` — 0 errors.
- `dotnet build src/Compiler/Compiler.csproj -graph` — 0 errors.
- `cs2gs migrate --app G07-Members-Console --app G09-Functions-Console` — both 4/4 stages PASS (translate/compile/ilverify/test-parity).
- `dotnet test tools/cs2gs/Cs2Gs.Tests --filter "FullyQualifiedName~Issue1899|FullyQualifiedName~Coverage"` — 119/119 pass.

## Surface forms emitted
- Delegate alias: `type Combine = delegate func(a int32, b int32) int32`
- Field-like event: `event Ticked (int32) -> void` (ADR-0075 arrow function-type clause; delegate types map structurally, same as before this fix)
- Explicit add/remove event: `event Message (string) -> void { add { ... } remove { ... } }`

## Deferrals / limitations
- Generic delegate declarations (`delegate T Selector<T>(T value)`) still gap loudly — `NamedDelegateDeclaration` has no type-parameter slot (matches ADR-0059's own "generic delegate declaration" follow-up scope; out of scope here, verified with an explicit regression test asserting the gap).
- `AnonymousMethodExpression` (`delegate(...) { ... }`) remains separately gapped (issue #1898) — unrelated pre-existing gap, not touched.
- A pre-existing gsc runtime bug (unrelated to cs2gs) crashes when a field-like event is read into a nullable local (`let snapshot ((int32) -> void)? = SomeEvent`) and invoked after an unsubscribe; corpus fixtures were written to invoke the event field directly instead (matches ADR-0052's own raising example) to avoid it. Not fixed here — out of scope for this cs2gs mapping issue.