### PR TITLE
gsc: diagnose private field write from outside declaring type (#2044)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -3331,7 +3331,7 @@ internal sealed partial class ExpressionBinder
                         // declaring type and its derived types may read it.
                         if (!AccessibilityChecker.IsAccessible(field.Accessibility, declaringType, this.function))
                         {
-                            Diagnostics.ReportProtectedMemberInaccessible(ne.IdentifierToken.Location, field.Name, declaringType.Name);
+                            Diagnostics.ReportProtectedMemberInaccessible(ne.IdentifierToken.Location, field.Name, declaringType.Name, field.Accessibility);
                         }
 
                         // ADR-0122 §10 / issue #1035: a fixed-size buffer field
@@ -3361,7 +3361,7 @@ internal sealed partial class ExpressionBinder
                         // Issue #950: enforce `protected` property access.
                         if (!AccessibilityChecker.IsAccessible(prop.Accessibility, propDeclaringType, this.function))
                         {
-                            Diagnostics.ReportProtectedMemberInaccessible(ne.IdentifierToken.Location, prop.Name, propDeclaringType.Name);
+                            Diagnostics.ReportProtectedMemberInaccessible(ne.IdentifierToken.Location, prop.Name, propDeclaringType.Name, prop.Accessibility);
                         }
 
                         return ApplyMemberNarrowing(new BoundPropertyAccessExpression(null, receiver, structSym, prop));
@@ -5596,7 +5596,7 @@ internal sealed partial class ExpressionBinder
 
                 if (!AccessibilityChecker.IsAccessible(field.Accessibility, fieldDeclaringType, this.function))
                 {
-                    Diagnostics.ReportProtectedMemberInaccessible(ne.IdentifierToken.Location, field.Name, fieldDeclaringType.Name);
+                    Diagnostics.ReportProtectedMemberInaccessible(ne.IdentifierToken.Location, field.Name, fieldDeclaringType.Name, field.Accessibility);
                 }
 
                 return ApplyMemberNarrowing(new BoundFieldAccessExpression(null, receiver, fieldDeclaringType, field));
@@ -5612,7 +5612,7 @@ internal sealed partial class ExpressionBinder
 
                 if (!AccessibilityChecker.IsAccessible(prop.Accessibility, propDeclaringType, this.function))
                 {
-                    Diagnostics.ReportProtectedMemberInaccessible(ne.IdentifierToken.Location, prop.Name, propDeclaringType.Name);
+                    Diagnostics.ReportProtectedMemberInaccessible(ne.IdentifierToken.Location, prop.Name, propDeclaringType.Name, prop.Accessibility);
                 }
 
                 return ApplyMemberNarrowing(new BoundPropertyAccessExpression(null, receiver, propDeclaringType, prop));

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -704,7 +704,7 @@ internal sealed partial class ExpressionBinder
                 // Issue #950: enforce `protected` property assignment.
                 if (!AccessibilityChecker.IsAccessible(prop.Accessibility, propDeclaringType, this.function))
                 {
-                    Diagnostics.ReportProtectedMemberInaccessible(syntax.FieldIdentifier.Location, prop.Name, propDeclaringType.Name);
+                    Diagnostics.ReportProtectedMemberInaccessible(syntax.FieldIdentifier.Location, prop.Name, propDeclaringType.Name, prop.Accessibility);
                 }
 
                 // Issue #1132: writing a property of a read-only value-type
@@ -759,7 +759,7 @@ internal sealed partial class ExpressionBinder
         // type and its derived types may write it.
         if (!AccessibilityChecker.IsAccessible(field.Accessibility, fieldDeclaringType, this.function))
         {
-            Diagnostics.ReportProtectedMemberInaccessible(syntax.FieldIdentifier.Location, field.Name, fieldDeclaringType.Name);
+            Diagnostics.ReportProtectedMemberInaccessible(syntax.FieldIdentifier.Location, field.Name, fieldDeclaringType.Name, field.Accessibility);
         }
 
         // Issue #947: a read-only field of `this` may be assigned inside the
@@ -1128,6 +1128,15 @@ internal sealed partial class ExpressionBinder
         // declaring struct as the owner for both the read access and assignment.
         if (TypeMemberModel.TryGetFieldIncludingInherited(structSym, memberName, MemberQuery.Instance(MemberKinds.Field), out var field, out var declaringType))
         {
+            // Issue #950 / #2044: enforce `protected`/`private` field access —
+            // mirrors the plain field-write and field-read checks; a compound
+            // assignment (`f.x += 1`) both reads and writes `x`, so accessible
+            // gets the same single diagnostic at the operator location.
+            if (!AccessibilityChecker.IsAccessible(field.Accessibility, declaringType, this.function))
+            {
+                Diagnostics.ReportProtectedMemberInaccessible(syntax.OperatorToken.Location, field.Name, declaringType.Name, field.Accessibility);
+            }
+
             if (field.IsReadOnly
                 && !IsReadOnlyFieldAssignmentAllowed(field, declaringType, ReceiverExpressionIsThis(boundReceiver)))
             {
@@ -1155,12 +1164,18 @@ internal sealed partial class ExpressionBinder
         }
 
         // ADR-0051: check properties.
-        if (TypeMemberModel.TryGetProperty(structSym, memberName, out var prop))
+        if (TypeMemberModel.TryGetProperty(structSym, memberName, out var prop, out var propDeclaringType))
         {
             if (!prop.HasGetter || !prop.HasSetter)
             {
                 Diagnostics.ReportCannotAssign(syntax.OperatorToken.Location, memberName);
                 return new BoundErrorExpression(null);
+            }
+
+            // Issue #950 / #2044: enforce `protected`/`private` property access.
+            if (!AccessibilityChecker.IsAccessible(prop.Accessibility, propDeclaringType, this.function))
+            {
+                Diagnostics.ReportProtectedMemberInaccessible(syntax.OperatorToken.Location, prop.Name, propDeclaringType.Name, prop.Accessibility);
             }
 
             // Issue #1132: compound-mutating a property of a read-only value-type

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -5704,7 +5704,7 @@ internal sealed partial class ExpressionBinder
         // Issue #950: enforce `protected` property access against the declaring type.
         if (!AccessibilityChecker.IsAccessible(prop.Accessibility, declaringType, this.function))
         {
-            Diagnostics.ReportProtectedMemberInaccessible(member.IdentifierToken.Location, prop.Name, declaringType.Name);
+            Diagnostics.ReportProtectedMemberInaccessible(member.IdentifierToken.Location, prop.Name, declaringType.Name, prop.Accessibility);
         }
 
         var receiver = new BoundVariableExpression(null, function.ThisParameter);
@@ -5791,7 +5791,7 @@ internal sealed partial class ExpressionBinder
         // Issue #950: enforce `protected` property assignment against the declaring type.
         if (!AccessibilityChecker.IsAccessible(prop.Accessibility, declaringType, this.function))
         {
-            Diagnostics.ReportProtectedMemberInaccessible(memberLocation, prop.Name, declaringType.Name);
+            Diagnostics.ReportProtectedMemberInaccessible(memberLocation, prop.Name, declaringType.Name, prop.Accessibility);
         }
 
         var converted = conversions.BindConversion(valueLocation, value, prop.Type);

--- a/src/Core/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.cs
@@ -1416,20 +1416,23 @@ public sealed class DiagnosticBag : IEnumerable<Diagnostic>
     }
 
     /// <summary>
-    /// Issue #950: GS0379 — a <c>protected</c> member of <paramref name="declaringTypeName"/>
-    /// was accessed from code that is neither the declaring type nor a type
-    /// deriving from it. A <c>protected</c> member is only reachable from the
-    /// declaring type and the bodies of its derived types.
+    /// Issue #950 / #2044: GS0379 — a <c>protected</c> or <c>private</c>
+    /// member of <paramref name="declaringTypeName"/> was accessed (read,
+    /// written, or called) from code outside its accessibility. A
+    /// <c>protected</c> member is only reachable from the declaring type and
+    /// the bodies of its derived types; a <c>private</c> member is only
+    /// reachable from the declaring type itself.
     /// </summary>
     /// <param name="location">The text location of the offending access.</param>
-    /// <param name="memberName">The protected member's name.</param>
+    /// <param name="memberName">The inaccessible member's name.</param>
     /// <param name="declaringTypeName">The declaring type's name.</param>
-    public void ReportProtectedMemberInaccessible(TextLocation location, string memberName, string declaringTypeName)
+    /// <param name="accessibility">The member's accessibility (<see cref="Accessibility.Protected"/> or <see cref="Accessibility.Private"/>).</param>
+    public void ReportProtectedMemberInaccessible(TextLocation location, string memberName, string declaringTypeName, Accessibility accessibility = Accessibility.Protected)
     {
-        Report(
-            location,
-            "GS0379",
-            $"'{declaringTypeName}.{memberName}' is inaccessible due to its protection level: a 'protected' member is only accessible within '{declaringTypeName}' and types derived from it.");
+        var message = accessibility == Accessibility.Private
+            ? $"'{declaringTypeName}.{memberName}' is inaccessible due to its protection level: a 'private' member is only accessible within '{declaringTypeName}'."
+            : $"'{declaringTypeName}.{memberName}' is inaccessible due to its protection level: a 'protected' member is only accessible within '{declaringTypeName}' and types derived from it.";
+        Report(location, "GS0379", message);
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Symbols/AccessibilityChecker.cs
+++ b/src/Core/CodeAnalysis/Symbols/AccessibilityChecker.cs
@@ -5,19 +5,20 @@
 namespace GSharp.Core.CodeAnalysis.Symbols;
 
 /// <summary>
-/// Issue #950: bind-time accessibility checks for the <c>protected</c>
-/// modifier. A <c>protected</c> member is accessible within its declaring type
-/// and within the bodies of types that derive from the declaring type; it is
-/// inaccessible from unrelated external code (e.g. the synthetic
-/// <c>&lt;Program&gt;</c> host or a sibling type).
+/// Issue #950 / #2044: bind-time accessibility checks for the
+/// <c>protected</c> and <c>private</c> modifiers. A <c>protected</c> member is
+/// accessible within its declaring type and within the bodies of types that
+/// derive from the declaring type; a <c>private</c> member is accessible only
+/// within its declaring type. Both are inaccessible from unrelated external
+/// code (e.g. the synthetic <c>&lt;Program&gt;</c> host or a sibling type).
 /// <para>
-/// Unlike <c>private</c>/<c>internal</c> — which G# leaves to the CLR to
-/// enforce at runtime via the emitted IL accessibility — <c>protected</c> adds
-/// a compile-time check so that external access is reported as a clean
+/// Unlike <c>internal</c> — which G# leaves to the CLR to enforce at runtime
+/// via the emitted IL accessibility — <c>protected</c>/<c>private</c> add a
+/// compile-time check so that external access is reported as a clean
 /// diagnostic (GS0379) rather than surfacing only as a runtime
 /// <see cref="System.MethodAccessException"/>/<see cref="System.FieldAccessException"/>.
-/// The emitted IL still carries CIL <c>family</c> accessibility, so the CLR
-/// independently enforces the same rule.
+/// The emitted IL still carries the matching CIL accessibility (<c>family</c>
+/// / <c>private</c>), so the CLR independently enforces the same rule.
 /// </para>
 /// </summary>
 internal static class AccessibilityChecker
@@ -26,9 +27,10 @@ internal static class AccessibilityChecker
     /// Returns <see langword="true"/> when a member declared on
     /// <paramref name="declaringType"/> with the given
     /// <paramref name="accessibility"/> is accessible from the body of
-    /// <paramref name="currentFunction"/>. Only the <c>protected</c> case is
-    /// enforced here; every other accessibility is treated as accessible (G#
-    /// defers private/internal enforcement to the CLR).
+    /// <paramref name="currentFunction"/>. Only the <c>protected</c> and
+    /// <c>private</c> cases are enforced here; every other accessibility is
+    /// treated as accessible (G# defers <c>internal</c> enforcement to the
+    /// CLR).
     /// </summary>
     /// <param name="accessibility">The accessed member's accessibility.</param>
     /// <param name="declaringType">The type that declares the member.</param>
@@ -36,7 +38,7 @@ internal static class AccessibilityChecker
     /// <returns><see langword="true"/> when the access is permitted.</returns>
     public static bool IsAccessible(Accessibility accessibility, StructSymbol declaringType, FunctionSymbol currentFunction)
     {
-        if (accessibility != Accessibility.Protected || declaringType == null)
+        if (declaringType == null)
         {
             return true;
         }
@@ -44,6 +46,19 @@ internal static class AccessibilityChecker
         var enclosingType = (currentFunction?.ReceiverType as StructSymbol)
             ?? (currentFunction?.StaticOwnerType as StructSymbol)
             ?? (currentFunction?.LexicalEnclosingType as StructSymbol);
+
+        // Issue #2044: `private` is stricter than `protected` — only the
+        // exact declaring type's own body may access it, derived types may
+        // not (mirrors CLR `private` semantics, unlike `family`/`protected`).
+        if (accessibility == Accessibility.Private)
+        {
+            return enclosingType != null && SameDeclaringType(enclosingType, declaringType);
+        }
+
+        if (accessibility != Accessibility.Protected)
+        {
+            return true;
+        }
 
         for (var t = enclosingType; t != null; t = t.BaseClass)
         {

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2044PrivateMemberWriteTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2044PrivateMemberWriteTests.cs
@@ -1,0 +1,139 @@
+// <copyright file="Issue2044PrivateMemberWriteTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2044 (follow-up to #950) — a <c>private</c> member is accessible
+/// only within its own declaring type's body, unlike <c>protected</c> (which
+/// also allows derived types). Reading, writing, and calling a private
+/// member from outside the declaring type all report GS0379, mirroring the
+/// existing <c>protected</c> checks exercised in
+/// <see cref="Issue950ProtectedModifierTests"/>.
+/// </summary>
+public class Issue2044PrivateMemberWriteTests
+{
+    [Fact]
+    public void ExternalCode_WritesPrivateField_ReportsGS0379()
+    {
+        var source = @"
+class Foo {
+    private var secret int32
+}
+
+var f = Foo{}
+f.secret = 5
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0379");
+    }
+
+    [Fact]
+    public void ExternalCode_ReadsPrivateField_ReportsGS0379()
+    {
+        var source = @"
+class Foo {
+    private var secret int32
+}
+
+var f = Foo{}
+f.secret
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0379");
+    }
+
+    [Fact]
+    public void ExternalCode_CompoundAssignsPrivateField_ReportsGS0379()
+    {
+        var source = @"
+class Foo {
+    private var secret int32
+}
+
+var f = Foo{}
+f.secret += 1
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0379");
+    }
+
+    [Fact]
+    public void ExternalCode_WritesPrivateProperty_ReportsGS0379()
+    {
+        var source = @"
+class Foo {
+    private var _v int32
+    private prop V int32 {
+        get { return _v }
+        set { _v = value }
+    }
+}
+
+var f = Foo{}
+f.V = 3
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0379");
+    }
+
+    [Fact]
+    public void DeclaringType_WritesOwnPrivateField_NoDiagnostics()
+    {
+        var source = @"
+class Foo {
+    private var secret int32
+    func Set(v int32) void {
+        secret = v
+    }
+    func Get() int32 {
+        return secret
+    }
+}
+
+var f = Foo{}
+f.Set(3)
+f.Get()
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(3, result.Value);
+    }
+
+    [Fact]
+    public void ExternalCode_WritesBasePrivateFieldViaDerivedInstance_ReportsGS0379()
+    {
+        // Unlike `protected`, `private` is not inherited: a private field
+        // declared on Base is inaccessible even via a Derived instance,
+        // from code outside Base.
+        var source = @"
+open class Base {
+    private var secret int32
+}
+
+class Derived : Base {
+}
+
+var d = Derived{}
+d.secret = 5
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0379");
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
## Root cause
`AccessibilityChecker.IsAccessible` (added for issue #950) only enforced `protected`; every other accessibility, including `private`, was treated as always accessible at bind time. Since every field/property read, write, and base-class-call site already routes through this single helper, a private field/property write (and read) from outside its declaring type compiled silently instead of reporting GS0379.

## Fix
- `AccessibilityChecker.IsAccessible` now also enforces `private`: accessible only from the exact declaring type's own body (no derived-type allowance, unlike `protected`).
- `DiagnosticBag.ReportProtectedMemberInaccessible` now takes the member's `Accessibility` so GS0379's message correctly says 'private member' vs 'protected member'; the same GS0379 code is reused (mirrors the existing read-side/protected diagnostic exactly).
- All existing field/property read, write, and base-class-call sites now pass the member's actual accessibility instead of implicitly assuming `protected` — this alone fixes both the read and write cases for private fields/properties with no new call sites needed.
- `TryBindChainedCompoundAssignment` (the `obj.field += x` / `obj.prop += x` path) had **no** accessibility check at all (a pre-existing gap that also affected `protected`); added the same check used by the plain read/write paths.

## Tests
New `test/Core.Tests/CodeAnalysis/Binding/Issue2044PrivateMemberWriteTests.cs`, mirroring `Issue950ProtectedModifierTests.cs`:
- external write / read / compound-assign of a private field → GS0379
- external write of a private property → GS0379
- same-type write of its own private field → still compiles, no diagnostics
- a private base-class field written through a derived instance → still GS0379 (private does not extend to derived types, unlike protected)

Ran narrowly (no full-suite run, per 16GB constraint):
- `--filter "FullyQualifiedName~Issue2044|FullyQualifiedName~Issue950|FullyQualifiedName~Issue1335"` → 22 passed
- `--filter "FullyQualifiedName~Accessib|FullyQualifiedName~Inaccessible|FullyQualifiedName~Protected|FullyQualifiedName~Private"` → 49 passed
- `--filter` covering every other existing test file that declares `private` fields/properties (Issue1070FieldInitializerStaticTests, Issue1088GenericIdentityTests, VisibilityModifierTests, Issue1240ParameterShadowsFieldTests, PropertyParserTests, Issue1202UnsafeClassModifierParserTests) → 71 passed

Fixes #2044