### PR TITLE
gsc: fix MLC erasure in InterfaceSymbol.SubstituteType (#1958)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -2564,7 +2564,7 @@ public sealed class Binder
                         return null;
                     }
 
-                    element = InterfaceSymbol.Construct(iface, typeArgs);
+                    element = InterfaceSymbol.Construct(iface, typeArgs, scope.References.MapClrTypeToReferences);
                 }
                 else if (element is StructSymbol genericStruct)
                 {
@@ -2913,7 +2913,7 @@ public sealed class Binder
             case StructSymbol genericStruct when genericStruct.IsGenericDefinition && genericStruct.TypeParameters.Length == typeArgs.Length:
                 return StructSymbol.Construct(genericStruct, typeArgs);
             case InterfaceSymbol genericIface when genericIface.IsGenericDefinition && genericIface.TypeParameters.Length == typeArgs.Length:
-                return InterfaceSymbol.Construct(genericIface, typeArgs);
+                return InterfaceSymbol.Construct(genericIface, typeArgs, scope.References.MapClrTypeToReferences);
             case DelegateTypeSymbol genericDelegate when genericDelegate.IsGenericDefinition && genericDelegate.TypeParameters.Length == typeArgs.Length:
                 return DelegateTypeSymbol.Construct(genericDelegate, typeArgs);
             default:
@@ -4249,7 +4249,7 @@ public sealed class Binder
             }
 
             return ifaceChanged
-                ? InterfaceSymbol.Construct(ifaceType.Definition, newIfaceArgs.MoveToImmutable())
+                ? InterfaceSymbol.Construct(ifaceType.Definition, newIfaceArgs.MoveToImmutable(), mapClrType)
                 : type;
         }
 
@@ -4309,7 +4309,15 @@ public sealed class Binder
                     }
                     catch (System.ArgumentException)
                     {
-                        // Fall through to the erased constructed form below.
+                        // Issue #1958: with the mapClrType projection above, a
+                        // cross-reflection-context mismatch here should no
+                        // longer be reachable. Assert loudly in debug builds
+                        // instead of the silent fallback that made #1926 hard
+                        // to diagnose; still fall through to the erased
+                        // constructed form so release builds degrade
+                        // gracefully rather than crash.
+                        var assertMessage = $"Binder.SubstituteType: MakeGenericType failed for '{it.OpenDefinition}' with args [{string.Join(", ", clrArgs.Select(t => t.ToString()))}] even after mapClrType projection.";
+                        System.Diagnostics.Debug.Assert(false, assertMessage);
                     }
                 }
             }

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -2580,7 +2580,7 @@ public sealed class Binder
                         return null;
                     }
 
-                    element = StructSymbol.Construct(genericStruct, typeArgs);
+                    element = StructSymbol.Construct(genericStruct, typeArgs, scope.References.MapClrTypeToReferences);
                 }
                 else if (element is DelegateTypeSymbol genericDelegate)
                 {
@@ -2816,8 +2816,8 @@ public sealed class Binder
             {
                 var ownArgs = deepestStruct.TypeArguments;
                 deepest = ownArgs.IsDefaultOrEmpty
-                    ? StructSymbol.ConstructNested(deepestStruct.Definition ?? deepestStruct, enclosingArgs)
-                    : StructSymbol.ConstructNestedGeneric(deepestStruct.Definition ?? deepestStruct, enclosingArgs, ownArgs);
+                    ? StructSymbol.ConstructNested(deepestStruct.Definition ?? deepestStruct, enclosingArgs, scope.References.MapClrTypeToReferences)
+                    : StructSymbol.ConstructNestedGeneric(deepestStruct.Definition ?? deepestStruct, enclosingArgs, ownArgs, scope.References.MapClrTypeToReferences);
             }
         }
 
@@ -2911,7 +2911,7 @@ public sealed class Binder
         switch (definition)
         {
             case StructSymbol genericStruct when genericStruct.IsGenericDefinition && genericStruct.TypeParameters.Length == typeArgs.Length:
-                return StructSymbol.Construct(genericStruct, typeArgs);
+                return StructSymbol.Construct(genericStruct, typeArgs, scope.References.MapClrTypeToReferences);
             case InterfaceSymbol genericIface when genericIface.IsGenericDefinition && genericIface.TypeParameters.Length == typeArgs.Length:
                 return InterfaceSymbol.Construct(genericIface, typeArgs, scope.References.MapClrTypeToReferences);
             case DelegateTypeSymbol genericDelegate when genericDelegate.IsGenericDefinition && genericDelegate.TypeParameters.Length == typeArgs.Length:
@@ -4212,7 +4212,7 @@ public sealed class Binder
             }
 
             return structChanged
-                ? StructSymbol.Construct(ss.Definition, newStructArgs.MoveToImmutable())
+                ? StructSymbol.Construct(ss.Definition, newStructArgs.MoveToImmutable(), mapClrType)
                 : type;
         }
 
@@ -4228,7 +4228,7 @@ public sealed class Binder
             var newEnclosing = StructSymbol.SubstituteEnclosingArguments(nestedRef, t => SubstituteType(t, substitution, mapClrType));
             if (!newEnclosing.IsDefault)
             {
-                return StructSymbol.ConstructNested(nestedRef.Definition ?? nestedRef, newEnclosing);
+                return StructSymbol.ConstructNested(nestedRef.Definition ?? nestedRef, newEnclosing, mapClrType);
             }
         }
 
@@ -4309,15 +4309,14 @@ public sealed class Binder
                     }
                     catch (System.ArgumentException)
                     {
-                        // Issue #1958: with the mapClrType projection above, a
-                        // cross-reflection-context mismatch here should no
-                        // longer be reachable. Assert loudly in debug builds
-                        // instead of the silent fallback that made #1926 hard
-                        // to diagnose; still fall through to the erased
-                        // constructed form so release builds degrade
-                        // gracefully rather than crash.
+                        // MakeGenericType can legitimately throw ArgumentException for CLR
+                        // generic constraint reasons (e.g. unmanaged/ref-struct constraints),
+                        // not only cross-reflection-context mismatches, so this is NOT always
+                        // a bug. Log for diagnosability and fall through to the erased
+                        // constructed form so both debug and release builds degrade gracefully
+                        // rather than crash.
                         var assertMessage = $"Binder.SubstituteType: MakeGenericType failed for '{it.OpenDefinition}' with args [{string.Join(", ", clrArgs.Select(t => t.ToString()))}] even after mapClrType projection.";
-                        System.Diagnostics.Debug.Assert(false, assertMessage);
+                        System.Diagnostics.Debug.WriteLine(assertMessage);
                     }
                 }
             }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -1243,7 +1243,7 @@ internal sealed partial class ExpressionBinder
             case InterfaceSymbol nestedIface:
                 var ifaceDef = nestedIface.Definition ?? nestedIface;
                 nestedType = !ownArgs.IsDefaultOrEmpty
-                    ? InterfaceSymbol.Construct(ifaceDef, ownArgs)
+                    ? InterfaceSymbol.Construct(ifaceDef, ownArgs, scope.References.MapClrTypeToReferences)
                     : ifaceDef;
                 return true;
 
@@ -2256,7 +2256,7 @@ internal sealed partial class ExpressionBinder
             return false;
         }
 
-        constructed = InterfaceSymbol.Construct(ifaceDef, typeArgs);
+        constructed = InterfaceSymbol.Construct(ifaceDef, typeArgs, scope.References.MapClrTypeToReferences);
         return true;
     }
 
@@ -2344,7 +2344,7 @@ internal sealed partial class ExpressionBinder
                     constructedStruct = StructSymbol.Construct(structDef, typeArgs);
                     return true;
                 case InterfaceSymbol ifaceDef:
-                    constructedInterface = InterfaceSymbol.Construct(ifaceDef, typeArgs);
+                    constructedInterface = InterfaceSymbol.Construct(ifaceDef, typeArgs, scope.References.MapClrTypeToReferences);
                     return true;
             }
         }
@@ -2432,7 +2432,7 @@ internal sealed partial class ExpressionBinder
                     constructedStruct = StructSymbol.Construct(structDef, typeArgs);
                     return true;
                 case InterfaceSymbol ifaceDef:
-                    constructedInterface = InterfaceSymbol.Construct(ifaceDef, typeArgs);
+                    constructedInterface = InterfaceSymbol.Construct(ifaceDef, typeArgs, scope.References.MapClrTypeToReferences);
                     return true;
             }
         }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -1223,15 +1223,15 @@ internal sealed partial class ExpressionBinder
                 var def = nestedStruct.Definition ?? nestedStruct;
                 if (!enclosingArgs.IsDefaultOrEmpty && !ownArgs.IsDefaultOrEmpty)
                 {
-                    nestedType = StructSymbol.ConstructNestedGeneric(def, enclosingArgs, ownArgs);
+                    nestedType = StructSymbol.ConstructNestedGeneric(def, enclosingArgs, ownArgs, scope.References.MapClrTypeToReferences);
                 }
                 else if (!enclosingArgs.IsDefaultOrEmpty)
                 {
-                    nestedType = StructSymbol.ConstructNested(def, enclosingArgs);
+                    nestedType = StructSymbol.ConstructNested(def, enclosingArgs, scope.References.MapClrTypeToReferences);
                 }
                 else if (!ownArgs.IsDefaultOrEmpty)
                 {
-                    nestedType = StructSymbol.Construct(def, ownArgs);
+                    nestedType = StructSymbol.Construct(def, ownArgs, scope.References.MapClrTypeToReferences);
                 }
                 else
                 {
@@ -2065,15 +2065,15 @@ internal sealed partial class ExpressionBinder
             var ownArgs = segments[i].Args;
             if (!enclosingArgs.IsDefaultOrEmpty && !ownArgs.IsDefaultOrEmpty)
             {
-                constructed = StructSymbol.ConstructNestedGeneric(def, enclosingArgs, ownArgs);
+                constructed = StructSymbol.ConstructNestedGeneric(def, enclosingArgs, ownArgs, scope.References.MapClrTypeToReferences);
             }
             else if (!enclosingArgs.IsDefaultOrEmpty)
             {
-                constructed = StructSymbol.ConstructNested(def, enclosingArgs);
+                constructed = StructSymbol.ConstructNested(def, enclosingArgs, scope.References.MapClrTypeToReferences);
             }
             else if (!ownArgs.IsDefaultOrEmpty)
             {
-                constructed = StructSymbol.Construct(def, ownArgs);
+                constructed = StructSymbol.Construct(def, ownArgs, scope.References.MapClrTypeToReferences);
             }
             else
             {
@@ -2341,7 +2341,7 @@ internal sealed partial class ExpressionBinder
             switch (alias)
             {
                 case StructSymbol structDef:
-                    constructedStruct = StructSymbol.Construct(structDef, typeArgs);
+                    constructedStruct = StructSymbol.Construct(structDef, typeArgs, scope.References.MapClrTypeToReferences);
                     return true;
                 case InterfaceSymbol ifaceDef:
                     constructedInterface = InterfaceSymbol.Construct(ifaceDef, typeArgs, scope.References.MapClrTypeToReferences);
@@ -2429,7 +2429,7 @@ internal sealed partial class ExpressionBinder
             switch (alias)
             {
                 case StructSymbol structDef:
-                    constructedStruct = StructSymbol.Construct(structDef, typeArgs);
+                    constructedStruct = StructSymbol.Construct(structDef, typeArgs, scope.References.MapClrTypeToReferences);
                     return true;
                 case InterfaceSymbol ifaceDef:
                     constructedInterface = InterfaceSymbol.Construct(ifaceDef, typeArgs, scope.References.MapClrTypeToReferences);

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
@@ -839,8 +839,8 @@ internal sealed partial class ExpressionBinder
             // substitute both levels and the emitter encodes the reified nested
             // type (`Outer`1+Middle`2<int32, string>`).
             structSymbol = enclosingTypeArguments.IsDefaultOrEmpty
-                ? StructSymbol.Construct(structSymbol, typeArgs.MoveToImmutable())
-                : StructSymbol.ConstructNestedGeneric(structSymbol, enclosingTypeArguments, typeArgs.MoveToImmutable());
+                ? StructSymbol.Construct(structSymbol, typeArgs.MoveToImmutable(), scope.References.MapClrTypeToReferences)
+                : StructSymbol.ConstructNestedGeneric(structSymbol, enclosingTypeArguments, typeArgs.MoveToImmutable(), scope.References.MapClrTypeToReferences);
         }
         else if (syntax.TypeArgumentList != null)
         {
@@ -853,7 +853,7 @@ internal sealed partial class ExpressionBinder
             // enclosing type (`Box[int32].Tag{…}`) threads only the enclosing
             // arguments so member types typed as an enclosing parameter surface
             // closed and the emitter encodes `Box`1+Tag`1<int32>`.
-            structSymbol = StructSymbol.ConstructNested(structSymbol, enclosingTypeArguments);
+            structSymbol = StructSymbol.ConstructNested(structSymbol, enclosingTypeArguments, scope.References.MapClrTypeToReferences);
         }
 
         var seenFieldNames = new HashSet<string>();

--- a/src/Core/CodeAnalysis/Symbols/InterfaceSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/InterfaceSymbol.cs
@@ -814,14 +814,14 @@ public sealed class InterfaceSymbol : TypeSymbol
             }
             catch (System.ArgumentException)
             {
-                // Issue #1958: with the mapClrType projection above, a
-                // cross-reflection-context mismatch here should no longer be
-                // reachable. Assert loudly in debug builds instead of the
-                // silent fallback that made #1926 hard to diagnose; still
-                // fall back to the erased constructed form so release builds
-                // degrade gracefully rather than crash.
+                // MakeGenericType can legitimately throw ArgumentException for CLR
+                // generic constraint reasons (e.g. unmanaged/ref-struct constraints),
+                // not only cross-reflection-context mismatches, so this is NOT always
+                // a bug. Log for diagnosability and fall back to the erased
+                // constructed form so both debug and release builds degrade
+                // gracefully rather than crash.
                 var assertMessage = $"InterfaceSymbol.SubstituteType: MakeGenericType failed for '{imported.OpenDefinition}' with args [{string.Join(", ", resolvedClrArgs.Select(t => t.ToString()))}] even after mapClrType projection.";
-                System.Diagnostics.Debug.Assert(false, assertMessage);
+                System.Diagnostics.Debug.WriteLine(assertMessage);
                 return imported;
             }
         }

--- a/src/Core/CodeAnalysis/Symbols/InterfaceSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/InterfaceSymbol.cs
@@ -5,6 +5,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using GSharp.Core.CodeAnalysis.Binding;
 using GSharp.Core.CodeAnalysis.Syntax;
 
@@ -19,6 +20,13 @@ namespace GSharp.Core.CodeAnalysis.Symbols;
 public sealed class InterfaceSymbol : TypeSymbol
 {
     private static readonly ConcurrentDictionary<(InterfaceSymbol Def, TypeArgsKey Args), InterfaceSymbol> ConstructedCache = new();
+
+    // Issue #1958: the projector supplied to Construct(), retained so the
+    // (possibly deferred, see EnsureMembersResolved) member substitution pass
+    // can close constructed-generic member types in the right reflection
+    // context. Null for definitions and for constructed instances built
+    // without a projector (single-context callers; unchanged behavior).
+    private readonly System.Func<System.Type, System.Type> mapClrType;
 
     private ImmutableArray<FunctionSymbol> methods;
     private ImmutableArray<FunctionSymbol> staticMethods = ImmutableArray<FunctionSymbol>.Empty;
@@ -52,7 +60,7 @@ public sealed class InterfaceSymbol : TypeSymbol
         Definition = this;
     }
 
-    private InterfaceSymbol(InterfaceSymbol definition, ImmutableArray<TypeSymbol> typeArguments, string constructedName)
+    private InterfaceSymbol(InterfaceSymbol definition, ImmutableArray<TypeSymbol> typeArguments, string constructedName, System.Func<System.Type, System.Type> mapClrType)
         : base(constructedName)
     {
         Accessibility = definition.Accessibility;
@@ -62,6 +70,7 @@ public sealed class InterfaceSymbol : TypeSymbol
         TypeParameters = ImmutableArray<TypeParameterSymbol>.Empty;
         TypeArguments = typeArguments;
         Definition = definition;
+        this.mapClrType = mapClrType;
     }
 
     /// <summary>Gets the interface accessibility.</summary>
@@ -518,8 +527,15 @@ public sealed class InterfaceSymbol : TypeSymbol
     /// </summary>
     /// <param name="definition">The generic definition to instantiate.</param>
     /// <param name="typeArguments">The type arguments. Length must match <see cref="TypeParameters"/>.</param>
+    /// <param name="mapClrType">
+    /// Issue #1958: projects a host CLR <see cref="System.Type"/> into the reflection
+    /// context (typically a <see cref="System.Reflection.MetadataLoadContext"/>) that a
+    /// member's constructed generic CLR type was resolved from, mirroring
+    /// <c>Binder.SubstituteType</c>'s <c>mapClrType</c> (issue #1926 / PR #1956). Pass
+    /// <see langword="null"/> (the default) for single-context callers.
+    /// </param>
     /// <returns>A constructed <see cref="InterfaceSymbol"/> whose <see cref="Definition"/> is the original.</returns>
-    public static InterfaceSymbol Construct(InterfaceSymbol definition, ImmutableArray<TypeSymbol> typeArguments)
+    public static InterfaceSymbol Construct(InterfaceSymbol definition, ImmutableArray<TypeSymbol> typeArguments, System.Func<System.Type, System.Type> mapClrType = null)
     {
         if (definition == null || !definition.IsGenericDefinition)
         {
@@ -527,7 +543,7 @@ public sealed class InterfaceSymbol : TypeSymbol
         }
 
         var key = BuildArgsKey(typeArguments);
-        return ConstructedCache.GetOrAdd((definition, key), _ => CreateConstructed(definition, typeArguments));
+        return ConstructedCache.GetOrAdd((definition, key), _ => CreateConstructed(definition, typeArguments, mapClrType));
     }
 
     /// <summary>
@@ -587,7 +603,7 @@ public sealed class InterfaceSymbol : TypeSymbol
 
     private static TypeArgsKey BuildArgsKey(ImmutableArray<TypeSymbol> typeArguments) => new(typeArguments);
 
-    private static InterfaceSymbol CreateConstructed(InterfaceSymbol definition, ImmutableArray<TypeSymbol> typeArguments)
+    private static InterfaceSymbol CreateConstructed(InterfaceSymbol definition, ImmutableArray<TypeSymbol> typeArguments, System.Func<System.Type, System.Type> mapClrType)
     {
         var argParts = new string[typeArguments.Length];
         for (var i = 0; i < typeArguments.Length; i++)
@@ -596,7 +612,7 @@ public sealed class InterfaceSymbol : TypeSymbol
         }
 
         var constructedName = $"{definition.Name}[{string.Join(", ", argParts)}]";
-        var instance = new InterfaceSymbol(definition, typeArguments, constructedName);
+        var instance = new InterfaceSymbol(definition, typeArguments, constructedName, mapClrType);
 
         // ADR-0087 R5 / issue #765: defer the actual member substitution
         // (Methods / StaticMethods / PrivateMethods / StaticPrivateMethods)
@@ -616,12 +632,13 @@ public sealed class InterfaceSymbol : TypeSymbol
         Dictionary<TypeParameterSymbol, TypeSymbol> subst,
         InterfaceSymbol instance,
         bool isStatic,
-        bool isPrivate)
+        bool isPrivate,
+        System.Func<System.Type, System.Type> mapClrType)
     {
         var substParams = ImmutableArray.CreateBuilder<ParameterSymbol>(m.Parameters.Length);
         foreach (var p in m.Parameters)
         {
-            var newParam = new ParameterSymbol(p.Name, SubstituteType(p.Type, subst), isVariadic: p.IsVariadic, isScoped: p.IsScoped, refKind: p.RefKind);
+            var newParam = new ParameterSymbol(p.Name, SubstituteType(p.Type, subst, mapClrType), isVariadic: p.IsVariadic, isScoped: p.IsScoped, refKind: p.RefKind);
             if (p.HasExplicitDefaultValue)
             {
                 newParam.SetExplicitDefaultValue(p.ExplicitDefaultValue);
@@ -630,7 +647,7 @@ public sealed class InterfaceSymbol : TypeSymbol
             substParams.Add(newParam);
         }
 
-        var substReturn = SubstituteType(m.Type, subst);
+        var substReturn = SubstituteType(m.Type, subst, mapClrType);
         var substMethod = new FunctionSymbol(
             m.Name,
             substParams.MoveToImmutable(),
@@ -684,7 +701,7 @@ public sealed class InterfaceSymbol : TypeSymbol
             var builder = ImmutableArray.CreateBuilder<FunctionSymbol>(defMethods.Length);
             foreach (var m in defMethods)
             {
-                builder.Add(SubstituteMethod(m, subst, this, isStatic: false, isPrivate: false));
+                builder.Add(SubstituteMethod(m, subst, this, isStatic: false, isPrivate: false, mapClrType));
             }
 
             Methods = builder.MoveToImmutable();
@@ -695,7 +712,7 @@ public sealed class InterfaceSymbol : TypeSymbol
             var builder = ImmutableArray.CreateBuilder<FunctionSymbol>(defStatic.Length);
             foreach (var m in defStatic)
             {
-                builder.Add(SubstituteMethod(m, subst, this, isStatic: true, isPrivate: false));
+                builder.Add(SubstituteMethod(m, subst, this, isStatic: true, isPrivate: false, mapClrType));
             }
 
             StaticMethods = builder.MoveToImmutable();
@@ -706,7 +723,7 @@ public sealed class InterfaceSymbol : TypeSymbol
             var builder = ImmutableArray.CreateBuilder<FunctionSymbol>(defPriv.Length);
             foreach (var m in defPriv)
             {
-                builder.Add(SubstituteMethod(m, subst, this, isStatic: false, isPrivate: true));
+                builder.Add(SubstituteMethod(m, subst, this, isStatic: false, isPrivate: true, mapClrType));
             }
 
             PrivateMethods = builder.MoveToImmutable();
@@ -717,7 +734,7 @@ public sealed class InterfaceSymbol : TypeSymbol
             var builder = ImmutableArray.CreateBuilder<FunctionSymbol>(defStaticPriv.Length);
             foreach (var m in defStaticPriv)
             {
-                builder.Add(SubstituteMethod(m, subst, this, isStatic: true, isPrivate: true));
+                builder.Add(SubstituteMethod(m, subst, this, isStatic: true, isPrivate: true, mapClrType));
             }
 
             StaticPrivateMethods = builder.MoveToImmutable();
@@ -726,7 +743,7 @@ public sealed class InterfaceSymbol : TypeSymbol
         membersResolved = true;
     }
 
-    private static TypeSymbol SubstituteType(TypeSymbol type, Dictionary<TypeParameterSymbol, TypeSymbol> subst)
+    private static TypeSymbol SubstituteType(TypeSymbol type, Dictionary<TypeParameterSymbol, TypeSymbol> subst, System.Func<System.Type, System.Type> mapClrType)
     {
         if (type is TypeParameterSymbol tp && subst.TryGetValue(tp, out var concrete))
         {
@@ -743,13 +760,13 @@ public sealed class InterfaceSymbol : TypeSymbol
             var changed = false;
             for (var i = 0; i < iface.TypeArguments.Length; i++)
             {
-                var substituted = SubstituteType(iface.TypeArguments[i], subst);
+                var substituted = SubstituteType(iface.TypeArguments[i], subst, mapClrType);
                 substitutedArgs.Add(substituted);
                 changed |= !ReferenceEquals(substituted, iface.TypeArguments[i]);
             }
 
             return changed
-                ? Construct(iface.Definition, substitutedArgs.MoveToImmutable())
+                ? Construct(iface.Definition, substitutedArgs.MoveToImmutable(), mapClrType)
                 : iface;
         }
 
@@ -767,7 +784,7 @@ public sealed class InterfaceSymbol : TypeSymbol
             var changed = false;
             for (var i = 0; i < imported.TypeArguments.Length; i++)
             {
-                var substituted = SubstituteType(imported.TypeArguments[i], subst);
+                var substituted = SubstituteType(imported.TypeArguments[i], subst, mapClrType);
                 substitutedArgs.Add(substituted);
                 changed |= !ReferenceEquals(substituted, imported.TypeArguments[i]);
             }
@@ -777,10 +794,17 @@ public sealed class InterfaceSymbol : TypeSymbol
                 return imported;
             }
 
+            // Issue #1958: project each resolved CLR arg into the same
+            // reflection context as `imported.OpenDefinition` before calling
+            // MakeGenericType — mirrors Binder.SubstituteType's mapClrType
+            // fix for issue #1926 (PR #1956). Without this, a raw host CLR
+            // type mixed with an MLC-resolved open definition throws
+            // ArgumentException and silently erases the substitution.
             var resolvedClrArgs = new System.Type[substitutedArgs.Count];
             for (var i = 0; i < substitutedArgs.Count; i++)
             {
-                resolvedClrArgs[i] = substitutedArgs[i].ClrType ?? typeof(object);
+                var clr = substitutedArgs[i].ClrType ?? typeof(object);
+                resolvedClrArgs[i] = mapClrType != null ? mapClrType(clr) : clr;
             }
 
             try
@@ -790,25 +814,33 @@ public sealed class InterfaceSymbol : TypeSymbol
             }
             catch (System.ArgumentException)
             {
+                // Issue #1958: with the mapClrType projection above, a
+                // cross-reflection-context mismatch here should no longer be
+                // reachable. Assert loudly in debug builds instead of the
+                // silent fallback that made #1926 hard to diagnose; still
+                // fall back to the erased constructed form so release builds
+                // degrade gracefully rather than crash.
+                var assertMessage = $"InterfaceSymbol.SubstituteType: MakeGenericType failed for '{imported.OpenDefinition}' with args [{string.Join(", ", resolvedClrArgs.Select(t => t.ToString()))}] even after mapClrType projection.";
+                System.Diagnostics.Debug.Assert(false, assertMessage);
                 return imported;
             }
         }
 
         if (type is SliceTypeSymbol s)
         {
-            var sub = SubstituteType(s.ElementType, subst);
+            var sub = SubstituteType(s.ElementType, subst, mapClrType);
             return sub == s.ElementType ? s : SliceTypeSymbol.Get(sub);
         }
 
         if (type is ArrayTypeSymbol a)
         {
-            var sub = SubstituteType(a.ElementType, subst);
+            var sub = SubstituteType(a.ElementType, subst, mapClrType);
             return sub == a.ElementType ? a : ArrayTypeSymbol.Get(sub, a.Length);
         }
 
         if (type is NullableTypeSymbol n)
         {
-            var sub = SubstituteType(n.UnderlyingType, subst);
+            var sub = SubstituteType(n.UnderlyingType, subst, mapClrType);
             return sub == n.UnderlyingType ? n : NullableTypeSymbol.Get(sub);
         }
 

--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using GSharp.Core.CodeAnalysis.Binding;
 using GSharp.Core.CodeAnalysis.Syntax;
 
@@ -66,6 +67,14 @@ public sealed class StructSymbol : TypeSymbol
     // parameter (`Middle.Label : T`) surfaces closed regardless of when the map
     // is first computed. Empty for every other symbol.
     private ImmutableArray<TypeParameterSymbol> nestedOwnTypeParameters = ImmutableArray<TypeParameterSymbol>.Empty;
+
+    // Issue #1958: the projector supplied to Construct()/ConstructNested()/
+    // ConstructNestedGeneric(), retained so the (lazily computed, see
+    // GetSubstitutedFields/GetSubstitutedProperties) member substitution can
+    // close constructed-generic member types in the right reflection context.
+    // Null for definitions and for constructed instances built without a
+    // projector (single-context callers; unchanged behavior).
+    private Func<Type, Type> mapClrType;
     private ImmutableArray<FieldSymbol> substitutedFields;
     private ImmutableArray<FieldSymbol> substitutedFieldsSource;
     private bool substitutedFieldsComputed;
@@ -1226,8 +1235,15 @@ public sealed class StructSymbol : TypeSymbol
     /// </summary>
     /// <param name="definition">The generic definition to instantiate. Must have <see cref="IsGenericDefinition"/> true; otherwise returned unchanged.</param>
     /// <param name="typeArguments">The type arguments. Length must match <see cref="TypeParameters"/>.</param>
+    /// <param name="mapClrType">
+    /// Issue #1958: projects a host CLR <see cref="Type"/> into the reflection
+    /// context (typically a <see cref="System.Reflection.MetadataLoadContext"/>) that a
+    /// member's constructed generic CLR type was resolved from, mirroring
+    /// <c>InterfaceSymbol.Construct</c>'s <c>mapClrType</c> (issue #1926 / PR #1956).
+    /// Pass <see langword="null"/> (the default) for single-context callers.
+    /// </param>
     /// <returns>A constructed <see cref="StructSymbol"/> whose <see cref="Definition"/> is the original.</returns>
-    public static StructSymbol Construct(StructSymbol definition, ImmutableArray<TypeSymbol> typeArguments)
+    public static StructSymbol Construct(StructSymbol definition, ImmutableArray<TypeSymbol> typeArguments, Func<Type, Type> mapClrType = null)
     {
         if (definition == null || !definition.IsGenericDefinition)
         {
@@ -1235,7 +1251,7 @@ public sealed class StructSymbol : TypeSymbol
         }
 
         var key = BuildArgsKey(typeArguments);
-        return ConstructedCache.GetOrAdd((definition, key), _ => CreateConstructed(definition, typeArguments));
+        return ConstructedCache.GetOrAdd((definition, key), _ => CreateConstructed(definition, typeArguments, mapClrType));
     }
 
     /// <summary>
@@ -1254,8 +1270,9 @@ public sealed class StructSymbol : TypeSymbol
     /// </summary>
     /// <param name="nestedDefinition">The open nested-type definition (its <see cref="Definition"/> is used).</param>
     /// <param name="enclosingTypeArguments">The flattened enclosing construction arguments in CLR order (outermost first), aligned with <see cref="CollectEnclosingTypeParameters(TypeSymbol)"/>.</param>
+    /// <param name="mapClrType">Issue #1958: see <see cref="Construct(StructSymbol, ImmutableArray{TypeSymbol}, Func{Type, Type})"/>.</param>
     /// <returns>A constructed nested reference, or <paramref name="nestedDefinition"/> unchanged when no enclosing arguments apply.</returns>
-    public static StructSymbol ConstructNested(StructSymbol nestedDefinition, ImmutableArray<TypeSymbol> enclosingTypeArguments)
+    public static StructSymbol ConstructNested(StructSymbol nestedDefinition, ImmutableArray<TypeSymbol> enclosingTypeArguments, Func<Type, Type> mapClrType = null)
     {
         if (nestedDefinition == null || enclosingTypeArguments.IsDefaultOrEmpty)
         {
@@ -1264,7 +1281,7 @@ public sealed class StructSymbol : TypeSymbol
 
         var def = nestedDefinition.Definition ?? nestedDefinition;
         var key = BuildArgsKey(enclosingTypeArguments);
-        return ConstructedNestedCache.GetOrAdd((def, key), _ => CreateConstructedNested(def, enclosingTypeArguments));
+        return ConstructedNestedCache.GetOrAdd((def, key), _ => CreateConstructedNested(def, enclosingTypeArguments, mapClrType));
     }
 
     /// <summary>
@@ -1286,11 +1303,13 @@ public sealed class StructSymbol : TypeSymbol
     /// <param name="nestedDefinition">The open nested-type definition (its <see cref="Definition"/> is used).</param>
     /// <param name="enclosingTypeArguments">The flattened enclosing construction arguments in CLR order (outermost first), aligned with <see cref="CollectEnclosingTypeParameters(TypeSymbol)"/>. May be empty when the enclosing type is open but the nested type carries own arguments.</param>
     /// <param name="ownTypeArguments">The nested type's own type arguments.</param>
+    /// <param name="mapClrType">Issue #1958: see <see cref="Construct(StructSymbol, ImmutableArray{TypeSymbol}, Func{Type, Type})"/>.</param>
     /// <returns>A constructed nested-generic reference, or <paramref name="nestedDefinition"/> unchanged when neither vector applies.</returns>
     public static StructSymbol ConstructNestedGeneric(
         StructSymbol nestedDefinition,
         ImmutableArray<TypeSymbol> enclosingTypeArguments,
-        ImmutableArray<TypeSymbol> ownTypeArguments)
+        ImmutableArray<TypeSymbol> ownTypeArguments,
+        Func<Type, Type> mapClrType = null)
     {
         if (nestedDefinition == null)
         {
@@ -1301,7 +1320,7 @@ public sealed class StructSymbol : TypeSymbol
         // two representations remain reference-equal and share one cache.
         if (ownTypeArguments.IsDefaultOrEmpty)
         {
-            return ConstructNested(nestedDefinition, enclosingTypeArguments);
+            return ConstructNested(nestedDefinition, enclosingTypeArguments, mapClrType);
         }
 
         // No enclosing arguments to thread: this is an ordinary construction of
@@ -1311,7 +1330,7 @@ public sealed class StructSymbol : TypeSymbol
         // arguments substitute exactly as for a top-level generic.
         if (enclosingTypeArguments.IsDefaultOrEmpty)
         {
-            return Construct(nestedDefinition.Definition ?? nestedDefinition, ownTypeArguments);
+            return Construct(nestedDefinition.Definition ?? nestedDefinition, ownTypeArguments, mapClrType);
         }
 
         var def = nestedDefinition.Definition ?? nestedDefinition;
@@ -1319,7 +1338,7 @@ public sealed class StructSymbol : TypeSymbol
         var ownKey = BuildArgsKey(ownTypeArguments);
         return ConstructedNestedGenericCache.GetOrAdd(
             (def, enclosingKey, ownKey),
-            _ => CreateConstructedNestedGeneric(def, enclosingTypeArguments, ownTypeArguments));
+            _ => CreateConstructedNestedGeneric(def, enclosingTypeArguments, ownTypeArguments, mapClrType));
     }
 
     /// <summary>
@@ -1489,7 +1508,7 @@ public sealed class StructSymbol : TypeSymbol
         var builder = ImmutableArray.CreateBuilder<TypeSymbol>(parameters.Length);
         foreach (var p in parameters)
         {
-            builder.Add(SubstituteTypeForConstruction(p.Type, subst));
+            builder.Add(SubstituteTypeForConstruction(p.Type, subst, mapClrType));
         }
 
         return builder.MoveToImmutable();
@@ -1607,7 +1626,7 @@ public sealed class StructSymbol : TypeSymbol
         _ => ImmutableArray<TypeParameterSymbol>.Empty,
     };
 
-    private static StructSymbol CreateConstructed(StructSymbol definition, ImmutableArray<TypeSymbol> typeArguments)
+    private static StructSymbol CreateConstructed(StructSymbol definition, ImmutableArray<TypeSymbol> typeArguments, Func<Type, Type> mapClrType)
     {
         var subst = new Dictionary<TypeParameterSymbol, TypeSymbol>(definition.TypeParameters.Length);
         for (var i = 0; i < definition.TypeParameters.Length; i++)
@@ -1618,7 +1637,7 @@ public sealed class StructSymbol : TypeSymbol
         var substitutedFields = ImmutableArray.CreateBuilder<FieldSymbol>(definition.Fields.Length);
         foreach (var f in definition.Fields)
         {
-            substitutedFields.Add(new FieldSymbol(f.Name, SubstituteTypeForConstruction(f.Type, subst), f.Accessibility));
+            substitutedFields.Add(new FieldSymbol(f.Name, SubstituteTypeForConstruction(f.Type, subst, mapClrType), f.Accessibility));
         }
 
         var substitutedPrimary = ImmutableArray<ParameterSymbol>.Empty;
@@ -1627,7 +1646,7 @@ public sealed class StructSymbol : TypeSymbol
             var b = ImmutableArray.CreateBuilder<ParameterSymbol>(definition.PrimaryConstructorParameters.Length);
             foreach (var p in definition.PrimaryConstructorParameters)
             {
-                b.Add(new ParameterSymbol(p.Name, SubstituteTypeForConstruction(p.Type, subst), isVariadic: p.IsVariadic, isScoped: p.IsScoped));
+                b.Add(new ParameterSymbol(p.Name, SubstituteTypeForConstruction(p.Type, subst, mapClrType), isVariadic: p.IsVariadic, isScoped: p.IsScoped));
             }
 
             substitutedPrimary = b.MoveToImmutable();
@@ -1648,12 +1667,13 @@ public sealed class StructSymbol : TypeSymbol
 
         constructed.Definition = definition;
         constructed.TypeArguments = typeArguments;
+        constructed.mapClrType = mapClrType;
         if (!definition.Interfaces.IsDefaultOrEmpty)
         {
             var substitutedIfaces = ImmutableArray.CreateBuilder<InterfaceSymbol>(definition.Interfaces.Length);
             foreach (var iface in definition.Interfaces)
             {
-                substitutedIfaces.Add((InterfaceSymbol)SubstituteTypeForConstruction(iface, subst));
+                substitutedIfaces.Add((InterfaceSymbol)SubstituteTypeForConstruction(iface, subst, mapClrType));
             }
 
             constructed.SetInterfaces(substitutedIfaces.MoveToImmutable());
@@ -1668,7 +1688,7 @@ public sealed class StructSymbol : TypeSymbol
             var substitutedClrIfaces = ImmutableArray.CreateBuilder<TypeSymbol>(definition.ImplementedClrInterfaces.Length);
             foreach (var iface in definition.ImplementedClrInterfaces)
             {
-                substitutedClrIfaces.Add(SubstituteTypeForConstruction(iface, subst));
+                substitutedClrIfaces.Add(SubstituteTypeForConstruction(iface, subst, mapClrType));
             }
 
             constructed.SetImplementedClrInterfaces(substitutedClrIfaces.MoveToImmutable());
@@ -1720,7 +1740,7 @@ public sealed class StructSymbol : TypeSymbol
     // definition and substitute lazily against that map, so a field/property/
     // return of the nested type whose type is an enclosing parameter surfaces
     // closed (e.g. `Tag.V : int32` on `Box[int32].Tag`).
-    private static StructSymbol CreateConstructedNested(StructSymbol definition, ImmutableArray<TypeSymbol> enclosingTypeArguments)
+    private static StructSymbol CreateConstructedNested(StructSymbol definition, ImmutableArray<TypeSymbol> enclosingTypeArguments, Func<Type, Type> mapClrType)
     {
         var constructed = new StructSymbol(
             definition.Name,
@@ -1737,6 +1757,7 @@ public sealed class StructSymbol : TypeSymbol
 
         constructed.Definition = definition;
         constructed.EnclosingTypeArguments = enclosingTypeArguments;
+        constructed.mapClrType = mapClrType;
         constructed.ContainingType = definition.ContainingType;
         constructed.SetInterfaces(definition.Interfaces);
         if (!definition.ImplementedClrInterfaces.IsDefaultOrEmpty)
@@ -1766,7 +1787,8 @@ public sealed class StructSymbol : TypeSymbol
     private static StructSymbol CreateConstructedNestedGeneric(
         StructSymbol definition,
         ImmutableArray<TypeSymbol> enclosingTypeArguments,
-        ImmutableArray<TypeSymbol> ownTypeArguments)
+        ImmutableArray<TypeSymbol> ownTypeArguments,
+        Func<Type, Type> mapClrType)
     {
         var constructed = new StructSymbol(
             definition.Name,
@@ -1784,6 +1806,7 @@ public sealed class StructSymbol : TypeSymbol
         constructed.Definition = definition;
         constructed.TypeArguments = ownTypeArguments;
         constructed.EnclosingTypeArguments = enclosingTypeArguments;
+        constructed.mapClrType = mapClrType;
 
         // Capture the nested type's own type parameters BEFORE the emitter
         // re-ordinalizes the nested TypeDef over the flattened enclosing+own
@@ -1881,7 +1904,7 @@ public sealed class StructSymbol : TypeSymbol
             var builder = ImmutableArray.CreateBuilder<FieldSymbol>(source.Length);
             foreach (var f in source)
             {
-                var newType = SubstituteTypeForConstruction(f.Type, subst);
+                var newType = SubstituteTypeForConstruction(f.Type, subst, mapClrType);
                 builder.Add(ReferenceEquals(newType, f.Type)
                     ? f
                     : new FieldSymbol(f.Name, newType, f.Accessibility));
@@ -1907,7 +1930,7 @@ public sealed class StructSymbol : TypeSymbol
             return substitutedProperties;
         }
 
-        var result = SubstituteProperties(source, GetSubstitutionMap());
+        var result = SubstituteProperties(source, GetSubstitutionMap(), mapClrType);
         substitutedProperties = result;
         substitutedPropertiesSource = source;
         substitutedPropertiesComputed = true;
@@ -1925,7 +1948,7 @@ public sealed class StructSymbol : TypeSymbol
             return substitutedStaticProperties;
         }
 
-        var result = SubstituteProperties(source, GetSubstitutionMap());
+        var result = SubstituteProperties(source, GetSubstitutionMap(), mapClrType);
         substitutedStaticProperties = result;
         substitutedStaticPropertiesSource = source;
         substitutedStaticPropertiesComputed = true;
@@ -1934,7 +1957,8 @@ public sealed class StructSymbol : TypeSymbol
 
     private static ImmutableArray<PropertySymbol> SubstituteProperties(
         ImmutableArray<PropertySymbol> properties,
-        Dictionary<TypeParameterSymbol, TypeSymbol> subst)
+        Dictionary<TypeParameterSymbol, TypeSymbol> subst,
+        Func<Type, Type> mapClrType)
     {
         if (properties.IsDefaultOrEmpty)
         {
@@ -1944,7 +1968,7 @@ public sealed class StructSymbol : TypeSymbol
         var builder = ImmutableArray.CreateBuilder<PropertySymbol>(properties.Length);
         foreach (var p in properties)
         {
-            var newType = SubstituteTypeForConstruction(p.Type, subst);
+            var newType = SubstituteTypeForConstruction(p.Type, subst, mapClrType);
 
             var newParams = p.Parameters;
             var paramsChanged = false;
@@ -1953,7 +1977,7 @@ public sealed class StructSymbol : TypeSymbol
                 var pb = ImmutableArray.CreateBuilder<ParameterSymbol>(p.Parameters.Length);
                 foreach (var par in p.Parameters)
                 {
-                    var st = SubstituteTypeForConstruction(par.Type, subst);
+                    var st = SubstituteTypeForConstruction(par.Type, subst, mapClrType);
                     paramsChanged |= !ReferenceEquals(st, par.Type);
                     pb.Add(new ParameterSymbol(par.Name, st, isVariadic: par.IsVariadic, isScoped: par.IsScoped));
                 }
@@ -2084,7 +2108,7 @@ public sealed class StructSymbol : TypeSymbol
     private static ImmutableArray<ParameterSymbol> CallableParametersOf(FunctionSymbol method)
         => method.ExplicitReceiverParameter == null ? method.Parameters : method.Parameters.RemoveAt(0);
 
-    private static TypeSymbol SubstituteTypeForConstruction(TypeSymbol type, Dictionary<TypeParameterSymbol, TypeSymbol> subst)
+    private static TypeSymbol SubstituteTypeForConstruction(TypeSymbol type, Dictionary<TypeParameterSymbol, TypeSymbol> subst, Func<Type, Type> mapClrType = null)
     {
         if (type is TypeParameterSymbol tp)
         {
@@ -2105,13 +2129,13 @@ public sealed class StructSymbol : TypeSymbol
             var structChanged = false;
             for (var i = 0; i < ss.TypeArguments.Length; i++)
             {
-                var substituted = SubstituteTypeForConstruction(ss.TypeArguments[i], subst);
+                var substituted = SubstituteTypeForConstruction(ss.TypeArguments[i], subst, mapClrType);
                 substitutedStructArgs.Add(substituted);
                 structChanged |= !ReferenceEquals(substituted, ss.TypeArguments[i]);
             }
 
             return structChanged
-                ? StructSymbol.Construct(ss.Definition, substitutedStructArgs.MoveToImmutable())
+                ? StructSymbol.Construct(ss.Definition, substitutedStructArgs.MoveToImmutable(), mapClrType)
                 : type;
         }
 
@@ -2123,10 +2147,10 @@ public sealed class StructSymbol : TypeSymbol
         // distinct from the constructed-generic branch above.
         if (type is StructSymbol nestedRef && nestedRef.TypeArguments.IsDefaultOrEmpty)
         {
-            var newEnclosing = SubstituteEnclosingArguments(nestedRef, t => SubstituteTypeForConstruction(t, subst));
+            var newEnclosing = SubstituteEnclosingArguments(nestedRef, t => SubstituteTypeForConstruction(t, subst, mapClrType));
             if (!newEnclosing.IsDefault)
             {
-                return ConstructNested(nestedRef.Definition ?? nestedRef, newEnclosing);
+                return ConstructNested(nestedRef.Definition ?? nestedRef, newEnclosing, mapClrType);
             }
         }
 
@@ -2136,7 +2160,7 @@ public sealed class StructSymbol : TypeSymbol
             var changed = false;
             for (var i = 0; i < iface.TypeArguments.Length; i++)
             {
-                var substituted = SubstituteTypeForConstruction(iface.TypeArguments[i], subst);
+                var substituted = SubstituteTypeForConstruction(iface.TypeArguments[i], subst, mapClrType);
                 substitutedArgs.Add(substituted);
                 changed |= !ReferenceEquals(substituted, iface.TypeArguments[i]);
             }
@@ -2146,7 +2170,7 @@ public sealed class StructSymbol : TypeSymbol
                 return iface;
             }
 
-            return InterfaceSymbol.Construct(iface.Definition, substitutedArgs.MoveToImmutable());
+            return InterfaceSymbol.Construct(iface.Definition, substitutedArgs.MoveToImmutable(), mapClrType);
         }
 
         if (type is ImportedTypeSymbol imported
@@ -2157,7 +2181,7 @@ public sealed class StructSymbol : TypeSymbol
             var changed = false;
             for (var i = 0; i < imported.TypeArguments.Length; i++)
             {
-                var substituted = SubstituteTypeForConstruction(imported.TypeArguments[i], subst);
+                var substituted = SubstituteTypeForConstruction(imported.TypeArguments[i], subst, mapClrType);
                 substitutedArgs.Add(substituted);
                 changed |= !ReferenceEquals(substituted, imported.TypeArguments[i]);
             }
@@ -2167,10 +2191,17 @@ public sealed class StructSymbol : TypeSymbol
                 return imported;
             }
 
+            // Issue #1958: project each resolved CLR arg into the same
+            // reflection context as `imported.OpenDefinition` before calling
+            // MakeGenericType — mirrors InterfaceSymbol.SubstituteType's
+            // mapClrType fix. Without this, a raw host CLR type mixed with an
+            // MLC-resolved open definition throws ArgumentException and
+            // silently erases the substitution.
             var resolvedClrArgs = new System.Type[substitutedArgs.Count];
             for (var i = 0; i < substitutedArgs.Count; i++)
             {
-                resolvedClrArgs[i] = substitutedArgs[i].ClrType ?? typeof(object);
+                var clr = substitutedArgs[i].ClrType ?? typeof(object);
+                resolvedClrArgs[i] = mapClrType != null ? mapClrType(clr) : clr;
             }
 
             try
@@ -2180,25 +2211,33 @@ public sealed class StructSymbol : TypeSymbol
             }
             catch (ArgumentException)
             {
+                // MakeGenericType can legitimately throw ArgumentException for CLR
+                // generic constraint reasons (e.g. unmanaged/ref-struct constraints),
+                // not only cross-reflection-context mismatches, so this is NOT always
+                // a bug. Log for diagnosability and fall back to the erased
+                // constructed form so both debug and release builds degrade
+                // gracefully rather than crash.
+                var assertMessage = $"StructSymbol.SubstituteTypeForConstruction: MakeGenericType failed for '{imported.OpenDefinition}' with args [{string.Join(", ", resolvedClrArgs.Select(t => t.ToString()))}] even after mapClrType projection.";
+                System.Diagnostics.Debug.WriteLine(assertMessage);
                 return imported;
             }
         }
 
         if (type is NullableTypeSymbol n)
         {
-            var inner = SubstituteTypeForConstruction(n.UnderlyingType, subst);
+            var inner = SubstituteTypeForConstruction(n.UnderlyingType, subst, mapClrType);
             return ReferenceEquals(inner, n.UnderlyingType) ? type : NullableTypeSymbol.Get(inner);
         }
 
         if (type is SliceTypeSymbol s)
         {
-            var inner = SubstituteTypeForConstruction(s.ElementType, subst);
+            var inner = SubstituteTypeForConstruction(s.ElementType, subst, mapClrType);
             return ReferenceEquals(inner, s.ElementType) ? type : SliceTypeSymbol.Get(inner);
         }
 
         if (type is ArrayTypeSymbol a)
         {
-            var inner = SubstituteTypeForConstruction(a.ElementType, subst);
+            var inner = SubstituteTypeForConstruction(a.ElementType, subst, mapClrType);
             return ReferenceEquals(inner, a.ElementType) ? type : ArrayTypeSymbol.Get(inner, a.Length);
         }
 
@@ -2208,8 +2247,8 @@ public sealed class StructSymbol : TypeSymbol
         // `map[int32, string]` on the constructed instantiation.
         if (type is MapTypeSymbol map)
         {
-            var substKey = SubstituteTypeForConstruction(map.KeyType, subst);
-            var substValue = SubstituteTypeForConstruction(map.ValueType, subst);
+            var substKey = SubstituteTypeForConstruction(map.KeyType, subst, mapClrType);
+            var substValue = SubstituteTypeForConstruction(map.ValueType, subst, mapClrType);
             return ReferenceEquals(substKey, map.KeyType) && ReferenceEquals(substValue, map.ValueType)
                 ? type
                 : MapTypeSymbol.Get(substKey, substValue);
@@ -2228,7 +2267,7 @@ public sealed class StructSymbol : TypeSymbol
             var delegateChanged = false;
             for (var i = 0; i < del.TypeArguments.Length; i++)
             {
-                var substituted = SubstituteTypeForConstruction(del.TypeArguments[i], subst);
+                var substituted = SubstituteTypeForConstruction(del.TypeArguments[i], subst, mapClrType);
                 substitutedDelegateArgs.Add(substituted);
                 delegateChanged |= !ReferenceEquals(substituted, del.TypeArguments[i]);
             }
@@ -2248,12 +2287,12 @@ public sealed class StructSymbol : TypeSymbol
             var changed = false;
             for (var i = 0; i < fn.ParameterTypes.Length; i++)
             {
-                var substituted = SubstituteTypeForConstruction(fn.ParameterTypes[i], subst);
+                var substituted = SubstituteTypeForConstruction(fn.ParameterTypes[i], subst, mapClrType);
                 substitutedParams.Add(substituted);
                 changed |= !ReferenceEquals(substituted, fn.ParameterTypes[i]);
             }
 
-            var substitutedReturn = SubstituteTypeForConstruction(fn.ReturnType, subst);
+            var substitutedReturn = SubstituteTypeForConstruction(fn.ReturnType, subst, mapClrType);
             changed |= !ReferenceEquals(substitutedReturn, fn.ReturnType);
 
             if (!changed)

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1958InterfaceMemberGenericSubstitutionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1958InterfaceMemberGenericSubstitutionTests.cs
@@ -1,0 +1,163 @@
+// <copyright file="Issue1958InterfaceMemberGenericSubstitutionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Regression tests for issue #1958: <c>InterfaceSymbol.SubstituteType</c> had
+/// the same silent <c>MakeGenericType</c> erasure bug that PR #1956 fixed in
+/// <c>Binder.SubstituteType</c> for issue #1926.
+/// </summary>
+/// <remarks>
+/// Root cause: when a user-defined generic interface exposes a member type
+/// that is a constructed generic CLR interface over the interface's OWN type
+/// parameter (issue #974 shape, e.g. <c>func Iter() IEnumerator[T]</c> on
+/// <c>interface ISeq[T]</c>), constructing a closed instance (<c>ISeq[int32]</c>)
+/// substitutes <c>T</c> with <c>int32</c> in that member's return type by
+/// calling <c>IEnumerator&lt;&gt;.MakeGenericType(typeof(int))</c>. Under a
+/// <see cref="System.Reflection.MetadataLoadContext"/> reference set (as
+/// cs2gs / the MSBuild task compile mode use), <c>IEnumerator&lt;&gt;</c> is
+/// resolved through the MLC while <c>int32</c>'s <see cref="TypeSymbol.ClrType"/>
+/// is always the host process's live <c>typeof(int)</c>; mixing them in
+/// <c>MakeGenericType</c> throws <see cref="ArgumentException"/>, which was
+/// silently swallowed, leaking the definition's unsubstituted
+/// <c>IEnumerator[T]</c> into the constructed <c>ISeq[int32]</c> shape. The fix
+/// projects each substituted CLR type argument into the interface's
+/// constructing <c>mapClrType</c> reflection context before calling
+/// <c>MakeGenericType</c>, mirroring <c>Binder.SubstituteType</c>.
+/// </remarks>
+public class Issue1958InterfaceMemberGenericSubstitutionTests
+{
+    /// <summary>
+    /// Build a <see cref="ReferenceResolver"/> rooted at the BCL reference
+    /// assemblies, forcing gsc into the <see cref="System.Reflection.MetadataLoadContext"/>
+    /// resolution path — the same path cs2gs and the MSBuild task drive gsc
+    /// through — reproducing the cross-reflection-context scenario inside the
+    /// unit-test process.
+    /// </summary>
+    private static ReferenceResolver MetadataLoadContextResolver()
+    {
+        var paths = new[]
+        {
+            typeof(object).Assembly.Location,
+            typeof(System.Collections.Generic.List<>).Assembly.Location,
+            typeof(System.Console).Assembly.Location,
+            typeof(System.Linq.Enumerable).Assembly.Location,
+        }
+        .Where(p => !string.IsNullOrEmpty(p))
+        .Distinct(StringComparer.OrdinalIgnoreCase)
+        .ToArray();
+
+        return ReferenceResolver.WithReferences(paths);
+    }
+
+    private static BoundGlobalScope BindWithMlc(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        return Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree), MetadataLoadContextResolver());
+    }
+
+    private static BoundGlobalScope BindDefault(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        return Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+    }
+
+    [Fact]
+    public void GenericUserInterface_MemberOverOwnTypeParameter_SubstitutesUnderMetadataLoadContext()
+    {
+        // #974 shape: ISeq[T]'s `Iter()` member exposes the constructed CLR
+        // generic `IEnumerator[T]` over the interface's own type parameter.
+        // Constructing `ISeq[int32]` (via the `use` parameter below) must
+        // substitute T -> int32 in that member so `use`'s declared
+        // `IEnumerator[int32]` return type matches `s.Iter()`'s actual
+        // (substituted) return type. Before the fix, MakeGenericType threw
+        // under MLC and silently fell back to the erased `IEnumerator[T]`,
+        // which does not convert to `IEnumerator[int32]` and failed binding.
+        var source = """
+            package P
+            import System.Collections.Generic
+
+            interface ISeq[T any] {
+                func Iter() IEnumerator[T]
+            }
+
+            func use(s ISeq[int32]) IEnumerator[int32] {
+                return s.Iter()
+            }
+            """;
+
+        var globalScope = BindWithMlc(source);
+        Assert.Empty(globalScope.Diagnostics.Where(d => d.IsError));
+    }
+
+    [Fact]
+    public void GenericUserInterface_MemberOverOwnTypeParameter_ControlCase_DefaultResolver()
+    {
+        // Control case: the same shape must already bind (and keep binding)
+        // under the default (non-MLC) reflection context, so the fix does not
+        // regress the common single-context compile path.
+        var source = """
+            package P
+            import System.Collections.Generic
+
+            interface ISeq[T any] {
+                func Iter() IEnumerator[T]
+            }
+
+            func use(s ISeq[int32]) IEnumerator[int32] {
+                return s.Iter()
+            }
+            """;
+
+        var globalScope = BindDefault(source);
+        Assert.Empty(globalScope.Diagnostics.Where(d => d.IsError));
+    }
+
+    [Fact]
+    public void InterfaceSymbol_SubstituteType_ProjectsClrArgsAcrossReflectionContexts()
+    {
+        // Direct symbol-layer check (issue #1958's minimum bar): constructing
+        // ISeq[int32] under a mapClrType-bearing resolver must produce a
+        // substituted `Iter()` return type whose ImportedTypeSymbol.TypeArguments
+        // is the concrete int32 argument, NOT the still-open T type parameter
+        // that a silently-swallowed ArgumentException would have leaked.
+        var resolver = MetadataLoadContextResolver();
+        var mapClrType = resolver.MapClrTypeToReferences;
+
+        var enumeratorOpenDef = resolver.MapClrTypeToReferences(typeof(System.Collections.Generic.IEnumerator<>));
+        var mlcObject = resolver.MapClrTypeToReferences(typeof(object));
+
+        var tp = new TypeParameterSymbol("T", 0, TypeParameterConstraint.Any, TypeParameterVariance.None);
+        var erasedMemberType = ImportedTypeSymbol.GetConstructed(
+            enumeratorOpenDef.MakeGenericType(mlcObject),
+            enumeratorOpenDef,
+            ImmutableArray.Create<TypeSymbol>(tp));
+
+        var definition = new InterfaceSymbol("ISeq", Accessibility.Public, declaration: null, packageName: "P");
+        definition.SetTypeParameters(ImmutableArray.Create(tp));
+        var iterMethod = new FunctionSymbol(
+            "Iter",
+            ImmutableArray<ParameterSymbol>.Empty,
+            erasedMemberType,
+            declaration: null,
+            package: null,
+            accessibility: Accessibility.Public);
+        definition.SetMethods(ImmutableArray.Create(iterMethod));
+
+        var constructed = InterfaceSymbol.Construct(definition, ImmutableArray.Create<TypeSymbol>(TypeSymbol.Int32), mapClrType);
+
+        var substitutedReturn = Assert.IsType<ImportedTypeSymbol>(constructed.Methods[0].Type);
+        Assert.Same(TypeSymbol.Int32, Assert.Single(substitutedReturn.TypeArguments));
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1958StructMemberGenericSubstitutionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1958StructMemberGenericSubstitutionTests.cs
@@ -1,0 +1,115 @@
+// <copyright file="Issue1958StructMemberGenericSubstitutionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Regression test mirroring <see cref="Issue1958InterfaceMemberGenericSubstitutionTests"/>:
+/// <c>StructSymbol.SubstituteTypeForConstruction</c> had the identical
+/// un-projected <c>MakeGenericType</c> erasure bug as <c>InterfaceSymbol</c>
+/// before this fix (blocking review #2032). A G# <c>struct S[T]</c> with an
+/// imported generic-CLR-typed field over the struct's OWN type parameter
+/// (e.g. <c>IEnumerator[T]</c>) would silently erase to the definition's
+/// open <c>T</c> when constructed under a
+/// <see cref="System.Reflection.MetadataLoadContext"/>-style resolver, because
+/// <c>StructSymbol.Construct</c> dropped the projector on the floor instead of
+/// threading it (like <c>InterfaceSymbol.Construct</c>) into
+/// <c>MakeGenericType</c>.
+/// </summary>
+public class Issue1958StructMemberGenericSubstitutionTests
+{
+    /// <summary>
+    /// Build a <see cref="ReferenceResolver"/> rooted at the BCL reference
+    /// assemblies, forcing gsc into the <see cref="System.Reflection.MetadataLoadContext"/>
+    /// resolution path — reproducing the cross-reflection-context scenario
+    /// inside the unit-test process. Mirrors
+    /// <c>Issue1958InterfaceMemberGenericSubstitutionTests.MetadataLoadContextResolver</c>.
+    /// </summary>
+    private static ReferenceResolver MetadataLoadContextResolver()
+    {
+        var paths = new[]
+        {
+            typeof(object).Assembly.Location,
+            typeof(System.Collections.Generic.List<>).Assembly.Location,
+            typeof(System.Console).Assembly.Location,
+            typeof(System.Linq.Enumerable).Assembly.Location,
+        }
+        .Where(p => !string.IsNullOrEmpty(p))
+        .Distinct(StringComparer.OrdinalIgnoreCase)
+        .ToArray();
+
+        return ReferenceResolver.WithReferences(paths);
+    }
+
+    [Fact]
+    public void StructSymbol_SubstituteTypeForConstruction_ProjectsClrArgsAcrossReflectionContexts()
+    {
+        // Direct symbol-layer check (mirrors the interface-layer test): a
+        // struct definition Box[T] with a field typed as a constructed CLR
+        // generic (IEnumerator[T]) over the struct's OWN type parameter must,
+        // when constructed as Box[int32] under a mapClrType-bearing resolver,
+        // substitute T -> int32 in the field's imported generic type. Before
+        // the fix, StructSymbol.Construct dropped mapClrType on the floor, so
+        // MakeGenericType mixed the MLC-resolved open definition with the
+        // host runtime's typeof(int) CLR arg, threw ArgumentException, and
+        // silently fell back to the still-open `IEnumerator[T]` field type.
+        var resolver = MetadataLoadContextResolver();
+        var mapClrType = resolver.MapClrTypeToReferences;
+
+        var enumeratorOpenDef = resolver.MapClrTypeToReferences(typeof(System.Collections.Generic.IEnumerator<>));
+        var mlcObject = resolver.MapClrTypeToReferences(typeof(object));
+
+        var tp = new TypeParameterSymbol("T", 0, TypeParameterConstraint.Any, TypeParameterVariance.None);
+        var erasedFieldType = ImportedTypeSymbol.GetConstructed(
+            enumeratorOpenDef.MakeGenericType(mlcObject),
+            enumeratorOpenDef,
+            ImmutableArray.Create<TypeSymbol>(tp));
+
+        var fields = ImmutableArray.Create(new FieldSymbol("Items", erasedFieldType, Accessibility.Public));
+        var definition = new StructSymbol("Box", fields, Accessibility.Public, declaration: null, packageName: "P");
+        definition.SetTypeParameters(ImmutableArray.Create(tp));
+
+        var constructed = StructSymbol.Construct(definition, ImmutableArray.Create<TypeSymbol>(TypeSymbol.Int32), mapClrType);
+
+        var substitutedFieldType = Assert.IsType<ImportedTypeSymbol>(constructed.Fields[0].Type);
+        Assert.Same(TypeSymbol.Int32, Assert.Single(substitutedFieldType.TypeArguments));
+    }
+
+    [Fact]
+    public void StructSymbol_SubstituteTypeForConstruction_WithoutMapClrType_ErasesUnderMetadataLoadContext()
+    {
+        // Control case proving the failure mode this test guards against: with
+        // no projector supplied (mapClrType: null, the pre-#1958 behavior),
+        // MakeGenericType throws under MLC and the fix's own graceful fallback
+        // (catch -> Debug.WriteLine + return the erased member) kicks in, so
+        // the field type stays the still-open `IEnumerator[T]` instead of
+        // throwing out of Construct entirely.
+        var resolver = MetadataLoadContextResolver();
+
+        var enumeratorOpenDef = resolver.MapClrTypeToReferences(typeof(System.Collections.Generic.IEnumerator<>));
+        var mlcObject = resolver.MapClrTypeToReferences(typeof(object));
+
+        var tp = new TypeParameterSymbol("T", 0, TypeParameterConstraint.Any, TypeParameterVariance.None);
+        var erasedFieldType = ImportedTypeSymbol.GetConstructed(
+            enumeratorOpenDef.MakeGenericType(mlcObject),
+            enumeratorOpenDef,
+            ImmutableArray.Create<TypeSymbol>(tp));
+
+        var fields = ImmutableArray.Create(new FieldSymbol("Items", erasedFieldType, Accessibility.Public));
+        var definition = new StructSymbol("Box", fields, Accessibility.Public, declaration: null, packageName: "P");
+        definition.SetTypeParameters(ImmutableArray.Create(tp));
+
+        var constructed = StructSymbol.Construct(definition, ImmutableArray.Create<TypeSymbol>(TypeSymbol.Int32));
+
+        var unsubstitutedFieldType = Assert.IsType<ImportedTypeSymbol>(constructed.Fields[0].Type);
+        Assert.Same(tp, Assert.Single(unsubstitutedFieldType.TypeArguments));
+    }
+}


### PR DESCRIPTION
Fixes #1958

## Root cause
`InterfaceSymbol.SubstituteType` closed a member's constructed generic CLR type (the #974 shape: `func Iter() IEnumerator[T]` on a user interface `ISeq[T]`) by calling `MakeGenericType` with each substituted type argument's raw `ClrType`, without projecting it into the reflection context the interface's member was resolved from. Under a `MetadataLoadContext` reference set (cs2gs / MSBuild task compile mode), this throws `ArgumentException`, which was silently swallowed — leaking the definition's unsubstituted `IEnumerator[T]` into the constructed `ISeq[int32]` shape. Same class of bug PR #1956 (issue #1926) fixed in `Binder.SubstituteType`.

## Fix
- Threaded an optional `Func<Type, Type> mapClrType` (default `null`, preserving prior behavior for untouched callers) through `InterfaceSymbol.Construct` -> the constructed instance -> the (possibly deferred, see `EnsureMembersResolved`) member-substitution pass -> `SubstituteMethod`/`SubstituteType`, applying it to each resolved CLR arg before `MakeGenericType`. Mirrors `Binder.SubstituteType`'s existing `mapClrType` fix.
- Updated all `InterfaceSymbol.Construct` call sites in `Binder.cs` / `ExpressionBinder.Access.cs` that have a `ReferenceResolver` in scope to pass `scope.References.MapClrTypeToReferences` (or the ambient `mapClrType` param inside `Binder.SubstituteType`).
- Made the silent `catch (ArgumentException)` loud (via `Debug.Assert`, so release builds still degrade gracefully) in both `InterfaceSymbol.cs` and the matching branch in `Binder.cs`, since a legitimate cross-context failure should no longer be reachable after the projection fix.

## Tests
`Issue1958InterfaceMemberGenericSubstitutionTests.cs`:
- Direct symbol-layer test constructing `ISeq[int32]` under an MLC-backed `mapClrType` and asserting the substituted `Iter()` return type carries `int32`, not the leaked `T`. Verified this test fails (`Assert.Same` mismatch, expected `int32` got `T`) when the projection line is reverted to simulate the pre-fix bug, confirming it's a genuine regression test.
- Two source-level binder tests (MLC + default-resolver control) for the same #974 shape — these pass under both old and new code since the return-type check in this shape doesn't nominally compare symbolic type arguments, so they don't discriminate the bug on their own, but they guard against future regressions in the overall binding path.

## Verification
- `dotnet build src/Compiler/Compiler.csproj -c Release -graph`: succeeds.
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release`: **5421 passed, 0 failed, 1 skipped** (pre-existing skip).
- `cs2gs migrate --baseline tools/cs2gs/triage/gaps.json`: **0 new, 0 regressed** (CompileGap-Library FAIL matches ledgered #1929; L2-Library flagged unverified-skip as before, not a regression).