### PR TITLE
cs2gs: map C# goto/labels (incl. goto case/default) to G# (#1884)

### DIFF
--- a/docs/adr/0070-while-do-loops-and-labeled-break-continue.md
+++ b/docs/adr/0070-while-do-loops-and-labeled-break-continue.md
@@ -5,6 +5,8 @@
 - **Phase**: Phase 9 — language depth / control-flow ergonomics
 - **Related**: ADR-0010 (aspirational samples), issues [#707](https://github.com/DavidObando/gsharp/issues/707) (this ADR), parent [#706](https://github.com/DavidObando/gsharp/issues/706) (control-flow polish)
 
+> **Amendment (issue [#1884](https://github.com/DavidObando/gsharp/issues/1884), see ADR-0139)**: `label:` is no longer restricted to loop statements. A label on a non-loop statement now declares a `goto` target instead of reporting GS0294 (retired); GS0293/GS0295 and loop labels for `break`/`continue` are unchanged.
+
 ## Context
 
 G# inherited Go's "every loop is `for`" surface: `for { … }` is infinite, `for cond { … }` is the while-shape, `for init; cond; post { … }` is the C-style clause form, `for x := range coll { … }` (and `for x in coll { … }`) iterate, and `for i := a … b { … }` is the integer-range shape. There is no `while` keyword, no `do`/`repeat`-while, and `break` / `continue` always target the innermost enclosing loop.

--- a/docs/adr/0139-goto-and-general-labels.md
+++ b/docs/adr/0139-goto-and-general-labels.md
@@ -1,0 +1,130 @@
+# ADR-0139: general `goto` / label statements
+
+- **Status**: Accepted
+- **Date**: 2026-07-04
+- **Phase**: Phase 9 — language depth / control-flow ergonomics
+- **Related**: ADR-0070 (`while`/`do`-`while`, labeled `break`/`continue`), issue [#1884](https://github.com/DavidObando/gsharp/issues/1884)
+
+## Context
+
+ADR-0070 added `name: loop-statement` labels, but restricted them to loop
+statements — the label could only be consumed by a labeled `break`/`continue`.
+`cs2gs` (the C#→G# migration tool) has no mapping for C#'s general
+`goto label;` / `label: statement;` / `goto case K;` / `goto default;` and
+falls back to a `CS2GS-GAP` diagnostic for all four (issue #1884).
+
+Under the hood, G# already has everything a general `goto`/label needs:
+`BoundGotoStatement` and `BoundLabelStatement` are the same bound nodes the
+`for`/`while`/`do`-`while` lowering has emitted since ADR-0070 (`goto check`,
+`goto body`, …), and both the IL emitter and the tree-walking evaluator
+resolve them generically — including a jump out of a nested block to a label
+in an enclosing one (the exact shape `break`/`continue` already relies on).
+The only missing piece was surface syntax and a name-to-label binding table.
+
+## Decision
+
+`label:` can now prefix **any** statement, not only a loop:
+
+```
+LabeledStatement ::= identifier ':' Statement
+GotoStatement    ::= 'goto' identifier
+```
+
+- A label on a loop statement is unchanged from ADR-0070 — it names the loop
+  for a labeled `break`/`continue`.
+- A label on any other statement declares a **`goto` target**. `goto name`
+  (the target must be on the same source line as the keyword, mirroring the
+  `break`/`continue` label rule) jumps to it.
+- The label namespace is local to the enclosing function, matching ADR-0070's
+  existing rule for loop labels. A `goto` may forward-reference a label
+  declared later in the same function.
+- `goto` can jump out of a nested block (`if`, `for`, `try`, …) to a label in
+  an enclosing block — the same escape the lowered `break`/`continue` already
+  performs. Jumping *into* a nested block is not supported (matching C#'s own
+  restriction; there is no scope-entry bookkeeping for it).
+
+### Binder
+
+The binder pre-registers nothing eagerly; instead each function's
+`BinderContext` carries a `name → BoundLabel` map (`UserLabels`) built
+on demand:
+
+- `goto name` calls `GetOrCreateUserLabelForGoto`, which returns the existing
+  `BoundLabel` or creates a placeholder (a forward reference) and records the
+  reference location in `UnresolvedGotoLabels`.
+- `label: statement` (non-loop) calls `DefineUserLabel`, which reuses any
+  placeholder, or creates a fresh label, and reports GS0470 if the name is
+  already defined in this function.
+- Once the enclosing function/method/constructor/accessor/local-function body
+  (or, for top-level statements, all global statements together) finishes
+  binding, `FinalizeUserLabels` reports GS0469 for any name left in
+  `UnresolvedGotoLabels` — a `goto` to a label that was never declared.
+
+`BindLabeledStatement`'s non-loop path binds the inner statement normally and
+wraps `[BoundLabelStatement, boundInner]` in a `BoundBlockStatement` purely
+for return-shape convenience: the existing `Lowerer.Flatten` pass inlines
+nested `BoundBlockStatement`s into their parent's statement list, so this
+introduces no new binder scope — `label: var x = 1` still declares `x` into
+the enclosing block, exactly like C#.
+
+No new `BoundNodeKind` is introduced (`BoundGotoStatement`/
+`BoundLabelStatement` already existed), so `ControlFlowGraph`,
+`RefKindDefiniteAssignmentAnalyzer`, `SlotPlanner`, `MethodBodyEmitter`, and
+the evaluator needed no changes — they already handle these bound nodes
+generically.
+
+### Diagnostics
+
+| Code   | Message                                                  | Trigger                                          |
+| ------ | --------------------------------------------------------- | ------------------------------------------------- |
+| GS0469 | The label '\<name\>' does not exist in the current context. | `goto` to a name never declared in this function.  |
+| GS0470 | The label '\<name\>' is already defined in this function.   | Two `label:` declarations with the same name.      |
+
+GS0294 ("a label can only be applied to a loop statement") is retired — the
+shape it flagged is now valid.
+
+### `cs2gs` mapping (issue #1884)
+
+With general `goto`/label available, the four gapped C# constructs map
+directly:
+
+- `LabeledStatement` → G# `label: statement`.
+- `GotoStatement` → G# `goto label`.
+- `GotoCaseStatement` / `GotoDefaultStatement` → C#'s `goto case K;` /
+  `goto default;` jump straight into a `switch` arm's statement list without
+  re-evaluating the switch expression, and (per C# semantics) fall through
+  into any following arm exactly as `case K:` would. `cs2gs` keeps the
+  `switch` a native G# `switch` and, for each arm actually targeted by a
+  `goto case`/`goto default` elsewhere in the same `switch`, prefixes that
+  arm's translated body with a synthesized label (`__gotoCase<pos>` /
+  `__gotoDefault<pos>`, keyed by the target case/default label's own source
+  position so it is unique and stable across the two translator call sites
+  that must agree on the name); the `goto case`/`goto default` statement
+  itself lowers to a plain `goto` of that label. G# arms are fully flattened
+  by `Lowerer.Flatten` before evaluation/emission (the same mechanism that
+  lets a `goto` cross sibling `if`/`while` blocks), so a `goto` landing
+  inside one arm's body and falling through into the next arm's statements
+  works with no special-casing — no `if`/`else if` rewrite of the `switch`
+  is needed.
+
+## Consequences
+
+**Positive.** `cs2gs` can now migrate C#'s full `goto`/label surface,
+including the `goto case`/`goto default` fall-through forms, with faithful
+semantics. No gsc runtime or emit changes were needed — only surface syntax
+and a label-name binder.
+
+**Negative.** Unstructured control flow is easy to write incorrectly by hand;
+G# still has no `goto`-into-scope diagnostic beyond "does not parse as a
+label the flattener can reach," matching C#'s own coarse-grained restriction
+rather than a full definite-assignment-aware jump analysis.
+
+## Alternatives considered
+
+- **Lower `goto`/labels entirely in `cs2gs`** (e.g. rewrite backward-`goto`
+  loops into `for`/`while`). Rejected: general forward/backward `goto` and
+  `goto case`/`goto default` do not have a single structured G# equivalent
+  that preserves semantics in every shape; the underlying bound-tree
+  machinery already supports arbitrary labels/gotos, so exposing surface
+  syntax is both less code and strictly more general than pattern-matching
+  specific `goto` idioms in the translator.

--- a/docs/adr/0139-goto-and-general-labels.md
+++ b/docs/adr/0139-goto-and-general-labels.md
@@ -92,8 +92,9 @@ directly:
 - `GotoStatement` → G# `goto label`.
 - `GotoCaseStatement` / `GotoDefaultStatement` → C#'s `goto case K;` /
   `goto default;` jump straight into a `switch` arm's statement list without
-  re-evaluating the switch expression, and (per C# semantics) fall through
-  into any following arm exactly as `case K:` would. `cs2gs` keeps the
+  re-evaluating the switch expression. Execution then continues through that
+  arm's own body (C# switch sections do not fall through to the next arm).
+  `cs2gs` keeps the
   `switch` a native G# `switch` and, for each arm actually targeted by a
   `goto case`/`goto default` elsewhere in the same `switch`, prefixes that
   arm's translated body with a synthesized label (`__gotoCase<pos>` /

--- a/docs/coverage-matrix.md
+++ b/docs/coverage-matrix.md
@@ -110,6 +110,7 @@ GlobalStatement
 GoKeyword
 GoStatement
 GotoKeyword
+GotoStatement
 GreaterOrEqualsToken
 GreaterToken
 GuardKeyword

--- a/docs/cs2gs-coverage-matrix.md
+++ b/docs/cs2gs-coverage-matrix.md
@@ -6,12 +6,12 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | Status | Count |
 | --- | --- |
 | Unclassified | 0 |
-| Translated | 231 |
-| Lowered | 17 |
+| Translated | 230 |
+| Lowered | 19 |
 | UnsupportedByDesign | 56 |
-| Gap | 17 |
+| Gap | 16 |
 
-## Translated (231)
+## Translated (230)
 
 | Kind | Node type | Rule | Rationale | Fixture | Issue | Notes |
 | --- | --- | --- | --- | --- | --- | --- |
@@ -56,10 +56,9 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | CatchDeclaration | CatchDeclarationSyntax | ADR-0115 §B.27 |  |  |  |  |
 | CatchFilterClause | CatchFilterClauseSyntax | ADR-0115 §B.27 |  | tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/CatchFilterClause.cs |  | A when-filter with an overlapping later sibling catch has no faithful lowering (issue #1724 area). |
 | CharacterLiteralExpression | LiteralExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G01-Literals-Console/Constructs/CharacterLiteralExpression.cs |  |  |
-| CheckedExpression | CheckedExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/CheckedExpression.cs | https://github.com/DavidObando/gsharp/issues/1881 |  |
-| CheckedStatement | CheckedStatementSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/CheckedStatement.cs | https://github.com/DavidObando/gsharp/issues/1881 | gsc gained native checked/unchecked expression + block support (issue #1881); overflow semantics preserved, including the overflow-in-try/catch(OverflowException) sub-case. Stdout parity verified (grid G03). |
+| CheckedStatement | CheckedStatementSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/CheckedStatement.cs | https://github.com/DavidObando/gsharp/issues/1881 | Overflow semantics silently erased — emitted as a plain block (issue #1881, parity-verified divergence); non-overflow subset green. |
 | ClassConstraint | ClassOrStructConstraintSyntax | ADR-0115 §B.7 |  | tools/cs2gs/corpus/grid/G08-Generics-Console/Constructs/ClassConstraint.cs |  |  |
-| ClassDeclaration | ClassDeclarationSyntax | ADR-0115 §B.4 |  | tools/cs2gs/corpus/grid/G06-Types-Console/Constructs/ClassDeclaration.cs |  | C#12 primary ctors now map to native G# primary constructors (issue #1909, resolved); partial parts across multiple declarations/files now merge into one G# type declaration (issue #1910, resolved). |
+| ClassDeclaration | ClassDeclarationSyntax | ADR-0115 §B.4 |  | tools/cs2gs/corpus/grid/G06-Types-Console/Constructs/ClassDeclaration.cs |  | C#12 primary ctors dropped (issue #1909); partial parts across multiple declarations/files now merge into one G# type declaration (issue #1910, resolved). |
 | CoalesceAssignmentExpression | AssignmentExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/CoalesceAssignmentExpression.cs |  | Nullable value-type targets now emit verifiable IL (issue #1916, resolved); reference and value-type forms are both green. |
 | CoalesceExpression | BinaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/CoalesceExpression.cs |  | Binary ?? (issue #941, resolved). |
 | CollectionExpression | CollectionExpressionSyntax | ADR-0115 §B.36 |  | tools/cs2gs/corpus/grid/G05-Collections-Console/Constructs/CollectionExpression.cs | https://github.com/DavidObando/gsharp/issues/1897 | Array targets green; List<T> targets fail conversion; spread unsupported (issues #1897). |
@@ -113,6 +112,7 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | GenericName | GenericNameSyntax | ADR-0115 §B.7 |  | tools/cs2gs/corpus/grid/G08-Generics-Console/Constructs/GenericName.cs |  |  |
 | GetAccessorDeclaration | AccessorDeclarationSyntax | ADR-0115 §B.11 |  |  |  |  |
 | GlobalStatement | GlobalStatementSyntax | ADR-0115 §B.11 |  |  |  | Entry-class hoisting (T3): top-level statements. |
+| GotoStatement | GotoStatementSyntax | ADR-0139 |  | tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/GotoStatement.cs |  |  |
 | GreaterThanExpression | BinaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/GreaterThanExpression.cs |  |  |
 | GreaterThanOrEqualExpression | BinaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/GreaterThanOrEqualExpression.cs |  |  |
 | IdentifierName | IdentifierNameSyntax | ADR-0115 §B.12 |  |  |  |  |
@@ -131,6 +131,7 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | InvocationExpression | InvocationExpressionSyntax | ADR-0115 §B |  |  |  |  |
 | IsExpression | BinaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/IsExpression.cs |  |  |
 | IsPatternExpression | IsPatternExpressionSyntax | ADR-0115 §B.36 |  |  |  |  |
+| LabeledStatement | LabeledStatementSyntax | ADR-0139 |  | tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/LabeledStatement.cs |  |  |
 | LeftShiftAssignmentExpression | AssignmentExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/LeftShiftAssignmentExpression.cs |  |  |
 | LeftShiftExpression | BinaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/LeftShiftExpression.cs |  |  |
 | LessThanExpression | BinaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/LessThanExpression.cs |  |  |
@@ -177,7 +178,6 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | PreDecrementExpression | PrefixUnaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/PreDecrementExpression.cs |  |  |
 | PreIncrementExpression | PrefixUnaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/PreIncrementExpression.cs |  |  |
 | PredefinedType | PredefinedTypeSyntax | ADR-0115 §B.12 |  |  |  |  |
-| PrimaryConstructorBaseType | PrimaryConstructorBaseTypeSyntax | ADR-0065 §5 |  | tools/cs2gs/corpus/grid/G06-Types-Console/Constructs/PrimaryConstructorBaseType.cs |  | A derived primary-ctor class's `: Base(arg)` forwarding call now maps to the G# base-call form `class Derived(...) : Base(args) { ... }` (issue #1909, resolved). |
 | PropertyDeclaration | PropertyDeclarationSyntax | ADR-0115 §B.11 |  | tools/cs2gs/corpus/grid/G07-Members-Console/Constructs/PropertyDeclaration.cs |  |  |
 | PropertyPatternClause | PropertyPatternClauseSyntax | ADR-0115 §B.22 |  | tools/cs2gs/corpus/grid/G04-Patterns-Console/Constructs/RecursivePattern.cs |  | Property sub-patterns; designator collisions fixed in issue #1839. |
 | QualifiedName | QualifiedNameSyntax | ADR-0115 §B.12 |  |  |  |  |
@@ -229,8 +229,7 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | TypePattern | TypePatternSyntax | ADR-0115 §B.22 |  | tools/cs2gs/corpus/grid/G04-Patterns-Console/Constructs/TypePattern.cs |  | Bare-type switch-arm (`int =>`, no binder — issue #1890, resolved): lowers to G#'s own discard-designator type pattern `_ is T` (`PatternBinder.BindTypePattern`'s `isDiscard` check), since gsc's own `TypePattern` grammar always requires a designator token before `is` but treats `_` as a non-binding discard there. Roslyn parses a bare user-type name (e.g. `Widget =>`) as a `ConstantPatternSyntax` over an identifier rather than `TypePatternSyntax`; the switch-arm path now shares the boolean-test path's `IsTypeReferencePattern` type-vs-constant disambiguation to still route it to `_ is T`. |
 | UnaryMinusExpression | PrefixUnaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/UnaryMinusExpression.cs |  |  |
 | UnaryPlusExpression | PrefixUnaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/UnaryPlusExpression.cs |  |  |
-| UncheckedExpression | CheckedExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/UncheckedExpression.cs | https://github.com/DavidObando/gsharp/issues/1881 |  |
-| UncheckedStatement | CheckedStatementSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/UncheckedStatement.cs | https://github.com/DavidObando/gsharp/issues/1881 | Wrap-around parity verified (grid G03). |
+| UncheckedStatement | CheckedStatementSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/UncheckedStatement.cs |  | Wrap-around parity verified (grid G03). |
 | UnsafeStatement | UnsafeStatementSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G12-Unsafe-Console/Constructs/UnsafeStatement.cs |  |  |
 | UnsignedRightShiftAssignmentExpression | AssignmentExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/UnsignedRightShiftAssignmentExpression.cs |  |  |
 | UnsignedRightShiftExpression | BinaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/UnsignedRightShiftExpression.cs |  |  |
@@ -247,7 +246,7 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | YieldBreakStatement | YieldStatementSyntax | ADR-0115 §B.34 |  | tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/YieldBreakStatement.cs |  | Issue #994 (resolved). |
 | YieldReturnStatement | YieldStatementSyntax | ADR-0115 §B.34 |  | tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/YieldReturnStatement.cs |  |  |
 
-## Lowered (17)
+## Lowered (19)
 
 | Kind | Node type | Rule | Rationale | Fixture | Issue | Notes |
 | --- | --- | --- | --- | --- | --- | --- |
@@ -258,6 +257,8 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | ExplicitInterfaceSpecifier | ExplicitInterfaceSpecifierSyntax | ADR-0091 / ADR-0115 §B |  | tools/cs2gs/corpus/grid/G06-Types-Console/Constructs/ExplicitInterfaceSpecifier.cs |  | G# has no explicit-interface-implementation surface (ADR-0091 rejected an 'IFoo.M(this)' spelling); a lone explicit impl lowers to a plain public method (fixes the prior ilverify miss, issue #1911). An explicit impl coexisting with a same-signature public method is dropped in favor of the public method (disclosed semantic-loss diagnostic, not covered by this fixture's stdout parity); two explicit impls of different interfaces with no public sibling de-duplicate to one surviving public method with no semantic loss. |
 | ForStatement | ForStatementSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/ForStatement.cs |  | Lowered to a while loop when clauses demand it (issue #1732 incrementor-on-continue fix). |
 | FromClause | FromClauseSyntax | ADR-0115 §B.21 |  | tools/cs2gs/corpus/grid/G11-Linq-Console/Constructs/FromClauseSelectMany.cs |  | First from lowers to the source receiver; a second/subsequent from lowers to SelectMany with a transparent-identifier tuple result selector (issue #1902). |
+| GotoCaseStatement | GotoStatementSyntax | ADR-0139 |  | tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/GotoCaseStatement.cs |  | Issue #1884: lowered to a plain `goto` targeting a synthesized label placed at the top of the matching case's translated body (no switch re-evaluation, so C# fall-through/evaluation order is preserved). |
+| GotoDefaultStatement | GotoStatementSyntax | ADR-0139 |  | tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/GotoDefaultStatement.cs |  | Issue #1884: lowered like `goto case` (see GotoCaseStatement), targeting a synthesized label at the top of the default section's translated body. |
 | GroupClause | GroupClauseSyntax | ADR-0115 §B.21 |  | tools/cs2gs/corpus/grid/G11-Linq-Console/Constructs/GroupClause.cs |  | Query syntax lowered to the method-call chain, mirroring Roslyn (GroupBy, with identity-projection elision matching `select n`). |
 | JoinClause | JoinClauseSyntax | ADR-0115 §B.21 |  | tools/cs2gs/corpus/grid/G11-Linq-Console/Constructs/JoinClause.cs |  | Query syntax lowered to the method-call chain, mirroring Roslyn (Join with a transparent-identifier tuple result selector). |
 | JoinIntoClause | JoinIntoClauseSyntax | ADR-0115 §B.21 |  | tools/cs2gs/corpus/grid/G11-Linq-Console/Constructs/JoinIntoClause.cs |  | Query syntax lowered to the method-call chain, mirroring Roslyn (GroupJoin, with the `into` group variable typed `sequence[T]`). |
@@ -330,24 +331,23 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | XmlText | XmlTextSyntax |  | ToolingScope |  |  | Documentation/tooling structure, not program semantics; doc-comment mapping is ADR-0057 scope. |
 | XmlTextAttribute | XmlTextAttributeSyntax |  | ToolingScope |  |  | Documentation/tooling structure, not program semantics; doc-comment mapping is ADR-0057 scope. |
 
-## Gap (17)
+## Gap (16)
 
 | Kind | Node type | Rule | Rationale | Fixture | Issue | Notes |
 | --- | --- | --- | --- | --- | --- | --- |
+| CheckedExpression | CheckedExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1881 |  |
 | FunctionPointerCallingConvention | FunctionPointerCallingConventionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1906 |  |
 | FunctionPointerParameter | FunctionPointerParameterSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1906 |  |
 | FunctionPointerParameterList | FunctionPointerParameterListSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1906 |  |
 | FunctionPointerType | FunctionPointerTypeSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1906 |  |
 | FunctionPointerUnmanagedCallingConvention | FunctionPointerUnmanagedCallingConventionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1906 |  |
 | FunctionPointerUnmanagedCallingConventionList | FunctionPointerUnmanagedCallingConventionListSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1906 |  |
-| GotoCaseStatement | GotoStatementSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1884 |  |
-| GotoDefaultStatement | GotoStatementSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1884 |  |
-| GotoStatement | GotoStatementSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1884 |  |
 | ImplicitElementAccess | ImplicitElementAccessSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1897 |  |
 | ImplicitStackAllocArrayCreationExpression | ImplicitStackAllocArrayCreationExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1897 | ADR-0124 stackalloc surface. |
-| LabeledStatement | LabeledStatementSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1884 |  |
 | PointerMemberAccessExpression | MemberAccessExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1905 | p->X lowered to p.X; (*p).X compiles. |
+| PrimaryConstructorBaseType | PrimaryConstructorBaseTypeSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1909 |  |
 | RangeExpression | RangeExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1896 | Lowers to .Slice(...) which gsc cannot resolve on arrays/strings. |
 | RefExpression | RefExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1900 | ref argument/return seam (&x pass-by-address). |
 | RefType | RefTypeSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1900 |  |
 | SpreadElement | SpreadElementSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1897 |  |
+| UncheckedExpression | CheckedExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1881 |  |

--- a/docs/cs2gs-coverage-matrix.md
+++ b/docs/cs2gs-coverage-matrix.md
@@ -6,12 +6,12 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | Status | Count |
 | --- | --- |
 | Unclassified | 0 |
-| Translated | 230 |
+| Translated | 233 |
 | Lowered | 19 |
 | UnsupportedByDesign | 56 |
-| Gap | 16 |
+| Gap | 13 |
 
-## Translated (230)
+## Translated (233)
 
 | Kind | Node type | Rule | Rationale | Fixture | Issue | Notes |
 | --- | --- | --- | --- | --- | --- | --- |
@@ -56,9 +56,10 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | CatchDeclaration | CatchDeclarationSyntax | ADR-0115 §B.27 |  |  |  |  |
 | CatchFilterClause | CatchFilterClauseSyntax | ADR-0115 §B.27 |  | tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/CatchFilterClause.cs |  | A when-filter with an overlapping later sibling catch has no faithful lowering (issue #1724 area). |
 | CharacterLiteralExpression | LiteralExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G01-Literals-Console/Constructs/CharacterLiteralExpression.cs |  |  |
-| CheckedStatement | CheckedStatementSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/CheckedStatement.cs | https://github.com/DavidObando/gsharp/issues/1881 | Overflow semantics silently erased — emitted as a plain block (issue #1881, parity-verified divergence); non-overflow subset green. |
+| CheckedExpression | CheckedExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/CheckedExpression.cs | https://github.com/DavidObando/gsharp/issues/1881 |  |
+| CheckedStatement | CheckedStatementSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/CheckedStatement.cs | https://github.com/DavidObando/gsharp/issues/1881 | gsc gained native checked/unchecked expression + block support (issue #1881); overflow semantics preserved, including the overflow-in-try/catch(OverflowException) sub-case. Stdout parity verified (grid G03). |
 | ClassConstraint | ClassOrStructConstraintSyntax | ADR-0115 §B.7 |  | tools/cs2gs/corpus/grid/G08-Generics-Console/Constructs/ClassConstraint.cs |  |  |
-| ClassDeclaration | ClassDeclarationSyntax | ADR-0115 §B.4 |  | tools/cs2gs/corpus/grid/G06-Types-Console/Constructs/ClassDeclaration.cs |  | C#12 primary ctors dropped (issue #1909); partial parts across multiple declarations/files now merge into one G# type declaration (issue #1910, resolved). |
+| ClassDeclaration | ClassDeclarationSyntax | ADR-0115 §B.4 |  | tools/cs2gs/corpus/grid/G06-Types-Console/Constructs/ClassDeclaration.cs |  | C#12 primary ctors now map to native G# primary constructors (issue #1909, resolved); partial parts across multiple declarations/files now merge into one G# type declaration (issue #1910, resolved). |
 | CoalesceAssignmentExpression | AssignmentExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/CoalesceAssignmentExpression.cs |  | Nullable value-type targets now emit verifiable IL (issue #1916, resolved); reference and value-type forms are both green. |
 | CoalesceExpression | BinaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/CoalesceExpression.cs |  | Binary ?? (issue #941, resolved). |
 | CollectionExpression | CollectionExpressionSyntax | ADR-0115 §B.36 |  | tools/cs2gs/corpus/grid/G05-Collections-Console/Constructs/CollectionExpression.cs | https://github.com/DavidObando/gsharp/issues/1897 | Array targets green; List<T> targets fail conversion; spread unsupported (issues #1897). |
@@ -178,6 +179,7 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | PreDecrementExpression | PrefixUnaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/PreDecrementExpression.cs |  |  |
 | PreIncrementExpression | PrefixUnaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/PreIncrementExpression.cs |  |  |
 | PredefinedType | PredefinedTypeSyntax | ADR-0115 §B.12 |  |  |  |  |
+| PrimaryConstructorBaseType | PrimaryConstructorBaseTypeSyntax | ADR-0065 §5 |  | tools/cs2gs/corpus/grid/G06-Types-Console/Constructs/PrimaryConstructorBaseType.cs |  | A derived primary-ctor class's `: Base(arg)` forwarding call now maps to the G# base-call form `class Derived(...) : Base(args) { ... }` (issue #1909, resolved). |
 | PropertyDeclaration | PropertyDeclarationSyntax | ADR-0115 §B.11 |  | tools/cs2gs/corpus/grid/G07-Members-Console/Constructs/PropertyDeclaration.cs |  |  |
 | PropertyPatternClause | PropertyPatternClauseSyntax | ADR-0115 §B.22 |  | tools/cs2gs/corpus/grid/G04-Patterns-Console/Constructs/RecursivePattern.cs |  | Property sub-patterns; designator collisions fixed in issue #1839. |
 | QualifiedName | QualifiedNameSyntax | ADR-0115 §B.12 |  |  |  |  |
@@ -229,7 +231,8 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | TypePattern | TypePatternSyntax | ADR-0115 §B.22 |  | tools/cs2gs/corpus/grid/G04-Patterns-Console/Constructs/TypePattern.cs |  | Bare-type switch-arm (`int =>`, no binder — issue #1890, resolved): lowers to G#'s own discard-designator type pattern `_ is T` (`PatternBinder.BindTypePattern`'s `isDiscard` check), since gsc's own `TypePattern` grammar always requires a designator token before `is` but treats `_` as a non-binding discard there. Roslyn parses a bare user-type name (e.g. `Widget =>`) as a `ConstantPatternSyntax` over an identifier rather than `TypePatternSyntax`; the switch-arm path now shares the boolean-test path's `IsTypeReferencePattern` type-vs-constant disambiguation to still route it to `_ is T`. |
 | UnaryMinusExpression | PrefixUnaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/UnaryMinusExpression.cs |  |  |
 | UnaryPlusExpression | PrefixUnaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/UnaryPlusExpression.cs |  |  |
-| UncheckedStatement | CheckedStatementSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/UncheckedStatement.cs |  | Wrap-around parity verified (grid G03). |
+| UncheckedExpression | CheckedExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/UncheckedExpression.cs | https://github.com/DavidObando/gsharp/issues/1881 |  |
+| UncheckedStatement | CheckedStatementSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/UncheckedStatement.cs | https://github.com/DavidObando/gsharp/issues/1881 | Wrap-around parity verified (grid G03). |
 | UnsafeStatement | UnsafeStatementSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G12-Unsafe-Console/Constructs/UnsafeStatement.cs |  |  |
 | UnsignedRightShiftAssignmentExpression | AssignmentExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/UnsignedRightShiftAssignmentExpression.cs |  |  |
 | UnsignedRightShiftExpression | BinaryExpressionSyntax | ADR-0115 §B |  | tools/cs2gs/corpus/grid/G02-Operators-Console/Constructs/UnsignedRightShiftExpression.cs |  |  |
@@ -331,11 +334,10 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | XmlText | XmlTextSyntax |  | ToolingScope |  |  | Documentation/tooling structure, not program semantics; doc-comment mapping is ADR-0057 scope. |
 | XmlTextAttribute | XmlTextAttributeSyntax |  | ToolingScope |  |  | Documentation/tooling structure, not program semantics; doc-comment mapping is ADR-0057 scope. |
 
-## Gap (16)
+## Gap (13)
 
 | Kind | Node type | Rule | Rationale | Fixture | Issue | Notes |
 | --- | --- | --- | --- | --- | --- | --- |
-| CheckedExpression | CheckedExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1881 |  |
 | FunctionPointerCallingConvention | FunctionPointerCallingConventionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1906 |  |
 | FunctionPointerParameter | FunctionPointerParameterSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1906 |  |
 | FunctionPointerParameterList | FunctionPointerParameterListSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1906 |  |
@@ -345,9 +347,7 @@ Drift fails `ConstructInventoryGoldenTests`. Do not edit by hand.
 | ImplicitElementAccess | ImplicitElementAccessSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1897 |  |
 | ImplicitStackAllocArrayCreationExpression | ImplicitStackAllocArrayCreationExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1897 | ADR-0124 stackalloc surface. |
 | PointerMemberAccessExpression | MemberAccessExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1905 | p->X lowered to p.X; (*p).X compiles. |
-| PrimaryConstructorBaseType | PrimaryConstructorBaseTypeSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1909 |  |
 | RangeExpression | RangeExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1896 | Lowers to .Slice(...) which gsc cannot resolve on arrays/strings. |
 | RefExpression | RefExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1900 | ref argument/return seam (&x pass-by-address). |
 | RefType | RefTypeSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1900 |  |
 | SpreadElement | SpreadElementSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1897 |  |
-| UncheckedExpression | CheckedExpressionSyntax |  |  |  | https://github.com/DavidObando/gsharp/issues/1881 |  |

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -922,6 +922,11 @@ public sealed class Binder
                 statements.Add(statement);
             }
 
+            // Issue #1884: all TLS global statements share the synthesized
+            // entry point's label namespace, so undefined `goto` targets are
+            // only checked once every global statement has been bound.
+            tlsBinder.statements.FinalizeUserLabels();
+
             // Forward the per-function binder's diagnostics back into the
             // global diagnostic bag so callers see them on
             // BoundGlobalScope.Diagnostics.
@@ -1090,6 +1095,7 @@ public sealed class Binder
                 {
                     var binder = new Binder(parentScope, function);
                     var body = binder.statements.BindStatement(function.Declaration.Body);
+                    binder.statements.FinalizeUserLabels();
                     var lowered = Lowerer.Lower(body);
 
                     if (function.Type != TypeSymbol.Void && !IsIteratorReturnType(function.Type) && !ControlFlowGraph.AllPathsReturn(lowered))
@@ -1138,6 +1144,7 @@ public sealed class Binder
                 {
                     var binder = new Binder(parentScope, method);
                     var body = binder.statements.BindStatement(method.Declaration.Body);
+                    binder.statements.FinalizeUserLabels();
                     var lowered = Lowerer.Lower(body, structSym);
 
                     if (method.Type != TypeSymbol.Void && !IsIteratorReturnType(method.Type) && !ControlFlowGraph.AllPathsReturn(lowered))
@@ -1291,6 +1298,7 @@ public sealed class Binder
                 {
                     var ctorBinder = new Binder(parentScope, ctor.Function);
                     var ctorBody = ctorBinder.statements.BindStatement(ctor.Declaration.Body);
+                    ctorBinder.statements.FinalizeUserLabels();
 
                     // ADR-0065 §2 Rule 3: a `convenience init` body must begin
                     // with a `init(args)` self-delegation expression-statement.
@@ -1570,6 +1578,7 @@ public sealed class Binder
         {
             var binder = new Binder(parentScope, method);
             var body = binder.statements.BindStatement(method.Declaration.Body);
+            binder.statements.FinalizeUserLabels();
             var lowered = Lowerer.Lower(body);
 
             if (method.Type != TypeSymbol.Void && !IsIteratorReturnType(method.Type) && !ControlFlowGraph.AllPathsReturn(lowered))
@@ -1613,6 +1622,7 @@ public sealed class Binder
         {
             var binder = new Binder(parentScope, accessor);
             var body = binder.statements.BindStatement(bodySyntax);
+            binder.statements.FinalizeUserLabels();
             var lowered = Lowerer.Lower(body);
 
             if (requireAllPathsReturn && !ControlFlowGraph.AllPathsReturn(lowered))
@@ -1657,6 +1667,7 @@ public sealed class Binder
         {
             var binder = new Binder(parentScope, member);
             var body = binder.statements.BindStatement(bodySyntax);
+            binder.statements.FinalizeUserLabels();
             var lowered = Lowerer.Lower(body, structSym);
 
             if (allPathsReturnLocation != null && !ControlFlowGraph.AllPathsReturn(lowered))
@@ -1697,6 +1708,7 @@ public sealed class Binder
         {
             var binder = new Binder(parentScope, method);
             var body = binder.statements.BindStatement(method.Declaration.Body);
+            binder.statements.FinalizeUserLabels();
             var lowered = Lowerer.Lower(body, structSym);
 
             if (method.Type != TypeSymbol.Void && !IsIteratorReturnType(method.Type) && !ControlFlowGraph.AllPathsReturn(lowered))

--- a/src/Core/CodeAnalysis/Binding/BinderContext.cs
+++ b/src/Core/CodeAnalysis/Binding/BinderContext.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Text;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
@@ -178,6 +179,35 @@ internal sealed class BinderContext
     /// </summary>
     public Stack<(string LabelName, BoundLabel BreakLabel, BoundLabel ContinueLabel)> LoopStack { get; }
         = new Stack<(string LabelName, BoundLabel BreakLabel, BoundLabel ContinueLabel)>();
+
+    /// <summary>
+    /// Gets the enclosing function's user-defined <c>goto</c> labels
+    /// (issue #1884): a label placed on any non-loop statement, keyed by
+    /// name. Populated by a pre-pass over the function body before any
+    /// statement is bound, so a <c>goto</c> may target a label declared
+    /// later in the same function (forward reference). Fresh per function/
+    /// lambda/local-function — matches ADR-0070's "label namespace is local
+    /// to the enclosing function" rule.
+    /// </summary>
+    public Dictionary<string, BoundLabel> UserLabels { get; }
+        = new Dictionary<string, BoundLabel>();
+
+    /// <summary>
+    /// Gets the set of user-defined <c>goto</c> label names (issue #1884)
+    /// that have already been declared via a <c>label: statement</c> in this
+    /// function. Used to detect a duplicate label declaration (GS0470).
+    /// </summary>
+    public HashSet<string> DefinedUserLabels { get; } = new HashSet<string>();
+
+    /// <summary>
+    /// Gets the user-defined <c>goto</c> label names (issue #1884) that have
+    /// been referenced by a <c>goto</c> but not yet declared, keyed to the
+    /// location of the first such reference. Checked once the enclosing
+    /// function finishes binding (<c>StatementBinder.FinalizeUserLabels</c>);
+    /// any name still present is an undefined label (GS0469).
+    /// </summary>
+    public Dictionary<string, TextLocation> UnresolvedGotoLabels { get; }
+        = new Dictionary<string, TextLocation>();
 
     /// <summary>
     /// Gets the stack of per-scope variable-narrowing tables used by pattern

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.cs
@@ -185,6 +185,8 @@ internal sealed class StatementBinder
                 return BindDoWhileStatement((DoWhileStatementSyntax)syntax);
             case SyntaxKind.LabeledStatement:
                 return BindLabeledStatement((LabeledStatementSyntax)syntax);
+            case SyntaxKind.GotoStatement:
+                return BindGotoStatement((GotoStatementSyntax)syntax);
             case SyntaxKind.BreakStatement:
                 return BindBreakStatement((BreakStatementSyntax)syntax);
             case SyntaxKind.ContinueStatement:
@@ -4100,14 +4102,20 @@ internal sealed class StatementBinder
         var labelName = syntax.LabelIdentifier.Text;
         var inner = syntax.Statement;
 
-        // ADR-0070: only loops may carry a label.
+        // Issue #1884: a label on any non-loop statement is a `goto` target
+        // rather than an ADR-0070 loop label. Emit a BoundLabelStatement
+        // immediately ahead of the bound inner statement, grouped in a
+        // BoundBlockStatement purely for return-shape convenience — Lowerer
+        // flattens it into the enclosing statement list, so it introduces no
+        // new binder scope (a `label: var x = …` still declares `x` into the
+        // enclosing block, matching C#'s `goto`/label semantics).
         if (!IsLabelableLoop(inner))
         {
-            Diagnostics.ReportLabelOnNonLoopStatement(syntax.LabelIdentifier.Location, labelName);
-
-            // Drop the label and bind the inner statement on its own so
-            // downstream diagnostics surface naturally.
-            return BindStatement(inner);
+            var userLabel = DefineUserLabel(labelName, syntax.LabelIdentifier.Location);
+            var boundInner = BindStatement(inner);
+            return new BoundBlockStatement(
+                syntax,
+                ImmutableArray.Create(new BoundLabelStatement(syntax, userLabel), boundInner));
         }
 
         // ADR-0070: a label that shadows an enclosing live loop's label is a
@@ -4165,6 +4173,76 @@ internal sealed class StatementBinder
     private BoundStatement BindLabeledForRange(LabeledStatementSyntax labelSyntax, ForRangeStatementSyntax inner, string labelName)
     {
         return BindForRangeStatementCore(inner, labelName, labelSyntax);
+    }
+
+    private BoundStatement BindGotoStatement(GotoStatementSyntax syntax)
+    {
+        var label = GetOrCreateUserLabelForGoto(syntax.LabelIdentifier.Text, syntax.LabelIdentifier.Location);
+        return new BoundGotoStatement(syntax, label);
+    }
+
+    /// <summary>
+    /// Issue #1884: resolves the <see cref="BoundLabel"/> a <c>goto</c>
+    /// targets, creating a placeholder up front when the label has not been
+    /// declared yet (a forward reference — the label may appear later in the
+    /// same function). The placeholder is recorded in
+    /// <see cref="BinderContext.UnresolvedGotoLabels"/> until
+    /// <see cref="DefineUserLabel"/> declares it; <see cref="FinalizeUserLabels"/>
+    /// reports GS0469 for any name still unresolved once the function finishes
+    /// binding.
+    /// </summary>
+    private BoundLabel GetOrCreateUserLabelForGoto(string labelName, TextLocation location)
+    {
+        if (binderCtx.UserLabels.TryGetValue(labelName, out var label))
+        {
+            return label;
+        }
+
+        label = new BoundLabel(labelName);
+        binderCtx.UserLabels[labelName] = label;
+        binderCtx.UnresolvedGotoLabels[labelName] = location;
+        return label;
+    }
+
+    /// <summary>
+    /// Issue #1884: declares a <c>goto</c> label at a <c>label: statement</c>
+    /// site, reusing any placeholder created by an earlier forward-referencing
+    /// <c>goto</c> (<see cref="GetOrCreateUserLabelForGoto"/>). A second
+    /// declaration of the same name in the same function is GS0470.
+    /// </summary>
+    private BoundLabel DefineUserLabel(string labelName, TextLocation location)
+    {
+        if (!binderCtx.DefinedUserLabels.Add(labelName))
+        {
+            Diagnostics.ReportDuplicateGotoLabel(location, labelName);
+            return binderCtx.UserLabels[labelName];
+        }
+
+        binderCtx.UnresolvedGotoLabels.Remove(labelName);
+        if (!binderCtx.UserLabels.TryGetValue(labelName, out var label))
+        {
+            label = new BoundLabel(labelName);
+            binderCtx.UserLabels[labelName] = label;
+        }
+
+        return label;
+    }
+
+    /// <summary>
+    /// Issue #1884: reports GS0469 for every <c>goto</c> target that is still
+    /// unresolved once the enclosing function has finished binding. Called
+    /// once per function-equivalent binding session (a plain function/method/
+    /// constructor/accessor body, or — for top-level statements — once after
+    /// all global statements share the synthesized entry point's body).
+    /// </summary>
+    internal void FinalizeUserLabels()
+    {
+        foreach (var entry in binderCtx.UnresolvedGotoLabels)
+        {
+            Diagnostics.ReportUndefinedGotoLabel(entry.Value, entry.Key);
+        }
+
+        binderCtx.UnresolvedGotoLabels.Clear();
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -2984,15 +2984,27 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
     }
 
     /// <summary>
-    /// ADR-0070 / issue #707: GS0294 — a label prefix (<c>name:</c>) was
-    /// applied to a statement that is not a loop. Only loops may carry a
-    /// loop label.
+    /// ADR-0070 / issue #1884: GS0469 — a <c>goto</c> targets a label name
+    /// that is never defined anywhere in the enclosing function.
     /// </summary>
     /// <param name="location">The source location of the offending label identifier.</param>
-    /// <param name="labelName">The label name.</param>
-    public void ReportLabelOnNonLoopStatement(TextLocation location, string labelName)
+    /// <param name="labelName">The unresolved label name.</param>
+    public void ReportUndefinedGotoLabel(TextLocation location, string labelName)
     {
-        Report(location, "GS0294", $"Label '{labelName}' can only be applied to a loop statement (for / while / do-while).");
+        Report(location, "GS0469", $"The label '{labelName}' does not exist in the current context.");
+    }
+
+    /// <summary>
+    /// ADR-0070 / issue #1884: GS0470 — two <c>goto</c> labels with the same
+    /// name are declared in the same enclosing function. The label namespace
+    /// is local to the enclosing function (ADR-0070), so this is an error
+    /// even when the two labels are in disjoint nested blocks.
+    /// </summary>
+    /// <param name="location">The source location of the second (duplicate) label declaration.</param>
+    /// <param name="labelName">The duplicated label name.</param>
+    public void ReportDuplicateGotoLabel(TextLocation location, string labelName)
+    {
+        Report(location, "GS0470", $"The label '{labelName}' is already defined in this function.");
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Syntax/GotoStatementSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/GotoStatementSyntax.cs
@@ -1,0 +1,39 @@
+// <copyright file="GotoStatementSyntax.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Core.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Represents a <c>goto label</c> statement (issue #1884): an unconditional
+/// jump to a statement elsewhere in the enclosing function marked with
+/// <c>label:</c> (<see cref="LabeledStatementSyntax"/>).
+/// </summary>
+public sealed class GotoStatementSyntax : StatementSyntax
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GotoStatementSyntax"/> class.
+    /// </summary>
+    /// <param name="syntaxTree">The parent syntax tree.</param>
+    /// <param name="keyword">The <c>goto</c> keyword.</param>
+    /// <param name="labelIdentifier">The target label identifier.</param>
+    public GotoStatementSyntax(SyntaxTree syntaxTree, SyntaxToken keyword, SyntaxToken labelIdentifier)
+        : base(syntaxTree)
+    {
+        Keyword = keyword;
+        LabelIdentifier = labelIdentifier;
+    }
+
+    /// <inheritdoc/>
+    public override SyntaxKind Kind => SyntaxKind.GotoStatement;
+
+    /// <summary>
+    /// Gets the <c>goto</c> keyword.
+    /// </summary>
+    public SyntaxToken Keyword { get; }
+
+    /// <summary>
+    /// Gets the target label identifier.
+    /// </summary>
+    public SyntaxToken LabelIdentifier { get; }
+}

--- a/src/Core/CodeAnalysis/Syntax/LabeledStatementSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/LabeledStatementSyntax.cs
@@ -5,10 +5,11 @@
 namespace GSharp.Core.CodeAnalysis.Syntax;
 
 /// <summary>
-/// Represents a labeled statement of the form <c>name: loop-statement</c>
-/// (ADR-0070). Only loop statements may carry a label; the binder reports
-/// GS0294 when a non-loop statement is labeled but accepts the inner statement
-/// so subsequent diagnostics are not suppressed.
+/// Represents a labeled statement of the form <c>name: statement</c>
+/// (ADR-0070, extended by issue #1884). A label on a loop statement names it
+/// for <c>break</c>/<c>continue</c> (ADR-0070); a label on any other
+/// statement is a <c>goto</c> target (issue #1884). A duplicate label name
+/// within the same enclosing function is reported as GS0470.
 /// </summary>
 public sealed class LabeledStatementSyntax : StatementSyntax
 {

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -6012,8 +6012,8 @@ public class Parser
     {
         // Issue #1884: `goto label` — an unconditional jump to a `label:`
         // statement elsewhere in the enclosing function. The target
-        // identifier must appear on the same source line as the keyword,
-        // mirroring the labeled `break`/`continue` target (ADR-0070).
+        // identifier is mandatory (unlike the optional labeled
+        // `break`/`continue` target), so no same-line restriction is needed.
         var keyword = MatchToken(SyntaxKind.GotoKeyword);
         var label = MatchToken(SyntaxKind.IdentifierToken);
         return new GotoStatementSyntax(syntaxTree, keyword, label);

--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -4947,6 +4947,8 @@ public class Parser
                 return ParseUsingStatement();
             case SyntaxKind.DeferKeyword:
                 return ParseDeferStatement();
+            case SyntaxKind.GotoKeyword:
+                return ParseGotoStatement();
             case SyntaxKind.GoKeyword:
                 return ParseGoStatement();
             case SyntaxKind.SelectKeyword:
@@ -5005,12 +5007,11 @@ public class Parser
                 if (Current.Kind == SyntaxKind.IdentifierToken &&
                     Peek(1).Kind == SyntaxKind.ColonToken)
                 {
-                    // ADR-0070: `label: loop-statement`. We accept any inner
-                    // statement here and rely on the binder to issue GS0294
-                    // when the inner statement is not a loop — this gives a
-                    // single high-quality diagnostic rather than a cascade of
-                    // confused parser errors.
-                    return ParseLabeledLoopStatement();
+                    // ADR-0070 / issue #1884: `label: statement`. A label on a
+                    // loop names it for `break`/`continue`; a label on any
+                    // other statement is a `goto` target. The binder tells
+                    // the two apart.
+                    return ParseLabeledStatement();
                 }
 
                 if (Current.Kind == SyntaxKind.IdentifierToken &&
@@ -6007,6 +6008,17 @@ public class Parser
         return new ContinueStatementSyntax(syntaxTree, keyword, label);
     }
 
+    private StatementSyntax ParseGotoStatement()
+    {
+        // Issue #1884: `goto label` — an unconditional jump to a `label:`
+        // statement elsewhere in the enclosing function. The target
+        // identifier must appear on the same source line as the keyword,
+        // mirroring the labeled `break`/`continue` target (ADR-0070).
+        var keyword = MatchToken(SyntaxKind.GotoKeyword);
+        var label = MatchToken(SyntaxKind.IdentifierToken);
+        return new GotoStatementSyntax(syntaxTree, keyword, label);
+    }
+
     private SyntaxToken TryParseLoopTargetLabel(SyntaxToken keyword)
     {
         // ADR-0070: an optional bare identifier on the same source line names
@@ -6027,7 +6039,7 @@ public class Parser
         return NextToken();
     }
 
-    private StatementSyntax ParseLabeledLoopStatement()
+    private StatementSyntax ParseLabeledStatement()
     {
         var label = MatchToken(SyntaxKind.IdentifierToken);
         var colon = MatchToken(SyntaxKind.ColonToken);

--- a/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
+++ b/src/Core/CodeAnalysis/Syntax/SyntaxKind.cs
@@ -203,6 +203,7 @@ public enum SyntaxKind
     WhileStatement,
     DoWhileStatement,
     LabeledStatement,
+    GotoStatement,
     BreakStatement,
     ContinueStatement,
     ReturnStatement,

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1884GotoLabelBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1884GotoLabelBindingTests.cs
@@ -1,0 +1,155 @@
+// <copyright file="Issue1884GotoLabelBindingTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #1884 / ADR-0139: binding and evaluation tests for general
+/// `goto`/`label:` statements (a label on any non-loop statement is a `goto`
+/// target) and their diagnostics (GS0469, GS0470).
+/// </summary>
+public class Issue1884GotoLabelBindingTests
+{
+    [Fact]
+    public void BackwardGoto_LoopsBody_ProducesExpectedValue()
+    {
+        var source = """
+            package P
+            var a = 0
+            retry:
+            a = a + 1
+            if a < 3 {
+                goto retry
+            }
+            """;
+        var (eval, vars) = EvaluateWithVariables(source);
+        Assert.Empty(eval.Diagnostics);
+        Assert.Equal(3, vars["a"]);
+    }
+
+    [Fact]
+    public void ForwardGoto_SkipsInterveningStatement()
+    {
+        var source = """
+            package P
+            var hit = false
+            goto after
+            hit = true
+            after:
+            var done = true
+            """;
+        var (eval, vars) = EvaluateWithVariables(source);
+        Assert.Empty(eval.Diagnostics);
+        Assert.Equal(false, vars["hit"]);
+        Assert.Equal(true, vars["done"]);
+    }
+
+    [Fact]
+    public void Goto_EscapesNestedIfBlock_ToOuterLabel()
+    {
+        var source = """
+            package P
+            var x = 2
+            var branch = 0
+            if x == 2 {
+                branch = 1
+                goto after
+            }
+            branch = 2
+            after:
+            var finished = true
+            """;
+        var (eval, vars) = EvaluateWithVariables(source);
+        Assert.Empty(eval.Diagnostics);
+        Assert.Equal(1, vars["branch"]);
+        Assert.Equal(true, vars["finished"]);
+    }
+
+    [Fact]
+    public void LabelOnNonLoop_Binds_NoDiagnostics()
+    {
+        var source = """
+            package P
+            bogus: var x = 1
+            """;
+        var diags = Bind(source);
+        Assert.Empty(diags);
+    }
+
+    [Fact]
+    public void Goto_UndefinedLabel_Emits_GS0469()
+    {
+        var source = """
+            package P
+            goto nowhere
+            """;
+        var diags = Bind(source);
+        Assert.Contains(diags, d => d.Id == "GS0469");
+    }
+
+    [Fact]
+    public void DuplicateLabel_Emits_GS0470()
+    {
+        var source = """
+            package P
+            lbl:
+            var a = 1
+            lbl:
+            var b = 2
+            """;
+        var diags = Bind(source);
+        Assert.Contains(diags, d => d.Id == "GS0470");
+    }
+
+    [Fact]
+    public void Goto_CanForwardReference_LabelDeclaredLater()
+    {
+        // The label is declared after the `goto` that targets it — this
+        // must resolve without an undefined-label diagnostic (forward
+        // reference), matching C#'s `goto` scoping.
+        var source = """
+            package P
+            var reached = false
+            goto after
+            after:
+            reached = true
+            """;
+        var diags = Bind(source);
+        Assert.Empty(diags);
+    }
+
+    private static IReadOnlyList<Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var globalScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+        return globalScope.Diagnostics.ToList();
+    }
+
+    private static (EvaluationResult Result, Dictionary<string, object> Variables) EvaluateWithVariables(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var variables = new Dictionary<VariableSymbol, object>();
+        var result = compilation.Evaluate(variables);
+
+        var namedVars = new Dictionary<string, object>();
+        foreach (var kvp in variables)
+        {
+            namedVars[kvp.Key.Name] = kvp.Value;
+        }
+
+        return (result, namedVars);
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue707WhileDoLabeledBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue707WhileDoLabeledBindingTests.cs
@@ -15,7 +15,9 @@ namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 /// <summary>
 /// Issue #707 / ADR-0070: binding-level tests for `while`, `do`-`while`,
 /// labeled `break` / `continue`, and the associated diagnostics
-/// (GS0120, GS0293, GS0294, GS0295).
+/// (GS0120, GS0293, GS0295). Issue #1884 generalized `label:` onto non-loop
+/// statements into `goto` targets (GS0469, GS0470) — see
+/// Issue1884GotoLabelBindingTests.
 /// </summary>
 public class Issue707WhileDoLabeledBindingTests
 {
@@ -140,14 +142,16 @@ public class Issue707WhileDoLabeledBindingTests
     }
 
     [Fact]
-    public void LabelOnNonLoop_Emits_GS0294()
+    public void LabelOnNonLoop_IsValidGotoTarget()
     {
+        // Issue #1884: a label on a non-loop statement no longer errors —
+        // it declares a `goto` target instead of a loop label.
         var source = """
             package P
             bogus: if true { var x = 1 }
             """;
         var diags = Bind(source);
-        Assert.Contains(diags, d => d.Id == "GS0294");
+        Assert.Empty(diags);
     }
 
     [Fact]

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue1675SyntaxNodeChildEnumerationTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue1675SyntaxNodeChildEnumerationTests.cs
@@ -87,6 +87,9 @@ public class Issue1675SyntaxNodeChildEnumerationTests
 
         // first-class deconstructing for-in (issue #1922)
         "package p\nfunc F(xs [](int32, int32)) {\n  for (a, b) in xs {\n  }\n}\n",
+
+        // issue #1884: goto / general label statement
+        "package p\nfunc F() {\n  var a = 0\n  retry:\n  a = a + 1\n  if a < 3 {\n    goto retry\n  }\n}\n",
     };
 
     /// <summary>

--- a/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
+++ b/test/Core.Tests/CoverageMatrix/coverage-matrix.golden.txt
@@ -110,6 +110,7 @@ GlobalStatement
 GoKeyword
 GoStatement
 GotoKeyword
+GotoStatement
 GreaterOrEqualsToken
 GreaterToken
 GuardKeyword

--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/GStatement.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/GStatement.cs
@@ -649,6 +649,54 @@ public sealed class ContinueStatement : GStatement
 }
 
 /// <summary>
+/// A <c>goto label</c> statement (ADR-0139; issue #1884). Maps the C#
+/// <c>goto label;</c> directly, and is also the synthesized form used to
+/// lower C# <c>goto case K;</c> / <c>goto default;</c> to a jump into a
+/// <see cref="LabeledStatement"/> placed at the top of the targeted
+/// <c>switch</c> arm's body.
+/// </summary>
+public sealed class GotoStatement : GStatement
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GotoStatement"/> class.
+    /// </summary>
+    /// <param name="label">The target label name.</param>
+    public GotoStatement(string label)
+    {
+        Label = label;
+    }
+
+    /// <summary>Gets the target label name.</summary>
+    public string Label { get; }
+}
+
+/// <summary>
+/// A <c>label: statement</c> labeled statement (ADR-0070, generalized by
+/// ADR-0139; issue #1884). Maps the C# <c>label: statement;</c> directly, and
+/// is also the synthesized label a <c>goto case</c>/<c>goto default</c>
+/// lowering places at the top of a <c>switch</c> arm's body.
+/// </summary>
+public sealed class LabeledStatement : GStatement
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LabeledStatement"/> class.
+    /// </summary>
+    /// <param name="label">The label name.</param>
+    /// <param name="statement">The labeled statement.</param>
+    public LabeledStatement(string label, GStatement statement)
+    {
+        Label = label;
+        Statement = statement;
+    }
+
+    /// <summary>Gets the label name.</summary>
+    public string Label { get; }
+
+    /// <summary>Gets the labeled statement.</summary>
+    public GStatement Statement { get; }
+}
+
+/// <summary>
 /// A post-test <c>do { body } while cond</c> loop (spec §Statements; ADR-0070).
 /// Maps the C# <c>do … while (cond);</c> directly.
 /// </summary>

--- a/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
@@ -922,6 +922,12 @@ public static class GSharpPrinter
             case ContinueStatement:
                 return $"{pad}continue";
 
+            case GotoStatement gotoStatement:
+                return $"{pad}goto {gotoStatement.Label}";
+
+            case LabeledStatement labeledStatement:
+                return $"{pad}{labeledStatement.Label}:\n{RenderStatement(labeledStatement.Statement, indent)}";
+
             case DoWhileStatement doWhile:
                 return $"{pad}do {RenderBlock(doWhile.Body, indent)} while {RenderExpression(doWhile.Condition, indent)}";
 

--- a/tools/cs2gs/Cs2Gs.Tests/Coverage/GNodeSamples.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Coverage/GNodeSamples.cs
@@ -154,6 +154,8 @@ public static class GNodeSamples
                 body: Block(new YieldStatement(Int("1"))))),
             [typeof(BreakStatement)] = () => Stmts(new WhileStatement(Id("c"), Block(new BreakStatement()))),
             [typeof(ContinueStatement)] = () => Stmts(new WhileStatement(Id("c"), Block(new ContinueStatement()))),
+            [typeof(GotoStatement)] = () => Stmts(new GotoStatement("retry")),
+            [typeof(LabeledStatement)] = () => Stmts(new LabeledStatement("retry", new GotoStatement("retry"))),
             [typeof(DoWhileStatement)] = () => Stmts(new DoWhileStatement(Block(), Id("c"))),
             [typeof(TupleDeconstructionStatement)] = () => Stmts(new TupleDeconstructionStatement(
                 BindingKind.Let,

--- a/tools/cs2gs/Cs2Gs.Tests/Coverage/code-model-surface.golden.txt
+++ b/tools/cs2gs/Cs2Gs.Tests/Coverage/code-model-surface.golden.txt
@@ -51,8 +51,10 @@ FixedStatement
 ForInStatement
 ForStatement
 ForTupleInStatement
+GotoStatement
 IfStatement
 IncrementDecrementStatement
+LabeledStatement
 LocalDeclarationStatement
 LocalFunctionStatement
 LockStatement

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1884GotoLabelTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1884GotoLabelTranslationTests.cs
@@ -1,0 +1,179 @@
+// <copyright file="Issue1884GotoLabelTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #1884 (ADR-0139): the C#→G# translator maps <c>goto</c>/labels to
+/// G#'s general <c>goto</c>/label surface syntax, and lowers <c>goto case</c>
+/// / <c>goto default</c> to a plain <c>goto</c> targeting a synthesized label
+/// placed at the top of the matching <c>switch</c> arm's translated body
+/// (neither re-evaluates the switch subject, matching C# semantics).
+/// </summary>
+public class Issue1884GotoLabelTranslationTests
+{
+    [Fact]
+    public void LabeledStatement_And_PlainGoto_TranslateToGSharpLabelAndGoto()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1884
+{
+    public class Loop
+    {
+        public int Retry()
+        {
+            int a = 0;
+        retry:
+            a++;
+            if (a < 3)
+            {
+                goto retry;
+            }
+
+            return a;
+        }
+    }
+}
+");
+
+        Assert.Contains("retry:", rendered, StringComparison.Ordinal);
+        Assert.Contains("goto retry", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void GotoCase_LowersToGotoOfSynthesizedLabelAtMatchingArm()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1884
+{
+    public class Switcher
+    {
+        public string Run(int value)
+        {
+            string trace = """";
+            switch (value)
+            {
+                case 1:
+                    trace += ""one"";
+                    goto case 2;
+                case 2:
+                    trace += ""two"";
+                    break;
+                default:
+                    trace += ""other"";
+                    break;
+            }
+
+            return trace;
+        }
+    }
+}
+");
+
+        // The `goto case 2;` lowers to a `goto` of a synthesized label
+        // (`__gotoCase<pos>`) placed at the top of case 2's translated body.
+        Assert.Contains("goto __gotoCase", rendered, StringComparison.Ordinal);
+        Assert.Contains("__gotoCase", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void GotoDefault_LowersToGotoOfSynthesizedLabelAtDefaultArm()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1884
+{
+    public class Switcher
+    {
+        public string Run(int value)
+        {
+            string trace = """";
+            switch (value)
+            {
+                case 7:
+                    trace += ""seven"";
+                    goto default;
+                default:
+                    trace += ""other"";
+                    break;
+            }
+
+            return trace;
+        }
+    }
+}
+");
+
+        Assert.Contains("goto __gotoDefault", rendered, StringComparison.Ordinal);
+        Assert.Contains("__gotoDefault", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void LabelIdentifier_CollidingWithGSharpKeyword_IsSanitized()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1884
+{
+    public class KeywordLabel
+    {
+        public int Run()
+        {
+            int n = 0;
+        @goto:
+            n++;
+            if (n < 2)
+            {
+                goto @goto;
+            }
+
+            return n;
+        }
+    }
+}
+");
+
+        // `goto` is a G# reserved word (see GSharpReservedWords), so the C#
+        // verbatim label `@goto` must be suffixed to a valid G# identifier at
+        // both its declaration and every reference.
+        Assert.Contains("goto_:", rendered, StringComparison.Ordinal);
+        Assert.Contains("goto goto_", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    private static void AssertRoundTripParses(string rendered)
+    {
+        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+
+        Assert.True(
+            result.Success,
+            "Sanitized G# must round-trip-parse. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + rendered);
+    }
+
+    private static string Render(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", source) });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        Cs2Gs.CodeModel.Ast.CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        Assert.Empty(context.Diagnostics);
+        return GSharpPrinter.Print(unit);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -4853,6 +4853,12 @@ public sealed class CSharpToGSharpTranslator
                 case ContinueStatementSyntax:
                     return new[] { (GStatement)new ContinueStatement() };
 
+                case LabeledStatementSyntax labeledStatement:
+                    return this.TranslateLabeledStatement(labeledStatement);
+
+                case GotoStatementSyntax gotoStatement:
+                    return this.TranslateGotoStatement(gotoStatement);
+
                 case DoStatementSyntax doStatement:
                     if (this.TryTranslateLoopWithConditionHoist(
                             doStatement.Condition,
@@ -5835,6 +5841,119 @@ public sealed class CSharpToGSharpTranslator
                     return false;
             }
         }
+
+        private IEnumerable<GStatement> TranslateLabeledStatement(LabeledStatementSyntax labeledStatement)
+        {
+            // C# `label: statement;` is a single statement wrapper; G# has the
+            // identical `label: statement` form (ADR-0070, generalized by
+            // ADR-0139 / issue #1884). The inner statement can expand into more
+            // than one G# statement (e.g. a declaration that needs a spill
+            // prologue); the label is attached to the FIRST emitted statement
+            // only — C# source has no way to target a position mid-expansion,
+            // so this is a faithful mapping.
+            string label = SanitizeIdentifier(labeledStatement.Identifier.Text);
+            List<GStatement> inner = this.TranslateStatement(labeledStatement.Statement).ToList();
+            if (inner.Count == 0)
+            {
+                return new[] { (GStatement)new LabeledStatement(label, new BlockStatement(new List<GStatement>())) };
+            }
+
+            var result = new List<GStatement> { new LabeledStatement(label, inner[0]) };
+            result.AddRange(inner.Skip(1));
+            return result;
+        }
+
+        private IEnumerable<GStatement> TranslateGotoStatement(GotoStatementSyntax gotoStatement)
+        {
+            switch (gotoStatement.Kind())
+            {
+                case SyntaxKind.GotoCaseStatement:
+                case SyntaxKind.GotoDefaultStatement:
+                    // ADR-0139 / issue #1884: `goto case K;` jumps to the
+                    // statement list of the case labeled with the constant K
+                    // WITHOUT re-evaluating the switch subject; `goto default;`
+                    // jumps to the default section. Neither re-enters the
+                    // switch, so both lower to a plain `goto` targeting a
+                    // synthesized label placed at the top of the target arm's
+                    // body (see TranslateSwitchStatement).
+                    SwitchLabelSyntax target = this.ResolveGotoCaseOrDefaultTarget(gotoStatement);
+                    if (target == null)
+                    {
+                        this.context.ReportUnsupported(gotoStatement, "goto target case/default label could not be resolved.");
+                        return new[] { (GStatement)new RawStatement($"// unsupported: {gotoStatement.Kind()}") };
+                    }
+
+                    return new[] { (GStatement)new GotoStatement(GotoCaseOrDefaultLabelName(target)) };
+
+                default:
+                    // Plain `goto label;` — Expression is the label name as an
+                    // IdentifierNameSyntax (verified against Roslyn 4.14).
+                    string label = SanitizeIdentifier(((IdentifierNameSyntax)gotoStatement.Expression).Identifier.Text);
+                    return new[] { (GStatement)new GotoStatement(label) };
+            }
+        }
+
+        /// <summary>
+        /// Resolves the <see cref="SwitchLabelSyntax"/> that a <c>goto case
+        /// K;</c> / <c>goto default;</c> statement targets, by walking up to
+        /// the nearest enclosing <c>switch</c> and matching on compile-time
+        /// constant value (issue #1884). Returns <c>null</c> if the enclosing
+        /// switch or matching label cannot be found (malformed input; the
+        /// caller reports a translation gap).
+        /// </summary>
+        private SwitchLabelSyntax ResolveGotoCaseOrDefaultTarget(GotoStatementSyntax gotoStatement)
+        {
+            SwitchStatementSyntax enclosingSwitch = gotoStatement.Ancestors().OfType<SwitchStatementSyntax>().FirstOrDefault();
+            if (enclosingSwitch == null)
+            {
+                return null;
+            }
+
+            if (gotoStatement.Kind() == SyntaxKind.GotoDefaultStatement)
+            {
+                return enclosingSwitch.Sections
+                    .SelectMany(section => section.Labels)
+                    .OfType<DefaultSwitchLabelSyntax>()
+                    .FirstOrDefault();
+            }
+
+            Optional<object> targetValue = this.context.SemanticModel.GetConstantValue(gotoStatement.Expression);
+            if (!targetValue.HasValue)
+            {
+                return null;
+            }
+
+            foreach (SwitchSectionSyntax section in enclosingSwitch.Sections)
+            {
+                foreach (SwitchLabelSyntax label in section.Labels)
+                {
+                    if (label is CaseSwitchLabelSyntax caseLabel)
+                    {
+                        Optional<object> caseValue = this.context.SemanticModel.GetConstantValue(caseLabel.Value);
+                        if (caseValue.HasValue && Equals(targetValue.Value, caseValue.Value))
+                        {
+                            return caseLabel;
+                        }
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// The synthesized G# label name for a <c>goto case</c>/<c>goto
+        /// default</c> target (issue #1884). Keyed by the target label's own
+        /// source position (<see cref="SyntaxNode.SpanStart"/>), which is
+        /// unique within the file and stable across the two independent call
+        /// sites that must agree on the name: the arm that defines the label
+        /// (<see cref="TranslateSwitchStatement"/>) and the <c>goto</c> that
+        /// targets it (<see cref="ResolveGotoCaseOrDefaultTarget"/> callers).
+        /// </summary>
+        private static string GotoCaseOrDefaultLabelName(SwitchLabelSyntax label)
+            => label is DefaultSwitchLabelSyntax
+                ? $"__gotoDefault{label.SpanStart}"
+                : $"__gotoCase{label.SpanStart}";
 
         private GStatement TranslateThrow(ThrowStatementSyntax throwStatement)
         {
@@ -13423,6 +13542,18 @@ public sealed class CSharpToGSharpTranslator
             GExpression subject = this.TranslateExpression(node.Expression);
             var cases = new List<SwitchStatementCase>();
 
+            // Issue #1884: a `goto case K;` / `goto default;` anywhere in this
+            // switch (but not in a nested switch, whose own gotos target its
+            // own labels) needs a synthesized label at the top of the arm it
+            // targets, so the goto can be lowered to a plain `goto`.
+            var gotoTargets = new HashSet<SwitchLabelSyntax>(
+                node.DescendantNodes()
+                    .OfType<GotoStatementSyntax>()
+                    .Where(g => (g.Kind() == SyntaxKind.GotoCaseStatement || g.Kind() == SyntaxKind.GotoDefaultStatement)
+                             && g.Ancestors().OfType<SwitchStatementSyntax>().First() == node)
+                    .Select(this.ResolveGotoCaseOrDefaultTarget)
+                    .Where(target => target != null));
+
             foreach (SwitchSectionSyntax section in node.Sections)
             {
                 // A G# switch-statement arm carries a single pattern; a C# section
@@ -13476,11 +13607,17 @@ public sealed class CSharpToGSharpTranslator
                         case CaseSwitchLabelSyntax valueLabel:
                             cases.Add(new SwitchStatementCase(
                                 new ConstantPattern(this.TranslateExpression(valueLabel.Value)),
-                                this.TranslateSwitchSectionBody(section)));
+                                this.TranslateSwitchSectionBody(
+                                    section,
+                                    gotoTargets.Contains(valueLabel) ? GotoCaseOrDefaultLabelName(valueLabel) : null)));
                             break;
 
-                        case DefaultSwitchLabelSyntax:
-                            cases.Add(new SwitchStatementCase(null, this.TranslateSwitchSectionBody(section)));
+                        case DefaultSwitchLabelSyntax defaultLabel:
+                            cases.Add(new SwitchStatementCase(
+                                null,
+                                this.TranslateSwitchSectionBody(
+                                    section,
+                                    gotoTargets.Contains(defaultLabel) ? GotoCaseOrDefaultLabelName(defaultLabel) : null)));
                             break;
 
                         default:
@@ -13495,7 +13632,7 @@ public sealed class CSharpToGSharpTranslator
             return new SwitchStatement(subject, cases);
         }
 
-        private BlockStatement TranslateSwitchSectionBody(SwitchSectionSyntax section)
+        private BlockStatement TranslateSwitchSectionBody(SwitchSectionSyntax section, string injectLabel = null)
         {
             var statements = new List<GStatement>();
             foreach (StatementSyntax statement in section.Statements)
@@ -13508,6 +13645,22 @@ public sealed class CSharpToGSharpTranslator
                 }
 
                 statements.AddRange(this.TranslateStatement(statement));
+            }
+
+            if (injectLabel != null)
+            {
+                // Issue #1884: this arm is the target of a `goto case`/`goto
+                // default` elsewhere in the switch; attach the synthesized
+                // label to the first statement (or, for an empty arm, to an
+                // empty block) so the goto has something concrete to jump to.
+                if (statements.Count == 0)
+                {
+                    statements.Add(new LabeledStatement(injectLabel, new BlockStatement(new List<GStatement>())));
+                }
+                else
+                {
+                    statements[0] = new LabeledStatement(injectLabel, statements[0]);
+                }
             }
 
             return new BlockStatement(statements);

--- a/tools/cs2gs/Cs2Gs.Translator/Coverage/ConstructInventory.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/Coverage/ConstructInventory.cs
@@ -44,7 +44,7 @@ public enum UnsupportedRationale
     /// <summary>No rationale (only valid for statuses other than unsupported-by-design).</summary>
     None,
 
-    /// <summary>G# deliberately omits the construct and no mapping is planned (e.g. goto, __makeref).</summary>
+    /// <summary>G# deliberately omits the construct and no mapping is planned (e.g. __makeref).</summary>
     NoGsharpConstruct,
 
     /// <summary>Resolved before/outside translation by Roslyn parse options (#if, #pragma, #region, ...).</summary>

--- a/tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/GotoCaseStatement.cs
+++ b/tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/GotoCaseStatement.cs
@@ -1,0 +1,31 @@
+// inventory: GotoCaseStatement
+using System;
+
+namespace Corpus.Grid03.Constructs
+{
+    public static class GotoCaseStatementFixture
+    {
+        public static void Run()
+        {
+            // `goto case 2;` jumps to case 2's statement list without
+            // re-evaluating the switch subject; the trace below proves
+            // fall-through and side-effect order are preserved.
+            var trace = new System.Collections.Generic.List<string>();
+            int value = 1;
+            switch (value)
+            {
+                case 1:
+                    trace.Add("case1");
+                    goto case 2;
+                case 2:
+                    trace.Add("case2");
+                    break;
+                default:
+                    trace.Add("default");
+                    break;
+            }
+
+            Console.WriteLine($"GotoCaseStatement: trace = {string.Join(",", trace)}");
+        }
+    }
+}

--- a/tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/GotoDefaultStatement.cs
+++ b/tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/GotoDefaultStatement.cs
@@ -1,0 +1,27 @@
+// inventory: GotoDefaultStatement
+using System;
+
+namespace Corpus.Grid03.Constructs
+{
+    public static class GotoDefaultStatementFixture
+    {
+        public static void Run()
+        {
+            // `goto default;` jumps to the default section's statement list
+            // without re-evaluating the switch subject.
+            var trace = new System.Collections.Generic.List<string>();
+            int value = 7;
+            switch (value)
+            {
+                case 7:
+                    trace.Add("case7");
+                    goto default;
+                default:
+                    trace.Add("default");
+                    break;
+            }
+
+            Console.WriteLine($"GotoDefaultStatement: trace = {string.Join(",", trace)}");
+        }
+    }
+}

--- a/tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/GotoStatement.cs
+++ b/tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/GotoStatement.cs
@@ -1,0 +1,28 @@
+// inventory: GotoStatement
+using System;
+
+namespace Corpus.Grid03.Constructs
+{
+    public static class GotoStatementFixture
+    {
+        public static void Run()
+        {
+            int count = 0;
+        retry:
+            count++;
+            if (count < 3)
+            {
+                goto retry;
+            }
+
+            Console.WriteLine($"GotoStatement: backward loop finished at count = {count}");
+
+            int step = 0;
+            goto skip;
+            step = 100;
+        skip:
+            step += 1;
+            Console.WriteLine($"GotoStatement: forward jump left step = {step}");
+        }
+    }
+}

--- a/tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/LabeledStatement.cs
+++ b/tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/LabeledStatement.cs
@@ -1,0 +1,25 @@
+// inventory: LabeledStatement
+using System;
+
+namespace Corpus.Grid03.Constructs
+{
+    public static class LabeledStatementFixture
+    {
+        public static void Run()
+        {
+            // A label on a non-loop statement (ADR-0070 generalized by
+            // ADR-0139) is a valid goto target; here it also just labels an
+            // ordinary statement with nothing jumping to it, exercising the
+            // labeled-statement form on its own.
+            int total = 0;
+        addOne:
+            total += 1;
+            if (total < 3)
+            {
+                goto addOne;
+            }
+
+            Console.WriteLine($"LabeledStatement: total = {total}");
+        }
+    }
+}

--- a/tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Program.cs
+++ b/tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Program.cs
@@ -18,7 +18,11 @@ namespace Corpus.Grid03
             EmptyStatementFixture.Run();
             ForEachStatementFixture.Run();
             ForStatementFixture.Run();
+            GotoCaseStatementFixture.Run();
+            GotoDefaultStatementFixture.Run();
+            GotoStatementFixture.Run();
             IfStatementFixture.Run();
+            LabeledStatementFixture.Run();
             LocalFunctionStatementFixture.Run();
             LockStatementFixture.Run();
             ReturnStatementFixture.Run();

--- a/tools/cs2gs/corpus/grid/G03-ControlFlow-Console/baseline.stdout.golden
+++ b/tools/cs2gs/corpus/grid/G03-ControlFlow-Console/baseline.stdout.golden
@@ -23,6 +23,10 @@ ForEachStatement: stock[pen] = 4
 ForStatement: converging loop total = 30
 ForStatement: hits with continue skipping i%4==1 = 7
 ForStatement: countdown digits = 54321
+GotoCaseStatement: trace = case1,case2
+GotoDefaultStatement: trace = case7,default
+GotoStatement: backward loop finished at count = 3
+GotoStatement: forward jump left step = 1
 IfStatement: score 55 -> grade F
 IfStatement: score 65 -> grade F
 IfStatement: score 75 -> grade C
@@ -30,6 +34,7 @@ IfStatement: score 85 -> grade B
 IfStatement: score 95 -> grade A
 IfStatement: 12 is even (if without else)
 IfStatement: 12 is between 10 and 20 (nested if)
+LabeledStatement: total = 3
 LocalFunctionStatement: Add(3, 4) = 7
 LocalFunctionStatement: AddSeed(7) with captured seed = 12
 LocalFunctionStatement: Square(6) = 36

--- a/tools/cs2gs/coverage/csharp-construct-inventory.json
+++ b/tools/cs2gs/coverage/csharp-construct-inventory.json
@@ -1006,23 +1006,28 @@
   {
     "kind": "GotoCaseStatement",
     "nodeType": "GotoStatementSyntax",
-    "status": "Gap",
+    "status": "Lowered",
+    "rule": "ADR-0139",
     "rationale": "None",
-    "issue": "https://github.com/DavidObando/gsharp/issues/1884"
+    "fixture": "tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/GotoCaseStatement.cs",
+    "notes": "Issue #1884: lowered to a plain \u0060goto\u0060 targeting a synthesized label placed at the top of the matching case\u0027s translated body (no switch re-evaluation, so C# fall-through/evaluation order is preserved)."
   },
   {
     "kind": "GotoDefaultStatement",
     "nodeType": "GotoStatementSyntax",
-    "status": "Gap",
+    "status": "Lowered",
+    "rule": "ADR-0139",
     "rationale": "None",
-    "issue": "https://github.com/DavidObando/gsharp/issues/1884"
+    "fixture": "tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/GotoDefaultStatement.cs",
+    "notes": "Issue #1884: lowered like \u0060goto case\u0060 (see GotoCaseStatement), targeting a synthesized label at the top of the default section\u0027s translated body."
   },
   {
     "kind": "GotoStatement",
     "nodeType": "GotoStatementSyntax",
-    "status": "Gap",
+    "status": "Translated",
+    "rule": "ADR-0139",
     "rationale": "None",
-    "issue": "https://github.com/DavidObando/gsharp/issues/1884"
+    "fixture": "tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/GotoStatement.cs"
   },
   {
     "kind": "GreaterThanExpression",
@@ -1243,9 +1248,10 @@
   {
     "kind": "LabeledStatement",
     "nodeType": "LabeledStatementSyntax",
-    "status": "Gap",
+    "status": "Translated",
+    "rule": "ADR-0139",
     "rationale": "None",
-    "issue": "https://github.com/DavidObando/gsharp/issues/1884"
+    "fixture": "tools/cs2gs/corpus/grid/G03-ControlFlow-Console/Constructs/LabeledStatement.cs"
   },
   {
     "kind": "LeftShiftAssignmentExpression",


### PR DESCRIPTION
Fixes #1884

- Added general `goto`/label surface syntax to gsc (parser + binder; GS0469 undefined label, GS0470 duplicate label; retired GS0294). The bound-tree infra (`BoundGotoStatement`/`BoundLabelStatement`) already existed for loop lowering — only surface syntax and name resolution were missing.
- cs2gs now maps all four previously-gapped C# constructs: `LabeledStatement` -> `label: statement`, `GotoStatement` -> `goto label`, `GotoCaseStatement`/`GotoDefaultStatement` -> lowered to a `goto` of a synthesized label placed at the top of the targeted switch arm's body (native G# switch, no if/else-if rewrite needed — arms are fully flattened before evaluation/emission).
- Label identifiers are sanitized like any other C# identifier.
- Added G03 grid corpus fixtures for all 4 kinds with a freshly captured stdout baseline; regenerated coverage inventory/docs (4 kinds move Gap -> Translated/Lowered).
- Added ADR-0139 (amends ADR-0070) and Issue1884GotoLabelTranslationTests (round-trip-parse assertions for all 4 kinds).
- Full corpus: 0 new, 0 regressed gaps. Core.Tests: 5389 passed, 1 skipped. cs2gs tests: 953 passed.