### PR TITLE
gsc: fix GS9998 ICE for generic class primary ctor construction from class methods

### DIFF
--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -8000,7 +8000,16 @@ internal sealed class ReflectionMetadataEmitter
     /// </summary>
     internal EntityHandle ResolveUserCtorTokenForPrimary(StructSymbol structType)
     {
-        if (!this.cache.ClassPrimaryCtorHandles.TryGetValue(structType, out var primaryDef))
+        // Issue #1920: the primary ctor's MethodDef is keyed by the OPEN
+        // definition (RegisterConstructedTypeAliases only mirrors it onto a
+        // CONSTRUCTED StructSymbol when that exact instance is referenced
+        // from a top-level function/lambda body — a construction inside a
+        // class/struct instance or shared method never runs through that
+        // collector). Look up via Definition first, matching the sibling
+        // ResolveUserCtorTokenForDefault (issue #810) and
+        // ResolveConstructedBaseParameterlessCtorToken (issue #1055).
+        var ctorKey = structType.Definition ?? structType;
+        if (!this.cache.ClassPrimaryCtorHandles.TryGetValue(ctorKey, out var primaryDef))
         {
             throw new InvalidOperationException($"Type '{structType.Name}' has no emitted primary ctor.");
         }

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue1920GenericPrimaryCtorFromClassMethodEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue1920GenericPrimaryCtorFromClassMethodEmitTests.cs
@@ -1,0 +1,180 @@
+// <copyright file="Issue1920GenericPrimaryCtorFromClassMethodEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #1920: a GENERIC class (or <c>data struct</c>) with a primary
+/// constructor ICEd at every instantiation with GS9998
+/// (<c>InvalidOperationException: Type '...' has no emitted primary ctor.</c>)
+/// whenever the construction happened from inside another type's method (a
+/// <c>shared</c>/static method or an instance method) rather than a top-level
+/// <c>func</c>. Root cause:
+/// <see cref="GSharp.Core.CodeAnalysis.Emit.ReflectionMetadataEmitter.ResolveUserCtorTokenForPrimary"/>
+/// looked up <c>ClassPrimaryCtorHandles</c> keyed by the CONSTRUCTED
+/// <c>StructSymbol</c> instead of falling back to its open
+/// <c>Definition</c> — the alias that mirrors the definition's handle onto a
+/// specific constructed instantiation
+/// (<c>MethodBodyPlanner.RegisterConstructedTypeAliases</c>) is only
+/// populated for constructions reachable from top-level function/lambda
+/// bodies, so any construction from within a class method never gets an
+/// alias entry and the lookup failed. These end-to-end emit+run tests prove
+/// the primary ctor executes at runtime for constrained, unconstrained,
+/// struct-kind, and multi-type-parameter generic types, all invoked from a
+/// class's <c>shared</c> method (the exact shape that reproduced the ICE).
+/// </summary>
+public class Issue1920GenericPrimaryCtorFromClassMethodEmitTests
+{
+    [Fact]
+    public void ClassConstrainedTypeParameter_ConstructsFromSharedMethod_ReadsField()
+    {
+        const string Source = @"package P
+class RefKeeper[T class](_kept T, _tag int32) {
+    func Kept() T { return _kept }
+    func Tag() int32 { return _tag }
+}
+class Fixture {
+    shared {
+        func Run() int32 {
+            let keeper = RefKeeper[string](""pinned"", 7)
+            return keeper.Tag()
+        }
+    }
+}
+func main() int32 {
+    return Fixture.Run()
+}
+";
+        Assert.Equal(7, RunMain(Source));
+    }
+
+    [Fact]
+    public void StructConstrainedTypeParameter_ConstructsFromSharedMethod_ReadsField()
+    {
+        const string Source = @"package P
+class ValueCell[T struct](_value T, _tag int32) {
+    func Value() T { return _value }
+    func Tag() int32 { return _tag }
+}
+class Fixture {
+    shared {
+        func Run() int32 {
+            let cell = ValueCell[int32](64, 9)
+            return cell.Value() + cell.Tag()
+        }
+    }
+}
+func main() int32 {
+    return Fixture.Run()
+}
+";
+        Assert.Equal(73, RunMain(Source));
+    }
+
+    [Fact]
+    public void UnconstrainedTypeParameter_ConstructsFromSharedMethod_ReadsField()
+    {
+        const string Source = @"package P
+class Box[T](_item T) {
+    func Item() T { return _item }
+}
+class Fixture {
+    shared {
+        func Run() int32 {
+            let box = Box[int32](21)
+            return box.Item()
+        }
+    }
+}
+func main() int32 {
+    return Fixture.Run()
+}
+";
+        Assert.Equal(21, RunMain(Source));
+    }
+
+    [Fact]
+    public void MultiTypeParameter_ConstructsFromSharedMethod_ReadsBothFields()
+    {
+        const string Source = @"package P
+class Pair[A, B](_first A, _second B) {
+    func First() A { return _first }
+    func Second() B { return _second }
+}
+class Fixture {
+    shared {
+        func Run() int32 {
+            let pair = Pair[int32, string](5, ""five"")
+            if (pair.Second() == ""five"") {
+                return pair.First()
+            }
+            return -1
+        }
+    }
+}
+func main() int32 {
+    return Fixture.Run()
+}
+";
+        Assert.Equal(5, RunMain(Source));
+    }
+
+    [Fact]
+    public void DataStructGeneric_ConstructsFromSharedMethod_ReadsField()
+    {
+        const string Source = @"package P
+data struct Wrapper[T](Value T) { }
+class Fixture {
+    shared {
+        func Run() int32 {
+            let w = Wrapper[int32](99)
+            return w.Value
+        }
+    }
+}
+func main() int32 {
+    return Fixture.Run()
+}
+";
+        Assert.Equal(99, RunMain(Source));
+    }
+
+    private static object RunMain(string source)
+    {
+        using var peStream = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Emit(peStream);
+
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(nameof(Issue1920GenericPrimaryCtorFromClassMethodEmitTests), isCollectible: true);
+        try
+        {
+            var asm = loadContext.LoadFromStream(peStream);
+            var programType = asm.GetTypes().FirstOrDefault(t => t.Name == "<Program>");
+            Assert.NotNull(programType);
+            var method = programType!.GetMethod("main", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(method);
+            return method!.Invoke(null, null);
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+}

--- a/tools/cs2gs/corpus/grid/G08-Generics-Console/Constructs/ClassConstraint.cs
+++ b/tools/cs2gs/corpus/grid/G08-Generics-Console/Constructs/ClassConstraint.cs
@@ -1,10 +1,11 @@
 // inventory: ClassConstraint — where T : class
-// QUARANTINED sub-probe: a generic class whose ctor only does once-only parameter
-// assignments is lowered to a G# primary ctor, and instantiating a GENERIC primary-
-// ctor class ICEs gsc (GS9998 InvalidOperationException: Type 'RefKeeper' has no
-// emitted primary ctor — reproduced with hand-written G#). The `_tag = seed + 1`
-// transformed-parameter assignment forces the translator to emit an explicit init
-// ctor instead (a plain literal is hoisted to a field initializer and still ICEs).
+// Issue #1920 (fixed): a ctor that only does once-only parameter assignments
+// is lowered to a G# primary ctor. Previously, instantiating a GENERIC
+// primary-ctor class from inside another class's static/instance method ICEd
+// gsc (GS9998 "Type 'RefKeeper' has no emitted primary ctor.") because the
+// ctor MemberRef lookup was keyed off the constructed StructSymbol instead of
+// its open definition. Kept as a trivial passthrough ctor (no transform) to
+// exercise the primary-ctor emission path directly.
 using System;
 
 namespace Corpus.Grid08
@@ -18,7 +19,7 @@ namespace Corpus.Grid08
         public RefKeeper(T kept, int seed)
         {
             _kept = kept;
-            _tag = seed + 1;
+            _tag = seed;
         }
 
         public T Kept()

--- a/tools/cs2gs/corpus/grid/G08-Generics-Console/Constructs/StructConstraint.cs
+++ b/tools/cs2gs/corpus/grid/G08-Generics-Console/Constructs/StructConstraint.cs
@@ -1,6 +1,8 @@
 // inventory: StructConstraint — where T : struct
-// Note: the `_tag = seed + 2` transformed-parameter assignment prevents the generic-primary-ctor gsc ICE (GS9998,
-// see ClassConstraint.cs).
+// Issue #1920 (fixed): previously the `_tag = seed + 2` transform was needed to
+// dodge the generic-primary-ctor gsc ICE (GS9998, see ClassConstraint.cs). Kept
+// as a trivial passthrough ctor now that the fix lands, exercising the same
+// primary-ctor path for a `struct` constraint.
 using System;
 
 namespace Corpus.Grid08
@@ -14,7 +16,7 @@ namespace Corpus.Grid08
         public ValueCell(T value, int seed)
         {
             _value = value;
-            _tag = seed + 2;
+            _tag = seed;
         }
 
         public T Value()

--- a/tools/cs2gs/corpus/grid/G08-Generics-Console/baseline.stdout.golden
+++ b/tools/cs2gs/corpus/grid/G08-Generics-Console/baseline.stdout.golden
@@ -1,7 +1,7 @@
 AllowsConstraintClause: int=held
 AllowsConstraintClause: string=held
 ClassConstraint: kept=pinned
-ClassConstraint: tag=1
+ClassConstraint: tag=0
 ConstructorConstraint: marks=3
 DefaultConstraint: string=value
 DefaultConstraint: null=null
@@ -12,7 +12,7 @@ GenericName: explicit-string=b
 OmittedTypeArgument: nameof=List
 OmittedTypeArgument: nameof-two-arity=Dictionary
 StructConstraint: int=64
-StructConstraint: tag=2
+StructConstraint: tag=0
 TypeArgumentList: evens=2
 TypeArgumentList: first-even=2
 TypeArgumentList: odds=1


### PR DESCRIPTION
Fixes #1920

## Root cause
`ResolveUserCtorTokenForPrimary` (src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs) looked up `cache.ClassPrimaryCtorHandles` keyed by the **constructed** `StructSymbol` instead of falling back to its open `Definition`. The alias that mirrors a generic definition's cached primary-ctor handle onto a specific constructed instantiation (`MethodBodyPlanner.RegisterConstructedTypeAliases`) only walks constructions reachable from top-level function/lambda bodies — it never visits class/struct method bodies. So a `newobj` against a generic primary-ctor class from inside another type's `shared`/instance method never got an alias entry, and the lookup threw `GS9998 InvalidOperationException: Type '...' has no emitted primary ctor.`

Sibling lookups (`ResolveUserCtorTokenForDefault`, issue #810; `ResolveConstructedBaseParameterlessCtorToken`, issue #1055) already fall back to `structType.Definition ?? structType` — this one didn't.

## Fix
One-line fallback added to `ResolveUserCtorTokenForPrimary`, matching the established pattern. Works for any generic class/struct-kind, any constraint (unconstrained, `class`, `struct`), any type-parameter arity.

## Tests
- `test/Core.Tests/CodeAnalysis/Emit/Issue1920GenericPrimaryCtorFromClassMethodEmitTests.cs`: 5 end-to-end emit+run tests (class constraint, struct constraint, unconstrained, multi-type-parameter, `data struct`), all constructing from inside a class's `shared` method — the exact shape that reproduced the ICE.
- Re-captured the G08-Generics-Console grid corpus: dropped the workaround param transforms in `ClassConstraint.cs`/`StructConstraint.cs` (now trivial passthrough primary ctors, exercising the real bug), updated `baseline.stdout.golden`. `cs2gs migrate --app G08-Generics-Console` now PASSes translate/compile/ilverify/test-parity.
- `csharp-construct-inventory.json` already covered this construct; `cs2gs coverage --write` reported 0 new rows.

## Verification
- `dotnet build src/Compiler/Compiler.csproj -c Release`: success.
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release`: 5321 passed, 0 failed, 1 skipped (pre-existing).
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Release -- xUnit.MaxParallelThreads=2`: 2462 passed, 0 failed (after building the pre-existing `Gsharp.Extensions` dependency, an unrelated environment gap).

No deferred work.