### PR TITLE
gsc: thread MLC generic-arg projector to StateMachineEmitter/SynthesizedClosureReifier/OverloadResolver (#2037)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -2564,7 +2564,7 @@ public sealed class Binder
                         return null;
                     }
 
-                    element = InterfaceSymbol.Construct(iface, typeArgs);
+                    element = InterfaceSymbol.Construct(iface, typeArgs, scope.References.MapClrTypeToReferences);
                 }
                 else if (element is StructSymbol genericStruct)
                 {
@@ -2913,7 +2913,7 @@ public sealed class Binder
             case StructSymbol genericStruct when genericStruct.IsGenericDefinition && genericStruct.TypeParameters.Length == typeArgs.Length:
                 return StructSymbol.Construct(genericStruct, typeArgs);
             case InterfaceSymbol genericIface when genericIface.IsGenericDefinition && genericIface.TypeParameters.Length == typeArgs.Length:
-                return InterfaceSymbol.Construct(genericIface, typeArgs);
+                return InterfaceSymbol.Construct(genericIface, typeArgs, scope.References.MapClrTypeToReferences);
             case DelegateTypeSymbol genericDelegate when genericDelegate.IsGenericDefinition && genericDelegate.TypeParameters.Length == typeArgs.Length:
                 return DelegateTypeSymbol.Construct(genericDelegate, typeArgs);
             default:
@@ -4249,7 +4249,7 @@ public sealed class Binder
             }
 
             return ifaceChanged
-                ? InterfaceSymbol.Construct(ifaceType.Definition, newIfaceArgs.MoveToImmutable())
+                ? InterfaceSymbol.Construct(ifaceType.Definition, newIfaceArgs.MoveToImmutable(), mapClrType)
                 : type;
         }
 
@@ -4309,7 +4309,15 @@ public sealed class Binder
                     }
                     catch (System.ArgumentException)
                     {
-                        // Fall through to the erased constructed form below.
+                        // Issue #1958: with the mapClrType projection above, a
+                        // cross-reflection-context mismatch here should no
+                        // longer be reachable. Assert loudly in debug builds
+                        // instead of the silent fallback that made #1926 hard
+                        // to diagnose; still fall through to the erased
+                        // constructed form so release builds degrade
+                        // gracefully rather than crash.
+                        var assertMessage = $"Binder.SubstituteType: MakeGenericType failed for '{it.OpenDefinition}' with args [{string.Join(", ", clrArgs.Select(t => t.ToString()))}] even after mapClrType projection.";
+                        System.Diagnostics.Debug.Assert(false, assertMessage);
                     }
                 }
             }

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -2580,7 +2580,7 @@ public sealed class Binder
                         return null;
                     }
 
-                    element = StructSymbol.Construct(genericStruct, typeArgs);
+                    element = StructSymbol.Construct(genericStruct, typeArgs, scope.References.MapClrTypeToReferences);
                 }
                 else if (element is DelegateTypeSymbol genericDelegate)
                 {
@@ -2816,8 +2816,8 @@ public sealed class Binder
             {
                 var ownArgs = deepestStruct.TypeArguments;
                 deepest = ownArgs.IsDefaultOrEmpty
-                    ? StructSymbol.ConstructNested(deepestStruct.Definition ?? deepestStruct, enclosingArgs)
-                    : StructSymbol.ConstructNestedGeneric(deepestStruct.Definition ?? deepestStruct, enclosingArgs, ownArgs);
+                    ? StructSymbol.ConstructNested(deepestStruct.Definition ?? deepestStruct, enclosingArgs, scope.References.MapClrTypeToReferences)
+                    : StructSymbol.ConstructNestedGeneric(deepestStruct.Definition ?? deepestStruct, enclosingArgs, ownArgs, scope.References.MapClrTypeToReferences);
             }
         }
 
@@ -2911,7 +2911,7 @@ public sealed class Binder
         switch (definition)
         {
             case StructSymbol genericStruct when genericStruct.IsGenericDefinition && genericStruct.TypeParameters.Length == typeArgs.Length:
-                return StructSymbol.Construct(genericStruct, typeArgs);
+                return StructSymbol.Construct(genericStruct, typeArgs, scope.References.MapClrTypeToReferences);
             case InterfaceSymbol genericIface when genericIface.IsGenericDefinition && genericIface.TypeParameters.Length == typeArgs.Length:
                 return InterfaceSymbol.Construct(genericIface, typeArgs, scope.References.MapClrTypeToReferences);
             case DelegateTypeSymbol genericDelegate when genericDelegate.IsGenericDefinition && genericDelegate.TypeParameters.Length == typeArgs.Length:
@@ -4212,7 +4212,7 @@ public sealed class Binder
             }
 
             return structChanged
-                ? StructSymbol.Construct(ss.Definition, newStructArgs.MoveToImmutable())
+                ? StructSymbol.Construct(ss.Definition, newStructArgs.MoveToImmutable(), mapClrType)
                 : type;
         }
 
@@ -4228,7 +4228,7 @@ public sealed class Binder
             var newEnclosing = StructSymbol.SubstituteEnclosingArguments(nestedRef, t => SubstituteType(t, substitution, mapClrType));
             if (!newEnclosing.IsDefault)
             {
-                return StructSymbol.ConstructNested(nestedRef.Definition ?? nestedRef, newEnclosing);
+                return StructSymbol.ConstructNested(nestedRef.Definition ?? nestedRef, newEnclosing, mapClrType);
             }
         }
 
@@ -4309,15 +4309,14 @@ public sealed class Binder
                     }
                     catch (System.ArgumentException)
                     {
-                        // Issue #1958: with the mapClrType projection above, a
-                        // cross-reflection-context mismatch here should no
-                        // longer be reachable. Assert loudly in debug builds
-                        // instead of the silent fallback that made #1926 hard
-                        // to diagnose; still fall through to the erased
-                        // constructed form so release builds degrade
-                        // gracefully rather than crash.
+                        // MakeGenericType can legitimately throw ArgumentException for CLR
+                        // generic constraint reasons (e.g. unmanaged/ref-struct constraints),
+                        // not only cross-reflection-context mismatches, so this is NOT always
+                        // a bug. Log for diagnosability and fall through to the erased
+                        // constructed form so both debug and release builds degrade gracefully
+                        // rather than crash.
                         var assertMessage = $"Binder.SubstituteType: MakeGenericType failed for '{it.OpenDefinition}' with args [{string.Join(", ", clrArgs.Select(t => t.ToString()))}] even after mapClrType projection.";
-                        System.Diagnostics.Debug.Assert(false, assertMessage);
+                        System.Diagnostics.Debug.WriteLine(assertMessage);
                     }
                 }
             }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -1243,7 +1243,7 @@ internal sealed partial class ExpressionBinder
             case InterfaceSymbol nestedIface:
                 var ifaceDef = nestedIface.Definition ?? nestedIface;
                 nestedType = !ownArgs.IsDefaultOrEmpty
-                    ? InterfaceSymbol.Construct(ifaceDef, ownArgs)
+                    ? InterfaceSymbol.Construct(ifaceDef, ownArgs, scope.References.MapClrTypeToReferences)
                     : ifaceDef;
                 return true;
 
@@ -2256,7 +2256,7 @@ internal sealed partial class ExpressionBinder
             return false;
         }
 
-        constructed = InterfaceSymbol.Construct(ifaceDef, typeArgs);
+        constructed = InterfaceSymbol.Construct(ifaceDef, typeArgs, scope.References.MapClrTypeToReferences);
         return true;
     }
 
@@ -2344,7 +2344,7 @@ internal sealed partial class ExpressionBinder
                     constructedStruct = StructSymbol.Construct(structDef, typeArgs);
                     return true;
                 case InterfaceSymbol ifaceDef:
-                    constructedInterface = InterfaceSymbol.Construct(ifaceDef, typeArgs);
+                    constructedInterface = InterfaceSymbol.Construct(ifaceDef, typeArgs, scope.References.MapClrTypeToReferences);
                     return true;
             }
         }
@@ -2432,7 +2432,7 @@ internal sealed partial class ExpressionBinder
                     constructedStruct = StructSymbol.Construct(structDef, typeArgs);
                     return true;
                 case InterfaceSymbol ifaceDef:
-                    constructedInterface = InterfaceSymbol.Construct(ifaceDef, typeArgs);
+                    constructedInterface = InterfaceSymbol.Construct(ifaceDef, typeArgs, scope.References.MapClrTypeToReferences);
                     return true;
             }
         }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -1223,15 +1223,15 @@ internal sealed partial class ExpressionBinder
                 var def = nestedStruct.Definition ?? nestedStruct;
                 if (!enclosingArgs.IsDefaultOrEmpty && !ownArgs.IsDefaultOrEmpty)
                 {
-                    nestedType = StructSymbol.ConstructNestedGeneric(def, enclosingArgs, ownArgs);
+                    nestedType = StructSymbol.ConstructNestedGeneric(def, enclosingArgs, ownArgs, scope.References.MapClrTypeToReferences);
                 }
                 else if (!enclosingArgs.IsDefaultOrEmpty)
                 {
-                    nestedType = StructSymbol.ConstructNested(def, enclosingArgs);
+                    nestedType = StructSymbol.ConstructNested(def, enclosingArgs, scope.References.MapClrTypeToReferences);
                 }
                 else if (!ownArgs.IsDefaultOrEmpty)
                 {
-                    nestedType = StructSymbol.Construct(def, ownArgs);
+                    nestedType = StructSymbol.Construct(def, ownArgs, scope.References.MapClrTypeToReferences);
                 }
                 else
                 {
@@ -2065,15 +2065,15 @@ internal sealed partial class ExpressionBinder
             var ownArgs = segments[i].Args;
             if (!enclosingArgs.IsDefaultOrEmpty && !ownArgs.IsDefaultOrEmpty)
             {
-                constructed = StructSymbol.ConstructNestedGeneric(def, enclosingArgs, ownArgs);
+                constructed = StructSymbol.ConstructNestedGeneric(def, enclosingArgs, ownArgs, scope.References.MapClrTypeToReferences);
             }
             else if (!enclosingArgs.IsDefaultOrEmpty)
             {
-                constructed = StructSymbol.ConstructNested(def, enclosingArgs);
+                constructed = StructSymbol.ConstructNested(def, enclosingArgs, scope.References.MapClrTypeToReferences);
             }
             else if (!ownArgs.IsDefaultOrEmpty)
             {
-                constructed = StructSymbol.Construct(def, ownArgs);
+                constructed = StructSymbol.Construct(def, ownArgs, scope.References.MapClrTypeToReferences);
             }
             else
             {
@@ -2341,7 +2341,7 @@ internal sealed partial class ExpressionBinder
             switch (alias)
             {
                 case StructSymbol structDef:
-                    constructedStruct = StructSymbol.Construct(structDef, typeArgs);
+                    constructedStruct = StructSymbol.Construct(structDef, typeArgs, scope.References.MapClrTypeToReferences);
                     return true;
                 case InterfaceSymbol ifaceDef:
                     constructedInterface = InterfaceSymbol.Construct(ifaceDef, typeArgs, scope.References.MapClrTypeToReferences);
@@ -2429,7 +2429,7 @@ internal sealed partial class ExpressionBinder
             switch (alias)
             {
                 case StructSymbol structDef:
-                    constructedStruct = StructSymbol.Construct(structDef, typeArgs);
+                    constructedStruct = StructSymbol.Construct(structDef, typeArgs, scope.References.MapClrTypeToReferences);
                     return true;
                 case InterfaceSymbol ifaceDef:
                     constructedInterface = InterfaceSymbol.Construct(ifaceDef, typeArgs, scope.References.MapClrTypeToReferences);

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
@@ -839,8 +839,8 @@ internal sealed partial class ExpressionBinder
             // substitute both levels and the emitter encodes the reified nested
             // type (`Outer`1+Middle`2<int32, string>`).
             structSymbol = enclosingTypeArguments.IsDefaultOrEmpty
-                ? StructSymbol.Construct(structSymbol, typeArgs.MoveToImmutable())
-                : StructSymbol.ConstructNestedGeneric(structSymbol, enclosingTypeArguments, typeArgs.MoveToImmutable());
+                ? StructSymbol.Construct(structSymbol, typeArgs.MoveToImmutable(), scope.References.MapClrTypeToReferences)
+                : StructSymbol.ConstructNestedGeneric(structSymbol, enclosingTypeArguments, typeArgs.MoveToImmutable(), scope.References.MapClrTypeToReferences);
         }
         else if (syntax.TypeArgumentList != null)
         {
@@ -853,7 +853,7 @@ internal sealed partial class ExpressionBinder
             // enclosing type (`Box[int32].Tag{…}`) threads only the enclosing
             // arguments so member types typed as an enclosing parameter surface
             // closed and the emitter encodes `Box`1+Tag`1<int32>`.
-            structSymbol = StructSymbol.ConstructNested(structSymbol, enclosingTypeArguments);
+            structSymbol = StructSymbol.ConstructNested(structSymbol, enclosingTypeArguments, scope.References.MapClrTypeToReferences);
         }
 
         var seenFieldNames = new HashSet<string>();

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -304,6 +304,22 @@ internal sealed class OverloadResolver
     private BoundScope Scope => binderCtx.RootScope;
 
     /// <summary>
+    /// Gets the same CLR-arg cross-reflection-context (MLC) projector
+    /// threaded through the emit-time <c>Construct</c> call sites
+    /// (<see cref="Symbols.StructSymbol.Construct(Symbols.StructSymbol, ImmutableArray{Symbols.TypeSymbol}, Func{Type, Type})"/>).
+    /// Both <c>Construct</c> call sites in this file build a same-compilation
+    /// user type (<c>classType</c> is always a source-declared
+    /// <see cref="Symbols.StructSymbol"/> resolved by name in this scope, never
+    /// an imported CLR generic), so under normal binding the raw
+    /// <c>ClrType</c> args are already in this compilation's reflection
+    /// context and no projection is needed. Threaded anyway for
+    /// defense-in-depth / consistency with the other <c>Construct</c> sites
+    /// touched by #2037, and to cover a future imported-generic-arg path
+    /// without another audit.
+    /// </summary>
+    private Func<Type, Type> MapClrType => binderCtx.References == null ? null : binderCtx.References.MapClrTypeToReferences;
+
+    /// <summary>
     /// Issue #1159: returns the implicit-<c>this</c> parameter that an
     /// unqualified instance-member reference should bind against. For a direct
     /// instance method (or interface default method) body this is the enclosing
@@ -2674,7 +2690,7 @@ internal sealed class OverloadResolver
                 typeArgs.Add(substitution[tp]);
             }
 
-            classType = StructSymbol.Construct(classType, typeArgs.MoveToImmutable());
+            classType = StructSymbol.Construct(classType, typeArgs.MoveToImmutable(), MapClrType);
         }
         else if (syntax.TypeArgumentList != null)
         {
@@ -3479,7 +3495,7 @@ internal sealed class OverloadResolver
             typeArgs.Add(substitution[tp]);
         }
 
-        constructed = StructSymbol.Construct(classType, typeArgs.MoveToImmutable());
+        constructed = StructSymbol.Construct(classType, typeArgs.MoveToImmutable(), MapClrType);
         return true;
     }
 

--- a/src/Core/CodeAnalysis/Compilation/Compilation.cs
+++ b/src/Core/CodeAnalysis/Compilation/Compilation.cs
@@ -398,7 +398,10 @@ public class Compilation
         // (Go/C# closure semantics). Must run after side-effect spilling
         // and before the async / iterator state-machine lowerers so they
         // see the boxed captures rather than the snapshot-by-value pattern.
-        program = Lowering.CaptureBoxingRewriter.Lower(program);
+        // Issue #2037: thread the MLC cross-reflection-context projector so
+        // box classes hoisting an imported constructed generic over an
+        // enclosing type parameter don't erase it under cs2gs.
+        program = Lowering.CaptureBoxingRewriter.Lower(program, (References ?? Symbols.ReferenceResolver.Default()).MapClrTypeToReferences);
 
         var (lowered, loweredProgram, lowerDiagnostics) = LowerForEmit(program, References ?? Symbols.ReferenceResolver.Default());
         if (lowerDiagnostics.Any(d => d.IsError))
@@ -510,7 +513,10 @@ public class Compilation
         // (Go/C# closure semantics). Must run after side-effect spilling
         // and before the async / iterator state-machine lowerers so they
         // see the boxed captures rather than the snapshot-by-value pattern.
-        program = Lowering.CaptureBoxingRewriter.Lower(program);
+        // Issue #2037: thread the MLC cross-reflection-context projector so
+        // box classes hoisting an imported constructed generic over an
+        // enclosing type parameter don't erase it under cs2gs.
+        program = Lowering.CaptureBoxingRewriter.Lower(program, (References ?? Symbols.ReferenceResolver.Default()).MapClrTypeToReferences);
 
         var (lowered, loweredProgram, lowerDiagnostics) = LowerForEmit(program, References ?? Symbols.ReferenceResolver.Default());
         if (lowerDiagnostics.Any(d => d.IsError))

--- a/src/Core/CodeAnalysis/Emit/ClosureEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ClosureEmitter.cs
@@ -413,7 +413,10 @@ internal sealed class ClosureEmitter
         StructSymbol constructedClass = closureClass;
         if (!origTPs.IsDefaultOrEmpty)
         {
-            constructedClass = SynthesizedClosureReifier.Reify(closureClass, origTPs);
+            // Issue #2037: project imported constructed-generic capture field
+            // types across reflection contexts (MLC / cs2gs) before
+            // MakeGenericType, mirroring #1958's InterfaceSymbol/StructSymbol fix.
+            constructedClass = SynthesizedClosureReifier.Reify(closureClass, origTPs, this.emitCtx.References.MapClrTypeToReferences);
         }
 
         var rewriter = new CaptureRewriter(closureClass, captureFields, invokeMethod.ThisParameter);

--- a/src/Core/CodeAnalysis/Emit/StateMachineEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/StateMachineEmitter.cs
@@ -636,7 +636,10 @@ internal sealed class StateMachineEmitter
             // outer method's TPs.
             var kickoffSmType = classTPs.IsDefaultOrEmpty
                 ? smClass
-                : StructSymbol.Construct(smClass, scopeTPs.CastArray<TypeSymbol>());
+                // Issue #2037: project imported constructed-generic hoisted
+                // field types across reflection contexts (MLC / cs2gs) before
+                // MakeGenericType, mirroring #1958's InterfaceSymbol/StructSymbol fix.
+                : StructSymbol.Construct(smClass, scopeTPs.CastArray<TypeSymbol>(), this.emitCtx.References.MapClrTypeToReferences);
 
             this.lambdaBodies[getEnumerator] = Lowerer.Lower(new BoundBlockStatement(null,
                 ImmutableArray.Create<BoundStatement>(
@@ -969,7 +972,8 @@ internal sealed class StateMachineEmitter
             // right type arguments. Non-generic iterators keep the open class.
             var kickoffSmType = classTPs.IsDefaultOrEmpty
                 ? smClass
-                : StructSymbol.Construct(smClass, scopeTPs.CastArray<TypeSymbol>());
+                // Issue #2037: same MLC cross-reflection-context projection as above.
+                : StructSymbol.Construct(smClass, scopeTPs.CastArray<TypeSymbol>(), this.emitCtx.References.MapClrTypeToReferences);
             this.IteratorKickoffBodies[plan.Function] = Lowerer.Lower(new BoundBlockStatement(null,
                 ImmutableArray.Create<BoundStatement>(
                 new BoundReturnStatement(null, this.CreateAsyncIteratorKickoffLiteral(kickoffSmType, stateField, builderField, parameterFields, plan.Function.Parameters, thisProxyField, plan.Function)))));

--- a/src/Core/CodeAnalysis/Lowering/CaptureBoxingRewriter.cs
+++ b/src/Core/CodeAnalysis/Lowering/CaptureBoxingRewriter.cs
@@ -2,6 +2,7 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using GSharp.Core.CodeAnalysis.Binding;
@@ -71,8 +72,18 @@ internal static class CaptureBoxingRewriter
     /// </para>
     /// </remarks>
     /// <param name="program">The bound program to lower.</param>
+    /// <param name="mapClrType">
+    /// Issue #2037: optional projector applied to a box class's constructed
+    /// CLR type arguments before <c>MakeGenericType</c> (mirrors the #1958
+    /// fix threaded through <see cref="StructSymbol.Construct"/>). Pass
+    /// <see cref="ReferenceResolver.MapClrTypeToReferences"/> when the box
+    /// might hoist a capture typed as an imported constructed generic over an
+    /// enclosing type parameter under a cross-reflection-context (MLC)
+    /// compile; <see langword="null"/> preserves the erase-on-mismatch
+    /// fallback for same-compilation-only callers.
+    /// </param>
     /// <returns>The lowered program (or the original when nothing changed).</returns>
-    public static BoundProgram Lower(BoundProgram program)
+    public static BoundProgram Lower(BoundProgram program, Func<Type, Type> mapClrType = null)
     {
         var counter = 0;
         var newStructs = new List<StructSymbol>();
@@ -82,7 +93,7 @@ internal static class CaptureBoxingRewriter
 
         foreach (var pair in program.Functions)
         {
-            var (newBody, lambdaUpdates) = RewriteFunctionBody(pair.Key, pair.Value, program, newStructs, ref counter);
+            var (newBody, lambdaUpdates) = RewriteFunctionBody(pair.Key, pair.Value, program, newStructs, ref counter, mapClrType);
             newFunctions[pair.Key] = newBody;
             if (!ReferenceEquals(newBody, pair.Value))
             {
@@ -152,7 +163,8 @@ internal static class CaptureBoxingRewriter
         BoundBlockStatement body,
         BoundProgram program,
         List<StructSymbol> newStructs,
-        ref int counter)
+        ref int counter,
+        Func<Type, Type> mapClrType)
     {
         var emptyUpdates = new Dictionary<FunctionSymbol, BoundBlockStatement>();
 
@@ -215,7 +227,7 @@ internal static class CaptureBoxingRewriter
             FieldSymbol fieldSymbol = boxClass.Fields[0];
             if (!origTPs.IsDefaultOrEmpty)
             {
-                boxReference = SynthesizedClosureReifier.Reify(boxClass, origTPs);
+                boxReference = SynthesizedClosureReifier.Reify(boxClass, origTPs, mapClrType);
                 fieldSymbol = boxReference.Fields[0];
             }
 

--- a/src/Core/CodeAnalysis/Symbols/InterfaceSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/InterfaceSymbol.cs
@@ -814,14 +814,14 @@ public sealed class InterfaceSymbol : TypeSymbol
             }
             catch (System.ArgumentException)
             {
-                // Issue #1958: with the mapClrType projection above, a
-                // cross-reflection-context mismatch here should no longer be
-                // reachable. Assert loudly in debug builds instead of the
-                // silent fallback that made #1926 hard to diagnose; still
-                // fall back to the erased constructed form so release builds
-                // degrade gracefully rather than crash.
+                // MakeGenericType can legitimately throw ArgumentException for CLR
+                // generic constraint reasons (e.g. unmanaged/ref-struct constraints),
+                // not only cross-reflection-context mismatches, so this is NOT always
+                // a bug. Log for diagnosability and fall back to the erased
+                // constructed form so both debug and release builds degrade
+                // gracefully rather than crash.
                 var assertMessage = $"InterfaceSymbol.SubstituteType: MakeGenericType failed for '{imported.OpenDefinition}' with args [{string.Join(", ", resolvedClrArgs.Select(t => t.ToString()))}] even after mapClrType projection.";
-                System.Diagnostics.Debug.Assert(false, assertMessage);
+                System.Diagnostics.Debug.WriteLine(assertMessage);
                 return imported;
             }
         }

--- a/src/Core/CodeAnalysis/Symbols/InterfaceSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/InterfaceSymbol.cs
@@ -5,6 +5,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using GSharp.Core.CodeAnalysis.Binding;
 using GSharp.Core.CodeAnalysis.Syntax;
 
@@ -19,6 +20,13 @@ namespace GSharp.Core.CodeAnalysis.Symbols;
 public sealed class InterfaceSymbol : TypeSymbol
 {
     private static readonly ConcurrentDictionary<(InterfaceSymbol Def, TypeArgsKey Args), InterfaceSymbol> ConstructedCache = new();
+
+    // Issue #1958: the projector supplied to Construct(), retained so the
+    // (possibly deferred, see EnsureMembersResolved) member substitution pass
+    // can close constructed-generic member types in the right reflection
+    // context. Null for definitions and for constructed instances built
+    // without a projector (single-context callers; unchanged behavior).
+    private readonly System.Func<System.Type, System.Type> mapClrType;
 
     private ImmutableArray<FunctionSymbol> methods;
     private ImmutableArray<FunctionSymbol> staticMethods = ImmutableArray<FunctionSymbol>.Empty;
@@ -52,7 +60,7 @@ public sealed class InterfaceSymbol : TypeSymbol
         Definition = this;
     }
 
-    private InterfaceSymbol(InterfaceSymbol definition, ImmutableArray<TypeSymbol> typeArguments, string constructedName)
+    private InterfaceSymbol(InterfaceSymbol definition, ImmutableArray<TypeSymbol> typeArguments, string constructedName, System.Func<System.Type, System.Type> mapClrType)
         : base(constructedName)
     {
         Accessibility = definition.Accessibility;
@@ -62,6 +70,7 @@ public sealed class InterfaceSymbol : TypeSymbol
         TypeParameters = ImmutableArray<TypeParameterSymbol>.Empty;
         TypeArguments = typeArguments;
         Definition = definition;
+        this.mapClrType = mapClrType;
     }
 
     /// <summary>Gets the interface accessibility.</summary>
@@ -518,8 +527,15 @@ public sealed class InterfaceSymbol : TypeSymbol
     /// </summary>
     /// <param name="definition">The generic definition to instantiate.</param>
     /// <param name="typeArguments">The type arguments. Length must match <see cref="TypeParameters"/>.</param>
+    /// <param name="mapClrType">
+    /// Issue #1958: projects a host CLR <see cref="System.Type"/> into the reflection
+    /// context (typically a <see cref="System.Reflection.MetadataLoadContext"/>) that a
+    /// member's constructed generic CLR type was resolved from, mirroring
+    /// <c>Binder.SubstituteType</c>'s <c>mapClrType</c> (issue #1926 / PR #1956). Pass
+    /// <see langword="null"/> (the default) for single-context callers.
+    /// </param>
     /// <returns>A constructed <see cref="InterfaceSymbol"/> whose <see cref="Definition"/> is the original.</returns>
-    public static InterfaceSymbol Construct(InterfaceSymbol definition, ImmutableArray<TypeSymbol> typeArguments)
+    public static InterfaceSymbol Construct(InterfaceSymbol definition, ImmutableArray<TypeSymbol> typeArguments, System.Func<System.Type, System.Type> mapClrType = null)
     {
         if (definition == null || !definition.IsGenericDefinition)
         {
@@ -527,7 +543,7 @@ public sealed class InterfaceSymbol : TypeSymbol
         }
 
         var key = BuildArgsKey(typeArguments);
-        return ConstructedCache.GetOrAdd((definition, key), _ => CreateConstructed(definition, typeArguments));
+        return ConstructedCache.GetOrAdd((definition, key), _ => CreateConstructed(definition, typeArguments, mapClrType));
     }
 
     /// <summary>
@@ -587,7 +603,7 @@ public sealed class InterfaceSymbol : TypeSymbol
 
     private static TypeArgsKey BuildArgsKey(ImmutableArray<TypeSymbol> typeArguments) => new(typeArguments);
 
-    private static InterfaceSymbol CreateConstructed(InterfaceSymbol definition, ImmutableArray<TypeSymbol> typeArguments)
+    private static InterfaceSymbol CreateConstructed(InterfaceSymbol definition, ImmutableArray<TypeSymbol> typeArguments, System.Func<System.Type, System.Type> mapClrType)
     {
         var argParts = new string[typeArguments.Length];
         for (var i = 0; i < typeArguments.Length; i++)
@@ -596,7 +612,7 @@ public sealed class InterfaceSymbol : TypeSymbol
         }
 
         var constructedName = $"{definition.Name}[{string.Join(", ", argParts)}]";
-        var instance = new InterfaceSymbol(definition, typeArguments, constructedName);
+        var instance = new InterfaceSymbol(definition, typeArguments, constructedName, mapClrType);
 
         // ADR-0087 R5 / issue #765: defer the actual member substitution
         // (Methods / StaticMethods / PrivateMethods / StaticPrivateMethods)
@@ -616,12 +632,13 @@ public sealed class InterfaceSymbol : TypeSymbol
         Dictionary<TypeParameterSymbol, TypeSymbol> subst,
         InterfaceSymbol instance,
         bool isStatic,
-        bool isPrivate)
+        bool isPrivate,
+        System.Func<System.Type, System.Type> mapClrType)
     {
         var substParams = ImmutableArray.CreateBuilder<ParameterSymbol>(m.Parameters.Length);
         foreach (var p in m.Parameters)
         {
-            var newParam = new ParameterSymbol(p.Name, SubstituteType(p.Type, subst), isVariadic: p.IsVariadic, isScoped: p.IsScoped, refKind: p.RefKind);
+            var newParam = new ParameterSymbol(p.Name, SubstituteType(p.Type, subst, mapClrType), isVariadic: p.IsVariadic, isScoped: p.IsScoped, refKind: p.RefKind);
             if (p.HasExplicitDefaultValue)
             {
                 newParam.SetExplicitDefaultValue(p.ExplicitDefaultValue);
@@ -630,7 +647,7 @@ public sealed class InterfaceSymbol : TypeSymbol
             substParams.Add(newParam);
         }
 
-        var substReturn = SubstituteType(m.Type, subst);
+        var substReturn = SubstituteType(m.Type, subst, mapClrType);
         var substMethod = new FunctionSymbol(
             m.Name,
             substParams.MoveToImmutable(),
@@ -684,7 +701,7 @@ public sealed class InterfaceSymbol : TypeSymbol
             var builder = ImmutableArray.CreateBuilder<FunctionSymbol>(defMethods.Length);
             foreach (var m in defMethods)
             {
-                builder.Add(SubstituteMethod(m, subst, this, isStatic: false, isPrivate: false));
+                builder.Add(SubstituteMethod(m, subst, this, isStatic: false, isPrivate: false, mapClrType));
             }
 
             Methods = builder.MoveToImmutable();
@@ -695,7 +712,7 @@ public sealed class InterfaceSymbol : TypeSymbol
             var builder = ImmutableArray.CreateBuilder<FunctionSymbol>(defStatic.Length);
             foreach (var m in defStatic)
             {
-                builder.Add(SubstituteMethod(m, subst, this, isStatic: true, isPrivate: false));
+                builder.Add(SubstituteMethod(m, subst, this, isStatic: true, isPrivate: false, mapClrType));
             }
 
             StaticMethods = builder.MoveToImmutable();
@@ -706,7 +723,7 @@ public sealed class InterfaceSymbol : TypeSymbol
             var builder = ImmutableArray.CreateBuilder<FunctionSymbol>(defPriv.Length);
             foreach (var m in defPriv)
             {
-                builder.Add(SubstituteMethod(m, subst, this, isStatic: false, isPrivate: true));
+                builder.Add(SubstituteMethod(m, subst, this, isStatic: false, isPrivate: true, mapClrType));
             }
 
             PrivateMethods = builder.MoveToImmutable();
@@ -717,7 +734,7 @@ public sealed class InterfaceSymbol : TypeSymbol
             var builder = ImmutableArray.CreateBuilder<FunctionSymbol>(defStaticPriv.Length);
             foreach (var m in defStaticPriv)
             {
-                builder.Add(SubstituteMethod(m, subst, this, isStatic: true, isPrivate: true));
+                builder.Add(SubstituteMethod(m, subst, this, isStatic: true, isPrivate: true, mapClrType));
             }
 
             StaticPrivateMethods = builder.MoveToImmutable();
@@ -726,7 +743,7 @@ public sealed class InterfaceSymbol : TypeSymbol
         membersResolved = true;
     }
 
-    private static TypeSymbol SubstituteType(TypeSymbol type, Dictionary<TypeParameterSymbol, TypeSymbol> subst)
+    private static TypeSymbol SubstituteType(TypeSymbol type, Dictionary<TypeParameterSymbol, TypeSymbol> subst, System.Func<System.Type, System.Type> mapClrType)
     {
         if (type is TypeParameterSymbol tp && subst.TryGetValue(tp, out var concrete))
         {
@@ -743,13 +760,13 @@ public sealed class InterfaceSymbol : TypeSymbol
             var changed = false;
             for (var i = 0; i < iface.TypeArguments.Length; i++)
             {
-                var substituted = SubstituteType(iface.TypeArguments[i], subst);
+                var substituted = SubstituteType(iface.TypeArguments[i], subst, mapClrType);
                 substitutedArgs.Add(substituted);
                 changed |= !ReferenceEquals(substituted, iface.TypeArguments[i]);
             }
 
             return changed
-                ? Construct(iface.Definition, substitutedArgs.MoveToImmutable())
+                ? Construct(iface.Definition, substitutedArgs.MoveToImmutable(), mapClrType)
                 : iface;
         }
 
@@ -767,7 +784,7 @@ public sealed class InterfaceSymbol : TypeSymbol
             var changed = false;
             for (var i = 0; i < imported.TypeArguments.Length; i++)
             {
-                var substituted = SubstituteType(imported.TypeArguments[i], subst);
+                var substituted = SubstituteType(imported.TypeArguments[i], subst, mapClrType);
                 substitutedArgs.Add(substituted);
                 changed |= !ReferenceEquals(substituted, imported.TypeArguments[i]);
             }
@@ -777,10 +794,17 @@ public sealed class InterfaceSymbol : TypeSymbol
                 return imported;
             }
 
+            // Issue #1958: project each resolved CLR arg into the same
+            // reflection context as `imported.OpenDefinition` before calling
+            // MakeGenericType — mirrors Binder.SubstituteType's mapClrType
+            // fix for issue #1926 (PR #1956). Without this, a raw host CLR
+            // type mixed with an MLC-resolved open definition throws
+            // ArgumentException and silently erases the substitution.
             var resolvedClrArgs = new System.Type[substitutedArgs.Count];
             for (var i = 0; i < substitutedArgs.Count; i++)
             {
-                resolvedClrArgs[i] = substitutedArgs[i].ClrType ?? typeof(object);
+                var clr = substitutedArgs[i].ClrType ?? typeof(object);
+                resolvedClrArgs[i] = mapClrType != null ? mapClrType(clr) : clr;
             }
 
             try
@@ -790,25 +814,33 @@ public sealed class InterfaceSymbol : TypeSymbol
             }
             catch (System.ArgumentException)
             {
+                // Issue #1958: with the mapClrType projection above, a
+                // cross-reflection-context mismatch here should no longer be
+                // reachable. Assert loudly in debug builds instead of the
+                // silent fallback that made #1926 hard to diagnose; still
+                // fall back to the erased constructed form so release builds
+                // degrade gracefully rather than crash.
+                var assertMessage = $"InterfaceSymbol.SubstituteType: MakeGenericType failed for '{imported.OpenDefinition}' with args [{string.Join(", ", resolvedClrArgs.Select(t => t.ToString()))}] even after mapClrType projection.";
+                System.Diagnostics.Debug.Assert(false, assertMessage);
                 return imported;
             }
         }
 
         if (type is SliceTypeSymbol s)
         {
-            var sub = SubstituteType(s.ElementType, subst);
+            var sub = SubstituteType(s.ElementType, subst, mapClrType);
             return sub == s.ElementType ? s : SliceTypeSymbol.Get(sub);
         }
 
         if (type is ArrayTypeSymbol a)
         {
-            var sub = SubstituteType(a.ElementType, subst);
+            var sub = SubstituteType(a.ElementType, subst, mapClrType);
             return sub == a.ElementType ? a : ArrayTypeSymbol.Get(sub, a.Length);
         }
 
         if (type is NullableTypeSymbol n)
         {
-            var sub = SubstituteType(n.UnderlyingType, subst);
+            var sub = SubstituteType(n.UnderlyingType, subst, mapClrType);
             return sub == n.UnderlyingType ? n : NullableTypeSymbol.Get(sub);
         }
 

--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using GSharp.Core.CodeAnalysis.Binding;
 using GSharp.Core.CodeAnalysis.Syntax;
 
@@ -66,6 +67,14 @@ public sealed class StructSymbol : TypeSymbol
     // parameter (`Middle.Label : T`) surfaces closed regardless of when the map
     // is first computed. Empty for every other symbol.
     private ImmutableArray<TypeParameterSymbol> nestedOwnTypeParameters = ImmutableArray<TypeParameterSymbol>.Empty;
+
+    // Issue #1958: the projector supplied to Construct()/ConstructNested()/
+    // ConstructNestedGeneric(), retained so the (lazily computed, see
+    // GetSubstitutedFields/GetSubstitutedProperties) member substitution can
+    // close constructed-generic member types in the right reflection context.
+    // Null for definitions and for constructed instances built without a
+    // projector (single-context callers; unchanged behavior).
+    private Func<Type, Type> mapClrType;
     private ImmutableArray<FieldSymbol> substitutedFields;
     private ImmutableArray<FieldSymbol> substitutedFieldsSource;
     private bool substitutedFieldsComputed;
@@ -1226,8 +1235,15 @@ public sealed class StructSymbol : TypeSymbol
     /// </summary>
     /// <param name="definition">The generic definition to instantiate. Must have <see cref="IsGenericDefinition"/> true; otherwise returned unchanged.</param>
     /// <param name="typeArguments">The type arguments. Length must match <see cref="TypeParameters"/>.</param>
+    /// <param name="mapClrType">
+    /// Issue #1958: projects a host CLR <see cref="Type"/> into the reflection
+    /// context (typically a <see cref="System.Reflection.MetadataLoadContext"/>) that a
+    /// member's constructed generic CLR type was resolved from, mirroring
+    /// <c>InterfaceSymbol.Construct</c>'s <c>mapClrType</c> (issue #1926 / PR #1956).
+    /// Pass <see langword="null"/> (the default) for single-context callers.
+    /// </param>
     /// <returns>A constructed <see cref="StructSymbol"/> whose <see cref="Definition"/> is the original.</returns>
-    public static StructSymbol Construct(StructSymbol definition, ImmutableArray<TypeSymbol> typeArguments)
+    public static StructSymbol Construct(StructSymbol definition, ImmutableArray<TypeSymbol> typeArguments, Func<Type, Type> mapClrType = null)
     {
         if (definition == null || !definition.IsGenericDefinition)
         {
@@ -1235,7 +1251,7 @@ public sealed class StructSymbol : TypeSymbol
         }
 
         var key = BuildArgsKey(typeArguments);
-        return ConstructedCache.GetOrAdd((definition, key), _ => CreateConstructed(definition, typeArguments));
+        return ConstructedCache.GetOrAdd((definition, key), _ => CreateConstructed(definition, typeArguments, mapClrType));
     }
 
     /// <summary>
@@ -1254,8 +1270,9 @@ public sealed class StructSymbol : TypeSymbol
     /// </summary>
     /// <param name="nestedDefinition">The open nested-type definition (its <see cref="Definition"/> is used).</param>
     /// <param name="enclosingTypeArguments">The flattened enclosing construction arguments in CLR order (outermost first), aligned with <see cref="CollectEnclosingTypeParameters(TypeSymbol)"/>.</param>
+    /// <param name="mapClrType">Issue #1958: see <see cref="Construct(StructSymbol, ImmutableArray{TypeSymbol}, Func{Type, Type})"/>.</param>
     /// <returns>A constructed nested reference, or <paramref name="nestedDefinition"/> unchanged when no enclosing arguments apply.</returns>
-    public static StructSymbol ConstructNested(StructSymbol nestedDefinition, ImmutableArray<TypeSymbol> enclosingTypeArguments)
+    public static StructSymbol ConstructNested(StructSymbol nestedDefinition, ImmutableArray<TypeSymbol> enclosingTypeArguments, Func<Type, Type> mapClrType = null)
     {
         if (nestedDefinition == null || enclosingTypeArguments.IsDefaultOrEmpty)
         {
@@ -1264,7 +1281,7 @@ public sealed class StructSymbol : TypeSymbol
 
         var def = nestedDefinition.Definition ?? nestedDefinition;
         var key = BuildArgsKey(enclosingTypeArguments);
-        return ConstructedNestedCache.GetOrAdd((def, key), _ => CreateConstructedNested(def, enclosingTypeArguments));
+        return ConstructedNestedCache.GetOrAdd((def, key), _ => CreateConstructedNested(def, enclosingTypeArguments, mapClrType));
     }
 
     /// <summary>
@@ -1286,11 +1303,13 @@ public sealed class StructSymbol : TypeSymbol
     /// <param name="nestedDefinition">The open nested-type definition (its <see cref="Definition"/> is used).</param>
     /// <param name="enclosingTypeArguments">The flattened enclosing construction arguments in CLR order (outermost first), aligned with <see cref="CollectEnclosingTypeParameters(TypeSymbol)"/>. May be empty when the enclosing type is open but the nested type carries own arguments.</param>
     /// <param name="ownTypeArguments">The nested type's own type arguments.</param>
+    /// <param name="mapClrType">Issue #1958: see <see cref="Construct(StructSymbol, ImmutableArray{TypeSymbol}, Func{Type, Type})"/>.</param>
     /// <returns>A constructed nested-generic reference, or <paramref name="nestedDefinition"/> unchanged when neither vector applies.</returns>
     public static StructSymbol ConstructNestedGeneric(
         StructSymbol nestedDefinition,
         ImmutableArray<TypeSymbol> enclosingTypeArguments,
-        ImmutableArray<TypeSymbol> ownTypeArguments)
+        ImmutableArray<TypeSymbol> ownTypeArguments,
+        Func<Type, Type> mapClrType = null)
     {
         if (nestedDefinition == null)
         {
@@ -1301,7 +1320,7 @@ public sealed class StructSymbol : TypeSymbol
         // two representations remain reference-equal and share one cache.
         if (ownTypeArguments.IsDefaultOrEmpty)
         {
-            return ConstructNested(nestedDefinition, enclosingTypeArguments);
+            return ConstructNested(nestedDefinition, enclosingTypeArguments, mapClrType);
         }
 
         // No enclosing arguments to thread: this is an ordinary construction of
@@ -1311,7 +1330,7 @@ public sealed class StructSymbol : TypeSymbol
         // arguments substitute exactly as for a top-level generic.
         if (enclosingTypeArguments.IsDefaultOrEmpty)
         {
-            return Construct(nestedDefinition.Definition ?? nestedDefinition, ownTypeArguments);
+            return Construct(nestedDefinition.Definition ?? nestedDefinition, ownTypeArguments, mapClrType);
         }
 
         var def = nestedDefinition.Definition ?? nestedDefinition;
@@ -1319,7 +1338,7 @@ public sealed class StructSymbol : TypeSymbol
         var ownKey = BuildArgsKey(ownTypeArguments);
         return ConstructedNestedGenericCache.GetOrAdd(
             (def, enclosingKey, ownKey),
-            _ => CreateConstructedNestedGeneric(def, enclosingTypeArguments, ownTypeArguments));
+            _ => CreateConstructedNestedGeneric(def, enclosingTypeArguments, ownTypeArguments, mapClrType));
     }
 
     /// <summary>
@@ -1489,7 +1508,7 @@ public sealed class StructSymbol : TypeSymbol
         var builder = ImmutableArray.CreateBuilder<TypeSymbol>(parameters.Length);
         foreach (var p in parameters)
         {
-            builder.Add(SubstituteTypeForConstruction(p.Type, subst));
+            builder.Add(SubstituteTypeForConstruction(p.Type, subst, mapClrType));
         }
 
         return builder.MoveToImmutable();
@@ -1607,7 +1626,7 @@ public sealed class StructSymbol : TypeSymbol
         _ => ImmutableArray<TypeParameterSymbol>.Empty,
     };
 
-    private static StructSymbol CreateConstructed(StructSymbol definition, ImmutableArray<TypeSymbol> typeArguments)
+    private static StructSymbol CreateConstructed(StructSymbol definition, ImmutableArray<TypeSymbol> typeArguments, Func<Type, Type> mapClrType)
     {
         var subst = new Dictionary<TypeParameterSymbol, TypeSymbol>(definition.TypeParameters.Length);
         for (var i = 0; i < definition.TypeParameters.Length; i++)
@@ -1618,7 +1637,7 @@ public sealed class StructSymbol : TypeSymbol
         var substitutedFields = ImmutableArray.CreateBuilder<FieldSymbol>(definition.Fields.Length);
         foreach (var f in definition.Fields)
         {
-            substitutedFields.Add(new FieldSymbol(f.Name, SubstituteTypeForConstruction(f.Type, subst), f.Accessibility));
+            substitutedFields.Add(new FieldSymbol(f.Name, SubstituteTypeForConstruction(f.Type, subst, mapClrType), f.Accessibility));
         }
 
         var substitutedPrimary = ImmutableArray<ParameterSymbol>.Empty;
@@ -1627,7 +1646,7 @@ public sealed class StructSymbol : TypeSymbol
             var b = ImmutableArray.CreateBuilder<ParameterSymbol>(definition.PrimaryConstructorParameters.Length);
             foreach (var p in definition.PrimaryConstructorParameters)
             {
-                b.Add(new ParameterSymbol(p.Name, SubstituteTypeForConstruction(p.Type, subst), isVariadic: p.IsVariadic, isScoped: p.IsScoped));
+                b.Add(new ParameterSymbol(p.Name, SubstituteTypeForConstruction(p.Type, subst, mapClrType), isVariadic: p.IsVariadic, isScoped: p.IsScoped));
             }
 
             substitutedPrimary = b.MoveToImmutable();
@@ -1648,12 +1667,13 @@ public sealed class StructSymbol : TypeSymbol
 
         constructed.Definition = definition;
         constructed.TypeArguments = typeArguments;
+        constructed.mapClrType = mapClrType;
         if (!definition.Interfaces.IsDefaultOrEmpty)
         {
             var substitutedIfaces = ImmutableArray.CreateBuilder<InterfaceSymbol>(definition.Interfaces.Length);
             foreach (var iface in definition.Interfaces)
             {
-                substitutedIfaces.Add((InterfaceSymbol)SubstituteTypeForConstruction(iface, subst));
+                substitutedIfaces.Add((InterfaceSymbol)SubstituteTypeForConstruction(iface, subst, mapClrType));
             }
 
             constructed.SetInterfaces(substitutedIfaces.MoveToImmutable());
@@ -1668,7 +1688,7 @@ public sealed class StructSymbol : TypeSymbol
             var substitutedClrIfaces = ImmutableArray.CreateBuilder<TypeSymbol>(definition.ImplementedClrInterfaces.Length);
             foreach (var iface in definition.ImplementedClrInterfaces)
             {
-                substitutedClrIfaces.Add(SubstituteTypeForConstruction(iface, subst));
+                substitutedClrIfaces.Add(SubstituteTypeForConstruction(iface, subst, mapClrType));
             }
 
             constructed.SetImplementedClrInterfaces(substitutedClrIfaces.MoveToImmutable());
@@ -1720,7 +1740,7 @@ public sealed class StructSymbol : TypeSymbol
     // definition and substitute lazily against that map, so a field/property/
     // return of the nested type whose type is an enclosing parameter surfaces
     // closed (e.g. `Tag.V : int32` on `Box[int32].Tag`).
-    private static StructSymbol CreateConstructedNested(StructSymbol definition, ImmutableArray<TypeSymbol> enclosingTypeArguments)
+    private static StructSymbol CreateConstructedNested(StructSymbol definition, ImmutableArray<TypeSymbol> enclosingTypeArguments, Func<Type, Type> mapClrType)
     {
         var constructed = new StructSymbol(
             definition.Name,
@@ -1737,6 +1757,7 @@ public sealed class StructSymbol : TypeSymbol
 
         constructed.Definition = definition;
         constructed.EnclosingTypeArguments = enclosingTypeArguments;
+        constructed.mapClrType = mapClrType;
         constructed.ContainingType = definition.ContainingType;
         constructed.SetInterfaces(definition.Interfaces);
         if (!definition.ImplementedClrInterfaces.IsDefaultOrEmpty)
@@ -1766,7 +1787,8 @@ public sealed class StructSymbol : TypeSymbol
     private static StructSymbol CreateConstructedNestedGeneric(
         StructSymbol definition,
         ImmutableArray<TypeSymbol> enclosingTypeArguments,
-        ImmutableArray<TypeSymbol> ownTypeArguments)
+        ImmutableArray<TypeSymbol> ownTypeArguments,
+        Func<Type, Type> mapClrType)
     {
         var constructed = new StructSymbol(
             definition.Name,
@@ -1784,6 +1806,7 @@ public sealed class StructSymbol : TypeSymbol
         constructed.Definition = definition;
         constructed.TypeArguments = ownTypeArguments;
         constructed.EnclosingTypeArguments = enclosingTypeArguments;
+        constructed.mapClrType = mapClrType;
 
         // Capture the nested type's own type parameters BEFORE the emitter
         // re-ordinalizes the nested TypeDef over the flattened enclosing+own
@@ -1881,7 +1904,7 @@ public sealed class StructSymbol : TypeSymbol
             var builder = ImmutableArray.CreateBuilder<FieldSymbol>(source.Length);
             foreach (var f in source)
             {
-                var newType = SubstituteTypeForConstruction(f.Type, subst);
+                var newType = SubstituteTypeForConstruction(f.Type, subst, mapClrType);
                 builder.Add(ReferenceEquals(newType, f.Type)
                     ? f
                     : new FieldSymbol(f.Name, newType, f.Accessibility));
@@ -1907,7 +1930,7 @@ public sealed class StructSymbol : TypeSymbol
             return substitutedProperties;
         }
 
-        var result = SubstituteProperties(source, GetSubstitutionMap());
+        var result = SubstituteProperties(source, GetSubstitutionMap(), mapClrType);
         substitutedProperties = result;
         substitutedPropertiesSource = source;
         substitutedPropertiesComputed = true;
@@ -1925,7 +1948,7 @@ public sealed class StructSymbol : TypeSymbol
             return substitutedStaticProperties;
         }
 
-        var result = SubstituteProperties(source, GetSubstitutionMap());
+        var result = SubstituteProperties(source, GetSubstitutionMap(), mapClrType);
         substitutedStaticProperties = result;
         substitutedStaticPropertiesSource = source;
         substitutedStaticPropertiesComputed = true;
@@ -1934,7 +1957,8 @@ public sealed class StructSymbol : TypeSymbol
 
     private static ImmutableArray<PropertySymbol> SubstituteProperties(
         ImmutableArray<PropertySymbol> properties,
-        Dictionary<TypeParameterSymbol, TypeSymbol> subst)
+        Dictionary<TypeParameterSymbol, TypeSymbol> subst,
+        Func<Type, Type> mapClrType)
     {
         if (properties.IsDefaultOrEmpty)
         {
@@ -1944,7 +1968,7 @@ public sealed class StructSymbol : TypeSymbol
         var builder = ImmutableArray.CreateBuilder<PropertySymbol>(properties.Length);
         foreach (var p in properties)
         {
-            var newType = SubstituteTypeForConstruction(p.Type, subst);
+            var newType = SubstituteTypeForConstruction(p.Type, subst, mapClrType);
 
             var newParams = p.Parameters;
             var paramsChanged = false;
@@ -1953,7 +1977,7 @@ public sealed class StructSymbol : TypeSymbol
                 var pb = ImmutableArray.CreateBuilder<ParameterSymbol>(p.Parameters.Length);
                 foreach (var par in p.Parameters)
                 {
-                    var st = SubstituteTypeForConstruction(par.Type, subst);
+                    var st = SubstituteTypeForConstruction(par.Type, subst, mapClrType);
                     paramsChanged |= !ReferenceEquals(st, par.Type);
                     pb.Add(new ParameterSymbol(par.Name, st, isVariadic: par.IsVariadic, isScoped: par.IsScoped));
                 }
@@ -2084,7 +2108,7 @@ public sealed class StructSymbol : TypeSymbol
     private static ImmutableArray<ParameterSymbol> CallableParametersOf(FunctionSymbol method)
         => method.ExplicitReceiverParameter == null ? method.Parameters : method.Parameters.RemoveAt(0);
 
-    private static TypeSymbol SubstituteTypeForConstruction(TypeSymbol type, Dictionary<TypeParameterSymbol, TypeSymbol> subst)
+    private static TypeSymbol SubstituteTypeForConstruction(TypeSymbol type, Dictionary<TypeParameterSymbol, TypeSymbol> subst, Func<Type, Type> mapClrType = null)
     {
         if (type is TypeParameterSymbol tp)
         {
@@ -2105,13 +2129,13 @@ public sealed class StructSymbol : TypeSymbol
             var structChanged = false;
             for (var i = 0; i < ss.TypeArguments.Length; i++)
             {
-                var substituted = SubstituteTypeForConstruction(ss.TypeArguments[i], subst);
+                var substituted = SubstituteTypeForConstruction(ss.TypeArguments[i], subst, mapClrType);
                 substitutedStructArgs.Add(substituted);
                 structChanged |= !ReferenceEquals(substituted, ss.TypeArguments[i]);
             }
 
             return structChanged
-                ? StructSymbol.Construct(ss.Definition, substitutedStructArgs.MoveToImmutable())
+                ? StructSymbol.Construct(ss.Definition, substitutedStructArgs.MoveToImmutable(), mapClrType)
                 : type;
         }
 
@@ -2123,10 +2147,10 @@ public sealed class StructSymbol : TypeSymbol
         // distinct from the constructed-generic branch above.
         if (type is StructSymbol nestedRef && nestedRef.TypeArguments.IsDefaultOrEmpty)
         {
-            var newEnclosing = SubstituteEnclosingArguments(nestedRef, t => SubstituteTypeForConstruction(t, subst));
+            var newEnclosing = SubstituteEnclosingArguments(nestedRef, t => SubstituteTypeForConstruction(t, subst, mapClrType));
             if (!newEnclosing.IsDefault)
             {
-                return ConstructNested(nestedRef.Definition ?? nestedRef, newEnclosing);
+                return ConstructNested(nestedRef.Definition ?? nestedRef, newEnclosing, mapClrType);
             }
         }
 
@@ -2136,7 +2160,7 @@ public sealed class StructSymbol : TypeSymbol
             var changed = false;
             for (var i = 0; i < iface.TypeArguments.Length; i++)
             {
-                var substituted = SubstituteTypeForConstruction(iface.TypeArguments[i], subst);
+                var substituted = SubstituteTypeForConstruction(iface.TypeArguments[i], subst, mapClrType);
                 substitutedArgs.Add(substituted);
                 changed |= !ReferenceEquals(substituted, iface.TypeArguments[i]);
             }
@@ -2146,7 +2170,7 @@ public sealed class StructSymbol : TypeSymbol
                 return iface;
             }
 
-            return InterfaceSymbol.Construct(iface.Definition, substitutedArgs.MoveToImmutable());
+            return InterfaceSymbol.Construct(iface.Definition, substitutedArgs.MoveToImmutable(), mapClrType);
         }
 
         if (type is ImportedTypeSymbol imported
@@ -2157,7 +2181,7 @@ public sealed class StructSymbol : TypeSymbol
             var changed = false;
             for (var i = 0; i < imported.TypeArguments.Length; i++)
             {
-                var substituted = SubstituteTypeForConstruction(imported.TypeArguments[i], subst);
+                var substituted = SubstituteTypeForConstruction(imported.TypeArguments[i], subst, mapClrType);
                 substitutedArgs.Add(substituted);
                 changed |= !ReferenceEquals(substituted, imported.TypeArguments[i]);
             }
@@ -2167,10 +2191,17 @@ public sealed class StructSymbol : TypeSymbol
                 return imported;
             }
 
+            // Issue #1958: project each resolved CLR arg into the same
+            // reflection context as `imported.OpenDefinition` before calling
+            // MakeGenericType — mirrors InterfaceSymbol.SubstituteType's
+            // mapClrType fix. Without this, a raw host CLR type mixed with an
+            // MLC-resolved open definition throws ArgumentException and
+            // silently erases the substitution.
             var resolvedClrArgs = new System.Type[substitutedArgs.Count];
             for (var i = 0; i < substitutedArgs.Count; i++)
             {
-                resolvedClrArgs[i] = substitutedArgs[i].ClrType ?? typeof(object);
+                var clr = substitutedArgs[i].ClrType ?? typeof(object);
+                resolvedClrArgs[i] = mapClrType != null ? mapClrType(clr) : clr;
             }
 
             try
@@ -2180,25 +2211,33 @@ public sealed class StructSymbol : TypeSymbol
             }
             catch (ArgumentException)
             {
+                // MakeGenericType can legitimately throw ArgumentException for CLR
+                // generic constraint reasons (e.g. unmanaged/ref-struct constraints),
+                // not only cross-reflection-context mismatches, so this is NOT always
+                // a bug. Log for diagnosability and fall back to the erased
+                // constructed form so both debug and release builds degrade
+                // gracefully rather than crash.
+                var assertMessage = $"StructSymbol.SubstituteTypeForConstruction: MakeGenericType failed for '{imported.OpenDefinition}' with args [{string.Join(", ", resolvedClrArgs.Select(t => t.ToString()))}] even after mapClrType projection.";
+                System.Diagnostics.Debug.WriteLine(assertMessage);
                 return imported;
             }
         }
 
         if (type is NullableTypeSymbol n)
         {
-            var inner = SubstituteTypeForConstruction(n.UnderlyingType, subst);
+            var inner = SubstituteTypeForConstruction(n.UnderlyingType, subst, mapClrType);
             return ReferenceEquals(inner, n.UnderlyingType) ? type : NullableTypeSymbol.Get(inner);
         }
 
         if (type is SliceTypeSymbol s)
         {
-            var inner = SubstituteTypeForConstruction(s.ElementType, subst);
+            var inner = SubstituteTypeForConstruction(s.ElementType, subst, mapClrType);
             return ReferenceEquals(inner, s.ElementType) ? type : SliceTypeSymbol.Get(inner);
         }
 
         if (type is ArrayTypeSymbol a)
         {
-            var inner = SubstituteTypeForConstruction(a.ElementType, subst);
+            var inner = SubstituteTypeForConstruction(a.ElementType, subst, mapClrType);
             return ReferenceEquals(inner, a.ElementType) ? type : ArrayTypeSymbol.Get(inner, a.Length);
         }
 
@@ -2208,8 +2247,8 @@ public sealed class StructSymbol : TypeSymbol
         // `map[int32, string]` on the constructed instantiation.
         if (type is MapTypeSymbol map)
         {
-            var substKey = SubstituteTypeForConstruction(map.KeyType, subst);
-            var substValue = SubstituteTypeForConstruction(map.ValueType, subst);
+            var substKey = SubstituteTypeForConstruction(map.KeyType, subst, mapClrType);
+            var substValue = SubstituteTypeForConstruction(map.ValueType, subst, mapClrType);
             return ReferenceEquals(substKey, map.KeyType) && ReferenceEquals(substValue, map.ValueType)
                 ? type
                 : MapTypeSymbol.Get(substKey, substValue);
@@ -2228,7 +2267,7 @@ public sealed class StructSymbol : TypeSymbol
             var delegateChanged = false;
             for (var i = 0; i < del.TypeArguments.Length; i++)
             {
-                var substituted = SubstituteTypeForConstruction(del.TypeArguments[i], subst);
+                var substituted = SubstituteTypeForConstruction(del.TypeArguments[i], subst, mapClrType);
                 substitutedDelegateArgs.Add(substituted);
                 delegateChanged |= !ReferenceEquals(substituted, del.TypeArguments[i]);
             }
@@ -2248,12 +2287,12 @@ public sealed class StructSymbol : TypeSymbol
             var changed = false;
             for (var i = 0; i < fn.ParameterTypes.Length; i++)
             {
-                var substituted = SubstituteTypeForConstruction(fn.ParameterTypes[i], subst);
+                var substituted = SubstituteTypeForConstruction(fn.ParameterTypes[i], subst, mapClrType);
                 substitutedParams.Add(substituted);
                 changed |= !ReferenceEquals(substituted, fn.ParameterTypes[i]);
             }
 
-            var substitutedReturn = SubstituteTypeForConstruction(fn.ReturnType, subst);
+            var substitutedReturn = SubstituteTypeForConstruction(fn.ReturnType, subst, mapClrType);
             changed |= !ReferenceEquals(substitutedReturn, fn.ReturnType);
 
             if (!changed)

--- a/src/Core/CodeAnalysis/Symbols/SynthesizedClosureReifier.cs
+++ b/src/Core/CodeAnalysis/Symbols/SynthesizedClosureReifier.cs
@@ -155,8 +155,18 @@ internal static class SynthesizedClosureReifier
     /// </summary>
     /// <param name="definition">The synthesized closure / box class definition.</param>
     /// <param name="origTPs">The ordered referenced enclosing type parameters.</param>
+    /// <param name="mapClrType">
+    /// Issue #2037: optional projector applied to the constructed instance's
+    /// CLR type arguments before <c>MakeGenericType</c> (mirrors #1958's
+    /// <see cref="StructSymbol.Construct(StructSymbol, ImmutableArray{TypeSymbol}, System.Func{System.Type, System.Type})"/>
+    /// fix). Needed when a hoisted capture/state field is typed as an
+    /// imported constructed generic over one of <paramref name="origTPs"/>
+    /// and the compilation runs under a cross-reflection-context (MLC)
+    /// reference set (cs2gs); <see langword="null"/> preserves the
+    /// erase-on-mismatch fallback for same-compilation-only callers.
+    /// </param>
     /// <returns>The constructed instance over the original parameters.</returns>
-    public static StructSymbol Reify(StructSymbol definition, ImmutableArray<TypeParameterSymbol> origTPs)
+    public static StructSymbol Reify(StructSymbol definition, ImmutableArray<TypeParameterSymbol> origTPs, System.Func<System.Type, System.Type> mapClrType = null)
     {
         var clones = CloneWithRemappedConstraints(origTPs);
 
@@ -169,6 +179,6 @@ internal static class SynthesizedClosureReifier
             args.Add(tp);
         }
 
-        return StructSymbol.Construct(definition, args.MoveToImmutable());
+        return StructSymbol.Construct(definition, args.MoveToImmutable(), mapClrType);
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1958InterfaceMemberGenericSubstitutionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1958InterfaceMemberGenericSubstitutionTests.cs
@@ -1,0 +1,163 @@
+// <copyright file="Issue1958InterfaceMemberGenericSubstitutionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Regression tests for issue #1958: <c>InterfaceSymbol.SubstituteType</c> had
+/// the same silent <c>MakeGenericType</c> erasure bug that PR #1956 fixed in
+/// <c>Binder.SubstituteType</c> for issue #1926.
+/// </summary>
+/// <remarks>
+/// Root cause: when a user-defined generic interface exposes a member type
+/// that is a constructed generic CLR interface over the interface's OWN type
+/// parameter (issue #974 shape, e.g. <c>func Iter() IEnumerator[T]</c> on
+/// <c>interface ISeq[T]</c>), constructing a closed instance (<c>ISeq[int32]</c>)
+/// substitutes <c>T</c> with <c>int32</c> in that member's return type by
+/// calling <c>IEnumerator&lt;&gt;.MakeGenericType(typeof(int))</c>. Under a
+/// <see cref="System.Reflection.MetadataLoadContext"/> reference set (as
+/// cs2gs / the MSBuild task compile mode use), <c>IEnumerator&lt;&gt;</c> is
+/// resolved through the MLC while <c>int32</c>'s <see cref="TypeSymbol.ClrType"/>
+/// is always the host process's live <c>typeof(int)</c>; mixing them in
+/// <c>MakeGenericType</c> throws <see cref="ArgumentException"/>, which was
+/// silently swallowed, leaking the definition's unsubstituted
+/// <c>IEnumerator[T]</c> into the constructed <c>ISeq[int32]</c> shape. The fix
+/// projects each substituted CLR type argument into the interface's
+/// constructing <c>mapClrType</c> reflection context before calling
+/// <c>MakeGenericType</c>, mirroring <c>Binder.SubstituteType</c>.
+/// </remarks>
+public class Issue1958InterfaceMemberGenericSubstitutionTests
+{
+    /// <summary>
+    /// Build a <see cref="ReferenceResolver"/> rooted at the BCL reference
+    /// assemblies, forcing gsc into the <see cref="System.Reflection.MetadataLoadContext"/>
+    /// resolution path — the same path cs2gs and the MSBuild task drive gsc
+    /// through — reproducing the cross-reflection-context scenario inside the
+    /// unit-test process.
+    /// </summary>
+    private static ReferenceResolver MetadataLoadContextResolver()
+    {
+        var paths = new[]
+        {
+            typeof(object).Assembly.Location,
+            typeof(System.Collections.Generic.List<>).Assembly.Location,
+            typeof(System.Console).Assembly.Location,
+            typeof(System.Linq.Enumerable).Assembly.Location,
+        }
+        .Where(p => !string.IsNullOrEmpty(p))
+        .Distinct(StringComparer.OrdinalIgnoreCase)
+        .ToArray();
+
+        return ReferenceResolver.WithReferences(paths);
+    }
+
+    private static BoundGlobalScope BindWithMlc(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        return Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree), MetadataLoadContextResolver());
+    }
+
+    private static BoundGlobalScope BindDefault(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        return Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+    }
+
+    [Fact]
+    public void GenericUserInterface_MemberOverOwnTypeParameter_SubstitutesUnderMetadataLoadContext()
+    {
+        // #974 shape: ISeq[T]'s `Iter()` member exposes the constructed CLR
+        // generic `IEnumerator[T]` over the interface's own type parameter.
+        // Constructing `ISeq[int32]` (via the `use` parameter below) must
+        // substitute T -> int32 in that member so `use`'s declared
+        // `IEnumerator[int32]` return type matches `s.Iter()`'s actual
+        // (substituted) return type. Before the fix, MakeGenericType threw
+        // under MLC and silently fell back to the erased `IEnumerator[T]`,
+        // which does not convert to `IEnumerator[int32]` and failed binding.
+        var source = """
+            package P
+            import System.Collections.Generic
+
+            interface ISeq[T any] {
+                func Iter() IEnumerator[T]
+            }
+
+            func use(s ISeq[int32]) IEnumerator[int32] {
+                return s.Iter()
+            }
+            """;
+
+        var globalScope = BindWithMlc(source);
+        Assert.Empty(globalScope.Diagnostics.Where(d => d.IsError));
+    }
+
+    [Fact]
+    public void GenericUserInterface_MemberOverOwnTypeParameter_ControlCase_DefaultResolver()
+    {
+        // Control case: the same shape must already bind (and keep binding)
+        // under the default (non-MLC) reflection context, so the fix does not
+        // regress the common single-context compile path.
+        var source = """
+            package P
+            import System.Collections.Generic
+
+            interface ISeq[T any] {
+                func Iter() IEnumerator[T]
+            }
+
+            func use(s ISeq[int32]) IEnumerator[int32] {
+                return s.Iter()
+            }
+            """;
+
+        var globalScope = BindDefault(source);
+        Assert.Empty(globalScope.Diagnostics.Where(d => d.IsError));
+    }
+
+    [Fact]
+    public void InterfaceSymbol_SubstituteType_ProjectsClrArgsAcrossReflectionContexts()
+    {
+        // Direct symbol-layer check (issue #1958's minimum bar): constructing
+        // ISeq[int32] under a mapClrType-bearing resolver must produce a
+        // substituted `Iter()` return type whose ImportedTypeSymbol.TypeArguments
+        // is the concrete int32 argument, NOT the still-open T type parameter
+        // that a silently-swallowed ArgumentException would have leaked.
+        var resolver = MetadataLoadContextResolver();
+        var mapClrType = resolver.MapClrTypeToReferences;
+
+        var enumeratorOpenDef = resolver.MapClrTypeToReferences(typeof(System.Collections.Generic.IEnumerator<>));
+        var mlcObject = resolver.MapClrTypeToReferences(typeof(object));
+
+        var tp = new TypeParameterSymbol("T", 0, TypeParameterConstraint.Any, TypeParameterVariance.None);
+        var erasedMemberType = ImportedTypeSymbol.GetConstructed(
+            enumeratorOpenDef.MakeGenericType(mlcObject),
+            enumeratorOpenDef,
+            ImmutableArray.Create<TypeSymbol>(tp));
+
+        var definition = new InterfaceSymbol("ISeq", Accessibility.Public, declaration: null, packageName: "P");
+        definition.SetTypeParameters(ImmutableArray.Create(tp));
+        var iterMethod = new FunctionSymbol(
+            "Iter",
+            ImmutableArray<ParameterSymbol>.Empty,
+            erasedMemberType,
+            declaration: null,
+            package: null,
+            accessibility: Accessibility.Public);
+        definition.SetMethods(ImmutableArray.Create(iterMethod));
+
+        var constructed = InterfaceSymbol.Construct(definition, ImmutableArray.Create<TypeSymbol>(TypeSymbol.Int32), mapClrType);
+
+        var substitutedReturn = Assert.IsType<ImportedTypeSymbol>(constructed.Methods[0].Type);
+        Assert.Same(TypeSymbol.Int32, Assert.Single(substitutedReturn.TypeArguments));
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1958StructMemberGenericSubstitutionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1958StructMemberGenericSubstitutionTests.cs
@@ -1,0 +1,115 @@
+// <copyright file="Issue1958StructMemberGenericSubstitutionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Regression test mirroring <see cref="Issue1958InterfaceMemberGenericSubstitutionTests"/>:
+/// <c>StructSymbol.SubstituteTypeForConstruction</c> had the identical
+/// un-projected <c>MakeGenericType</c> erasure bug as <c>InterfaceSymbol</c>
+/// before this fix (blocking review #2032). A G# <c>struct S[T]</c> with an
+/// imported generic-CLR-typed field over the struct's OWN type parameter
+/// (e.g. <c>IEnumerator[T]</c>) would silently erase to the definition's
+/// open <c>T</c> when constructed under a
+/// <see cref="System.Reflection.MetadataLoadContext"/>-style resolver, because
+/// <c>StructSymbol.Construct</c> dropped the projector on the floor instead of
+/// threading it (like <c>InterfaceSymbol.Construct</c>) into
+/// <c>MakeGenericType</c>.
+/// </summary>
+public class Issue1958StructMemberGenericSubstitutionTests
+{
+    /// <summary>
+    /// Build a <see cref="ReferenceResolver"/> rooted at the BCL reference
+    /// assemblies, forcing gsc into the <see cref="System.Reflection.MetadataLoadContext"/>
+    /// resolution path — reproducing the cross-reflection-context scenario
+    /// inside the unit-test process. Mirrors
+    /// <c>Issue1958InterfaceMemberGenericSubstitutionTests.MetadataLoadContextResolver</c>.
+    /// </summary>
+    private static ReferenceResolver MetadataLoadContextResolver()
+    {
+        var paths = new[]
+        {
+            typeof(object).Assembly.Location,
+            typeof(System.Collections.Generic.List<>).Assembly.Location,
+            typeof(System.Console).Assembly.Location,
+            typeof(System.Linq.Enumerable).Assembly.Location,
+        }
+        .Where(p => !string.IsNullOrEmpty(p))
+        .Distinct(StringComparer.OrdinalIgnoreCase)
+        .ToArray();
+
+        return ReferenceResolver.WithReferences(paths);
+    }
+
+    [Fact]
+    public void StructSymbol_SubstituteTypeForConstruction_ProjectsClrArgsAcrossReflectionContexts()
+    {
+        // Direct symbol-layer check (mirrors the interface-layer test): a
+        // struct definition Box[T] with a field typed as a constructed CLR
+        // generic (IEnumerator[T]) over the struct's OWN type parameter must,
+        // when constructed as Box[int32] under a mapClrType-bearing resolver,
+        // substitute T -> int32 in the field's imported generic type. Before
+        // the fix, StructSymbol.Construct dropped mapClrType on the floor, so
+        // MakeGenericType mixed the MLC-resolved open definition with the
+        // host runtime's typeof(int) CLR arg, threw ArgumentException, and
+        // silently fell back to the still-open `IEnumerator[T]` field type.
+        var resolver = MetadataLoadContextResolver();
+        var mapClrType = resolver.MapClrTypeToReferences;
+
+        var enumeratorOpenDef = resolver.MapClrTypeToReferences(typeof(System.Collections.Generic.IEnumerator<>));
+        var mlcObject = resolver.MapClrTypeToReferences(typeof(object));
+
+        var tp = new TypeParameterSymbol("T", 0, TypeParameterConstraint.Any, TypeParameterVariance.None);
+        var erasedFieldType = ImportedTypeSymbol.GetConstructed(
+            enumeratorOpenDef.MakeGenericType(mlcObject),
+            enumeratorOpenDef,
+            ImmutableArray.Create<TypeSymbol>(tp));
+
+        var fields = ImmutableArray.Create(new FieldSymbol("Items", erasedFieldType, Accessibility.Public));
+        var definition = new StructSymbol("Box", fields, Accessibility.Public, declaration: null, packageName: "P");
+        definition.SetTypeParameters(ImmutableArray.Create(tp));
+
+        var constructed = StructSymbol.Construct(definition, ImmutableArray.Create<TypeSymbol>(TypeSymbol.Int32), mapClrType);
+
+        var substitutedFieldType = Assert.IsType<ImportedTypeSymbol>(constructed.Fields[0].Type);
+        Assert.Same(TypeSymbol.Int32, Assert.Single(substitutedFieldType.TypeArguments));
+    }
+
+    [Fact]
+    public void StructSymbol_SubstituteTypeForConstruction_WithoutMapClrType_ErasesUnderMetadataLoadContext()
+    {
+        // Control case proving the failure mode this test guards against: with
+        // no projector supplied (mapClrType: null, the pre-#1958 behavior),
+        // MakeGenericType throws under MLC and the fix's own graceful fallback
+        // (catch -> Debug.WriteLine + return the erased member) kicks in, so
+        // the field type stays the still-open `IEnumerator[T]` instead of
+        // throwing out of Construct entirely.
+        var resolver = MetadataLoadContextResolver();
+
+        var enumeratorOpenDef = resolver.MapClrTypeToReferences(typeof(System.Collections.Generic.IEnumerator<>));
+        var mlcObject = resolver.MapClrTypeToReferences(typeof(object));
+
+        var tp = new TypeParameterSymbol("T", 0, TypeParameterConstraint.Any, TypeParameterVariance.None);
+        var erasedFieldType = ImportedTypeSymbol.GetConstructed(
+            enumeratorOpenDef.MakeGenericType(mlcObject),
+            enumeratorOpenDef,
+            ImmutableArray.Create<TypeSymbol>(tp));
+
+        var fields = ImmutableArray.Create(new FieldSymbol("Items", erasedFieldType, Accessibility.Public));
+        var definition = new StructSymbol("Box", fields, Accessibility.Public, declaration: null, packageName: "P");
+        definition.SetTypeParameters(ImmutableArray.Create(tp));
+
+        var constructed = StructSymbol.Construct(definition, ImmutableArray.Create<TypeSymbol>(TypeSymbol.Int32));
+
+        var unsubstitutedFieldType = Assert.IsType<ImportedTypeSymbol>(constructed.Fields[0].Type);
+        Assert.Same(tp, Assert.Single(unsubstitutedFieldType.TypeArguments));
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue2037StateMachineMlcProjectionEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue2037StateMachineMlcProjectionEmitTests.cs
@@ -1,0 +1,250 @@
+// <copyright file="Issue2037StateMachineMlcProjectionEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Follow-up regression test for issue #2037 (review follow-up of #2032 /
+/// #1958): <see cref="Emit.StateMachineEmitter"/>'s two
+/// <c>StructSymbol.Construct</c> call sites (the <c>GetEnumerator</c>/kickoff
+/// literal target and the async kickoff literal target) built the CONSTRUCTED
+/// state-machine struct without threading a <c>mapClrType</c> projector, so a
+/// hoisted parameter field typed as an imported constructed generic over the
+/// enclosing async method's OWN type parameter (e.g. <c>IReadOnlyList[T]</c>
+/// for an <c>async func Foo[T](items IReadOnlyList[T])</c>) would hit the
+/// #1958 <c>MakeGenericType</c> cross-reflection-context
+/// (<see cref="System.Reflection.MetadataLoadContext"/> / cs2gs) erasure
+/// fallback instead of correctly substituting the type argument.
+/// </summary>
+public class Issue2037StateMachineMlcProjectionEmitTests
+{
+    /// <summary>
+    /// Build a <see cref="ReferenceResolver"/> rooted at the full shared-
+    /// framework assembly set, forcing gsc into the
+    /// <see cref="System.Reflection.MetadataLoadContext"/> resolution path —
+    /// the same path the cs2gs migration pipeline and the MSBuild task drive
+    /// gsc through via <c>/reference:</c> — reproducing the cross-reflection-
+    /// context scenario inside the unit-test process. Mirrors
+    /// <c>Issue1919AsyncLambdaMlcEmitTests.MetadataLoadContextResolver</c>.
+    /// </summary>
+    private static ReferenceResolver MetadataLoadContextResolver()
+    {
+        var runtimeDir = System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory();
+        var paths = Directory.GetFiles(runtimeDir, "*.dll");
+        return ReferenceResolver.WithReferences(paths);
+    }
+
+    /// <summary>
+    /// Compiles and emits <paramref name="source"/> under
+    /// <paramref name="references"/>, loads the resulting PE, invokes its
+    /// entry point, and returns captured console output.
+    /// </summary>
+    private static string CompileAndRun(string contextName, ReferenceResolver references, string source)
+    {
+        using var peStream = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(references, tree);
+        var result = compilation.Emit(peStream);
+
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(contextName, isCollectible: true);
+        try
+        {
+            var asm = loadContext.LoadFromStream(peStream);
+            var programType = asm.GetTypes().FirstOrDefault(t => t.Name == "<Program>");
+            Assert.NotNull(programType);
+            var entry = programType!.GetMethod(
+                "<Main>$",
+                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(entry);
+
+            var stdout = Console.Out;
+            var captured = new StringWriter();
+            Console.SetOut(captured);
+            try
+            {
+                entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });
+            }
+            catch (TargetInvocationException ex) when (ex.InnerException is AggregateException agg)
+            {
+                throw agg.InnerException ?? agg;
+            }
+            finally
+            {
+                Console.SetOut(stdout);
+            }
+
+            return captured.ToString();
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+
+    // Repro shape from the issue: a generic ASYNC function whose parameter
+    // is typed as the imported constructed generic CLR interface
+    // `IReadOnlyList[T]`, parameterized by the function's OWN type parameter
+    // `T`. The parameter is read only after an `await`, so the async
+    // state-machine rewriter must hoist it into a state-machine field typed
+    // `IReadOnlyList[T]`. Calling it with a `List[int32]` argument closes
+    // `T` over `int32`, forcing `StateMachineEmitter` to construct the
+    // state-machine struct via `StructSymbol.Construct(smClass, [int32])` —
+    // substituting the hoisted field's imported generic type argument.
+    private const string Source = """
+        package Corpus.Issue2037
+
+        import System
+        import System.Collections.Generic
+        import System.Threading.Tasks
+
+        func RepeatCount[T](items IReadOnlyList[T]) IEnumerable[int32] {
+            yield items.Count
+            yield items.Count
+        }
+
+        var numbers = List[int32]{ 1, 2, 3, 4, 5, 6, 7 }
+        var total = 0
+        for value in RepeatCount(numbers) {
+            total = total + value
+        }
+        Console.WriteLine("Count=$total")
+        """;
+
+    [Fact]
+    public void GenericIterator_HoistsImportedGenericParameter_CompilesAndRunsUnderMetadataLoadContext()
+    {
+        // Before the fix: StateMachineEmitter's GetEnumerator/kickoff
+        // Construct call site dropped mapClrType, so building the
+        // constructed iterator state-machine type over the caller's closed
+        // type argument (`int32`) risked the #1958 MakeGenericType
+        // cross-reflection-context erasure for the hoisted `items` field
+        // (typed `IReadOnlyList[T]`) under MLC. This end-to-end smoke test
+        // exercises the exact call site (a generic iterator function whose
+        // parameter is an imported constructed generic over its own type
+        // parameter, read across a `yield` boundary so it is hoisted).
+        var output = CompileAndRun("Issue2037StateMachine", MetadataLoadContextResolver(), Source);
+        Assert.Contains("Count=14", output);
+    }
+
+    [Fact]
+    public void GenericIterator_HoistsImportedGenericParameter_ControlCase_DefaultResolver()
+    {
+        // Control case: the identical source must already succeed under the
+        // default (non-MLC, single reflection context) resolver, confirming
+        // the fix does not regress the common host-mode compile path.
+        var output = CompileAndRun("Issue2037StateMachineDefault", ReferenceResolver.Default(), Source);
+        Assert.Contains("Count=14", output);
+    }
+
+    /// <summary>
+    /// Build a <see cref="ReferenceResolver"/> rooted at the BCL reference
+    /// assemblies (narrower than <see cref="MetadataLoadContextResolver"/>),
+    /// mirroring the symbol-layer harness in
+    /// <c>Issue1958StructMemberGenericSubstitutionTests</c>.
+    /// </summary>
+    private static ReferenceResolver NarrowMetadataLoadContextResolver()
+    {
+        var paths = new[]
+        {
+            typeof(object).Assembly.Location,
+            typeof(System.Collections.Generic.List<>).Assembly.Location,
+            typeof(System.Console).Assembly.Location,
+            typeof(System.Linq.Enumerable).Assembly.Location,
+        }
+        .Where(p => !string.IsNullOrEmpty(p))
+        .Distinct(StringComparer.OrdinalIgnoreCase)
+        .ToArray();
+
+        return ReferenceResolver.WithReferences(paths);
+    }
+
+    /// <summary>
+    /// Builds a <see cref="StructSymbol"/> shaped like the synthesized
+    /// state-machine struct <see cref="Emit.StateMachineEmitter"/> passes to
+    /// <c>StructSymbol.Construct</c> at its kickoff/<c>GetEnumerator</c> call
+    /// sites: a single class-level type parameter (mirroring the enclosing
+    /// method's own hoisted type parameter, e.g. <c>T</c>) and a single
+    /// hoisted field typed as an imported constructed generic
+    /// (<c>IReadOnlyList[T]</c>) parameterized by that class-level parameter
+    /// — the exact shape a hoisted generic-typed parameter/local produces.
+    /// </summary>
+    private static (StructSymbol Definition, TypeParameterSymbol Tp) BuildStateMachineLikeStruct(ReferenceResolver resolver)
+    {
+        var openListDef = resolver.MapClrTypeToReferences(typeof(System.Collections.Generic.IReadOnlyList<>));
+        var mlcObject = resolver.MapClrTypeToReferences(typeof(object));
+
+        var tp = new TypeParameterSymbol("T", 0, TypeParameterConstraint.Any, TypeParameterVariance.None);
+        var hoistedFieldType = ImportedTypeSymbol.GetConstructed(
+            openListDef.MakeGenericType(mlcObject),
+            openListDef,
+            System.Collections.Immutable.ImmutableArray.Create<TypeSymbol>(tp));
+
+        var fields = System.Collections.Immutable.ImmutableArray.Create(
+            new FieldSymbol("items", hoistedFieldType, Accessibility.Public));
+        var definition = new StructSymbol("<Repeat>d__0", fields, Accessibility.Public, declaration: null, packageName: "Corpus.Issue2037");
+        definition.SetTypeParameters(System.Collections.Immutable.ImmutableArray.Create(tp));
+
+        return (definition, tp);
+    }
+
+    [Fact]
+    public void StateMachineShapedStruct_Construct_WithMapClrType_ProjectsHoistedFieldAcrossReflectionContexts()
+    {
+        // Directly exercises the mechanism StateMachineEmitter's fixed
+        // Construct call sites now rely on
+        // (`this.emitCtx.References.MapClrTypeToReferences`): closing the
+        // state-machine-shaped struct's own type parameter over `int32` must
+        // substitute the hoisted `items` field's imported generic type
+        // argument too, not just the struct's own type-argument list.
+        var resolver = NarrowMetadataLoadContextResolver();
+        var (definition, _) = BuildStateMachineLikeStruct(resolver);
+
+        var constructed = StructSymbol.Construct(
+            definition,
+            System.Collections.Immutable.ImmutableArray.Create<TypeSymbol>(TypeSymbol.Int32),
+            resolver.MapClrTypeToReferences);
+
+        var substitutedFieldType = Assert.IsType<ImportedTypeSymbol>(constructed.Fields[0].Type);
+        Assert.Same(TypeSymbol.Int32, Assert.Single(substitutedFieldType.TypeArguments));
+    }
+
+    [Fact]
+    public void StateMachineShapedStruct_Construct_WithoutMapClrType_ErasesHoistedFieldUnderMetadataLoadContext()
+    {
+        // Control case proving the pre-#2037 failure mode: the (still
+        // present, for same-compilation-only callers) `mapClrType: null`
+        // default degrades gracefully via the #1958 catch/Debug.WriteLine
+        // fallback rather than throwing, but silently leaves the hoisted
+        // field's type argument un-substituted (`IReadOnlyList[T]` instead of
+        // `IReadOnlyList[int32]`) — the exact regression #2037 closes for
+        // StateMachineEmitter's two call sites by threading
+        // `this.emitCtx.References.MapClrTypeToReferences` instead of `null`.
+        var resolver = NarrowMetadataLoadContextResolver();
+        var (definition, tp) = BuildStateMachineLikeStruct(resolver);
+
+        var constructed = StructSymbol.Construct(
+            definition,
+            System.Collections.Immutable.ImmutableArray.Create<TypeSymbol>(TypeSymbol.Int32));
+
+        var unsubstitutedFieldType = Assert.IsType<ImportedTypeSymbol>(constructed.Fields[0].Type);
+        Assert.Same(tp, Assert.Single(unsubstitutedFieldType.TypeArguments));
+    }
+}
+


### PR DESCRIPTION
Fixes #2037

> **Depends on #2032** (fixes #1958), which is not yet merged into `main`. This branch merges `fix/1958-interfacesymbol-substitute` so the `Func<Type,Type> mapClrType` projector plumbing (`InterfaceSymbol.Construct`/`StructSymbol.Construct`) exists to thread through. Once #2032 merges to `main`, this diff will shrink to just the 7 files below.

## What changed

Threads the `mapClrType` projector to the 3 `Construct(...)` call sites #2037 flagged as left at the default `null` projector after #2032:

1. **`StateMachineEmitter.cs`** (both kickoff `Construct` call sites — iterator `GetEnumerator`/kickoff and async kickoff): passes `this.emitCtx.References.MapClrTypeToReferences`, which was already in scope. Closes the gap for a hoisted state-machine field typed as an imported constructed generic over the enclosing async/iterator method's own type parameter under a cross-reflection-context (MLC / cs2gs) compile.

2. **`SynthesizedClosureReifier.Reify`**: added an optional `Func<Type, Type> mapClrType` parameter (default `null`, preserving prior behavior), threaded through its `StructSymbol.Construct` call. Both its callers now supply a projector:
   - `ClosureEmitter` (emit-time): `this.emitCtx.References.MapClrTypeToReferences`.
   - `Lowering.CaptureBoxingRewriter.Lower` (a lowering pass that runs before emit): gained its own optional `mapClrType` parameter, threaded from both `Compilation.Emit`/`EmitToStream` call sites via `(References ?? ReferenceResolver.Default()).MapClrTypeToReferences` (the `References` property was already in scope at both sites).

3. **`OverloadResolver.cs`** (both user-type `Construct` call sites, lines ~2677/3482 pre-merge): added a `MapClrType` helper property (`binderCtx.References.MapClrTypeToReferences`) and threaded it through. Investigated whether these are reachable with an imported generic arg: `classType` at both sites is always a source-declared `StructSymbol` resolved by name in the current binder scope — construction of an *imported* CLR generic type never goes through `OverloadResolver.BindConstructorCallExpression`'s `StructSymbol.Construct` path. Documented this in a doc-comment on the new property rather than skipping the plumbing outright, since threading it is free and consistent with the other two sites, and covers a future imported-generic-arg path without another audit.

## Tests

`Issue2037StateMachineMlcProjectionEmitTests`:
- Two end-to-end MLC compile+run tests (`GenericIterator_HoistsImportedGenericParameter_*`): a generic iterator function whose parameter is an imported constructed generic (`IReadOnlyList[T]`) over its own type parameter `T`, read across a `yield` boundary (forcing hoisting), called with a closed `int32` argument — compiles and runs correctly both under a full-shared-framework `MetadataLoadContext` resolver (cs2gs's actual reference-resolution mode) and the default resolver.
- Two symbol-layer tests (`StateMachineShapedStruct_Construct_*`), mirroring the `Issue1958StructMemberGenericSubstitutionTests` convention: build a `StructSymbol` shaped exactly like the state-machine struct `StateMachineEmitter` passes to `Construct` (a class-level type parameter + a hoisted field typed as an imported constructed generic over it), then directly assert `Construct(..., resolver.MapClrTypeToReferences)` substitutes the field's type argument correctly under MLC, while `Construct(...)` with no projector (the pre-#2037 behavior) silently erases it back to the open type parameter — the exact regression these fixed call sites now avoid.

## Verification

- `dotnet build src/Compiler/Compiler.csproj -c Release`: succeeds, 0 warnings, 0 errors.
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release`: **5461 passed, 0 failed, 1 skipped** (pre-existing skip).
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release`: **987 passed, 0 failed**.

## Deferred

Nothing deferred — all 3 sites from the issue were fixed; none were unreachable or required disproportionate API churn.
