### PR TITLE
gsc+cs2gs: harden typeof open-generic _ placeholder + add cs2gs producer (#2012)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
@@ -81,9 +81,21 @@ internal sealed partial class ExpressionBinder
             }
             else if (TryGetUnboundGenericArity(typeClause, out var arity))
             {
-                if (!TryResolveOpenGenericImportedTypeWithArity(typeClause.Identifier.Text, arity, out typeSymbol))
+                if (!TryResolveOpenGenericImportedTypeWithArity(typeClause.Identifier.Text, arity, out typeSymbol, out var isAmbiguous))
                 {
-                    Diagnostics.ReportUndefinedType(typeClause.Location, typeClause.Identifier.Text + "`" + arity);
+                    // Issue #2012 (N3): "ambiguous across imports" and "no
+                    // match at all" are different failure modes and deserve
+                    // different diagnostics — ambiguous means too MANY
+                    // candidates matched, not that the type is undefined.
+                    if (isAmbiguous)
+                    {
+                        Diagnostics.ReportAmbiguousImportedType(typeClause.Location, typeClause.Identifier.Text + "`" + arity);
+                    }
+                    else
+                    {
+                        Diagnostics.ReportUndefinedType(typeClause.Location, typeClause.Identifier.Text + "`" + arity);
+                    }
+
                     return new BoundErrorExpression(null);
                 }
             }
@@ -123,6 +135,17 @@ internal sealed partial class ExpressionBinder
         // really exist, so we walk arities upward and stop once a small
         // streak of consecutive misses (BCL generic families are always
         // contiguous, e.g. Func`1..Func`16) confirms there's nothing higher.
+        //
+        // Issue #2012 (N2): this walk assumes CONTIGUOUS arity families —
+        // a family with real members only at, say, arity 1 and arity 4,
+        // with gaps at 2 and 3, would stop after the 2-miss streak and never
+        // reach arity 4. No BCL family is shaped like this today (every
+        // multi-arity BCL generic — Func, Action, Tuple, ValueTuple, etc. —
+        // fills every arity in its range), so this is a documented
+        // limitation rather than a bug fix: a gapped family simply falls
+        // back to the ordinary "type doesn't exist" diagnostic (GS0113),
+        // never a silent wrong resolution. If a real gapped family ever
+        // needs support, bump <see cref="MaxConsecutiveArityMisses"/>.
         Type match = null;
         var missStreak = 0;
         for (var arity = 1; missStreak < MaxConsecutiveArityMisses; arity++)
@@ -157,7 +180,12 @@ internal sealed partial class ExpressionBinder
         return true;
     }
 
-    /// <summary>Issue #1989: consecutive-arity-miss streak that stops the upward arity walk in <see cref="TryResolveOpenGenericImportedType"/>.</summary>
+    /// <summary>
+    /// Issue #1989: consecutive-arity-miss streak that stops the upward
+    /// arity walk in <see cref="TryResolveOpenGenericImportedType"/>. Issue
+    /// #2012 (N2): this assumes CONTIGUOUS arity families (no gaps) — see
+    /// the walk's comment for details on why that's safe today.
+    /// </summary>
     private const int MaxConsecutiveArityMisses = 2;
 
     /// <summary>
@@ -171,13 +199,36 @@ internal sealed partial class ExpressionBinder
     /// qualifier, nested type arguments, array shape, or nullable suffix) —
     /// any real type argument is an ordinary bound generic and is left to
     /// <see cref="bindTypeClause"/>.
+    /// <para>
+    /// Issue #2012 (N1): <c>_</c> is an ordinary identifier in G#'s grammar
+    /// (it is only special-cased in pattern/discard positions, never
+    /// reserved as a type-name token), so user code CAN legally declare a
+    /// real type literally named <c>_</c> (<c>class _ {}</c>, <c>type _ =
+    /// ...</c>, or a type parameter named <c>_</c>). If such a type is in
+    /// scope, treating every <c>_</c> type argument as the unbound-generic
+    /// placeholder would silently ignore it and flip <c>Func[_]</c> from
+    /// "bound to the real type <c>_</c>" to "unbound <c>Func`1</c>" — a
+    /// genuine (if contrived) silent semantic change. So a real type named
+    /// <c>_</c> in scope always wins: this method only claims the
+    /// placeholder reading when no such type is resolvable, deferring to
+    /// <see cref="bindTypeClause"/> otherwise.
+    /// </para>
     /// </summary>
-    private static bool TryGetUnboundGenericArity(TypeClauseSyntax typeClause, out int arity)
+    private bool TryGetUnboundGenericArity(TypeClauseSyntax typeClause, out int arity)
     {
         arity = 0;
         var args = typeClause.TypeArguments;
         if (args.Count == 0)
         {
+            return false;
+        }
+
+        if (lookupType("_") != null)
+        {
+            // A real type named `_` is in scope (respecting normal
+            // shadowing/scoping rules via `lookupType`) — every `_` type
+            // argument binds to it as an ordinary type, never the
+            // open-generic placeholder.
             return false;
         }
 
@@ -203,9 +254,19 @@ internal sealed partial class ExpressionBinder
     /// never silently return the wrong (non-generic) type for names like
     /// <c>Action</c> that have both a non-generic and generic overload set.
     /// </summary>
-    private bool TryResolveOpenGenericImportedTypeWithArity(string name, int arity, out TypeSymbol type)
+    /// <param name="name">The bare generic base name (e.g. <c>Func</c>).</param>
+    /// <param name="arity">The exact requested arity.</param>
+    /// <param name="type">The resolved open-generic type on success.</param>
+    /// <param name="isAmbiguous">
+    /// Issue #2012 (N3): set to <see langword="true"/> when two or more
+    /// imports contribute DIFFERENT candidates at this arity — distinct from
+    /// the "no match at all" case — so the caller can raise the correct
+    /// ambiguity diagnostic instead of the misleading "type doesn't exist".
+    /// </param>
+    private bool TryResolveOpenGenericImportedTypeWithArity(string name, int arity, out TypeSymbol type, out bool isAmbiguous)
     {
         type = null;
+        isAmbiguous = false;
         if (string.IsNullOrEmpty(name) || arity <= 0)
         {
             return false;
@@ -219,7 +280,9 @@ internal sealed partial class ExpressionBinder
             {
                 if (match != null && match != candidate)
                 {
-                    // Ambiguous across imports — defer to the caller's diagnostic.
+                    // Ambiguous across imports — let the caller raise the
+                    // ambiguity diagnostic rather than "type doesn't exist".
+                    isAmbiguous = true;
                     return false;
                 }
 

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -4410,6 +4410,29 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
     }
 
     /// <summary>
+    /// Issue #2012 (N3): an explicit-arity open-generic <c>typeof(Name[_,
+    /// ...])</c> whose base name + requested arity (e.g. <c>Func`1</c>)
+    /// resolves to two or more DIFFERENT CLR types across the imports in
+    /// scope. Distinct from <see cref="ReportUndefinedType"/> (which means no
+    /// type matched at all): here at least two imports each contribute a
+    /// candidate and they disagree, so the previous behavior of reporting
+    /// "type doesn't exist" was a misleading diagnostic for a genuinely
+    /// different failure mode (nothing was undefined — too many things were
+    /// defined). Mirrors the wording of <see cref="ReportAmbiguousImportedStaticMember"/>
+    /// (#1201) for the analogous ambiguous-import-member case.
+    /// </summary>
+    /// <param name="location">The source location of the ambiguous type reference.</param>
+    /// <param name="name">The ambiguous arity-suffixed type name (e.g. <c>Func`1</c>).</param>
+    public void ReportAmbiguousImportedType(TextLocation location, string name)
+    {
+        Report(
+            location,
+            "GS0471",
+            $"Type '{name}' is ambiguous between two or more imported namespaces; qualify the reference to disambiguate (issue #2012).",
+            DiagnosticSeverity.Error);
+    }
+
+    /// <summary>
     /// Issue #1336: GS0415 — a <c>sizeof(T)</c> expression names a type that is
     /// not an unmanaged type. <c>sizeof</c> measures the unmanaged byte size of
     /// its operand, so the operand must be a blittable primitive, an enum, a

--- a/test/Compiler.Tests/Emit/Issue1989MultiArityOpenGenericTypeOfEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1989MultiArityOpenGenericTypeOfEmitTests.cs
@@ -99,6 +99,131 @@ public class Issue1989MultiArityOpenGenericTypeOfEmitTests
         Assert.Equal("Action\n", output);
     }
 
+    /// <summary>
+    /// Issue #2012 (S3): hardens the existing emit coverage — which only
+    /// asserted on <c>.Name</c> (a string that collapses closed and open
+    /// generics to the same value, e.g. both <c>Func&lt;int&gt;</c> and open
+    /// <c>Func`1</c> print "Func`1") — with an actual reflection <see
+    /// cref="Type"/> equality check against <c>typeof(System.Func&lt;&gt;)</c>,
+    /// proving <c>typeof(Func[_])</c> really is the same CLR open-generic
+    /// type definition, not merely a type whose name happens to match.
+    /// </summary>
+    [Fact]
+    public void EndToEnd_FuncArity1_TypeOf_ReflectionEquals_ClrOpenGenericFuncDefinition()
+    {
+        const string source = """
+            package i2012s3func1
+            import System
+
+            func Main() { System.Console.WriteLine(typeof(Func[_]).AssemblyQualifiedName) }
+            """;
+
+        var output = CompileAndRun(source);
+        var resolvedType = Type.GetType(output.Trim());
+        Assert.Equal(typeof(Func<>), resolvedType);
+    }
+
+    /// <summary>
+    /// Issue #2012 (N3): when the requested arity resolves to two or more
+    /// DIFFERENT CLR types across the imports in scope, the previous
+    /// behavior misreported "type doesn't exist" (GS0113). This is a genuine
+    /// ambiguity, not an absence, and now reports GS0471 instead.
+    /// </summary>
+    [Fact]
+    public void ExplicitArity_AmbiguousAcrossTwoImportedAssemblies_ReportsGS0471()
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_2012_amb_").FullName;
+        try
+        {
+            var aDll = Path.Combine(tempDir, "a.dll");
+            var bDll = Path.Combine(tempDir, "b.dll");
+            CompileLibrary("package pkg.a\nclass Foo[T any] {\n}\n", aDll, tempDir);
+            CompileLibrary("package pkg.b\nclass Foo[T any] {\n}\n", bDll, tempDir);
+
+            const string source = """
+                package pkg.c
+                import pkg.a
+                import pkg.b
+
+                func Main() {
+                    let t = typeof(Foo[_])
+                }
+                """;
+            var srcPath = Path.Combine(tempDir, "c.gs");
+            File.WriteAllText(srcPath, source);
+            var dllPath = Path.Combine(tempDir, "c.dll");
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/r:" + aDll,
+                "/r:" + bDll,
+                "/nowarn:GS9100",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.NotEqual(0, compileExit);
+            Assert.Contains("GS0471", stdoutWriter.ToString() + stderrWriter.ToString());
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static void CompileLibrary(string source, string dllPath, string tempDir)
+    {
+        var srcPath = Path.Combine(tempDir, Path.GetFileNameWithoutExtension(dllPath) + ".gs");
+        File.WriteAllText(srcPath, source);
+        var args = new[]
+        {
+            "/out:" + dllPath,
+            "/target:library",
+            "/targetframework:net10.0",
+            srcPath,
+        };
+
+        using var stdoutWriter = new StringWriter();
+        using var stderrWriter = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(stdoutWriter);
+        Console.SetError(stderrWriter);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed compiling library {dllPath}:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+    }
+
     private static string CompileAndRun(string source)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_1989_exe_").FullName;

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1989MultiArityOpenGenericTypeOfBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1989MultiArityOpenGenericTypeOfBindingTests.cs
@@ -121,6 +121,33 @@ class C {
         Assert.Contains(result.Diagnostics, d => d.Id == "GS0113");
     }
 
+    /// <summary>
+    /// Issue #2012 (N1): <c>_</c> is an ordinary identifier in G#'s grammar
+    /// (not a reserved type-name token), so user code can legally declare a
+    /// real type literally named <c>_</c>. When it does, <c>typeof(Func[_])</c>
+    /// must bind the type argument to that REAL type (an ordinary closed
+    /// generic <c>Func&lt;_&gt;</c>) rather than silently reading <c>_</c> as
+    /// the open-generic placeholder and flipping to unbound <c>Func`1</c>.
+    /// </summary>
+    [Fact]
+    public void RealTypeNamedUnderscore_TypeOf_BindsToClosedGeneric_NotOpenGeneric()
+    {
+        var source = @"
+import System
+
+class _ {
+}
+
+class C {
+    func run() {
+        let t = typeof(Func[_])
+    }
+}
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+    }
+
     private static EvaluationResult Evaluate(string source)
     {
         var tree = SyntaxTree.Parse(SourceText.From(source));

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1915OpenGenericTypeOfTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1915OpenGenericTypeOfTranslationTests.cs
@@ -14,22 +14,32 @@ namespace Cs2Gs.Tests;
 
 /// <summary>
 /// Issue #1915 (sub-bug b): <c>typeof(List&lt;&gt;)</c> (an unbound generic
-/// operand, <c>GenericNameSyntax.IsUnboundGenericName == true</c>) already
+/// operand, <c>GenericNameSyntax.IsUnboundGenericName == true</c>) originally
 /// translated to the bare generic-definition name <c>typeof(List)</c> — that
-/// half was correct (G# has no bracket syntax for an open generic, so the
-/// bare name is the only spelling available), but gsc's OWN binder could not
-/// resolve a bare imported-CLR-generic name at all (it only tried the exact,
-/// non-generic reflection name), so the printed G# failed to compile with
-/// GS0113 "Type 'List' doesn't exist." Fixed on the gsc side: a bare simple
-/// name inside <c>typeof(...)</c> now falls back to an arity-suffixed
-/// (<c>`1</c>, <c>`2</c>, …) reflection lookup across the file's imports and
-/// binds to the CLR open generic type definition when exactly one match
-/// exists.
+/// half was correct at the time (G# had no bracket syntax for an open
+/// generic, so the bare name was the only spelling available), but gsc's OWN
+/// binder could not resolve a bare imported-CLR-generic name at all (it only
+/// tried the exact, non-generic reflection name), so the printed G# failed
+/// to compile with GS0113 "Type 'List' doesn't exist." Fixed on the gsc side:
+/// a bare simple name inside <c>typeof(...)</c> now falls back to an
+/// arity-suffixed (<c>`1</c>, <c>`2</c>, …) reflection lookup across the
+/// file's imports and binds to the CLR open generic type definition when
+/// exactly one match exists.
+/// <para>
+/// Issue #2012 (S1): the bare-name fallback stays ambiguous (GS0113) for
+/// same-base-name multi-arity BCL families (<c>Func</c>, <c>Action</c>, …),
+/// so #1989/#2011 added an explicit-arity spelling via <c>_</c> placeholder
+/// bracket type arguments (<c>typeof(Name[_, ...])</c>). cs2gs now emits
+/// THAT canonical form for every unbound generic — carrying the arity C#
+/// derives from comma count the same way — rather than the bare name, so the
+/// translated output round-trips correctly for every family, not just
+/// single-arity ones.
+/// </para>
 /// </summary>
 public class Issue1915OpenGenericTypeOfTranslationTests
 {
     [Fact]
-    public void UnboundGenericType_TypeOf_TranslatesToBareNameAndRoundTrips()
+    public void UnboundGenericType_TypeOf_TranslatesToUnderscorePlaceholderAndRoundTrips()
     {
         string printed = TranslateUnit(@"
 using System;
@@ -43,11 +53,11 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("typeof(List)", printed);
+        Assert.Contains("typeof(List[_])", printed);
     }
 
     [Fact]
-    public void UnboundGenericType_TwoArity_TranslatesToBareNameAndRoundTrips()
+    public void UnboundGenericType_TwoArity_TranslatesToUnderscorePlaceholderAndRoundTrips()
     {
         string printed = TranslateUnit(@"
 using System;
@@ -61,7 +71,7 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("typeof(Dictionary)", printed);
+        Assert.Contains("typeof(Dictionary[_, _])", printed);
     }
 
     private static string TranslateUnit(string source)

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2012OpenGenericTypeOfProducerTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2012OpenGenericTypeOfProducerTests.cs
@@ -1,0 +1,187 @@
+// <copyright file="Issue2012OpenGenericTypeOfProducerTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #2012 (S1): cs2gs's translation of a C# unbound generic
+/// <c>typeof(...)</c> operand (<c>typeof(Func&lt;&gt;)</c>,
+/// <c>typeof(Dictionary&lt;,&gt;)</c>) was untouched by #1989/#2011 — it kept
+/// emitting the bare generic-definition name (<c>typeof(Func)</c>), which
+/// stays ambiguous (GS0113) for a same-base-name multi-arity BCL family. cs2gs
+/// now emits the canonical explicit-arity <c>_</c> placeholder form
+/// established by #1989/#2011 (<c>typeof(Func[_])</c>,
+/// <c>typeof(Dictionary[_, _])</c>) so the syntax has an automated C# → G#
+/// producer, and proves the full round-trip: translate → compile with the
+/// real <c>gsc</c> → run → the reflected <see cref="Type"/> is bit-for-bit
+/// the same CLR open generic type definition as C#'s own <c>typeof(Func&lt;&gt;)</c>.
+/// </summary>
+public class Issue2012OpenGenericTypeOfProducerTests
+{
+    [Fact]
+    public void UnboundFunc_TypeOf_TranslatesToUnderscorePlaceholderAndRoundTrips()
+    {
+        string printed = TranslateUnit(@"
+using System;
+
+namespace Demo
+{
+    public class C
+    {
+        public Type Describe() => typeof(Func<>);
+    }
+}");
+
+        Assert.Contains("typeof(Func[_])", printed);
+    }
+
+    [Fact]
+    public void UnboundFunc_TwoArity_TypeOf_TranslatesToUnderscorePlaceholderAndRoundTrips()
+    {
+        string printed = TranslateUnit(@"
+using System;
+
+namespace Demo
+{
+    public class C
+    {
+        public Type Describe() => typeof(Func<,>);
+    }
+}");
+
+        Assert.Contains("typeof(Func[_, _])", printed);
+    }
+
+    /// <summary>
+    /// Full producer round-trip: the translated <c>typeof(Func[_])</c>
+    /// compiles with the real <c>gsc</c> and, at run time, is REFLECTION-equal
+    /// (not merely name-equal) to C#'s own <c>typeof(System.Func&lt;&gt;)</c> —
+    /// proving cs2gs's emitted <c>_</c> placeholder form really does round-trip
+    /// to the same CLR open generic type definition.
+    /// </summary>
+    [Fact]
+    public void UnboundFunc_TypeOf_CompilesAndReflectsSameClrOpenGenericDefinition()
+    {
+        string compiler = FindCompiler();
+        if (compiler is null)
+        {
+            // gsc.dll not built in this run (e.g. cs2gs-only build); the
+            // translation-level assertions above still cover the producer.
+            return;
+        }
+
+        string printed = TranslateUnit(@"
+using System;
+
+namespace Demo
+{
+    public class C
+    {
+        public Type Describe() => typeof(Func<>);
+    }
+}");
+        Assert.Contains("typeof(Func[_])", printed);
+
+        string source = """
+            package i2012s1func1
+            import System
+
+            func Main() { System.Console.WriteLine(typeof(Func[_]).AssemblyQualifiedName) }
+            """;
+
+        string workDir = Path.Combine(AppContext.BaseDirectory, "i2012-e2e");
+        Directory.CreateDirectory(workDir);
+        string gsPath = Path.Combine(workDir, "Program.gs");
+        string dllPath = Path.Combine(workDir, "Program.dll");
+        File.WriteAllText(gsPath, source);
+
+        (int compileExit, string compileOut) = RunDotnet(
+            $"\"{compiler}\" /target:exe /out:\"{dllPath}\" \"{gsPath}\"");
+        Assert.True(
+            compileExit == 0 && !compileOut.Contains("error", StringComparison.OrdinalIgnoreCase),
+            "gsc must compile the emitted `_` placeholder form with zero errors. Output:\n" + compileOut);
+
+        var runResult = RunDotnetFull($"\"{dllPath}\"");
+        Assert.True(runResult.Exit == 0, "The compiled program must run successfully. Output:\n" + runResult.Combined);
+        string stdout = runResult.Stdout;
+
+        var reflectedType = Type.GetType(stdout.Trim());
+        Assert.Equal(typeof(Func<>), reflectedType);
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        Assert.Empty(context.Diagnostics);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+
+    private static (int Exit, string Stdout, string Combined) RunDotnetFull(string arguments)
+    {
+        var psi = new ProcessStartInfo("dotnet", arguments)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        using var process = Process.Start(psi);
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        return (process.ExitCode, stdout, stdout + stderr);
+    }
+
+    private static (int Exit, string Output) RunDotnet(string arguments)
+    {
+        (int exit, string _, string combined) = RunDotnetFull(arguments);
+        return (exit, combined);
+    }
+
+    private static string FindCompiler()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            foreach (string config in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(dir.FullName, "out", "bin", config, "Compiler", "gsc.dll");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            dir = dir.Parent;
+        }
+
+        return null;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/OahuFoundationTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuFoundationTranslationTests.cs
@@ -210,7 +210,7 @@ namespace Demo
     /// `typeof(IEnumerable)` (the only parseable G# form).
     /// </summary>
     [Fact]
-    public void UnboundGenericTypeof_MapsToBareName()
+    public void UnboundGenericTypeof_MapsToUnderscorePlaceholder()
     {
         string printed = TranslateUnit(@"
 namespace Demo
@@ -221,7 +221,9 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("typeof(IEnumerable)", printed);
+        // Issue #2012 (S1): cs2gs now emits the explicit-arity `_` placeholder
+        // form (#1989/#2011) rather than the bare generic-definition name.
+        Assert.Contains("typeof(IEnumerable[_])", printed);
     }
 
     /// <summary>

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -13438,19 +13438,37 @@ public sealed class CSharpToGSharpTranslator
         // to the open type (issue #1915: gsc's binder now resolves a bare
         // imported generic name inside `typeof(...)` to the CLR open generic
         // definition via an arity-suffixed reflection lookup).
+        // `typeof(IEnumerable<>)` over an unbound generic has no bound symbol for
+        // the omitted type argument, so the general type mapper cannot resolve it.
+        // Issue #2012 (S1): G# has no `Name<>`/`Name<,>` comma-count unbound-generic
+        // spelling; the canonical form carries the requested arity explicitly via
+        // `_` placeholder bracket type arguments (issue #1989/#2011) —
+        // `typeof(IEnumerable<>)` maps to `typeof(IEnumerable[_])`,
+        // `typeof(Dictionary<,>)` maps to `typeof(Dictionary[_, _])`, etc. This
+        // form always resolves the arity-suffixed generic and never falls back
+        // to a same-named non-generic type (unlike the older bare-name form,
+        // which stayed ambiguous for same-base-name multi-arity families such
+        // as `Func`/`Action`).
         private GTypeReference MapTypeOfOperand(TypeSyntax type)
         {
-            if (IsUnboundGeneric(type, out string unboundName))
+            if (IsUnboundGeneric(type, out string unboundName, out int arity))
             {
-                return new NamedTypeReference(unboundName);
+                var placeholders = new GTypeReference[arity];
+                for (int i = 0; i < arity; i++)
+                {
+                    placeholders[i] = new NamedTypeReference("_");
+                }
+
+                return new NamedTypeReference(unboundName, placeholders);
             }
 
             return this.MapTypeSyntax(type);
         }
 
-        private static bool IsUnboundGeneric(TypeSyntax type, out string name)
+        private static bool IsUnboundGeneric(TypeSyntax type, out string name, out int arity)
         {
             name = null;
+            arity = 0;
             GenericNameSyntax generic = type switch
             {
                 GenericNameSyntax g => g,
@@ -13465,6 +13483,7 @@ public sealed class CSharpToGSharpTranslator
             }
 
             name = generic.Identifier.Text;
+            arity = generic.TypeArgumentList.Arguments.Count;
             return true;
         }
 

--- a/tools/cs2gs/corpus/grid/G08-Generics-Console/Constructs/OmittedTypeArgument.cs
+++ b/tools/cs2gs/corpus/grid/G08-Generics-Console/Constructs/OmittedTypeArgument.cs
@@ -1,9 +1,9 @@
 // inventory: OmittedTypeArgument — nameof/typeof of an unbound generic (C#14 probe)
 // issue #1915 (fixed): typeof of an unbound generic (`typeof(List<>)`,
-// `typeof(Dictionary<,>)`) translates to the bare generic-definition name
-// (`typeof(List)`, `typeof(Dictionary)` — G# has no open-generic `typeof`
-// spelling); gsc's binder now resolves that bare imported-generic name to the
-// CLR open generic type definition via an arity-suffixed reflection lookup.
+// `typeof(Dictionary<,>)`) translates to G#'s explicit-arity `_` placeholder
+// form (`typeof(List[_])`, `typeof(Dictionary[_, _])` — G# has no
+// `Name<>`/`Name<,>` comma-count spelling; issue #2012 (S1) wires cs2gs to
+// emit the canonical arity-suffixed form established by #1989/#2011).
 using System;
 using System.Collections.Generic;
 


### PR DESCRIPTION
Fixes #2012

Non-blocking follow-ups from PR #2011 (#1989) Opus review. All 5 sub-items investigated and fixed:

## N1 (`_` type-arg collision) — FIXED
`_` is an ordinary identifier in G#'s grammar (only special-cased in pattern/discard positions, never reserved as a type-name token), so `class _ {}` / `type _ = ...` / a type parameter named `_` are all legal. Verified empirically: before this fix, `class _ {}` + `typeof(Func[_])` silently resolved to open `Func` (arity 1), ignoring the real type. `TryGetUnboundGenericArity` now probes the binding scope (via the existing `lookupType` delegate, respecting normal shadowing) for a real type named `_` before treating `_` arguments as the placeholder; if one exists, `Func[_]` binds as an ordinary closed generic over the real type instead.

## N2 (gapped-arity walk) — DOCUMENTED (no code behavior change)
No BCL generic family is gapped today (every multi-arity family — Func, Action, Tuple, ValueTuple, etc. — fills every arity in its range), so a gapped family falls back to GS0113, never a silent miscompile. Added a code comment on `TryResolveOpenGenericImportedType` and `MaxConsecutiveArityMisses` documenting the "contiguous families only" assumption and how to bump the cap if a real gapped family is ever needed.

## N3 (wrong diagnostic id) — FIXED
`TryResolveOpenGenericImportedTypeWithArity` now distinguishes "ambiguous across imports" from "no match at all" via an `out bool isAmbiguous` parameter. The caller reports the new `GS0471` ("Type '...' is ambiguous between two or more imported namespaces") instead of the misleading `GS0113` ("doesn't exist"). No existing "ambiguous type across imports" diagnostic existed to reuse (the closest, GS0414, is worded specifically for ambiguous *members*, not types, so reusing it verbatim would have been equally confusing) — added GS0471 following the same pattern/wording style as GS0414. Verified end-to-end with two gsc-compiled reference assemblies each declaring a generic type of the same simple name, both imported into a third program: the explicit-arity `typeof(...)` now reports GS0471.

## S1 (cs2gs producer) — FIXED
`CSharpToGSharpTranslator.MapTypeOfOperand`/`IsUnboundGeneric` previously emitted the bare generic-definition name (`typeof(Func)`), which is ambiguous (GS0113) for same-base-name multi-arity families. Now emits the canonical `_` placeholder form for every unbound-generic arity (`typeof(Func<>)` maps to `typeof(Func[_])`, `typeof(Dictionary<,>)` maps to `typeof(Dictionary[_, _])`, etc.), matching whatever arity C#'s comma count specifies. Added `Issue2012OpenGenericTypeOfProducerTests` proving the full round trip: translate then compiles with the real gsc then runs then the reflected `Type` is `Assert.Equal`-equal to C#'s own `typeof(System.Func<>)`. Updated the two existing translation tests that asserted the old bare-name output.

## S3 (reflection test) — FIXED
Hardened `Issue1989MultiArityOpenGenericTypeOfEmitTests` with a new test asserting genuine reflection `Type` equality (`Assert.Equal(typeof(Func<>), resolvedType)`) rather than just the pre-existing `.Name` string checks (which can't distinguish an open generic from a closed one with the same base name).

## Verification
- `dotnet build src/Compiler/Compiler.csproj -c Release` — 0 warnings/errors
- `dotnet build GSharp.sln -c Release` — 0 warnings/errors
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release` — 5453 passed, 1 pre-existing skip
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Release` — 2708 passed
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release` — 990 passed
- `dotnet out/bin/Release/Cs2Gs.Cli/cs2gs.dll coverage --write` — no diff (no new gaps)
- `dotnet out/bin/Release/Cs2Gs.Cli/cs2gs.dll migrate --corpus tools/cs2gs/corpus --baseline tools/cs2gs/triage/gaps.json` — 16/20 apps green, baseline: 3 known (pre-existing), 0 new, 0 regressed, 0 stale

Nothing deferred.
