### PR TITLE
gsc: diagnose private method call from outside declaring type (#2058)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -2789,6 +2789,16 @@ internal sealed partial class ExpressionBinder
                 return new BoundErrorExpression(null);
             }
 
+            // Issue #950 / #2058: enforce `protected`/`private` static method
+            // access — mirrors the instance-call check in
+            // OverloadResolver.BindUserInstanceCall. Interface static methods
+            // already have their own private-visibility diagnostic (issue
+            // #756), so this only applies to class/struct owners.
+            if (structSym != null && !AccessibilityChecker.IsAccessible(method.Accessibility, structSym, this.function))
+            {
+                Diagnostics.ReportMemberInaccessible(ce.Identifier.Location, method.Name, structSym.Name, method.Accessibility);
+            }
+
             // Issue #951: bind any deferred un-typed arrow lambda against the
             // selected static method's delegate-typed parameter so its omitted
             // parameter type(s) and inferred return type are filled in from the

--- a/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolver.cs
@@ -5719,14 +5719,14 @@ internal sealed class OverloadResolver
 
     public BoundExpression BindUserInstanceCall(BoundExpression receiver, FunctionSymbol method, ImmutableArray<BoundExpression> arguments, CallExpressionSyntax ce, ImmutableArray<string> argumentNames = default, TypeParameterSymbol constrainedReceiverTypeParameter = null)
     {
-        // Issue #950: enforce `protected` method access — only the declaring
-        // type and its derived types may call it. The emitted IL also carries
-        // CIL `family` accessibility so the CLR enforces the same rule.
-        if (method.Accessibility == Accessibility.Protected
-            && method.ReceiverType is StructSymbol protMethodDeclaringType
-            && !AccessibilityChecker.IsAccessible(method.Accessibility, protMethodDeclaringType, getCurrentFunction()))
+        // Issue #950 / #2058: enforce `protected`/`private` method access —
+        // only the declaring type (and, for `protected`, its derived types)
+        // may call it. The emitted IL also carries the matching CIL
+        // accessibility so the CLR enforces the same rule.
+        if (method.ReceiverType is StructSymbol methodDeclaringType
+            && !AccessibilityChecker.IsAccessible(method.Accessibility, methodDeclaringType, getCurrentFunction()))
         {
-            Diagnostics.ReportProtectedMemberInaccessible(ce.Identifier.Location, method.Name, protMethodDeclaringType.Name);
+            Diagnostics.ReportMemberInaccessible(ce.Identifier.Location, method.Name, methodDeclaringType.Name, method.Accessibility);
         }
 
         var parameterOffset = method.ExplicitReceiverParameter == null ? 0 : 1;

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2058PrivateMethodCallTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2058PrivateMethodCallTests.cs
@@ -1,0 +1,150 @@
+// <copyright file="Issue2058PrivateMethodCallTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2058: a <c>private</c> method called from outside its declaring
+/// type is now diagnosed (GS0472), mirroring the existing <c>protected</c>
+/// method-call enforcement (issue #950 / GS0379) and the field/property
+/// enforcement added for issue #2044. Covers instance and static (<c>shared</c>)
+/// private methods called from outside the declaring type (must report), and
+/// legal same-type, inherited-protected, and public calls (must not report).
+/// </summary>
+public class Issue2058PrivateMethodCallTests
+{
+    [Fact]
+    public void ExternalCode_CallsPrivateInstanceMethod_ReportsGS0472()
+    {
+        var source = @"
+class Foo {
+    private func Secret() int32 { return 42 }
+}
+
+class Other {
+    func Poke(f Foo) int32 {
+        return f.Secret()
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    [Fact]
+    public void ExternalCode_CallsPrivateStaticMethod_ReportsGS0472()
+    {
+        var source = @"
+class Foo {
+    shared {
+        private func Secret() int32 { return 42 }
+    }
+}
+
+class Other {
+    func Poke() int32 {
+        return Foo.Secret()
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    [Fact]
+    public void InternalCode_CallsPrivateInstanceMethodFromSameType_NoDiagnostics()
+    {
+        var source = @"
+class Foo {
+    private func Secret() int32 { return 42 }
+    func Reveal() int32 { return Secret() }
+}
+
+class Other {
+    func Poke(f Foo) int32 {
+        return f.Reveal()
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    [Fact]
+    public void InternalCode_CallsPrivateStaticMethodFromSameType_NoDiagnostics()
+    {
+        var source = @"
+class Foo {
+    shared {
+        func Reveal() int32 { return Secret() }
+        private func Secret() int32 { return 42 }
+    }
+}
+
+class Other {
+    func Poke() int32 {
+        return Foo.Reveal()
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    [Fact]
+    public void DerivedClass_CallsInheritedProtectedMethod_NoDiagnostics()
+    {
+        var source = @"
+open class Base {
+    protected func Helper() int32 { return 1 }
+}
+
+class Derived : Base {
+    func Poke() int32 { return Helper() }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0379");
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    [Fact]
+    public void ExternalCode_CallsPublicMethod_NoDiagnostics()
+    {
+        var source = @"
+class Foo {
+    func Greet() int32 { return 42 }
+}
+
+class Other {
+    func Poke(f Foo) int32 {
+        return f.Greet()
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
## Root cause
Two call-binding sites checked method accessibility incorrectly/incompletely:
- `OverloadResolver.BindUserInstanceCall` gated the check on `method.Accessibility == Accessibility.Protected` only, so `private` instance methods called from outside their declaring type were never diagnosed.
- `ExpressionBinder.BindUserTypeStaticCall` (static/`shared` method calls) had **no** accessibility enforcement at all.

## Fix
Both sites now call `AccessibilityChecker.IsAccessible` (the same checker added for field/property access in #2044) and report via the shared `DiagnosticBag.ReportMemberInaccessible` helper (GS0379 for protected, GS0472 for private) — no new diagnostic invented, no parallel checker.

## Call sites changed
- `src/Core/CodeAnalysis/Binding/OverloadResolver.cs`: `BindUserInstanceCall` — replaced the protected-only gate with a general `IsAccessible` check covering private too.
- `src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs`: `BindUserTypeStaticCall` — added the same check for static (`shared`) method calls (class/struct owners only; interface static methods keep their existing private-visibility diagnostic from #756).

## Tests
Added `test/Core.Tests/CodeAnalysis/Binding/Issue2058PrivateMethodCallTests.cs` mirroring `Issue2044PrivateAccessibilityTests.cs`:
- private instance method called from outside → GS0472
- private static method called from outside → GS0472
- private instance/static method called from inside declaring type → no diagnostic
- inherited protected method call → no diagnostic
- public method call → no diagnostic

Verified:
- `dotnet build src/Compiler/Compiler.csproj -c Release -graph` — succeeds.
- Targeted filter (Issue2058/Issue2044/Issue950/Issue1585/Accessib): 56/56 pass.
- Broader regression filter (Call/Overload/Interface/Visibility/Protected): 790/790 pass.
- Manual repro via `gsc` CLI reproduces the GS0472 diagnostic; `samples/PrivateInterfaceHelpers.gs` still compiles clean.

Fixes #2058