### PR TITLE
cs2gs: map bare-type switch-expression arms (TypePattern) to G# (#1890)

### DIFF
--- a/docs/cs2gs-coverage-matrix.md
+++ b/docs/cs2gs-coverage-matrix.md
@@ -6,12 +6,12 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | Status | Count |
 | --- | --- |
 | Unclassified | 0 |
-| Translated | 221 |
+| Translated | 222 |
 | Lowered | 12 |
 | UnsupportedByDesign | 56 |
-| Gap | 32 |
+| Gap | 31 |
 
-## Translated (221)
+## Translated (222)
 
 | Kind | Node type | Rule | Rationale | Fixture | Issue | Notes |
 | --- | --- | --- | --- | --- | --- | --- |
@@ -220,6 +220,7 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | TypeParameter | TypeParameterSyntax | ADR-0115 §B.7 |  | tools/cs2gs/corpus/grid/G08-Generics-Console/Constructs/TypeParameter.cs |  | Declaration-site variance (out/in) conversions: gsc issue #1927 (fixed). |
 | TypeParameterConstraintClause | TypeParameterConstraintClauseSyntax | ADR-0115 §B.7 |  |  |  |  |
 | TypeParameterList | TypeParameterListSyntax | ADR-0115 §B.7 |  | tools/cs2gs/corpus/grid/G08-Generics-Console/Constructs/TypeParameterList.cs |  | Generic class + primary ctor ICEs gsc (issue #1920). |
+| TypePattern | TypePatternSyntax | ADR-0115 §B.22 |  | tools/cs2gs/corpus/grid/G04-Patterns-Console/Constructs/TypePattern.cs |  | Bare-type switch-arm (`int =>`, no binder — issue #1890, resolved): lowers to G#'s own discard-designator type pattern `_ is T` (`PatternBinder.BindTypePattern`'s `isDiscard` check), since gsc's own `TypePattern` grammar always requires a designator token before `is` but treats `_` as a non-binding discard there. Roslyn parses a bare user-type name (e.g. `Widget =>`) as a `ConstantPatternSyntax` over an identifier rather than `TypePatternSyntax`; the switch-arm path now shares the boolean-test path's `IsTypeReferencePattern` type-vs-constant disambiguation to still route it to `_ is T`. |
 | UnaryMinusExpression | PrefixUnaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/UnaryMinusExpression.cs |  |  |
 | UnaryPlusExpression | PrefixUnaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/UnaryPlusExpression.cs |  |  |
 | UncheckedStatement | CheckedStatementSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/UncheckedStatement.cs |  | Wrap-around parity verified (grid G03). |
@@ -315,7 +316,7 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | XmlText | XmlTextSyntax |  | ToolingScope |  |  | Documentation/tooling structure, not program semantics; doc-comment mapping is ADR-0057 scope. |
 | XmlTextAttribute | XmlTextAttributeSyntax |  | ToolingScope |  |  | Documentation/tooling structure, not program semantics; doc-comment mapping is ADR-0057 scope. |
 
-## Gap (32)
+## Gap (31)
 
 | Kind | Node type | Rule | Rationale | Fixture | Issue | Notes |
 | --- | --- | --- | --- | --- | --- | --- |
@@ -347,7 +348,6 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | RefExpression | RefExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1900 | ref argument/return seam (&x pass-by-address). |
 | RefType | RefTypeSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1900 |  |
 | SpreadElement | SpreadElementSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1897 |  |
-| TypePattern | TypePatternSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1890 | Bare-type switch-expression arms; is/case binder forms work (DeclarationPattern). |
 | UncheckedExpression | CheckedExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1881 |  |
 | UnsignedRightShiftAssignmentExpression | AssignmentExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1880 | Emits >>>= verbatim; never parses. |
 | UnsignedRightShiftExpression | BinaryExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1880 | Translator crash: Unknown binary operator >>>. |

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1890TypePatternTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1890TypePatternTranslationTests.cs
@@ -1,0 +1,126 @@
+// <copyright file="Issue1890TypePatternTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #1890: a bare-type C# switch-arm pattern (<c>int =&gt;</c>, no
+/// binder — Roslyn's <c>TypePatternSyntax</c>) had no canonical G# form and
+/// reported the CS2GS-GAP "pattern 'TypePattern' has no canonical G# form
+/// yet". G#'s own <c>TypePattern</c> grammar always requires a designator
+/// before <c>is</c>, but treats <c>_</c> as a real discard there
+/// (<c>PatternBinder.BindTypePattern</c>'s <c>isDiscard</c> check), so the
+/// bare arm lowers to <c>_ is T</c> with no binding introduced.
+/// </summary>
+public class Issue1890TypePatternTranslationTests
+{
+    [Fact]
+    public void SwitchExpression_BareTypeArms_LowerToDiscardTypePatterns()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1890
+{
+    public class Widget
+    {
+    }
+
+    public class Holder
+    {
+        public string Describe(object mystery) => mystery switch
+        {
+            int => ""int"",
+            Widget => ""widget"",
+            _ => ""other"",
+        };
+    }
+}
+");
+
+        Assert.Contains("case _ is int32:", rendered, StringComparison.Ordinal);
+        Assert.Contains("case _ is Widget:", rendered, StringComparison.Ordinal);
+        Assert.Contains("default:", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void SwitchStatement_BareTypeArm_LowersToDiscardTypePattern()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1890
+{
+    public class Holder
+    {
+        public string Describe(object mystery)
+        {
+            switch (mystery)
+            {
+                case string:
+                    return ""string"";
+                default:
+                    return ""other"";
+            }
+        }
+    }
+}
+");
+
+        Assert.Contains("case _ is string {", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void SwitchExpression_BareTypeArmInsideOrCombinator_LowersToDiscardTypePattern()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1890
+{
+    public class Holder
+    {
+        public string Describe(object mystery) => mystery switch
+        {
+            int or long => ""whole number"",
+            _ => ""other"",
+        };
+    }
+}
+");
+
+        Assert.Contains("case _ is int32 or _ is int64:", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    private static void AssertRoundTripParses(string rendered)
+    {
+        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+
+        Assert.True(
+            result.Success,
+            "Sanitized G# must round-trip-parse. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + rendered);
+    }
+
+    private static string Render(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", source) });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        Cs2Gs.CodeModel.Ast.CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        Assert.Empty(context.Diagnostics);
+        return GSharpPrinter.Print(unit);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -11526,6 +11526,15 @@ public sealed class CSharpToGSharpTranslator
         {
             switch (pattern)
             {
+                // Issue #1890: Roslyn parses a bare TYPE name after a combinator
+                // (e.g. `int or Widget`) as a ConstantPattern over an identifier
+                // — same ambiguity as the boolean-test path's
+                // `IsTypeReferencePattern` check — so it must be recognized as a
+                // type test before falling through to the literal-equality case
+                // below.
+                case ConstantPatternSyntax constant when this.IsTypeReferencePattern(constant.Expression):
+                    return new TypePattern("_", this.MapTypeSyntax((TypeSyntax)constant.Expression));
+
                 case ConstantPatternSyntax constant:
                     return new ConstantPattern(this.TranslateExpression(constant.Expression));
 
@@ -11543,6 +11552,15 @@ public sealed class CSharpToGSharpTranslator
                     return new TypePattern(
                         SanitizeIdentifier(variable.Identifier.Text),
                         this.MapTypeSyntax(declaration.Type));
+
+                // Issue #1890: a bare-type arm (`int =>`, no binder) is Roslyn's
+                // `TypePatternSyntax` — same shape as `DeclarationPatternSyntax`
+                // but with no designation at all. G#'s own `TypePattern` grammar
+                // always requires a designator before `is`, but treats `_` as a
+                // real discard there (PatternBinder.BindTypePattern's `isDiscard`
+                // check), so no binding is introduced — this is the bare form.
+                case TypePatternSyntax typePattern:
+                    return new TypePattern("_", this.MapTypeSyntax(typePattern.Type));
 
                 // `var v` (a top-level switch arm, or a nested `{ Prop: var v }`
                 // subpattern — this method recurses for both) ALWAYS matches, so

--- a/tools/cs2gs/corpus/grid/G04-Patterns-Console/Constructs/TypePattern.cs
+++ b/tools/cs2gs/corpus/grid/G04-Patterns-Console/Constructs/TypePattern.cs
@@ -1,0 +1,44 @@
+// inventory: TypePattern
+using System;
+
+namespace Corpus.Grid04.Constructs
+{
+    public static class TypePatternFixture
+    {
+        public static void Run()
+        {
+            object number = 42;
+            string classifyNumber = number switch
+            {
+                int => "int",
+                string => "string",
+                _ => "other",
+            };
+            Console.WriteLine($"TypePattern: switch({classifyNumber}) = int expected");
+
+            object text = "hi";
+            if (text is string)
+            {
+                Console.WriteLine("TypePattern: is-test string match");
+            }
+
+            switch (number)
+            {
+                case int:
+                    Console.WriteLine("TypePattern: switch-statement int match");
+                    break;
+                default:
+                    Console.WriteLine("TypePattern: switch-statement default");
+                    break;
+            }
+
+            object whole = 7L;
+            string classifyWhole = whole switch
+            {
+                int or long => "whole number",
+                _ => "other",
+            };
+            Console.WriteLine($"TypePattern: or-combinator switch({classifyWhole}) = whole number expected");
+        }
+    }
+}

--- a/tools/cs2gs/corpus/grid/G04-Patterns-Console/Program.cs
+++ b/tools/cs2gs/corpus/grid/G04-Patterns-Console/Program.cs
@@ -24,6 +24,7 @@ namespace Corpus.Grid04
             RecursivePatternFixture.Run();
             RelationalPatternFixture.Run();
             SwitchExpressionFixture.Run();
+            TypePatternFixture.Run();
         }
     }
 }

--- a/tools/cs2gs/corpus/grid/G04-Patterns-Console/baseline.stdout.golden
+++ b/tools/cs2gs/corpus/grid/G04-Patterns-Console/baseline.stdout.golden
@@ -80,3 +80,7 @@ SwitchExpression: 0 -> zero
 SwitchExpression: 2 -> plain positive (2)
 SwitchExpression: 4 -> multiple of four (4)
 SwitchExpression: quarter 3 -> summer
+TypePattern: switch(int) = int expected
+TypePattern: is-test string match
+TypePattern: switch-statement int match
+TypePattern: or-combinator switch(whole number) = whole number expected

--- a/tools/cs2gs/coverage/csharp-construct-inventory.json
+++ b/tools/cs2gs/coverage/csharp-construct-inventory.json
@@ -2248,10 +2248,11 @@
   {
     "kind": "TypePattern",
     "nodeType": "TypePatternSyntax",
-    "status": "Gap",
+    "status": "Translated",
+    "rule": "ADR-0115 \u00A7B.22",
     "rationale": "None",
-    "issue": "https://github.com/DavidObando/gsharp/issues/1890",
-    "notes": "Bare-type switch-expression arms; is/case binder forms work (DeclarationPattern)."
+    "fixture": "tools/cs2gs/corpus/grid/G04-Patterns-Console/Constructs/TypePattern.cs",
+    "notes": "Bare-type switch-arm (\u0060int =\u003E\u0060, no binder \u2014 issue #1890, resolved): lowers to G#\u0027s own discard-designator type pattern \u0060_ is T\u0060 (\u0060PatternBinder.BindTypePattern\u0060\u0027s \u0060isDiscard\u0060 check), since gsc\u0027s own \u0060TypePattern\u0060 grammar always requires a designator token before \u0060is\u0060 but treats \u0060_\u0060 as a non-binding discard there. Roslyn parses a bare user-type name (e.g. \u0060Widget =\u003E\u0060) as a \u0060ConstantPatternSyntax\u0060 over an identifier rather than \u0060TypePatternSyntax\u0060; the switch-arm path now shares the boolean-test path\u0027s \u0060IsTypeReferencePattern\u0060 type-vs-constant disambiguation to still route it to \u0060_ is T\u0060."
   },
   {
     "kind": "UnaryMinusExpression",


### PR DESCRIPTION
Fixes #1890

Root cause: switch-arm G#-pattern path had no case for bare TypePatternSyntax, and treated bare user-type-name arms (Roslyn parses as ConstantPattern-over-identifier) as literal equality. Boolean-test path (is/not) already handled both correctly.

Fix: bare-type arm lowers to G#'s own `_ is T` — gsc's PatternBinder.BindTypePattern already treats `_` as non-binding discard, so no synthesized real binder needed. Works for predefined/user/generic types, switch-expression + switch-statement, and or/and/not combinators (shared recursive TranslatePattern).

## DoD
- [x] Bare TypePatternSyntax + type-ref ConstantPatternSyntax handled in switch-arm path
- [x] Issue1890TypePatternTranslationTests.cs (switch-expr, switch-stmt, or-combinator)
- [x] G04 TypePattern.cs fixture added, wired into Program.cs, baseline.stdout.golden recaptured
- [x] csharp-construct-inventory.json TypePattern row: Gap -> Translated; docs/cs2gs-coverage-matrix.md regenerated
- [x] No new GNode/Ast enum member needed (reused existing TypePattern node) -> no GNodeSamples/surface-golden change required

## Verify
- Translator build: 0 errors
- gsc build: 0 errors
- migrate --app G04-Patterns-Console: translate/compile/ilverify/test-parity all PASS
- dotnet test --filter Issue1890|Coverage: 121/121 passed

## Deferrals
None. No gsc limitation hit for this issue's scope.