### PR TITLE
gsc: honor checked context for unary negation overflow (#2023)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundUnaryExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundUnaryExpression.cs
@@ -18,11 +18,19 @@ public sealed class BoundUnaryExpression : BoundExpression
     /// <param name="syntax">The originating syntax.</param>
     /// <param name="op">The bound unary operator.</param>
     /// <param name="operand">The bound expression.</param>
-    public BoundUnaryExpression(SyntaxNode syntax, BoundUnaryOperator op, BoundExpression operand)
+    /// <param name="isChecked">
+    /// When true and <paramref name="op"/> is a <see cref="BoundUnaryOperatorKind.Negation"/>
+    /// over an integral operand, the emitter and interpreter use overflow-trapping
+    /// arithmetic (issue #2023, follow-up to #1881): a `checked(...)` expression or
+    /// `checked { }` statement puts its arithmetic in this context; the default (no
+    /// `checked` context) is unchecked, matching the C# project default.
+    /// </param>
+    public BoundUnaryExpression(SyntaxNode syntax, BoundUnaryOperator op, BoundExpression operand, bool isChecked = false)
         : base(syntax)
     {
         Op = op;
         Operand = operand;
+        IsChecked = isChecked;
     }
 
     /// <inheritdoc/>
@@ -40,4 +48,11 @@ public sealed class BoundUnaryExpression : BoundExpression
     /// Gets the bound expression.
     /// </summary>
     public BoundExpression Operand { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether this operator runs in a checked /
+    /// overflow-trapping context (issue #2023). Only observed for
+    /// <see cref="BoundUnaryOperatorKind.Negation"/> on integral operands.
+    /// </summary>
+    public bool IsChecked { get; }
 }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
@@ -112,7 +112,14 @@ internal sealed partial class ExpressionBinder
             return new BoundErrorExpression(null);
         }
 
-        return new BoundUnaryExpression(null, boundOperator, boundOperand);
+        // Issue #2023: unary negation on an integral operand bound inside a
+        // `checked` context traps on overflow (e.g. `checked(-int.MinValue)`),
+        // mirroring #1881's checked Sum/Difference/Product. Mirroring
+        // BoundBinaryExpression, the flag is threaded unconditionally from
+        // the current checked/unchecked context; every operator kind other
+        // than Negation (and Negation over float/double/decimal, which never
+        // overflows) simply ignores it downstream.
+        return new BoundUnaryExpression(null, boundOperator, boundOperand, binderCtx.IsCheckedContext);
     }
 
     /// <summary>ADR-0039: Binds <c>&amp;expr</c> — takes managed pointer to an lvalue.</summary>

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
@@ -152,6 +152,21 @@ internal sealed partial class MethodBodyEmitter
             return;
         }
 
+        // Issue #2023: checked integral negation (`-x` where x could be the
+        // type's MinValue) must trap on overflow, matching #1881's checked
+        // Sum/Difference/Product. Roslyn's own approach is followed: lower
+        // `-x` to `0 - x` and emit it via the same overflow-trapping `sub.ovf`
+        // used for checked binary subtraction, rather than the plain `neg`
+        // opcode (whose 2's-complement semantics silently wrap MinValue back
+        // to itself). This must happen *before* the generic
+        // `this.EmitExpression(u.Operand)` below because the constant `0`
+        // has to be pushed first.
+        if (u.Op.Kind == BoundUnaryOperatorKind.Negation && u.IsChecked && IsIntegralNegationOperand(u.Op.OperandType))
+        {
+            this.EmitCheckedIntegralNegation(u);
+            return;
+        }
+
         this.EmitExpression(u.Operand);
         switch (u.Op.Kind)
         {
@@ -185,6 +200,65 @@ internal sealed partial class MethodBodyEmitter
             || u.Op.Kind == BoundUnaryOperatorKind.Negation)
         {
             EmitSubI4Truncation(u.Op.Type);
+        }
+    }
+
+    /// <summary>
+    /// Issue #2023: true when <paramref name="operandType"/> is one of the
+    /// signed integral primitives that unary negation (ADR-0044) is defined
+    /// over — the only shapes where a checked context can observe overflow
+    /// (floating-point negation never traps: IEEE 754 negation is exact, and
+    /// <see cref="TypeSymbol.Decimal"/> negation is handled by
+    /// <c>decimal.op_UnaryNegation</c>, which is symmetric around zero and
+    /// never overflows either).
+    /// </summary>
+    private static bool IsIntegralNegationOperand(TypeSymbol operandType) =>
+        operandType == TypeSymbol.Int8
+        || operandType == TypeSymbol.Int16
+        || operandType == TypeSymbol.Int32
+        || operandType == TypeSymbol.Int64
+        || operandType == TypeSymbol.NInt;
+
+    /// <summary>
+    /// Issue #2023: emits <c>checked(0 - x)</c> for an integral unary
+    /// negation bound inside a <c>checked(...)</c>/<c>checked { }</c>
+    /// context. The constant zero is pushed first (per ECMA-335 III.3.62's
+    /// binary-numeric-operator table an <c>int32</c> literal freely combines
+    /// with an <c>int32</c>-, sub-<c>int32</c>-, or native-int-typed value —
+    /// only <c>int64</c> requires the widened <c>int64</c> zero), then the
+    /// operand, then <c>sub.ovf</c> (never the <c>.un</c> variant: negation is
+    /// only ever defined over the signed integral primitives). For the
+    /// sub-<c>int32</c> operand widths (<c>sbyte</c>/<c>short</c>) the CLR
+    /// promotes both operands to <c>int32</c> before subtracting, so
+    /// <c>sub.ovf</c> alone cannot observe the exact-<c>MinValue</c>
+    /// overflow (e.g. <c>0 - sbyte.MinValue</c> == 128, which fits an
+    /// <c>int32</c> comfortably); a checked narrowing conversion
+    /// (<c>conv.ovf.i1</c>/<c>conv.ovf.i2</c>) back to the operand's own
+    /// width closes that gap, mirroring how checked narrowing conversions
+    /// (issue #1881) already trap the same shape.
+    /// </summary>
+    private void EmitCheckedIntegralNegation(BoundUnaryExpression u)
+    {
+        var operandType = u.Op.OperandType;
+        if (operandType == TypeSymbol.Int64)
+        {
+            this.il.LoadConstantI8(0);
+        }
+        else
+        {
+            this.il.LoadConstantI4(0);
+        }
+
+        this.EmitExpression(u.Operand);
+        this.il.OpCode(ILOpCode.Sub_ovf);
+
+        if (operandType == TypeSymbol.Int8)
+        {
+            this.il.OpCode(ILOpCode.Conv_ovf_i1);
+        }
+        else if (operandType == TypeSymbol.Int16)
+        {
+            this.il.OpCode(ILOpCode.Conv_ovf_i2);
         }
     }
 

--- a/src/Core/CodeAnalysis/Evaluator.cs
+++ b/src/Core/CodeAnalysis/Evaluator.cs
@@ -2648,7 +2648,13 @@ public sealed class Evaluator
                 result = rawOperand;
                 break;
             case BoundUnaryOperatorKind.Negation:
-                result = Negate(rawOperand);
+                // Issue #2023: mirror #1881's checked binary Add/Sub/Mul —
+                // Negate/NegateChecked both promote sub-int32 operands to int
+                // (matching NumericAdd/Sub/Mul), and NarrowToResultType narrows
+                // back to the operator's declared result type, itself
+                // overflow-checked when u.IsChecked (e.g. `checked(-sbyte.MinValue)`
+                // promotes to 128, which then traps narrowing back to sbyte).
+                result = NarrowToResultType(u.IsChecked ? NegateChecked(rawOperand) : Negate(rawOperand), u.Type, u.IsChecked);
                 break;
             case BoundUnaryOperatorKind.LogicalNegation:
                 return !(bool)operand;
@@ -2681,9 +2687,31 @@ public sealed class Evaluator
     {
         int i => -i,
         long l => -l,
-        sbyte sb => (sbyte)-sb,
-        short sh => (short)-sh,
+
+        // sbyte/short negation promotes to int (matching NumericAdd/Sub/Mul);
+        // NarrowToResultType narrows back to the declared sbyte/short result.
+        sbyte sb => -sb,
+        short sh => -sh,
         nint ni => -ni,
+        float f => -f,
+        double d => -d,
+        decimal dec => -dec,
+        _ => throw new InvalidOperationException($"Unsupported negation operand type {v?.GetType()}"),
+    };
+
+    // Issue #2023: `checked(-x)` — identical shape to <see cref="Negate"/> but
+    // every integral arm runs in a checked context (the `checked(...)` keyword
+    // traps int/long/nint MinValue negation directly; sbyte/short still widen
+    // to int here with no possible overflow, same as unchecked, but the
+    // widened value is later narrowed back by <see cref="NarrowToResultType"/>
+    // with isChecked: true, which is where their MinValue case actually traps).
+    private static object NegateChecked(object v) => v switch
+    {
+        int i => (object)checked(-i),
+        long l => (object)checked(-l),
+        sbyte sb => (object)checked(-sb),
+        short sh => (object)checked(-sh),
+        nint ni => (object)checked(-ni),
         float f => -f,
         double d => -d,
         decimal dec => -dec,

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2023CheckedUnaryNegationInterpreterTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2023CheckedUnaryNegationInterpreterTests.cs
@@ -1,0 +1,173 @@
+// <copyright file="Issue2023CheckedUnaryNegationInterpreterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2023: interpreter counterpart of
+/// <see cref="GSharp.Core.Tests.CodeAnalysis.Emit.Issue2023CheckedUnaryNegationEmitTests"/>.
+/// Asserts the tree-walking evaluator agrees with the compiled/emitted IL for
+/// unary negation of the each width's <c>MinValue</c> inside a
+/// <c>checked</c>/<c>unchecked</c> context: overflow throws
+/// <see cref="System.OverflowException"/> in a checked context and wraps
+/// silently in an unchecked context (the project default per #1881), while
+/// floating-point negation never traps regardless of context.
+/// </summary>
+public class Issue2023CheckedUnaryNegationInterpreterTests
+{
+    [Fact]
+    public void CheckedNegation_Int32MinValue_ThrowsOverflowException()
+    {
+        var result = Evaluate(
+            "var minInt int32 = -2147483647 - 1\n" +
+            "var caught = \"no\"\n" +
+            "try {\n" +
+            "    var boom = checked(-minInt)\n" +
+            "} catch (e OverflowException) {\n" +
+            "    caught = \"yes\"\n" +
+            "}\n" +
+            "caught");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("yes", result.Value);
+    }
+
+    [Fact]
+    public void CheckedNegation_Int64MinValue_ThrowsOverflowException()
+    {
+        var result = Evaluate(
+            "var minLong int64 = -9223372036854775807 - 1\n" +
+            "var caught = \"no\"\n" +
+            "try {\n" +
+            "    var boom = checked(-minLong)\n" +
+            "} catch (e OverflowException) {\n" +
+            "    caught = \"yes\"\n" +
+            "}\n" +
+            "caught");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("yes", result.Value);
+    }
+
+    [Fact]
+    public void CheckedNegation_Int8MinValue_ThrowsOverflowException()
+    {
+        var result = Evaluate(
+            "var minI8 int8 = -128\n" +
+            "var caught = \"no\"\n" +
+            "try {\n" +
+            "    var boom = checked(-minI8)\n" +
+            "} catch (e OverflowException) {\n" +
+            "    caught = \"yes\"\n" +
+            "}\n" +
+            "caught");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("yes", result.Value);
+    }
+
+    [Fact]
+    public void CheckedNegation_Int16MinValue_ThrowsOverflowException()
+    {
+        var result = Evaluate(
+            "var minI16 int16 = -32768\n" +
+            "var caught = \"no\"\n" +
+            "try {\n" +
+            "    var boom = checked(-minI16)\n" +
+            "} catch (e OverflowException) {\n" +
+            "    caught = \"yes\"\n" +
+            "}\n" +
+            "caught");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("yes", result.Value);
+    }
+
+    [Fact]
+    public void CheckedNegation_OrdinaryValue_ReturnsNegated()
+    {
+        var result = Evaluate("var five int32 = 5\nchecked(-five)");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(-5, result.Value);
+    }
+
+    [Fact]
+    public void UncheckedNegation_Int32MinValue_Wraps()
+    {
+        var result = Evaluate("var minInt int32 = -2147483647 - 1\nunchecked(-minInt)");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(-2147483648, result.Value);
+    }
+
+    [Fact]
+    public void UncheckedNegation_Int64MinValue_Wraps()
+    {
+        var result = Evaluate("var minLong int64 = -9223372036854775807 - 1\nunchecked(-minLong)");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(long.MinValue, result.Value);
+    }
+
+    [Fact]
+    public void UncheckedNegation_Int8MinValue_Wraps()
+    {
+        var result = Evaluate("var minI8 int8 = -128\nunchecked(-minI8)");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(sbyte.MinValue, result.Value);
+    }
+
+    [Fact]
+    public void DefaultContext_NegationOfInt32MinValue_Wraps()
+    {
+        // Issue #1881 established unchecked as the project default when no
+        // explicit checked/unchecked context is in scope; negation must match.
+        var result = Evaluate("var minInt int32 = -2147483647 - 1\nvar wrapped = -minInt\nwrapped");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(-2147483648, result.Value);
+    }
+
+    [Fact]
+    public void CheckedStatement_NegationOfMinValue_ThrowsOverflowException()
+    {
+        var result = Evaluate(
+            "var caught = \"no\"\n" +
+            "checked {\n" +
+            "    var minInt int32 = -2147483647 - 1\n" +
+            "    try {\n" +
+            "        var boom = -minInt\n" +
+            "    } catch (e OverflowException) {\n" +
+            "        caught = \"yes\"\n" +
+            "    }\n" +
+            "}\n" +
+            "caught");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("yes", result.Value);
+    }
+
+    [Fact]
+    public void CheckedFloatNegation_NoOverflowEverOccurs()
+    {
+        var result = Evaluate("var big float64 = -1.7976931348623157e308\nchecked(-big)");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(1.7976931348623157e308, result.Value);
+    }
+
+    [Fact]
+    public void CheckedDecimalNegation_NoOverflowEverOccurs()
+    {
+        var result = Evaluate("var d decimal = 5.5m\nchecked(-d)");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(-5.5m, result.Value);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue2023CheckedUnaryNegationEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue2023CheckedUnaryNegationEmitTests.cs
@@ -1,0 +1,240 @@
+// <copyright file="Issue2023CheckedUnaryNegationEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #2023: follow-up to #1881 — unary negation (<c>-x</c>) did not honor
+/// a <c>checked</c> context at all: the emitter always emitted the plain
+/// <c>neg</c> opcode (2's-complement negation, which silently wraps
+/// <c>MinValue</c> back to itself) regardless of context. These tests
+/// exercise the compiled (emit) backend; <see
+/// cref="GSharp.Core.Tests.CodeAnalysis.Binding.Issue2023CheckedUnaryNegationInterpreterTests"/>
+/// exercises the interpreter and asserts the two backends agree.
+/// </summary>
+public class Issue2023CheckedUnaryNegationEmitTests
+{
+    [Fact]
+    public void CheckedNegation_Int32MinValue_Throws()
+    {
+        const string Source = @"package Issue2023Int32
+import System
+
+func run() {
+    var minInt int32 = -2147483647 - 1
+    var caught = ""no""
+    try {
+        var boom = checked(-minInt)
+        Console.WriteLine(boom)
+    } catch (e OverflowException) {
+        caught = ""yes""
+    }
+    Console.WriteLine(caught)
+}
+
+run()
+";
+        var output = CompileAndRun(Source, "Issue2023Int32");
+        Assert.Contains("yes", output);
+    }
+
+    [Fact]
+    public void CheckedNegation_Int64MinValue_Throws()
+    {
+        const string Source = @"package Issue2023Int64
+import System
+
+func run() {
+    var minLong int64 = -9223372036854775807 - 1
+    var caught = ""no""
+    try {
+        var boom = checked(-minLong)
+        Console.WriteLine(boom)
+    } catch (e OverflowException) {
+        caught = ""yes""
+    }
+    Console.WriteLine(caught)
+}
+
+run()
+";
+        var output = CompileAndRun(Source, "Issue2023Int64");
+        Assert.Contains("yes", output);
+    }
+
+    [Fact]
+    public void CheckedNegation_Int8MinValue_Throws()
+    {
+        const string Source = @"package Issue2023Int8
+import System
+
+func run() {
+    var minI8 int8 = -128
+    var caught = ""no""
+    try {
+        var boom = checked(-minI8)
+        Console.WriteLine(boom)
+    } catch (e OverflowException) {
+        caught = ""yes""
+    }
+    Console.WriteLine(caught)
+}
+
+run()
+";
+        var output = CompileAndRun(Source, "Issue2023Int8");
+        Assert.Contains("yes", output);
+    }
+
+    [Fact]
+    public void CheckedNegation_Int16MinValue_Throws()
+    {
+        const string Source = @"package Issue2023Int16
+import System
+
+func run() {
+    var minI16 int16 = -32768
+    var caught = ""no""
+    try {
+        var boom = checked(-minI16)
+        Console.WriteLine(boom)
+    } catch (e OverflowException) {
+        caught = ""yes""
+    }
+    Console.WriteLine(caught)
+}
+
+run()
+";
+        var output = CompileAndRun(Source, "Issue2023Int16");
+        Assert.Contains("yes", output);
+    }
+
+    [Fact]
+    public void CheckedNegation_OrdinaryValue_ReturnsNegated()
+    {
+        const string Source = @"package Issue2023Ordinary
+import System
+
+func run() {
+    var five int32 = 5
+    var negated = checked(-five)
+    Console.WriteLine(negated)
+}
+
+run()
+";
+        var output = CompileAndRun(Source, "Issue2023Ordinary");
+        Assert.Contains("-5", output);
+    }
+
+    [Fact]
+    public void UncheckedNegation_Int32MinValue_Wraps()
+    {
+        const string Source = @"package Issue2023Unchecked
+import System
+
+func run() {
+    var minInt int32 = -2147483647 - 1
+    var wrapped = unchecked(-minInt)
+    Console.WriteLine(wrapped)
+}
+
+run()
+";
+        var output = CompileAndRun(Source, "Issue2023Unchecked");
+        Assert.Contains("-2147483648", output);
+    }
+
+    [Fact]
+    public void DefaultContext_NegationOfInt32MinValue_Wraps()
+    {
+        // Issue #1881 established unchecked as the project default when no
+        // explicit checked/unchecked context is in scope; negation must match.
+        const string Source = @"package Issue2023Default
+import System
+
+func run() {
+    var minInt int32 = -2147483647 - 1
+    var wrapped = -minInt
+    Console.WriteLine(wrapped)
+}
+
+run()
+";
+        var output = CompileAndRun(Source, "Issue2023Default");
+        Assert.Contains("-2147483648", output);
+    }
+
+    [Fact]
+    public void CheckedNegation_Float64_NoOverflowEverOccurs()
+    {
+        const string Source = @"package Issue2023Float
+import System
+
+func run() {
+    var big float64 = -1.7976931348623157e308
+    var negated = checked(-big)
+    Console.WriteLine(negated)
+}
+
+run()
+";
+        var output = CompileAndRun(Source, "Issue2023Float");
+        Assert.Contains("1.7976931348623157E+308", output);
+    }
+
+    private static string CompileAndRun(string source, string contextName)
+    {
+        using var peStream = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        var result = compilation.Emit(peStream);
+
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(contextName, isCollectible: true);
+        try
+        {
+            var asm = loadContext.LoadFromStream(peStream);
+            var programType = asm.GetTypes().FirstOrDefault(t => t.Name == "<Program>");
+            Assert.NotNull(programType);
+            var entry = programType!.GetMethod(
+                "<Main>$",
+                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(entry);
+
+            var stdout = Console.Out;
+            var captured = new StringWriter();
+            Console.SetOut(captured);
+            try
+            {
+                entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+            }
+            finally
+            {
+                Console.SetOut(stdout);
+            }
+
+            return captured.ToString();
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2023

Follow-up to #2021/#1881: unary negation now honors the checked/unchecked context, matching the treatment already given to binary +, -, * and narrowing conversions.

## Changes

- `BoundUnaryExpression`: new `IsChecked` flag (threaded from the binder's ambient checked context, mirroring `BoundBinaryExpression`).
- `ExpressionBinder.Operators.cs`: threads `binderCtx.IsCheckedContext` onto every bound unary expression.
- `MethodBodyEmitter.Operators.cs`: checked integral negation (`int8`/`int16`/`int32`/`int64`/`nint`) is lowered to `0 - x` and emitted with `sub.ovf`, per Roslyn's approach, instead of the plain `neg` opcode (whose 2's-complement semantics silently wrap `MinValue` back to itself). Because this language's unary minus does *not* promote sub-int32 operands to `int32` (unlike C#), `int8`/`int16` additionally get a checked narrowing conversion (`conv.ovf.i1`/`conv.ovf.i2`) back to their own width after the subtraction, closing the gap where `0 - int8.MinValue` (128) would otherwise fit comfortably in `int32`.
- `Evaluator.cs` (interpreter): added `NegateChecked`, mirroring `NumericAdd/Sub/MulChecked` — sub-`int32` operands widen to `int`, and the existing `NarrowToResultType` helper narrows back to the declared result type, itself overflow-checked when `IsChecked` is set.
- Float32/float64/decimal negation is unaffected in either context — negation is exact for IEEE 754 and symmetric for decimal, so neither can overflow.

## Tests

- `test/Core.Tests/CodeAnalysis/Emit/Issue2023CheckedUnaryNegationEmitTests.cs` (compiled backend)
- `test/Core.Tests/CodeAnalysis/Binding/Issue2023CheckedUnaryNegationInterpreterTests.cs` (interpreter)

Covering: `checked(-x)` throwing `OverflowException` for `int32`/`int64`/`int8`/`int16` `MinValue`, ordinary values still negating correctly under `checked`, `unchecked(-int.MinValue)` and default-context negation still wrapping silently (matching #1881's established default), a `checked { }` block variant, and `float64`/`decimal` negation being unaffected by context.

## Validation

- `dotnet build src/Compiler/Compiler.csproj -c Release` — 0 warnings, 0 errors.
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release` — **5444 passed, 1 pre-existing skip, 0 failed** (full suite, 100% green).
- `coverage-matrix.golden.txt` untouched — no new `SyntaxKind`/`BoundNodeKind` was needed, confirming the fix stayed within the existing checked-context architecture from #1881.