### PR TITLE
cs2gs: lower range indexing to gsc-resolvable slice forms (#1896)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue1731DoubleEvaluationTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1731DoubleEvaluationTranslationTests.cs
@@ -225,8 +225,11 @@ namespace Demo
     }
 }");
 
+        // Issue #1896: the native `recv[start..end]` range-index form embeds
+        // `Next()` exactly once with no `.Slice` desugaring/spill needed.
         Assert.Equal(2, CountOccurrences(printed, "Next()")); // 1 declaration + 1 call
-        Assert.Contains(".Slice(", printed);
+        Assert.Contains("s[Next()..j]", printed);
+        Assert.DoesNotContain(".Slice(", printed);
     }
 
     /// <summary>
@@ -299,15 +302,21 @@ namespace Demo
     // arbitrary parenthesized expression" postfix form to smuggle one in as
     // an immediately-invoked lambda either. #1731 settled for REPORTING the
     // gap (TranslationSeverity.Unsupported) instead of silently
-    // double-evaluating. Issue #1849 closes the gap for real: the whole
-    // null-seam initializer/argument is lowered to a call to a synthesized
-    // private static helper method, so the non-trivial operand is evaluated
-    // exactly once (by the caller, as the helper-call argument) instead of
+    // double-evaluating. Issue #1849 closes the gap for real for a
+    // non-trivial `is`-pattern scrutinee: the whole null-seam
+    // initializer/argument is lowered to a call to a synthesized private
+    // static helper method, so the non-trivial operand is evaluated exactly
+    // once (by the caller, as the helper-call argument) instead of
     // re-embedded — see Issue1849NullSeamHelperLoweringTests for the full
     // helper-lowering coverage (all four sites, static-vs-instance/ctor-
-    // parameter passthrough, name uniquification). These four cases are kept
-    // here, updated to assert the fixed behavior, since they are the exact
-    // reproducers #1731 N1 originally reported as unsupported.) ------------
+    // parameter passthrough, name uniquification). Issue #1896 then closed
+    // the range-slice half of the original N1 gap a different way: the
+    // native `recv[start..end]` range-index form embeds each bound exactly
+    // once in ANY context, so a range-slice null-seam operand no longer
+    // needs the #1849 helper (or any spill) at all — see the two
+    // RangeSlice* cases below, kept here as the exact reproducers #1731 N1
+    // originally reported as unsupported, updated to assert the current
+    // native-form behavior. ------------------------------------------------
 
     [Fact]
     public void FieldInitializer_PatternScrutineeSideEffectingReceiver_LowersToHelper()
@@ -341,7 +350,7 @@ namespace Demo
     }
 
     [Fact]
-    public void FieldInitializer_RangeSliceSideEffectingOperand_LowersToHelper()
+    public void FieldInitializer_RangeSliceSideEffectingOperand_LowersToNativeRangeIndex()
     {
         (string printed, TranslationContext context) = TranslateUnitWithContext(@"
 namespace Demo
@@ -358,9 +367,12 @@ namespace Demo
     }
 }");
 
+        // Issue #1896: no helper needed — the native range-index form
+        // already embeds `Next()` exactly once.
         Assert.Equal(2, CountOccurrences(printed, "Next()")); // 1 declaration + 1 call-site use
-        Assert.Contains(".Slice(", printed);
-        Assert.Contains("__init0(", printed);
+        Assert.Contains("Data[C.Next()..2]", printed);
+        Assert.DoesNotContain(".Slice(", printed);
+        Assert.DoesNotContain("__init0(", printed);
         Assert.DoesNotContain(
             context.Diagnostics,
             d => d.Severity == TranslationSeverity.Unsupported && d.Message.Contains("1731 N1"));
@@ -399,7 +411,7 @@ namespace Demo
     }
 
     [Fact]
-    public void ThisConstructorArgument_RangeSliceSideEffectingOperand_LowersToHelper()
+    public void ThisConstructorArgument_RangeSliceSideEffectingOperand_LowersToNativeRangeIndex()
     {
         (string printed, TranslationContext context) = TranslateUnitWithContext(@"
 namespace Demo
@@ -416,9 +428,13 @@ namespace Demo
     }
 }");
 
+        // Issue #1896: no helper needed — `s`/`j` are already in scope at
+        // the `this(...)` argument list, and the native range-index form
+        // already embeds `Next()` exactly once.
         Assert.Equal(2, CountOccurrences(printed, "Next()")); // 1 declaration + 1 call-site use
-        Assert.Contains(".Slice(", printed);
-        Assert.Contains("__init0(", printed);
+        Assert.Contains("init(s[C.Next()..j])", printed);
+        Assert.DoesNotContain(".Slice(", printed);
+        Assert.DoesNotContain("__init0(", printed);
         Assert.DoesNotContain(
             context.Diagnostics,
             d => d.Severity == TranslationSeverity.Unsupported && d.Message.Contains("1731 N1"));

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1849NullSeamHelperLoweringTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1849NullSeamHelperLoweringTests.cs
@@ -35,6 +35,17 @@ namespace Cs2Gs.Tests;
 /// method body with a normal statement seam. No parser/grammar change is
 /// needed, and the shape is no longer reported <c>Unsupported</c>.
 /// </para>
+/// <para>
+/// Issue #1896 update: a range-slice's start/end bounds are no longer
+/// desugared to a double-embedding <c>.Slice(start, end - start)</c> call —
+/// gsc's own native <c>recv[start..end]</c> range-index form embeds each
+/// bound exactly once, in any context, with no spill needed at all. A
+/// range-slice operand is therefore no longer a null-seam site by itself;
+/// the helper lowering below remains reachable only via a non-trivial
+/// <c>is</c>-pattern scrutinee (a range-slice nested inside one is simply
+/// embedded once, as part of the scrutinee capture — see
+/// <see cref="FieldInitializer_NestedNullSeamOperand_LowersCleanlyWithNoDanglingHelperCall"/>).
+/// </para>
 /// </summary>
 public class Issue1849NullSeamHelperLoweringTests
 {
@@ -69,8 +80,14 @@ namespace Demo
     }
 
     [Fact]
-    public void FieldInitializer_RangeSliceSideEffectingOperand_LowersToHelper()
+    public void FieldInitializer_RangeSliceSideEffectingOperand_LowersToNativeRangeIndex()
     {
+        // Issue #1896 follow-up: a range-slice's native `recv[start..end]`
+        // form embeds each bound exactly once regardless of context, so a
+        // field initializer never needs the #1849 helper lowering for a
+        // range-slice operand — that helper machinery only remains reachable
+        // for a non-trivial `is`-pattern scrutinee (see the sibling
+        // `PatternScrutineeSideEffectingReceiver` tests above).
         (string printed, TranslationContext context) = TranslateUnitWithContext(@"
 namespace Demo
 {
@@ -86,9 +103,10 @@ namespace Demo
     }
 }");
 
-        Assert.Equal(2, CountOccurrences(printed, "Next()")); // 1 declaration + 1 call-site use (was N-per-embed before the fix)
-        Assert.Contains(".Slice(", printed);
-        Assert.Contains("__init0(", printed);
+        Assert.Equal(2, CountOccurrences(printed, "Next()")); // 1 declaration + 1 call-site use
+        Assert.Contains("Data[C.Next()..2]", printed);
+        Assert.DoesNotContain(".Slice(", printed);
+        Assert.DoesNotContain("__init0", printed);
         Assert.DoesNotContain(context.Diagnostics, d => d.Severity == TranslationSeverity.Unsupported);
     }
 
@@ -118,8 +136,10 @@ namespace Demo
     }
 
     [Fact]
-    public void StaticPropertyInitializer_RangeSliceSideEffectingOperand_LowersToHelper()
+    public void StaticPropertyInitializer_RangeSliceSideEffectingOperand_LowersToNativeRangeIndex()
     {
+        // Issue #1896 follow-up: same as the field-initializer case above —
+        // the native range-index form needs no helper here either.
         (string printed, TranslationContext context) = TranslateUnitWithContext(@"
 namespace Demo
 {
@@ -135,9 +155,10 @@ namespace Demo
     }
 }");
 
-        Assert.Equal(2, CountOccurrences(printed, "Next()")); // 1 declaration + 1 call-site use (was N-per-embed before the fix)
-        Assert.Contains(".Slice(", printed);
-        Assert.Contains("__init0(", printed);
+        Assert.Equal(2, CountOccurrences(printed, "Next()")); // 1 declaration + 1 call-site use
+        Assert.Contains("Data[C.Next()..2]", printed);
+        Assert.DoesNotContain(".Slice(", printed);
+        Assert.DoesNotContain("__init0", printed);
         Assert.DoesNotContain(context.Diagnostics, d => d.Severity == TranslationSeverity.Unsupported);
     }
 
@@ -173,7 +194,7 @@ namespace Demo
     }
 
     [Fact]
-    public void ThisConstructorArgument_RangeSliceSideEffectingOperand_LowersToHelper()
+    public void ThisConstructorArgument_RangeSliceSideEffectingOperand_LowersToNativeRangeIndex()
     {
         (string printed, TranslationContext context) = TranslateUnitWithContext(@"
 namespace Demo
@@ -190,15 +211,14 @@ namespace Demo
     }
 }");
 
-        // `s` and `j` are the DELEGATING constructor's own parameters, not
-        // field/static state — they must be threaded through as additional
-        // (same-named) helper parameters alongside the genuinely captured
-        // `Next()` operand, since a static helper method cannot otherwise see
-        // them at all.
-        Assert.Equal(2, CountOccurrences(printed, "Next()")); // 1 declaration + 1 call-site use (was N-per-embed before the fix)
-        Assert.Contains(".Slice(", printed);
-        Assert.Contains("__init0(s, j,", printed);
-        Assert.Contains("private func __init0(s []int32, j int32,", printed);
+        // Issue #1896 follow-up: the delegating constructor's own parameters
+        // (`s`, `j`) are already in scope at the `this(...)` argument list —
+        // no helper is needed to thread them through, since the native
+        // range-index form needs no helper at all here.
+        Assert.Equal(2, CountOccurrences(printed, "Next()")); // 1 declaration + 1 call-site use
+        Assert.Contains("init(s[C.Next()..j])", printed);
+        Assert.DoesNotContain(".Slice(", printed);
+        Assert.DoesNotContain("__init0", printed);
         Assert.DoesNotContain(context.Diagnostics, d => d.Severity == TranslationSeverity.Unsupported);
     }
 
@@ -282,20 +302,26 @@ namespace Demo
     }
 
     /// <summary>
-    /// Reviewer follow-up: a null-seam operand that is ITSELF nested inside
-    /// another null-seam operand — here, the is-pattern scrutinee
-    /// <c>Y[Z()..a]</c> is a range-slice whose start <c>Z()</c> is also
-    /// non-trivial and gets spilled first. Naively lowering both to captures
-    /// of the SAME helper would pass the inner spill's synthesized parameter
-    /// name (<c>__p0</c>) as part of the outer capture's call-site argument
-    /// (<c>__init0(Z(), Y[__p0..a])</c>) — but <c>__p0</c> only exists as a
-    /// parameter INSIDE the helper body, so it is a dangling identifier at
-    /// the field-initializer call site. This must bail to the loud
-    /// <c>Unsupported</c> diagnostic (the pre-#1849 behavior) instead of
-    /// emitting a broken helper call.
+    /// Reviewer follow-up, re-verified after #1896: a null-seam operand
+    /// nested inside another null-seam operand — here, the is-pattern
+    /// scrutinee <c>Y[Z()..a]</c> is a range-slice whose start <c>Z()</c> is
+    /// non-trivial. Before #1896, the range-slice's <c>.Slice</c> desugaring
+    /// ALSO needed a single-evaluation spill of <c>Z()</c>, so this was two
+    /// nested null-seam lowerings sharing one synthesized helper — and the
+    /// inner spill's parameter name (<c>__p0</c>) leaking into the outer
+    /// capture's own call-site argument was a genuine dangling-identifier
+    /// hazard, guarded by bailing to the loud <c>Unsupported</c> diagnostic.
+    /// #1896's native <c>recv[start..end]</c> range-index form embeds
+    /// <c>Z()</c> exactly once with no spill of its own — the range-slice is
+    /// no longer a null-seam site at all, only the outer <c>is</c>-pattern
+    /// scrutinee is. So there is only ONE capture now (the whole
+    /// <c>Y[Z()..a]</c> expression, captured as-is by the pattern-match
+    /// helper), the dangling-<c>__p0</c> hazard this test guarded no longer
+    /// exists, and the correct current behavior is a clean helper lowering
+    /// with no <c>Unsupported</c> diagnostic.
     /// </summary>
     [Fact]
-    public void FieldInitializer_NestedNullSeamOperand_ReportsUnsupportedInsteadOfDanglingHelperCall()
+    public void FieldInitializer_NestedNullSeamOperand_LowersCleanlyWithNoDanglingHelperCall()
     {
         (string printed, TranslationContext context) = TranslateUnitWithContext(@"
 namespace Demo
@@ -312,9 +338,13 @@ namespace Demo
     }
 }");
 
-        Assert.Contains(context.Diagnostics, d => d.Severity == TranslationSeverity.Unsupported);
-        Assert.DoesNotContain("__init0", printed);
-        Assert.DoesNotContain("__p0", printed);
+        Assert.DoesNotContain(context.Diagnostics, d => d.Severity == TranslationSeverity.Unsupported);
+        // The whole range-slice `Y[Z()..a]` is the single (only) capture, at
+        // the call site, exactly once — no dangling `__p0` leaks into the
+        // argument list itself (a `__p0` parameter name is fine INSIDE the
+        // synthesized helper's own body/signature, since it is in scope
+        // there).
+        Assert.Contains("__init0(C.Y[C.Z()..C.a])", printed);
     }
 
     private static int CountOccurrences(string haystack, string needle)

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1894IndexLocalTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1894IndexLocalTranslationTests.cs
@@ -39,8 +39,10 @@ namespace Cs2Gs.Tests;
 /// </list>
 /// The direct inline case, <c>a[^3]</c>, is unaffected: it still lowers to
 /// the bare native G# <c>a[^3]</c>. An inline range bound, <c>a[1..^2]</c>,
-/// is also unaffected: <c>CSharpToGSharpTranslator.TranslateRangeBound</c>
-/// folds it into <c>Length</c>-relative arithmetic instead of gapping.
+/// is also unaffected: issue #1896 root-caused range-slice lowering to gsc's
+/// own native <c>a[1..^2]</c> range-index syntax (see
+/// <c>CSharpToGSharpTranslator.TranslateRangeSlice</c>), which accepts a
+/// bracket-scoped <c>^n</c> bound directly — no arithmetic folding needed.
 /// </summary>
 public class Issue1894IndexLocalTranslationTests
 {
@@ -68,9 +70,10 @@ namespace Corpus.Issue1894
     {
         // `a[1..^2]`, `a[^2..]`, `a[..^1]`: the `^n` bound is nested inside a
         // `RangeExpressionSyntax` that is itself a direct bracket argument —
-        // a valid, working inline slice (folded to `Length`-relative
-        // arithmetic by `TranslateRangeBound`), not the #1894 silent-
-        // miscompile shape (a bare `^n` stored/reused outside any bracket).
+        // a valid, working inline slice. Issue #1896 root-caused this: gsc
+        // has its OWN native range-index syntax, so the whole range (`^n`
+        // bound included) now round-trips to the identical native G# form
+        // instead of being desugared to `.Slice(...)`.
         string rendered = Render(@"
 namespace Corpus.Issue1894
 {
@@ -85,19 +88,21 @@ namespace Corpus.Issue1894
 }
 ");
 
-        Assert.Contains(".Slice(", rendered, StringComparison.Ordinal);
+        Assert.Contains("a[1..^2]", rendered, StringComparison.Ordinal);
+        Assert.Contains("a[^2..]", rendered, StringComparison.Ordinal);
+        Assert.Contains("a[..^1]", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain(".Slice(", rendered, StringComparison.Ordinal);
         AssertRoundTripParses(rendered);
     }
 
     [Fact]
-    public void InlineRangeSlice_FromEndBound_SpillsSideEffectingReceiverOnce()
+    public void InlineRangeSlice_FromEndBound_EvaluatesSideEffectingReceiverOnce()
     {
-        // Regression: `TranslateRangeBound` re-embeds the receiver inside
-        // `receiver.Length` alongside the `.Slice(...)` call built in
-        // `TranslateRangeSlice` — a side-effecting receiver (`Src()`) must be
-        // evaluated exactly once, not twice, when a from-end bound is
-        // present. A trivial identifier receiver (`a`) must stay unchanged,
-        // no spill temp introduced.
+        // Issue #1896: the native `recv[start..^n]` form embeds `recv` exactly
+        // once (unlike the retired `.Slice(...)` desugaring, which needed a
+        // receiver spill to avoid a double-evaluated `receiver.Length` +
+        // `.Slice(...)` pair). A side-effecting receiver (`Src()`) must still
+        // be called exactly once, now with no spill temp at all.
         string rendered = Render(@"
 namespace Corpus.Issue1894
 {
@@ -117,11 +122,12 @@ namespace Corpus.Issue1894
         string sideEffectingBody = rendered.Substring(sideEffectingStart, sideEffectingEnd - sideEffectingStart);
         int srcCallCount = System.Text.RegularExpressions.Regex.Matches(sideEffectingBody, @"Src\(\)").Count;
         Assert.Equal(1, srcCallCount);
-        Assert.Contains("let __spill", sideEffectingBody, StringComparison.Ordinal);
+        Assert.DoesNotContain("let __", sideEffectingBody, StringComparison.Ordinal);
+        Assert.Contains("Src()[1..^2]", sideEffectingBody, StringComparison.Ordinal);
 
         string trivialBody = rendered.Substring(sideEffectingEnd);
         Assert.DoesNotContain("let __", trivialBody, StringComparison.Ordinal);
-        Assert.Contains("a.Slice(", trivialBody, StringComparison.Ordinal);
+        Assert.Contains("a[1..^2]", trivialBody, StringComparison.Ordinal);
         AssertRoundTripParses(rendered);
     }
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1896RangeSliceTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1896RangeSliceTranslationTests.cs
@@ -1,0 +1,186 @@
+// <copyright file="Issue1896RangeSliceTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #1896: a C# range-index expression (<c>a[1..3]</c>) was desugared to
+/// <c>a.Slice(1, 3 - 1)</c> — gsc has no <c>Slice</c> member on arrays or
+/// <c>string</c>, so every range-index form failed to compile (GS0159).
+/// gsc actually has its OWN native range-index syntax
+/// (<c>Parser.ParseIndexArgument</c>/<c>ParseIndexBound</c>), and its binder
+/// (<c>ExpressionBinder.BindRangeSlice</c>) resolves it directly against
+/// arrays, <c>string</c>, and any CLR span-like type with a
+/// <c>Length</c>+<c>Slice(int,int)</c> shape or a <c>System.Range</c> indexer
+/// — exactly the set of receivers C# itself allows a range index against. So
+/// <c>CSharpToGSharpTranslator.TranslateRangeSlice</c> now emits the
+/// unchanged native form (<c>GExpression.IndexExpression</c> wrapping a
+/// <c>RangeIndexExpression</c>, the same node already used by the issue
+/// #1889 list-pattern slice lowering) instead of desugaring to <c>.Slice</c>.
+/// </summary>
+public class Issue1896RangeSliceTranslationTests
+{
+    [Fact]
+    public void ArrayRange_BothBounds_LowersToNativeRangeIndex()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1896
+{
+    public class Holder
+    {
+        public int[] Middle(int[] a) => a[1..3];
+    }
+}
+");
+
+        Assert.Contains("a[1..3]", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain(".Slice(", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void ArrayRange_OpenStart_LowersToNativeRangeIndex()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1896
+{
+    public class Holder
+    {
+        public int[] Head(int[] a) => a[..2];
+    }
+}
+");
+
+        Assert.Contains("a[..2]", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain(".Slice(", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void ArrayRange_OpenEnd_LowersToNativeRangeIndex()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1896
+{
+    public class Holder
+    {
+        public int[] Tail(int[] a) => a[1..];
+    }
+}
+");
+
+        Assert.Contains("a[1..]", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain(".Slice(", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void ArrayRange_FullyOpen_LowersToNativeRangeIndex()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1896
+{
+    public class Holder
+    {
+        public int[] All(int[] a) => a[..];
+    }
+}
+");
+
+        Assert.Contains("a[..]", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain(".Slice(", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void ArrayRange_FromEndBothBounds_LowersToNativeRangeIndex()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1896
+{
+    public class Holder
+    {
+        public int[] TailFromEnd(int[] a) => a[^2..];
+
+        public int[] MiddleFromEnd(int[] a) => a[1..^1];
+    }
+}
+");
+
+        Assert.Contains("a[^2..]", rendered, StringComparison.Ordinal);
+        Assert.Contains("a[1..^1]", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain(".Slice(", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void StringLiteralRange_LowersToNativeRangeIndex()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1896
+{
+    public class Holder
+    {
+        public string Slice() => ""gsharp""[1..4];
+    }
+}
+");
+
+        Assert.Contains("\"gsharp\"[1..4]", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain(".Slice(", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void StringVariableRange_OpenEnd_LowersToNativeRangeIndex()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1896
+{
+    public class Holder
+    {
+        public string Tail(string s) => s[2..];
+    }
+}
+");
+
+        Assert.Contains("s[2..]", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain(".Slice(", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    private static void AssertRoundTripParses(string rendered)
+    {
+        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+
+        Assert.True(
+            result.Success,
+            "Sanitized G# must round-trip-parse. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + rendered);
+    }
+
+    private static string Render(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", source) });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        Cs2Gs.CodeModel.Ast.CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        Assert.Empty(context.Diagnostics);
+        return GSharpPrinter.Print(unit);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1896RangeSliceTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1896RangeSliceTranslationTests.cs
@@ -111,12 +111,15 @@ namespace Corpus.Issue1896
         public int[] TailFromEnd(int[] a) => a[^2..];
 
         public int[] MiddleFromEnd(int[] a) => a[1..^1];
+
+        public int[] HeadTrimFromEnd(int[] a) => a[..^1];
     }
 }
 ");
 
         Assert.Contains("a[^2..]", rendered, StringComparison.Ordinal);
         Assert.Contains("a[1..^1]", rendered, StringComparison.Ordinal);
+        Assert.Contains("a[..^1]", rendered, StringComparison.Ordinal);
         Assert.DoesNotContain(".Slice(", rendered, StringComparison.Ordinal);
         AssertRoundTripParses(rendered);
     }

--- a/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
@@ -133,11 +133,15 @@ namespace Demo
     }
 
     /// <summary>
-    /// A range index over a span (<c>s[a..b]</c>) lowers to a <c>.Slice(start,
-    /// length)</c> call — G# has no range operator (gsc gap; ADR-0115 §G).
+    /// A range index over a span (<c>s[a..b]</c>) lowers to gsc's OWN native
+    /// range-index syntax (<c>recv[start..end]</c>) — gsc's binder
+    /// (<c>ExpressionBinder.BindRangeSlice</c>) resolves it directly against
+    /// any CLR span-like type with a <c>Length</c>+<c>Slice(int,int)</c>
+    /// shape, so no <c>.Slice</c> desugaring is needed here either (issue
+    /// #1896).
     /// </summary>
     [Fact]
-    public void RangeExpression_OverSpan_LoweredToSlice()
+    public void RangeExpression_OverSpan_LoweredToNativeRangeIndex()
     {
         string printed = TranslateUnit(@"
 namespace Demo
@@ -152,9 +156,10 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("Slice(1, 3 - 1)", printed);
-        Assert.Contains("Slice(2)", printed);
-        Assert.Contains("Slice(0, 4)", printed);
+        Assert.Contains("s[1..3]", printed);
+        Assert.Contains("s[2..]", printed);
+        Assert.Contains("s[..4]", printed);
+        Assert.DoesNotContain(".Slice(", printed);
     }
 
     /// <summary>

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -9496,74 +9496,29 @@ public sealed class CSharpToGSharpTranslator
             }
         }
 
+        // Issue #1896: gsc has its OWN native range-index syntax
+        // (`recv[start..end]` / `recv[..end]` / `recv[start..]` / `recv[..]`,
+        // with `^n` from-end bounds on either side — Parser.ParseIndexArgument /
+        // ParseIndexBound) and its binder (BindRangeSlice) resolves it directly
+        // against arrays, `string`, and any CLR span-like type with a
+        // `Length`+`Slice(int,int)` shape or a `System.Range` indexer — the same
+        // set of receivers C# itself allows a range index against. So the
+        // C# range index needs no desugaring at all: it round-trips to the
+        // identical native G# form (`GExpression.IndexExpression` wrapping a
+        // `RangeIndexExpression`, already used by the issue #1889 list-pattern
+        // slice lowering below). This also drops #1894's `Length`-arithmetic
+        // and receiver-spill workarounds entirely — gsc's own `^n` bound
+        // handles from-end offsets and the receiver is only ever embedded once.
         private GExpression TranslateRangeSlice(GExpression receiver, ExpressionSyntax receiverSyntax, RangeExpressionSyntax range)
         {
-            // Issue #1894 follow-up: a from-end bound (`^n`) folds into
-            // `receiver.Length - n` below (see `TranslateRangeBound`), which
-            // embeds `receiver` a SECOND time alongside the `.Slice(...)` call
-            // built here — a side-effecting receiver (e.g. `GetArray()[1..^2]`)
-            // would otherwise run twice. Spill it first so both embeds read the
-            // same evaluation; `SpillOperand` already no-ops for a trivial
-            // receiver (bare identifier/`this`/literal), so `a[1..^2]` is
-            // unchanged.
-            if (IsFromEndBound(range.LeftOperand) || IsFromEndBound(range.RightOperand))
-            {
-                receiver = this.SpillOperand(receiver, receiverSyntax);
-            }
-
-            // `recv[start..end]` → `recv.Slice(start, end - start)`;
-            // `recv[start..]`    → `recv.Slice(start)`;
-            // `recv[..end]`      → `recv.Slice(0, end)`.
-            GExpression start = range.LeftOperand != null
-                ? this.TranslateRangeBound(receiver, range.LeftOperand)
-                : LiteralExpression.Int("0");
-
-            var slice = new MemberAccessExpression(receiver, "Slice");
-
-            if (range.RightOperand == null)
-            {
-                return new InvocationExpression(slice, new List<GExpression> { start });
-            }
-
-            // `start` is embedded both as the `Slice` start argument and inside
-            // the `end - start` length below; a non-trivial left operand (e.g. a
-            // side-effecting `Next()`) would otherwise be re-evaluated a second
-            // time here — C# evaluates the range's start once (issue #1731).
-            if (range.LeftOperand != null)
-            {
-                start = this.SpillOperand(start, range.LeftOperand);
-            }
-
-            GExpression end = this.TranslateRangeBound(receiver, range.RightOperand);
-            GExpression length = range.LeftOperand == null
-                ? end
-                : new BinaryExpression(end, "-", start);
-
-            return new InvocationExpression(slice, new List<GExpression> { start, length });
+            GExpression start = range.LeftOperand != null ? this.TranslateRangeBound(range.LeftOperand) : null;
+            GExpression end = range.RightOperand != null ? this.TranslateRangeBound(range.RightOperand) : null;
+            return new IndexExpression(receiver, new RangeIndexExpression(start, end));
         }
 
-        // Issue #1894 regression: a from-end range bound (`a[start..^n]`,
-        // `a[^n..]`) has its `^n` printed OUTSIDE any bracket once the range is
-        // desugared to a plain `.Slice(start, length)` call above — the ONE
-        // bracket-argument position gsc's own parser (Parser.ParseIndexBound)
-        // accepts a bare `^n` in is gone by then, so letting it fall through to
-        // the generic `TranslateExpression` would (correctly, per issue #1894)
-        // gap it as an ambiguous bitwise-complement. Rather than lose an
-        // otherwise-valid inline slice to that gap, fold the from-end bound
-        // directly into arithmetic against the sliced receiver's own `Length`:
-        // "n back from the end" is exactly `receiver.Length - n`. `receiver` is
-        // already spilled by `TranslateRangeSlice` above when a from-end bound
-        // is present, so re-embedding it here (and again in `.Slice(...)`)
-        // reads the same single evaluation rather than re-running it.
-        private static bool IsFromEndBound(ExpressionSyntax bound) =>
-            bound is PrefixUnaryExpressionSyntax fromEnd && fromEnd.IsKind(SyntaxKind.IndexExpression);
-
-        private GExpression TranslateRangeBound(GExpression receiver, ExpressionSyntax bound) =>
-            IsFromEndBound(bound)
-                ? new BinaryExpression(
-                    new MemberAccessExpression(receiver, "Length"),
-                    "-",
-                    this.TranslateExpression(((PrefixUnaryExpressionSyntax)bound).Operand))
+        private GExpression TranslateRangeBound(ExpressionSyntax bound) =>
+            bound is PrefixUnaryExpressionSyntax fromEnd && fromEnd.IsKind(SyntaxKind.IndexExpression)
+                ? new FromEndIndexExpression(this.TranslateExpression(fromEnd.Operand))
                 : this.TranslateExpression(bound);
 
         private GTypeReference ResolveExpressionType(ExpressionSyntax expression)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -4485,11 +4485,10 @@ public sealed class CSharpToGSharpTranslator
         // where gsc's own parser recognises a leading `^` as a from-end marker
         // rather than one's-complement (Parser.ParseIndexBound). A `^n` nested
         // any deeper (e.g. as a `RangeExpressionSyntax` bound, `recv[a..^n]`) is
-        // NOT a direct argument — the translator pre-lowers ranges to
-        // `Slice(start, length)` arithmetic outside any bracket, so a `^` bound
-        // there is folded into `Length`-relative arithmetic by
-        // `TranslateRangeBound` before it ever reaches this generic prefix-
-        // unary path (an inline `recv[a..^n]` slice never gaps).
+        // NOT a direct argument — `TranslateRangeBound` emits it as its own
+        // native `FromEndIndexExpression` (gsc's `^n`) before it ever reaches
+        // this generic prefix-unary path (an inline `recv[a..^n]` slice never
+        // gaps).
         private static bool IsDirectIndexBracketArgument(ExpressionSyntax expression) =>
             expression.Parent is ArgumentSyntax
             {
@@ -8096,10 +8095,10 @@ public sealed class CSharpToGSharpTranslator
                     if (elementAccess.ArgumentList.Arguments.Count == 1 &&
                         elementAccess.ArgumentList.Arguments[0].Expression is RangeExpressionSyntax sliceRange)
                     {
-                        // `span[a..b]` / `span[..n]` / `span[i..]`: G# has no range
-                        // operator, so lower the System.Range indexer to the
-                        // faithful `Slice(start, length)` / `Slice(start)` call the
-                        // C# range indexer itself lowers to (ADR-0115 §B).
+                        // `span[a..b]` / `span[..n]` / `span[i..]`: gsc has its own
+                        // native range-index operator (Issue #1896), so lower
+                        // directly to that same `recv[start..end]` form instead
+                        // of desugaring to `Slice`.
                         return this.TranslateRangeSlice(
                             this.TranslateReceiverWithNullForgiveness(elementAccess.Expression),
                             elementAccess.Expression,
@@ -9530,8 +9529,9 @@ public sealed class CSharpToGSharpTranslator
             // `Data[Next()..2]`) is implicitly converted by the C# compiler to
             // `System.Index` purely because it sits inside a `Range`-indexer
             // argument list — the value itself is, and always was, an `int`.
-            // `TranslateRangeSlice` already re-lowers the whole range to a plain
-            // `Slice(start, length)` call before this operand is ever typed, so
+            // `TranslateRangeSlice` already re-lowers the whole range to its
+            // own native `RangeIndexExpression` (with `^n` bounds emitted as
+            // `FromEndIndexExpression`) before this operand is ever typed, so
             // that Index/Range conversion is a compiler-internal artifact, never
             // an actual value the translation carries forward. Falling back to
             // the operand's own natural type here avoids gapping perfectly valid

--- a/tools/cs2gs/corpus/grid/G05-Collections-Console/Constructs/RangeExpression.cs
+++ b/tools/cs2gs/corpus/grid/G05-Collections-Console/Constructs/RangeExpression.cs
@@ -1,7 +1,6 @@
-// inventory: RangeExpression — QUARANTINED at compile (gsc): GS0159 "Cannot
-// find function Slice." Every range form (a[1..3], a[..2], a[^2..], a[..],
-// "gsharp"[1..4]) is lowered to <receiver>.Slice(...), which resolves for
-// neither arrays nor strings in G#; String.Join/Length then cascade-fail.
+// Issue #1896: range-index forms (a[1..3], a[..2], a[^2..], a[..],
+// "gsharp"[1..4]) now lower to gsc's own native range-index syntax instead of
+// the unresolvable <receiver>.Slice(...) desugaring.
 using System;
 
 namespace Corpus.Grid05

--- a/tools/cs2gs/corpus/grid/G05-Collections-Console/Constructs/RangeExpression.cs
+++ b/tools/cs2gs/corpus/grid/G05-Collections-Console/Constructs/RangeExpression.cs
@@ -20,6 +20,12 @@ namespace Corpus.Grid05
             int[] tail = a[^2..];
             Console.WriteLine($"RangeExpression: tail={string.Join(",", tail)}");
 
+            int[] endTrim = a[1..^1];
+            Console.WriteLine($"RangeExpression: endTrim={string.Join(",", endTrim)}");
+
+            int[] allButLast = a[..^1];
+            Console.WriteLine($"RangeExpression: allButLast={string.Join(",", allButLast)}");
+
             int[] all = a[..];
             Console.WriteLine($"RangeExpression: allLen={all.Length}");
 

--- a/tools/cs2gs/corpus/grid/G05-Collections-Console/Program.cs
+++ b/tools/cs2gs/corpus/grid/G05-Collections-Console/Program.cs
@@ -19,6 +19,7 @@ namespace Corpus.Grid05
             IndexExpressionFixture.Run();
             ObjectCreationExpressionFixture.Run();
             OmittedArraySizeExpressionFixture.Run();
+            RangeExpressionFixture.Run();
             TupleExpressionFixture.Run();
         }
     }

--- a/tools/cs2gs/corpus/grid/G05-Collections-Console/baseline.stdout.golden
+++ b/tools/cs2gs/corpus/grid/G05-Collections-Console/baseline.stdout.golden
@@ -28,6 +28,8 @@ OmittedArraySizeExpression: ys=solo len=1
 RangeExpression: mid=2,3
 RangeExpression: head=1,2
 RangeExpression: tail=5,6
+RangeExpression: endTrim=2,3,4,5
+RangeExpression: allButLast=1,2,3,4,5
 RangeExpression: allLen=6
 RangeExpression: sliced=sha
 TupleExpression: items=2,two

--- a/tools/cs2gs/corpus/grid/G05-Collections-Console/baseline.stdout.golden
+++ b/tools/cs2gs/corpus/grid/G05-Collections-Console/baseline.stdout.golden
@@ -25,6 +25,11 @@ ObjectCreationExpression: byCtorAndInit=(9,8)
 ObjectCreationExpression: implicitNew=(7,7)
 OmittedArraySizeExpression: xs=1,2,3
 OmittedArraySizeExpression: ys=solo len=1
+RangeExpression: mid=2,3
+RangeExpression: head=1,2
+RangeExpression: tail=5,6
+RangeExpression: allLen=6
+RangeExpression: sliced=sha
 TupleExpression: items=2,two
 TupleExpression: named=3,three
 TupleExpression: deconstructed=2,two


### PR DESCRIPTION
Fixes #1896