### PR TITLE
Add checked/unchecked support to gsc and cs2gs (#1881)

### DIFF
--- a/docs/coverage-matrix.md
+++ b/docs/coverage-matrix.md
@@ -40,6 +40,7 @@ ChanKeyword
 ChannelReceiveExpression
 ChannelSendStatement
 CharacterToken
+CheckedExpression
 ClassKeyword
 CloseBraceToken
 CloseParenthesisToken
@@ -251,6 +252,7 @@ TypeParameter
 TypeParameterList
 TypePattern
 UnaryExpression
+UncheckedExpression
 UnsignedShiftRightEqualsToken
 UnsignedShiftRightToken
 UsingKeyword

--- a/docs/cs2gs-coverage-matrix.md
+++ b/docs/cs2gs-coverage-matrix.md
@@ -6,12 +6,12 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | Status | Count |
 | --- | --- |
 | Unclassified | 0 |
-| Translated | 228 |
+| Translated | 229 |
 | Lowered | 17 |
 | UnsupportedByDesign | 56 |
-| Gap | 20 |
+| Gap | 19 |
 
-## Translated (228)
+## Translated (229)
 
 | Kind | Node type | Rule | Rationale | Fixture | Issue | Notes |
 | --- | --- | --- | --- | --- | --- | --- |
@@ -56,9 +56,10 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | CatchDeclaration | CatchDeclarationSyntax | ADR-0115 §B.27 |  |  |  |  |
 | CatchFilterClause | CatchFilterClauseSyntax | ADR-0115 §B.27 |  | tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/CatchFilterClause.cs |  | A when-filter with an overlapping later sibling catch has no faithful lowering (issue #1724 area). |
 | CharacterLiteralExpression | LiteralExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G01-Literals-Console/Constructs/CharacterLiteralExpression.cs |  |  |
-| CheckedStatement | CheckedStatementSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/CheckedStatement.cs | https://github.com/DavidObando/gsharp/issues/1881 | Overflow semantics silently erased — emitted as a plain block (issue #1881, parity-verified divergence); non-overflow subset green. |
+| CheckedExpression | CheckedExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/CheckedExpression.cs | https://github.com/DavidObando/gsharp/issues/1881 |  |
+| CheckedStatement | CheckedStatementSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/CheckedStatement.cs | https://github.com/DavidObando/gsharp/issues/1881 | gsc gained native checked/unchecked expression + block support (issue #1881); overflow semantics preserved, including the overflow-in-try/catch(OverflowException) sub-case. Stdout parity verified (grid G03). |
 | ClassConstraint | ClassOrStructConstraintSyntax | ADR-0115 §B.7 |  | tools/cs2gs/corpus/grid/G08-Generics-Console/Constructs/ClassConstraint.cs |  |  |
-| ClassDeclaration | ClassDeclarationSyntax | ADR-0115 §B.4 |  | tools/cs2gs/corpus/grid/G06-Types-Console/Constructs/ClassDeclaration.cs |  | C#12 primary ctors now map to native G# primary constructors (issue #1909, resolved); partial parts across multiple declarations/files now merge into one G# type declaration (issue #1910, resolved). |
+| ClassDeclaration | ClassDeclarationSyntax | ADR-0115 §B.4 |  | tools/cs2gs/corpus/grid/G06-Types-Console/Constructs/ClassDeclaration.cs |  | C#12 primary ctors dropped (issue #1909); partial parts across multiple declarations/files now merge into one G# type declaration (issue #1910, resolved). |
 | CoalesceAssignmentExpression | AssignmentExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/CoalesceAssignmentExpression.cs |  | Nullable value-type targets now emit verifiable IL (issue #1916, resolved); reference and value-type forms are both green. |
 | CoalesceExpression | BinaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/CoalesceExpression.cs |  | Binary ?? (issue #941, resolved). |
 | CollectionExpression | CollectionExpressionSyntax | ADR-0115 §B.36 |  | tools/cs2gs/corpus/grid/G05-Collections-Console/Constructs/CollectionExpression.cs | https://github.com/DavidObando/gsharp/issues/1897 | Array targets green; List<T> targets fail conversion; spread unsupported (issues #1897). |
@@ -103,7 +104,6 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | ExtensionBlockDeclaration | ExtensionBlockDeclarationSyntax | ADR-0115 §B.19 |  | tools/cs2gs/corpus/grid/G13-Extensions-Console/Constructs/ExtensionBlockDeclaration.cs | https://github.com/DavidObando/gsharp/issues/1879 | C# 14 `extension(T x)`/`extension(T)` block members map onto the same target as a classic this-param extension method (ADR-0115 §B.19): an instance method/property lowers to a receiver-clause func (a property becomes a get-only func, since G#'s prop grammar has no receiver clause, with call sites rewritten to a zero-arg call); a static member becomes a plain shared member of the declaring class, with call sites rewritten from the extended type's name to the real owner. An enum receiver and a settable instance extension property are each reported as an explicit gap (grid G13). |
 | FalseLiteralExpression | LiteralExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G01-Literals-Console/Constructs/FalseLiteralExpression.cs |  |  |
 | FieldDeclaration | FieldDeclarationSyntax | ADR-0115 §B.3 |  | tools/cs2gs/corpus/grid/G07-Members-Console/Constructs/FieldDeclaration.cs |  |  |
-| FieldExpression | FieldExpressionSyntax | ADR-0051 §2 |  | tools/cs2gs/corpus/grid/G07-Members-Console/Constructs/FieldExpression.cs |  |  |
 | FileScopedNamespaceDeclaration | FileScopedNamespaceDeclarationSyntax | ADR-0115 §B.1 |  |  |  |  |
 | FinallyClause | FinallyClauseSyntax | ADR-0115 §B.27 |  |  |  |  |
 | FixedStatement | FixedStatementSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G12-Unsafe-Console/Constructs/FixedStatement.cs | https://github.com/DavidObando/gsharp/issues/1933 | Compiles end-to-end under the ilverify allow-unsafe policy (issue #1933); IL is unverifiable by design, not a gsc defect. |
@@ -176,7 +176,6 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | PreDecrementExpression | PrefixUnaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/PreDecrementExpression.cs |  |  |
 | PreIncrementExpression | PrefixUnaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/PreIncrementExpression.cs |  |  |
 | PredefinedType | PredefinedTypeSyntax | ADR-0115 §B.12 |  |  |  |  |
-| PrimaryConstructorBaseType | PrimaryConstructorBaseTypeSyntax | ADR-0065 §5 |  | tools/cs2gs/corpus/grid/G06-Types-Console/Constructs/PrimaryConstructorBaseType.cs |  | A derived primary-ctor class's `: Base(arg)` forwarding call now maps to the G# base-call form `class Derived(...) : Base(args) { ... }` (issue #1909, resolved). |
 | PropertyDeclaration | PropertyDeclarationSyntax | ADR-0115 §B.11 |  | tools/cs2gs/corpus/grid/G07-Members-Console/Constructs/PropertyDeclaration.cs |  |  |
 | PropertyPatternClause | PropertyPatternClauseSyntax | ADR-0115 §B.22 |  | tools/cs2gs/corpus/grid/G04-Patterns-Console/Constructs/RecursivePattern.cs |  | Property sub-patterns; designator collisions fixed in issue #1839. |
 | QualifiedName | QualifiedNameSyntax | ADR-0115 §B.12 |  |  |  |  |
@@ -228,7 +227,8 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | TypePattern | TypePatternSyntax | ADR-0115 §B.22 |  | tools/cs2gs/corpus/grid/G04-Patterns-Console/Constructs/TypePattern.cs |  | Bare-type switch-arm (`int =>`, no binder — issue #1890, resolved): lowers to G#'s own discard-designator type pattern `_ is T` (`PatternBinder.BindTypePattern`'s `isDiscard` check), since gsc's own `TypePattern` grammar always requires a designator token before `is` but treats `_` as a non-binding discard there. Roslyn parses a bare user-type name (e.g. `Widget =>`) as a `ConstantPatternSyntax` over an identifier rather than `TypePatternSyntax`; the switch-arm path now shares the boolean-test path's `IsTypeReferencePattern` type-vs-constant disambiguation to still route it to `_ is T`. |
 | UnaryMinusExpression | PrefixUnaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/UnaryMinusExpression.cs |  |  |
 | UnaryPlusExpression | PrefixUnaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/UnaryPlusExpression.cs |  |  |
-| UncheckedStatement | CheckedStatementSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/UncheckedStatement.cs |  | Wrap-around parity verified (grid G03). |
+| UncheckedExpression | CheckedExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/UncheckedExpression.cs | https://github.com/DavidObando/gsharp/issues/1881 |  |
+| UncheckedStatement | CheckedStatementSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/UncheckedStatement.cs | https://github.com/DavidObando/gsharp/issues/1881 | Wrap-around parity verified (grid G03). |
 | UnsafeStatement | UnsafeStatementSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G12-Unsafe-Console/Constructs/UnsafeStatement.cs |  |  |
 | UnsignedRightShiftAssignmentExpression | AssignmentExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/UnsignedRightShiftAssignmentExpression.cs |  |  |
 | UnsignedRightShiftExpression | BinaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/UnsignedRightShiftExpression.cs |  |  |
@@ -328,11 +328,11 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | XmlText | XmlTextSyntax |  | ToolingScope |  |  | Documentation/tooling structure, not program semantics; doc-comment mapping is ADR-0057 scope. |
 | XmlTextAttribute | XmlTextAttributeSyntax |  | ToolingScope |  |  | Documentation/tooling structure, not program semantics; doc-comment mapping is ADR-0057 scope. |
 
-## Gap (20)
+## Gap (19)
 
 | Kind | Node type | Rule | Rationale | Fixture | Issue | Notes |
 | --- | --- | --- | --- | --- | --- | --- |
-| CheckedExpression | CheckedExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1881 |  |
+| FieldExpression | FieldExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1907 | C# 14 field keyword. |
 | FunctionPointerCallingConvention | FunctionPointerCallingConventionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1906 |  |
 | FunctionPointerParameter | FunctionPointerParameterSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1906 |  |
 | FunctionPointerParameterList | FunctionPointerParameterListSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1906 |  |
@@ -346,8 +346,8 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | ImplicitStackAllocArrayCreationExpression | ImplicitStackAllocArrayCreationExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1897 | ADR-0124 stackalloc surface. |
 | LabeledStatement | LabeledStatementSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1884 |  |
 | PointerMemberAccessExpression | MemberAccessExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1905 | p->X lowered to p.X; (*p).X compiles. |
+| PrimaryConstructorBaseType | PrimaryConstructorBaseTypeSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1909 |  |
 | RangeExpression | RangeExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1896 | Lowers to .Slice(...) which gsc cannot resolve on arrays/strings. |
 | RefExpression | RefExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1900 | ref argument/return seam (&x pass-by-address). |
 | RefType | RefTypeSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1900 |  |
 | SpreadElement | SpreadElementSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1897 |  |
-| UncheckedExpression | CheckedExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1881 |  |

--- a/docs/cs2gs-coverage-matrix.md
+++ b/docs/cs2gs-coverage-matrix.md
@@ -6,12 +6,12 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | Status | Count |
 | --- | --- |
 | Unclassified | 0 |
-| Translated | 229 |
+| Translated | 231 |
 | Lowered | 17 |
 | UnsupportedByDesign | 56 |
-| Gap | 19 |
+| Gap | 17 |
 
-## Translated (229)
+## Translated (231)
 
 | Kind | Node type | Rule | Rationale | Fixture | Issue | Notes |
 | --- | --- | --- | --- | --- | --- | --- |
@@ -59,7 +59,7 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | CheckedExpression | CheckedExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/CheckedExpression.cs | https://github.com/DavidObando/gsharp/issues/1881 |  |
 | CheckedStatement | CheckedStatementSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/CheckedStatement.cs | https://github.com/DavidObando/gsharp/issues/1881 | gsc gained native checked/unchecked expression + block support (issue #1881); overflow semantics preserved, including the overflow-in-try/catch(OverflowException) sub-case. Stdout parity verified (grid G03). |
 | ClassConstraint | ClassOrStructConstraintSyntax | ADR-0115 §B.7 |  | tools/cs2gs/corpus/grid/G08-Generics-Console/Constructs/ClassConstraint.cs |  |  |
-| ClassDeclaration | ClassDeclarationSyntax | ADR-0115 §B.4 |  | tools/cs2gs/corpus/grid/G06-Types-Console/Constructs/ClassDeclaration.cs |  | C#12 primary ctors dropped (issue #1909); partial parts across multiple declarations/files now merge into one G# type declaration (issue #1910, resolved). |
+| ClassDeclaration | ClassDeclarationSyntax | ADR-0115 §B.4 |  | tools/cs2gs/corpus/grid/G06-Types-Console/Constructs/ClassDeclaration.cs |  | C#12 primary ctors now map to native G# primary constructors (issue #1909, resolved); partial parts across multiple declarations/files now merge into one G# type declaration (issue #1910, resolved). |
 | CoalesceAssignmentExpression | AssignmentExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/CoalesceAssignmentExpression.cs |  | Nullable value-type targets now emit verifiable IL (issue #1916, resolved); reference and value-type forms are both green. |
 | CoalesceExpression | BinaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/CoalesceExpression.cs |  | Binary ?? (issue #941, resolved). |
 | CollectionExpression | CollectionExpressionSyntax | ADR-0115 §B.36 |  | tools/cs2gs/corpus/grid/G05-Collections-Console/Constructs/CollectionExpression.cs | https://github.com/DavidObando/gsharp/issues/1897 | Array targets green; List<T> targets fail conversion; spread unsupported (issues #1897). |
@@ -104,6 +104,7 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | ExtensionBlockDeclaration | ExtensionBlockDeclarationSyntax | ADR-0115 §B.19 |  | tools/cs2gs/corpus/grid/G13-Extensions-Console/Constructs/ExtensionBlockDeclaration.cs | https://github.com/DavidObando/gsharp/issues/1879 | C# 14 `extension(T x)`/`extension(T)` block members map onto the same target as a classic this-param extension method (ADR-0115 §B.19): an instance method/property lowers to a receiver-clause func (a property becomes a get-only func, since G#'s prop grammar has no receiver clause, with call sites rewritten to a zero-arg call); a static member becomes a plain shared member of the declaring class, with call sites rewritten from the extended type's name to the real owner. An enum receiver and a settable instance extension property are each reported as an explicit gap (grid G13). |
 | FalseLiteralExpression | LiteralExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G01-Literals-Console/Constructs/FalseLiteralExpression.cs |  |  |
 | FieldDeclaration | FieldDeclarationSyntax | ADR-0115 §B.3 |  | tools/cs2gs/corpus/grid/G07-Members-Console/Constructs/FieldDeclaration.cs |  |  |
+| FieldExpression | FieldExpressionSyntax | ADR-0051 §2 |  | tools/cs2gs/corpus/grid/G07-Members-Console/Constructs/FieldExpression.cs |  |  |
 | FileScopedNamespaceDeclaration | FileScopedNamespaceDeclarationSyntax | ADR-0115 §B.1 |  |  |  |  |
 | FinallyClause | FinallyClauseSyntax | ADR-0115 §B.27 |  |  |  |  |
 | FixedStatement | FixedStatementSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G12-Unsafe-Console/Constructs/FixedStatement.cs | https://github.com/DavidObando/gsharp/issues/1933 | Compiles end-to-end under the ilverify allow-unsafe policy (issue #1933); IL is unverifiable by design, not a gsc defect. |
@@ -176,6 +177,7 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | PreDecrementExpression | PrefixUnaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/PreDecrementExpression.cs |  |  |
 | PreIncrementExpression | PrefixUnaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/PreIncrementExpression.cs |  |  |
 | PredefinedType | PredefinedTypeSyntax | ADR-0115 §B.12 |  |  |  |  |
+| PrimaryConstructorBaseType | PrimaryConstructorBaseTypeSyntax | ADR-0065 §5 |  | tools/cs2gs/corpus/grid/G06-Types-Console/Constructs/PrimaryConstructorBaseType.cs |  | A derived primary-ctor class's `: Base(arg)` forwarding call now maps to the G# base-call form `class Derived(...) : Base(args) { ... }` (issue #1909, resolved). |
 | PropertyDeclaration | PropertyDeclarationSyntax | ADR-0115 §B.11 |  | tools/cs2gs/corpus/grid/G07-Members-Console/Constructs/PropertyDeclaration.cs |  |  |
 | PropertyPatternClause | PropertyPatternClauseSyntax | ADR-0115 §B.22 |  | tools/cs2gs/corpus/grid/G04-Patterns-Console/Constructs/RecursivePattern.cs |  | Property sub-patterns; designator collisions fixed in issue #1839. |
 | QualifiedName | QualifiedNameSyntax | ADR-0115 §B.12 |  |  |  |  |
@@ -328,11 +330,10 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | XmlText | XmlTextSyntax |  | ToolingScope |  |  | Documentation/tooling structure, not program semantics; doc-comment mapping is ADR-0057 scope. |
 | XmlTextAttribute | XmlTextAttributeSyntax |  | ToolingScope |  |  | Documentation/tooling structure, not program semantics; doc-comment mapping is ADR-0057 scope. |
 
-## Gap (19)
+## Gap (17)
 
 | Kind | Node type | Rule | Rationale | Fixture | Issue | Notes |
 | --- | --- | --- | --- | --- | --- | --- |
-| FieldExpression | FieldExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1907 | C# 14 field keyword. |
 | FunctionPointerCallingConvention | FunctionPointerCallingConventionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1906 |  |
 | FunctionPointerParameter | FunctionPointerParameterSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1906 |  |
 | FunctionPointerParameterList | FunctionPointerParameterListSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1906 |  |
@@ -346,7 +347,6 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | ImplicitStackAllocArrayCreationExpression | ImplicitStackAllocArrayCreationExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1897 | ADR-0124 stackalloc surface. |
 | LabeledStatement | LabeledStatementSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1884 |  |
 | PointerMemberAccessExpression | MemberAccessExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1905 | p->X lowered to p.X; (*p).X compiles. |
-| PrimaryConstructorBaseType | PrimaryConstructorBaseTypeSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1909 |  |
 | RangeExpression | RangeExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1896 | Lowers to .Slice(...) which gsc cannot resolve on arrays/strings. |
 | RefExpression | RefExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1900 | ref argument/return seam (&x pass-by-address). |
 | RefType | RefTypeSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1900 |  |

--- a/src/Core/CodeAnalysis/Binding/BinderContext.cs
+++ b/src/Core/CodeAnalysis/Binding/BinderContext.cs
@@ -149,6 +149,19 @@ internal sealed class BinderContext
     public bool InUnsafeContext => UnsafeDepth > 0;
 
     /// <summary>
+    /// Gets a value indicating whether the current <c>checked</c>/<c>unchecked</c>
+    /// arithmetic context is checked (issue #1881): <see langword="true"/> inside
+    /// a `checked(...)` expression or a `checked { }` statement,
+    /// <see langword="false"/> inside `unchecked(...)`/`unchecked { }` or when no
+    /// such context has been entered (the C# project default is unchecked).
+    /// Innermost context wins — <see cref="PushCheckedContext"/> saves and
+    /// restores the previous value, so nesting `checked { unchecked { … } }`
+    /// resolves correctly. Only observed by the Sum/Difference/Product binary
+    /// operator and by narrowing numeric conversions.
+    /// </summary>
+    public bool IsCheckedContext { get; private set; }
+
+    /// <summary>
     /// Gets or sets the scope the binder currently operates against. Starts
     /// at the binder's root scope; mutated during nested-scope push/pop by
     /// statement, expression, and lambda binding helpers — so a writable
@@ -457,6 +470,20 @@ internal sealed class BinderContext
     }
 
     /// <summary>
+    /// Issue #1881. Enters a `checked`/`unchecked` arithmetic context for the
+    /// lifetime of the returned token; disposing the token restores the
+    /// previous context (innermost nesting wins).
+    /// </summary>
+    /// <param name="isChecked">Whether the entered context is checked (true) or unchecked (false).</param>
+    /// <returns>A disposable token that restores the previous context when disposed.</returns>
+    public CheckedContextScope PushCheckedContext(bool isChecked)
+    {
+        var previous = IsCheckedContext;
+        IsCheckedContext = isChecked;
+        return new CheckedContextScope(this, previous);
+    }
+
+    /// <summary>
     /// Disposable token returned by <see cref="PushUnsafeContext"/> that
     /// decrements <see cref="UnsafeDepth"/> on disposal (ADR-0122 / issue #1014).
     /// </summary>
@@ -477,6 +504,31 @@ internal sealed class BinderContext
             if (active)
             {
                 owner.UnsafeDepth--;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Disposable token returned by <see cref="PushCheckedContext"/> that
+    /// restores the enclosing checked/unchecked context on disposal (issue #1881).
+    /// </summary>
+    public readonly struct CheckedContextScope : IDisposable
+    {
+        private readonly BinderContext owner;
+        private readonly bool previous;
+
+        internal CheckedContextScope(BinderContext owner, bool previous)
+        {
+            this.owner = owner;
+            this.previous = previous;
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            if (owner != null)
+            {
+                owner.IsCheckedContext = previous;
             }
         }
     }

--- a/src/Core/CodeAnalysis/Binding/BoundBinaryExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundBinaryExpression.cs
@@ -19,12 +19,20 @@ public sealed class BoundBinaryExpression : BoundExpression
     /// <param name="left">The left bound expression.</param>
     /// <param name="op">The bound binary operator.</param>
     /// <param name="right">The right bound expression.</param>
-    public BoundBinaryExpression(SyntaxNode syntax, BoundExpression left, BoundBinaryOperator op, BoundExpression right)
+    /// <param name="isChecked">
+    /// When true and <paramref name="op"/> is Sum/Difference/Product, the emitter
+    /// and interpreter use overflow-trapping arithmetic (issue #1881): a
+    /// `checked(...)` expression or `checked { }` statement puts its arithmetic
+    /// in this context; the default (no `checked` context) is unchecked, matching
+    /// the C# project default.
+    /// </param>
+    public BoundBinaryExpression(SyntaxNode syntax, BoundExpression left, BoundBinaryOperator op, BoundExpression right, bool isChecked = false)
         : base(syntax)
     {
         Left = left;
         Op = op;
         Right = right;
+        IsChecked = isChecked;
     }
 
     /// <inheritdoc/>
@@ -47,4 +55,11 @@ public sealed class BoundBinaryExpression : BoundExpression
     /// Gets the rught bound expression.
     /// </summary>
     public BoundExpression Right { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether this operator runs in a checked /
+    /// overflow-trapping context (issue #1881). Only observed for Sum,
+    /// Difference, and Product on integral operands.
+    /// </summary>
+    public bool IsChecked { get; }
 }

--- a/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -577,7 +577,7 @@ public abstract class BoundTreeRewriter
             return node;
         }
 
-        return new BoundBinaryExpression(null, left, node.Op, right);
+        return new BoundBinaryExpression(null, left, node.Op, right, node.IsChecked);
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -539,7 +539,12 @@ internal sealed class ConversionClassifier
             return BindTupleConversion(diagnosticLocation, expression, sourceTuple, targetTuple, allowExplicit);
         }
 
-        return new BoundConversionExpression(null, type, expression);
+        // Issue #1881: a conversion bound inside a `checked(...)`/`checked { }`
+        // context traps on narrowing overflow via the emitter's `conv.ovf.*`
+        // opcodes (and the interpreter's checked numeric convert) instead of
+        // truncating. Harmless for non-numeric / widening conversions, which
+        // never consult the flag.
+        return new BoundConversionExpression(null, type, expression, binderCtx.IsCheckedContext);
     }
 
     // ----- CLR parameter / argument conversions -----

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
@@ -1377,7 +1377,10 @@ internal sealed partial class ExpressionBinder
             boundRight = conversions.BindConversion(syntax.Right.Location, boundRight, boundOperator.Type);
         }
 
-        return new BoundBinaryExpression(null, boundLeft, boundOperator, boundRight);
+        // Issue #1881: Sum/Difference/Product bound inside a `checked`
+        // context trap on overflow; every other operator kind ignores the
+        // flag (comparisons, bitwise ops, etc. never overflow-check).
+        return new BoundBinaryExpression(null, boundLeft, boundOperator, boundRight, binderCtx.IsCheckedContext);
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -264,6 +264,9 @@ internal sealed partial class ExpressionBinder
         {
             case SyntaxKind.ParenthesizedExpression:
                 return BindParenthesizedExpression((ParenthesizedExpressionSyntax)syntax);
+            case SyntaxKind.CheckedExpression:
+            case SyntaxKind.UncheckedExpression:
+                return BindCheckedExpression((CheckedExpressionSyntax)syntax);
             case SyntaxKind.LiteralExpression:
                 return BindLiteralExpression((LiteralExpressionSyntax)syntax);
             case SyntaxKind.InterpolatedStringExpression:
@@ -396,6 +399,17 @@ internal sealed partial class ExpressionBinder
 
     private BoundExpression BindParenthesizedExpression(ParenthesizedExpressionSyntax syntax)
     {
+        return BindExpression(syntax.Expression);
+    }
+
+    // Issue #1881: `checked(expr)` / `unchecked(expr)` binds the inner
+    // expression under the named overflow context — no dedicated bound node
+    // is needed (mirrors Roslyn: the context only steers which opcodes the
+    // arithmetic/conversions inside pick). Innermost nesting wins via the
+    // save/restore scope.
+    private BoundExpression BindCheckedExpression(CheckedExpressionSyntax syntax)
+    {
+        using var scope = binderCtx.PushCheckedContext(syntax.IsChecked);
         return BindExpression(syntax.Expression);
     }
 

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.cs
@@ -243,6 +243,14 @@ internal sealed class StatementBinder
         // unsafe context — its top-level block carries no `unsafe` keyword, so
         // consult the current function's unsafe flag as well.
         var entersUnsafe = syntax.IsUnsafe || (function?.IsUnsafe ?? false);
+
+        // Issue #1881: a `checked { … }` / `unchecked { … }` block establishes
+        // the named overflow context for its statements; an ordinary block
+        // leaves the enclosing context untouched (unlike `unsafe`, there is no
+        // ambient default to fall back to).
+        using var checkedScope = syntax.IsChecked || syntax.IsUnchecked
+            ? binderCtx.PushCheckedContext(syntax.IsChecked)
+            : default;
         using (binderCtx.PushUnsafeContext(entersUnsafe))
         {
             BindBlockStatements(syntax.Statements, 0, statements);

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
@@ -668,13 +668,18 @@ internal sealed partial class MethodBodyEmitter
         switch (b.Op.Kind)
         {
             case BoundBinaryOperatorKind.Sum:
-                this.il.OpCode(ILOpCode.Add);
+                // Issue #1881: inside a `checked(...)`/`checked { }` context
+                // (b.IsChecked), integral +/-/* trap on overflow via the
+                // `.ovf` opcodes; floating-point never traps (IEEE 754
+                // overflow saturates to infinity) so it always uses the
+                // plain opcode regardless of the checked context.
+                this.il.OpCode(b.IsChecked && !isFloat ? (isUnsigned ? ILOpCode.Add_ovf_un : ILOpCode.Add_ovf) : ILOpCode.Add);
                 break;
             case BoundBinaryOperatorKind.Difference:
-                this.il.OpCode(ILOpCode.Sub);
+                this.il.OpCode(b.IsChecked && !isFloat ? (isUnsigned ? ILOpCode.Sub_ovf_un : ILOpCode.Sub_ovf) : ILOpCode.Sub);
                 break;
             case BoundBinaryOperatorKind.Product:
-                this.il.OpCode(ILOpCode.Mul);
+                this.il.OpCode(b.IsChecked && !isFloat ? (isUnsigned ? ILOpCode.Mul_ovf_un : ILOpCode.Mul_ovf) : ILOpCode.Mul);
                 break;
             case BoundBinaryOperatorKind.Quotient:
                 this.il.OpCode(isUnsigned ? ILOpCode.Div_un : ILOpCode.Div);
@@ -1119,7 +1124,7 @@ internal sealed partial class MethodBodyEmitter
             ?? throw new InvalidOperationException(
                 $"Lifted binary result Nullable<{resultUnderlying.Name}>: underlying has no CLR type.");
 
-        this.EmitLiftedArithmetic(b.Op.Kind, lhsSlot, rhsSlot, slots.ResultSlot, leftUnderlying, leftUnderlyingClr, rightUnderlyingClr, resultUnderlyingClr);
+        this.EmitLiftedArithmetic(b.Op.Kind, lhsSlot, rhsSlot, slots.ResultSlot, leftUnderlying, leftUnderlyingClr, rightUnderlyingClr, resultUnderlyingClr, b.IsChecked);
     }
 
     private void EmitLiftedEquality(
@@ -1232,7 +1237,8 @@ internal sealed partial class MethodBodyEmitter
         TypeSymbol underlying,
         Type leftUnderlyingClr,
         Type rightUnderlyingClr,
-        Type resultUnderlyingClr)
+        Type resultUnderlyingClr,
+        bool isChecked = false)
     {
         var getHasValueLhs = this.outer.wellKnown.GetNullableGetHasValueReference(leftUnderlyingClr);
         var getHasValueRhs = this.outer.wellKnown.GetNullableGetHasValueReference(rightUnderlyingClr);
@@ -1272,7 +1278,7 @@ internal sealed partial class MethodBodyEmitter
         this.il.LoadLocalAddress(rhsSlot);
         this.il.OpCode(ILOpCode.Call);
         this.il.Token(getValueRhs);
-        this.EmitUnderlyingArithmetic(kind, underlying);
+        this.EmitUnderlyingArithmetic(kind, underlying, isChecked);
         this.il.OpCode(ILOpCode.Newobj);
         this.il.Token(this.outer.GetCtorReference(ctor));
         this.il.Branch(ILOpCode.Br, end);
@@ -1356,7 +1362,7 @@ internal sealed partial class MethodBodyEmitter
     // op_* methods; primitive types map to the matching opcode and then
     // apply sub-i4 truncation when the underlying is byte / sbyte /
     // short / ushort / char.
-    private void EmitUnderlyingArithmetic(BoundBinaryOperatorKind kind, TypeSymbol underlying)
+    private void EmitUnderlyingArithmetic(BoundBinaryOperatorKind kind, TypeSymbol underlying, bool isChecked = false)
     {
         if (underlying == TypeSymbol.Decimal)
         {
@@ -1369,16 +1375,19 @@ internal sealed partial class MethodBodyEmitter
         }
 
         bool isUnsigned = IsUnsignedOrChar(underlying);
+        bool isFloatUnderlying = underlying == TypeSymbol.Float32 || underlying == TypeSymbol.Float64;
         switch (kind)
         {
             case BoundBinaryOperatorKind.Sum:
-                this.il.OpCode(ILOpCode.Add);
+                // Issue #1881: lifted (Nullable<T>) checked arithmetic traps the
+                // same as the non-lifted path — see EmitBinary below.
+                this.il.OpCode(isChecked && !isFloatUnderlying ? (isUnsigned ? ILOpCode.Add_ovf_un : ILOpCode.Add_ovf) : ILOpCode.Add);
                 break;
             case BoundBinaryOperatorKind.Difference:
-                this.il.OpCode(ILOpCode.Sub);
+                this.il.OpCode(isChecked && !isFloatUnderlying ? (isUnsigned ? ILOpCode.Sub_ovf_un : ILOpCode.Sub_ovf) : ILOpCode.Sub);
                 break;
             case BoundBinaryOperatorKind.Product:
-                this.il.OpCode(ILOpCode.Mul);
+                this.il.OpCode(isChecked && !isFloatUnderlying ? (isUnsigned ? ILOpCode.Mul_ovf_un : ILOpCode.Mul_ovf) : ILOpCode.Mul);
                 break;
             case BoundBinaryOperatorKind.Quotient:
                 this.il.OpCode(isUnsigned ? ILOpCode.Div_un : ILOpCode.Div);

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -2797,11 +2797,15 @@ public sealed class Evaluator
         switch (b.Op.Kind)
         {
             case BoundBinaryOperatorKind.Sum:
-                return NarrowToResultType(NumericAdd(left, right), resultType);
+                // Issue #1881: `checked(...)` traps on overflow (matching the
+                // emitter's `add.ovf`/`conv.ovf.*`); the narrowing back to a
+                // sub-int32 result type must also be range-checked in that
+                // context (e.g. `checked(byte.MaxValue + one)`).
+                return NarrowToResultType(b.IsChecked ? NumericAddChecked(left, right) : NumericAdd(left, right), resultType, b.IsChecked);
             case BoundBinaryOperatorKind.Difference:
-                return NarrowToResultType(NumericSub(left, right), resultType);
+                return NarrowToResultType(b.IsChecked ? NumericSubChecked(left, right) : NumericSub(left, right), resultType, b.IsChecked);
             case BoundBinaryOperatorKind.Product:
-                return NarrowToResultType(NumericMul(left, right), resultType);
+                return NarrowToResultType(b.IsChecked ? NumericMulChecked(left, right) : NumericMul(left, right), resultType, b.IsChecked);
             case BoundBinaryOperatorKind.Quotient:
                 return NarrowToResultType(NumericDiv(left, right), resultType);
             case BoundBinaryOperatorKind.Remainder:
@@ -2866,6 +2870,36 @@ public sealed class Evaluator
         _ => throw new InvalidOperationException($"Unsupported + on {l?.GetType()} and {r?.GetType()}"),
     };
 
+    // Issue #1881: `checked(a + b)` — identical shape to <see cref="NumericAdd"/>
+    // but every integral arm runs in a checked context (the `checked(...)`
+    // operator applies lexically to every arithmetic operator nested inside
+    // it, including switch-expression arms) so int/long/uint/ulong/nint/nuint
+    // trap with <see cref="OverflowException"/> instead of wrapping. Narrower
+    // widths (sbyte/byte/short/ushort/char) promote to `int` for the add
+    // itself (which cannot overflow at that width) — their overflow check
+    // happens when the result narrows back in <see cref="NarrowToResultType"/>.
+    // Floating-point and decimal are unaffected by `checked`/`unchecked` in C#
+    // (float/double never trap; decimal always does), so their arms are
+    // identical to the unchecked version.
+    private static object NumericAddChecked(object l, object r) => l switch
+    {
+        int li when r is int ri => (object)checked(li + ri),
+        long li when r is long ri => (object)checked(li + ri),
+        uint li when r is uint ri => (object)checked(li + ri),
+        ulong li when r is ulong ri => (object)checked(li + ri),
+        sbyte li when r is sbyte ri => (object)checked(li + ri),
+        byte li when r is byte ri => (object)checked(li + ri),
+        short li when r is short ri => (object)checked(li + ri),
+        ushort li when r is ushort ri => (object)checked(li + ri),
+        nint li when r is nint ri => (object)checked(li + ri),
+        nuint li when r is nuint ri => (object)checked(li + ri),
+        float li when r is float ri => (object)(li + ri),
+        double li when r is double ri => (object)(li + ri),
+        decimal li when r is decimal ri => (object)(li + ri),
+        char li when r is char ri => (object)checked(li + ri),
+        _ => throw new InvalidOperationException($"Unsupported + on {l?.GetType()} and {r?.GetType()}"),
+    };
+
     private static object NumericSub(object l, object r) => l switch
     {
         int li when r is int ri => li - ri,
@@ -2884,6 +2918,26 @@ public sealed class Evaluator
         _ => throw new InvalidOperationException($"Unsupported - on {l?.GetType()} and {r?.GetType()}"),
     };
 
+    // Issue #1881: checked counterpart of <see cref="NumericSub"/> — see
+    // <see cref="NumericAddChecked"/> for why this mirrors the arm shapes.
+    private static object NumericSubChecked(object l, object r) => l switch
+    {
+        int li when r is int ri => (object)checked(li - ri),
+        long li when r is long ri => (object)checked(li - ri),
+        uint li when r is uint ri => (object)checked(li - ri),
+        ulong li when r is ulong ri => (object)checked(li - ri),
+        sbyte li when r is sbyte ri => (object)checked(li - ri),
+        byte li when r is byte ri => (object)checked(li - ri),
+        short li when r is short ri => (object)checked(li - ri),
+        ushort li when r is ushort ri => (object)checked(li - ri),
+        nint li when r is nint ri => (object)checked(li - ri),
+        nuint li when r is nuint ri => (object)checked(li - ri),
+        float li when r is float ri => (object)(li - ri),
+        double li when r is double ri => (object)(li - ri),
+        decimal li when r is decimal ri => (object)(li - ri),
+        _ => throw new InvalidOperationException($"Unsupported - on {l?.GetType()} and {r?.GetType()}"),
+    };
+
     private static object NumericMul(object l, object r) => l switch
     {
         int li when r is int ri => li * ri,
@@ -2899,6 +2953,26 @@ public sealed class Evaluator
         float li when r is float ri => li * ri,
         double li when r is double ri => li * ri,
         decimal li when r is decimal ri => li * ri,
+        _ => throw new InvalidOperationException($"Unsupported * on {l?.GetType()} and {r?.GetType()}"),
+    };
+
+    // Issue #1881: checked counterpart of <see cref="NumericMul"/> — see
+    // <see cref="NumericAddChecked"/> for why this mirrors the arm shapes.
+    private static object NumericMulChecked(object l, object r) => l switch
+    {
+        int li when r is int ri => (object)checked(li * ri),
+        long li when r is long ri => (object)checked(li * ri),
+        uint li when r is uint ri => (object)checked(li * ri),
+        ulong li when r is ulong ri => (object)checked(li * ri),
+        sbyte li when r is sbyte ri => (object)checked(li * ri),
+        byte li when r is byte ri => (object)checked(li * ri),
+        short li when r is short ri => (object)checked(li * ri),
+        ushort li when r is ushort ri => (object)checked(li * ri),
+        nint li when r is nint ri => (object)checked(li * ri),
+        nuint li when r is nuint ri => (object)checked(li * ri),
+        float li when r is float ri => (object)(li * ri),
+        double li when r is double ri => (object)(li * ri),
+        decimal li when r is decimal ri => (object)(li * ri),
         _ => throw new InvalidOperationException($"Unsupported * on {l?.GetType()} and {r?.GetType()}"),
     };
 
@@ -3061,34 +3135,42 @@ public sealed class Evaluator
         _ => throw new InvalidOperationException($"Unsupported comparison on {l?.GetType()} and {r?.GetType()}"),
     };
 
-    private static object NarrowToResultType(object value, TypeSymbol resultType)
+    private static object NarrowToResultType(object value, TypeSymbol resultType, bool isChecked = false)
     {
         // C# arithmetic on sub-int types promotes to int. To preserve the
         // operator's declared result type (e.g. byte + byte → byte) we
         // narrow back here. Other widths already match their CLR type.
+        // Issue #1881: inside a `checked` context the narrowing back to the
+        // sub-int32 result type is itself overflow-checked (matching the
+        // emitter's `conv.ovf.*` narrowing conversions).
         if (resultType == TypeSymbol.Int8)
         {
-            return unchecked((sbyte)Convert.ToInt32(value));
+            var i32 = Convert.ToInt32(value);
+            return isChecked ? checked((sbyte)i32) : unchecked((sbyte)i32);
         }
 
         if (resultType == TypeSymbol.UInt8)
         {
-            return unchecked((byte)Convert.ToInt32(value));
+            var i32 = Convert.ToInt32(value);
+            return isChecked ? checked((byte)i32) : unchecked((byte)i32);
         }
 
         if (resultType == TypeSymbol.Int16)
         {
-            return unchecked((short)Convert.ToInt32(value));
+            var i32 = Convert.ToInt32(value);
+            return isChecked ? checked((short)i32) : unchecked((short)i32);
         }
 
         if (resultType == TypeSymbol.UInt16)
         {
-            return unchecked((ushort)Convert.ToInt32(value));
+            var i32 = Convert.ToInt32(value);
+            return isChecked ? checked((ushort)i32) : unchecked((ushort)i32);
         }
 
         if (resultType == TypeSymbol.Char)
         {
-            return unchecked((char)Convert.ToInt32(value));
+            var i32 = Convert.ToInt32(value);
+            return isChecked ? checked((char)i32) : unchecked((char)i32);
         }
 
         // Issue #615: when the result type is an enum, produce a properly-typed
@@ -4392,7 +4474,12 @@ public sealed class Evaluator
             // ADR-0044: numeric conversions across the primitive lattice.
             // Cast unchecked to match the IL `conv.*` opcodes' truncation
             // semantics (Convert.ChangeType throws on overflow instead).
-            return UncheckedNumericConvert(value, node.Type.ClrType);
+            // Issue #1881: inside a `checked` context (node.IsChecked), route
+            // through the overflow-trapping conversion instead, matching the
+            // emitter's `conv.ovf.*` opcodes.
+            return node.IsChecked
+                ? CheckedNumericConvert(value, node.Type.ClrType)
+                : UncheckedNumericConvert(value, node.Type.ClrType);
         }
         else
         {
@@ -4494,6 +4581,91 @@ public sealed class Evaluator
             _ => Convert.ChangeType(value, to, System.Globalization.CultureInfo.InvariantCulture),
         };
     }
+
+    // Issue #1881: checked counterpart of <see cref="UncheckedNumericConvert"/>.
+    // Float/double sources use a direct `checked` cast per target (matching
+    // C#'s own checked-conversion truncation/range-check semantics, including
+    // trapping on NaN/Infinity). Every integral/char source first widens
+    // losslessly to <see cref="Int128"/> — which exactly preserves both sign
+    // and full magnitude for every supported width, including `ulong`/`nuint`,
+    // unlike a `long` intermediate which would misread the top bit of an
+    // unsigned 64-bit value — then a single checked narrowing switch below
+    // range-checks against the true value regardless of the source's
+    // signedness. decimal is unaffected by checked/unchecked in C# (decimal
+    // arithmetic/conversions always overflow-check), so it reuses the
+    // unchecked path's decimal handling.
+    private static object CheckedNumericConvert(object value, Type to)
+    {
+        if (value is decimal || to.IsSameAs(typeof(decimal)))
+        {
+            return UncheckedNumericConvert(value, to);
+        }
+
+        if (value is float fv)
+        {
+            return CheckedFloatingConvert(fv, to);
+        }
+
+        if (value is double dv)
+        {
+            return CheckedFloatingConvert(dv, to);
+        }
+
+        Int128 asInt128 = value switch
+        {
+            sbyte x => x,
+            byte x => x,
+            short x => x,
+            ushort x => x,
+            int x => x,
+            uint x => x,
+            long x => x,
+            ulong x => x,
+            nint x => x,
+            nuint x => (ulong)x,
+            char x => x,
+            bool x => x ? 1 : 0,
+            _ => throw new InvalidOperationException($"Unsupported checked conversion source {value?.GetType()}"),
+        };
+
+        return CheckedNarrowFromInt128(asInt128, to);
+    }
+
+    private static object CheckedNarrowFromInt128(Int128 v, Type to) => checked(to switch
+    {
+        Type t when t.IsSameAs(typeof(sbyte)) => (object)(sbyte)v,
+        Type t when t.IsSameAs(typeof(byte)) => (object)(byte)v,
+        Type t when t.IsSameAs(typeof(short)) => (object)(short)v,
+        Type t when t.IsSameAs(typeof(ushort)) => (object)(ushort)v,
+        Type t when t.IsSameAs(typeof(int)) => (object)(int)v,
+        Type t when t.IsSameAs(typeof(uint)) => (object)(uint)v,
+        Type t when t.IsSameAs(typeof(long)) => (object)(long)v,
+        Type t when t.IsSameAs(typeof(ulong)) => (object)(ulong)v,
+        Type t when t.IsSameAs(typeof(nint)) => (object)(nint)(long)v,
+        Type t when t.IsSameAs(typeof(nuint)) => (object)(nuint)(ulong)v,
+        Type t when t.IsSameAs(typeof(char)) => (object)(char)(ushort)v,
+        Type t when t.IsSameAs(typeof(float)) => (object)(float)v,
+        Type t when t.IsSameAs(typeof(double)) => (object)(double)v,
+        _ => throw new InvalidOperationException($"Unsupported checked conversion target {to}"),
+    });
+
+    private static object CheckedFloatingConvert(double d, Type to) => checked(to switch
+    {
+        Type t when t.IsSameAs(typeof(sbyte)) => (object)(sbyte)d,
+        Type t when t.IsSameAs(typeof(byte)) => (object)(byte)d,
+        Type t when t.IsSameAs(typeof(short)) => (object)(short)d,
+        Type t when t.IsSameAs(typeof(ushort)) => (object)(ushort)d,
+        Type t when t.IsSameAs(typeof(int)) => (object)(int)d,
+        Type t when t.IsSameAs(typeof(uint)) => (object)(uint)d,
+        Type t when t.IsSameAs(typeof(long)) => (object)(long)d,
+        Type t when t.IsSameAs(typeof(ulong)) => (object)(ulong)d,
+        Type t when t.IsSameAs(typeof(nint)) => (object)(nint)(long)d,
+        Type t when t.IsSameAs(typeof(nuint)) => (object)(nuint)(ulong)d,
+        Type t when t.IsSameAs(typeof(char)) => (object)(char)(ushort)d,
+        Type t when t.IsSameAs(typeof(float)) => (object)(float)d,
+        Type t when t.IsSameAs(typeof(double)) => d,
+        _ => throw new InvalidOperationException($"Unsupported checked conversion target {to}"),
+    });
 
     private object EvaluateImportedCallExpression(BoundImportedCallExpression node)
     {

--- a/src/Core/CodeAnalysis/Syntax/BlockStatementSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/BlockStatementSyntax.cs
@@ -15,6 +15,11 @@ public sealed class BlockStatementSyntax : StatementSyntax
     // invalidates the node's cached span (issue #1675).
     private SyntaxToken unsafeKeyword;
 
+    // Issue #1881: backing fields for the checked/unchecked contextual block
+    // keyword, mirroring the unsafeKeyword pattern above.
+    private SyntaxToken checkedKeyword;
+    private SyntaxToken uncheckedKeyword;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="BlockStatementSyntax"/> class.
     /// </summary>
@@ -56,6 +61,45 @@ public sealed class BlockStatementSyntax : StatementSyntax
 
     /// <summary>Gets a value indicating whether this block is an <c>unsafe { … }</c> block (ADR-0122 / issue #1014).</summary>
     public bool IsUnsafe => UnsafeKeyword != null;
+
+    /// <summary>
+    /// Gets or sets the optional <c>checked</c> contextual keyword (issue #1881)
+    /// that introduces this block as a <c>checked { … }</c> block. When
+    /// non-null, integral <c>+</c>/<c>-</c>/<c>*</c> and narrowing numeric
+    /// conversions inside the block trap on overflow. Assigned by the parser;
+    /// <c>null</c> for ordinary blocks.
+    /// </summary>
+    public SyntaxToken CheckedKeyword
+    {
+        get => checkedKeyword;
+        set
+        {
+            checkedKeyword = value;
+            InvalidateCachedSpan();
+        }
+    }
+
+    /// <summary>Gets a value indicating whether this block is a <c>checked { … }</c> block (issue #1881).</summary>
+    public bool IsChecked => CheckedKeyword != null;
+
+    /// <summary>
+    /// Gets or sets the optional <c>unchecked</c> contextual keyword (issue #1881)
+    /// that introduces this block as an <c>unchecked { … }</c> block, restoring
+    /// truncating arithmetic/conversions inside the block. Assigned by the
+    /// parser; <c>null</c> for ordinary blocks.
+    /// </summary>
+    public SyntaxToken UncheckedKeyword
+    {
+        get => uncheckedKeyword;
+        set
+        {
+            uncheckedKeyword = value;
+            InvalidateCachedSpan();
+        }
+    }
+
+    /// <summary>Gets a value indicating whether this block is an <c>unchecked { … }</c> block (issue #1881).</summary>
+    public bool IsUnchecked => UncheckedKeyword != null;
 
     /// <summary>
     /// Gets the open brace token.

--- a/src/Core/CodeAnalysis/Syntax/CheckedExpressionSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/CheckedExpressionSyntax.cs
@@ -1,0 +1,59 @@
+// <copyright file="CheckedExpressionSyntax.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Core.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Represents the built-in <c>checked(expr)</c> / <c>unchecked(expr)</c>
+/// operator (issue #1881). <c>checked</c>/<c>unchecked</c> are recognized as
+/// contextual identifiers when immediately followed by <c>(</c>. Inside
+/// <c>checked(expr)</c>, integral <c>+</c>/<c>-</c>/<c>*</c> and narrowing
+/// numeric conversions trap on overflow (throwing
+/// <see cref="System.OverflowException"/>) instead of truncating;
+/// <c>unchecked(expr)</c> restores the (default) truncating behavior. Nesting
+/// is lexical — the innermost <c>checked</c>/<c>unchecked</c> wins.
+/// </summary>
+public sealed class CheckedExpressionSyntax : ExpressionSyntax
+{
+    /// <summary>Initializes a new instance of the <see cref="CheckedExpressionSyntax"/> class.</summary>
+    /// <param name="syntaxTree">The parent syntax tree.</param>
+    /// <param name="keyword">The <c>checked</c> or <c>unchecked</c> identifier token.</param>
+    /// <param name="openParenthesis">The <c>(</c> token.</param>
+    /// <param name="expression">The wrapped expression argument.</param>
+    /// <param name="closeParenthesis">The <c>)</c> token.</param>
+    /// <param name="isChecked">Whether the keyword was <c>checked</c> (true) or <c>unchecked</c> (false).</param>
+    public CheckedExpressionSyntax(
+        SyntaxTree syntaxTree,
+        SyntaxToken keyword,
+        SyntaxToken openParenthesis,
+        ExpressionSyntax expression,
+        SyntaxToken closeParenthesis,
+        bool isChecked)
+        : base(syntaxTree)
+    {
+        Keyword = keyword;
+        OpenParenthesis = openParenthesis;
+        Expression = expression;
+        CloseParenthesis = closeParenthesis;
+        IsChecked = isChecked;
+    }
+
+    /// <inheritdoc/>
+    public override SyntaxKind Kind => IsChecked ? SyntaxKind.CheckedExpression : SyntaxKind.UncheckedExpression;
+
+    /// <summary>Gets the <c>checked</c> or <c>unchecked</c> identifier token.</summary>
+    public SyntaxToken Keyword { get; }
+
+    /// <summary>Gets the opening <c>(</c> token.</summary>
+    public SyntaxToken OpenParenthesis { get; }
+
+    /// <summary>Gets the wrapped expression argument.</summary>
+    public ExpressionSyntax Expression { get; }
+
+    /// <summary>Gets the closing <c>)</c> token.</summary>
+    public SyntaxToken CloseParenthesis { get; }
+
+    /// <summary>Gets a value indicating whether the keyword was <c>checked</c> (true) or <c>unchecked</c> (false).</summary>
+    public bool IsChecked { get; }
+}

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -4862,6 +4862,30 @@ public class Parser
             return unsafeBlock;
         }
 
+        // Issue #1881: a `checked { … }` / `unchecked { … }` block establishes
+        // the named overflow context for the statements inside it. Both are
+        // contextual keywords — only immediately followed by `{` are they
+        // treated as the block form (a bare identifier named `checked` used
+        // as an ordinary value is unaffected).
+        if (Current.Kind == SyntaxKind.IdentifierToken
+            && (Current.Text == "checked" || Current.Text == "unchecked")
+            && Peek(1).Kind == SyntaxKind.OpenBraceToken)
+        {
+            var isCheckedBlock = Current.Text == "checked";
+            var checkedKeyword = NextToken();
+            var checkedBlock = ParseBlockStatement();
+            if (isCheckedBlock)
+            {
+                checkedBlock.CheckedKeyword = checkedKeyword;
+            }
+            else
+            {
+                checkedBlock.UncheckedKeyword = checkedKeyword;
+            }
+
+            return checkedBlock;
+        }
+
         // ADR-0125 / issue #1026: a `fixed name *T = source { … }` pinning
         // statement. `fixed` is a contextual keyword — only the precise
         // `fixed IDENT *` shape (the binding name followed by a pointer type)
@@ -8421,6 +8445,14 @@ public class Parser
             current = ParseSizeOfExpression();
         }
         else if (Current.Kind == SyntaxKind.IdentifierToken
+            && (Current.Text == "checked" || Current.Text == "unchecked")
+            && Peek(1).Kind == SyntaxKind.OpenParenthesisToken)
+        {
+            // Issue #1881: contextual `checked(expr)` / `unchecked(expr)` —
+            // argument is an arithmetic expression, not a type clause.
+            current = ParseCheckedExpression();
+        }
+        else if (Current.Kind == SyntaxKind.IdentifierToken
             && Current.Text == "nameof"
             && Peek(1).Kind == SyntaxKind.OpenParenthesisToken)
         {
@@ -9360,6 +9392,18 @@ public class Parser
         var typeClause = ParseTypeClause();
         var closeParen = MatchToken(SyntaxKind.CloseParenthesisToken);
         return new SizeOfExpressionSyntax(syntaxTree, sizeOfIdentifier, openParen, typeClause, closeParen);
+    }
+
+    private ExpressionSyntax ParseCheckedExpression()
+    {
+        // Issue #1881: `checked(expr)` / `unchecked(expr)` — the argument is
+        // an ordinary expression evaluated in the named overflow context.
+        var isChecked = Current.Text == "checked";
+        var keyword = MatchToken(SyntaxKind.IdentifierToken);
+        var openParen = MatchToken(SyntaxKind.OpenParenthesisToken);
+        var expression = ParseExpression();
+        var closeParen = MatchToken(SyntaxKind.CloseParenthesisToken);
+        return new CheckedExpressionSyntax(syntaxTree, keyword, openParen, expression, closeParen, isChecked);
     }
 
     private DefaultExpressionSyntax ParseDefaultExpression()

--- a/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
@@ -157,6 +157,8 @@ public enum SyntaxKind
     UnaryExpression,
     BinaryExpression,
     ParenthesizedExpression,
+    CheckedExpression,
+    UncheckedExpression,
     LiteralExpression,
     InterpolatedStringExpression,
     NameExpression,

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1881CheckedUncheckedInterpreterTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1881CheckedUncheckedInterpreterTests.cs
@@ -1,0 +1,226 @@
+// <copyright file="Issue1881CheckedUncheckedInterpreterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1881: interpreter counterpart of
+/// <see cref="GSharp.Core.Tests.CodeAnalysis.Emit.Issue1881CheckedUncheckedEmitTests"/>.
+/// Asserts the tree-walking evaluator agrees with the compiled/emitted IL for
+/// <c>checked</c>/<c>unchecked</c> expressions and blocks: overflow throws
+/// <see cref="System.OverflowException"/> (caught here via a G#-level
+/// try/catch, mirroring real usage) in a checked context, and wraps silently
+/// in an unchecked context (the C# project default), across signed/unsigned
+/// integer widths and narrowing conversions.
+/// </summary>
+public class Issue1881CheckedUncheckedInterpreterTests
+{
+    [Fact]
+    public void CheckedAddition_Int32_Overflow_ThrowsOverflowException()
+    {
+        var result = Evaluate(
+            "var maxInt int32 = 2147483647\n" +
+            "var one int32 = 1\n" +
+            "var caught = \"no\"\n" +
+            "try {\n" +
+            "    var boom = checked(maxInt + one)\n" +
+            "} catch (e OverflowException) {\n" +
+            "    caught = \"yes\"\n" +
+            "}\n" +
+            "caught");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("yes", result.Value);
+    }
+
+    [Fact]
+    public void UncheckedAddition_Int32_Overflow_Wraps()
+    {
+        var result = Evaluate("var maxInt int32 = 2147483647\nvar one int32 = 1\nunchecked(maxInt + one)");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(-2147483648, result.Value);
+    }
+
+    [Fact]
+    public void CheckedStatement_BlockOverflow_ThrowsOverflowException()
+    {
+        var result = Evaluate(
+            "var caught = \"no\"\n" +
+            "checked {\n" +
+            "    var maxInt int32 = 2147483647\n" +
+            "    var one int32 = 1\n" +
+            "    try {\n" +
+            "        var boom = maxInt + one\n" +
+            "    } catch (e OverflowException) {\n" +
+            "        caught = \"yes\"\n" +
+            "    }\n" +
+            "}\n" +
+            "caught");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("yes", result.Value);
+    }
+
+    [Fact]
+    public void UncheckedStatement_BlockOverflow_Wraps()
+    {
+        var result = Evaluate(
+            "var wrapped int32 = 0\n" +
+            "unchecked {\n" +
+            "    var maxInt int32 = 2147483647\n" +
+            "    var one int32 = 1\n" +
+            "    wrapped = maxInt + one\n" +
+            "}\n" +
+            "wrapped");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(-2147483648, result.Value);
+    }
+
+    [Fact]
+    public void CheckedSubtraction_UInt64_Underflow_ThrowsOverflowException()
+    {
+        var result = Evaluate(
+            "var zero uint64 = 0\n" +
+            "var one uint64 = 1\n" +
+            "var caught = \"no\"\n" +
+            "try {\n" +
+            "    var boom = checked(zero - one)\n" +
+            "} catch (e OverflowException) {\n" +
+            "    caught = \"yes\"\n" +
+            "}\n" +
+            "caught");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("yes", result.Value);
+    }
+
+    [Fact]
+    public void UncheckedSubtraction_UInt64_Underflow_Wraps()
+    {
+        var result = Evaluate("var zero uint64 = 0\nvar one uint64 = 1\nunchecked(zero - one)");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(ulong.MaxValue, result.Value);
+    }
+
+    [Fact]
+    public void CheckedMultiplication_Int64_Overflow_ThrowsOverflowException()
+    {
+        var result = Evaluate(
+            "var big int64 = 9223372036854775807\n" +
+            "var two int64 = 2\n" +
+            "var caught = \"no\"\n" +
+            "try {\n" +
+            "    var boom = checked(big * two)\n" +
+            "} catch (e OverflowException) {\n" +
+            "    caught = \"yes\"\n" +
+            "}\n" +
+            "caught");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("yes", result.Value);
+    }
+
+    [Fact]
+    public void CheckedNarrowingConversion_ByteFromInt32_Overflow_ThrowsOverflowException()
+    {
+        var result = Evaluate(
+            "var big int32 = 300\n" +
+            "var caught = \"no\"\n" +
+            "try {\n" +
+            "    var narrow = checked(byte(big))\n" +
+            "} catch (e OverflowException) {\n" +
+            "    caught = \"yes\"\n" +
+            "}\n" +
+            "caught");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("yes", result.Value);
+    }
+
+    [Fact]
+    public void UncheckedNarrowingConversion_ByteFromInt32_Truncates()
+    {
+        var result = Evaluate("unchecked(byte(300))");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal((byte)44, result.Value);
+    }
+
+    [Fact]
+    public void CheckedMultiplication_Int64_NoOverflow_MatchesEmitPrecision()
+    {
+        // Regression for the switch-expression "best common type" boxing bug
+        // caught during development: mixed-type switch arms inside `checked(...)`
+        // implicitly widened every arm to `double`, silently corrupting
+        // magnitudes before the checked narrow-back — this exact shape
+        // (`long(x) * long(y)` inside `checked { }`) triggered an
+        // InvalidCastException at the enclosing conversion instead of the
+        // correct result.
+        var result = Evaluate(
+            "var lz int64 = 0\n" +
+            "checked {\n" +
+            "    var x int32 = 1000000\n" +
+            "    var y int32 = 2000\n" +
+            "    lz = long(x) * long(y)\n" +
+            "}\n" +
+            "lz");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(2000000000L, result.Value);
+    }
+
+    [Fact]
+    public void NestedContexts_InnermostUncheckedInsideChecked_Wraps()
+    {
+        var result = Evaluate(
+            "var wrapped int32 = 0\n" +
+            "checked {\n" +
+            "    var maxInt int32 = 2147483647\n" +
+            "    var one int32 = 1\n" +
+            "    unchecked {\n" +
+            "        wrapped = maxInt + one\n" +
+            "    }\n" +
+            "}\n" +
+            "wrapped");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(-2147483648, result.Value);
+    }
+
+    [Fact]
+    public void NestedContexts_InnermostCheckedInsideUnchecked_Throws()
+    {
+        var result = Evaluate(
+            "var caught = \"no\"\n" +
+            "unchecked {\n" +
+            "    var maxInt int32 = 2147483647\n" +
+            "    var one int32 = 1\n" +
+            "    try {\n" +
+            "        checked {\n" +
+            "            var boom = maxInt + one\n" +
+            "        }\n" +
+            "    } catch (e OverflowException) {\n" +
+            "        caught = \"yes\"\n" +
+            "    }\n" +
+            "}\n" +
+            "caught");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("yes", result.Value);
+    }
+
+    [Fact]
+    public void CheckedFloatMultiplication_Overflow_ProducesInfinityNotException()
+    {
+        var result = Evaluate("var big float64 = 1.0e308\nvar ten float64 = 10.0\nchecked(big * ten)");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(double.PositiveInfinity, result.Value);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue1881CheckedUncheckedEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue1881CheckedUncheckedEmitTests.cs
@@ -1,0 +1,372 @@
+// <copyright file="Issue1881CheckedUncheckedEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #1881: G# had no <c>checked</c>/<c>unchecked</c> support at all — a
+/// <c>checked { }</c> statement translated (by cs2gs) to a plain block,
+/// silently erasing overflow-trap semantics, and <c>checked(...)</c>/
+/// <c>unchecked(...)</c> expressions had no G# equivalent whatsoever. This
+/// adds the language feature to gsc itself (syntax, binding, emission,
+/// interpreter) so cs2gs can translate faithfully. These tests exercise the
+/// compiled (emit) backend; <see cref="GSharp.Core.Tests.CodeAnalysis.Binding.Issue1881CheckedUncheckedInterpreterTests"/>
+/// exercises the interpreter and asserts the two backends agree.
+/// </summary>
+public class Issue1881CheckedUncheckedEmitTests
+{
+    [Fact]
+    public void CheckedExpression_Int32Addition_OverflowThrows()
+    {
+        const string Source = @"package Issue1881Add
+import System
+
+func run() {
+    var maxInt int32 = 2147483647
+    var one int32 = 1
+    var caught = ""no""
+    try {
+        var boom = checked(maxInt + one)
+        Console.WriteLine(boom)
+    } catch (e OverflowException) {
+        caught = ""yes""
+    }
+    Console.WriteLine(caught)
+}
+
+run()
+";
+        var output = CompileAndRun(Source, "Issue1881Add");
+        Assert.Contains("yes", output);
+    }
+
+    [Fact]
+    public void UncheckedExpression_Int32Addition_Wraps()
+    {
+        const string Source = @"package Issue1881Wrap
+import System
+
+func run() {
+    var maxInt int32 = 2147483647
+    var one int32 = 1
+    var wrapped = unchecked(maxInt + one)
+    Console.WriteLine(wrapped)
+}
+
+run()
+";
+        var output = CompileAndRun(Source, "Issue1881Wrap");
+        Assert.Contains("-2147483648", output);
+    }
+
+    [Fact]
+    public void CheckedStatement_BlockContainingOverflow_Throws()
+    {
+        // The exact silent-divergence shape from the issue: a `checked { }`
+        // block around a plain `+` inside a try/catch(OverflowException).
+        const string Source = @"package Issue1881Block
+import System
+
+func run() {
+    var caught = ""no""
+    checked {
+        var maxInt int32 = 2147483647
+        var one int32 = 1
+        try {
+            var boom = maxInt + one
+            Console.WriteLine(boom)
+        } catch (e OverflowException) {
+            caught = ""yes""
+        }
+    }
+    Console.WriteLine(caught)
+}
+
+run()
+";
+        var output = CompileAndRun(Source, "Issue1881Block");
+        Assert.Contains("yes", output);
+    }
+
+    [Fact]
+    public void UncheckedStatement_BlockContainingOverflow_Wraps()
+    {
+        const string Source = @"package Issue1881BlockWrap
+import System
+
+func run() {
+    unchecked {
+        var maxInt int32 = 2147483647
+        var one int32 = 1
+        var wrapped = maxInt + one
+        Console.WriteLine(wrapped)
+    }
+}
+
+run()
+";
+        var output = CompileAndRun(Source, "Issue1881BlockWrap");
+        Assert.Contains("-2147483648", output);
+    }
+
+    [Fact]
+    public void CheckedExpression_UnsignedInt32Addition_OverflowThrows()
+    {
+        const string Source = @"package Issue1881UAdd
+import System
+
+func run() {
+    var maxU uint32 = 4294967295
+    var one uint32 = 1
+    var caught = ""no""
+    try {
+        var boom = checked(maxU + one)
+        Console.WriteLine(boom)
+    } catch (e OverflowException) {
+        caught = ""yes""
+    }
+    Console.WriteLine(caught)
+}
+
+run()
+";
+        var output = CompileAndRun(Source, "Issue1881UAdd");
+        Assert.Contains("yes", output);
+    }
+
+    [Fact]
+    public void UncheckedExpression_UnsignedInt32Addition_Wraps()
+    {
+        const string Source = @"package Issue1881UWrap
+import System
+
+func run() {
+    var maxU uint32 = 4294967295
+    var one uint32 = 1
+    var wrapped = unchecked(maxU + one)
+    Console.WriteLine(wrapped)
+}
+
+run()
+";
+        var output = CompileAndRun(Source, "Issue1881UWrap");
+        Assert.Contains("0", output);
+    }
+
+    [Fact]
+    public void CheckedExpression_Int64Multiplication_OverflowThrows()
+    {
+        const string Source = @"package Issue1881LongMul
+import System
+
+func run() {
+    var big int64 = 9223372036854775807
+    var two int64 = 2
+    var caught = ""no""
+    try {
+        var boom = checked(big * two)
+        Console.WriteLine(boom)
+    } catch (e OverflowException) {
+        caught = ""yes""
+    }
+    Console.WriteLine(caught)
+}
+
+run()
+";
+        var output = CompileAndRun(Source, "Issue1881LongMul");
+        Assert.Contains("yes", output);
+    }
+
+    [Fact]
+    public void CheckedExpression_UInt64Subtraction_UnderflowThrows()
+    {
+        const string Source = @"package Issue1881ULongSub
+import System
+
+func run() {
+    var zero uint64 = 0
+    var one uint64 = 1
+    var caught = ""no""
+    try {
+        var boom = checked(zero - one)
+        Console.WriteLine(boom)
+    } catch (e OverflowException) {
+        caught = ""yes""
+    }
+    Console.WriteLine(caught)
+}
+
+run()
+";
+        var output = CompileAndRun(Source, "Issue1881ULongSub");
+        Assert.Contains("yes", output);
+    }
+
+    [Fact]
+    public void CheckedExpression_NarrowingByteConversion_OverflowThrows()
+    {
+        const string Source = @"package Issue1881ByteNarrow
+import System
+
+func run() {
+    var big int32 = 300
+    var caught = ""no""
+    try {
+        var narrow = checked(byte(big))
+        Console.WriteLine(narrow)
+    } catch (e OverflowException) {
+        caught = ""yes""
+    }
+    Console.WriteLine(caught)
+}
+
+run()
+";
+        var output = CompileAndRun(Source, "Issue1881ByteNarrow");
+        Assert.Contains("yes", output);
+    }
+
+    [Fact]
+    public void UncheckedExpression_NarrowingByteConversion_Truncates()
+    {
+        const string Source = @"package Issue1881ByteWrap
+import System
+
+func run() {
+    var wide = unchecked(byte(300))
+    Console.WriteLine(wide)
+}
+
+run()
+";
+        var output = CompileAndRun(Source, "Issue1881ByteWrap");
+        Assert.Contains("44", output);
+    }
+
+    [Fact]
+    public void NestedContexts_InnermostUncheckedInsideChecked_Wraps()
+    {
+        const string Source = @"package Issue1881NestUnchecked
+import System
+
+func run() {
+    checked {
+        var maxInt int32 = 2147483647
+        var one int32 = 1
+        unchecked {
+            var wrapped = maxInt + one
+            Console.WriteLine(wrapped)
+        }
+    }
+}
+
+run()
+";
+        var output = CompileAndRun(Source, "Issue1881NestUnchecked");
+        Assert.Contains("-2147483648", output);
+    }
+
+    [Fact]
+    public void NestedContexts_InnermostCheckedInsideUnchecked_Throws()
+    {
+        const string Source = @"package Issue1881NestChecked
+import System
+
+func run() {
+    var caught = ""no""
+    unchecked {
+        var maxInt int32 = 2147483647
+        var one int32 = 1
+        try {
+            checked {
+                var boom = maxInt + one
+                Console.WriteLine(boom)
+            }
+        } catch (e OverflowException) {
+            caught = ""yes""
+        }
+    }
+    Console.WriteLine(caught)
+}
+
+run()
+";
+        var output = CompileAndRun(Source, "Issue1881NestChecked");
+        Assert.Contains("yes", output);
+    }
+
+    [Fact]
+    public void CheckedExpression_FloatingPointOverflow_DoesNotThrow()
+    {
+        // C# float/double never trap on overflow regardless of checked context.
+        const string Source = @"package Issue1881Float
+import System
+
+func run() {
+    var big float64 = 1.0e308
+    var ten float64 = 10.0
+    var result = checked(big * ten)
+    Console.WriteLine(Double.IsPositiveInfinity(result))
+}
+
+run()
+";
+        var output = CompileAndRun(Source, "Issue1881Float");
+        Assert.Contains("True", output);
+    }
+
+    private static string CompileAndRun(string source, string contextName)
+    {
+        using var peStream = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Emit(peStream);
+
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(contextName, isCollectible: true);
+        try
+        {
+            var asm = loadContext.LoadFromStream(peStream);
+            var programType = asm.GetTypes().FirstOrDefault(t => t.Name == "<Program>");
+            Assert.NotNull(programType);
+            var entry = programType!.GetMethod(
+                "<Main>$",
+                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(entry);
+
+            var stdout = Console.Out;
+            var captured = new StringWriter();
+            Console.SetOut(captured);
+            try
+            {
+                entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+            }
+            finally
+            {
+                Console.SetOut(stdout);
+            }
+
+            return captured.ToString();
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue1675SyntaxNodeChildEnumerationTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue1675SyntaxNodeChildEnumerationTests.cs
@@ -64,6 +64,9 @@ public class Issue1675SyntaxNodeChildEnumerationTests
         // issue #1925: compound indirect assignment through a pointer-arithmetic dereference
         "package p\nunsafe func F() {\n  var arr = []int32{1, 2, 3}\n  var p *int32 = &arr[0]\n  var i int32 = 0\n  *(p + i) += 1\n}\n",
 
+        // issue #1881: checked/unchecked expressions and blocks
+        "package p\nfunc F() {\n  var a int32 = 1\n  var b int32 = 2\n  var c = checked(a + b)\n  var d = unchecked(a + b)\n  checked {\n    var e = a + b\n  }\n  unchecked {\n    var f = a + b\n  }\n}\n",
+
         // member field / member index / compound index assignments
         "package p\nstruct Inner { var x int32 }\nstruct S {\n  var arr []int32\n  var inner Inner\n}\nfunc F(s S, arr []int32) {\n  s.inner.x = 1\n  s.arr[0] = 1\n  arr[0] += 1\n  s.arr[0] += 2\n}\n",
 

--- a/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
+++ b/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
@@ -40,6 +40,7 @@ ChanKeyword
 ChannelReceiveExpression
 ChannelSendStatement
 CharacterToken
+CheckedExpression
 ClassKeyword
 CloseBraceToken
 CloseParenthesisToken
@@ -251,6 +252,7 @@ TypeParameter
 TypeParameterList
 TypePattern
 UnaryExpression
+UncheckedExpression
 UnsignedShiftRightEqualsToken
 UnsignedShiftRightToken
 UsingKeyword

--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/GExpression.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/GExpression.cs
@@ -653,6 +653,32 @@ public sealed class ParenthesizedExpression : GExpression
 }
 
 /// <summary>
+/// A <c>checked(inner)</c>/<c>unchecked(inner)</c> expression (issue #1881).
+/// G# has no compile-time constant folding, so unlike real C# a checked
+/// constant overflow is not a translation-time error here — it is simply
+/// evaluated at run time like any other checked arithmetic.
+/// </summary>
+public sealed class CheckedExpression : GExpression
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CheckedExpression"/> class.
+    /// </summary>
+    /// <param name="inner">The inner expression.</param>
+    /// <param name="isChecked"><see langword="true"/> for <c>checked(...)</c>, <see langword="false"/> for <c>unchecked(...)</c>.</param>
+    public CheckedExpression(GExpression inner, bool isChecked)
+    {
+        Inner = inner;
+        IsChecked = isChecked;
+    }
+
+    /// <summary>Gets the inner expression.</summary>
+    public GExpression Inner { get; }
+
+    /// <summary>Gets a value indicating whether this is <c>checked(...)</c> (true) or <c>unchecked(...)</c> (false).</summary>
+    public bool IsChecked { get; }
+}
+
+/// <summary>
 /// A lambda (ADR-0074). An expression body renders as the arrow form
 /// <c>(x int32) -&gt; expr</c> (an expression-block); a block body renders as the
 /// function-literal form <c>func (x int32) RetType { … }</c> (a statement-block),

--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/GStatement.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/GStatement.cs
@@ -24,10 +24,14 @@ public sealed class BlockStatement : GStatement
     /// </summary>
     /// <param name="statements">The contained statements.</param>
     /// <param name="isUnsafe">Whether this block is an <c>unsafe { … }</c> block (ADR-0122 / issue #1014).</param>
-    public BlockStatement(IReadOnlyList<GStatement> statements = null, bool isUnsafe = false)
+    /// <param name="isChecked">Whether this block is a <c>checked { … }</c> block (issue #1881).</param>
+    /// <param name="isUnchecked">Whether this block is an <c>unchecked { … }</c> block (issue #1881).</param>
+    public BlockStatement(IReadOnlyList<GStatement> statements = null, bool isUnsafe = false, bool isChecked = false, bool isUnchecked = false)
     {
         Statements = statements ?? new List<GStatement>();
         IsUnsafe = isUnsafe;
+        IsChecked = isChecked;
+        IsUnchecked = isUnchecked;
     }
 
     /// <summary>Gets the contained statements.</summary>
@@ -38,6 +42,18 @@ public sealed class BlockStatement : GStatement
     /// introducing an unsafe context (ADR-0122 / issue #1014).
     /// </summary>
     public bool IsUnsafe { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether this block is a <c>checked { … }</c> block
+    /// introducing a checked arithmetic context (issue #1881).
+    /// </summary>
+    public bool IsChecked { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether this block is an <c>unchecked { … }</c> block
+    /// introducing an unchecked arithmetic context (issue #1881).
+    /// </summary>
+    public bool IsUnchecked { get; }
 }
 
 /// <summary>

--- a/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
@@ -530,6 +530,9 @@ public static class GSharpPrinter
             case ParenthesizedExpression parenthesized:
                 return $"({RenderExpression(parenthesized.Inner, indent)})";
 
+            case CheckedExpression checkedExpr:
+                return $"{(checkedExpr.IsChecked ? "checked" : "unchecked")}({RenderExpression(checkedExpr.Inner, indent)})";
+
             case LambdaExpression lambda:
                 return RenderLambda(lambda, indent);
 
@@ -1041,7 +1044,7 @@ public static class GSharpPrinter
 
     private static string RenderBlock(BlockStatement block, int indent)
     {
-        var prefix = block.IsUnsafe ? "unsafe " : string.Empty;
+        var prefix = block.IsUnsafe ? "unsafe " : block.IsChecked ? "checked " : block.IsUnchecked ? "unchecked " : string.Empty;
         if (block.Statements.Count == 0)
         {
             return prefix + "{\n" + Indent(indent) + "}";

--- a/tools/cs2gs/Cs2Gs.Tests/Coverage/GNodeSamples.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Coverage/GNodeSamples.cs
@@ -89,6 +89,7 @@ public static class GNodeSamples
                     initializer: new StackAllocExpression(Type("uint8"), Int("4")))),
                 isUnsafe: true)),
             [typeof(ParenthesizedExpression)] = () => Expr(new ParenthesizedExpression(Int("1"))),
+            [typeof(CheckedExpression)] = () => Expr(new CheckedExpression(new BinaryExpression(Int("1"), "+", Int("2")), isChecked: true)),
             [typeof(LambdaExpression)] = () => Expr(new LambdaExpression(
                 List(new Parameter("n", Type("int32"))),
                 expressionBody: Id("n"))),

--- a/tools/cs2gs/Cs2Gs.Tests/Coverage/TranslatorExhaustivenessTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Coverage/TranslatorExhaustivenessTests.cs
@@ -78,19 +78,21 @@ public class TranslatorExhaustivenessTests
     [Fact]
     public void UnregisteredConstruct_IsClassifiedAsGap()
     {
-        // The C# 14 `field` keyword (FieldExpression) currently has no
-        // translation rule and is deliberately NOT in the
-        // UnsupportedByDesign registry, so the choke point must classify
-        // this as an accidental gap. If this construct gains a translation
-        // (or a registry entry), swap the snippet for another unregistered
-        // kind — the mechanism under test is the classification.
+        // A function-pointer type (`delegate*<…>`, FunctionPointerType) currently
+        // has no translation rule and is deliberately NOT in the
+        // UnsupportedByDesign registry, so the choke point must classify this as
+        // an accidental gap (tracked as issue #1906). (The C# 14 `field` keyword —
+        // the previous probe here — gained a translation in #1907.) If this
+        // construct gains a translation (or a registry entry), swap the snippet
+        // for another unregistered kind — the mechanism under test is the
+        // classification.
         TranslationContext context = Translate(
-            "namespace S { public class C { public int P { get => field; set => field = value; } } }");
+            "namespace S { public unsafe class C { public delegate*<int, int> M() { return null; } } }");
 
         TranslationDiagnostic diagnostic = context.Diagnostics.FirstOrDefault(d => d.IsUnsupported);
         Assert.True(
             diagnostic is not null,
-            "expected the field-expression property to be unsupported; if it translates now, update this test's snippet.");
+            "expected the function-pointer type to be unsupported; if it translates now, update this test's snippet.");
         Assert.Equal(UnsupportedClassification.Gap, diagnostic.Classification);
         Assert.Equal(UnsupportedRationale.None, diagnostic.Rationale);
     }

--- a/tools/cs2gs/Cs2Gs.Tests/Coverage/TranslatorExhaustivenessTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Coverage/TranslatorExhaustivenessTests.cs
@@ -78,19 +78,19 @@ public class TranslatorExhaustivenessTests
     [Fact]
     public void UnregisteredConstruct_IsClassifiedAsGap()
     {
-        // Checked expressions (`checked(...)`) currently have no translation
-        // rule and are deliberately NOT in the UnsupportedByDesign registry,
-        // so the choke point must classify this as an accidental gap. If
-        // this construct gains a translation (or a registry entry), swap the
-        // snippet for another unregistered kind — the mechanism under test
-        // is the classification.
+        // The C# 14 `field` keyword (FieldExpression) currently has no
+        // translation rule and is deliberately NOT in the
+        // UnsupportedByDesign registry, so the choke point must classify
+        // this as an accidental gap. If this construct gains a translation
+        // (or a registry entry), swap the snippet for another unregistered
+        // kind — the mechanism under test is the classification.
         TranslationContext context = Translate(
-            "namespace S { public static class C { public static void M() { int x = checked(1 + 1); } } }");
+            "namespace S { public class C { public int P { get => field; set => field = value; } } }");
 
         TranslationDiagnostic diagnostic = context.Diagnostics.FirstOrDefault(d => d.IsUnsupported);
         Assert.True(
             diagnostic is not null,
-            "expected the checked expression to be unsupported; if it translates now, update this test's snippet.");
+            "expected the field-expression property to be unsupported; if it translates now, update this test's snippet.");
         Assert.Equal(UnsupportedClassification.Gap, diagnostic.Classification);
         Assert.Equal(UnsupportedRationale.None, diagnostic.Rationale);
     }

--- a/tools/cs2gs/Cs2Gs.Tests/Coverage/code-model-surface.golden.txt
+++ b/tools/cs2gs/Cs2Gs.Tests/Coverage/code-model-surface.golden.txt
@@ -7,6 +7,7 @@ ArrayAllocationExpression
 ArrayLiteralExpression
 AwaitExpression
 BinaryExpression
+CheckedExpression
 CollectionInitializerExpression
 CompositeLiteralExpression
 ConditionalAccessExpression

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1881CheckedUncheckedTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1881CheckedUncheckedTranslationTests.cs
@@ -1,0 +1,198 @@
+// <copyright file="Issue1881CheckedUncheckedTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #1881: cs2gs silently dropped C# <c>checked</c>/<c>unchecked</c>
+/// overflow semantics. A <c>checked(expr)</c>/<c>unchecked(expr)</c>
+/// expression fell to the expression fallback (reported as CS2GS-GAP), and a
+/// <c>checked { }</c>/<c>unchecked { }</c> statement translated to a plain
+/// block — silently erasing the overflow-trap behavior (the worst kind of
+/// divergence: the migrated program compiles and runs, but disagrees on
+/// stdout with the C# oracle). gsc now has native <c>checked</c>/<c>unchecked</c>
+/// expression and block support, so both forms translate directly with no
+/// gap and no silent behavior change.
+/// </summary>
+public class Issue1881CheckedUncheckedTranslationTests
+{
+    [Fact]
+    public void CheckedExpression_TranslatesToCheckedExpression_NoGap()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1881
+{
+    public static class E
+    {
+        public static int Run(int a, int b)
+        {
+            return checked(a + b);
+        }
+    }
+}
+");
+
+        Assert.Contains("checked(a + b)", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void UncheckedExpression_TranslatesToUncheckedExpression_NoGap()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1881
+{
+    public static class E
+    {
+        public static int Run(int a, int b)
+        {
+            return unchecked(a + b);
+        }
+    }
+}
+");
+
+        Assert.Contains("unchecked(a + b)", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void CheckedExpression_NarrowingConversion_TranslatesToCheckedExpression()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1881
+{
+    public static class E
+    {
+        public static byte Run(int wide)
+        {
+            return checked((byte)wide);
+        }
+    }
+}
+");
+
+        Assert.Contains("checked(", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void CheckedStatement_TranslatesToCheckedBlock_NotPlainBlock()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1881
+{
+    public static class E
+    {
+        public static int Run(int a, int b)
+        {
+            int result = 0;
+            checked
+            {
+                result = a + b;
+            }
+
+            return result;
+        }
+    }
+}
+");
+
+        // The pre-fix translator emitted a plain `{ }` block here, silently
+        // erasing the overflow-trap semantics (issue #1881's core bug).
+        Assert.Contains("checked {", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void UncheckedStatement_TranslatesToUncheckedBlock_NotPlainBlock()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1881
+{
+    public static class E
+    {
+        public static int Run(int a, int b)
+        {
+            int result = 0;
+            unchecked
+            {
+                result = a + b;
+            }
+
+            return result;
+        }
+    }
+}
+");
+
+        Assert.Contains("unchecked {", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void CheckedStatement_NestedUnchecked_BothContextsTranslate()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1881
+{
+    public static class E
+    {
+        public static int Run(int a, int b)
+        {
+            int result = 0;
+            checked
+            {
+                unchecked
+                {
+                    result = a + b;
+                }
+            }
+
+            return result;
+        }
+    }
+}
+");
+
+        Assert.Contains("checked {", rendered, StringComparison.Ordinal);
+        Assert.Contains("unchecked {", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    private static void AssertRoundTripParses(string rendered)
+    {
+        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+
+        Assert.True(
+            result.Success,
+            "Sanitized G# must round-trip-parse. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + rendered);
+    }
+
+    private static string Render(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", source) });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        Cs2Gs.CodeModel.Ast.CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        Assert.DoesNotContain(context.Diagnostics, d => d.Severity == TranslationSeverity.Unsupported);
+        return GSharpPrinter.Print(unit);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -4877,9 +4877,17 @@ public sealed class CSharpToGSharpTranslator
                     return new[] { this.TranslateLocalFunction(localFunction) };
 
                 case CheckedStatementSyntax checkedStatement:
-                    // G# arithmetic is unchecked by default and has no
-                    // `checked`/`unchecked` block keyword; emit the inner block.
-                    return new[] { (GStatement)this.TranslateBlock(checkedStatement.Block) };
+                    // Issue #1881: a C# `checked { }`/`unchecked { }` block maps to
+                    // the G# `checked { }`/`unchecked { }` block (gsc now supports
+                    // both natively), introducing a checked/unchecked arithmetic
+                    // context instead of silently dropping the overflow semantics.
+                    return new[]
+                    {
+                        (GStatement)new BlockStatement(
+                            this.TranslateBlock(checkedStatement.Block).Statements,
+                            isChecked: checkedStatement.IsKind(SyntaxKind.CheckedStatement),
+                            isUnchecked: checkedStatement.IsKind(SyntaxKind.UncheckedStatement)),
+                    };
 
                 case UnsafeStatementSyntax unsafeStatement:
                     // ADR-0122 / issue #1014: a C# `unsafe { … }` block maps to the
@@ -9172,6 +9180,14 @@ public sealed class CSharpToGSharpTranslator
 
                 case ParenthesizedExpressionSyntax parenthesized:
                     return new ParenthesizedExpression(this.TranslateExpression(parenthesized.Expression));
+
+                case CheckedExpressionSyntax checkedExpr:
+                    // Issue #1881: `checked(expr)`/`unchecked(expr)` maps directly to
+                    // the G# `checked(...)`/`unchecked(...)` expression (gsc now
+                    // supports both natively).
+                    return new CheckedExpression(
+                        this.TranslateExpression(checkedExpr.Expression),
+                        checkedExpr.IsKind(SyntaxKind.CheckedExpression));
 
                 case InterpolatedStringExpressionSyntax interpolated:
                     return this.TranslateInterpolatedString(interpolated);

--- a/tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/CheckedExpression.cs
+++ b/tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/CheckedExpression.cs
@@ -1,0 +1,46 @@
+// inventory: CheckedExpression
+using System;
+
+namespace Corpus.Grid02
+{
+    public static class CheckedExpressionFixture
+    {
+        public static void Run()
+        {
+            int a = 1000000;
+            int b = 2000;
+            int sum = checked(a + b);
+            long product = checked((long)a * b);
+            Console.WriteLine($"CheckedExpression: sum={sum} product={product}");
+
+            int max = int.MaxValue;
+            int one = 1;
+            bool caught = false;
+            int wrapped = 0;
+            try
+            {
+                wrapped = checked(max + one);
+            }
+            catch (OverflowException)
+            {
+                caught = true;
+            }
+
+            Console.WriteLine($"CheckedExpression: overflow caught={caught} wrapped={wrapped}");
+
+            int wide = 300;
+            bool byteCaught = false;
+            try
+            {
+                byte narrow = checked((byte)wide);
+                Console.WriteLine($"CheckedExpression: narrow={narrow}");
+            }
+            catch (OverflowException)
+            {
+                byteCaught = true;
+            }
+
+            Console.WriteLine($"CheckedExpression: byte overflow caught={byteCaught}");
+        }
+    }
+}

--- a/tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/UncheckedExpression.cs
+++ b/tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/UncheckedExpression.cs
@@ -1,0 +1,24 @@
+// inventory: UncheckedExpression
+using System;
+
+namespace Corpus.Grid02
+{
+    public static class UncheckedExpressionFixture
+    {
+        public static void Run()
+        {
+            int max = int.MaxValue;
+            int one = 1;
+            int wrapped = unchecked(max + one);
+            Console.WriteLine($"UncheckedExpression: wrapped={wrapped}");
+
+            uint maxU = uint.MaxValue;
+            uint oneU = 1;
+            uint wrappedU = unchecked(maxU + oneU);
+            Console.WriteLine($"UncheckedExpression: wrappedU={wrappedU}");
+
+            byte narrowed = unchecked((byte)300);
+            Console.WriteLine($"UncheckedExpression: narrowed={narrowed}");
+        }
+    }
+}

--- a/tools/cs2gs/corpus/grid/G02-Operators-Console/Program.cs
+++ b/tools/cs2gs/corpus/grid/G02-Operators-Console/Program.cs
@@ -16,6 +16,7 @@ namespace Corpus.Grid02
             BitwiseNotExpressionFixture.Run();
             BitwiseOrExpressionFixture.Run();
             CastExpressionFixture.Run();
+            CheckedExpressionFixture.Run();
             CoalesceAssignmentExpressionFixture.Run();
             CoalesceExpressionFixture.Run();
             ConditionalAccessExpressionFixture.Run();
@@ -59,6 +60,7 @@ namespace Corpus.Grid02
             TypeOfExpressionFixture.Run();
             UnaryMinusExpressionFixture.Run();
             UnaryPlusExpressionFixture.Run();
+            UncheckedExpressionFixture.Run();
             UnsignedRightShiftAssignmentExpressionFixture.Run();
             UnsignedRightShiftExpressionFixture.Run();
         }

--- a/tools/cs2gs/corpus/grid/G02-Operators-Console/baseline.stdout.golden
+++ b/tools/cs2gs/corpus/grid/G02-Operators-Console/baseline.stdout.golden
@@ -7,6 +7,9 @@ BitwiseAndExpression: int=8 bool=False
 BitwiseNotExpression: notFive=-6 notZero=-1
 BitwiseOrExpression: int=14 bool=True
 CastExpression: truncated=3 half=3.5 letter=B narrowed=44
+CheckedExpression: sum=1002000 product=2000000000
+CheckedExpression: overflow caught=True wrapped=0
+CheckedExpression: byte overflow caught=True
 CoalesceAssignmentExpression: name=fallback keep=kept count=9 keptCount=3
 CoalesceExpression: first=value picked=21
 ConditionalAccessExpression: len=5 nullLen=-1
@@ -51,5 +54,8 @@ SuppressNullableWarningExpression: value=present len=7
 TypeOfExpression: int=Int32 string=String double=System.Double
 UnaryMinusExpression: negated=-5 double=-2.5 expr=-7
 UnaryPlusExpression: plus=5 double=2.5
+UncheckedExpression: wrapped=-2147483648
+UncheckedExpression: wrappedU=0
+UncheckedExpression: narrowed=44
 UnsignedRightShiftAssignmentExpression: v=6 w=1073741816
 UnsignedRightShiftExpression: a=8 logical=2147483644 arithmetic=-4 long=9223372036854775804 uint=2147483644

--- a/tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/CheckedStatement.cs
+++ b/tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/CheckedStatement.cs
@@ -1,10 +1,4 @@
 // inventory: CheckedStatement
-// NOTE: quarantined sub-case (stage-4 silent divergence, STDOUT-MISMATCH):
-//   checked { int wrapped = max + one; } inside try/catch(OverflowException) —
-//   C# throws and prints "overflow caught = True"; the migrated G# emits the
-//   checked statement as a plain block (overflow semantics NOT preserved) and
-//   prints "unexpected wrap = -2147483648" / "overflow caught = False".
-// Only non-overflowing arithmetic is kept inside the checked block below.
 using System;
 
 namespace Corpus.Grid03.Constructs
@@ -27,6 +21,28 @@ namespace Corpus.Grid03.Constructs
                 int y = x + 1;
                 Console.WriteLine($"CheckedStatement: checked sum without overflow = {y}");
             }
+
+            // issue #1881: the overflow-in-try/catch(OverflowException) case —
+            // previously quarantined because cs2gs erased the checked context,
+            // silently wrapping instead of throwing.
+            bool caught = false;
+            int wrapped = 0;
+            try
+            {
+                int max = int.MaxValue;
+                int one = 1;
+                checked
+                {
+                    wrapped = max + one;
+                }
+            }
+            catch (OverflowException)
+            {
+                caught = true;
+            }
+
+            Console.WriteLine($"CheckedStatement: overflow caught = {caught}");
+            Console.WriteLine($"CheckedStatement: unexpected wrap = {wrapped}");
         }
     }
 }

--- a/tools/cs2gs/corpus/grid/G03-ControlFlow-Console/baseline.stdout.golden
+++ b/tools/cs2gs/corpus/grid/G03-ControlFlow-Console/baseline.stdout.golden
@@ -4,6 +4,8 @@ CatchFilterClause: filter accepted code-1
 CatchFilterClause: filter rejected, outer caught code-2
 CheckedStatement: checked product = 2000000000
 CheckedStatement: checked sum without overflow = 42
+CheckedStatement: overflow caught = True
+CheckedStatement: unexpected wrap = 0
 ContinueStatement: sum of odds 1..10 = 25
 ContinueStatement: multiples of 3 in 1..9 = 3
 DoStatement: doubled to 128 in 7 steps

--- a/tools/cs2gs/coverage/csharp-construct-inventory.json
+++ b/tools/cs2gs/coverage/csharp-construct-inventory.json
@@ -368,8 +368,10 @@
   {
     "kind": "CheckedExpression",
     "nodeType": "CheckedExpressionSyntax",
-    "status": "Gap",
+    "status": "Translated",
+    "rule": "ADR-0115 \u00A7B",
     "rationale": "None",
+    "fixture": "tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/CheckedExpression.cs",
     "issue": "https://github.com/DavidObando/gsharp/issues/1881"
   },
   {
@@ -380,7 +382,7 @@
     "rationale": "None",
     "fixture": "tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/CheckedStatement.cs",
     "issue": "https://github.com/DavidObando/gsharp/issues/1881",
-    "notes": "Overflow semantics silently erased \u2014 emitted as a plain block (issue #1881, parity-verified divergence); non-overflow subset green."
+    "notes": "gsc gained native checked/unchecked expression \u002B block support (issue #1881); overflow semantics preserved, including the overflow-in-try/catch(OverflowException) sub-case. Stdout parity verified (grid G03)."
   },
   {
     "kind": "ClassConstraint",
@@ -2284,8 +2286,10 @@
   {
     "kind": "UncheckedExpression",
     "nodeType": "CheckedExpressionSyntax",
-    "status": "Gap",
+    "status": "Translated",
+    "rule": "ADR-0115 \u00A7B",
     "rationale": "None",
+    "fixture": "tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/UncheckedExpression.cs",
     "issue": "https://github.com/DavidObando/gsharp/issues/1881"
   },
   {
@@ -2295,6 +2299,7 @@
     "rule": "ADR-0115 \u00A7B",
     "rationale": "None",
     "fixture": "tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/UncheckedStatement.cs",
+    "issue": "https://github.com/DavidObando/gsharp/issues/1881",
     "notes": "Wrap-around parity verified (grid G03)."
   },
   {


### PR DESCRIPTION
Fixes #1881

- gsc gains real checked(expr)/unchecked(expr) expressions and checked { }/unchecked { } block statements (contextual keywords, ambient binder-time context, no new BoundNodeKind, innermost-wins nesting, unchecked default matching C#).
- Emit: add.ovf/sub.ovf/mul.ovf (+ .un variants) for +,-,* and conv.ovf.* for narrowing conversions, across all integer widths/signs.
- Interpreter: throws OverflowException in checked context on overflow, matching emitted behavior.
- cs2gs: checked/unchecked statements now carry context onto the emitted block instead of silently dropping it; checked/unchecked expressions translate directly instead of falling to CS2GS-GAP.
- Re-enabled the quarantined G03 CheckedStatement grid fixture and added new G02 CheckedExpression/UncheckedExpression fixtures; goldens recaptured live against the C# oracle, full stdout parity.
- coverage inventory + docs updated to Translated with no divergence notes.
- 14 gsc emit tests, 13 gsc interpreter tests, 6 cs2gs translation tests added.
- Full corpus migration: 0 new, 0 regressed. Full Core.Tests: 5408 passed/1 skipped. Full cs2gs tests: 945 passed.