### PR TITLE
gsc: disambiguate multi-arity BCL open-generic typeof via comma-count arity (#1989)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
@@ -61,11 +61,32 @@ internal sealed partial class ExpressionBinder
         // and a bare name legitimately stays a GS0113). Attempted BEFORE the
         // ordinary type-clause bind so a hit here never also trips the
         // `ReportUndefinedType` diagnostic that path raises on failure.
+        // Issue #1989: a bare name only ever disambiguates a UNIQUE arity
+        // (`List` → `List`1`). Same-base-name BCL families across several
+        // arities (`Func`, `Action`, `Tuple`, `ValueTuple`, …) need an
+        // explicit arity. G# has no `Name<>`/`Name<,>` spelling, so the
+        // arity is carried the same way C# derives it — by comma count — but
+        // over G#'s own bracket generics via `_` placeholder arguments:
+        // `typeof(Func[_])` is arity 1, `typeof(Func[_, _])` is arity 2, etc.
+        // This form always resolves the arity-suffixed generic and never
+        // falls back to a same-named non-generic type (`typeof(Action[_])`
+        // can never silently become non-generic `Action`).
         var typeClause = syntax.TypeClause;
         TypeSymbol typeSymbol = null;
-        if (!typeClause.HasQualifier && !typeClause.HasTypeArguments && !typeClause.IsArray && !typeClause.IsNullable)
+        if (!typeClause.HasQualifier && !typeClause.IsArray && !typeClause.IsNullable)
         {
-            TryResolveOpenGenericImportedType(typeClause.Identifier.Text, out typeSymbol);
+            if (!typeClause.HasTypeArguments)
+            {
+                TryResolveOpenGenericImportedType(typeClause.Identifier.Text, out typeSymbol);
+            }
+            else if (TryGetUnboundGenericArity(typeClause, out var arity))
+            {
+                if (!TryResolveOpenGenericImportedTypeWithArity(typeClause.Identifier.Text, arity, out typeSymbol))
+                {
+                    Diagnostics.ReportUndefinedType(typeClause.Location, typeClause.Identifier.Text + "`" + arity);
+                    return new BoundErrorExpression(null);
+                }
+            }
         }
 
         typeSymbol ??= bindTypeClause(syntax.TypeClause);
@@ -98,14 +119,21 @@ internal sealed partial class ExpressionBinder
             return false;
         }
 
+        // Issue #1989: no fixed arity cap — a metadata arity limit doesn't
+        // really exist, so we walk arities upward and stop once a small
+        // streak of consecutive misses (BCL generic families are always
+        // contiguous, e.g. Func`1..Func`16) confirms there's nothing higher.
         Type match = null;
-        foreach (var import in scope.GetDeclaredImports())
+        var missStreak = 0;
+        for (var arity = 1; missStreak < MaxConsecutiveArityMisses; arity++)
         {
-            for (var arity = 1; arity <= 8; arity++)
+            var foundAtThisArity = false;
+            foreach (var import in scope.GetDeclaredImports())
             {
                 var candidateName = import.Target + "." + name + "`" + arity;
                 if (scope.References.TryResolveType(candidateName, out var candidate))
                 {
+                    foundAtThisArity = true;
                     if (match != null && match != candidate)
                     {
                         // Ambiguous across imports/arities — defer to the
@@ -115,6 +143,87 @@ internal sealed partial class ExpressionBinder
 
                     match = candidate;
                 }
+            }
+
+            missStreak = foundAtThisArity ? 0 : missStreak + 1;
+        }
+
+        if (match == null)
+        {
+            return false;
+        }
+
+        type = TypeSymbol.FromClrType(match);
+        return true;
+    }
+
+    /// <summary>Issue #1989: consecutive-arity-miss streak that stops the upward arity walk in <see cref="TryResolveOpenGenericImportedType"/>.</summary>
+    private const int MaxConsecutiveArityMisses = 2;
+
+    /// <summary>
+    /// Issue #1989: an unbound-generic <c>typeof(...)</c> target with an
+    /// EXPLICIT requested arity, spelled with <c>_</c> placeholder type
+    /// arguments (G#'s analogue of C#'s comma-count <c>Name&lt;&gt;</c> /
+    /// <c>Name&lt;,&gt;</c> unbound-generic syntax, since G# generics use
+    /// <c>Name[T1, T2]</c> brackets rather than angle brackets). Returns
+    /// <see langword="true"/> with <paramref name="arity"/> set to the
+    /// argument count only when every type argument is a bare <c>_</c> (no
+    /// qualifier, nested type arguments, array shape, or nullable suffix) —
+    /// any real type argument is an ordinary bound generic and is left to
+    /// <see cref="bindTypeClause"/>.
+    /// </summary>
+    private static bool TryGetUnboundGenericArity(TypeClauseSyntax typeClause, out int arity)
+    {
+        arity = 0;
+        var args = typeClause.TypeArguments;
+        if (args.Count == 0)
+        {
+            return false;
+        }
+
+        foreach (var arg in args)
+        {
+            if (arg.Identifier.Text != "_" || arg.HasQualifier || arg.HasTypeArguments || arg.IsArray || arg.IsNullable)
+            {
+                return false;
+            }
+        }
+
+        arity = args.Count;
+        return true;
+    }
+
+    /// <summary>
+    /// Issue #1989: resolves <paramref name="name"/> to an imported CLR
+    /// generic type's OPEN definition at the EXACT requested
+    /// <paramref name="arity"/> (e.g. <c>Func</c> + arity 2 → <c>Func`2</c>).
+    /// Unlike <see cref="TryResolveOpenGenericImportedType"/>, this never
+    /// considers the plain non-generic name a match — the caller already
+    /// determined the target is an explicit unbound generic — so it can
+    /// never silently return the wrong (non-generic) type for names like
+    /// <c>Action</c> that have both a non-generic and generic overload set.
+    /// </summary>
+    private bool TryResolveOpenGenericImportedTypeWithArity(string name, int arity, out TypeSymbol type)
+    {
+        type = null;
+        if (string.IsNullOrEmpty(name) || arity <= 0)
+        {
+            return false;
+        }
+
+        Type match = null;
+        foreach (var import in scope.GetDeclaredImports())
+        {
+            var candidateName = import.Target + "." + name + "`" + arity;
+            if (scope.References.TryResolveType(candidateName, out var candidate))
+            {
+                if (match != null && match != candidate)
+                {
+                    // Ambiguous across imports — defer to the caller's diagnostic.
+                    return false;
+                }
+
+                match = candidate;
             }
         }
 

--- a/test/Compiler.Tests/Emit/Issue1989MultiArityOpenGenericTypeOfEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1989MultiArityOpenGenericTypeOfEmitTests.cs
@@ -1,0 +1,183 @@
+// <copyright file="Issue1989MultiArityOpenGenericTypeOfEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1989: same-base-name multi-arity BCL generic families (<c>Func</c>,
+/// <c>Action</c>, …) broke the #1915 bare-name open-generic <c>typeof(...)</c>
+/// fallback — <c>typeof(Func)</c> stayed GS0113 (every arity 1..16 matches
+/// "Func", so the fallback correctly bails as ambiguous), and <c>typeof(Action)</c>
+/// SILENTLY resolved to the non-generic <c>System.Action</c> instead of ever
+/// reaching a generic <c>Action`N</c>.
+/// <para>
+/// G# has no <c>Name&lt;&gt;</c>/<c>Name&lt;,&gt;</c> unbound-generic spelling
+/// (generics use <c>Name[T1, T2]</c> brackets), so the fix carries the
+/// explicit requested arity the same way C# derives it from comma count —
+/// via <c>_</c> placeholder type arguments: <c>typeof(Func[_])</c> is arity 1,
+/// <c>typeof(Func[_, _])</c> is arity 2, etc. This always requires the
+/// arity-suffixed generic and never falls back to a same-named non-generic
+/// type, fixing the <c>Action</c> silent-wrong-type case for good.
+/// </para>
+/// </summary>
+public class Issue1989MultiArityOpenGenericTypeOfEmitTests
+{
+    [Fact]
+    public void EndToEnd_FuncArity1_TypeOf_ResolvesGenericOneArity()
+    {
+        const string source = """
+            package i1989func1
+            import System
+
+            func Main() { System.Console.WriteLine(typeof(Func[_]).Name) }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("Func`1\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_FuncArity2_TypeOf_ResolvesGenericTwoArity()
+    {
+        const string source = """
+            package i1989func2
+            import System
+
+            func Main() { System.Console.WriteLine(typeof(Func[_, _]).Name) }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("Func`2\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_ActionArity1_TypeOf_ResolvesGenericOneArity_NotNonGenericAction()
+    {
+        const string source = """
+            package i1989action1
+            import System
+
+            func Main() { System.Console.WriteLine(typeof(Action[_]).Name) }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("Action`1\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_ActionArity2_TypeOf_ResolvesGenericTwoArity()
+    {
+        const string source = """
+            package i1989action2
+            import System
+
+            func Main() { System.Console.WriteLine(typeof(Action[_, _]).Name) }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("Action`2\n", output);
+    }
+
+    [Fact]
+    public void EndToEnd_BareAction_TypeOf_StillResolvesNonGenericAction()
+    {
+        const string source = """
+            package i1989actionbare
+            import System
+
+            func Main() { System.Console.WriteLine(typeof(Action).Name) }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("Action\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1989_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1989MultiArityOpenGenericTypeOfBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1989MultiArityOpenGenericTypeOfBindingTests.cs
@@ -1,0 +1,130 @@
+// <copyright file="Issue1989MultiArityOpenGenericTypeOfBindingTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1989: same-base-name multi-arity BCL generic families broke the
+/// #1915 bare-name open-generic <c>typeof(...)</c> fallback. <c>typeof(Func)</c>
+/// stays GS0113 (ambiguous across Func`1..Func`16 — correct, still requires
+/// disambiguation) and <c>typeof(Action)</c> keeps resolving the non-generic
+/// <c>System.Action</c> (unchanged, still correct on its own). The NEW
+/// explicit-arity form <c>typeof(Name[_, ...])</c> (<c>_</c> placeholder type
+/// arguments, G#'s analogue of C#'s comma-count <c>Name&lt;&gt;</c>) lets a
+/// caller pick a specific arity out of a same-base-name family, and NEVER
+/// falls back to a same-named non-generic type.
+/// </summary>
+public class Issue1989MultiArityOpenGenericTypeOfBindingTests
+{
+    [Fact]
+    public void BareFunc_TypeOf_StillReportsAmbiguousGS0113()
+    {
+        var source = @"
+import System
+
+class C {
+    func run() {
+        let t = typeof(Func)
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0113");
+    }
+
+    [Fact]
+    public void ExplicitArityOneFunc_TypeOf_BindsToOpenGenericOneArityDefinition()
+    {
+        var source = @"
+import System
+
+class C {
+    func run() {
+        let t = typeof(Func[_])
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void ExplicitArityTwoFunc_TypeOf_BindsToOpenGenericTwoArityDefinition()
+    {
+        var source = @"
+import System
+
+class C {
+    func run() {
+        let t = typeof(Func[_, _])
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void ExplicitArityOneAction_TypeOf_BindsToGenericAction_NotNonGenericAction()
+    {
+        var source = @"
+import System
+
+class C {
+    func run() {
+        let t = typeof(Action[_])
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void BareAction_TypeOf_StillResolvesNonGenericAction()
+    {
+        var source = @"
+import System
+
+class C {
+    func run() {
+        let t = typeof(Action)
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void ExplicitArityHuge_NoMatch_ReportsUndefinedTypeGS0113()
+    {
+        var source = @"
+import System
+
+class C {
+    func run() {
+        let t = typeof(Func[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _])
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0113");
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
Fixes #1989

- typeof(Func) / typeof(Action) share a base name across many CLR generic arities; the #1915 bare-name typeof(...) fallback can't pick one, and typeof(Action) previously silently resolved to the non-generic System.Action instead of ever reaching a generic Action`N.
- G# has no C#-style Name<>/Name<,> unbound-generic spelling (generics use Name[T1, T2] brackets), so the explicit requested arity is carried the same way C# derives it from comma count — via `_` placeholder type arguments: typeof(Func[_]) is arity 1, typeof(Func[_, _]) is arity 2. Works for any same-base-name BCL family (Func, Action, Tuple, ValueTuple, ...), driven purely off (baseName, arity).
- This explicit form always requires the arity-suffixed generic and never falls back to a same-named non-generic type — fixes the Action silent-wrong-type bug for good. An unresolved explicit arity reports a precise GS0113.
- Widened the #1915 bare-name arity search: removed the fixed arity <= 8 cap; it now walks arities upward and stops after two consecutive misses (BCL families are contiguous), since no real metadata arity limit exists.
- Added Core.Tests binder tests and Compiler.Tests end-to-end emit tests (runtime System.Type.Name checks for Func`1/Func`2/Action`1/Action`2, plus typeof(Action) still resolving non-generic Action).
- No new SyntaxKind/BoundNodeKind; coverage-matrix guard test passes unchanged. Full Core.Tests suite (5380 tests) green.