### PR TITLE
cs2gs: fix raw interpolated string brace handling for 3+ dollar sigils (#2015)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue2015RawInterpolatedStringBraceTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2015RawInterpolatedStringBraceTranslationTests.cs
@@ -1,0 +1,119 @@
+// <copyright file="Issue2015RawInterpolatedStringBraceTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #2015: follow-up to #1882's <c>{{</c>/<c>}}</c> unescape fix. That fix
+/// assumed a hole-delimiter width of exactly 1 brace (the classic <c>$"..."</c>
+/// form), where a doubled brace run is C#'s "escaped literal single brace".
+/// Raw interpolated strings with N&gt;=2 leading <c>$</c> signs (<c>$$"""..."""</c>,
+/// <c>$$$"""..."""</c>, ...) use a WIDER hole delimiter of N consecutive braces:
+/// per the C# spec, a brace run SHORTER than N is embedded verbatim (no escaping
+/// at all), so blindly collapsing <c>{{</c> to <c>{</c> would corrupt literal
+/// text that legitimately contains a two-brace run. This must only unescape for
+/// N==1 and copy raw (N&gt;=2) interpolated-string text verbatim.
+/// </summary>
+public class Issue2015RawInterpolatedStringBraceTranslationTests
+{
+    [Fact]
+    public void ClassicOneDollarInterpolatedString_DoubledBraces_StillUnescape()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue2015
+{
+    public class Holder
+    {
+        public string Describe()
+        {
+            return $""braces={{x}} literal"";
+        }
+    }
+}
+");
+
+        Assert.Contains("\"braces={x} literal\"", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("{{", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void ThreeDollarRawInterpolatedString_LiteralDoubleBraces_DoNotCollapse()
+    {
+        // N=3 raw interpolated string: hole delimiter is `{{{` / `}}}`. A run of
+        // two braces is shorter than N, so it is literal text and must NOT be
+        // collapsed to a single brace by the (N==1-only) unescape logic.
+        string rendered = Render(""""
+namespace Corpus.Issue2015
+{
+    public class Holder
+    {
+        public string Describe()
+        {
+            return $$$"""literal braces: {{ and }} stay doubled""";
+        }
+    }
+}
+"""");
+
+        Assert.Contains("literal braces: {{ and }} stay doubled", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void ThreeDollarRawInterpolatedString_ActualHole_TranslatesInterpolation()
+    {
+        // N=3 raw interpolated string with an actual interpolation hole, opened
+        // and closed with exactly three braces each side.
+        string rendered = Render(""""
+namespace Corpus.Issue2015
+{
+    public class Holder
+    {
+        public string Describe(int x)
+        {
+            return $$$"""value={{{x}}} done""";
+        }
+    }
+}
+"""");
+
+        Assert.Contains("value=$x done", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    private static void AssertRoundTripParses(string rendered)
+    {
+        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+
+        Assert.True(
+            result.Success,
+            "Sanitized G# must round-trip-parse. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + rendered);
+    }
+
+    private static string Render(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", source) });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        Cs2Gs.CodeModel.Ast.CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        Assert.Empty(context.Diagnostics);
+        return GSharpPrinter.Print(unit);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -12992,6 +12992,27 @@ public sealed class CSharpToGSharpTranslator
 
         private GExpression TranslateInterpolatedString(InterpolatedStringExpressionSyntax interpolated)
         {
+            // Issue #2015: the number of leading `$` characters on the string-start
+            // token (StringStartToken.Text, e.g. "$\"", "$$\"\"\"", "$$$\"\"\"")
+            // determines the interpolation-hole delimiter width N for THIS string.
+            // For classic/N==1 interpolated strings (including 1-dollar raw
+            // strings), a brace run of exactly 2 in the text token is Roslyn's
+            // "escaped single literal brace" (see #1882) and must collapse to 1.
+            // For raw interpolated strings with N>=2 dollars, brace-doubling is
+            // NOT an escape at all: per the C# spec, any brace run SHORTER than N
+            // is embedded verbatim, and any run of length >= N is already split by
+            // the parser into (literal remainder) + (an actual hole, handled by
+            // the InterpolationSyntax case below) — so InterpolatedStringTextSyntax
+            // content for N>=2 never needs unescaping and must be copied as-is.
+            int dollarCount = 0;
+            while (dollarCount < interpolated.StringStartToken.Text.Length
+                && interpolated.StringStartToken.Text[dollarCount] == '$')
+            {
+                dollarCount++;
+            }
+
+            bool isClassicSingleDollar = dollarCount <= 1;
+
             var parts = new List<InterpolationPart>();
             foreach (InterpolatedStringContentSyntax content in interpolated.Contents)
             {
@@ -13004,10 +13025,10 @@ public sealed class CSharpToGSharpTranslator
                         // see Lexer.cs), so `{`/`}` are always plain literal chars in G#
                         // and need no escaping at all. Unescape here or the doubled
                         // braces get copied verbatim into the G# output.
-                        string unescapedBraces = text.TextToken.ValueText
-                            .Replace("{{", "{")
-                            .Replace("}}", "}");
-                        parts.Add(InterpolationPart.Literal(unescapedBraces));
+                        string literalText = isClassicSingleDollar
+                            ? text.TextToken.ValueText.Replace("{{", "{").Replace("}}", "}")
+                            : text.TextToken.ValueText;
+                        parts.Add(InterpolationPart.Literal(literalText));
                         break;
 
                     case InterpolationSyntax hole:

--- a/tools/cs2gs/corpus/grid/G14-Strings-Console/Constructs/InterpolatedStringText.cs
+++ b/tools/cs2gs/corpus/grid/G14-Strings-Console/Constructs/InterpolatedStringText.cs
@@ -19,6 +19,13 @@ namespace Corpus.Grid14
             // Literal braces in a plain (non-interpolated) string need no
             // escaping at all in C# or G#.
             Console.WriteLine("plain braces: {x} and {{y}}");
+
+            // Issue #2015: a raw interpolated string with 3 `$` sigils uses a
+            // WIDER `{{{`/`}}}` hole delimiter. A literal `{{`/`}}` run (shorter
+            // than the 3-brace delimiter width) is genuine literal text and must
+            // NOT be collapsed like the 1-dollar case above.
+            Console.WriteLine($$$"""RawInterpolatedStringText: literal braces {{ and }} stay doubled""");
+            Console.WriteLine($$$"""RawInterpolatedStringText: hole value={{{x}}} done""");
         }
     }
 }

--- a/tools/cs2gs/corpus/grid/G14-Strings-Console/baseline.stdout.golden
+++ b/tools/cs2gs/corpus/grid/G14-Strings-Console/baseline.stdout.golden
@@ -11,6 +11,8 @@ InterpolatedStringText: left-5-middle-6-right
 braces={x} dollar=$9.99
 braces={5} hole=5
 plain braces: {x} and {{y}}
+RawInterpolatedStringText: literal braces {{ and }} stay doubled
+RawInterpolatedStringText: hole value=5 done
 Interpolation: sum=13 product=42
 Interpolation: call=IN cond=less
 Interpolation: nested=outer[inner(in)]


### PR DESCRIPTION
Fixes #2015

## Problem
`TranslateInterpolatedString`'s brace-unescape (`Replace("{{","{")`/`Replace("}}","}")`, added in #2014/#1882) is only correct for the classic 1-dollar interpolated string, where a doubled brace is C#'s escape for a literal single brace.

Raw interpolated strings with N>=2 leading `$` signs use a WIDER N-brace hole delimiter (`{{{...}}}` for N=3, etc). Per the C# spec, any brace run *shorter* than N is embedded verbatim — it is **not** a doubling-escape at all. Blindly collapsing `{{` to `{` corrupted legitimate 2-brace literal text inside N>=2 raw interpolated strings (e.g. `$$$"""...{{..."""`).

## Fix
Count the leading `$` characters on `InterpolatedStringExpressionSyntax.StringStartToken.Text` to get the hole-delimiter width N:
- **N==1** (classic interpolated string, including 1-dollar raw strings): keep the existing `{{`->`{`/`}}`->`}` unescape — Roslyn's grammar doubles braces here as an actual escape.
- **N>=2** (raw interpolated string): copy `InterpolatedStringTextSyntax` text verbatim, no unescaping. Roslyn's raw-string grammar already splits real interpolation holes into separate `InterpolationSyntax` nodes, so brace runs remaining in text tokens are never an escape — they're literal, unless their length happens to equal N (which the parser never allows to survive as a text token; it would already be a hole).

## Tests
- New `Issue2015RawInterpolatedStringBraceTranslationTests.cs`: covers 1-dollar interpolated strings (existing unescape behavior preserved), a 3-dollar raw interpolated string with literal `{{`/`}}` text (must NOT collapse), and a 3-dollar raw interpolated string with a real `{{{expr}}}` hole (must translate to a real interpolation).
- Extended the `G14-Strings-Console` conformance-grid fixture (`Constructs/InterpolatedStringText.cs`) with the same raw-string scenarios and regenerated `baseline.stdout.golden` accordingly.

## Validation
- `dotnet build tools/cs2gs/Cs2Gs.Translator/Cs2Gs.Translator.csproj -c Release` — clean.
- `dotnet build tools/cs2gs/Cs2Gs.Cli/Cs2Gs.Cli.csproj -c Release` — clean.
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release` — 949/949 passing (excluding one pre-existing, unrelated flaky test, see below).
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release` — 5382 passed, 1 pre-existing skip.
- `cs2gs migrate --corpus tools/cs2gs/corpus --baseline tools/cs2gs/triage/gaps.json --config Release` — 0 new/regressed gaps; all 20 apps unaffected by this change (`CompileGap-Library` is an intentionally-failing pre-existing fixture); G14-Strings-Console PASS on all stages with the new fixture content.

## Deferred / filed separately
While validating, `Cs2Gs.Tests.Coverage.ConstructInventoryGoldenTests.MatrixDocument_IsInSync` was found to fail even on a clean, unmodified `main` checkout whenever `cs2gs coverage --write` is re-run (the generated `docs/cs2gs-coverage-matrix.md` summary counts drift from its own table rows, reproducibly, with zero underlying data change). This is pre-existing and unrelated to this fix, so I did not touch `docs/cs2gs-coverage-matrix.md` in this PR and instead filed it as #2020.