### PR TITLE
cs2gs: typed positional subpatterns + nullable tuple guard (#1943)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue1943TypedPositionalSubpatternTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1943TypedPositionalSubpatternTests.cs
@@ -1,0 +1,260 @@
+// <copyright file="Issue1943TypedPositionalSubpatternTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #1943 (follow-up from PR #1939 / issue #1887): a TYPED recursive
+/// pattern (<c>Point(0, 0) =&gt; …</c>) lowers to a G# <c>TypePattern</c>
+/// node, which — unlike a bare/untyped positional arm's <c>PropertyPattern</c>
+/// — has no room for an extra equality/relational field. A constant or
+/// relational (or nested) positional subpattern in that position previously
+/// only accepted <c>var</c>; anything else emitted a loud
+/// <c>CS2GS-GAP: positional subpattern has no canonical G# form yet</c>
+/// diagnostic. It now generalizes the untyped-arm lowering by synthesizing the
+/// same member-access boolean test and AND-ing it into the arm's <c>when</c>
+/// guard (<c>case Point point when point.X == 0 &amp;&amp; point.Y == 0:</c>).
+/// <para>
+/// Also covers the related null-guard gap: a nullable value-type tuple
+/// subject (<c>(int, int)? is (0, 0)</c>) narrows to the same non-nullable
+/// <c>MatchedType</c> a non-nullable tuple does, which previously skipped the
+/// null check unconditionally for any value-type receiver — wrongly, since a
+/// nullable subject can still be null at runtime and the emitted G#
+/// (<c>p.Item1 == 0</c>) would fault. It now guards nullable value-type
+/// subjects with the same <c>!= nil</c> test a reference-type receiver gets.
+/// </para>
+/// </summary>
+public class Issue1943TypedPositionalSubpatternTests
+{
+    [Fact]
+    public void SwitchExpression_TypedPositionalConstantSubpattern_LowersToWhenGuard()
+    {
+        // `Point(0, 0) =>` must keep BOTH constant positions as a `when`
+        // guard on the synthesized `point` designator, not silently accept
+        // only `var` positions.
+        string rendered = Render(@"
+namespace Corpus.Issue1943
+{
+    public record Point(int X, int Y);
+
+    public class Holder
+    {
+        public string Describe(object o)
+        {
+            return o switch
+            {
+                Point(0, 0) => ""origin"",
+                _ => ""other"",
+            };
+        }
+    }
+}
+");
+
+        Assert.Contains("case point is Point when point.X == 0 && point.Y == 0", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("CS2GS-GAP", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void SwitchExpression_TypedPositionalRelationalSubpattern_LowersToWhenGuard()
+    {
+        // `Point(> 0, _) =>`: a relational sub-pattern alongside a discard
+        // position — the discard contributes no test, the relational
+        // position becomes the sole guard clause.
+        string rendered = Render(@"
+namespace Corpus.Issue1943
+{
+    public record Point(int X, int Y);
+
+    public class Holder
+    {
+        public string Describe(object o)
+        {
+            return o switch
+            {
+                Point( > 0, _) => ""positive-x"",
+                _ => ""other"",
+            };
+        }
+    }
+}
+");
+
+        Assert.Contains("case point is Point when point.X > 0", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("CS2GS-GAP", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void SwitchExpression_TypedPositionalSubpattern_CombinesWithExplicitWhenClause()
+    {
+        // The synthesized guard must AND with (not replace) an explicit
+        // user `when` clause on the same arm.
+        string rendered = Render(@"
+namespace Corpus.Issue1943
+{
+    public record Point(int X, int Y);
+
+    public class Holder
+    {
+        public string Describe(object o, bool flag)
+        {
+            return o switch
+            {
+                Point(0, 0) when flag => ""origin-flagged"",
+                _ => ""other"",
+            };
+        }
+    }
+}
+");
+
+        Assert.Contains("when point.X == 0 && point.Y == 0 && flag", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void SwitchExpression_NestedTypedPositionalSubpattern_LowersToWhenGuard()
+    {
+        // A nested typed positional pattern (`Line(Point(0, 0), _)`) inside a
+        // typed positional slot: the nested test recurses through the same
+        // boolean-test machinery the untyped arm form already uses.
+        string rendered = Render(@"
+namespace Corpus.Issue1943
+{
+    public record Point(int X, int Y);
+    public record Line(Point Start, Point End);
+
+    public class Holder
+    {
+        public string Describe(object o)
+        {
+            return o switch
+            {
+                Line(Point(0, 0), _) => ""starts-at-origin"",
+                _ => ""other"",
+            };
+        }
+    }
+}
+");
+
+        Assert.Contains("case line is Line when", rendered, StringComparison.Ordinal);
+        Assert.Contains("line.Start.X == 0 && line.Start.Y == 0", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("CS2GS-GAP", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void SwitchStatement_TypedPositionalConstantSubpattern_LowersToWhenGuard()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1943
+{
+    public record Point(int X, int Y);
+
+    public class Holder
+    {
+        public bool IsOrigin(object o)
+        {
+            switch (o)
+            {
+                case Point(0, 0):
+                    return true;
+                default:
+                    return false;
+            }
+        }
+    }
+}
+");
+
+        Assert.Contains("case point is Point when point.X == 0 && point.Y == 0", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("CS2GS-GAP", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void IsPattern_NullableValueTypeTuplePositionalSubject_GuardsAgainstNull()
+    {
+        // `(int, int)? is (0, 0)`: the pattern narrows to the same
+        // non-nullable `(int, int)` a non-nullable tuple receiver would, but
+        // the SUBJECT can still be null at runtime — the emitted G# must keep
+        // the `!= nil` guard before testing `Item1`/`Item2`, unlike the
+        // non-nullable-tuple case (issue #1887), which correctly omits it.
+        string rendered = Render(@"
+namespace Corpus.Issue1943
+{
+    public class Holder
+    {
+        public bool IsOrigin((int, int)? p)
+        {
+            return p is (0, 0);
+        }
+    }
+}
+");
+
+        Assert.Contains("p != nil && p!!.Item1 == 0 && p!!.Item2 == 0", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void IsPattern_NonNullableValueTypeTuplePositionalSubject_OmitsNullGuard()
+    {
+        // Regression guard (issue #1887): a NON-nullable tuple subject must
+        // keep skipping the null check — G# rejects `!= nil` against a
+        // value type that can never be null.
+        string rendered = Render(@"
+namespace Corpus.Issue1943
+{
+    public class Holder
+    {
+        public bool IsOrigin((int, int) p)
+        {
+            return p is (0, 0);
+        }
+    }
+}
+");
+
+        Assert.Contains("p.Item1 == 0 && p.Item2 == 0", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("p != nil", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    private static void AssertRoundTripParses(string rendered)
+    {
+        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+
+        Assert.True(
+            result.Success,
+            "Sanitized G# must round-trip-parse. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + rendered);
+    }
+
+    private static string Render(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", source) });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        Cs2Gs.CodeModel.Ast.CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        return GSharpPrinter.Print(unit);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -10080,8 +10080,28 @@ public sealed class CSharpToGSharpTranslator
             // receiver; the member-access sub-tests below are the whole test
             // (and if there happen to be none, e.g. every position is a discard,
             // `true` is the correct always-matches result).
+            IOperation patternOperation = this.context.SemanticModel.GetOperation(recursive);
             bool receiverIsValueType = recursive.Type == null &&
-                this.context.SemanticModel.GetOperation(recursive) is IRecursivePatternOperation { MatchedType.IsValueType: true };
+                patternOperation is IRecursivePatternOperation { MatchedType.IsValueType: true };
+
+            // Issue #1943: a NULLABLE value-type receiver (`(int, int)?`)
+            // narrows to the SAME non-nullable `MatchedType` a non-nullable
+            // value-type receiver (`(int, int)`) does, so the check above can't
+            // tell the two apart — but unlike the non-nullable case, it CAN be
+            // null at runtime; skipping its guard the same way would let a null
+            // subject fault the member-access chain below (`p.Item1` on a null
+            // `p`). `IPatternOperation.InputType` (the pattern's UN-narrowed
+            // input type, unlike `MatchedType`) still reports the original
+            // `System.Nullable<T>`, so it reliably distinguishes the two shapes
+            // regardless of the corpus's nullable-annotations context (the same
+            // concern `ResolveDeclaredReceiverType` documents below for a
+            // reference-type receiver). G# models a value-type `T?` directly
+            // (no `Nullable<T>` member surface, see
+            // <see cref="TranslateMemberAccess"/>'s `Value`/`HasValue` rewrite)
+            // and relies on the same Kotlin-style smart-cast a reference-type
+            // receiver does, so the guard is the same `!= nil` test.
+            bool receiverIsNullableValueType = recursive.Type == null &&
+                patternOperation is IPatternOperation { InputType.OriginalDefinition.SpecialType: SpecialType.System_Nullable_T };
 
             // Issue #1923: a NESTED bare recursive pattern (`{ Address: { City:
             // "Lima" } }`) recurses into this method with `receiver` bound to the
@@ -10123,7 +10143,25 @@ public sealed class CSharpToGSharpTranslator
 
             GExpression test = recursive.Type != null
                 ? new BinaryExpression(receiver, "is", new TypeExpression(this.MapTypeSyntax(recursive.Type)))
-                : (receiverIsValueType || receiverIsNonNullableReference) ? null : new BinaryExpression(receiver, "!=", LiteralExpression.Null());
+                : ((receiverIsValueType && !receiverIsNullableValueType) || receiverIsNonNullableReference) ? null : new BinaryExpression(receiver, "!=", LiteralExpression.Null());
+
+            // Issue #1943/#1545: gsc's `&&`/`||` short-circuit narrowing
+            // classifier (`SmartCastStability.TryClassifyNilGuardLeaf`,
+            // `referenceNullableOnly: true`) deliberately rejects a nullable
+            // VALUE type — narrowing `Nullable<T>` to `T` is not an IL no-op
+            // the way narrowing a nullable reference is, and the short-circuit
+            // path doesn't emit the unwrap (a separately-tracked gsc-side
+            // gap). So `candidate != nil && candidate.Item1 == 0` does NOT
+            // smart-cast `candidate` inside the `&&` chain and fails to
+            // compile (GS0158, "Cannot find member Item1"). The member
+            // accesses below must instead force-unwrap explicitly (`candidate
+            // !! .Item1`, the same `!!` rewrite <see cref="TranslateMemberAccess"/>
+            // already uses for a C# `Nullable<T>.Value` read) — safe here
+            // because `test`'s own `!= nil` guard already proved it non-null
+            // at runtime.
+            GExpression memberReceiver = receiverIsNullableValueType
+                ? new NonNullAssertionExpression(receiver)
+                : receiver;
 
             if (recursive.PropertyPatternClause != null)
             {
@@ -10137,7 +10175,7 @@ public sealed class CSharpToGSharpTranslator
 
                     string memberName = sub.NameColon?.Name.Identifier.Text
                         ?? sub.ExpressionColon?.Expression.ToString();
-                    GExpression memberAccess = new MemberAccessExpression(receiver, SanitizeIdentifier(memberName));
+                    GExpression memberAccess = new MemberAccessExpression(memberReceiver, SanitizeIdentifier(memberName));
                     ITypeSymbol memberType = this.TryGetSubpatternMemberType(sub);
                     GExpression memberTest = this.TranslatePatternTest(memberAccess, sub.Pattern, memberType, isNestedPatternMember: true);
                     test = test == null ? memberTest : new BinaryExpression(test, "&&", memberTest);
@@ -10173,7 +10211,7 @@ public sealed class CSharpToGSharpTranslator
                         continue;
                     }
 
-                    GExpression memberAccess = new MemberAccessExpression(receiver, SanitizeIdentifier(memberName));
+                    GExpression memberAccess = new MemberAccessExpression(memberReceiver, SanitizeIdentifier(memberName));
                     GExpression memberTest = this.TranslatePatternTest(memberAccess, sub.Pattern, isNestedPatternMember: true);
                     test = test == null ? memberTest : new BinaryExpression(test, "&&", memberTest);
                 }
@@ -10253,7 +10291,8 @@ public sealed class CSharpToGSharpTranslator
             PatternSyntax leafPattern,
             GExpression receiver,
             List<(ISymbol Symbol, GExpression Replacement)> bindings,
-            HashSet<string> usedDesignators)
+            HashSet<string> usedDesignators,
+            List<GExpression> guards)
         {
             var names = new List<string>();
             ExpressionSyntax current = memberPath;
@@ -10274,7 +10313,7 @@ public sealed class CSharpToGSharpTranslator
             string leafName = SanitizeIdentifier(names[^1]);
             PropertyPatternField field = new PropertyPatternField(
                 leafName,
-                this.TranslatePattern(leafPattern, new MemberAccessExpression(memberReceiver, leafName), bindings, usedDesignators));
+                this.TranslatePattern(leafPattern, new MemberAccessExpression(memberReceiver, leafName), bindings, usedDesignators, guards));
 
             for (int i = names.Count - 2; i >= 0; i--)
             {
@@ -13592,7 +13631,8 @@ public sealed class CSharpToGSharpTranslator
                 // out of scope.
                 var bindings = new List<(ISymbol Symbol, GExpression Replacement)>();
                 var usedDesignators = new HashSet<string>(StringComparer.Ordinal);
-                GPattern pattern = this.TranslatePattern(arm.Pattern, subject, bindings, usedDesignators);
+                var guards = new List<GExpression>();
+                GPattern pattern = this.TranslatePattern(arm.Pattern, subject, bindings, usedDesignators, guards);
 
                 foreach ((ISymbol symbol, GExpression replacement) in bindings)
                 {
@@ -13604,9 +13644,16 @@ public sealed class CSharpToGSharpTranslator
                 try
                 {
                     // Issue #991: C# `when` guards now have a canonical G# form.
+                    // Issue #1943: a typed positional/property subpattern that
+                    // has no room in its `TypePattern` GPattern node (a
+                    // constant/relational/nested test) was collected into
+                    // `guards` above instead; AND it together with any explicit
+                    // `when` clause (`case Point p when p.X == 0 && p.Y == 0 &&
+                    // <user guard>:`).
                     guard = arm.WhenClause != null
                         ? this.TranslateExpression(arm.WhenClause.Condition)
                         : null;
+                    guard = CombinePatternGuards(guards, guard);
                     body = this.TranslateExpression(arm.Expression);
                 }
                 finally
@@ -13657,7 +13704,8 @@ public sealed class CSharpToGSharpTranslator
                         case CasePatternSwitchLabelSyntax patternLabel:
                             var bindings = new List<(ISymbol Symbol, GExpression Replacement)>();
                             var usedDesignators = new HashSet<string>(StringComparer.Ordinal);
-                            GPattern pattern = this.TranslatePattern(patternLabel.Pattern, subject, bindings, usedDesignators);
+                            var guards = new List<GExpression>();
+                            GPattern pattern = this.TranslatePattern(patternLabel.Pattern, subject, bindings, usedDesignators, guards);
 
                             // Issue #1730: install the pattern's bindings before
                             // translating the `when` guard and the case body, so
@@ -13674,9 +13722,14 @@ public sealed class CSharpToGSharpTranslator
                             try
                             {
                                 // Issue #991: C# `when` guards now have a canonical G# form.
+                                // Issue #1943: see the switch-EXPRESSION arm above —
+                                // a typed positional/property subpattern with no
+                                // room in its `TypePattern` node is collected into
+                                // `guards` and AND-ed with any explicit `when`.
                                 guard = patternLabel.WhenClause != null
                                     ? this.TranslateExpression(patternLabel.WhenClause.Condition)
                                     : null;
+                                guard = CombinePatternGuards(guards, guard);
                                 patternBody = this.TranslateSwitchSectionBody(section);
                             }
                             finally
@@ -13855,11 +13908,35 @@ public sealed class CSharpToGSharpTranslator
             }
         }
 
+        // Issue #1943: AND-folds every boolean test `TranslatePattern` collected
+        // into `guards` (a typed positional/property subpattern with no room in
+        // its `TypePattern` GPattern node — see `TranslateRecursivePattern`'s
+        // `PositionalPatternClause` branch) together with the arm's own explicit
+        // `when` clause, if any. Returns <see langword="null"/> when there is
+        // nothing to guard on, so a plain arm with no synthesized test and no
+        // `when` clause keeps emitting no guard at all.
+        private static GExpression CombinePatternGuards(List<GExpression> guards, GExpression whenGuard)
+        {
+            GExpression combined = null;
+            foreach (GExpression guardTest in guards)
+            {
+                combined = combined == null ? guardTest : new BinaryExpression(combined, "&&", guardTest);
+            }
+
+            if (whenGuard == null)
+            {
+                return combined;
+            }
+
+            return combined == null ? whenGuard : new BinaryExpression(combined, "&&", whenGuard);
+        }
+
         private GPattern TranslatePattern(
             PatternSyntax pattern,
             GExpression receiver,
             List<(ISymbol Symbol, GExpression Replacement)> bindings,
-            HashSet<string> usedDesignators)
+            HashSet<string> usedDesignators,
+            List<GExpression> guards)
         {
             switch (pattern)
             {
@@ -13922,7 +13999,7 @@ public sealed class CSharpToGSharpTranslator
                     return new DiscardPattern();
 
                 case RecursivePatternSyntax recursive:
-                    return this.TranslateRecursivePattern(recursive, receiver, bindings, usedDesignators);
+                    return this.TranslateRecursivePattern(recursive, receiver, bindings, usedDesignators, guards);
 
                 // Issue #992: C# `and` / `or` pattern combinators map to G#
                 // `and` / `or`. C# `BinaryPatternSyntax` carries an `and`/`or`
@@ -13931,19 +14008,19 @@ public sealed class CSharpToGSharpTranslator
                     when binary.OperatorToken.IsKind(SyntaxKind.AndKeyword) || binary.OperatorToken.IsKind(SyntaxKind.OrKeyword):
                     return new BinaryPattern(
                         binary.OperatorToken.IsKind(SyntaxKind.AndKeyword),
-                        this.TranslatePattern(binary.Left, receiver, bindings, usedDesignators),
-                        this.TranslatePattern(binary.Right, receiver, bindings, usedDesignators));
+                        this.TranslatePattern(binary.Left, receiver, bindings, usedDesignators, guards),
+                        this.TranslatePattern(binary.Right, receiver, bindings, usedDesignators, guards));
 
                 // Issue #992: C# `not <pattern>` maps to G# `not <pattern>`.
                 case UnaryPatternSyntax unary
                     when unary.OperatorToken.IsKind(SyntaxKind.NotKeyword):
-                    return new NotPattern(this.TranslatePattern(unary.Pattern, receiver, bindings, usedDesignators));
+                    return new NotPattern(this.TranslatePattern(unary.Pattern, receiver, bindings, usedDesignators, guards));
 
                 case ParenthesizedPatternSyntax parenthesized:
-                    return new ParenthesizedPattern(this.TranslatePattern(parenthesized.Pattern, receiver, bindings, usedDesignators));
+                    return new ParenthesizedPattern(this.TranslatePattern(parenthesized.Pattern, receiver, bindings, usedDesignators, guards));
 
                 case ListPatternSyntax listPattern:
-                    return this.TranslateListPattern(listPattern, receiver, bindings, usedDesignators);
+                    return this.TranslateListPattern(listPattern, receiver, bindings, usedDesignators, guards);
 
                 default:
                     this.context.ReportUnsupported(
@@ -13968,7 +14045,8 @@ public sealed class CSharpToGSharpTranslator
             ListPatternSyntax listPattern,
             GExpression receiver,
             List<(ISymbol Symbol, GExpression Replacement)> bindings,
-            HashSet<string> usedDesignators)
+            HashSet<string> usedDesignators,
+            List<GExpression> guards)
         {
             SeparatedSyntaxList<PatternSyntax> elements = listPattern.Patterns;
             int sliceIndex = FindSlicePatternIndex(elements);
@@ -13980,7 +14058,7 @@ public sealed class CSharpToGSharpTranslator
                 PatternSyntax element = elements[i];
                 if (element is SlicePatternSyntax slice)
                 {
-                    translated.Add(this.TranslateSlicePattern(slice, receiver, i, elements.Count - i - 1, bindings, usedDesignators));
+                    translated.Add(this.TranslateSlicePattern(slice, receiver, i, elements.Count - i - 1, bindings, usedDesignators, guards));
                     continue;
                 }
 
@@ -13991,7 +14069,7 @@ public sealed class CSharpToGSharpTranslator
                 }
 
                 GExpression elementReceiver = this.BuildListElementReceiver(receiver, lengthAccess, i, elements.Count, sliceIndex);
-                translated.Add(this.TranslatePattern(element, elementReceiver, bindings, usedDesignators));
+                translated.Add(this.TranslatePattern(element, elementReceiver, bindings, usedDesignators, guards));
             }
 
             return new ListPattern(translated);
@@ -14011,7 +14089,8 @@ public sealed class CSharpToGSharpTranslator
             int prefixCount,
             int suffixCount,
             List<(ISymbol Symbol, GExpression Replacement)> bindings,
-            HashSet<string> usedDesignators)
+            HashSet<string> usedDesignators,
+            List<GExpression> guards)
         {
             switch (slice.Pattern)
             {
@@ -14036,7 +14115,7 @@ public sealed class CSharpToGSharpTranslator
 
                 default:
                     GExpression sliceValue = BuildSliceExpression(receiver, prefixCount, suffixCount);
-                    return new SlicePattern(designator: null, this.TranslatePattern(slice.Pattern, sliceValue, bindings, usedDesignators));
+                    return new SlicePattern(designator: null, this.TranslatePattern(slice.Pattern, sliceValue, bindings, usedDesignators, guards));
             }
         }
 
@@ -14044,7 +14123,8 @@ public sealed class CSharpToGSharpTranslator
             RecursivePatternSyntax recursive,
             GExpression receiver,
             List<(ISymbol Symbol, GExpression Replacement)> bindings,
-            HashSet<string> usedDesignators)
+            HashSet<string> usedDesignators,
+            List<GExpression> guards)
         {
             // A pure property pattern (`{ A: 0, B: 0 }`) with no type maps to the
             // G# property pattern; a typed recursive pattern (`Circle { Radius: var r }`)
@@ -14065,7 +14145,8 @@ public sealed class CSharpToGSharpTranslator
                                     sub.Pattern,
                                     new MemberAccessExpression(receiver, fieldName),
                                     bindings,
-                                    usedDesignators)));
+                                    usedDesignators,
+                                    guards)));
                             continue;
                         }
 
@@ -14080,7 +14161,7 @@ public sealed class CSharpToGSharpTranslator
                             // with the nested-pattern form a user could already
                             // write directly. Works to any chain depth.
                             fields.Add(this.BuildExtendedPropertyField(
-                                sub.ExpressionColon.Expression, sub.Pattern, receiver, bindings, usedDesignators));
+                                sub.ExpressionColon.Expression, sub.Pattern, receiver, bindings, usedDesignators, guards));
                             continue;
                         }
 
@@ -14121,7 +14202,8 @@ public sealed class CSharpToGSharpTranslator
                                 sub.Pattern,
                                 new MemberAccessExpression(receiver, SanitizeIdentifier(memberName)),
                                 bindings,
-                                usedDesignators)));
+                                usedDesignators,
+                                guards)));
                     }
                 }
 
@@ -14180,11 +14262,21 @@ public sealed class CSharpToGSharpTranslator
                 // as the typed property-pattern branch above — carries only a
                 // designator and a type, no room for an extra equality/relational
                 // test. A `var` positional subpattern still binds cleanly (a member
-                // access on the designator); anything else has no canonical G#
-                // form in this position (ADR-0115 §B) and is reported loudly rather
-                // than silently dropped. The untyped bare-tuple arm form above
-                // (`(0, 0) =>`) is unaffected and fully supports constant/
-                // relational positional subpatterns.
+                // access on the designator).
+                //
+                // Issue #1943: anything else (a constant/relational/nested
+                // positional subpattern, e.g. `Point(0, 0)`, `Point(> 0, _)`)
+                // generalizes the same lowering the untyped bare-tuple arm form
+                // already uses (`TranslateRecursivePatternTest`'s
+                // `PositionalPatternClause` loop) — a boolean member-access test —
+                // but since a `TypePattern` has no room for it, the test is
+                // appended to the arm's `guards` list instead, to be AND-ed with
+                // any explicit `when` clause by the caller (`case Point p when
+                // p.X == 0 && p.Y == 0:`). Any designator a nested subpattern
+                // binds (e.g. `Point(Sub(var a, 0), _)`) is captured into
+                // `bindings` the same way the property-pattern loop above does,
+                // so it is installed/removed on the same schedule as every other
+                // arm-scoped binding.
                 SeparatedSyntaxList<SubpatternSyntax> subs = recursive.PositionalPatternClause.Subpatterns;
                 string[] memberNames = this.TryGetPositionalMemberNames(recursive, subs.Count);
                 for (int i = 0; i < subs.Count; i++)
@@ -14198,8 +14290,15 @@ public sealed class CSharpToGSharpTranslator
                     }
 
                     string memberName = sub.NameColon?.Name.Identifier.Text ?? memberNames?[i];
-                    if (memberName != null &&
-                        sub.Pattern is VarPatternSyntax { Designation: SingleVariableDesignationSyntax posBound } &&
+                    if (memberName == null)
+                    {
+                        this.context.ReportUnsupported(
+                            sub,
+                            "typed positional subpattern has no canonical G# form yet (ADR-0115 §B).");
+                        continue;
+                    }
+
+                    if (sub.Pattern is VarPatternSyntax { Designation: SingleVariableDesignationSyntax posBound } &&
                         this.context.GetDeclaredSymbol(posBound) is { } posBoundSymbol)
                     {
                         bindings.Add((
@@ -14207,13 +14306,29 @@ public sealed class CSharpToGSharpTranslator
                             new MemberAccessExpression(
                                 new IdentifierExpression(designator),
                                 SanitizeIdentifier(memberName))));
+                        continue;
                     }
-                    else
+
+                    GExpression memberAccess = new MemberAccessExpression(
+                        new IdentifierExpression(designator), SanitizeIdentifier(memberName));
+                    var bindingsBefore = new HashSet<ISymbol>(this.patternBindings.Keys, SymbolEqualityComparer.Default);
+                    GExpression memberTest = this.TranslatePatternTest(memberAccess, sub.Pattern, isNestedPatternMember: true);
+                    foreach (ISymbol added in this.patternBindings.Keys.ToList())
                     {
-                        this.context.ReportUnsupported(
-                            sub,
-                            "typed positional subpattern other than a 'var' binding has no canonical G# form yet (ADR-0115 §B).");
+                        if (!bindingsBefore.Contains(added))
+                        {
+                            // A nested subpattern (e.g. `Point(Sub(var a, 0), _)`)
+                            // binds its own designator directly into
+                            // `patternBindings` (the same mechanism an `is`
+                            // expression uses). Route it through `bindings` too so
+                            // the caller's install/remove-around-guard-and-body
+                            // scoping (mirroring the `is`-expression pattern
+                            // above) cleans it up like every other arm binding.
+                            bindings.Add((added, this.patternBindings[added]));
+                        }
                     }
+
+                    guards.Add(memberTest);
                 }
             }
 

--- a/tools/cs2gs/corpus/grid/G04-Patterns-Console/Constructs/PositionalPatternClause.cs
+++ b/tools/cs2gs/corpus/grid/G04-Patterns-Console/Constructs/PositionalPatternClause.cs
@@ -4,11 +4,32 @@
 // Item2: 0 }`); gsc's property-pattern matcher now accepts a ValueTuple
 // subject (previously GS0172). Both the record and raw-tuple switch-expression
 // forms — plus the `is`-expression boolean form — are exercised below.
+//
+// Issue #1943 (follow-up): a TYPED recursive positional arm (`Point(0, 0) =>
+// ...`) lowers to a G# `TypePattern` node, which has no room for an extra
+// equality/relational test — previously only a `var` positional subpattern
+// was accepted there, and anything else emitted a loud CS2GS-GAP. Constant,
+// relational, and nested positional subpatterns in that position now
+// generalize the untyped-arm lowering above by synthesizing a `when` guard
+// (`case point is Point when point.X == 0 && point.Y == 0:`).
+//
+// A companion null-guard fix (also #1943) makes a nullable value-type tuple
+// subject (`(int, int)? is (0, 0)`) keep its `!= nil` guard — verified at the
+// translator-unit level in Issue1943TypedPositionalSubpatternTests.cs. It is
+// NOT exercised in this end-to-end corpus fixture: writing a nullable
+// value-type tuple (`(int, int)?`) at all trips an unrelated, pre-existing
+// gsc IL-emission bug (implicit `T -> Nullable<T>` wrapping is dropped for
+// ValueTuple value types at the boundary of ANY conversion — reproduced with
+// a plain `var p (int, int)? = (0, 0)`, no pattern matching involved) that
+// fails ilverify with StackUnexpected. That gap is out of scope for #1943
+// and is tracked separately as issue #2051.
 using System;
 
 namespace Corpus.Grid04.Constructs
 {
     internal sealed record PpPoint(int X, int Y);
+
+    internal sealed record PpLine(PpPoint Start, PpPoint End);
 
     public static class PositionalPatternClauseFixture
     {
@@ -57,6 +78,37 @@ namespace Corpus.Grid04.Constructs
                     _ => "other",
                 };
                 Console.WriteLine($"PositionalPatternClause: ({tp.Item1}, {tp.Item2}) tuple-> {tupleQuadrant}");
+            }
+
+            // Issue #1943: a TYPED recursive arm's positional subpattern —
+            // constant, relational, and nested — previously accepted only
+            // `var` (anything else was a loud gap).
+            object[] typedSubjects = { new PpPoint(0, 0), new PpPoint(3, 0), new PpPoint(3, 4) };
+            foreach (object subject in typedSubjects)
+            {
+                string typedQuadrant = subject switch
+                {
+                    PpPoint(0, 0) => "typed-origin",
+                    PpPoint( > 0, 0) => "typed-x-axis",
+                    PpPoint( > 0, > 0) => "typed-ne",
+                    _ => "typed-other",
+                };
+                if (subject is PpPoint typedPoint)
+                {
+                    Console.WriteLine($"PositionalPatternClause: typed ({typedPoint.X}, {typedPoint.Y}) -> {typedQuadrant}");
+                }
+            }
+
+            PpLine originLine = new PpLine(new PpPoint(0, 0), new PpPoint(3, 4));
+            PpLine otherLine = new PpLine(new PpPoint(1, 1), new PpPoint(3, 4));
+            foreach (PpLine line in new[] { originLine, otherLine })
+            {
+                string lineDescription = line switch
+                {
+                    PpLine(PpPoint(0, 0), _) => "starts-at-origin",
+                    _ => "other-start",
+                };
+                Console.WriteLine($"PositionalPatternClause: line ({line.Start.X}, {line.Start.Y})->({line.End.X}, {line.End.Y}) -> {lineDescription}");
             }
         }
     }

--- a/tools/cs2gs/corpus/grid/G04-Patterns-Console/baseline.stdout.golden
+++ b/tools/cs2gs/corpus/grid/G04-Patterns-Console/baseline.stdout.golden
@@ -64,6 +64,11 @@ PositionalPatternClause: (0, 0) tuple-> origin
 PositionalPatternClause: (0, 4) tuple-> y-axis
 PositionalPatternClause: (3, 0) tuple-> x-axis
 PositionalPatternClause: (3, 4) tuple-> ne
+PositionalPatternClause: typed (0, 0) -> typed-origin
+PositionalPatternClause: typed (3, 0) -> typed-x-axis
+PositionalPatternClause: typed (3, 4) -> typed-ne
+PositionalPatternClause: line (0, 0)->(3, 4) -> starts-at-origin
+PositionalPatternClause: line (1, 1)->(3, 4) -> other-start
 RecursivePattern: person is in Lima = True
 RecursivePattern: person has a Lima-range zip
 RecursivePattern: name length 3 = True


### PR DESCRIPTION
Fixes #1943

## Generalization approach

- `TranslateRecursivePattern`'s typed branch (`recursive.Type != null`) previously emitted a bare G# `TypePattern` (designator + type only) and reported a loud `CS2GS-GAP` for any non-`var` positional subpattern, because `TypePattern` has no field slots.
- Threaded a new `guards: List<GExpression>` parameter alongside the existing `bindings` parameter through `TranslatePattern`/`TranslateListPattern`/`TranslateSlicePattern`/`TranslateRecursivePattern`/`BuildExtendedPropertyField`.
- For typed positional constant/relational/nested subpatterns, the translator now reuses `TranslatePatternTest` (the same boolean-test builder that already handles the untyped-arm case from #1887/#1939) to synthesize a member-access boolean test, appended to `guards`. Any `var`-bindings created inside that nested test are captured via a before/after key-diff on `patternBindings` and routed into the arm's normal binding-install schedule.
- At the switch-arm call sites, all collected `guards` are AND-folded together with the explicit `when` clause (new `CombinePatternGuards` helper), e.g. `case point is Point when point.X == 0 && point.Y == 0:`.
- `ReportUnsupported`/the ADR-0115 §B gap is now only reported when there is truly no canonical member mapping — not merely because the subpattern is non-`var`.

## Null-guard approach (nullable value-type tuple subject)

- `IRecursivePatternOperation.MatchedType` always narrows to the non-nullable form, even for a nullable subject, which is why the pre-existing `receiverIsValueType` check couldn't distinguish `(int,int)` from `(int,int)?`. Added a `receiverIsNullableValueType` check based on the un-narrowed `IPatternOperation.InputType` (`OriginalDefinition.SpecialType == System_Nullable_T`).
- Changed the null-check-skip condition so a nullable value-type subject keeps its `!= nil` guard: `(receiverIsValueType && !receiverIsNullableValueType) || receiverIsNonNullableReference`.
- gsc's `&&`/`||` short-circuit narrowing classifier (`SmartCastStability.TryClassifyNilGuardLeaf`, issue #1545) explicitly does not narrow nullable **value types** across `&&` (only if-statement context does). To keep the emitted G# compiling under this documented restriction, member accesses on the guarded receiver now go through an explicit `!!` (`p != nil && p!!.Item1 == 0 && p!!.Item2 == 0`), mirroring the existing `.Value`→`!!` rewrite used elsewhere in the translator.

## Tests / baselines

- New `Issue1943TypedPositionalSubpatternTests.cs` (7 tests): typed positional constant, relational, combined with an explicit `when`, nested typed positional, switch-statement typed positional constant, nullable-tuple null-guard (positive), and non-nullable-tuple regression (no null-guard). Full `Cs2Gs.Tests` suite: 1001/1001 green (994 pre-existing + 7 new), zero regressions.
- Extended the G04 corpus fixture (`PositionalPatternClause.cs`) with typed constant/relational/nested positional switch-expression arms and re-captured `baseline.stdout.golden`. `migrate --baseline tools/cs2gs/triage/gaps.json` reports translate/compile/ilverify/test-parity all **PASS**, and **0 new / 0 regressed** against the ledgered baseline.
- `coverage --write` reported 0 appended rows (no new `SyntaxKind`, as expected — this generalizes existing recursive-pattern coverage rather than adding a new construct).
- `Core.Tests` CoverageMatrix/Exhaustiveness filter: 23/23 green.

## Deferred work: none in scope, but one pre-existing bug discovered and filed separately

While validating the nullable-tuple-subject fix end-to-end through the corpus/ilverify pipeline, I found that gsc itself has a **pre-existing, unrelated** IL-emission bug: writing *any* nullable value-type tuple (`(int,int)?`) — even a bare `var p (int,int)? = (0, 0)` with no pattern matching involved — drops the implicit `T -> Nullable<T>` wrap and fails `ilverify` with `StackUnexpected`. This is orthogonal to #1943 (it reproduces without any pattern-matching code at all, and nullable **scalar** value types like `int32?` are unaffected). I filed it as #2051 and intentionally kept the G04 corpus fixture from exercising nullable tuples end-to-end (validating that specific null-guard shape at the translator-unit level instead, per `Issue1943TypedPositionalSubpatternTests`) so this PR's corpus/ilverify/test-parity gates stay green and don't conflate the two issues.

No other sub-problems from the issue's Definition of Done were deferred.