### PR TITLE
gsc: enforce accessibility on static/shared method calls

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -2789,6 +2789,17 @@ internal sealed partial class ExpressionBinder
                 return new BoundErrorExpression(null);
             }
 
+            // Issue #2071: enforce `protected`/`private` accessibility on static
+            // (`shared`) method calls, mirroring the instance-call check in
+            // OverloadResolver.BindUserInstanceCall (#950/#2044/#2058). Static
+            // methods carry their declaring type via StaticOwnerType (they have
+            // no receiver), unlike instance methods which use ReceiverType.
+            if (method.StaticOwnerType is StructSymbol methodDeclaringType
+                && !AccessibilityChecker.IsAccessible(method.Accessibility, methodDeclaringType, function))
+            {
+                Diagnostics.ReportMemberInaccessible(ce.Identifier.Location, method.Name, methodDeclaringType.Name, method.Accessibility);
+            }
+
             // Issue #951: bind any deferred un-typed arrow lambda against the
             // selected static method's delegate-typed parameter so its omitted
             // parameter type(s) and inferred return type are filled in from the

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2071StaticMethodCallAccessibilityTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2071StaticMethodCallAccessibilityTests.cs
@@ -1,0 +1,154 @@
+// <copyright file="Issue2071StaticMethodCallAccessibilityTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #2071: <see cref="GSharp.Core.CodeAnalysis.Binding.ExpressionBinder.BindUserTypeStaticCall(TypeSymbol, CallExpressionSyntax)"/>
+/// never consulted <see cref="AccessibilityChecker.IsAccessible"/> at all, so
+/// a <c>private</c>/<c>protected</c> static (<c>shared</c>) method called
+/// from outside its declaring type was never diagnosed — the same class of
+/// hole that #2058/#2062 fixed for instance-method calls
+/// (<c>OverloadResolver.BindUserInstanceCall</c>), but left open for
+/// <c>TypeName.Method()</c> static calls.
+/// </summary>
+public class Issue2071StaticMethodCallAccessibilityTests
+{
+    [Fact]
+    public void ExternalCode_CallsPrivateStaticMethod_ReportsGS0472()
+    {
+        var source = @"
+class Foo {
+    shared {
+        private func Secret() int32 {
+            return 42
+        }
+    }
+}
+
+class Other {
+    func Poke() int32 {
+        return Foo.Secret()
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    [Fact]
+    public void ExternalCode_CallsProtectedStaticMethod_ReportsGS0379NotGS0472()
+    {
+        var source = @"
+open class Base {
+    shared {
+        protected func Guarded() int32 {
+            return 7
+        }
+    }
+}
+
+class Other {
+    func Poke() int32 {
+        return Base.Guarded()
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0379");
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    [Fact]
+    public void DerivedClass_CallsBaseProtectedStaticMethod_NoDiagnostics()
+    {
+        var source = @"
+open class Base {
+    shared {
+        protected func Guarded() int32 {
+            return 7
+        }
+    }
+}
+
+class Derived : Base {
+    func Poke() int32 {
+        return Base.Guarded()
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0379");
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    [Fact]
+    public void InternalCode_CallsPrivateStaticMethodFromSameType_NoDiagnostics()
+    {
+        var source = @"
+class Foo {
+    shared {
+        private func Secret() int32 {
+            return 42
+        }
+
+        func Reveal() int32 {
+            return Secret()
+        }
+    }
+}
+
+class Other {
+    func Poke() int32 {
+        return Foo.Reveal()
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0472");
+    }
+
+    [Fact]
+    public void ExternalCode_CallsPublicStaticMethod_NoDiagnostics()
+    {
+        var source = @"
+class Foo {
+    shared {
+        func Open() int32 {
+            return 42
+        }
+    }
+}
+
+class Other {
+    func Poke() int32 {
+        return Foo.Open()
+    }
+}
+0
+";
+        var result = Evaluate(source);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0472");
+        Assert.DoesNotContain(result.Diagnostics, d => d.Id == "GS0379");
+    }
+
+    private static EvaluationResult Evaluate(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        var compilation = new Compilation(tree);
+        return compilation.Evaluate(new Dictionary<VariableSymbol, object>());
+    }
+}


### PR DESCRIPTION
Fixes #2071

## Root cause
`ExpressionBinder.BindUserTypeStaticCall` (static/`shared` method calls, e.g. `Foo.PrivateStatic()`) had NO accessibility enforcement at all. A `private`/`protected` static method called from outside its declaring type was never diagnosed. This is separate from `OverloadResolver.BindUserInstanceCall` (instance calls), which #2058/#2062 already fixed.

## Fix
Once the static method overload is resolved, gate it through `AccessibilityChecker.IsAccessible` + `DiagnosticBag.ReportMemberInaccessible` (GS0472 private / GS0379 protected), mirroring the instance-call fix. Static methods carry their declaring type via `StaticOwnerType` (they have no `ReceiverType`), so the check keys off that instead.

Verified there is only one binding path for `TypeName.Method()` static calls (struct, generic-owner struct, and interface owners all route through the same `BindUserTypeStaticCall`), so this single fix covers every static-call call site — no sibling gaps found.

## Tests
Added `Issue2071StaticMethodCallAccessibilityTests` (5 cases):
- private static call from outside declaring type -> GS0472
- protected static call from outside -> GS0379 (not GS0472)
- derived class calling base's protected static method -> compiles clean
- same-type private static call (via internal caller) -> compiles clean
- public static call -> compiles clean

## Test results
- `dotnet build src/Compiler/Compiler.csproj -c Release`: succeeded, 0 warnings, 0 errors
- `dotnet test test/Core.Tests/Core.Tests.csproj -c Release`: 5517 passed, 1 pre-existing skip, 0 failed

No work deferred.