### PR TITLE
gsc: recognize same-compilation user-defined attribute classes (GS0200)

### DIFF
--- a/docs/cs2gs-coverage-matrix.md
+++ b/docs/cs2gs-coverage-matrix.md
@@ -35,7 +35,7 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | Attribute | AttributeSyntax | ADR-0115 §B.11 |  | tools/cs2gs/corpus/grid/G07-Members-Console/Constructs/AttributeList.cs |  | User-defined attribute classes blocked by gsc GS0200 (issue #1921). |
 | AttributeArgument | AttributeArgumentSyntax | ADR-0115 §B.11 |  |  |  |  |
 | AttributeArgumentList | AttributeArgumentListSyntax | ADR-0115 §B.11 |  |  |  |  |
-| AttributeList | AttributeListSyntax | ADR-0115 §B.11 |  | tools/cs2gs/corpus/grid/G07-Members-Console/Constructs/AttributeList.cs | https://github.com/DavidObando/gsharp/issues/1913 | BCL attributes green; parameter attributes silently dropped and generic attributes emit non-parsing G# (issue #1913). |
+| AttributeList | AttributeListSyntax | ADR-0115 §B.11 |  | tools/cs2gs/corpus/grid/G07-Members-Console/Constructs/AttributeList.cs | https://github.com/DavidObando/gsharp/issues/1913 | BCL attributes and user-defined attribute classes (issue #1921, fixed) green; parameter attributes silently dropped and generic attributes emit non-parsing G# (issue #1913). |
 | AttributeTargetSpecifier | AttributeTargetSpecifierSyntax | ADR-0115 §B.11 |  |  |  |  |
 | AwaitExpression | AwaitExpressionSyntax | ADR-0115 §B.23 |  | tools/cs2gs/corpus/grid/G10-Async-Console/Constructs/AwaitExpression.cs |  | Task/Task<T> green incl. ConfigureAwait and await foreach; ValueTask blocked by gsc (issue #1918); async Main mislowers (issue #1904). |
 | BaseConstructorInitializer | ConstructorInitializerSyntax | ADR-0115 §B.28 |  | tools/cs2gs/corpus/grid/G07-Members-Console/Constructs/BaseConstructorInitializer.cs |  |  |

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -8010,6 +8010,21 @@ internal sealed class DeclarationBinder
             {
                 if (argSyntax is NamedArgumentExpressionSyntax namedArg)
                 {
+                    // Issue #1921 code review (GS0466): the emitter can only
+                    // write named args against an already-emitted CLR type
+                    // (it resolves the target member via reflection); a
+                    // same-compilation user attribute has no ClrType yet, so
+                    // reject named args on it here instead of silently
+                    // dropping them at emit time.
+                    if (attrType is StructSymbol { ClrType: null })
+                    {
+                        Diagnostics.ReportNamedArgumentsNotSupportedOnUserAttribute(
+                            namedArg.NameToken.Location,
+                            nameIsExact ? nameText : (nameText + "Attribute"),
+                            namedArg.NameToken.Text);
+                        continue;
+                    }
+
                     if (!TryBindAttributeArgument(namedArg.Expression, out var value, out var valueType))
                     {
                         Diagnostics.ReportAttributeArgumentNotConstant(namedArg.Expression.Location);

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -8117,9 +8117,15 @@ internal sealed class DeclarationBinder
 
     private static bool IsAttributeType(TypeSymbol typeSymbol)
     {
-        if (typeSymbol is StructSymbol structSym && structSym.IsAttributeClass)
+        // Issue #1921: a same-compilation user class deriving from
+        // System.Attribute (via either the `@Attribute` sugar or a plain
+        // `: Attribute` / `: System.Attribute` base clause) has no CLR type
+        // yet — it hasn't been emitted — so ClrType is null and the CLR
+        // base-chain walk below can't see it. StructSymbol.DerivesFromSystemAttribute
+        // walks the symbol-level BaseClass chain instead of relying on ClrType.
+        if (typeSymbol is StructSymbol structSym)
         {
-            return true;
+            return structSym.DerivesFromSystemAttribute();
         }
 
         var clr = typeSymbol?.ClrType;

--- a/src/Core/CodeAnalysis/Binding/KnownAttributes.cs
+++ b/src/Core/CodeAnalysis/Binding/KnownAttributes.cs
@@ -517,7 +517,7 @@ internal static class KnownAttributes
             return;
         }
 
-        if (attributeType is StructSymbol structSym && structSym.IsAttributeClass)
+        if (attributeType is StructSymbol structSym && structSym.DerivesFromSystemAttribute())
         {
             if (TryReadAttributeUsageFromBound(structSym.Attributes, out var v, out var am))
             {

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -705,6 +705,23 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
     }
 
     /// <summary>
+    /// Issue #1921 code review: reports GS0466 when a named (property/field
+    /// style) argument is used on a same-compilation user-defined attribute
+    /// type. The emitter has no way to resolve the target member's CLR type
+    /// for a type that hasn't been emitted yet, so named-arg emission for
+    /// user attributes is not supported; rejecting it here at bind time turns
+    /// what would otherwise be a silently-dropped argument into a clear
+    /// compile error instead.
+    /// </summary>
+    /// <param name="location">The source location of the named argument.</param>
+    /// <param name="attributeName">The display name of the attribute type.</param>
+    /// <param name="argumentName">The name of the rejected named argument.</param>
+    public void ReportNamedArgumentsNotSupportedOnUserAttribute(TextLocation location, string attributeName, string argumentName)
+    {
+        Report(location, "GS0466", $"Named argument '{argumentName}' is not supported on user-defined attribute '{attributeName}': named arguments on same-compilation attribute types are not yet implemented. Use a constructor argument instead.");
+    }
+
+    /// <summary>
     /// Reports that the operand of a channel-receive expression (<c>&lt;-ch</c>) is not a channel (Phase 5.5 / ADR-0022).
     /// </summary>
     /// <param name="location">The text location of the operand.</param>

--- a/src/Core/CodeAnalysis/Emit/CustomAttributeEncoder.cs
+++ b/src/Core/CodeAnalysis/Emit/CustomAttributeEncoder.cs
@@ -69,15 +69,24 @@ internal sealed class CustomAttributeEncoder
     private readonly EmitContext emitCtx;
     private readonly WellKnownReferences wellKnown;
     private readonly Func<Type, TypeReferenceHandle> getTypeReference;
+    private readonly Func<StructSymbol, EntityHandle> resolvePrimaryCtorToken;
+    private readonly Func<StructSymbol, EntityHandle> resolveDefaultCtorToken;
+    private readonly Func<StructSymbol, ConstructorSymbol, EntityHandle> resolveExplicitCtorToken;
 
     public CustomAttributeEncoder(
         EmitContext emitCtx,
         WellKnownReferences wellKnown,
-        Func<Type, TypeReferenceHandle> getTypeReference)
+        Func<Type, TypeReferenceHandle> getTypeReference,
+        Func<StructSymbol, EntityHandle> resolvePrimaryCtorToken = null,
+        Func<StructSymbol, EntityHandle> resolveDefaultCtorToken = null,
+        Func<StructSymbol, ConstructorSymbol, EntityHandle> resolveExplicitCtorToken = null)
     {
         this.emitCtx = emitCtx ?? throw new ArgumentNullException(nameof(emitCtx));
         this.wellKnown = wellKnown ?? throw new ArgumentNullException(nameof(wellKnown));
         this.getTypeReference = getTypeReference ?? throw new ArgumentNullException(nameof(getTypeReference));
+        this.resolvePrimaryCtorToken = resolvePrimaryCtorToken;
+        this.resolveDefaultCtorToken = resolveDefaultCtorToken;
+        this.resolveExplicitCtorToken = resolveExplicitCtorToken;
     }
 
     /// <summary>
@@ -467,6 +476,19 @@ internal sealed class CustomAttributeEncoder
 
     public void EmitBoundAttribute(EntityHandle parent, BoundAttribute attr)
     {
+        // Issue #1921: a same-compilation user class deriving from
+        // System.Attribute (accepted by GS0200 via
+        // StructSymbol.DerivesFromSystemAttribute) has no ClrType until
+        // emitted — the CLR-reflection path below can't resolve its
+        // constructor. Mirror that path symbolically instead so a plain
+        // `@Note("x")` on a user `NoteAttribute` round-trips into a real
+        // CustomAttribute row the same way a BCL attribute does.
+        if (attr.AttributeType is StructSymbol userAttrType && userAttrType.ClrType == null)
+        {
+            this.EmitUserBoundAttribute(parent, userAttrType, attr);
+            return;
+        }
+
         var clrType = attr.AttributeType.ClrType;
         if (clrType == null)
         {
@@ -532,6 +554,145 @@ internal sealed class CustomAttributeEncoder
             parent: parent,
             constructor: ctorRef,
             value: this.emitCtx.Metadata.GetOrAddBlob(valueBlob));
+    }
+
+    /// <summary>
+    /// Issue #1921: emits a <c>CustomAttribute</c> row for an attribute whose
+    /// resolved type is a same-compilation <see cref="StructSymbol"/> (no
+    /// <c>ClrType</c> yet — it hasn't been emitted). Selects the
+    /// primary or an explicit constructor by exact arity against
+    /// <paramref name="attr"/>'s positional arguments (the same "match the
+    /// constructor shape" step <see cref="ResolveAttributeConstructor"/> does
+    /// for CLR types, minus params-array expansion, which no G# constructor
+    /// declaration can express) and writes the fixed-argument blob using each
+    /// parameter's own (always-primitive-or-string, hence already-resolved)
+    /// <c>TypeSymbol.ClrType</c>.
+    /// </summary>
+    /// <remarks>
+    /// Named (property/field) arguments are intentionally NOT supported for
+    /// user-defined attribute types here: <see cref="WriteCustomAttributeNamedArg"/>
+    /// resolves the target member's CLR type via <c>Type.GetProperty</c>/
+    /// <c>Type.GetField</c> reflection, which is unavailable for a type
+    /// that hasn't been emitted yet. Reimplementing that against
+    /// <see cref="StructSymbol"/> fields/properties (including nested-enum
+    /// underlying types, <see cref="System.Type"/> arguments, etc.) is a
+    /// separate, considerably larger feature than closing the GS0200
+    /// recognition gap this issue is about; named arguments on a user
+    /// attribute are silently dropped rather than crashing, matching the
+    /// existing "unknown member — skip silently" behavior in
+    /// <see cref="WriteCustomAttributeNamedArg"/> for the CLR path.
+    /// </remarks>
+    private void EmitUserBoundAttribute(EntityHandle parent, StructSymbol attributeType, BoundAttribute attr)
+    {
+        if (!this.TryResolveUserAttributeConstructor(attributeType, attr.PositionalArguments.Length, out var ctorToken, out var paramTypes))
+        {
+            return;
+        }
+
+        var valueBlob = new BlobBuilder();
+        valueBlob.WriteUInt16(0x0001); // Prolog
+        for (int i = 0; i < paramTypes.Length; i++)
+        {
+            var writeType = NormalizeWellKnownType(paramTypes[i]);
+            WriteCustomAttributeFixedArg(valueBlob, writeType, attr.PositionalArguments[i].Value);
+        }
+
+        valueBlob.WriteUInt16(0); // NumNamed — see remarks above.
+
+        this.emitCtx.Metadata.AddCustomAttribute(
+            parent: parent,
+            constructor: ctorToken,
+            value: this.emitCtx.Metadata.GetOrAddBlob(valueBlob));
+    }
+
+    /// <summary>
+    /// Selects the primary or an explicit constructor of <paramref name="attributeType"/>
+    /// whose arity exactly matches <paramref name="argCount"/> and returns the
+    /// already-correct emit-ready <see cref="EntityHandle"/> for it (a bare
+    /// <c>MethodDef</c>, or — for a constructed generic attribute type — a
+    /// <c>MemberRef</c> parented at the constructed TypeSpec; both cases are
+    /// handled by the injected resolver delegates, the same ones used for
+    /// `newobj` against a user constructor). Returns <see langword="false"/>
+    /// when no arity match exists or a parameter's type has no
+    /// <see cref="TypeSymbol.ClrType"/> (an as-yet-unemitted user type used as
+    /// an attribute constructor parameter — unsupported, same as the CLR path
+    /// bailing out when it can't resolve a parameter type).
+    /// </summary>
+    private bool TryResolveUserAttributeConstructor(
+        StructSymbol attributeType,
+        int argCount,
+        out EntityHandle ctorToken,
+        out Type[] paramTypes)
+    {
+        ctorToken = default;
+        paramTypes = null;
+
+        if (attributeType.HasPrimaryConstructor
+            && attributeType.PrimaryConstructorParameters.Length == argCount
+            && this.resolvePrimaryCtorToken != null
+            && TryGetClrParameterTypes(attributeType.PrimaryConstructorParameters, out paramTypes))
+        {
+            ctorToken = this.resolvePrimaryCtorToken(attributeType);
+            return true;
+        }
+
+        if (this.resolveExplicitCtorToken != null)
+        {
+            foreach (var ctor in attributeType.EffectiveExplicitConstructors)
+            {
+                if (ctor.Parameters.Length != argCount)
+                {
+                    continue;
+                }
+
+                if (!TryGetClrParameterTypes(ctor.Parameters, out paramTypes))
+                {
+                    continue;
+                }
+
+                ctorToken = this.resolveExplicitCtorToken(attributeType, ctor);
+                return true;
+            }
+        }
+
+        if (argCount == 0 && this.resolveDefaultCtorToken != null)
+        {
+            try
+            {
+                ctorToken = this.resolveDefaultCtorToken(attributeType);
+            }
+            catch (InvalidOperationException)
+            {
+                // No emitted default ctor (e.g. an attribute class declared
+                // with only explicit `init(...)` constructors) — nothing
+                // else to try for a zero-arg application.
+                return false;
+            }
+
+            paramTypes = Array.Empty<Type>();
+            return true;
+        }
+
+        paramTypes = null;
+        return false;
+    }
+
+    private static bool TryGetClrParameterTypes(ImmutableArray<ParameterSymbol> parameters, out Type[] clrTypes)
+    {
+        clrTypes = new Type[parameters.Length];
+        for (int i = 0; i < parameters.Length; i++)
+        {
+            var clr = parameters[i].Type?.ClrType;
+            if (clr == null)
+            {
+                clrTypes = null;
+                return false;
+            }
+
+            clrTypes[i] = clr;
+        }
+
+        return true;
     }
 
     private static ConstructorInfo ResolveAttributeConstructor(Type attributeType, ImmutableArray<BoundAttributeArgument> positional)

--- a/src/Core/CodeAnalysis/Emit/CustomAttributeEncoder.cs
+++ b/src/Core/CodeAnalysis/Emit/CustomAttributeEncoder.cs
@@ -577,14 +577,15 @@ internal sealed class CustomAttributeEncoder
     /// <see cref="StructSymbol"/> fields/properties (including nested-enum
     /// underlying types, <see cref="System.Type"/> arguments, etc.) is a
     /// separate, considerably larger feature than closing the GS0200
-    /// recognition gap this issue is about; named arguments on a user
-    /// attribute are silently dropped rather than crashing, matching the
-    /// existing "unknown member — skip silently" behavior in
-    /// <see cref="WriteCustomAttributeNamedArg"/> for the CLR path.
+    /// recognition gap this issue is about. Named arguments on a
+    /// same-compilation user attribute are now rejected at bind time (GS0466,
+    /// see <c>DeclarationBinder.BindAttribute</c>), so <paramref name="attr"/>
+    /// never carries any by the time it reaches the emitter — this method
+    /// only ever writes <c>NumNamed = 0</c>.
     /// </remarks>
     private void EmitUserBoundAttribute(EntityHandle parent, StructSymbol attributeType, BoundAttribute attr)
     {
-        if (!this.TryResolveUserAttributeConstructor(attributeType, attr.PositionalArguments.Length, out var ctorToken, out var paramTypes))
+        if (!this.TryResolveUserAttributeConstructor(attributeType, attr, out var ctorToken, out var paramTypes))
         {
             return;
         }
@@ -607,23 +608,30 @@ internal sealed class CustomAttributeEncoder
 
     /// <summary>
     /// Selects the primary or an explicit constructor of <paramref name="attributeType"/>
-    /// whose arity exactly matches <paramref name="argCount"/> and returns the
-    /// already-correct emit-ready <see cref="EntityHandle"/> for it (a bare
-    /// <c>MethodDef</c>, or — for a constructed generic attribute type — a
-    /// <c>MemberRef</c> parented at the constructed TypeSpec; both cases are
-    /// handled by the injected resolver delegates, the same ones used for
-    /// `newobj` against a user constructor). Returns <see langword="false"/>
-    /// when no arity match exists or a parameter's type has no
-    /// <see cref="TypeSymbol.ClrType"/> (an as-yet-unemitted user type used as
-    /// an attribute constructor parameter — unsupported, same as the CLR path
-    /// bailing out when it can't resolve a parameter type).
+    /// whose arity matches <paramref name="attr"/>'s positional argument count
+    /// AND whose parameter types actually accept the supplied argument values
+    /// (the same <see cref="ArgAssignable"/> check <see cref="ResolveAttributeConstructor"/>
+    /// uses for CLR-imported attribute types), returning the already-correct
+    /// emit-ready <see cref="EntityHandle"/> for it (a bare <c>MethodDef</c>,
+    /// or — for a constructed generic attribute type — a <c>MemberRef</c>
+    /// parented at the constructed TypeSpec; both cases are handled by the
+    /// injected resolver delegates, the same ones used for `newobj` against a
+    /// user constructor). Returns <see langword="false"/> when no arity match
+    /// exists or a parameter's type has no <see cref="TypeSymbol.ClrType"/>
+    /// (an as-yet-unemitted user type used as an attribute constructor
+    /// parameter — unsupported, same as the CLR path bailing out when it
+    /// can't resolve a parameter type). Throws <see cref="EmitDiagnosticException"/>
+    /// (surfaced as GS9998) when two or more same-arity explicit constructors
+    /// both accept the supplied arguments — overload resolution has no way to
+    /// silently guess which one the user meant (issue #1921 code review).
     /// </summary>
     private bool TryResolveUserAttributeConstructor(
         StructSymbol attributeType,
-        int argCount,
+        BoundAttribute attr,
         out EntityHandle ctorToken,
         out Type[] paramTypes)
     {
+        var argCount = attr.PositionalArguments.Length;
         ctorToken = default;
         paramTypes = null;
 
@@ -638,6 +646,10 @@ internal sealed class CustomAttributeEncoder
 
         if (this.resolveExplicitCtorToken != null)
         {
+            ConstructorSymbol matchedCtor = null;
+            Type[] matchedParamTypes = null;
+            ConstructorSymbol ambiguousCtor = null;
+
             foreach (var ctor in attributeType.EffectiveExplicitConstructors)
             {
                 if (ctor.Parameters.Length != argCount)
@@ -645,12 +657,37 @@ internal sealed class CustomAttributeEncoder
                     continue;
                 }
 
-                if (!TryGetClrParameterTypes(ctor.Parameters, out paramTypes))
+                if (!TryGetClrParameterTypes(ctor.Parameters, out var candidateParamTypes))
                 {
                     continue;
                 }
 
-                ctorToken = this.resolveExplicitCtorToken(attributeType, ctor);
+                if (!ArgumentsAssignable(attr.PositionalArguments, candidateParamTypes))
+                {
+                    continue;
+                }
+
+                if (matchedCtor != null)
+                {
+                    ambiguousCtor = ctor;
+                    break;
+                }
+
+                matchedCtor = ctor;
+                matchedParamTypes = candidateParamTypes;
+            }
+
+            if (ambiguousCtor != null)
+            {
+                EmitDiagnosticException.Throw(
+                    attr.Syntax,
+                    $"Ambiguous constructor for attribute '{attributeType.Name}': more than one 'init(...)' overload with {argCount} parameter(s) accepts the given argument types. Add an explicit conversion or change the argument types to disambiguate.");
+            }
+
+            if (matchedCtor != null)
+            {
+                ctorToken = this.resolveExplicitCtorToken(attributeType, matchedCtor);
+                paramTypes = matchedParamTypes;
                 return true;
             }
         }
@@ -793,6 +830,27 @@ internal sealed class CustomAttributeEncoder
         }
 
         return IsTriviallyConvertible(supplied.GetType(), paramType);
+    }
+
+    /// <summary>
+    /// Issue #1921 code review (overload disambiguation): checks every
+    /// positional argument against the corresponding same-compilation
+    /// constructor parameter type using the same <see cref="ArgAssignable"/>
+    /// rule the CLR-attribute path applies via <see cref="ParametersMatch"/>.
+    /// No params-array expansion — no G# constructor declaration can express
+    /// a trailing params array.
+    /// </summary>
+    private static bool ArgumentsAssignable(ImmutableArray<BoundAttributeArgument> positional, Type[] paramTypes)
+    {
+        for (int i = 0; i < paramTypes.Length; i++)
+        {
+            if (!ArgAssignable(positional[i].Value, paramTypes[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -751,7 +751,13 @@ internal sealed class ReflectionMetadataEmitter
         // dedup-cached root resolver) and wellKnown's GetIsReadOnlyAttributeCtorRef.
         // It owns every custom-attribute blob-encoding helper; the assembly-
         // level orchestrators on this root forward into it.
-        this.customAttrEncoder = new CustomAttributeEncoder(this.emitCtx, this.wellKnown, this.GetTypeReference);
+        this.customAttrEncoder = new CustomAttributeEncoder(
+            this.emitCtx,
+            this.wellKnown,
+            this.GetTypeReference,
+            this.ResolveUserCtorTokenForPrimary,
+            this.ResolveUserCtorTokenForDefault,
+            this.ResolveUserCtorTokenForExplicit);
 
         // PR-E-12: MethodBodyPlanner owns the per-body planning orchestrators
         // (CollectLocalsAndLabels and friends) that drive SlotPlanner's

--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -850,6 +850,45 @@ public sealed class StructSymbol : TypeSymbol
     }
 
     /// <summary>
+    /// Issue #1921: returns true when this class is — or transitively
+    /// derives from — <see cref="System.Attribute"/>, whether reached via
+    /// the <c>@Attribute</c> declaration sugar (<see cref="IsAttributeClass"/>)
+    /// or an explicit <c>: Attribute</c> / <c>: System.Attribute</c> base
+    /// clause naming the imported CLR type. Same-compilation user classes
+    /// have no <see cref="TypeSymbol.ClrType"/> until emitted, so a naive
+    /// CLR base-chain walk on this type alone can't see it; this walks the
+    /// symbol-level <see cref="BaseClass"/> chain instead, falling back to
+    /// the CLR chain only once an <see cref="ImportedBaseType"/> is reached.
+    /// </summary>
+    /// <returns><c>true</c> when this class is or derives from <see cref="System.Attribute"/>.</returns>
+    public bool DerivesFromSystemAttribute()
+    {
+        for (var current = this; current != null; current = current.BaseClass)
+        {
+            if (current.IsAttributeClass)
+            {
+                return true;
+            }
+
+            if (current.ImportedBaseType != null)
+            {
+                var clr = current.ImportedBaseType.ClrType;
+                for (var t = clr; t != null; t = t.BaseType)
+                {
+                    if (t.FullName == typeof(System.Attribute).FullName)
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Sets the resolved <see cref="LayoutMetadata"/>. Intended to be
     /// called once by the binder after attributes have been bound; the
     /// <see cref="StructLayoutBinder"/> helper writes the resolved

--- a/test/Core.Tests/CodeAnalysis/Binding/AttributeBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/AttributeBinderTests.cs
@@ -94,6 +94,41 @@ public class AttributeBinderTests
     }
 
     [Fact]
+    public void Issue1921_NamedArgumentOnUserAttribute_ReportsGS0466()
+    {
+        // Code-review follow-up: a named (property/field-style) argument on a
+        // same-compilation user attribute type used to bind clean and then be
+        // silently dropped by the emitter (never written to metadata). It
+        // must now be rejected at bind time with a clear diagnostic instead.
+        var source = """
+            class NoteAttribute : Attribute {
+                var Tag string = ""
+            }
+
+            @Note(Tag: "x")
+            func Helper() {
+            }
+            """;
+
+        var globalScope = BindSource(source);
+        Assert.Contains(GetBinderDiagnostics(globalScope), d => d.Id == "GS0466" && d.Message.Contains("Tag"));
+    }
+
+    [Fact]
+    public void Issue1921_NamedArgumentOnClrAttribute_StillWorks()
+    {
+        // Sanity check: the GS0466 rejection is scoped to same-compilation
+        // user attribute types only; a CLR-imported attribute with named args
+        // (e.g. System.Diagnostics.Conditional's implicit named-arg support
+        // via AttributeUsage) must be unaffected. Using a positional-only CLR
+        // attribute here since most BCL attributes usable from G# take no
+        // named args; this asserts no GS0466 leaks onto the CLR path.
+        var globalScope = BindSource("@Obsolete(\"msg\")\nfunc Helper() {\n}\n");
+
+        Assert.DoesNotContain(GetBinderDiagnostics(globalScope), d => d.Id == "GS0466");
+    }
+
+    [Fact]
     public void Reports_Invalid_Use_Site_Target_On_Function()
     {
         // `@field:` is not valid on a function declaration.

--- a/test/Core.Tests/CodeAnalysis/Binding/AttributeBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/AttributeBinderTests.cs
@@ -66,6 +66,34 @@ public class AttributeBinderTests
     }
 
     [Fact]
+    public void Issue1921_PlainColonAttributeBase_DoesNotReportGS0200()
+    {
+        // Issue #1921: a same-compilation user class with a plain
+        // `: Attribute` base clause (no `@Attribute` declaration sugar) must
+        // be recognized as a valid attribute type — GS0200 previously fired
+        // here because IsAttributeType only consulted the IsAttributeClass
+        // sugar flag or the (still-null, pre-emission) ClrType, never the
+        // symbol-level BaseClass/ImportedBaseType chain.
+        var globalScope = BindSource(
+            "class NoteAttribute : Attribute {\n}\n\n@Note\nfunc Helper() {\n}\n");
+
+        Assert.DoesNotContain(GetBinderDiagnostics(globalScope), d => d.Id == "GS0200");
+        var helper = globalScope.Functions.Single(f => f.Name == "Helper");
+        Assert.Single(helper.Attributes);
+        Assert.Equal("NoteAttribute", helper.Attributes[0].AttributeType.Name);
+    }
+
+    [Fact]
+    public void Issue1921_FullyQualifiedSystemAttributeBase_DoesNotReportGS0200()
+    {
+        // Same as above but spelled with the fully-qualified base name.
+        var globalScope = BindSource(
+            "class NoteAttribute : System.Attribute {\n}\n\n@Note\nfunc Helper() {\n}\n");
+
+        Assert.DoesNotContain(GetBinderDiagnostics(globalScope), d => d.Id == "GS0200");
+    }
+
+    [Fact]
     public void Reports_Invalid_Use_Site_Target_On_Function()
     {
         // `@field:` is not valid on a function declaration.

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue1921UserAttributeClassEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue1921UserAttributeClassEmitTests.cs
@@ -1,0 +1,180 @@
+// <copyright file="Issue1921UserAttributeClassEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #1921: a hand-written G# class explicitly deriving from
+/// <c>System.Attribute</c> — <c>class NoteAttribute : Attribute { … }</c>, with
+/// no <c>@Attribute</c> declaration sugar — used to be rejected with GS0200
+/// ("Type 'NoteAttribute' is not an attribute class") even though it plainly
+/// derives from <c>System.Attribute</c>. The root cause was
+/// <c>DeclarationBinder.IsAttributeType</c> checking only the
+/// <c>StructSymbol.IsAttributeClass</c> flag (set exclusively by the
+/// <c>@Attribute</c> sugar path) or the type's own (still-null,
+/// pre-emission) <c>ClrType</c>, never walking the symbol-level
+/// <c>BaseClass</c>/<c>ImportedBaseType</c> chain a same-compilation class
+/// actually has. Once GS0200 recognition was fixed
+/// (<see cref="StructSymbol.DerivesFromSystemAttribute"/>), a second gap
+/// surfaced: <c>CustomAttributeEncoder.EmitBoundAttribute</c> also keyed off
+/// <c>ClrType</c> and silently dropped the attribute application from the
+/// emitted metadata entirely. Both are exercised here end to end: the type
+/// declares, the annotation applies, and the applied attribute — including
+/// its constructor argument — round-trips through real
+/// <see cref="System.Type.GetCustomAttributes(bool)"/> reflection on the
+/// compiled assembly.
+/// </summary>
+public class Issue1921UserAttributeClassEmitTests
+{
+    [Fact]
+    public void PlainColonAttributeBase_WithPrimaryCtorArg_AppliesAndRoundTripsThroughReflection()
+    {
+        const string Source = @"package Issue1921Plain
+import System
+
+class NoteAttribute(Text string) : Attribute {
+}
+
+@Note(""hello-world"")
+class Widget {
+}
+
+func run() {
+    var t Type = typeof(Widget)
+    var attrs = t.GetCustomAttributes(true)
+    for var i int32 = 0; i < attrs.Length; i += 1 {
+        if attrs[i].GetType().Name == ""NoteAttribute"" {
+            var a NoteAttribute = attrs[i] as NoteAttribute
+            Console.WriteLine(""Note:"" + a.Text)
+        }
+    }
+}
+
+run()
+";
+
+        var output = CompileAndRun(Source, nameof(PlainColonAttributeBase_WithPrimaryCtorArg_AppliesAndRoundTripsThroughReflection));
+        Assert.Contains("Note:hello-world", output);
+    }
+
+    [Fact]
+    public void FullyQualifiedSystemAttributeBase_ParameterlessMarker_AppliesAndRoundTrips()
+    {
+        const string Source = @"package Issue1921Qualified
+import System
+
+class MarkerAttribute : System.Attribute {
+}
+
+@Marker
+class Widget {
+}
+
+func run() {
+    var t Type = typeof(Widget)
+    var attrs = t.GetCustomAttributes(true)
+    var found bool = false
+    for var i int32 = 0; i < attrs.Length; i += 1 {
+        if attrs[i].GetType().Name == ""MarkerAttribute"" {
+            found = true
+        }
+    }
+    Console.WriteLine(""found="" + found.ToString())
+}
+
+run()
+";
+
+        var output = CompileAndRun(Source, nameof(FullyQualifiedSystemAttributeBase_ParameterlessMarker_AppliesAndRoundTrips));
+        Assert.Contains("found=True", output);
+    }
+
+    [Fact]
+    public void AttributeSugarClass_StillDerivesFromSystemAttribute_AndApplies()
+    {
+        // ADR-0047 §5's `@Attribute` sugar predates this issue and must keep
+        // working unchanged alongside the newly recognized plain `: Attribute`
+        // spelling fixed here.
+        const string Source = @"package Issue1921Sugar
+import System
+
+@Attribute
+class SugarAttribute {
+}
+
+@Sugar
+class Widget {
+}
+
+func run() {
+    var t Type = typeof(Widget)
+    var attrs = t.GetCustomAttributes(true)
+    var found bool = false
+    for var i int32 = 0; i < attrs.Length; i += 1 {
+        if attrs[i].GetType().Name == ""SugarAttribute"" {
+            found = true
+        }
+    }
+    Console.WriteLine(""found="" + found.ToString())
+}
+
+run()
+";
+
+        var output = CompileAndRun(Source, nameof(AttributeSugarClass_StillDerivesFromSystemAttribute_AndApplies));
+        Assert.Contains("found=True", output);
+    }
+
+    private static string CompileAndRun(string source, string contextName)
+    {
+        using var peStream = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Emit(peStream);
+
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(contextName, isCollectible: true);
+        try
+        {
+            var asm = loadContext.LoadFromStream(peStream);
+            var programType = asm.GetTypes().FirstOrDefault(t => t.Name == "<Program>");
+            Assert.NotNull(programType);
+            var entry = programType!.GetMethod(
+                "<Main>$",
+                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(entry);
+
+            var stdout = System.Console.Out;
+            var captured = new StringWriter();
+            System.Console.SetOut(captured);
+            try
+            {
+                entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { System.Array.Empty<string>() });
+            }
+            finally
+            {
+                System.Console.SetOut(stdout);
+            }
+
+            return captured.ToString();
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue1921UserAttributeClassEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue1921UserAttributeClassEmitTests.cs
@@ -135,6 +135,81 @@ run()
         Assert.Contains("found=True", output);
     }
 
+    [Fact]
+    public void OverloadedExplicitCtors_SameArity_SelectsMatchingParameterType()
+    {
+        // Code-review follow-up: two `init(...)` overloads with the same
+        // arity but different parameter types used to be disambiguated by
+        // declaration order alone (whichever came first in
+        // EffectiveExplicitConstructors), regardless of the actual argument
+        // type. `@Tag(42)` must select the int32 overload, not string.
+        const string Source = @"package Issue1921Overload
+import System
+
+class TagAttribute : Attribute {
+    var Which int32 = 0
+    init(x string) {
+        Which = 1
+    }
+    init(x int32) {
+        Which = 2
+    }
+}
+
+@Tag(42)
+class Widget {
+}
+
+func run() {
+    var t Type = typeof(Widget)
+    var attrs = t.GetCustomAttributes(true)
+    for var i int32 = 0; i < attrs.Length; i += 1 {
+        if attrs[i].GetType().Name == ""TagAttribute"" {
+            var a TagAttribute = attrs[i] as TagAttribute
+            Console.WriteLine(""Which:"" + a.Which.ToString())
+        }
+    }
+}
+
+run()
+";
+
+        var output = CompileAndRun(Source, nameof(OverloadedExplicitCtors_SameArity_SelectsMatchingParameterType));
+        Assert.Contains("Which:2", output);
+    }
+
+    [Fact]
+    public void OverloadedExplicitCtors_AmbiguousArgument_ReportsGS9998()
+    {
+        // A `string` overload and an `Object` overload both accept a string
+        // argument (everything is assignable to Object) — genuinely
+        // ambiguous, no argument-type information can disambiguate. Must be
+        // rejected with a diagnostic rather than silently picking whichever
+        // came first in declaration order.
+        const string Source = @"package Issue1921Ambiguous
+import System
+
+class TagAttribute : Attribute {
+    init(x string) {
+    }
+    init(x Object) {
+    }
+}
+
+@Tag(""hello"")
+class Widget {
+}
+";
+
+        using var peStream = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(Source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Emit(peStream);
+
+        Assert.False(result.Success);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS9998");
+    }
+
     private static string CompileAndRun(string source, string contextName)
     {
         using var peStream = new MemoryStream();

--- a/tools/cs2gs/corpus/grid/G07-Members-Console/Constructs/AttributeList.cs
+++ b/tools/cs2gs/corpus/grid/G07-Members-Console/Constructs/AttributeList.cs
@@ -1,12 +1,11 @@
-// inventory: AttributeList — BCL attributes applied to a type and a member
+// inventory: AttributeList — BCL attributes applied to a type and a member,
+// plus (issue #1921, fixed) a user-defined attribute class applied to a type.
 // QUARANTINED sub-probes:
-//   * a user-defined attribute class (`class NoteAttribute : Attribute`) translates
-//     but gsc rejects the application with GS0200 "Type 'NoteAttribute' is not an
-//     attribute class (it does not derive from System.Attribute)" — reproduced with
-//     hand-written G# too, so it is a gsc limitation, not a translation bug;
 //   * an attribute on a parameter ([Note] int seed) is SILENTLY dropped from the
 //     emitted G# (no diagnostic; not observable via stdout without reflection).
 using System;
+using System.Linq;
+using System.Reflection;
 
 namespace Corpus.Grid07
 {
@@ -25,6 +24,28 @@ namespace Corpus.Grid07
         }
     }
 
+    // Issue #1921: user-defined attribute class — a plain `: Attribute` base
+    // clause (translated verbatim, no `@Attribute` sugar needed) used to be
+    // rejected by gsc with GS0200 "Type 'NoteAttribute' is not an attribute
+    // class". Both the declaration and the application are exercised below;
+    // the applied instance and its constructor argument are read back via
+    // reflection since custom-attribute application isn't otherwise
+    // observable through stdout.
+    public class NoteAttribute : Attribute
+    {
+        public string Text { get; }
+
+        public NoteAttribute(string text)
+        {
+            Text = text;
+        }
+    }
+
+    [Note("hand-written note")]
+    public class AnnotatedGadget
+    {
+    }
+
     public static class AttributeListFixture
     {
         public static void Run()
@@ -33,6 +54,11 @@ namespace Corpus.Grid07
             LegacyGadget gadget = new LegacyGadget();
             Console.WriteLine("AttributeList: old=" + gadget.OldWay(41).ToString());
             Console.WriteLine("AttributeList: renew=" + gadget.Renew(40).ToString());
+
+            NoteAttribute note = typeof(AnnotatedGadget).GetCustomAttributes(true)
+                .OfType<NoteAttribute>()
+                .First();
+            Console.WriteLine("AttributeList: note=" + note.Text);
         }
     }
 }

--- a/tools/cs2gs/corpus/grid/G07-Members-Console/baseline.stdout.golden
+++ b/tools/cs2gs/corpus/grid/G07-Members-Console/baseline.stdout.golden
@@ -3,6 +3,7 @@ ArrowExpressionClause: doubled=42
 ArrowExpressionClause: tripled=63
 AttributeList: old=42
 AttributeList: renew=42
+AttributeList: note=hand-written note
 BaseConstructorInitializer: kind=truck wheels=6
 ConstructorDeclaration: blank=unassigned@0
 ConstructorDeclaration: assigned=kim@12

--- a/tools/cs2gs/coverage/csharp-construct-inventory.json
+++ b/tools/cs2gs/coverage/csharp-construct-inventory.json
@@ -206,7 +206,7 @@
     "rationale": "None",
     "fixture": "tools/cs2gs/corpus/grid/G07-Members-Console/Constructs/AttributeList.cs",
     "issue": "https://github.com/DavidObando/gsharp/issues/1913",
-    "notes": "BCL attributes green; parameter attributes silently dropped and generic attributes emit non-parsing G# (issue #1913)."
+    "notes": "BCL attributes and user-defined attribute classes (issue #1921, fixed) green; parameter attributes silently dropped and generic attributes emit non-parsing G# (issue #1913)."
   },
   {
     "kind": "AttributeTargetSpecifier",


### PR DESCRIPTION
Fixes #1921

## Root cause
`DeclarationBinder.IsAttributeType` only checked the `StructSymbol.IsAttributeClass` sugar flag (set exclusively by the `@Attribute` declaration sugar) or the type's own `ClrType`. A same-compilation user class has a null `ClrType` until it is emitted, so a plain `class NoteAttribute : Attribute` (or `: System.Attribute`) was rejected with GS0200 even though it explicitly derives from `System.Attribute` — the check never walked the symbol-level `BaseClass`/`ImportedBaseType` chain.

A second, deeper gap surfaced once GS0200 was fixed: `CustomAttributeEncoder.EmitBoundAttribute` (the emitter) also keyed off `ClrType`, so an accepted `@Note(...)` application on a user-defined attribute type was silently dropped from the CustomAttribute metadata table — the attribute never actually applied at runtime.

## Fix
- Added `StructSymbol.DerivesFromSystemAttribute()`: walks the `BaseClass` chain checking `IsAttributeClass`, and once an `ImportedBaseType` is reached, its CLR base-type chain. Used by both `DeclarationBinder.IsAttributeType` and `KnownAttributes.GetAttributeUsage` (previously duplicated/inconsistent logic).
- Extended `CustomAttributeEncoder.EmitBoundAttribute` to resolve a same-compilation attribute type's primary/explicit constructor by exact arity (reusing the existing `ResolveUserCtorToken*` helpers already used for `newobj` against user types) and write the fixed-argument blob with the already-emit-ready `TypeSymbol.ClrType` of each parameter.

## Scope decisions
- **In scope, verified working:** declaring a user attribute class (plain `: Attribute`, fully-qualified `: System.Attribute`, and the pre-existing `@Attribute` sugar), applying it to a type, and reading back the applied instance + constructor argument via real `Type.GetCustomAttributes` reflection on the compiled assembly.
- **Explicitly out of scope:** named (property/field) attribute arguments on user-defined attribute types (e.g. `@Note(Text = "x")`). The existing emitter resolves named-argument member types via CLR reflection (`Type.GetProperty`/`GetField`), which doesn't exist for an unemitted user type; supporting it would require a parallel `FieldSymbol`/`PropertySymbol`-based lookup (including enum-underlying-type and `System.Type`-argument handling) — a materially larger feature than closing the GS0200 recognition gap this issue is about. Positional constructor arguments (the pattern in the issue's repro and in the grid fixture) are fully supported.

## Tests
- `test/Core.Tests/CodeAnalysis/Emit/Issue1921UserAttributeClassEmitTests.cs`: declare + apply + reflect-read-back for plain `: Attribute`, fully-qualified `: System.Attribute`, and `@Attribute`-sugar spellings.
- `AttributeBinderTests.cs`: two new binder-level tests asserting GS0200 is no longer reported for same-compilation attribute classes.
- Re-enabled the user-defined-attribute-class sub-probe in `tools/cs2gs/corpus/grid/G07-Members-Console/Constructs/AttributeList.cs` (previously quarantined inline), recaptured its C# baseline, and re-ran the cs2gs migrate pipeline for `G07-Members-Console` — green.
- Regenerated `tools/cs2gs/coverage/csharp-construct-inventory.json` (via `cs2gs coverage --write`) and `docs/cs2gs-coverage-matrix.md`.
- Full `Core.Tests`: **5321 passed, 0 failed, 1 skipped** (pre-existing, unrelated baseline-regen test).
