### PR TITLE
cs2gs: fix coverage --write summary-count/row-count inconsistency (#2020)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Cli/CoverageCommand.cs
+++ b/tools/cs2gs/Cs2Gs.Cli/CoverageCommand.cs
@@ -81,6 +81,24 @@ internal static class CoverageCommand
         }
 
         var inventory = new ConstructInventory(entries);
+
+        // Never write (or report "in sync") from a structurally-broken
+        // inventory (e.g. a duplicate-kind row surviving a bad merge/hand
+        // edit): a duplicate row inflates the row count invisibly in one
+        // status bucket while the header total silently drifts out of sync
+        // with the docs matrix on a later regeneration (#2020).
+        IReadOnlyList<string> violations = inventory.Validate(repoRoot);
+        if (violations.Count > 0)
+        {
+            Console.Error.WriteLine("cs2gs coverage: construct inventory is invalid; fix before writing:");
+            foreach (string violation in violations)
+            {
+                Console.Error.WriteLine($"  {violation}");
+            }
+
+            return 2;
+        }
+
         string inventoryJson = inventory.ToJson();
         string matrix = inventory.BuildMatrixMarkdown();
         string golden = RoslynSurface.BuildSnapshot();

--- a/tools/cs2gs/Cs2Gs.Tests/Coverage/ConstructInventoryGoldenTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Coverage/ConstructInventoryGoldenTests.cs
@@ -89,6 +89,80 @@ public class ConstructInventoryGoldenTests
         }
     }
 
+    /// <summary>
+    /// Guards against #2020: the generated matrix's "| Status | Count |" header
+    /// table and each "## Status (N)" section heading must always equal the
+    /// number of rows actually printed under that status — computed from the
+    /// SAME markdown text BuildMatrixMarkdown produced, not from the inventory
+    /// a second time. A regression here (e.g. a duplicate-counting bug, or a
+    /// header computed from a different collection than the rows) would
+    /// otherwise only surface as an opaque "drifted, run coverage --write"
+    /// failure in MatrixDocument_IsInSync.
+    /// </summary>
+    [Fact]
+    public void MatrixDocument_HeaderCountsMatchRowCounts()
+    {
+        ConstructInventory inventory = LoadInventory();
+        string[] lines = inventory.BuildMatrixMarkdown().Split('\n');
+
+        var summaryCounts = new Dictionary<string, int>(StringComparer.Ordinal);
+        var sectionHeadingCounts = new Dictionary<string, int>(StringComparer.Ordinal);
+        var actualRowCounts = new Dictionary<string, int>(StringComparer.Ordinal);
+        string currentSection = null;
+
+        foreach (string line in lines)
+        {
+            if (line.StartsWith("## ", StringComparison.Ordinal))
+            {
+                // "## Translated (229)"
+                int open = line.LastIndexOf('(');
+                int close = line.LastIndexOf(')');
+                currentSection = line.Substring(3, open - 3).Trim();
+                sectionHeadingCounts[currentSection] = int.Parse(line.Substring(open + 1, close - open - 1));
+                continue;
+            }
+
+            bool isDataRow = line.StartsWith("| ", StringComparison.Ordinal)
+                && !line.StartsWith("| Kind ", StringComparison.Ordinal)
+                && !line.StartsWith("| --- ", StringComparison.Ordinal)
+                && !line.StartsWith("| Status ", StringComparison.Ordinal);
+            if (!isDataRow)
+            {
+                continue;
+            }
+
+            string[] cells = line.Trim('|').Split('|').Select(c => c.Trim()).ToArray();
+            if (currentSection is null && cells.Length == 2 && int.TryParse(cells[1], out int summaryCount))
+            {
+                // The "| Status | Count |" summary table, before any "## " section.
+                summaryCounts[cells[0]] = summaryCount;
+            }
+            else if (currentSection is not null)
+            {
+                actualRowCounts[currentSection] = actualRowCounts.GetValueOrDefault(currentSection) + 1;
+            }
+        }
+
+        foreach (ConstructStatus status in Enum.GetValues<ConstructStatus>())
+        {
+            string name = status.ToString();
+            int actual = actualRowCounts.GetValueOrDefault(name);
+
+            Assert.True(summaryCounts.TryGetValue(name, out int summary), $"summary table is missing a row for status '{name}'.");
+            Assert.True(
+                summary == actual,
+                $"'{name}' summary count ({summary}) does not match the actual printed row count ({actual}).");
+
+            if (actual > 0)
+            {
+                Assert.True(sectionHeadingCounts.TryGetValue(name, out int heading), $"'## {name}' section heading is missing.");
+                Assert.True(
+                    heading == actual,
+                    $"'## {name} ({heading})' heading does not match its own printed row count ({actual}).");
+            }
+        }
+    }
+
     [Fact]
     public void UnclassifiedRatchet_DoesNotRegress()
     {


### PR DESCRIPTION
Fixes #2020

## Root cause

`coverage --write` / `ConstructInventory.BuildMatrixMarkdown()` are already deterministic and idempotent — verified empirically:
- Running `coverage --write` twice back-to-back produces an **empty diff**.
- Running it after a **partial** `Cs2Gs.Cli`-only build vs. after a **full** `GSharp.sln` build produces **byte-identical** output (ruling out the "stale other-project build output" hypothesis from the issue).

The reported 228→229 drift traces back to a historical commit (`f7a591be`, PR #1909) whose diff moved `PrimaryConstructorBaseType` from the Gap section to the Translated section in `docs/cs2gs-coverage-matrix.md` **without updating the two summary header count lines** — i.e. the checked-in doc was hand-edited/merged out of sync with its own row content, not generated via `cs2gs coverage --write`. Every subsequent regeneration correctly self-healed the header to match the real row count (229/19), which is what looked like "flaky drift" but was actually the tool correcting a stale, internally-inconsistent checked-in file. By the current `main` HEAD, a later PR had already regenerated the doc and it is self-consistent (verified: no diff, `MatrixDocument_IsInSync` passes).

The actual gap: nothing prevented a structurally-invalid or hand-patched inventory/doc from being written or reported "in sync" — there was no defense in depth beyond the full-text golden comparison in the xunit test.

## Fix

- `CoverageCommand.Run` now calls `ConstructInventory.Validate(repoRoot)` before writing or reporting drift, and aborts (exit 2) with the concrete violations if the inventory is structurally broken (duplicate kind rows, stale/missing surface kinds, etc.), instead of silently proceeding.
- Added `MatrixDocument_HeaderCountsMatchRowCounts`, an invariant test that parses the generated matrix and asserts the summary-table counts and `## Status (N)` section headings always equal the actual printed row counts — so a future regression in `BuildMatrixMarkdown` fails with a precise, targeted message instead of the generic "drifted, run coverage --write".

## Verification

- `coverage --write` run twice in a row: empty diff (idempotent).
- `coverage --write` after a partial `Cs2Gs.Cli` build vs. after a full `GSharp.sln` build: byte-identical output.
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release --filter "FullyQualifiedName~ConstructInventoryGoldenTests"`: all 7 tests pass (6 existing + new invariant test).
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release`: 987 passed.
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release`: 5424 passed, 1 pre-existing skip.
- Full corpus sanity (`cs2gs migrate --corpus tools/cs2gs/corpus --baseline tools/cs2gs/triage/gaps.json`): 0 new/regressed gaps vs. baseline.

Nothing deferred.
