### PR TITLE
gsc: parenthesized arrow assignment target parses (#2002)

### DIFF
--- a/src/Core/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.cs
@@ -7885,6 +7885,81 @@ public class Parser
             return false;
         }
 
+        // ADR-0122 §4 / issue #2002: `(<receiver>)->member = value` is
+        // ambiguous with a lambda whenever the receiver's leading token looks
+        // like a parameter name — grammatically, some receivers (e.g. a bare
+        // identifier `(p)`, or even a call `(getPtr())` — a call's argument
+        // list is *also* a valid lambda-parameter type-clause shape, see
+        // `getPtr ()` parsed as "parameter getPtr of tuple type ()" — both
+        // commit cleanly as a lambda parameter list, so grammar-only
+        // trial-parsing (below) cannot disambiguate them from a genuine
+        // pointer-arrow receiver. Break the tie using the tokens immediately
+        // following the arrow: a lambda whose entire body is a bare
+        // `member = value` (or compound-assignment) is vanishingly rare,
+        // while this exact shape is the whole point of a parenthesized
+        // arrow-assignment target — and mirrors the unparenthesized form,
+        // where `unsafeDepth > 0` already commits `IDENT -> member` to
+        // pointer-arrow access unconditionally (see the bare-identifier
+        // dispatch case above in ParsePrimaryExpression). Bias towards
+        // arrow-member ASSIGNMENT whenever the arrow is immediately followed
+        // by `IDENT =` / `IDENT <compound-op>=`, for ANY receiver shape.
+        // ponytail: this narrowly misclassifies the rare unsafe-context
+        // multi-param lambda whose body happens to start with exactly that
+        // shape (e.g. `(a, b) -> total = a + b`); upgrade to a fuller
+        // parameter-count-aware check if that pattern is ever needed.
+        if (this.unsafeDepth > 0
+            && Peek(offset + 2).Kind == SyntaxKind.IdentifierToken
+            && (Peek(offset + 3).Kind == SyntaxKind.EqualsToken
+                || SyntaxFacts.TryGetCompoundAssignmentBaseOperator(Peek(offset + 3).Kind, out _)))
+        {
+            return false;
+        }
+
+        // ADR-0122 §4 / issue #2002: inside an unsafe context, `->` after a
+        // PARENTHESIZED receiver is ambiguous with a parenthesized lambda —
+        // both `(p) -> body` (lambda) and `(p)->member` (pointer-arrow member
+        // access on receiver `p`, desugared to `(*p).member` by
+        // ParsePostfixChainCore) share the exact same leading shape (an
+        // identifier-first interior followed by a matching `)` then `->`).
+        // The cheap heuristic above (first interior token looks like a
+        // parameter name) is exact for a genuine parameter list but
+        // over-commits for a parenthesized arrow-receiver whose interior
+        // continues with anything a parameter list can never contain — e.g.
+        // `(a.b)->X`, or the double-indirection assignment target
+        // `(*pp)->X = v` (already excluded above since `*` isn't an
+        // identifier).
+        //
+        // Disambiguate precisely, but only where the ambiguity exists
+        // (unsafeDepth > 0): speculatively trial-parse the interior as a
+        // lambda parameter list. Only commit to the lambda if the trial
+        // parse both consumes the interior without reporting any diagnostic
+        // AND lands exactly on the closing `)` already located above —
+        // otherwise the interior is not a valid parameter list, so this is a
+        // parenthesized arrow-receiver instead and we fall through to the
+        // normal expression/postfix-chain path (which handles arrow-member
+        // access — and, transitively via TryLiftTrailingMemberAccess, arrow
+        // assignment targets — for any receiver shape, including double
+        // indirection). The trial parse never mutates externally-visible
+        // parser state: position and diagnostics are unconditionally rolled
+        // back.
+        if (this.unsafeDepth > 0)
+        {
+            var savedPosition = this.position;
+            var savedDiagnosticCount = Diagnostics.Count;
+            try
+            {
+                this.position = savedPosition + startOffset + 1;
+                ParseLambdaParameterList();
+                return Current.Kind == SyntaxKind.CloseParenthesisToken
+                    && Diagnostics.Count == savedDiagnosticCount;
+            }
+            finally
+            {
+                this.position = savedPosition;
+                Diagnostics.TruncateTo(savedDiagnosticCount);
+            }
+        }
+
         return true;
     }
 

--- a/test/Compiler.Tests/Emit/Issue2002ParenthesizedArrowAssignmentEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2002ParenthesizedArrowAssignmentEmitTests.cs
@@ -1,0 +1,163 @@
+// <copyright file="Issue2002ParenthesizedArrowAssignmentEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2002 / ADR-0122 §4: end-to-end emit + execution tests for
+/// assignment through an EXPLICITLY PARENTHESIZED pointer-arrow receiver —
+/// <c>(expr)-&gt;Member = value</c>. Before the fix, the parser's <c>(...) -&gt;</c>
+/// lambda-vs-pointer-arrow disambiguator (<c>LooksLikeLambdaStart</c>)
+/// mis-parsed this shape as a lambda expression (silently, for a bare
+/// identifier receiver) or reported a spurious GS0005 (for any other
+/// receiver, e.g. a dereference), depending on the exact interior shape.
+/// Covers the motivating double-indirection write <c>(*pp)-&gt;X = value</c>
+/// (where <c>pp</c> is a pointer-to-a-pointer, <c>**Point</c>) alongside the
+/// simpler single-parenthesized-receiver write, confirming both that parsing
+/// no longer fails and that the write actually lands at runtime.
+/// </summary>
+public class Issue2002ParenthesizedArrowAssignmentEmitTests
+{
+    private static readonly string[] UnsafeIlVerifyIgnored =
+    {
+        "UnmanagedPointer",
+        "StackUnexpected",
+        "StackByRef",
+        "ExpectedPtr",
+        "StackUnexpectedArrayType",
+    };
+
+    private const string PointStruct = """
+        package Probe
+        import System
+
+        struct Point {
+            var x int32
+        }
+
+        """;
+
+    [Fact]
+    public void ParenthesizedArrowReceiver_Assignment_CompilesAndRuns()
+    {
+        var source = PointStruct + """
+            unsafe func run() {
+                var arr = []Point{Point{x: 1}}
+                var p = &arr[0]
+                (p)->x = 42
+                Console.WriteLine(arr[0].x)
+            }
+
+            run()
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void DoubleIndirection_ParenthesizedDerefArrow_Assignment_CompilesAndRuns()
+    {
+        var source = PointStruct + """
+            unsafe func run() {
+                var arr = []Point{Point{x: 1}}
+                var p *Point = &arr[0]
+                var pp **Point = &p
+                Console.WriteLine((*pp)->x)
+                (*pp)->x = 77
+                Console.WriteLine(arr[0].x)
+                Console.WriteLine((*pp)->x)
+            }
+
+            run()
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal("1\n77\n77\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue2002_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            // Unsafe pointer code is unverifiable by design; tolerate the
+            // inherent-unsafety error codes while still gating on other
+            // verification regressions.
+            IlVerifier.Verify(outPath, null, UnsafeIlVerifyIgnored);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+                // ignored
+            }
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue2002ParenthesizedArrowAssignmentParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue2002ParenthesizedArrowAssignmentParserTests.cs
@@ -1,0 +1,140 @@
+// <copyright file="Issue2002ParenthesizedArrowAssignmentParserTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Issue #2002 / ADR-0122 §4: an assignment whose LHS is a parenthesized
+/// pointer-arrow member access — <c>(expr)-&gt;Member = value</c> — must parse
+/// (no GS0005), for ANY parenthesized receiver shape, not just the bare
+/// unparenthesized <c>p-&gt;Member = value</c> form. The unparenthesized arrow
+/// (<c>p-&gt;X = v</c>) and the explicit dot-desugared form (<c>(p).X = v</c>)
+/// already worked; only the explicitly-parenthesized arrow-receiver form was
+/// broken.
+/// <para>
+/// Root cause: <c>LooksLikeLambdaStart</c> (the <c>(...) -&gt;</c> lambda vs.
+/// pointer-arrow disambiguator) committed to a lambda parse for ANY
+/// parenthesized interior whose first token looked like an identifier,
+/// without validating the rest of the interior or considering the unsafe
+/// context — so <c>(p)-&gt;X = 10</c> silently mis-parsed as the lambda
+/// <c>(p) -&gt; (X = 10)</c>, and <c>(a.b)-&gt;X = 10</c> (an interior that
+/// merely *starts* with an identifier but isn't a valid parameter list) hit a
+/// genuine GS0005 once the lambda-parameter-list parse choked on the stray
+/// <c>.</c>.
+/// </para>
+/// </summary>
+public class Issue2002ParenthesizedArrowAssignmentParserTests
+{
+    private static IEnumerable<SyntaxNode> Descendants(SyntaxNode node)
+    {
+        foreach (var child in node.GetChildren())
+        {
+            yield return child;
+            foreach (var d in Descendants(child))
+            {
+                yield return d;
+            }
+        }
+    }
+
+    [Theory]
+    [InlineData("(p)->X = 10")]
+    [InlineData("(a.b)->X = 10")]
+    [InlineData("(arr[0])->X = 10")]
+    [InlineData("(*pp)->X = 10")]
+    [InlineData("(getPtr())->X = 10")]
+    public void ParenthesizedArrowReceiver_AssignmentTarget_ParsesWithoutGS0005(string statement)
+    {
+        var source = $$"""
+            unsafe func run() {
+                {{statement}}
+            }
+            """;
+
+        var tree = SyntaxTree.Parse(source);
+
+        Assert.DoesNotContain(tree.Diagnostics, d => d.Id == "GS0005");
+        Assert.Empty(tree.Diagnostics);
+
+        var assignment = Descendants(tree.Root).OfType<MemberFieldAssignmentExpressionSyntax>().SingleOrDefault();
+        Assert.NotNull(assignment);
+        Assert.Equal(SyntaxKind.RightArrowToken, assignment.DotToken.Kind);
+        Assert.Equal("X", assignment.FieldIdentifier.Text);
+    }
+
+    [Fact]
+    public void DoubleIndirection_ParenthesizedDerefArrow_AssignmentTarget_Parses()
+    {
+        // The motivating double-indirection shape from the issue:
+        // `(*pp)->X = value`, where `pp` is itself a pointer-to-pointer.
+        const string source = """
+            unsafe func run() {
+                (*pp)->X = 77
+            }
+            """;
+
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var assignment = Descendants(tree.Root).OfType<MemberFieldAssignmentExpressionSyntax>().Single();
+        var derefReceiver = Assert.IsType<UnaryExpressionSyntax>(assignment.Receiver);
+        Assert.Equal(SyntaxKind.StarToken, derefReceiver.OperatorToken.Kind);
+        var parenthesized = Assert.IsType<ParenthesizedExpressionSyntax>(derefReceiver.Operand);
+        var innerDeref = Assert.IsType<UnaryExpressionSyntax>(parenthesized.Expression);
+        Assert.Equal(SyntaxKind.StarToken, innerDeref.OperatorToken.Kind);
+    }
+
+    // ADR-0122 §4: outside an unsafe context, `->` is exclusively the lambda
+    // operator (there is no pointer-arrow feature to disambiguate against),
+    // so a genuinely malformed lambda parameter list must keep reporting a
+    // diagnostic there — this fix is scoped to unsafe contexts only.
+    [Fact]
+    public void OutsideUnsafeContext_DottedParenthesizedArrow_StillReportsDiagnostic()
+    {
+        const string source = """
+            func run() {
+                (a.b)->X = 10
+            }
+            """;
+
+        var tree = SyntaxTree.Parse(source);
+        Assert.NotEmpty(tree.Diagnostics);
+    }
+
+    // Non-assignment parenthesized-arrow shapes are unaffected by this fix and
+    // keep their pre-existing (ADR-documented) lambda interpretation for the
+    // maximally-ambiguous bare-single-identifier interior.
+    [Fact]
+    public void BareIdentifierParens_NonAssignmentArrowBody_StillParsesAsLambda()
+    {
+        const string source = """
+            unsafe func run() {
+                var f = (p) -> p + 1
+            }
+            """;
+
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+        Assert.Single(Descendants(tree.Root).OfType<LambdaExpressionSyntax>());
+    }
+
+    [Fact]
+    public void MultiParamLambda_StillParsesAsLambda_InUnsafeContext()
+    {
+        const string source = """
+            unsafe func run() {
+                var f = (a, b) -> a + b
+            }
+            """;
+
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+        Assert.Single(Descendants(tree.Root).OfType<LambdaExpressionSyntax>());
+    }
+}


### PR DESCRIPTION
Fixes #2002

## Root cause
`LooksLikeLambdaStart` (the `(...) ->` lambda-vs-pointer-arrow disambiguator) committed to a lambda parse for ANY parenthesized interior whose first token merely looked like an identifier — without validating the rest of the interior or considering the unsafe context. So:
- `(p)->X = 10` silently mis-parsed as the lambda `(p) -> (X = 10)` (no parse error, wrong tree — binder then reported unrelated GS0304/GS0125).
- `(a.b)->X = 10` (an interior that merely *starts* with an identifier but isn't a valid parameter list) hit a genuine GS0005 once the lambda-parameter-list parse choked on the stray `.`.
- `(*pp)->X = 10` (double indirection) already worked in isolation, but was easy to conflate with the above during triage.

## Fix (`src/Core/CodeAnalysis/Syntax/Parser.cs`, `LooksLikeLambdaStart`)
Scoped to `unsafeDepth > 0` only (outside unsafe, `->` is exclusively the lambda operator, so behavior there is unchanged):
1. **Assignment-shape tie-break**: if the arrow is immediately followed by `IDENT =` or `IDENT <compound-op>=`, treat it as an arrow-member assignment target (not a lambda), for ANY receiver shape — this mirrors how the unparenthesized `p->X = v` already always commits to pointer-arrow access in unsafe code.
2. **Speculative trial-parse fallback**: for non-assignment shapes, speculatively parse the interior as a real lambda parameter list (reusing `ParseLambdaParameterList`, snapshotting/rolling back position + diagnostics via the existing `DiagnosticBag.Count`/`TruncateTo`). Only commit to a lambda if the trial both parses cleanly and lands exactly on the already-located closing `)`; otherwise fall through to the normal expression/postfix-chain path, which already handles arrow-member access (and, via `TryLiftTrailingMemberAccess`, arrow-assignment targets) for any receiver shape.

Non-assignment parenthesized-arrow reads on a bare identifier (e.g. `(p)->X` used as a value) are unchanged and still parse as the ADR-0122-documented lambda reservation — the fix is scoped precisely to the assignment-target ambiguity the issue calls out.

## Tests
- `test/Core.Tests/CodeAnalysis/Syntax/Issue2002ParenthesizedArrowAssignmentParserTests.cs`: parser-level coverage — `(p)->X = 10`, `(a.b)->X = 10`, `(arr[0])->X = 10`, `(*pp)->X = 10`, `(getPtr())->X = 10` all parse with zero diagnostics as `MemberFieldAssignmentExpressionSyntax`; confirms the double-indirection receiver tree shape; confirms behavior outside unsafe context and non-assignment lambda forms (single/multi-param) are unaffected.
- `test/Compiler.Tests/Emit/Issue2002ParenthesizedArrowAssignmentEmitTests.cs`: end-to-end compile + `dotnet exec` — `(p)->x = 42` and the double-indirection `(*pp)->x = 77` (via a `**Point` pointer-to-pointer) both compile, ilverify (with the standard unsafe-pointer-code ignore list), and the write actually lands at runtime.

Validated: full `Core.Tests` suite (5475 passed / 1 skipped baseline-regen), and `Compiler.Tests` filtered to Arrow/Pointer/Lambda/Issue2002/Issue1034/Issue1925 (247 passed). No new `SyntaxKind`/`BoundNodeKind` added, so the coverage-matrix golden is unaffected.

No work deferred.