### PR TITLE
cs2gs: qualify extension-block static owner + map receiver-parameter modifiers (#2009)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue2009ExtensionBlockFollowUpTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2009ExtensionBlockFollowUpTranslationTests.cs
@@ -1,0 +1,310 @@
+// <copyright file="Issue2009ExtensionBlockFollowUpTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #2009: PR #2007 (#1879) Opus-review follow-ups, hardening the C# 14
+/// <c>extension(T x) { ... }</c> block translation:
+/// <list type="bullet">
+/// <item>a static extension member's call-site qualifier used the extension
+/// block's containing class's BARE simple name
+/// (<c>IdentifierExpression(SanitizeIdentifier(extOwner.Name))</c>), which does
+/// not resolve when that class is nested inside another type and its simple
+/// name collides with another source type elsewhere in the compilation. The
+/// fix routes the qualifier through <c>StaticQualifierReceiver</c> — the same
+/// nested-type-qualification machinery (<c>CSharpTypeMapper.QualifiedTypeName</c>)
+/// already used for a bare sibling static field/call reference
+/// (ADR-0115 §B.18).</item>
+/// <item>a <c>ref</c>/<c>in</c>/<c>scoped</c> modifier on the block's receiver
+/// parameter (<c>extension(ref T x)</c>) was silently ignored. gsc's receiver
+/// clause grammar (ADR-0019) accepts the same modifier tokens syntactically,
+/// but its declaration binder never threads by-ref/scoped semantics onto the
+/// bound receiver parameter — printing the modifier would therefore parse but
+/// silently drop its semantics (a genuine silent miscompile). There is no safe
+/// mapping, so this now reports an explicit, loud CS2GS-GAP diagnostic instead.</item>
+/// </list>
+/// </summary>
+public class Issue2009ExtensionBlockFollowUpTranslationTests
+{
+    [Fact]
+    public void StaticExtensionMember_CrossNamespaceCaller_QualifiesOwnerAndResolves()
+    {
+        // The extension block's declaring class (`Corpus.Ext.Helpers`) must be
+        // top-level and non-generic (Roslyn CS9283), so it can never itself be
+        // nested/generic — but the CALLER can legitimately live in a different
+        // namespace, exactly as a classic extension method requires a `using`
+        // for the declaring namespace. This proves the rewritten qualifier
+        // still resolves correctly through the shared
+        // `StaticQualifierReceiver`/`QualifiedTypeName` machinery once the
+        // owner is threaded through it instead of a raw bare identifier.
+        string rendered = Render(@"
+namespace Corpus.Ext
+{
+    public static class Helpers
+    {
+        extension(string s)
+        {
+            public static string Shout(string value)
+            {
+                return value.ToUpperInvariant() + ""!"";
+            }
+        }
+    }
+}
+
+namespace Corpus.Caller
+{
+    using Corpus.Ext;
+
+    public static class Program
+    {
+        public static string Run()
+        {
+            return string.Shout(""hi"");
+        }
+    }
+}
+");
+
+        Assert.Contains("Helpers.Shout(\"hi\")", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("string.Shout", rendered, StringComparison.Ordinal);
+
+        AssertRoundTripParses(rendered);
+
+        var diagnostics = BindDiagnostics(rendered);
+        Assert.DoesNotContain(diagnostics, d => d.Severity == GSharp.Core.CodeAnalysis.DiagnosticSeverity.Error);
+    }
+
+    [Fact]
+    public void SiblingStaticCall_NestedHomonymOwner_QualifiesThroughContainingTypeChain()
+    {
+        // `StaticQualifierReceiver` is the SAME shared qualifier the extension-
+        // block owner rewrite now reuses (issue #2009); this proves its
+        // non-generic branch — previously a raw `owner.Name` bypassing
+        // `CSharpTypeMapper.QualifiedTypeName` entirely — now correctly
+        // qualifies a NESTED owner through its containing-type chain when its
+        // simple name collides with another source type, exactly like the
+        // nested-type reference fix in issue #1174. `Holder` is declared twice:
+        // once as an unrelated top-level class, and once nested inside
+        // `Outer`, where the actual sibling static method being called lives.
+        string rendered = Render(@"
+namespace Corpus.Sibling
+{
+    public class Holder
+    {
+        public int Unrelated;
+    }
+
+    public static class Outer
+    {
+        public static class Holder
+        {
+            private static int Tab = 5;
+
+            public static int Read()
+            {
+                return Tab;
+            }
+
+            public static int ReadTwice()
+            {
+                return Read() + Read();
+            }
+        }
+    }
+}
+");
+
+        // The bare sibling call is rewritten to the FULLY qualified nested
+        // owner...
+        Assert.Contains("Outer.Holder.Read()", rendered, StringComparison.Ordinal);
+
+        AssertRoundTripParses(rendered);
+
+        // Binding the printed G# end to end proves the qualified reference
+        // resolves against the NESTED type — the top-level homonym does not
+        // declare `Read` at all and would fail member lookup (GS0158) if the
+        // bare simple name had bound to it instead.
+        var diagnostics = BindDiagnostics(rendered);
+        Assert.DoesNotContain(diagnostics, d => d.Id == "GS0158");
+        Assert.DoesNotContain(diagnostics, d => d.Severity == GSharp.Core.CodeAnalysis.DiagnosticSeverity.Error);
+    }
+
+    [Fact]
+    public void StaticExtensionMember_NoHomonymOwner_KeepsSimpleNameQualifier()
+    {
+        // Without a homonym collision, the owner keeps its bare simple name
+        // (no gratuitous qualification), mirroring issue #1174's
+        // no-collision case for nested-type references.
+        string rendered = Render(@"
+namespace Corpus.NoCollision
+{
+    public static class Extensions
+    {
+        extension(string)
+        {
+            public static string Meaning => ""forty-two"";
+        }
+    }
+
+    public static class Caller
+    {
+        public static string Run()
+        {
+            return string.Meaning;
+        }
+    }
+}
+");
+
+        Assert.Contains("Extensions.Meaning", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+
+        var diagnostics = BindDiagnostics(rendered);
+        Assert.DoesNotContain(diagnostics, d => d.Severity == GSharp.Core.CodeAnalysis.DiagnosticSeverity.Error);
+    }
+
+    [Fact]
+    public void ExtensionBlock_RefReceiver_ReportsLoudGap()
+    {
+        AssertReceiverModifierReportsLoudGap(@"
+namespace Corpus.Issue2009
+{
+    public struct Point
+    {
+        public int X;
+    }
+
+    public static class E
+    {
+        extension(ref Point p)
+        {
+            public void DoubleX()
+            {
+                p.X *= 2;
+            }
+        }
+    }
+}
+");
+    }
+
+    [Fact]
+    public void ExtensionBlock_InReceiver_ReportsLoudGap()
+    {
+        AssertReceiverModifierReportsLoudGap(@"
+namespace Corpus.Issue2009
+{
+    public struct Point
+    {
+        public int X;
+    }
+
+    public static class E
+    {
+        extension(in Point p)
+        {
+            public int GetX()
+            {
+                return p.X;
+            }
+        }
+    }
+}
+");
+    }
+
+    [Fact]
+    public void ExtensionBlock_ScopedReceiver_ReportsLoudGap()
+    {
+        AssertReceiverModifierReportsLoudGap(@"
+using System;
+
+namespace Corpus.Issue2009
+{
+    public static class E
+    {
+        extension(scoped Span<int> s)
+        {
+            public int FirstOrZero()
+            {
+                return s.Length == 0 ? 0 : s[0];
+            }
+        }
+    }
+}
+");
+    }
+
+    private static void AssertReceiverModifierReportsLoudGap(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Source.cs", source) });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        Assert.Contains(
+            context.Diagnostics,
+            d => d.Severity == TranslationSeverity.Unsupported
+                && d.Message.Contains("receiver parameter modifier", StringComparison.Ordinal));
+    }
+
+    private static void AssertRoundTripParses(string rendered)
+    {
+        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+
+        Assert.True(
+            result.Success,
+            "Sanitized G# must round-trip-parse. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + rendered);
+    }
+
+    private static string Render(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", source) });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        // A `static class` always carries the (expected, unrelated) info-level
+        // "no direct G# form; mapped to ... 'shared { }'" diagnostic
+        // (ADR-0115 §B.11/§B.53); every extension-block fixture here needs a
+        // static class, so only assert no GAP-level diagnostic fired.
+        Assert.DoesNotContain(context.Diagnostics, d => d.Severity == TranslationSeverity.Unsupported);
+        return GSharpPrinter.Print(unit);
+    }
+
+    private static System.Collections.Generic.IEnumerable<GSharp.Core.CodeAnalysis.Diagnostic> BindDiagnostics(string gsharpSource)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(gsharpSource));
+        var scope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+        return scope.Diagnostics;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -2386,6 +2386,29 @@ public sealed class CSharpToGSharpTranslator
                 ? node.ParameterList.Parameters[0]
                 : null;
 
+            // Issue #2009: the C# 14 receiver parameter may carry `ref`/`in`/
+            // `scoped`/`ref readonly` modifiers (`extension(ref T x)`,
+            // `extension(in T x)`, `extension(scoped T x)`). G#'s own receiver
+            // CLAUSE (`func (x T) M()`, ADR-0019) reuses the general `Parameter`
+            // grammar, which syntactically accepts the same modifier tokens —
+            // but gsc's declaration binder (`DeclarationBinder.BindFunctionDeclaration`)
+            // never reads `syntax.Receiver`'s ref-kind/scoped modifier tokens when
+            // constructing the receiver's bound `ParameterSymbol`: it always binds
+            // a plain by-value receiver. Printing the modifier would therefore
+            // parse silently while gsc silently discards its by-ref/scoped
+            // semantics — a genuine silent miscompile (a `ref` receiver mutating
+            // the caller's struct in C# would instead operate on a throwaway
+            // copy in G#, with no diagnostic). No canonical G# mapping exists
+            // yet, so gap loudly instead of emitting a modifier gsc will ignore.
+            if (receiverParameter?.Modifiers.Count > 0)
+            {
+                string modifierText = string.Join(" ", receiverParameter.Modifiers.Select(m => m.Text));
+                this.context.ReportUnsupported(
+                    node,
+                    $"an extension block receiver parameter modifier ('{modifierText}') has no canonical G# mapping yet; G#'s receiver-clause grammar accepts the same modifier tokens syntactically, but gsc's binder does not honor by-ref/scoped semantics on a receiver-clause parameter, so mapping the modifier through would silently change behavior rather than gap (ADR-0115 §B.19, ADR-0019).");
+                yield break;
+            }
+
             // A receiverless block (`extension(string) { ... }`) names only the
             // extended type, with no identifier to bind — it may declare static
             // members only. A named block (`extension(string s) { ... }`) binds
@@ -11048,7 +11071,20 @@ public sealed class CSharpToGSharpTranslator
                 return new TypeExpression(this.typeMapper.Map(owner, this.context, location));
             }
 
-            return new IdentifierExpression(owner.Name);
+            // Issue #2009: route the non-generic case through the same
+            // `CSharpTypeMapper.QualifiedTypeName` logic the generic branch above
+            // already uses (via `Map`), rather than the owner's bare simple name.
+            // A top-level owner still prints as its bare (sanitized) name, but a
+            // NESTED owner — e.g. the containing class of a C# 14 `extension`
+            // block declared inside another type, or nested arbitrarily deep — is
+            // qualified through its containing-type chain (`Outer.Inner`) whenever
+            // its simple name collides with another source type, matching the
+            // qualification the generic path already gets. Without this, a bare
+            // nested owner name can bind the wrong homonymous type (or fail to
+            // resolve at all) at the call site.
+            GTypeReference mapped = this.typeMapper.Map(owner, this.context, location);
+            string qualifiedName = mapped is NamedTypeReference named ? named.Name : owner.Name;
+            return new IdentifierExpression(qualifiedName);
         }
 
         private GExpression TranslateLiteral(LiteralExpressionSyntax literal)
@@ -11230,9 +11266,15 @@ public sealed class CSharpToGSharpTranslator
                     // receiver-clause form exists for statics, ADR-0115 §B.19).
                     // Rewrite the qualifier to the real owner; the (predefined- or
                     // named-type) qualifier syntax on the C# side carries no value
-                    // to translate.
+                    // to translate. Issue #2009: use the same fully-qualified
+                    // (nested-type-aware, generic-aware) owner receiver as a bare
+                    // sibling static call/member (`StaticQualifierReceiver`),
+                    // rather than the owner's bare simple name — a bare name is
+                    // wrong when the extension block's containing class is nested
+                    // inside another type or shares its simple name with another
+                    // source type elsewhere in the compilation.
                     return new MemberAccessExpression(
-                        new IdentifierExpression(SanitizeIdentifier(extOwner.Name)),
+                        this.StaticQualifierReceiver(extOwner, member.GetLocation()),
                         SanitizeIdentifier(member.Name.Identifier.Text));
                 }
 


### PR DESCRIPTION
Fixes #2009

Follow-ups from PR #2007 (#1879) Opus review — both are hardening-only, and both currently produce loud gsc errors rather than silent miscompiles.

## Item 1 — qualified static owner

`TranslateMemberAccess`'s static-extension-member rewrite used a raw
`IdentifierExpression(SanitizeIdentifier(extOwner.Name))` for the call-site
qualifier, bypassing the translator's existing, established
nested-type/generic-aware qualification machinery
(`StaticQualifierReceiver` → `CSharpTypeMapper.QualifiedTypeName`, ADR-0115
§B.18) already used for the analogous bare-sibling-static-call/field case.

Fix: route the extension-block owner through `StaticQualifierReceiver`
instead.

Note: Roslyn (CS9283) requires a C# 14 extension block's containing class to
be **top-level and non-generic**, so the owner itself can never actually be
nested or generic — the observable output for a real extension block is
therefore unchanged today. The real, testable payoff is in
`StaticQualifierReceiver` itself: its non-generic branch previously bypassed
`QualifiedTypeName` entirely (`new IdentifierExpression(owner.Name)`, no
sanitization, no nested-homonym qualification), a latent bug shared by the
**pre-existing** bare-sibling-static-call/field path (used for ordinary
classes, which *can* be nested). Hardening it here fixes that too, and
future-proofs the extension-block path if Roslyn's restriction is ever
relaxed.

## Item 2 — receiver-parameter modifiers

`extension(ref T x)` / `in` / `scoped` variants on the block's receiver were
silently dropped. Investigation: gsc's receiver-clause grammar (`ReceiverClause
= "(" Parameter ")"`, ADR-0019) syntactically accepts the same
`ref`/`out`/`in`/`scoped` modifier tokens as an ordinary parameter — but
`DeclarationBinder`'s extension-function binder never reads
`syntax.Receiver`'s modifier tokens when constructing the bound receiver
`ParameterSymbol`; it always binds a plain by-value receiver. Printing the
modifier would therefore parse silently while gsc discards its by-ref/scoped
semantics — an actual silent miscompile (a `ref` receiver mutating the
caller's struct in C# would instead operate on a throwaway copy in G#, with no
diagnostic).

Since no safe mapping exists today, this now reports an explicit
`ReportUnsupported` (CS2GS-GAP) diagnostic and skips translating the block,
rather than emitting a modifier gsc would silently ignore.

## Tests

`Issue2009ExtensionBlockFollowUpTranslationTests.cs`:
- cross-namespace extension-block static call still resolves through the
  shared qualifier machinery (regression safety)
- a nested-homonym-owner sibling static call now qualifies through its
  containing-type chain and binds against the correct (nested) type, not a
  top-level homonym — proven via `gsc`'s own `Binder.BindGlobalScope` with no
  `GS0158`/error diagnostics
- `extension(ref T x)`, `extension(in T x)`, and `extension(scoped Span<int> s)`
  each report a loud `CS2GS-GAP` mentioning "receiver parameter modifier"

## Verification

- `dotnet build tools/cs2gs/Cs2Gs.Cli/Cs2Gs.Cli.csproj -c Release` — clean
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release` — 993/993 green (up from 987)
- `dotnet build GSharp.sln -c Release` — clean, then `cs2gs coverage --write` — no diff (behavior for tracked constructs unchanged, as expected)
- `cs2gs migrate --corpus tools/cs2gs/corpus --baseline tools/cs2gs/triage/gaps.json` — baseline: 3 known, **0 new, 0 regressed**, 0 stale

## Deferred / out of scope

- The general (non-extension) cross-namespace, top-level same-simple-name
  collision gap (two top-level classes sharing a simple name in different C#
  namespaces both print as their bare name, since `QualifiedTypeName` only
  disambiguates *nested* types) is a **pre-existing, broader** translator
  limitation, not specific to extension blocks. Left out of scope for this
  issue; worth its own follow-up if it surfaces in practice.
