### PR TITLE
gsc: emit & run generic async functions (#2030)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs
@@ -452,16 +452,23 @@ internal sealed partial class ExpressionBinder
     // just like the bare struct/enum case. Symbol-based detection (not
     // ClrType.IsValueType, which is null for in-flight user types) is
     // required to recognize it below.
+    //
+    // Issue #2030: a bare or nullable-wrapped open type parameter (e.g.
+    // `await` on a `Task[U]` produced by calling another generic async
+    // function from within a generic caller) reaches here the same way —
+    // its `ClrType` is erased to `object`, just like a same-compilation
+    // struct/enum. Build the symbolic awaiter type (`TaskAwaiter[U]`) so the
+    // emitted awaiter pool field and `GetAwaiter()`/`GetResult()` call sites
+    // agree on `!!0`/`!0` instead of the erased `object`.
     private static bool IsAwaiterTypeArgumentCandidate(TypeSymbol a) =>
-        a is StructSymbol or InterfaceSymbol or EnumSymbol
-        || (a is NullableTypeSymbol nt && nt.UnderlyingType is StructSymbol or InterfaceSymbol or EnumSymbol);
+        a is StructSymbol or InterfaceSymbol or EnumSymbol or TypeParameterSymbol
+        || (a is NullableTypeSymbol nt && nt.UnderlyingType is StructSymbol or InterfaceSymbol or EnumSymbol or TypeParameterSymbol);
 
     private static TypeSymbol TryGetAwaiterTypeSymbol(TypeSymbol awaitableType)
     {
         if (awaitableType is not ImportedTypeSymbol importedAwaitable
             || importedAwaitable.OpenDefinition == null
             || importedAwaitable.TypeArguments.IsDefaultOrEmpty
-            || importedAwaitable.HasTypeParameterArgument
             || !importedAwaitable.TypeArguments.Any(IsAwaiterTypeArgumentCandidate))
         {
             return null;

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -2974,8 +2974,19 @@ internal sealed class ReflectionMetadataEmitter
         {
             if (asyncSmPlansByStruct.TryGetValue(s, out var smPlan))
             {
-                this.stateMachines.EmitStateMachineMoveNext(smPlan);
-                this.stateMachines.EmitStateMachineSetStateMachine(smPlan);
+                // Issue #2030 (gap 2): mirror the TypeDef emission above —
+                // MoveNext/SetStateMachine bodies must see the same
+                // outer-method-TP → SM-TP remap as the FieldDefs, or a
+                // reference to a hoisted field/local whose declared type was
+                // the kickoff's own type parameter (e.g. the retVal local for
+                // `async func Foo[U](x U) U`) encodes as a dangling method
+                // type-var (`!!0`) instead of the SM's own class type-var
+                // (`!0`) — unverifiable IL / BadImageFormatException at load.
+                using (this.PushSmRemap(s))
+                {
+                    this.stateMachines.EmitStateMachineMoveNext(smPlan);
+                    this.stateMachines.EmitStateMachineSetStateMachine(smPlan);
+                }
             }
         }
 
@@ -10439,8 +10450,8 @@ internal sealed class ReflectionMetadataEmitter
     // kickoff method's real Task<T?> return type is closed over the emitted
     // Nullable<UserT> instead of falling back to the erased Task<object>.
     private static bool IsAsyncUserDefinedResultType(TypeSymbol type)
-        => type is StructSymbol or InterfaceSymbol or EnumSymbol
-        || (type is NullableTypeSymbol nullableUserVt && nullableUserVt.UnderlyingType is StructSymbol or InterfaceSymbol or EnumSymbol);
+        => type is StructSymbol or InterfaceSymbol or EnumSymbol or TypeParameterSymbol
+        || (type is NullableTypeSymbol nullableUserVt && nullableUserVt.UnderlyingType is StructSymbol or InterfaceSymbol or EnumSymbol or TypeParameterSymbol);
 
     /// <summary>
     /// ADR-0122 §9 / issue #1035: builds a standalone method signature for a

--- a/src/Core/CodeAnalysis/Emit/StateMachineEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/StateMachineEmitter.cs
@@ -1463,10 +1463,40 @@ internal sealed class StateMachineEmitter
     public int EmitAsyncKickoffBody(FunctionSymbol function, AsyncStateMachinePlan plan, bool driveSynchronously = false)
     {
         var smStruct = plan.StateMachine.MaterializeAsStructSymbol();
-        var smTypeDef = this.getStructTypeToken(smStruct);
+
+        // Issue #2030 (gap 2): when the kickoff method (or its enclosing
+        // type) is generic, `smStruct` carries its OWN reified type
+        // parameters (set by RegisterStateMachineEnclosingGenerics) — these
+        // encode as Var(idx) when referenced from WITHIN an SM member
+        // (MoveNext etc., a legitimate self-instantiation). But this kickoff
+        // body is NOT a member of the SM struct: it is a member of the
+        // kickoff's own (possibly non-generic) enclosing type. Referencing
+        // the SM type here must instantiate it over the kickoff's ORIGINAL
+        // in-scope type parameters (enclosing class TPs as Var, the
+        // kickoff's own TPs as MVar) — mirroring the iterator kickoff's
+        // `kickoffSmType` pattern elsewhere in this file — otherwise the
+        // emitted `!0` self-instantiation is meaningless outside the SM
+        // struct (BadImageFormatException at load).
+        var kickoffClassTPs = function.ReceiverType is StructSymbol kickoffRecv
+            ? (kickoffRecv.Definition ?? kickoffRecv).TypeParameters
+            : ImmutableArray<TypeParameterSymbol>.Empty;
+        if (kickoffClassTPs.IsDefault)
+        {
+            kickoffClassTPs = ImmutableArray<TypeParameterSymbol>.Empty;
+        }
+
+        var kickoffMethodTPs = function.TypeParameters.IsDefaultOrEmpty
+            ? ImmutableArray<TypeParameterSymbol>.Empty
+            : function.TypeParameters;
+        var kickoffScopeTPs = kickoffClassTPs.AddRange(kickoffMethodTPs);
+        var kickoffSmStruct = kickoffScopeTPs.IsDefaultOrEmpty
+            ? smStruct
+            : StructSymbol.Construct(smStruct, kickoffScopeTPs.CastArray<TypeSymbol>());
+
+        var smTypeDef = this.getStructTypeToken(kickoffSmStruct);
         var builderInfo = plan.StateMachine.BuilderInfo;
-        var stateFieldHandle = this.resolveFieldToken(smStruct, plan.FieldMap.StateField);
-        var builderFieldHandle = this.resolveFieldToken(smStruct, plan.FieldMap.BuilderField);
+        var stateFieldHandle = this.resolveFieldToken(kickoffSmStruct, plan.FieldMap.StateField);
+        var builderFieldHandle = this.resolveFieldToken(kickoffSmStruct, plan.FieldMap.BuilderField);
 
         var il = new InstructionEncoder(new BlobBuilder());
 
@@ -1487,7 +1517,7 @@ internal sealed class StateMachineEmitter
         // Copy this (for instance methods)
         if (plan.FieldMap.ThisField != null && function.IsInstanceMethod)
         {
-            var thisFieldHandle = this.resolveFieldToken(smStruct, plan.FieldMap.ThisField);
+            var thisFieldHandle = this.resolveFieldToken(kickoffSmStruct, plan.FieldMap.ThisField);
             il.LoadLocalAddress(0);
             il.LoadArgument(0);
             il.OpCode(ILOpCode.Stfld);
@@ -1499,7 +1529,7 @@ internal sealed class StateMachineEmitter
         var paramIndex = 0;
         foreach (var copy in plan.KickoffPlan.ParameterCopies)
         {
-            var fieldHandle = this.resolveFieldToken(smStruct, copy.Field);
+            var fieldHandle = this.resolveFieldToken(kickoffSmStruct, copy.Field);
             il.LoadLocalAddress(0);
             il.LoadArgument(paramIndex + paramSlotShift);
             il.OpCode(ILOpCode.Stfld);
@@ -1525,7 +1555,7 @@ internal sealed class StateMachineEmitter
 
         // Start is generic: Start<TStateMachine>(ref TStateMachine).
         // We need a MethodSpec for Start<SM>.
-        var startMethodSpec = this.GetStateMachineStartMethodSpec(builderInfo.StartMethod, smStruct, plan.FieldMap.BuilderField.Type);
+        var startMethodSpec = this.GetStateMachineStartMethodSpec(builderInfo.StartMethod, kickoffSmStruct, plan.FieldMap.BuilderField.Type);
         il.OpCode(ILOpCode.Call);
         il.Token(startMethodSpec);
 
@@ -1574,7 +1604,7 @@ internal sealed class StateMachineEmitter
         // VALUETYPE token.
         var localsSigBlob = new BlobBuilder();
         var localsEncoder = new BlobEncoder(localsSigBlob).LocalVariableSignature(awaiterClrType != null ? 2 : 1);
-        this.encodeTypeSymbol(localsEncoder.AddVariable().Type(), smStruct);
+        this.encodeTypeSymbol(localsEncoder.AddVariable().Type(), kickoffSmStruct);
         if (awaiterClrType != null)
         {
             this.encodeClrType(localsEncoder.AddVariable().Type(), awaiterClrType);

--- a/src/Core/CodeAnalysis/Lowering/Async/AsyncStateMachineTypeBuilder.cs
+++ b/src/Core/CodeAnalysis/Lowering/Async/AsyncStateMachineTypeBuilder.cs
@@ -115,8 +115,8 @@ public static class AsyncStateMachineTypeBuilder
         sm.StateField = stateField;
 
         var builderFieldType = TypeSymbol.FromClrType(builderInfo.BuilderType);
-        if ((kickoff.Type is StructSymbol or InterfaceSymbol or EnumSymbol
-                || (kickoff.Type is NullableTypeSymbol nullableUserVt3 && nullableUserVt3.UnderlyingType is StructSymbol or InterfaceSymbol or EnumSymbol))
+        if ((kickoff.Type is StructSymbol or InterfaceSymbol or EnumSymbol or TypeParameterSymbol
+                || (kickoff.Type is NullableTypeSymbol nullableUserVt3 && nullableUserVt3.UnderlyingType is StructSymbol or InterfaceSymbol or EnumSymbol or TypeParameterSymbol))
             && builderInfo.BuilderType is { IsConstructedGenericType: true } builderClrType)
         {
             builderFieldType = ImportedTypeSymbol.GetConstructed(
@@ -244,8 +244,19 @@ public static class AsyncStateMachineTypeBuilder
                 // and falls through. Erase to `object` the same way the bare
                 // struct/enum case does, using symbol-based detection instead
                 // of the null ClrType.
-                if (kickoff.Type is StructSymbol or InterfaceSymbol or EnumSymbol
-                    || (kickoff.Type is NullableTypeSymbol nullableUserVt2 && nullableUserVt2.UnderlyingType is StructSymbol or InterfaceSymbol or EnumSymbol))
+                //
+                // Issue #2030 (gap 1): a bare or nullable-wrapped open method
+                // type parameter (`U` / `U?`) has no `ClrType` either — it
+                // reaches here the same way. Erase to `object` too, so the
+                // reflection-only pipeline below can still resolve a
+                // `Task<object>` / `AsyncTaskMethodBuilder<object>` shape to
+                // discover the builder's members (Create/Start/SetResult/…).
+                // The SM's actual field/return type is re-widened to the real
+                // open type parameter afterward (see the `builderFieldType`
+                // override in `Build` and `ResultTypeSymbol`), so the emitted
+                // IL still carries `!!0`/`!0`, not `object`.
+                if (kickoff.Type is StructSymbol or InterfaceSymbol or EnumSymbol or TypeParameterSymbol
+                    || (kickoff.Type is NullableTypeSymbol nullableUserVt2 && nullableUserVt2.UnderlyingType is StructSymbol or InterfaceSymbol or EnumSymbol or TypeParameterSymbol))
                 {
                     inner = references.MapClrTypeToReferences(typeof(object));
                 }

--- a/test/Compiler.Tests/Emit/Issue2026GenericAsyncTaskWrapEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2026GenericAsyncTaskWrapEmitTests.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using Xunit;
 
@@ -16,25 +17,19 @@ namespace GSharp.Compiler.Tests.Emit;
 /// <c>gsc</c> reported GS0133 ("cannot be awaited") for this shape.
 /// </summary>
 /// <remarks>
-/// A full compile-AND-RUN round trip of the exact issue repro is currently
-/// blocked by a separate, pre-existing GS0190 diagnostic ("Could not
-/// synthesize the state machine for this async function") — generic
-/// <c>async func</c>s cannot yet fully lower to a runnable state machine
-/// because their observable return type is an open method type parameter,
-/// which the async state-machine builder resolution (which needs a real CLR
-/// <c>System.Type</c> to resolve <c>AsyncTaskMethodBuilder&lt;T&gt;</c>) does
-/// not yet support. That gap is tracked separately in
-/// https://github.com/DavidObando/gsharp/issues/2030 and is unrelated to this
-/// issue's binder-level return-type-substitution bug. This test therefore
-/// pins the GS0133 regression fix at the full-compiler level (via
-/// <c>gsc</c>, not just the binder unit tests in Core.Tests) and documents
-/// the current, separate GS0190 blocker rather than silently skipping
-/// coverage.
+/// A full compile-AND-RUN round trip of the exact issue repro used to be
+/// blocked by two separate, pre-existing emit-layer gaps tracked in
+/// https://github.com/DavidObando/gsharp/issues/2030: (1) state-machine
+/// synthesis reported GS0190 whenever the declared inner return type was an
+/// open type parameter, and (2) hoisting a generic-typed parameter/local into
+/// the state machine crashed at runtime with <see cref="BadImageFormatException"/>.
+/// Both gaps are now fixed — these tests exercise the full compile-and-run
+/// round trip rather than only pinning the binder-level GS0133 fix.
 /// </remarks>
 public class Issue2026GenericAsyncTaskWrapEmitTests
 {
     [Fact]
-    public void GenericAsyncFunctionCall_InsideAnotherGeneric_NeverReportsGS0133()
+    public void GenericAsyncFunctionCall_InsideAnotherGeneric_CompilesAndRuns()
     {
         var source = """
             package P
@@ -50,28 +45,17 @@ public class Issue2026GenericAsyncTaskWrapEmitTests
             Console.WriteLine(t.Result)
             """;
 
-        var (_, stdout, stderr) = CompileRaw(source);
+        var output = CompileAndRun(source);
 
-        // The bug this issue reports: the type-check must never regress back
-        // to GS0133 for this call shape.
-        Assert.DoesNotContain("GS0133", stdout + stderr);
-
-        // Currently blocked by the separate, pre-existing GS0190 emit-layer
-        // gap (see remarks above) — tracked separately, not fixed here.
-        Assert.Contains("GS0190", stdout + stderr);
+        Assert.Equal("hi\n", output);
     }
 
     [Fact]
-    public void NonGenericAsyncFunctionCall_InsideGenericCaller_CompilesWithoutGS0133_Regression()
+    public void NonGenericAsyncFunctionCall_InsideGenericCaller_CompilesAndRuns()
     {
-        // Regression: the non-generic async call-site Task-wrap path (already
-        // working before this fix) must keep type-checking without GS0133,
-        // even when the caller itself is generic. (A full compile-AND-RUN
-        // round trip of a generic async CALLER is separately blocked by the
-        // pre-existing emit-layer gap described in the class remarks above —
-        // hoisting a generic-typed parameter/local into the async state
-        // machine is not yet fully supported — so this test only asserts the
-        // type-check outcome, matching the scope of this issue's fix.)
+        // Issue #2030 gap 2 repro: a generic async caller hoisting its own
+        // type-parameter-typed parameter (`seed U`) into the state machine,
+        // even though the declared return type (`int32`) is concrete.
         var source = """
             package P
             async func Answer() int32 {
@@ -82,13 +66,16 @@ public class Issue2026GenericAsyncTaskWrapEmitTests
                 return await r
             }
             var t = Outer("hi")
+            t.Wait()
+            Console.WriteLine(t.Result)
             """;
 
-        var (_, stdout, stderr) = CompileRaw(source);
-        Assert.DoesNotContain("GS0133", stdout + stderr);
+        var output = CompileAndRun(source);
+
+        Assert.Equal("42\n", output);
     }
 
-    private static (int ExitCode, string Stdout, string Stderr) CompileRaw(string source)
+    private static string CompileAndRun(string source)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_issue2026_").FullName;
         try
@@ -120,7 +107,33 @@ public class Issue2026GenericAsyncTaskWrapEmitTests
                 Console.SetError(prevErr);
             }
 
-            return (compileExit, compileOut.ToString(), compileErr.ToString());
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+            IlVerifier.Verify(outPath);
+            Assert.True(File.Exists(outPath), $"expected emitted assembly at {outPath}");
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi);
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
         }
         finally
         {

--- a/test/Compiler.Tests/Emit/Issue2030GenericAsyncEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2030GenericAsyncEmitTests.cs
@@ -1,0 +1,193 @@
+// <copyright file="Issue2030GenericAsyncEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #2030: generic <c>async func</c>s could not be emitted/run due to
+/// two separate emit-layer gaps:
+/// <list type="number">
+/// <item><description>Gap 1 — state-machine synthesis reported GS0190
+/// whenever the declared inner return type was an open type parameter (e.g.
+/// <c>async func Foo[U](x U) U</c>), because
+/// <c>AsyncStateMachineTypeBuilder.ResolveAsyncReturnClrType</c> had no
+/// branch to resolve a CLR type for a bare/nullable-wrapped
+/// <c>TypeParameterSymbol</c>.</description></item>
+/// <item><description>Gap 2 — even when the declared return type was
+/// concrete, hoisting a parameter/local typed as the kickoff method's own
+/// type parameter (e.g. <c>seed U</c>) into the state machine crashed at
+/// runtime with <see cref="BadImageFormatException"/>, because (a) the
+/// kickoff body's own references to the constructed state-machine type used
+/// the SM struct's self-instantiation (<c>!0</c>, a class type-var) instead
+/// of the kickoff's own type parameters (<c>!!0</c>, a method type-var, since
+/// the kickoff is not itself a member of the SM struct), and (b)
+/// <c>MoveNext</c>/<c>SetStateMachine</c> body emission did not push the same
+/// outer-method-TP → SM-TP remap used for the SM's FieldDefs, so a hoisted
+/// local typed as the kickoff's own type parameter (e.g. the state machine's
+/// <c>retVal</c> temp) encoded as a dangling method type-var
+/// instead.</description></item>
+/// </list>
+/// </summary>
+public class Issue2030GenericAsyncEmitTests
+{
+    [Fact]
+    public void OpenTypeParameterReturn_CompilesAndRuns()
+    {
+        // Gap 1 repro (issue body): declared inner return type is the bare
+        // open type parameter U.
+        var source = """
+            package issue2030gap1
+            import System
+            async func Foo2030A[U](x U) U {
+                return x
+            }
+            var t1 = Foo2030A(42)
+            var t2 = Foo2030A("hello")
+            Console.WriteLine(t1.Result)
+            Console.WriteLine(t2.Result)
+            """;
+
+        var output = CompileAndRun(source);
+
+        Assert.Equal("42\nhello\n", output);
+    }
+
+    [Fact]
+    public void HoistedTypeParameterParameter_ConcreteReturn_CompilesAndRuns()
+    {
+        // Gap 2 repro (issue body): declared return type is concrete
+        // (int32), but the kickoff's own parameter `seed U` must be hoisted
+        // into the state machine.
+        var source = """
+            package issue2030gap2
+            async func Answer2030B() int32 {
+                return 42
+            }
+            async func Outer2030B[U](seed U) int32 {
+                var r = Answer2030B()
+                return await r
+            }
+            var t = Outer2030B("hi")
+            t.Wait()
+            Console.WriteLine(t.Result)
+            """;
+
+        var output = CompileAndRun(source);
+
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void MultipleTypeParametersAndGenericInstanceMethod_CompileAndRun()
+    {
+        // Generalization: more than one method type parameter, plus a
+        // generic async INSTANCE method (own type parameters come from the
+        // enclosing class, not the method) hoisting a field typed after the
+        // class's own type parameter.
+        var source = """
+            package issue2030gap3
+            import System
+            import System.Threading.Tasks
+
+            class Box2030C[T] {
+                var Value T
+                public func init(v T) {
+                    Value = v
+                }
+                public async func GetAsync() T {
+                    await Task.Delay(1)
+                    return Value
+                }
+            }
+
+            async func Pair2030C[A, B](a A, b B) A {
+                var x = a
+                await Task.Delay(1)
+                return x
+            }
+
+            var box = Box2030C[int32](7)
+            var boxed = box.GetAsync()
+            Console.WriteLine(boxed.Result)
+
+            var t = Pair2030C[string, int32]("first", 99)
+            Console.WriteLine(t.Result)
+            """;
+
+        var output = CompileAndRun(source);
+
+        Assert.Equal("7\nfirst\n", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue2030_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+            IlVerifier.Verify(outPath);
+            Assert.True(File.Exists(outPath), $"expected emitted assembly at {outPath}");
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi);
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.Replace("\r\n", "\n");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
Fixes two pre-existing emit-layer gaps that prevented generic `async func`s from compiling and/or running correctly (unrelated to #2026's binder fix).

## Gap 1 — GS0190 for open-type-parameter return
```gsharp
async func Foo[U](x U) U { return x }
```
`AsyncStateMachineTypeBuilder.ResolveAsyncReturnClrType` had no branch to resolve a placeholder CLR type for a bare/nullable-wrapped `TypeParameterSymbol`, so it returned null and `AsyncEmitPrecheck` reported GS0190.

Fix: extended the existing struct/interface/enum "erase to `object`" handling to also cover `TypeParameterSymbol` (in `ResolveAsyncReturnClrType` and the builder-field-type override in `Build()`), and extended `IsAsyncUserDefinedResultType` (`ReflectionMetadataEmitter`) so the kickoff method's own return-type signature stays symbolic (`Task<!!U>`) instead of erasing to `Task<object>`.

## Gap 2 — BadImageFormatException hoisting a type-parameter-typed param/local
```gsharp
async func Answer() int32 { return 42 }
async func Outer[U](seed U) int32 {
    var r = Answer()
    return await r
}
```
`EmitAsyncKickoffBody` referenced the synthesized state-machine struct using its own "class-level" reified type parameters (`Var`/`!0`), which is only valid from within SM members (`MoveNext`, `SetStateMachine`). The kickoff method itself is not a member of the SM struct, so it must reference the SM type via its own method type parameters (`MVar`/`!!0`).

Fix: construct a kickoff-scoped instantiation of the SM struct (`StructSymbol.Construct`), mirroring the existing iterator kickoff pattern, and use it for all field/type/locals/`Start<SM>` token resolution in the kickoff body. Also found `MoveNext`/`SetStateMachine` body emission (the "B6" loop in `ReflectionMetadataEmitter`) was missing the `PushSmRemap(...)` wrapper already used for FieldDef emission, causing a hoisted local typed after the kickoff's own type parameter to encode as a dangling method type-var instead of the SM struct's class type-var.

## Gap 3 (found while generalizing) — awaiting a nested generic async call
Awaiting the `Task[U]` result of calling another generic async function from within a generic caller (`await Foo(seed)` where `Foo` returns `U`) produced a `TaskAwaiter<T0>` vs `TaskAwaiter<object>` stack-type mismatch. `ExpressionBinder.Async`'s `TryGetAwaiterTypeSymbol` explicitly bailed out whenever the awaited `Task`'s type argument was an open type parameter. Extended the same struct/interface/enum symbolic-awaiter construction to also cover `TypeParameterSymbol`.

## Testing
- Added `test/Compiler.Tests/Emit/Issue2030GenericAsyncEmitTests.cs`: compile-and-run coverage for both issue repros, plus a generalization case (two method type parameters, a generic class instance method hoisting a class-type-parameter-typed field).
- Updated `test/Compiler.Tests/Emit/Issue2026GenericAsyncTaskWrapEmitTests.cs`, whose tests previously pinned the GS0190 gap as a documented known limitation (`Assert.Contains("GS0190", ...)`), to compile-and-run instead.
- `dotnet test --filter "FullyQualifiedName~Issue2030|FullyQualifiedName~Issue2026"` (Compiler.Tests) → 5/5 passed.
- `dotnet test --filter "FullyQualifiedName~Async"` (Compiler.Tests) → 130/130 passed (no regressions).
- `dotnet test --filter "FullyQualifiedName~Await"` (Compiler.Tests) → 89/89 passed (no regressions).
- `dotnet test --filter "FullyQualifiedName~AsyncAwaitTests|FullyQualifiedName~Issue2026GenericAsyncTaskWrap"` (Core.Tests) → 15/15 passed (no regressions).
- Manual repro of both issue snippets: compiles and runs, prints expected output (`hi`, `42`).

Fixes #2030
