### PR TITLE
cs2gs: support collection-expression spread, List<T> targets, dict indexer init, stackalloc (#1897)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue1897CollectionExpressionTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1897CollectionExpressionTranslationTests.cs
@@ -1,0 +1,161 @@
+// <copyright file="Issue1897CollectionExpressionTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #1897: four distinct C# collection-expression gaps in the G05
+/// grid corpus, each fixed independently:
+/// <list type="bullet">
+/// <item>a collection-expression spread element (<c>[0, ..rest, 9]</c>) —
+/// was CS2GS-GAP "SpreadElement ... has no canonical G# composite-literal
+/// form yet"; lowers to a build-and-append <c>List[T]</c> temporary
+/// (<c>Add</c>/<c>AddRange</c> calls hoisted into the enclosing statement's
+/// prologue), converted back via <c>.ToArray()</c> for an array/span
+/// target.</item>
+/// <item>a <c>List&lt;T&gt;</c>-targeted collection expression
+/// (<c>List&lt;int&gt; l = [10, 20];</c>) — previously mistranslated to a
+/// G# array literal (<c>[]int32{10, 20}</c>) that does not convert to
+/// <c>List[int32]</c> (gsc GS0155); now lowers to the canonical G#
+/// collection-initializer form (<c>List[int32]{10, 20}</c>, ADR-0117).</item>
+/// <item>the <c>["key"] = value</c> dictionary-initializer form — already
+/// had a canonical G# form via the existing indexed
+/// <c>CollectionInitializerElement</c> path (<c>TryTranslateCollectionInitializer</c>);
+/// this test just locks in that it stays gap-free and round-trips.</item>
+/// <item>the implicit-typed <c>stackalloc[] { 5, 6, 7 }</c> form — was
+/// CS2GS-GAP "ImplicitStackAllocArrayCreationExpression has no canonical G#
+/// form yet"; now maps to the same G# count-inferred stackalloc initializer
+/// (<c>stackalloc []T{...}</c>) as the explicit omitted-size form.</item>
+/// </list>
+/// </summary>
+public class Issue1897CollectionExpressionTranslationTests
+{
+    [Fact]
+    public void SpreadElement_LowersToBuildAndAppendTemporary()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1897
+{
+    public class Holder
+    {
+        public int[] Combine(int[] rest)
+        {
+            int[] s = [0, .. rest, 9];
+            return s;
+        }
+    }
+}
+");
+
+        Assert.Contains("List[int32]()", rendered, StringComparison.Ordinal);
+        Assert.Contains(".Add(0)", rendered, StringComparison.Ordinal);
+        Assert.Contains(".AddRange(rest)", rendered, StringComparison.Ordinal);
+        Assert.Contains(".Add(9)", rendered, StringComparison.Ordinal);
+        Assert.Contains(".ToArray()", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void ListTarget_LowersToCollectionInitializerNotArrayLiteral()
+    {
+        string rendered = Render(@"
+using System.Collections.Generic;
+
+namespace Corpus.Issue1897
+{
+    public class Holder
+    {
+        public List<int> Make()
+        {
+            List<int> l = [10, 20];
+            return l;
+        }
+    }
+}
+");
+
+        Assert.Contains("List[int32]{ 10, 20 }", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("[]int32{10, 20}", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void DictionaryIndexedInitializer_TranslatesGapFreeAndRoundTrips()
+    {
+        string rendered = Render(@"
+using System.Collections.Generic;
+
+namespace Corpus.Issue1897
+{
+    public class Holder
+    {
+        public Dictionary<string, int> Make()
+        {
+            return new Dictionary<string, int> { [""blue""] = 2 };
+        }
+    }
+}
+");
+
+        Assert.Contains("[\"blue\"] = 2", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void ImplicitStackAlloc_LowersToCountInferredStackAllocInitializer()
+    {
+        string rendered = Render(@"
+using System;
+
+namespace Corpus.Issue1897
+{
+    public class Holder
+    {
+        public int First()
+        {
+            Span<int> t = stackalloc[] { 5, 6, 7 };
+            return t[0];
+        }
+    }
+}
+");
+
+        Assert.Contains("stackalloc [3]int32{5, 6, 7}", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    private static void AssertRoundTripParses(string rendered)
+    {
+        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+
+        Assert.True(
+            result.Success,
+            "Sanitized G# must round-trip-parse. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + rendered);
+    }
+
+    private static string Render(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", source) });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        Cs2Gs.CodeModel.Ast.CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        Assert.Empty(context.Diagnostics);
+        return GSharpPrinter.Print(unit);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -540,6 +540,11 @@ public sealed class CSharpToGSharpTranslator
         // Monotonic counter for synthesizing spill temporaries (issue #1731).
         private int spillCounter;
 
+        // Issue #1897: numbers the `__spreadN` temporary built to lower a
+        // collection-expression spread element (see
+        // <see cref="TranslateSpreadCollectionExpression"/>).
+        private int spreadCounter;
+
         // Issue #1849: when non-null, `SpillOperand` is inside a "null-seam"
         // expression context — a field/property initializer or a
         // base(...)/this(...) constructor argument (issue #1731 N1) — that has
@@ -8324,6 +8329,9 @@ public sealed class CSharpToGSharpTranslator
                 case StackAllocArrayCreationExpressionSyntax stackAlloc:
                     return this.TranslateStackAlloc(stackAlloc);
 
+                case ImplicitStackAllocArrayCreationExpressionSyntax implicitStackAlloc:
+                    return this.TranslateImplicitStackAlloc(implicitStackAlloc);
+
                 case CollectionExpressionSyntax collectionExpression:
                     return this.TranslateCollectionExpression(collectionExpression);
 
@@ -9348,6 +9356,23 @@ public sealed class CSharpToGSharpTranslator
             return new StackAllocExpression(elementType, count ?? LiteralExpression.Int("0"), elements);
         }
 
+        // Issue #1897: the implicit-typed form `stackalloc[] { 5, 6, 7 }` (no
+        // element-type spelled at all — C# infers it from the initializer/
+        // target). Maps to the same G# count-inferred initializer shape
+        // (`stackalloc []T{a, b, …}`) as the explicit omitted-size form
+        // (`stackalloc int[] { … }`, handled by <see cref="TranslateStackAlloc"/>);
+        // the element type is recovered from the expression's converted type
+        // (`Span<T>`/`T*`) since there is no type syntax on this node to read.
+        private GExpression TranslateImplicitStackAlloc(ImplicitStackAllocArrayCreationExpressionSyntax node)
+        {
+            GTypeReference elementType = this.GetArrayElementType(node, null);
+            List<GExpression> elements = node.Initializer.Expressions.Select(this.TranslateExpression).ToList();
+            GExpression count = LiteralExpression.Int(
+                node.Initializer.Expressions.Count.ToString(CultureInfo.InvariantCulture));
+
+            return new StackAllocExpression(elementType, count, elements);
+        }
+
         private GExpression TranslateImplicitArrayCreation(ImplicitArrayCreationExpressionSyntax creation)
         {
             GTypeReference elementType = this.GetArrayElementType(creation, null);
@@ -9427,9 +9452,14 @@ public sealed class CSharpToGSharpTranslator
             // emitted into a malformed `[]KeyValuePair[…]{}` literal (ADR-0115 §B).
             ITypeSymbol target = this.context.GetTypeInfo(collection).ConvertedType
                 ?? this.context.GetTypeInfo(collection).Type;
-            if (collection.Elements.Count == 0 &&
+            bool isConstructibleClassTarget =
                 target is INamedTypeSymbol { TypeKind: TypeKind.Class } namedTarget &&
-                this.typeMapper.Map(namedTarget, this.context, collection.GetLocation()) is NamedTypeReference targetRef)
+                this.typeMapper.Map(namedTarget, this.context, collection.GetLocation()) is NamedTypeReference;
+            NamedTypeReference targetRef = isConstructibleClassTarget
+                ? (NamedTypeReference)this.typeMapper.Map((INamedTypeSymbol)target, this.context, collection.GetLocation())
+                : null;
+
+            if (collection.Elements.Count == 0 && isConstructibleClassTarget)
             {
                 return new InvocationExpression(
                     new IdentifierExpression(targetRef.Name),
@@ -9437,27 +9467,101 @@ public sealed class CSharpToGSharpTranslator
                     targetRef.TypeArguments.Count > 0 ? targetRef.TypeArguments : null);
             }
 
-            // C# 12 collection expression `[a, b, c]`. The target type (array,
-            // span, or any IEnumerable<T>) supplies the element type, so it maps to
-            // the canonical G# slice literal `[]T{ … }` (ADR-0115 §B). Spread
-            // elements `[..xs]` have no G# composite-literal form yet.
             GTypeReference elementType = this.GetCollectionElementType(collection);
+
+            // A spread element (`[a, ..rest, b]`) has no G# composite-literal
+            // form (gsc's own collection-initializer grammar only has bare,
+            // keyed, and indexed elements — no spread). It lowers to a
+            // build-and-append temporary: a `List[T]` populated via `Add`/
+            // `AddRange` calls hoisted into the enclosing statement's prologue
+            // (issue #1897), then — for an array/span target — converted back
+            // via `.ToArray()`.
+            if (collection.Elements.Any(e => e is SpreadElementSyntax))
+            {
+                return this.TranslateSpreadCollectionExpression(collection, elementType, isConstructibleClassTarget);
+            }
+
+            // A `List<T>`/`HashSet<T>`/... collection-expression target maps to
+            // the canonical G# collection-initializer form (`List[int32]{...}`,
+            // ADR-0117) — NOT the array/slice literal `[]T{...}`, which does not
+            // convert to a constructed collection class (issue #1897).
+            if (isConstructibleClassTarget)
+            {
+                var initElements = new List<CollectionInitializerElement>();
+                foreach (CollectionElementSyntax element in collection.Elements)
+                {
+                    var expressionElement = (ExpressionElementSyntax)element;
+                    initElements.Add(new CollectionInitializerElement(
+                        this.CoerceCollectionElement(expressionElement.Expression, elementType)));
+                }
+
+                return new CollectionInitializerExpression(
+                    BuildConstruction(targetRef, new List<GExpression>()), initElements);
+            }
+
+            // C# 12 collection expression `[a, b, c]` targeting an array/span.
+            // The target type supplies the element type, so it maps to the
+            // canonical G# slice literal `[]T{ … }` (ADR-0115 §B).
             var elements = new List<GExpression>();
             foreach (CollectionElementSyntax element in collection.Elements)
             {
-                if (element is ExpressionElementSyntax expressionElement)
-                {
-                    elements.Add(this.CoerceCollectionElement(expressionElement.Expression, elementType));
-                }
-                else
-                {
-                    this.context.ReportUnsupported(
-                        element,
-                        $"collection-expression element '{element.Kind()}' (spread) has no canonical G# composite-literal form yet (ADR-0115 §B).");
-                }
+                var expressionElement = (ExpressionElementSyntax)element;
+                elements.Add(this.CoerceCollectionElement(expressionElement.Expression, elementType));
             }
 
             return new ArrayLiteralExpression(elementType, elements);
+        }
+
+        private GExpression TranslateSpreadCollectionExpression(
+            CollectionExpressionSyntax collection, GTypeReference elementType, bool isConstructibleClassTarget)
+        {
+            if (this.pendingSpillPrologue == null)
+            {
+                string message =
+                    "a collection-expression spread element here has no enclosing statement to host the " +
+                    "build-and-append lowering it needs (e.g. a field/property initializer); emitted an " +
+                    "identifier placeholder (ADR-0115 §B).";
+                this.context.ReportUnsupported(collection, message);
+                return new IdentifierExpression("nil");
+            }
+
+            string temp = $"__spread{this.spreadCounter++}";
+            this.pendingSpillPrologue.Add(new LocalDeclarationStatement(
+                BindingKind.Let,
+                temp,
+                type: null,
+                initializer: new InvocationExpression(
+                    new IdentifierExpression("List"),
+                    new List<GExpression>(),
+                    new List<GTypeReference> { elementType })));
+
+            foreach (CollectionElementSyntax element in collection.Elements)
+            {
+                if (element is SpreadElementSyntax spread)
+                {
+                    this.pendingSpillPrologue.Add(new ExpressionStatement(new InvocationExpression(
+                        new MemberAccessExpression(new IdentifierExpression(temp), "AddRange"),
+                        new List<GExpression> { this.TranslateExpression(spread.Expression) })));
+                }
+                else
+                {
+                    var expressionElement = (ExpressionElementSyntax)element;
+                    this.pendingSpillPrologue.Add(new ExpressionStatement(new InvocationExpression(
+                        new MemberAccessExpression(new IdentifierExpression(temp), "Add"),
+                        new List<GExpression> { this.CoerceCollectionElement(expressionElement.Expression, elementType) })));
+                }
+            }
+
+            if (isConstructibleClassTarget)
+            {
+                return new IdentifierExpression(temp);
+            }
+
+            // `List[T].ToArray()` is the real (non-generic) BCL instance
+            // method — no bracket type argument (unlike the LINQ
+            // `Enumerable.ToArray[T]()` extension method).
+            return new InvocationExpression(
+                new MemberAccessExpression(new IdentifierExpression(temp), "ToArray"));
         }
 
         private GExpression CoerceCollectionElement(ExpressionSyntax element, GTypeReference elementType)

--- a/tools/cs2gs/corpus/grid/G05-Collections-Console/Constructs/CollectionExpression.cs
+++ b/tools/cs2gs/corpus/grid/G05-Collections-Console/Constructs/CollectionExpression.cs
@@ -1,5 +1,6 @@
 // inventory: CollectionExpression
 using System;
+using System.Collections.Generic;
 
 namespace Corpus.Grid05
 {
@@ -10,17 +11,25 @@ namespace Corpus.Grid05
             int[] a = [1, 2, 3];
             Console.WriteLine($"CollectionExpression: array={string.Join(",", a)}");
 
-            // QUARANTINED (GS0155): List<T>-targeted collection expressions
-            // (List<int> l = [10, 20];) lower to a G# array literal []int32{...}
-            // that does not convert to List[int32].
-            // QUARANTINED (CS2GS-GAP): SpreadElement — collection-expression
-            // spread ([0, .. rest, 9]) has no canonical G# composite-literal
-            // form yet.
             string[] ss = ["x", "y", "z"];
             Console.WriteLine($"CollectionExpression: strings={string.Join(",", ss)}");
 
             int[] empty = [];
             Console.WriteLine($"CollectionExpression: emptyLen={empty.Length}");
+
+            // List<T>-targeted collection expression (issue #1897): lowers to
+            // the G# collection-initializer form (List[int32]{...}), not an
+            // array literal (which does not convert to List[int32]).
+            List<int> list = [10, 20];
+            Console.WriteLine($"CollectionExpression: list={string.Join(",", list)} count={list.Count}");
+
+            // SpreadElement (issue #1897): lowers to a build-and-append
+            // temporary List populated via Add/AddRange, converted back with
+            // ToArray() for the array target.
+            int[] rest = [2, 3];
+            int[] spread = [1, .. rest, 9];
+            Console.WriteLine($"CollectionExpression: spread={string.Join(",", spread)}");
         }
     }
 }
+

--- a/tools/cs2gs/corpus/grid/G05-Collections-Console/Constructs/CollectionInitializerExpression.cs
+++ b/tools/cs2gs/corpus/grid/G05-Collections-Console/Constructs/CollectionInitializerExpression.cs
@@ -20,14 +20,15 @@ namespace Corpus.Grid05
             };
             PrintOrdered("pairs", pairs);
 
-            // QUARANTINED (CS2GS-GAP): ImplicitElementAccess — the
-            // ["key"] = value dictionary-initializer form has no canonical G#
-            // form yet (and its placeholder fails round-trip parse).
+            // ImplicitElementAccess: the ["key"] = value dictionary-initializer
+            // form (issue #1897 — was CS2GS-GAP; already had a canonical G#
+            // form via the existing indexed CollectionInitializerElement path,
+            // this fixture just re-enables the corpus coverage for it).
             var indexed = new Dictionary<string, int>
             {
-                { "blue", 2 },
-                { "red", 5 },
-                { "green", 4 },
+                ["blue"] = 2,
+                ["red"] = 5,
+                ["green"] = 4,
             };
             PrintOrdered("indexed", indexed);
         }

--- a/tools/cs2gs/corpus/grid/G05-Collections-Console/Constructs/StackAllocArrayCreationExpression.cs
+++ b/tools/cs2gs/corpus/grid/G05-Collections-Console/Constructs/StackAllocArrayCreationExpression.cs
@@ -1,10 +1,12 @@
-// inventory: StackAllocArrayCreationExpression — QUARANTINED at ilverify:
-// [IL]: Error [Unverifiable] in StackAllocArrayCreationExpressionFixture::Run()
-// (offset 0x0000000D, localloc). Translate and gsc compile both PASSED for the
-// explicit 'stackalloc int[4]' form, but the emitted IL is unverifiable.
-// The implicit form 'stackalloc[] { 5, 6, 7 }' additionally fails translate:
-// CS2GS-GAP "expression 'ImplicitStackAllocArrayCreationExpression' has no
-// canonical G# form yet".
+// inventory: StackAllocArrayCreationExpression. Covers both the explicit
+// sized form ('stackalloc int[4]') and the implicit form
+// ('stackalloc[] { 5, 6, 7 }', issue #1897 — was CS2GS-GAP
+// "ImplicitStackAllocArrayCreationExpression has no canonical G# form yet";
+// now maps to the same G# count-inferred stackalloc initializer as the
+// explicit omitted-size form). `stackalloc` lowers to CIL 'localloc', which
+// gsc's emitter marks unverifiable by design (a real, tracked gsc emitter
+// gap, issue #1933) — G05 opts into the 'ilverify.allow-unsafe' marker so
+// this app's stage 3 (ilverify) treats that as expected rather than gating.
 using System;
 
 namespace Corpus.Grid05

--- a/tools/cs2gs/corpus/grid/G05-Collections-Console/Program.cs
+++ b/tools/cs2gs/corpus/grid/G05-Collections-Console/Program.cs
@@ -20,6 +20,7 @@ namespace Corpus.Grid05
             ObjectCreationExpressionFixture.Run();
             OmittedArraySizeExpressionFixture.Run();
             RangeExpressionFixture.Run();
+            StackAllocArrayCreationExpressionFixture.Run();
             TupleExpressionFixture.Run();
         }
     }

--- a/tools/cs2gs/corpus/grid/G05-Collections-Console/baseline.stdout.golden
+++ b/tools/cs2gs/corpus/grid/G05-Collections-Console/baseline.stdout.golden
@@ -11,6 +11,8 @@ ArrayInitializerExpression: single=42 len=1
 CollectionExpression: array=1,2,3
 CollectionExpression: strings=x,y,z
 CollectionExpression: emptyLen=0
+CollectionExpression: list=10,20 count=2
+CollectionExpression: spread=1,2,3,9
 CollectionInitializerExpression: list=1,2,3
 CollectionInitializerExpression: pairs apple=3;kiwi=1;pear=2
 CollectionInitializerExpression: indexed blue=2;green=4;red=5
@@ -32,6 +34,8 @@ RangeExpression: endTrim=2,3,4,5
 RangeExpression: allButLast=1,2,3,4,5
 RangeExpression: allLen=6
 RangeExpression: sliced=sha
+StackAllocArrayCreationExpression: sum=100 len=4
+StackAllocArrayCreationExpression: implicit=5,6,7
 TupleExpression: items=2,two
 TupleExpression: named=3,three
 TupleExpression: deconstructed=2,two


### PR DESCRIPTION
Fixes #1897

4 gaps, 4 fixes:

1. **Spread element** `[a, ..rest, b]`: gsc collection-initializer grammar has no spread. Lower to build-and-append `List[T]` temp (`Add`/`AddRange` hoisted into enclosing statement prologue), `.ToArray()` back for array/span target.
2. **`List<T>` collection-expression target**: was mistranslated to array literal `[]int32{...}`, which gsc rejects (GS0155, array literal doesn't convert to List). Now lowers to native `List[int32]{10, 20}` collection-initializer form (ADR-0117).
3. **Dict indexer init** `["blue"] = 2`: already had a native G# form via existing indexed `CollectionInitializerElement` path. Only the corpus fixture/quarantine comment was stale — nothing to fix in translator, added regression test to lock it in.
4. **Implicit stackalloc** `stackalloc[] { 5, 6, 7 }`: maps to same G# count-inferred `stackalloc []T{...}` form gsc already has for the explicit omitted-size form. `stackalloc`'s CIL `localloc` is unverifiable by gsc's emitter (pre-existing, tracked separately as issue #1933) — G05 now opts into the existing `ilverify.allow-unsafe` marker (same one G12-Unsafe-Console uses) so ilverify treats that as expected, not gating.

Re-enabled G05-Collections-Console quarantined fixtures (spread, List target, dict indexer, stackalloc explicit+implicit), recaptured `baseline.stdout.golden` live from the C# oracle. All 4 migrate stages (translate/compile/ilverify/test-parity) PASS for G05. Full corpus migrate: 19/20 real apps green (CompileGap-Library is a deliberate always-fails ledger fixture, untouched, unrelated). Full Cs2Gs.Tests: 873/873 passed (869 pre-existing + 4 new Issue1897 tests). No new GNode subclass added — reused existing CollectionInitializerExpression/StackAllocExpression, so no coverage-surface/GNodeSamples regen needed (coverage --write ran clean, 0 new rows).