### PR TITLE
Wire gsi REPL to interactive stdin/stdout/stderr

### DIFF
--- a/src/Repl/Engine/SessionEngine.cs
+++ b/src/Repl/Engine/SessionEngine.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.IO;
 using System.Linq;
 using GSharp.Core.CodeAnalysis;
 using GSharp.Core.CodeAnalysis.Compilation;
@@ -27,29 +28,80 @@ public sealed class SessionEngine
 
     public IReadOnlyDictionary<VariableSymbol, object> Variables => variables;
 
+    /// <summary>
+    /// When <see langword="true"/>, standard output and error produced while evaluating a cell
+    /// are captured into the cell (see <see cref="Cell.Output"/> / <see cref="Cell.StandardError"/>)
+    /// instead of leaking to the raw terminal. The interactive TUI enables this; the script runner
+    /// leaves it off so output streams straight through.
+    /// </summary>
+    public bool CaptureConsole { get; set; }
+
+    /// <summary>
+    /// Optional provider that supplies a line of standard input when evaluated code reads from
+    /// <see cref="Console.In"/> (e.g. <c>Console.ReadLine()</c>). Returning <see langword="null"/>
+    /// signals end-of-input. When unset, <see cref="Console.In"/> is left untouched.
+    /// </summary>
+    public Func<string?>? InputProvider { get; set; }
+
     /// <summary>Evaluate a submission, append a cell, and return it. Never throws.</summary>
     public Cell Evaluate(string text)
     {
         var index = cells.Count + 1;
+
+        var originalOut = Console.Out;
+        var originalError = Console.Error;
+        var originalIn = Console.In;
+        StringWriter? stdout = null;
+        StringWriter? stderr = null;
+
+        if (CaptureConsole)
+        {
+            stdout = new StringWriter { NewLine = "\n" };
+            stderr = new StringWriter { NewLine = "\n" };
+            Console.SetOut(stdout);
+            Console.SetError(stderr);
+        }
+
+        if (InputProvider is not null)
+        {
+            Console.SetIn(new CallbackTextReader(InputProvider));
+        }
+
         Cell cell;
         try
         {
-            var tree = SyntaxTree.Parse(text);
-            var compilation = previous == null ? new Compilation(tree) : previous.ContinueWith(tree);
-            var result = compilation.Evaluate(variables);
-
-            var hasError = result.Diagnostics.Any(d => d.IsError);
-            if (!hasError)
+            try
             {
-                previous = compilation;
+                var tree = SyntaxTree.Parse(text);
+                var compilation = previous == null ? new Compilation(tree) : previous.ContinueWith(tree);
+                var result = compilation.Evaluate(variables);
+
+                var hasError = result.Diagnostics.Any(d => d.IsError);
+                if (!hasError)
+                {
+                    previous = compilation;
+                }
+
+                cell = new Cell(index, text, result.Value, result.Diagnostics, hasError, stdout?.ToString() ?? string.Empty, stderr?.ToString() ?? string.Empty);
+            }
+            catch (Exception ex)
+            {
+                var diag = new Diagnostic(default, "GSI001", DiagnosticSeverity.Error, $"Evaluation error: {ex.Message}");
+                cell = new Cell(index, text, null, ImmutableArray.Create(diag), true, stdout?.ToString() ?? string.Empty, stderr?.ToString() ?? string.Empty);
+            }
+        }
+        finally
+        {
+            if (CaptureConsole)
+            {
+                Console.SetOut(originalOut);
+                Console.SetError(originalError);
             }
 
-            cell = new Cell(index, text, result.Value, result.Diagnostics, hasError);
-        }
-        catch (Exception ex)
-        {
-            var diag = new Diagnostic(default, "GSI001", DiagnosticSeverity.Error, $"Evaluation error: {ex.Message}");
-            cell = new Cell(index, text, null, ImmutableArray.Create(diag), true);
+            if (InputProvider is not null)
+            {
+                Console.SetIn(originalIn);
+            }
         }
 
         cells.Add(cell);
@@ -76,5 +128,63 @@ public sealed class SessionEngine
     }
 }
 
-/// <summary>One transcript entry: input plus its result or diagnostics.</summary>
-public sealed record Cell(int Index, string Input, object? Value, ImmutableArray<Diagnostic> Diagnostics, bool HasError);
+/// <summary>One transcript entry: input plus its result, captured console output, or diagnostics.</summary>
+public sealed record Cell(
+    int Index,
+    string Input,
+    object? Value,
+    ImmutableArray<Diagnostic> Diagnostics,
+    bool HasError,
+    string Output = "",
+    string StandardError = "");
+
+/// <summary>
+/// A <see cref="TextReader"/> that sources whole lines from a callback, letting the interactive
+/// REPL prompt the user on demand when evaluated code reads from <see cref="Console.In"/>.
+/// </summary>
+internal sealed class CallbackTextReader : TextReader
+{
+    private readonly Func<string?> readLine;
+    private string? buffer;
+    private int bufferPos;
+
+    public CallbackTextReader(Func<string?> readLine) => this.readLine = readLine ?? throw new ArgumentNullException(nameof(readLine));
+
+    public override string? ReadLine() => readLine();
+
+    public override int Peek() => EnsureBuffer() ? buffer![bufferPos] : -1;
+
+    public override int Read()
+    {
+        if (!EnsureBuffer())
+        {
+            return -1;
+        }
+
+        var ch = buffer![bufferPos++];
+        if (bufferPos >= buffer!.Length)
+        {
+            buffer = null;
+        }
+
+        return ch;
+    }
+
+    private bool EnsureBuffer()
+    {
+        if (buffer is not null && bufferPos < buffer.Length)
+        {
+            return true;
+        }
+
+        var line = readLine();
+        if (line is null)
+        {
+            return false;
+        }
+
+        buffer = line + "\n";
+        bufferPos = 0;
+        return true;
+    }
+}

--- a/src/Repl/Screens/ReplScreen.cs
+++ b/src/Repl/Screens/ReplScreen.cs
@@ -28,7 +28,12 @@ public sealed class ReplScreen : ITabScreen
     private int completionTop;
     private string? hover;
 
-    public ReplScreen(SessionEngine engine) => this.engine = engine;
+    public ReplScreen(SessionEngine engine)
+    {
+        this.engine = engine;
+        engine.CaptureConsole = true;
+        engine.InputProvider = InlinePrompt.ReadLine;
+    }
 
     public string Title => "REPL";
 
@@ -147,6 +152,17 @@ public sealed class ReplScreen : ITabScreen
                 rows.Add(new Markup($"    [{c}]● {Markup.Escape(d.Id)} {Markup.Escape(d.Message)}[/]"));
             }
 
+            foreach (var line in SplitOutput(cell.Output))
+            {
+                rows.Add(new Markup($"    [{secondary}]{Markup.Escape(line)}[/]"));
+            }
+
+            foreach (var line in SplitOutput(cell.StandardError))
+            {
+                var c = Tokens.Tokens.StatusError.Value.ToMarkup();
+                rows.Add(new Markup($"    [{c}]{Markup.Escape(line)}[/]"));
+            }
+
             if (!cell.HasError && cell.Value is not null)
             {
                 rows.Add(new Markup($"    [{primary}]{Markup.Escape(cell.Value.ToString() ?? string.Empty)}[/]"));
@@ -217,6 +233,25 @@ public sealed class ReplScreen : ITabScreen
             BorderStyle = new Style(Tokens.Tokens.BorderNeutral),
             Expand = true,
         };
+    }
+
+    private static IEnumerable<string> SplitOutput(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            yield break;
+        }
+
+        var normalized = text.Replace("\r\n", "\n").Replace('\r', '\n').TrimEnd('\n');
+        if (normalized.Length == 0)
+        {
+            yield break;
+        }
+
+        foreach (var line in normalized.Split('\n'))
+        {
+            yield return line;
+        }
     }
 
     private void Move(int delta)

--- a/src/Repl/Shell/InlinePrompt.cs
+++ b/src/Repl/Shell/InlinePrompt.cs
@@ -1,0 +1,105 @@
+// <copyright file="InlinePrompt.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Text;
+
+namespace GSharp.Repl.Shell;
+
+/// <summary>
+/// Reads a single line of standard input from the user while the alt-screen TUI is active.
+/// Evaluation runs synchronously inside the shell's key loop, so when interpreted code calls
+/// <c>Console.ReadLine()</c> we pause and draw an inline prompt at the bottom of the screen,
+/// echoing keystrokes until Enter. Output is written straight to the real terminal stream so it
+/// is unaffected by the per-cell <see cref="Console.Out"/> capture.
+/// </summary>
+public static class InlinePrompt
+{
+    private static readonly TextWriter Terminal = CreateTerminalWriter();
+
+    /// <summary>Prompt for and return one line of input, or <see langword="null"/> on Esc/EOF.</summary>
+    public static string? ReadLine()
+    {
+        var sb = new StringBuilder();
+        Draw(sb.ToString());
+        while (true)
+        {
+            ConsoleKeyInfo key;
+            try
+            {
+                key = Console.ReadKey(intercept: true);
+            }
+            catch (InvalidOperationException)
+            {
+                return sb.Length == 0 ? null : sb.ToString();
+            }
+
+            switch (key.Key)
+            {
+                case ConsoleKey.Enter:
+                    return sb.ToString();
+                case ConsoleKey.Escape:
+                    return null;
+                case ConsoleKey.Backspace:
+                    if (sb.Length > 0)
+                    {
+                        sb.Length--;
+                    }
+
+                    break;
+                default:
+                    if (!char.IsControl(key.KeyChar))
+                    {
+                        sb.Append(key.KeyChar);
+                    }
+
+                    break;
+            }
+
+            Draw(sb.ToString());
+        }
+    }
+
+    private static void Draw(string current)
+    {
+        int row;
+        try
+        {
+            row = Math.Max(1, Console.WindowHeight);
+        }
+        catch
+        {
+            row = 24;
+        }
+
+        var line = $"stdin \u203a {current}\u2588";
+        try
+        {
+            Terminal.Write($"{AltScreen.SyncStartSequence}\u001b[{row};1H\u001b[2K{line}\u001b[K{AltScreen.SyncEndSequence}");
+            Terminal.Flush();
+        }
+        catch
+        {
+            // Best effort: the frame re-render after evaluation restores the screen anyway.
+        }
+    }
+
+    private static TextWriter CreateTerminalWriter()
+    {
+        try
+        {
+            // Bind to the raw stdout stream so drawing bypasses any Console.SetOut redirection
+            // installed while a cell is being evaluated. leaveOpen keeps stdout usable afterwards.
+            return new StreamWriter(Console.OpenStandardOutput(), Console.OutputEncoding, 1024, leaveOpen: true)
+            {
+                AutoFlush = true,
+            };
+        }
+        catch
+        {
+            return Console.Out;
+        }
+    }
+}

--- a/test/Interpreter.Tests/SessionEngineConsoleIoTests.cs
+++ b/test/Interpreter.Tests/SessionEngineConsoleIoTests.cs
@@ -1,0 +1,67 @@
+// <copyright file="SessionEngineConsoleIoTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Repl.Engine;
+using Xunit;
+
+namespace GSharp.Interpreter.Tests;
+
+/// <summary>
+/// Verifies that the REPL session engine captures interpreted standard output/error and can
+/// source standard input, so the interactive gsi shell can surface them in the transcript.
+/// </summary>
+[Collection("ConsoleIo")]
+public class SessionEngineConsoleIoTests
+{
+    [Fact]
+    public void CaptureConsole_WriteLine_IsCapturedInCell()
+    {
+        var engine = new SessionEngine { CaptureConsole = true };
+        var cell = engine.Evaluate("Console.WriteLine(\"hello\")");
+
+        Assert.False(cell.HasError);
+        Assert.Contains("hello", cell.Output);
+        Assert.Equal(string.Empty, cell.StandardError);
+    }
+
+    [Fact]
+    public void CaptureConsole_Disabled_LeavesOutputEmpty()
+    {
+        var engine = new SessionEngine { CaptureConsole = false };
+        var cell = engine.Evaluate("1 + 1");
+
+        Assert.False(cell.HasError);
+        Assert.Equal(string.Empty, cell.Output);
+    }
+
+    [Fact]
+    public void CaptureConsole_Error_IsCapturedSeparately()
+    {
+        var engine = new SessionEngine { CaptureConsole = true };
+        var cell = engine.Evaluate("Console.Error.WriteLine(\"oops\")");
+
+        Assert.False(cell.HasError);
+        Assert.Contains("oops", cell.StandardError);
+    }
+
+    [Fact]
+    public void InputProvider_ReadLine_FeedsStandardInput()
+    {
+        var engine = new SessionEngine
+        {
+            CaptureConsole = true,
+            InputProvider = () => "world",
+        };
+
+        var cell = engine.Evaluate("Console.WriteLine(Console.ReadLine())");
+
+        Assert.False(cell.HasError);
+        Assert.Contains("world", cell.Output);
+    }
+}
+
+[CollectionDefinition("ConsoleIo", DisableParallelization = true)]
+public class ConsoleIoCollection
+{
+}


### PR DESCRIPTION
## Summary

Wires the G# interactive REPL (`gsi`) to properly support **stdin**, **stdout**, and **stderr**. Previously the interpreter's `Console.WriteLine` / `Console.ReadLine` calls wrote directly to the raw terminal, which was invisible or garbled behind the Spectre alt-screen TUI. Now, typing `Console.WriteLine("hello")` in the REPL prints `hello` in the transcript output as expected.

## Changes

- **`src/Repl/Engine/SessionEngine.cs`** — Added `CaptureConsole` and `InputProvider` options. During `Evaluate`, stdout/stderr are redirected into per-cell buffers (restored in a `finally`), and stdin is sourced from a callback. Added `CallbackTextReader` (a `TextReader` supporting `ReadLine` plus char-level `Read`/`Peek`). The `Cell` record now carries `Output` and `StandardError`.
- **`src/Repl/Shell/InlinePrompt.cs`** (new) — Synchronous inline stdin prompt drawn at the bottom of the alt-screen, echoing keystrokes until Enter (Esc/EOF → `null`). It writes to the raw stdout stream (`Console.OpenStandardOutput`, `leaveOpen`) so it bypasses the per-cell output capture, and reads via `Console.ReadKey`.
- **`src/Repl/Screens/ReplScreen.cs`** — Enables `CaptureConsole` and wires `InputProvider` to `InlinePrompt.ReadLine`; renders captured stdout (secondary color) and stderr (error color) lines in the transcript.

The script-runner path (`Program.cs`, `gsi file.gs`) is intentionally unaffected — it leaves `CaptureConsole` off so output and stdin stream straight through the real terminal.

## Testing

- Added `test/Interpreter.Tests/SessionEngineConsoleIoTests.cs` (4 tests): stdout capture, capture-disabled passthrough, stderr captured separately, and stdin fed via `InputProvider`.
- `dotnet test test/Interpreter.Tests/Interpreter.Tests.csproj -c Release` — all REPL/SessionEngine/layout tests pass (26 + 4 new).
- `dotnet build src/Repl/Repl.csproj -c Release` — succeeds with 0 warnings.
