### PR TITLE
gsc: enforce accessibility on composite/struct literal member initializers (#2059)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
@@ -931,15 +931,35 @@ internal sealed partial class ExpressionBinder
             // accessor). Resolve fields first, then fall back to properties so
             // both `class C { var X int32 }` and `class C { prop X int32 { get;
             // init; } }` accept `C{X: ...}`.
-            var hasField = TypeMemberModel.TryGetFieldIncludingInherited(structSymbol, fieldName, MemberQuery.Instance(MemberKinds.Field), out var field, out _);
+            var hasField = TypeMemberModel.TryGetFieldIncludingInherited(structSymbol, fieldName, MemberQuery.Instance(MemberKinds.Field), out var field, out var fieldDeclaringType);
             PropertySymbol property = null;
+            StructSymbol propertyDeclaringType = null;
             if (!hasField)
             {
-                if (!TypeMemberModel.TryGetProperty(structSymbol, fieldName, out property))
+                if (!TypeMemberModel.TryGetProperty(structSymbol, fieldName, out property, out propertyDeclaringType))
                 {
                     Diagnostics.ReportUnableToFindMember(initSyntax.FieldIdentifier.Location, fieldName);
                     continue;
                 }
+            }
+
+            // Issue #2059: a composite/struct literal `Foo{ member: value }`
+            // writes the member directly, bypassing normal assignment binding
+            // — so it must enforce the SAME `private`/`protected` accessibility
+            // rule as a qualified write (`receiver.field = value`, #2044/#2048).
+            // This is independent of the get-only/init "is it writable at all"
+            // check below; an inaccessible member is rejected here even when it
+            // otherwise has a setter.
+            if (!AccessibilityChecker.IsAccessible(
+                hasField ? field.Accessibility : property.Accessibility,
+                hasField ? fieldDeclaringType : propertyDeclaringType,
+                this.function))
+            {
+                Diagnostics.ReportMemberInaccessible(
+                    initSyntax.FieldIdentifier.Location,
+                    fieldName,
+                    (hasField ? fieldDeclaringType : propertyDeclaringType).Name,
+                    hasField ? field.Accessibility : property.Accessibility);
             }
 
             // Issue #1567: a braced member value `Member: { a, b }` populates the

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2059StructLiteralAccessibilityTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2059StructLiteralAccessibilityTests.cs
@@ -1,0 +1,161 @@
+// <copyright file="Issue2059StructLiteralAccessibilityTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2059: a composite/struct literal <c>Foo{ member: value }</c> writes
+/// each named member directly (<c>BoundFieldInitializer</c>), bypassing the
+/// qualified-assignment path (<c>receiver.field = value</c>) that #2044/#2048
+/// already gate on <c>private</c>/<c>protected</c> accessibility (GS0472 /
+/// GS0379). This closes the same gap for literal-init syntax.
+/// </summary>
+public class Issue2059StructLiteralAccessibilityTests
+{
+    [Fact]
+    public void ExternalCode_LiteralInitsPrivateField_ReportsGS0472()
+    {
+        var source = @"
+class Foo {
+    private var Secret int32
+}
+
+class Other {
+    func Make() Foo {
+        return Foo{ Secret: 5 }
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    [Fact]
+    public void ExternalCode_LiteralInitsPrivateProperty_ReportsGS0472()
+    {
+        var source = @"
+class Foo {
+    private prop Secret int32 { get; set }
+}
+
+class Other {
+    func Make() Foo {
+        return Foo{ Secret: 5 }
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    [Fact]
+    public void SameType_LiteralInitsOwnPrivateField_NoDiagnostics()
+    {
+        var source = @"
+class Foo {
+    private var Secret int32
+
+    func Make(v int32) Foo {
+        return Foo{ Secret: v }
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    [Fact]
+    public void ExternalCode_LiteralInitsPublicField_NoDiagnostics()
+    {
+        var source = @"
+class Foo {
+    var Visible int32
+}
+
+class Other {
+    func Make() Foo {
+        return Foo{ Visible: 5 }
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    [Fact]
+    public void ExternalCode_LiteralInitsInitOnlyProperty_NoDiagnostics()
+    {
+        var source = @"
+class Foo {
+    prop Visible int32 { get; init }
+}
+
+class Other {
+    func Make() Foo {
+        return Foo{ Visible: 5 }
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    [Fact]
+    public void DerivedType_LiteralInitsProtectedField_NoDiagnostics()
+    {
+        var source = @"
+open class Base {
+    protected var Secret int32
+}
+
+class Derived : Base {
+    func Make(v int32) Derived {
+        return Derived{ Secret: v }
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0379");
+    }
+
+    [Fact]
+    public void UnrelatedExternalCode_LiteralInitsProtectedField_ReportsGS0379()
+    {
+        var source = @"
+open class Base {
+    protected var Secret int32
+}
+
+class Other {
+    func Make() Base {
+        return Base{ Secret: 5 }
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0379");
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
Fixes #2059

## Problem
`ExpressionBinder.Literals.cs::BindStructLiteralExpression` wrote each named member of a composite/struct literal (`Foo{ member: value }`) directly via `BoundFieldInitializer`, with no `AccessibilityChecker.IsAccessible` check at all. So `Foo{ secret: 5 }` from outside the declaring type compiled silently even when `secret` was `private` or `protected` — bypassing the qualified-write accessibility enforcement already fixed for `receiver.field = value` in #2044/#2048.

## Fix
For each named member initializer, resolve its declaring type (field or property) and run `AccessibilityChecker.IsAccessible(...)`, reporting the existing diagnostic via `Diagnostics.ReportMemberInaccessible` (GS0472 for `private`, GS0379 for `protected`) when it fails. This check is independent of, and added alongside, the existing get-only/init "is this member writable via literal syntax at all" check — a public or `init`-accessible member from outside the declaring type still compiles; a get-only property still reports the pre-existing "cannot assign" diagnostic regardless of accessibility.

## Tests
Added `test/Core.Tests/CodeAnalysis/Binding/Issue2059StructLiteralAccessibilityTests.cs`:
- external private field/property literal-init → GS0472
- same-type literal-init of own private field → no diagnostic
- external public field literal-init → no diagnostic
- external `init`-only property literal-init → no diagnostic
- derived-type literal-init of base's protected field → no diagnostic
- unrelated external literal-init of protected field → GS0379

## Validation
- `dotnet build src/Compiler/Compiler.csproj -c Release` — 0 warnings, 0 errors.
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release` — **5502 passed, 0 failed, 1 pre-existing skip** (full suite, no regressions from this change).
