### PR TITLE
gsc: diagnose generic local function referencing enclosing type parameter (#1940)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -1883,6 +1883,13 @@ internal sealed class LambdaBinder
                 case BoundSizeOfExpression sizeOfExpression:
                     CheckType(sizeOfExpression.MeasuredType);
                     break;
+
+                // Issue #1940 (NB1): a constrained static-abstract call `U.M()` with
+                // void return has node.Type == void, so the enclosing type parameter
+                // in the constrained receiver is otherwise missed -> silent invalid IL.
+                case BoundConstrainedStaticCallExpression constrainedStaticCall:
+                    CheckType(constrainedStaticCall.TypeParameter);
+                    break;
             }
 
             base.VisitExpression(node);

--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -425,6 +425,28 @@ internal sealed class LambdaBinder
                 Diagnostics.ReportGenericLocalFunctionCannotCapture(syntax.Identifier.Location, name);
             }
 
+            // Issue #1940: a generic local function is hoisted to its own
+            // top-level static method carrying only ITS OWN type parameters
+            // as CLR MVAR slots. Referencing a type parameter owned by an
+            // enclosing generic method or class (available here only because
+            // BindFunctionLiteralExpression's body bind saw the merged
+            // enclosing + own CurrentTypeParameters dictionary above) has no
+            // corresponding slot on that hoisted method and would silently
+            // emit invalid IL. Detect any such reference — in a parameter
+            // type, the return type, or anywhere in the body — and report a
+            // diagnostic instead of letting it reach the emitter.
+            var enclosingTypeParameters = previousTypeParameters == null
+                ? ImmutableArray<TypeParameterSymbol>.Empty
+                : previousTypeParameters.Values.ToImmutableArray();
+            if (enclosingTypeParameters.Length > 0)
+            {
+                var offender = FindEnclosingTypeParameterReference(literal.Function, literal.Body, enclosingTypeParameters);
+                if (offender != null)
+                {
+                    Diagnostics.ReportGenericLocalFunctionCannotReferenceEnclosingTypeParameter(syntax.Identifier.Location, name, offender.Name);
+                }
+            }
+
             if (!Scope.TryDeclareFunction(literal.Function))
             {
                 Diagnostics.ReportSymbolAlreadyDeclared(syntax.Identifier.Location, name);
@@ -1322,6 +1344,31 @@ internal sealed class LambdaBinder
         return ReferenceEquals(literalReturn, targetReturn);
     }
 
+    /// <summary>
+    /// Issue #1940: scans a generic local function's parameter types, return type, and body for any
+    /// reference to a <paramref name="enclosingTypeParameters"/> member — a type parameter owned by an
+    /// enclosing generic method or class rather than the local function's own <c>[T, U, …]</c> list.
+    /// </summary>
+    /// <param name="function">The generic local function's symbol (already carrying its own type parameters).</param>
+    /// <param name="body">The bound body to scan.</param>
+    /// <param name="enclosingTypeParameters">The in-scope type parameters owned by an enclosing method or class.</param>
+    /// <returns>The first offending enclosing type parameter found, or <see langword="null"/> if none.</returns>
+    private static TypeParameterSymbol FindEnclosingTypeParameterReference(
+        FunctionSymbol function,
+        BoundStatement body,
+        ImmutableArray<TypeParameterSymbol> enclosingTypeParameters)
+    {
+        var walker = new EnclosingTypeParameterReferenceWalker(enclosingTypeParameters);
+        foreach (var parameter in function.Parameters)
+        {
+            walker.CheckType(parameter.Type);
+        }
+
+        walker.CheckType(function.Type);
+        walker.Visit(body);
+        return walker.Found;
+    }
+
     private static ImmutableArray<VariableSymbol> CollectCapturedVariables(BoundStatement body, ImmutableArray<ParameterSymbol> parameters)
     {
         var paramSet = new HashSet<VariableSymbol>(parameters);
@@ -1763,6 +1810,88 @@ internal sealed class LambdaBinder
             {
                 this.captured.Add(variable);
             }
+        }
+    }
+
+    // Issue #1940: walks a generic local function's bound body looking for any reference — an
+    // expression's type, a local's declared type, an explicit/inferred method type argument, or a
+    // type-pattern's tested type — to a type parameter owned by an enclosing generic method or class.
+    // Stops at nested function literals (BoundTreeWalker already treats FunctionLiteralExpression as
+    // opaque): a nested generic local function is checked independently, against its own enclosing set,
+    // when it is bound.
+    private sealed class EnclosingTypeParameterReferenceWalker : BoundTreeWalker
+    {
+        private readonly ImmutableArray<TypeParameterSymbol> enclosingTypeParameters;
+
+        public EnclosingTypeParameterReferenceWalker(ImmutableArray<TypeParameterSymbol> enclosingTypeParameters)
+        {
+            this.enclosingTypeParameters = enclosingTypeParameters;
+        }
+
+        public TypeParameterSymbol Found { get; private set; }
+
+        public void CheckType(TypeSymbol type)
+        {
+            if (Found != null || type == null)
+            {
+                return;
+            }
+
+            TypeSymbol.AnyTypeParameter(type, tp =>
+            {
+                if (Found == null && enclosingTypeParameters.Contains(tp))
+                {
+                    Found = tp;
+                }
+
+                return Found != null;
+            });
+        }
+
+        public override void VisitExpression(BoundExpression node)
+        {
+            if (node == null || Found != null)
+            {
+                return;
+            }
+
+            CheckType(node.Type);
+            if (node is BoundCallExpression call && !call.MethodTypeArguments.IsDefaultOrEmpty)
+            {
+                foreach (var typeArgument in call.MethodTypeArguments)
+                {
+                    CheckType(typeArgument);
+                }
+            }
+
+            base.VisitExpression(node);
+        }
+
+        public override void VisitPattern(BoundPattern node)
+        {
+            if (node == null || Found != null)
+            {
+                return;
+            }
+
+            CheckType(node.Type);
+            if (node is BoundTypePattern typePattern)
+            {
+                CheckType(typePattern.TargetType);
+            }
+
+            base.VisitPattern(node);
+        }
+
+        protected override void VisitVariableDeclaration(BoundVariableDeclaration node)
+        {
+            if (Found != null)
+            {
+                return;
+            }
+
+            CheckType(node.Variable.Type);
+            base.VisitVariableDeclaration(node);
         }
     }
 }

--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -1856,12 +1856,33 @@ internal sealed class LambdaBinder
             }
 
             CheckType(node.Type);
-            if (node is BoundCallExpression call && !call.MethodTypeArguments.IsDefaultOrEmpty)
+            switch (node)
             {
-                foreach (var typeArgument in call.MethodTypeArguments)
-                {
-                    CheckType(typeArgument);
-                }
+                case BoundCallExpression call:
+                    CheckTypeArguments(call.MethodTypeArguments);
+                    break;
+                case BoundUserInstanceCallExpression userInstanceCall:
+                    CheckTypeArguments(userInstanceCall.MethodTypeArguments);
+                    break;
+                case BoundImportedCallExpression importedCall:
+                    CheckTypeArguments(importedCall.TypeArgumentSymbols);
+                    break;
+                case BoundImportedInstanceCallExpression importedInstanceCall:
+                    CheckTypeArguments(importedInstanceCall.TypeArgumentSymbols);
+                    break;
+                case BoundIsExpression isExpression:
+                    CheckType(isExpression.TargetType);
+                    break;
+
+                // Issue #1940: TypeOf/SizeOf are opaque leaves in BoundTreeWalker
+                // (no VisitXxx dispatch), so their referenced type must be checked
+                // here — base.VisitExpression never reaches it otherwise.
+                case BoundTypeOfExpression typeOfExpression:
+                    CheckType(typeOfExpression.OperandType);
+                    break;
+                case BoundSizeOfExpression sizeOfExpression:
+                    CheckType(sizeOfExpression.MeasuredType);
+                    break;
             }
 
             base.VisitExpression(node);
@@ -1892,6 +1913,19 @@ internal sealed class LambdaBinder
 
             CheckType(node.Variable.Type);
             base.VisitVariableDeclaration(node);
+        }
+
+        private void CheckTypeArguments(ImmutableArray<TypeSymbol> typeArguments)
+        {
+            if (typeArguments.IsDefaultOrEmpty)
+            {
+                return;
+            }
+
+            foreach (var typeArgument in typeArguments)
+            {
+                CheckType(typeArgument);
+            }
         }
     }
 }

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -694,6 +694,25 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
     }
 
     /// <summary>
+    /// Reports that a generic local function (issue #1886) references a type parameter owned by an
+    /// enclosing generic method or class (issue #1940). A generic local function is hoisted to its own
+    /// top-level static method carrying only its own type-parameter list as CLR method-generic (MVAR)
+    /// slots; the enclosing method/class type parameter has no corresponding slot on that hoisted method,
+    /// so referencing it (in a parameter type, return type, local declaration, or body expression) would
+    /// silently emit invalid IL (an unresolvable MVAR/VAR reference) that crashes at run time with
+    /// <c>InvalidProgramException</c> instead of failing to compile.
+    /// </summary>
+    /// <param name="location">The text location of the declaration's identifier.</param>
+    /// <param name="name">The name of the declared local function.</param>
+    /// <param name="enclosingTypeParameterName">The name of the referenced enclosing type parameter.</param>
+    public void ReportGenericLocalFunctionCannotReferenceEnclosingTypeParameter(TextLocation location, string name, string enclosingTypeParameterName)
+    {
+        var message = $"Generic local function '{name}' cannot reference '{enclosingTypeParameterName}', a type parameter of an enclosing method or class. " +
+            "A generic local function is emitted as its own generic method and cannot close over an enclosing type parameter.";
+        Report(location, "GS0468", message);
+    }
+
+    /// <summary>
     /// Reports a file-level <c>@assembly:</c> annotation whose name is not
     /// <c>InternalsVisibleTo</c> — the only assembly-scoped annotation gsc
     /// currently understands (issue #1929/#1953 friend-assembly opt-in).

--- a/test/Compiler.Tests/Emit/Issue1940GenericLocalFunctionEnclosingTypeParameterTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1940GenericLocalFunctionEnclosingTypeParameterTests.cs
@@ -1,0 +1,251 @@
+// <copyright file="Issue1940GenericLocalFunctionEnclosingTypeParameterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #1940: a generic local function (<c>let Inner[T] = func (...) ... { ... }</c>, issue #1886) is
+/// hoisted to its own top-level static method carrying only ITS OWN type-parameter list as CLR MVAR
+/// slots. Referencing a type parameter owned by an enclosing generic method or class — in the local
+/// function's parameter types, return type, or body — has no corresponding slot on that hoisted method.
+/// Before this fix that silently emitted invalid IL that crashed at run time with
+/// <see cref="InvalidProgramException"/> and no compile-time diagnostic. These tests assert the new
+/// GS0468 diagnostic fires for every such reference shape and does NOT false-positive on a generic local
+/// function that only uses its own type parameters.
+/// </summary>
+public class Issue1940GenericLocalFunctionEnclosingTypeParameterTests
+{
+    [Fact]
+    public void GenericLocalFunction_ParameterReferencesEnclosingMethodTypeParameter_ReportsGS0468()
+    {
+        var source = """
+            package P
+
+            func Outer[U]() {
+                let Inner[T] = func (x T, y U) T {
+                    return x
+                }
+                Console.WriteLine(Inner(1, "hi"))
+            }
+            Outer[string]()
+            """;
+
+        var (exitCode, stdout, stderr) = CompileAndRunRaw(source, expectSuccess: false);
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("GS0468", stdout + stderr);
+    }
+
+    [Fact]
+    public void GenericLocalFunction_ReturnTypeReferencesEnclosingMethodTypeParameter_ReportsGS0468()
+    {
+        var source = """
+            package P
+
+            func Outer[U]() {
+                let Inner[T] = func (x T) U {
+                    return default
+                }
+            }
+            Outer[string]()
+            """;
+
+        var (exitCode, stdout, stderr) = CompileAndRunRaw(source, expectSuccess: false);
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("GS0468", stdout + stderr);
+    }
+
+    [Fact]
+    public void GenericLocalFunction_BodyReferencesEnclosingMethodTypeParameter_ReportsGS0468()
+    {
+        var source = """
+            package P
+
+            func Outer[U]() {
+                let Inner[T] = func (x T) T {
+                    let z U = default
+                    return x
+                }
+            }
+            Outer[string]()
+            """;
+
+        var (exitCode, stdout, stderr) = CompileAndRunRaw(source, expectSuccess: false);
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("GS0468", stdout + stderr);
+    }
+
+    [Fact]
+    public void GenericLocalFunction_ReferencesEnclosingClassTypeParameter_ReportsGS0468()
+    {
+        var source = """
+            package P
+
+            class Box[U] {
+                func Run() {
+                    let Inner[T] = func (x T, y U) T {
+                        return x
+                    }
+                }
+            }
+            """;
+
+        var (exitCode, stdout, stderr) = CompileAndRunRaw(source, expectSuccess: false);
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("GS0468", stdout + stderr);
+    }
+
+    [Fact]
+    public void GenericLocalFunction_UsesOnlyItsOwnTypeParameters_CompilesAndRunsWithoutGS0468()
+    {
+        // No enclosing generic method/class in scope — must not false-positive.
+        var source = """
+            package P
+
+            func Foo() int32 {
+                let Identity[T] = func (a T) T {
+                    return a
+                }
+                return Identity(42)
+            }
+            Console.WriteLine(Foo())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void GenericLocalFunction_NestedInGenericOuterFunctionButUsingOnlyOwnTypeParameter_CompilesAndRunsWithoutGS0468()
+    {
+        // The enclosing function IS generic, but the local function's signature and body reference
+        // only its own type parameter T, never the enclosing U — must not false-positive.
+        var source = """
+            package P
+
+            func Outer[U](seed U) U {
+                let Identity[T] = func (a T) T {
+                    return a
+                }
+                Console.WriteLine(Identity(42))
+                return seed
+            }
+            Console.WriteLine(Outer("done"))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\ndone\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var (exitCode, stdout, stderr) = CompileAndRunRaw(source, expectSuccess: true);
+        Assert.True(
+            exitCode == 0,
+            $"exited {exitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout;
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) CompileAndRunRaw(
+        string source,
+        bool expectSuccess)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_1940_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+            };
+
+            foreach (var bcl in BclReferences.Value)
+            {
+                args.Add("/r:" + bcl);
+            }
+
+            args.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            if (!expectSuccess)
+            {
+                return (compileExit, compileOut.ToString(), compileErr.ToString());
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            return (proc.ExitCode, stdout.Replace("\r\n", "\n"), stderr.Replace("\r\n", "\n"));
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static readonly Lazy<IReadOnlyList<string>> BclReferences = new(() =>
+    {
+        var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location);
+        if (string.IsNullOrEmpty(runtimeDir) || !Directory.Exists(runtimeDir))
+        {
+            return Array.Empty<string>();
+        }
+
+        return Directory.EnumerateFiles(runtimeDir, "*.dll", SearchOption.TopDirectoryOnly)
+            .Where(p =>
+            {
+                var name = Path.GetFileName(p);
+                return name.StartsWith("System.", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "mscorlib.dll", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "netstandard.dll", StringComparison.OrdinalIgnoreCase);
+            })
+            .ToList();
+    });
+}

--- a/test/Compiler.Tests/Emit/Issue1940GenericLocalFunctionEnclosingTypeParameterTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1940GenericLocalFunctionEnclosingTypeParameterTests.cs
@@ -319,6 +319,44 @@ public class Issue1940GenericLocalFunctionEnclosingTypeParameterTests
         Assert.Equal("7\n", output);
     }
 
+    [Fact]
+    public void GenericLocalFunction_ConstrainedStaticVoidCallTargetsEnclosingTypeParameter_ReportsGS0468()
+    {
+        // NB1 (review #2013): a static-virtual interface call `U.M(...)` with a
+        // VOID return has node.Type == void, so the enclosing type parameter `U`
+        // in the constrained receiver is only reachable via the call node's own
+        // TypeParameter field — otherwise silent invalid IL.
+        var source = """
+            package P
+
+            import System
+
+            sealed interface ISink {
+                shared {
+                    func Consume(x int32);
+                }
+            }
+
+            class Printer : ISink {
+                shared {
+                    func Consume(x int32) {
+                    }
+                }
+            }
+
+            func Outer[U ISink](w U) {
+                let Inner[V] = func () {
+                    U.Consume(1)
+                }
+            }
+            Outer(Printer{})
+            """;
+
+        var (exitCode, stdout, stderr) = CompileAndRunRaw(source, expectSuccess: false);
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("GS0468", stdout + stderr);
+    }
+
     private static string CompileAndRun(string source)
     {
         var (exitCode, stdout, stderr) = CompileAndRunRaw(source, expectSuccess: true);

--- a/test/Compiler.Tests/Emit/Issue1940GenericLocalFunctionEnclosingTypeParameterTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1940GenericLocalFunctionEnclosingTypeParameterTests.cs
@@ -144,6 +144,181 @@ public class Issue1940GenericLocalFunctionEnclosingTypeParameterTests
         Assert.Equal("42\ndone\n", output);
     }
 
+    [Fact]
+    public void GenericLocalFunction_IsExpressionTargetsEnclosingTypeParameter_ReportsGS0468()
+    {
+        var source = """
+            package P
+
+            func Outer[U]() {
+                let Inner[T] = func (x object) bool {
+                    return x is U
+                }
+            }
+            Outer[string]()
+            """;
+
+        var (exitCode, stdout, stderr) = CompileAndRunRaw(source, expectSuccess: false);
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("GS0468", stdout + stderr);
+    }
+
+    [Fact]
+    public void GenericLocalFunction_TypeOfTargetsEnclosingTypeParameter_ReportsGS0468()
+    {
+        var source = """
+            package P
+            import System
+
+            func Outer[U]() {
+                let Inner[T] = func () Type {
+                    return typeof(U)
+                }
+            }
+            Outer[string]()
+            """;
+
+        var (exitCode, stdout, stderr) = CompileAndRunRaw(source, expectSuccess: false);
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("GS0468", stdout + stderr);
+    }
+
+    [Fact]
+    public void GenericLocalFunction_SizeOfTargetsEnclosingTypeParameter_ReportsGS0468()
+    {
+        var source = """
+            package P
+
+            func Outer[U unmanaged](seed U) {
+                let Inner[T] = func () int32 {
+                    return sizeof(U)
+                }
+            }
+            Outer(42)
+            """;
+
+        var (exitCode, stdout, stderr) = CompileAndRunRaw(source, expectSuccess: false);
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("GS0468", stdout + stderr);
+    }
+
+    [Fact]
+    public void GenericLocalFunction_UserInstanceGenericCallTargetsEnclosingTypeParameter_ReportsGS0468()
+    {
+        var source = """
+            package P
+
+            class Box {
+                func Peek[T]() int32 {
+                    return 0
+                }
+            }
+
+            func Outer[U]() {
+                let b = Box{}
+                let Inner[T] = func () int32 {
+                    return b.Peek[U]()
+                }
+            }
+            Outer[string]()
+            """;
+
+        var (exitCode, stdout, stderr) = CompileAndRunRaw(source, expectSuccess: false);
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("GS0468", stdout + stderr);
+    }
+
+    [Fact]
+    public void GenericLocalFunction_ImportedStaticGenericCallTargetsEnclosingTypeParameter_ReportsGS0468()
+    {
+        var source = """
+            package P
+            import System.Runtime.CompilerServices
+
+            func Outer[U]() {
+                let Inner[T] = func () bool {
+                    return RuntimeHelpers.IsReferenceOrContainsReferences[U]()
+                }
+            }
+            Outer[string]()
+            """;
+
+        var (exitCode, stdout, stderr) = CompileAndRunRaw(source, expectSuccess: false);
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("GS0468", stdout + stderr);
+    }
+
+    [Fact]
+    public void NestedGenericLocalFunctions_InnermostReferencesOutermostTypeParameter_ReportsGS0468()
+    {
+        // Two levels of local-function nesting: Innermost[V] must see the outermost
+        // Outer[T]'s T as an enclosing type parameter, skipping over Middle[U]'s scope.
+        var source = """
+            package P
+
+            func Outer[T]() {
+                let Middle[U] = func () {
+                    let Innermost[V] = func (x V) T {
+                        return default
+                    }
+                }
+            }
+            Outer[string]()
+            """;
+
+        var (exitCode, stdout, stderr) = CompileAndRunRaw(source, expectSuccess: false);
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("GS0468", stdout + stderr);
+    }
+
+    [Fact]
+    public void NonGenericLocalFunction_ReferencesEnclosingMethodTypeParameter_CompilesAndRunsWithoutGS0468()
+    {
+        // N2: a NON-generic local function (no [T] of its own) referencing the
+        // enclosing method's type parameter is legal — it is hoisted with the
+        // enclosing generic's own MVAR slots reachable, not a fresh method with
+        // an unrelated type-parameter list. Must not false-positive.
+        var source = """
+            package P
+
+            func Outer[U](seed U) U {
+                let Echo = func () {
+                    var z U = seed
+                    Console.WriteLine(z)
+                }
+                Echo()
+                return seed
+            }
+            Console.WriteLine(Outer("hi"))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("hi\nhi\n", output);
+    }
+
+    [Fact]
+    public void GenericLocalFunction_ShadowingSameNameAsEnclosingTypeParameter_CompilesAndRunsWithoutGS0468()
+    {
+        // N3: `Inner[T]` nested in `Outer[T]` — the inner `T` SHADOWS the outer
+        // `T` (a distinct symbol with the same name). Referencing `T` inside
+        // `Inner` resolves to the inner function's own type parameter, not the
+        // enclosing one, and must not false-positive.
+        var source = """
+            package P
+
+            func Outer[T](seed T) T {
+                let Inner[T] = func (x T) T {
+                    return x
+                }
+                return Inner(seed)
+            }
+            Console.WriteLine(Outer(7))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("7\n", output);
+    }
+
     private static string CompileAndRun(string source)
     {
         var (exitCode, stdout, stderr) = CompileAndRunRaw(source, expectSuccess: true);


### PR DESCRIPTION
Fixes #1940

- Root cause: a generic local function (`let Inner[T] = func (...) {...}`) is hoisted at emit time to its own top-level static method carrying only its OWN type parameters as CLR MVAR slots. LambdaBinder merges enclosing method/class type parameters into scope while binding the literal, so referencing an enclosing type parameter (e.g. `U` from an enclosing `func Outer[U]`) bound silently but had no corresponding slot on the hoisted method — invalid IL, crashing at run time with `InvalidProgramException`, no diagnostic.
- Chose option B (diagnostic) over option A (correct emit): correct emit would require threading the enclosing type parameter(s) through as additional MVARs on the hoisted method plus every call site's type-argument list/inference — high-risk, broad surface for a narrow feature. A precise diagnostic turns the silent miscompile into a clear compile error per the issue's DoD.
- Added `GS0468`: after binding a generic local function, walks its parameter types, return type, and body (expression types, explicit/inferred method type arguments on calls, local declaration types, and type-pattern target types) for any reference to a type parameter owned by an enclosing generic method or class, at any nesting depth and for any number of enclosing type parameters. Does not false-positive on a generic local function that only uses its own type parameters.
- Added `test/Compiler.Tests/Emit/Issue1940GenericLocalFunctionEnclosingTypeParameterTests.cs`: parameter-type, return-type, and body reference shapes; both an enclosing method and an enclosing class; two no-false-positive cases (own-type-param-only, and nested inside a generic outer function but referencing only its own type parameter).
- Verified: full `Core.Tests` (5380 passed), `Compiler.Tests` local-function/generic filter (357 passed), new Issue1940 tests (6 passed).