### PR TITLE
gsc: emit user attributes on primary-ctor and delegate Invoke parameters (#2006)

### DIFF
--- a/src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/TypeDefEmitter.cs
@@ -950,6 +950,7 @@ internal sealed class TypeDefEmitter
                 });
 
         var invokeFirstParamHandle = this.nextParameterHandle();
+        var invokeParamHandles = ImmutableArray.CreateBuilder<ParameterHandle>(delegateSym.Parameters.Length);
         for (var i = 0; i < delegateSym.Parameters.Length; i++)
         {
             var p = delegateSym.Parameters[i];
@@ -970,6 +971,7 @@ internal sealed class TypeDefEmitter
                 attributes: paramAttributes,
                 name: this.emitCtx.Metadata.GetOrAddString(p.Name ?? $"arg{i + 1}"),
                 sequenceNumber: (ushort)(i + 1));
+            invokeParamHandles.Add(paramHandle);
 
             if (p.RefKind == RefKind.In)
             {
@@ -1000,6 +1002,11 @@ internal sealed class TypeDefEmitter
             bodyOffset: -1,
             parameterList: invokeParamList);
         this.cache.DelegateInvokeHandles[delegateSym] = invokeHandle;
+
+        // Issue #2006: delegate Invoke parameters must keep their user
+        // annotations same as the other Parameter-row-minting emit sites, or
+        // @Note-style attributes silently vanish for delegate params.
+        this.EmitUserAttributesOnParameters(invokeParamHandles.MoveToImmutable(), delegateSym.Parameters);
 
         // ADR-0047 §3: user annotations targeting the delegate type land on
         // the TypeDef row (same as struct/interface/enum).
@@ -1397,9 +1404,9 @@ internal sealed class TypeDefEmitter
         // consumers see `params` at the construction site. Adding Parameter
         // rows here also gives every primary-ctor parameter a metadata name
         // (parallel to the explicit `init(...)` emit path).
-        var firstParamHandle = this.AddPrimaryCtorParameterRows(parameters);
+        var firstParamHandle = this.AddPrimaryCtorParameterRows(parameters, out var paramHandles);
 
-        return this.emitCtx.Metadata.AddMethodDefinition(
+        var ctorHandle = this.emitCtx.Metadata.AddMethodDefinition(
             attributes: MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.SpecialName
                 | MethodAttributes.RTSpecialName,
             implAttributes: MethodImplAttributes.IL | MethodImplAttributes.Managed,
@@ -1407,6 +1414,13 @@ internal sealed class TypeDefEmitter
             signature: this.emitCtx.Metadata.GetOrAddBlob(ctorSig),
             bodyOffset: bodyOffset,
             parameterList: firstParamHandle);
+
+        // Issue #2006: primary-ctor parameters must keep their user
+        // annotations same as explicit ctors / interface methods, or
+        // @Note-style attributes silently vanish for primary-ctor params.
+        this.EmitUserAttributesOnParameters(paramHandles, parameters);
+
+        return ctorHandle;
     }
 
     /// <summary>
@@ -1449,9 +1463,9 @@ internal sealed class TypeDefEmitter
         // consumers see `params` at the construction site. Adding Parameter
         // rows here also gives every primary-ctor parameter a metadata name
         // (parallel to the explicit `init(...)` emit path).
-        var firstParamHandle = this.AddPrimaryCtorParameterRows(parameters);
+        var firstParamHandle = this.AddPrimaryCtorParameterRows(parameters, out var paramHandles);
 
-        return this.emitCtx.Metadata.AddMethodDefinition(
+        var ctorHandle = this.emitCtx.Metadata.AddMethodDefinition(
             attributes: MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.SpecialName
                 | MethodAttributes.RTSpecialName,
             implAttributes: MethodImplAttributes.IL | MethodImplAttributes.Managed,
@@ -1459,6 +1473,13 @@ internal sealed class TypeDefEmitter
             signature: this.emitCtx.Metadata.GetOrAddBlob(ctorSig),
             bodyOffset: bodyOffset,
             parameterList: firstParamHandle);
+
+        // Issue #2006: primary-ctor parameters must keep their user
+        // annotations same as explicit ctors / interface methods, or
+        // @Note-style attributes silently vanish for primary-ctor params.
+        this.EmitUserAttributesOnParameters(paramHandles, parameters);
+
+        return ctorHandle;
     }
 
     /// <summary>
@@ -1474,14 +1495,18 @@ internal sealed class TypeDefEmitter
     /// <see cref="ParameterAttributes.Out"/> or the
     /// <c>IsReadOnlyAttribute</c> modreq.
     /// </summary>
-    private ParameterHandle AddPrimaryCtorParameterRows(ImmutableArray<ParameterSymbol> parameters)
+    /// <param name="parameters">The primary constructor's source parameters.</param>
+    /// <param name="paramHandles">Every emitted Parameter row handle, in source-parameter order — feed into <see cref="EmitUserAttributesOnParameters"/> so per-parameter annotations are never dropped (issue #2006).</param>
+    private ParameterHandle AddPrimaryCtorParameterRows(ImmutableArray<ParameterSymbol> parameters, out ImmutableArray<ParameterHandle> paramHandles)
     {
         if (parameters.IsDefaultOrEmpty)
         {
+            paramHandles = ImmutableArray<ParameterHandle>.Empty;
             return this.nextParameterHandle();
         }
 
         var first = this.nextParameterHandle();
+        var handles = ImmutableArray.CreateBuilder<ParameterHandle>(parameters.Length);
         for (var i = 0; i < parameters.Length; i++)
         {
             var p = parameters[i];
@@ -1489,6 +1514,7 @@ internal sealed class TypeDefEmitter
                 attributes: ParameterAttributes.None,
                 name: this.emitCtx.Metadata.GetOrAddString(p.Name ?? string.Empty),
                 sequenceNumber: i + 1);
+            handles.Add(paramHandle);
 
             if (p.IsVariadic)
             {
@@ -1496,6 +1522,7 @@ internal sealed class TypeDefEmitter
             }
         }
 
+        paramHandles = handles.MoveToImmutable();
         return first;
     }
 

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue2006ParamAttributeEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue2006ParamAttributeEmitTests.cs
@@ -1,0 +1,142 @@
+// <copyright file="Issue2006ParamAttributeEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Core.Tests.Fixtures;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #2006 (round-3 rubber-duck re-review follow-up to #1913/#1993): two
+/// more <c>TypeDefEmitter</c> emit paths mint Parameter rows but never call
+/// <c>EmitUserAttributesOnParameters</c> — <c>AddPrimaryCtorParameterRows</c>
+/// (used by both <c>EmitClassPrimaryConstructor</c> and
+/// <c>EmitClassConstructorWithBaseInitializer</c>) and the delegate
+/// <c>Invoke</c> parameter loop in <c>EmitDelegateTypeDef</c>. The binder
+/// attaches the attribute to the <c>ParameterSymbol</c> correctly (proven by
+/// AttributeUsage validation firing), but it silently never reaches the
+/// emitted metadata. These tests read the compiled assembly's real Parameter
+/// metadata via reflection (<see cref="ParameterInfo.GetCustomAttributes(bool)"/>)
+/// — the same empirical technique used in <c>Issue1913ParamAttributeEmitTests</c>
+/// — rather than just asserting the binder-level symbol.
+/// </summary>
+public class Issue2006ParamAttributeEmitTests
+{
+    private const string NoteAttributeDecl = @"
+class NoteAttribute(Text string) : Attribute {
+}
+";
+
+    [Fact]
+    public void PrimaryCtorParameter_NoBaseInitializer_UserAttribute_RoundTripsThroughReflection()
+    {
+        const string Source = @"package Issue2006PrimCtor
+import System
+" + NoteAttributeDecl + @"
+
+class Box(@Note(""prim"") z int32) {
+}
+";
+        var asm = CompileToAssembly(Source, nameof(PrimaryCtorParameter_NoBaseInitializer_UserAttribute_RoundTripsThroughReflection));
+        var box = asm.GetTypes().Single(t => t.Name == "Box");
+        var ctor = box.GetConstructors().Single(c => c.GetParameters().Length == 1);
+        var param = ctor.GetParameters()[0];
+        Assert.Equal("z", param.Name);
+
+        var attrs = param.GetCustomAttributes(true);
+        Assert.Single(attrs);
+        Assert.Equal("NoteAttribute", attrs[0].GetType().Name);
+        var textProp = attrs[0].GetType().GetField("Text") ?? (MemberInfo)attrs[0].GetType().GetProperty("Text");
+        var textValue = textProp switch
+        {
+            FieldInfo f => f.GetValue(attrs[0]),
+            PropertyInfo p => p.GetValue(attrs[0]),
+            _ => null,
+        };
+        Assert.Equal("prim", textValue);
+    }
+
+    [Fact]
+    public void PrimaryCtorParameter_WithBaseInitializer_UserAttribute_RoundTripsThroughReflection()
+    {
+        const string Source = @"package Issue2006PrimCtorBase
+import System
+" + NoteAttributeDecl + @"
+
+open class Animal(Name string) {
+}
+
+class Dog(@Note(""derived"") Name string) : Animal(Name) {
+}
+";
+        var asm = CompileToAssembly(Source, nameof(PrimaryCtorParameter_WithBaseInitializer_UserAttribute_RoundTripsThroughReflection));
+        var dog = asm.GetTypes().Single(t => t.Name == "Dog");
+        var ctor = dog.GetConstructors().Single(c => c.GetParameters().Length == 1);
+        var param = ctor.GetParameters()[0];
+        Assert.Equal("Name", param.Name);
+
+        var attrs = param.GetCustomAttributes(true);
+        Assert.Single(attrs);
+        Assert.Equal("NoteAttribute", attrs[0].GetType().Name);
+        var textProp = attrs[0].GetType().GetField("Text") ?? (MemberInfo)attrs[0].GetType().GetProperty("Text");
+        var textValue = textProp switch
+        {
+            FieldInfo f => f.GetValue(attrs[0]),
+            PropertyInfo p => p.GetValue(attrs[0]),
+            _ => null,
+        };
+        Assert.Equal("derived", textValue);
+    }
+
+    [Fact]
+    public void DelegateInvokeParameter_UserAttribute_RoundTripsThroughReflection()
+    {
+        // Named delegates are bound before user struct/class declarations in
+        // the same compilation (ADR-0059 / issue #255 declaration ordering),
+        // so a delegate-parameter attribute type must come from an already
+        //-compiled reference assembly here rather than a same-file
+        // `class NoteAttribute(...)`, which would not yet be resolvable when
+        // the delegate's parameters are bound.
+        const string Source = @"package Issue2006Delegate
+import System
+import GSharp.Core.Tests.Fixtures
+
+type IntPredicate = delegate func(@ImportedDefault a int32) bool
+";
+        var asm = CompileToAssembly(Source, nameof(DelegateInvokeParameter_UserAttribute_RoundTripsThroughReflection));
+        var del = asm.GetTypes().Single(t => t.Name == "IntPredicate");
+        var invoke = del.GetMethod("Invoke", BindingFlags.Public | BindingFlags.Instance);
+        Assert.NotNull(invoke);
+        var param = invoke!.GetParameters()[0];
+        Assert.Equal("a", param.Name);
+
+        var attrs = param.GetCustomAttributes(true);
+        Assert.Single(attrs);
+        Assert.Equal("ImportedDefaultAttribute", attrs[0].GetType().Name);
+    }
+
+    private static Assembly CompileToAssembly(string source, string contextName)
+    {
+        using var peStream = new MemoryStream();
+        var fixturePath = typeof(ImportedGreeter).Assembly.Location;
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(ReferenceResolver.WithReferences(new[] { fixturePath }), tree);
+        var result = compilation.Emit(peStream);
+        Assert.True(
+            result.Success,
+            "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        var loadContext = new AssemblyLoadContext(contextName, isCollectible: true);
+        return loadContext.LoadFromStream(peStream);
+    }
+}


### PR DESCRIPTION
Fixes #2006

PR #1993 added a shared `EmitUserAttributesOnParameters` helper for regular constructors, interface methods, and static-virtual interface methods, but two more Parameter-row-minting emit sites had the exact same bug and were missed:

- `AddPrimaryCtorParameterRows` (feeds both `EmitClassPrimaryConstructor` and `EmitClassConstructorWithBaseInitializer`) minted Parameter rows but never called the helper, so a primary-ctor parameter's user attributes were silently dropped at emit even though the binder attached them correctly (AttributeUsage validation fires at bind time — this was purely an emit-layer gap).
- `EmitDelegateTypeDef`'s `Invoke` parameter loop had the same gap for named-delegate parameters.

## Fix

Both sites now collect their Parameter handles (`AddPrimaryCtorParameterRows` gained an `out ImmutableArray<ParameterHandle>` like the sibling `AddRefKindAwareParameterRows`) and call `EmitUserAttributesOnParameters` right after minting the rows, matching the three already-fixed call sites exactly.

## Audit of other Parameter-row-minting sites

Checked every remaining `AddParameter` call site in `TypeDefEmitter.cs`, `MemberDefEmitter.cs`, and `ReflectionMetadataEmitter.cs`:
- `EmitFunction`, the `@DllImport` path, and the `@LibraryImport` outer stub already call the attribute helper (lines already wired from prior fixes).
- The rest — delegate `.ctor`'s synthesized `object`/`IntPtr` params, property/event `value` setter params, event-invoke `argN` params, and the `@LibraryImport` inner P/Invoke stub params — are all compiler-synthesized parameters with no source `ParameterSymbol` a user attribute could ever attach to, so no further fix is needed.

## Tests

Added `Issue2006ParamAttributeEmitTests` (same reflection-readback pattern as `Issue1913ParamAttributeEmitTests`) covering:
- A primary-ctor parameter with no base-constructor initializer (`EmitClassPrimaryConstructor`).
- A primary-ctor parameter with an explicit base-constructor initializer (`EmitClassConstructorWithBaseInitializer`).
- A named-delegate `Invoke` parameter.

Verified all three tests fail (empty attribute list) against the pre-fix code and pass after the fix.

## Test results

- `dotnet build src/Compiler/Compiler.csproj -c Release`: succeeded.
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release`: 5455 passed, 0 failed, 1 skipped (pre-existing).