### PR TITLE
cs2gs: bare-type switch-expr exhaustiveness, null & nullable-value-type arms (#1962)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue1962SwitchExprFollowUpTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1962SwitchExprFollowUpTests.cs
@@ -1,0 +1,308 @@
+// <copyright file="Issue1962SwitchExprFollowUpTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Follow-ups from issue #1962 (PR #1961 / #1890 review) on bare-type
+/// switch-expression arms.
+/// <para>
+/// (1) GS0176: a C# switch expression can be exhaustive purely by its TYPE
+/// (and `null`) arms — with no `_`/`var` catch-all at all — cases Roslyn
+/// itself proves exhaustive (e.g. `int? x switch { int =&gt;, null =&gt; }`,
+/// since `HasValue` is a closed true/false domain). gsc's own exhaustiveness
+/// check has no equivalent proof for type-pattern arms, so the translated
+/// arm set trips GS0176 unless a synthesized `default:` arm is added.
+/// </para>
+/// <para>
+/// (2) A `null` arm ahead of a type arm (`object? x switch { null =&gt; ..,
+/// int =&gt; .., _ =&gt; .. }`) must keep that order in the emitted G#, and
+/// the type arm's `_ is int32` test must not accidentally match `null`.
+/// </para>
+/// <para>
+/// (3) A bare-type arm over a nullable VALUE type (`int? x switch { int
+/// =&gt; .. }`) must match only when `HasValue`, mirroring Roslyn's `HasValue`
+/// narrowing — verified here by actually compiling and running the emitted
+/// G# (gsc's `box`+`isinst` emit strategy for `Nullable&lt;T&gt;` gives this
+/// for free per ECMA-335's special `Nullable&lt;T&gt;` boxing rule; see
+/// <c>MethodBodyEmitter.Patterns.EmitTypePattern</c>).
+/// </para>
+/// </summary>
+public class Issue1962SwitchExprFollowUpTests
+{
+    /// <summary>
+    /// `int? x switch { int =&gt;, null =&gt; }` has no `_`/`var` catch-all,
+    /// but Roslyn proves it exhaustive (HasValue true/false is a closed
+    /// domain) — so C# accepts it with no CS8509. The translated G# arms
+    /// (`case _ is int32:` / `case nil:`) carry no unguarded discard, which
+    /// would trip gsc's GS0176 without the synthesized `default:` arm.
+    /// </summary>
+    /// <remarks>
+    /// Structural-only: actually compiling this shape currently hits an
+    /// unrelated, pre-existing gsc binder bug — <c>case nil:</c> against a
+    /// value-type-<c>Nullable</c> discriminant (`int32?`) crashes emit with
+    /// GS9998 (<c>PatternBinder.BindConstantPattern</c> builds the nil-arm's
+    /// <c>BoundConversionExpression</c> directly instead of through
+    /// <c>ConversionClassifier</c>'s issue-#504 nil→Nullable-value-type
+    /// lowering, so <c>EmitConversion</c> never sees the required
+    /// <c>BoundDefaultExpression</c>). Reproduces with plain hand-written G#,
+    /// independent of cs2gs; filed as gsc issue #2072. The runtime
+    /// (`HasValue`) semantics for a bare-type arm over a nullable value type
+    /// are instead verified end-to-end by
+    /// <see cref="SwitchExpression_BareTypeArmOverNullableValueType_MatchesOnlyWhenHasValue"/>,
+    /// which uses a discard rather than an explicit `null` arm and so never
+    /// touches the buggy path.
+    /// </remarks>
+    [Fact]
+    public void SwitchExpression_ExhaustiveByNullableValueTypeArmsAlone_SynthesizesDefaultArm()
+    {
+        string printed = TranslateAndValidate(@"
+using System;
+
+namespace Demo
+{
+    public sealed class C
+    {
+        public static string Describe(int? x) => x switch
+        {
+            int => ""has value"",
+            null => ""none"",
+        };
+    }
+}");
+
+        Assert.Contains("case _ is int32:", printed, StringComparison.Ordinal);
+        Assert.Contains("case nil:", printed, StringComparison.Ordinal);
+        Assert.Contains("default: throw", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Item #1962(3): a bare-type arm over a nullable VALUE type (`int? x
+    /// switch { int =&gt; .. }`) must match only when `HasValue` — Roslyn's
+    /// own narrowing rule. Compiled and run end-to-end (avoiding the `case
+    /// nil:` gsc bug noted above by using a discard for the null case
+    /// instead of an explicit `null` arm).
+    /// </summary>
+    [Fact]
+    public void SwitchExpression_BareTypeArmOverNullableValueType_MatchesOnlyWhenHasValue()
+    {
+        string printed = TranslateAndValidate(@"
+using System;
+
+namespace Demo
+{
+    public sealed class C
+    {
+        public static string Describe(int? x) => x switch
+        {
+            int => ""has value"",
+            _ => ""none"",
+        };
+    }
+}");
+
+        Assert.Contains("case _ is int32:", printed, StringComparison.Ordinal);
+        Assert.Contains("default:", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("default: throw", printed, StringComparison.Ordinal);
+
+        Assert.Equal("has value", CompileAndRun(printed, "C.Describe(5)").Trim());
+        Assert.Equal("none", CompileAndRun(printed, "C.Describe(nil)").Trim());
+    }
+
+    /// <summary>
+    /// `bool flag switch { true =&gt;, false =&gt; }` is Roslyn-exhaustive
+    /// with no discard — same GS0176 gap, but via plain constant patterns
+    /// rather than a type pattern (pre-existing, not introduced by #1890,
+    /// but the same fix generalizes to it).
+    /// </summary>
+    [Fact]
+    public void SwitchExpression_ExhaustiveByBooleanConstantArmsAlone_SynthesizesDefaultArm()
+    {
+        string printed = TranslateAndValidate(@"
+using System;
+
+namespace Demo
+{
+    public sealed class C
+    {
+        public static string Describe(bool flag) => flag switch
+        {
+            true => ""yes"",
+            false => ""no"",
+        };
+    }
+}");
+
+        Assert.Contains("default: throw", printed, StringComparison.Ordinal);
+        Assert.Equal("yes", CompileAndRun(printed, "C.Describe(true)").Trim());
+        Assert.Equal("no", CompileAndRun(printed, "C.Describe(false)").Trim());
+    }
+
+    /// <summary>
+    /// A guarded discard (`case _ when …`) never satisfies exhaustiveness
+    /// (GS0176: "a guarded discard … does not act as a total/default arm"),
+    /// so a switch expression whose only catch-all is guarded must still get
+    /// a synthesized `default:` arm.
+    /// </summary>
+    [Fact]
+    public void SwitchExpression_OnlyCatchAllIsGuarded_StillSynthesizesDefaultArm()
+    {
+        string printed = TranslateAndValidate(@"
+using System;
+
+namespace Demo
+{
+    public sealed class C
+    {
+        public static string Describe(int n) => n switch
+        {
+            _ when n > 0 => ""positive"",
+            _ => ""other"",
+        };
+    }
+}");
+
+        // The source's own unguarded `_ =>` already covers the total case —
+        // no synthesized arm should be added on top of it.
+        Assert.DoesNotContain("default: throw", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// `object? x switch { null =&gt; .., int =&gt; .., _ =&gt; .. }`: the
+    /// `null` arm must stay ahead of the type arm in the emitted G#, and the
+    /// type arm's `_ is int32` test must reject `null` (never accidentally
+    /// matching it) and reject a non-`int` value, falling through to the
+    /// discard.
+    /// </summary>
+    [Fact]
+    public void SwitchExpression_NullArmPrecedesTypeArm_RejectsNullAndNonMatchingType()
+    {
+        string printed = TranslateAndValidate(@"
+using System;
+
+namespace Demo
+{
+    public sealed class C
+    {
+        public static string Describe(object? x) => x switch
+        {
+            null => ""none"",
+            int => ""int"",
+            _ => ""other"",
+        };
+    }
+}");
+
+        Assert.True(
+            printed.IndexOf("case nil:", StringComparison.Ordinal) <
+                printed.IndexOf("case _ is int32:", StringComparison.Ordinal),
+            "the `null` arm must precede the type arm in emit order:\n" + printed);
+
+        Assert.Equal("int", CompileAndRun(printed, "C.Describe(5)").Trim());
+        Assert.Equal("none", CompileAndRun(printed, "C.Describe(nil)").Trim());
+        Assert.Equal("other", CompileAndRun(printed, "C.Describe(\"hi\")").Trim());
+    }
+
+    private static string TranslateAndValidate(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        Assert.DoesNotContain(
+            context.Diagnostics,
+            d => d.Severity == TranslationSeverity.Unsupported);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = GSharpRoundTrip.Validate(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+
+    /// <summary>
+    /// Compiles <paramref name="printed"/> (with <paramref name="callExpression"/>
+    /// appended, wrapped in a `Console.WriteLine`, as a top-level entry
+    /// statement) with the real <c>gsc</c> — proving gsc itself accepts the
+    /// synthesized arm (no GS0176) — and runs it, returning stdout.
+    /// </summary>
+    private static string CompileAndRun(string printed, string callExpression)
+    {
+        string compiler = FindCompiler();
+        Assert.True(compiler != null, "gsc.dll must be built (dotnet build GSharp.sln) before running this test.");
+
+        string workDir = Path.Combine(AppContext.BaseDirectory, "issue-1962-e2e", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(workDir);
+        string gsPath = Path.Combine(workDir, "Snippet.gs");
+        string dllPath = Path.Combine(workDir, "Snippet.dll");
+        File.WriteAllText(gsPath, printed + Environment.NewLine + $"Console.WriteLine({callExpression})" + Environment.NewLine);
+
+        (int compileExit, string compileOut) = RunDotnet(
+            $"\"{compiler}\" /target:exe /out:\"{dllPath}\" \"{gsPath}\"");
+        Assert.True(
+            compileExit == 0 && !compileOut.Contains("error", StringComparison.OrdinalIgnoreCase),
+            "gsc must compile the translated snippet with zero errors. Output:\n" + compileOut +
+                "\n\nTranslated G#:\n" + printed);
+
+        (int runExit, string stdout) = RunDotnet($"\"{dllPath}\"");
+        Assert.True(runExit == 0, "Translated snippet must run successfully. Output:\n" + stdout);
+        return stdout;
+    }
+
+    private static (int Exit, string Output) RunDotnet(string arguments)
+    {
+        var psi = new ProcessStartInfo("dotnet", arguments)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        using var process = Process.Start(psi);
+        var output = new StringBuilder();
+        output.Append(process.StandardOutput.ReadToEnd());
+        output.Append(process.StandardError.ReadToEnd());
+        process.WaitForExit();
+        return (process.ExitCode, output.ToString());
+    }
+
+    private static string FindCompiler()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            foreach (string config in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(dir.FullName, "out", "bin", config, "Compiler", "gsc.dll");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            dir = dir.Parent;
+        }
+
+        return null;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.cs
@@ -13904,6 +13904,7 @@ public sealed class CSharpToGSharpTranslator
         {
             GExpression subject = this.TranslateExpression(node.GoverningExpression);
             var arms = new List<SwitchArm>();
+            bool hasTotalArm = false;
 
             foreach (SwitchExpressionArmSyntax arm in node.Arms)
             {
@@ -13948,6 +13949,42 @@ public sealed class CSharpToGSharpTranslator
                 }
 
                 arms.Add(new SwitchArm(pattern, body, guard));
+
+                // A guarded discard (`case _ when …`) can still fail at run
+                // time, so — mirroring gsc's own exhaustiveness rule
+                // (diagnostics.md GS0176: "a guarded discard … does not act
+                // as a total/default arm") — only an unguarded discard/`default`
+                // arm counts as total. `pattern` is `null` for a real C#
+                // discard (`_ =>`); it is a `DiscardPattern` node (not `null`)
+                // for a `var v =>` arm, which also always matches (it never
+                // narrows, so it is total too — see `TranslatePattern`'s
+                // `VarPatternSyntax` case above).
+                hasTotalArm |= guard == null && (pattern == null || pattern is DiscardPattern);
+            }
+
+            // Issue #1962: a C# switch expression can be exhaustive purely by
+            // its TYPE arms (e.g. every case of a sealed hierarchy is covered,
+            // or a `bool`'s `true`/`false` are both present) with no `_`/`var`
+            // catch-all at all — Roslyn proves that exhaustive and requires no
+            // default arm. gsc's own exhaustiveness check has no equivalent
+            // type-hierarchy proof: it only recognizes a literal unguarded
+            // discard/`default:` arm as total (see GS0176 above), so the
+            // translated arm set would otherwise trip GS0176 even though the
+            // source compiled cleanly. Synthesize a trailing default arm that
+            // mirrors C#'s own runtime behavior for an unmatched switch
+            // expression value (an implicit throw — C#'s own
+            // `SwitchExpressionException`) so gsc accepts the switch and a
+            // genuinely-unreachable value still fails loudly instead of
+            // silently miscompiling.
+            if (!hasTotalArm)
+            {
+                GTypeReference resultType = this.ResolveExpressionType(node);
+                GExpression unmatchedThrow = new ThrowExpression(
+                    BuildConstruction(
+                        new NamedTypeReference("InvalidOperationException"),
+                        new List<GExpression> { LiteralExpression.String("Unmatched switch expression value.") }),
+                    resultType);
+                arms.Add(new SwitchArm(null, unmatchedThrow, null));
             }
 
             return new SwitchExpression(subject, arms);


### PR DESCRIPTION
Follow-ups from PR #1961/#1890 review, tracked as #1962.

## 1. Exhaustiveness / GS0176 — fixed

A C# switch-expr can be exhaustive purely by its type/`null` arms — Roslyn
proves it (e.g. `int? x switch { int => .., null => .. }` via `HasValue`, or
`bool flag switch { true => .., false => .. }`) — with no `_`/`var`
catch-all at all. gsc's own exhaustiveness check has no equivalent proof for
type-pattern arms (only a literal unguarded discard/`default:` arm counts as
total), so the translated arm set trips GS0176 even though the C# source
compiled cleanly.

`TranslateSwitchExpression` now tracks whether any arm is an unguarded
discard/`default` (a real C# discard lowers `Pattern` to `null`; a `var v =>`
arm lowers to a G# `DiscardPattern` node instead — both are total). If none
is present, it appends a synthesized `default:` arm that throws
`InvalidOperationException`, mirroring C#'s own implicit
`SwitchExpressionException` semantics for an unmatched switch value — so a
genuinely-unreachable value still fails loudly at runtime instead of gsc
rejecting an otherwise-correct translation.

A guarded discard (`case _ when …`) still does not count as total, per
gsc's own documented GS0176 rule — covered by a regression test.

## 2. Null arm interaction — verified (no fix needed)

`object? x switch { null => .., int => .., _ => .. }`: arm order is already
preserved by translation (arms are emitted in source order), and the type
arm's `_ is int32` test structurally can never match `null` (`isinst`
against a `null` reference is always `false`). Added a fixture that compiles
and runs this shape end-to-end to lock in the behavior.

## 3. Nullable value-type type test — verified (no fix needed)

`int? x switch { int => .. }`: gsc's existing `EmitTypePattern` strategy
(uniform for ref + value targets: box the source, then `isinst` the target)
already gives the correct `HasValue` semantics for a `Nullable<T>` source,
per the CLR's special `Nullable<T>` boxing rule (ECMA-335 §I.8.2.4) — boxing
a `Nullable<T>` produces a boxed `T` when `HasValue`, or `null` otherwise.
Added a fixture that compiles and runs this end-to-end, confirming the match
only happens when `HasValue`.

## Follow-up gsc bug filed

While building the nullable-value-type exhaustiveness fixture (item 1 + 3
combined: `int? x switch { int => .., null => .. }`, no discard), found an
independent, pre-existing gsc binder bug: a `null` constant pattern
(`case nil:`) against a value-type-`Nullable<T>` discriminant crashes emit
with GS9998. Reproduces with plain hand-written G#, unrelated to cs2gs.
Filed as DavidObando/gsharp#2072 (`Oats` label). That specific combined
shape is covered structurally-only in the new test suite, with a comment
pointing at the filed issue; the HasValue runtime behavior itself (item 3)
is still fully verified via a discard-based fixture that avoids the buggy
path.

## Tests

- New `Issue1962SwitchExprFollowUpTests.cs`: 5 tests (structural + real
  `gsc` compile+run assertions for the runtime-behavior claims).
- `dotnet test tools/cs2gs/Cs2Gs.Tests`: 1027/1027 passed (no regressions).
- `cs2gs migrate --baseline tools/cs2gs/triage/gaps.json`: 0 new, 0
  regressed (pre-existing ledgered #1929 stale + L2-Library unverified,
  both unrelated to this change).
- No coverage-matrix/inventory changes needed (no new GNode/construct; this
  is a behavioral fix to an already-translated construct).

Fixes #1962
