### PR TITLE
gsc: diagnose inaccessible private method calls (OverloadResolver accessibility gate) (#2058)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -5719,14 +5719,16 @@ internal sealed class OverloadResolver
 
     public BoundExpression BindUserInstanceCall(BoundExpression receiver, FunctionSymbol method, ImmutableArray<BoundExpression> arguments, CallExpressionSyntax ce, ImmutableArray<string> argumentNames = default, TypeParameterSymbol constrainedReceiverTypeParameter = null)
     {
-        // Issue #950: enforce `protected` method access — only the declaring
-        // type and its derived types may call it. The emitted IL also carries
-        // CIL `family` accessibility so the CLR enforces the same rule.
-        if (method.Accessibility == Accessibility.Protected
-            && method.ReceiverType is StructSymbol protMethodDeclaringType
-            && !AccessibilityChecker.IsAccessible(method.Accessibility, protMethodDeclaringType, getCurrentFunction()))
+        // Issue #950 / #2044 / #2058: enforce `protected`/`private` method
+        // access — a `protected` method is only callable from the declaring
+        // type and its derived types, and a `private` method is only
+        // callable from within its declaring top-level type's body. The
+        // emitted IL also carries the matching CIL accessibility so the CLR
+        // enforces the same rule independently.
+        if (method.ReceiverType is StructSymbol methodDeclaringType
+            && !AccessibilityChecker.IsAccessible(method.Accessibility, methodDeclaringType, getCurrentFunction()))
         {
-            Diagnostics.ReportProtectedMemberInaccessible(ce.Identifier.Location, method.Name, protMethodDeclaringType.Name);
+            Diagnostics.ReportMemberInaccessible(ce.Identifier.Location, method.Name, methodDeclaringType.Name, method.Accessibility);
         }
 
         var parameterOffset = method.ExplicitReceiverParameter == null ? 0 : 1;

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2058PrivateMethodCallAccessibilityTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2058PrivateMethodCallAccessibilityTests.cs
@@ -1,0 +1,179 @@
+// <copyright file="Issue2058PrivateMethodCallAccessibilityTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2058: <see cref="GSharp.Core.CodeAnalysis.Binding.OverloadResolver.BindUserInstanceCall"/>
+/// previously only consulted <see cref="AccessibilityChecker.IsAccessible"/>
+/// when a called method's accessibility was exactly <c>protected</c>, so a
+/// <c>private</c> method called from outside its declaring type was never
+/// diagnosed — the same class of hole that issue #2044 fixed for field/
+/// property reads and writes, but left open for method calls. This mirrors
+/// <c>Issue2044PrivateAccessibilityTests</c>, but exercises method calls
+/// specifically.
+/// </summary>
+public class Issue2058PrivateMethodCallAccessibilityTests
+{
+    [Fact]
+    public void ExternalCode_CallsPrivateMethod_ReportsGS0472()
+    {
+        var source = @"
+class Foo {
+    private func Secret() int32 {
+        return 42
+    }
+}
+
+class Other {
+    func Poke(f Foo) int32 {
+        return f.Secret()
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    [Fact]
+    public void ExternalCode_CallsPrivateMethodViaChainedReceiver_ReportsGS0472()
+    {
+        // Issue #2058: same gated path, but reached through a chained member
+        // access (`Make().Secret()`) rather than a bare parameter receiver.
+        var source = @"
+class Foo {
+    private func Secret() int32 {
+        return 42
+    }
+}
+
+class Other {
+    func Make() Foo {
+        return Foo()
+    }
+
+    func Poke() int32 {
+        return Make().Secret()
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    [Fact]
+    public void InternalCode_CallsPrivateMethodFromSameType_NoDiagnostics()
+    {
+        var source = @"
+class Foo {
+    private func Secret() int32 {
+        return 42
+    }
+
+    func Reveal() int32 {
+        return Secret()
+    }
+}
+
+class Other {
+    func Poke(f Foo) int32 {
+        return f.Reveal()
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    [Fact]
+    public void NestedType_CallsEnclosingTypePrivateMethod_NoDiagnostics()
+    {
+        var source = @"
+class Outer {
+    private func Secret() int32 {
+        return 42
+    }
+
+    class Inner {
+        func Poke(o Outer) int32 {
+            return o.Secret()
+        }
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    [Fact]
+    public void DerivedClass_CallsBaseProtectedMethod_NoDiagnostics()
+    {
+        // A derived class calling its base's `protected` method must still
+        // compile cleanly — the private-method fix must not accidentally
+        // over-broaden the check to also require `protected` methods be
+        // publicly visible.
+        var source = @"
+open class Base {
+    protected func Guarded() int32 {
+        return 7
+    }
+}
+
+class Derived : Base {
+    func Poke() int32 {
+        return Guarded()
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0379");
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    [Fact]
+    public void ExternalCode_CallsProtectedMethod_ReportsGS0379NotGS0472()
+    {
+        // Issue #2058: the diagnostic reporter must be passed the member's
+        // real accessibility, not a hardcoded `protected`, so a `protected`
+        // method still reports GS0379 (not GS0472) once the gate covers all
+        // non-public accessibilities.
+        var source = @"
+open class Base {
+    protected func Guarded() int32 {
+        return 7
+    }
+}
+
+class Other {
+    func Poke(b Base) int32 {
+        return b.Guarded()
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0379");
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
Fixes #2058

`OverloadResolver.BindUserInstanceCall` hard-gated its accessibility check on `method.Accessibility == Accessibility.Protected` before calling `AccessibilityChecker.IsAccessible`, so a `private` method called from OUTSIDE its declaring type was never diagnosed — the same soundness hole issue #2044 closed for field/property reads and writes, but left open for method calls.

## Fix
- Dropped the `== Protected` gate; the check now runs `AccessibilityChecker.IsAccessible` for any non-public accessibility (`protected` or `private`).
- The diagnostic reporter (`DiagnosticBag.ReportMemberInaccessible`) is now passed the method's real `Accessibility` instead of a hardcoded `Protected`, so `private` method calls correctly report **GS0472** and `protected` method calls still correctly report **GS0379**.
- `ReportMemberInaccessible` already has no default `accessibility` parameter (added during #2044), so no further signature change was needed there.

## Tests
Added `Issue2058PrivateMethodCallAccessibilityTests` mirroring the #2044 test pattern for method calls:
- External call to a `private` method (bare receiver and chained receiver expression) → GS0472.
- Same-type and nested-type calls to a `private` method → clean.
- Derived-class call to a base's `protected` method → clean (no over-broad blocking).
- External call to a `protected` method → still GS0379, not GS0472 (confirms real accessibility is passed through).

`dotnet test test/Core.Tests/Core.Tests.csproj -c Release`: 5501 passed, 1 pre-existing skip, 0 failed.