### PR TITLE
cs2gs: unescape interpolated-string brace escapes for G# (#1882)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue1882InterpolatedBraceEscapeTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1882InterpolatedBraceEscapeTranslationTests.cs
@@ -1,0 +1,118 @@
+// <copyright file="Issue1882InterpolatedBraceEscapeTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #1882: C#'s <c>{{</c>/<c>}}</c> interpolated-string brace escapes
+/// were copied verbatim into the G# output instead of being unescaped.
+/// Roslyn's <c>InterpolatedStringTextSyntax.TextToken.ValueText</c> does NOT
+/// unescape brace doubling (only C-style escapes like <c>\n</c> go through
+/// <c>ValueText</c>; brace doubling is an interpolated-string-grammar concept,
+/// not a token escape). G# has no bare <c>{expr}</c> hole syntax at all
+/// (only <c>${expr}</c>/<c>$ident</c>, see src/Core/CodeAnalysis/Syntax/Lexer.cs),
+/// so <c>{</c>/<c>}</c> are always plain literal characters in G# — in both
+/// interpolated and non-interpolated strings — and need no escaping.
+/// </summary>
+public class Issue1882InterpolatedBraceEscapeTranslationTests
+{
+    [Fact]
+    public void InterpolatedString_DoubledBraces_UnescapeToSingleLiteralBraces()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1882
+{
+    public class Holder
+    {
+        public string Describe()
+        {
+            return $""braces={{x}} dollar=$9.99"";
+        }
+    }
+}
+");
+
+        Assert.Contains("\"braces={x} dollar=$$9.99\"", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("{{", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("}}", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void InterpolatedString_DoubledBracesAroundRealHole_KeepsHoleAndUnescapesBraces()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1882
+{
+    public class Holder
+    {
+        public string Describe(int x)
+        {
+            return $""braces={{{x}}} hole={x}"";
+        }
+    }
+}
+");
+
+        // literal '{' + hole(x) + literal '}' + literal " hole=" + hole(x).
+        Assert.Contains("{$x} hole=$x", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void PlainStringLiteral_BracesNeedNoEscaping()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1882
+{
+    public class Holder
+    {
+        public string Describe()
+        {
+            return ""plain braces: {x} and {{y}}"";
+        }
+    }
+}
+");
+
+        // A non-interpolated C# string literal has no brace-escape grammar at
+        // all: `{{` is just two literal braces already, unaffected by this fix.
+        Assert.Contains("\"plain braces: {x} and {{y}}\"", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    private static void AssertRoundTripParses(string rendered)
+    {
+        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+
+        Assert.True(
+            result.Success,
+            "Sanitized G# must round-trip-parse. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + rendered);
+    }
+
+    private static string Render(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", source) });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        Cs2Gs.CodeModel.Ast.CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        Assert.Empty(context.Diagnostics);
+        return GSharpPrinter.Print(unit);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -12778,7 +12778,16 @@ public sealed class CSharpToGSharpTranslator
                 switch (content)
                 {
                     case InterpolatedStringTextSyntax text:
-                        parts.Add(InterpolationPart.Literal(text.TextToken.ValueText));
+                        // Issue #1882: Roslyn's ValueText does NOT unescape `{{`/`}}`
+                        // (those are interpolation-hole delimiters, not string escapes).
+                        // G# has no bare `{expr}` hole syntax (only `${expr}`/`$ident`,
+                        // see Lexer.cs), so `{`/`}` are always plain literal chars in G#
+                        // and need no escaping at all. Unescape here or the doubled
+                        // braces get copied verbatim into the G# output.
+                        string unescapedBraces = text.TextToken.ValueText
+                            .Replace("{{", "{")
+                            .Replace("}}", "}");
+                        parts.Add(InterpolationPart.Literal(unescapedBraces));
                         break;
 
                     case InterpolationSyntax hole:

--- a/tools/cs2gs/corpus/grid/G14-Strings-Console/Constructs/InterpolatedStringText.cs
+++ b/tools/cs2gs/corpus/grid/G14-Strings-Console/Constructs/InterpolatedStringText.cs
@@ -10,6 +10,15 @@ namespace Corpus.Grid14
             int x = 5;
             Console.WriteLine($"InterpolatedStringText: value={x} dollar=$9.99");
             Console.WriteLine($"InterpolatedStringText: left-{x}-middle-{x + 1}-right");
+
+            // Issue #1882: literal brace escapes (`{{`/`}}`) alongside a real
+            // hole and a literal `$`, in a non-verbatim interpolated string.
+            Console.WriteLine($"braces={{x}} dollar=$9.99");
+            Console.WriteLine($"braces={{{x}}} hole={x}");
+
+            // Literal braces in a plain (non-interpolated) string need no
+            // escaping at all in C# or G#.
+            Console.WriteLine("plain braces: {x} and {{y}}");
         }
     }
 }

--- a/tools/cs2gs/corpus/grid/G14-Strings-Console/baseline.stdout.golden
+++ b/tools/cs2gs/corpus/grid/G14-Strings-Console/baseline.stdout.golden
@@ -8,6 +8,9 @@ InterpolatedStringExpression: verbatim=C:\data\Ada
 InterpolatedStringExpression: raw="Ada" quoted
 InterpolatedStringText: value=5 dollar=$9.99
 InterpolatedStringText: left-5-middle-6-right
+braces={x} dollar=$9.99
+braces={5} hole=5
+plain braces: {x} and {{y}}
 Interpolation: sum=13 product=42
 Interpolation: call=IN cond=less
 Interpolation: nested=outer[inner(in)]


### PR DESCRIPTION
Fixes #1882

- Roslyn's InterpolatedStringTextSyntax.TextToken.ValueText does not unescape `{{`/`}}` brace-doubling (only C-style escapes go through ValueText), so cs2gs copied the escaped text verbatim into G# output: `$"braces={{x}}"` became G# `"braces={{x}}"` instead of `"braces={x}"`.
- G# has no bare `{expr}` interpolation-hole syntax at all (only `${expr}`/`$ident`), so `{`/`}` are always plain literal chars in G#, interpolated or not — no escaping needed in either context.
- Fix: unescape `{{` -> `{` and `}}` -> `}` from ValueText before building the literal interpolation part; real holes unaffected.
- Extended G14-Strings-Console's InterpolatedStringText construct with brace-escape cases (doubled braces alone, doubled braces around a real hole, plain non-interpolated string) and regenerated baseline.stdout.golden from the C# oracle.
- Added Issue1882InterpolatedBraceEscapeTranslationTests.cs.
- Full `Cs2Gs.Tests` suite: 941/941 passed. `migrate --app G14-Strings-Console`: 1/1 apps green, stdout parity PASSED.