### PR TITLE
gsc: diagnose inaccessible member init in composite/struct literals (#2059)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -419,20 +419,35 @@ internal sealed partial class ExpressionBinder
 
         if (receiverType is StructSymbol structSymbol)
         {
-            if (TypeMemberModel.TryGetFieldIncludingInherited(structSymbol, propertyName, MemberQuery.Instance(MemberKinds.Field), out var field, out _))
+            if (TypeMemberModel.TryGetFieldIncludingInherited(structSymbol, propertyName, MemberQuery.Instance(MemberKinds.Field), out var field, out var fieldDeclaringType))
             {
+                // Issue #2059: an object-initializer-suffix (`T(){ Field = v }`)
+                // member write is subject to the same `protected`/`private`
+                // accessibility rule as a plain assignment (issue #950 / #2044).
+                if (!AccessibilityChecker.IsAccessible(field.Accessibility, fieldDeclaringType, this.function))
+                {
+                    Diagnostics.ReportMemberInaccessible(initSyntax.PropertyIdentifier.Location, field.Name, fieldDeclaringType.Name, field.Accessibility);
+                }
+
                 var value = BindExpression(initSyntax.Value);
                 var converted = conversions.BindConversion(initSyntax.Value.Location, value, field.Type);
                 return new BoundFieldAssignmentExpression(initSyntax, receiverLocal, structSymbol, field, converted);
             }
 
-            if (TypeMemberModel.TryGetProperty(structSymbol, propertyName, out var prop))
+            if (TypeMemberModel.TryGetProperty(structSymbol, propertyName, out var prop, out var propDeclaringType))
             {
                 if (!prop.HasSetter)
                 {
                     Diagnostics.ReportCannotAssign(initSyntax.EqualsToken.Location, propertyName);
                     _ = BindExpression(initSyntax.Value);
                     return null;
+                }
+
+                // Issue #2059: object-initializer-suffix property write —
+                // mirrors the field check above.
+                if (!AccessibilityChecker.IsAccessible(prop.Accessibility, propDeclaringType, this.function))
+                {
+                    Diagnostics.ReportMemberInaccessible(initSyntax.PropertyIdentifier.Location, prop.Name, propDeclaringType.Name, prop.Accessibility);
                 }
 
                 var value = BindExpression(initSyntax.Value);

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -64,6 +64,15 @@ internal sealed partial class ExpressionBinder
                 continue;
             }
 
+            // Issue #2059: a `with` update is a write to the named field —
+            // enforce the same `protected`/`private` accessibility rule as a
+            // plain assignment / composite literal member init (issue #950 /
+            // #2044 / #2059).
+            if (!AccessibilityChecker.IsAccessible(field.Accessibility, declaringType, this.function))
+            {
+                Diagnostics.ReportMemberInaccessible(initSyntax.FieldIdentifier.Location, field.Name, declaringType.Name, field.Accessibility);
+            }
+
             var valueExpr = BindExpression(initSyntax.Value);
             valueExpr = conversions.BindConversion(initSyntax.Value.Location, valueExpr, field.Type);
             explicitValues[fieldName] = (field, declaringType, valueExpr);

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
@@ -931,15 +931,29 @@ internal sealed partial class ExpressionBinder
             // accessor). Resolve fields first, then fall back to properties so
             // both `class C { var X int32 }` and `class C { prop X int32 { get;
             // init; } }` accept `C{X: ...}`.
-            var hasField = TypeMemberModel.TryGetFieldIncludingInherited(structSymbol, fieldName, MemberQuery.Instance(MemberKinds.Field), out var field, out _);
+            var hasField = TypeMemberModel.TryGetFieldIncludingInherited(structSymbol, fieldName, MemberQuery.Instance(MemberKinds.Field), out var field, out var fieldDeclaringType);
             PropertySymbol property = null;
+            StructSymbol propertyDeclaringType = null;
             if (!hasField)
             {
-                if (!TypeMemberModel.TryGetProperty(structSymbol, fieldName, out property))
+                if (!TypeMemberModel.TryGetProperty(structSymbol, fieldName, out property, out propertyDeclaringType))
                 {
                     Diagnostics.ReportUnableToFindMember(initSyntax.FieldIdentifier.Location, fieldName);
                     continue;
                 }
+            }
+
+            // Issue #2059: a composite/struct literal member initializer is a
+            // write to the named member — enforce the same `protected`/`private`
+            // accessibility rule as a plain assignment (issue #950 / #2044),
+            // reusing the same checker + diagnostic so `Foo{ secret: 1 }` from
+            // outside the declaring type is diagnosed instead of silently
+            // compiling.
+            var literalMemberAccessibility = hasField ? field.Accessibility : property.Accessibility;
+            var literalMemberDeclaringType = hasField ? fieldDeclaringType : propertyDeclaringType;
+            if (!AccessibilityChecker.IsAccessible(literalMemberAccessibility, literalMemberDeclaringType, this.function))
+            {
+                Diagnostics.ReportMemberInaccessible(initSyntax.FieldIdentifier.Location, fieldName, literalMemberDeclaringType.Name, literalMemberAccessibility);
             }
 
             // Issue #1567: a braced member value `Member: { a, b }` populates the

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2059LiteralAccessibilityTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2059LiteralAccessibilityTests.cs
@@ -1,0 +1,189 @@
+// <copyright file="Issue2059LiteralAccessibilityTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2059: a composite/struct literal member initializer
+/// (<c>Foo{ Secret: v }</c>), a <c>with</c>-expression field update
+/// (<c>p with { Secret = v }</c>), and an object-initializer-suffix member
+/// write (<c>Foo(){ Secret = v }</c>) are all writes to the named member —
+/// each now enforces the same <c>protected</c>/<c>private</c> accessibility
+/// rule as a plain assignment (issue #950 / #2044), reusing
+/// <see cref="Symbols.AccessibilityChecker.IsAccessible"/> and
+/// <see cref="DiagnosticBag.ReportMemberInaccessible"/>.
+/// </summary>
+public class Issue2059LiteralAccessibilityTests
+{
+    [Fact]
+    public void ExternalCode_StructLiteralInitsPrivateField_ReportsGS0472()
+    {
+        var source = @"
+class Foo {
+    private var Secret int32
+}
+
+class Other {
+    func Poke() int32 {
+        let f = Foo{Secret: 42}
+        return 0
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    [Fact]
+    public void ExternalCode_StructLiteralInitsProtectedField_ReportsGS0379()
+    {
+        var source = @"
+open class Foo {
+    protected var Secret int32
+}
+
+class Other {
+    func Poke() int32 {
+        let f = Foo{Secret: 42}
+        return 0
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0379");
+    }
+
+    [Fact]
+    public void ExternalCode_StructLiteralInitsPrivateProperty_ReportsGS0472()
+    {
+        var source = @"
+class Foo {
+    private prop Secret int32 { get; set }
+}
+
+class Other {
+    func Poke() int32 {
+        let f = Foo{Secret: 42}
+        return 0
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    [Fact]
+    public void SameType_StructLiteralInitsPrivateField_NoDiagnostics()
+    {
+        var source = @"
+class Foo {
+    private var Secret int32
+
+    static func Make(v int32) Foo {
+        return Foo{Secret: v}
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    [Fact]
+    public void ExternalCode_StructLiteralInitsPublicField_NoDiagnostics()
+    {
+        var source = @"
+class Foo {
+    var Value int32
+}
+
+class Other {
+    func Poke() int32 {
+        let f = Foo{Value: 42}
+        return f.Value
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0472");
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0379");
+    }
+
+    [Fact]
+    public void ExternalCode_WithExpressionUpdatesPrivateField_ReportsGS0472()
+    {
+        var source = @"
+data struct Point {
+    private var x int32
+    var y int32
+}
+
+class Other {
+    func Poke(p Point) Point {
+        return p with { x = 10 }
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    [Fact]
+    public void SameType_WithExpressionUpdatesPrivateField_NoDiagnostics()
+    {
+        var source = @"
+data struct Point {
+    private var x int32
+    var y int32
+
+    func Bump() Point {
+        return this with { x = 10 }
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    [Fact]
+    public void ExternalCode_ObjectInitializerSuffixWritesPrivateField_ReportsGS0472()
+    {
+        var source = @"
+class Foo {
+    private var Secret int32
+}
+
+class Other {
+    func Poke() int32 {
+        let f = Foo(){Secret = 42}
+        return 0
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
## Root cause

Issue #2044 (external commit 5bbadbfd) added `protected`/`private` accessibility enforcement for plain field/property assignment (`f.Secret = v`), reusing `AccessibilityChecker.IsAccessible` + `DiagnosticBag.ReportMemberInaccessible` (GS0379 protected / GS0472 private). That enforcement never covered the composite/struct-literal member-init path — `BindStructLiteralExpression` lowered named literal members straight to `BoundFieldInitializer`/`BoundPropertyAssignmentExpression`-equivalents with no accessibility check, so `Foo{ secret: 42 }` from outside the declaring type silently compiled for private/protected members. The same gap existed in two sibling member-write paths that don't route through the plain-assignment binder: the `with`-expression field update (`p with { x = v }`) and the object-initializer suffix (`Foo(){ Secret = v }`).

## Fix

Reused the existing `AccessibilityChecker.IsAccessible` check and `DiagnosticBag.ReportMemberInaccessible` (no new diagnostic/checker) at each of the three gap sites:
- `ExpressionBinder.Literals.cs` — `BindStructLiteralExpression`'s named-member-init loop (struct/class composite literals, fields and properties).
- `ExpressionBinder.Calls.cs` — `LowerCopyOrWith` (`with`-expression field updates on `data struct`).
- `ExpressionBinder.Assignments.cs` — `BindObjectInitializerAssignment` (`Foo(){ Prop = v }` object-initializer suffix, fields and properties).

The imported-CLR-class literal path (`BindImportedClassLiteralExpression`) already only reflects `BindingFlags.Public` members, so it needed no change.

## Tests

New `test/Core.Tests/CodeAnalysis/Binding/Issue2059LiteralAccessibilityTests.cs`, mirroring `Issue2044PrivateAccessibilityTests.cs`:
- struct-literal private field init from outside → GS0472
- struct-literal protected field init from outside → GS0379
- struct-literal private property init from outside → GS0472
- struct-literal private field init from the same type → no diagnostic
- struct-literal public field init from outside → no diagnostic
- `with`-expression private field update from outside → GS0472
- `with`-expression private field update from the same type (`this with {...}`) → no diagnostic
- object-initializer-suffix private field write from outside → GS0472

## Validation

    dotnet build src/Compiler/Compiler.csproj -c Release -graph        # succeeds
    dotnet test test/Core.Tests/Core.Tests.csproj -c Release --filter "FullyQualifiedName~Issue2059|FullyQualifiedName~Issue2044|FullyQualifiedName~DataStructErgonomics|FullyQualifiedName~ObjectInitializer" -- xUnit.MaxParallelThreads=2   # 50/50 passed
    dotnet test test/Core.Tests/Core.Tests.csproj -c Release --filter "FullyQualifiedName~Literal|FullyQualifiedName~StructLiteral|FullyQualifiedName~ObjectCreation|FullyQualifiedName~Accessib|FullyQualifiedName~Inaccessible|FullyQualifiedName~Protected" -- xUnit.MaxParallelThreads=2   # 332/332 passed

Manual `gsc` smoke test on `Foo{ Secret: 42 }` from outside the declaring type reproduces `error GS0472: 'Foo.Secret' is inaccessible...`.

`samples/` grepped for struct/class literals writing private members from outside — none found, no regressions to fix there.

Fixes #2059
