### PR TITLE
cs2gs: detect backing-field collisions against cs2gs-synthesized siblings (#2003)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue2003FieldKeywordSynthesizedSiblingCollisionTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2003FieldKeywordSynthesizedSiblingCollisionTests.cs
@@ -1,0 +1,126 @@
+// <copyright file="Issue2003FieldKeywordSynthesizedSiblingCollisionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #2003 (follow-up from PR #2000 / #1907 Opus review): the C#14
+/// <c>field</c>-keyword synthesized backing-field name (<c>_&lt;prop&gt;</c>,
+/// see <see cref="Issue1907FieldKeywordTranslationTests"/>) is collision-
+/// checked against <c>ContainingType.GetMembers()</c> — Roslyn SOURCE symbols
+/// only. A cs2gs-synthesized sibling with no Roslyn source-symbol counterpart
+/// is invisible to that check. The primary case: a primary-constructor
+/// parameter that is captured (read inside the type) but never assigned to an
+/// explicit field/property becomes a same-named G# field (ADR-0065 §5) with
+/// NO corresponding Roslyn field/property symbol — so it was previously
+/// missed, and a same-named `field`-keyword backing field would silently
+/// double-declare it (a gsc-loud duplicate-member error, not a silent
+/// miscompile). These tests verify the SAME mangled-suffix resolution used
+/// for source-symbol collisions (see
+/// <see cref="Issue1907FieldKeywordTranslationTests.SynthesizedBackingFieldName_AvoidsCollisionWithExistingMember"/>)
+/// now also applies here.
+/// </summary>
+public class Issue2003FieldKeywordSynthesizedSiblingCollisionTests
+{
+    [Fact]
+    public void FieldKeywordBackingField_AvoidsCollisionWithPrimaryCtorParameterCapture()
+    {
+        // `_x` is a native C#12 primary-constructor parameter that is merely
+        // captured (read in `UseX`), never assigned to any field/property, so
+        // Roslyn synthesizes no source field/property symbol for it — it only
+        // becomes a real field once cs2gs maps the primary ctor (ADR-0065 §5).
+        // Property `X`'s `field`-keyword backing field would independently
+        // synthesize the SAME name `_x` from camelCasing "X"; the second one
+        // synthesized must be suffixed to avoid a duplicate member.
+        string rendered = Render(@"
+namespace Corpus.Issue2003
+{
+    public class Foo(int _x)
+    {
+        public int X
+        {
+            get => field;
+            set => field = value;
+        }
+
+        public int UseX() => _x;
+    }
+}
+");
+
+        Assert.Contains("class Foo(_x int32)", rendered, StringComparison.Ordinal);
+        Assert.Contains("private var _x2 int32", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("private var _x int32", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void FieldKeywordBackingField_AvoidsCollisionWithLiftedPrimaryCtorParameterField()
+    {
+        // T2 (ADR-0115 §B.3): an explicit constructor whose only statement is
+        // `_level = level` is canonicalized into a primary-constructor
+        // parameter field named after the ORIGINAL source field `_level`.
+        // That source field IS visible via `GetMembers()` before the lift, so
+        // this case is already handled by the pre-existing check — kept here
+        // as a regression guard alongside the true synthesized-sibling case
+        // above.
+        string rendered = Render(@"
+namespace Corpus.Issue2003
+{
+    public class Gauge
+    {
+        private int _level;
+
+        public Gauge(int level)
+        {
+            _level = level;
+        }
+
+        public int Level
+        {
+            get => field;
+            set => field = value < 0 ? 0 : value;
+        }
+    }
+}
+");
+
+        Assert.Contains("class Gauge(_level int32)", rendered, StringComparison.Ordinal);
+        Assert.Contains("private var _level2 int32", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    private static void AssertRoundTripParses(string rendered)
+    {
+        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+
+        Assert.True(
+            result.Success,
+            "Sanitized G# must round-trip-parse. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + rendered);
+    }
+
+    private static string Render(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", source) });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        Cs2Gs.CodeModel.Ast.CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        return GSharpPrinter.Print(unit);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -1570,6 +1570,21 @@ public sealed class CSharpToGSharpTranslator
             // fields directly, which is now valid G#.
             ConstructorLift lift = this.AnalyzeConstructorLift(node, mergedMembers, symbol, kind.Value);
 
+            // Issue #2003: a primary-constructor parameter (native C#12 shape or
+            // T2-lifted from an explicit ctor) becomes a same-named G# field
+            // (ADR-0065 §5) that is a cs2gs-SYNTHESIZED sibling — it has no
+            // corresponding Roslyn source symbol for a captured-but-never-assigned
+            // parameter, so `symbol.ContainingType.GetMembers()` (used by the
+            // `field`-keyword backing-field collision check below) cannot see it.
+            // Computed here — before the member loop that translates properties —
+            // so it can be threaded into that collision check as an extra reserved
+            // name set.
+            IReadOnlyList<Parameter> primaryCtor = lift.DropConstructor
+                ? lift.PrimaryParameters
+                : this.MapPrimaryConstructor(node);
+            var primaryCtorParamNames = new HashSet<string>(
+                primaryCtor?.Select(p => p.Name) ?? Enumerable.Empty<string>(), StringComparer.Ordinal);
+
             // OD-T1: when the explicit constructor is kept (not lifted to a primary
             // constructor) and the type is a plain class/struct, get-only
             // auto-property inline initializers (`{ get; } = new();`) must move into
@@ -1600,7 +1615,7 @@ public sealed class CSharpToGSharpTranslator
                 // in a different `SyntaxTree`; resolve it (and everything nested
                 // inside it) through that tree's own semantic model.
                 using IDisposable modelScope = this.context.UseSemanticModelFor(member.SyntaxTree);
-                foreach ((GMember translated, bool isStatic) in this.TranslateMember(member, kind.Value, lift, propertyCtorInits))
+                foreach ((GMember translated, bool isStatic) in this.TranslateMember(member, kind.Value, lift, propertyCtorInits, primaryCtorParamNames))
                 {
                     // A C# operator overload translates to a receiver-clause
                     // `func (a T) operator <op>(...)`; like every receiver-clause
@@ -1710,9 +1725,6 @@ public sealed class CSharpToGSharpTranslator
             (GTypeReference baseType, List<GTypeReference> interfaces) = this.MapBaseClause(symbol, node, kind.Value);
             List<GExpression> baseConstructorArguments = this.MapPrimaryConstructorBaseArguments(node, baseType);
             List<TypeParameter> typeParameters = this.MapTypeParameters(symbol);
-            IReadOnlyList<Parameter> primaryCtor = lift.DropConstructor
-                ? lift.PrimaryParameters
-                : this.MapPrimaryConstructor(node);
 
             // A class with `protected` members must be an `open class` in G#
             // (GS0380) — `protected` is meaningless on a non-inheritable type. A C#
@@ -2177,7 +2189,8 @@ public sealed class CSharpToGSharpTranslator
             MemberDeclarationSyntax member,
             TypeDeclarationKind ownerKind,
             ConstructorLift lift,
-            IReadOnlyList<(string Name, GExpression Value)> propertyCtorInits)
+            IReadOnlyList<(string Name, GExpression Value)> propertyCtorInits,
+            IReadOnlyCollection<string> primaryCtorParamNames = null)
         {
             switch (member)
             {
@@ -2253,7 +2266,7 @@ public sealed class CSharpToGSharpTranslator
                     }
 
                     (GMember propMember, bool propIsStatic, GMember fieldKeywordBackingField) =
-                        this.TranslateProperty(property);
+                        this.TranslateProperty(property, primaryCtorParamNames);
                     if (fieldKeywordBackingField != null)
                     {
                         // Issue #1907: the synthesized backing field for a `field`-
@@ -3386,7 +3399,8 @@ public sealed class CSharpToGSharpTranslator
             return true;
         }
 
-        private (GMember Member, bool IsStatic, GMember BackingField) TranslateProperty(PropertyDeclarationSyntax node)
+        private (GMember Member, bool IsStatic, GMember BackingField) TranslateProperty(
+            PropertyDeclarationSyntax node, IReadOnlyCollection<string> primaryCtorParamNames = null)
         {
             var symbol = this.context.GetDeclaredSymbol(node) as IPropertySymbol;
             bool isStatic = symbol != null && symbol.IsStatic;
@@ -3408,7 +3422,7 @@ public sealed class CSharpToGSharpTranslator
             // accessor bodies below, so a `field` reference inside them (bound via
             // TranslateExpression's FieldExpressionSyntax case) resolves to it.
             string fieldKeywordBackingName = this.TryRegisterFieldKeywordBackingField(
-                node, symbol, out IFieldSymbol fieldKeywordBackingSymbol);
+                node, symbol, primaryCtorParamNames, out IFieldSymbol fieldKeywordBackingSymbol);
 
             // Issue #1907 / #1072: the backing field can be used as nullable
             // independently of the property's own declared nullability (e.g.
@@ -3465,13 +3479,19 @@ public sealed class CSharpToGSharpTranslator
         // Issue #1907: a property using the C#14 `field` keyword in any accessor
         // shares ONE compiler-synthesized backing field across all its accessors.
         // Detects that usage and synthesizes+registers a real G# field name for it
-        // (collision-checked against the containing type's other members and any
-        // backing field already synthesized for a sibling property), returning
-        // null when the property does not use `field` at all. Also returns the
-        // synthesized field's own Roslyn IFieldSymbol (needed for its independent
-        // nullable-usage promotion) via <paramref name="fieldSymbol"/>.
+        // (collision-checked against the containing type's other members, any
+        // backing field already synthesized for a sibling property, and any
+        // cs2gs-synthesized primary-constructor-parameter field — issue #2003;
+        // none of the latter are Roslyn source symbols, so `GetMembers()` alone
+        // cannot see them), returning null when the property does not use `field`
+        // at all. Also returns the synthesized field's own Roslyn IFieldSymbol
+        // (needed for its independent nullable-usage promotion) via
+        // <paramref name="fieldSymbol"/>.
         private string TryRegisterFieldKeywordBackingField(
-            PropertyDeclarationSyntax node, IPropertySymbol symbol, out IFieldSymbol fieldSymbol)
+            PropertyDeclarationSyntax node,
+            IPropertySymbol symbol,
+            IReadOnlyCollection<string> primaryCtorParamNames,
+            out IFieldSymbol fieldSymbol)
         {
             fieldSymbol = null;
             if (symbol == null)
@@ -3499,6 +3519,11 @@ public sealed class CSharpToGSharpTranslator
             foreach (ISymbol member in symbol.ContainingType.GetMembers())
             {
                 taken.Add(member.Name);
+            }
+
+            if (primaryCtorParamNames != null)
+            {
+                taken.UnionWith(primaryCtorParamNames);
             }
 
             taken.UnionWith(this.fieldKeywordBackingFieldNames.Values);


### PR DESCRIPTION
Fixes #2003

## Problem

The synthesized `_<prop>` backing-field name collision check for C#14 `field`-keyword properties (`TryRegisterFieldKeywordBackingField`) only checked `ContainingType.GetMembers()` — Roslyn SOURCE symbols. A native C#12 primary-constructor parameter that is captured (read somewhere in the type) but never assigned to an explicit field/property has no Roslyn field/property symbol of its own; it only becomes a real field once cs2gs maps the primary constructor to a same-named G# field (ADR-0065 §5). That made it invisible to the collision check, so a `field`-keyword property whose synthesized backing name happened to match the primary-ctor parameter name would silently double-declare the field (a gsc-loud duplicate-member error, not a silent miscompile — but still a translation defect).

Repro (previously produced a duplicate `_x` field):
```csharp
public class Foo(int _x)
{
    public int X { get => field; set => field = value; }
    public int UseX() => _x;
}
```

## Fix

Compute the primary-constructor parameter name set (covering both the native C#12 primary-ctor shape and the T2 lifted-from-explicit-ctor shape) *before* the type's member-translation loop, and thread it into `TryRegisterFieldKeywordBackingField` as an additional reserved-name set. Collisions resolve with the SAME mangled-suffix strategy already used for source-symbol collisions (e.g. `_x` → `_x2`), so behavior is consistent and no new resolution logic was invented.

## Investigation of other synthesis paths

Per the issue's request to audit all synthesized-field-producing paths:
- **Primary-ctor parameter captures** — real gap, fixed above.
- **Get-only auto-property backing (ADR-0051)** — this maps directly to G#'s own `prop X T { get }` auto-property form; cs2gs emits no textual backing-field name for it at all (gsc synthesizes it internally at compile time as `<X>k__BackingField`), so there is no naming surface to collide with. No change needed; verified via translation output inspection.
- **Static auto-property → static field** (`TryTranslateStaticAutoPropertyField`) and **T2 lifted primary-ctor fields sourced from an explicit source field** — both use the ORIGINAL (non-mangled) member name, which remains visible via `GetMembers()`. No gap.
- Confirmed the only other cs2gs name-mangling site (`fieldKeywordBackingFieldNames`, i.e. sibling `field`-keyword properties on the same type) was already covered by the pre-existing check.

## Testing

- New tests in `Cs2Gs.Tests/Issue2003FieldKeywordSynthesizedSiblingCollisionTests.cs`:
  - `FieldKeywordBackingField_AvoidsCollisionWithPrimaryCtorParameterCapture` — reproduces the true synthesized-sibling collision (native C#12 primary-ctor param capture) and asserts it resolves to `_x2` instead of duplicating `_x`.
  - `FieldKeywordBackingField_AvoidsCollisionWithLiftedPrimaryCtorParameterField` — regression guard for the T2-lifted-from-source-field case (already worked before this fix, since the source field is visible via `GetMembers()`).
- Full `Cs2Gs.Tests` suite: 989/989 passed.
- Full solution build (`GSharp.sln`, Release): 0 errors/warnings.
- Coverage matrix regenerated (`cs2gs coverage --write`): no diff — translator's observable coverage surface unchanged.
- Corpus sanity (`cs2gs migrate`): 16/20 apps green; 3 known baseline gaps, 0 new, 0 regressed, 0 stale (matches `tools/cs2gs/triage/gaps.json`).