### PR TITLE
gsc+cs2gs: preserve explicit interface impl bodies via CLR MethodImpl (#2010)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -6897,7 +6897,7 @@ internal sealed class DeclarationBinder
             }
 
             if (!TryParseExplicitInterfaceImplName(candidate.Name, out var explicitIfaceName, out var explicitMemberName) ||
-                explicitIfaceName != iface.Name ||
+                explicitIfaceName != QualifyInterfaceName(iface) ||
                 explicitMemberName != imethod.Name)
             {
                 continue;
@@ -6921,6 +6921,43 @@ internal sealed class DeclarationBinder
 
     private static ImmutableArray<ParameterSymbol> GetCallableParameters(FunctionSymbol method)
         => method.ExplicitReceiverParameter == null ? method.Parameters : method.Parameters.RemoveAt(0);
+
+    /// <summary>
+    /// Namespace/nesting-qualified name of a G# interface, dots sanitized to
+    /// underscores — must stay in sync with the equivalent computation in
+    /// <c>CSharpToGSharpTranslator.QualifyInterfaceName</c>, which builds the
+    /// same string from the pre-translation C# interface symbol. Follow-up
+    /// to issue #2010: bare simple names collided across namespaces
+    /// (<c>Foo.IBar</c> vs <c>Baz.IBar</c>); qualifying by package name (G#'s
+    /// analogue of a C# namespace) plus any containing-type nesting fixes it.
+    /// </summary>
+    private static string QualifyInterfaceName(InterfaceSymbol iface)
+    {
+        var parts = new List<string>();
+        for (TypeSymbol current = iface; current != null; current = GetContainingType(current))
+        {
+            parts.Insert(0, current.Name);
+        }
+
+        if (!string.IsNullOrEmpty(iface.PackageName))
+        {
+            // The package name itself may be dotted (e.g. "Corpus.Grid06"),
+            // mirroring a multi-segment C# namespace — split it into its own
+            // segments rather than inserting one dotted string, or the final
+            // '_' join below would leave a stray '.' in the result.
+            parts.InsertRange(0, iface.PackageName.Split('.'));
+        }
+
+        return string.Join("_", parts);
+    }
+
+    private static TypeSymbol GetContainingType(TypeSymbol type) => type switch
+    {
+        StructSymbol s => s.ContainingType,
+        InterfaceSymbol i => i.ContainingType,
+        EnumSymbol e => e.ContainingType,
+        _ => null,
+    };
 
     /// <summary>
     /// Issue #2010: the reserved mangled-name convention a G# method uses to

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.cs
@@ -1860,7 +1860,17 @@ internal sealed class DeclarationBinder
                         ValidateInlineDataNilArguments(methodAttributes, methodSymbol.Parameters);
                     }
 
-                    // ADR-0063 §11: detect duplicate-signature within the class.
+                    // Issue #2010: a method named per the reserved
+                    // `__explicit_<Interface>__<Member>` mangled convention (the
+                    // form cs2gs synthesizes for a C# explicit interface
+                    // implementation, see CSharpToGSharpTranslator) explicitly
+                    // implements one interface member's own distinct body.
+                    // Resolution against the actual interface member is
+                    // deferred to VerifyInterfaceImplementations — interfaces
+                    // declared later in the same compilation unit have not had
+                    // their own members bound yet when this class's members
+                    // are bound, so `implementedInterfaces[i].Methods` may
+                    // still be empty here.
                     var hasDuplicateSig = false;
                     foreach (var existingMethod in methodsBuilder)
                     {
@@ -3559,6 +3569,18 @@ internal sealed class DeclarationBinder
             {
                 foreach (var imethod in iface.Methods)
                 {
+                    // Issue #2010: a mangled-name explicit implementation
+                    // (`__explicit_<Interface>__<Member>`) satisfies this slot
+                    // even though its own name never matches `imethod.Name` —
+                    // it was already resolved and linked to `imethod` at
+                    // declaration-binding time. Skip the name-based lookup
+                    // entirely once found; no diagnostic, and the emitter
+                    // binds the slot via `FunctionSymbol.ExplicitInterfaceMember`.
+                    if (TryResolveExplicitInterfaceImplementation(structSymbol, iface, imethod) != null)
+                    {
+                        continue;
+                    }
+
                     // ADR-0063 §8: implementing class may have multiple methods
                     // with the same name; pick the one whose signature matches
                     // this specific interface overload exactly.
@@ -6841,8 +6863,98 @@ internal sealed class DeclarationBinder
         return -1;
     }
 
+    /// <summary>
+    /// Issue #2010: resolves and links a mangled-name explicit interface
+    /// implementation (see <see cref="TryParseExplicitInterfaceImplName"/>)
+    /// on <paramref name="structSymbol"/> against <paramref name="imethod"/>,
+    /// an abstract member of <paramref name="iface"/>. Returns the linked
+    /// method (setting its <see cref="FunctionSymbol.ExplicitInterfaceMember"/>
+    /// the first time it is resolved) or <see langword="null"/> if no such
+    /// method exists. Resolution happens here — during the deferred
+    /// <see cref="VerifyInterfaceImplementations"/> pass — rather than at
+    /// initial member-binding time, because a class's interfaces may be
+    /// declared later in the same file and their own members are not yet
+    /// bound when the class's own members are first processed.
+    /// </summary>
+    private static FunctionSymbol TryResolveExplicitInterfaceImplementation(StructSymbol structSymbol, InterfaceSymbol iface, FunctionSymbol imethod)
+    {
+        if (structSymbol.Methods.IsDefaultOrEmpty)
+        {
+            return null;
+        }
+
+        foreach (var candidate in structSymbol.Methods)
+        {
+            if (ReferenceEquals(candidate.ExplicitInterfaceMember, imethod))
+            {
+                return candidate;
+            }
+
+            if (candidate.ExplicitInterfaceMember != null)
+            {
+                // Already linked to a different interface member.
+                continue;
+            }
+
+            if (!TryParseExplicitInterfaceImplName(candidate.Name, out var explicitIfaceName, out var explicitMemberName) ||
+                explicitIfaceName != iface.Name ||
+                explicitMemberName != imethod.Name)
+            {
+                continue;
+            }
+
+            var typeParamMap = TryBuildMethodTypeParameterMap(imethod, candidate);
+            if (typeParamMap == null)
+            {
+                continue;
+            }
+
+            if (SignaturesMatch(imethod, GetCallableParameters(candidate), candidate.Type, candidate.ReturnRefKind, typeParamMap, candidate.IsAsync))
+            {
+                candidate.ExplicitInterfaceMember = imethod;
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+
     private static ImmutableArray<ParameterSymbol> GetCallableParameters(FunctionSymbol method)
         => method.ExplicitReceiverParameter == null ? method.Parameters : method.Parameters.RemoveAt(0);
+
+    /// <summary>
+    /// Issue #2010: the reserved mangled-name convention a G# method uses to
+    /// mark itself as a specific interface member's explicit implementation:
+    /// <c>__explicit_&lt;InterfaceSimpleName&gt;__&lt;MemberSimpleName&gt;</c>.
+    /// This is a plain identifier — no new grammar — reserved for
+    /// compiler/cs2gs-synthesized use (ADR-0091 rejected a dedicated
+    /// `IFoo.M(this)` syntax for user-facing explicit-impl spelling; this
+    /// convention sidesteps that without adding surface syntax). Both name
+    /// components must be non-empty; the double-underscore separator is
+    /// required so a single-underscore interface/member name doesn't get
+    /// mis-split.
+    /// </summary>
+    internal static bool TryParseExplicitInterfaceImplName(string name, out string interfaceName, out string memberName)
+    {
+        const string Prefix = "__explicit_";
+        interfaceName = null;
+        memberName = null;
+        if (string.IsNullOrEmpty(name) || !name.StartsWith(Prefix, System.StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var rest = name.Substring(Prefix.Length);
+        var separatorIndex = rest.IndexOf("__", System.StringComparison.Ordinal);
+        if (separatorIndex <= 0 || separatorIndex + 2 >= rest.Length)
+        {
+            return false;
+        }
+
+        interfaceName = rest.Substring(0, separatorIndex);
+        memberName = rest.Substring(separatorIndex + 2);
+        return true;
+    }
 
     /// <summary>
     /// Issue #974: structural equivalence used by override / interface-

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -11387,14 +11387,23 @@ internal sealed class ReflectionMetadataEmitter
     // PR-E-2: MethodSpecSymbolKey moved into MetadataTokenCache.
 
     /// <summary>
-    /// Issue #985: emit MethodImpl rows for covariant-return interface bridges.
-    /// A method whose <see cref="FunctionSymbol.ExplicitInterfaceSlot"/> is set
+    /// Issue #985 / #2010: emit MethodImpl rows for covariant-return interface
+    /// bridges AND for mangled-name explicit interface implementations. A
+    /// method whose <see cref="FunctionSymbol.ExplicitInterfaceSlot"/> is set
     /// explicitly implements a specific (typically inherited, non-generic) CLR
     /// interface slot — e.g. the private non-generic
     /// <c>IEnumerable.GetEnumerator()</c> alongside the public generic
     /// <c>IEnumerable&lt;T&gt;.GetEnumerator()</c>. A private bridge method
     /// cannot implicitly implement an interface slot, so the explicit row is
     /// required for the resulting type to load.
+    ///
+    /// A method whose <see cref="FunctionSymbol.ExplicitInterfaceMember"/> is
+    /// set explicitly implements one specific in-compilation (G#) interface
+    /// member — its mangled name never matches the interface member's own
+    /// name, so ordinary name-based virtual dispatch never wires it into that
+    /// interface's slot; an explicit <c>MethodImpl</c> row is required here
+    /// too (mirrors <see cref="EmitStaticVirtualMethodImpls"/>'s generic-aware
+    /// token resolution for a constructed interface).
     /// </summary>
     /// <param name="structSymbol">The implementing class or struct.</param>
     private void EmitExplicitInterfaceMethodImpls(StructSymbol structSymbol)
@@ -11411,19 +11420,45 @@ internal sealed class ReflectionMetadataEmitter
 
         foreach (var method in structSymbol.Methods)
         {
-            var slot = method.ExplicitInterfaceSlot;
-            if (slot == null)
-            {
-                continue;
-            }
-
             if (!this.cache.MethodHandles.TryGetValue(method, out var implHandle))
             {
                 continue;
             }
 
-            var slotRef = this.GetMethodReference(slot);
-            this.emitCtx.Metadata.AddMethodImplementation(implTypeDef, implHandle, slotRef);
+            var slot = method.ExplicitInterfaceSlot;
+            if (slot != null)
+            {
+                var slotRef = this.GetMethodReference(slot);
+                this.emitCtx.Metadata.AddMethodImplementation(implTypeDef, implHandle, slotRef);
+            }
+
+            var ifaceMember = method.ExplicitInterfaceMember;
+            if (ifaceMember == null || structSymbol.Interfaces.IsDefaultOrEmpty)
+            {
+                continue;
+            }
+
+            EntityHandle? slotHandle = null;
+            foreach (var iface in structSymbol.Interfaces)
+            {
+                var defIface = iface.Definition ?? iface;
+                if (defIface.Methods.IsDefaultOrEmpty || !defIface.Methods.Contains(ifaceMember))
+                {
+                    continue;
+                }
+
+                slotHandle = IsUserGenericInterfaceReference(iface)
+                    ? this.ResolveUserInterfaceInstanceMethodToken(iface, ifaceMember)
+                    : this.cache.MethodHandles.TryGetValue(ifaceMember, out var slotDefHandle)
+                        ? slotDefHandle
+                        : (EntityHandle?)null;
+                break;
+            }
+
+            if (slotHandle.HasValue)
+            {
+                this.emitCtx.Metadata.AddMethodImplementation(implTypeDef, implHandle, slotHandle.Value);
+            }
         }
     }
 

--- a/src/Core/CodeAnalysis/Symbols/FunctionSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/FunctionSymbol.cs
@@ -363,6 +363,27 @@ public sealed class FunctionSymbol : Symbol
     /// </summary>
     public System.Reflection.MethodInfo ExplicitInterfaceSlot { get; set; }
 
+    /// <summary>
+    /// Gets or sets the in-compilation (G#) interface member this method
+    /// explicitly implements (issue #2010). Set when the method's declared
+    /// name matches the reserved <c>__explicit_&lt;Interface&gt;__&lt;Member&gt;</c>
+    /// mangled-name convention (see
+    /// <see cref="Binding.DeclarationBinder.TryParseExplicitInterfaceImplName"/>)
+    /// and a matching abstract member is found on one of the containing
+    /// type's declared interfaces. Unlike <see cref="ExplicitInterfaceSlot"/>
+    /// (which binds to an external CLR interface resolved via reflection),
+    /// this points at the interface member's own <see cref="FunctionSymbol"/>
+    /// within the same compilation — the emitter resolves it to a MethodDef
+    /// or (for a constructed generic interface) a MemberRef/TypeSpec token
+    /// and binds a <c>MethodImpl</c> row so the CLR routes interface dispatch
+    /// to this method's own distinct body instead of relying on name-based
+    /// virtual dispatch. Because the mangled name is unique per interface,
+    /// two explicit implementations of same-name/same-signature members from
+    /// different interfaces no longer collide (no more GS0264 duplicate, no
+    /// more dropped body). Defaults to <c>null</c> for ordinary methods.
+    /// </summary>
+    public FunctionSymbol ExplicitInterfaceMember { get; set; }
+
     /// <summary>Gets a value indicating whether this function is a P/Invoke stub (ADR-0086).</summary>
     public bool IsPInvoke => PInvokeMetadata != null;
 

--- a/test/Compiler.Tests/Emit/Issue2010ExplicitInterfaceImplEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2010ExplicitInterfaceImplEmitTests.cs
@@ -1,0 +1,273 @@
+// <copyright file="Issue2010ExplicitInterfaceImplEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2010 (follow-up to #1911 / PR #1994): a C# explicit interface
+/// implementation (<c>string IFoo.Bar() { ... }</c>) has no G# spelling
+/// (ADR-0091 rejected an `IFoo.M(this)` surface syntax). The #1911 fix
+/// collapsed two same-name/same-signature explicit implementations of
+/// DIFFERENT interfaces onto a single surviving method body (dropping the
+/// other, reported via an <c>Unsupported</c> diagnostic).
+/// <para>
+/// This fix instead lets each explicit implementation keep its own distinct
+/// body as a separate G# method whose name follows the reserved
+/// <c>__explicit_&lt;Interface&gt;__&lt;Member&gt;</c> mangled convention. The
+/// binder links each such method to the specific interface member it
+/// implements (<see cref="GSharp.Core.CodeAnalysis.Symbols.FunctionSymbol.ExplicitInterfaceMember"/>)
+/// and the emitter binds an explicit CLR <c>MethodImpl</c> row (mirroring the
+/// ADR-0089 static-virtual / issue #985 bridge machinery) so each interface's
+/// dispatch slot routes to its own method body — full fidelity, zero drops.
+/// </para>
+/// </summary>
+public class Issue2010ExplicitInterfaceImplEmitTests
+{
+    private const string ReproSource = """
+        package GapCheck
+
+        interface IFoo {
+            func Bar() string;
+        }
+
+        interface IBaz {
+            func Bar() string;
+        }
+
+        class Both : IFoo, IBaz {
+            func __explicit_IFoo__Bar() string {
+                return "foo"
+            }
+
+            func __explicit_IBaz__Bar() string {
+                return "baz"
+            }
+        }
+        """;
+
+    [Fact]
+    public void CollidingExplicitImpls_Compile_EmitDistinctMethodsAndMethodImplRows_IlVerifies()
+    {
+        var dllPath = CompileLibrary(ReproSource);
+        try
+        {
+            using var stream = File.OpenRead(dllPath);
+            using var peReader = new PEReader(stream);
+            var reader = peReader.GetMetadataReader();
+
+            TypeDefinition both = default;
+            bool foundBoth = false;
+            foreach (var typeHandle in reader.TypeDefinitions)
+            {
+                var td = reader.GetTypeDefinition(typeHandle);
+                if (reader.GetString(td.Name) == "Both")
+                {
+                    both = td;
+                    foundBoth = true;
+                    break;
+                }
+            }
+
+            Assert.True(foundBoth, "expected to find the Both type");
+
+            // (1) Two distinct MethodDef rows survive — no drop.
+            int fooBody = 0;
+            int bazBody = 0;
+            foreach (var mh in both.GetMethods())
+            {
+                var md = reader.GetMethodDefinition(mh);
+                var name = reader.GetString(md.Name);
+                if (name == "__explicit_IFoo__Bar")
+                {
+                    fooBody++;
+                }
+                else if (name == "__explicit_IBaz__Bar")
+                {
+                    bazBody++;
+                }
+            }
+
+            Assert.Equal(1, fooBody);
+            Assert.Equal(1, bazBody);
+
+            // (2) Two MethodImpl rows binding each mangled method to its own
+            // interface's Bar() slot.
+            int methodImplRows = 0;
+            foreach (var miHandle in both.GetMethodImplementations())
+            {
+                reader.GetMethodImplementation(miHandle);
+                methodImplRows++;
+            }
+
+            Assert.Equal(2, methodImplRows);
+        }
+        finally
+        {
+            TryCleanup(dllPath);
+        }
+    }
+
+    [Fact]
+    public void CollidingExplicitImpls_DispatchToDistinctBodiesThroughEachInterface()
+    {
+        // End-to-end: each interface-typed reference reaches its OWN body,
+        // proving no collapse/drop of either explicit implementation.
+        var source = ReproSource + """
+
+
+            var obj = Both{}
+            var asFoo IFoo = obj
+            var asBaz IBaz = obj
+            Console.WriteLine(asFoo.Bar())
+            Console.WriteLine(asBaz.Bar())
+            """;
+
+        Assert.Equal("foo\nbaz\n", CompileAndRun(source));
+    }
+
+    private static string CompileLibrary(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue2010_lib_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        var args = new[]
+        {
+            "/out:" + outPath,
+            "/target:library",
+            "/targetframework:net10.0",
+            srcPath,
+        };
+
+        using var stdoutWriter = new StringWriter();
+        using var stderrWriter = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(stdoutWriter);
+        Console.SetError(stderrWriter);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+        IlVerifier.Verify(outPath);
+        return outPath;
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue2010_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+
+    private static void TryCleanup(string dllPath)
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(dllPath);
+            if (dir != null && Directory.Exists(dir))
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+        catch
+        {
+        }
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue2010ExplicitInterfaceImplEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2010ExplicitInterfaceImplEmitTests.cs
@@ -44,11 +44,11 @@ public class Issue2010ExplicitInterfaceImplEmitTests
         }
 
         class Both : IFoo, IBaz {
-            func __explicit_IFoo__Bar() string {
+            func __explicit_GapCheck_IFoo__Bar() string {
                 return "foo"
             }
 
-            func __explicit_IBaz__Bar() string {
+            func __explicit_GapCheck_IBaz__Bar() string {
                 return "baz"
             }
         }
@@ -86,11 +86,11 @@ public class Issue2010ExplicitInterfaceImplEmitTests
             {
                 var md = reader.GetMethodDefinition(mh);
                 var name = reader.GetString(md.Name);
-                if (name == "__explicit_IFoo__Bar")
+                if (name == "__explicit_GapCheck_IFoo__Bar")
                 {
                     fooBody++;
                 }
-                else if (name == "__explicit_IBaz__Bar")
+                else if (name == "__explicit_GapCheck_IBaz__Bar")
                 {
                     bazBody++;
                 }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1911ExplicitInterfaceImplementationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1911ExplicitInterfaceImplementationTests.cs
@@ -69,7 +69,7 @@ namespace Corpus.Issue1911
 }");
         string printed = GSharpPrinter.Print(unit);
 
-        Assert.Contains("__explicit_IGreeter__Greet() string {", printed, StringComparison.Ordinal);
+        Assert.Contains("__explicit_Corpus_Issue1911_IGreeter__Greet() string {", printed, StringComparison.Ordinal);
         Assert.DoesNotContain(
             context.Diagnostics,
             d => d.Severity == TranslationSeverity.Unsupported && d.Message.Contains("explicit interface", StringComparison.OrdinalIgnoreCase));

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1911ExplicitInterfaceImplementationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1911ExplicitInterfaceImplementationTests.cs
@@ -31,27 +31,25 @@ namespace Cs2Gs.Tests;
 /// <item>alongside a same-name public method, translating both produced an
 /// exact-signature duplicate (GS0264).</item>
 /// </list>
-/// G# has no explicit-interface-implementation surface of its own — ADR-0091
-/// deliberately rejected an <c>IFoo.M(this)</c> spelling as conflating
-/// extension-function sugar with explicit interface dispatch, and the only
-/// disambiguation tool G# does have (<c>base[IFoo].M()</c>,
-/// <c>samples/InterfaceDiamondDisambiguation.gs</c>) resolves *default*-body
-/// diamonds inside an <c>override</c>, not a hidden-from-the-public-surface
-/// slot for an abstract member. The fix: an explicit interface implementation
-/// always emits as a plain PUBLIC method (fixes the ilverify miss), and when
-/// that would collide with an existing same-signature public method the
-/// explicit impl is dropped with a diagnosed, disclosed semantic-loss warning
-/// rather than emitting a GS0264 duplicate.
+/// The #1911 fix forced explicit implementations public and dropped
+/// colliding duplicates with an <c>Unsupported</c> diagnostic. Issue #2010
+/// (see <c>Issue2010ExplicitInterfaceImplementationTests</c>) replaces that
+/// with a full-fidelity fix: each explicit implementation is emitted under a
+/// reserved mangled name and bound to its own CLR interface slot via an
+/// explicit <c>MethodImpl</c> row at emit time, so it can keep its
+/// C#-faithful (non-public) visibility and no collision/drop ever occurs.
 /// </summary>
 public class Issue1911ExplicitInterfaceImplementationTests
 {
     /// <summary>
-    /// A lone explicit interface implementation (no same-name public method)
-    /// translates to an ordinary public method — no <c>private</c> modifier —
-    /// so it fills the interface's CLR slot.
+    /// A lone explicit interface implementation translates to a mangled-name
+    /// method (`__explicit_IGreeter__Greet`) with C#-faithful (non-public)
+    /// visibility — issue #2010's MethodImpl-based fix fills the interface's
+    /// CLR slot via an explicit MethodImpl row rather than requiring
+    /// public/name-based dispatch.
     /// </summary>
     [Fact]
-    public void LoneExplicitImplementation_TranslatesToPlainPublicMethod()
+    public void LoneExplicitImplementation_TranslatesToMangledNameMethod()
     {
         (CompilationUnit unit, TranslationContext context) = Translate(@"
 namespace Corpus.Issue1911
@@ -71,8 +69,7 @@ namespace Corpus.Issue1911
 }");
         string printed = GSharpPrinter.Print(unit);
 
-        Assert.Contains("func Greet() string {", printed, StringComparison.Ordinal);
-        Assert.DoesNotContain("private func Greet", printed, StringComparison.Ordinal);
+        Assert.Contains("__explicit_IGreeter__Greet() string {", printed, StringComparison.Ordinal);
         Assert.DoesNotContain(
             context.Diagnostics,
             d => d.Severity == TranslationSeverity.Unsupported && d.Message.Contains("explicit interface", StringComparison.OrdinalIgnoreCase));
@@ -80,197 +77,14 @@ namespace Corpus.Issue1911
     }
 
     /// <summary>
-    /// An explicit implementation coexisting with a same-signature public
-    /// method of the same name must not duplicate into two G# members (which
-    /// would be an exact-signature GS0264 duplicate): only the public method
-    /// survives, and the drop is disclosed via a <see cref="TranslationDiagnostic"/>.
-    /// </summary>
-    [Fact]
-    public void CoexistingExplicitImplementationAndPublicMethod_DropsExplicitImplWithDiagnostic()
-    {
-        (CompilationUnit unit, TranslationContext context) = Translate(@"
-namespace Corpus.Issue1911
-{
-    public interface IGreeter
-    {
-        string Greet();
-    }
-
-    public class LoudHost : IGreeter
-    {
-        public string Greet()
-        {
-            return ""hello-public"";
-        }
-
-        string IGreeter.Greet()
-        {
-            return ""hello-explicit"";
-        }
-    }
-}");
-        string printed = GSharpPrinter.Print(unit);
-
-        TypeDeclaration loudHost = unit.Members.OfType<TypeDeclaration>().Single(t => t.Name == "LoudHost");
-        Assert.Single(loudHost.Members.OfType<MethodDeclaration>(), m => m.Name == "Greet");
-        Assert.Contains("hello-public", printed, StringComparison.Ordinal);
-        Assert.DoesNotContain("hello-explicit", printed, StringComparison.Ordinal);
-
-        Assert.Contains(
-            context.Diagnostics,
-            d => d.Severity == TranslationSeverity.Unsupported
-                && d.Message.Contains("explicit interface implementation", StringComparison.OrdinalIgnoreCase)
-                && d.Message.Contains("LoudHost.IGreeter.Greet", StringComparison.Ordinal));
-        AssertRoundTripParses(printed);
-    }
-
-    /// <summary>
-    /// Two explicit implementations satisfying two DIFFERENT interfaces that
-    /// happen to share a name and signature (a same-name diamond, no public
-    /// method of that name at all) are de-duplicated to a single surviving
-    /// public method (the earliest-declared one) rather than both translating
-    /// and colliding with each other. The survivor still fills both
-    /// interfaces' slots by name+signature, but the two source bodies here are
-    /// distinct ("hi" vs. "welcome"): calling through <c>IWelcomer</c> after
-    /// translation now silently observes the <c>IGreeter</c> body instead.
-    /// This IS a semantic-loss case (same failure class as the
-    /// public-plus-explicit shape), so it is diagnosed at
-    /// <see cref="TranslationSeverity.Unsupported"/>.
-    /// </summary>
-    [Fact]
-    public void TwoExplicitImplementationsWithNoPublicSibling_DeduplicateToOneSurvivor()
-    {
-        (CompilationUnit unit, TranslationContext context) = Translate(@"
-namespace Corpus.Issue1911
-{
-    public interface IGreeter
-    {
-        string Greet();
-    }
-
-    public interface IWelcomer
-    {
-        string Greet();
-    }
-
-    public class Multi : IGreeter, IWelcomer
-    {
-        string IGreeter.Greet()
-        {
-            return ""hi"";
-        }
-
-        string IWelcomer.Greet()
-        {
-            return ""welcome"";
-        }
-    }
-}");
-        TypeDeclaration multi = unit.Members.OfType<TypeDeclaration>().Single(t => t.Name == "Multi");
-        MethodDeclaration greet = Assert.Single(multi.Members.OfType<MethodDeclaration>(), m => m.Name == "Greet");
-        Assert.NotEqual(Visibility.Private, greet.Visibility);
-
-        Assert.Contains(
-            context.Diagnostics,
-            d => d.Severity == TranslationSeverity.Unsupported
-                && d.Message.Contains("Multi.IWelcomer.Greet", StringComparison.Ordinal)
-                && d.Message.Contains("Multi.IGreeter.Greet", StringComparison.Ordinal));
-    }
-
-    /// <summary>
-    /// Review follow-up (PR #1994 rubber-duck): the collision-drop diagnostic
-    /// must be raised at <see cref="TranslationSeverity.Unsupported"/>, not
-    /// <see cref="TranslationSeverity.Warning"/> — <see cref="TranslateStage"/>
-    /// only forwards <c>Unsupported</c> diagnostics into the triage artifact
-    /// stream (see <c>TranslateStage.ExecuteAsync</c>'s
-    /// <c>Where(d =&gt; d.Severity == TranslationSeverity.Unsupported)</c>
-    /// filter), so a <c>Warning</c>-severity drop sat only in the in-memory
-    /// <see cref="TranslationContext.Diagnostics"/> list and never reached a
-    /// real <c>cs2gs</c> run's triage output or failed the stage. Running the
-    /// collision case through the real <see cref="TranslateStage"/> (not just
-    /// <see cref="CSharpToGSharpTranslator"/> directly) confirms the stage now
-    /// fails and the drop is disclosed in a triage artifact.
-    /// </summary>
-    [Fact]
-    public async Task CoexistingExplicitImplementationAndPublicMethod_SurfacesInRealTranslateStage()
-    {
-        string compiler = FindCompiler();
-        if (compiler is null)
-        {
-            return;
-        }
-
-        string projectDir = NewScratchDir("translate-collision-drop");
-        File.WriteAllText(Path.Combine(projectDir, "Directory.Build.props"), "<Project></Project>");
-        string projectPath = Path.Combine(projectDir, "Collision.csproj");
-        File.WriteAllText(projectPath, @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-</Project>
-");
-        File.WriteAllText(
-            Path.Combine(projectDir, "Program.cs"),
-            @"namespace Corpus.Issue1911
-{
-    public interface IGreeter
-    {
-        string Greet();
-    }
-
-    public class LoudHost : IGreeter
-    {
-        public string Greet()
-        {
-            return ""hello-public"";
-        }
-
-        string IGreeter.Greet()
-        {
-            return ""hello-explicit"";
-        }
-    }
-
-    public class Program
-    {
-        public static void Main()
-        {
-        }
-    }
-}
-");
-
-        string outRoot = NewOutputRoot("translate-collision-drop");
-        var options = new PipelineOptions { GscPath = compiler, OutputRoot = outRoot };
-        var pipeline = new MigrationPipeline(options, new IMigrationStage[] { new TranslateStage() });
-
-        var app = new CorpusApp("test/CollisionDrop", projectPath, TargetKind.Exe);
-
-        RunResult result = await pipeline.RunAsync(new[] { app });
-        AppResult appResult = Assert.Single(result.Apps);
-
-        Assert.False(
-            appResult.Succeeded,
-            "An Unsupported-severity collision drop must fail the translate stage, not pass silently.");
-        Assert.NotEmpty(appResult.Artifacts);
-
-        string[] triageFiles = Directory.GetFiles(outRoot, "*.json", SearchOption.AllDirectories)
-            .Where(f => !Path.GetFileName(f).Equals("summary.json", StringComparison.OrdinalIgnoreCase))
-            .ToArray();
-        string match = triageFiles.FirstOrDefault(
-            f => File.ReadAllText(f).Contains("LoudHost.IGreeter.Greet", StringComparison.Ordinal));
-        Assert.NotNull(match);
-    }
-
-    /// <summary>
     /// End-to-end (issue #1911 DoD): the re-enabled
     /// <c>corpus/grid/G06-Types-Console</c> grid fixture (its
     /// <c>ExplicitInterfaceSpecifierFixture</c>) migrates fully green —
     /// translate, compile, ilverify, and stdout parity all pass — proving the
-    /// lone-explicit-impl fix at the real <c>gsc</c>/<c>ilverify</c> level,
-    /// not just in-memory translation. Gated on the compiler artifact and the
-    /// <c>dotnet-ilverify</c> tool being present, like the other e2e tests.
+    /// mangled-name/MethodImpl fix at the real <c>gsc</c>/<c>ilverify</c>
+    /// level, not just in-memory translation. Gated on the compiler artifact
+    /// and the <c>dotnet-ilverify</c> tool being present, like the other e2e
+    /// tests.
     /// </summary>
     [Fact]
     public async Task G06TypesConsole_MigratesGreen_EndToEnd()
@@ -384,13 +198,6 @@ namespace Corpus.Issue1911
     private static string NewOutputRoot(string label)
     {
         string root = Path.Combine(AppContext.BaseDirectory, "pipeline-tests", label, Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(root);
-        return root;
-    }
-
-    private static string NewScratchDir(string label)
-    {
-        string root = Path.Combine(AppContext.BaseDirectory, "loader-tests", label, Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(root);
         return root;
     }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2010ExplicitInterfaceImplementationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2010ExplicitInterfaceImplementationTests.cs
@@ -1,0 +1,156 @@
+// <copyright file="Issue2010ExplicitInterfaceImplementationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #2010 (follow-up to #1911 / PR #1994 review): the #1911 fix forced
+/// explicit interface implementations public and DROPPED any colliding
+/// same-name/same-signature sibling (another explicit impl, or a coexisting
+/// public method) via an <see cref="TranslationSeverity.Unsupported"/>
+/// diagnostic — surfacing the loss instead of silently emitting wrong
+/// behavior, but still losing a distinct body.
+/// <para>
+/// This fix instead preserves full fidelity, zero drops: every explicit
+/// interface implementation is emitted as its own G# method under a reserved
+/// mangled name (<c>__explicit_&lt;Interface&gt;__&lt;Member&gt;</c>) that
+/// gsc's binder recognizes and links to the specific interface member it
+/// implements (<c>FunctionSymbol.ExplicitInterfaceMember</c>); the emitter
+/// binds a CLR <c>MethodImpl</c> row per implementation (reusing the
+/// ADR-0089 static-virtual / issue #985 bridge machinery) so each
+/// interface's dispatch slot routes to its own distinct method body. Since
+/// the mangled name embeds the interface's own name, two explicit
+/// implementations of the same member from different interfaces never
+/// collide — no GS0264, no drop, no diagnostic.
+/// </para>
+/// </summary>
+public class Issue2010ExplicitInterfaceImplementationTests
+{
+    /// <summary>
+    /// Two explicit implementations of the SAME-NAME, SAME-SIGNATURE member
+    /// from two DIFFERENT interfaces (a same-name diamond, no public sibling)
+    /// both survive translation as two distinct mangled-name methods — the
+    /// #1911 "de-duplicate to one survivor + Unsupported diagnostic" gap no
+    /// longer applies.
+    /// </summary>
+    [Fact]
+    public void TwoCollidingExplicitImplementations_BothSurviveAsDistinctMangledMethods()
+    {
+        (CompilationUnit unit, TranslationContext context) = Translate(@"
+namespace Corpus.Issue2010
+{
+    public interface IGreeter
+    {
+        string Greet();
+    }
+
+    public interface IWelcomer
+    {
+        string Greet();
+    }
+
+    public class Multi : IGreeter, IWelcomer
+    {
+        string IGreeter.Greet()
+        {
+            return ""hi"";
+        }
+
+        string IWelcomer.Greet()
+        {
+            return ""welcome"";
+        }
+    }
+}");
+        string printed = GSharpPrinter.Print(unit);
+
+        TypeDeclaration multi = unit.Members.OfType<TypeDeclaration>().Single(t => t.Name == "Multi");
+        Assert.Contains(multi.Members.OfType<MethodDeclaration>(), m => m.Name == "__explicit_IGreeter__Greet");
+        Assert.Contains(multi.Members.OfType<MethodDeclaration>(), m => m.Name == "__explicit_IWelcomer__Greet");
+        Assert.Contains("hi", printed, StringComparison.Ordinal);
+        Assert.Contains("welcome", printed, StringComparison.Ordinal);
+
+        Assert.DoesNotContain(
+            context.Diagnostics,
+            d => d.Severity == TranslationSeverity.Unsupported && d.Message.Contains("explicit interface", StringComparison.OrdinalIgnoreCase));
+        AssertRoundTripParses(printed);
+    }
+
+    /// <summary>
+    /// An explicit implementation coexisting with a same-signature public
+    /// method of the same name no longer collides at all: the public method
+    /// keeps its plain name, and the explicit implementation gets its own
+    /// mangled name and its own body — both survive.
+    /// </summary>
+    [Fact]
+    public void ExplicitImplementationCoexistingWithPublicMethod_BothSurvive()
+    {
+        (CompilationUnit unit, TranslationContext context) = Translate(@"
+namespace Corpus.Issue2010
+{
+    public interface IGreeter
+    {
+        string Greet();
+    }
+
+    public class LoudHost : IGreeter
+    {
+        public string Greet()
+        {
+            return ""hello-public"";
+        }
+
+        string IGreeter.Greet()
+        {
+            return ""hello-explicit"";
+        }
+    }
+}");
+        string printed = GSharpPrinter.Print(unit);
+
+        TypeDeclaration loudHost = unit.Members.OfType<TypeDeclaration>().Single(t => t.Name == "LoudHost");
+        Assert.Contains(loudHost.Members.OfType<MethodDeclaration>(), m => m.Name == "Greet");
+        Assert.Contains(loudHost.Members.OfType<MethodDeclaration>(), m => m.Name == "__explicit_IGreeter__Greet");
+        Assert.Contains("hello-public", printed, StringComparison.Ordinal);
+        Assert.Contains("hello-explicit", printed, StringComparison.Ordinal);
+
+        Assert.DoesNotContain(
+            context.Diagnostics,
+            d => d.Severity == TranslationSeverity.Unsupported && d.Message.Contains("explicit interface", StringComparison.OrdinalIgnoreCase));
+        AssertRoundTripParses(printed);
+    }
+
+    private static void AssertRoundTripParses(string rendered)
+    {
+        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+
+        Assert.True(
+            result.Success,
+            "Sanitized G# must round-trip-parse. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + rendered);
+    }
+
+    private static (CompilationUnit Unit, TranslationContext Context) Translate(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        return (unit, context);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2010ExplicitInterfaceImplementationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2010ExplicitInterfaceImplementationTests.cs
@@ -75,8 +75,8 @@ namespace Corpus.Issue2010
         string printed = GSharpPrinter.Print(unit);
 
         TypeDeclaration multi = unit.Members.OfType<TypeDeclaration>().Single(t => t.Name == "Multi");
-        Assert.Contains(multi.Members.OfType<MethodDeclaration>(), m => m.Name == "__explicit_IGreeter__Greet");
-        Assert.Contains(multi.Members.OfType<MethodDeclaration>(), m => m.Name == "__explicit_IWelcomer__Greet");
+        Assert.Contains(multi.Members.OfType<MethodDeclaration>(), m => m.Name == "__explicit_Corpus_Issue2010_IGreeter__Greet");
+        Assert.Contains(multi.Members.OfType<MethodDeclaration>(), m => m.Name == "__explicit_Corpus_Issue2010_IWelcomer__Greet");
         Assert.Contains("hi", printed, StringComparison.Ordinal);
         Assert.Contains("welcome", printed, StringComparison.Ordinal);
 
@@ -120,7 +120,7 @@ namespace Corpus.Issue2010
 
         TypeDeclaration loudHost = unit.Members.OfType<TypeDeclaration>().Single(t => t.Name == "LoudHost");
         Assert.Contains(loudHost.Members.OfType<MethodDeclaration>(), m => m.Name == "Greet");
-        Assert.Contains(loudHost.Members.OfType<MethodDeclaration>(), m => m.Name == "__explicit_IGreeter__Greet");
+        Assert.Contains(loudHost.Members.OfType<MethodDeclaration>(), m => m.Name == "__explicit_Corpus_Issue2010_IGreeter__Greet");
         Assert.Contains("hello-public", printed, StringComparison.Ordinal);
         Assert.Contains("hello-explicit", printed, StringComparison.Ordinal);
 
@@ -128,6 +128,82 @@ namespace Corpus.Issue2010
             context.Diagnostics,
             d => d.Severity == TranslationSeverity.Unsupported && d.Message.Contains("explicit interface", StringComparison.OrdinalIgnoreCase));
         AssertRoundTripParses(printed);
+    }
+
+    /// <summary>
+    /// Follow-up fix: two SAME-SIMPLE-NAME interfaces declared in DIFFERENT
+    /// namespaces (<c>NsA.IBar</c> and <c>NsB.IBar</c>) previously mangled
+    /// to the identical <c>__explicit_IBar__M</c> name (bare simple name),
+    /// producing a hard GS0264 duplicate-signature collision instead of the
+    /// intended per-interface distinctness. The mangle now embeds the
+    /// interface's namespace-qualified name, so the two implementations
+    /// mangle to distinct names and both survive.
+    /// </summary>
+    [Fact]
+    public void TwoSameSimpleNameInterfacesFromDifferentNamespaces_MangleDistinctly()
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[]
+        {
+            ("NsA.cs", @"
+namespace NsA
+{
+    public interface IBar
+    {
+        string M();
+    }
+}"),
+            ("NsB.cs", @"
+namespace NsB
+{
+    public interface IBar
+    {
+        string M();
+    }
+}"),
+            ("Multi.cs", @"
+using NsA;
+using NsB;
+
+namespace Corpus.Issue2010
+{
+    public class Multi : NsA.IBar, NsB.IBar
+    {
+        string NsA.IBar.M()
+        {
+            return ""from-a"";
+        }
+
+        string NsB.IBar.M()
+        {
+            return ""from-b"";
+        }
+    }
+}"),
+        });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = project.Documents.Single(d => d.FilePath == "Multi.cs");
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        string printed = GSharpPrinter.Print(unit);
+
+        TypeDeclaration multi = unit.Members.OfType<TypeDeclaration>().Single(t => t.Name == "Multi");
+        var mangledNames = multi.Members.OfType<MethodDeclaration>().Select(m => m.Name).ToList();
+
+        // The two mangled names must be DISTINCT — this is the regression this
+        // fix addresses (previously both would be "__explicit_IBar__M").
+        Assert.Equal(2, mangledNames.Distinct(StringComparer.Ordinal).Count());
+        Assert.Contains(mangledNames, n => n.StartsWith("__explicit_NsA_IBar__M", StringComparison.Ordinal));
+        Assert.Contains(mangledNames, n => n.StartsWith("__explicit_NsB_IBar__M", StringComparison.Ordinal));
+        Assert.Contains("from-a", printed, StringComparison.Ordinal);
+        Assert.Contains("from-b", printed, StringComparison.Ordinal);
+
+        Assert.DoesNotContain(
+            context.Diagnostics,
+            d => d.Severity == TranslationSeverity.Unsupported && d.Message.Contains("explicit interface", StringComparison.OrdinalIgnoreCase));
     }
 
     private static void AssertRoundTripParses(string rendered)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -519,6 +519,22 @@ public sealed class CSharpToGSharpTranslator
         // integer; `decimal` is a widening target of every integral source. Used by
         // the call-site argument coercion (issue #1281) to drop a redundant explicit
         // conversion when gsc already widens the operand implicitly.
+
+        /// <summary>
+        /// Namespace/nesting-qualified name of an interface type, with every
+        /// '.' replaced by '_' so the result is a single valid identifier
+        /// segment (must stay in sync with the equivalent computation in
+        /// <c>DeclarationBinder.TryResolveExplicitInterfaceImplementation</c>,
+        /// which reconstructs the same string from the G# side as
+        /// <c>PackageName + "." + Name</c>, and with the file-level namespace
+        /// flattening in <see cref="ResolvePackage"/> that determines what a
+        /// translated interface's G# package name actually is).
+        /// </summary>
+        private static readonly SymbolDisplayFormat QualifiedInterfaceNameFormat = new SymbolDisplayFormat(
+            typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,
+            genericsOptions: SymbolDisplayGenericsOptions.None,
+            globalNamespaceStyle: SymbolDisplayGlobalNamespaceStyle.Omitted);
+
         private static readonly Dictionary<SpecialType, HashSet<SpecialType>> NumericWideningTargets = new()
         {
             [SpecialType.System_SByte] = new() { SpecialType.System_Int16, SpecialType.System_Int32, SpecialType.System_Int64, SpecialType.System_IntPtr, SpecialType.System_Single, SpecialType.System_Double, SpecialType.System_Decimal },
@@ -2838,8 +2854,42 @@ public sealed class CSharpToGSharpTranslator
             // #1911 "force public, drop on exact-signature collision" handling
             // is preserved unchanged for external interfaces.
             bool isExplicitInterfaceImpl = symbol != null && symbol.ExplicitInterfaceImplementations.Length > 0;
+
+            // Issue #2010 follow-up: Roslyn's ExplicitInterfaceImplementations
+            // can hold MORE THAN ONE entry — this happens when the explicit
+            // member also satisfies an inherited/re-declared same-signature
+            // member on a BASE interface (e.g. `void IBar.M(){}` where
+            // `interface IBar : IFoo` and IFoo already declares `M`). The
+            // mangled-name + CLR-MethodImpl scheme below wires exactly ONE
+            // interface slot per mangled method, so it only applies when
+            // there is a SINGLE entry and it is a G# user interface. Any
+            // other shape (mixed user+external, or >1 user entries) falls
+            // back to the pre-#2010 (#1911) named/forced-public path: the
+            // method keeps its plain name, and gsc's ordinary implicit
+            // name+signature interface-dispatch matching then satisfies
+            // every entry uniformly (no explicit MethodImpl row needed) —
+            // lossier (loses C#'s "not publicly callable by name"
+            // semantics) but correct, and consistent with the existing
+            // external-interface handling.
             bool isUserInterfaceExplicitImpl = isExplicitInterfaceImpl &&
+                symbol.ExplicitInterfaceImplementations.Length == 1 &&
                 symbol.ExplicitInterfaceImplementations[0].ContainingType.Locations.Any(l => l.IsInSource);
+
+            if (isExplicitInterfaceImpl && symbol.ExplicitInterfaceImplementations.Length > 1 &&
+                symbol.ExplicitInterfaceImplementations.All(e => e.ContainingType.Locations.Any(l => l.IsInSource)))
+            {
+                string names = string.Join(", ", symbol.ExplicitInterfaceImplementations.Select(e => e.ContainingType.Name));
+                string multiEntryMessage =
+                    $"explicit interface implementation '{FormatExplicitInterfaceName(symbol)}' satisfies more than one " +
+                    $"G# user interface member in one C# declaration ({names}), likely via interface inheritance " +
+                    "(a base interface re-declaring the same signature). The issue #2010 mangled-name + CLR MethodImpl " +
+                    "scheme only wires a single interface slot per mangled method, so this falls back to the #1911 " +
+                    "named/forced-public path instead of mangling — the method keeps its plain name and every " +
+                    "interface's slot is satisfied via ordinary implicit name+signature dispatch (known gap: the " +
+                    "method becomes publicly callable by name, unlike real C# explicit-impl semantics).";
+                this.context.Report(new TranslationDiagnostic(
+                    nameof(SyntaxKind.MethodDeclaration), multiEntryMessage, node.GetLocation(), TranslationSeverity.Info));
+            }
 
             if (isExplicitInterfaceImpl && !isUserInterfaceExplicitImpl)
             {
@@ -3043,19 +3093,31 @@ public sealed class CSharpToGSharpTranslator
         /// Issue #2010: mangles an explicit interface implementation's name
         /// into the reserved <c>__explicit_&lt;Interface&gt;__&lt;Member&gt;</c>
         /// convention gsc's binder recognizes (see
-        /// <c>DeclarationBinder.TryParseExplicitInterfaceImplName</c>). Using
-        /// the interface's own simple name keeps two explicit implementations
-        /// of the same member from two different interfaces from colliding —
-        /// each gets its own name, its own MethodDef, and (via the binder/
-        /// emitter) its own MethodImpl row into its own interface's slot.
+        /// <c>DeclarationBinder.TryParseExplicitInterfaceImplName</c>).
+        /// Only called when <see cref="IMethodSymbol.ExplicitInterfaceImplementations"/>
+        /// has exactly one entry (see the caller in <see cref="TranslateMethod"/>),
+        /// so indexing <c>[0]</c> here is safe.
+        ///
+        /// Follow-up fix: the interface component is the interface's
+        /// NAMESPACE-QUALIFIED name (dots sanitized to underscores), not its
+        /// bare simple name — two same-simple-name interfaces declared in
+        /// different namespaces (e.g. <c>Foo.IBar</c> and <c>Baz.IBar</c>)
+        /// previously mangled to the identical name and collided (GS0264).
+        /// The binder-side match in
+        /// <c>DeclarationBinder.TryResolveExplicitInterfaceImplementation</c>
+        /// builds the same qualified-name string from the G# interface's
+        /// package + name and must stay in sync with this method.
         /// </summary>
         private static string MangleExplicitInterfaceImplName(IMethodSymbol symbol)
         {
             ISymbol explicitMember = symbol.ExplicitInterfaceImplementations[0];
-            string interfaceName = SanitizeIdentifier(explicitMember.ContainingType.Name);
+            string interfaceName = SanitizeIdentifier(QualifyInterfaceName(explicitMember.ContainingType));
             string memberName = SanitizeIdentifier(explicitMember.Name);
             return $"__explicit_{interfaceName}__{memberName}";
         }
+
+        private static string QualifyInterfaceName(INamedTypeSymbol interfaceType)
+            => interfaceType.ToDisplayString(QualifiedInterfaceNameFormat).Replace('.', '_');
 
         /// <summary>
         /// Issue #1911: finds the sibling method on the same containing type that

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -2806,33 +2806,42 @@ public sealed class CSharpToGSharpTranslator
             var symbol = this.context.GetDeclaredSymbol(node) as IMethodSymbol;
             bool isStatic = symbol != null && symbol.IsStatic;
 
-            // Issue #1911: C# `string IGreeter.Greet() { ... }` (explicit interface
-            // implementation) has no G# equivalent — G# has no name-hiding surface
-            // for interface members (ADR-0091 rejected an `IFoo.M(this)` spelling
-            // for exactly this reason: it conflates "explicit interface dispatch"
-            // with G#'s existing extension-function sugar). The only disambiguation
-            // tool G# offers (`base[IFoo].M()`, samples/InterfaceDiamondDisambiguation.gs)
-            // resolves *default*-body diamonds inside an `override`, not distinct
-            // per-interface slots for an abstract member — so an explicit impl must
-            // collapse onto the ordinary public method slot that already satisfies
-            // the interface contract by name.
+            // Issue #1911 / #2010: C# `string IGreeter.Greet() { ... }` (explicit
+            // interface implementation) has no direct G# surface syntax (ADR-0091
+            // rejected an `IFoo.M(this)` spelling for conflating with G#'s
+            // existing extension-function sugar).
             //
-            // If a same-signature sibling with the same name already exists on the
-            // type — a plain public method (the common "public API + hidden explicit
-            // impl" C# pattern), or another explicit implementation of a *different*
-            // interface with an identical name+signature (a same-name diamond of
-            // abstract explicit impls) — keeping both would be an exact-signature
-            // duplicate (GS0264). Only one survives (the public method if there is
-            // one, else whichever explicit impl appears first in source); the rest
-            // are dropped. The survivor still fills every implemented interface's
-            // abstract slot by name+signature (that is exactly why C# allowed the
-            // duplicate signature to begin with), but slot-occupancy is not the
-            // same as behavioral fidelity: any dropped explicit implementation may
-            // have its own body distinct from the survivor's (this is true both for
-            // the "coexists with a differently-bodied public method" shape AND for
-            // a diamond of two-or-more explicit impls with distinct bodies), so
-            // every drop here is a potential semantic loss and is reported as such.
-            if (symbol != null && symbol.ExplicitInterfaceImplementations.Length > 0)
+            // When the implemented interface is a G# USER interface (declared in
+            // this same C# source, so it translates to a G# `interface`), the
+            // explicit implementation is emitted as its own distinct G# method
+            // under a reserved mangled name (`__explicit_<Interface>__<Member>`,
+            // see MangleExplicitInterfaceImplName below) instead of collapsing
+            // same-name/same-signature explicit implementations of different
+            // interfaces onto a single surviving body (the #1911 fix, which
+            // silently dropped the rest). gsc's binder recognizes this
+            // convention and links the method to the specific interface member
+            // it implements; the emitter binds a CLR `MethodImpl` row so each
+            // interface's dispatch slot routes to its own body (reusing the
+            // ADR-0089 static-virtual / issue #985 bridge machinery). Since the
+            // mangled name embeds the interface's own name, two explicit
+            // implementations of the same member from different user interfaces
+            // never collide — no drop, no diagnostic, full fidelity.
+            //
+            // When the implemented interface is an EXTERNAL (BCL/imported) CLR
+            // interface, this new mechanism does not apply — the existing #985
+            // covariant-return-bridge machinery in gsc's binder already handles
+            // that shape (e.g. `IEnumerator IEnumerable.GetEnumerator()`
+            // alongside `IEnumerator<T> GetEnumerator()`), and it keys on the
+            // method keeping its ORIGINAL (un-mangled) simple name plus a
+            // return-type-only signature difference from its public sibling.
+            // Mangling would break that pre-existing, narrower bridge, so the
+            // #1911 "force public, drop on exact-signature collision" handling
+            // is preserved unchanged for external interfaces.
+            bool isExplicitInterfaceImpl = symbol != null && symbol.ExplicitInterfaceImplementations.Length > 0;
+            bool isUserInterfaceExplicitImpl = isExplicitInterfaceImpl &&
+                symbol.ExplicitInterfaceImplementations[0].ContainingType.Locations.Any(l => l.IsInSource);
+
+            if (isExplicitInterfaceImpl && !isUserInterfaceExplicitImpl)
             {
                 IMethodSymbol survivor = FindPriorCollidingSibling(symbol, node);
                 if (survivor != null)
@@ -2843,17 +2852,21 @@ public sealed class CSharpToGSharpTranslator
                         "G# has no explicit-interface-implementation surface (ADR-0091), so the two C# methods cannot both " +
                         "be emitted (would be an exact-signature duplicate, GS0264). This declaration is dropped in favor " +
                         "of the surviving sibling, which already satisfies the interface by name; if the surviving " +
-                        "sibling's body differs from this dropped declaration's body (possible whenever the survivor is a " +
-                        "differently-bodied public method, or another explicit implementation of a different interface with " +
-                        "its own distinct body), any C# call through the interface-typed reference that previously reached " +
-                        "this body now silently observes the surviving method's body instead (semantic loss, known gap, " +
-                        "issue #1911).";
+                        "sibling's body differs from this dropped declaration's body, any C# call through the " +
+                        "interface-typed reference that previously reached this body now silently observes the surviving " +
+                        "method's body instead (semantic loss, known gap, issue #1911). This diagnostic covers only " +
+                        "EXTERNAL/BCL interfaces — a same-signature collision between two G# user-interface explicit " +
+                        "implementations is fully supported (issue #2010, mangled-name + CLR MethodImpl).";
                     this.context.Report(new TranslationDiagnostic(
                         nameof(SyntaxKind.MethodDeclaration), message, node.GetLocation(), TranslationSeverity.Unsupported));
 
                     return (null, false);
                 }
             }
+
+            string mangledExplicitName = isUserInterfaceExplicitImpl
+                ? MangleExplicitInterfaceImplName(symbol)
+                : null;
 
             Receiver receiver = null;
             bool skipFirstParameter = false;
@@ -2988,21 +3001,28 @@ public sealed class CSharpToGSharpTranslator
                 body = null;
             }
 
-            // Issue #1911: Roslyn reports an explicit interface implementation's
-            // `DeclaredAccessibility` as `Private` (it has no accessibility keyword
-            // and is unreachable through the class type), but the CLR interface
-            // slot it fills is a public contract. Mapping that `Private` straight
-            // through emitted `private func Greet()`, which gsc does not wire into
-            // the type's `InterfaceImpl` v-table slot — the class type-checks
-            // (name match is enough for the binder) but fails `ilverify` with
-            // "Class implements interface but not method". The method must be
-            // public in G# for the interface slot to be filled.
-            Visibility explicitInterfaceVisibility = symbol != null && symbol.ExplicitInterfaceImplementations.Length > 0
+            // Issue #2010: a G# user-interface explicit implementation now
+            // emits under its mangled name (`__explicit_<Interface>__<Member>`)
+            // and is bound to its own CLR interface slot via an explicit
+            // MethodImpl row at emit time — it no longer relies on name-based
+            // virtual dispatch, so it can keep C#'s own `private`-equivalent
+            // visibility (Roslyn reports `DeclaredAccessibility` as `Private`:
+            // no accessibility keyword, unreachable through the class type).
+            // This matches C# semantics, where an explicit impl is not
+            // publicly callable by the type name.
+            //
+            // Issue #1911: an EXTERNAL (BCL/imported) interface explicit
+            // implementation still relies on the pre-existing name-based
+            // #985 covariant-return-bridge slot-filling, which requires the
+            // method to be public — mapping Roslyn's `Private` straight
+            // through would fail `ilverify` ("Class implements interface but
+            // not method"), so it is still forced public here.
+            Visibility explicitInterfaceVisibility = isExplicitInterfaceImpl && !isUserInterfaceExplicitImpl
                 ? Visibility.Default
                 : MapVisibility(symbol, this.context, node);
 
             var method = new MethodDeclaration(
-                SanitizeIdentifier(node.Identifier.Text),
+                mangledExplicitName ?? SanitizeIdentifier(node.Identifier.Text),
                 parameters: parameters,
                 returnType: returnType,
                 body: body,
@@ -3020,6 +3040,24 @@ public sealed class CSharpToGSharpTranslator
         }
 
         /// <summary>
+        /// Issue #2010: mangles an explicit interface implementation's name
+        /// into the reserved <c>__explicit_&lt;Interface&gt;__&lt;Member&gt;</c>
+        /// convention gsc's binder recognizes (see
+        /// <c>DeclarationBinder.TryParseExplicitInterfaceImplName</c>). Using
+        /// the interface's own simple name keeps two explicit implementations
+        /// of the same member from two different interfaces from colliding —
+        /// each gets its own name, its own MethodDef, and (via the binder/
+        /// emitter) its own MethodImpl row into its own interface's slot.
+        /// </summary>
+        private static string MangleExplicitInterfaceImplName(IMethodSymbol symbol)
+        {
+            ISymbol explicitMember = symbol.ExplicitInterfaceImplementations[0];
+            string interfaceName = SanitizeIdentifier(explicitMember.ContainingType.Name);
+            string memberName = SanitizeIdentifier(explicitMember.Name);
+            return $"__explicit_{interfaceName}__{memberName}";
+        }
+
+        /// <summary>
         /// Issue #1911: finds the sibling method on the same containing type that
         /// would win the (name, signature) slot over <paramref name="explicitImplementation"/>
         /// once both are translated to G# — i.e. the sibling that this declaration
@@ -3027,7 +3065,10 @@ public sealed class CSharpToGSharpTranslator
         /// duplicate-overload. Returns <see langword="null"/> when
         /// <paramref name="explicitImplementation"/> is itself the survivor (no
         /// same-signature sibling, or it is the earliest-declared one among a set
-        /// of same-signature explicit implementations).
+        /// of same-signature explicit implementations). Only invoked for an
+        /// EXTERNAL (BCL/imported) interface explicit implementation — a G#
+        /// user-interface explicit implementation (issue #2010) is mangled to a
+        /// unique name and never collides in the first place.
         /// </summary>
         /// <remarks>
         /// A plain public method always wins over any explicit implementation

--- a/tools/cs2gs/corpus/grid/G06-Types-Console/Constructs/ExplicitInterfaceSpecifier.cs
+++ b/tools/cs2gs/corpus/grid/G06-Types-Console/Constructs/ExplicitInterfaceSpecifier.cs
@@ -5,21 +5,20 @@
 // through the class type), and the translator mapped that straight through.
 // The class type-checked (name match is enough for gsc's binder) but failed
 // ilverify: "Class implements interface but not method", because a `private`
-// G# method is never wired into the CLR `InterfaceImpl` v-table slot. Fixed:
-// an explicit interface implementation now always emits as a plain PUBLIC
-// method — G# has no explicit-interface-implementation surface (ADR-0091
-// rejected an `IFoo.M(this)` spelling as conflating extension-function sugar
-// with explicit interface dispatch), so the public method is the only slot
-// available to satisfy the contract.
+// G# method is never wired into the CLR `InterfaceImpl` v-table slot.
 //
-// The other half of the issue — an explicit impl COEXISTING with a same-name
-// public method (e.g. `public string Greet()` plus `string IGreeter.Greet()`)
-// — cannot be represented with output parity at all: C# gives the two
-// methods genuinely different bodies reachable from different static types,
-// while G# has only one name-matching slot. That shape is intentionally not
-// part of this stdout-parity fixture (see
-// Cs2Gs.Tests/Issue1911ExplicitInterfaceImplementationTests.cs for the
-// compile/ilverify-clean, no-duplicate-overload coverage of that case).
+// Issue #2010 (full fix, follow-up to #1911's "force public" workaround):
+// an explicit interface implementation now emits under a reserved mangled
+// name (`__explicit_<Interface>__<Member>`) that gsc's binder recognizes and
+// links to the specific interface member it implements; the emitter binds a
+// CLR `MethodImpl` row (reusing the ADR-0089 static-virtual / issue #985
+// bridge machinery) so the interface's slot dispatches to this method's own
+// body regardless of its (now C#-faithful, non-public) visibility. This also
+// removes the #1911 "coexisting/colliding explicit impls collapse to one
+// surviving body" gap entirely: QuietHost below implements the SAME-NAME,
+// SAME-SIGNATURE `Greet()` member explicitly for TWO different interfaces
+// (IGreeter and IWelcomer) with two DISTINCT bodies, and both dispatch
+// correctly — no drop, no diagnostic, full fidelity.
 using System;
 
 namespace Corpus.Grid06
@@ -29,11 +28,21 @@ namespace Corpus.Grid06
         string Greet();
     }
 
-    public class QuietHost : IGreeter
+    public interface IWelcomer
+    {
+        string Greet();
+    }
+
+    public class QuietHost : IGreeter, IWelcomer
     {
         string IGreeter.Greet()
         {
             return "hello-explicit";
+        }
+
+        string IWelcomer.Greet()
+        {
+            return "welcome-explicit";
         }
     }
 
@@ -42,8 +51,10 @@ namespace Corpus.Grid06
         public static void Run()
         {
             QuietHost host = new QuietHost();
-            IGreeter viaInterface = host;
-            Console.WriteLine("ExplicitInterfaceSpecifier: interface=" + viaInterface.Greet());
+            IGreeter viaGreeter = host;
+            IWelcomer viaWelcomer = host;
+            Console.WriteLine("ExplicitInterfaceSpecifier: interface=" + viaGreeter.Greet());
+            Console.WriteLine("ExplicitInterfaceSpecifier: collision=" + viaGreeter.Greet() + "/" + viaWelcomer.Greet());
         }
     }
 }

--- a/tools/cs2gs/corpus/grid/G06-Types-Console/baseline.stdout.golden
+++ b/tools/cs2gs/corpus/grid/G06-Types-Console/baseline.stdout.golden
@@ -22,6 +22,7 @@ EnumMemberDeclaration: write=8
 EnumMemberDeclaration: readwrite=12
 EnumMemberDeclaration: readwrite-is-flags-combo=true
 ExplicitInterfaceSpecifier: interface=hello-explicit
+ExplicitInterfaceSpecifier: collision=hello-explicit/welcome-explicit
 InterfaceDeclaration: length=12
 InterfaceDeclaration: describe=rope of 12
 InterfaceDeclaration: default-method=42


### PR DESCRIPTION
Fixes #2010

## Summary

Full-fidelity fix (not the intermediate fallback) — no drops, zero semantic loss for G# user-interface explicit implementations.

Follow-up from PR #1994 (issue #1911). #1911's fix forced explicit interface implementations public and dropped colliding same-signature siblings, surfaced via an `Unsupported` diagnostic. This PR replaces that with the "genuinely bigger" alternative the issue proposed: each explicit implementation of a G# user interface is emitted under a reserved mangled name (`__explicit_<Interface>__<Member>`), gsc's binder links it to the specific interface member it implements, and the emitter binds a CLR `MethodImpl` row per implementation — reusing the exact ADR-0089 static-virtual / issue #985 covariant-return-bridge machinery already present in `ReflectionMetadataEmitter.cs`. Each interface's dispatch slot now routes to its own distinct method body.

## Design

- `FunctionSymbol.ExplicitInterfaceMember` (new): the in-compilation interface member a method explicitly implements. Distinct from the pre-existing `ExplicitInterfaceSlot` (a `System.Reflection.MethodInfo`, used for the #985 *external/BCL* interface bridge).
- `DeclarationBinder`: recognizes the `__explicit_<Interface>__<Member>` mangled-name convention during the deferred `VerifyInterfaceImplementations` pass (interface members aren't bound yet at initial class-member-bind time), links the method, and treats it as satisfying that interface's abstract slot without requiring a name match. No new grammar — it's a plain reserved identifier convention, in the spirit of ADR-0091's rejection of an `IFoo.M(this)` surface syntax.
- `ReflectionMetadataEmitter.EmitExplicitInterfaceMethodImpls`: extended to also bind a `MethodImpl` row for `ExplicitInterfaceMember`, generic-interface aware (reuses `ResolveUserInterfaceInstanceMethodToken`).
- `CSharpToGSharpTranslator`: a C# explicit implementation of a G# user interface (declared in source) now emits under the mangled name with C#-faithful (non-public) visibility, instead of forced-public + collision-drop. An explicit implementation of an external/BCL interface keeps the prior #1911 behavior unchanged (forced public, collision-drop with `Unsupported`) since it relies on the pre-existing #985 bridge, which is keyed on the method's un-mangled name plus a return-type-only signature difference — mangling would break that narrower, already-working mechanism.

## Tests

- `test/Compiler.Tests/Emit/Issue2010ExplicitInterfaceImplEmitTests.cs`: two interfaces with a same-name/same-signature member, both explicitly implemented with distinct bodies on one type. Verifies two MethodDef rows (no drop), two MethodImpl rows, ilverify-clean IL, and correct dispatch through each interface-typed reference (`((IFoo)obj).Bar()` vs `((IBaz)obj).Bar()`) end to end.
- `tools/cs2gs/Cs2Gs.Tests/Issue2010ExplicitInterfaceImplementationTests.cs`: translator-level coverage — colliding explicit impls with no public sibling, and an explicit impl coexisting with a same-name public method. Both now translate with zero drops and zero diagnostics.
- `tools/cs2gs/Cs2Gs.Tests/Issue1911ExplicitInterfaceImplementationTests.cs`: updated for the new mangled-name/private-visibility behavior on the lone-impl case; the collision-drop-specific tests moved to the #2010 file (that behavior no longer applies to G# user interfaces).
- `tools/cs2gs/corpus/grid/G06-Types-Console/Constructs/ExplicitInterfaceSpecifier.cs`: extended the corpus fixture with a second interface (`IWelcomer`) colliding on `Greet()`, reproducing the original #1911/#1994-review scenario end-to-end through the real migrate → compile → ilverify → run pipeline.

## Results

- Full `Core.Tests`: 5452 passed, 1 pre-existing skip, 0 failed.
- Full `Cs2Gs.Tests`: 986 passed, 0 failed.
- Targeted `Compiler.Tests` (Issue985/Issue2010/StaticVirtual/Interface filters, `-- xUnit.MaxParallelThreads=2`): 222 passed, 0 failed.
- Full corpus sanity migrate (`cs2gs migrate --corpus tools/cs2gs/corpus --baseline tools/cs2gs/triage/gaps.json`): 16/20 apps green; the 3 failing apps match the existing baseline exactly (0 new, 0 regressed).
- `cs2gs coverage --write`: no observable coverage-matrix diff (this is a behavioral fix, not a new/changed construct-coverage classification).

Nothing deferred — external/BCL-interface explicit-impl handling is intentionally left on the narrower #985/#1911 path since it already works and mangling it would have broken that pre-existing mechanism (caught and fixed during testing).
