### PR TITLE
gsc: fix NRE binding ??= compound-assignment on static field (#2043)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/StatementBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.cs
@@ -4826,7 +4826,14 @@ internal sealed class StatementBinder
                     }
                 }
 
-                var receiver = CaptureReceiver(syntax, fieldAccess.Receiver, preStatements);
+                // Issue #2043: a static field's bound read has a null
+                // Receiver (there is no instance to dereference); only
+                // capture a receiver local when one actually exists. Calling
+                // CaptureReceiver unconditionally NREs on receiver.Type for
+                // the static case.
+                var receiver = fieldAccess.Receiver == null
+                    ? null
+                    : CaptureReceiver(syntax, fieldAccess.Receiver, preStatements);
                 var read = new BoundFieldAccessExpression(syntax, receiver, fieldAccess.StructType, fieldAccess.Field);
 
                 // Use the VariableSymbol-based constructor: every receiver
@@ -4836,7 +4843,7 @@ internal sealed class StatementBinder
                 // existing rewriters all assume this shape for the simple
                 // receiver path; routing through ReceiverExpression bypasses
                 // the interpreter's class-field write logic (issue #709).
-                var write = new BoundFieldAssignmentExpression(syntax, receiver.Variable, fieldAccess.StructType, fieldAccess.Field, boundRhs);
+                var write = new BoundFieldAssignmentExpression(syntax, receiver?.Variable, fieldAccess.StructType, fieldAccess.Field, boundRhs);
                 return (read, write);
             }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2043NullCoalesceStaticFieldTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2043NullCoalesceStaticFieldTests.cs
@@ -1,0 +1,129 @@
+// <copyright file="Issue2043NullCoalesceStaticFieldTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2043: a null-coalescing compound assignment (<c>??=</c>) targeting a
+/// <c>shared{}</c> (static) field crashed the binder with a
+/// <see cref="System.NullReferenceException"/>. <see cref="StatementBinder.TryBuildNullCoalescingReadWrite"/>
+/// unconditionally called <c>CaptureReceiver</c> on the bound field access's
+/// <c>Receiver</c>, which is <c>null</c> for a static field (there is no
+/// instance to spill into a synthetic local) — dereferencing
+/// <c>receiver.Type</c> inside <c>CaptureReceiver</c> then NREd. The fix
+/// mirrors the existing null-receiver handling already used for property
+/// access (<c>propAccess.Receiver == null ? null : CaptureReceiver(...)</c>)
+/// and for plain/compound (<c>+=</c>) assignment of static fields in
+/// <c>ExpressionBinder.Assignments.cs</c>. These tests pin that a static
+/// field <c>??=</c> now binds and evaluates cleanly (no crash, no spurious
+/// diagnostics), and that the sibling instance-field case keeps working.
+/// </summary>
+public class Issue2043NullCoalesceStaticFieldTests
+{
+    [Fact]
+    public void StaticField_NullCoalesceAssign_DoesNotThrowNRE()
+    {
+        // This is the primary regression test: prior to the fix, evaluating
+        // this source threw a NullReferenceException out of the binder
+        // (surfaced by gsc as GS9998) instead of returning a clean result.
+        var source = @"
+class C {
+  shared {
+    var Field string? = nil
+  }
+}
+
+C.Field ??= ""default""
+C.Field
+";
+
+        var exception = Record.Exception(() => Evaluate(source));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void StaticField_NullCoalesceAssign_FiresWhenNil()
+    {
+        var source = @"
+class C {
+  shared {
+    var Field string? = nil
+  }
+}
+
+C.Field ??= ""default""
+C.Field
+";
+
+        var result = Evaluate(source);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("default", result.Value);
+    }
+
+    [Fact]
+    public void StaticField_NullCoalesceAssign_DoesNotFireWhenAlreadySet()
+    {
+        // The static field is set via a plain assignment first (rather than
+        // relying on its declaration initializer, which the tree-walking
+        // Evaluator does not eagerly run — a separate, pre-existing
+        // limitation unrelated to this issue) so the ??= is exercised against
+        // a genuinely non-nil static field.
+        var source = @"
+class C {
+  shared {
+    var Field string? = nil
+  }
+}
+
+C.Field = ""already""
+C.Field ??= ""default""
+C.Field
+";
+
+        var result = Evaluate(source);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("already", result.Value);
+    }
+
+    [Fact]
+    public void InstanceField_NullCoalesceAssign_StillBindsAndEvaluates()
+    {
+        // Sibling instance-field case: makes sure the static-field fix does
+        // not regress the (already-working) instance-receiver path, which
+        // spills the instance receiver into a synthetic local via
+        // CaptureReceiver.
+        var source = @"
+class C {
+  var Field string? = nil
+}
+
+var c C = C{}
+c.Field ??= ""default""
+c.Field
+";
+
+        var result = Evaluate(source);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("default", result.Value);
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
Fixes #2043

## Root cause
`TryBuildNullCoalescingReadWrite` (the binder path for `target ??= value`) unconditionally called `CaptureReceiver` on the bound field access's `Receiver` when the LHS is a field. For a **static** field the bound `Receiver` is `null` (there is no instance to spill into a synthetic local) — `CaptureReceiver` dereferences `receiver.Type` unconditionally, so it threw a `NullReferenceException` during binding. gsc surfaced this as a hard crash (`GS9998`) instead of a diagnostic.

Repro:
```
class C {
  shared {
    var Field string? = nil
  }
}

func Run() {
  C.Field ??= "default"
}
```

## Fix
Only call `CaptureReceiver` when a receiver actually exists, mirroring the pattern already used for the sibling `BoundPropertyAccessExpression` case in the same switch, and for plain/compound (`+=`) static-field assignment in `ExpressionBinder.Assignments.cs` (both already pass `receiver: null` for statics). `BoundFieldAccessExpression`/`BoundFieldAssignmentExpression` already accept a null receiver, so no downstream changes were needed.

## Other compound-assignment operators
Checked `+=`/`-=` on static fields — they bind through `ExpressionBinder.Assignments.cs`, which already null-checks the receiver correctly, so they were **not** affected by this bug. Only the `??=` path in `StatementBinder` had the unconditional dereference.

## Tests
Added `test/Core.Tests/CodeAnalysis/Binding/Issue2043NullCoalesceStaticFieldTests.cs`:
- A crash regression test asserting no exception escapes `Evaluate` for the repro above.
- A binder/interpreter test that `??=` on a nil static field fires the coalesce.
- A binder/interpreter test that `??=` on an already-set static field does **not** overwrite it.
- A sibling instance-field `??=` test guarding against regressing the existing (working) receiver-spill path.

## Verification
- `dotnet build src/Compiler/Compiler.csproj -c Release` — succeeds.
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release` — 5456 passed, 1 pre-existing skip, 0 failed.