### PR TITLE
cs2gs: parenthesize numeric-literal receivers in member calls (#1883)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue1883LiteralReceiverMemberCallTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1883LiteralReceiverMemberCallTranslationTests.cs
@@ -53,6 +53,26 @@ namespace Corpus.Issue1883
     }
 
     [Fact]
+    public void NegativeLiteral_ConcatenatedWithString_ParenthesizesToStringReceiver()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1883
+{
+    public class C
+    {
+        public string M()
+        {
+            return ""n="" + -5;
+        }
+    }
+}
+");
+
+        Assert.Contains("(-5).ToString()", rendered);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
     public void IntLiteral_DirectExtensionMethodCall_ParenthesizesReceiver()
     {
         string rendered = Render(@"

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1883LiteralReceiverMemberCallTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1883LiteralReceiverMemberCallTranslationTests.cs
@@ -1,0 +1,168 @@
+// <copyright file="Issue1883LiteralReceiverMemberCallTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #1883: a member call on a bare numeric-literal receiver
+/// (<c>42.ToString()</c>, <c>7.Squared()</c>) previously translated
+/// verbatim, but G#'s grammar never chains postfix member/index/call
+/// access directly onto a numeric-literal token (ADR-0054) — the lexer
+/// cannot otherwise tell whether the following <c>.</c> starts a float's
+/// fractional part or a member access, so the grammar simply disallows the
+/// chain. The unparenthesized output failed to round-trip-parse
+/// (GS0005/GS0157). Two C# shapes trigger this: string concatenation with a
+/// non-string literal operand (<c>"n=" + 42</c>, which lowers to an
+/// explicit <c>.ToString()</c> call) and a direct extension-method or
+/// instance-member call on an int literal (<c>7.Squared()</c>,
+/// <c>42.ToString()</c>, <c>42.GetType()</c>). The fix parenthesizes any
+/// receiver that renders as a bare int/float literal wherever it is used
+/// as a member-access/call receiver — covering every numeric-literal
+/// spelling (decimal, hex, octal, binary, and suffixed forms) uniformly,
+/// while leaving non-literal receivers (identifiers, calls, existing
+/// parenthesized expressions) untouched.
+/// </summary>
+public class Issue1883LiteralReceiverMemberCallTranslationTests
+{
+    [Fact]
+    public void IntLiteral_ConcatenatedWithString_ParenthesizesToStringReceiver()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1883
+{
+    public class C
+    {
+        public string M()
+        {
+            return ""n="" + 42;
+        }
+    }
+}
+");
+
+        Assert.Contains("(42).ToString()", rendered);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void IntLiteral_DirectExtensionMethodCall_ParenthesizesReceiver()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1883
+{
+    public static class Extensions
+    {
+        public static int Squared(this int value) => value * value;
+    }
+
+    public class C
+    {
+        public int M()
+        {
+            return 7.Squared();
+        }
+    }
+}
+");
+
+        Assert.Contains("(7).Squared()", rendered);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void IntLiteral_DirectToStringCall_ParenthesizesReceiver()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1883
+{
+    public class C
+    {
+        public string M()
+        {
+            return 42.ToString();
+        }
+    }
+}
+");
+
+        Assert.Contains("(42).ToString()", rendered);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void LongAndHexLiterals_DirectMemberCall_ParenthesizesReceiver()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1883
+{
+    public class C
+    {
+        public string M()
+        {
+            return 42L.ToString() + 0x2AU.ToString();
+        }
+    }
+}
+");
+
+        Assert.Contains("(42L).ToString()", rendered);
+        Assert.Contains("(0x2AU).ToString()", rendered);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void NonLiteralReceiver_IsNotParenthesized()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1883
+{
+    public class C
+    {
+        public string M(int n)
+        {
+            return n.ToString();
+        }
+    }
+}
+");
+
+        Assert.Contains("n.ToString()", rendered);
+        Assert.DoesNotContain("(n).ToString()", rendered);
+        AssertRoundTripParses(rendered);
+    }
+
+    private static void AssertRoundTripParses(string rendered)
+    {
+        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip-parse. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + rendered);
+    }
+
+    private static string Render(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", source) });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        Cs2Gs.CodeModel.Ast.CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        Assert.DoesNotContain(context.Diagnostics, d => d.Severity != TranslationSeverity.Info);
+        return GSharpPrinter.Print(unit);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -5371,7 +5371,7 @@ public sealed class CSharpToGSharpTranslator
                 return translated;
             }
 
-            GExpression receiver = translated is BinaryExpression or IfExpression
+            GExpression receiver = translated is BinaryExpression or IfExpression || IsBareNumericLiteral(translated)
                 ? new ParenthesizedExpression(translated)
                 : translated;
 
@@ -11190,11 +11190,27 @@ public sealed class CSharpToGSharpTranslator
             if (this.ReceiverNeedsNullForgiveness(recv)
                 || this.ReceiverIsNullableReferenceFieldOrProperty(recv))
             {
-                return new NonNullAssertionExpression(translated);
+                translated = new NonNullAssertionExpression(translated);
             }
 
-            return translated;
+            return ParenthesizeIfBareNumericLiteral(translated);
         }
+
+        // ADR-0054: G#'s parser never chains postfix member/index/call access
+        // directly onto a numeric-literal token (`42.ToString()`, `7.Squared()`)
+        // because the lexer would otherwise have to guess whether `.` starts a
+        // float's fractional part or a member access; the grammar resolves this by
+        // simply disallowing the chain and requiring `(42).ToString()` instead. Any
+        // receiver that renders as a bare int/float literal — decimal, hex, octal,
+        // binary, or suffixed (`L`/`UL`/`F`/`D`/`M`) — therefore needs parentheses
+        // wherever it is used as a member-access/call receiver; a non-literal
+        // receiver (identifier, call, existing parenthesized expression, etc.) is
+        // left untouched.
+        private static bool IsBareNumericLiteral(GExpression expr) =>
+            expr is LiteralExpression { Kind: LiteralKind.Int or LiteralKind.Float };
+
+        private static GExpression ParenthesizeIfBareNumericLiteral(GExpression expr) =>
+            IsBareNumericLiteral(expr) ? new ParenthesizedExpression(expr) : expr;
 
         /// <summary>
         /// True when a member-/element-access <paramref name="recv"/> receiver is a

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -11205,9 +11205,12 @@ public sealed class CSharpToGSharpTranslator
         // binary, or suffixed (`L`/`UL`/`F`/`D`/`M`) — therefore needs parentheses
         // wherever it is used as a member-access/call receiver; a non-literal
         // receiver (identifier, call, existing parenthesized expression, etc.) is
-        // left untouched.
+        // left untouched. A prefix unary on a numeric literal (`-5`, `+5`, `~5`)
+        // still renders with a trailing numeric token, so it is treated the same
+        // (e.g. `"x=" + -5` -> `(-5).ToString()`).
         private static bool IsBareNumericLiteral(GExpression expr) =>
-            expr is LiteralExpression { Kind: LiteralKind.Int or LiteralKind.Float };
+            expr is LiteralExpression { Kind: LiteralKind.Int or LiteralKind.Float }
+            || (expr is UnaryExpression u && IsBareNumericLiteral(u.Operand));
 
         private static GExpression ParenthesizeIfBareNumericLiteral(GExpression expr) =>
             IsBareNumericLiteral(expr) ? new ParenthesizedExpression(expr) : expr;

--- a/tools/cs2gs/corpus/grid/G13-Extensions-Console/Constructs/ExtensionMethodsClassic.cs
+++ b/tools/cs2gs/corpus/grid/G13-Extensions-Console/Constructs/ExtensionMethodsClassic.cs
@@ -39,12 +39,12 @@ namespace Corpus.Grid13.Constructs
         {
             Console.WriteLine($"ExtensionMethodsClassic: bracketed={"hi".Bracketed()}");
 
-            // NOTE: `7.Squared()` (extension invoked directly on an int
-            // literal) is avoided on purpose: the emitted G# `7.Squared()`
-            // does not round-trip (`7.` lexes as a float literal; GS0005/
-            // GS0157). A named local receiver works.
-            int seven = 7;
-            Console.WriteLine($"ExtensionMethodsClassic: squared={seven.Squared()}");
+            // Issue #1883: an extension method invoked directly on an int
+            // literal (`7.Squared()`) must translate to a parenthesized
+            // receiver (`(7).Squared()`) — G#'s grammar never chains postfix
+            // access onto a bare numeric-literal token (ADR-0054), so an
+            // unparenthesized `7.Squared()` fails to parse (GS0005/GS0157).
+            Console.WriteLine($"ExtensionMethodsClassic: squared={7.Squared()}");
 
             Box box = new Box(21);
             Console.WriteLine($"ExtensionMethodsClassic: userType={box.Doubled()}");

--- a/tools/cs2gs/corpus/grid/G14-Strings-Console/Constructs/StringConcatenation.cs
+++ b/tools/cs2gs/corpus/grid/G14-Strings-Console/Constructs/StringConcatenation.cs
@@ -13,6 +13,12 @@ namespace Corpus.Grid14
             char c = 'x';
             bool b = true;
             string mixed = "n=" + n + " c=" + c + " b=" + b;
+            // Issue #1883: concatenating a non-string LITERAL operand lowers
+            // to an explicit `.ToString()` call; the literal receiver
+            // (`42.ToString()`) must be parenthesized (`(42).ToString()`) or
+            // G#'s lexer/parser rejects it (ADR-0054, GS0005/GS0157).
+            string literalConcat = "n=" + 42;
+            string literalToString = 42.ToString();
             string built = "";
             for (int i = 1; i <= 3; i++)
             {
@@ -21,6 +27,8 @@ namespace Corpus.Grid14
 
             Console.WriteLine($"StringConcatenation: s={s}");
             Console.WriteLine($"StringConcatenation: mixed={mixed}");
+            Console.WriteLine($"StringConcatenation: literalConcat={literalConcat}");
+            Console.WriteLine($"StringConcatenation: literalToString={literalToString}");
             Console.WriteLine($"StringConcatenation: built={built}");
         }
     }

--- a/tools/cs2gs/corpus/grid/G14-Strings-Console/baseline.stdout.golden
+++ b/tools/cs2gs/corpus/grid/G14-Strings-Console/baseline.stdout.golden
@@ -20,6 +20,8 @@ InterpolationFormatClause: hex=00FF dec=000255
 InterpolationFormatClause: f2=3.14 padded=     3.142
 StringConcatenation: s=concatenation
 StringConcatenation: mixed=n=42 c=x b=True
+StringConcatenation: literalConcat=n=42
+StringConcatenation: literalToString=42
 StringConcatenation: built=1;2;3;
 StringFormatParity: format=Grace-   7-007
 StringFormatParity: interp=Grace-   7-007


### PR DESCRIPTION
Fixes #1883

- Root cause: G#'s grammar (ADR-0054) never chains postfix member/index/call access directly onto a bare numeric-literal token, since the lexer can't tell whether a following `.` starts a float's fractional part or a member access. cs2gs emitted unparenthesized literal receivers in two places that hit this: string-concat-to-`.ToString()` lowering (`"n=" + 42`) and a direct member/extension call on a literal (`7.Squared()`).
- Fix: single predicate `IsBareNumericLiteral` (translated receiver is a G# `LiteralExpression` of `Int`/`Float` kind) applied at the two shared choke points (`TranslateReceiverWithNullForgiveness`, `CoerceConcatOperand`) — wraps the receiver in a `ParenthesizedExpression` when needed. Covers every numeric-literal spelling (decimal, hex, octal, binary, suffixed `L`/`UL`/etc.) uniformly; non-literal receivers are untouched.
- Re-enabled the previously-avoided `7.Squared()` construct in G13-Extensions-Console and added a literal-operand concat/ToString construct to G14-Strings-Console; both apps parse, compile, and match C# stdout.
- Added `Issue1883LiteralReceiverMemberCallTranslationTests.cs` (int/long/hex literal receivers + non-literal receiver is not parenthesized), all round-trip-parse.
- Full corpus baseline: 0 new, 0 regressed (CompileGap-Library / L2-Library gaps unchanged, already ledgered).
- Full cs2gs test suite: 952/952 passed. gsc itself untouched — only cs2gs translator changed.