### PR TITLE
cs2gs: fix ToEnumBitPattern top-bit value drop for unsigned enum underlying types (#2005)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue2005EnumTopBitValueTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2005EnumTopBitValueTranslationTests.cs
@@ -1,0 +1,285 @@
+// <copyright file="Issue2005EnumTopBitValueTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #2005: <see cref="CSharpToGSharpTranslator.VisitEnumDeclaration"/>
+/// reinterprets each member's constant bits via <c>ToEnumBitPattern</c> (a
+/// <c>ulong</c>) and then range-checked it as a signed <c>long</c> against
+/// <c>int.MinValue</c>/<c>int.MaxValue</c>. For an unsigned underlying type's
+/// top-bit-set value (e.g. <c>enum X : uint { High = 1u &lt;&lt; 31 }</c>), the
+/// bit pattern (<c>2147483648UL</c>) is a POSITIVE <c>long</c> above
+/// <c>int.MaxValue</c>, even though its low 32 bits are the perfectly valid
+/// (negative) int32 bit pattern <c>int.MinValue</c> — so the check incorrectly
+/// dropped the member's value (with an Info diagnostic) instead of
+/// reinterpreting it. This is distinct from issue #1912 (fixed): that issue
+/// covers the binder's own G# constant-folding; this one is cs2gs's C#→G#
+/// value-printing side.
+/// <para>
+/// Fix: reinterpret the low 32 bits of the bit pattern directly as an int32
+/// bit pattern (<c>unchecked((int)(uint)bits)</c>) for every underlying type
+/// whose width is <![CDATA[<=]]> 32 bits (byte/sbyte/short/ushort/int/uint —
+/// always representable this way), and only fall back to the drop+diagnostic
+/// path for a genuine 64-bit (<c>long</c>/<c>ulong</c>) value whose high 32
+/// bits aren't the sign-extension of its low 32 bits (i.e. truly has no int32
+/// spelling).
+/// </para>
+/// Every claim here is verified by actually compiling the translated G# with
+/// the real <c>gsc</c> and running it, so a value that merely LOOKS right in
+/// the printed text (but binds/emits wrong) cannot slip through.
+/// </summary>
+public class Issue2005EnumTopBitValueTranslationTests
+{
+    [Fact]
+    public void UintTopBitValue_SurvivesTranslationAndMatchesCSharpBitPatternAtRuntime()
+    {
+        const string Source = @"
+using System;
+
+namespace Demo
+{
+    public enum Flags32 : uint { High = 1u << 31 }
+
+    public static class C
+    {
+        public static void Run()
+        {
+            Console.WriteLine(unchecked((int)(uint)Flags32.High).ToString());
+        }
+    }
+}
+";
+        string printed = TranslateAndValidate(Source);
+
+        Assert.Contains("High = -2147483648", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("dropped", printed, StringComparison.Ordinal);
+
+        string stdout = CompileAndRun(printed, "C.Run()");
+        Assert.Equal("-2147483648", stdout.Trim());
+    }
+
+    [Fact]
+    public void ByteTopBitValue_SurvivesTranslationAndMatchesCSharpBitPatternAtRuntime()
+    {
+        const string Source = @"
+using System;
+
+namespace Demo
+{
+    public enum Flags8 : byte { High = 0x80 }
+
+    public static class C
+    {
+        public static void Run()
+        {
+            Console.WriteLine(((int)(byte)Flags8.High).ToString());
+        }
+    }
+}
+";
+        string printed = TranslateAndValidate(Source);
+
+        Assert.Contains("High = 128", printed, StringComparison.Ordinal);
+
+        string stdout = CompileAndRun(printed, "C.Run()");
+        Assert.Equal("128", stdout.Trim());
+    }
+
+    [Fact]
+    public void UshortTopBitValue_SurvivesTranslationAndMatchesCSharpBitPatternAtRuntime()
+    {
+        const string Source = @"
+using System;
+
+namespace Demo
+{
+    public enum Flags16 : ushort { High = 0x8000 }
+
+    public static class C
+    {
+        public static void Run()
+        {
+            Console.WriteLine(((int)(ushort)Flags16.High).ToString());
+        }
+    }
+}
+";
+        string printed = TranslateAndValidate(Source);
+
+        Assert.Contains("High = 32768", printed, StringComparison.Ordinal);
+
+        string stdout = CompileAndRun(printed, "C.Run()");
+        Assert.Equal("32768", stdout.Trim());
+    }
+
+    [Fact]
+    public void UlongValueRepresentableAsInt32BitPattern_SurvivesTranslationAndMatchesCSharpBitPatternAtRuntime()
+    {
+        // 0xFFFFFFFF80000000 is a 64-bit value whose high 32 bits ARE the
+        // proper sign-extension of its low 32 bits (0x80000000 = int.MinValue);
+        // it has a faithful int32 spelling even though it's `ulong`-backed and
+        // its low 32 bits have the top bit set, so it must survive translation
+        // exactly like the 32-bit-underlying-type cases above.
+        const string Source = @"
+using System;
+
+namespace Demo
+{
+    public enum Flags64 : ulong { High = 0xFFFFFFFF80000000UL }
+
+    public static class C
+    {
+        public static void Run()
+        {
+            Console.WriteLine(unchecked((int)(ulong)Flags64.High).ToString());
+        }
+    }
+}
+";
+        string printed = TranslateAndValidate(Source);
+
+        Assert.Contains("High = -2147483648", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("dropped", printed, StringComparison.Ordinal);
+
+        string stdout = CompileAndRun(printed, "C.Run()");
+        Assert.Equal("-2147483648", stdout.Trim());
+    }
+
+    [Fact]
+    public void UlongValueWithNoInt32Spelling_IsDroppedWithDiagnostic()
+    {
+        // A genuinely non-representable 64-bit value: high 32 bits (0x1) are
+        // NOT the sign-extension of the low 32 bits (0x0), so no int32 bit
+        // pattern can stand in for it — the Info diagnostic + drop-to-ordinal
+        // fallback must still fire here.
+        const string Source = @"
+using System;
+
+namespace Demo
+{
+    public enum Flags64 : ulong { Unrepresentable = 0x1_0000_0000UL }
+}
+";
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", Source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        Assert.Contains(
+            context.Diagnostics,
+            d => d.Severity == TranslationSeverity.Info &&
+                d.Message.Contains("outside the int32 range", StringComparison.Ordinal));
+    }
+
+    private static string TranslateAndValidate(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        Assert.DoesNotContain(
+            context.Diagnostics,
+            d => d.Severity == TranslationSeverity.Unsupported);
+        Assert.DoesNotContain(
+            context.Diagnostics,
+            d => d.Severity == TranslationSeverity.Info &&
+                d.Message.Contains("outside the int32 range", StringComparison.Ordinal));
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+
+    /// <summary>
+    /// Compiles <paramref name="printed"/> (with <paramref name="callExpression"/>
+    /// appended as a top-level entry statement) with the real <c>gsc</c> and runs
+    /// it, returning stdout.
+    /// </summary>
+    private static string CompileAndRun(string printed, string callExpression)
+    {
+        string compiler = FindCompiler();
+        Assert.True(compiler != null, "gsc.dll must be built (dotnet build GSharp.sln) before running this test.");
+
+        string workDir = Path.Combine(AppContext.BaseDirectory, "issue-2005-e2e", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(workDir);
+        string gsPath = Path.Combine(workDir, "Snippet.gs");
+        string dllPath = Path.Combine(workDir, "Snippet.dll");
+        File.WriteAllText(gsPath, printed + Environment.NewLine + callExpression + Environment.NewLine);
+
+        (int compileExit, string compileOut) = RunDotnet(
+            $"\"{compiler}\" /target:exe /out:\"{dllPath}\" \"{gsPath}\"");
+        Assert.True(
+            compileExit == 0 && !compileOut.Contains("error", StringComparison.OrdinalIgnoreCase),
+            "gsc must compile the translated snippet with zero errors. Output:\n" + compileOut +
+                "\n\nTranslated G#:\n" + printed);
+
+        (int runExit, string stdout) = RunDotnet($"\"{dllPath}\"");
+        Assert.True(runExit == 0, "Translated snippet must run successfully. Output:\n" + stdout);
+        return stdout;
+    }
+
+    private static (int Exit, string Output) RunDotnet(string arguments)
+    {
+        var psi = new ProcessStartInfo("dotnet", arguments)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        using var process = Process.Start(psi);
+        var output = new StringBuilder();
+        output.Append(process.StandardOutput.ReadToEnd());
+        output.Append(process.StandardError.ReadToEnd());
+        process.WaitForExit();
+        return (process.ExitCode, output.ToString());
+    }
+
+    private static string FindCompiler()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            foreach (string config in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(dir.FullName, "out", "bin", config, "Compiler", "gsc.dll");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            dir = dir.Parent;
+        }
+
+        return null;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -806,8 +806,24 @@ public sealed class CSharpToGSharpTranslator
                 int? explicitValue = null;
                 if (this.context.GetDeclaredSymbol(member) is IFieldSymbol { HasConstantValue: true } fieldSymbol)
                 {
-                    long signedBits = unchecked((long)ToEnumBitPattern(fieldSymbol.ConstantValue, underlyingType));
-                    if (signedBits < int.MinValue || signedBits > int.MaxValue)
+                    // Issue #2005: a signed `long`-range check on the raw bit
+                    // pattern (`signedBits < int.MinValue || > int.MaxValue`)
+                    // incorrectly drops legitimate top-bit-set values of 32-bit
+                    // (and narrower) unsigned underlying types — e.g. `enum X :
+                    // uint { High = 1u << 31 }` produces `signedBits ==
+                    // 2147483648L`, which is a positive `long` above
+                    // `int.MaxValue` even though its low 32 bits are a perfectly
+                    // valid (negative) int32 bit pattern. `byte`/`sbyte`/`short`/
+                    // `ushort`/`int`/`uint` (width <= 32) always fit in int32 once
+                    // reinterpreted this way, since only their low 32 bits are
+                    // ever meaningful; only a genuine 64-bit (`long`/`ulong`)
+                    // value whose high 32 bits aren't the sign-extension of its
+                    // low 32 bits truly has no int32 spelling.
+                    ulong bits = ToEnumBitPattern(fieldSymbol.ConstantValue, underlyingType);
+                    int candidate = unchecked((int)(uint)bits);
+                    bool is64BitWidth = underlyingType == SpecialType.System_Int64 || underlyingType == SpecialType.System_UInt64;
+                    bool fitsInt32 = !is64BitWidth || unchecked((ulong)(long)candidate) == bits;
+                    if (!fitsInt32)
                     {
                         // G# enums are always int32-backed (issue #1912 doesn't
                         // extend to non-default underlying types); a value outside
@@ -824,7 +840,7 @@ public sealed class CSharpToGSharpTranslator
                         continue;
                     }
 
-                    var constantValue = (int)signedBits;
+                    var constantValue = candidate;
                     if (constantValue != nextOrdinal)
                     {
                         explicitValue = constantValue;


### PR DESCRIPTION
Fixes #2005

`VisitEnumDeclaration` range-checked each enum member's raw bit pattern (from `ToEnumBitPattern`, a `ulong`) as a signed `long` against `int.MinValue`/`int.MaxValue`. For a top-bit-set value of a 32-bit-or-narrower unsigned underlying type (e.g. `enum X : uint { High = 1u << 31 }`), the bit pattern (`2147483648UL`) is a positive `long` above `int.MaxValue`, even though its low 32 bits are the perfectly valid (negative) int32 bit pattern `int.MinValue` — so the member's value was silently dropped (with an Info diagnostic) instead of being reinterpreted.

## Fix

Reinterpret the low 32 bits of the bit pattern directly as an int32 bit pattern (`unchecked((int)(uint)bits)`) for every underlying type whose width is <= 32 bits (`byte`/`sbyte`/`short`/`ushort`/`int`/`uint`) — always representable this way, since only the low 32 bits are ever meaningful for these widths.

For genuinely 64-bit underlying types (`long`/`ulong`), the drop+diagnostic path is preserved, but now only fires for a value whose high 32 bits AREN'T the sign-extension of its low 32 bits (i.e. truly has no int32 spelling) — a 64-bit value whose bits do happen to fit an int32 spelling now also survives.

This is distinct from #1912 (fixed by an earlier PR): that issue is the G# binder's own constant-folding; this is cs2gs's C#→G# value-printing side (`ToEnumBitPattern`/`VisitEnumDeclaration`, ~line 663 of `CSharpToGSharpTranslator.cs`).

## Tests

Added `Issue2005EnumTopBitValueTranslationTests` (following the `Issue1912ExplicitEnumValueTranslationTests` pattern), covering:
- `uint`, `byte`, `ushort` top-bit-set values — translated, no Info diagnostic, and round-tripped through a real `gsc` compile+run confirming the emitted G# int32 value bit-for-bit matches the original C# value.
- A `ulong` value whose bits DO fit an int32 spelling (`0xFFFFFFFF80000000`) — now correctly survives.
- A `ulong` value with genuinely no int32 spelling (`0x1_0000_0000`) — still correctly dropped with the Info diagnostic (no false-positive fix).

## Validation

- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release` — 992/992 passed.
- Coverage matrix regenerated (`cs2gs coverage --write`) — no changes (translator behavior already fully covered).
- Corpus sanity (`cs2gs migrate --corpus tools/cs2gs/corpus --baseline tools/cs2gs/triage/gaps.json`) — 16/20 apps green (pre-existing unrelated failures), baseline: 3 known, 0 new, 0 regressed, 0 stale.
