### PR TITLE
cs2gs: harden multi-dim array flat-lowering (per-dim bounds, coercion, aliasing, tests) (#1954)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue1893MultiDimArrayTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1893MultiDimArrayTranslationTests.cs
@@ -72,12 +72,26 @@ namespace Corpus.Issue1893
         Assert.Contains("let gridDim1", rendered, StringComparison.Ordinal);
         Assert.Contains("let grid = [gridDim0 * gridDim1]int32", rendered, StringComparison.Ordinal);
 
-        // Every write keeps both indices, flattened row-major (r * cols + c).
-        Assert.Contains("grid[0 * gridDim1 + 0] = 1", rendered, StringComparison.Ordinal);
-        Assert.Contains("grid[1 * gridDim1 + 2] = 6", rendered, StringComparison.Ordinal);
+        // Every write keeps both indices, flattened row-major (r * cols + c),
+        // guarded by a per-dimension bounds check (issue #1954) that throws
+        // instead of silently landing on the wrong cell.
+        Assert.Contains(
+            "grid[if 0 >= 0 && 0 < gridDim0 && (0 >= 0 && 0 < gridDim1) { 0 * gridDim1 + 0 } " +
+                "else { throw IndexOutOfRangeException()",
+            rendered,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "grid[if 1 >= 0 && 1 < gridDim0 && (2 >= 0 && 2 < gridDim1) { 1 * gridDim1 + 2 } " +
+                "else { throw IndexOutOfRangeException()",
+            rendered,
+            StringComparison.Ordinal);
 
-        // The read in the sum loop also keeps both indices.
-        Assert.Contains("grid[r * gridDim1 + c]", rendered, StringComparison.Ordinal);
+        // The read in the sum loop also keeps both indices and the bounds check.
+        Assert.Contains(
+            "grid[if r >= 0 && r < gridDim0 && (c >= 0 && c < gridDim1) { r * gridDim1 + c } " +
+                "else { throw IndexOutOfRangeException()",
+            rendered,
+            StringComparison.Ordinal);
 
         // GetLength(0)/GetLength(1) resolve to the tracked per-dimension sizes,
         // not a call into a rank-1 CLR array's GetLength (which would throw).
@@ -111,8 +125,13 @@ namespace Corpus.Issue1893
         Assert.DoesNotContain("object", rendered, StringComparison.Ordinal);
 
         // The read keeps both indices, flattened against the constant column
-        // count (3) inferred from the initializer's shape.
-        Assert.Contains("lit[1 * 3 + 2]", rendered, StringComparison.Ordinal);
+        // count (3) inferred from the initializer's shape, guarded by the same
+        // per-dimension bounds check (issue #1954).
+        Assert.Contains(
+            "lit[if 1 >= 0 && 1 < 2 && (2 >= 0 && 2 < 3) { 1 * 3 + 2 } " +
+                "else { throw IndexOutOfRangeException()",
+            rendered,
+            StringComparison.Ordinal);
 
         AssertRoundTripParses(rendered);
     }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1954MultiDimArrayHardeningTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1954MultiDimArrayHardeningTests.cs
@@ -1,0 +1,252 @@
+// <copyright file="Issue1954MultiDimArrayHardeningTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #1954: follow-ups from the #1893/#1952 flat-lowering review.
+/// <list type="number">
+/// <item>Per-dimension bounds are now enforced on every tracked multi-dim
+/// access: <c>grid[r, c]</c> with <c>r</c> in range but <c>c</c> out of range
+/// used to still land inside the flat backing array's overall bounds (a
+/// silent wrong-cell read/write); it now throws
+/// <c>IndexOutOfRangeException</c> like C# does per-dimension.</item>
+/// <item>A simple `var` local-to-local alias of a tracked multi-dim local
+/// (<c>var g2 = grid;</c>) now keeps the SAME tracking instead of losing it.</item>
+/// <item>A wide (`long`/`byte`) index expression is coerced the same way the
+/// single-index path coerces it (via `CoerceIndexToInt32`'s widening rule).</item>
+/// </list>
+/// </summary>
+public class Issue1954MultiDimArrayHardeningTests
+{
+    [Fact]
+    public void Rank3Access_FlatLowersAllThreeIndicesWithPerDimensionBoundsChecks()
+    {
+        string rendered = Render(@"
+namespace Corpus.Issue1954
+{
+    public class Cube
+    {
+        public static int Run()
+        {
+            int[,,] cube = new int[2, 3, 4];
+            cube[1, 2, 3] = 42;
+            return cube[1, 2, 3];
+        }
+    }
+}
+");
+
+        Assert.Contains("let cubeDim0", rendered, StringComparison.Ordinal);
+        Assert.Contains("let cubeDim1", rendered, StringComparison.Ordinal);
+        Assert.Contains("let cubeDim2", rendered, StringComparison.Ordinal);
+        Assert.Contains(
+            "let cube = [cubeDim0 * cubeDim1 * cubeDim2]int32", rendered, StringComparison.Ordinal);
+
+        // All three indices participate in both the row-major flat index and
+        // the per-dimension bounds check (issue #1954).
+        Assert.Contains(
+            "cube[if 1 >= 0 && 1 < cubeDim0 && (2 >= 0 && 2 < cubeDim1) && (3 >= 0 && 3 < cubeDim2) " +
+                "{ (1 * cubeDim1 + 2) * cubeDim2 + 3 } else { throw IndexOutOfRangeException()",
+            rendered,
+            StringComparison.Ordinal);
+
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void CrossDimensionOutOfRangeIndex_ThrowsInsteadOfSilentlyReadingWrongCell()
+    {
+        // grid[r, c] with r < rows but c >= cols used to still compute a flat
+        // index r*cols + c that is < rows*cols, silently landing on a
+        // different, WRONG cell instead of throwing like C# does per-dimension.
+        string rendered = Render(@"
+namespace Corpus.Issue1954
+{
+    public class Grid
+    {
+        public static int Run()
+        {
+            int[,] grid = new int[2, 3];
+            return grid[0, 5];
+        }
+    }
+}
+");
+
+        // The read is guarded by a per-dimension bounds check that throws
+        // rather than silently computing a wrong-but-in-range flat index.
+        Assert.Contains(
+            "grid[if 0 >= 0 && 0 < gridDim0 && (5 >= 0 && 5 < gridDim1) { 0 * gridDim1 + 5 } " +
+                "else { throw IndexOutOfRangeException()",
+            rendered,
+            StringComparison.Ordinal);
+
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void VarAliasOfTrackedMultiDimLocal_PropagatesTrackingInsteadOfGapping()
+    {
+        // `var g2 = grid;` used to lose multi-dim tracking entirely, so
+        // `g2[r, c]` reported the loud "no tracked per-dimension sizes" gap.
+        // A simple local-to-local `var` alias of an already-tracked multi-dim
+        // local now keeps the SAME tracking.
+        string rendered = Render(@"
+namespace Corpus.Issue1954
+{
+    public class Grid
+    {
+        public static int Run()
+        {
+            int[,] grid = new int[2, 3];
+            var g2 = grid;
+            return g2[1, 2];
+        }
+    }
+}
+");
+
+        // `g2[1, 2]` flattens against grid's OWN hoisted dimensions (g2 has no
+        // dimensions of its own — it is the same flat array), proving the
+        // alias kept the original MultiDimArrayInfo rather than gapping.
+        Assert.Contains(
+            "g2[if 1 >= 0 && 1 < gridDim0 && (2 >= 0 && 2 < gridDim1) { 1 * gridDim1 + 2 } " +
+                "else { throw IndexOutOfRangeException()",
+            rendered,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain("no tracked per-dimension sizes", rendered, StringComparison.Ordinal);
+
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void WideIndexExpression_CoercedToInt32JustLikeTheSingleIndexPath()
+    {
+        // Issue #1954 item 3: `TranslateMultiDimElementAccess` used raw
+        // `TranslateExpression` for indices while the single-index path
+        // coerces a wide (non-widening-to-int32) index via
+        // `CoerceIndexToInt32`. A `long` index must now get the same
+        // `int32(...)` coercion; a `byte` index (which widens to `int32`
+        // implicitly in C#) needs none.
+        string rendered = Render(@"
+namespace Corpus.Issue1954
+{
+    public class Grid
+    {
+        public static int Run()
+        {
+            int[,] grid = new int[2, 3];
+            long r = 1;
+            byte c = 2;
+            return grid[r, c];
+        }
+    }
+}
+");
+
+        // The long index is wrapped in the width-bearing int32(...) coercion.
+        Assert.Contains("int32(r)", rendered, StringComparison.Ordinal);
+
+        // The byte index needs no coercion call at all.
+        Assert.DoesNotContain("int32(c)", rendered, StringComparison.Ordinal);
+
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void FieldTypedMultiDimParameter_ElementRead_StaysLoudGap()
+    {
+        // A multi-dim array reached through a PARAMETER (not a direct
+        // declaration-with-initializer local) has no symbol for the
+        // translator to hang per-dimension sizes on.
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", @"
+namespace Corpus.Issue1954
+{
+    public class Grid
+    {
+        public static int Get(int[,] grid, int r, int c)
+        {
+            return grid[r, c];
+        }
+    }
+}
+") });
+
+        Assert.True(project.BoundWithoutErrors);
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        Assert.Contains(
+            context.Diagnostics,
+            d => d.Message.Contains("no tracked per-dimension sizes", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void FieldTargetMultiDimElementAssignment_StaysLoudGap()
+    {
+        // `Grid[r, c] = v;` where `Grid` is a FIELD (not a tracked local) has
+        // no per-dimension sizes to flatten the WRITE against either — the
+        // assignment-target path routes through the same
+        // `TranslateMultiDimElementAccess` and must report the same gap.
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", @"
+namespace Corpus.Issue1954
+{
+    public class Holder
+    {
+        public int[,] Grid;
+
+        public void Set(int r, int c, int v)
+        {
+            Grid[r, c] = v;
+        }
+    }
+}
+") });
+
+        Assert.True(project.BoundWithoutErrors);
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        Assert.Contains(
+            context.Diagnostics,
+            d => d.Message.Contains("no tracked per-dimension sizes", StringComparison.Ordinal));
+    }
+
+    private static void AssertRoundTripParses(string rendered)
+    {
+        RoundTripResult result = GSharpRoundTrip.Validate(rendered);
+
+        Assert.True(
+            result.Success,
+            "Sanitized G# must round-trip-parse. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + rendered);
+    }
+
+    private static string Render(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", source) });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        Cs2Gs.CodeModel.Ast.CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        Assert.Empty(context.Diagnostics);
+        return GSharpPrinter.Print(unit);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -5167,6 +5167,25 @@ public sealed class CSharpToGSharpTranslator
                     }
                 }
 
+                // Issue #1954: `var g2 = grid;` — a simple `var` local initialized
+                // directly from another local/parameter/field that is ITSELF a
+                // tracked flat-lowered multi-dim array (see `multiDimArrays`)
+                // aliases the SAME flat backing array, so `g2` is registered under
+                // the SAME `MultiDimArrayInfo` (any rank) rather than losing
+                // tracking and reporting the loud gap on its first `g2[i, j]`
+                // access. An explicitly-typed declaration, or a RHS that is
+                // anything other than a bare name/member reference to a tracked
+                // symbol (a method call, a conditional, ...), is not "simple
+                // aliasing" and is left to report the gap as before.
+                if (!hasExplicitType &&
+                    declarator.Initializer?.Value is IdentifierNameSyntax or MemberAccessExpressionSyntax &&
+                    this.context.GetSymbolInfo(declarator.Initializer.Value).Symbol is { } rhsAliasSymbol &&
+                    this.multiDimArrays.TryGetValue(rhsAliasSymbol, out MultiDimArrayInfo aliasedInfo) &&
+                    this.context.GetDeclaredSymbol(declarator) is { } declaredAliasSymbol)
+                {
+                    this.multiDimArrays[declaredAliasSymbol] = aliasedInfo;
+                }
+
                 // Issue #1894: a local's declared type normally only reaches
                 // CSharpTypeMapper.Map when an explicit type clause is emitted
                 // below — but when the declared type equals the initializer's
@@ -5589,6 +5608,31 @@ public sealed class CSharpToGSharpTranslator
             }
 
             ExpressionSyntax indexSyntax = elementAccess.ArgumentList.Arguments[0].Expression;
+            ITypeSymbol indexType = this.context.GetTypeInfo(indexSyntax).Type;
+            if (indexType != null &&
+                IsNonNullableValueType(indexType) &&
+                IsIntegerNotWideningToInt32(indexType))
+            {
+                ITypeSymbol int32Type =
+                    this.context.Compilation.GetSpecialType(SpecialType.System_Int32);
+                return this.CoerceOperandTo(index, int32Type);
+            }
+
+            return index;
+        }
+
+        // Issue #1954: a multi-index access's flat index is rebuilt with real
+        // arithmetic (`i0*dim1 + i1`, each `dim` an int32 hoisted `let`/
+        // literal — see `TranslateMultiDimElementAccess`), unlike the
+        // single-index path above where the index is handed unmodified to
+        // gsc's own indexer, which itself accepts any integer kind (#1279).
+        // Mixing a wide index (`long`/`ulong`/`nint`/`nuint`) into that int32
+        // arithmetic needs the same widening-coercion rule `CoerceIndexToInt32`
+        // applies, so this mirrors its tail check directly against the index
+        // syntax rather than re-deriving it from an `ElementAccessExpression`
+        // argument-count/indexer-target shape that does not apply here.
+        private GExpression CoerceMultiDimIndexToInt32(ExpressionSyntax indexSyntax, GExpression index)
+        {
             ITypeSymbol indexType = this.context.GetTypeInfo(indexSyntax).Type;
             if (indexType != null &&
                 IsNonNullableValueType(indexType) &&
@@ -10601,6 +10645,18 @@ public sealed class CSharpToGSharpTranslator
         /// field, parameter, or return value — see the deliberate scope note on
         /// <see cref="multiDimArrays"/>) reports the loud gap instead of
         /// silently collapsing to 1-D.
+        /// <para>
+        /// Issue #1954: a flat index that is in range overall
+        /// (<c>0 &lt;= flat &lt; dim0*dim1*...</c>) is not necessarily in range
+        /// PER DIMENSION — <c>grid[r, c]</c> with <c>r &lt; rows</c> but
+        /// <c>c &gt;= cols</c> can still land at a flat index
+        /// <c>r*cols + c &lt; rows*cols</c>, silently reading/writing the WRONG
+        /// cell instead of C#'s per-dimension <c>IndexOutOfRangeException</c>.
+        /// Every index is therefore range-checked against its own dimension
+        /// size (<c>0 &lt;= i_k &lt; dim_k</c>) before the flat index is used,
+        /// throwing <c>IndexOutOfRangeException</c> to match C#'s crash instead
+        /// of continuing on to the wrong cell.
+        /// </para>
         /// </summary>
         private GExpression TranslateMultiDimElementAccess(ElementAccessExpressionSyntax elementAccess, int rank)
         {
@@ -10619,8 +10675,13 @@ public sealed class CSharpToGSharpTranslator
                     target, this.TranslateExpression(elementAccess.ArgumentList.Arguments[0].Expression));
             }
 
+            // Each index is spilled (issue #1731 machinery) so a non-trivial
+            // index expression (a call, a mutating pre/post-increment, ...) is
+            // evaluated exactly once even though it is read again below by the
+            // per-dimension bounds check.
             List<GExpression> indexArguments = elementAccess.ArgumentList.Arguments
-                .Select(a => this.TranslateExpression(a.Expression))
+                .Select(a => this.SpillOperand(
+                    this.CoerceMultiDimIndexToInt32(a.Expression, this.TranslateExpression(a.Expression))))
                 .ToList();
 
             // Row-major flattening: acc = i0; acc = acc*dim1 + i1; acc = acc*dim2 + i2; ...
@@ -10631,7 +10692,25 @@ public sealed class CSharpToGSharpTranslator
                     new BinaryExpression(flatIndex, "*", info.DimensionSizes[i]), "+", indexArguments[i]);
             }
 
-            return new IndexExpression(target, flatIndex);
+            GExpression inBoundsCheck = null;
+            for (int i = 0; i < rank; i++)
+            {
+                GExpression dimensionInBounds = new BinaryExpression(
+                    new BinaryExpression(indexArguments[i], ">=", LiteralExpression.Int("0")),
+                    "&&",
+                    new BinaryExpression(indexArguments[i], "<", info.DimensionSizes[i]));
+                inBoundsCheck = inBoundsCheck == null
+                    ? dimensionInBounds
+                    : new BinaryExpression(inBoundsCheck, "&&", dimensionInBounds);
+            }
+
+            GTypeReference int32Type = this.typeMapper.Map(
+                this.context.Compilation.GetSpecialType(SpecialType.System_Int32), this.context, elementAccess.GetLocation());
+            GExpression outOfRangeThrow = new ThrowExpression(
+                BuildConstruction(new NamedTypeReference("IndexOutOfRangeException"), Array.Empty<GExpression>()),
+                int32Type);
+
+            return new IndexExpression(target, new IfExpression(inBoundsCheck, flatIndex, outOfRangeThrow));
         }
 
         private GExpression TranslateStackAlloc(StackAllocArrayCreationExpressionSyntax node)


### PR DESCRIPTION
Follow-ups from PR #1952 / issue #1893 review (issue #1954).

## 1. Per-dimension bounds (silent wrong-cell) — REQUIRED, done
`grid[r, c]` with `r < rows` but `c >= cols` used to still compute a flat index `r*cols + c` that lands `< rows*cols`, silently reading/writing the WRONG cell instead of C#'s per-dimension `IndexOutOfRangeException`. `TranslateMultiDimElementAccess` now wraps the flat index in a per-dimension range check (`0 <= i_k < dim_k` for every index, AND'd together) that throws `IndexOutOfRangeException` on failure instead of falling through to the wrong cell. Each index is read twice now (bounds check + flat arithmetic), so index expressions are spilled through the existing #1731 single-evaluation machinery (`SpillOperand`) to keep a non-trivial index (a call, a mutating increment, ...) evaluated exactly once.

## 2. Index coercion asymmetry — REQUIRED, done
Added `CoerceMultiDimIndexToInt32`, mirroring `CoerceIndexToInt32`'s widening rule (`long`/`ulong`/`nint`/`nuint` → `int32(...)`, narrower kinds untouched) but applied per-index against the index syntax directly, since the multi-dim path builds its own int32 arithmetic instead of handing the index to gsc's own (any-integer-kind) array indexer.

## 3. Rank-3 + gap-path tests — REQUIRED, done
New `Issue1954MultiDimArrayHardeningTests.cs`:
- rank-3 fixture (all three indices flatten + bounds-check correctly)
- cross-dimension out-of-range regression test (item 1)
- wide (`long`)/narrow (`byte`) index coercion test (item 2)
- `var g2 = grid` aliasing test (item 4, now propagating — see below)
- `T[,]` parameter loud-gap read test
- field-target `Grid[r, c] = v` loud-gap assignment test

Updated `Issue1893MultiDimArrayTranslationTests.cs`'s existing assertions for the new bounds-checked rendered output.

## 4. Aliasing propagation — attempted and done
`var g2 = grid;` now propagates the same `MultiDimArrayInfo` to `g2` when the RHS is a simple identifier/member reference to an already-tracked multi-dim local/field/parameter (any rank), instead of losing tracking. Kept narrow (var-only, simple-reference-only) since a method call, conditional, etc. on the RHS is not a straightforward alias of the same flat backing array.

## Verification
- `dotnet build tools/cs2gs/Cs2Gs.Pipeline/Cs2Gs.Pipeline.csproj -c Release` — clean
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release -- xUnit.MaxParallelThreads=2` — 1010/1010 passed
- `dotnet run --project tools/cs2gs/Cs2Gs.Cli -c Release -- migrate --baseline tools/cs2gs/triage/gaps.json` — 0 new, 0 regressed (ledgered #1929 / L2-Library unverified-app skip unaffected)

Fixes #1954
