### PR TITLE
gsc: enforce accessibility on bare-name inherited-private field access (#2060)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -360,17 +360,15 @@ public sealed class Binder
                                     continue;
                                 }
 
-                                // Issue #2044: `private` is not inherited (unlike
-                                // `protected`) — a base class's private field must
-                                // not be exposed as a bare name inside a derived
-                                // type's methods. Only the declaring type itself
-                                // (t == receiverStruct) sees its own private fields
-                                // this way.
-                                if (fld.Accessibility == Accessibility.Private && !ReferenceEquals(t, receiverStruct))
-                                {
-                                    continue;
-                                }
-
+                                // Issue #2060 (follow-up to #2044): `private` is
+                                // not inherited (unlike `protected`), but the
+                                // pseudo-variable is still declared here for an
+                                // inherited private field so bare-name access
+                                // resolves to it — BindVariableReference then
+                                // runs it through AccessibilityChecker.IsAccessible
+                                // and reports GS0472, instead of silently
+                                // dropping the name (which used to surface as a
+                                // misleading "undefined variable").
                                 if (seenMembers.Add(fld.Name))
                                 {
                                     scope.TryDeclareVariable(new ImplicitFieldVariableSymbol(function.ThisParameter, t, fld));

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -1105,6 +1105,21 @@ internal sealed partial class ExpressionBinder
         switch (scope.TryLookupSymbol(name))
         {
             case VariableSymbol variable:
+                // Issue #2060 (follow-up to #2044): a bare identifier resolving
+                // to an inherited field's ImplicitFieldVariableSymbol bypassed
+                // AccessibilityChecker entirely (unlike the qualified
+                // `receiver.field` paths already fixed for #2044). Run the
+                // same check here so both read and write of an inherited
+                // `private` field via bare name report GS0472. Own-type
+                // private fields (declaringType == enclosing type) and
+                // inherited `protected` fields remain accessible.
+                if (variable is ImplicitFieldVariableSymbol implicitField
+                    && !AccessibilityChecker.IsAccessible(implicitField.Field.Accessibility, implicitField.StructType, this.function))
+                {
+                    Diagnostics.ReportMemberInaccessible(location, implicitField.Field.Name, implicitField.StructType.Name, implicitField.Field.Accessibility);
+                    return null;
+                }
+
                 reportObsoleteUseIfApplicable(location, variable, variable.Name);
                 return variable;
 

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2044PrivateAccessibilityTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2044PrivateAccessibilityTests.cs
@@ -173,10 +173,12 @@ class Outer {
     [Fact]
     public void DerivedClass_BareNameDoesNotSeeBasePrivateField()
     {
-        // Unlike `protected`, `private` is NOT inherited: a base class's
-        // private field must not be exposed as a bare name inside a derived
-        // type's methods (matching C#: unqualified lookup never finds a
-        // base's private members, so the name simply doesn't resolve).
+        // Issue #2060 (follow-up to #2044): a base class's private field is
+        // not inherited, but a bare (unqualified) reference to it from a
+        // derived type's method now reports the same inaccessible-member
+        // diagnostic (GS0472) as the qualified `this.Secret` / `obj.Secret`
+        // form, instead of the misleading "undefined variable" (GS0125) it
+        // used to surface.
         var source = @"
 open class Base {
     private var Secret int32
@@ -191,7 +193,8 @@ class Derived : Base {
 0
 ";
         var result = Evaluate(source);
-        Assert.Contains(result.Diagnostics, d => d.Id == "GS0125");
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0472");
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0125");
     }
 
     private static EvaluationResult Evaluate(string source)

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2060BareNameInheritedPrivateFieldTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2060BareNameInheritedPrivateFieldTests.cs
@@ -1,0 +1,119 @@
+// <copyright file="Issue2060BareNameInheritedPrivateFieldTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2060 (follow-up to #2044/#2048): a bare (unqualified, no
+/// <c>this.</c>/receiver) reference inside a derived class's method body that
+/// names an inherited base field resolved via a binder-internal
+/// <see cref="Symbols.ImplicitFieldVariableSymbol"/> pseudo-variable that
+/// bypassed <c>AccessibilityChecker</c> entirely. A base class's <c>private</c>
+/// field was therefore both readable and writable by bare name from a derived
+/// type with no diagnostic. <c>BindVariableReference</c> now runs every
+/// resolved <see cref="Symbols.ImplicitFieldVariableSymbol"/> through
+/// <c>AccessibilityChecker.IsAccessible</c>, reporting GS0472 for both the
+/// read and write paths — mirroring the qualified <c>receiver.field</c> checks
+/// already in place. Inherited <c>protected</c> fields and a type's own
+/// <c>private</c> fields (declared directly in the accessing type) remain
+/// reachable by bare name with no diagnostic.
+/// </summary>
+public class Issue2060BareNameInheritedPrivateFieldTests
+{
+    [Fact]
+    public void DerivedClass_BareNameReadOfInheritedPrivateField_ReportsGS0472()
+    {
+        var source = @"
+open class Base {
+    private var Secret int32
+}
+
+class Derived : Base {
+    func Poke() int32 {
+        return Secret
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    [Fact]
+    public void DerivedClass_BareNameWriteOfInheritedPrivateField_ReportsGS0472()
+    {
+        var source = @"
+open class Base {
+    private var Secret int32
+}
+
+class Derived : Base {
+    func Poke() int32 {
+        Secret = 42
+        return 0
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    [Fact]
+    public void DerivedClass_BareNameOfInheritedProtectedField_NoDiagnostics()
+    {
+        // `protected` IS inherited-visible (unlike `private`): a derived
+        // type's bare-name read/write of an inherited protected field must
+        // keep compiling cleanly.
+        var source = @"
+open class Base {
+    protected var Secret int32
+}
+
+class Derived : Base {
+    func Poke() int32 {
+        Secret = 5
+        return Secret
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    [Fact]
+    public void SameType_BareNameOfOwnPrivateField_NoDiagnostics()
+    {
+        // A type's own private field, declared directly in the same type as
+        // the accessing code (not inherited), must remain legal by bare name.
+        var source = @"
+class Foo {
+    private var Secret int32
+    func Poke() int32 {
+        Secret = 5
+        return Secret
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
Fixes #2060

## Root cause
Bare-name (no `this.`/receiver) resolution of an inherited base field went through a binder-internal `ImplicitFieldVariableSymbol` pseudo-variable that never consulted `AccessibilityChecker`. A base class's `private` field was therefore readable AND writable by bare name from a derived class's body with zero diagnostic — while the qualified `receiver.field` form was already checked (#2044/#2048).

Main already stopped declaring the pseudo-variable for an inherited private field (added by #2044's merge), but that surfaced as a misleading GS0125 ("undefined variable") instead of the correct inaccessible-member diagnostic.

## Fix
- `Binder.cs`: the per-method field-exposure loop now declares the `ImplicitFieldVariableSymbol` for an inherited private field like any other field (no special-case skip).
- `ExpressionBinder.BindVariableReference` — the single choke point every bare-identifier lookup (read, plain write, compound-assignment receiver) routes through — now runs each resolved `ImplicitFieldVariableSymbol` through `AccessibilityChecker.IsAccessible` and reports **GS0472** when inaccessible, mirroring the qualified-access paths exactly (same diagnostic, same helper).
- Inherited `protected` fields and a type's own `private` fields are unaffected — `AccessibilityChecker` already distinguishes both correctly.

## Tests
- Updated `Issue2044PrivateAccessibilityTests.DerivedClass_BareNameDoesNotSeeBasePrivateField` to assert GS0472 (was GS0125).
- New `Issue2060BareNameInheritedPrivateFieldTests`: inherited-private bare-name read → GS0472, inherited-private bare-name write → GS0472, inherited-protected bare-name → clean, own-type private bare-name → clean.

## Verification
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release`: **5499 passed, 1 skipped (pre-existing), 0 failed** (full suite, not narrow-filtered).
- Manual repro compiles confirm: inherited private bare-name read/write → GS0472; inherited protected bare-name → Success; own-type private bare-name → Success.