### PR TITLE
cs2gs: map anonymous methods to G# function literals (#1898)

### DIFF
--- a/docs/cs2gs-coverage-matrix.md
+++ b/docs/cs2gs-coverage-matrix.md
@@ -6,12 +6,12 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | Status | Count |
 | --- | --- |
 | Unclassified | 0 |
-| Translated | 222 |
+| Translated | 223 |
 | Lowered | 12 |
 | UnsupportedByDesign | 56 |
-| Gap | 31 |
+| Gap | 30 |
 
-## Translated (222)
+## Translated (223)
 
 | Kind | Node type | Rule | Rationale | Fixture | Issue | Notes |
 | --- | --- | --- | --- | --- | --- | --- |
@@ -24,6 +24,7 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | AllowsConstraintClause | AllowsConstraintClauseSyntax | ADR-0115 §B.7 |  | tools/cs2gs/corpus/grid/G08-Generics-Console/Constructs/AllowsConstraintClause.cs |  | C#13 allows ref struct passes E2E (grid G08). |
 | AndAssignmentExpression | AssignmentExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/AndAssignmentExpression.cs |  |  |
 | AndPattern | BinaryPatternSyntax | ADR-0115 §B.22 |  | tools/cs2gs/corpus/grid/G04-Patterns-Console/Constructs/AndPattern.cs |  |  |
+| AnonymousMethodExpression | AnonymousMethodExpressionSyntax | ADR-0115 §B.20 |  | tools/cs2gs/corpus/grid/G09-Functions-Console/Constructs/AnonymousMethodExpression.cs |  |  |
 | Argument | ArgumentSyntax | ADR-0115 §B |  |  |  |  |
 | ArgumentList | ArgumentListSyntax | ADR-0115 §B |  |  |  |  |
 | ArrayCreationExpression | ArrayCreationExpressionSyntax | ADR-0115 §B.16 |  | tools/cs2gs/corpus/grid/G05-Collections-Console/Constructs/ArrayCreationExpression.cs | https://github.com/DavidObando/gsharp/issues/1893 | 1-D/jagged green; rank>1 (issue #1893) flat-lowers a tracked local's rectangular `new T[d0, d1, ...]`/`new T[,]{{...}}` to a single backing array with hoisted per-dimension sizes, preserving every index (see ArrayCreationExpressionMultiDim.cs, parity-verified). An untracked rank>1 shape (field/parameter/no-initializer) reports the CS2GS-GAP instead of silently collapsing to 1-D. |
@@ -316,11 +317,10 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | XmlText | XmlTextSyntax |  | ToolingScope |  |  | Documentation/tooling structure, not program semantics; doc-comment mapping is ADR-0057 scope. |
 | XmlTextAttribute | XmlTextAttributeSyntax |  | ToolingScope |  |  | Documentation/tooling structure, not program semantics; doc-comment mapping is ADR-0057 scope. |
 
-## Gap (31)
+## Gap (30)
 
 | Kind | Node type | Rule | Rationale | Fixture | Issue | Notes |
 | --- | --- | --- | --- | --- | --- | --- |
-| AnonymousMethodExpression | AnonymousMethodExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1898 |  |
 | CheckedExpression | CheckedExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1881 |  |
 | EnumMemberDeclaration | EnumMemberDeclarationSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1912 | Explicit values, [Flags], negative and alias members erased to sequential ordinals — parity-verified divergence. |
 | ExplicitInterfaceSpecifier | ExplicitInterfaceSpecifierSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1911 |  |

--- a/tools/cs2gs/Cs2Gs.Tests/Coverage/TranslatorExhaustivenessTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Coverage/TranslatorExhaustivenessTests.cs
@@ -78,19 +78,19 @@ public class TranslatorExhaustivenessTests
     [Fact]
     public void UnregisteredConstruct_IsClassifiedAsGap()
     {
-        // Anonymous method expressions (`delegate { ... }`) currently have no
-        // translation rule and are deliberately NOT in the UnsupportedByDesign
-        // registry, so the choke point must classify this as an accidental
-        // gap. If this construct gains a translation (or a registry entry),
-        // swap the snippet for another unregistered kind — the mechanism
-        // under test is the classification.
+        // Checked expressions (`checked(...)`) currently have no translation
+        // rule and are deliberately NOT in the UnsupportedByDesign registry,
+        // so the choke point must classify this as an accidental gap. If
+        // this construct gains a translation (or a registry entry), swap the
+        // snippet for another unregistered kind — the mechanism under test
+        // is the classification.
         TranslationContext context = Translate(
-            "namespace S { public static class C { public static void M() { System.Func<int> f = delegate { return 1; }; } } }");
+            "namespace S { public static class C { public static void M() { int x = checked(1 + 1); } } }");
 
         TranslationDiagnostic diagnostic = context.Diagnostics.FirstOrDefault(d => d.IsUnsupported);
         Assert.True(
             diagnostic is not null,
-            "expected the anonymous method to be unsupported; if it translates now, update this test's snippet.");
+            "expected the checked expression to be unsupported; if it translates now, update this test's snippet.");
         Assert.Equal(UnsupportedClassification.Gap, diagnostic.Classification);
         Assert.Equal(UnsupportedRationale.None, diagnostic.Rationale);
     }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1898AnonMethodTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1898AnonMethodTranslationTests.cs
@@ -111,6 +111,38 @@ namespace Corpus.Issue1898
     }
 
     [Fact]
+    public void ParameterlessDelegateBlock_SynthesizedParamNeverShadowsCapturedOuterLocal()
+    {
+        // Bug: synthesizing the Action<string>.Invoke param with its DECLARED
+        // name ("obj") would shadow the outer captured `obj` local — the body
+        // can never reference the delegate's own param (it has no source name
+        // in this form), so a fresh non-source name is required.
+        string rendered = Render(@"
+using System;
+
+namespace Corpus.Issue1898
+{
+    public class Holder
+    {
+        public void Describe()
+        {
+            int obj = 42;
+            Action<string> a = delegate
+            {
+                Console.WriteLine(obj);
+            };
+            a(""ignored"");
+        }
+    }
+}
+");
+
+        Assert.DoesNotContain("(obj string)", rendered, StringComparison.Ordinal);
+        Assert.Contains("Console.WriteLine(obj)", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
     public void TwoParameters_LowersToBlockBodiedFunctionLiteral()
     {
         string rendered = Render(@"

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1898AnonMethodTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1898AnonMethodTranslationTests.cs
@@ -1,0 +1,193 @@
+// <copyright file="Issue1898AnonMethodTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #1898: a C# anonymous method (<c>delegate (params) { … }</c>,
+/// <c>AnonymousMethodExpressionSyntax</c>) had no canonical G# form and
+/// reported the CS2GS-GAP "expression 'AnonymousMethodExpression' has no
+/// canonical G# form yet" for every shape. An anonymous method is
+/// semantically a block-bodied lambda (C# spec §12.19), so it is routed
+/// through the same <c>TranslateLambda</c> lowering already used for
+/// <c>ParenthesizedLambdaExpressionSyntax</c>/<c>SimpleLambdaExpressionSyntax</c>
+/// — closures, spills, and mutability scoping all just work. The one
+/// anonymous-method-specific wrinkle is the parameterless
+/// <c>delegate { … }</c> form (distinct from <c>delegate () { … }</c>): C#
+/// infers its parameter list from the target delegate type, so the
+/// translator synthesizes G# parameters from the converted delegate type's
+/// Invoke signature.
+/// </summary>
+public class Issue1898AnonMethodTranslationTests
+{
+    [Fact]
+    public void SingleParameter_LowersToBlockBodiedFunctionLiteral()
+    {
+        string rendered = Render(@"
+using System;
+
+namespace Corpus.Issue1898
+{
+    public class Holder
+    {
+        public int Describe()
+        {
+            Func<int, int> inc = delegate (int x)
+            {
+                return x + 1;
+            };
+            return inc(41);
+        }
+    }
+}
+");
+
+        Assert.Contains("(x int32) -> {", rendered, StringComparison.Ordinal);
+        Assert.Contains("return x + 1", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void ParameterlessDelegateBlock_TargetingAction_InfersZeroParams()
+    {
+        string rendered = Render(@"
+using System;
+
+namespace Corpus.Issue1898
+{
+    public class Holder
+    {
+        public void Describe()
+        {
+            Action greet = delegate
+            {
+                Console.WriteLine(""hi"");
+            };
+            greet();
+        }
+    }
+}
+");
+
+        Assert.Contains("() -> {", rendered, StringComparison.Ordinal);
+        Assert.Contains("Console.WriteLine(\"hi\")", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void ParameterlessDelegateBlock_TargetingFuncWithParams_SynthesizesParamsFromDelegateSignature()
+    {
+        string rendered = Render(@"
+using System;
+
+namespace Corpus.Issue1898
+{
+    public class Holder
+    {
+        public int Describe()
+        {
+            // The block ignores both incoming args entirely; the parameter
+            // list still must be inferred from Func<int, int, int>.
+            Func<int, int, int> ignoreArgs = delegate
+            {
+                return 7;
+            };
+            return ignoreArgs(1, 2);
+        }
+    }
+}
+");
+
+        Assert.Contains("return 7", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void TwoParameters_LowersToBlockBodiedFunctionLiteral()
+    {
+        string rendered = Render(@"
+using System;
+
+namespace Corpus.Issue1898
+{
+    public class Holder
+    {
+        public int Describe()
+        {
+            Func<int, int, int> add = delegate (int a, int b)
+            {
+                return a + b;
+            };
+            return add(3, 4);
+        }
+    }
+}
+");
+
+        Assert.Contains("(a int32, b int32) -> {", rendered, StringComparison.Ordinal);
+        Assert.Contains("return a + b", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void CapturesOuterLocal_ClosureWorksViaSharedLambdaPath()
+    {
+        string rendered = Render(@"
+using System;
+
+namespace Corpus.Issue1898
+{
+    public class Holder
+    {
+        public int Describe()
+        {
+            int offset = 10;
+            Func<int, int> addOffset = delegate (int x)
+            {
+                return x + offset;
+            };
+            return addOffset(5);
+        }
+    }
+}
+");
+
+        Assert.Contains("x + offset", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    private static void AssertRoundTripParses(string rendered)
+    {
+        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+
+        Assert.True(
+            result.Success,
+            "Sanitized G# must round-trip-parse. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + rendered);
+    }
+
+    private static string Render(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", source) });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        Cs2Gs.CodeModel.Ast.CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        Assert.Empty(context.Diagnostics);
+        return GSharpPrinter.Print(unit);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -11517,9 +11517,17 @@ public sealed class CSharpToGSharpTranslator
                 // a genuine gap rather than a silent zero-arg guess.
                 if (this.context.GetTypeInfo(implicitParamsAnonymousMethod).ConvertedType is INamedTypeSymbol { DelegateInvokeMethod: { } invokeMethod })
                 {
+                    // The body can never reference these params (C# gives them no
+                    // source names here), so reusing the delegate's DECLARED param
+                    // name (e.g. `Action<string>.Invoke`'s `obj`) would silently
+                    // shadow an outer captured local of the same name. Keep
+                    // MapParameter's type/refkind mapping but override the name
+                    // with a fresh `__anon{n}` identifier C# source can't produce.
+                    int index = 0;
                     foreach (IParameterSymbol invokeParameter in invokeMethod.Parameters)
                     {
-                        parameters.Add(this.MapParameter(invokeParameter, implicitParamsAnonymousMethod));
+                        Parameter mapped = this.MapParameter(invokeParameter, implicitParamsAnonymousMethod);
+                        parameters.Add(new Parameter($"__anon{index++}", mapped.Type, mapped.IsVariadic, mapped.RefKind, mapped.DefaultValue, mapped.Attributes));
                     }
                 }
                 else

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -8130,6 +8130,13 @@ public sealed class CSharpToGSharpTranslator
                 case ParenthesizedLambdaExpressionSyntax parenLambda:
                     return this.TranslateLambda(parenLambda);
 
+                // `delegate (params) { … }` is semantically a block-bodied lambda
+                // (C# spec §12.19); route it through the same lowering rather than
+                // a parallel path so closures, spills, and mutability scoping all
+                // just work (issue #1898).
+                case AnonymousMethodExpressionSyntax anonymousMethod:
+                    return this.TranslateLambda(anonymousMethod);
+
                 case AwaitExpressionSyntax awaitExpression:
                     return new AwaitExpression(this.TranslateExpression(awaitExpression.Expression));
 
@@ -11484,6 +11491,7 @@ public sealed class CSharpToGSharpTranslator
             ParameterListSyntax parameterList = lambda switch
             {
                 ParenthesizedLambdaExpressionSyntax paren => paren.ParameterList,
+                AnonymousMethodExpressionSyntax anonymousMethod => anonymousMethod.ParameterList,
                 _ => null,
             };
 
@@ -11496,6 +11504,29 @@ public sealed class CSharpToGSharpTranslator
                 foreach (ParameterSyntax parameter in parameterList.Parameters)
                 {
                     parameters.Add(this.MapLambdaParameter(parameter));
+                }
+            }
+            else if (lambda is AnonymousMethodExpressionSyntax implicitParamsAnonymousMethod)
+            {
+                // `delegate { … }` (no parameter list at all, distinct from
+                // `delegate () { … }`) binds to whatever parameter list the target
+                // delegate type declares (C# spec §12.19) — the block simply may
+                // not reference them. G# function literals always name params
+                // explicitly, so synthesize them from the converted delegate
+                // type's Invoke signature; if that type can't be resolved, this is
+                // a genuine gap rather than a silent zero-arg guess.
+                if (this.context.GetTypeInfo(implicitParamsAnonymousMethod).ConvertedType is INamedTypeSymbol { DelegateInvokeMethod: { } invokeMethod })
+                {
+                    foreach (IParameterSymbol invokeParameter in invokeMethod.Parameters)
+                    {
+                        parameters.Add(this.MapParameter(invokeParameter, implicitParamsAnonymousMethod));
+                    }
+                }
+                else
+                {
+                    this.context.ReportUnsupported(
+                        implicitParamsAnonymousMethod,
+                        "parameterless 'delegate { … }' anonymous method whose target delegate type could not be resolved; cannot infer its parameter list (ADR-0115 §B).");
                 }
             }
 

--- a/tools/cs2gs/corpus/grid/G09-Functions-Console/Constructs/AnonymousMethodExpression.cs
+++ b/tools/cs2gs/corpus/grid/G09-Functions-Console/Constructs/AnonymousMethodExpression.cs
@@ -1,7 +1,4 @@
-// inventory: AnonymousMethodExpression — QUARANTINED at translate:
-// CS2GS-GAP "expression 'AnonymousMethodExpression' has no canonical G# form
-// yet; emitted an identifier placeholder (ADR-0115 §B)." for every form
-// (delegate (int x) {...}, parameterless delegate {...}, Action-typed).
+// inventory: AnonymousMethodExpression
 using System;
 
 namespace Corpus.Grid09
@@ -22,6 +19,13 @@ namespace Corpus.Grid09
                 return 42;
             };
             Console.WriteLine($"AnonymousMethodExpression: answer={answer()}");
+
+            // Parameterless anonymous method targeting a zero-arg delegate type.
+            Action greet = delegate
+            {
+                Console.WriteLine("AnonymousMethodExpression: greet=hi");
+            };
+            greet();
 
             Action<string> shout = delegate (string s)
             {

--- a/tools/cs2gs/corpus/grid/G09-Functions-Console/Constructs/AnonymousMethodExpression.cs
+++ b/tools/cs2gs/corpus/grid/G09-Functions-Console/Constructs/AnonymousMethodExpression.cs
@@ -32,6 +32,17 @@ namespace Corpus.Grid09
                 Console.WriteLine($"AnonymousMethodExpression: shout {s}!");
             };
             shout("hey");
+
+            // Parameterless anonymous method targeting Action<string>: the
+            // synthesized param must NOT reuse Invoke's declared param name
+            // ("obj"), else it silently shadows the captured outer "obj"
+            // local below and the call argument leaks into the body instead.
+            string obj = "captured";
+            Action<string> shoutObj = delegate
+            {
+                Console.WriteLine($"AnonymousMethodExpression: shoutObj={obj}");
+            };
+            shoutObj("ignored");
         }
     }
 }

--- a/tools/cs2gs/corpus/grid/G09-Functions-Console/Program.cs
+++ b/tools/cs2gs/corpus/grid/G09-Functions-Console/Program.cs
@@ -10,6 +10,7 @@ namespace Corpus.Grid09
     {
         private static void Main()
         {
+            AnonymousMethodExpressionFixture.Run();
             ConditionalAccessExpressionFixture.Run();
             DeclarationExpressionFixture.Run();
             DelegateDeclarationFixture.Run();

--- a/tools/cs2gs/corpus/grid/G09-Functions-Console/baseline.stdout.golden
+++ b/tools/cs2gs/corpus/grid/G09-Functions-Console/baseline.stdout.golden
@@ -1,3 +1,7 @@
+AnonymousMethodExpression: inc(41)=42
+AnonymousMethodExpression: answer=42
+AnonymousMethodExpression: greet=hi
+AnonymousMethodExpression: shout hey!
 ConditionalAccessExpression: nullHandler=null
 ConditionalAccessExpression: got ping
 ConditionalAccessExpression: missed=none

--- a/tools/cs2gs/corpus/grid/G09-Functions-Console/baseline.stdout.golden
+++ b/tools/cs2gs/corpus/grid/G09-Functions-Console/baseline.stdout.golden
@@ -2,6 +2,7 @@ AnonymousMethodExpression: inc(41)=42
 AnonymousMethodExpression: answer=42
 AnonymousMethodExpression: greet=hi
 AnonymousMethodExpression: shout hey!
+AnonymousMethodExpression: shoutObj=captured
 ConditionalAccessExpression: nullHandler=null
 ConditionalAccessExpression: got ping
 ConditionalAccessExpression: missed=none

--- a/tools/cs2gs/coverage/csharp-construct-inventory.json
+++ b/tools/cs2gs/coverage/csharp-construct-inventory.json
@@ -73,9 +73,10 @@
   {
     "kind": "AnonymousMethodExpression",
     "nodeType": "AnonymousMethodExpressionSyntax",
-    "status": "Gap",
+    "status": "Translated",
+    "rule": "ADR-0115 \u00A7B.20",
     "rationale": "None",
-    "issue": "https://github.com/DavidObando/gsharp/issues/1898"
+    "fixture": "tools/cs2gs/corpus/grid/G09-Functions-Console/Constructs/AnonymousMethodExpression.cs"
   },
   {
     "kind": "AnonymousObjectCreationExpression",


### PR DESCRIPTION
Fixes #1898