### PR TITLE
cs2gs: preserve lambda default params + lower params-collection calls (#1901)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue1901LambdaDefaultsTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1901LambdaDefaultsTranslationTests.cs
@@ -1,0 +1,225 @@
+// <copyright file="Issue1901LambdaDefaultsTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #1901: two grid-corpus gaps, both about a callee whose parameter
+/// list gsc cannot express 1:1 the way C# does.
+/// <list type="bullet">
+/// <item>
+/// A C#12 lambda default parameter (<c>(int x = 10) =&gt; x * 2</c>) IS
+/// preserved on the emitted G# lambda parameter (gsc's
+/// <c>LambdaBinder.BindAndAttachParameterDefaultValue</c> already supports a
+/// default there) — but that default lives only on the lambda's own
+/// <c>ParameterSymbol</c>, never on the structural <c>FunctionTypeSymbol</c>
+/// that types the variable holding it. Every INDIRECT call through that
+/// variable (<c>f()</c>) binds against the structural type
+/// (<c>OverloadResolver.TryBindFunctionTypeArguments</c>), which carries only
+/// parameter TYPES, so gsc always demands the full arity there — the default
+/// is otherwise unreachable. Roslyn already resolves the omitted argument to
+/// its constant default regardless of call shape
+/// (<c>IArgumentOperation.ArgumentKind.DefaultValue</c>), so the translator
+/// materializes it explicitly at the call site instead.
+/// </item>
+/// <item>
+/// A C#13 "params collection" parameter (<c>params List&lt;int&gt;</c>,
+/// <c>params IEnumerable&lt;string&gt;</c>) is declared as an ordinary
+/// (non-variadic) G# parameter of the full collection type — gsc's own
+/// variadic parameter is always an array/slice. An expanded call site
+/// (<c>Total(1, 2, 3)</c>, including the zero-argument <c>Total()</c> form)
+/// is lowered into an explicit collection construction
+/// (<c>List[int32]{1, 2, 3}</c> / <c>List[int32]()</c>) that becomes that
+/// single ordinary argument; the direct-collection call form
+/// (<c>Total(someList)</c>) already binds a single ordinary argument and
+/// needs no lowering.
+/// </item>
+/// </list>
+/// </summary>
+public class Issue1901LambdaDefaultsTranslationTests
+{
+    [Fact]
+    public void LambdaDefaultParameter_PreservedOnParameter_AndMaterializedAtOmittedCallSite()
+    {
+        string rendered = Render(@"
+using System;
+namespace Corpus.Issue1901
+{
+    public class LambdaDefaults
+    {
+        public static void Run()
+        {
+            var f = (int x = 10) => x * 2;
+            Console.WriteLine(f());
+            Console.WriteLine(f(3));
+        }
+    }
+}
+");
+
+        Assert.Contains("let f = (x int32 = 10) -> x * 2", rendered, StringComparison.Ordinal);
+        Assert.Contains("Console.WriteLine(f(10))", rendered, StringComparison.Ordinal);
+        Assert.Contains("Console.WriteLine(f(3))", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void LambdaMultipleDefaultParameters_OnlyOmittedTrailingArgsMaterialized()
+    {
+        string rendered = Render(@"
+using System;
+namespace Corpus.Issue1901
+{
+    public class LambdaDefaults
+    {
+        public static void Run()
+        {
+            var g = (int a, int b = 5) => a + b;
+            Console.WriteLine(g(1));
+            Console.WriteLine(g(1, 2));
+        }
+    }
+}
+");
+
+        Assert.Contains("let g = (a int32, b int32 = 5) -> a + b", rendered, StringComparison.Ordinal);
+        Assert.Contains("Console.WriteLine(g(1, 5))", rendered, StringComparison.Ordinal);
+        Assert.Contains("Console.WriteLine(g(1, 2))", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void ParamsCollection_ExpandedCall_LowersToCollectionConstruction()
+    {
+        string rendered = Render(@"
+using System.Collections.Generic;
+namespace Corpus.Issue1901
+{
+    public class ParamsCollections
+    {
+        public static int Total(params List<int> values)
+        {
+            int total = 0;
+            foreach (int v in values)
+            {
+                total += v;
+            }
+
+            return total;
+        }
+
+        public static void Run()
+        {
+            var zero = Total();
+            var three = Total(1, 2, 3);
+        }
+    }
+}
+");
+
+        Assert.Contains("func Total(values List[int32]) int32", rendered, StringComparison.Ordinal);
+        Assert.Contains("let zero = ParamsCollections.Total(List[int32]())", rendered, StringComparison.Ordinal);
+        Assert.Contains("let three = ParamsCollections.Total(List[int32]{ 1, 2, 3 })", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void ParamsCollection_DirectCollectionCall_PassesThroughUnchanged()
+    {
+        string rendered = Render(@"
+using System.Collections.Generic;
+namespace Corpus.Issue1901
+{
+    public class ParamsCollections
+    {
+        public static int Total(params List<int> values)
+        {
+            int total = 0;
+            foreach (int v in values)
+            {
+                total += v;
+            }
+
+            return total;
+        }
+
+        public static void Run()
+        {
+            var lst = new List<int> { 4, 5 };
+            var sum = Total(lst);
+        }
+    }
+}
+");
+
+        Assert.Contains("let sum = ParamsCollections.Total(lst)", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("List[int32]{ lst }", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void ParamsCollection_EnumerableInterfaceParameter_ExpandedCallLowersToListConstruction()
+    {
+        string rendered = Render(@"
+using System;
+using System.Collections.Generic;
+namespace Corpus.Issue1901
+{
+    public class ParamsCollections
+    {
+        public static string JoinParts(params IEnumerable<string> parts)
+        {
+            return string.Join(""+"", parts);
+        }
+
+        public static void Run()
+        {
+            var joined = JoinParts(""a"", ""b"", ""c"");
+        }
+    }
+}
+");
+
+        Assert.Contains("func JoinParts(parts IEnumerable[string]) string", rendered, StringComparison.Ordinal);
+        Assert.Contains(
+            "let joined = ParamsCollections.JoinParts(List[string]{ \"a\", \"b\", \"c\" })",
+            rendered,
+            StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    private static void AssertRoundTripParses(string rendered)
+    {
+        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+
+        Assert.True(
+            result.Success,
+            "Sanitized G# must round-trip-parse. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + rendered);
+    }
+
+    private static string Render(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", source) });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        Cs2Gs.CodeModel.Ast.CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        Assert.Empty(context.Diagnostics);
+        return GSharpPrinter.Print(unit);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1901LambdaDefaultsTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1901LambdaDefaultsTranslationTests.cs
@@ -292,6 +292,36 @@ namespace Corpus.Issue1901
     }
 
     /// <summary>
+    /// Regression test: <c>Task.WhenAll(params ReadOnlySpan&lt;Task&gt;)</c> is a BCL
+    /// overload from a REFERENCED assembly, never translated as a declaration
+    /// (only user-declared callees route through <c>MapParameter</c>'s matching
+    /// gap). There is nothing for a call-site gap to stay "consistent" with here,
+    /// so — unlike the user-declared <see cref="ParamsCollection_ReadOnlySpan_ExpandedCall_ReportsUnsupported"/>
+    /// case above — this must fall back to the pre-issue-1901 ordinary argument
+    /// translation silently, with no Unsupported diagnostic.
+    /// </summary>
+    [Fact]
+    public void ParamsCollection_ExternalBclReadOnlySpanOverload_ExpandedCall_TranslatesWithoutGap()
+    {
+        string rendered = Render(@"
+using System.Threading.Tasks;
+namespace Corpus.Issue1901
+{
+    public class BclParamsCollections
+    {
+        public static async Task Run()
+        {
+            await Task.WhenAll(Task.CompletedTask, Task.CompletedTask);
+        }
+    }
+}
+");
+
+        Assert.Contains("Task.WhenAll(Task.CompletedTask, Task.CompletedTask)", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    /// <summary>
     /// A lambda default that is not a primitive/enum/null constant (here
     /// <c>decimal</c>) has no gsc literal form; the translator must gap loudly
     /// rather than substitute the wrong value AND type via <c>nil</c>.

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1901LambdaDefaultsTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1901LambdaDefaultsTranslationTests.cs
@@ -97,6 +97,30 @@ namespace Corpus.Issue1901
     }
 
     [Fact]
+    public void LambdaDefaultParameter_EnumAndNullConstants_MaterializedAtOmittedCallSite()
+    {
+        string rendered = Render(@"
+using System;
+namespace Corpus.Issue1901
+{
+    public enum Color { Red, Green, Blue }
+
+    public class LambdaDefaults
+    {
+        public static void Run()
+        {
+            var f = (Color c = Color.Blue, string s = null) => c;
+            Console.WriteLine(f());
+        }
+    }
+}
+");
+
+        Assert.Contains("Console.WriteLine(f(Color.Blue, nil))", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
     public void ParamsCollection_ExpandedCall_LowersToCollectionConstruction()
     {
         string rendered = Render(@"
@@ -194,6 +218,118 @@ namespace Corpus.Issue1901
             rendered,
             StringComparison.Ordinal);
         AssertRoundTripParses(rendered);
+    }
+
+    /// <summary>
+    /// A <c>params ReadOnlySpan&lt;T&gt;</c> callee (C#13's PREFERRED params-collection
+    /// overload) has no gsc construction form at an expanded call site — gsc can
+    /// only build a <c>List[T]{...}</c> literal, and a <c>List&lt;T&gt;</c> does not
+    /// convert to <c>ReadOnlySpan&lt;T&gt;</c>. Must gap loudly, not silently emit a
+    /// type-mismatched call.
+    /// </summary>
+    [Fact]
+    public void ParamsCollection_ReadOnlySpan_ExpandedCall_ReportsUnsupported()
+    {
+        (_, TranslationContext context) = Translate(@"
+using System;
+namespace Corpus.Issue1901
+{
+    public class ParamsCollections
+    {
+        public static int Total(params ReadOnlySpan<int> values)
+        {
+            int total = 0;
+            foreach (int v in values)
+            {
+                total += v;
+            }
+
+            return total;
+        }
+
+        public static void Run()
+        {
+            var three = Total(1, 2, 3);
+        }
+    }
+}
+");
+
+        Assert.Contains(context.Diagnostics, d => d.Severity == TranslationSeverity.Unsupported
+            && d.Message.Contains("ReadOnlySpan", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ParamsCollection_Span_ExpandedCall_ReportsUnsupported()
+    {
+        (_, TranslationContext context) = Translate(@"
+using System;
+namespace Corpus.Issue1901
+{
+    public class ParamsCollections
+    {
+        public static int Total(params Span<int> values)
+        {
+            int total = 0;
+            foreach (int v in values)
+            {
+                total += v;
+            }
+
+            return total;
+        }
+
+        public static void Run()
+        {
+            var three = Total(1, 2, 3);
+        }
+    }
+}
+");
+
+        Assert.Contains(context.Diagnostics, d => d.Severity == TranslationSeverity.Unsupported
+            && d.Message.Contains("Span", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// A lambda default that is not a primitive/enum/null constant (here
+    /// <c>decimal</c>) has no gsc literal form; the translator must gap loudly
+    /// rather than substitute the wrong value AND type via <c>nil</c>.
+    /// </summary>
+    [Fact]
+    public void LambdaDefaultParameter_DecimalConstant_ReportsUnsupported()
+    {
+        (_, TranslationContext context) = Translate(@"
+using System;
+namespace Corpus.Issue1901
+{
+    public class LambdaDefaults
+    {
+        public static void Run()
+        {
+            var f = (decimal x = 1.5m) => x;
+            Console.WriteLine(f());
+        }
+    }
+}
+");
+
+        Assert.Contains(context.Diagnostics, d => d.Severity == TranslationSeverity.Unsupported
+            && d.Message.Contains("default value", StringComparison.Ordinal));
+    }
+
+    private static (Cs2Gs.CodeModel.Ast.CompilationUnit Unit, TranslationContext Context) Translate(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        Cs2Gs.CodeModel.Ast.CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        return (unit, context);
     }
 
     private static void AssertRoundTripParses(string rendered)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
 using Cs2Gs.CodeModel.Ast;
@@ -1218,24 +1219,27 @@ public sealed class CSharpToGSharpTranslator
                     (c.Initializer == null || c.Initializer.ThisOrBaseKeyword.IsKind(SyntaxKind.BaseKeyword)));
         }
 
-        private GExpression MapConstantDefault(IParameterSymbol symbol, SyntaxNode fallbackNode)
-        {
-            object value = symbol.ExplicitDefaultValue;
+        private GExpression MapConstantDefault(IParameterSymbol symbol, SyntaxNode fallbackNode) =>
+            this.MapConstantValue(symbol.ExplicitDefaultValue, symbol.Type, symbol.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax() ?? fallbackNode, $"parameter '{symbol.Name}''s default value");
 
+        /// <summary>
+        /// Maps a compile-time constant <paramref name="value"/> of type
+        /// <paramref name="type"/> to its G# literal expression. Shared between an
+        /// optional parameter's own default (<see cref="MapConstantDefault"/>) and
+        /// a call site's <c>ArgumentKind.DefaultValue</c> argument (issue #1901:
+        /// <see cref="TranslateCallArguments"/> materializes a skipped default
+        /// argument explicitly when the callee is invoked indirectly through a
+        /// function-typed value — gsc's structural function type, unlike a named
+        /// function/method symbol, carries no default to fill in on its own).
+        /// </summary>
+        private GExpression MapConstantValue(object value, ITypeSymbol type, SyntaxNode fallbackNode, string diagnosticSubject)
+        {
             // Issue #1733: an enum-typed default (`Color c = Color.Blue`) must
-            // resolve to the member reference, not `symbol.ExplicitDefaultValue`'s
-            // boxed underlying integer — see the remarks on
-            // <see cref="MapEnumConstant"/>.
-            if (value != null && symbol.Type?.TypeKind == TypeKind.Enum && IsIntegral(value))
+            // resolve to the member reference, not the boxed underlying integer —
+            // see the remarks on <see cref="MapEnumConstant"/>.
+            if (value != null && type?.TypeKind == TypeKind.Enum && IsIntegral(value))
             {
-                // A parameter symbol declared in a REFERENCED assembly (e.g. a
-                // base-class/interface method whose parameters are enumerated via
-                // `IMethodSymbol.Parameters` rather than parsed from local syntax)
-                // has no `DeclaringSyntaxReferences` — fall back to the call-site
-                // node already in hand so the Unsupported diagnostic still fires
-                // instead of the default being dropped silently.
-                SyntaxNode node = symbol.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax() ?? fallbackNode;
-                return this.MapEnumConstant(symbol.Type, value, node, $"parameter '{symbol.Name}''s default value");
+                return this.MapEnumConstant(type, value, fallbackNode, diagnosticSubject);
             }
 
             switch (value)
@@ -3504,7 +3508,15 @@ public sealed class CSharpToGSharpTranslator
                 _ => null,
             };
 
-            bool variadic = symbol.IsParams;
+            // gsc's own variadic parameter (`...T`, DeclarationBinder.cs) is always
+            // an array/slice — it has no params-COLLECTION concept (C#13). A C#
+            // `params List<int>`/`params IEnumerable<T>` parameter therefore maps
+            // to an ordinary (non-variadic) G# parameter of the FULL collection
+            // type; `variadic` here is only ever true for the genuine `params T[]`
+            // shape, which gsc's variadic slice already models 1:1. The
+            // corresponding expanded call site (`Total(1, 2, 3)`) is lowered at the
+            // CALL, not the declaration — see <see cref="TranslateParamsCollectionArguments"/>.
+            bool variadic = symbol.IsParams && symbol.Type is IArrayTypeSymbol;
             ITypeSymbol parameterType = symbol.Type;
             if (variadic && parameterType is IArrayTypeSymbol arrayType)
             {
@@ -10781,7 +10793,7 @@ public sealed class CSharpToGSharpTranslator
                 target = this.TranslateExpression(invocation.Expression);
             }
 
-            var arguments = this.TranslateArguments(invocation.ArgumentList.Arguments);
+            var arguments = this.TranslateCallArguments(invocation, invocation.ArgumentList.Arguments);
 
             // Directly invoking a nullable-reference delegate field/property
             // (`handler(args)` where `handler` is `((T) -> R)?`) needs a `!!`
@@ -10966,6 +10978,147 @@ public sealed class CSharpToGSharpTranslator
             }
 
             return this.TranslateNamedArguments(arguments);
+        }
+
+        /// <summary>
+        /// Translates an argument list at a call site that may need lowering
+        /// gsc's structural call model cannot express on its own (issue #1901):
+        /// <list type="bullet">
+        /// <item>a C#13 "params collection" parameter (<c>params List&lt;T&gt;</c>,
+        /// <c>params IEnumerable&lt;T&gt;</c>, …) — gsc's own variadic parameter is
+        /// always an array/slice (<see cref="MapParameter"/>), so such a C#
+        /// parameter is declared in G# as an ordinary parameter of the full
+        /// collection type. An EXPANDED call (<c>Total(1, 2, 3)</c>, including the
+        /// zero-argument <c>Total()</c> form) has no matching G# argument shape,
+        /// so it is lowered here into an explicit collection construction
+        /// (<c>Total(List[int32]{1, 2, 3})</c>) that becomes that single ordinary
+        /// argument; the non-expanded, direct-collection form (<c>Total(someList)</c>)
+        /// already binds a single ordinary argument as-is and needs no lowering.</item>
+        /// <item>a C#12 lambda default parameter value omitted at an INDIRECT call
+        /// (<c>f()</c> where <c>f</c> is a local/field holding a lambda declared
+        /// <c>(int x = 10) =&gt; …</c>). gsc's lambda parameters DO carry a default
+        /// (<c>LambdaBinder.BindAndAttachParameterDefaultValue</c>), but it lives
+        /// only on the lambda's own <c>ParameterSymbol</c> — the structural
+        /// <c>FunctionTypeSymbol</c> that types the variable holding it (and that
+        /// every indirect call through that variable binds against,
+        /// <c>OverloadResolver.TryBindFunctionTypeArguments</c>) carries only
+        /// parameter TYPES, never defaults, so gsc always requires the full arity
+        /// at an indirect call. Roslyn already resolves the omitted argument to
+        /// its constant default (<c>ArgumentKind.DefaultValue</c>) regardless of
+        /// how the callee is invoked, so the missing argument is materialized
+        /// explicitly here instead of being dropped.</item>
+        /// </list>
+        /// </summary>
+        private List<GExpression> TranslateCallArguments(SyntaxNode callSyntax, SeparatedSyntaxList<ArgumentSyntax> arguments)
+        {
+            IMethodSymbol targetMethod = this.context.SemanticModel.GetOperation(callSyntax) switch
+            {
+                IInvocationOperation invocationOp => invocationOp.TargetMethod,
+                IObjectCreationOperation creationOp => creationOp.Constructor,
+                _ => null,
+            };
+            ImmutableArray<IArgumentOperation> operationArguments = this.context.SemanticModel.GetOperation(callSyntax) switch
+            {
+                IInvocationOperation invocationOp => invocationOp.Arguments,
+                IObjectCreationOperation creationOp => creationOp.Arguments,
+                _ => default,
+            };
+
+            if (operationArguments.IsDefaultOrEmpty)
+            {
+                return this.TranslateArguments(arguments);
+            }
+
+            if (targetMethod?.MethodKind == MethodKind.DelegateInvoke
+                && operationArguments.Any(a => a.ArgumentKind == ArgumentKind.DefaultValue))
+            {
+                return this.TranslateDelegateInvokeArgumentsWithDefaults(callSyntax, arguments, operationArguments);
+            }
+
+            IArgumentOperation paramsCollectionArg =
+                operationArguments.FirstOrDefault(a => a.ArgumentKind == ArgumentKind.ParamCollection);
+
+            if (paramsCollectionArg == null)
+            {
+                return this.TranslateArguments(arguments);
+            }
+
+            if (arguments.Any(a => a.NameColon != null))
+            {
+                // A named argument feeding into (or skipping ahead of) a params
+                // collection is rare enough, and interacts with enough of the
+                // existing named-argument reordering machinery, that guessing a
+                // lowering here risks silently mis-binding. Gap loudly instead
+                // (falls through to the ordinary named-argument path, which at
+                // least keeps every OTHER argument correct).
+                this.context.ReportUnsupported(
+                    callSyntax,
+                    "a named argument alongside an expanded 'params' collection call has no canonical G# lowering yet.");
+                return this.TranslateNamedArguments(arguments);
+            }
+
+            int paramsOrdinal = paramsCollectionArg.Parameter.Ordinal;
+            var translatedArguments = arguments.Take(paramsOrdinal).Select(a => this.TranslateArgument(a)).ToList();
+
+            GTypeReference elementType = paramsCollectionArg.Parameter.Type is INamedTypeSymbol { TypeArguments: [ITypeSymbol single] }
+                ? this.typeMapper.Map(single, this.context, callSyntax.GetLocation())
+                : new NamedTypeReference(CSharpTypeMapper.UnsupportedPlaceholderType);
+
+            var collectionElements = arguments.Skip(paramsOrdinal)
+                .Select(a => new CollectionInitializerElement(this.TranslateArgument(a)))
+                .ToList();
+            var listType = new NamedTypeReference("List", new List<GTypeReference> { elementType });
+            GExpression construction = BuildConstruction(listType, new List<GExpression>());
+
+            // A zero-element params-collection call (`Total()`) has no elements to
+            // brace — gsc's collection-initializer form requires at least one
+            // element (an empty `{ }` fails to bind, GS0157); the bare
+            // construction call (`List[int32]()`) is the canonical empty form
+            // (mirrors the C# `[]`-collection-expression lowering above).
+            translatedArguments.Add(collectionElements.Count == 0
+                ? construction
+                : new CollectionInitializerExpression(construction, collectionElements));
+            return translatedArguments;
+        }
+
+        /// <summary>
+        /// Rebuilds a delegate-invoke call's full argument list — issue #1901 —
+        /// walking Roslyn's already-resolved <paramref name="operationArguments"/>
+        /// in parameter order: an <c>Explicit</c> slot consumes the next syntax
+        /// argument (translated exactly as any ordinary argument would be, so
+        /// numeric coercion/spill behavior is unchanged), and a <c>DefaultValue</c>
+        /// slot materializes that parameter's constant default directly — the
+        /// explicit value gsc's structural function-type call has no other way to
+        /// supply. Named arguments are excluded up front: C# forbids a named
+        /// argument through a delegate/lambda invocation entirely (no parameter
+        /// names survive the natural delegate type), so <paramref name="arguments"/>
+        /// is always in positional/Explicit order already.
+        /// </summary>
+        private List<GExpression> TranslateDelegateInvokeArgumentsWithDefaults(
+            SyntaxNode callSyntax,
+            SeparatedSyntaxList<ArgumentSyntax> arguments,
+            ImmutableArray<IArgumentOperation> operationArguments)
+        {
+            var result = new List<GExpression>(operationArguments.Length);
+            int nextSyntaxArgument = 0;
+            foreach (IArgumentOperation argumentOperation in operationArguments)
+            {
+                if (argumentOperation.ArgumentKind == ArgumentKind.DefaultValue)
+                {
+                    GExpression defaultValue = this.MapConstantValue(
+                        argumentOperation.Value.ConstantValue.HasValue ? argumentOperation.Value.ConstantValue.Value : null,
+                        argumentOperation.Parameter.Type,
+                        callSyntax,
+                        $"parameter '{argumentOperation.Parameter.Name}''s default value");
+                    result.Add(defaultValue ?? new IdentifierExpression("nil"));
+                    continue;
+                }
+
+                result.Add(this.TranslateArgument(arguments[nextSyntaxArgument]));
+                nextSyntaxArgument++;
+            }
+
+            return result;
         }
 
         // Reorders a named/mixed argument list into parameter DECLARATION order
@@ -11359,7 +11512,7 @@ public sealed class CSharpToGSharpTranslator
 
             var arguments = creation.ArgumentList == null
                 ? new List<GExpression>()
-                : this.TranslateArguments(creation.ArgumentList.Arguments);
+                : this.TranslateCallArguments(creation, creation.ArgumentList.Arguments);
 
             // A C# delegate creation `new SomeDelegate(target)` wraps a method
             // group, lambda, or another delegate in a named delegate type. G# has
@@ -12327,7 +12480,7 @@ public sealed class CSharpToGSharpTranslator
 
             var arguments = creation.ArgumentList == null
                 ? new List<GExpression>()
-                : this.TranslateArguments(creation.ArgumentList.Arguments);
+                : this.TranslateCallArguments(creation, creation.ArgumentList.Arguments);
 
             return this.BuildObjectCreationCore(creation, typeSymbol, type, arguments, creation.Initializer);
         }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -3523,6 +3523,20 @@ public sealed class CSharpToGSharpTranslator
                 parameterType = arrayType.ElementType;
             }
 
+            if (symbol.IsParams && !variadic && !IsSupportedParamsCollectionType(parameterType))
+            {
+                // The call-site expansion (TranslateCallArguments) only knows how
+                // to lower an expanded 'params' call into a List[T]{...} literal
+                // for the allowlisted collection shapes below. A callee declared
+                // with e.g. `params ReadOnlySpan<T>`/`params HashSet<T>` would
+                // otherwise translate "successfully" here while every call site
+                // gaps — a half-translated callee with no working caller. Gap the
+                // declaration too, so the two sides stay consistent.
+                this.context.ReportUnsupported(
+                    fallbackNode,
+                    $"params collection of type '{parameterType}' has no gsc construction form.");
+            }
+
             GTypeReference type = this.typeMapper.Map(parameterType, this.context, symbol.Locations.FirstOrDefault());
 
             // Issue #1072: a non-nullable reference/array parameter that is
@@ -11009,6 +11023,37 @@ public sealed class CSharpToGSharpTranslator
         /// explicitly here instead of being dropped.</item>
         /// </list>
         /// </summary>
+        /// <summary>
+        /// The params-collection shapes gsc can build FROM a call-site
+        /// <c>List[T]{...}</c> literal (BuildConstruction has no other collection
+        /// constructor to reach for): the concrete <c>List&lt;T&gt;</c> class itself,
+        /// plus the interfaces it already implements. Matched structurally (single
+        /// type argument) rather than by shape, per issue #1901 follow-up — a
+        /// <c>ReadOnlySpan&lt;T&gt;</c>/<c>Span&lt;T&gt;</c> (C#13's PREFERRED params-collection
+        /// overload), a <c>HashSet&lt;T&gt;</c>, or any user <c>[CollectionBuilder]</c> type
+        /// has no gsc construction form and must gap instead of silently mismatching
+        /// the declared parameter type.
+        /// </summary>
+        private static bool IsSupportedParamsCollectionType(ITypeSymbol type)
+        {
+            if (type is not INamedTypeSymbol { TypeArguments: [ITypeSymbol] } named)
+            {
+                return false;
+            }
+
+            if (named.Name == "List" && named.ContainingNamespace?.ToDisplayString() == "System.Collections.Generic")
+            {
+                return true;
+            }
+
+            return named.OriginalDefinition.SpecialType is
+                SpecialType.System_Collections_Generic_IEnumerable_T or
+                SpecialType.System_Collections_Generic_ICollection_T or
+                SpecialType.System_Collections_Generic_IList_T or
+                SpecialType.System_Collections_Generic_IReadOnlyList_T or
+                SpecialType.System_Collections_Generic_IReadOnlyCollection_T;
+        }
+
         private List<GExpression> TranslateCallArguments(SyntaxNode callSyntax, SeparatedSyntaxList<ArgumentSyntax> arguments)
         {
             IMethodSymbol targetMethod = this.context.SemanticModel.GetOperation(callSyntax) switch
@@ -11058,11 +11103,26 @@ public sealed class CSharpToGSharpTranslator
             }
 
             int paramsOrdinal = paramsCollectionArg.Parameter.Ordinal;
+
+            if (!IsSupportedParamsCollectionType(paramsCollectionArg.Parameter.Type))
+            {
+                // gsc can only construct a List[T]{...} literal at the call site
+                // (BuildConstruction below has no other collection constructor to
+                // reach for). Anything else — params Span<T>/ReadOnlySpan<T> (the
+                // PREFERRED C#13 overload), HashSet<T>, a [CollectionBuilder] type,
+                // or a collection type with other than one type argument — has no
+                // gsc construction form. Gap loudly instead of emitting a
+                // List[T]{...} that silently mismatches the declared parameter type.
+                this.context.ReportUnsupported(
+                    callSyntax,
+                    $"params collection of type '{paramsCollectionArg.Parameter.Type}' has no gsc construction form.");
+                return this.TranslateArguments(arguments);
+            }
+
             var translatedArguments = arguments.Take(paramsOrdinal).Select(a => this.TranslateArgument(a)).ToList();
 
-            GTypeReference elementType = paramsCollectionArg.Parameter.Type is INamedTypeSymbol { TypeArguments: [ITypeSymbol single] }
-                ? this.typeMapper.Map(single, this.context, callSyntax.GetLocation())
-                : new NamedTypeReference(CSharpTypeMapper.UnsupportedPlaceholderType);
+            ITypeSymbol paramsElementType = ((INamedTypeSymbol)paramsCollectionArg.Parameter.Type).TypeArguments[0];
+            GTypeReference elementType = this.typeMapper.Map(paramsElementType, this.context, callSyntax.GetLocation());
 
             var collectionElements = arguments.Skip(paramsOrdinal)
                 .Select(a => new CollectionInitializerElement(this.TranslateArgument(a)))
@@ -11105,12 +11165,33 @@ public sealed class CSharpToGSharpTranslator
             {
                 if (argumentOperation.ArgumentKind == ArgumentKind.DefaultValue)
                 {
-                    GExpression defaultValue = this.MapConstantValue(
-                        argumentOperation.Value.ConstantValue.HasValue ? argumentOperation.Value.ConstantValue.Value : null,
-                        argumentOperation.Parameter.Type,
-                        callSyntax,
-                        $"parameter '{argumentOperation.Parameter.Name}''s default value");
-                    result.Add(defaultValue ?? new IdentifierExpression("nil"));
+                    Optional<object> constant = argumentOperation.Value.ConstantValue;
+                    GExpression defaultValue = constant.HasValue
+                        ? this.MapConstantValue(
+                            constant.Value,
+                            argumentOperation.Parameter.Type,
+                            callSyntax,
+                            $"parameter '{argumentOperation.Parameter.Name}''s default value")
+                        : null;
+                    if (defaultValue == null)
+                    {
+                        // `nil` is the CORRECT mapping for a legitimate null/default
+                        // constant (constant.Value == null); anything else that
+                        // failed to map (decimal, default(struct), or no constant
+                        // at all) has no gsc literal form — `nil` there would
+                        // silently substitute the wrong value AND type. Gap loudly.
+                        bool legitimateNull = constant.HasValue && constant.Value == null;
+                        if (!legitimateNull)
+                        {
+                            this.context.ReportUnsupported(
+                                callSyntax,
+                                $"lambda default value of type '{argumentOperation.Parameter.Type}' has no gsc constant form.");
+                        }
+
+                        defaultValue = new IdentifierExpression("nil");
+                    }
+
+                    result.Add(defaultValue);
                     continue;
                 }
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -11111,11 +11111,23 @@ public sealed class CSharpToGSharpTranslator
                 // reach for). Anything else — params Span<T>/ReadOnlySpan<T> (the
                 // PREFERRED C#13 overload), HashSet<T>, a [CollectionBuilder] type,
                 // or a collection type with other than one type argument — has no
-                // gsc construction form. Gap loudly instead of emitting a
-                // List[T]{...} that silently mismatches the declared parameter type.
-                this.context.ReportUnsupported(
-                    callSyntax,
-                    $"params collection of type '{paramsCollectionArg.Parameter.Type}' has no gsc construction form.");
+                // gsc construction form.
+                //
+                // Only gap when the callee itself is declared IN SOURCE: MapParameter
+                // gaps that same declaration (issue #1901 follow-up), and a half-
+                // translated callee with no working caller is what we're guarding
+                // against here — so both sides need to stay consistent. A callee from
+                // a REFERENCED assembly (e.g. BCL `Task.WhenAll(params ReadOnlySpan<Task>)`)
+                // is never translated as a declaration in the first place, so there is
+                // nothing to stay consistent with; fall back to the pre-#1901 ordinary
+                // argument translation silently, exactly as it worked before this PR.
+                if (targetMethod?.DeclaringSyntaxReferences.IsEmpty == false)
+                {
+                    this.context.ReportUnsupported(
+                        callSyntax,
+                        $"params collection of type '{paramsCollectionArg.Parameter.Type}' has no gsc construction form.");
+                }
+
                 return this.TranslateArguments(arguments);
             }
 

--- a/tools/cs2gs/corpus/grid/G09-Functions-Console/Constructs/ParamsCollectionsProbe.cs
+++ b/tools/cs2gs/corpus/grid/G09-Functions-Console/Constructs/ParamsCollectionsProbe.cs
@@ -1,10 +1,9 @@
-// inventory: Parameter — QUARANTINED at compile (gsc): C#13 params
-// collections translate but the expanded-form call sites do not bind:
-//   GS0154 "Parameter 'values' requires a value of type List`1[Int32]"
-//     for Total(1, 2, 3),
-//   GS0129 "Binary operator '+=' is not defined for types 'int32' and
-//     List`1[Int32]" inside the foreach lowering,
-//   GS0154 for JoinParts("a", "b", "c") against IEnumerable<string>.
+// inventory: Parameter — C#13 params collections (params List&lt;int&gt;,
+// params IEnumerable&lt;string&gt;). Issue #1901: gsc's own variadic parameter
+// is always an array/slice, so these are declared as ordinary parameters of
+// the full collection type; an expanded call site (`Total(1, 2, 3)`,
+// including the zero-arg `Total()` form) is lowered into an explicit
+// collection construction (`List[int32]{1, 2, 3}` / `List[int32]()`).
 using System;
 using System.Collections.Generic;
 

--- a/tools/cs2gs/corpus/grid/G09-Functions-Console/Constructs/ParenthesizedLambdaExpressionDefaults.cs
+++ b/tools/cs2gs/corpus/grid/G09-Functions-Console/Constructs/ParenthesizedLambdaExpressionDefaults.cs
@@ -1,7 +1,8 @@
-// inventory: ParenthesizedLambdaExpression — QUARANTINED at compile (gsc):
-// C#12 lambda default parameters are dropped in the emitted G# lambda, so the
-// zero-argument call fails: GS0144 "Function 'f' requires 1 arguments but was
-// given 0."
+// inventory: ParenthesizedLambdaExpression — C#12 lambda default parameters.
+// Issue #1901: a call through the lambda's variable that omits a defaulted
+// trailing argument (`f()`) is lowered to materialize that default explicitly
+// (`f(10)`) — gsc's own structural function type has no default to fall back
+// on for an indirect call, only the lambda's own ParameterSymbol does.
 using System;
 
 namespace Corpus.Grid09

--- a/tools/cs2gs/corpus/grid/G09-Functions-Console/Program.cs
+++ b/tools/cs2gs/corpus/grid/G09-Functions-Console/Program.cs
@@ -18,9 +18,11 @@ namespace Corpus.Grid09
             MethodGroupConversionFixture.Run();
             NameColonFixture.Run();
             OptionalAndParamsArrayFixture.Run();
+            ParamsCollectionsProbeFixture.Run();
             ParenthesizedLambdaExpressionFixture.Run();
             ParenthesizedLambdaExpressionAsyncFixture.Run();
             ParenthesizedLambdaExpressionAttributedFixture.Run();
+            ParenthesizedLambdaExpressionDefaultsFixture.Run();
             SimpleLambdaExpressionFixture.Run();
         }
     }

--- a/tools/cs2gs/corpus/grid/G09-Functions-Console/baseline.stdout.golden
+++ b/tools/cs2gs/corpus/grid/G09-Functions-Console/baseline.stdout.golden
@@ -32,6 +32,9 @@ OptionalAndParamsArray: namedSkip=Hello Cid x2
 OptionalAndParamsArray: sumNone=0
 OptionalAndParamsArray: sumThree=6
 OptionalAndParamsArray: sumArray=9
+ParamsCollectionsProbe: totalNone=0
+ParamsCollectionsProbe: totalThree=6
+ParamsCollectionsProbe: joined=a+b+c
 ParenthesizedLambdaExpression: add=5
 ParenthesizedLambdaExpression: mul=20
 ParenthesizedLambdaExpression: hello=hello
@@ -39,6 +42,8 @@ ParenthesizedLambdaExpression: stmt=16
 ParenthesizedLambdaExpression: report=6/7
 ParenthesizedLambdaExpressionAsync: result=42
 ParenthesizedLambdaExpressionAttributed: result=42
+ParenthesizedLambdaExpressionDefaults: fDefault=20 fGiven=6
+ParenthesizedLambdaExpressionDefaults: gDefault=6 gGiven=3
 SimpleLambdaExpression: twice=16
 SimpleLambdaExpression: scale=40
 SimpleLambdaExpression: bang=go!


### PR DESCRIPTION
Fixes #1901

Two gaps, both callee param-list shapes gsc can't do 1:1 like C#.

**Lambda defaults (C#12).** gsc's LambdaBinder already stashes the default on the lambda's own ParameterSymbol. Bug: the structural FunctionTypeSymbol typing the variable holding the lambda carries only param TYPES, not defaults — every indirect call through that variable (`f()`) demanded full arity regardless. Roslyn already resolves the skipped arg to its constant default (ArgumentKind.DefaultValue) no matter how the callee is invoked, so cs2gs now materializes it explicitly at the call site: `f()` -> `f(10)`. Root cause is a real gsc gap (structural fn types can't carry defaults); fixed translator-side by inlining the known constant instead of touching gsc's type-interning.

**Params collections (C#13).** gsc's variadic param is always an array/slice — no params-COLLECTION concept. `params List<int>`/`params IEnumerable<T>` now maps to an ordinary (non-variadic) G# param of the FULL collection type. Expanded call site (`Total(1,2,3)`, incl. zero-arg `Total()`) lowers to an explicit `List[T]{...}`/`List[T]()` construction; direct-collection call (`Total(someList)`) already binds fine, untouched. Generalizes to any single-type-arg collection interface (List/IEnumerable/ICollection/IList/...); Span/ReadOnlySpan excluded (no construction-literal equivalent in gsc).

Both quarantined G09-Functions-Console fixtures moved back to Constructs/; baseline.stdout.golden recaptured live from the real C# program (never hand-written). migrate G09 all 4 stages PASS (translate/compile/ilverify/test-parity). New Issue1901LambdaDefaultsTranslationTests (5 cases). Full Cs2Gs.Tests: 887/887 passed, 0 failed.