### PR TITLE
Fix #1922: accept ValueTuple in let-deconstruction; add first-class for-in tuple syntax

### DIFF
--- a/docs/coverage-matrix.md
+++ b/docs/coverage-matrix.md
@@ -99,6 +99,7 @@ ForEllipsisStatement
 ForInfiniteStatement
 ForKeyword
 ForRangeStatement
+ForTupleRangeStatement
 FromEndIndexExpression
 FuncKeyword
 FunctionDeclaration

--- a/docs/cs2gs-coverage-matrix.md
+++ b/docs/cs2gs-coverage-matrix.md
@@ -100,7 +100,7 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | FinallyClause | FinallyClauseSyntax | ADR-0115 §B.27 |  |  |  |  |
 | FixedStatement | FixedStatementSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G12-Unsafe-Console/Constructs/FixedStatement.cs | https://github.com/DavidObando/gsharp/issues/1933 | Compiles end-to-end under the ilverify allow-unsafe policy (issue #1933); IL is unverifiable by design, not a gsc defect. |
 | ForEachStatement | ForEachStatementSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/ForEachStatement.cs |  |  |
-| ForEachVariableStatement | ForEachVariableStatementSyntax | ADR-0115 §B |  |  | https://github.com/DavidObando/gsharp/issues/1922 | Translates; blocked by gsc ValueTuple deconstruction (issue #1922). |
+| ForEachVariableStatement | ForEachVariableStatementSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G05-Collections-Console/Constructs/TupleExpression.cs | https://github.com/DavidObando/gsharp/issues/1922 | Sync foreach tuple-deconstruction translates to first-class G# `for (a, b) in xs`; ValueTuple deconstruction now supported by gsc (issue #1922 fixed). await foreach still lowers via temp+let (no first-class async form). |
 | GenericName | GenericNameSyntax | ADR-0115 §B.7 |  | tools/cs2gs/corpus/grid/G08-Generics-Console/Constructs/GenericName.cs |  |  |
 | GetAccessorDeclaration | AccessorDeclarationSyntax | ADR-0115 §B.11 |  |  |  |  |
 | GlobalStatement | GlobalStatementSyntax | ADR-0115 §B.11 |  |  |  | Entry-class hoisting (T3): top-level statements. |

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -4283,6 +4283,15 @@ internal sealed class DeclarationBinder
                     : new[] { forRange.FirstIdentifier.Text };
                 return TryFindInstanceMemberReference(forRange.Body, forbiddenNames, WithShadowed(shadowedNames, forRangeNames), out offendingName, out offendingLocation);
 
+            case ForTupleRangeStatementSyntax forTupleRange:
+                if (TryFindInstanceMemberReference(forTupleRange.Collection, forbiddenNames, shadowedNames, out offendingName, out offendingLocation))
+                {
+                    return true;
+                }
+
+                var forTupleRangeNames = forTupleRange.Identifiers.Select(t => t.Text);
+                return TryFindInstanceMemberReference(forTupleRange.Body, forbiddenNames, WithShadowed(shadowedNames, forTupleRangeNames), out offendingName, out offendingLocation);
+
             case ForEllipsisStatementSyntax forEllipsis:
                 if (TryFindInstanceMemberReference(forEllipsis.LowerBound, forbiddenNames, shadowedNames, out offendingName, out offendingLocation) ||
                     TryFindInstanceMemberReference(forEllipsis.UpperBound, forbiddenNames, shadowedNames, out offendingName, out offendingLocation))

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.cs
@@ -175,6 +175,8 @@ internal sealed class StatementBinder
                 return BindForClauseStatement((ForClauseStatementSyntax)syntax);
             case SyntaxKind.ForRangeStatement:
                 return BindForRangeStatement((ForRangeStatementSyntax)syntax);
+            case SyntaxKind.ForTupleRangeStatement:
+                return BindForTupleRangeStatement((ForTupleRangeStatementSyntax)syntax);
             case SyntaxKind.WhileStatement:
                 return BindWhileStatement((WhileStatementSyntax)syntax);
             case SyntaxKind.LockStatement:
@@ -1217,6 +1219,91 @@ internal sealed class StatementBinder
 
         Diagnostics.ReportDeconstructionRequiresTupleOrDataStruct(syntax.OpenParenToken.Location, initializer.Type);
         return new BoundExpressionStatement(syntax, new BoundErrorExpression(null));
+    }
+
+    /// <summary>
+    /// Issue #1922: the <c>for (a, b) in coll { ... }</c> loop-prelude hook
+    /// passed to <see cref="BindForRangeStatementCore"/>. Declares one
+    /// read-only local per identifier (visible to the loop body, matching
+    /// <see cref="BindTupleDeconstructionStatement"/>'s tuple/data-struct
+    /// handling) and returns the field-extraction statements to prepend —
+    /// reading each element straight off <paramref name="elementVariable"/>
+    /// instead of a redundant synthetic temp, since the loop variable already
+    /// is one.
+    /// </summary>
+    /// <param name="identifiers">The parenthesized loop-target identifiers.</param>
+    /// <param name="closeParenLocation">Location used for an arity-mismatch diagnostic.</param>
+    /// <param name="openParenLocation">Location used for a wrong-shape-initializer diagnostic.</param>
+    /// <param name="elementVariable">The already-declared, single, hidden loop variable.</param>
+    /// <returns>The bound field-extraction statements, or empty on error (identifiers still get error-typed locals so the body doesn't cascade "undefined variable" diagnostics).</returns>
+    private ImmutableArray<BoundStatement> BindForTupleLoopPrelude(
+        SeparatedSyntaxList<SyntaxToken> identifiers,
+        TextLocation closeParenLocation,
+        TextLocation openParenLocation,
+        VariableSymbol elementVariable)
+    {
+        var elementType = elementVariable.Type;
+        var elementAccessBase = new BoundVariableExpression(null, elementVariable);
+
+        if (elementType is TupleTypeSymbol tupleType)
+        {
+            if (identifiers.Count != tupleType.Arity)
+            {
+                Diagnostics.ReportDeconstructionFieldCountMismatch(closeParenLocation, tupleType.Arity, identifiers.Count);
+                DeclareErrorTypedLocals(identifiers);
+                return ImmutableArray<BoundStatement>.Empty;
+            }
+
+            var statements = ImmutableArray.CreateBuilder<BoundStatement>();
+            for (var i = 0; i < identifiers.Count; i++)
+            {
+                var elemType = tupleType.ElementTypes[i];
+                var elemVar = bindLocalVariable(identifiers[i], isReadOnly: true, elemType);
+                var access = new BoundTupleElementAccessExpression(null, elementAccessBase, tupleType, i);
+                statements.Add(new BoundVariableDeclaration(null, elemVar, access));
+            }
+
+            return statements.ToImmutable();
+        }
+
+        if (elementType is StructSymbol structType && (structType.IsData || structType.IsInline))
+        {
+            var fields = structType.Fields;
+            if (identifiers.Count != fields.Length)
+            {
+                Diagnostics.ReportDeconstructionFieldCountMismatch(closeParenLocation, fields.Length, identifiers.Count);
+                DeclareErrorTypedLocals(identifiers);
+                return ImmutableArray<BoundStatement>.Empty;
+            }
+
+            var statements = ImmutableArray.CreateBuilder<BoundStatement>();
+            for (var i = 0; i < identifiers.Count; i++)
+            {
+                var field = fields[i];
+                var elemVar = bindLocalVariable(identifiers[i], isReadOnly: true, field.Type);
+                var access = new BoundFieldAccessExpression(null, elementAccessBase, structType, field);
+                statements.Add(new BoundVariableDeclaration(null, elemVar, access));
+            }
+
+            return statements.ToImmutable();
+        }
+
+        if (elementType != TypeSymbol.Error)
+        {
+            Diagnostics.ReportDeconstructionRequiresTupleOrDataStruct(openParenLocation, elementType);
+        }
+
+        DeclareErrorTypedLocals(identifiers);
+        return ImmutableArray<BoundStatement>.Empty;
+    }
+
+    /// <summary>Declares each identifier as an error-typed local so a deconstruction failure doesn't cascade "variable doesn't exist" diagnostics through the loop body.</summary>
+    private void DeclareErrorTypedLocals(SeparatedSyntaxList<SyntaxToken> identifiers)
+    {
+        for (var i = 0; i < identifiers.Count; i++)
+        {
+            bindLocalVariable(identifiers[i], isReadOnly: true, TypeSymbol.Error);
+        }
     }
 
     private BoundStatement BindNamedDeconstructionStatement(NamedDeconstructionStatementSyntax syntax)
@@ -3400,6 +3487,51 @@ internal sealed class StatementBinder
         return BindForRangeStatementCore(syntax, labelName: null, originatingSyntax: syntax);
     }
 
+    private BoundStatement BindForTupleRangeStatement(ForTupleRangeStatementSyntax syntax)
+    {
+        return BindForTupleRangeStatementCore(syntax, labelName: null, originatingSyntax: syntax);
+    }
+
+    /// <summary>
+    /// Issue #1922: binds <c>for (a, b, ...) in coll { ... }</c> by
+    /// synthesizing a hidden single-identifier <see cref="ForRangeStatementSyntax"/>
+    /// (same shape cs2gs used to hand-emit as a temp variable plus a separate
+    /// <c>let (a, b) = tmp</c>) and delegating to
+    /// <see cref="BindForRangeStatementCore"/>'s <c>bindLoopPrelude</c> hook —
+    /// so every iteration strategy (arrays, slices, dictionaries, CLR/pattern
+    /// enumerables, sequences, strings) keeps working with zero duplication.
+    /// </summary>
+    /// <param name="syntax">The deconstructing for-range syntax.</param>
+    /// <param name="labelName">The ADR-0070 label, or <see langword="null"/>.</param>
+    /// <param name="originatingSyntax">Syntax node used for the resulting bound node.</param>
+    /// <returns>The bound for-range statement.</returns>
+    private BoundStatement BindForTupleRangeStatementCore(ForTupleRangeStatementSyntax syntax, string labelName, SyntaxNode originatingSyntax)
+    {
+        var tempName = $"<fortuple{System.Threading.Interlocked.Increment(ref binderCtx.SyntheticLocalCounter)}>";
+        var tempIdentifier = new SyntaxToken(syntax.SyntaxTree, SyntaxKind.IdentifierToken, syntax.OpenParenToken.Position, tempName, null);
+        var syntheticForRange = new ForRangeStatementSyntax(
+            syntax.SyntaxTree,
+            syntax.Keyword,
+            tempIdentifier,
+            commaToken: null,
+            secondIdentifier: null,
+            colonEqualsToken: null,
+            rangeKeyword: null,
+            inToken: syntax.InToken,
+            collection: syntax.Collection,
+            body: syntax.Body);
+
+        return BindForRangeStatementCore(
+            syntheticForRange,
+            labelName,
+            originatingSyntax,
+            bindLoopPrelude: elementVariable => BindForTupleLoopPrelude(
+                syntax.Identifiers,
+                syntax.CloseParenToken.Location,
+                syntax.OpenParenToken.Location,
+                elementVariable));
+    }
+
     /// <summary>
     /// Core for-range binder; accepts an optional ADR-0070 label name that is
     /// pushed onto the loop stack so a nested <c>break label</c> / <c>continue
@@ -3408,8 +3540,21 @@ internal sealed class StatementBinder
     /// <param name="syntax">The for-range syntax.</param>
     /// <param name="labelName">The ADR-0070 label, or <see langword="null"/>.</param>
     /// <param name="originatingSyntax">Syntax node used for the resulting bound node.</param>
+    /// <param name="bindLoopPrelude">
+    /// Issue #1922: optional hook invoked with the newly-declared single loop
+    /// variable, still inside its scope, right before the body is bound.
+    /// Lets <c>for (a, b) in coll</c> declare its deconstructed element
+    /// locals (visible to the body) and return the field-extraction
+    /// statements to prepend, reusing this method's entire iteration-strategy
+    /// dispatch (arrays, slices, dictionaries, CLR/pattern enumerables,
+    /// sequences, strings) instead of duplicating it.
+    /// </param>
     /// <returns>The bound for-range statement.</returns>
-    private BoundStatement BindForRangeStatementCore(ForRangeStatementSyntax syntax, string labelName, SyntaxNode originatingSyntax)
+    private BoundStatement BindForRangeStatementCore(
+        ForRangeStatementSyntax syntax,
+        string labelName,
+        SyntaxNode originatingSyntax,
+        Func<VariableSymbol, ImmutableArray<BoundStatement>> bindLoopPrelude = null)
     {
         var collection = bindExpression(syntax.Collection);
 
@@ -3610,7 +3755,12 @@ internal sealed class StatementBinder
             valueVariable = bindLocalVariable(syntax.FirstIdentifier, isReadOnly: false, type: singleVarType);
         }
 
+        var prelude = bindLoopPrelude?.Invoke(valueVariable) ?? ImmutableArray<BoundStatement>.Empty;
         var body = BindLoopBody(syntax.Body, labelName, out var breakLabel, out var continueLabel);
+        if (!prelude.IsEmpty)
+        {
+            body = new BoundBlockStatement(originatingSyntax, prelude.Add(body));
+        }
 
         scope = scope.Parent;
 
@@ -3979,6 +4129,8 @@ internal sealed class StatementBinder
                 BindForClauseStatementCore((ForClauseStatementSyntax)inner, syntax, labelName),
             SyntaxKind.ForRangeStatement =>
                 BindForRangeStatementCore((ForRangeStatementSyntax)inner, labelName, syntax),
+            SyntaxKind.ForTupleRangeStatement =>
+                BindForTupleRangeStatementCore((ForTupleRangeStatementSyntax)inner, labelName, syntax),
             SyntaxKind.AwaitForRangeStatement =>
                 BindAwaitForRangeStatementCore((AwaitForRangeStatementSyntax)inner, labelName, syntax),
             _ => BindStatement(inner),
@@ -3996,6 +4148,7 @@ internal sealed class StatementBinder
             SyntaxKind.ForConditionStatement => true,
             SyntaxKind.ForClauseStatement => true,
             SyntaxKind.ForRangeStatement => true,
+            SyntaxKind.ForTupleRangeStatement => true,
             SyntaxKind.AwaitForRangeStatement => true,
             _ => false,
         };

--- a/src/Core/CodeAnalysis/Symbols/TypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/TypeSymbol.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 
 namespace GSharp.Core.CodeAnalysis.Symbols;
 
@@ -166,6 +167,19 @@ public class TypeSymbol : Symbol
         if (clrType.IsPointer)
         {
             return PointerTypeSymbol.Get(FromClrType(clrType.GetElementType()));
+        }
+
+        // Issue #1922: a `System.ValueTuple<...>`/`System.Tuple<...>` CLR type
+        // reaching here (e.g. the element type of `for x in list` over an
+        // imported `List[(T1, T2)]`, resolved via reflection rather than
+        // parsed from G# tuple-literal syntax) must map back onto GSharp's own
+        // `TupleTypeSymbol` — not a plain `ImportedTypeSymbol` — so downstream
+        // binders (deconstruction, member access) recognize it as a tuple.
+        // Same arity ceiling as `TupleTypeSymbol.BuildClrType` (2–7): higher
+        // arities and the `Rest`-chained 8+ shapes are left as imported types.
+        if (TryGetTupleTypeSymbol(clrType, out var tupleTypeSymbol))
+        {
+            return tupleTypeSymbol;
         }
 
         // Compare by FullName so types loaded from a MetadataLoadContext (carrying the
@@ -761,5 +775,38 @@ public class TypeSymbol : Symbol
 
                 break;
         }
+    }
+
+    /// <summary>
+    /// Issue #1922: recognizes a closed generic <c>System.ValueTuple&lt;...&gt;</c>
+    /// or <c>System.Tuple&lt;...&gt;</c> CLR type (arity 2–7, matching
+    /// <see cref="TupleTypeSymbol"/>'s own CLR-backing ceiling) and maps it onto
+    /// the equivalent <see cref="TupleTypeSymbol"/> by recursively resolving
+    /// each generic argument through <see cref="FromClrType"/>.
+    /// </summary>
+    /// <param name="clrType">The candidate CLR type.</param>
+    /// <param name="tupleTypeSymbol">The resulting tuple symbol, if matched.</param>
+    /// <returns><see langword="true"/> if <paramref name="clrType"/> is a supported tuple shape.</returns>
+    private static bool TryGetTupleTypeSymbol(Type clrType, out TupleTypeSymbol tupleTypeSymbol)
+    {
+        tupleTypeSymbol = null;
+        if (!clrType.IsGenericType || clrType.IsGenericTypeDefinition)
+        {
+            return false;
+        }
+
+        var defName = clrType.GetGenericTypeDefinition().FullName;
+        var isTupleFamily = defName is "System.ValueTuple`2" or "System.ValueTuple`3" or "System.ValueTuple`4"
+            or "System.ValueTuple`5" or "System.ValueTuple`6" or "System.ValueTuple`7"
+            or "System.Tuple`2" or "System.Tuple`3" or "System.Tuple`4"
+            or "System.Tuple`5" or "System.Tuple`6" or "System.Tuple`7";
+        if (!isTupleFamily)
+        {
+            return false;
+        }
+
+        var elementTypes = clrType.GetGenericArguments().Select(FromClrType).ToImmutableArray();
+        tupleTypeSymbol = TupleTypeSymbol.Get(elementTypes);
+        return true;
     }
 }

--- a/src/Core/CodeAnalysis/Syntax/ForTupleRangeStatementSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/ForTupleRangeStatementSyntax.cs
@@ -1,0 +1,68 @@
+// <copyright file="ForTupleRangeStatementSyntax.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Core.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Represents a deconstructing for-in loop, <c>for (a, b, ...) in coll { ... }</c>
+/// (issue #1922). Each loop iteration binds one read-only local per
+/// identifier to the corresponding element of the current tuple- or
+/// data-struct-typed sequence value, instead of requiring a separate hidden
+/// loop variable plus a <c>let (a, b) = tmp</c> deconstruction statement.
+/// </summary>
+public sealed class ForTupleRangeStatementSyntax : StatementSyntax
+{
+    /// <summary>Initializes a new instance of the <see cref="ForTupleRangeStatementSyntax"/> class.</summary>
+    /// <param name="syntaxTree">The parent syntax tree.</param>
+    /// <param name="keyword">The <c>for</c> keyword.</param>
+    /// <param name="openParenToken">The opening <c>(</c>.</param>
+    /// <param name="identifiers">The comma-separated deconstruction target identifiers.</param>
+    /// <param name="closeParenToken">The closing <c>)</c>.</param>
+    /// <param name="inToken">The contextual <c>in</c> token.</param>
+    /// <param name="collection">The collection expression.</param>
+    /// <param name="body">The loop body.</param>
+    public ForTupleRangeStatementSyntax(
+        SyntaxTree syntaxTree,
+        SyntaxToken keyword,
+        SyntaxToken openParenToken,
+        SeparatedSyntaxList<SyntaxToken> identifiers,
+        SyntaxToken closeParenToken,
+        SyntaxToken inToken,
+        ExpressionSyntax collection,
+        StatementSyntax body)
+        : base(syntaxTree)
+    {
+        Keyword = keyword;
+        OpenParenToken = openParenToken;
+        Identifiers = identifiers;
+        CloseParenToken = closeParenToken;
+        InToken = inToken;
+        Collection = collection;
+        Body = body;
+    }
+
+    /// <inheritdoc/>
+    public override SyntaxKind Kind => SyntaxKind.ForTupleRangeStatement;
+
+    /// <summary>Gets the <c>for</c> keyword.</summary>
+    public SyntaxToken Keyword { get; }
+
+    /// <summary>Gets the opening parenthesis token.</summary>
+    public SyntaxToken OpenParenToken { get; }
+
+    /// <summary>Gets the deconstruction target identifiers.</summary>
+    public SeparatedSyntaxList<SyntaxToken> Identifiers { get; }
+
+    /// <summary>Gets the closing parenthesis token.</summary>
+    public SyntaxToken CloseParenToken { get; }
+
+    /// <summary>Gets the contextual <c>in</c> token.</summary>
+    public SyntaxToken InToken { get; }
+
+    /// <summary>Gets the collection expression.</summary>
+    public ExpressionSyntax Collection { get; }
+
+    /// <summary>Gets the loop body.</summary>
+    public StatementSyntax Body { get; }
+}

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -5506,6 +5506,16 @@ public class Parser
             return ParseForInfiniteStatement();
         }
 
+        // Issue #1922: `for (a, b, ...) in coll { ... }` — checked before
+        // `LooksLikeForRange` (which requires an identifier right after
+        // `for`, so it never matches here) and before `LooksLikeForClause`
+        // (whose plain semicolon scan would otherwise misparse the `(a, b)`
+        // header as a parenthesized C-style-for expression).
+        if (LooksLikeForTupleRange())
+        {
+            return ParseForTupleRangeStatement();
+        }
+
         if (LooksLikeForRange())
         {
             return ParseForRangeStatement();
@@ -5522,6 +5532,55 @@ public class Parser
         }
 
         return ParseForConditionStatement();
+    }
+
+    private bool LooksLikeForTupleRange()
+    {
+        // `for ( <ident> (, <ident>)+ ) in <expr> { ... }` — at least two
+        // identifiers (arity ≥ 2, matching TupleTypeSymbol's minimum) so this
+        // never collides with a parenthesized boolean condition such as
+        // `for (x > 0) { ... }` (no comma) or a single-name grouped
+        // expression `for (x) in xs { ... }` isn't legal G# anyway, but the
+        // 2+ identifier requirement keeps this check unambiguous and cheap.
+        if (Peek(1).Kind != SyntaxKind.OpenParenthesisToken || Peek(2).Kind != SyntaxKind.IdentifierToken)
+        {
+            return false;
+        }
+
+        int o = 3;
+        var sawComma = false;
+        while (Peek(o).Kind == SyntaxKind.CommaToken && Peek(o + 1).Kind == SyntaxKind.IdentifierToken)
+        {
+            sawComma = true;
+            o += 2;
+        }
+
+        if (!sawComma || Peek(o).Kind != SyntaxKind.CloseParenthesisToken)
+        {
+            return false;
+        }
+
+        return Peek(o + 1).Kind == SyntaxKind.IdentifierToken && Peek(o + 1).Text == "in";
+    }
+
+    private StatementSyntax ParseForTupleRangeStatement()
+    {
+        var keyword = MatchToken(SyntaxKind.ForKeyword);
+        var openParen = MatchToken(SyntaxKind.OpenParenthesisToken);
+        var nodesAndSeparators = ImmutableArray.CreateBuilder<SyntaxNode>();
+        nodesAndSeparators.Add(MatchToken(SyntaxKind.IdentifierToken));
+        while (Current.Kind == SyntaxKind.CommaToken)
+        {
+            nodesAndSeparators.Add(MatchToken(SyntaxKind.CommaToken));
+            nodesAndSeparators.Add(MatchToken(SyntaxKind.IdentifierToken));
+        }
+
+        var identifiers = new SeparatedSyntaxList<SyntaxToken>(nodesAndSeparators.ToImmutable());
+        var closeParen = MatchToken(SyntaxKind.CloseParenthesisToken);
+        var inToken = MatchToken(SyntaxKind.IdentifierToken); // contextual `in`, guarded by LooksLikeForTupleRange
+        var collection = ParseExpressionInBodyHeader(allowEmptyStructLiteralCollection: true);
+        var body = ParseStatement();
+        return new ForTupleRangeStatementSyntax(syntaxTree, keyword, openParen, identifiers, closeParen, inToken, collection, body);
     }
 
     private bool LooksLikeForRange()

--- a/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
@@ -195,6 +195,7 @@ public enum SyntaxKind
     ForConditionStatement,
     ForClauseStatement,
     ForRangeStatement,
+    ForTupleRangeStatement,
     WhileStatement,
     DoWhileStatement,
     LabeledStatement,

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1922TupleForInStatementTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1922TupleForInStatementTests.cs
@@ -1,0 +1,159 @@
+// <copyright file="Issue1922TupleForInStatementTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1922: cs2gs lowered a C# <c>foreach (var (a, b) in list)</c> over a
+/// <c>List&lt;(T1, T2)&gt;</c> to <c>for tmp in list { let (a, b) = tmp ... }</c>,
+/// which failed <c>GS0164</c> because the loop element's static type — a
+/// CLR <c>System.ValueTuple&lt;...&gt;</c> reached via reflection (the
+/// element type of an imported generic collection), not a G# tuple-literal
+/// parse — surfaced as a plain <see cref="ImportedTypeSymbol"/> rather than
+/// <see cref="TupleTypeSymbol"/>. Covers both halves of the fix: (1)
+/// <c>let (a, b) = expr</c> deconstruction now accepts that CLR-shaped
+/// tuple, and (2) G#'s new first-class <c>for (a, b) in coll</c> loop header.
+/// </summary>
+public class Issue1922TupleForInStatementTests
+{
+    [Fact]
+    public void LetDeconstruction_AcceptsValueTupleElementFromClrListIteration()
+    {
+        // Reproduces the exact shape cs2gs used to hand-emit: a hidden
+        // single-var loop over `List[(string, int32)]` whose element type is
+        // resolved through the CLR-generic-argument path (not a G# tuple
+        // literal), then deconstructed via `let`.
+        var source = @"
+import System.Collections.Generic
+
+var list = List[(string, int32)]()
+list.Add((""alice"", 1))
+list.Add((""bob"", 2))
+
+var total = 0
+for tmp in list {
+    let (name, score) = tmp
+    total = total + score
+}
+total
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(1 + 2, result.Value);
+    }
+
+    [Fact]
+    public void ForTupleIn_DeconstructsListOfValueTuples()
+    {
+        var source = @"
+import System.Collections.Generic
+
+var list = List[(string, int32)]()
+list.Add((""alice"", 1))
+list.Add((""bob"", 2))
+
+var total = 0
+for (name, score) in list {
+    total = total + score
+}
+total
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(1 + 2, result.Value);
+    }
+
+    [Fact]
+    public void ForTupleIn_DeconstructsArrayOfTupleLiterals()
+    {
+        // Also exercise the indexed (array) iteration strategy, not just the
+        // CLR-enumerable one, since `BindForTupleRangeStatementCore` reuses
+        // the shared `BindForRangeStatementCore` dispatch for both.
+        var source = @"
+var pairs = [2](int32, int32){(1, 2), (3, 4)}
+
+var total = 0
+for (a, b) in pairs {
+    total = total + a + b
+}
+total
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(1 + 2 + 3 + 4, result.Value);
+    }
+
+    [Fact]
+    public void ForTupleIn_ArityMismatch_ReportsGS0163()
+    {
+        var source = @"
+var pairs = [2](int32, int32){(1, 2), (3, 4)}
+
+for (a, b, c) in pairs {
+}
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0163");
+    }
+
+    [Fact]
+    public void ForTupleIn_NonTupleElement_ReportsGS0164()
+    {
+        var source = @"
+var xs = [3]int32{1, 2, 3}
+
+for (a, b) in xs {
+}
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0164");
+    }
+
+    [Fact]
+    public void ForTupleIn_Labeled_BreakByLabelExitsLoop()
+    {
+        var source = @"
+var pairs = [3](int32, int32){(1, 2), (3, 4), (5, 6)}
+
+var seen = 0
+outer: for (a, b) in pairs {
+    if a == 3 {
+        break outer
+    }
+
+    seen = seen + 1
+}
+seen
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(1, result.Value);
+    }
+
+    [Fact]
+    public void ForTupleIn_ParsesAsForTupleRangeStatement()
+    {
+        const string source = @"
+package p
+class C { func F(xs [](int32, int32)) { for (a, b) in xs { } } }
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue1675SyntaxNodeChildEnumerationTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue1675SyntaxNodeChildEnumerationTests.cs
@@ -81,6 +81,9 @@ public class Issue1675SyntaxNodeChildEnumerationTests
 
         // lock statement (issue #1885)
         "package p\nclass Gate {}\nfunc F(g Gate) {\n  lock g {\n    var x = 1\n  }\n}\n",
+
+        // first-class deconstructing for-in (issue #1922)
+        "package p\nfunc F(xs [](int32, int32)) {\n  for (a, b) in xs {\n  }\n}\n",
     };
 
     /// <summary>

--- a/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
+++ b/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
@@ -99,6 +99,7 @@ ForEllipsisStatement
 ForInfiniteStatement
 ForKeyword
 ForRangeStatement
+ForTupleRangeStatement
 FromEndIndexExpression
 FuncKeyword
 FunctionDeclaration

--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/GStatement.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/GStatement.cs
@@ -352,6 +352,37 @@ public sealed class ForInStatement : GStatement
 }
 
 /// <summary>
+/// A deconstructing <c>for (a, b, ...) in coll</c> loop (issue #1922): the
+/// first-class G# form of a C# <c>foreach (var (a, b) in xs)</c> over a
+/// tuple-typed sequence. Unlike <see cref="ForInStatement"/>'s two-name
+/// key/value form, every name here binds a positional element of the
+/// current tuple-typed value — there is no hidden temp variable or
+/// separate <see cref="TupleDeconstructionStatement"/> in the body.
+/// </summary>
+public sealed class ForTupleInStatement : GStatement
+{
+    /// <summary>Initializes a new instance of the <see cref="ForTupleInStatement"/> class.</summary>
+    /// <param name="names">The deconstruction target names, in order (arity ≥ 2).</param>
+    /// <param name="iterable">The iterated expression.</param>
+    /// <param name="body">The loop body.</param>
+    public ForTupleInStatement(IReadOnlyList<string> names, GExpression iterable, BlockStatement body)
+    {
+        Names = names;
+        Iterable = iterable;
+        Body = body;
+    }
+
+    /// <summary>Gets the deconstruction target names, in order.</summary>
+    public IReadOnlyList<string> Names { get; }
+
+    /// <summary>Gets the iterated expression.</summary>
+    public GExpression Iterable { get; }
+
+    /// <summary>Gets the loop body.</summary>
+    public BlockStatement Body { get; }
+}
+
+/// <summary>
 /// A <c>throw</c> statement.
 /// </summary>
 public sealed class ThrowStatement : GStatement

--- a/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
@@ -888,6 +888,10 @@ public static class GSharpPrinter
                 var forKeyword = forIn.IsAwait ? "await for" : "for";
                 return $"{pad}{forKeyword} {loopVars} in {RenderExpression(forIn.Iterable, indent)} {RenderBlock(forIn.Body, indent)}";
 
+            case ForTupleInStatement forTupleIn:
+                var tupleLoopVars = string.Join(", ", forTupleIn.Names);
+                return $"{pad}for ({tupleLoopVars}) in {RenderExpression(forTupleIn.Iterable, indent)} {RenderBlock(forTupleIn.Body, indent)}";
+
             case DeferStatement defer:
                 return $"{pad}defer {RenderExpression(defer.Call, indent)}";
 

--- a/tools/cs2gs/Cs2Gs.Tests/Coverage/GNodeSamples.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Coverage/GNodeSamples.cs
@@ -138,6 +138,7 @@ public static class GNodeSamples
                 new LocalDeclarationStatement(BindingKind.Var, "i", initializer: Int("0")),
                 new IncrementDecrementStatement(Id("i"), "++")),
             [typeof(ForInStatement)] = () => Stmts(new ForInStatement("item", Id("items"), Block())),
+            [typeof(ForTupleInStatement)] = () => Stmts(new ForTupleInStatement(new[] { "a", "b" }, Id("items"), Block())),
             [typeof(ThrowStatement)] = () => Stmts(new ThrowStatement(
                 new InvocationExpression(Id("Exception"), List<GExpression>(LiteralExpression.String("boom"))))),
             [typeof(DeferStatement)] = () => Stmts(new DeferStatement(new InvocationExpression(Id("cleanup")))),

--- a/tools/cs2gs/Cs2Gs.Tests/Coverage/code-model-surface.golden.txt
+++ b/tools/cs2gs/Cs2Gs.Tests/Coverage/code-model-surface.golden.txt
@@ -49,6 +49,7 @@ ExpressionStatement
 FixedStatement
 ForInStatement
 ForStatement
+ForTupleInStatement
 IfStatement
 IncrementDecrementStatement
 LocalDeclarationStatement

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1922ForEachTupleDeconstructionTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1922ForEachTupleDeconstructionTests.cs
@@ -1,0 +1,125 @@
+// <copyright file="Issue1922ForEachTupleDeconstructionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Regression tests for issue #1922: cs2gs used to lower a C#
+/// <c>foreach (var (a, b) in xs)</c> to a hidden temp variable plus a
+/// separate <c>let (a, b) = tmp</c> deconstruction statement, which then
+/// failed to compile in gsc (<c>GS0164</c>) once the loop's tuple-typed
+/// element resolved to a raw imported <c>System.ValueTuple&lt;...&gt;</c>.
+/// Now that G# has a first-class deconstructing loop header
+/// (<c>for (a, b) in xs { ... }</c>), a synchronous <c>foreach</c> tuple
+/// deconstruction should translate directly to it instead.
+/// </summary>
+public class Issue1922ForEachTupleDeconstructionTests
+{
+    [Fact]
+    public void ForEachTupleDeconstruction_TranslatesToFirstClassForTupleIn()
+    {
+        string printed = TranslateUnit(@"
+using System;
+using System.Collections.Generic;
+
+namespace Demo
+{
+    public sealed class C
+    {
+        public void M(List<(string Name, int Score)> xs)
+        {
+            foreach (var (name, score) in xs)
+            {
+                Console.WriteLine(name);
+            }
+        }
+    }
+}");
+
+        Assert.Contains("for (name, score) in xs {", printed);
+
+        // The old two-step lowering (hidden temp variable plus a separate
+        // `let (a, b) = tmp` statement) must be gone.
+        Assert.DoesNotContain("__decon", printed);
+        Assert.DoesNotContain("let (name, score)", printed);
+    }
+
+    [Fact]
+    public void ForEachTupleDeconstruction_DiscardName_TranslatesToUnderscore()
+    {
+        string printed = TranslateUnit(@"
+using System.Collections.Generic;
+
+namespace Demo
+{
+    public sealed class C
+    {
+        public void M(List<(string, int)> xs)
+        {
+            foreach (var (name, _) in xs)
+            {
+            }
+        }
+    }
+}");
+
+        Assert.Contains("for (name, _) in xs {", printed);
+    }
+
+    [Fact]
+    public void AwaitForEachTupleDeconstruction_KeepsTempPlusLetLowering()
+    {
+        // G# has no first-class `await for (a, b) in` header, so the async
+        // form must keep the older temp-variable-plus-`let` lowering instead
+        // of emitting syntax G# cannot parse.
+        string printed = TranslateUnit(@"
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Demo
+{
+    public sealed class C
+    {
+        public async Task M(IAsyncEnumerable<(string Name, int Score)> xs)
+        {
+            await foreach (var (name, score) in xs)
+            {
+            }
+        }
+    }
+}");
+
+        Assert.Contains("await for __decon", printed);
+        Assert.Contains("let (name, score) = __decon", printed);
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
@@ -299,10 +299,11 @@ namespace Demo
     }
 
     /// <summary>
-    /// A <c>foreach</c> over a tuple deconstruction iterates a single element and
-    /// deconstructs it inside the body (<c>for __deconN in xs { let (a, b) =
-    /// __deconN; … }</c>). The G# two-name <c>for k, v in xs</c> form is
-    /// index/element iteration, NOT tuple deconstruction (ADR-0115 §B).
+    /// A <c>foreach</c> over a tuple deconstruction translates directly to G#'s
+    /// first-class deconstructing for-in header (<c>for (a, b) in xs { … }</c>,
+    /// issue #1922) instead of a hidden temp variable plus a separate
+    /// <c>let (a, b) = tmp</c> statement. The G# two-name <c>for k, v in xs</c>
+    /// form is index/element iteration, NOT tuple deconstruction (ADR-0115 §B).
     /// </summary>
     [Fact]
     public void ForEachVariable_TupleDeconstruction_DeconstructsElementInBody()
@@ -325,8 +326,8 @@ namespace Demo
     }
 }");
 
-        Assert.Matches(@"for __decon\d+ in xs", printed);
-        Assert.Matches(@"let \(a, b\) = __decon\d+", printed);
+        Assert.Contains("for (a, b) in xs {", printed);
+        Assert.DoesNotContain("__decon", printed);
         Assert.DoesNotContain("for a, b in xs", printed);
     }
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -11356,16 +11356,27 @@ public sealed class CSharpToGSharpTranslator
             // sequence whose element is a tuple. G#'s two-name `for k, v in xs`
             // form is NOT tuple deconstruction — it is index/element iteration
             // (the key is the int32 index), so emitting `for a, b in xs` would
-            // bind `a` to the loop index. Instead iterate a single element and
-            // deconstruct it inside the body: `for __deconN in xs { let (a, b) =
-            // __deconN; <body> }` (ADR-0115 §B).
+            // bind `a` to the loop index. Issue #1922: G# now has a first-class
+            // deconstructing loop header, `for (a, b) in xs { <body> }`, so a
+            // synchronous foreach translates directly to that instead of a
+            // hidden temp variable plus a separate `let (a, b) = tmp` (ADR-0115
+            // §B's older form). G# has no first-class `await for (a, b) in`
+            // form, so `await foreach` keeps the older temp+let lowering.
             List<string> names = new List<string>();
             CollectForEachVariableNames(node.Variable, names);
 
             if (names.Count >= 2)
             {
-                string pair = $"__decon{this.deconCounter++}";
+                bool isAwait = !node.AwaitKeyword.IsKind(SyntaxKind.None);
                 BlockStatement body = this.TranslateStatementAsBlock(node.Statement);
+                var iterable = this.TranslateReceiverWithNullForgiveness(node.Expression);
+
+                if (!isAwait)
+                {
+                    return new ForTupleInStatement(names, iterable, body);
+                }
+
+                string pair = $"__decon{this.deconCounter++}";
                 var statements = new List<GStatement>(body.Statements.Count + 1)
                 {
                     new TupleDeconstructionStatement(
@@ -11375,11 +11386,7 @@ public sealed class CSharpToGSharpTranslator
                 };
                 statements.AddRange(body.Statements);
 
-                return new ForInStatement(
-                    pair,
-                    this.TranslateReceiverWithNullForgiveness(node.Expression),
-                    new BlockStatement(statements),
-                    isAwait: !node.AwaitKeyword.IsKind(SyntaxKind.None));
+                return new ForInStatement(pair, iterable, new BlockStatement(statements), isAwait: true);
             }
 
             this.context.ReportUnsupported(

--- a/tools/cs2gs/corpus/grid/G05-Collections-Console/Constructs/TupleExpression.cs
+++ b/tools/cs2gs/corpus/grid/G05-Collections-Console/Constructs/TupleExpression.cs
@@ -1,5 +1,6 @@
 // inventory: TupleExpression
 using System;
+using System.Collections.Generic;
 
 namespace Corpus.Grid05
 {
@@ -24,6 +25,14 @@ namespace Corpus.Grid05
             // Nested tuple.
             var nested = ((1, 2), "pair");
             Console.WriteLine($"TupleExpression: nested={nested.Item1.Item1},{nested.Item1.Item2},{nested.Item2}");
+
+            // Issue #1922: foreach over a tuple-deconstructing pattern
+            // translates to G#'s first-class `for (a, b) in xs` header.
+            var pairs = new List<(string Name, int Score)> { ("alice", 1), ("bob", 2) };
+            foreach (var (name, score) in pairs)
+            {
+                Console.WriteLine($"TupleExpression: foreach={name},{score}");
+            }
         }
     }
 }

--- a/tools/cs2gs/corpus/grid/G05-Collections-Console/baseline.stdout.golden
+++ b/tools/cs2gs/corpus/grid/G05-Collections-Console/baseline.stdout.golden
@@ -29,3 +29,5 @@ TupleExpression: items=2,two
 TupleExpression: named=3,three
 TupleExpression: deconstructed=2,two
 TupleExpression: nested=1,2,pair
+TupleExpression: foreach=alice,1
+TupleExpression: foreach=bob,2

--- a/tools/cs2gs/coverage/csharp-construct-inventory.json
+++ b/tools/cs2gs/coverage/csharp-construct-inventory.json
@@ -901,8 +901,9 @@
     "status": "Translated",
     "rule": "ADR-0115 \u00A7B",
     "rationale": "None",
+    "fixture": "tools/cs2gs/corpus/grid/G05-Collections-Console/Constructs/TupleExpression.cs",
     "issue": "https://github.com/DavidObando/gsharp/issues/1922",
-    "notes": "Translates; blocked by gsc ValueTuple deconstruction (issue #1922)."
+    "notes": "Sync foreach tuple-deconstruction translates to first-class G# \u0060for (a, b) in xs\u0060; ValueTuple deconstruction now supported by gsc (issue #1922 fixed). await foreach still lowers via temp\u002Blet (no first-class async form)."
   },
   {
     "kind": "ForStatement",


### PR DESCRIPTION
Fixes #1922

## Root cause
`TypeSymbol.FromClrType` is the single chokepoint every reflection-derived type resolution path routes through (for-in loop element types, nullability decoding, generic-argument mapping, etc.), but it had no case for CLR `System.ValueTuple<...>`/`System.Tuple<...>` generic instantiations. Any tuple type reached via reflection (e.g. the element type of `List<(string, int)>`) therefore surfaced as a raw `ImportedTypeSymbol` instead of G#'s native `TupleTypeSymbol`, so `let (a, b) = x` rejected it with GS0164 even though G# already fully supports deconstructing its own tuple literals.

## What changed
1. **gsc — ValueTuple/Tuple deconstruction (Part 1):** `TypeSymbol.FromClrType` now recognizes `ValueTuple`/`Tuple` CLR generic types (arity 2-7, matching `TupleTypeSymbol`'s own CLR-backing ceiling) and maps them to `TupleTypeSymbol`, so `let (a, b) = x` now binds correctly for any CLR-sourced tuple value.
2. **gsc — first-class `for (a, b) in xs` syntax (Part 2):** added `ForTupleRangeStatementSyntax` + parser support for a deconstructing for-in loop header. The binder reuses the existing `BindForRangeStatementCore` (via a new `bindLoopPrelude` hook) instead of duplicating the iteration-strategy switch, so all existing for-range semantics (arrays, slices, dictionaries, CLR enumerables, pattern-enumerators, labels, break/continue) are inherited as-is with zero changes to Lowerer/Emitter/Evaluator.
3. **cs2gs (Part 3):** `foreach (var (a, b) in xs)` now translates directly to the new first-class `for (a, b) in xs` form instead of the old hidden temp-variable-plus-separate-`let` lowering. `await foreach` keeps the old lowering since G# has no first-class async tuple-for (not requested by the issue).
4. Regression tests added on both sides (`Issue1922*` in `test/Core.Tests` and `tools/cs2gs/Cs2Gs.Tests`), plus coverage/code-model-surface goldens refreshed and the `G05-Collections-Console` grid fixture extended to exercise the new construct end-to-end (translate → gsc compile → run, verified against the corpus `migrate` pipeline).

## Testing
- `dotnet build src/Compiler/Compiler.csproj -c Release` — clean.
- `dotnet build tools/cs2gs/Cs2Gs.Cli/Cs2Gs.Cli.csproj -c Release` — clean.
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release` — 5318 passed, 0 failed, 1 skipped (pre-existing skip).
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release` — 818 passed, 0 failed.
- `cs2gs migrate` full corpus run — `G05-Collections-Console` PASS on translate/compile/ilverify/test-parity (the one pre-existing `CompileGap-Library` failure is an intentional, unrelated gap fixture).
- `cs2gs coverage --write` — 0 new rows appended (construct was already inventoried).

Nothing deferred.