### PR TITLE
Fix #1924: composite type arguments fail in expression position

### DIFF
--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -7998,7 +7998,21 @@ public class Parser
         // non-identifier type clause (`[][]int32{ … }`, `[]*int32{ … }`, …).
         // Parse the element recursively when the token after `]` does not begin
         // a plain identifier element; otherwise keep the flat identifier form.
-        if (Current.Kind != SyntaxKind.IdentifierToken)
+        //
+        // Issue #1924: an array-of-generic literal (`[]Task[int32]{ … }`) or an
+        // array of a dotted/qualified named type (`[]Outer.Inner{ … }`) also
+        // needs the recursive `ParseTypeClause()` route — the flat identifier
+        // fast path below has no way to consume a trailing `[T, ...]`
+        // type-argument list or a `.Member` qualifier tail. `TryScanTypeClause`
+        // (used by the expression-position generic-call/index disambiguation)
+        // already parses these composite shapes in TYPE position, so the same
+        // `[` / `.` lookahead used there disambiguates here too — a `[` or `.`
+        // right after the element identifier can only start a type-argument
+        // list or dotted-name tail in this array-element-type position, never
+        // an index or member-access expression.
+        if (Current.Kind != SyntaxKind.IdentifierToken
+            || Peek(1).Kind == SyntaxKind.OpenSquareBracketToken
+            || Peek(1).Kind == SyntaxKind.DotToken)
         {
             var nestedElementType = ParseTypeClause();
             var (nestedOpenBrace, nestedElements, nestedCloseBrace, nestedHasElements) = ParseOptionalArrayInitializer();

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue1924CompositeTypeArgumentInExpressionParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue1924CompositeTypeArgumentInExpressionParserTests.cs
@@ -1,0 +1,180 @@
+// <copyright file="Issue1924CompositeTypeArgumentInExpressionParserTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Issue #1924: a composite type argument (an array/slice shape <c>[]T</c>, or
+/// a dotted/qualified name <c>Outer.Inner</c>) parsed fine in TYPE position
+/// (<c>var x []Task[int32]</c>, per issue #1046 / #526) but failed with
+/// GS0005 ("Unexpected token &lt;CloseSquareBracketToken&gt;, expected
+/// &lt;IdentifierToken&gt;") in EXPRESSION position for the array-of-generic
+/// literal (<c>[]Task[int32]{ … }</c>) and array-of-qualified-name literal
+/// (<c>[]Outer.Inner{ … }</c>).
+/// <para>
+/// Root cause: <c>ParseArrayCreationExpression</c>'s flat-identifier fast path
+/// matched the element type as a single <see cref="SyntaxToken"/> and jumped
+/// straight to the <c>{</c> initializer, never consuming a trailing
+/// <c>[T, ...]</c> type-argument list or <c>.Member</c> qualifier tail on the
+/// element name. The nested/jagged-element path (issue #1046) already routes
+/// through the general <c>ParseTypeClause()</c>, which handles both shapes
+/// (see <c>Issue1046JaggedArrayParserTests.Slice_OfGenericName_StillParses_Flat</c>
+/// and <c>Slice_OfQualifiedName_StillParses_Flat</c> for the TYPE-position
+/// equivalents); the fix widens the "route through <c>ParseTypeClause()</c>"
+/// condition to also fire when the element identifier is followed by <c>[</c>
+/// or <c>.</c>, generalizing the fix to the whole family of composite type
+/// arguments (not just the two examples from the issue body).
+/// </para>
+/// <para>
+/// The other reported repro, <c>List[[]object]{ … }</c> (a composite array
+/// type ARGUMENT to a generic collection literal, as opposed to an array-OF-
+/// generic literal), already parsed correctly before this fix — the
+/// generic-call-site disambiguation (<c>LooksLikeGenericCallSite</c> /
+/// <c>TryScanTypeClause</c>) already recurses into a bracketed type argument
+/// that itself starts with <c>[]</c>. Coverage for that shape is included here
+/// too, to lock in the whole family per the issue's "generalize, don't
+/// special-case" convention.
+/// </para>
+/// </summary>
+public class Issue1924CompositeTypeArgumentInExpressionParserTests
+{
+    private static ArrayCreationExpressionSyntax GetArrayCreation(string initializer)
+    {
+        var tree = SyntaxTree.Parse($"package P\nlet x = {initializer}\n");
+        Assert.Empty(tree.Diagnostics);
+        var decl = tree.Root.Members
+            .OfType<GlobalStatementSyntax>()
+            .Select(g => g.Statement)
+            .OfType<VariableDeclarationSyntax>()
+            .Single();
+        return Assert.IsType<ArrayCreationExpressionSyntax>(decl.Initializer);
+    }
+
+    [Fact]
+    public void ArrayOfGeneric_Literal_Parses_WithNestedElementTypeClause()
+    {
+        // The exact repro from the issue body: `[]Task[int32]{…}`.
+        var creation = GetArrayCreation("[]Task[int32]{Foo(), Bar()}");
+
+        Assert.True(creation.HasNestedElementTypeClause);
+        Assert.Null(creation.ElementTypeIdentifier);
+        Assert.Equal(2, creation.Elements.Count);
+
+        var elementType = creation.ElementTypeClause;
+        Assert.Equal("Task", elementType.Identifier.Text);
+        Assert.True(elementType.HasTypeArguments);
+        Assert.Single(elementType.TypeArguments);
+        Assert.Equal("int32", elementType.TypeArguments[0].Identifier.Text);
+    }
+
+    [Fact]
+    public void ArrayOfGeneric_Literal_WithMultipleTypeArguments_Parses()
+    {
+        var creation = GetArrayCreation("[]Dictionary[string, int32]{Make()}");
+
+        Assert.True(creation.HasNestedElementTypeClause);
+        Assert.Equal("Dictionary", creation.ElementTypeClause.Identifier.Text);
+        Assert.Equal(2, creation.ElementTypeClause.TypeArguments.Count);
+    }
+
+    [Fact]
+    public void ArrayOfQualifiedName_Literal_Parses_WithNestedElementTypeClause()
+    {
+        var creation = GetArrayCreation("[]Outer.Inner{Make()}");
+
+        Assert.True(creation.HasNestedElementTypeClause);
+        Assert.Null(creation.ElementTypeIdentifier);
+
+        var elementType = creation.ElementTypeClause;
+        Assert.Equal("Outer.Inner", elementType.DottedName);
+    }
+
+    [Fact]
+    public void SizedArrayOfGeneric_Literal_Parses()
+    {
+        var creation = GetArrayCreation("[2]Task[int32]{Foo(), Bar()}");
+
+        Assert.False(creation.IsRuntimeLengthAllocation);
+        Assert.True(creation.HasNestedElementTypeClause);
+        Assert.Equal("Task", creation.ElementTypeClause.Identifier.Text);
+    }
+
+    [Fact]
+    public void ArrayOfGeneric_NoInitializer_RuntimeAllocationForm_Parses()
+    {
+        var creation = GetArrayCreation("[n]Task[int32]");
+
+        Assert.True(creation.IsRuntimeLengthAllocation);
+        Assert.True(creation.HasNestedElementTypeClause);
+        Assert.False(creation.HasInitializer);
+        Assert.Equal("Task", creation.ElementTypeClause.Identifier.Text);
+    }
+
+    // ---- Regression: existing plain-identifier element forms are unaffected. ----
+
+    [Fact]
+    public void ArrayOfPlainIdentifier_Literal_StillParses_Flat()
+    {
+        var creation = GetArrayCreation("[]int32{1, 2, 3}");
+
+        Assert.False(creation.HasNestedElementTypeClause);
+        Assert.Equal("int32", creation.ElementTypeIdentifier.Text);
+        Assert.Equal(3, creation.Elements.Count);
+    }
+
+    [Fact]
+    public void ArrayOfNullableIdentifier_Literal_StillParses()
+    {
+        var tree = SyntaxTree.Parse("package P\nlet x = []int32?{1, 2}\n");
+        Assert.Empty(tree.Diagnostics);
+    }
+
+    // ---- The other reported shape: a composite array TYPE ARGUMENT to a ----
+    // ---- generic collection literal (`List[[]object]{…}`).              ----
+
+    [Fact]
+    public void GenericCollectionLiteral_WithArrayTypeArgument_Parses()
+    {
+        const string source = @"
+package P
+func Use() {
+    var a1 = []object{1, ""two""}
+    var xs = List[[]object]{a1, a1}
+}
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+    }
+
+    [Fact]
+    public void GenericCollectionLiteral_WithArrayTypeArgument_ParsesAsCollectionInitializer()
+    {
+        const string source = @"
+package P
+func Use() {
+    var a1 = []object{1}
+    var xs = List[[]object]{a1}
+}
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var fn = tree.Root.Members.OfType<FunctionDeclarationSyntax>().Single();
+        var xsDecl = fn.Body.Statements
+            .OfType<VariableDeclarationSyntax>()
+            .Single(d => d.Identifier.Text == "xs");
+
+        var init = Assert.IsType<CollectionInitializerExpressionSyntax>(xsDecl.Initializer);
+        var target = Assert.IsType<CallExpressionSyntax>(init.Target);
+        Assert.Equal("List", target.Identifier.Text);
+        Assert.NotNull(target.TypeArgumentList);
+        var typeArg = Assert.Single(target.TypeArgumentList.Arguments);
+        Assert.True(typeArg.IsSlice);
+        Assert.Equal("object", typeArg.Identifier.Text);
+    }
+}

--- a/tools/cs2gs/corpus/grid/G10-Async-Console/Constructs/AwaitExpressionWhenAll.cs
+++ b/tools/cs2gs/corpus/grid/G10-Async-Console/Constructs/AwaitExpressionWhenAll.cs
@@ -10,16 +10,21 @@ namespace Corpus.Grid10.Constructs
     {
         public static async Task RunAsync()
         {
-            // NOTE: an explicit Task<int>[] array literal is avoided on purpose —
-            // the generic-element array creation (`new Task<int>[] { ... }`) is a
-            // separate construct that currently fails G# round-trip parsing
-            // (GS0005 on `[]Task[int32]{...}`). WhenAll's params form still
-            // exercises the deterministic composition.
-            Task<int> first = Task.FromResult(1);
-            Task<int> second = Task.FromResult(4);
-            Task<int> third = Task.FromResult(9);
+            // Issue #1924 (resolved): the generic-element array creation
+            // (`new Task<int>[] { ... }`) previously failed G# round-trip
+            // parsing (GS0005 on `[]Task[int32]{...}`) because the array-of-
+            // generic-element-type literal only handled a bare identifier
+            // element and had no way to consume the element's own
+            // type-argument list. Now exercised directly alongside WhenAll's
+            // params form.
+            Task<int>[] tasks = new Task<int>[]
+            {
+                Task.FromResult(1),
+                Task.FromResult(4),
+                Task.FromResult(9),
+            };
 
-            int[] results = await Task.WhenAll(first, second, third);
+            int[] results = await Task.WhenAll(tasks);
             int total = 0;
             for (int i = 0; i < results.Length; i++)
             {


### PR DESCRIPTION
Fixes #1924

## Root cause
`ParseArrayCreationExpression`'s flat-identifier fast path matched the array-literal element type as a single token and jumped straight to the initializer `{`, never consuming a trailing `[T, ...]` type-argument list or `.Member` qualifier tail on that identifier. That made `[]Task[int32]{...}` (and, generally, any `[]Generic[Args]{...}` or `[]Outer.Inner{...}` array literal) fail with GS0005 in expression position, even though the identical shape already parsed fine in type position via `ParseTypeClause`/`ParseDottedTypeNameTail` (issue #1046 / #526).

The other reported repro, `List[[]object]{...}` (a composite array type ARGUMENT to a generic collection literal, as opposed to an array-OF-generic literal), already parsed correctly on `main` -- `LooksLikeGenericCallSite`/`TryScanTypeClause` already recurse into a bracketed type argument that itself starts with `[]`. Added regression coverage locking that shape in too.

## Fix
Widened the existing "route through `ParseTypeClause()`" condition in `ParseArrayCreationExpression` so it also fires when the element identifier is followed by `[` or `.` -- a nested-type-argument-list or dotted-name tail can only start there, never an index/member-access expression, so no new ambiguity is introduced. This generalizes the fix to the whole family of composite element types (generic type args, dotted/qualified names, and any combination), not just the two examples from the issue body.

## Grid fixture
Un-workaround the `G10-Async-Console` grid fixture (`AwaitExpressionWhenAll.cs`), which had a NOTE explaining why it avoided the `Task<int>[]` array-literal form pending this fix. Re-ran the full `cs2gs migrate` pipeline (translate/compile/ilverify/test-parity) for that app -- all 4 stages PASS, stdout baseline byte-identical (no `.golden` change needed).

Regenerated `tools/cs2gs/coverage/csharp-construct-inventory.json` via `cs2gs coverage --write` -- no changes (the `ArrayCreationExpression` construct row already existed; this issue didn't add a new Roslyn node kind).

## Tests
- New `test/Core.Tests/CodeAnalysis/Syntax/Issue1924CompositeTypeArgumentInExpressionParserTests.cs` (9 tests): array-of-generic literal, array-of-generic with multiple type args, array-of-qualified-name literal, sized and runtime-length allocation forms, plain-identifier/nullable regression coverage, and the `List[[]object]{...}` composite-type-argument shape.
- Full `test/Core.Tests` suite: 5320 passed, 0 failed, 1 skipped (pre-existing).
- Filtered `test/Compiler.Tests` (Array/Generic/#1046/#693): 479 passed, 0 failed.
- `tools/cs2gs/Cs2Gs.Tests` coverage/translator-exhaustiveness tests: 13 passed, 0 failed.
- `cs2gs migrate --app corpus/G10-Async-Console`: translate/compile/ilverify/test-parity all PASS.
