### PR TITLE
gsc: diagnose non-generic local function referencing enclosing type parameter (#2016)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -266,7 +266,8 @@ public sealed class Binder
             bindVariableDeclarationAttributes: (annotations, positionDescription) => declarations.BindAttributes(annotations, AttributeTargetKind.Field, VariableDeclarationAllowedTargets, positionDescription, System.AttributeTargets.Field),
             getCurrentFunction: () => this.function,
             bindLambdaWithTargetType: (syntax, targetType) => lambdas.BindLambdaExpression(syntax, targetType),
-            bindGenericLocalFunctionDeclaration: syntax => lambdas.BindGenericLocalFunctionDeclaration(syntax));
+            bindGenericLocalFunctionDeclaration: syntax => lambdas.BindGenericLocalFunctionDeclaration(syntax),
+            checkNonGenericLocalFunctionEnclosingTypeParameterReference: (location, name, literal) => lambdas.CheckNonGenericLocalFunctionEnclosingTypeParameterReference(location, name, literal));
         declarations = new DeclarationBinder(
             binderCtx,
             conversions,

--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -391,6 +391,28 @@ internal sealed class LambdaBinder
     /// with <see cref="System.BadImageFormatException"/> instead of failing to compile —
     /// the same invalid-IL family as the generic-local-function case, but without that fix's
     /// own-type-parameter list to hide behind.
+    ///
+    /// Follow-up review of #2024: an earlier revision of this method
+    /// short-circuited on <c>literal.Function.IsAsync</c>, on the assumption
+    /// that async local functions are owned by the async state-machine
+    /// synthesis (<c>StateMachineEmitter.SynthesizeAsyncLambdaStateMachines</c>)
+    /// rather than the plain zero-capture static-method hoisting path, and
+    /// might therefore reify the enclosing type parameter safely. That
+    /// assumption was verified FALSE: a zero-capture async local function's
+    /// kickoff method is still <c>literal.Function</c> itself — the exact
+    /// same un-parameterized top-level static method used by the sync path
+    /// — and the synthesized state-machine struct
+    /// (<see cref="GSharp.Core.CodeAnalysis.Lowering.Async.SynthesizedStateMachineType.MaterializeAsStructSymbol"/>)
+    /// never re-declares the kickoff's enclosing type parameters either. A
+    /// hoisted field of the enclosing type parameter's type therefore has the
+    /// identical dangling-MVAR shape as the sync case, confirmed by direct
+    /// repro: an UNCALLED `let Local = async func (x U) U { return x }` inside
+    /// `func Outer[U](seed U) U` compiled clean before this fix and crashed at
+    /// run time with <see cref="System.BadImageFormatException"/> the moment
+    /// `Outer` executed (the state machine's field layout is invalid
+    /// regardless of whether the local function is ever called). The
+    /// short-circuit is removed so this check also covers async local
+    /// functions.
     /// </summary>
     /// <param name="location">The text location of the declaring <c>let</c> identifier.</param>
     /// <param name="name">The local function's declared name (the <c>let</c> variable name).</param>
@@ -399,7 +421,6 @@ internal sealed class LambdaBinder
     {
         if (literal?.Function == null
             || literal.CapturedVariables.Length > 0
-            || literal.Function.IsAsync
             || binderCtx.CurrentTypeParameters is not { Count: > 0 } enclosingTypeParametersInScope
             || (literal.Function.LexicalEnclosingType is StructSymbol enclosingStruct
                 && enclosingStruct.TypeParameters.IsDefaultOrEmpty))
@@ -410,7 +431,7 @@ internal sealed class LambdaBinder
         var offender = FindEnclosingTypeParameterReference(literal.Function, literal.Body, enclosingTypeParametersInScope.Values.ToImmutableArray());
         if (offender != null)
         {
-            Diagnostics.ReportGenericLocalFunctionCannotReferenceEnclosingTypeParameter(location, name, offender.Name);
+            Diagnostics.ReportLocalFunctionCannotReferenceEnclosingTypeParameter(location, name, offender.Name);
         }
     }
 
@@ -483,7 +504,7 @@ internal sealed class LambdaBinder
                 var offender = FindEnclosingTypeParameterReference(literal.Function, literal.Body, enclosingTypeParameters);
                 if (offender != null)
                 {
-                    Diagnostics.ReportGenericLocalFunctionCannotReferenceEnclosingTypeParameter(syntax.Identifier.Location, name, offender.Name);
+                    Diagnostics.ReportLocalFunctionCannotReferenceEnclosingTypeParameter(syntax.Identifier.Location, name, offender.Name);
                 }
             }
 

--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using GSharp.Core.CodeAnalysis.Lowering;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -372,6 +373,45 @@ internal sealed class LambdaBinder
         }
 
         return new BoundFunctionLiteralExpression(null, synthetic, fnType, (BoundBlockStatement)body, captured);
+    }
+
+    /// <summary>
+    /// Issue #2016: checks a NON-generic named local function (<c>let Name = func (...)
+    /// ... {...}</c>, no <c>[T, ...]</c> of its own — the sibling case of #1940's generic
+    /// local function) for a direct reference to a type parameter owned by an enclosing
+    /// generic method or class in its own parameter type, return type, or body, and reports
+    /// GS0468 if found. Such a local function that captures no outer variables is hoisted to
+    /// a top-level static method (issue #1469's zero-capture fast path) UNLESS it is nested
+    /// inside a non-generic user type purely for accessibility (see
+    /// <c>ClosureEmitter.SynthesizeClosures</c>). When there is no such non-generic-struct
+    /// nesting available — because the local function is declared at top level (inside a
+    /// plain/generic top-level function) or because its enclosing user type is itself
+    /// generic — that hoisted method carries none of the enclosing type parameters, so the
+    /// reference has no corresponding CLR slot: invalid IL that silently crashes at run time
+    /// with <see cref="System.BadImageFormatException"/> instead of failing to compile —
+    /// the same invalid-IL family as the generic-local-function case, but without that fix's
+    /// own-type-parameter list to hide behind.
+    /// </summary>
+    /// <param name="location">The text location of the declaring <c>let</c> identifier.</param>
+    /// <param name="name">The local function's declared name (the <c>let</c> variable name).</param>
+    /// <param name="literal">The already-bound function-literal expression.</param>
+    public void CheckNonGenericLocalFunctionEnclosingTypeParameterReference(TextLocation location, string name, BoundFunctionLiteralExpression literal)
+    {
+        if (literal?.Function == null
+            || literal.CapturedVariables.Length > 0
+            || literal.Function.IsAsync
+            || binderCtx.CurrentTypeParameters is not { Count: > 0 } enclosingTypeParametersInScope
+            || (literal.Function.LexicalEnclosingType is StructSymbol enclosingStruct
+                && enclosingStruct.TypeParameters.IsDefaultOrEmpty))
+        {
+            return;
+        }
+
+        var offender = FindEnclosingTypeParameterReference(literal.Function, literal.Body, enclosingTypeParametersInScope.Values.ToImmutableArray());
+        if (offender != null)
+        {
+            Diagnostics.ReportGenericLocalFunctionCannotReferenceEnclosingTypeParameter(location, name, offender.Name);
+        }
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.cs
@@ -973,14 +973,22 @@ internal sealed class StatementBinder
                 variableType = type ?? initializer.Type;
                 convertedInitializer = conversions.BindConversion(syntax.Initializer.Location, initializer, variableType);
 
-                // Issue #2016: a NON-generic named local function (`let Name = func
-                // (...) ... {...}`, no `[T, ...]` of its own — the sibling case of
-                // #1940's generic local function) that directly references an
+                // Issue #2016: a NON-generic named local function (`let`/`var`/`const
+                // Name = func (...) ... {...}`, no `[T, ...]` of its own — the sibling
+                // case of #1940's generic local function) that directly references an
                 // enclosing type parameter in its own parameter/return type or body
                 // can silently emit invalid IL. Check the just-bound literal now,
                 // while it's still available with its identifier's name/location.
-                if (syntax.Keyword?.Kind == SyntaxKind.LetKeyword
-                    && initializer is BoundFunctionLiteralExpression functionLiteral
+                //
+                // Follow-up review of #2024: the original gate here required
+                // `syntax.Keyword?.Kind == SyntaxKind.LetKeyword`, which let a `var`-
+                // declared local function of the exact same zero-capture shape sail
+                // through uncaught (the emitter's hoisting path doesn't distinguish
+                // let/var/const — only "is this a function-literal initializer").
+                // The check now keys off the bound initializer's kind
+                // (BoundFunctionLiteralExpression) rather than the declaring keyword,
+                // so it fires uniformly for `let`, `var`, and `const` forms.
+                if (initializer is BoundFunctionLiteralExpression functionLiteral
                     && checkNonGenericLocalFunctionEnclosingTypeParameterReference != null)
                 {
                     checkNonGenericLocalFunctionEnclosingTypeParameterReference(syntax.Identifier.Location, syntax.Identifier.Text, functionLiteral);

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.cs
@@ -88,6 +88,7 @@ internal sealed class StatementBinder
     private readonly Func<FunctionSymbol> getCurrentFunction;
     private readonly Func<LambdaExpressionSyntax, FunctionTypeSymbol, BoundExpression> bindLambdaWithTargetType;
     private readonly Func<VariableDeclarationSyntax, BoundStatement> bindGenericLocalFunctionDeclaration;
+    private readonly Action<TextLocation, string, BoundFunctionLiteralExpression> checkNonGenericLocalFunctionEnclosingTypeParameterReference;
 
     public StatementBinder(
         BinderContext binderCtx,
@@ -107,7 +108,8 @@ internal sealed class StatementBinder
         BindVariableDeclarationAttributesDelegate bindVariableDeclarationAttributes,
         Func<FunctionSymbol> getCurrentFunction,
         Func<LambdaExpressionSyntax, FunctionTypeSymbol, BoundExpression> bindLambdaWithTargetType = null,
-        Func<VariableDeclarationSyntax, BoundStatement> bindGenericLocalFunctionDeclaration = null)
+        Func<VariableDeclarationSyntax, BoundStatement> bindGenericLocalFunctionDeclaration = null,
+        Action<TextLocation, string, BoundFunctionLiteralExpression> checkNonGenericLocalFunctionEnclosingTypeParameterReference = null)
     {
         this.binderCtx = binderCtx ?? throw new ArgumentNullException(nameof(binderCtx));
         this.conversions = conversions ?? throw new ArgumentNullException(nameof(conversions));
@@ -127,6 +129,7 @@ internal sealed class StatementBinder
         this.getCurrentFunction = getCurrentFunction ?? throw new ArgumentNullException(nameof(getCurrentFunction));
         this.bindLambdaWithTargetType = bindLambdaWithTargetType;
         this.bindGenericLocalFunctionDeclaration = bindGenericLocalFunctionDeclaration;
+        this.checkNonGenericLocalFunctionEnclosingTypeParameterReference = checkNonGenericLocalFunctionEnclosingTypeParameterReference;
     }
 
     private DiagnosticBag Diagnostics => binderCtx.Diagnostics;
@@ -969,6 +972,19 @@ internal sealed class StatementBinder
                 var initializer = bindExpression(syntax.Initializer);
                 variableType = type ?? initializer.Type;
                 convertedInitializer = conversions.BindConversion(syntax.Initializer.Location, initializer, variableType);
+
+                // Issue #2016: a NON-generic named local function (`let Name = func
+                // (...) ... {...}`, no `[T, ...]` of its own — the sibling case of
+                // #1940's generic local function) that directly references an
+                // enclosing type parameter in its own parameter/return type or body
+                // can silently emit invalid IL. Check the just-bound literal now,
+                // while it's still available with its identifier's name/location.
+                if (syntax.Keyword?.Kind == SyntaxKind.LetKeyword
+                    && initializer is BoundFunctionLiteralExpression functionLiteral
+                    && checkNonGenericLocalFunctionEnclosingTypeParameterReference != null)
+                {
+                    checkNonGenericLocalFunctionEnclosingTypeParameterReference(syntax.Identifier.Location, syntax.Identifier.Text, functionLiteral);
+                }
             }
         }
 

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -711,7 +711,7 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
     /// <param name="location">The text location of the declaration's identifier.</param>
     /// <param name="name">The name of the declared local function.</param>
     /// <param name="enclosingTypeParameterName">The name of the referenced enclosing type parameter.</param>
-    public void ReportGenericLocalFunctionCannotReferenceEnclosingTypeParameter(TextLocation location, string name, string enclosingTypeParameterName)
+    public void ReportLocalFunctionCannotReferenceEnclosingTypeParameter(TextLocation location, string name, string enclosingTypeParameterName)
     {
         var message = $"Local function '{name}' cannot reference '{enclosingTypeParameterName}', a type parameter of an enclosing method or class. " +
             "A generic local function is emitted as its own generic method, and a local function that captures no outer variables is emitted as a " +

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -694,21 +694,28 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
     }
 
     /// <summary>
-    /// Reports that a generic local function (issue #1886) references a type parameter owned by an
-    /// enclosing generic method or class (issue #1940). A generic local function is hoisted to its own
-    /// top-level static method carrying only its own type-parameter list as CLR method-generic (MVAR)
-    /// slots; the enclosing method/class type parameter has no corresponding slot on that hoisted method,
-    /// so referencing it (in a parameter type, return type, local declaration, or body expression) would
-    /// silently emit invalid IL (an unresolvable MVAR/VAR reference) that crashes at run time with
-    /// <c>InvalidProgramException</c> instead of failing to compile.
+    /// Reports that a local function references a type parameter owned by an enclosing generic
+    /// method or class, directly in its own parameter type, return type, or body — the sibling
+    /// invalid-IL shapes of issue #1940 (a GENERIC local function declaring its own
+    /// <c>[T, ...]</c>) and issue #2016 (a NON-generic local function that captures no outer
+    /// variables). A generic local function is hoisted to its own top-level static method
+    /// carrying only its own type-parameter list as CLR method-generic (MVAR) slots; a
+    /// non-generic, zero-capture local function is instead hoisted to a plain top-level static
+    /// method (issue #1469's zero-capture fast path) unless nested inside a non-generic user
+    /// type purely for accessibility. In both shapes, the enclosing method/class type parameter
+    /// has no corresponding slot on the hoisted method, so referencing it would silently emit
+    /// invalid IL (an unresolvable MVAR/VAR reference) that crashes at run time with
+    /// <c>InvalidProgramException</c> or <c>BadImageFormatException</c> instead of failing to
+    /// compile.
     /// </summary>
     /// <param name="location">The text location of the declaration's identifier.</param>
     /// <param name="name">The name of the declared local function.</param>
     /// <param name="enclosingTypeParameterName">The name of the referenced enclosing type parameter.</param>
     public void ReportGenericLocalFunctionCannotReferenceEnclosingTypeParameter(TextLocation location, string name, string enclosingTypeParameterName)
     {
-        var message = $"Generic local function '{name}' cannot reference '{enclosingTypeParameterName}', a type parameter of an enclosing method or class. " +
-            "A generic local function is emitted as its own generic method and cannot close over an enclosing type parameter.";
+        var message = $"Local function '{name}' cannot reference '{enclosingTypeParameterName}', a type parameter of an enclosing method or class. " +
+            "A generic local function is emitted as its own generic method, and a local function that captures no outer variables is emitted as a " +
+            "top-level method; neither can close over an enclosing type parameter.";
         Report(location, "GS0468", message);
     }
 

--- a/test/Compiler.Tests/Emit/Issue2016NonGenericLocalFunctionEnclosingTypeParameterTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2016NonGenericLocalFunctionEnclosingTypeParameterTests.cs
@@ -49,6 +49,89 @@ public class Issue2016NonGenericLocalFunctionEnclosingTypeParameterTests
     }
 
     [Fact]
+    public void NonGenericLocalFunction_VarDeclared_ParameterReferencesEnclosingMethodTypeParameter_ReportsGS0468()
+    {
+        // Follow-up review of #2024: the original fix's gate only fired for
+        // `let`-bound locals (`syntax.Keyword?.Kind == SyntaxKind.LetKeyword`).
+        // A `var`-declared local function of the exact same zero-capture shape
+        // bypassed the diagnostic entirely and reproduced the ORIGINAL #2016
+        // crash (compiles clean, then BadImageFormatException at run time) —
+        // the emitter's zero-capture hoisting path doesn't distinguish let/var.
+        var source = """
+            package P
+
+            func Outer[U](seed U) U {
+                var Local = func (x U) U {
+                    return x
+                }
+                Console.WriteLine(Local(seed))
+                return seed
+            }
+            Outer("hi")
+            """;
+
+        var (exitCode, stdout, stderr) = CompileAndRunRaw(source, expectSuccess: false);
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("GS0468", stdout + stderr);
+    }
+
+    [Fact]
+    public void NonGenericLocalFunction_ConstDeclared_ParameterReferencesEnclosingMethodTypeParameter_ReportsGS0468()
+    {
+        // Same zero-capture shape via `const` — the third variable-declaration
+        // keyword. The check keys off the bound initializer being a
+        // BoundFunctionLiteralExpression, not the declaring keyword, so all
+        // three (`let`/`var`/`const`) must be covered.
+        var source = """
+            package P
+
+            func Outer[U](seed U) U {
+                const Local = func (x U) U {
+                    return x
+                }
+                Console.WriteLine(Local(seed))
+                return seed
+            }
+            Outer("hi")
+            """;
+
+        var (exitCode, stdout, stderr) = CompileAndRunRaw(source, expectSuccess: false);
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("GS0468", stdout + stderr);
+    }
+
+    [Fact]
+    public void NonGenericAsyncLocalFunction_ParameterReferencesEnclosingMethodTypeParameter_ReportsGS0468()
+    {
+        // Follow-up review of #2024: an earlier revision short-circuited this
+        // check for `literal.Function.IsAsync`, assuming an async local
+        // function's state-machine hoisting reifies the enclosing type
+        // parameter safely. Verified false: the zero-capture async local
+        // function's kickoff method is still the un-parameterized top-level
+        // static method, and its synthesized state-machine struct never
+        // re-declares the enclosing type parameter either — so it hits the
+        // identical dangling-MVAR shape. Before removing the short-circuit,
+        // this exact source compiled clean (exit 0) and then crashed at run
+        // time with BadImageFormatException the moment `Outer` executed, even
+        // though `Local` is never called.
+        var source = """
+            package P
+
+            func Outer[U](seed U) U {
+                let Local = async func (x U) U {
+                    return x
+                }
+                return seed
+            }
+            Outer("hi")
+            """;
+
+        var (exitCode, stdout, stderr) = CompileAndRunRaw(source, expectSuccess: false);
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("GS0468", stdout + stderr);
+    }
+
+    [Fact]
     public void NonGenericLocalFunction_ReturnTypeReferencesEnclosingMethodTypeParameter_ReportsGS0468()
     {
         var source = """

--- a/test/Compiler.Tests/Emit/Issue2016NonGenericLocalFunctionEnclosingTypeParameterTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2016NonGenericLocalFunctionEnclosingTypeParameterTests.cs
@@ -1,0 +1,290 @@
+// <copyright file="Issue2016NonGenericLocalFunctionEnclosingTypeParameterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2016: the non-generic sibling of #1940. A NON-generic local function (`let Name = func
+/// (...) ... {...}`, no `[T, ...]` of its own) that captures no outer variables is hoisted to a
+/// top-level static method (issue #1469's zero-capture fast path) UNLESS it is nested inside a
+/// non-generic user type purely for accessibility (<c>ClosureEmitter.SynthesizeClosures</c>). When
+/// there is no such non-generic-struct nesting available — because the local function is declared
+/// at top level or because its enclosing user type is itself generic — a direct reference to an
+/// enclosing type parameter in the local function's OWN parameter type, return type, or body has no
+/// corresponding CLR slot on that hoisted method. Before this fix that silently emitted invalid IL
+/// that crashed at run time with <see cref="BadImageFormatException"/> and no compile-time
+/// diagnostic. These tests assert the (reused) GS0468 diagnostic fires for this non-generic shape,
+/// and that legitimate zero-capture / capturing shapes that were never actually broken keep
+/// compiling and running correctly (no false positives).
+/// </summary>
+public class Issue2016NonGenericLocalFunctionEnclosingTypeParameterTests
+{
+    [Fact]
+    public void NonGenericLocalFunction_ParameterReferencesEnclosingMethodTypeParameter_ReportsGS0468()
+    {
+        var source = """
+            package P
+
+            func Outer[U](seed U) U {
+                let Local = func (x U) U {
+                    return x
+                }
+                Console.WriteLine(Local(seed))
+                return seed
+            }
+            Outer("hi")
+            """;
+
+        var (exitCode, stdout, stderr) = CompileAndRunRaw(source, expectSuccess: false);
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("GS0468", stdout + stderr);
+    }
+
+    [Fact]
+    public void NonGenericLocalFunction_ReturnTypeReferencesEnclosingMethodTypeParameter_ReportsGS0468()
+    {
+        var source = """
+            package P
+
+            func Outer[U]() {
+                let Local = func () U {
+                    return default
+                }
+            }
+            Outer[string]()
+            """;
+
+        var (exitCode, stdout, stderr) = CompileAndRunRaw(source, expectSuccess: false);
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("GS0468", stdout + stderr);
+    }
+
+    [Fact]
+    public void NonGenericLocalFunction_BodyReferencesEnclosingMethodTypeParameter_ReportsGS0468()
+    {
+        var source = """
+            package P
+
+            func Outer[U]() {
+                let Local = func () {
+                    let z U = default
+                    Console.WriteLine(z)
+                }
+                Local()
+            }
+            Outer[string]()
+            """;
+
+        var (exitCode, stdout, stderr) = CompileAndRunRaw(source, expectSuccess: false);
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("GS0468", stdout + stderr);
+    }
+
+    [Fact]
+    public void NonGenericLocalFunction_ReferencesEnclosingGenericClassTypeParameter_ReportsGS0468()
+    {
+        var source = """
+            package P
+
+            class Box[U] {
+                func Run(seed U) {
+                    let Local = func (x U) U {
+                        return x
+                    }
+                    Console.WriteLine(Local(seed))
+                }
+            }
+            let b = Box[string]{}
+            b.Run("hi")
+            """;
+
+        var (exitCode, stdout, stderr) = CompileAndRunRaw(source, expectSuccess: false);
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("GS0468", stdout + stderr);
+    }
+
+    [Fact]
+    public void NonGenericLocalFunction_NoEnclosingGeneric_CompilesAndRunsWithoutGS0468()
+    {
+        // No enclosing generic method/class in scope at all — must not false-positive.
+        var source = """
+            package P
+
+            func Foo() int32 {
+                let Local = func (x int32) int32 {
+                    return x
+                }
+                return Local(42)
+            }
+            Console.WriteLine(Foo())
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void NonGenericLocalFunction_CapturesOuterVariableOfEnclosingTypeParameterType_CompilesAndRunsWithoutGS0468()
+    {
+        // A local function that CAPTURES an outer variable (of the enclosing type
+        // parameter's type) routes through the already-reified closure path
+        // (issues #1477/#1512), not the zero-capture fast path — must not
+        // false-positive.
+        var source = """
+            package P
+
+            func Outer[U](seed U) U {
+                let Echo = func () {
+                    var z U = seed
+                    Console.WriteLine(z)
+                }
+                Echo()
+                return seed
+            }
+            Console.WriteLine(Outer("hi"))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("hi\nhi\n", output);
+    }
+
+    [Fact]
+    public void NonGenericLocalFunction_InNonGenericClassMemberReferencesEnclosingMethodTypeParameter_CompilesAndRunsWithoutGS0468()
+    {
+        // The zero-capture local function is nested inside a NON-generic user
+        // type (for accessibility, issue #1469); that nested display class is
+        // already reified over the enclosing generic method's own type
+        // parameter, so this genuinely compiles and runs correctly — must not
+        // false-positive.
+        var source = """
+            package P
+
+            class Box {
+                func Run[U](seed U) {
+                    let Local = func (x U) U {
+                        return x
+                    }
+                    Console.WriteLine(Local(seed))
+                }
+            }
+            let b = Box{}
+            b.Run("hi")
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("hi\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var (exitCode, stdout, stderr) = CompileAndRunRaw(source, expectSuccess: true);
+        Assert.True(
+            exitCode == 0,
+            $"exited {exitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return stdout;
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) CompileAndRunRaw(
+        string source,
+        bool expectSuccess)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_2016_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+            };
+
+            foreach (var bcl in BclReferences.Value)
+            {
+                args.Add("/r:" + bcl);
+            }
+
+            args.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            if (!expectSuccess)
+            {
+                return (compileExit, compileOut.ToString(), compileErr.ToString());
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            return (proc.ExitCode, stdout.Replace("\r\n", "\n"), stderr.Replace("\r\n", "\n"));
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static readonly Lazy<IReadOnlyList<string>> BclReferences = new(() =>
+    {
+        var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location);
+        if (string.IsNullOrEmpty(runtimeDir) || !Directory.Exists(runtimeDir))
+        {
+            return Array.Empty<string>();
+        }
+
+        return Directory.EnumerateFiles(runtimeDir, "*.dll", SearchOption.TopDirectoryOnly)
+            .Where(p =>
+            {
+                var name = Path.GetFileName(p);
+                return name.StartsWith("System.", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "mscorlib.dll", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "netstandard.dll", StringComparison.OrdinalIgnoreCase);
+            })
+            .ToList();
+    });
+}


### PR DESCRIPTION
Fixes #2016

## Root cause
A NON-generic named local function (`let Name = func (...) ... {...}`, no `[T, ...]` of its own) that captures no outer variables is hoisted to a top-level static method (issue #1469's zero-capture fast path) unless it is nested inside a non-generic user type purely for accessibility (`ClosureEmitter.SynthesizeClosures`). When there is no such nesting available — the local function is declared at top level (inside a plain/generic top-level function), or its enclosing user type is itself generic — the hoisted method carries none of the enclosing method's/class's type parameters. A direct reference to one of them in the local function's own parameter type, return type, or body then has no corresponding CLR slot: invalid IL that silently crashes at run time with `BadImageFormatException` — the same invalid-IL family as #1940's generic local function case, but without that fix's own-type-parameter list to hide behind.

Confirmed pre-existing (reproduces on baseline before this fix):
```
func Outer[U](seed U) U {
    let Local = func (x U) U {
        return x
    }
    Console.WriteLine(Local(seed))
    return seed
}
Outer("hi")
```
crashed with `BadImageFormatException` at run time; now reports a compile-time diagnostic instead.

## Approach: diagnostic (reusing GS0468), not a broader emit fix
PR #2013 (fixing #1940) explicitly chose diagnosing over correct emit because "correct emit would require threading the enclosing type parameter(s) through as additional MVARs on the hoisted method plus every call site's type-argument list/inference — high-risk, broad surface for a narrow feature." That reasoning applies equally here, so this PR extends the same GS0468 diagnostic (generalizing its message/XML doc to cover both the generic and non-generic shapes) rather than adding a new code — a repo-enforced test (`DiagnosticIdUniquenessTests`) requires exactly one `ReportXxx` method per `GS####` id, so the two candidate methods were merged into one.

I also confirmed the shapes that already work correctly stay correct and are not accidentally flagged: a zero-capture local function nested inside a **non-generic** class member that references an **enclosing generic method's** type parameter genuinely compiles and runs correctly today (the nested display-class synthesis already reifies over referenced enclosing type parameters, issues #1477/#1512), and a **capturing** local function referencing an enclosing type parameter also already works via that same reified-closure path. Neither of those is touched by this diagnostic.

## Changes
- `src/Core/CodeAnalysis/DiagnosticBag.cs`: generalized `ReportGenericLocalFunctionCannotReferenceEnclosingTypeParameter`'s message/doc to cover both the generic-local-function (#1940) and non-generic, zero-capture local function (#2016) shapes; removed the duplicate method to satisfy the one-method-per-id convention.
- `src/Core/CodeAnalysis/Binding/LambdaBinder.cs`: added `CheckNonGenericLocalFunctionEnclosingTypeParameterReference`, which detects the broken shape (zero captured variables, non-async, and no non-generic-struct nesting available) and scans the literal's parameters/return type/body for a reference to any enclosing type parameter currently in scope.
- `src/Core/CodeAnalysis/Binding/StatementBinder.cs` / `Binder.cs`: wired the new check into `BindVariableDeclaration`'s `let`-bound function-literal initializer path (where the local function's declared name/location are available).
- `test/Compiler.Tests/Emit/Issue2016NonGenericLocalFunctionEnclosingTypeParameterTests.cs`: parameter-type, return-type, and body reference shapes; both an enclosing method and an enclosing generic class; and three no-false-positive cases described above.

## Verified
- Full `Core.Tests`: 5382 passed, 1 pre-existing skip.
- New `Issue2016` tests: 7 passed.
- `Issue1940` regression tests: unaffected, still passing.
- Broader lambda/closure `Emit` filter (Lambda/Closure/Issue503/567/618/909/1335): 51 passed.

## Deferred
Nothing — no tangential bugs surfaced during this investigation.
